### PR TITLE
feat(log): Phase G.1 — atm log port + CLI + test-double coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "atm-core",
  "chrono",
  "clap",
+ "serde",
  "serde_json",
  "tempfile",
  "tracing",

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -167,6 +167,14 @@ impl AtmError {
     pub fn observability_emit(message: impl Into<String>) -> Self {
         Self::new(AtmErrorKind::ObservabilityEmit, message)
     }
+
+    pub fn observability_query(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::ObservabilityQuery, message)
+    }
+
+    pub fn observability_health(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::ObservabilityHealth, message)
+    }
 }
 
 impl fmt::Display for AtmError {

--- a/crates/atm-core/src/log/filters.rs
+++ b/crates/atm-core/src/log/filters.rs
@@ -1,1 +1,92 @@
-// TODO: define log filtering types and helpers.
+use serde_json::Value;
+
+use super::{LogFieldFilter, LogLevel, LogRecord};
+
+pub fn matches_query(
+    record: &LogRecord,
+    level: Option<LogLevel>,
+    filters: &[LogFieldFilter],
+) -> bool {
+    level.map_or(true, |level_filter| record.level == level_filter)
+        && filters
+            .iter()
+            .all(|filter| matches_field_filter(record, filter))
+}
+
+fn matches_field_filter(record: &LogRecord, filter: &LogFieldFilter) -> bool {
+    match record.fields.get(&filter.key) {
+        Some(Value::String(value)) => value == &filter.value,
+        Some(value) => render_value(value) == filter.value,
+        None => false,
+    }
+}
+
+fn render_value(value: &Value) -> String {
+    match value {
+        Value::Null => "null".into(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) => value.clone(),
+        Value::Array(_) | Value::Object(_) => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::types::IsoTimestamp;
+
+    use super::{matches_query, LogFieldFilter, LogLevel, LogRecord};
+
+    fn record() -> LogRecord {
+        LogRecord {
+            timestamp: IsoTimestamp::now(),
+            level: LogLevel::Warn,
+            service: "atm".into(),
+            event: "command.failed".into(),
+            message: Some("failed".into()),
+            fields: serde_json::from_value(json!({
+                "command": "read",
+                "team": "atm-dev",
+                "count": 2
+            }))
+            .expect("fields"),
+        }
+    }
+
+    #[test]
+    fn matches_level_filter() {
+        assert!(matches_query(&record(), Some(LogLevel::Warn), &[]));
+        assert!(!matches_query(&record(), Some(LogLevel::Info), &[]));
+    }
+
+    #[test]
+    fn matches_field_filters() {
+        let record = record();
+        assert!(matches_query(
+            &record,
+            None,
+            &[LogFieldFilter {
+                key: "command".into(),
+                value: "read".into(),
+            }]
+        ));
+        assert!(matches_query(
+            &record,
+            None,
+            &[LogFieldFilter {
+                key: "count".into(),
+                value: "2".into(),
+            }]
+        ));
+        assert!(!matches_query(
+            &record,
+            None,
+            &[LogFieldFilter {
+                key: "command".into(),
+                value: "send".into(),
+            }]
+        ));
+    }
+}

--- a/crates/atm-core/src/log/mod.rs
+++ b/crates/atm-core/src/log/mod.rs
@@ -1,3 +1,62 @@
 pub mod filters;
 
-// TODO: implement log query and follow services.
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::error::AtmError;
+use crate::observability::{LogFollowSession, ObservabilityPort};
+use crate::types::IsoTimestamp;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogFieldFilter {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogQuery {
+    pub level: Option<LogLevel>,
+    pub filters: Vec<LogFieldFilter>,
+    pub follow: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LogRecord {
+    pub timestamp: IsoTimestamp,
+    pub level: LogLevel,
+    pub service: String,
+    pub event: String,
+    pub message: Option<String>,
+    pub fields: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LogQueryResult {
+    pub action: &'static str,
+    pub follow: bool,
+    pub records: Vec<LogRecord>,
+}
+
+pub fn query_logs(
+    query: LogQuery,
+    observability: &dyn ObservabilityPort,
+) -> Result<LogQueryResult, AtmError> {
+    observability.query_logs(&query)
+}
+
+pub fn follow_logs(
+    query: LogQuery,
+    observability: &dyn ObservabilityPort,
+) -> Result<Box<dyn LogFollowSession>, AtmError> {
+    observability.follow_logs(&query)
+}

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use crate::error::AtmError;
+use crate::log::{LogQuery, LogQueryResult, LogRecord};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct CommandEvent {
@@ -17,8 +18,23 @@ pub struct CommandEvent {
     pub task_id: Option<String>,
 }
 
+pub trait LogFollowSession: Send {
+    fn next_record(&mut self) -> Result<Option<LogRecord>, AtmError>;
+}
+
 pub trait ObservabilityPort {
+    /// Best-effort emit path used by mail commands. Failures must not block
+    /// send/read/ack/clear correctness.
     fn emit_command_event(&self, event: CommandEvent) -> Result<(), AtmError>;
+
+    /// Explicit log-consumer query path. Unlike `emit_command_event`, failures
+    /// here are surfaced to the caller because `atm log` is itself an
+    /// observability consumer.
+    fn query_logs(&self, query: &LogQuery) -> Result<LogQueryResult, AtmError>;
+
+    /// Explicit follow/tail path for `atm log --follow`. The returned session
+    /// owns any adapter-specific state needed to yield matching records.
+    fn follow_logs(&self, query: &LogQuery) -> Result<Box<dyn LogFollowSession>, AtmError>;
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -27,5 +43,21 @@ pub struct NullObservability;
 impl ObservabilityPort for NullObservability {
     fn emit_command_event(&self, _event: CommandEvent) -> Result<(), AtmError> {
         Ok(())
+    }
+
+    fn query_logs(&self, _query: &LogQuery) -> Result<LogQueryResult, AtmError> {
+        Err(
+            AtmError::observability_query("observability query API is unavailable").with_recovery(
+                "Inject a concrete observability port that supports ATM log queries.",
+            ),
+        )
+    }
+
+    fn follow_logs(&self, _query: &LogQuery) -> Result<Box<dyn LogFollowSession>, AtmError> {
+        Err(
+            AtmError::observability_query("observability follow API is unavailable").with_recovery(
+                "Inject a concrete observability port that supports ATM log follow.",
+            ),
+        )
     }
 }

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -11,6 +11,7 @@ atm-core = { path = "../atm-core" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/atm/src/commands/ack.rs
+++ b/crates/atm/src/commands/ack.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result};
 use atm_core::ack::{self, AckRequest};
 use atm_core::home;
+use atm_core::observability::ObservabilityPort;
 use clap::Args;
 use uuid::Uuid;
 
-use crate::observability::CliObservability;
 use crate::output;
 
 #[derive(Debug, Args)]
@@ -23,7 +23,7 @@ pub struct AckCommand {
 }
 
 impl AckCommand {
-    pub fn run(self, observability: &CliObservability) -> Result<()> {
+    pub fn run(self, observability: &dyn ObservabilityPort) -> Result<()> {
         let current_dir = std::env::current_dir()?;
         let home_dir = home::atm_home()?;
         let message_id = Uuid::parse_str(&self.message_id)

--- a/crates/atm/src/commands/clear.rs
+++ b/crates/atm/src/commands/clear.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use atm_core::clear::{self, ClearQuery};
 use atm_core::home;
+use atm_core::observability::ObservabilityPort;
 use clap::Args;
 
-use crate::observability::CliObservability;
 use crate::output;
 
 #[derive(Debug, Args)]
@@ -32,7 +32,7 @@ pub struct ClearCommand {
 }
 
 impl ClearCommand {
-    pub fn run(self, observability: &CliObservability) -> Result<()> {
+    pub fn run(self, observability: &dyn ObservabilityPort) -> Result<()> {
         let current_dir = std::env::current_dir()?;
         let home_dir = home::atm_home()?;
         let older_than = self.older_than.as_deref().map(parse_duration).transpose()?;

--- a/crates/atm/src/commands/log.rs
+++ b/crates/atm/src/commands/log.rs
@@ -1,12 +1,83 @@
-use anyhow::Result;
-use clap::Args;
+use anyhow::{Context, Result};
+use atm_core::log::{self, LogFieldFilter, LogLevel, LogQuery};
+use atm_core::observability::ObservabilityPort;
+use clap::{Args, ValueEnum};
+
+use crate::output;
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum LogLevelArg {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl From<LogLevelArg> for LogLevel {
+    fn from(value: LogLevelArg) -> Self {
+        match value {
+            LogLevelArg::Trace => LogLevel::Trace,
+            LogLevelArg::Debug => LogLevel::Debug,
+            LogLevelArg::Info => LogLevel::Info,
+            LogLevelArg::Warn => LogLevel::Warn,
+            LogLevelArg::Error => LogLevel::Error,
+        }
+    }
+}
 
 #[derive(Debug, Args)]
-pub struct LogCommand {}
+pub struct LogCommand {
+    #[arg(long)]
+    level: Option<LogLevelArg>,
+
+    #[arg(long = "filter")]
+    filters: Vec<String>,
+
+    #[arg(long = "follow")]
+    follow: bool,
+
+    #[arg(long)]
+    json: bool,
+}
 
 impl LogCommand {
-    pub fn run(self) -> Result<()> {
-        println!("log not yet implemented");
-        Ok(())
+    pub fn run(self, observability: &dyn ObservabilityPort) -> Result<()> {
+        let query = LogQuery {
+            level: self.level.map(Into::into),
+            filters: self
+                .filters
+                .iter()
+                .map(|raw| parse_filter(raw))
+                .collect::<Result<Vec<_>>>()?,
+            follow: self.follow,
+        };
+
+        if self.follow {
+            let mut session = log::follow_logs(query, observability)?;
+            while let Some(record) = session.next_record()? {
+                output::print_log_record(&record, self.json)?;
+            }
+            return Ok(());
+        }
+
+        let result = log::query_logs(query, observability)?;
+        output::print_log_result(&result, self.json)
     }
+}
+
+fn parse_filter(raw: &str) -> Result<LogFieldFilter> {
+    let (key, value) = raw
+        .split_once('=')
+        .with_context(|| format!("invalid filter '{raw}'; expected key=value"))?;
+    if key.trim().is_empty() {
+        anyhow::bail!("invalid filter '{raw}'; key must not be empty");
+    }
+    if value.is_empty() {
+        anyhow::bail!("invalid filter '{raw}'; value must not be empty");
+    }
+    Ok(LogFieldFilter {
+        key: key.trim().to_string(),
+        value: value.to_string(),
+    })
 }

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use atm_core::observability::ObservabilityPort;
 use clap::{Parser, Subcommand};
 
 pub mod ack;
@@ -46,13 +47,13 @@ enum Command {
 }
 
 impl Command {
-    fn run(self, observability: &CliObservability) -> Result<()> {
+    fn run(self, observability: &dyn ObservabilityPort) -> Result<()> {
         match self {
             Self::Send(command) => command.run(observability),
             Self::Read(command) => command.run(observability),
             Self::Ack(command) => command.run(observability),
             Self::Clear(command) => command.run(observability),
-            Self::Log(command) => command.run(),
+            Self::Log(command) => command.run(observability),
             Self::Doctor(command) => command.run(),
         }
     }

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result};
 use atm_core::home;
+use atm_core::observability::ObservabilityPort;
 use atm_core::read::{self, ReadQuery};
 use atm_core::types::{AckActivationMode, IsoTimestamp, ReadSelection};
 use clap::Args;
 
-use crate::observability::CliObservability;
 use crate::output;
 
 #[derive(Debug, Args)]
@@ -58,7 +58,7 @@ pub struct ReadCommand {
 }
 
 impl ReadCommand {
-    pub fn run(self, observability: &CliObservability) -> Result<()> {
+    pub fn run(self, observability: &dyn ObservabilityPort) -> Result<()> {
         let current_dir = std::env::current_dir()?;
         let home_dir = home::atm_home()?;
         // --since-last-seen is the default; explicitly setting it has the same effect.

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -2,10 +2,10 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use atm_core::home;
+use atm_core::observability::ObservabilityPort;
 use atm_core::send::{self, SendMessageSource, SendRequest};
 use clap::Args;
 
-use crate::observability::CliObservability;
 use crate::output;
 
 #[derive(Debug, Args)]
@@ -45,7 +45,7 @@ pub struct SendCommand {
 }
 
 impl SendCommand {
-    pub fn run(self, observability: &CliObservability) -> Result<()> {
+    pub fn run(self, observability: &dyn ObservabilityPort) -> Result<()> {
         let current_dir = std::env::current_dir()?;
         let home_dir = home::atm_home()?;
         let message_source = self.build_message_source()?;

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -1,34 +1,143 @@
-use anyhow::Result;
+use std::env;
+use std::fs;
+
+use anyhow::{Context, Result};
 use atm_core::error::AtmError;
-use atm_core::observability::{CommandEvent, ObservabilityPort};
+use atm_core::log::{filters, LogQuery, LogQueryResult, LogRecord};
+use atm_core::observability::{CommandEvent, LogFollowSession, ObservabilityPort};
+use serde::Deserialize;
 use tracing::info;
 
-#[derive(Debug, Default, Clone, Copy)]
-pub struct CliObservability;
+#[derive(Debug, Default, Clone)]
+pub struct CliObservability {
+    backend: ObservabilityBackend,
+}
+
+#[derive(Debug, Default, Clone)]
+enum ObservabilityBackend {
+    #[default]
+    Live,
+    Test(TestLogFixture),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TestLogFixture {
+    #[serde(default)]
+    records: Vec<LogRecord>,
+    #[serde(default)]
+    follow_records: Vec<LogRecord>,
+    #[serde(default)]
+    emit_fails: bool,
+}
+
+#[derive(Debug)]
+struct TestFollowSession {
+    records: std::vec::IntoIter<LogRecord>,
+}
 
 pub fn init() -> Result<CliObservability> {
+    if let Ok(path) = env::var("ATM_TEST_LOG_FIXTURE") {
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read ATM_TEST_LOG_FIXTURE at {path}"))?;
+        let fixture: TestLogFixture =
+            serde_json::from_str(&raw).context("failed to decode ATM test log fixture")?;
+        return Ok(CliObservability {
+            backend: ObservabilityBackend::Test(fixture),
+        });
+    }
+
     let _ = tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .try_init();
-    Ok(CliObservability)
+    Ok(CliObservability {
+        backend: ObservabilityBackend::Live,
+    })
 }
 
 impl ObservabilityPort for CliObservability {
     fn emit_command_event(&self, event: CommandEvent) -> Result<(), AtmError> {
-        let message_id = event.message_id.map(|value| value.to_string());
-        info!(
-            command = event.command,
-            action = event.action,
-            outcome = event.outcome,
-            team = event.team,
-            agent = event.agent,
-            sender = event.sender,
-            message_id = message_id.as_deref().unwrap_or(""),
-            requires_ack = event.requires_ack,
-            dry_run = event.dry_run,
-            task_id = event.task_id.as_deref().unwrap_or(""),
-            "atm command event"
-        );
-        Ok(())
+        match &self.backend {
+            ObservabilityBackend::Test(fixture) if fixture.emit_fails => Err(
+                AtmError::observability_emit("test fixture forced emit failure"),
+            ),
+            ObservabilityBackend::Test(_) | ObservabilityBackend::Live => {
+                let message_id = event.message_id.map(|value| value.to_string());
+                info!(
+                    command = event.command,
+                    action = event.action,
+                    outcome = event.outcome,
+                    team = event.team,
+                    agent = event.agent,
+                    sender = event.sender,
+                    message_id = message_id.as_deref().unwrap_or(""),
+                    requires_ack = event.requires_ack,
+                    dry_run = event.dry_run,
+                    task_id = event.task_id.as_deref().unwrap_or(""),
+                    "atm command event"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    fn query_logs(&self, query: &LogQuery) -> Result<LogQueryResult, AtmError> {
+        match &self.backend {
+            ObservabilityBackend::Test(fixture) => {
+                let mut records = fixture
+                    .records
+                    .iter()
+                    .filter(|record| filters::matches_query(record, query.level, &query.filters))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                records.sort_by(|left, right| right.timestamp.cmp(&left.timestamp));
+                Ok(LogQueryResult {
+                    action: "log",
+                    follow: false,
+                    records,
+                })
+            }
+            ObservabilityBackend::Live => Err(
+                AtmError::observability_query(
+                    "shared sc-observability query API is not yet integrated for atm log",
+                )
+                .with_recovery(
+                    "Use the ATM test double for Phase G validation or wait for arch-obs to land the shared query API.",
+                ),
+            ),
+        }
+    }
+
+    fn follow_logs(&self, query: &LogQuery) -> Result<Box<dyn LogFollowSession>, AtmError> {
+        match &self.backend {
+            ObservabilityBackend::Test(fixture) => {
+                let source = if fixture.follow_records.is_empty() {
+                    &fixture.records
+                } else {
+                    &fixture.follow_records
+                };
+                let records = source
+                    .iter()
+                    .filter(|record| filters::matches_query(record, query.level, &query.filters))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                Ok(Box::new(TestFollowSession {
+                    records: records.into_iter(),
+                }))
+            }
+            ObservabilityBackend::Live => Err(
+                AtmError::observability_query(
+                    "shared sc-observability follow API is not yet integrated for atm log --follow",
+                )
+                .with_recovery(
+                    "Use the ATM test double for Phase G validation or wait for arch-obs to land the shared follow API.",
+                ),
+            ),
+        }
+    }
+}
+
+impl LogFollowSession for TestFollowSession {
+    fn next_record(&mut self) -> Result<Option<LogRecord>, AtmError> {
+        Ok(self.records.next())
     }
 }

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use atm_core::ack::AckOutcome;
 use atm_core::clear::ClearOutcome;
+use atm_core::log::{LogQueryResult, LogRecord};
 use atm_core::read::ReadOutcome;
 use atm_core::send::SendOutcome;
 use atm_core::types::DisplayBucket;
@@ -93,6 +94,29 @@ pub fn print_clear_result(outcome: &ClearOutcome, dry_run: bool, json: bool) -> 
     Ok(())
 }
 
+pub fn print_log_result(outcome: &LogQueryResult, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+        return Ok(());
+    }
+
+    for record in &outcome.records {
+        print_log_human(record);
+    }
+
+    Ok(())
+}
+
+pub fn print_log_record(record: &LogRecord, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string(record)?);
+    } else {
+        print_log_human(record);
+    }
+
+    Ok(())
+}
+
 fn print_bucket(outcome: &ReadOutcome, bucket: DisplayBucket, label: &str) {
     let messages = outcome
         .messages
@@ -120,5 +144,44 @@ fn print_bucket(outcome: &ReadOutcome, bucket: DisplayBucket, label: &str) {
         if let Some(message_id) = message.envelope.message_id {
             println!("  message_id: {message_id}");
         }
+    }
+}
+
+fn print_log_human(record: &LogRecord) {
+    let message = record.message.as_deref().unwrap_or(record.event.as_str());
+    let mut field_pairs = record
+        .fields
+        .iter()
+        .map(|(key, value)| format!("{key}={}", render_value(value)))
+        .collect::<Vec<_>>();
+    field_pairs.sort();
+
+    if field_pairs.is_empty() {
+        println!(
+            "{} {:?} {} {}",
+            record.timestamp.into_inner().to_rfc3339(),
+            record.level,
+            record.service,
+            message
+        );
+    } else {
+        println!(
+            "{} {:?} {} {} {}",
+            record.timestamp.into_inner().to_rfc3339(),
+            record.level,
+            record.service,
+            message,
+            field_pairs.join(" ")
+        );
+    }
+}
+
+fn render_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => "null".into(),
+        serde_json::Value::Bool(value) => value.to_string(),
+        serde_json::Value::Number(value) => value.to_string(),
+        serde_json::Value::String(value) => value.clone(),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => value.to_string(),
     }
 }

--- a/crates/atm/tests/log.rs
+++ b/crates/atm/tests/log.rs
@@ -1,0 +1,175 @@
+use std::fs;
+use std::process::Command;
+
+use serde_json::json;
+use tempfile::TempDir;
+
+#[test]
+fn test_log_json_output() {
+    let fixture = Fixture::new(json!({
+        "records": [
+            record("2026-03-31T06:00:00Z", "info", "atm", "command.started", "started", json!({
+                "command": "read",
+                "team": "atm-dev"
+            })),
+            record("2026-03-31T06:00:05Z", "warn", "atm", "command.failed", "failed", json!({
+                "command": "send",
+                "team": "atm-dev"
+            }))
+        ]
+    }));
+
+    let output = fixture.run(&["log", "--json"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid log json");
+    assert_eq!(parsed["action"], "log");
+    assert_eq!(parsed["follow"], false);
+    assert_eq!(parsed["records"].as_array().map(Vec::len), Some(2));
+    assert_eq!(parsed["records"][0]["level"], "warn");
+    assert_eq!(parsed["records"][0]["fields"]["command"], "send");
+}
+
+#[test]
+fn test_log_level_filter() {
+    let fixture = Fixture::new(json!({
+        "records": [
+            record("2026-03-31T06:00:00Z", "info", "atm", "command.started", "started", json!({
+                "command": "read"
+            })),
+            record("2026-03-31T06:00:05Z", "error", "atm", "command.failed", "failed", json!({
+                "command": "send"
+            }))
+        ]
+    }));
+
+    let output = fixture.run(&["log", "--level", "error", "--json"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid log json");
+    assert_eq!(parsed["records"].as_array().map(Vec::len), Some(1));
+    assert_eq!(parsed["records"][0]["level"], "error");
+}
+
+#[test]
+fn test_log_field_filter() {
+    let fixture = Fixture::new(json!({
+        "records": [
+            record("2026-03-31T06:00:00Z", "info", "atm", "command.started", "started", json!({
+                "command": "read",
+                "team": "atm-dev"
+            })),
+            record("2026-03-31T06:00:05Z", "info", "atm", "command.started", "started", json!({
+                "command": "send",
+                "team": "atm-dev"
+            }))
+        ]
+    }));
+
+    let output = fixture.run(&["log", "--filter", "command=read", "--json"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid log json");
+    assert_eq!(parsed["records"].as_array().map(Vec::len), Some(1));
+    assert_eq!(parsed["records"][0]["fields"]["command"], "read");
+}
+
+#[test]
+fn test_log_follow_mode_exits_when_fixture_stream_ends() {
+    let fixture = Fixture::new(json!({
+        "follow_records": [
+            record("2026-03-31T06:00:10Z", "info", "atm", "command.started", "started", json!({
+                "command": "read"
+            })),
+            record("2026-03-31T06:00:11Z", "warn", "atm", "command.failed", "failed", json!({
+                "command": "read"
+            }))
+        ]
+    }));
+
+    let output = fixture.run(&["log", "--follow", "--json"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let stdout = fixture.stdout(&output);
+    let lines = stdout.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 2);
+
+    let first: serde_json::Value = serde_json::from_str(lines[0]).expect("first json line");
+    let second: serde_json::Value = serde_json::from_str(lines[1]).expect("second json line");
+    assert_eq!(first["event"], "command.started");
+    assert_eq!(second["level"], "warn");
+}
+
+fn record(
+    timestamp: &str,
+    level: &str,
+    service: &str,
+    event: &str,
+    message: &str,
+    fields: serde_json::Value,
+) -> serde_json::Value {
+    json!({
+        "timestamp": timestamp,
+        "level": level,
+        "service": service,
+        "event": event,
+        "message": message,
+        "fields": fields
+    })
+}
+
+struct Fixture {
+    tempdir: TempDir,
+    log_fixture_path: std::path::PathBuf,
+}
+
+impl Fixture {
+    fn new(log_fixture: serde_json::Value) -> Self {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let log_fixture_path = tempdir.path().join("log-fixture.json");
+        fs::write(
+            &log_fixture_path,
+            serde_json::to_vec(&log_fixture).expect("log fixture"),
+        )
+        .expect("write log fixture");
+
+        Self {
+            tempdir,
+            log_fixture_path,
+        }
+    }
+
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_atm"))
+            .args(args)
+            .env("ATM_HOME", self.tempdir.path())
+            .env("ATM_TEST_LOG_FIXTURE", &self.log_fixture_path)
+            .current_dir(self.tempdir.path())
+            .output()
+            .expect("run atm")
+    }
+
+    fn stdout(&self, output: &std::process::Output) -> String {
+        String::from_utf8(output.stdout.clone()).expect("stdout utf8")
+    }
+
+    fn stderr(&self, output: &std::process::Output) -> String {
+        String::from_utf8(output.stderr.clone()).expect("stderr utf8")
+    }
+}


### PR DESCRIPTION
## Summary
- Defines ATM log port contract (query/follow/filter trait) in atm-core
- Wires `atm log` CLI (--level, --filter, --follow, --json) through injected port
- Adds fixture-backed integration tests for query/filter/follow/JSON output
- Live sc-observability query/follow integration deferred: concrete adapter returns structured error pending arch-obs API delivery
- All existing tests continue to pass

## Scope note
Phase G.1 narrowed from full sc-observability integration: sc-observability exposes emit/health only; no query/follow API exists yet. ATM-side port contract is now defined — arch-obs can implement against it.

## Test plan
- [ ] `cargo test --workspace` green
- [ ] Clippy + format clean
- [ ] Log port trait covers query, follow, filter
- [ ] Test-double integration tests pass for all `atm log` behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)