### PR TITLE
fix: rust-best-practices blockers (typestate, IsoTimestamp, clear counters, parse_duration)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop, main, "integrate/**"]
   push:
-    branches: [develop, main]
+    branches: [develop, main, "integrate/**"]
 
 jobs:
   fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,39 +2,58 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop, main, "integrate/**"]
+    branches: [develop, main, "integrate/*"]
   push:
-    branches: [develop, main, "integrate/**"]
+    branches: [develop, main]
 
 jobs:
   fmt:
+    name: Format check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
+
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: cargo fmt --check --all
 
   clippy:
+    name: Clippy
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
         with:
-          toolchain: stable
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
+          path: ~/.cargo/registry
+          key: ubuntu-clippy-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ubuntu-clippy-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ubuntu-clippy-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
+    name: Test (${{ matrix.os }})
     needs: [clippy]
     strategy:
       fail-fast: false
@@ -43,10 +62,30 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
         with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build workspace
+        run: cargo build --verbose
+
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo test --verbose

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 use serde_json::Map;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::address::AgentAddress;
@@ -276,7 +277,18 @@ fn discover_origin_inboxes(inboxes_dir: &Path, agent: &str) -> Result<Vec<PathBu
             )
             .with_source(error)
         })?
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry.path()),
+            Err(error) => {
+                warn!(
+                    inbox_dir = %inboxes_dir.display(),
+                    agent,
+                    %error,
+                    "skipping unreadable origin inbox entry"
+                );
+                None
+            }
+        })
         .filter(|path| {
             path.file_name()
                 .and_then(|value| value.to_str())

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 use serde_json::Map;
-use tracing::warn;
+use tracing::{trace, warn};
 use uuid::Uuid;
 
 use crate::address::AgentAddress;
@@ -80,6 +80,17 @@ pub fn ack_mail(
     let mut source_files = load_source_files(&request.home_dir, &team, &actor)?;
     let source_message = dedupe_sourced_messages(merged_surface(&source_files))
         .into_iter()
+        .filter_map(|message| match message.envelope.message_id {
+            Some(_) => Some(message),
+            None => {
+                trace!(
+                    source_path = %message.source_path.display(),
+                    source_index = message.source_index,
+                    "skipping source message without message_id during ack lookup"
+                );
+                None
+            }
+        })
         .find(|message| message.envelope.message_id == Some(request.message_id))
         .ok_or_else(|| {
             AtmError::validation(format!(
@@ -166,7 +177,7 @@ pub fn ack_mail(
         team,
         agent: actor.clone(),
         sender: actor,
-        message_id: request.message_id.to_string(),
+        message_id: Some(request.message_id),
         requires_ack: false,
         dry_run: false,
         task_id: source_task_id,
@@ -266,6 +277,7 @@ fn discover_origin_inboxes(inboxes_dir: &Path, agent: &str) -> Result<Vec<PathBu
     }
 
     let prefix = format!("{agent}.");
+    let primary = format!("{agent}.json");
     let mut paths = fs::read_dir(inboxes_dir)
         .map_err(|error| {
             AtmError::new(
@@ -292,11 +304,7 @@ fn discover_origin_inboxes(inboxes_dir: &Path, agent: &str) -> Result<Vec<PathBu
         .filter(|path| {
             path.file_name()
                 .and_then(|value| value.to_str())
-                .map(|name| {
-                    name.starts_with(&prefix)
-                        && name.ends_with(".json")
-                        && name != format!("{agent}.json")
-                })
+                .map(|name| name.starts_with(&prefix) && name.ends_with(".json") && name != primary)
                 .unwrap_or(false)
         })
         .collect::<Vec<_>>();
@@ -319,7 +327,6 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
                     source_path: source.path.clone(),
                     source_index,
                 })
-                .collect::<Vec<_>>()
         })
         .collect()
 }
@@ -381,7 +388,7 @@ fn update_source_message(
     let transitioned = state::StoredMessage::<
         crate::types::ReadReadState,
         crate::types::PendingAckState,
-    >::from_envelope(stored.clone())
+    >::read_pending_ack(stored.clone())
     .acknowledge(acknowledged_at)
     .envelope;
     *stored = transitioned;

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::Map;
 use uuid::Uuid;
@@ -17,7 +16,7 @@ use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
 use crate::schema::{MessageEnvelope, TeamConfig};
 use crate::send::{input, summary};
-use crate::types::{IsoTimestamp, MessageClass};
+use crate::types::IsoTimestamp;
 
 #[derive(Debug, Clone)]
 pub struct AckRequest {
@@ -88,9 +87,12 @@ pub fn ack_mail(
             ))
         })?;
 
-    match state::classify_message(&source_message.envelope) {
-        MessageClass::PendingAck => {}
-        MessageClass::Acknowledged => {
+    match (
+        state::derive_read_state(&source_message.envelope),
+        state::derive_ack_state(&source_message.envelope),
+    ) {
+        (crate::types::ReadState::Read, crate::types::AckState::PendingAck) => {}
+        (_, crate::types::AckState::Acknowledged) => {
             return Err(AtmError::validation(format!(
                 "message {} is already acknowledged",
                 request.message_id
@@ -98,7 +100,7 @@ pub fn ack_mail(
         }
         _ => {
             return Err(AtmError::validation(format!(
-                "message {} is not pending acknowledgement",
+                "message {} is not in the (read, pending_ack) state",
                 request.message_id
             )));
         }
@@ -126,7 +128,7 @@ pub fn ack_mail(
     let reply_message = MessageEnvelope {
         from: actor.clone(),
         text: reply_text.clone(),
-        timestamp: ack_timestamp.into_inner(),
+        timestamp: ack_timestamp,
         read: false,
         source_team: Some(team.clone()),
         summary: Some(summary::build_summary(&reply_text, None)),
@@ -138,11 +140,7 @@ pub fn ack_mail(
         extra: Map::new(),
     };
 
-    update_source_message(
-        &mut source_files,
-        &source_message,
-        ack_timestamp.into_inner(),
-    )?;
+    update_source_message(&mut source_files, &source_message, ack_timestamp)?;
 
     let reply_inbox_path =
         home::inbox_path_from_home(&request.home_dir, &reply_team, &reply_agent)?;
@@ -315,7 +313,7 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
-    let mut latest_for_id: HashMap<Uuid, (DateTime<Utc>, usize)> = HashMap::new();
+    let mut latest_for_id: HashMap<Uuid, (IsoTimestamp, usize)> = HashMap::new();
     for (index, message) in messages.iter().enumerate() {
         if let Some(message_id) = message.envelope.message_id {
             latest_for_id
@@ -346,7 +344,7 @@ fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage>
 fn update_source_message(
     source_files: &mut [SourceFile],
     source_message: &SourcedMessage,
-    acknowledged_at: DateTime<Utc>,
+    acknowledged_at: IsoTimestamp,
 ) -> Result<(), AtmError> {
     let source_file = source_files
         .iter_mut()
@@ -368,9 +366,13 @@ fn update_source_message(
             ))
         })?;
 
-    stored.read = true;
-    stored.pending_ack_at = None;
-    stored.acknowledged_at = Some(acknowledged_at);
+    let transitioned = state::StoredMessage::<
+        crate::types::ReadReadState,
+        crate::types::PendingAckState,
+    >::from_envelope(stored.clone())
+    .acknowledge(acknowledged_at)
+    .envelope;
+    *stored = transitioned;
     Ok(())
 }
 

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -133,7 +133,7 @@ pub fn clear_mail(
         team: outcome.team.clone(),
         agent: outcome.agent.clone(),
         sender: actor,
-        message_id: String::new(),
+        message_id: None,
         requires_ack: false,
         dry_run: query.dry_run,
         task_id: None,
@@ -249,6 +249,7 @@ fn discover_origin_inboxes(inboxes_dir: &Path, agent: &str) -> Result<Vec<PathBu
     }
 
     let prefix = format!("{agent}.");
+    let primary = format!("{agent}.json");
     let mut paths = fs::read_dir(inboxes_dir)
         .map_err(|error| {
             AtmError::new(
@@ -275,11 +276,7 @@ fn discover_origin_inboxes(inboxes_dir: &Path, agent: &str) -> Result<Vec<PathBu
         .filter(|path| {
             path.file_name()
                 .and_then(|value| value.to_str())
-                .map(|name| {
-                    name.starts_with(&prefix)
-                        && name.ends_with(".json")
-                        && name != format!("{agent}.json")
-                })
+                .map(|name| name.starts_with(&prefix) && name.ends_with(".json") && name != primary)
                 .unwrap_or(false)
         })
         .collect::<Vec<_>>();
@@ -302,7 +299,6 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
                     source_path: source.path.clone(),
                     source_index,
                 })
-                .collect::<Vec<_>>()
         })
         .collect()
 }

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use chrono::{DateTime, TimeDelta, Utc};
 use serde::Serialize;
 use serde_json::Value;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::address::AgentAddress;
@@ -259,7 +260,18 @@ fn discover_origin_inboxes(inboxes_dir: &Path, agent: &str) -> Result<Vec<PathBu
             )
             .with_source(error)
         })?
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry.path()),
+            Err(error) => {
+                warn!(
+                    inbox_dir = %inboxes_dir.display(),
+                    agent,
+                    %error,
+                    "skipping unreadable origin inbox entry"
+                );
+                None
+            }
+        })
         .filter(|path| {
             path.file_name()
                 .and_then(|value| value.to_str())

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -33,8 +33,6 @@ pub struct ClearQuery {
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct RemovedByClass {
-    pub unread: usize,
-    pub pending_ack: usize,
     pub acknowledged: usize,
     pub read: usize,
 }
@@ -298,7 +296,7 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
-    let mut latest_for_id: HashMap<Uuid, (DateTime<Utc>, usize)> = HashMap::new();
+    let mut latest_for_id: HashMap<Uuid, (crate::types::IsoTimestamp, usize)> = HashMap::new();
     for (index, message) in messages.iter().enumerate() {
         if let Some(message_id) = message.envelope.message_id {
             latest_for_id
@@ -342,7 +340,7 @@ fn is_clearable(message: &SourcedMessage, cutoff: Option<DateTime<Utc>>, idle_on
     let class = state::classify_message(&message.envelope);
     matches!(class, MessageClass::Read | MessageClass::Acknowledged)
         && cutoff
-            .map(|cutoff| message.envelope.timestamp <= cutoff)
+            .map(|cutoff| message.envelope.timestamp.into_inner() <= cutoff)
             .unwrap_or(true)
         && (!idle_only || is_idle_notification(&message.envelope))
 }
@@ -357,8 +355,8 @@ fn is_idle_notification(message: &MessageEnvelope) -> bool {
 
 fn count_removed(counts: &mut RemovedByClass, class: MessageClass) {
     match class {
-        MessageClass::Unread => counts.unread += 1,
-        MessageClass::PendingAck => counts.pending_ack += 1,
+        MessageClass::Unread => unreachable!("unread messages are never clearable"),
+        MessageClass::PendingAck => unreachable!("pending-ack messages are never clearable"),
         MessageClass::Acknowledged => counts.acknowledged += 1,
         MessageClass::Read => counts.read += 1,
     }

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -356,9 +356,8 @@ fn is_clearable(message: &SourcedMessage, cutoff: Option<DateTime<Utc>>, idle_on
 fn is_idle_notification(message: &MessageEnvelope) -> bool {
     serde_json::from_str::<Value>(&message.text)
         .ok()
-        .and_then(|value| value.get("type").and_then(Value::as_str).map(str::to_owned))
-        .as_deref()
-        == Some("idle_notification")
+        .map(|value| value.get("type").and_then(Value::as_str) == Some("idle_notification"))
+        .unwrap_or(false)
 }
 
 fn count_removed(counts: &mut RemovedByClass, class: MessageClass) {

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -16,14 +16,21 @@ pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
         return Ok(None);
     };
 
-    let contents = fs::read_to_string(path).map_err(|error| {
+    let contents = fs::read_to_string(&path).map_err(|error| {
         AtmError::new(
             AtmErrorKind::Config,
-            format!("failed to read config: {error}"),
+            format!("failed to read config at {}: {error}", path.display()),
         )
         .with_source(error)
     })?;
-    Ok(Some(toml::from_str(&contents)?))
+    let parsed = toml::from_str(&contents).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::Config,
+            format!("failed to parse config at {}: {error}", path.display()),
+        )
+        .with_source(error)
+    })?;
+    Ok(Some(parsed))
 }
 
 pub fn resolve_identity(config: Option<&AtmConfig>) -> Option<String> {

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -1,3 +1,4 @@
+use std::backtrace::Backtrace;
 use std::error::Error as StdError;
 use std::fmt;
 
@@ -21,10 +22,11 @@ pub enum AtmErrorKind {
 
 #[derive(Debug)]
 pub struct AtmError {
-    pub kind: AtmErrorKind,
+    pub(crate) kind: AtmErrorKind,
     pub message: String,
     pub recovery: Option<String>,
     pub source: Option<Box<dyn StdError + Send + Sync>>,
+    pub backtrace: Backtrace,
 }
 
 impl AtmError {
@@ -34,7 +36,64 @@ impl AtmError {
             message: message.into(),
             recovery: None,
             source: None,
+            backtrace: Backtrace::capture(),
         }
+    }
+
+    pub fn is_config(&self) -> bool {
+        self.kind == AtmErrorKind::Config
+    }
+
+    pub fn is_address(&self) -> bool {
+        self.kind == AtmErrorKind::Address
+    }
+
+    pub fn is_identity(&self) -> bool {
+        self.kind == AtmErrorKind::Identity
+    }
+
+    pub fn is_team_not_found(&self) -> bool {
+        self.kind == AtmErrorKind::TeamNotFound
+    }
+
+    pub fn is_agent_not_found(&self) -> bool {
+        self.kind == AtmErrorKind::AgentNotFound
+    }
+
+    pub fn is_mailbox_read(&self) -> bool {
+        self.kind == AtmErrorKind::MailboxRead
+    }
+
+    pub fn is_mailbox_write(&self) -> bool {
+        self.kind == AtmErrorKind::MailboxWrite
+    }
+
+    pub fn is_file_policy(&self) -> bool {
+        self.kind == AtmErrorKind::FilePolicy
+    }
+
+    pub fn is_validation(&self) -> bool {
+        self.kind == AtmErrorKind::Validation
+    }
+
+    pub fn is_serialization(&self) -> bool {
+        self.kind == AtmErrorKind::Serialization
+    }
+
+    pub fn is_timeout(&self) -> bool {
+        self.kind == AtmErrorKind::Timeout
+    }
+
+    pub fn is_observability_emit(&self) -> bool {
+        self.kind == AtmErrorKind::ObservabilityEmit
+    }
+
+    pub fn is_observability_query(&self) -> bool {
+        self.kind == AtmErrorKind::ObservabilityQuery
+    }
+
+    pub fn is_observability_health(&self) -> bool {
+        self.kind == AtmErrorKind::ObservabilityHealth
     }
 
     pub fn with_recovery(mut self, recovery: impl Into<String>) -> Self {
@@ -125,12 +184,6 @@ impl StdError for AtmError {
         self.source
             .as_deref()
             .map(|source| source as &(dyn StdError + 'static))
-    }
-}
-
-impl From<std::io::Error> for AtmError {
-    fn from(source: std::io::Error) -> Self {
-        Self::new(AtmErrorKind::MailboxWrite, format!("io error: {source}")).with_source(source)
     }
 }
 

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -3,7 +3,7 @@ use std::error::Error as StdError;
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AtmErrorKind {
+pub(crate) enum AtmErrorKind {
     Config,
     Address,
     Identity,
@@ -30,7 +30,7 @@ pub struct AtmError {
 }
 
 impl AtmError {
-    pub fn new(kind: AtmErrorKind, message: impl Into<String>) -> Self {
+    pub(crate) fn new(kind: AtmErrorKind, message: impl Into<String>) -> Self {
         Self {
             kind,
             message: message.into(),

--- a/crates/atm-core/src/identity/hook.rs
+++ b/crates/atm-core/src/identity/hook.rs
@@ -6,6 +6,7 @@ use crate::error::AtmError;
 
 const HOOK_FILE_TTL_SECS: f64 = 5.0;
 
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HookIdentity {
     pub agent: String,

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -1,6 +1,7 @@
 pub mod hook;
 
-pub use hook::HookIdentity;
+#[cfg(test)]
+use hook::HookIdentity;
 
 use crate::config::AtmConfig;
 use crate::error::AtmError;
@@ -9,6 +10,7 @@ pub fn resolve_sender_identity(config: Option<&AtmConfig>) -> Result<String, Atm
     crate::config::resolve_identity(config).ok_or_else(AtmError::identity_unavailable)
 }
 
+#[cfg(test)]
 pub fn resolve_hook_identity(
     team_override: Option<&str>,
     config: Option<&AtmConfig>,

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -1,17 +1,34 @@
+/// Acknowledgement workflows for ack-required mailbox messages.
 pub mod ack;
-pub mod address;
+/// Internal agent-address parsing and normalization helpers.
+pub(crate) mod address;
+/// Mailbox cleanup workflows for read and acknowledged messages.
 pub mod clear;
-pub mod config;
+/// Internal configuration discovery and resolution helpers.
+pub(crate) mod config;
+/// Doctor-report types and health checks for the CLI surface.
 pub mod doctor;
+/// Shared ATM error types and recovery-oriented error helpers.
 pub mod error;
+/// Public ATM home and team-path resolution helpers.
 pub mod home;
-pub mod identity;
+/// Internal identity resolution and hook lookup helpers.
+pub(crate) mod identity;
+/// Log query and filtering types for the CLI log surface.
 pub mod log;
-pub mod mailbox;
-pub mod model_registry;
+/// Internal mailbox persistence and parsing helpers.
+pub(crate) mod mailbox;
+/// Internal model-registry plumbing reserved for follow-on work.
+pub(crate) mod model_registry;
+/// Observability adapter traits and event payload types.
 pub mod observability;
+/// Mailbox read/query workflows and output models.
 pub mod read;
+/// Public mailbox and team schema types shared with CLI tests and adapters.
 pub mod schema;
+/// Mailbox send workflows and request/response models.
 pub mod send;
-pub mod text;
+/// Internal text-formatting helpers used by ATM core surfaces.
+pub(crate) mod text;
+/// Shared enums and semantic newtypes used across ATM core workflows.
 pub mod types;

--- a/crates/atm-core/src/mailbox/hash.rs
+++ b/crates/atm-core/src/mailbox/hash.rs
@@ -1,1 +1,1 @@
-// TODO: implement mailbox hashing helpers.
+//! Internal mailbox hashing helpers reserved for future implementation.

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -1,1 +1,1 @@
-// TODO: implement mailbox locking helpers.
+//! Internal mailbox locking helpers reserved for future implementation.

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -27,7 +27,7 @@ pub fn read_messages(path: &Path) -> Result<Vec<MessageEnvelope>, AtmError> {
     let file = fs::File::open(path).map_err(|error| {
         AtmError::new(
             AtmErrorKind::MailboxRead,
-            format!("failed to open mailbox file: {error}"),
+            format!("failed to open mailbox file {}: {error}", path.display()),
         )
         .with_source(error)
     })?;
@@ -38,7 +38,11 @@ pub fn read_messages(path: &Path) -> Result<Vec<MessageEnvelope>, AtmError> {
         let line = line.map_err(|error| {
             AtmError::new(
                 AtmErrorKind::MailboxRead,
-                format!("failed to read mailbox line: {error}"),
+                format!(
+                    "failed to read mailbox line {} from {}: {error}",
+                    index + 1,
+                    path.display()
+                ),
             )
             .with_source(error)
         })?;

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -1,7 +1,7 @@
-pub mod atomic;
-pub mod hash;
-pub mod lock;
-pub mod store;
+pub(crate) mod atomic;
+pub(crate) mod hash;
+pub(crate) mod lock;
+pub(crate) mod store;
 
 use std::collections::HashMap;
 use std::fs;
@@ -124,7 +124,7 @@ mod tests {
         let message_id = Uuid::new_v4();
         let first = sample_message(message_id, "first");
         let mut second = sample_message(message_id, "second");
-        second.timestamp = IsoTimestamp(
+        second.timestamp = IsoTimestamp::from_datetime(
             Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
                 .single()
                 .expect("timestamp"),
@@ -146,7 +146,7 @@ mod tests {
         MessageEnvelope {
             from: "arch-ctm".into(),
             text: body.into(),
-            timestamp: IsoTimestamp(
+            timestamp: IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
                     .single()
                     .expect("timestamp"),

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -82,6 +82,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::schema::MessageEnvelope;
+    use crate::types::IsoTimestamp;
 
     use super::{append_message, read_messages};
 
@@ -119,10 +120,11 @@ mod tests {
         let message_id = Uuid::new_v4();
         let first = sample_message(message_id, "first");
         let mut second = sample_message(message_id, "second");
-        second.timestamp = Utc
-            .with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
-            .single()
-            .expect("timestamp");
+        second.timestamp = IsoTimestamp(
+            Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
+                .single()
+                .expect("timestamp"),
+        );
 
         let contents = format!(
             "{}\n{}\n",
@@ -140,10 +142,11 @@ mod tests {
         MessageEnvelope {
             from: "arch-ctm".into(),
             text: body.into(),
-            timestamp: Utc
-                .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
-                .single()
-                .expect("timestamp"),
+            timestamp: IsoTimestamp(
+                Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                    .single()
+                    .expect("timestamp"),
+            ),
             read: false,
             source_team: Some("atm-dev".into()),
             summary: None,

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -1,1 +1,1 @@
-// TODO: implement mailbox storage access.
+//! Internal mailbox storage helpers reserved for future implementation.

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use uuid::Uuid;
 
 use crate::error::AtmError;
 
@@ -10,7 +11,7 @@ pub struct CommandEvent {
     pub team: String,
     pub agent: String,
     pub sender: String,
-    pub message_id: String,
+    pub message_id: Option<Uuid>,
     pub requires_ack: bool,
     pub dry_run: bool,
     pub task_id: Option<String>,

--- a/crates/atm-core/src/read/filters.rs
+++ b/crates/atm-core/src/read/filters.rs
@@ -23,7 +23,7 @@ pub fn apply_timestamp_filter(
     match since {
         Some(since) => messages
             .into_iter()
-            .filter(|message| message.envelope.timestamp >= since)
+            .filter(|message| message.envelope.timestamp.into_inner() >= since)
             .collect(),
         None => messages,
     }
@@ -54,7 +54,7 @@ pub fn apply_selection_mode(
 
 fn history_visible(message: &ClassifiedMessage, seen_watermark: Option<DateTime<Utc>>) -> bool {
     match seen_watermark {
-        Some(watermark) => message.envelope.timestamp > watermark,
+        Some(watermark) => message.envelope.timestamp.into_inner() > watermark,
         None => true,
     }
 }

--- a/crates/atm-core/src/read/filters.rs
+++ b/crates/atm-core/src/read/filters.rs
@@ -1,7 +1,5 @@
-use chrono::{DateTime, Utc};
-
 use crate::read::ClassifiedMessage;
-use crate::types::{DisplayBucket, ReadSelection};
+use crate::types::{DisplayBucket, IsoTimestamp, ReadSelection};
 
 pub fn apply_sender_filter(
     messages: Vec<ClassifiedMessage>,
@@ -18,12 +16,12 @@ pub fn apply_sender_filter(
 
 pub fn apply_timestamp_filter(
     messages: Vec<ClassifiedMessage>,
-    since: Option<DateTime<Utc>>,
+    since: Option<IsoTimestamp>,
 ) -> Vec<ClassifiedMessage> {
     match since {
         Some(since) => messages
             .into_iter()
-            .filter(|message| message.envelope.timestamp.into_inner() >= since)
+            .filter(|message| message.envelope.timestamp >= since)
             .collect(),
         None => messages,
     }
@@ -32,7 +30,7 @@ pub fn apply_timestamp_filter(
 pub fn apply_selection_mode(
     messages: Vec<ClassifiedMessage>,
     mode: ReadSelection,
-    seen_watermark: Option<DateTime<Utc>>,
+    seen_watermark: Option<IsoTimestamp>,
 ) -> Vec<ClassifiedMessage> {
     messages
         .into_iter()
@@ -52,9 +50,9 @@ pub fn apply_selection_mode(
         .collect()
 }
 
-fn history_visible(message: &ClassifiedMessage, seen_watermark: Option<DateTime<Utc>>) -> bool {
+fn history_visible(message: &ClassifiedMessage, seen_watermark: Option<IsoTimestamp>) -> bool {
     match seen_watermark {
-        Some(watermark) => message.envelope.timestamp.into_inner() > watermark,
+        Some(watermark) => message.envelope.timestamp > watermark,
         None => true,
     }
 }

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::address::AgentAddress;
@@ -368,7 +369,18 @@ fn discover_origin_inboxes(inboxes_dir: &Path, agent: &str) -> Result<Vec<PathBu
             )
             .with_source(error)
         })?
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry.path()),
+            Err(error) => {
+                warn!(
+                    inbox_dir = %inboxes_dir.display(),
+                    agent,
+                    %error,
+                    "skipping unreadable origin inbox entry"
+                );
+                None
+            }
+        })
         .filter(|path| {
             path.file_name()
                 .and_then(|value| value.to_str())

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tracing::warn;
 use uuid::Uuid;
@@ -35,7 +34,7 @@ pub struct ReadQuery {
     pub ack_activation_mode: AckActivationMode,
     pub limit: Option<usize>,
     pub sender_filter: Option<String>,
-    pub timestamp_filter: Option<DateTime<Utc>>,
+    pub timestamp_filter: Option<IsoTimestamp>,
     pub timeout_secs: Option<u64>,
 }
 
@@ -78,7 +77,7 @@ struct SourceFile {
 }
 
 #[derive(Debug, Clone)]
-pub struct SourcedMessage {
+struct SourcedMessage {
     pub envelope: MessageEnvelope,
     pub source_path: PathBuf,
     pub source_index: usize,
@@ -200,7 +199,7 @@ pub fn read_mail(
                 &query.home_dir,
                 &target.team,
                 &target.agent,
-                latest_timestamp.into_inner(),
+                latest_timestamp,
             )?;
         }
     }
@@ -244,7 +243,7 @@ pub fn read_mail(
         team: outcome.team.clone(),
         agent: outcome.agent.clone(),
         sender: actor,
-        message_id: String::new(),
+        message_id: None,
         requires_ack: false,
         dry_run: false,
         task_id: None,
@@ -358,6 +357,7 @@ fn discover_origin_inboxes(inboxes_dir: &Path, agent: &str) -> Result<Vec<PathBu
     }
 
     let prefix = format!("{agent}.");
+    let primary = format!("{agent}.json");
     let mut paths = fs::read_dir(inboxes_dir)
         .map_err(|error| {
             AtmError::new(
@@ -384,11 +384,7 @@ fn discover_origin_inboxes(inboxes_dir: &Path, agent: &str) -> Result<Vec<PathBu
         .filter(|path| {
             path.file_name()
                 .and_then(|value| value.to_str())
-                .map(|name| {
-                    name.starts_with(&prefix)
-                        && name.ends_with(".json")
-                        && name != format!("{agent}.json")
-                })
+                .map(|name| name.starts_with(&prefix) && name.ends_with(".json") && name != primary)
                 .unwrap_or(false)
         })
         .collect::<Vec<_>>();
@@ -411,7 +407,6 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
                     source_path: source.path.clone(),
                     source_index,
                 })
-                .collect::<Vec<_>>()
         })
         .collect()
 }
@@ -466,7 +461,7 @@ fn classify_all(messages: Vec<SourcedMessage>) -> Vec<ClassifiedMessage> {
 fn apply_filters(
     messages: Vec<ClassifiedMessage>,
     sender_filter: Option<&str>,
-    timestamp_filter: Option<DateTime<Utc>>,
+    timestamp_filter: Option<IsoTimestamp>,
 ) -> Vec<ClassifiedMessage> {
     filters::apply_timestamp_filter(
         filters::apply_sender_filter(messages, sender_filter),
@@ -495,7 +490,7 @@ fn bucket_counts_for(messages: &[ClassifiedMessage]) -> BucketCounts {
 fn select_messages(
     messages: &[ClassifiedMessage],
     selection_mode: ReadSelection,
-    seen_watermark: Option<DateTime<Utc>>,
+    seen_watermark: Option<IsoTimestamp>,
 ) -> Vec<ClassifiedMessage> {
     let watermark = if selection_mode == ReadSelection::All {
         None
@@ -509,7 +504,7 @@ fn select_messages(
 fn selected_after_filters(
     messages: &[SourcedMessage],
     query: &ReadQuery,
-    seen_watermark: Option<DateTime<Utc>>,
+    seen_watermark: Option<IsoTimestamp>,
 ) -> Vec<ClassifiedMessage> {
     let classified = classify_all(messages.to_vec());
     let filtered = apply_filters(
@@ -561,7 +556,7 @@ fn transition_displayed_message(
     match (read_state, ack_state) {
         (crate::types::ReadState::Unread, crate::types::AckState::NoAckRequired) if promote_unread => {
             state::TransitionedMessage::ReadPendingAck(
-                state::StoredMessage::<crate::types::UnreadReadState, crate::types::NoAckState>::from_envelope(
+                state::StoredMessage::<crate::types::UnreadReadState, crate::types::NoAckState>::unread_no_ack(
                     message.envelope.clone(),
                 )
                 .display_and_require_ack(now),
@@ -569,7 +564,7 @@ fn transition_displayed_message(
         }
         (crate::types::ReadState::Unread, crate::types::AckState::NoAckRequired) => {
             state::TransitionedMessage::ReadNoAck(
-                state::StoredMessage::<crate::types::UnreadReadState, crate::types::NoAckState>::from_envelope(
+                state::StoredMessage::<crate::types::UnreadReadState, crate::types::NoAckState>::unread_no_ack(
                     message.envelope.clone(),
                 )
                 .display_without_ack(),
@@ -580,7 +575,7 @@ fn transition_displayed_message(
                 state::StoredMessage::<
                     crate::types::UnreadReadState,
                     crate::types::PendingAckState,
-                >::from_envelope(message.envelope.clone())
+                >::unread_pending_ack(message.envelope.clone())
                 .mark_read_pending_ack(),
             )
         }

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -199,7 +199,7 @@ pub fn read_mail(
                 &query.home_dir,
                 &target.team,
                 &target.agent,
-                latest_timestamp,
+                latest_timestamp.into_inner(),
             )?;
         }
     }
@@ -405,7 +405,7 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
-    let mut latest_for_id: HashMap<Uuid, (DateTime<Utc>, usize)> = HashMap::new();
+    let mut latest_for_id: HashMap<Uuid, (IsoTimestamp, usize)> = HashMap::new();
     for (index, message) in messages.iter().enumerate() {
         if let Some(message_id) = message.envelope.message_id {
             latest_for_id
@@ -569,7 +569,7 @@ fn transition_displayed_message(
                     crate::types::UnreadReadState,
                     crate::types::PendingAckState,
                 >::from_envelope(message.envelope.clone())
-                .mark_read(),
+                .mark_read_pending_ack(),
             )
         }
         (crate::types::ReadState::Unread, crate::types::AckState::Acknowledged)

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -1,7 +1,7 @@
-pub mod filters;
-pub mod seen_state;
-pub mod state;
-pub mod wait;
+pub(crate) mod filters;
+pub(crate) mod seen_state;
+pub(crate) mod state;
+pub(crate) mod wait;
 
 use std::collections::HashMap;
 use std::fs;
@@ -77,7 +77,7 @@ struct SourceFile {
 }
 
 #[derive(Debug, Clone)]
-struct SourcedMessage {
+pub(crate) struct SourcedMessage {
     pub envelope: MessageEnvelope,
     pub source_path: PathBuf,
     pub source_index: usize,

--- a/crates/atm-core/src/read/seen_state.rs
+++ b/crates/atm-core/src/read/seen_state.rs
@@ -2,15 +2,14 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Utc};
-
 use crate::error::{AtmError, AtmErrorKind};
+use crate::types::IsoTimestamp;
 
 pub fn load_seen_watermark(
     home_dir: &Path,
     team: &str,
     agent: &str,
-) -> Result<Option<DateTime<Utc>>, AtmError> {
+) -> Result<Option<IsoTimestamp>, AtmError> {
     let path = seen_state_path(home_dir, team, agent);
     if !path.exists() {
         return Ok(None);
@@ -29,7 +28,7 @@ pub fn load_seen_watermark(
         return Ok(None);
     }
 
-    let parsed = DateTime::parse_from_rfc3339(trimmed).map_err(|error| {
+    let parsed = chrono::DateTime::parse_from_rfc3339(trimmed).map_err(|error| {
         AtmError::new(
             AtmErrorKind::Serialization,
             format!("invalid seen-state watermark: {error}"),
@@ -37,14 +36,14 @@ pub fn load_seen_watermark(
         .with_source(error)
     })?;
 
-    Ok(Some(parsed.with_timezone(&Utc)))
+    Ok(Some(parsed.with_timezone(&chrono::Utc).into()))
 }
 
 pub fn save_seen_watermark(
     home_dir: &Path,
     team: &str,
     agent: &str,
-    timestamp: DateTime<Utc>,
+    timestamp: IsoTimestamp,
 ) -> Result<(), AtmError> {
     let path = seen_state_path(home_dir, team, agent);
     if let Some(parent) = path.parent() {
@@ -66,7 +65,7 @@ pub fn save_seen_watermark(
             )
             .with_source(error)
         })?;
-        file.write_all(timestamp.to_rfc3339().as_bytes())
+        file.write_all(timestamp.into_inner().to_rfc3339().as_bytes())
             .map_err(|error| {
                 AtmError::new(
                     AtmErrorKind::MailboxWrite,
@@ -108,6 +107,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{load_seen_watermark, save_seen_watermark};
+    use crate::types::IsoTimestamp;
 
     #[test]
     fn load_missing_seen_state_returns_none() {
@@ -119,10 +119,12 @@ mod tests {
     #[test]
     fn save_and_load_seen_state_round_trips() {
         let tempdir = TempDir::new().expect("tempdir");
-        let timestamp = chrono::Utc
-            .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
-            .single()
-            .expect("timestamp");
+        let timestamp = IsoTimestamp(
+            chrono::Utc
+                .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                .single()
+                .expect("timestamp"),
+        );
 
         save_seen_watermark(tempdir.path(), "atm-dev", "arch-ctm", timestamp).expect("save");
         let loaded = load_seen_watermark(tempdir.path(), "atm-dev", "arch-ctm").expect("load");

--- a/crates/atm-core/src/read/seen_state.rs
+++ b/crates/atm-core/src/read/seen_state.rs
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn save_and_load_seen_state_round_trips() {
         let tempdir = TempDir::new().expect("tempdir");
-        let timestamp = IsoTimestamp(
+        let timestamp = IsoTimestamp::from_datetime(
             chrono::Utc
                 .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
                 .single()

--- a/crates/atm-core/src/read/state.rs
+++ b/crates/atm-core/src/read/state.rs
@@ -9,9 +9,8 @@ use crate::types::{
 #[derive(Debug, Clone)]
 pub struct StoredMessage<R, A> {
     pub envelope: MessageEnvelope,
-    // Phantom typestate markers keep legal transitions on the type without storing runtime data.
-    _read: PhantomData<R>,
-    _ack: PhantomData<A>,
+    _read: PhantomData<R>, // covariant in R; the typestate marker is never mutably borrowed.
+    _ack: PhantomData<A>,  // covariant in A; the typestate marker is never mutably borrowed.
 }
 
 impl StoredMessage<UnreadReadState, NoAckState> {

--- a/crates/atm-core/src/read/state.rs
+++ b/crates/atm-core/src/read/state.rs
@@ -9,24 +9,23 @@ use crate::types::{
 #[derive(Debug, Clone)]
 pub struct StoredMessage<R, A> {
     pub envelope: MessageEnvelope,
+    // Phantom typestate markers keep legal transitions on the type without storing runtime data.
     _read: PhantomData<R>,
     _ack: PhantomData<A>,
 }
 
-impl<R, A> StoredMessage<R, A> {
-    pub(crate) fn from_envelope(envelope: MessageEnvelope) -> Self {
+impl StoredMessage<UnreadReadState, NoAckState> {
+    pub(crate) fn unread_no_ack(envelope: MessageEnvelope) -> Self {
         Self {
             envelope,
             _read: PhantomData,
             _ack: PhantomData,
         }
     }
-}
 
-impl StoredMessage<UnreadReadState, NoAckState> {
     pub fn display_without_ack(mut self) -> StoredMessage<ReadReadState, NoAckState> {
         self.envelope.read = true;
-        StoredMessage::from_envelope(self.envelope)
+        StoredMessage::read_no_ack(self.envelope)
     }
 
     pub fn display_and_require_ack(
@@ -35,30 +34,66 @@ impl StoredMessage<UnreadReadState, NoAckState> {
     ) -> StoredMessage<ReadReadState, PendingAckState> {
         self.envelope.read = true;
         self.envelope.pending_ack_at = Some(at);
-        StoredMessage::from_envelope(self.envelope)
+        StoredMessage::read_pending_ack(self.envelope)
     }
 
     pub fn mark_read(mut self) -> StoredMessage<ReadReadState, NoAckState> {
         self.envelope.read = true;
-        StoredMessage::from_envelope(self.envelope)
+        StoredMessage::read_no_ack(self.envelope)
     }
 }
 
 impl StoredMessage<UnreadReadState, PendingAckState> {
+    pub(crate) fn unread_pending_ack(envelope: MessageEnvelope) -> Self {
+        Self {
+            envelope,
+            _read: PhantomData,
+            _ack: PhantomData,
+        }
+    }
+
     pub fn mark_read_pending_ack(mut self) -> StoredMessage<ReadReadState, PendingAckState> {
         self.envelope.read = true;
-        StoredMessage::from_envelope(self.envelope)
+        StoredMessage::read_pending_ack(self.envelope)
+    }
+}
+
+impl StoredMessage<ReadReadState, NoAckState> {
+    pub(crate) fn read_no_ack(envelope: MessageEnvelope) -> Self {
+        Self {
+            envelope,
+            _read: PhantomData,
+            _ack: PhantomData,
+        }
     }
 }
 
 impl StoredMessage<ReadReadState, PendingAckState> {
+    pub(crate) fn read_pending_ack(envelope: MessageEnvelope) -> Self {
+        Self {
+            envelope,
+            _read: PhantomData,
+            _ack: PhantomData,
+        }
+    }
+
     pub fn acknowledge(
         mut self,
         at: IsoTimestamp,
     ) -> StoredMessage<ReadReadState, AcknowledgedAckState> {
         self.envelope.acknowledged_at = Some(at);
         self.envelope.pending_ack_at = None;
-        StoredMessage::from_envelope(self.envelope)
+        StoredMessage::read_acknowledged(self.envelope)
+    }
+}
+
+impl StoredMessage<ReadReadState, AcknowledgedAckState> {
+    pub(crate) fn read_acknowledged(envelope: MessageEnvelope) -> Self {
+        Self {
+            envelope,
+            _read: PhantomData,
+            _ack: PhantomData,
+        }
     }
 }
 
@@ -100,6 +135,14 @@ pub fn derive_ack_state(message: &MessageEnvelope) -> AckState {
 pub fn classify_message(message: &MessageEnvelope) -> MessageClass {
     let read_state = derive_read_state(message);
     let ack_state = derive_ack_state(message);
+
+    debug_assert!(
+        !matches!(
+            (read_state, ack_state),
+            (ReadState::Unread, AckState::Acknowledged)
+        ),
+        "inconsistent message state: unread message cannot already be acknowledged"
+    );
 
     match (read_state, ack_state) {
         (ReadState::Unread, AckState::NoAckRequired) => MessageClass::Unread,

--- a/crates/atm-core/src/read/state.rs
+++ b/crates/atm-core/src/read/state.rs
@@ -23,9 +23,8 @@ impl StoredMessage<UnreadReadState, NoAckState> {
         }
     }
 
-    pub fn display_without_ack(mut self) -> StoredMessage<ReadReadState, NoAckState> {
-        self.envelope.read = true;
-        StoredMessage::read_no_ack(self.envelope)
+    pub fn display_without_ack(self) -> StoredMessage<ReadReadState, NoAckState> {
+        self.mark_read()
     }
 
     pub fn display_and_require_ack(

--- a/crates/atm-core/src/read/state.rs
+++ b/crates/atm-core/src/read/state.rs
@@ -34,13 +34,18 @@ impl StoredMessage<UnreadReadState, NoAckState> {
         at: IsoTimestamp,
     ) -> StoredMessage<ReadReadState, PendingAckState> {
         self.envelope.read = true;
-        self.envelope.pending_ack_at = Some(at.into_inner());
+        self.envelope.pending_ack_at = Some(at);
+        StoredMessage::from_envelope(self.envelope)
+    }
+
+    pub fn mark_read(mut self) -> StoredMessage<ReadReadState, NoAckState> {
+        self.envelope.read = true;
         StoredMessage::from_envelope(self.envelope)
     }
 }
 
 impl StoredMessage<UnreadReadState, PendingAckState> {
-    pub fn mark_read(mut self) -> StoredMessage<ReadReadState, PendingAckState> {
+    pub fn mark_read_pending_ack(mut self) -> StoredMessage<ReadReadState, PendingAckState> {
         self.envelope.read = true;
         StoredMessage::from_envelope(self.envelope)
     }
@@ -51,7 +56,7 @@ impl StoredMessage<ReadReadState, PendingAckState> {
         mut self,
         at: IsoTimestamp,
     ) -> StoredMessage<ReadReadState, AcknowledgedAckState> {
-        self.envelope.acknowledged_at = Some(at.into_inner());
+        self.envelope.acknowledged_at = Some(at);
         self.envelope.pending_ack_at = None;
         StoredMessage::from_envelope(self.envelope)
     }

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -1,13 +1,14 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use uuid::Uuid;
+
+use crate::types::IsoTimestamp;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MessageEnvelope {
     pub from: String,
     pub text: String,
-    pub timestamp: DateTime<Utc>,
+    pub timestamp: IsoTimestamp,
     pub read: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -20,10 +21,10 @@ pub struct MessageEnvelope {
     pub message_id: Option<Uuid>,
 
     #[serde(rename = "pendingAckAt", skip_serializing_if = "Option::is_none")]
-    pub pending_ack_at: Option<DateTime<Utc>>,
+    pub pending_ack_at: Option<IsoTimestamp>,
 
     #[serde(rename = "acknowledgedAt", skip_serializing_if = "Option::is_none")]
-    pub acknowledged_at: Option<DateTime<Utc>>,
+    pub acknowledged_at: Option<IsoTimestamp>,
 
     #[serde(
         rename = "acknowledgesMessageId",
@@ -43,7 +44,7 @@ pub struct PendingAck {
     pub message_id: Uuid,
     pub from: String,
     pub acked: bool,
-    pub acked_at: Option<DateTime<Utc>>,
+    pub acked_at: Option<IsoTimestamp>,
 }
 
 #[cfg(test)]
@@ -51,26 +52,29 @@ mod tests {
     use chrono::TimeZone;
     use serde_json::{json, Map};
 
-    use super::{MessageEnvelope, PendingAck, Utc, Uuid};
+    use chrono::Utc;
+
+    use super::{IsoTimestamp, MessageEnvelope, PendingAck, Uuid};
 
     #[test]
     fn message_envelope_round_trips_with_current_inbox_shape() {
         let envelope = MessageEnvelope {
             from: "arch-ctm".into(),
             text: "hello".into(),
-            timestamp: Utc
-                .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
-                .single()
-                .expect("timestamp"),
+            timestamp: IsoTimestamp(
+                Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                    .single()
+                    .expect("timestamp"),
+            ),
             read: false,
             source_team: Some("atm-dev".into()),
             summary: Some("hello".into()),
             message_id: Some(Uuid::new_v4()),
-            pending_ack_at: Some(
+            pending_ack_at: Some(IsoTimestamp(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
                     .single()
                     .expect("timestamp"),
-            ),
+            )),
             acknowledged_at: None,
             acknowledges_message_id: None,
             task_id: Some("TASK-123".into()),
@@ -120,11 +124,11 @@ mod tests {
             message_id: Uuid::new_v4(),
             from: "team-lead".into(),
             acked: true,
-            acked_at: Some(
+            acked_at: Some(IsoTimestamp(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
                     .single()
                     .expect("timestamp"),
-            ),
+            )),
         };
 
         let encoded = serde_json::to_string(&pending_ack).expect("encode");

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -61,7 +61,7 @@ mod tests {
         let envelope = MessageEnvelope {
             from: "arch-ctm".into(),
             text: "hello".into(),
-            timestamp: IsoTimestamp(
+            timestamp: IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
                     .single()
                     .expect("timestamp"),
@@ -70,7 +70,7 @@ mod tests {
             source_team: Some("atm-dev".into()),
             summary: Some("hello".into()),
             message_id: Some(Uuid::new_v4()),
-            pending_ack_at: Some(IsoTimestamp(
+            pending_ack_at: Some(IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
                     .single()
                     .expect("timestamp"),
@@ -124,7 +124,7 @@ mod tests {
             message_id: Uuid::new_v4(),
             from: "team-lead".into(),
             acked: true,
-            acked_at: Some(IsoTimestamp(
+            acked_at: Some(IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
                     .single()
                     .expect("timestamp"),

--- a/crates/atm-core/src/send/file_policy.rs
+++ b/crates/atm-core/src/send/file_policy.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::error::AtmError;
+use crate::error::{AtmError, AtmErrorKind};
 
 pub fn process_file_reference(
     file_path: &Path,
@@ -26,7 +26,16 @@ pub fn process_file_reference(
         .join("atm")
         .join("share")
         .join(team_name);
-    fs::create_dir_all(&share_dir)?;
+    fs::create_dir_all(&share_dir).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::FilePolicy,
+            format!(
+                "failed to create share directory {}: {error}",
+                share_dir.display()
+            ),
+        )
+        .with_source(error)
+    })?;
 
     let file_name = file_path
         .file_name()

--- a/crates/atm-core/src/send/input.rs
+++ b/crates/atm-core/src/send/input.rs
@@ -1,12 +1,18 @@
 use std::io::Read;
 
-use crate::error::AtmError;
+use crate::error::{AtmError, AtmErrorKind};
 
 pub fn read_message_from_stdin() -> Result<String, AtmError> {
     let mut buffer = String::new();
     std::io::stdin()
         .read_to_string(&mut buffer)
-        .map_err(|error| AtmError::validation(format!("failed to read stdin: {error}")))?;
+        .map_err(|error| {
+            AtmError::new(
+                AtmErrorKind::MailboxRead,
+                format!("failed to read stdin: {error}"),
+            )
+            .with_source(error)
+        })?;
     validate_message_text(buffer)
 }
 

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use chrono::Utc;
 use serde::Serialize;
 use serde_json::Map;
 use uuid::Uuid;
@@ -14,6 +13,7 @@ use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::schema::{MessageEnvelope, TeamConfig};
+use crate::types::IsoTimestamp;
 
 pub mod file_policy;
 pub mod input;
@@ -98,7 +98,7 @@ pub fn send_mail(
     )?;
     let summary = summary::build_summary(&body, request.summary_override);
     let message_id = Uuid::new_v4();
-    let timestamp = Utc::now();
+    let timestamp = IsoTimestamp::now();
 
     if !request.dry_run {
         let envelope = MessageEnvelope {

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -191,11 +191,12 @@ fn resolve_recipient(
 fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
     let config_path = team_dir.join("config.json");
     let raw = fs::read_to_string(&config_path).map_err(|error| {
-        AtmError::team_not_found(
-            team_dir
-                .file_name()
-                .and_then(|value| value.to_str())
-                .unwrap_or("unknown"),
+        AtmError::new(
+            AtmErrorKind::Config,
+            format!(
+                "failed to read team config at {}: {error}",
+                config_path.display()
+            ),
         )
         .with_source(error)
     })?;

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -15,9 +15,9 @@ use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::schema::{MessageEnvelope, TeamConfig};
 use crate::types::IsoTimestamp;
 
-pub mod file_policy;
-pub mod input;
-pub mod summary;
+pub(crate) mod file_policy;
+pub(crate) mod input;
+pub(crate) mod summary;
 
 #[derive(Debug, Clone)]
 pub enum SendMessageSource {

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -141,7 +141,7 @@ pub fn send_mail(
         team: outcome.team.clone(),
         agent: outcome.agent.clone(),
         sender,
-        message_id: outcome.message_id.to_string(),
+        message_id: Some(outcome.message_id),
         requires_ack: outcome.requires_ack,
         dry_run: outcome.dry_run,
         task_id,

--- a/crates/atm-core/src/text.rs
+++ b/crates/atm-core/src/text.rs
@@ -9,6 +9,7 @@ pub fn truncate(s: &str, max_chars: usize) -> &str {
     }
 }
 
+#[cfg(test)]
 pub fn wrap_lines(s: &str, width: usize) -> String {
     if width == 0 {
         return s.to_string();

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -3,11 +3,15 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct IsoTimestamp(pub DateTime<Utc>);
+pub struct IsoTimestamp(DateTime<Utc>);
 
 impl IsoTimestamp {
     pub fn now() -> Self {
         Self(Utc::now())
+    }
+
+    pub fn from_datetime(datetime: DateTime<Utc>) -> Self {
+        Self(datetime)
     }
 
     pub fn into_inner(self) -> DateTime<Utc> {

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct IsoTimestamp(pub DateTime<Utc>);
 
 impl IsoTimestamp {

--- a/crates/atm/src/commands/clear.rs
+++ b/crates/atm/src/commands/clear.rs
@@ -57,7 +57,10 @@ impl ClearCommand {
 
 fn parse_duration(raw: &str) -> Result<Duration> {
     let value = raw.trim();
-    let (amount, unit) = value.split_at(value.len().saturating_sub(1));
+    let Some((unit_index, unit_char)) = value.char_indices().last() else {
+        anyhow::bail!("invalid duration: {value}");
+    };
+    let amount = &value[..unit_index];
     if amount.is_empty() {
         anyhow::bail!("invalid duration: {value}");
     }
@@ -66,11 +69,22 @@ fn parse_duration(raw: &str) -> Result<Duration> {
         .parse::<u64>()
         .with_context(|| format!("invalid duration: {value}"))?;
 
-    match unit {
-        "s" => Ok(Duration::from_secs(amount)),
-        "m" => Ok(Duration::from_secs(amount * 60)),
-        "h" => Ok(Duration::from_secs(amount * 60 * 60)),
-        "d" => Ok(Duration::from_secs(amount * 60 * 60 * 24)),
+    let secs = match unit_char {
+        's' => amount,
+        'm' => amount
+            .checked_mul(60)
+            .ok_or_else(|| anyhow::anyhow!("duration overflow: {value}"))?,
+        'h' => amount
+            .checked_mul(60)
+            .and_then(|value| value.checked_mul(60))
+            .ok_or_else(|| anyhow::anyhow!("duration overflow: {value}"))?,
+        'd' => amount
+            .checked_mul(60)
+            .and_then(|value| value.checked_mul(60))
+            .and_then(|value| value.checked_mul(24))
+            .ok_or_else(|| anyhow::anyhow!("duration overflow: {value}"))?,
         _ => anyhow::bail!("invalid duration unit in {value}; use s, m, h, or d"),
-    }
+    };
+
+    Ok(Duration::from_secs(secs))
 }

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use atm_core::home;
 use atm_core::read::{self, ReadQuery};
-use atm_core::types::{AckActivationMode, ReadSelection};
+use atm_core::types::{AckActivationMode, IsoTimestamp, ReadSelection};
 use clap::Args;
 
 use crate::observability::CliObservability;
@@ -107,8 +107,8 @@ impl ReadCommand {
     }
 }
 
-fn parse_timestamp(value: &str) -> Result<chrono::DateTime<chrono::Utc>> {
+fn parse_timestamp(value: &str) -> Result<IsoTimestamp> {
     chrono::DateTime::parse_from_rfc3339(value)
         .with_context(|| format!("invalid ISO 8601 timestamp: {value}"))
-        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc).into())
 }

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -15,6 +15,7 @@ pub fn init() -> Result<CliObservability> {
 
 impl ObservabilityPort for CliObservability {
     fn emit_command_event(&self, event: CommandEvent) -> Result<(), AtmError> {
+        let message_id = event.message_id.map(|value| value.to_string());
         info!(
             command = event.command,
             action = event.action,
@@ -22,10 +23,10 @@ impl ObservabilityPort for CliObservability {
             team = event.team,
             agent = event.agent,
             sender = event.sender,
-            message_id = event.message_id,
+            message_id = message_id.as_deref().unwrap_or(""),
             requires_ack = event.requires_ack,
             dry_run = event.dry_run,
-            task_id = event.task_id,
+            task_id = event.task_id.as_deref().unwrap_or(""),
             "atm command event"
         );
         Ok(())

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -84,9 +84,7 @@ pub fn print_clear_result(outcome: &ClearOutcome, dry_run: bool, json: bool) -> 
     }
 
     println!(
-        "Unread: {} | Pending-Ack: {} | Acknowledged: {} | Read: {} | Remaining: {}",
-        outcome.removed_by_class.unread,
-        outcome.removed_by_class.pending_ack,
+        "Acknowledged: {} | Read: {} | Remaining: {}",
         outcome.removed_by_class.acknowledged,
         outcome.removed_by_class.read,
         outcome.remaining_total
@@ -111,7 +109,7 @@ fn print_bucket(outcome: &ReadOutcome, bucket: DisplayBucket, label: &str) {
     for message in messages {
         println!(
             "- {} {}: {}",
-            message.envelope.timestamp.to_rfc3339(),
+            message.envelope.timestamp.into_inner().to_rfc3339(),
             message.envelope.from,
             message
                 .envelope

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::process::Command;
 
 use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
+use atm_core::types::IsoTimestamp;
 use chrono::{Duration, Utc};
 use serde_json::Value;
 use uuid::Uuid;
@@ -128,7 +129,7 @@ fn test_ack_rejects_message_that_is_not_pending() {
     assert!(
         fixture
             .stderr(&output)
-            .contains("is not pending acknowledgement"),
+            .contains("is not in the (read, pending_ack) state"),
         "stderr: {}",
         fixture.stderr(&output)
     );
@@ -256,13 +257,13 @@ impl Fixture {
         MessageEnvelope {
             from: from.to_string(),
             text: text.to_string(),
-            timestamp,
+            timestamp: timestamp.into(),
             read,
             source_team: Some("atm-dev".into()),
             summary: None,
             message_id: Some(message_id),
-            pending_ack_at: pending_offset.map(|offset| timestamp + offset),
-            acknowledged_at: acknowledged_offset.map(|offset| timestamp + offset),
+            pending_ack_at: pending_offset.map(|offset| IsoTimestamp(timestamp + offset)),
+            acknowledged_at: acknowledged_offset.map(|offset| IsoTimestamp(timestamp + offset)),
             acknowledges_message_id: None,
             task_id: None,
             extra: serde_json::Map::new(),

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -262,8 +262,10 @@ impl Fixture {
             source_team: Some("atm-dev".into()),
             summary: None,
             message_id: Some(message_id),
-            pending_ack_at: pending_offset.map(|offset| IsoTimestamp(timestamp + offset)),
-            acknowledged_at: acknowledged_offset.map(|offset| IsoTimestamp(timestamp + offset)),
+            pending_ack_at: pending_offset
+                .map(|offset| IsoTimestamp::from_datetime(timestamp + offset)),
+            acknowledged_at: acknowledged_offset
+                .map(|offset| IsoTimestamp::from_datetime(timestamp + offset)),
             acknowledges_message_id: None,
             task_id: None,
             extra: serde_json::Map::new(),

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -152,6 +152,7 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_IDENTITY", "arch-ctm")
+            .env("ATM_TEAM", "atm-dev")
             .current_dir(self.tempdir.path())
             .output()
             .expect("run atm")

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -339,6 +339,7 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_IDENTITY", "arch-ctm")
+            .env("ATM_TEAM", "atm-dev")
             .current_dir(self.tempdir.path())
             .output()
             .expect("run atm")

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::process::Command;
 
 use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
+use atm_core::types::IsoTimestamp;
 use chrono::{Duration, Utc};
 use serde_json::Value;
 use uuid::Uuid;
@@ -60,8 +61,8 @@ fn test_clear_default_removes_only_read_and_acknowledged() {
     assert_eq!(parsed["remaining_total"], 2);
     assert_eq!(parsed["removed_by_class"]["read"], 1);
     assert_eq!(parsed["removed_by_class"]["acknowledged"], 1);
-    assert_eq!(parsed["removed_by_class"]["unread"], 0);
-    assert_eq!(parsed["removed_by_class"]["pending_ack"], 0);
+    assert!(parsed["removed_by_class"]["unread"].is_null());
+    assert!(parsed["removed_by_class"]["pending_ack"].is_null());
 
     let inbox = fixture.inbox_contents("arch-ctm");
     assert_eq!(inbox.len(), 2);
@@ -442,13 +443,13 @@ impl Fixture {
         MessageEnvelope {
             from: from.to_string(),
             text: text.to_string(),
-            timestamp,
+            timestamp: timestamp.into(),
             read,
             source_team: Some("atm-dev".into()),
             summary: None,
             message_id: Some(Uuid::new_v4()),
-            pending_ack_at,
-            acknowledged_at,
+            pending_ack_at: pending_ack_at.map(Into::into),
+            acknowledged_at: acknowledged_at.map(Into::into),
             acknowledges_message_id: None,
             task_id: None,
             extra: serde_json::Map::new(),
@@ -460,7 +461,7 @@ fn idle_notification_text(from: &str) -> String {
     serde_json::json!({
         "type": "idle_notification",
         "from": from,
-        "timestamp": Utc::now().to_rfc3339(),
+        "timestamp": IsoTimestamp::now().into_inner().to_rfc3339(),
         "idleReason": "available"
     })
     .to_string()

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -466,13 +466,15 @@ impl Fixture {
         MessageEnvelope {
             from: from.to_string(),
             text: text.to_string(),
-            timestamp: IsoTimestamp(self.timestamp(timestamp_offset)),
+            timestamp: IsoTimestamp::from_datetime(self.timestamp(timestamp_offset)),
             read,
             source_team: Some("atm-dev".into()),
             summary: None,
             message_id: Some(Uuid::new_v4()),
-            pending_ack_at: pending_ack_offset.map(|offset| IsoTimestamp(self.timestamp(offset))),
-            acknowledged_at: acknowledged_offset.map(|offset| IsoTimestamp(self.timestamp(offset))),
+            pending_ack_at: pending_ack_offset
+                .map(|offset| IsoTimestamp::from_datetime(self.timestamp(offset))),
+            acknowledged_at: acknowledged_offset
+                .map(|offset| IsoTimestamp::from_datetime(self.timestamp(offset))),
             acknowledges_message_id: None,
             task_id: None,
             extra: serde_json::Map::new(),

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::process::Command;
 
 use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
+use atm_core::types::IsoTimestamp;
 use chrono::{TimeZone, Utc};
 use serde_json::Value;
 use uuid::Uuid;
@@ -465,13 +466,13 @@ impl Fixture {
         MessageEnvelope {
             from: from.to_string(),
             text: text.to_string(),
-            timestamp: self.timestamp(timestamp_offset),
+            timestamp: IsoTimestamp(self.timestamp(timestamp_offset)),
             read,
             source_team: Some("atm-dev".into()),
             summary: None,
             message_id: Some(Uuid::new_v4()),
-            pending_ack_at: pending_ack_offset.map(|offset| self.timestamp(offset)),
-            acknowledged_at: acknowledged_offset.map(|offset| self.timestamp(offset)),
+            pending_ack_at: pending_ack_offset.map(|offset| IsoTimestamp(self.timestamp(offset))),
+            acknowledged_at: acknowledged_offset.map(|offset| IsoTimestamp(self.timestamp(offset))),
             acknowledges_message_id: None,
             task_id: None,
             extra: serde_json::Map::new(),

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -366,6 +366,7 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_IDENTITY", "arch-ctm")
+            .env("ATM_TEAM", "atm-dev")
             .current_dir(self.tempdir.path())
             .output()
             .expect("run atm")

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -165,6 +165,7 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_IDENTITY", "arch-ctm")
+            .env("ATM_TEAM", "atm-dev")
             .current_dir(self.tempdir.path())
             .output()
             .expect("run atm")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,7 +268,7 @@ impl StoredMessage<UnreadReadState, NoAckState> {
 }
 
 impl StoredMessage<UnreadReadState, PendingAckState> {
-    pub fn mark_read(self) -> StoredMessage<ReadReadState, PendingAckState>;
+    pub fn mark_read_pending_ack(self) -> StoredMessage<ReadReadState, PendingAckState>;
 }
 
 impl StoredMessage<ReadReadState, PendingAckState> {

--- a/docs/read-behavior.md
+++ b/docs/read-behavior.md
@@ -272,7 +272,7 @@ impl StoredMessage<UnreadReadState, NoAckState> {
 }
 
 impl StoredMessage<UnreadReadState, PendingAckState> {
-    pub fn mark_read(self) -> StoredMessage<ReadReadState, PendingAckState>;
+    pub fn mark_read_pending_ack(self) -> StoredMessage<ReadReadState, PendingAckState>;
 }
 
 impl StoredMessage<ReadReadState, PendingAckState> {


### PR DESCRIPTION
Fixes BP-001 through BP-005 + BP-I-013 + BP-I-014 from ATM-CORE-RBP-REVIEW-1.

- BP-001: mark_read on correct state (UnreadReadState, NoAckState)
- BP-002: ack_mail flows through StoredMessage::acknowledge() typestate
- BP-003: RemovedByClass dead arms → unreachable!(); pending_ack/unread fields removed
- BP-004: MessageEnvelope/PendingAck timestamp fields → IsoTimestamp
- BP-005: update_source_message accepts IsoTimestamp; into_inner() at assignment site only
- BP-I-013: parse_duration char boundary safety
- BP-I-014: parse_duration checked_mul overflow