### PR TITLE
feat(phase-e): implement atm read path (Sprint E.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,10 +82,61 @@ name = "atm-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "serde",
  "serde_json",
  "thiserror",
+ "toml",
  "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -126,10 +186,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -144,10 +298,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -168,6 +359,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +385,24 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -229,6 +448,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +498,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -303,10 +578,160 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"
@@ -315,12 +740,127 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,10 @@ dependencies = [
  "anyhow",
  "atm-core",
  "clap",
+ "serde_json",
+ "tempfile",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -198,6 +201,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +327,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +361,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-traits"
@@ -391,6 +431,19 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -457,10 +510,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -477,6 +545,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -497,6 +578,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -569,6 +659,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -600,6 +716,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14,6 +64,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atm-core",
+ "clap",
  "tracing",
 ]
 
@@ -27,6 +78,64 @@ dependencies = [
  "thiserror",
  "tracing",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -45,6 +154,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
@@ -114,6 +229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +301,27 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,11 +73,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atm-core",
+ "chrono",
  "clap",
  "serde_json",
  "tempfile",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,8 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "serial_test",
+ "tempfile",
  "thiserror",
  "toml",
  "tracing",
@@ -198,6 +200,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +226,41 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -320,6 +373,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +419,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -393,10 +484,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -457,10 +591,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -477,6 +649,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -15,3 +15,7 @@ tracing.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"
 uuid = { version = "1", features = ["serde", "v4"] }
+
+[dev-dependencies]
+serial_test = "3"
+tempfile = "3"

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -12,3 +12,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
+chrono = { version = "0.4", features = ["serde"] }
+toml = "0.8"
+uuid = { version = "1", features = ["serde", "v4"] }

--- a/crates/atm-core/src/address.rs
+++ b/crates/atm-core/src/address.rs
@@ -14,20 +14,20 @@ impl FromStr for AgentAddress {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let trimmed = value.trim();
         if trimmed.is_empty() {
-            return Err(Error::AddressParse("agent name must not be empty".into()));
+            return Err(Error::address_parse("agent name must not be empty"));
         }
 
         match trimmed.split_once('@') {
             Some((agent, team)) => {
                 if agent.is_empty() {
-                    return Err(Error::AddressParse("agent name must not be empty".into()));
+                    return Err(Error::address_parse("agent name must not be empty"));
                 }
                 if team.is_empty() {
-                    return Err(Error::AddressParse("team name must not be empty".into()));
+                    return Err(Error::address_parse("team name must not be empty"));
                 }
                 if team.contains('@') {
-                    return Err(Error::AddressParse(
-                        "address must contain at most one @ separator".into(),
+                    return Err(Error::address_parse(
+                        "address must contain at most one @ separator",
                     ));
                 }
 

--- a/crates/atm-core/src/address.rs
+++ b/crates/atm-core/src/address.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use crate::error::Error;
+use crate::error::AtmError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentAddress {
@@ -9,25 +9,25 @@ pub struct AgentAddress {
 }
 
 impl FromStr for AgentAddress {
-    type Err = Error;
+    type Err = AtmError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let trimmed = value.trim();
         if trimmed.is_empty() {
-            return Err(Error::AddressParse("agent name must not be empty".into()));
+            return Err(AtmError::address_parse("agent name must not be empty"));
         }
 
         match trimmed.split_once('@') {
             Some((agent, team)) => {
                 if agent.is_empty() {
-                    return Err(Error::AddressParse("agent name must not be empty".into()));
+                    return Err(AtmError::address_parse("agent name must not be empty"));
                 }
                 if team.is_empty() {
-                    return Err(Error::AddressParse("team name must not be empty".into()));
+                    return Err(AtmError::address_parse("team name must not be empty"));
                 }
                 if team.contains('@') {
-                    return Err(Error::AddressParse(
-                        "address must contain at most one @ separator".into(),
+                    return Err(AtmError::address_parse(
+                        "address must contain at most one @ separator",
                     ));
                 }
 

--- a/crates/atm-core/src/address.rs
+++ b/crates/atm-core/src/address.rs
@@ -1,1 +1,78 @@
-// TODO: implement address parsing and validation services.
+use std::str::FromStr;
+
+use crate::error::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentAddress {
+    pub agent: String,
+    pub team: Option<String>,
+}
+
+impl FromStr for AgentAddress {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(Error::AddressParse("agent name must not be empty".into()));
+        }
+
+        match trimmed.split_once('@') {
+            Some((agent, team)) => {
+                if agent.is_empty() {
+                    return Err(Error::AddressParse("agent name must not be empty".into()));
+                }
+                if team.is_empty() {
+                    return Err(Error::AddressParse("team name must not be empty".into()));
+                }
+                if team.contains('@') {
+                    return Err(Error::AddressParse(
+                        "address must contain at most one @ separator".into(),
+                    ));
+                }
+
+                Ok(Self {
+                    agent: agent.to_string(),
+                    team: Some(team.to_string()),
+                })
+            }
+            None => Ok(Self {
+                agent: trimmed.to_string(),
+                team: None,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::AgentAddress;
+
+    #[test]
+    fn parses_bare_agent_address() {
+        let parsed = AgentAddress::from_str("arch-ctm").expect("address");
+        assert_eq!(parsed.agent, "arch-ctm");
+        assert_eq!(parsed.team, None);
+    }
+
+    #[test]
+    fn parses_agent_with_team() {
+        let parsed = AgentAddress::from_str("arch-ctm@atm-dev").expect("address");
+        assert_eq!(parsed.agent, "arch-ctm");
+        assert_eq!(parsed.team.as_deref(), Some("atm-dev"));
+    }
+
+    #[test]
+    fn rejects_empty_agent_name() {
+        assert!(AgentAddress::from_str("").is_err());
+        assert!(AgentAddress::from_str("@atm-dev").is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_team_segment() {
+        assert!(AgentAddress::from_str("arch-ctm@").is_err());
+        assert!(AgentAddress::from_str("arch-ctm@atm@dev").is_err());
+    }
+}

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -61,14 +61,8 @@ mod tests {
     use std::env;
     use std::fs;
     use std::path::PathBuf;
-    use std::sync::{Mutex, OnceLock};
 
     use super::{load_config, resolve_identity, resolve_team, AtmConfig};
-
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
 
     #[test]
     fn load_config_walks_upward_for_dot_atm_toml() {
@@ -87,8 +81,8 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn identity_prefers_environment_over_config() {
-        let _guard = env_lock().lock().expect("env lock");
         let original_identity = env::var_os("ATM_IDENTITY");
         env::set_var("ATM_IDENTITY", "env-identity");
 
@@ -105,8 +99,8 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn team_resolution_prefers_flag_then_env_then_config() {
-        let _guard = env_lock().lock().expect("env lock");
         let original_team = env::var_os("ATM_TEAM");
         env::set_var("ATM_TEAM", "env-team");
 

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -3,4 +3,140 @@ pub mod bridge;
 pub mod discovery;
 pub mod types;
 
-// TODO: implement config resolution and loading.
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub use types::AtmConfig;
+
+use crate::error::Error;
+
+pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, Error> {
+    let Some(path) = find_config_path(start_dir) else {
+        return Ok(None);
+    };
+
+    let contents = fs::read_to_string(path)?;
+    Ok(Some(toml::from_str(&contents)?))
+}
+
+pub fn resolve_identity(config: Option<&AtmConfig>) -> Option<String> {
+    env::var("ATM_IDENTITY")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| config.and_then(|cfg| cfg.identity.clone()))
+}
+
+pub fn resolve_team(team_override: Option<&str>, config: Option<&AtmConfig>) -> Option<String> {
+    team_override
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| env::var("ATM_TEAM").ok().filter(|value| !value.is_empty()))
+        .or_else(|| config.and_then(|cfg| cfg.default_team.clone()))
+}
+
+fn find_config_path(start_dir: &Path) -> Option<PathBuf> {
+    let mut current = Some(start_dir);
+
+    while let Some(dir) = current {
+        let candidate = dir.join(".atm.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+
+        current = dir.parent();
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+
+    use super::{load_config, resolve_identity, resolve_team, AtmConfig};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn load_config_walks_upward_for_dot_atm_toml() {
+        let root = unique_temp_dir("config-discovery");
+        let nested = root.join("workspace").join("nested");
+        fs::create_dir_all(&nested).expect("nested dir");
+        fs::write(
+            root.join(".atm.toml"),
+            "identity = \"arch-ctm\"\ndefault_team = \"atm-dev\"\n",
+        )
+        .expect("config");
+
+        let config = load_config(&nested).expect("config").expect("present");
+        assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
+        assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+    }
+
+    #[test]
+    fn identity_prefers_environment_over_config() {
+        let _guard = env_lock().lock().expect("env lock");
+        let original_identity = env::var_os("ATM_IDENTITY");
+        env::set_var("ATM_IDENTITY", "env-identity");
+
+        let config = AtmConfig {
+            identity: Some("config-identity".into()),
+            default_team: None,
+        };
+
+        assert_eq!(
+            resolve_identity(Some(&config)).as_deref(),
+            Some("env-identity")
+        );
+        restore("ATM_IDENTITY", original_identity);
+    }
+
+    #[test]
+    fn team_resolution_prefers_flag_then_env_then_config() {
+        let _guard = env_lock().lock().expect("env lock");
+        let original_team = env::var_os("ATM_TEAM");
+        env::set_var("ATM_TEAM", "env-team");
+
+        let config = AtmConfig {
+            identity: None,
+            default_team: Some("config-team".into()),
+        };
+
+        assert_eq!(
+            resolve_team(Some("flag-team"), Some(&config)).as_deref(),
+            Some("flag-team")
+        );
+        assert_eq!(
+            resolve_team(None, Some(&config)).as_deref(),
+            Some("env-team")
+        );
+
+        env::remove_var("ATM_TEAM");
+        assert_eq!(
+            resolve_team(None, Some(&config)).as_deref(),
+            Some("config-team")
+        );
+
+        restore("ATM_TEAM", original_team);
+    }
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let path = env::temp_dir().join(format!("{label}-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&path).expect("temp dir");
+        path
+    }
+
+    fn restore(key: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => env::set_var(key, value),
+            None => env::remove_var(key),
+        }
+    }
+}

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -9,14 +9,20 @@ use std::path::{Path, PathBuf};
 
 pub use types::AtmConfig;
 
-use crate::error::Error;
+use crate::error::{AtmError, AtmErrorKind};
 
-pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, Error> {
+pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
     let Some(path) = find_config_path(start_dir) else {
         return Ok(None);
     };
 
-    let contents = fs::read_to_string(path)?;
+    let contents = fs::read_to_string(path).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::Config,
+            format!("failed to read config: {error}"),
+        )
+        .with_source(error)
+    })?;
     Ok(Some(toml::from_str(&contents)?))
 }
 

--- a/crates/atm-core/src/config/types.rs
+++ b/crates/atm-core/src/config/types.rs
@@ -1,1 +1,7 @@
-// TODO: define config-facing data types.
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct AtmConfig {
+    pub identity: Option<String>,
+    pub default_team: Option<String>,
+}

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -1,19 +1,147 @@
-use thiserror::Error;
+use std::fmt;
 
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("home directory is unavailable")]
-    HomeDirectoryUnavailable,
-    #[error("address parse failed: {0}")]
-    AddressParse(String),
-    #[error("identity is not configured")]
-    IdentityUnavailable,
-    #[error("team is not configured")]
-    TeamUnavailable,
-    #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("json error: {0}")]
-    Json(#[from] serde_json::Error),
-    #[error("toml error: {0}")]
-    Toml(#[from] toml::de::Error),
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtmErrorKind {
+    Config,
+    Address,
+    Identity,
+    TeamNotFound,
+    AgentNotFound,
+    MailboxRead,
+    MailboxWrite,
+    FilePolicy,
+    Validation,
+    Serialization,
+    Timeout,
+    ObservabilityEmit,
+    ObservabilityQuery,
+    ObservabilityHealth,
+}
+
+#[derive(Debug)]
+pub struct AtmError {
+    pub kind: AtmErrorKind,
+    pub message: String,
+    pub recovery: Option<String>,
+    pub source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+pub type Error = AtmError;
+
+impl AtmError {
+    pub fn new(kind: AtmErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            recovery: None,
+            source: None,
+        }
+    }
+
+    pub fn with_recovery(mut self, recovery: impl Into<String>) -> Self {
+        self.recovery = Some(recovery.into());
+        self
+    }
+
+    pub fn with_source<E>(mut self, source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        self.source = Some(Box::new(source));
+        self
+    }
+
+    pub fn home_directory_unavailable() -> Self {
+        Self::new(AtmErrorKind::Config, "home directory is unavailable")
+            .with_recovery("Set ATM_HOME or ensure the OS home directory can be resolved.")
+    }
+
+    pub fn address_parse(message: impl Into<String>) -> Self {
+        Self::new(
+            AtmErrorKind::Address,
+            format!("address parse failed: {}", message.into()),
+        )
+    }
+
+    pub fn identity_unavailable() -> Self {
+        Self::new(AtmErrorKind::Identity, "identity is not configured")
+            .with_recovery("Set ATM_IDENTITY, configure identity in .atm.toml, or pass --from once that flag is available.")
+    }
+
+    pub fn team_unavailable() -> Self {
+        Self::new(AtmErrorKind::TeamNotFound, "team is not configured")
+            .with_recovery("Pass an explicit team in the address or configure a default team.")
+    }
+
+    pub fn team_not_found(team: &str) -> Self {
+        Self::new(
+            AtmErrorKind::TeamNotFound,
+            format!("team '{team}' was not found"),
+        )
+        .with_recovery("Create the team config or target a different team.")
+    }
+
+    pub fn agent_not_found(agent: &str, team: &str) -> Self {
+        Self::new(
+            AtmErrorKind::AgentNotFound,
+            format!("agent '{agent}' was not found in team '{team}'"),
+        )
+        .with_recovery("Update the team membership or target a different recipient.")
+    }
+
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::Validation, message)
+    }
+
+    pub fn file_policy(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::FilePolicy, message)
+    }
+
+    pub fn mailbox_read(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::MailboxRead, message)
+    }
+
+    pub fn mailbox_write(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::MailboxWrite, message)
+    }
+
+    pub fn observability_emit(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::ObservabilityEmit, message)
+    }
+}
+
+impl fmt::Display for AtmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)?;
+        if let Some(recovery) = &self.recovery {
+            write!(f, " Recovery: {recovery}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for AtmError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_deref()
+            .map(|error| error as &(dyn std::error::Error + 'static))
+    }
+}
+
+impl From<std::io::Error> for AtmError {
+    fn from(source: std::io::Error) -> Self {
+        Self::new(AtmErrorKind::MailboxWrite, format!("io error: {source}")).with_source(source)
+    }
+}
+
+impl From<serde_json::Error> for AtmError {
+    fn from(source: serde_json::Error) -> Self {
+        Self::new(AtmErrorKind::Serialization, format!("json error: {source}")).with_source(source)
+    }
+}
+
+impl From<toml::de::Error> for AtmError {
+    fn from(source: toml::de::Error) -> Self {
+        Self::new(AtmErrorKind::Config, format!("toml error: {source}")).with_source(source)
+    }
 }

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -2,6 +2,18 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("bootstrap placeholder error")]
-    Bootstrap,
+    #[error("home directory is unavailable")]
+    HomeDirectoryUnavailable,
+    #[error("address parse failed: {0}")]
+    AddressParse(String),
+    #[error("identity is not configured")]
+    IdentityUnavailable,
+    #[error("team is not configured")]
+    TeamUnavailable,
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("toml error: {0}")]
+    Toml(#[from] toml::de::Error),
 }

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -1,19 +1,105 @@
-use thiserror::Error;
+use std::error::Error as StdError;
+use std::fmt;
 
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("home directory is unavailable")]
-    HomeDirectoryUnavailable,
-    #[error("address parse failed: {0}")]
-    AddressParse(String),
-    #[error("identity is not configured")]
-    IdentityUnavailable,
-    #[error("team is not configured")]
-    TeamUnavailable,
-    #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("json error: {0}")]
-    Json(#[from] serde_json::Error),
-    #[error("toml error: {0}")]
-    Toml(#[from] toml::de::Error),
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtmErrorKind {
+    Config,
+    Address,
+    Identity,
+    TeamNotFound,
+    AgentNotFound,
+    MailboxRead,
+    MailboxWrite,
+    FilePolicy,
+    Validation,
+    Serialization,
+    Timeout,
+    ObservabilityEmit,
+    ObservabilityQuery,
+    ObservabilityHealth,
+}
+
+#[derive(Debug)]
+pub struct AtmError {
+    pub kind: AtmErrorKind,
+    pub message: String,
+    pub recovery: Option<String>,
+    pub source: Option<Box<dyn StdError + Send + Sync>>,
+}
+
+impl AtmError {
+    pub fn new(kind: AtmErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            recovery: None,
+            source: None,
+        }
+    }
+
+    pub fn with_recovery(mut self, recovery: impl Into<String>) -> Self {
+        self.recovery = Some(recovery.into());
+        self
+    }
+
+    pub fn with_source<E>(mut self, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        self.source = Some(Box::new(source));
+        self
+    }
+
+    pub fn home_directory_unavailable() -> Self {
+        Self::new(AtmErrorKind::Config, "home directory is unavailable")
+            .with_recovery("set ATM_HOME or ensure HOME/USERPROFILE is available")
+    }
+
+    pub fn address_parse(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::Address, message)
+            .with_recovery("use agent or agent@team with non-empty segments")
+    }
+
+    pub fn identity_unavailable() -> Self {
+        Self::new(AtmErrorKind::Identity, "identity is not configured")
+            .with_recovery("set ATM_IDENTITY or configure identity in .atm.toml")
+    }
+
+    pub fn team_unavailable() -> Self {
+        Self::new(AtmErrorKind::TeamNotFound, "team is not configured")
+            .with_recovery("pass --team, set ATM_TEAM, or configure default_team in .atm.toml")
+    }
+}
+
+impl fmt::Display for AtmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl StdError for AtmError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source
+            .as_deref()
+            .map(|source| source as &(dyn StdError + 'static))
+    }
+}
+
+impl From<std::io::Error> for AtmError {
+    fn from(error: std::io::Error) -> Self {
+        AtmError::new(AtmErrorKind::MailboxWrite, format!("io error: {error}")).with_source(error)
+    }
+}
+
+impl From<serde_json::Error> for AtmError {
+    fn from(error: serde_json::Error) -> Self {
+        AtmError::new(AtmErrorKind::Serialization, format!("json error: {error}"))
+            .with_source(error)
+    }
+}
+
+impl From<toml::de::Error> for AtmError {
+    fn from(error: toml::de::Error) -> Self {
+        AtmError::new(AtmErrorKind::Config, format!("toml error: {error}")).with_source(error)
+    }
 }

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -28,7 +28,7 @@ fn resolve_user_home() -> Result<PathBuf, Error> {
                 .filter(|value| !value.is_empty())
                 .map(PathBuf::from)
         })
-        .ok_or(Error::HomeDirectoryUnavailable)
+        .ok_or_else(Error::home_directory_unavailable)
 }
 
 #[cfg(test)]

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -1,9 +1,9 @@
 use std::env;
 use std::path::PathBuf;
 
-use crate::error::Error;
+use crate::error::AtmError;
 
-pub fn atm_home() -> Result<PathBuf, Error> {
+pub fn atm_home() -> Result<PathBuf, AtmError> {
     if let Some(home) = env::var_os("ATM_HOME").filter(|value| !value.is_empty()) {
         return Ok(PathBuf::from(home));
     }
@@ -11,15 +11,15 @@ pub fn atm_home() -> Result<PathBuf, Error> {
     resolve_user_home().map(|home| home.join(".local").join("share").join("atm"))
 }
 
-pub fn team_dir(team: &str) -> Result<PathBuf, Error> {
+pub fn team_dir(team: &str) -> Result<PathBuf, AtmError> {
     Ok(atm_home()?.join("teams").join(team))
 }
 
-pub fn inbox_path(team: &str, agent: &str) -> Result<PathBuf, Error> {
+pub fn inbox_path(team: &str, agent: &str) -> Result<PathBuf, AtmError> {
     Ok(team_dir(team)?.join("inbox").join(format!("{agent}.jsonl")))
 }
 
-fn resolve_user_home() -> Result<PathBuf, Error> {
+fn resolve_user_home() -> Result<PathBuf, AtmError> {
     env::var_os("HOME")
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
@@ -28,7 +28,7 @@ fn resolve_user_home() -> Result<PathBuf, Error> {
                 .filter(|value| !value.is_empty())
                 .map(PathBuf::from)
         })
-        .ok_or(Error::HomeDirectoryUnavailable)
+        .ok_or_else(AtmError::home_directory_unavailable)
 }
 
 #[cfg(test)]

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -8,15 +8,17 @@ pub fn atm_home() -> Result<PathBuf, AtmError> {
         return Ok(PathBuf::from(home));
     }
 
-    resolve_user_home().map(|home| home.join(".local").join("share").join("atm"))
+    resolve_user_home()
 }
 
 pub fn team_dir(team: &str) -> Result<PathBuf, AtmError> {
-    Ok(atm_home()?.join("teams").join(team))
+    Ok(atm_home()?.join(".claude").join("teams").join(team))
 }
 
 pub fn inbox_path(team: &str, agent: &str) -> Result<PathBuf, AtmError> {
-    Ok(team_dir(team)?.join("inbox").join(format!("{agent}.jsonl")))
+    Ok(team_dir(team)?
+        .join("inboxes")
+        .join(format!("{agent}.json")))
 }
 
 fn resolve_user_home() -> Result<PathBuf, AtmError> {
@@ -33,9 +35,10 @@ fn resolve_user_home() -> Result<PathBuf, AtmError> {
 
 #[cfg(test)]
 mod tests {
-    use std::env;
-    use std::path::PathBuf;
+    use std::ffi::OsString;
     use std::sync::{Mutex, OnceLock};
+
+    use tempfile::TempDir;
 
     use super::{atm_home, inbox_path, team_dir};
 
@@ -44,64 +47,83 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &std::path::Path) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
+        #[cfg(unix)]
+        fn set_raw(key: &'static str, value: &str) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
+        #[cfg(unix)]
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn atm_home_prefers_atm_home_env() {
         let _guard = env_lock().lock().expect("env lock");
-        let original_atm_home = env::var_os("ATM_HOME");
-        let original_home = env::var_os("HOME");
-
-        env::set_var("ATM_HOME", "/tmp/atm-home");
-        env::set_var("HOME", "/tmp/user-home");
+        let tempdir = TempDir::new().expect("tempdir");
+        let _atm_home = EnvGuard::set("ATM_HOME", tempdir.path());
 
         let resolved = atm_home().expect("atm home");
-        assert_eq!(resolved, PathBuf::from("/tmp/atm-home"));
+        assert_eq!(resolved, tempdir.path());
+    }
 
-        restore("ATM_HOME", original_atm_home);
-        restore("HOME", original_home);
+    #[cfg(unix)]
+    #[test]
+    fn atm_home_falls_back_to_home_dir() {
+        let _guard = env_lock().lock().expect("env lock");
+        let tempdir = TempDir::new().expect("tempdir");
+        let _atm_home = EnvGuard::remove("ATM_HOME");
+        let _home = EnvGuard::set_raw("HOME", tempdir.path().to_str().expect("utf8 path"));
+
+        let resolved = atm_home().expect("atm home");
+        assert_eq!(resolved, tempdir.path());
     }
 
     #[test]
-    fn atm_home_falls_back_to_local_share_atm() {
+    fn team_and_inbox_paths_use_claude_team_layout() {
         let _guard = env_lock().lock().expect("env lock");
-        let original_atm_home = env::var_os("ATM_HOME");
-        let original_home = env::var_os("HOME");
-
-        env::remove_var("ATM_HOME");
-        env::set_var("HOME", "/tmp/fallback-home");
-
-        let resolved = atm_home().expect("atm home");
-        assert_eq!(
-            resolved,
-            PathBuf::from("/tmp/fallback-home/.local/share/atm")
-        );
-
-        restore("ATM_HOME", original_atm_home);
-        restore("HOME", original_home);
-    }
-
-    #[test]
-    fn team_and_inbox_paths_use_atm_home_layout() {
-        let _guard = env_lock().lock().expect("env lock");
-        let original_atm_home = env::var_os("ATM_HOME");
-
-        env::set_var("ATM_HOME", "/tmp/atm-home");
+        let tempdir = TempDir::new().expect("tempdir");
+        let _atm_home = EnvGuard::set("ATM_HOME", tempdir.path());
 
         assert_eq!(
             team_dir("atm-dev").expect("team dir"),
-            PathBuf::from("/tmp/atm-home/teams/atm-dev")
+            tempdir.path().join(".claude").join("teams").join("atm-dev")
         );
         assert_eq!(
             inbox_path("atm-dev", "arch-ctm").expect("inbox path"),
-            PathBuf::from("/tmp/atm-home/teams/atm-dev/inbox/arch-ctm.jsonl")
+            tempdir
+                .path()
+                .join(".claude")
+                .join("teams")
+                .join("atm-dev")
+                .join("inboxes")
+                .join("arch-ctm.json")
         );
-
-        restore("ATM_HOME", original_atm_home);
-    }
-
-    fn restore(key: &str, value: Option<std::ffi::OsString>) {
-        match value {
-            Some(value) => env::set_var(key, value),
-            None => env::remove_var(key),
-        }
     }
 }

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -1,1 +1,107 @@
-// TODO: implement home and path resolution helpers.
+use std::env;
+use std::path::PathBuf;
+
+use crate::error::Error;
+
+pub fn atm_home() -> Result<PathBuf, Error> {
+    if let Some(home) = env::var_os("ATM_HOME").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(home));
+    }
+
+    resolve_user_home().map(|home| home.join(".local").join("share").join("atm"))
+}
+
+pub fn team_dir(team: &str) -> Result<PathBuf, Error> {
+    Ok(atm_home()?.join("teams").join(team))
+}
+
+pub fn inbox_path(team: &str, agent: &str) -> Result<PathBuf, Error> {
+    Ok(team_dir(team)?.join("inbox").join(format!("{agent}.jsonl")))
+}
+
+fn resolve_user_home() -> Result<PathBuf, Error> {
+    env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            env::var_os("USERPROFILE")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .ok_or(Error::HomeDirectoryUnavailable)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+
+    use super::{atm_home, inbox_path, team_dir};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn atm_home_prefers_atm_home_env() {
+        let _guard = env_lock().lock().expect("env lock");
+        let original_atm_home = env::var_os("ATM_HOME");
+        let original_home = env::var_os("HOME");
+
+        env::set_var("ATM_HOME", "/tmp/atm-home");
+        env::set_var("HOME", "/tmp/user-home");
+
+        let resolved = atm_home().expect("atm home");
+        assert_eq!(resolved, PathBuf::from("/tmp/atm-home"));
+
+        restore("ATM_HOME", original_atm_home);
+        restore("HOME", original_home);
+    }
+
+    #[test]
+    fn atm_home_falls_back_to_local_share_atm() {
+        let _guard = env_lock().lock().expect("env lock");
+        let original_atm_home = env::var_os("ATM_HOME");
+        let original_home = env::var_os("HOME");
+
+        env::remove_var("ATM_HOME");
+        env::set_var("HOME", "/tmp/fallback-home");
+
+        let resolved = atm_home().expect("atm home");
+        assert_eq!(
+            resolved,
+            PathBuf::from("/tmp/fallback-home/.local/share/atm")
+        );
+
+        restore("ATM_HOME", original_atm_home);
+        restore("HOME", original_home);
+    }
+
+    #[test]
+    fn team_and_inbox_paths_use_atm_home_layout() {
+        let _guard = env_lock().lock().expect("env lock");
+        let original_atm_home = env::var_os("ATM_HOME");
+
+        env::set_var("ATM_HOME", "/tmp/atm-home");
+
+        assert_eq!(
+            team_dir("atm-dev").expect("team dir"),
+            PathBuf::from("/tmp/atm-home/teams/atm-dev")
+        );
+        assert_eq!(
+            inbox_path("atm-dev", "arch-ctm").expect("inbox path"),
+            PathBuf::from("/tmp/atm-home/teams/atm-dev/inbox/arch-ctm.jsonl")
+        );
+
+        restore("ATM_HOME", original_atm_home);
+    }
+
+    fn restore(key: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => env::set_var(key, value),
+            None => env::remove_var(key),
+        }
+    }
+}

--- a/crates/atm-core/src/identity/hook.rs
+++ b/crates/atm-core/src/identity/hook.rs
@@ -1,1 +1,5 @@
-// TODO: implement hook-based identity resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookIdentity {
+    pub agent: String,
+    pub team: String,
+}

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -3,18 +3,19 @@ pub mod hook;
 pub use hook::HookIdentity;
 
 use crate::config::AtmConfig;
-use crate::error::Error;
+use crate::error::AtmError;
 
-pub fn resolve_sender_identity(config: Option<&AtmConfig>) -> Result<String, Error> {
-    crate::config::resolve_identity(config).ok_or(Error::IdentityUnavailable)
+pub fn resolve_sender_identity(config: Option<&AtmConfig>) -> Result<String, AtmError> {
+    crate::config::resolve_identity(config).ok_or_else(AtmError::identity_unavailable)
 }
 
 pub fn resolve_hook_identity(
     team_override: Option<&str>,
     config: Option<&AtmConfig>,
-) -> Result<HookIdentity, Error> {
+) -> Result<HookIdentity, AtmError> {
     let agent = resolve_sender_identity(config)?;
-    let team = crate::config::resolve_team(team_override, config).ok_or(Error::TeamUnavailable)?;
+    let team = crate::config::resolve_team(team_override, config)
+        .ok_or_else(AtmError::team_unavailable)?;
     Ok(HookIdentity { agent, team })
 }
 

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -1,3 +1,122 @@
 pub mod hook;
 
-// TODO: implement identity resolution services.
+pub use hook::HookIdentity;
+
+use crate::config::AtmConfig;
+use crate::error::Error;
+
+pub fn resolve_sender_identity(config: Option<&AtmConfig>) -> Result<String, Error> {
+    crate::config::resolve_identity(config).ok_or(Error::IdentityUnavailable)
+}
+
+pub fn resolve_hook_identity(
+    team_override: Option<&str>,
+    config: Option<&AtmConfig>,
+) -> Result<HookIdentity, Error> {
+    let agent = resolve_sender_identity(config)?;
+    let team = crate::config::resolve_team(team_override, config).ok_or(Error::TeamUnavailable)?;
+    Ok(HookIdentity { agent, team })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::sync::{Mutex, OnceLock};
+
+    use crate::config::AtmConfig;
+
+    use super::{resolve_hook_identity, resolve_sender_identity};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn resolves_sender_identity_from_environment() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let original_identity = env::var_os("ATM_IDENTITY");
+        env::set_var("ATM_IDENTITY", "arch-ctm");
+
+        let config = AtmConfig {
+            identity: Some("config-agent".into()),
+            default_team: None,
+        };
+        assert_eq!(
+            resolve_sender_identity(Some(&config)).expect("identity"),
+            "arch-ctm"
+        );
+
+        restore("ATM_IDENTITY", original_identity);
+    }
+
+    #[test]
+    fn resolves_sender_identity_from_config_when_env_missing() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let original_identity = env::var_os("ATM_IDENTITY");
+        env::set_var("ATM_IDENTITY", "");
+
+        let config = AtmConfig {
+            identity: Some("config-agent".into()),
+            default_team: None,
+        };
+        assert_eq!(
+            resolve_sender_identity(Some(&config)).expect("identity"),
+            "config-agent"
+        );
+
+        restore("ATM_IDENTITY", original_identity);
+    }
+
+    #[test]
+    fn resolves_hook_identity_from_environment() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let original_identity = env::var_os("ATM_IDENTITY");
+        let original_team = env::var_os("ATM_TEAM");
+        env::set_var("ATM_IDENTITY", "arch-ctm");
+        env::set_var("ATM_TEAM", "atm-dev");
+
+        let identity = resolve_hook_identity(None, None).expect("hook identity");
+        assert_eq!(identity.agent, "arch-ctm");
+        assert_eq!(identity.team, "atm-dev");
+
+        restore("ATM_IDENTITY", original_identity);
+        restore("ATM_TEAM", original_team);
+    }
+
+    #[test]
+    fn resolves_hook_identity_from_config_when_env_missing() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let original_identity = env::var_os("ATM_IDENTITY");
+        let original_team = env::var_os("ATM_TEAM");
+        env::set_var("ATM_IDENTITY", "");
+        env::set_var("ATM_TEAM", "");
+
+        let config = AtmConfig {
+            identity: Some("config-agent".into()),
+            default_team: Some("config-team".into()),
+        };
+
+        let identity = resolve_hook_identity(None, Some(&config)).expect("hook identity");
+        assert_eq!(identity.agent, "config-agent");
+        assert_eq!(identity.team, "config-team");
+
+        restore("ATM_IDENTITY", original_identity);
+        restore("ATM_TEAM", original_team);
+    }
+
+    fn restore(key: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => env::set_var(key, value),
+            None => env::remove_var(key),
+        }
+    }
+}

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -22,22 +22,14 @@ pub fn resolve_hook_identity(
 #[cfg(test)]
 mod tests {
     use std::env;
-    use std::sync::{Mutex, OnceLock};
 
     use crate::config::AtmConfig;
 
     use super::{resolve_hook_identity, resolve_sender_identity};
 
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
     #[test]
+    #[serial_test::serial]
     fn resolves_sender_identity_from_environment() {
-        let _guard = env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
         let original_identity = env::var_os("ATM_IDENTITY");
         env::set_var("ATM_IDENTITY", "arch-ctm");
 
@@ -54,10 +46,8 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn resolves_sender_identity_from_config_when_env_missing() {
-        let _guard = env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
         let original_identity = env::var_os("ATM_IDENTITY");
         env::set_var("ATM_IDENTITY", "");
 
@@ -74,10 +64,8 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn resolves_hook_identity_from_environment() {
-        let _guard = env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
         let original_identity = env::var_os("ATM_IDENTITY");
         let original_team = env::var_os("ATM_TEAM");
         env::set_var("ATM_IDENTITY", "arch-ctm");
@@ -92,10 +80,8 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn resolves_hook_identity_from_config_when_env_missing() {
-        let _guard = env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
         let original_identity = env::var_os("ATM_IDENTITY");
         let original_team = env::var_os("ATM_TEAM");
         env::set_var("ATM_IDENTITY", "");

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -6,7 +6,7 @@ use crate::config::AtmConfig;
 use crate::error::Error;
 
 pub fn resolve_sender_identity(config: Option<&AtmConfig>) -> Result<String, Error> {
-    crate::config::resolve_identity(config).ok_or(Error::IdentityUnavailable)
+    crate::config::resolve_identity(config).ok_or_else(Error::identity_unavailable)
 }
 
 pub fn resolve_hook_identity(
@@ -14,7 +14,8 @@ pub fn resolve_hook_identity(
     config: Option<&AtmConfig>,
 ) -> Result<HookIdentity, Error> {
     let agent = resolve_sender_identity(config)?;
-    let team = crate::config::resolve_team(team_override, config).ok_or(Error::TeamUnavailable)?;
+    let team =
+        crate::config::resolve_team(team_override, config).ok_or_else(Error::team_unavailable)?;
     Ok(HookIdentity { agent, team })
 }
 

--- a/crates/atm-core/src/mailbox/atomic.rs
+++ b/crates/atm-core/src/mailbox/atomic.rs
@@ -2,12 +2,18 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-use crate::error::Error;
+use crate::error::{AtmError, AtmErrorKind};
 use crate::schema::MessageEnvelope;
 
-pub fn write_messages(path: &Path, messages: &[MessageEnvelope]) -> Result<(), Error> {
+pub fn write_messages(path: &Path, messages: &[MessageEnvelope]) -> Result<(), AtmError> {
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+        fs::create_dir_all(parent).map_err(|error| {
+            AtmError::new(
+                AtmErrorKind::MailboxWrite,
+                format!("failed to create mailbox directory: {error}"),
+            )
+            .with_source(error)
+        })?;
     }
 
     let temp_path = path.with_extension(format!(
@@ -19,14 +25,38 @@ pub fn write_messages(path: &Path, messages: &[MessageEnvelope]) -> Result<(), E
     ));
 
     {
-        let mut file = fs::File::create(&temp_path)?;
+        let mut file = fs::File::create(&temp_path).map_err(|error| {
+            AtmError::new(
+                AtmErrorKind::MailboxWrite,
+                format!("failed to create mailbox temp file: {error}"),
+            )
+            .with_source(error)
+        })?;
         for message in messages {
             serde_json::to_writer(&mut file, message)?;
-            file.write_all(b"\n")?;
+            file.write_all(b"\n").map_err(|error| {
+                AtmError::new(
+                    AtmErrorKind::MailboxWrite,
+                    format!("failed to write mailbox record: {error}"),
+                )
+                .with_source(error)
+            })?;
         }
-        file.sync_all()?;
+        file.sync_all().map_err(|error| {
+            AtmError::new(
+                AtmErrorKind::MailboxWrite,
+                format!("failed to fsync mailbox temp file: {error}"),
+            )
+            .with_source(error)
+        })?;
     }
 
-    fs::rename(&temp_path, path)?;
+    fs::rename(&temp_path, path).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::MailboxWrite,
+            format!("failed to replace mailbox file: {error}"),
+        )
+        .with_source(error)
+    })?;
     Ok(())
 }

--- a/crates/atm-core/src/mailbox/atomic.rs
+++ b/crates/atm-core/src/mailbox/atomic.rs
@@ -1,1 +1,32 @@
-// TODO: implement atomic mailbox write helpers.
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use crate::error::Error;
+use crate::schema::MessageEnvelope;
+
+pub fn write_messages(path: &Path, messages: &[MessageEnvelope]) -> Result<(), Error> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let temp_path = path.with_extension(format!(
+        "{}tmp",
+        path.extension()
+            .and_then(|value| value.to_str())
+            .map(|value| format!("{value}."))
+            .unwrap_or_default()
+    ));
+
+    {
+        let mut file = fs::File::create(&temp_path)?;
+        for message in messages {
+            serde_json::to_writer(&mut file, message)?;
+            file.write_all(b"\n")?;
+        }
+        file.sync_all()?;
+    }
+
+    fs::rename(&temp_path, path)?;
+    Ok(())
+}

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -154,6 +154,7 @@ mod tests {
             pending_ack_at: None,
             acknowledged_at: None,
             acknowledges_message_id: None,
+            task_id: None,
             extra: serde_json::Map::new(),
         }
     }

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -75,10 +75,10 @@ pub fn read_messages(path: &Path) -> Result<Vec<MessageEnvelope>, AtmError> {
 
 #[cfg(test)]
 mod tests {
-    use std::env;
     use std::fs;
 
     use chrono::{TimeZone, Utc};
+    use tempfile::TempDir;
     use uuid::Uuid;
 
     use crate::schema::MessageEnvelope;
@@ -87,7 +87,8 @@ mod tests {
 
     #[test]
     fn append_message_persists_one_jsonl_record() {
-        let path = unique_path("append-message.jsonl");
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("append-message.jsonl");
         let envelope = sample_message(Uuid::new_v4(), "first");
 
         append_message(&path, &envelope).expect("append");
@@ -100,7 +101,8 @@ mod tests {
 
     #[test]
     fn read_messages_skips_malformed_lines() {
-        let path = unique_path("skip-malformed.jsonl");
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("skip-malformed.jsonl");
         let valid =
             serde_json::to_string(&sample_message(Uuid::new_v4(), "valid")).expect("valid json");
         fs::write(&path, format!("{valid}\n{{not-json}}\n")).expect("write");
@@ -112,7 +114,8 @@ mod tests {
 
     #[test]
     fn read_messages_deduplicates_by_message_id_last_wins() {
-        let path = unique_path("dedupe.jsonl");
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("dedupe.jsonl");
         let message_id = Uuid::new_v4();
         let first = sample_message(message_id, "first");
         let mut second = sample_message(message_id, "second");
@@ -131,12 +134,6 @@ mod tests {
         let messages = read_messages(&path).expect("read");
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].text, "second");
-    }
-
-    fn unique_path(name: &str) -> std::path::PathBuf {
-        let dir = env::temp_dir().join(format!("atm-mailbox-{}", Uuid::new_v4()));
-        fs::create_dir_all(&dir).expect("temp dir");
-        dir.join(name)
     }
 
     fn sample_message(message_id: Uuid, body: &str) -> MessageEnvelope {

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -10,26 +10,38 @@ use std::path::Path;
 
 use tracing::warn;
 
-use crate::error::Error;
+use crate::error::{AtmError, AtmErrorKind};
 use crate::schema::MessageEnvelope;
 
-pub fn append_message(path: &Path, envelope: &MessageEnvelope) -> Result<(), Error> {
+pub fn append_message(path: &Path, envelope: &MessageEnvelope) -> Result<(), AtmError> {
     let mut messages = read_messages(path)?;
     messages.push(envelope.clone());
     atomic::write_messages(path, &messages)
 }
 
-pub fn read_messages(path: &Path) -> Result<Vec<MessageEnvelope>, Error> {
+pub fn read_messages(path: &Path) -> Result<Vec<MessageEnvelope>, AtmError> {
     if !path.exists() {
         return Ok(Vec::new());
     }
 
-    let file = fs::File::open(path)?;
+    let file = fs::File::open(path).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::MailboxRead,
+            format!("failed to open mailbox file: {error}"),
+        )
+        .with_source(error)
+    })?;
     let reader = std::io::BufReader::new(file);
     let mut messages = Vec::new();
 
     for (index, line) in reader.lines().enumerate() {
-        let line = line?;
+        let line = line.map_err(|error| {
+            AtmError::new(
+                AtmErrorKind::MailboxRead,
+                format!("failed to read mailbox line: {error}"),
+            )
+            .with_source(error)
+        })?;
         if line.trim().is_empty() {
             continue;
         }

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -3,4 +3,139 @@ pub mod hash;
 pub mod lock;
 pub mod store;
 
-// TODO: implement mailbox read and write services.
+use std::collections::HashMap;
+use std::fs;
+use std::io::BufRead;
+use std::path::Path;
+
+use tracing::warn;
+
+use crate::error::Error;
+use crate::schema::MessageEnvelope;
+
+pub fn append_message(path: &Path, envelope: &MessageEnvelope) -> Result<(), Error> {
+    let mut messages = read_messages(path)?;
+    messages.push(envelope.clone());
+    atomic::write_messages(path, &messages)
+}
+
+pub fn read_messages(path: &Path) -> Result<Vec<MessageEnvelope>, Error> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let file = fs::File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+    let mut messages = Vec::new();
+
+    for (index, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        match serde_json::from_str::<MessageEnvelope>(&line) {
+            Ok(message) => messages.push(message),
+            Err(error) => warn!(
+                line = index + 1,
+                %error,
+                "skipping malformed mailbox record"
+            ),
+        }
+    }
+
+    let mut last_indices = HashMap::new();
+    for (index, message) in messages.iter().enumerate() {
+        last_indices.insert(message.message_id, index);
+    }
+
+    Ok(messages
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, message)| {
+            (last_indices.get(&message.message_id) == Some(&index)).then_some(message)
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::fs;
+
+    use chrono::{TimeZone, Utc};
+    use uuid::Uuid;
+
+    use crate::schema::MessageEnvelope;
+
+    use super::{append_message, read_messages};
+
+    #[test]
+    fn append_message_persists_one_jsonl_record() {
+        let path = unique_path("append-message.jsonl");
+        let envelope = sample_message(Uuid::new_v4(), "first");
+
+        append_message(&path, &envelope).expect("append");
+
+        let raw = fs::read_to_string(&path).expect("raw contents");
+        assert!(raw.contains("\"body\":\"first\""));
+        let read_back = read_messages(&path).expect("read back");
+        assert_eq!(read_back, vec![envelope]);
+    }
+
+    #[test]
+    fn read_messages_skips_malformed_lines() {
+        let path = unique_path("skip-malformed.jsonl");
+        let valid =
+            serde_json::to_string(&sample_message(Uuid::new_v4(), "valid")).expect("valid json");
+        fs::write(&path, format!("{valid}\n{{not-json}}\n")).expect("write");
+
+        let messages = read_messages(&path).expect("read");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].body, "valid");
+    }
+
+    #[test]
+    fn read_messages_deduplicates_by_message_id_last_wins() {
+        let path = unique_path("dedupe.jsonl");
+        let message_id = Uuid::new_v4();
+        let first = sample_message(message_id, "first");
+        let mut second = sample_message(message_id, "second");
+        second.sent_at = Utc
+            .with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
+            .single()
+            .expect("timestamp");
+
+        let contents = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&first).expect("json"),
+            serde_json::to_string(&second).expect("json")
+        );
+        fs::write(&path, contents).expect("write");
+
+        let messages = read_messages(&path).expect("read");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].body, "second");
+    }
+
+    fn unique_path(name: &str) -> std::path::PathBuf {
+        let dir = env::temp_dir().join(format!("atm-mailbox-{}", Uuid::new_v4()));
+        fs::create_dir_all(&dir).expect("temp dir");
+        dir.join(name)
+    }
+
+    fn sample_message(message_id: Uuid, body: &str) -> MessageEnvelope {
+        MessageEnvelope {
+            message_id,
+            from: "arch-ctm".into(),
+            team: "atm-dev".into(),
+            body: body.into(),
+            requires_ack: false,
+            task_id: None,
+            sent_at: Utc
+                .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                .single()
+                .expect("timestamp"),
+        }
+    }
+}

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -58,14 +58,17 @@ pub fn read_messages(path: &Path) -> Result<Vec<MessageEnvelope>, AtmError> {
 
     let mut last_indices = HashMap::new();
     for (index, message) in messages.iter().enumerate() {
-        last_indices.insert(message.message_id, index);
+        if let Some(message_id) = message.message_id {
+            last_indices.insert(message_id, index);
+        }
     }
 
     Ok(messages
         .into_iter()
         .enumerate()
-        .filter_map(|(index, message)| {
-            (last_indices.get(&message.message_id) == Some(&index)).then_some(message)
+        .filter_map(|(index, message)| match message.message_id {
+            Some(message_id) => (last_indices.get(&message_id) == Some(&index)).then_some(message),
+            None => Some(message),
         })
         .collect())
 }
@@ -90,7 +93,7 @@ mod tests {
         append_message(&path, &envelope).expect("append");
 
         let raw = fs::read_to_string(&path).expect("raw contents");
-        assert!(raw.contains("\"body\":\"first\""));
+        assert!(raw.contains("\"text\":\"first\""));
         let read_back = read_messages(&path).expect("read back");
         assert_eq!(read_back, vec![envelope]);
     }
@@ -104,7 +107,7 @@ mod tests {
 
         let messages = read_messages(&path).expect("read");
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].body, "valid");
+        assert_eq!(messages[0].text, "valid");
     }
 
     #[test]
@@ -113,7 +116,7 @@ mod tests {
         let message_id = Uuid::new_v4();
         let first = sample_message(message_id, "first");
         let mut second = sample_message(message_id, "second");
-        second.sent_at = Utc
+        second.timestamp = Utc
             .with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
             .single()
             .expect("timestamp");
@@ -127,7 +130,7 @@ mod tests {
 
         let messages = read_messages(&path).expect("read");
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].body, "second");
+        assert_eq!(messages[0].text, "second");
     }
 
     fn unique_path(name: &str) -> std::path::PathBuf {
@@ -138,16 +141,20 @@ mod tests {
 
     fn sample_message(message_id: Uuid, body: &str) -> MessageEnvelope {
         MessageEnvelope {
-            message_id,
             from: "arch-ctm".into(),
-            team: "atm-dev".into(),
-            body: body.into(),
-            requires_ack: false,
-            task_id: None,
-            sent_at: Utc
+            text: body.into(),
+            timestamp: Utc
                 .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
                 .single()
                 .expect("timestamp"),
+            read: false,
+            source_team: Some("atm-dev".into()),
+            summary: None,
+            message_id: Some(message_id),
+            pending_ack_at: None,
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            extra: serde_json::Map::new(),
         }
     }
 }

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -1,1 +1,30 @@
-// TODO: define the ATM-owned observability boundary.
+use serde::Serialize;
+
+use crate::error::AtmError;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CommandEvent {
+    pub command: &'static str,
+    pub action: &'static str,
+    pub outcome: &'static str,
+    pub team: String,
+    pub agent: String,
+    pub sender: String,
+    pub message_id: String,
+    pub requires_ack: bool,
+    pub dry_run: bool,
+    pub task_id: Option<String>,
+}
+
+pub trait ObservabilityPort {
+    fn emit_command_event(&self, event: CommandEvent) -> Result<(), AtmError>;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullObservability;
+
+impl ObservabilityPort for NullObservability {
+    fn emit_command_event(&self, _event: CommandEvent) -> Result<(), AtmError> {
+        Ok(())
+    }
+}

--- a/crates/atm-core/src/read/filters.rs
+++ b/crates/atm-core/src/read/filters.rs
@@ -1,1 +1,62 @@
-// TODO: define read filtering and selection helpers.
+use chrono::{DateTime, Utc};
+
+use crate::read::ClassifiedMessage;
+use crate::types::{DisplayBucket, ReadSelection};
+
+use crate::schema::MessageEnvelope;
+
+pub fn apply_sender_filter(
+    messages: Vec<MessageEnvelope>,
+    sender: Option<&str>,
+) -> Vec<MessageEnvelope> {
+    match sender {
+        Some(sender) => messages
+            .into_iter()
+            .filter(|message| message.from == sender)
+            .collect(),
+        None => messages,
+    }
+}
+
+pub fn apply_timestamp_filter(
+    messages: Vec<MessageEnvelope>,
+    since: Option<DateTime<Utc>>,
+) -> Vec<MessageEnvelope> {
+    match since {
+        Some(since) => messages
+            .into_iter()
+            .filter(|message| message.timestamp >= since)
+            .collect(),
+        None => messages,
+    }
+}
+
+pub fn apply_selection_mode(
+    messages: Vec<ClassifiedMessage>,
+    mode: ReadSelection,
+    seen_watermark: Option<DateTime<Utc>>,
+) -> Vec<ClassifiedMessage> {
+    messages
+        .into_iter()
+        .filter(|message| match mode {
+            ReadSelection::Actionable => matches!(
+                message.bucket,
+                DisplayBucket::Unread | DisplayBucket::PendingAck
+            ),
+            ReadSelection::UnreadOnly => message.bucket == DisplayBucket::Unread,
+            ReadSelection::PendingAckOnly => message.bucket == DisplayBucket::PendingAck,
+            ReadSelection::ActionableWithHistory => match message.bucket {
+                DisplayBucket::Unread | DisplayBucket::PendingAck => true,
+                DisplayBucket::History => history_visible(message, seen_watermark),
+            },
+            ReadSelection::All => true,
+        })
+        .collect()
+}
+
+fn history_visible(message: &ClassifiedMessage, seen_watermark: Option<DateTime<Utc>>) -> bool {
+    match seen_watermark {
+        Some(watermark) => message.message.timestamp > watermark,
+        None => true,
+    }
+}

--- a/crates/atm-core/src/read/filters.rs
+++ b/crates/atm-core/src/read/filters.rs
@@ -3,29 +3,27 @@ use chrono::{DateTime, Utc};
 use crate::read::ClassifiedMessage;
 use crate::types::{DisplayBucket, ReadSelection};
 
-use crate::schema::MessageEnvelope;
-
 pub fn apply_sender_filter(
-    messages: Vec<MessageEnvelope>,
+    messages: Vec<ClassifiedMessage>,
     sender: Option<&str>,
-) -> Vec<MessageEnvelope> {
+) -> Vec<ClassifiedMessage> {
     match sender {
         Some(sender) => messages
             .into_iter()
-            .filter(|message| message.from == sender)
+            .filter(|message| message.envelope.from == sender)
             .collect(),
         None => messages,
     }
 }
 
 pub fn apply_timestamp_filter(
-    messages: Vec<MessageEnvelope>,
+    messages: Vec<ClassifiedMessage>,
     since: Option<DateTime<Utc>>,
-) -> Vec<MessageEnvelope> {
+) -> Vec<ClassifiedMessage> {
     match since {
         Some(since) => messages
             .into_iter()
-            .filter(|message| message.timestamp >= since)
+            .filter(|message| message.envelope.timestamp >= since)
             .collect(),
         None => messages,
     }
@@ -56,7 +54,7 @@ pub fn apply_selection_mode(
 
 fn history_visible(message: &ClassifiedMessage, seen_watermark: Option<DateTime<Utc>>) -> bool {
     match seen_watermark {
-        Some(watermark) => message.message.timestamp > watermark,
+        Some(watermark) => message.envelope.timestamp > watermark,
         None => true,
     }
 }

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -49,10 +49,12 @@ pub struct BucketCounts {
 pub struct ClassifiedMessage {
     #[serde(skip)]
     source_index: usize,
+    #[serde(skip)]
+    source_path: PathBuf,
     pub bucket: DisplayBucket,
     pub class: MessageClass,
     #[serde(flatten)]
-    pub message: MessageEnvelope,
+    pub envelope: MessageEnvelope,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -66,6 +68,19 @@ pub struct ReadOutcome {
     pub count: usize,
     pub messages: Vec<ClassifiedMessage>,
     pub bucket_counts: BucketCounts,
+}
+
+#[derive(Debug, Clone)]
+struct SourceFile {
+    path: PathBuf,
+    messages: Vec<MessageEnvelope>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SourcedMessage {
+    pub envelope: MessageEnvelope,
+    pub source_path: PathBuf,
+    pub source_index: usize,
 }
 
 pub fn read_mail(
@@ -104,45 +119,42 @@ pub fn read_mail(
         None
     };
 
-    let mut mailbox_messages = load_inbox_messages(&query.home_dir, &target.team, &target.agent)?;
-    let mut derived = build_derived_messages(
-        mailbox_messages.clone(),
+    let mut source_files = load_source_files(&query.home_dir, &target.team, &target.agent)?;
+    let mut classified_all = classify_all(dedupe_sourced_messages(merged_surface(&source_files)));
+    let mut bucket_counts = bucket_counts_for(&classified_all);
+    let mut filtered = apply_filters(
+        classified_all.clone(),
         query.sender_filter.as_deref(),
         query.timestamp_filter,
     );
-
-    let mut bucket_counts = bucket_counts_for(&derived, query.selection_mode, seen_watermark);
-    let mut selected = select_messages(&derived, query.selection_mode, seen_watermark);
+    let mut selected = select_messages(&filtered, query.selection_mode, seen_watermark);
     let mut timed_out = false;
 
     if selected.is_empty() {
         if let Some(timeout_secs) = query.timeout_secs {
             let wait_satisfied = wait::wait_for_eligible_message(
-                &query.home_dir,
-                &target.team,
-                &target.agent,
                 timeout_secs,
-                |message| {
-                    message_matches_filters(
-                        message,
-                        query.sender_filter.as_deref(),
-                        query.timestamp_filter,
-                        query.selection_mode,
-                        seen_watermark,
-                    )
+                || {
+                    Ok(dedupe_sourced_messages(merged_surface(&load_source_files(
+                        &query.home_dir,
+                        &target.team,
+                        &target.agent,
+                    )?)))
                 },
+                |messages| !selected_after_filters(messages, &query, seen_watermark).is_empty(),
             )?;
 
             if wait_satisfied {
-                mailbox_messages =
-                    load_inbox_messages(&query.home_dir, &target.team, &target.agent)?;
-                derived = build_derived_messages(
-                    mailbox_messages.clone(),
+                source_files = load_source_files(&query.home_dir, &target.team, &target.agent)?;
+                classified_all =
+                    classify_all(dedupe_sourced_messages(merged_surface(&source_files)));
+                bucket_counts = bucket_counts_for(&classified_all);
+                filtered = apply_filters(
+                    classified_all.clone(),
                     query.sender_filter.as_deref(),
                     query.timestamp_filter,
                 );
-                bucket_counts = bucket_counts_for(&derived, query.selection_mode, seen_watermark);
-                selected = select_messages(&derived, query.selection_mode, seen_watermark);
+                selected = select_messages(&filtered, query.selection_mode, seen_watermark);
             } else {
                 timed_out = true;
             }
@@ -151,10 +163,10 @@ pub fn read_mail(
 
     selected.sort_by(|left, right| {
         right
-            .message
+            .envelope
             .timestamp
-            .cmp(&left.message.timestamp)
-            .then_with(|| right.message.message_id.cmp(&left.message.message_id))
+            .cmp(&left.envelope.timestamp)
+            .then_with(|| right.envelope.message_id.cmp(&left.envelope.message_id))
             .then_with(|| right.source_index.cmp(&left.source_index))
     });
 
@@ -166,7 +178,7 @@ pub fn read_mail(
         false
     } else {
         apply_display_mutations(
-            &mut mailbox_messages,
+            &mut source_files,
             &selected,
             query.ack_activation_mode,
             own_inbox,
@@ -174,14 +186,13 @@ pub fn read_mail(
     };
 
     if mutation_applied {
-        let inbox_path = home::inbox_path_from_home(&query.home_dir, &target.team, &target.agent)?;
-        mailbox::atomic::write_messages(&inbox_path, &mailbox_messages)?;
+        persist_source_files(&source_files)?;
     }
 
     if query.seen_state_update && !selected.is_empty() {
         if let Some(latest_timestamp) = selected
             .iter()
-            .map(|message| message.message.timestamp)
+            .map(|message| message.envelope.timestamp)
             .max()
         {
             seen_state::save_seen_watermark(
@@ -197,9 +208,15 @@ pub fn read_mail(
         .into_iter()
         .map(|selected_message| ClassifiedMessage {
             source_index: selected_message.source_index,
+            source_path: selected_message.source_path.clone(),
             bucket: selected_message.bucket,
             class: selected_message.class,
-            message: mailbox_messages[selected_message.source_index].clone(),
+            envelope: source_files
+                .iter()
+                .find(|source| source.path == selected_message.source_path)
+                .and_then(|source| source.messages.get(selected_message.source_index))
+                .cloned()
+                .unwrap_or(selected_message.envelope),
         })
         .collect::<Vec<_>>();
 
@@ -311,37 +328,103 @@ fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
     })
 }
 
-fn load_inbox_messages(
+fn load_source_files(
     home_dir: &Path,
     team: &str,
     agent: &str,
-) -> Result<Vec<MessageEnvelope>, AtmError> {
+) -> Result<Vec<SourceFile>, AtmError> {
     let inbox_path = home::inbox_path_from_home(home_dir, team, agent)?;
-    let messages = mailbox::read_messages(&inbox_path)?;
-    Ok(dedupe_messages(messages))
+    let inboxes_dir = inbox_path
+        .parent()
+        .ok_or_else(|| AtmError::mailbox_read("inbox path has no parent directory"))?;
+    let inboxes_dir = inboxes_dir.to_path_buf();
+
+    let mut paths = vec![inbox_path];
+    paths.extend(discover_origin_inboxes(&inboxes_dir, agent)?);
+
+    let mut sources = Vec::with_capacity(paths.len());
+    for path in paths {
+        let messages = mailbox::read_messages(&path)?;
+        sources.push(SourceFile { path, messages });
+    }
+
+    Ok(sources)
 }
 
-fn dedupe_messages(messages: Vec<MessageEnvelope>) -> Vec<MessageEnvelope> {
+fn discover_origin_inboxes(inboxes_dir: &Path, agent: &str) -> Result<Vec<PathBuf>, AtmError> {
+    if !inboxes_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let prefix = format!("{agent}.");
+    let mut paths = fs::read_dir(inboxes_dir)
+        .map_err(|error| {
+            AtmError::new(
+                AtmErrorKind::MailboxRead,
+                format!(
+                    "failed to read inbox directory {}: {error}",
+                    inboxes_dir.display()
+                ),
+            )
+            .with_source(error)
+        })?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| {
+            path.file_name()
+                .and_then(|value| value.to_str())
+                .map(|name| {
+                    name.starts_with(&prefix)
+                        && name.ends_with(".json")
+                        && name != format!("{agent}.json")
+                })
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+
+    paths.sort();
+    Ok(paths)
+}
+
+fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
+    source_files
+        .iter()
+        .flat_map(|source| {
+            source
+                .messages
+                .iter()
+                .cloned()
+                .enumerate()
+                .map(|(source_index, envelope)| SourcedMessage {
+                    envelope,
+                    source_path: source.path.clone(),
+                    source_index,
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
     let mut latest_for_id: HashMap<Uuid, (DateTime<Utc>, usize)> = HashMap::new();
     for (index, message) in messages.iter().enumerate() {
-        if let Some(message_id) = message.message_id {
+        if let Some(message_id) = message.envelope.message_id {
             latest_for_id
                 .entry(message_id)
                 .and_modify(|entry| {
-                    if message.timestamp > entry.0
-                        || (message.timestamp == entry.0 && index > entry.1)
+                    if message.envelope.timestamp > entry.0
+                        || (message.envelope.timestamp == entry.0 && index > entry.1)
                     {
-                        *entry = (message.timestamp, index);
+                        *entry = (message.envelope.timestamp, index);
                     }
                 })
-                .or_insert((message.timestamp, index));
+                .or_insert((message.envelope.timestamp, index));
         }
     }
 
     messages
         .into_iter()
         .enumerate()
-        .filter_map(|(index, message)| match message.message_id {
+        .filter_map(|(index, message)| match message.envelope.message_id {
             Some(message_id) => latest_for_id
                 .get(&message_id)
                 .and_then(|(_, keep_index)| (*keep_index == index).then_some(message)),
@@ -350,52 +433,37 @@ fn dedupe_messages(messages: Vec<MessageEnvelope>) -> Vec<MessageEnvelope> {
         .collect()
 }
 
-fn build_derived_messages(
-    messages: Vec<MessageEnvelope>,
-    sender_filter: Option<&str>,
-    timestamp_filter: Option<DateTime<Utc>>,
-) -> Vec<ClassifiedMessage> {
+fn classify_all(messages: Vec<SourcedMessage>) -> Vec<ClassifiedMessage> {
     messages
         .into_iter()
-        .enumerate()
-        .filter(|(_, message)| {
-            sender_filter
-                .map(|sender| message.from == sender)
-                .unwrap_or(true)
-                && timestamp_filter
-                    .map(|since| message.timestamp >= since)
-                    .unwrap_or(true)
-        })
-        .map(|(source_index, message)| {
-            let class = state::classify_message(&message);
+        .map(|message| {
+            let class = state::classify_message(&message.envelope);
             let bucket = state::display_bucket_for_class(class);
 
             ClassifiedMessage {
-                source_index,
+                source_index: message.source_index,
+                source_path: message.source_path,
                 bucket,
                 class,
-                message,
+                envelope: message.envelope,
             }
         })
         .collect()
 }
 
-fn bucket_counts_for(
-    messages: &[ClassifiedMessage],
-    selection_mode: ReadSelection,
-    seen_watermark: Option<DateTime<Utc>>,
-) -> BucketCounts {
-    let count_source = if selection_mode == ReadSelection::All {
-        filters::apply_selection_mode(messages.to_vec(), ReadSelection::All, None)
-    } else {
-        filters::apply_selection_mode(
-            messages.to_vec(),
-            ReadSelection::ActionableWithHistory,
-            seen_watermark,
-        )
-    };
+fn apply_filters(
+    messages: Vec<ClassifiedMessage>,
+    sender_filter: Option<&str>,
+    timestamp_filter: Option<DateTime<Utc>>,
+) -> Vec<ClassifiedMessage> {
+    filters::apply_timestamp_filter(
+        filters::apply_sender_filter(messages, sender_filter),
+        timestamp_filter,
+    )
+}
 
-    count_source.into_iter().fold(
+fn bucket_counts_for(messages: &[ClassifiedMessage]) -> BucketCounts {
+    messages.iter().fold(
         BucketCounts {
             unread: 0,
             pending_ack: 0,
@@ -426,37 +494,22 @@ fn select_messages(
     filters::apply_selection_mode(messages.to_vec(), selection_mode, watermark)
 }
 
-fn message_matches_filters(
-    message: &MessageEnvelope,
-    sender_filter: Option<&str>,
-    timestamp_filter: Option<DateTime<Utc>>,
-    selection_mode: ReadSelection,
+fn selected_after_filters(
+    messages: &[SourcedMessage],
+    query: &ReadQuery,
     seen_watermark: Option<DateTime<Utc>>,
-) -> bool {
-    if let Some(sender) = sender_filter {
-        if message.from != sender {
-            return false;
-        }
-    }
-
-    if let Some(since) = timestamp_filter {
-        if message.timestamp < since {
-            return false;
-        }
-    }
-
-    let classified = ClassifiedMessage {
-        source_index: 0,
-        class: state::classify_message(message),
-        bucket: state::display_bucket_for_class(state::classify_message(message)),
-        message: message.clone(),
-    };
-
-    !select_messages(&[classified], selection_mode, seen_watermark).is_empty()
+) -> Vec<ClassifiedMessage> {
+    let classified = classify_all(messages.to_vec());
+    let filtered = apply_filters(
+        classified,
+        query.sender_filter.as_deref(),
+        query.timestamp_filter,
+    );
+    select_messages(&filtered, query.selection_mode, seen_watermark)
 }
 
 fn apply_display_mutations(
-    mailbox_messages: &mut [MessageEnvelope],
+    source_files: &mut [SourceFile],
     displayed_messages: &[ClassifiedMessage],
     ack_activation_mode: AckActivationMode,
     own_inbox: bool,
@@ -467,21 +520,96 @@ fn apply_display_mutations(
     let now = Utc::now();
 
     for message in displayed_messages {
-        let stored = &mut mailbox_messages[message.source_index];
-        let was_read = stored.read;
-        let had_pending_ack = stored.pending_ack_at.is_some();
-        let had_acknowledged = stored.acknowledged_at.is_some();
-
-        stored.read = true;
-        if !was_read {
-            mutation_applied = true;
-        }
-
-        if promote_unread && !was_read && !had_pending_ack && !had_acknowledged {
-            stored.pending_ack_at = Some(now);
-            mutation_applied = true;
+        let transitioned = transition_displayed_message(message, promote_unread, now);
+        let updated = transitioned.into_envelope();
+        if updated != message.envelope {
+            if let Some(source_file) = source_files
+                .iter_mut()
+                .find(|source| source.path == message.source_path)
+            {
+                if let Some(stored) = source_file.messages.get_mut(message.source_index) {
+                    *stored = updated;
+                    mutation_applied = true;
+                }
+            }
         }
     }
 
     mutation_applied
+}
+
+fn transition_displayed_message(
+    message: &ClassifiedMessage,
+    promote_unread: bool,
+    now: DateTime<Utc>,
+) -> state::TransitionedMessage {
+    let read_state = state::derive_read_state(&message.envelope);
+    let ack_state = state::derive_ack_state(&message.envelope);
+
+    match (read_state, ack_state) {
+        (crate::types::ReadState::Unread, crate::types::AckState::NoAckRequired) if promote_unread => {
+            state::TransitionedMessage::ReadPendingAck(
+                state::StoredMessage::<crate::types::UnreadReadState, crate::types::NoAckState>::from_envelope(
+                    message.envelope.clone(),
+                )
+                .display_and_require_ack(now),
+            )
+        }
+        (crate::types::ReadState::Unread, crate::types::AckState::NoAckRequired) => {
+            state::TransitionedMessage::ReadNoAck(
+                state::StoredMessage::<crate::types::UnreadReadState, crate::types::NoAckState>::from_envelope(
+                    message.envelope.clone(),
+                )
+                .display_without_ack(),
+            )
+        }
+        (crate::types::ReadState::Unread, crate::types::AckState::PendingAck) => {
+            state::TransitionedMessage::ReadPendingAck(
+                state::StoredMessage::<
+                    crate::types::UnreadReadState,
+                    crate::types::PendingAckState,
+                >::from_envelope(message.envelope.clone())
+                .mark_read(),
+            )
+        }
+        (crate::types::ReadState::Unread, crate::types::AckState::Acknowledged)
+        | (crate::types::ReadState::Read, crate::types::AckState::NoAckRequired)
+        | (crate::types::ReadState::Read, crate::types::AckState::PendingAck)
+        | (crate::types::ReadState::Read, crate::types::AckState::Acknowledged) => {
+            let mut unchanged = message.envelope.clone();
+            if !unchanged.read {
+                unchanged.read = true;
+            }
+            state::TransitionedMessage::Unchanged(unchanged)
+        }
+    }
+}
+
+fn persist_source_files(source_files: &[SourceFile]) -> Result<(), AtmError> {
+    for source in source_files {
+        mailbox::atomic::write_messages(&source.path, &source.messages)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::discover_origin_inboxes;
+
+    #[test]
+    fn discover_origin_inboxes_ignores_primary_and_sorts_matches() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let inboxes = tempdir.path();
+        std::fs::write(inboxes.join("arch-ctm.json"), "").expect("primary");
+        std::fs::write(inboxes.join("arch-ctm.host-b.json"), "").expect("host b");
+        std::fs::write(inboxes.join("arch-ctm.host-a.json"), "").expect("host a");
+        std::fs::write(inboxes.join("other.json"), "").expect("other");
+
+        let discovered = discover_origin_inboxes(inboxes, "arch-ctm").expect("discover");
+
+        assert_eq!(discovered.len(), 2);
+        assert!(discovered[0].ends_with("arch-ctm.host-a.json"));
+        assert!(discovered[1].ends_with("arch-ctm.host-b.json"));
+    }
 }

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -3,4 +3,485 @@ pub mod seen_state;
 pub mod state;
 pub mod wait;
 
-// TODO: implement read service entry points.
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::address::AgentAddress;
+use crate::config;
+use crate::error::{AtmError, AtmErrorKind};
+use crate::home;
+use crate::identity;
+use crate::mailbox;
+use crate::observability::{CommandEvent, ObservabilityPort};
+use crate::schema::{MessageEnvelope, TeamConfig};
+use crate::types::{AckActivationMode, DisplayBucket, MessageClass, ReadSelection};
+
+#[derive(Debug, Clone)]
+pub struct ReadQuery {
+    pub home_dir: PathBuf,
+    pub current_dir: PathBuf,
+    pub actor_override: Option<String>,
+    pub target_address: Option<String>,
+    pub team_override: Option<String>,
+    pub selection_mode: ReadSelection,
+    pub seen_state_filter: bool,
+    pub seen_state_update: bool,
+    pub ack_activation_mode: AckActivationMode,
+    pub limit: Option<usize>,
+    pub sender_filter: Option<String>,
+    pub timestamp_filter: Option<DateTime<Utc>>,
+    pub timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BucketCounts {
+    pub unread: usize,
+    pub pending_ack: usize,
+    pub history: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ClassifiedMessage {
+    #[serde(skip)]
+    source_index: usize,
+    pub bucket: DisplayBucket,
+    pub class: MessageClass,
+    #[serde(flatten)]
+    pub message: MessageEnvelope,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReadOutcome {
+    pub action: &'static str,
+    pub team: String,
+    pub agent: String,
+    pub selection_mode: ReadSelection,
+    pub history_collapsed: bool,
+    pub mutation_applied: bool,
+    pub count: usize,
+    pub messages: Vec<ClassifiedMessage>,
+    pub bucket_counts: BucketCounts,
+}
+
+pub fn read_mail(
+    query: ReadQuery,
+    observability: &dyn ObservabilityPort,
+) -> Result<ReadOutcome, AtmError> {
+    let config = config::load_config(&query.current_dir)?;
+    let actor = resolve_actor_identity(query.actor_override.as_deref(), config.as_ref())?;
+    let actor_team = config::resolve_team(query.team_override.as_deref(), config.as_ref());
+    let target = resolve_target(
+        query.target_address.as_deref(),
+        &actor,
+        query.team_override.as_deref(),
+        config.as_ref(),
+    )?;
+
+    let team_dir = home::team_dir_from_home(&query.home_dir, &target.team)?;
+    if !team_dir.exists() {
+        return Err(AtmError::team_not_found(&target.team));
+    }
+
+    let team_config = load_team_config(&team_dir)?;
+    if target.explicit
+        && !team_config
+            .members
+            .iter()
+            .any(|member| member.name == target.agent)
+    {
+        return Err(AtmError::agent_not_found(&target.agent, &target.team));
+    }
+
+    let own_inbox = actor == target.agent && actor_team.as_deref() == Some(target.team.as_str());
+    let seen_watermark = if query.seen_state_filter && query.selection_mode != ReadSelection::All {
+        seen_state::load_seen_watermark(&query.home_dir, &target.team, &target.agent)?
+    } else {
+        None
+    };
+
+    let mut mailbox_messages = load_inbox_messages(&query.home_dir, &target.team, &target.agent)?;
+    let mut derived = build_derived_messages(
+        mailbox_messages.clone(),
+        query.sender_filter.as_deref(),
+        query.timestamp_filter,
+    );
+
+    let mut bucket_counts = bucket_counts_for(&derived, query.selection_mode, seen_watermark);
+    let mut selected = select_messages(&derived, query.selection_mode, seen_watermark);
+    let mut timed_out = false;
+
+    if selected.is_empty() {
+        if let Some(timeout_secs) = query.timeout_secs {
+            let wait_satisfied = wait::wait_for_eligible_message(
+                &query.home_dir,
+                &target.team,
+                &target.agent,
+                timeout_secs,
+                |message| {
+                    message_matches_filters(
+                        message,
+                        query.sender_filter.as_deref(),
+                        query.timestamp_filter,
+                        query.selection_mode,
+                        seen_watermark,
+                    )
+                },
+            )?;
+
+            if wait_satisfied {
+                mailbox_messages =
+                    load_inbox_messages(&query.home_dir, &target.team, &target.agent)?;
+                derived = build_derived_messages(
+                    mailbox_messages.clone(),
+                    query.sender_filter.as_deref(),
+                    query.timestamp_filter,
+                );
+                bucket_counts = bucket_counts_for(&derived, query.selection_mode, seen_watermark);
+                selected = select_messages(&derived, query.selection_mode, seen_watermark);
+            } else {
+                timed_out = true;
+            }
+        }
+    }
+
+    selected.sort_by(|left, right| {
+        right
+            .message
+            .timestamp
+            .cmp(&left.message.timestamp)
+            .then_with(|| right.message.message_id.cmp(&left.message.message_id))
+            .then_with(|| right.source_index.cmp(&left.source_index))
+    });
+
+    if let Some(limit) = query.limit {
+        selected.truncate(limit);
+    }
+
+    let mutation_applied = if timed_out || selected.is_empty() {
+        false
+    } else {
+        apply_display_mutations(
+            &mut mailbox_messages,
+            &selected,
+            query.ack_activation_mode,
+            own_inbox,
+        )
+    };
+
+    if mutation_applied {
+        let inbox_path = home::inbox_path_from_home(&query.home_dir, &target.team, &target.agent)?;
+        mailbox::atomic::write_messages(&inbox_path, &mailbox_messages)?;
+    }
+
+    if query.seen_state_update && !selected.is_empty() {
+        if let Some(latest_timestamp) = selected
+            .iter()
+            .map(|message| message.message.timestamp)
+            .max()
+        {
+            seen_state::save_seen_watermark(
+                &query.home_dir,
+                &target.team,
+                &target.agent,
+                latest_timestamp,
+            )?;
+        }
+    }
+
+    let output_messages = selected
+        .into_iter()
+        .map(|selected_message| ClassifiedMessage {
+            source_index: selected_message.source_index,
+            bucket: selected_message.bucket,
+            class: selected_message.class,
+            message: mailbox_messages[selected_message.source_index].clone(),
+        })
+        .collect::<Vec<_>>();
+
+    let history_collapsed = query.selection_mode != ReadSelection::All
+        && query.selection_mode != ReadSelection::ActionableWithHistory
+        && bucket_counts.history > 0;
+
+    let outcome = ReadOutcome {
+        action: "read",
+        team: target.team,
+        agent: target.agent,
+        selection_mode: query.selection_mode,
+        history_collapsed,
+        mutation_applied,
+        count: output_messages.len(),
+        messages: output_messages,
+        bucket_counts,
+    };
+
+    let _ = observability.emit_command_event(CommandEvent {
+        command: "read",
+        action: "read",
+        outcome: if timed_out { "timeout" } else { "ok" },
+        team: outcome.team.clone(),
+        agent: outcome.agent.clone(),
+        sender: actor,
+        message_id: String::new(),
+        requires_ack: false,
+        dry_run: false,
+        task_id: None,
+    });
+
+    Ok(outcome)
+}
+
+#[derive(Debug)]
+struct ResolvedTarget {
+    agent: String,
+    team: String,
+    explicit: bool,
+}
+
+fn resolve_actor_identity(
+    actor_override: Option<&str>,
+    config: Option<&config::AtmConfig>,
+) -> Result<String, AtmError> {
+    if let Some(actor) = actor_override.filter(|value| !value.trim().is_empty()) {
+        return Ok(actor.to_string());
+    }
+
+    if let Some(identity) = identity::hook::read_hook_identity()? {
+        return Ok(identity);
+    }
+
+    identity::resolve_sender_identity(config)
+}
+
+fn resolve_target(
+    target_address: Option<&str>,
+    actor: &str,
+    team_override: Option<&str>,
+    config: Option<&config::AtmConfig>,
+) -> Result<ResolvedTarget, AtmError> {
+    let Some(target_address) = target_address else {
+        let team =
+            config::resolve_team(team_override, config).ok_or_else(AtmError::team_unavailable)?;
+        return Ok(ResolvedTarget {
+            agent: actor.to_string(),
+            team,
+            explicit: false,
+        });
+    };
+
+    let parsed: AgentAddress = target_address.parse()?;
+    let team = parsed
+        .team
+        .or_else(|| config::resolve_team(team_override, config))
+        .ok_or_else(AtmError::team_unavailable)?;
+
+    Ok(ResolvedTarget {
+        agent: parsed.agent,
+        team,
+        explicit: true,
+    })
+}
+
+fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
+    let config_path = team_dir.join("config.json");
+    let raw = fs::read_to_string(&config_path).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::Config,
+            format!(
+                "failed to read team config at {}: {error}",
+                config_path.display()
+            ),
+        )
+        .with_source(error)
+    })?;
+
+    serde_json::from_str(&raw).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::Config,
+            format!(
+                "failed to parse team config at {}: {error}",
+                config_path.display()
+            ),
+        )
+        .with_source(error)
+    })
+}
+
+fn load_inbox_messages(
+    home_dir: &Path,
+    team: &str,
+    agent: &str,
+) -> Result<Vec<MessageEnvelope>, AtmError> {
+    let inbox_path = home::inbox_path_from_home(home_dir, team, agent)?;
+    let messages = mailbox::read_messages(&inbox_path)?;
+    Ok(dedupe_messages(messages))
+}
+
+fn dedupe_messages(messages: Vec<MessageEnvelope>) -> Vec<MessageEnvelope> {
+    let mut latest_for_id: HashMap<Uuid, (DateTime<Utc>, usize)> = HashMap::new();
+    for (index, message) in messages.iter().enumerate() {
+        if let Some(message_id) = message.message_id {
+            latest_for_id
+                .entry(message_id)
+                .and_modify(|entry| {
+                    if message.timestamp > entry.0
+                        || (message.timestamp == entry.0 && index > entry.1)
+                    {
+                        *entry = (message.timestamp, index);
+                    }
+                })
+                .or_insert((message.timestamp, index));
+        }
+    }
+
+    messages
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, message)| match message.message_id {
+            Some(message_id) => latest_for_id
+                .get(&message_id)
+                .and_then(|(_, keep_index)| (*keep_index == index).then_some(message)),
+            None => Some(message),
+        })
+        .collect()
+}
+
+fn build_derived_messages(
+    messages: Vec<MessageEnvelope>,
+    sender_filter: Option<&str>,
+    timestamp_filter: Option<DateTime<Utc>>,
+) -> Vec<ClassifiedMessage> {
+    messages
+        .into_iter()
+        .enumerate()
+        .filter(|(_, message)| {
+            sender_filter
+                .map(|sender| message.from == sender)
+                .unwrap_or(true)
+                && timestamp_filter
+                    .map(|since| message.timestamp >= since)
+                    .unwrap_or(true)
+        })
+        .map(|(source_index, message)| {
+            let class = state::classify_message(&message);
+            let bucket = state::display_bucket_for_class(class);
+
+            ClassifiedMessage {
+                source_index,
+                bucket,
+                class,
+                message,
+            }
+        })
+        .collect()
+}
+
+fn bucket_counts_for(
+    messages: &[ClassifiedMessage],
+    selection_mode: ReadSelection,
+    seen_watermark: Option<DateTime<Utc>>,
+) -> BucketCounts {
+    let count_source = if selection_mode == ReadSelection::All {
+        filters::apply_selection_mode(messages.to_vec(), ReadSelection::All, None)
+    } else {
+        filters::apply_selection_mode(
+            messages.to_vec(),
+            ReadSelection::ActionableWithHistory,
+            seen_watermark,
+        )
+    };
+
+    count_source.into_iter().fold(
+        BucketCounts {
+            unread: 0,
+            pending_ack: 0,
+            history: 0,
+        },
+        |mut counts, message| {
+            match message.bucket {
+                DisplayBucket::Unread => counts.unread += 1,
+                DisplayBucket::PendingAck => counts.pending_ack += 1,
+                DisplayBucket::History => counts.history += 1,
+            }
+            counts
+        },
+    )
+}
+
+fn select_messages(
+    messages: &[ClassifiedMessage],
+    selection_mode: ReadSelection,
+    seen_watermark: Option<DateTime<Utc>>,
+) -> Vec<ClassifiedMessage> {
+    let watermark = if selection_mode == ReadSelection::All {
+        None
+    } else {
+        seen_watermark
+    };
+
+    filters::apply_selection_mode(messages.to_vec(), selection_mode, watermark)
+}
+
+fn message_matches_filters(
+    message: &MessageEnvelope,
+    sender_filter: Option<&str>,
+    timestamp_filter: Option<DateTime<Utc>>,
+    selection_mode: ReadSelection,
+    seen_watermark: Option<DateTime<Utc>>,
+) -> bool {
+    if let Some(sender) = sender_filter {
+        if message.from != sender {
+            return false;
+        }
+    }
+
+    if let Some(since) = timestamp_filter {
+        if message.timestamp < since {
+            return false;
+        }
+    }
+
+    let classified = ClassifiedMessage {
+        source_index: 0,
+        class: state::classify_message(message),
+        bucket: state::display_bucket_for_class(state::classify_message(message)),
+        message: message.clone(),
+    };
+
+    !select_messages(&[classified], selection_mode, seen_watermark).is_empty()
+}
+
+fn apply_display_mutations(
+    mailbox_messages: &mut [MessageEnvelope],
+    displayed_messages: &[ClassifiedMessage],
+    ack_activation_mode: AckActivationMode,
+    own_inbox: bool,
+) -> bool {
+    let mut mutation_applied = false;
+    let promote_unread =
+        own_inbox && ack_activation_mode == AckActivationMode::PromoteDisplayedUnread;
+    let now = Utc::now();
+
+    for message in displayed_messages {
+        let stored = &mut mailbox_messages[message.source_index];
+        let was_read = stored.read;
+        let had_pending_ack = stored.pending_ack_at.is_some();
+        let had_acknowledged = stored.acknowledged_at.is_some();
+
+        stored.read = true;
+        if !was_read {
+            mutation_applied = true;
+        }
+
+        if promote_unread && !was_read && !had_pending_ack && !had_acknowledged {
+            stored.pending_ack_at = Some(now);
+            mutation_applied = true;
+        }
+    }
+
+    mutation_applied
+}

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -19,7 +19,7 @@ use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::schema::{MessageEnvelope, TeamConfig};
-use crate::types::{AckActivationMode, DisplayBucket, MessageClass, ReadSelection};
+use crate::types::{AckActivationMode, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection};
 
 #[derive(Debug, Clone)]
 pub struct ReadQuery {
@@ -517,7 +517,7 @@ fn apply_display_mutations(
     let mut mutation_applied = false;
     let promote_unread =
         own_inbox && ack_activation_mode == AckActivationMode::PromoteDisplayedUnread;
-    let now = Utc::now();
+    let now = IsoTimestamp::now();
 
     for message in displayed_messages {
         let transitioned = transition_displayed_message(message, promote_unread, now);
@@ -541,7 +541,7 @@ fn apply_display_mutations(
 fn transition_displayed_message(
     message: &ClassifiedMessage,
     promote_unread: bool,
-    now: DateTime<Utc>,
+    now: IsoTimestamp,
 ) -> state::TransitionedMessage {
     let read_state = state::derive_read_state(&message.envelope);
     let ack_state = state::derive_ack_state(&message.envelope);

--- a/crates/atm-core/src/read/seen_state.rs
+++ b/crates/atm-core/src/read/seen_state.rs
@@ -1,1 +1,132 @@
-// TODO: implement seen-state tracking rules.
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+
+use crate::error::{AtmError, AtmErrorKind};
+
+pub fn load_seen_watermark(
+    home_dir: &Path,
+    team: &str,
+    agent: &str,
+) -> Result<Option<DateTime<Utc>>, AtmError> {
+    let path = seen_state_path(home_dir, team, agent);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let raw = fs::read_to_string(&path).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::MailboxRead,
+            format!("failed to read seen-state watermark: {error}"),
+        )
+        .with_source(error)
+    })?;
+
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let parsed = DateTime::parse_from_rfc3339(trimmed).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::Serialization,
+            format!("invalid seen-state watermark: {error}"),
+        )
+        .with_source(error)
+    })?;
+
+    Ok(Some(parsed.with_timezone(&Utc)))
+}
+
+pub fn save_seen_watermark(
+    home_dir: &Path,
+    team: &str,
+    agent: &str,
+    timestamp: DateTime<Utc>,
+) -> Result<(), AtmError> {
+    let path = seen_state_path(home_dir, team, agent);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AtmError::new(
+                AtmErrorKind::MailboxWrite,
+                format!("failed to create seen-state directory: {error}"),
+            )
+            .with_source(error)
+        })?;
+    }
+
+    let temp_path = path.with_extension("tmp");
+    {
+        let mut file = fs::File::create(&temp_path).map_err(|error| {
+            AtmError::new(
+                AtmErrorKind::MailboxWrite,
+                format!("failed to create seen-state temp file: {error}"),
+            )
+            .with_source(error)
+        })?;
+        file.write_all(timestamp.to_rfc3339().as_bytes())
+            .map_err(|error| {
+                AtmError::new(
+                    AtmErrorKind::MailboxWrite,
+                    format!("failed to write seen-state watermark: {error}"),
+                )
+                .with_source(error)
+            })?;
+        file.sync_all().map_err(|error| {
+            AtmError::new(
+                AtmErrorKind::MailboxWrite,
+                format!("failed to sync seen-state watermark: {error}"),
+            )
+            .with_source(error)
+        })?;
+    }
+
+    fs::rename(&temp_path, &path).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::MailboxWrite,
+            format!("failed to replace seen-state watermark: {error}"),
+        )
+        .with_source(error)
+    })?;
+    Ok(())
+}
+
+fn seen_state_path(home_dir: &Path, team: &str, agent: &str) -> PathBuf {
+    home_dir
+        .join(".claude")
+        .join("teams")
+        .join(team)
+        .join(".seen")
+        .join(agent)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use tempfile::TempDir;
+
+    use super::{load_seen_watermark, save_seen_watermark};
+
+    #[test]
+    fn load_missing_seen_state_returns_none() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let loaded = load_seen_watermark(tempdir.path(), "atm-dev", "arch-ctm").expect("load");
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn save_and_load_seen_state_round_trips() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let timestamp = chrono::Utc
+            .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+            .single()
+            .expect("timestamp");
+
+        save_seen_watermark(tempdir.path(), "atm-dev", "arch-ctm", timestamp).expect("save");
+        let loaded = load_seen_watermark(tempdir.path(), "atm-dev", "arch-ctm").expect("load");
+
+        assert_eq!(loaded, Some(timestamp));
+    }
+}

--- a/crates/atm-core/src/read/state.rs
+++ b/crates/atm-core/src/read/state.rs
@@ -1,1 +1,35 @@
-// TODO: define read-state transitions and workflow classification.
+use crate::schema::MessageEnvelope;
+use crate::types::{AckState, DisplayBucket, MessageClass, ReadState};
+
+pub fn classify_message(message: &MessageEnvelope) -> MessageClass {
+    let read_state = if message.read {
+        ReadState::Read
+    } else {
+        ReadState::Unread
+    };
+
+    let ack_state = if message.pending_ack_at.is_some() && message.acknowledged_at.is_none() {
+        AckState::PendingAck
+    } else if message.acknowledged_at.is_some() {
+        AckState::Acknowledged
+    } else {
+        AckState::NoAckRequired
+    };
+
+    match (read_state, ack_state) {
+        (ReadState::Unread, AckState::NoAckRequired) => MessageClass::Unread,
+        (ReadState::Unread, AckState::PendingAck) => MessageClass::PendingAck,
+        (ReadState::Read, AckState::PendingAck) => MessageClass::PendingAck,
+        (ReadState::Read, AckState::Acknowledged) => MessageClass::Acknowledged,
+        (ReadState::Read, AckState::NoAckRequired) => MessageClass::Read,
+        _ => MessageClass::Read,
+    }
+}
+
+pub fn display_bucket_for_class(class: MessageClass) -> DisplayBucket {
+    match class {
+        MessageClass::Unread => DisplayBucket::Unread,
+        MessageClass::PendingAck => DisplayBucket::PendingAck,
+        MessageClass::Acknowledged | MessageClass::Read => DisplayBucket::History,
+    }
+}

--- a/crates/atm-core/src/read/state.rs
+++ b/crates/atm-core/src/read/state.rs
@@ -1,28 +1,110 @@
-use crate::schema::MessageEnvelope;
-use crate::types::{AckState, DisplayBucket, MessageClass, ReadState};
+use std::marker::PhantomData;
 
-pub fn classify_message(message: &MessageEnvelope) -> MessageClass {
-    let read_state = if message.read {
+use chrono::{DateTime, Utc};
+
+use crate::schema::MessageEnvelope;
+use crate::types::{
+    AckState, AcknowledgedAckState, DisplayBucket, MessageClass, NoAckState, PendingAckState,
+    ReadReadState, ReadState, UnreadReadState,
+};
+
+#[derive(Debug, Clone)]
+pub struct StoredMessage<R, A> {
+    pub envelope: MessageEnvelope,
+    _read: PhantomData<R>,
+    _ack: PhantomData<A>,
+}
+
+impl<R, A> StoredMessage<R, A> {
+    pub(crate) fn from_envelope(envelope: MessageEnvelope) -> Self {
+        Self {
+            envelope,
+            _read: PhantomData,
+            _ack: PhantomData,
+        }
+    }
+}
+
+impl StoredMessage<UnreadReadState, NoAckState> {
+    pub fn display_without_ack(mut self) -> StoredMessage<ReadReadState, NoAckState> {
+        self.envelope.read = true;
+        StoredMessage::from_envelope(self.envelope)
+    }
+
+    pub fn display_and_require_ack(
+        mut self,
+        at: DateTime<Utc>,
+    ) -> StoredMessage<ReadReadState, PendingAckState> {
+        self.envelope.read = true;
+        self.envelope.pending_ack_at = Some(at);
+        StoredMessage::from_envelope(self.envelope)
+    }
+}
+
+impl StoredMessage<UnreadReadState, PendingAckState> {
+    pub fn mark_read(mut self) -> StoredMessage<ReadReadState, PendingAckState> {
+        self.envelope.read = true;
+        StoredMessage::from_envelope(self.envelope)
+    }
+}
+
+impl StoredMessage<ReadReadState, PendingAckState> {
+    pub fn acknowledge(
+        mut self,
+        at: DateTime<Utc>,
+    ) -> StoredMessage<ReadReadState, AcknowledgedAckState> {
+        self.envelope.acknowledged_at = Some(at);
+        self.envelope.pending_ack_at = None;
+        StoredMessage::from_envelope(self.envelope)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum TransitionedMessage {
+    ReadNoAck(StoredMessage<ReadReadState, NoAckState>),
+    ReadPendingAck(StoredMessage<ReadReadState, PendingAckState>),
+    Unchanged(MessageEnvelope),
+}
+
+impl TransitionedMessage {
+    pub fn into_envelope(self) -> MessageEnvelope {
+        match self {
+            Self::ReadNoAck(message) => message.envelope,
+            Self::ReadPendingAck(message) => message.envelope,
+            Self::Unchanged(envelope) => envelope,
+        }
+    }
+}
+
+pub fn derive_read_state(message: &MessageEnvelope) -> ReadState {
+    if message.read {
         ReadState::Read
     } else {
         ReadState::Unread
-    };
+    }
+}
 
-    let ack_state = if message.pending_ack_at.is_some() && message.acknowledged_at.is_none() {
-        AckState::PendingAck
-    } else if message.acknowledged_at.is_some() {
+pub fn derive_ack_state(message: &MessageEnvelope) -> AckState {
+    if message.acknowledged_at.is_some() {
         AckState::Acknowledged
+    } else if message.pending_ack_at.is_some() {
+        AckState::PendingAck
     } else {
         AckState::NoAckRequired
-    };
+    }
+}
+
+pub fn classify_message(message: &MessageEnvelope) -> MessageClass {
+    let read_state = derive_read_state(message);
+    let ack_state = derive_ack_state(message);
 
     match (read_state, ack_state) {
         (ReadState::Unread, AckState::NoAckRequired) => MessageClass::Unread,
         (ReadState::Unread, AckState::PendingAck) => MessageClass::PendingAck,
+        (ReadState::Unread, AckState::Acknowledged) => MessageClass::Acknowledged,
+        (ReadState::Read, AckState::NoAckRequired) => MessageClass::Read,
         (ReadState::Read, AckState::PendingAck) => MessageClass::PendingAck,
         (ReadState::Read, AckState::Acknowledged) => MessageClass::Acknowledged,
-        (ReadState::Read, AckState::NoAckRequired) => MessageClass::Read,
-        _ => MessageClass::Read,
     }
 }
 

--- a/crates/atm-core/src/read/state.rs
+++ b/crates/atm-core/src/read/state.rs
@@ -1,11 +1,9 @@
 use std::marker::PhantomData;
 
-use chrono::{DateTime, Utc};
-
 use crate::schema::MessageEnvelope;
 use crate::types::{
-    AckState, AcknowledgedAckState, DisplayBucket, MessageClass, NoAckState, PendingAckState,
-    ReadReadState, ReadState, UnreadReadState,
+    AckState, AcknowledgedAckState, DisplayBucket, IsoTimestamp, MessageClass, NoAckState,
+    PendingAckState, ReadReadState, ReadState, UnreadReadState,
 };
 
 #[derive(Debug, Clone)]
@@ -33,10 +31,10 @@ impl StoredMessage<UnreadReadState, NoAckState> {
 
     pub fn display_and_require_ack(
         mut self,
-        at: DateTime<Utc>,
+        at: IsoTimestamp,
     ) -> StoredMessage<ReadReadState, PendingAckState> {
         self.envelope.read = true;
-        self.envelope.pending_ack_at = Some(at);
+        self.envelope.pending_ack_at = Some(at.into_inner());
         StoredMessage::from_envelope(self.envelope)
     }
 }
@@ -51,9 +49,9 @@ impl StoredMessage<UnreadReadState, PendingAckState> {
 impl StoredMessage<ReadReadState, PendingAckState> {
     pub fn acknowledge(
         mut self,
-        at: DateTime<Utc>,
+        at: IsoTimestamp,
     ) -> StoredMessage<ReadReadState, AcknowledgedAckState> {
-        self.envelope.acknowledged_at = Some(at);
+        self.envelope.acknowledged_at = Some(at.into_inner());
         self.envelope.pending_ack_at = None;
         StoredMessage::from_envelope(self.envelope)
     }

--- a/crates/atm-core/src/read/wait.rs
+++ b/crates/atm-core/src/read/wait.rs
@@ -1,35 +1,29 @@
-use std::path::Path;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::error::AtmError;
-use crate::home;
-use crate::mailbox;
-use crate::schema::MessageEnvelope;
 
-pub fn wait_for_eligible_message<F>(
-    home_dir: &Path,
-    team: &str,
-    agent: &str,
+pub fn wait_for_eligible_message<T, FLoad, FEligible>(
     timeout_secs: u64,
-    is_eligible: F,
+    mut load_messages: FLoad,
+    is_eligible: FEligible,
 ) -> Result<bool, AtmError>
 where
-    F: Fn(&MessageEnvelope) -> bool,
+    FLoad: FnMut() -> Result<Vec<T>, AtmError>,
+    FEligible: Fn(&[T]) -> bool,
 {
-    let inbox_path = home::inbox_path_from_home(home_dir, team, agent)?;
     let timeout = Duration::from_secs(timeout_secs);
     let poll_interval = Duration::from_millis(100);
     let start = Instant::now();
 
     loop {
-        let messages = mailbox::read_messages(&inbox_path)?;
-        if messages.iter().any(&is_eligible) {
-            return Ok(true);
-        }
-
         if start.elapsed() >= timeout {
             return Ok(false);
+        }
+
+        let messages = load_messages()?;
+        if is_eligible(&messages) {
+            return Ok(true);
         }
 
         thread::sleep(poll_interval);

--- a/crates/atm-core/src/read/wait.rs
+++ b/crates/atm-core/src/read/wait.rs
@@ -1,1 +1,37 @@
-// TODO: implement blocking wait behavior for read operations.
+use std::path::Path;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::error::AtmError;
+use crate::home;
+use crate::mailbox;
+use crate::schema::MessageEnvelope;
+
+pub fn wait_for_eligible_message<F>(
+    home_dir: &Path,
+    team: &str,
+    agent: &str,
+    timeout_secs: u64,
+    is_eligible: F,
+) -> Result<bool, AtmError>
+where
+    F: Fn(&MessageEnvelope) -> bool,
+{
+    let inbox_path = home::inbox_path_from_home(home_dir, team, agent)?;
+    let timeout = Duration::from_secs(timeout_secs);
+    let poll_interval = Duration::from_millis(100);
+    let start = Instant::now();
+
+    loop {
+        let messages = mailbox::read_messages(&inbox_path)?;
+        if messages.iter().any(&is_eligible) {
+            return Ok(true);
+        }
+
+        if start.elapsed() >= timeout {
+            return Ok(false);
+        }
+
+        thread::sleep(poll_interval);
+    }
+}

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -1,1 +1,6 @@
-// TODO: define agent member schema models.
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentMember {
+    pub name: String,
+}

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -1,1 +1,70 @@
-// TODO: define inbox message schema models.
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageEnvelope {
+    pub message_id: Uuid,
+    pub from: String,
+    pub team: String,
+    pub body: String,
+    pub requires_ack: bool,
+    pub task_id: Option<String>,
+    pub sent_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PendingAck {
+    pub message_id: Uuid,
+    pub from: String,
+    pub acked: bool,
+    pub acked_at: Option<DateTime<Utc>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use uuid::Uuid;
+
+    use super::{MessageEnvelope, PendingAck};
+
+    #[test]
+    fn message_envelope_round_trips_with_uuid_message_id() {
+        let envelope = MessageEnvelope {
+            message_id: Uuid::new_v4(),
+            from: "arch-ctm".into(),
+            team: "atm-dev".into(),
+            body: "hello".into(),
+            requires_ack: true,
+            task_id: Some("TASK-1".into()),
+            sent_at: Utc
+                .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                .single()
+                .expect("timestamp"),
+        };
+
+        let encoded = serde_json::to_string(&envelope).expect("encode");
+        let decoded: MessageEnvelope = serde_json::from_str(&encoded).expect("decode");
+
+        assert_eq!(decoded, envelope);
+    }
+
+    #[test]
+    fn pending_ack_round_trips() {
+        let pending_ack = PendingAck {
+            message_id: Uuid::new_v4(),
+            from: "team-lead".into(),
+            acked: true,
+            acked_at: Some(
+                Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
+                    .single()
+                    .expect("timestamp"),
+            ),
+        };
+
+        let encoded = serde_json::to_string(&pending_ack).expect("encode");
+        let decoded: PendingAck = serde_json::from_str(&encoded).expect("decode");
+
+        assert_eq!(decoded, pending_ack);
+    }
+}

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -1,16 +1,38 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MessageEnvelope {
-    pub message_id: Uuid,
     pub from: String,
-    pub team: String,
-    pub body: String,
-    pub requires_ack: bool,
-    pub task_id: Option<String>,
-    pub sent_at: DateTime<Utc>,
+    pub text: String,
+    pub timestamp: DateTime<Utc>,
+    pub read: bool,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_team: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<Uuid>,
+
+    #[serde(rename = "pendingAckAt", skip_serializing_if = "Option::is_none")]
+    pub pending_ack_at: Option<DateTime<Utc>>,
+
+    #[serde(rename = "acknowledgedAt", skip_serializing_if = "Option::is_none")]
+    pub acknowledged_at: Option<DateTime<Utc>>,
+
+    #[serde(
+        rename = "acknowledgesMessageId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub acknowledges_message_id: Option<Uuid>,
+
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -23,30 +45,68 @@ pub struct PendingAck {
 
 #[cfg(test)]
 mod tests {
-    use chrono::{TimeZone, Utc};
-    use uuid::Uuid;
+    use chrono::TimeZone;
+    use serde_json::{json, Map};
 
-    use super::{MessageEnvelope, PendingAck};
+    use super::{MessageEnvelope, PendingAck, Utc, Uuid};
 
     #[test]
-    fn message_envelope_round_trips_with_uuid_message_id() {
+    fn message_envelope_round_trips_with_current_inbox_shape() {
         let envelope = MessageEnvelope {
-            message_id: Uuid::new_v4(),
             from: "arch-ctm".into(),
-            team: "atm-dev".into(),
-            body: "hello".into(),
-            requires_ack: true,
-            task_id: Some("TASK-1".into()),
-            sent_at: Utc
+            text: "hello".into(),
+            timestamp: Utc
                 .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
                 .single()
                 .expect("timestamp"),
+            read: false,
+            source_team: Some("atm-dev".into()),
+            summary: Some("hello".into()),
+            message_id: Some(Uuid::new_v4()),
+            pending_ack_at: Some(
+                Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
+                    .single()
+                    .expect("timestamp"),
+            ),
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            extra: Map::new(),
         };
 
         let encoded = serde_json::to_string(&envelope).expect("encode");
         let decoded: MessageEnvelope = serde_json::from_str(&encoded).expect("decode");
 
         assert_eq!(decoded, envelope);
+    }
+
+    #[test]
+    fn unknown_fields_are_preserved() {
+        let json = json!({
+            "from": "team-lead",
+            "text": "hello",
+            "timestamp": "2026-03-30T00:00:00Z",
+            "read": false,
+            "futureField": {"nested": true}
+        });
+
+        let decoded: MessageEnvelope = serde_json::from_value(json).expect("decode");
+        assert_eq!(decoded.extra["futureField"], json!({"nested": true}));
+
+        let reencoded = serde_json::to_value(&decoded).expect("encode");
+        assert_eq!(reencoded["futureField"], json!({"nested": true}));
+    }
+
+    #[test]
+    fn message_id_is_optional() {
+        let json = json!({
+            "from": "team-lead",
+            "text": "hello",
+            "timestamp": "2026-03-30T00:00:00Z",
+            "read": false
+        });
+
+        let decoded: MessageEnvelope = serde_json::from_value(json).expect("decode");
+        assert!(decoded.message_id.is_none());
     }
 
     #[test]

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -31,6 +31,9 @@ pub struct MessageEnvelope {
     )]
     pub acknowledges_message_id: Option<Uuid>,
 
+    #[serde(rename = "taskId", skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+
     #[serde(flatten)]
     pub extra: Map<String, Value>,
 }
@@ -70,6 +73,7 @@ mod tests {
             ),
             acknowledged_at: None,
             acknowledges_message_id: None,
+            task_id: Some("TASK-123".into()),
             extra: Map::new(),
         };
 
@@ -107,6 +111,7 @@ mod tests {
 
         let decoded: MessageEnvelope = serde_json::from_value(json).expect("decode");
         assert!(decoded.message_id.is_none());
+        assert!(decoded.task_id.is_none());
     }
 
     #[test]

--- a/crates/atm-core/src/schema/mod.rs
+++ b/crates/atm-core/src/schema/mod.rs
@@ -4,4 +4,6 @@ pub mod permissions;
 pub mod settings;
 pub mod team_config;
 
+pub use agent_member::AgentMember;
 pub use inbox_message::{MessageEnvelope, PendingAck};
+pub use team_config::TeamConfig;

--- a/crates/atm-core/src/schema/mod.rs
+++ b/crates/atm-core/src/schema/mod.rs
@@ -4,4 +4,4 @@ pub mod permissions;
 pub mod settings;
 pub mod team_config;
 
-// TODO: define ATM mailbox and config schema modules.
+pub use inbox_message::{MessageEnvelope, PendingAck};

--- a/crates/atm-core/src/schema/team_config.rs
+++ b/crates/atm-core/src/schema/team_config.rs
@@ -1,1 +1,9 @@
-// TODO: define team config schema models.
+use serde::{Deserialize, Serialize};
+
+use super::agent_member::AgentMember;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamConfig {
+    #[serde(default)]
+    pub members: Vec<AgentMember>,
+}

--- a/crates/atm-core/src/send/file_policy.rs
+++ b/crates/atm-core/src/send/file_policy.rs
@@ -1,1 +1,72 @@
-// TODO: implement send file policy checks.
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::AtmError;
+use crate::home::atm_home;
+
+pub fn process_file_reference(
+    file_path: &Path,
+    message_text: Option<&str>,
+    team_name: &str,
+    current_dir: &Path,
+) -> Result<String, AtmError> {
+    if !file_path.is_file() {
+        return Err(AtmError::file_policy(format!(
+            "file not found: {}",
+            file_path.display()
+        )));
+    }
+
+    if is_file_in_repo(file_path, current_dir) {
+        return Ok(render_reference_message(message_text, file_path));
+    }
+
+    let share_dir = atm_home()?
+        .join(".config")
+        .join("atm")
+        .join("share")
+        .join(team_name);
+    fs::create_dir_all(&share_dir)?;
+
+    let file_name = file_path
+        .file_name()
+        .ok_or_else(|| AtmError::file_policy("file path has no file name"))?;
+    let share_copy = share_dir.join(file_name);
+    fs::copy(file_path, &share_copy).map_err(|error| {
+        AtmError::file_policy(format!("failed to copy file into share directory: {error}"))
+            .with_source(error)
+    })?;
+
+    Ok(render_reference_message(message_text, &share_copy))
+}
+
+fn render_reference_message(message_text: Option<&str>, file_path: &Path) -> String {
+    match message_text.filter(|message| !message.trim().is_empty()) {
+        Some(message_text) => {
+            format!("{message_text}\n\nFile reference: {}", file_path.display())
+        }
+        None => format!("File reference: {}", file_path.display()),
+    }
+}
+
+fn is_file_in_repo(file_path: &Path, current_dir: &Path) -> bool {
+    match (canonical(file_path), find_git_root(current_dir)) {
+        (Some(file_path), Some(repo_root)) => file_path.starts_with(repo_root),
+        _ => false,
+    }
+}
+
+fn canonical(path: &Path) -> Option<PathBuf> {
+    path.canonicalize().ok()
+}
+
+fn find_git_root(start_dir: &Path) -> Option<PathBuf> {
+    let mut current = Some(start_dir);
+    while let Some(dir) = current {
+        if dir.join(".git").exists() {
+            return canonical(dir);
+        }
+        current = dir.parent();
+    }
+    None
+}

--- a/crates/atm-core/src/send/input.rs
+++ b/crates/atm-core/src/send/input.rs
@@ -1,1 +1,30 @@
-// TODO: define send input models and parsing helpers.
+use std::io::Read;
+
+use crate::error::AtmError;
+
+pub fn read_message_from_stdin() -> Result<String, AtmError> {
+    let mut buffer = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buffer)
+        .map_err(|error| AtmError::validation(format!("failed to read stdin: {error}")))?;
+    validate_message_text(buffer)
+}
+
+pub fn validate_message_text(message: impl Into<String>) -> Result<String, AtmError> {
+    let message = message.into();
+    if message.trim().is_empty() {
+        return Err(AtmError::validation("message text cannot be empty"));
+    }
+
+    Ok(message)
+}
+
+pub fn validate_task_id(task_id: Option<String>) -> Result<Option<String>, AtmError> {
+    match task_id {
+        Some(task_id) if task_id.trim().is_empty() => {
+            Err(AtmError::validation("task id must not be blank"))
+        }
+        Some(task_id) => Ok(Some(task_id)),
+        None => Ok(None),
+    }
+}

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -112,6 +112,7 @@ pub fn send_mail(
             pending_ack_at: requires_ack.then_some(timestamp),
             acknowledged_at: None,
             acknowledges_message_id: None,
+            task_id: task_id.clone(),
             extra: Map::new(),
         };
         let inbox_path =

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -1,5 +1,214 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::address::AgentAddress;
+use crate::config;
+use crate::error::AtmError;
+use crate::home;
+use crate::identity;
+use crate::mailbox;
+use crate::observability::{CommandEvent, ObservabilityPort};
+use crate::schema::{MessageEnvelope, TeamConfig};
+
 pub mod file_policy;
 pub mod input;
 pub mod summary;
 
-// TODO: implement send service entry points.
+#[derive(Debug, Clone)]
+pub enum SendMessageSource {
+    InlineText(String),
+    StdinText(String),
+    FileReference(PathBuf),
+}
+
+#[derive(Debug, Clone)]
+pub struct SendRequest {
+    pub current_dir: PathBuf,
+    pub sender_override: Option<String>,
+    pub target_address: String,
+    pub team_override: Option<String>,
+    pub message_source: SendMessageSource,
+    pub summary_override: Option<String>,
+    pub requires_ack: bool,
+    pub task_id: Option<String>,
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SendOutcome {
+    pub action: &'static str,
+    pub team: String,
+    pub agent: String,
+    pub sender: String,
+    pub outcome: &'static str,
+    pub message_id: Uuid,
+    pub requires_ack: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub dry_run: bool,
+}
+
+pub fn execute(
+    request: SendRequest,
+    observability: &dyn ObservabilityPort,
+) -> Result<SendOutcome, AtmError> {
+    let config = config::load_config(&request.current_dir)?;
+    let sender = resolve_sender_identity(request.sender_override.as_deref(), config.as_ref())?;
+    let recipient = resolve_recipient(
+        &request.target_address,
+        request.team_override.as_deref(),
+        config.as_ref(),
+    )?;
+
+    let team_dir = home::team_dir(&recipient.team)?;
+    if !team_dir.exists() {
+        return Err(AtmError::team_not_found(&recipient.team));
+    }
+
+    let team_config = load_team_config(&team_dir)?;
+    if !team_config
+        .members
+        .iter()
+        .any(|member| member.name == recipient.agent)
+    {
+        return Err(AtmError::agent_not_found(&recipient.agent, &recipient.team));
+    }
+
+    let task_id = input::validate_task_id(request.task_id)?;
+    let requires_ack = request.requires_ack || task_id.is_some();
+    let body = resolve_message_body(
+        &request.message_source,
+        &request.current_dir,
+        &recipient.team,
+    )?;
+    let summary = summary::build_summary(&body, request.summary_override);
+    let message_id = Uuid::new_v4();
+
+    if !request.dry_run {
+        let envelope = MessageEnvelope {
+            message_id,
+            from: sender.clone(),
+            team: recipient.team.clone(),
+            body: body.clone(),
+            requires_ack,
+            task_id: task_id.clone(),
+            sent_at: Utc::now(),
+        };
+        let inbox_path = home::inbox_path(&recipient.team, &recipient.agent)?;
+        mailbox::append_message(&inbox_path, &envelope)?;
+    }
+
+    let outcome = SendOutcome {
+        action: "send",
+        team: recipient.team.clone(),
+        agent: recipient.agent.clone(),
+        sender: sender.clone(),
+        outcome: if request.dry_run { "dry_run" } else { "sent" },
+        message_id,
+        requires_ack,
+        task_id: task_id.clone(),
+        summary: Some(summary),
+        message: request.dry_run.then_some(body.clone()),
+        dry_run: request.dry_run,
+    };
+
+    let _ = observability.emit_command_event(CommandEvent {
+        command: "send",
+        action: "send",
+        outcome: outcome.outcome,
+        team: outcome.team.clone(),
+        agent: outcome.agent.clone(),
+        sender,
+        message_id: outcome.message_id.to_string(),
+        requires_ack: outcome.requires_ack,
+        dry_run: outcome.dry_run,
+        task_id,
+    });
+
+    Ok(outcome)
+}
+
+#[derive(Debug)]
+struct ResolvedRecipient {
+    agent: String,
+    team: String,
+}
+
+fn resolve_sender_identity(
+    sender_override: Option<&str>,
+    config: Option<&config::AtmConfig>,
+) -> Result<String, AtmError> {
+    match sender_override.filter(|value| !value.trim().is_empty()) {
+        Some(sender) => Ok(sender.to_string()),
+        None => identity::resolve_sender_identity(config),
+    }
+}
+
+fn resolve_recipient(
+    target_address: &str,
+    team_override: Option<&str>,
+    config: Option<&config::AtmConfig>,
+) -> Result<ResolvedRecipient, AtmError> {
+    let parsed: AgentAddress = target_address.parse()?;
+    let team = parsed
+        .team
+        .or_else(|| config::resolve_team(team_override, config))
+        .ok_or_else(AtmError::team_unavailable)?;
+
+    Ok(ResolvedRecipient {
+        agent: parsed.agent,
+        team,
+    })
+}
+
+fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
+    let config_path = team_dir.join("config.json");
+    let raw = fs::read_to_string(&config_path).map_err(|error| {
+        AtmError::team_not_found(
+            team_dir
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or("unknown"),
+        )
+        .with_source(error)
+    })?;
+
+    serde_json::from_str(&raw).map_err(|error| {
+        AtmError::new(
+            crate::error::AtmErrorKind::Config,
+            format!(
+                "failed to parse team config at {}: {error}",
+                config_path.display()
+            ),
+        )
+        .with_source(error)
+    })
+}
+
+fn resolve_message_body(
+    source: &SendMessageSource,
+    current_dir: &Path,
+    team_name: &str,
+) -> Result<String, AtmError> {
+    match source {
+        SendMessageSource::InlineText(message) | SendMessageSource::StdinText(message) => {
+            input::validate_message_text(message.clone())
+        }
+        SendMessageSource::FileReference(path) => {
+            file_policy::process_file_reference(path, None, team_name, current_dir)
+        }
+    }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}

--- a/crates/atm-core/src/send/summary.rs
+++ b/crates/atm-core/src/send/summary.rs
@@ -1,1 +1,20 @@
-// TODO: define send summary projections.
+use crate::text::truncate;
+
+const SUMMARY_LIMIT: usize = 100;
+
+pub fn build_summary(message: &str, explicit_summary: Option<String>) -> String {
+    if let Some(summary) = explicit_summary.filter(|value| !value.trim().is_empty()) {
+        return summary;
+    }
+
+    let trimmed = message.trim();
+    if trimmed.chars().count() <= SUMMARY_LIMIT {
+        return trimmed.to_string();
+    }
+
+    let slice = truncate(trimmed, SUMMARY_LIMIT);
+    match slice.rfind(char::is_whitespace) {
+        Some(index) => format!("{}...", slice[..index].trim_end()),
+        None => format!("{slice}..."),
+    }
+}

--- a/crates/atm-core/src/text.rs
+++ b/crates/atm-core/src/text.rs
@@ -1,1 +1,72 @@
-// TODO: implement shared text helpers.
+pub fn truncate(s: &str, max_chars: usize) -> &str {
+    if max_chars == 0 {
+        return "";
+    }
+
+    match s.char_indices().nth(max_chars) {
+        Some((index, _)) => &s[..index],
+        None => s,
+    }
+}
+
+pub fn wrap_lines(s: &str, width: usize) -> String {
+    if width == 0 {
+        return s.to_string();
+    }
+
+    let mut result = String::new();
+
+    for (line_index, line) in s.lines().enumerate() {
+        if line_index > 0 {
+            result.push('\n');
+        }
+
+        let mut current_len = 0usize;
+        for word in line.split_whitespace() {
+            let word_len = word.chars().count();
+            let separator_len = usize::from(current_len > 0);
+
+            if current_len > 0 && current_len + separator_len + word_len > width {
+                result.push('\n');
+                result.push_str(word);
+                current_len = word_len;
+            } else {
+                if current_len > 0 {
+                    result.push(' ');
+                }
+                result.push_str(word);
+                current_len += separator_len + word_len;
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{truncate, wrap_lines};
+
+    #[test]
+    fn truncate_is_char_boundary_safe() {
+        assert_eq!(truncate("naive cafe", 5), "naive");
+        assert_eq!(truncate("cafe\u{301}", 4), "cafe");
+    }
+
+    #[test]
+    fn truncate_returns_original_when_shorter_than_limit() {
+        assert_eq!(truncate("short", 10), "short");
+    }
+
+    #[test]
+    fn wrap_lines_wraps_on_word_boundaries() {
+        let wrapped = wrap_lines("alpha beta gamma", 10);
+        assert_eq!(wrapped, "alpha beta\ngamma");
+    }
+
+    #[test]
+    fn wrap_lines_preserves_existing_line_breaks() {
+        let wrapped = wrap_lines("alpha beta\ngamma delta", 6);
+        assert_eq!(wrapped, "alpha\nbeta\ngamma\ndelta");
+    }
+}

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -1,4 +1,24 @@
+use chrono::{DateTime, Utc};
 use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IsoTimestamp(pub DateTime<Utc>);
+
+impl IsoTimestamp {
+    pub fn now() -> Self {
+        Self(Utc::now())
+    }
+
+    pub fn into_inner(self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+impl From<DateTime<Utc>> for IsoTimestamp {
+    fn from(datetime: DateTime<Utc>) -> Self {
+        Self(datetime)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnreadReadState;

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -1,5 +1,20 @@
 use serde::Serialize;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnreadReadState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadReadState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NoAckState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PendingAckState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AcknowledgedAckState;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReadState {

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -1,1 +1,50 @@
-// TODO: define validated semantic newtypes and common value objects.
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadState {
+    Unread,
+    Read,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AckState {
+    NoAckRequired,
+    PendingAck,
+    Acknowledged,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageClass {
+    Unread,
+    PendingAck,
+    Acknowledged,
+    Read,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DisplayBucket {
+    Unread,
+    PendingAck,
+    History,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadSelection {
+    Actionable,
+    UnreadOnly,
+    PendingAckOnly,
+    ActionableWithHistory,
+    All,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AckActivationMode {
+    PromoteDisplayedUnread,
+    ReadOnly,
+}

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -10,4 +10,9 @@ license.workspace = true
 atm-core = { path = "../atm-core" }
 anyhow.workspace = true
 clap = { version = "4", features = ["derive"] }
+serde_json.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -9,4 +9,5 @@ license.workspace = true
 [dependencies]
 atm-core = { path = "../atm-core" }
 anyhow.workspace = true
+clap = { version = "4", features = ["derive"] }
 tracing.workspace = true

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 atm-core = { path = "../atm-core" }
 anyhow.workspace = true
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 serde_json.workspace = true
 tracing.workspace = true
@@ -16,3 +17,4 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+uuid = { version = "1", features = ["v4"] }

--- a/crates/atm/src/commands/ack.rs
+++ b/crates/atm/src/commands/ack.rs
@@ -1,1 +1,12 @@
-// TODO: implement the ack command.
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct AckCommand {}
+
+impl AckCommand {
+    pub fn run(self) -> Result<()> {
+        println!("ack not yet implemented");
+        Ok(())
+    }
+}

--- a/crates/atm/src/commands/clear.rs
+++ b/crates/atm/src/commands/clear.rs
@@ -1,1 +1,12 @@
-// TODO: implement the clear command.
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct ClearCommand {}
+
+impl ClearCommand {
+    pub fn run(self) -> Result<()> {
+        println!("clear not yet implemented");
+        Ok(())
+    }
+}

--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -1,1 +1,12 @@
-// TODO: implement the doctor command.
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct DoctorCommand {}
+
+impl DoctorCommand {
+    pub fn run(self) -> Result<()> {
+        println!("doctor not yet implemented");
+        Ok(())
+    }
+}

--- a/crates/atm/src/commands/log.rs
+++ b/crates/atm/src/commands/log.rs
@@ -1,1 +1,12 @@
-// TODO: implement the log command.
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct LogCommand {}
+
+impl LogCommand {
+    pub fn run(self) -> Result<()> {
+        println!("log not yet implemented");
+        Ok(())
+    }
+}

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -1,3 +1,6 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
 pub mod ack;
 pub mod clear;
 pub mod doctor;
@@ -5,4 +8,45 @@ pub mod log;
 pub mod read;
 pub mod send;
 
-// TODO: implement CLI command definitions and dispatch helpers.
+pub use ack::AckCommand;
+pub use clear::ClearCommand;
+pub use doctor::DoctorCommand;
+pub use log::LogCommand;
+pub use read::ReadCommand;
+pub use send::SendCommand;
+
+#[derive(Debug, Parser)]
+#[command(name = "atm", about = "ATM CLI", version)]
+pub struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+impl Cli {
+    pub fn run(self) -> Result<()> {
+        self.command.run()
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    Send(SendCommand),
+    Read(ReadCommand),
+    Ack(AckCommand),
+    Clear(ClearCommand),
+    Log(LogCommand),
+    Doctor(DoctorCommand),
+}
+
+impl Command {
+    fn run(self) -> Result<()> {
+        match self {
+            Self::Send(command) => command.run(),
+            Self::Read(command) => command.run(),
+            Self::Ack(command) => command.run(),
+            Self::Clear(command) => command.run(),
+            Self::Log(command) => command.run(),
+            Self::Doctor(command) => command.run(),
+        }
+    }
+}

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -49,7 +49,7 @@ impl Command {
     fn run(self, observability: &CliObservability) -> Result<()> {
         match self {
             Self::Send(command) => command.run(observability),
-            Self::Read(command) => command.run(),
+            Self::Read(command) => command.run(observability),
             Self::Ack(command) => command.run(),
             Self::Clear(command) => command.run(),
             Self::Log(command) => command.run(),

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -1,3 +1,6 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
 pub mod ack;
 pub mod clear;
 pub mod doctor;
@@ -5,4 +8,50 @@ pub mod log;
 pub mod read;
 pub mod send;
 
-// TODO: implement CLI command definitions and dispatch helpers.
+pub use ack::AckCommand;
+pub use clear::ClearCommand;
+pub use doctor::DoctorCommand;
+pub use log::LogCommand;
+pub use read::ReadCommand;
+pub use send::SendCommand;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "atm",
+    about = "ATM CLI",
+    version,
+    disable_help_subcommand = true
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+impl Cli {
+    pub fn run(self) -> Result<()> {
+        self.command.run()
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    Send(SendCommand),
+    Read(ReadCommand),
+    Ack(AckCommand),
+    Clear(ClearCommand),
+    Log(LogCommand),
+    Doctor(DoctorCommand),
+}
+
+impl Command {
+    fn run(self) -> Result<()> {
+        match self {
+            Self::Send(command) => command.run(),
+            Self::Read(command) => command.run(),
+            Self::Ack(command) => command.run(),
+            Self::Clear(command) => command.run(),
+            Self::Log(command) => command.run(),
+            Self::Doctor(command) => command.run(),
+        }
+    }
+}

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -16,7 +16,12 @@ pub use read::ReadCommand;
 pub use send::SendCommand;
 
 #[derive(Debug, Parser)]
-#[command(name = "atm", about = "ATM CLI", version)]
+#[command(
+    name = "atm",
+    about = "ATM CLI",
+    version,
+    disable_help_subcommand = true
+)]
 pub struct Cli {
     #[command(subcommand)]
     command: Command,

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -15,6 +15,8 @@ pub use log::LogCommand;
 pub use read::ReadCommand;
 pub use send::SendCommand;
 
+use crate::observability::CliObservability;
+
 #[derive(Debug, Parser)]
 #[command(
     name = "atm",
@@ -28,8 +30,8 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn run(self) -> Result<()> {
-        self.command.run()
+    pub fn run(self, observability: &CliObservability) -> Result<()> {
+        self.command.run(observability)
     }
 }
 
@@ -44,9 +46,9 @@ enum Command {
 }
 
 impl Command {
-    fn run(self) -> Result<()> {
+    fn run(self, observability: &CliObservability) -> Result<()> {
         match self {
-            Self::Send(command) => command.run(),
+            Self::Send(command) => command.run(observability),
             Self::Read(command) => command.run(),
             Self::Ack(command) => command.run(),
             Self::Clear(command) => command.run(),

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -1,1 +1,12 @@
-// TODO: implement the read command.
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct ReadCommand {}
+
+impl ReadCommand {
+    pub fn run(self) -> Result<()> {
+        println!("read not yet implemented");
+        Ok(())
+    }
+}

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -1,12 +1,112 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
+use atm_core::home;
+use atm_core::read::{self, ReadQuery};
+use atm_core::types::{AckActivationMode, ReadSelection};
 use clap::Args;
 
+use crate::observability::CliObservability;
+use crate::output;
+
 #[derive(Debug, Args)]
-pub struct ReadCommand {}
+pub struct ReadCommand {
+    target: Option<String>,
+
+    #[arg(long)]
+    team: Option<String>,
+
+    #[arg(long, conflicts_with_all = ["unread_only", "pending_ack_only", "history"])]
+    all: bool,
+
+    #[arg(long, conflicts_with_all = ["pending_ack_only", "history", "all"])]
+    unread_only: bool,
+
+    #[arg(long, conflicts_with_all = ["unread_only", "history", "all"])]
+    pending_ack_only: bool,
+
+    #[arg(long, conflicts_with_all = ["unread_only", "pending_ack_only", "all"])]
+    history: bool,
+
+    #[arg(long)]
+    since_last_seen: bool,
+
+    #[arg(long = "no-since-last-seen", default_value_t = false)]
+    no_since_last_seen: bool,
+
+    #[arg(long)]
+    no_mark: bool,
+
+    #[arg(long)]
+    no_update_seen: bool,
+
+    #[arg(long)]
+    limit: Option<usize>,
+
+    #[arg(long)]
+    since: Option<String>,
+
+    #[arg(long)]
+    from: Option<String>,
+
+    #[arg(long)]
+    json: bool,
+
+    #[arg(long)]
+    timeout: Option<u64>,
+
+    #[arg(long = "as")]
+    actor: Option<String>,
+}
 
 impl ReadCommand {
-    pub fn run(self) -> Result<()> {
-        println!("read not yet implemented");
-        Ok(())
+    pub fn run(self, observability: &CliObservability) -> Result<()> {
+        let current_dir = std::env::current_dir()?;
+        let home_dir = home::atm_home()?;
+        let selection_mode = self.selection_mode();
+        let timestamp_filter = self.since.as_deref().map(parse_timestamp).transpose()?;
+
+        let outcome = read::read_mail(
+            ReadQuery {
+                home_dir,
+                current_dir,
+                actor_override: self.actor,
+                target_address: self.target,
+                team_override: self.team,
+                selection_mode,
+                seen_state_filter: !self.no_since_last_seen,
+                seen_state_update: !self.no_update_seen,
+                ack_activation_mode: if self.no_mark {
+                    AckActivationMode::ReadOnly
+                } else {
+                    AckActivationMode::PromoteDisplayedUnread
+                },
+                limit: self.limit,
+                sender_filter: self.from,
+                timestamp_filter,
+                timeout_secs: self.timeout,
+            },
+            observability,
+        )?;
+
+        output::print_read_result(&outcome, self.json)
     }
+
+    fn selection_mode(&self) -> ReadSelection {
+        if self.all {
+            ReadSelection::All
+        } else if self.unread_only {
+            ReadSelection::UnreadOnly
+        } else if self.pending_ack_only {
+            ReadSelection::PendingAckOnly
+        } else if self.history {
+            ReadSelection::ActionableWithHistory
+        } else {
+            ReadSelection::Actionable
+        }
+    }
+}
+
+fn parse_timestamp(value: &str) -> Result<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .with_context(|| format!("invalid ISO 8601 timestamp: {value}"))
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
 }

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -61,6 +61,8 @@ impl ReadCommand {
     pub fn run(self, observability: &CliObservability) -> Result<()> {
         let current_dir = std::env::current_dir()?;
         let home_dir = home::atm_home()?;
+        // --since-last-seen is the default; explicitly setting it has the same effect.
+        let _ = self.since_last_seen;
         let selection_mode = self.selection_mode();
         let timestamp_filter = self.since.as_deref().map(parse_timestamp).transpose()?;
 

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -1,1 +1,12 @@
-// TODO: implement the send command.
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct SendCommand {}
+
+impl SendCommand {
+    pub fn run(self) -> Result<()> {
+        println!("send not yet implemented");
+        Ok(())
+    }
+}

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -13,7 +13,7 @@ pub struct SendCommand {
     #[arg()]
     to: String,
 
-    #[arg(long = "message", short = 'm')]
+    #[arg(index = 2)]
     message: Option<String>,
 
     #[arg(long)]
@@ -75,7 +75,7 @@ impl SendCommand {
         }
 
         if self.stdin && self.message.is_some() {
-            anyhow::bail!("--stdin and --message are mutually exclusive");
+            anyhow::bail!("--stdin and positional message text are mutually exclusive");
         }
 
         match (&self.file, self.stdin, &self.message) {
@@ -86,7 +86,7 @@ impl SendCommand {
             (None, true, None) => Ok(SendMessageSource::Stdin),
             (None, false, Some(message)) => Ok(SendMessageSource::Inline(message.clone())),
             (None, false, None) => {
-                anyhow::bail!("provide exactly one of --message, --file, or --stdin")
+                anyhow::bail!("provide message text, --file, or --stdin")
             }
             (Some(_), true, _) => unreachable!("validated above"),
             (None, true, Some(_)) => unreachable!("validated above"),

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -10,7 +10,7 @@ use crate::output;
 
 #[derive(Debug, Args)]
 pub struct SendCommand {
-    #[arg(long = "to")]
+    #[arg()]
     to: String,
 
     #[arg(long = "message", short = 'm')]

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -1,12 +1,54 @@
 use anyhow::Result;
+use atm_core::send::{self, SendMessageSource, SendRequest};
 use clap::Args;
 
+use crate::observability::CliObservability;
+use crate::output;
+
 #[derive(Debug, Args)]
-pub struct SendCommand {}
+pub struct SendCommand {
+    #[arg(long = "to")]
+    to: String,
+
+    #[arg(long = "message", short = 'm')]
+    message: Option<String>,
+
+    #[arg(long)]
+    ack: bool,
+
+    #[arg(long)]
+    task: Option<String>,
+
+    #[arg(long)]
+    dry_run: bool,
+
+    #[arg(long)]
+    json: bool,
+}
 
 impl SendCommand {
-    pub fn run(self) -> Result<()> {
-        println!("send not yet implemented");
-        Ok(())
+    pub fn run(self, observability: &CliObservability) -> Result<()> {
+        let current_dir = std::env::current_dir()?;
+        let message_source = match self.message {
+            Some(message) => SendMessageSource::InlineText(message),
+            None => SendMessageSource::StdinText(send::input::read_message_from_stdin()?),
+        };
+
+        let outcome = send::execute(
+            SendRequest {
+                current_dir,
+                sender_override: None,
+                target_address: self.to,
+                team_override: None,
+                message_source,
+                summary_override: None,
+                requires_ack: self.ack,
+                task_id: self.task,
+                dry_run: self.dry_run,
+            },
+            observability,
+        )?;
+
+        output::print_send_result(&outcome, self.json)
     }
 }

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use clap::Parser;
 
 fn main() -> Result<()> {
+    let observability = observability::init()?;
     let cli = commands::Cli::parse();
-    cli.run()
+    cli.run(&observability)
 }

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -2,6 +2,10 @@ mod commands;
 mod observability;
 mod output;
 
-fn main() {
-    println!("atm placeholder");
+use anyhow::Result;
+use clap::Parser;
+
+fn main() -> Result<()> {
+    let cli = commands::Cli::parse();
+    cli.run()
 }

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -1,1 +1,33 @@
-// TODO: implement CLI observability bootstrap and adapter wiring.
+use anyhow::Result;
+use atm_core::error::AtmError;
+use atm_core::observability::{CommandEvent, ObservabilityPort};
+use tracing::info;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CliObservability;
+
+pub fn init() -> Result<CliObservability> {
+    let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .try_init();
+    Ok(CliObservability)
+}
+
+impl ObservabilityPort for CliObservability {
+    fn emit_command_event(&self, event: CommandEvent) -> Result<(), AtmError> {
+        info!(
+            command = event.command,
+            action = event.action,
+            outcome = event.outcome,
+            team = event.team,
+            agent = event.agent,
+            sender = event.sender,
+            message_id = event.message_id,
+            requires_ack = event.requires_ack,
+            dry_run = event.dry_run,
+            task_id = event.task_id,
+            "atm command event"
+        );
+        Ok(())
+    }
+}

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -1,1 +1,15 @@
-// TODO: implement CLI output rendering helpers.
+use anyhow::Result;
+use atm_core::send::SendOutcome;
+
+pub fn print_send_result(outcome: &SendOutcome, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+    } else {
+        println!(
+            "Sent to {}@{} [message_id: {}]",
+            outcome.agent, outcome.team, outcome.message_id
+        );
+    }
+
+    Ok(())
+}

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
+use atm_core::read::ReadOutcome;
 use atm_core::send::SendOutcome;
+use atm_core::types::DisplayBucket;
 
 pub fn print_send_result(outcome: &SendOutcome, json: bool) -> Result<()> {
     if json {
@@ -12,4 +14,64 @@ pub fn print_send_result(outcome: &SendOutcome, json: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+pub fn print_read_result(outcome: &ReadOutcome, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+        return Ok(());
+    }
+
+    println!("Queue: {}@{}", outcome.agent, outcome.team);
+    println!(
+        "Unread: {} | Pending-Ack: {} | History: {}",
+        outcome.bucket_counts.unread,
+        outcome.bucket_counts.pending_ack,
+        outcome.bucket_counts.history
+    );
+
+    print_bucket(outcome, DisplayBucket::Unread, "Unread");
+    print_bucket(outcome, DisplayBucket::PendingAck, "Pending Ack");
+
+    if !outcome.history_collapsed {
+        print_bucket(outcome, DisplayBucket::History, "History");
+    } else if outcome.bucket_counts.history > 0 {
+        println!();
+        println!(
+            "History: {} older messages hidden. Use --history or --all to show them.",
+            outcome.bucket_counts.history
+        );
+    }
+
+    Ok(())
+}
+
+fn print_bucket(outcome: &ReadOutcome, bucket: DisplayBucket, label: &str) {
+    let messages = outcome
+        .messages
+        .iter()
+        .filter(|message| message.bucket == bucket)
+        .collect::<Vec<_>>();
+
+    if messages.is_empty() {
+        return;
+    }
+
+    println!();
+    println!("{label}:");
+    for message in messages {
+        println!(
+            "- {} {}: {}",
+            message.message.timestamp.to_rfc3339(),
+            message.message.from,
+            message
+                .message
+                .summary
+                .as_deref()
+                .unwrap_or(message.message.text.as_str())
+        );
+        if let Some(message_id) = message.message.message_id {
+            println!("  message_id: {message_id}");
+        }
+    }
 }

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -62,15 +62,15 @@ fn print_bucket(outcome: &ReadOutcome, bucket: DisplayBucket, label: &str) {
     for message in messages {
         println!(
             "- {} {}: {}",
-            message.message.timestamp.to_rfc3339(),
-            message.message.from,
+            message.envelope.timestamp.to_rfc3339(),
+            message.envelope.from,
             message
-                .message
+                .envelope
                 .summary
                 .as_deref()
-                .unwrap_or(message.message.text.as_str())
+                .unwrap_or(message.envelope.text.as_str())
         );
-        if let Some(message_id) = message.message.message_id {
+        if let Some(message_id) = message.envelope.message_id {
             println!("  message_id: {message_id}");
         }
     }

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -1,0 +1,329 @@
+use std::fs;
+use std::process::Command;
+
+use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
+use chrono::{TimeZone, Utc};
+use serde_json::Value;
+use uuid::Uuid;
+
+#[test]
+fn test_read_own_inbox_default() {
+    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[fixture.message("team-lead", "hello", false, None, None, 0)],
+    );
+
+    let output = fixture.run(&["read", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["action"], "read");
+    assert_eq!(parsed["agent"], "arch-ctm");
+    assert_eq!(parsed["count"], 1);
+    assert_eq!(parsed["bucket_counts"]["unread"], 1);
+    assert_eq!(parsed["messages"][0]["bucket"], "unread");
+}
+
+#[test]
+fn test_read_marks_read() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[fixture.message("team-lead", "hello", false, None, None, 0)],
+    );
+
+    let output = fixture.run(&["read", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let inbox = fixture.inbox_contents("arch-ctm");
+    assert!(inbox[0].read);
+}
+
+#[test]
+fn test_read_ack_activation() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[fixture.message("team-lead", "hello", false, None, None, 0)],
+    );
+
+    let output = fixture.run(&["read", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let inbox = fixture.inbox_contents("arch-ctm");
+    assert!(inbox[0].pending_ack_at.is_some());
+}
+
+#[test]
+fn test_read_no_mark() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[fixture.message("team-lead", "hello", false, None, None, 0)],
+    );
+
+    let output = fixture.run(&["read", "--no-mark", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let inbox = fixture.inbox_contents("arch-ctm");
+    assert!(inbox[0].read);
+    assert!(inbox[0].pending_ack_at.is_none());
+}
+
+#[test]
+fn test_read_unread_only() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[
+            fixture.message("team-lead", "unread", false, None, None, 2),
+            fixture.message("team-lead", "pending", true, Some(1), None, 1),
+            fixture.message("team-lead", "history", true, None, None, 0),
+        ],
+    );
+
+    let output = fixture.run(&["read", "--unread-only", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 1);
+    assert_eq!(parsed["messages"][0]["text"], "unread");
+    assert_eq!(parsed["bucket_counts"]["unread"], 1);
+    assert_eq!(parsed["bucket_counts"]["pending_ack"], 1);
+    assert_eq!(parsed["bucket_counts"]["history"], 1);
+}
+
+#[test]
+fn test_read_json_output() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[fixture.message("team-lead", "hello", false, None, None, 0)],
+    );
+
+    let output = fixture.run(&["read", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["action"], "read");
+    assert_eq!(parsed["team"], "atm-dev");
+    assert_eq!(parsed["history_collapsed"], false);
+    assert_eq!(parsed["messages"][0]["from"], "team-lead");
+}
+
+#[test]
+fn test_read_seen_state() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[
+            fixture.message("team-lead", "history", true, None, None, 0),
+            fixture.message("team-lead", "new unread", false, None, None, 10),
+        ],
+    );
+    fixture.write_seen_state("arch-ctm", fixture.timestamp(5));
+
+    let output = fixture.run(&["read", "--history", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 1);
+    assert_eq!(parsed["messages"][0]["text"], "new unread");
+    assert_eq!(parsed["bucket_counts"]["history"], 0);
+}
+
+#[test]
+fn test_read_limit() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[
+            fixture.message("team-lead", "first", false, None, None, 0),
+            fixture.message("team-lead", "second", false, None, None, 1),
+        ],
+    );
+
+    let output = fixture.run(&["read", "--limit", "1", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 1);
+    assert_eq!(parsed["messages"][0]["text"], "second");
+}
+
+#[test]
+fn test_read_timeout_with_existing_pending_ack_returns_immediately() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[fixture.message("team-lead", "pending", true, Some(0), None, 0)],
+    );
+
+    let start = std::time::Instant::now();
+    let output = fixture.run(&["read", "--timeout", "5", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    assert!(start.elapsed() < std::time::Duration::from_secs(1));
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 1);
+    assert_eq!(parsed["messages"][0]["bucket"], "pending_ack");
+}
+
+struct Fixture {
+    tempdir: tempfile::TempDir,
+}
+
+impl Fixture {
+    fn new(members: &[&str]) -> Self {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let fixture = Self { tempdir };
+        fixture.write_team_config(members);
+        fixture
+    }
+
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_atm"))
+            .args(args)
+            .env("ATM_HOME", self.tempdir.path())
+            .env("ATM_IDENTITY", "arch-ctm")
+            .current_dir(self.tempdir.path())
+            .output()
+            .expect("run atm")
+    }
+
+    fn write_team_config(&self, members: &[&str]) {
+        let team_dir = self.team_dir();
+        fs::create_dir_all(&team_dir).expect("team dir");
+        let config = TeamConfig {
+            members: members
+                .iter()
+                .map(|member| AgentMember {
+                    name: (*member).to_string(),
+                })
+                .collect(),
+        };
+        fs::write(
+            team_dir.join("config.json"),
+            serde_json::to_vec(&config).expect("team config"),
+        )
+        .expect("write team config");
+    }
+
+    fn write_inbox(&self, agent: &str, messages: &[MessageEnvelope]) {
+        let inbox_path = self.inbox_path(agent);
+        if let Some(parent) = inbox_path.parent() {
+            fs::create_dir_all(parent).expect("inbox dir");
+        }
+        let raw = messages
+            .iter()
+            .map(|message| serde_json::to_string(message).expect("json line"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(inbox_path, format!("{raw}\n")).expect("write inbox");
+    }
+
+    fn write_seen_state(&self, agent: &str, timestamp: chrono::DateTime<Utc>) {
+        let path = self.team_dir().join(".seen").join(agent);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("seen dir");
+        }
+        fs::write(path, timestamp.to_rfc3339()).expect("write seen state");
+    }
+
+    fn inbox_path(&self, agent: &str) -> std::path::PathBuf {
+        self.team_dir()
+            .join("inboxes")
+            .join(format!("{agent}.json"))
+    }
+
+    fn inbox_contents(&self, agent: &str) -> Vec<MessageEnvelope> {
+        let raw = fs::read_to_string(self.inbox_path(agent)).expect("inbox contents");
+        raw.lines()
+            .map(|line| serde_json::from_str(line).expect("json line"))
+            .collect()
+    }
+
+    fn stdout_json(&self, output: &std::process::Output) -> Value {
+        serde_json::from_slice(&output.stdout).expect("valid read json")
+    }
+
+    fn stderr(&self, output: &std::process::Output) -> String {
+        String::from_utf8(output.stderr.clone()).expect("stderr utf8")
+    }
+
+    fn team_dir(&self) -> std::path::PathBuf {
+        self.tempdir
+            .path()
+            .join(".claude")
+            .join("teams")
+            .join("atm-dev")
+    }
+
+    fn timestamp(&self, seconds: i64) -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+            .single()
+            .expect("timestamp")
+            + chrono::Duration::seconds(seconds)
+    }
+
+    fn message(
+        &self,
+        from: &str,
+        text: &str,
+        read: bool,
+        pending_ack_offset: Option<i64>,
+        acknowledged_offset: Option<i64>,
+        timestamp_offset: i64,
+    ) -> MessageEnvelope {
+        MessageEnvelope {
+            from: from.to_string(),
+            text: text.to_string(),
+            timestamp: self.timestamp(timestamp_offset),
+            read,
+            source_team: Some("atm-dev".into()),
+            summary: None,
+            message_id: Some(Uuid::new_v4()),
+            pending_ack_at: pending_ack_offset.map(|offset| self.timestamp(offset)),
+            acknowledged_at: acknowledged_offset.map(|offset| self.timestamp(offset)),
+            acknowledges_message_id: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+}

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -323,6 +323,7 @@ impl Fixture {
             pending_ack_at: pending_ack_offset.map(|offset| self.timestamp(offset)),
             acknowledged_at: acknowledged_offset.map(|offset| self.timestamp(offset)),
             acknowledges_message_id: None,
+            task_id: None,
             extra: serde_json::Map::new(),
         }
     }

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -133,6 +133,10 @@ fn test_read_json_output() {
     assert_eq!(parsed["action"], "read");
     assert_eq!(parsed["team"], "atm-dev");
     assert_eq!(parsed["history_collapsed"], false);
+    assert_eq!(parsed["count"].as_u64(), Some(1));
+    assert!(parsed["bucket_counts"]["unread"].as_u64().is_some());
+    assert!(parsed["bucket_counts"]["pending_ack"].as_u64().is_some());
+    assert!(parsed["bucket_counts"]["history"].as_u64().is_some());
     assert_eq!(parsed["messages"][0]["from"], "team-lead");
 }
 
@@ -158,7 +162,7 @@ fn test_read_seen_state() {
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["count"], 1);
     assert_eq!(parsed["messages"][0]["text"], "new unread");
-    assert_eq!(parsed["bucket_counts"]["history"], 0);
+    assert_eq!(parsed["bucket_counts"]["history"], 1);
 }
 
 #[test]
@@ -204,6 +208,144 @@ fn test_read_timeout_with_existing_pending_ack_returns_immediately() {
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["count"], 1);
     assert_eq!(parsed["messages"][0]["bucket"], "pending_ack");
+}
+
+#[test]
+fn test_read_pending_ack_only() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[fixture.message("team-lead", "pending", true, Some(0), None, 0)],
+    );
+
+    let output = fixture.run(&["read", "--pending-ack-only", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 1);
+    assert_eq!(parsed["messages"][0]["bucket"], "pending_ack");
+}
+
+#[test]
+fn test_read_all_flag() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[
+            fixture.message("sender-a", "unread", false, None, None, 0),
+            fixture.message("sender-b", "pending", true, Some(1), None, 1),
+            fixture.message("sender-c", "history", true, None, None, 2),
+        ],
+    );
+
+    let output = fixture.run(&["read", "--all", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 3);
+}
+
+#[test]
+fn test_read_no_update_seen() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[fixture.message("team-lead", "history", true, None, None, 10)],
+    );
+    let initial = fixture.timestamp(0);
+    fixture.write_seen_state("arch-ctm", initial);
+
+    let output = fixture.run(&["read", "--history", "--no-update-seen", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    assert_eq!(fixture.read_seen_state("arch-ctm"), Some(initial));
+}
+
+#[test]
+fn test_read_from_filter() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[
+            fixture.message("sender-a", "alpha", false, None, None, 0),
+            fixture.message("sender-b", "beta", false, None, None, 1),
+        ],
+    );
+
+    let output = fixture.run(&["read", "--from", "sender-a", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 1);
+    assert_eq!(parsed["messages"][0]["from"], "sender-a");
+    assert_eq!(parsed["bucket_counts"]["unread"], 2);
+}
+
+#[test]
+fn test_read_mutual_exclusion() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+
+    let output = fixture.run(&["read", "--all", "--unread-only"]);
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_read_timeout_expiry() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+
+    let output = fixture.run(&["read", "--timeout", "0", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 0);
+}
+
+#[test]
+fn test_read_no_since_last_seen_wins() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[fixture.message("team-lead", "history", true, None, None, 0)],
+    );
+    fixture.write_seen_state("arch-ctm", fixture.timestamp(10));
+
+    let output = fixture.run(&[
+        "read",
+        "--history",
+        "--since-last-seen",
+        "--no-since-last-seen",
+        "--json",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 1);
+    assert_eq!(parsed["messages"][0]["bucket"], "history");
 }
 
 struct Fixture {
@@ -265,6 +407,14 @@ impl Fixture {
             fs::create_dir_all(parent).expect("seen dir");
         }
         fs::write(path, timestamp.to_rfc3339()).expect("write seen state");
+    }
+
+    fn read_seen_state(&self, agent: &str) -> Option<chrono::DateTime<Utc>> {
+        let path = self.team_dir().join(".seen").join(agent);
+        let raw = fs::read_to_string(path).ok()?;
+        chrono::DateTime::parse_from_rfc3339(raw.trim())
+            .ok()
+            .map(|timestamp| timestamp.with_timezone(&Utc))
     }
 
     fn inbox_path(&self, agent: &str) -> std::path::PathBuf {

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -7,7 +7,7 @@ use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
 fn test_send_creates_inbox_file() {
     let fixture = Fixture::new("recipient");
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "--message", "hello from test"]);
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello from test"]);
 
     assert!(
         output.status.success(),
@@ -36,7 +36,6 @@ fn test_send_dry_run_no_file() {
     let output = fixture.run(&[
         "send",
         "recipient@atm-dev",
-        "--message",
         "hello from test",
         "--dry-run",
         "--json",
@@ -64,13 +63,7 @@ fn test_send_dry_run_no_file() {
 fn test_send_json_output() {
     let fixture = Fixture::new("recipient");
 
-    let output = fixture.run(&[
-        "send",
-        "recipient@atm-dev",
-        "--message",
-        "hello json",
-        "--json",
-    ]);
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello json", "--json"]);
 
     assert!(
         output.status.success(),
@@ -92,13 +85,7 @@ fn test_send_json_output() {
 fn test_send_requires_ack() {
     let fixture = Fixture::new("recipient");
 
-    let output = fixture.run(&[
-        "send",
-        "recipient@atm-dev",
-        "--message",
-        "please ack",
-        "--requires-ack",
-    ]);
+    let output = fixture.run(&["send", "recipient@atm-dev", "please ack", "--requires-ack"]);
 
     assert!(
         output.status.success(),
@@ -118,7 +105,6 @@ fn test_send_persists_task_id() {
     let output = fixture.run(&[
         "send",
         "recipient@atm-dev",
-        "--message",
         "task assignment",
         "--task-id",
         "TASK-123",
@@ -133,6 +119,33 @@ fn test_send_persists_task_id() {
     let inbox = fixture.inbox_contents("recipient");
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].task_id.as_deref(), Some("TASK-123"));
+}
+
+#[test]
+fn test_send_supports_positional_message_with_file() {
+    let fixture = Fixture::new("recipient");
+    let attachment = fixture.tempdir.path().join("notes.txt");
+    fs::write(&attachment, "attachment body").expect("attachment");
+
+    let output = fixture.run(&[
+        "send",
+        "recipient@atm-dev",
+        "context first",
+        "--file",
+        attachment.to_str().expect("attachment path"),
+    ]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let inbox = fixture.inbox_contents("recipient");
+    assert_eq!(inbox.len(), 1);
+    assert!(inbox[0]
+        .text
+        .starts_with("context first\n\nFile reference:"));
 }
 
 struct Fixture {

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -1,0 +1,183 @@
+use std::fs;
+use std::process::Command;
+
+use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
+
+#[test]
+fn test_send_creates_inbox_file() {
+    let fixture = Fixture::new("recipient");
+
+    let output = fixture.run(&[
+        "send",
+        "--to",
+        "recipient@atm-dev",
+        "--message",
+        "hello from test",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    assert!(
+        fixture
+            .stdout(&output)
+            .contains("Sent to recipient@atm-dev [message_id:"),
+        "stdout: {}",
+        fixture.stdout(&output)
+    );
+
+    let inbox = fixture.inbox_contents("recipient");
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].body, "hello from test");
+    assert_eq!(inbox[0].from, "arch-ctm");
+}
+
+#[test]
+fn test_send_dry_run_no_file() {
+    let fixture = Fixture::new("recipient");
+
+    let output = fixture.run(&[
+        "send",
+        "--to",
+        "recipient@atm-dev",
+        "--message",
+        "hello from test",
+        "--dry-run",
+        "--json",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid dry-run json");
+    assert_eq!(parsed["action"], "send");
+    assert_eq!(parsed["team"], "atm-dev");
+    assert_eq!(parsed["agent"], "recipient");
+    assert_eq!(parsed["message"], "hello from test");
+    assert_eq!(parsed["dry_run"], true);
+    assert_eq!(parsed["requires_ack"], false);
+
+    assert!(!fixture.inbox_path("recipient").exists());
+}
+
+#[test]
+fn test_send_json_output() {
+    let fixture = Fixture::new("recipient");
+
+    let output = fixture.run(&[
+        "send",
+        "--to",
+        "recipient@atm-dev",
+        "--message",
+        "hello json",
+        "--json",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid send json");
+    assert_eq!(parsed["action"], "send");
+    assert_eq!(parsed["team"], "atm-dev");
+    assert_eq!(parsed["agent"], "recipient");
+    assert_eq!(parsed["outcome"], "sent");
+    assert_eq!(parsed["requires_ack"], false);
+    assert!(parsed["message_id"].as_str().is_some());
+}
+
+#[test]
+fn test_send_requires_ack() {
+    let fixture = Fixture::new("recipient");
+
+    let output = fixture.run(&[
+        "send",
+        "--to",
+        "recipient@atm-dev",
+        "--message",
+        "please ack",
+        "--ack",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let inbox = fixture.inbox_contents("recipient");
+    assert_eq!(inbox.len(), 1);
+    assert!(inbox[0].requires_ack);
+}
+
+struct Fixture {
+    tempdir: tempfile::TempDir,
+}
+
+impl Fixture {
+    fn new(recipient: &str) -> Self {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let fixture = Self { tempdir };
+        fixture.write_team_config(recipient);
+        fixture
+    }
+
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_atm"))
+            .args(args)
+            .env("ATM_HOME", self.tempdir.path())
+            .env("ATM_IDENTITY", "arch-ctm")
+            .current_dir(self.tempdir.path())
+            .output()
+            .expect("run atm")
+    }
+
+    fn write_team_config(&self, recipient: &str) {
+        let team_dir = self.tempdir.path().join("teams").join("atm-dev");
+        fs::create_dir_all(&team_dir).expect("team dir");
+        let config = TeamConfig {
+            members: vec![AgentMember {
+                name: recipient.to_string(),
+            }],
+        };
+        fs::write(
+            team_dir.join("config.json"),
+            serde_json::to_vec(&config).expect("team config"),
+        )
+        .expect("write team config");
+    }
+
+    fn inbox_path(&self, recipient: &str) -> std::path::PathBuf {
+        self.tempdir
+            .path()
+            .join("teams")
+            .join("atm-dev")
+            .join("inbox")
+            .join(format!("{recipient}.jsonl"))
+    }
+
+    fn inbox_contents(&self, recipient: &str) -> Vec<MessageEnvelope> {
+        let inbox_path = self.inbox_path(recipient);
+        let raw = fs::read_to_string(&inbox_path).expect("inbox contents");
+        raw.lines()
+            .map(|line| serde_json::from_str(line).expect("json line"))
+            .collect()
+    }
+
+    fn stdout(&self, output: &std::process::Output) -> String {
+        String::from_utf8(output.stdout.clone()).expect("stdout utf8")
+    }
+
+    fn stderr(&self, output: &std::process::Output) -> String {
+        String::from_utf8(output.stderr.clone()).expect("stderr utf8")
+    }
+}

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -7,13 +7,7 @@ use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
 fn test_send_creates_inbox_file() {
     let fixture = Fixture::new("recipient");
 
-    let output = fixture.run(&[
-        "send",
-        "--to",
-        "recipient@atm-dev",
-        "--message",
-        "hello from test",
-    ]);
+    let output = fixture.run(&["send", "recipient@atm-dev", "--message", "hello from test"]);
 
     assert!(
         output.status.success(),
@@ -41,7 +35,6 @@ fn test_send_dry_run_no_file() {
 
     let output = fixture.run(&[
         "send",
-        "--to",
         "recipient@atm-dev",
         "--message",
         "hello from test",
@@ -73,7 +66,6 @@ fn test_send_json_output() {
 
     let output = fixture.run(&[
         "send",
-        "--to",
         "recipient@atm-dev",
         "--message",
         "hello json",
@@ -102,7 +94,6 @@ fn test_send_requires_ack() {
 
     let output = fixture.run(&[
         "send",
-        "--to",
         "recipient@atm-dev",
         "--message",
         "please ack",
@@ -118,6 +109,30 @@ fn test_send_requires_ack() {
     let inbox = fixture.inbox_contents("recipient");
     assert_eq!(inbox.len(), 1);
     assert!(inbox[0].pending_ack_at.is_some());
+}
+
+#[test]
+fn test_send_persists_task_id() {
+    let fixture = Fixture::new("recipient");
+
+    let output = fixture.run(&[
+        "send",
+        "recipient@atm-dev",
+        "--message",
+        "task assignment",
+        "--task-id",
+        "TASK-123",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let inbox = fixture.inbox_contents("recipient");
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].task_id.as_deref(), Some("TASK-123"));
 }
 
 struct Fixture {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -336,6 +336,12 @@ Persisted fields used by the rewrite:
 
 Canonical read and ack axes are derived from persisted fields and not serialized separately.
 
+Invariant:
+- every ATM-authored message written by `send::send_mail` carries a non-null
+  UUID v4 `message_id`
+- legacy or externally imported records may still lack `message_id` and must be
+  preserved as-is
+
 ## 6. Public Service APIs
 
 ### 6.1 Send Service
@@ -399,6 +405,7 @@ Send ordering rules:
 - resolve target address, team existence, and agent membership as one address-resolution stage before mailbox path selection
 - enter the atomic append boundary before final inbox mutation
 - validate message text inside the atomic append boundary
+- generate UUID v4 `message_id` inside the atomic append boundary
 - perform duplicate suppression and final append inside the same atomic append boundary
 
 ### 6.2 Read Service
@@ -444,6 +451,11 @@ Timeout rule:
 - unread
 - pending_ack
 - history
+
+Read deduplication rule:
+- collapse multiple entries with the same non-null `message_id` to the most
+  recent entry before bucket selection and output rendering
+- when timestamps tie, keep the later encountered inbox record
 
 The read service derives `MessageClass` from `(ReadState, AckState)` and applies display-bucket selection to the derived class, not to raw persisted fields.
 
@@ -497,6 +509,7 @@ Public entrypoint:
 - optional target address
 - team override
 - optional age filter
+- include pending-ack flag
 - idle-only flag
 - dry-run flag
 
@@ -511,6 +524,10 @@ Public entrypoint:
 Clear eligibility is computed from the two-axis model:
 - clearable: `(Read, NoAckRequired)` and `(Read, Acknowledged)`
 - non-clearable: every other combination
+
+If `include pending-ack flag` is enabled, the clearable set expands to include:
+- `(Unread, PendingAck)`
+- `(Read, PendingAck)`
 
 ### 6.5 Observability Boundary
 
@@ -585,16 +602,17 @@ The read pipeline stages are:
 1. resolve actor and target inbox
 2. build the hostname registry for configured origin inboxes
 3. load mailbox records from the merged inbox surface
-4. classify read axis, ack axis, and derived message class
-5. apply sender and timestamp filters
-6. apply seen-state filter unless selection is `All`
-7. map derived message class to display bucket and apply selection mode
-8. wait if `timeout` is set and the current selection is empty
-9. sort newest-first and apply limit
-10. apply legal read-axis and ack-axis transitions for displayed messages
-11. persist state changes atomically
-12. update seen-state when enabled
-13. return outcome
+4. collapse duplicate `message_id` entries to the newest visible record
+5. classify read axis, ack axis, and derived message class
+6. apply sender and timestamp filters
+7. apply seen-state filter unless selection is `All`
+8. map derived message class to display bucket and apply selection mode
+9. wait if `timeout` is set and the current selection is empty
+10. sort newest-first and apply limit
+11. apply legal read-axis and ack-axis transitions for displayed messages
+12. persist state changes atomically
+13. update seen-state when enabled
+14. return outcome
 
 This ordering is part of the architecture contract.
 
@@ -616,7 +634,7 @@ The clear pipeline stages are:
 1. resolve actor identity and target inbox
 2. load the persisted inbox surface
 3. classify each message into read axis and ack axis
-4. compute clear eligibility from the two-axis model
+4. compute clear eligibility from the two-axis model plus pending-ack override
 5. apply optional age and idle-only filters
 6. atomically persist the kept set when not in dry-run mode
 7. emit command lifecycle records
@@ -762,6 +780,7 @@ If a trait becomes necessary:
 - origin-inbox merge
 - atomic append behavior
 - duplicate suppression
+- read-time duplicate collapse by `message_id`
 - workflow axis classification
 - workflow axis transitions
 - task-linked ack-required classification
@@ -769,6 +788,7 @@ If a trait becomes necessary:
 - timeout behavior
 - ack transition behavior
 - clear eligibility behavior
+- pending-ack clear override behavior
 - observability port emission behavior
 - observability port query/filter behavior
 - observability port failure behavior

--- a/docs/file-migration-plan.md
+++ b/docs/file-migration-plan.md
@@ -138,7 +138,7 @@ Change:
 - expose retained command surface as `atm clear`
 - replace command-local business logic with `atm_core::clear::clear_mail` plus the injected observability port
 - make the default clear set exactly the two-axis clearable set
-- never clear pending-ack messages
+- clear pending-ack messages only behind the explicit override flag
 - never clear unread messages
 - keep only the clear subcommand behavior; drop inbox summary/watch behavior
 
@@ -465,7 +465,8 @@ Change:
 - reduce the source to clear-only behavior
 - compute clear eligibility from the two-axis model instead of ad hoc flags
 - preserve idle-only filtering as an optional narrower mode
-- never remove pending-ack or unread messages
+- never remove unread messages
+- remove pending-ack messages only when the explicit override flag is set
 
 ### 2.18 `copy crates/atm/src/commands/logs.rs -> crates/atm-core/src/log/mod.rs`
 
@@ -920,6 +921,7 @@ Change:
 - narrow the source suite to clear-only behavior
 - align expected removals with the two-axis clearable set
 - add negative tests for pending-ack and unread messages
+- add override coverage for stale pending-ack clearing
 
 ### 8.6 `copy crates/atm/tests/integration_auto_identity.rs -> crates/atm/tests/integration_auto_identity.rs`
 

--- a/docs/obs-gap-analysis.md
+++ b/docs/obs-gap-analysis.md
@@ -1,0 +1,357 @@
+# OBS-GAP-1: `sc-observability` API Gap Analysis For ATM
+
+## 1. Purpose
+
+This document closes Phase A sprint `OBS-GAP-1` for `atm-core`.
+
+Its purpose is to verify whether the current shared `sc-observability` workspace
+already provides the capability surface required by the retained ATM commands:
+
+- `atm send`
+- `atm read`
+- `atm ack`
+- `atm clear`
+- `atm log`
+- `atm doctor`
+
+The focus is the observability boundary only. This is a planning artifact, not
+an implementation plan for Rust code inside `atm-core`.
+
+## 2. ATM-Side Required Capability List
+
+ATM needs four observability-facing responsibilities at the `atm-core`
+boundary:
+
+1. best-effort command/event emission for normal mail commands
+2. historical log query for `atm log`
+3. follow/tail of new matching log records for `atm log --tail`
+4. health/readiness inspection for `atm doctor`
+
+The retained ATM architecture already fixes the ownership split:
+
+- `atm-core` owns the sealed `ObservabilityPort`
+- `atm-core` owns ATM-specific event/query vocabulary
+- `atm` owns the concrete shared-crate integration
+- shared `sc-observability` should own generic log storage/query/follow/filter
+  behavior
+
+### 2.1 Required `ObservabilityPort` Capabilities
+
+The ATM-owned port needs to support the following operations:
+
+| Port responsibility | Used by | Requirement |
+| --- | --- | --- |
+| emit ATM command lifecycle records | `send`, `read`, `ack`, `clear` | best-effort, must not break core command correctness |
+| query retained log records | `log` | historical record access with filters and ordering |
+| follow new matching log records | `log --tail` | long-lived follow mode over the shared log store |
+| read logging health | `doctor` | in-process health snapshot and active log-path visibility |
+| check query readiness | `doctor` | verify the query/follow surface is usable for `atm log` |
+
+### 2.2 `atm log` Required Capabilities
+
+`atm log` needs the following shared behavior:
+
+- read retained structured records
+- follow new matching records
+- filter by severity level
+- filter by structured ATM fields such as `command`, `team`, `actor`, `target`,
+  `task_id`, and `outcome`
+- filter by time window
+- apply limit and ordering controls
+- render either human output or JSON from the ATM side without re-parsing raw
+  daemon-era files
+
+ATM-specific ownership for `atm log` should remain limited to:
+
+- ATM default filters
+- ATM field names and field projection
+- CLI rendering and JSON output shape
+
+### 2.3 `atm doctor` Required Capabilities
+
+`atm doctor` needs the following shared behavior:
+
+- initialize observability at process startup
+- expose in-process health state
+- report active log path / log-root resolution
+- expose sink/runtime degradation information
+- provide a queryable surface that can be probed so `doctor` can report whether
+  `atm log` is operational
+
+ATM-specific ownership for `atm doctor` should remain limited to:
+
+- command-local findings and severity grading
+- ATM config/env/path checks
+- ATM-specific recovery messaging
+
+## 3. Gap List Against Current `sc-observability`
+
+This section compares ATM requirements with the current shared repo at:
+
+- `/Users/randlee/Documents/github/sc-observability/crates/sc-observability`
+- `/Users/randlee/Documents/github/sc-observability/crates/sc-observe`
+- `/Users/randlee/Documents/github/sc-observability/crates/sc-observability-types`
+
+### 3.1 Capability Matrix
+
+| Required capability | Status | Current evidence | Gap summary |
+| --- | --- | --- | --- |
+| Structured log emission | Present | `sc-observability::Logger::emit`, `LogEmitter`, `LogEvent` | Shared logging emission already exists and matches ATM best-effort needs. |
+| In-process logging health | Present | `Logger::health`, `LoggingHealthReport`, `active_log_path` | Sufficient baseline for `atm doctor` health reporting. |
+| Top-level routing health | Present | `sc-observe::Observability::health`, `ObservabilityHealthReport` | Available if ATM later adopts typed routing; not required for MVP. |
+| Historical retained-log query | Missing | no public query/read API in `sc-observability` or `sc-observe` | ATM cannot implement `atm log` without building its own reader unless shared API is added. |
+| Follow/tail of new matching records | Missing | no public follow/tail API in `sc-observability` or `sc-observe` | ATM cannot implement `atm log --tail` on shared infra today. |
+| Severity filter on consumer path | Partial | `Level`, `LevelFilter`, `LogEvent.level` exist | The schema supports level filtering, but only emit/config surfaces exist; there is no shared query API to apply it on read. |
+| Structured field filtering on consumer path | Partial | `LogEvent.fields` exists | Structured fields exist, but there is no shared query/follow filter surface. |
+| Time-window filtering | Partial | `LogEvent.timestamp` exists | Timestamps exist, but there is no query surface for `since` / `until` filtering. |
+| Limit and ordering controls | Missing | no query result model | ATM has no shared way to request newest-first snapshots or capped result sets. |
+| Query readiness probe for doctor | Missing | health exists, query surface does not | `atm doctor` cannot verify `atm log` readiness until shared query/follow APIs exist. |
+
+### 3.2 Interpretation
+
+The current shared workspace is already good enough for:
+
+- ATM best-effort emission
+- ATM logging health inspection
+- future routing health, if ATM later chooses to emit typed observations
+
+The current shared workspace is not yet good enough for:
+
+- `atm log`
+- `atm log --tail`
+- the `atm doctor` check that verifies log-query readiness
+
+The missing capability is not generic logging itself. The missing capability is
+consumer-side access to the retained structured log records.
+
+## 4. Concrete API Requests For `arch-obs`
+
+ATM should ask `arch-obs` to add a shared log-reader/query/follow surface to
+`sc-observability`.
+
+This should live in `sc-observability`, not `sc-observe`, because the required
+behavior is part of the logging-only layer:
+
+- it operates on persisted `LogEvent` records
+- it should work for a basic CLI without the typed routing runtime
+- the shared repo architecture already says generic log query/follow behavior
+  belongs in the shared logging layer when possible
+
+### 4.1 Request 1: Public Log Query Model
+
+Add public neutral query types to `sc-observability` (or
+`sc-observability-types` if shared across crates) for retained-log access.
+
+Recommended minimum shape:
+
+```rust
+pub struct LogQuery {
+    pub service: Option<ServiceName>,
+    pub levels: Vec<Level>,
+    pub field_matches: Vec<FieldMatch>,
+    pub since: Option<Timestamp>,
+    pub until: Option<Timestamp>,
+    pub limit: Option<usize>,
+    pub order: LogOrder,
+}
+
+pub struct FieldMatch {
+    pub key: String,
+    pub value: serde_json::Value,
+}
+
+pub enum LogOrder {
+    NewestFirst,
+    OldestFirst,
+}
+```
+
+Required behavior:
+
+- service scoping
+- level filtering
+- exact structured field matching
+- time-window filtering
+- limit and ordering
+
+V1 does not need regex, fuzzy matching, or advanced predicates.
+
+### 4.2 Request 2: Public Historical Query API
+
+Add a public shared query surface in `sc-observability` for reading retained
+records.
+
+Recommended minimum shape:
+
+```rust
+pub struct LogSnapshot {
+    pub records: Vec<LogEvent>,
+    pub truncated: bool,
+}
+
+impl Logger {
+    pub fn query(&self, query: &LogQuery) -> Result<LogSnapshot, QueryError>;
+}
+```
+
+Equivalent alternatives are acceptable if they preserve the same behavior.
+
+Required behavior:
+
+- read from the shared JSONL log store
+- return structured `LogEvent` values, not raw lines
+- treat malformed/unreadable lines as typed query errors or skipped-record
+  accounting, not silent ATM-owned parsing work
+
+### 4.3 Request 3: Public Follow/Tail API
+
+Add a public follow surface for new matching records.
+
+Recommended minimum shape:
+
+```rust
+pub struct LogFollowOptions {
+    pub query: LogQuery,
+    pub from_end: bool,
+}
+
+pub struct LogFollowSession { /* opaque */ }
+
+impl Logger {
+    pub fn follow(&self, options: LogFollowOptions) -> Result<LogFollowSession, QueryError>;
+}
+
+impl LogFollowSession {
+    pub fn next(&mut self) -> Result<Option<LogEvent>, QueryError>;
+}
+```
+
+Required behavior:
+
+- filter new records using the same query semantics as historical reads
+- support tailing from the live end of the file
+- expose an owning session type rather than a callback-only API
+
+ATM does not need shared async streams in v1. A blocking iterator/session model
+is sufficient.
+
+### 4.4 Request 4: Query/Follow Error Surface
+
+Add a typed shared error for query/follow operations.
+
+Recommended minimum shape:
+
+- `QueryError` with structured diagnostic context
+- clear distinction between:
+  - invalid query input
+  - unreadable/missing log store
+  - malformed record decoding
+  - follow-session shutdown/unavailable state
+
+This is needed so `atm doctor` can convert shared query failures into stable
+diagnostic findings.
+
+### 4.5 Request 5: Query Health / Readiness Signal
+
+Either of the following is acceptable:
+
+1. extend `LoggingHealthReport` with explicit query-readiness information, or
+2. guarantee that `Logger::query(...limit=1...)` is the supported readiness
+   probe for the log reader surface
+
+ATM does not need a second health subsystem. It needs a reliable way for
+`atm doctor` to answer:
+
+- is logging initialized?
+- where is the active log file?
+- is the shared log query surface operational?
+
+### 4.6 Request 6: File-Scope Reader Independence
+
+Ensure the shared query/follow API works for logging-only consumers that use
+`sc-observability` directly, without forcing adoption of `sc-observe` or OTLP.
+
+This keeps the query/follow surface aligned with the documented layered design.
+
+## 5. ATM Port Boundary Decision
+
+The boundary decision is:
+
+- `atm-core::ObservabilityPort` stays ATM-owned
+- shared `sc-observability` owns generic emission, storage, query, follow, and
+  health mechanics
+- `atm` implements the ATM port by translating ATM query/event models into the
+  shared `sc-observability` API
+
+### 5.1 ATM-Owned Responsibilities
+
+The ATM port should continue to own:
+
+- ATM command lifecycle event names
+- ATM field names and ATM default query presets
+- CLI-facing `atm log` render/output behavior
+- CLI-facing `atm doctor` finding/report behavior
+- best-effort policy for mail-command emission
+
+### 5.2 Shared Responsibilities
+
+Shared `sc-observability` should own:
+
+- JSONL log writing
+- retained-record decoding
+- generic historical query
+- generic follow/tail mechanics
+- generic level/field/time filtering
+- generic limit/order behavior
+- in-process logging health snapshots
+
+### 5.3 Shared Responsibilities That ATM Does Not Need Yet
+
+ATM does not need the following to start Phase A/B implementation:
+
+- OTLP export
+- typed observation routing through `sc-observe`
+- ATM-specific envelope compatibility behavior
+- daemon-era spool/fan-in behavior
+
+Those remain separate concerns.
+
+## 6. Conclusion
+
+### 6.1 Shared-Crate Readiness
+
+Current shared-crate readiness is:
+
+- sufficient for ATM best-effort log emission
+- sufficient for ATM in-process logging health
+- not yet sufficient for `atm log`
+- not yet sufficient for the `atm doctor` check that validates `atm log`
+  readiness
+
+### 6.2 ATM-Local Query Engine Decision
+
+ATM should **not** build a local ad hoc log query engine.
+
+Reason:
+
+- the missing behavior is generic shared logging functionality, not ATM-specific
+  product logic
+- building an ATM-only JSONL reader/tailer would duplicate the shared logging
+  layer and create long-term ownership drift
+- the retained ATM architecture already expects generic query/follow mechanics
+  to live in the shared observability layer
+
+Therefore the required path is:
+
+1. `arch-obs` adds the shared query/follow/readiness API
+2. `atm` implements `ObservabilityPort` against that shared API
+3. `atm-core` keeps only ATM-specific event/query vocabulary and command logic
+
+### 6.3 Phase A Exit Condition
+
+`OBS-GAP-1` is complete once the shared API request is explicit and the ATM
+boundary decision is fixed.
+
+`OBS-GAP-1` does **not** require ATM to implement observability code yet. It
+requires the shared-observability blocker to be clearly defined so Phase B/C
+implementation can proceed without ATM inventing its own log-reader stack.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -82,6 +82,11 @@ Acceptance:
 
 ### Phase B: Core Skeleton
 
+| Sprint | Scope | Required outcome |
+| --- | --- | --- |
+| B.1 | CLI skeleton | `atm` exposes exactly `send`, `read`, `ack`, `clear`, `log`, `doctor` as clap subcommands and all CI gates pass |
+| B.2 | Documentation gap closure | lock the remaining send/read/clear requirements and architecture details before Phase C begins |
+
 Create:
 - workspace manifests
 - `atm-core`
@@ -91,6 +96,9 @@ Create:
 Acceptance:
 - workspace builds
 - CLI help shows `send`, `read`, `ack`, `clear`, `log`, and `doctor`
+- B.1 and B.2 are both complete before Phase C starts
+- requirements and architecture lock the message id, read dedupe, and clear
+  override semantics needed for implementation
 
 ### Phase C: Low-Level Reuse
 
@@ -209,7 +217,8 @@ Cross-document invariants that must stay locked during implementation:
 - `taskId` implies ack-required send behavior
 - displayed messages always persist `read = true`
 - pending-ack messages remain actionable until acknowledged
-- `atm clear` never removes unread or pending-ack messages
+- `atm clear` never removes unread messages
+- `atm clear` removes pending-ack messages only with explicit override
 - `atm read --timeout` returns immediately when the requested selection is already non-empty
 
 ## 6. Done Definition
@@ -222,7 +231,8 @@ The rewrite is ready when:
 - `atm log` works through shared observability APIs
 - `atm doctor` works as a local diagnostics command
 - retained non-daemon functionality is preserved or intentionally documented as changed
-- task-linked mail remains pending until acknowledged and cannot be cleared early
+- task-linked mail remains pending until acknowledged unless the operator uses
+  the explicit pending-ack clear override
 - the file-by-file migration plan is complete enough to implement directly
 - the retained command tests pass against the new crate layout
 

--- a/docs/read-behavior.md
+++ b/docs/read-behavior.md
@@ -25,6 +25,8 @@ The current command already has useful queue behavior that should survive the re
 - default view shows actionable work only
 - pending-ack messages stay visible until they are acknowledged
 - task-linked ack-required messages arrive already actionable
+- duplicate deliveries should collapse by `message_id` instead of showing the
+  same message repeatedly
 - history can be expanded without hiding actionable work
 - `--all` shows everything
 - older unread messages remain visible even when the seen-state watermark is newer
@@ -77,7 +79,8 @@ Current ack behavior:
 
 Current clear behavior that must survive:
 - clear removes acknowledged messages
-- pending-ack messages are not clearable
+- pending-ack messages are not clearable by default
+- an explicit override may clear stale pending-ack entries
 
 This behavior is messy in the current code because the state machine is implicit. The rewrite keeps the behavior but makes the state model explicit.
 
@@ -159,13 +162,14 @@ Ack workflow
 
 Clear workflow
   remove only (Read, NoAckRequired) and (Read, Acknowledged)
+  with explicit pending-ack override, also allow removal of pending-ack entries
 ```
 
 Disallowed transitions:
 - any transition that makes the read axis move from `Read` back to `Unread`
 - `Acknowledged -> PendingAck`
 - `Acknowledged -> NoAckRequired`
-- clearing a pending-ack message
+- clearing a pending-ack message without the explicit override
 - clearing an unread message
 - any transition that skips the legal graph
 
@@ -197,6 +201,12 @@ Watermark update rule:
 `--since <iso8601>` filters by message timestamp greater than or equal to the given value.
 
 `--from <name>` filters by sender name.
+
+Duplicate-collapse rule:
+- if multiple entries share the same non-null `message_id`, show only the most
+  recent entry
+- suppress earlier duplicates silently
+- if a record lacks `message_id`, do not merge it with any other record
 
 ## 8. Wait-Mode Rules
 
@@ -323,7 +333,9 @@ Cross-document invariants:
 - displayed messages always persist `read = true`
 - task-linked messages are ack-required from send time
 - pending-ack messages remain actionable until acknowledged
-- `atm clear` never removes unread or pending-ack messages
+- `atm clear` never removes unread messages
+- `atm clear` removes pending-ack messages only when the explicit override is
+  set
 - `--timeout` returns immediately when the requested selection is already non-empty
 
 `bucket_counts` fields:
@@ -338,6 +350,7 @@ An implementation of `atm read` is acceptable only if:
 - it keeps display buckets separate from the canonical axes
 - it preserves default actionable-queue behavior
 - it preserves the current pending-ack lifecycle
-- it preserves task-linked pending-ack visibility until acknowledgement
+- it preserves task-linked pending-ack visibility until acknowledgement unless
+  the operator explicitly invokes the pending-ack clear override
 - no daemon-only logic survives in core read behavior
 - read-axis and ack-axis transitions are enforced by API shape, not only by tests

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -206,6 +206,15 @@ Retired from the current implementation:
 - support dry-run without mutation
 - support sender-controlled ack-required messages
 - support optional task metadata on sent messages
+- write a non-null `message_id` on every ATM-authored message
+- generate `message_id` as a UUID v4 at send time
+
+`message_id` is required on every message written by `atm send`.
+
+Recipients use `message_id` for:
+- duplicate suppression
+- read-time duplicate collapse
+- acknowledgement targeting
 
 ### 6.4 Message Source Semantics
 
@@ -305,6 +314,7 @@ Read messages from one inbox.
 - verify target team exists
 - verify explicit target agent exists in team config
 - load messages from the merged inbox surface
+- deduplicate entries by `message_id` before bucket selection and output rendering
 - classify each message into the read axis, the ack axis, and a derived message class
 - map the derived message class into display buckets
 - support filtering by sender and timestamp
@@ -315,6 +325,16 @@ Read messages from one inbox.
 - persist read-triggered state changes back to the physical inbox file that owns each displayed message when origin inbox files are present in the merged surface
 - support optional wait mode with timeout
 - support optional seen-state filtering and updates
+
+When multiple inbox entries share the same non-null `message_id`, `atm read`
+must display only the most recent entry. Earlier duplicates are silently
+suppressed.
+
+Deduplication order:
+- compare entries by `message_id`
+- keep the newest entry by message timestamp
+- when timestamps are equal, keep the later record encountered in inbox order
+- do not emit suppressed duplicates in either human or JSON output
 
 `--timeout` preserves the current queue-first behavior: if the requested read selection already contains unread or pending-ack messages at command start, the command returns immediately with those messages. It blocks only when the requested selection is empty at command start.
 
@@ -507,6 +527,7 @@ Remove non-actionable messages from one inbox without touching actionable work.
 - optional target agent: `agent` or `agent@team`
 - `--team <name>`
 - `--older-than <duration>`
+- `--all-pending-ack`
 - `--idle-only`
 - `--dry-run`
 - `--json`
@@ -522,7 +543,7 @@ Default clear behavior removes only clearable messages:
 - `(Read, NoAckRequired)`
 - `(Read, Acknowledged)`
 
-Clear must never remove:
+Without `--all-pending-ack`, clear must never remove:
 - `(Unread, NoAckRequired)`
 - `(Unread, PendingAck)`
 - `(Read, PendingAck)`
@@ -530,8 +551,14 @@ Clear must never remove:
 Additional rules:
 - `--idle-only` narrows removal to idle-notification messages only
 - `--older-than` further filters the clearable set by message timestamp age
+- `--all-pending-ack` expands the clearable set to include entries with ack
+  axis `PendingAck`
+- combining `--older-than 7d --all-pending-ack` clears stale pending-ack items
 - dry-run returns the computed removal set without mutation
 - clearing must preserve unknown fields on messages that remain
+
+`--all-pending-ack` does not make unread non-ack mail clearable. It only adds
+pending-ack entries to the otherwise clearable set.
 
 ### 9.4 Output Contract
 
@@ -675,6 +702,14 @@ Optional fields:
 - `acknowledgesMessageId`
 
 Unknown fields must be preserved.
+
+For ATM-authored messages:
+- `message_id` is mandatory
+- `message_id` must be UUID v4
+- `message_id` must not be null or blank
+
+Legacy or externally imported records may still omit `message_id`; the rewrite
+must preserve such records without inventing synthetic ids during read.
 
 ### 12.2 Two-Axis Canonical Model
 
@@ -822,6 +857,7 @@ Mutation failures must be fail-safe:
 - mailbox writes must be atomic
 - concurrent appends must not silently lose messages
 - duplicate message ids must not be appended twice
+- read-time duplicate message ids collapse to the newest visible entry
 - corrupt records should be skipped individually when possible
 - missing inbox files are treated as empty inboxes
 - seen-state races must not corrupt mailbox data
@@ -862,7 +898,8 @@ The rewrite is ready when:
 - workflow-axis classification is correct
 - workflow-axis transitions are encoded in implementation structure
 - display buckets are derived consistently from the two-axis model
-- task-linked messages remain pending until acknowledged and cannot be cleared early
+- task-linked messages remain pending until acknowledged unless the operator
+  explicitly invokes `--all-pending-ack`
 - observability integration is exercised by automated tests
 - the file-by-file migration plan is complete enough to implement directly
 
@@ -870,5 +907,7 @@ Cross-document invariants that must remain true:
 - `taskId` implies ack-required behavior at send time
 - displayed messages always persist `read = true`
 - pending-ack messages remain actionable until acknowledged
-- `atm clear` never removes unread or pending-ack messages
+- `atm clear` never removes unread messages
+- `atm clear` removes pending-ack messages only when `--all-pending-ack` is
+  explicitly set
 - `atm read --timeout` returns immediately when the requested selection is already non-empty

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -206,6 +206,7 @@ Retired from the current implementation:
 - support dry-run without mutation
 - support sender-controlled ack-required messages
 - support optional task metadata on sent messages
+- `atm send` MUST generate and write a non-null UUID v4 as `message_id` for every sent message. `message_id` is optional in the persisted schema (§12.1) to support legacy messages written by older clients, but `atm send` never omits it.
 - write a non-null `message_id` on every ATM-authored message
 - generate `message_id` as a UUID v4 at send time
 


### PR DESCRIPTION
## Sprint E.1 — Read Path

Implements the full `atm read` command end-to-end.

### Deliverables
- `read/state.rs` — `classify_message()` deriving `MessageClass` from persisted fields
- `read/filters.rs` — sender, timestamp, and selection-mode filters with seen-state watermark logic
- `read/seen_state.rs` — load/save watermark at `.claude/teams/<team>/.seen/<agent>`
- `read/wait.rs` — polling timeout wait for eligible messages
- `read/mod.rs` — `read_mail(query: ReadQuery, obs) -> Result<ReadOutcome>` (16-step pipeline)
- `commands/read.rs` — all flags from requirements §7.2, mutual exclusion, ack-activation
- `output.rs` — human (queue heading + buckets + collapsed-history note) + JSON output
- Integration tests with tempdir ATM_HOME

### Validation
- `cargo build --workspace` ✓
- `cargo test --workspace` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo fmt --all -- --check` ✓

🤖 Generated with [Claude Code](https://claude.ai/claude-code)