### PR TITLE
feat(config): add AgentConfig and extend AtmConfig with agents map (PG.1)

### DIFF
--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -7,7 +7,6 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[allow(unused_imports)]
 pub use types::{AgentConfig, AtmConfig};
 
 use crate::error::{AtmError, AtmErrorKind};

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -7,7 +7,8 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-pub use types::AtmConfig;
+#[allow(unused_imports)]
+pub use types::{AgentConfig, AtmConfig};
 
 use crate::error::{AtmError, AtmErrorKind};
 
@@ -65,11 +66,12 @@ fn find_config_path(start_dir: &Path) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::env;
     use std::fs;
     use std::path::PathBuf;
 
-    use super::{load_config, resolve_identity, resolve_team, AtmConfig};
+    use super::{load_config, resolve_identity, resolve_team, AgentConfig, AtmConfig};
 
     #[test]
     fn load_config_walks_upward_for_dot_atm_toml() {
@@ -85,6 +87,45 @@ mod tests {
         let config = load_config(&nested).expect("config").expect("present");
         assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
         assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+        assert!(config.agents.is_empty());
+    }
+
+    #[test]
+    fn load_config_deserializes_agent_post_send_hooks() {
+        let root = unique_temp_dir("config-agents");
+        let nested = root.join("workspace").join("nested");
+        fs::create_dir_all(&nested).expect("nested dir");
+        fs::write(
+            root.join(".atm.toml"),
+            concat!(
+                "identity = \"arch-ctm\"\n",
+                "default_team = \"atm-dev\"\n\n",
+                "[agents.arch-ctm]\n",
+                "post_send = \"echo hello\"\n",
+            ),
+        )
+        .expect("config");
+
+        let config = load_config(&nested).expect("config").expect("present");
+        assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
+        assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+        assert_eq!(
+            config.agents.get("arch-ctm"),
+            Some(&AgentConfig {
+                post_send: Some("echo hello".into()),
+            })
+        );
+    }
+
+    #[test]
+    fn atm_config_deserializes_missing_agents_section_as_empty_map() {
+        let config: AtmConfig =
+            toml::from_str("identity = \"arch-ctm\"\ndefault_team = \"atm-dev\"\n")
+                .expect("config");
+
+        assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
+        assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+        assert!(config.agents.is_empty());
     }
 
     #[test]
@@ -96,6 +137,7 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-identity".into()),
             default_team: None,
+            agents: HashMap::new(),
         };
 
         assert_eq!(
@@ -114,6 +156,7 @@ mod tests {
         let config = AtmConfig {
             identity: None,
             default_team: Some("config-team".into()),
+            agents: HashMap::new(),
         };
 
         assert_eq!(

--- a/crates/atm-core/src/config/types.rs
+++ b/crates/atm-core/src/config/types.rs
@@ -1,7 +1,16 @@
+use std::collections::HashMap;
+
 use serde::Deserialize;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct AgentConfig {
+    pub post_send: Option<String>,
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 pub struct AtmConfig {
     pub identity: Option<String>,
     pub default_team: Option<String>,
+    #[serde(default)]
+    pub agents: HashMap<String, AgentConfig>,
 }

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -23,6 +23,7 @@ pub fn resolve_hook_identity(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::env;
 
     use crate::config::AtmConfig;
@@ -38,6 +39,7 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-agent".into()),
             default_team: None,
+            agents: HashMap::new(),
         };
         assert_eq!(
             resolve_sender_identity(Some(&config)).expect("identity"),
@@ -56,6 +58,7 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-agent".into()),
             default_team: None,
+            agents: HashMap::new(),
         };
         assert_eq!(
             resolve_sender_identity(Some(&config)).expect("identity"),
@@ -92,6 +95,7 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-agent".into()),
             default_team: Some("config-team".into()),
+            agents: HashMap::new(),
         };
 
         let identity = resolve_hook_identity(None, Some(&config)).expect("hook identity");

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -4,8 +4,8 @@ pub mod ack;
 pub(crate) mod address;
 /// Mailbox cleanup workflows for read and acknowledged messages.
 pub mod clear;
-/// Internal configuration discovery and resolution helpers.
-pub(crate) mod config;
+/// Configuration discovery, resolution, and typed config models.
+pub mod config;
 /// Doctor-report types and health checks for the CLI surface.
 pub mod doctor;
 /// Shared ATM error types and recovery-oriented error helpers.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -21,6 +21,10 @@ Status:
   Phase D.
 - Phase G is in progress and is the next delivery focus.
 
+| Phase | Goal | Status | Depends on |
+| --- | --- | --- | --- |
+| PG | post_send hook implementation | in-progress | Phase D (send path) |
+
 ## 2. Deliverables
 
 - Rust workspace with `crates/atm-core` and `crates/atm`


### PR DESCRIPTION
## Summary
- Adds `AgentConfig { post_send: Option<String> }` to `crates/atm-core/src/config/types.rs`
- Extends `AtmConfig` with `agents: HashMap<String, AgentConfig>` (`#[serde(default)]`)
- Exports `AgentConfig` publicly from `crates/atm-core/src/config/mod.rs`
- TOML round-trip tests for present and absent `[agents]` sections

## Test plan
- [ ] cargo test -p atm-core passes (30 tests)
- [ ] AtmConfig without [agents] section deserializes cleanly
- [ ] [agents.arch-ctm] post_send = "echo hello" deserializes correctly

Part of Phase PG — post_send hook implementation. PG.2 (send path) depends on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)