### PR TITLE
docs: crate-level documentation structure and guidelines

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,39 +31,22 @@ moved into:
 
 ## 2. Crate Boundaries
 
-### 2.1 `atm-core`
+The product is implemented by two crates:
 
-`atm-core` owns:
-- path and home resolution
-- config and Claude settings resolution
-- bridge-hostname resolution for origin inbox merge
-- hook-based identity resolution
-- address parsing
-- file policy enforcement for `send --file`
-- team config loading
-- mailbox read and write logic
-- canonical two-axis workflow classification
-- legal workflow-axis transitions
-- send, read, ack, and clear service functions
-- log query/follow service functions over an injected observability port
-- local doctor/diagnostic service functions
-- structured error types
-- observability event/query models and the injected observability boundary
+- `atm-core`
+- `atm`
 
-`atm-core` must not depend on clap or terminal formatting concerns.
+Product-level boundary rules:
 
-### 2.2 `atm`
+- `atm-core` owns daemon-free ATM business logic.
+- `atm` owns CLI parsing, dispatch, rendering, and bootstrap.
+- `atm-core` must not own clap or terminal-formatting concerns.
+- `atm` must not own mailbox, workflow, log-query, or doctor business logic.
 
-`atm` owns:
-- clap argument parsing
-- command dispatch
-- output rendering
-- process exit behavior
-- one-time observability initialization
-- the concrete `sc-observability` implementation of the observability port
-- injection of that implementation into `atm-core` services at startup
+Crate-local boundary detail is owned by:
 
-`atm` must not implement mailbox, config, workflow, logging-query, or doctor business logic directly.
+- [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
+- [`docs/atm/architecture.md`](./atm/architecture.md)
 
 ### 2.3 Shared Observability Boundary
 
@@ -90,86 +73,17 @@ An early ATM planning/coordination sprint, `OBS-GAP-1`, must verify and close th
 
 ## 3. Module Layout
 
-Planned `atm-core` layout:
+Detailed crate/module layout is owned by the crate-level docs:
 
-```text
-crates/atm-core/src/
-  lib.rs
-  address.rs
-  ack/
-    mod.rs
-  clear/
-    mod.rs
-  config/
-    aliases.rs
-    bridge.rs
-    discovery.rs
-    mod.rs
-    types.rs
-  doctor/
-    health.rs
-    mod.rs
-    report.rs
-  error.rs
-  home.rs
-  identity/
-    hook.rs
-    mod.rs
-  log/
-    filters.rs
-    mod.rs
-  mailbox/
-    atomic.rs
-    hash.rs
-    lock.rs
-    mod.rs
-    store.rs
-  model_registry.rs
-  observability.rs
-  read/
-    filters.rs
-    mod.rs
-    seen_state.rs
-    state.rs
-    wait.rs
-  schema/
-    agent_member.rs
-    inbox_message.rs
-    mod.rs
-    permissions.rs
-    settings.rs
-    team_config.rs
-  send/
-    file_policy.rs
-    input.rs
-    mod.rs
-    summary.rs
-  text.rs
-  types.rs
-```
+- [`docs/atm-core/modules/`](./atm-core/modules/)
+- [`docs/atm/commands/`](./atm/commands/)
 
-Planned `atm` layout:
+Product-level constraints that remain relevant here:
 
-```text
-crates/atm/src/
-  main.rs
-  commands/
-    ack.rs
-    clear.rs
-    doctor.rs
-    log.rs
-    mod.rs
-    read.rs
-    send.rs
-  observability.rs
-  output.rs
-```
-
-Notes:
 - no plugin framework
 - no daemon client
 - no runtime spawning layer
-- no separate `tail` command
+- no separate `tail` command in the initial rewrite
 - no separate `status` command in the initial rewrite
 
 ## 4. Core Types

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,17 @@ The retained command surface is:
 - `log`
 - `doctor`
 
+## 1.1 Documentation Structure
+
+Documentation structure is governed by
+[`documentation-guidelines.md`](./documentation-guidelines.md).
+
+This file owns product architecture. Crate-local architectural detail is being
+moved into:
+
+- [`docs/atm/architecture.md`](./atm/architecture.md)
+- [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
+
 ## 2. Crate Boundaries
 
 ### 2.1 `atm-core`

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -1,0 +1,31 @@
+# ATM-Core Crate Architecture
+
+## 1. Purpose
+
+This document defines the `atm-core` crate architectural boundary.
+
+It complements the product architecture in
+[`../architecture.md`](../architecture.md) and owns crate-local structure and
+service boundaries.
+
+## 2. Architectural Rules
+
+- `atm-core` exposes request/result/service boundaries, not clap surfaces.
+- `atm-core` owns workflow/state transitions and must enforce them by code
+  structure.
+- `atm-core` owns observability as an injected boundary, not as a concrete
+  dependency on `sc-observability`.
+- `atm-core` must keep mailbox/config/workflow/log/doctor logic reusable across
+  CLI contexts.
+
+## 3. ADR Namespace
+
+The `atm-core` crate uses the `ADR-CORE-*` namespace.
+
+Initial use cases:
+
+- typestate and workflow decisions
+- mailbox boundary decisions
+- config/loading decisions
+- observability port decisions
+- service/module boundary decisions

--- a/docs/atm-core/modules/ack.md
+++ b/docs/atm-core/modules/ack.md
@@ -1,0 +1,4 @@
+# `atm-core::ack`
+
+Owns acknowledgement transitions, reply-message creation, and legal movement
+from pending-ack to acknowledged.

--- a/docs/atm-core/modules/ack.md
+++ b/docs/atm-core/modules/ack.md
@@ -2,3 +2,11 @@
 
 Owns acknowledgement transitions, reply-message creation, and legal movement
 from pending-ack to acknowledged.
+
+References:
+
+- Product requirements: `docs/requirements.md` §8 and §12
+- `REQ-P-ACK-001`
+- `REQ-P-WORKFLOW-001`
+- `REQ-CORE-WORKFLOW-001`
+- CLI surface: `docs/atm/commands/ack.md`

--- a/docs/atm-core/modules/clear.md
+++ b/docs/atm-core/modules/clear.md
@@ -1,0 +1,4 @@
+# `atm-core::clear`
+
+Owns clear eligibility, dry-run accounting, and enforcement that unread and
+pending-ack messages are never removed by clear.

--- a/docs/atm-core/modules/clear.md
+++ b/docs/atm-core/modules/clear.md
@@ -2,3 +2,11 @@
 
 Owns clear eligibility, dry-run accounting, and enforcement that unread and
 pending-ack messages are never removed by clear.
+
+References:
+
+- Product requirements: `docs/requirements.md` §9 and §12
+- `REQ-P-CLEAR-001`
+- `REQ-P-WORKFLOW-001`
+- `REQ-CORE-WORKFLOW-001`
+- CLI surface: `docs/atm/commands/clear.md`

--- a/docs/atm-core/modules/config.md
+++ b/docs/atm-core/modules/config.md
@@ -1,0 +1,4 @@
+# `atm-core::config`
+
+Owns configuration discovery, precedence rules, alias and bridge-hostname
+resolution, and translation into validated core request inputs.

--- a/docs/atm-core/modules/config.md
+++ b/docs/atm-core/modules/config.md
@@ -2,3 +2,11 @@
 
 Owns configuration discovery, precedence rules, alias and bridge-hostname
 resolution, and translation into validated core request inputs.
+
+References:
+
+- Product requirements: `docs/requirements.md` §3.3, §3.4, and §4
+- `REQ-P-CONTRACT-001`
+- `REQ-P-IDENTITY-001`
+- `REQ-CORE-MAILBOX-001`
+- Migration artifact: `docs/file-migration-plan.md`

--- a/docs/atm-core/modules/doctor.md
+++ b/docs/atm-core/modules/doctor.md
@@ -2,3 +2,18 @@
 
 Owns local diagnostics, config/path/inbox checks, observability readiness
 checks, and the finding model used by the CLI renderer.
+
+It must not own:
+
+- clap parsing
+- terminal grouping/formatting
+- process exit mapping
+
+References:
+
+- Product requirements: `docs/requirements.md` §11 and §13
+- `REQ-P-DOCTOR-001`
+- `REQ-P-OBS-001`
+- `REQ-CORE-DOCTOR-001`
+- CLI surface: `docs/atm/commands/doctor.md`
+- Supporting boundary: `docs/atm-core/modules/observability.md`

--- a/docs/atm-core/modules/doctor.md
+++ b/docs/atm-core/modules/doctor.md
@@ -1,0 +1,4 @@
+# `atm-core::doctor`
+
+Owns local diagnostics, config/path/inbox checks, observability readiness
+checks, and the finding model used by the CLI renderer.

--- a/docs/atm-core/modules/log.md
+++ b/docs/atm-core/modules/log.md
@@ -2,3 +2,19 @@
 
 Owns ATM-owned log query and tail request models, filtering semantics, and the
 mapping from CLI queries into the injected observability boundary.
+
+It must not own:
+
+- clap parsing
+- human-readable line formatting
+- JSON CLI envelopes
+- direct dependency on concrete `sc-observability` types
+
+References:
+
+- Product requirements: `docs/requirements.md` §10 and §13
+- `REQ-P-LOG-001`
+- `REQ-P-OBS-001`
+- `REQ-CORE-LOG-001`
+- CLI surface: `docs/atm/commands/log.md`
+- Supporting boundary: `docs/atm-core/modules/observability.md`

--- a/docs/atm-core/modules/log.md
+++ b/docs/atm-core/modules/log.md
@@ -1,0 +1,4 @@
+# `atm-core::log`
+
+Owns ATM-owned log query and tail request models, filtering semantics, and the
+mapping from CLI queries into the injected observability boundary.

--- a/docs/atm-core/modules/mailbox.md
+++ b/docs/atm-core/modules/mailbox.md
@@ -2,3 +2,11 @@
 
 Owns mailbox file discovery, atomic read/write helpers, locking, duplicate
 suppression, and origin-inbox merge primitives.
+
+References:
+
+- Product requirements: `docs/requirements.md` §3.2 and §12
+- `REQ-P-CONTRACT-001`
+- `REQ-P-WORKFLOW-001`
+- `REQ-CORE-MAILBOX-001`
+- Migration artifact: `docs/file-migration-plan.md`

--- a/docs/atm-core/modules/mailbox.md
+++ b/docs/atm-core/modules/mailbox.md
@@ -1,0 +1,4 @@
+# `atm-core::mailbox`
+
+Owns mailbox file discovery, atomic read/write helpers, locking, duplicate
+suppression, and origin-inbox merge primitives.

--- a/docs/atm-core/modules/observability.md
+++ b/docs/atm-core/modules/observability.md
@@ -1,0 +1,4 @@
+# `atm-core::observability`
+
+Owns the injected observability boundary used by `atm-core` services and the
+ATM-owned event/query models that sit above shared observability crates.

--- a/docs/atm-core/modules/observability.md
+++ b/docs/atm-core/modules/observability.md
@@ -2,3 +2,18 @@
 
 Owns the injected observability boundary used by `atm-core` services and the
 ATM-owned event/query models that sit above shared observability crates.
+
+It must not own:
+
+- direct `sc-observability` initialization
+- CLI flag parsing
+- CLI output rendering
+
+References:
+
+- Product requirements: `docs/requirements.md` §3.5, §10, §11, and §13
+- `REQ-P-LOG-001`
+- `REQ-P-DOCTOR-001`
+- `REQ-P-OBS-001`
+- `REQ-CORE-OBS-001`
+- Product architecture: `docs/architecture.md` §2.3

--- a/docs/atm-core/modules/read.md
+++ b/docs/atm-core/modules/read.md
@@ -1,0 +1,4 @@
+# `atm-core::read`
+
+Owns read selection, bucket classification, seen-state updates, timeout
+behavior, and readable result shaping for the CLI layer to render.

--- a/docs/atm-core/modules/read.md
+++ b/docs/atm-core/modules/read.md
@@ -2,3 +2,12 @@
 
 Owns read selection, bucket classification, seen-state updates, timeout
 behavior, and readable result shaping for the CLI layer to render.
+
+References:
+
+- Product requirements: `docs/requirements.md` §7 and §12
+- `REQ-P-READ-001`
+- `REQ-P-WORKFLOW-001`
+- `REQ-CORE-WORKFLOW-001`
+- Cross-cutting behavior: `docs/read-behavior.md`
+- CLI surface: `docs/atm/commands/read.md`

--- a/docs/atm-core/modules/send.md
+++ b/docs/atm-core/modules/send.md
@@ -2,3 +2,11 @@
 
 Owns send request validation, message construction, summary generation,
 ack-required/task metadata handling, and atomic inbox append orchestration.
+
+References:
+
+- Product requirements: `docs/requirements.md` §6 and §12
+- `REQ-P-SEND-001`
+- `REQ-P-WORKFLOW-001`
+- `REQ-CORE-MAILBOX-001`
+- CLI surface: `docs/atm/commands/send.md`

--- a/docs/atm-core/modules/send.md
+++ b/docs/atm-core/modules/send.md
@@ -1,0 +1,4 @@
+# `atm-core::send`
+
+Owns send request validation, message construction, summary generation,
+ack-required/task metadata handling, and atomic inbox append orchestration.

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -44,6 +44,26 @@ Initial allocation:
 - `REQ-CORE-DOCTOR-*`
 - `REQ-CORE-OBS-*`
 
+Initial crate requirement IDs:
+
+- `REQ-CORE-MAILBOX-001` `atm-core` owns daemon-free mailbox/store behavior.
+  Satisfies:
+  `REQ-P-CONTRACT-001`, `REQ-P-SEND-001`, `REQ-P-READ-001`,
+  `REQ-P-ACK-001`, `REQ-P-CLEAR-001`, `REQ-P-RELIABILITY-001`.
+- `REQ-CORE-WORKFLOW-001` `atm-core` owns the two-axis workflow model and legal
+  transitions. Satisfies:
+  `REQ-P-READ-001`, `REQ-P-ACK-001`, `REQ-P-CLEAR-001`,
+  `REQ-P-WORKFLOW-001`.
+- `REQ-CORE-LOG-001` `atm-core` owns ATM log query/follow service behavior over
+  the injected observability boundary. Satisfies:
+  `REQ-P-LOG-001`, `REQ-P-OBS-001`.
+- `REQ-CORE-DOCTOR-001` `atm-core` owns local doctor diagnostics and readiness
+  evaluation. Satisfies:
+  `REQ-P-DOCTOR-001`, `REQ-P-OBS-001`.
+- `REQ-CORE-OBS-001` `atm-core` owns the abstract observability boundary and
+  ATM-owned event/query models above shared crates. Satisfies:
+  `REQ-P-OBS-001`.
+
 ## 4. Module Ownership
 
 Per-module documentation lives under:

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -1,0 +1,75 @@
+# ATM-Core Crate Requirements
+
+## 1. Purpose
+
+This document defines the `atm-core` crate requirements.
+
+The `atm-core` crate owns the reusable daemon-free ATM business logic. Product
+behavior remains defined in [`../requirements.md`](../requirements.md).
+
+## 2. Ownership
+
+`atm-core` owns:
+
+- path and config resolution policy
+- address parsing and validation
+- mailbox I/O
+- workflow and typestate rules
+- send/read/ack/clear service behavior
+- log query/follow service behavior over the observability boundary
+- doctor service behavior
+- structured core errors
+
+`atm-core` does not own:
+
+- clap parsing
+- terminal formatting
+- process exit policy
+- direct dependency on concrete observability crates
+
+## 3. Requirement Namespace
+
+The `atm-core` crate uses the `REQ-CORE-*` namespace.
+
+Initial allocation:
+
+- `REQ-CORE-CONFIG-*`
+- `REQ-CORE-MAILBOX-*`
+- `REQ-CORE-WORKFLOW-*`
+- `REQ-CORE-SEND-*`
+- `REQ-CORE-READ-*`
+- `REQ-CORE-ACK-*`
+- `REQ-CORE-CLEAR-*`
+- `REQ-CORE-LOG-*`
+- `REQ-CORE-DOCTOR-*`
+- `REQ-CORE-OBS-*`
+
+## 4. Module Ownership
+
+Per-module documentation lives under:
+
+- [`modules/send.md`](./modules/send.md)
+- [`modules/read.md`](./modules/read.md)
+- [`modules/ack.md`](./modules/ack.md)
+- [`modules/clear.md`](./modules/clear.md)
+- [`modules/log.md`](./modules/log.md)
+- [`modules/doctor.md`](./modules/doctor.md)
+- [`modules/mailbox.md`](./modules/mailbox.md)
+- [`modules/config.md`](./modules/config.md)
+- [`modules/observability.md`](./modules/observability.md)
+
+Each module document defines:
+
+- service responsibility
+- invariants
+- inputs and outputs
+- references to the product requirements it implements
+
+## 5. Required References
+
+The `atm-core` crate docs must remain aligned with:
+
+- [`../requirements.md`](../requirements.md)
+- [`../architecture.md`](../architecture.md)
+- [`../project-plan.md`](../project-plan.md)
+- [`../documentation-guidelines.md`](../documentation-guidelines.md)

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -1,0 +1,39 @@
+# ATM Crate Architecture
+
+## 1. Purpose
+
+This document defines the `atm` crate architectural boundary.
+
+It complements the product architecture in
+[`../architecture.md`](../architecture.md) and owns only CLI-layer decisions.
+
+## 2. Responsibilities
+
+The `atm` crate is responsible for:
+
+- clap argument parsing
+- command dispatch into `atm-core`
+- output selection and rendering
+- process exit status mapping
+- constructing and injecting the concrete observability adapter
+
+The `atm` crate must remain thin.
+
+## 3. Architectural Rules
+
+- `atm` may validate CLI syntax, but not reimplement `atm-core` business rules.
+- `atm` may shape output, but not change core service semantics.
+- `atm` owns mapping of CLI flags to `atm-core` request structs.
+- `atm` owns bootstrap of shared observability implementations used by
+  `atm-core`.
+
+## 4. ADR Namespace
+
+The `atm` crate uses the `ADR-ATM-*` namespace.
+
+Initial use cases:
+
+- clap surface decisions
+- output-format decisions
+- observability bootstrap wiring
+- command-dispatch structure

--- a/docs/atm/commands/ack.md
+++ b/docs/atm/commands/ack.md
@@ -9,3 +9,12 @@ CLI ownership for `atm ack`:
 - JSON output
 
 Ack transition semantics remain owned by `atm-core`.
+
+References:
+
+- Product requirements: `docs/requirements.md` §8
+- `REQ-P-ACK-001`
+- `REQ-ATM-CMD-001`
+- `REQ-ATM-OUT-001`
+- Product architecture: `docs/architecture.md`
+- Core module: `docs/atm-core/modules/ack.md`

--- a/docs/atm/commands/ack.md
+++ b/docs/atm/commands/ack.md
@@ -1,0 +1,11 @@
+# `atm ack`
+
+CLI ownership for `atm ack`:
+
+- message-id and reply parsing
+- actor override parsing
+- conversion into `atm-core` ack requests
+- human-readable output
+- JSON output
+
+Ack transition semantics remain owned by `atm-core`.

--- a/docs/atm/commands/clear.md
+++ b/docs/atm/commands/clear.md
@@ -10,3 +10,12 @@ CLI ownership for `atm clear`:
 - JSON output
 
 Clear eligibility remains owned by `atm-core`.
+
+References:
+
+- Product requirements: `docs/requirements.md` §9
+- `REQ-P-CLEAR-001`
+- `REQ-ATM-CMD-001`
+- `REQ-ATM-OUT-001`
+- Product architecture: `docs/architecture.md`
+- Core module: `docs/atm-core/modules/clear.md`

--- a/docs/atm/commands/clear.md
+++ b/docs/atm/commands/clear.md
@@ -1,0 +1,12 @@
+# `atm clear`
+
+CLI ownership for `atm clear`:
+
+- clear-mode flag parsing
+- actor override parsing
+- conversion into `atm-core` clear requests
+- dry-run rendering
+- human-readable output
+- JSON output
+
+Clear eligibility remains owned by `atm-core`.

--- a/docs/atm/commands/doctor.md
+++ b/docs/atm/commands/doctor.md
@@ -1,0 +1,10 @@
+# `atm doctor`
+
+CLI ownership for `atm doctor`:
+
+- doctor-mode and output flag parsing
+- conversion into `atm-core` doctor requests
+- human-readable finding rendering
+- JSON output
+
+Diagnostic logic remains owned by `atm-core`.

--- a/docs/atm/commands/doctor.md
+++ b/docs/atm/commands/doctor.md
@@ -8,3 +8,15 @@ CLI ownership for `atm doctor`:
 - JSON output
 
 Diagnostic logic remains owned by `atm-core`.
+
+References:
+
+- Product requirements: `docs/requirements.md` §11
+- `REQ-P-DOCTOR-001`
+- `REQ-ATM-CMD-001`
+- `REQ-ATM-OUT-001`
+- `REQ-ATM-OBS-001`
+- Product architecture: `docs/architecture.md`
+- Core modules:
+  - `docs/atm-core/modules/doctor.md`
+  - `docs/atm-core/modules/observability.md`

--- a/docs/atm/commands/log.md
+++ b/docs/atm/commands/log.md
@@ -1,0 +1,11 @@
+# `atm log`
+
+CLI ownership for `atm log`:
+
+- filter flag parsing
+- tail-mode parsing
+- JSON output selection
+- human-readable rendering of queried or tailed records
+
+Generic log query/follow behavior remains owned by the observability-backed
+`atm-core` log service.

--- a/docs/atm/commands/log.md
+++ b/docs/atm/commands/log.md
@@ -9,3 +9,26 @@ CLI ownership for `atm log`:
 
 Generic log query/follow behavior remains owned by the observability-backed
 `atm-core` log service.
+
+Specific CLI-owned flags:
+
+- `--tail`
+- `--level`
+- repeatable `--match key=value`
+- `--since`
+- `--limit`
+- `--json`
+
+`atm` must not implement ad hoc file parsing for `atm log`.
+
+References:
+
+- Product requirements: `docs/requirements.md` §10
+- `REQ-P-LOG-001`
+- `REQ-ATM-CMD-001`
+- `REQ-ATM-OUT-001`
+- `REQ-ATM-OBS-001`
+- Product architecture: `docs/architecture.md`
+- Core modules:
+  - `docs/atm-core/modules/log.md`
+  - `docs/atm-core/modules/observability.md`

--- a/docs/atm/commands/read.md
+++ b/docs/atm/commands/read.md
@@ -9,3 +9,12 @@ CLI ownership for `atm read`:
 - JSON output
 
 Workflow/state behavior remains owned by `atm-core`.
+
+References:
+
+- Product requirements: `docs/requirements.md` §7 and `read-behavior.md`
+- `REQ-P-READ-001`
+- `REQ-ATM-CMD-001`
+- `REQ-ATM-OUT-001`
+- Product architecture: `docs/architecture.md`
+- Core module: `docs/atm-core/modules/read.md`

--- a/docs/atm/commands/read.md
+++ b/docs/atm/commands/read.md
@@ -1,0 +1,11 @@
+# `atm read`
+
+CLI ownership for `atm read`:
+
+- selection flag parsing
+- timeout flag parsing
+- conversion into `atm-core` read requests
+- human-readable queue rendering
+- JSON output
+
+Workflow/state behavior remains owned by `atm-core`.

--- a/docs/atm/commands/send.md
+++ b/docs/atm/commands/send.md
@@ -8,3 +8,12 @@ CLI ownership for `atm send`:
 - JSON output
 
 Core send behavior remains owned by `atm-core`.
+
+References:
+
+- Product requirements: `docs/requirements.md` §6
+- `REQ-P-SEND-001`
+- `REQ-ATM-CMD-001`
+- `REQ-ATM-OUT-001`
+- Product architecture: `docs/architecture.md`
+- Core module: `docs/atm-core/modules/send.md`

--- a/docs/atm/commands/send.md
+++ b/docs/atm/commands/send.md
@@ -1,0 +1,10 @@
+# `atm send`
+
+CLI ownership for `atm send`:
+
+- positional and flag parsing
+- conversion into `atm-core` send requests
+- human-readable output
+- JSON output
+
+Core send behavior remains owned by `atm-core`.

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -1,0 +1,65 @@
+# ATM Crate Requirements
+
+## 1. Purpose
+
+This document defines the `atm` crate requirements.
+
+The `atm` crate owns the CLI layer only. Product behavior remains defined in
+[`../requirements.md`](../requirements.md). `atm` must satisfy those product
+requirements without re-owning `atm-core` business logic.
+
+## 2. Ownership
+
+`atm` owns:
+
+- clap command parsing
+- command dispatch
+- user-facing output rendering
+- process exit behavior
+- one-time observability bootstrap
+- concrete implementation of the `atm-core` observability boundary
+
+`atm` does not own:
+
+- mailbox mutation logic
+- state-machine logic
+- config resolution policy
+- log query business logic
+- doctor business logic
+
+## 3. Requirement Namespace
+
+The `atm` crate uses the `REQ-ATM-*` namespace.
+
+Initial allocation:
+
+- `REQ-ATM-CMD-*` for command-entry requirements
+- `REQ-ATM-OUT-*` for output/rendering requirements
+- `REQ-ATM-OBS-*` for observability-bootstrap requirements
+
+## 4. Command Ownership
+
+Per-command documentation lives under:
+
+- [`commands/send.md`](./commands/send.md)
+- [`commands/read.md`](./commands/read.md)
+- [`commands/ack.md`](./commands/ack.md)
+- [`commands/clear.md`](./commands/clear.md)
+- [`commands/log.md`](./commands/log.md)
+- [`commands/doctor.md`](./commands/doctor.md)
+
+Each command document defines:
+
+- CLI-owned flags and parsing rules
+- CLI-to-core mapping
+- output rendering behavior
+- references to the relevant product and `atm-core` requirements
+
+## 5. Required References
+
+The `atm` crate docs must remain aligned with:
+
+- [`../requirements.md`](../requirements.md)
+- [`../architecture.md`](../architecture.md)
+- [`../project-plan.md`](../project-plan.md)
+- [`../documentation-guidelines.md`](../documentation-guidelines.md)

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -37,6 +37,20 @@ Initial allocation:
 - `REQ-ATM-OUT-*` for output/rendering requirements
 - `REQ-ATM-OBS-*` for observability-bootstrap requirements
 
+Initial crate requirement IDs:
+
+- `REQ-ATM-CMD-001` `atm` owns clap parsing and command dispatch for the
+  retained command surface. Satisfies:
+  `REQ-P-SEND-001`, `REQ-P-READ-001`, `REQ-P-ACK-001`, `REQ-P-CLEAR-001`,
+  `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`.
+- `REQ-ATM-OUT-001` `atm` owns human-readable and JSON rendering for retained
+  commands. Satisfies:
+  `REQ-P-SEND-001`, `REQ-P-READ-001`, `REQ-P-ACK-001`, `REQ-P-CLEAR-001`,
+  `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`.
+- `REQ-ATM-OBS-001` `atm` owns concrete observability bootstrap and injection
+  into `atm-core`. Satisfies:
+  `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`, `REQ-P-OBS-001`.
+
 ## 4. Command Ownership
 
 Per-command documentation lives under:

--- a/docs/documentation-guidelines.md
+++ b/docs/documentation-guidelines.md
@@ -174,6 +174,9 @@ Examples:
 If a supporting document becomes crate-specific, move it under the owning crate
 directory.
 
+If a supporting document exists only for the migration program, mark it
+explicitly as migration-phase/temporary and remove it once its role is complete.
+
 ## 5. Crate-Level Document Responsibilities
 
 ### 5.1 `docs/atm/`
@@ -287,6 +290,15 @@ Required migration order:
 3. move crate-local detail out of top-level docs into owning crate docs
 4. replace duplicated prose with references
 5. keep top-level product docs concise and cross-cutting
+
+Migration-phase supporting docs such as `read-behavior.md`,
+`file-migration-plan.md`, and `migration-map.md` must be explicitly classified
+as either:
+
+- permanent cross-cutting documents
+- or temporary migration artifacts
+
+Do not leave their lifecycle implicit.
 
 During migration:
 

--- a/docs/documentation-guidelines.md
+++ b/docs/documentation-guidelines.md
@@ -1,0 +1,310 @@
+# ATM-Core Documentation Guidelines
+
+## 1. Purpose
+
+This document defines how `atm-core` product and crate documentation is
+organized.
+
+The goals are:
+
+- one clear source of truth for each requirement or architectural decision
+- explicit ownership boundaries between product documentation and crate
+  documentation
+- no duplicated requirement text across files
+- traceability from product behavior to crate implementation responsibility
+- easier review of boundary leakage between `atm` and `atm-core`
+
+## 2. Principles
+
+### 2.1 One Requirement, One Home
+
+A requirement must be written in exactly one place.
+
+- Product-level behavior belongs in product-level requirements.
+- Crate-level implementation obligations belong in crate-level requirements.
+- A document may reference a requirement owned elsewhere, but it must not copy
+  the requirement text.
+
+### 2.2 Product Docs Define Behavior
+
+Files in `docs/` at the top level define:
+
+- the product contract
+- the system architecture
+- the implementation plan
+- cross-cutting behavior that spans more than one crate
+
+Top-level docs must not drift into crate-local implementation detail unless that
+detail is necessary to explain a product-level decision.
+
+### 2.3 Crate Docs Define Ownership
+
+Files in `docs/atm/` and `docs/atm-core/` define:
+
+- what each crate owns
+- how each crate satisfies referenced product requirements
+- crate-local API and module boundaries
+- crate-local architectural decisions
+
+Crate docs must not redefine the product contract.
+
+### 2.4 Traceability Over Duplication
+
+When a product requirement is implemented by one or more crates:
+
+- the product requirement references the owning crate requirement IDs
+- the crate requirement references the product requirement it satisfies
+
+This traceability is required so reviewers can see:
+
+- missing ownership
+- overlapping ownership
+- boundary leakage
+
+### 2.5 Boundary Leaks Must Be Obvious
+
+The documentation structure should make these failures easy to detect:
+
+- `atm` owning core workflow logic
+- `atm-core` owning clap/terminal/UI behavior
+- product behavior duplicated in multiple files
+- two crates both claiming the same responsibility
+
+## 3. Directory Layout
+
+The required documentation layout is:
+
+```text
+docs/
+  documentation-guidelines.md
+  requirements.md
+  architecture.md
+  project-plan.md
+  read-behavior.md
+  file-migration-plan.md
+  migration-map.md
+  atm/
+    requirements.md
+    architecture.md
+    commands/
+      send.md
+      read.md
+      ack.md
+      clear.md
+      log.md
+      doctor.md
+  atm-core/
+    requirements.md
+    architecture.md
+    modules/
+      send.md
+      read.md
+      ack.md
+      clear.md
+      log.md
+      doctor.md
+      mailbox.md
+      config.md
+      observability.md
+```
+
+Notes:
+
+- Additional supporting docs may be added under `docs/atm/` or
+  `docs/atm-core/` when justified.
+- Top-level docs remain the only product-level source of truth.
+- Command docs belong under `docs/atm/commands/`.
+- Core service and module ownership docs belong under `docs/atm-core/modules/`.
+
+## 4. Top-Level Document Responsibilities
+
+### 4.1 `docs/requirements.md`
+
+Owns:
+
+- retained product surface
+- user-visible behavior
+- command semantics
+- mailbox/workflow behavior
+- external contracts
+- product-level non-functional requirements
+
+Must not own:
+
+- crate-local clap wiring
+- crate-local module layouts
+- crate-local implementation details beyond what is needed to define behavior
+
+### 4.2 `docs/architecture.md`
+
+Owns:
+
+- system shape
+- crate boundaries
+- shared models
+- integration boundaries
+- cross-cutting architecture decisions
+
+Must not duplicate full crate-local API specs when those are owned by crate
+docs.
+
+### 4.3 `docs/project-plan.md`
+
+Owns:
+
+- work phases
+- sequencing
+- milestones
+- acceptance gates
+- migration strategy
+
+Must reference requirement and architecture IDs instead of restating those
+contracts in full.
+
+### 4.4 Supporting Top-Level Docs
+
+Top-level supporting docs are allowed only when they remain cross-cutting.
+
+Examples:
+
+- `read-behavior.md`
+- `file-migration-plan.md`
+- `migration-map.md`
+
+If a supporting document becomes crate-specific, move it under the owning crate
+directory.
+
+## 5. Crate-Level Document Responsibilities
+
+### 5.1 `docs/atm/`
+
+Owns CLI-specific documentation:
+
+- clap command surfaces
+- flag semantics owned by the CLI layer
+- human-readable and JSON output contracts
+- command dispatch boundaries
+- `atm` architectural decisions
+
+`docs/atm/commands/` owns one file per retained command.
+
+Each command file must document:
+
+- the command entrypoint
+- CLI-owned flags and parsing rules
+- how the command maps into `atm-core`
+- output shaping and rendering behavior owned by `atm`
+- references to the product and core requirements it depends on
+
+### 5.2 `docs/atm-core/`
+
+Owns core library documentation:
+
+- service/API ownership
+- state machines
+- typestate and transition rules
+- mailbox/config/observability boundaries
+- module-level contracts
+- `atm-core` architectural decisions
+
+`docs/atm-core/modules/` owns one file per significant module or service area.
+
+Each module file must document:
+
+- the module’s responsibility
+- inputs and outputs
+- invariant rules
+- referenced product requirements
+- referenced crate-level requirements and ADRs
+
+## 6. Requirement IDs
+
+Formal requirement IDs are required.
+
+Use these prefixes:
+
+- `REQ-P-*` for product-level requirements
+- `REQ-ATM-*` for `atm` crate requirements
+- `REQ-CORE-*` for `atm-core` crate requirements
+
+ID rules:
+
+- IDs must be stable once published
+- IDs must not be reused for unrelated requirements
+- requirement text must appear only at the owning ID location
+
+Examples:
+
+- `REQ-P-READ-001`
+- `REQ-ATM-LOG-001`
+- `REQ-CORE-MAILBOX-003`
+
+## 7. Architecture Decision IDs
+
+Formal ADR IDs are required.
+
+Use these prefixes:
+
+- `ADR-P-*` for product-level architecture decisions
+- `ADR-ATM-*` for `atm` decisions
+- `ADR-CORE-*` for `atm-core` decisions
+
+Examples:
+
+- `ADR-P-001`
+- `ADR-ATM-002`
+- `ADR-CORE-004`
+
+## 8. Referencing Rules
+
+### 8.1 Product To Crate
+
+A product requirement must reference the crate requirement IDs that satisfy it.
+
+### 8.2 Crate To Product
+
+A crate requirement must reference the product requirement IDs it implements.
+
+### 8.3 ADR References
+
+When a requirement depends on an architectural decision, reference the ADR ID
+instead of repeating the decision text.
+
+### 8.4 File References
+
+When a document references implementation files, use exact repo-relative paths.
+Do not rely on ambiguous prose references.
+
+## 9. Migration Rules For Existing Docs
+
+The existing top-level docs are the starting point. They must be cleaned up
+into this structure incrementally.
+
+Required migration order:
+
+1. create crate directories and crate-level skeleton docs
+2. assign requirement and ADR ID namespaces
+3. move crate-local detail out of top-level docs into owning crate docs
+4. replace duplicated prose with references
+5. keep top-level product docs concise and cross-cutting
+
+During migration:
+
+- do not delete product-level requirements without rehoming them
+- do not duplicate content as a temporary “copy first” step unless immediately
+  followed by removal from the old location in the same change
+- note unresolved ownership gaps explicitly instead of leaving them implicit
+
+## 10. Review Checklist
+
+Before a documentation change is review-ready, verify:
+
+- every new requirement has exactly one owning file
+- every product requirement has crate-level ownership references where needed
+- no crate doc restates the full product requirement text
+- command docs live under `docs/atm/commands/`
+- core module docs live under `docs/atm-core/modules/`
+- boundary ownership between `atm` and `atm-core` is explicit
+- requirement and ADR IDs are stable and correctly prefixed
+- the top-level docs stay readable as product documents rather than devolving
+  into crate-internal notes

--- a/docs/file-migration-plan.md
+++ b/docs/file-migration-plan.md
@@ -1,5 +1,11 @@
 # File Migration Plan
 
+**Lifecycle**: Temporary migration artifact
+
+This document is authoritative only for the rewrite/migration program. Once the
+rewrite is complete and the retained source layout is stable, this document
+should be retired rather than maintained as permanent product documentation.
+
 This is the authoritative implementation plan.
 
 Format:

--- a/docs/migration-map.md
+++ b/docs/migration-map.md
@@ -1,5 +1,11 @@
 # Migration Summary
 
+**Lifecycle**: Temporary migration artifact
+
+This document exists only to summarize the rewrite strategy while the migration
+program is active. It should be retired once the permanent docs fully describe
+the post-migration system.
+
 `file-migration-plan.md` is the authoritative migration document.
 
 This file is only a summary of the rewrite strategy:

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -27,34 +27,17 @@ restructured, product docs remain in `docs/` and crate-local detail moves into
 
 ## 3. Crates
 
-### 3.1 `crates/atm-core`
+The implementation remains split across:
 
-Implements:
-- path and home resolution
-- config, bridge, and settings resolution
-- hook identity resolution
-- file policy
-- mailbox I/O and origin merge
-- workflow axis model and transitions
-- send, read, ack, and clear services
-- log query/follow service over the injected observability port
-- doctor diagnostics service
-- observability event/query models and the observability port boundary
-- error model
+- `crates/atm-core`
+- `crates/atm`
 
-### 3.2 `crates/atm`
+Crate-local scope detail is owned by:
 
-Implements:
-- clap parser
-- `send`
-- `read`
-- `ack`
-- `clear`
-- `log`
-- `doctor`
-- output formatting
-- observability bootstrap
-- concrete `sc-observability` port implementation and injection
+- [`docs/atm-core/requirements.md`](./atm-core/requirements.md)
+- [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
+- [`docs/atm/requirements.md`](./atm/requirements.md)
+- [`docs/atm/architecture.md`](./atm/architecture.md)
 
 ## 4. Work Sequence
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -9,6 +9,11 @@ The authoritative migration document is:
 
 This plan sequences the work. File-level migration decisions live in `file-migration-plan.md`.
 
+Documentation organization and cleanup are governed by
+[`documentation-guidelines.md`](./documentation-guidelines.md). As the docs are
+restructured, product docs remain in `docs/` and crate-local detail moves into
+`docs/atm/` and `docs/atm-core/`.
+
 ## 2. Deliverables
 
 - Rust workspace with `crates/atm-core` and `crates/atm`

--- a/docs/read-behavior.md
+++ b/docs/read-behavior.md
@@ -1,5 +1,11 @@
 # ATM Read Behavior Review
 
+**Lifecycle**: Permanent cross-cutting document
+
+This document remains part of the durable documentation set because read
+selection, bucket behavior, seen-state rules, and wait semantics are
+cross-cutting product behavior rather than crate-local implementation detail.
+
 This document defines the canonical read behavior for the rewrite and records which parts of current ATM behavior are preserved.
 
 ## 1. Why This Document Exists

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,6 +2,10 @@
 
 ## 1. Product Definition
 
+Product requirement ID:
+- `REQ-P-PRODUCT-001` The retained daemon-free ATM product surface consists of
+  `send`, `read`, `ack`, `clear`, `log`, and `doctor`.
+
 The product is a local command-line tool named `atm`.
 
 This rewrite removes daemon architecture. It does not intentionally remove core non-daemon ATM functionality.
@@ -35,6 +39,11 @@ During the cleanup/restructure phase, product requirements stay here while
 crate-local ownership is moved out of this file into the crate directories.
 
 ## 2. Scope
+
+Product requirement ID:
+- `REQ-P-SCOPE-001` The rewrite retains the documented command surface and
+  removes daemon architecture without intentionally removing retained
+  functionality.
 
 ### 2.1 In Scope
 
@@ -71,6 +80,10 @@ crate-local ownership is moved out of this file into the crate directories.
 - team lifecycle management outside what the retained commands need
 
 ## 3. External Contracts
+
+Product requirement ID:
+- `REQ-P-CONTRACT-001` External path/config/store/observability contracts must
+  match the documented daemon-free behavior.
 
 ### 3.1 Home And Path Resolution
 
@@ -147,6 +160,10 @@ ATM must not implement a parallel ad hoc log-query engine when shared `sc-observ
 
 ## 4. Identity Resolution
 
+Product requirement ID:
+- `REQ-P-IDENTITY-001` Identity resolution must follow the documented command
+  precedence rules.
+
 ### 4.1 Send Identity Resolution Order
 
 1. `--from`
@@ -169,6 +186,10 @@ If command identity cannot be determined where required, the command must fail w
 
 ## 5. Address Resolution
 
+Product requirement ID:
+- `REQ-P-ADDRESS-001` Address resolution must support the documented
+  `agent`/`agent@team` forms and precedence rules.
+
 Supported address forms:
 - `agent`
 - `agent@team`
@@ -183,6 +204,9 @@ An explicit `@team` suffix takes precedence over `--team`.
 Roles and aliases are resolved after splitting `agent@team`, so only the agent token is rewritten.
 
 ## 6. `atm send`
+
+Product requirement ID:
+- `REQ-P-SEND-001` `atm send` must satisfy the documented send contract.
 
 ### 6.1 Purpose
 
@@ -291,6 +315,10 @@ Dry-run JSON output must include:
 - `task_id`
 
 ## 7. `atm read`
+
+Product requirement ID:
+- `REQ-P-READ-001` `atm read` must satisfy the documented read/selection/wait
+  contract.
 
 ### 7.1 Purpose
 
@@ -477,6 +505,10 @@ JSON output must include:
 
 ## 8. `atm ack`
 
+Product requirement ID:
+- `REQ-P-ACK-001` `atm ack` must satisfy the documented acknowledgement
+  contract.
+
 ### 8.1 Purpose
 
 Acknowledge a pending-ack message in the caller's own inbox and send a visible reply to the original sender.
@@ -514,6 +546,10 @@ JSON output must include:
 - `reply_target`
 
 ## 9. `atm clear`
+
+Product requirement ID:
+- `REQ-P-CLEAR-001` `atm clear` must satisfy the documented clear contract and
+  preserve pending-ack protection.
 
 ### 9.1 Purpose
 
@@ -561,6 +597,10 @@ JSON output must include:
 - removal counters by class
 
 ## 10. `atm log`
+
+Product requirement ID:
+- `REQ-P-LOG-001` `atm log` must satisfy the documented shared-observability
+  query/follow contract.
 
 ### 10.1 Purpose
 
@@ -625,6 +665,10 @@ Each JSON record must expose at least:
 
 ## 11. `atm doctor`
 
+Product requirement ID:
+- `REQ-P-DOCTOR-001` `atm doctor` must satisfy the documented local diagnostics
+  contract.
+
 ### 11.1 Purpose
 
 Run local ATM diagnostics for the retained daemon-free system.
@@ -673,6 +717,10 @@ Each doctor finding must expose at least:
 Critical findings must cause a non-zero exit status.
 
 ## 12. Message And Workflow Model
+
+Product requirement ID:
+- `REQ-P-WORKFLOW-001` The message/workflow model must satisfy the documented
+  persisted-field, two-axis, and legal-transition rules.
 
 ### 12.1 Persisted Message Fields
 
@@ -782,6 +830,10 @@ Required rules:
 
 ## 13. Observability Requirements
 
+Product requirement ID:
+- `REQ-P-OBS-001` ATM observability must satisfy the documented best-effort
+  emit behavior and shared query/follow/health expectations.
+
 ATM must emit structured records through `sc-observability`.
 
 Required ATM event classes:
@@ -811,6 +863,10 @@ Emission is best-effort:
 
 ## 14. Error Requirements
 
+Product requirement ID:
+- `REQ-P-ERROR-001` Public command failures must satisfy the documented
+  structured error requirements.
+
 All user-visible failures must use structured errors with recovery guidance.
 
 Minimum error categories:
@@ -836,6 +892,10 @@ Mutation failures must be fail-safe:
 
 ## 15. Reliability Requirements
 
+Product requirement ID:
+- `REQ-P-RELIABILITY-001` The retained command surface must satisfy the
+  documented durability and consistency constraints.
+
 - mailbox writes must be atomic
 - concurrent appends must not silently lose messages
 - duplicate message ids must not be appended twice
@@ -845,6 +905,9 @@ Mutation failures must be fail-safe:
 - observability emission failures must not corrupt command behavior
 
 ## 16. Testing Requirements
+
+Product requirement ID:
+- `REQ-P-TEST-001` The rewrite must satisfy the documented testing obligations.
 
 Because `sc-observability` is newly introduced into ATM, the rewrite must add explicit test coverage for:
 - ATM event emission through the observability port boundary
@@ -867,6 +930,10 @@ The implementation must include:
 - CLI integration tests for `atm clear`
 
 ## 17. Acceptance Criteria
+
+Product requirement ID:
+- `REQ-P-ACCEPTANCE-001` The rewrite is complete only when the documented
+  acceptance criteria are met.
 
 The rewrite is ready when:
 - `atm send` works without daemon support

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -18,6 +18,22 @@ The rewritten system must preserve usable non-daemon behavior already present in
 
 The system uses structured logging through `sc-observability`.
 
+## 1.1 Documentation Structure
+
+Documentation organization is defined in
+[`documentation-guidelines.md`](./documentation-guidelines.md).
+
+Top-level product docs in `docs/` remain the product source of truth.
+Crate-local ownership docs live under:
+
+- [`docs/atm/requirements.md`](./atm/requirements.md)
+- [`docs/atm/architecture.md`](./atm/architecture.md)
+- [`docs/atm-core/requirements.md`](./atm-core/requirements.md)
+- [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
+
+During the cleanup/restructure phase, product requirements stay here while
+crate-local ownership is moved out of this file into the crate directories.
+
 ## 2. Scope
 
 ### 2.1 In Scope
@@ -206,6 +222,7 @@ Retired from the current implementation:
 - support dry-run without mutation
 - support sender-controlled ack-required messages
 - support optional task metadata on sent messages
+- `atm send` MUST generate and write a non-null UUID v4 as `message_id` for every sent message. `message_id` is optional in the persisted schema (§12.1) to support legacy messages written by older clients, but `atm send` never omits it.
 
 ### 6.4 Message Source Semantics
 


### PR DESCRIPTION
## Summary

- Adds `docs/documentation-guidelines.md` defining top-level vs crate-level doc split, REQ/ADR ID scheme, no-duplication rule, and migration order rules
- Scaffolds `docs/atm/` and `docs/atm-core/` crate-level doc structure with per-command and per-module stubs
- Moves crate-local ownership/layout detail out of `docs/architecture.md` and `docs/project-plan.md`, replacing with references to crate-level docs
- Classifies migration-phase supporting docs as temporary vs permanent

## Test plan

- [ ] QA (ATM-CORE-DOCS-QA-1) in flight — requirements integrity audit (no requirements dropped or altered during move+remove)
- [ ] `cargo test` green (rust-qa-agent running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)