### PR TITLE
docs: fix stale layout tree and examples in documentation-guidelines

### DIFF
--- a/docs/documentation-guidelines.md
+++ b/docs/documentation-guidelines.md
@@ -88,8 +88,10 @@ docs/
   architecture.md
   project-plan.md
   read-behavior.md
-  file-migration-plan.md  # temporary migration artifact
-  migration-map.md        # temporary migration artifact
+  archive/
+    file-migration-plan.md
+    migration-map.md
+    obs-gap-analysis.md
   atm/
     requirements.md
     architecture.md
@@ -175,8 +177,12 @@ Top-level supporting docs are allowed only when they remain cross-cutting.
 Examples:
 
 - `read-behavior.md`
-- `file-migration-plan.md`
-- `migration-map.md`
+
+Migration-only supporting documents now live under `docs/archive/`:
+
+- `archive/file-migration-plan.md`
+- `archive/migration-map.md`
+- `archive/obs-gap-analysis.md`
 
 If a supporting document becomes crate-specific, move it under the owning crate
 directory.


### PR DESCRIPTION
## Summary
- Closes DOCS-QA-004: §3 layout tree now shows `docs/archive/` with all 3 archived files
- Closes DOCS-QA-005: §4.4 examples updated to `read-behavior.md` as sole permanent top-level supporting doc; notes migration docs moved to `docs/archive/`
- Single file change: `docs/documentation-guidelines.md`

## Test plan
- [ ] §3 layout tree accurately reflects current `docs/` structure including `docs/archive/`
- [ ] §4.4 examples no longer reference stale filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)