### PR TITLE
harden team-config loading: distinct missing/malformed handling, actionable warnings, repair notices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -97,6 +97,7 @@ dependencies = [
  "toml",
  "tracing",
  "uuid",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -212,7 +213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -417,7 +418,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -523,7 +524,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -691,7 +692,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1015,12 +1016,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -20,3 +20,6 @@ uuid = { version = "1", features = ["serde", "v4"] }
 [dev-dependencies]
 serial_test = "3"
 tempfile = "3"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading"] }

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -15,7 +15,7 @@ use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
-use crate::schema::{MessageEnvelope, TeamConfig};
+use crate::schema::MessageEnvelope;
 use crate::send::{input, summary};
 use crate::types::IsoTimestamp;
 
@@ -68,7 +68,7 @@ pub fn ack_mail(
         return Err(AtmError::team_not_found(&team));
     }
 
-    let team_config = load_team_config(&team_dir)?;
+    let team_config = config::load_team_config(&team_dir)?;
     if !team_config
         .members
         .iter()
@@ -124,7 +124,7 @@ pub fn ack_mail(
         return Err(AtmError::team_not_found(&reply_team));
     }
 
-    let reply_team_config = load_team_config(&reply_team_dir)?;
+    let reply_team_config = config::load_team_config(&reply_team_dir)?;
     if !reply_team_config
         .members
         .iter()
@@ -219,31 +219,6 @@ fn resolve_reply_target(
 
     let team = parsed.team.ok_or_else(AtmError::team_unavailable)?;
     Ok((parsed.agent, team))
-}
-
-fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
-    let config_path = team_dir.join("config.json");
-    let raw = fs::read_to_string(&config_path).map_err(|error| {
-        AtmError::new(
-            AtmErrorKind::Config,
-            format!(
-                "failed to read team config at {}: {error}",
-                config_path.display()
-            ),
-        )
-        .with_source(error)
-    })?;
-
-    serde_json::from_str(&raw).map_err(|error| {
-        AtmError::new(
-            AtmErrorKind::Config,
-            format!(
-                "failed to parse team config at {}: {error}",
-                config_path.display()
-            ),
-        )
-        .with_source(error)
-    })
 }
 
 fn load_source_files(

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -17,7 +17,7 @@ use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
-use crate::schema::{MessageEnvelope, TeamConfig};
+use crate::schema::MessageEnvelope;
 use crate::types::MessageClass;
 
 #[derive(Debug, Clone)]
@@ -79,7 +79,7 @@ pub fn clear_mail(
         return Err(AtmError::team_not_found(&target.team));
     }
 
-    let team_config = load_team_config(&team_dir)?;
+    let team_config = config::load_team_config(&team_dir)?;
     if target.explicit
         && !team_config
             .members
@@ -190,31 +190,6 @@ fn resolve_target(
         agent: parsed.agent,
         team,
         explicit: true,
-    })
-}
-
-fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
-    let config_path = team_dir.join("config.json");
-    let raw = fs::read_to_string(&config_path).map_err(|error| {
-        AtmError::new(
-            AtmErrorKind::Config,
-            format!(
-                "failed to read team config at {}: {error}",
-                config_path.display()
-            ),
-        )
-        .with_source(error)
-    })?;
-
-    serde_json::from_str(&raw).map_err(|error| {
-        AtmError::new(
-            AtmErrorKind::Config,
-            format!(
-                "failed to parse team config at {}: {error}",
-                config_path.display()
-            ),
-        )
-        .with_source(error)
     })
 }
 

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -7,9 +7,13 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use serde_json::Value;
+use tracing::warn;
+
 pub use types::AtmConfig;
 
 use crate::error::{AtmError, AtmErrorKind};
+use crate::schema::{AgentMember, TeamConfig};
 
 pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
     let Some(path) = find_config_path(start_dir) else {
@@ -31,6 +35,34 @@ pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
         .with_source(error)
     })?;
     Ok(Some(parsed))
+}
+
+pub fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
+    let config_path = team_dir.join("config.json");
+    let raw = fs::read_to_string(&config_path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            AtmError::missing_document(format!(
+                "team config is missing at {}",
+                config_path.display()
+            ))
+            .with_recovery(
+                "Restore config.json for the team or use only the documented send fallback.",
+            )
+            .with_source(error)
+        } else {
+            AtmError::new(
+                AtmErrorKind::Config,
+                format!(
+                    "failed to read team config at {}: {error}",
+                    config_path.display()
+                ),
+            )
+            .with_recovery("Create config.json or restore it from a known-good copy.")
+            .with_source(error)
+        }
+    })?;
+
+    parse_team_config(&config_path, &raw)
 }
 
 pub fn resolve_identity(config: Option<&AtmConfig>) -> Option<String> {
@@ -63,13 +95,86 @@ fn find_config_path(start_dir: &Path) -> Option<PathBuf> {
     None
 }
 
+fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmError> {
+    let root: Value = serde_json::from_str(raw).map_err(|error| {
+        AtmError::new(
+            AtmErrorKind::Config,
+            format!(
+                "failed to parse team config at {}: {error}",
+                config_path.display()
+            ),
+        )
+        .with_recovery("Repair the JSON syntax in config.json or restore a valid file.")
+        .with_source(error)
+    })?;
+
+    let object = root.as_object().ok_or_else(|| {
+        AtmError::new(
+            AtmErrorKind::Config,
+            format!(
+                "failed to parse team config at {}: root value must be a JSON object",
+                config_path.display()
+            ),
+        )
+        .with_recovery("Repair config.json so the root value is an object with a 'members' array.")
+    })?;
+
+    let members = match object.get("members") {
+        None => Vec::new(),
+        Some(Value::Array(entries)) => entries
+            .iter()
+            .enumerate()
+            .filter_map(|(index, entry)| parse_team_member(config_path, index, entry))
+            .collect(),
+        Some(_) => {
+            return Err(AtmError::new(
+                AtmErrorKind::Config,
+                format!(
+                    "failed to parse team config at {}: field 'members' must be a JSON array",
+                    config_path.display()
+                ),
+            )
+            .with_recovery(
+                "Repair config.json so 'members' is an array of agent records or agent names.",
+            ));
+        }
+    };
+
+    Ok(TeamConfig { members })
+}
+
+fn parse_team_member(config_path: &Path, index: usize, entry: &Value) -> Option<AgentMember> {
+    match entry {
+        Value::String(name) => Some(AgentMember { name: name.clone() }),
+        _ => match serde_json::from_value::<AgentMember>(entry.clone()) {
+            Ok(member) => Some(member),
+            Err(error) => {
+                let member_label = entry
+                    .as_object()
+                    .and_then(|object| object.get("name"))
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| format!("#{index}"));
+                warn!(
+                    path = %config_path.display(),
+                    member_index = index,
+                    member = %member_label,
+                    %error,
+                    "skipping invalid team member record"
+                );
+                None
+            }
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::env;
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
-    use super::{load_config, resolve_identity, resolve_team, AtmConfig};
+    use super::{load_config, parse_team_config, resolve_identity, resolve_team, AtmConfig};
 
     #[test]
     fn load_config_walks_upward_for_dot_atm_toml() {
@@ -85,6 +190,105 @@ mod tests {
         let config = load_config(&nested).expect("config").expect("present");
         assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
         assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+    }
+
+    #[test]
+    fn parse_team_config_accepts_object_members() {
+        let config = parse_team_config(
+            Path::new("/tmp/config.json"),
+            r#"{"members":[{"name":"arch-ctm"},{"name":"team-lead"}]}"#,
+        )
+        .expect("team config");
+
+        assert_eq!(config.members.len(), 2);
+        assert_eq!(config.members[0].name, "arch-ctm");
+        assert_eq!(config.members[1].name, "team-lead");
+    }
+
+    #[test]
+    fn parse_team_config_accepts_string_member_compatibility() {
+        let config = parse_team_config(
+            Path::new("/tmp/config.json"),
+            r#"{"members":["arch-ctm",{"name":"team-lead"}]}"#,
+        )
+        .expect("team config");
+
+        assert_eq!(config.members.len(), 2);
+        assert_eq!(config.members[0].name, "arch-ctm");
+        assert_eq!(config.members[1].name, "team-lead");
+    }
+
+    #[test]
+    fn parse_team_config_skips_invalid_member_records() {
+        let config = parse_team_config(
+            Path::new("/tmp/config.json"),
+            r#"{"members":[{"name":"arch-ctm"},{"broken":true},17,{"name":"team-lead"}]}"#,
+        )
+        .expect("team config");
+
+        assert_eq!(config.members.len(), 2);
+        assert_eq!(config.members[0].name, "arch-ctm");
+        assert_eq!(config.members[1].name, "team-lead");
+    }
+
+    #[test]
+    fn parse_team_config_defaults_missing_members_to_empty() {
+        let config =
+            parse_team_config(Path::new("/tmp/config.json"), r#"{}"#).expect("team config");
+
+        assert!(config.members.is_empty());
+    }
+
+    #[test]
+    fn parse_team_config_reports_json_syntax_errors_with_detail() {
+        let error = parse_team_config(
+            Path::new("/tmp/config.json"),
+            r#"{"members":[{"name":"arch-ctm"}"#,
+        )
+        .expect_err("syntax error");
+
+        assert!(error.is_config());
+        assert!(error.message.contains("/tmp/config.json"));
+        assert!(error.message.contains("EOF while parsing"));
+        assert!(error.recovery.as_deref().is_some());
+    }
+
+    #[test]
+    fn parse_team_config_rejects_non_object_root() {
+        let error = parse_team_config(Path::new("/tmp/config.json"), r#"["arch-ctm"]"#)
+            .expect_err("root shape error");
+
+        assert!(error.is_config());
+        assert!(error.message.contains("root value must be a JSON object"));
+        assert!(error.recovery.as_deref().is_some());
+    }
+
+    #[test]
+    fn parse_team_config_rejects_non_array_members() {
+        let error = parse_team_config(
+            Path::new("/tmp/config.json"),
+            r#"{"members":{"name":"arch-ctm"}}"#,
+        )
+        .expect_err("members shape error");
+
+        assert!(error.is_config());
+        assert!(error
+            .message
+            .contains("field 'members' must be a JSON array"));
+        assert!(error.recovery.as_deref().is_some());
+    }
+
+    #[test]
+    fn load_team_config_reports_missing_document_distinctly() {
+        let root = unique_temp_dir("missing-team-config");
+        let team_dir = root.join("team");
+        fs::create_dir_all(&team_dir).expect("team dir");
+
+        let error = super::load_team_config(&team_dir).expect_err("missing config");
+
+        assert!(error.is_missing_document());
+        assert!(error.message.contains("team config is missing"));
+        assert!(error.recovery.as_deref().is_some());
     }
 
     #[test]

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -145,7 +145,10 @@ fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmErr
 
 fn parse_team_member(config_path: &Path, index: usize, entry: &Value) -> Option<AgentMember> {
     match entry {
-        Value::String(name) => Some(AgentMember { name: name.clone() }),
+        Value::String(name) => Some(AgentMember {
+            name: name.clone(),
+            ..Default::default()
+        }),
         _ => match serde_json::from_value::<AgentMember>(entry.clone()) {
             Ok(member) => Some(member),
             Err(error) => {
@@ -172,7 +175,7 @@ fn parse_team_member(config_path: &Path, index: usize, entry: &Value) -> Option<
 mod tests {
     use std::env;
     use std::fs;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
 
     use super::{load_config, parse_team_config, resolve_identity, resolve_team, AtmConfig};
 
@@ -194,8 +197,9 @@ mod tests {
 
     #[test]
     fn parse_team_config_accepts_object_members() {
+        let config_path = temp_config_path();
         let config = parse_team_config(
-            Path::new("/tmp/config.json"),
+            &config_path,
             r#"{"members":[{"name":"arch-ctm"},{"name":"team-lead"}]}"#,
         )
         .expect("team config");
@@ -207,8 +211,9 @@ mod tests {
 
     #[test]
     fn parse_team_config_accepts_string_member_compatibility() {
+        let config_path = temp_config_path();
         let config = parse_team_config(
-            Path::new("/tmp/config.json"),
+            &config_path,
             r#"{"members":["arch-ctm",{"name":"team-lead"}]}"#,
         )
         .expect("team config");
@@ -220,8 +225,9 @@ mod tests {
 
     #[test]
     fn parse_team_config_skips_invalid_member_records() {
+        let config_path = temp_config_path();
         let config = parse_team_config(
-            Path::new("/tmp/config.json"),
+            &config_path,
             r#"{"members":[{"name":"arch-ctm"},{"broken":true},17,{"name":"team-lead"}]}"#,
         )
         .expect("team config");
@@ -233,30 +239,29 @@ mod tests {
 
     #[test]
     fn parse_team_config_defaults_missing_members_to_empty() {
-        let config =
-            parse_team_config(Path::new("/tmp/config.json"), r#"{}"#).expect("team config");
+        let config_path = temp_config_path();
+        let config = parse_team_config(&config_path, r#"{}"#).expect("team config");
 
         assert!(config.members.is_empty());
     }
 
     #[test]
     fn parse_team_config_reports_json_syntax_errors_with_detail() {
-        let error = parse_team_config(
-            Path::new("/tmp/config.json"),
-            r#"{"members":[{"name":"arch-ctm"}"#,
-        )
-        .expect_err("syntax error");
+        let config_path = temp_config_path();
+        let error = parse_team_config(&config_path, r#"{"members":[{"name":"arch-ctm"}"#)
+            .expect_err("syntax error");
 
         assert!(error.is_config());
-        assert!(error.message.contains("/tmp/config.json"));
+        assert!(error.message.contains("config.json"));
         assert!(error.message.contains("EOF while parsing"));
         assert!(error.recovery.as_deref().is_some());
     }
 
     #[test]
     fn parse_team_config_rejects_non_object_root() {
-        let error = parse_team_config(Path::new("/tmp/config.json"), r#"["arch-ctm"]"#)
-            .expect_err("root shape error");
+        let config_path = temp_config_path();
+        let error =
+            parse_team_config(&config_path, r#"["arch-ctm"]"#).expect_err("root shape error");
 
         assert!(error.is_config());
         assert!(error.message.contains("root value must be a JSON object"));
@@ -265,11 +270,9 @@ mod tests {
 
     #[test]
     fn parse_team_config_rejects_non_array_members() {
-        let error = parse_team_config(
-            Path::new("/tmp/config.json"),
-            r#"{"members":{"name":"arch-ctm"}}"#,
-        )
-        .expect_err("members shape error");
+        let config_path = temp_config_path();
+        let error = parse_team_config(&config_path, r#"{"members":{"name":"arch-ctm"}}"#)
+            .expect_err("members shape error");
 
         assert!(error.is_config());
         assert!(error
@@ -342,6 +345,10 @@ mod tests {
         let path = env::temp_dir().join(format!("{label}-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&path).expect("temp dir");
         path
+    }
+
+    fn temp_config_path() -> PathBuf {
+        env::temp_dir().join("config.json")
     }
 
     fn restore(key: &str, value: Option<std::ffi::OsString>) {

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -5,6 +5,7 @@ use std::fmt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AtmErrorKind {
     Config,
+    MissingDocument,
     Address,
     Identity,
     TeamNotFound,
@@ -46,6 +47,10 @@ impl AtmError {
 
     pub fn is_address(&self) -> bool {
         self.kind == AtmErrorKind::Address
+    }
+
+    pub fn is_missing_document(&self) -> bool {
+        self.kind == AtmErrorKind::MissingDocument
     }
 
     pub fn is_identity(&self) -> bool {
@@ -150,6 +155,10 @@ impl AtmError {
 
     pub fn validation(message: impl Into<String>) -> Self {
         Self::new(AtmErrorKind::Validation, message)
+    }
+
+    pub fn missing_document(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::MissingDocument, message)
     }
 
     pub fn file_policy(message: impl Into<String>) -> Self {

--- a/crates/atm-core/src/mailbox/atomic.rs
+++ b/crates/atm-core/src/mailbox/atomic.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use crate::error::{AtmError, AtmErrorKind};
 use crate::schema::MessageEnvelope;
+use uuid::Uuid;
 
 pub fn write_messages(path: &Path, messages: &[MessageEnvelope]) -> Result<(), AtmError> {
     if let Some(parent) = path.parent() {
@@ -16,12 +17,13 @@ pub fn write_messages(path: &Path, messages: &[MessageEnvelope]) -> Result<(), A
         })?;
     }
 
-    let temp_path = path.with_extension(format!(
-        "{}tmp",
-        path.extension()
+    let temp_path = path.with_file_name(format!(
+        "{}.{}.{}.tmp",
+        path.file_name()
             .and_then(|value| value.to_str())
-            .map(|value| format!("{value}."))
-            .unwrap_or_default()
+            .unwrap_or("mailbox"),
+        std::process::id(),
+        Uuid::new_v4()
     ));
 
     {

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -18,7 +18,7 @@ use crate::home;
 use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
-use crate::schema::{MessageEnvelope, TeamConfig};
+use crate::schema::MessageEnvelope;
 use crate::types::{AckActivationMode, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection};
 
 #[derive(Debug, Clone)]
@@ -102,7 +102,7 @@ pub fn read_mail(
         return Err(AtmError::team_not_found(&target.team));
     }
 
-    let team_config = load_team_config(&team_dir)?;
+    let team_config = config::load_team_config(&team_dir)?;
     if target.explicit
         && !team_config
             .members
@@ -300,31 +300,6 @@ fn resolve_target(
         agent: parsed.agent,
         team,
         explicit: true,
-    })
-}
-
-fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
-    let config_path = team_dir.join("config.json");
-    let raw = fs::read_to_string(&config_path).map_err(|error| {
-        AtmError::new(
-            AtmErrorKind::Config,
-            format!(
-                "failed to read team config at {}: {error}",
-                config_path.display()
-            ),
-        )
-        .with_source(error)
-    })?;
-
-    serde_json::from_str(&raw).map_err(|error| {
-        AtmError::new(
-            AtmErrorKind::Config,
-            format!(
-                "failed to parse team config at {}: {error}",
-                config_path.display()
-            ),
-        )
-        .with_source(error)
     })
 }
 

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -1,6 +1,90 @@
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AgentMember {
     pub name: String,
+
+    #[serde(default)]
+    pub agent_id: String,
+
+    #[serde(default)]
+    pub agent_type: String,
+
+    #[serde(default)]
+    pub model: String,
+
+    #[serde(default)]
+    pub joined_at: Option<u64>,
+
+    #[serde(default)]
+    pub tmux_pane_id: String,
+
+    #[serde(default)]
+    pub cwd: String,
+
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AgentMember;
+
+    #[test]
+    fn parse_name_only_record_defaults_optional_fields() {
+        let member: AgentMember = serde_json::from_str(r#"{"name":"arch-ctm"}"#).expect("member");
+
+        assert_eq!(member.name, "arch-ctm");
+        assert!(member.agent_id.is_empty());
+        assert!(member.agent_type.is_empty());
+        assert!(member.model.is_empty());
+        assert_eq!(member.joined_at, None);
+        assert!(member.tmux_pane_id.is_empty());
+        assert!(member.cwd.is_empty());
+        assert!(member.extra.is_empty());
+    }
+
+    #[test]
+    fn parse_full_claude_code_record_preserves_values_and_extra() {
+        let raw = r#"{
+            "agentId":"arch-ctm@atm-dev",
+            "name":"arch-ctm",
+            "agentType":"general-purpose",
+            "model":"claude-sonnet-4-5",
+            "joinedAt":1770765919076,
+            "tmuxPaneId":"%1",
+            "cwd":"/workspace",
+            "color":"blue"
+        }"#;
+
+        let member: AgentMember = serde_json::from_str(raw).expect("member");
+        assert_eq!(member.agent_id, "arch-ctm@atm-dev");
+        assert_eq!(member.name, "arch-ctm");
+        assert_eq!(member.agent_type, "general-purpose");
+        assert_eq!(member.model, "claude-sonnet-4-5");
+        assert_eq!(member.joined_at, Some(1770765919076));
+        assert_eq!(member.tmux_pane_id, "%1");
+        assert_eq!(member.cwd, "/workspace");
+        assert_eq!(member.extra["color"], serde_json::json!("blue"));
+
+        let encoded = serde_json::to_string(&member).expect("encode");
+        let decoded: AgentMember = serde_json::from_str(&encoded).expect("decode");
+        assert_eq!(decoded, member);
+    }
+
+    #[test]
+    fn parse_name_and_agent_type_record_succeeds() {
+        let member: AgentMember =
+            serde_json::from_str(r#"{"name":"arch-ctm","agentType":"plan"}"#).expect("member");
+
+        assert_eq!(member.name, "arch-ctm");
+        assert_eq!(member.agent_type, "plan");
+        assert!(member.agent_id.is_empty());
+        assert!(member.model.is_empty());
+        assert_eq!(member.joined_at, None);
+        assert!(member.tmux_pane_id.is_empty());
+        assert!(member.cwd.is_empty());
+    }
 }

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeSet;
 use std::fs;
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
@@ -329,6 +332,15 @@ fn missing_team_config_alert_key(team_dir: &Path) -> String {
 
 fn register_missing_team_config_alert(home_dir: &Path, key: &str) -> bool {
     let state_path = send_alert_state_path(home_dir);
+    let lock_path = send_alert_lock_path(home_dir);
+    let Some(_guard) = acquire_send_alert_lock(&lock_path) else {
+        warn!(
+            path = %lock_path.display(),
+            "failed to acquire send alert lock; skipping team-lead notification"
+        );
+        return false;
+    };
+
     let mut state = load_send_alert_state(&state_path).unwrap_or_default();
     if state.missing_team_config_keys.contains(key) {
         return false;
@@ -343,6 +355,15 @@ fn register_missing_team_config_alert(home_dir: &Path, key: &str) -> bool {
 
 fn clear_missing_team_config_alert(home_dir: &Path, team_dir: &Path) {
     let state_path = send_alert_state_path(home_dir);
+    let lock_path = send_alert_lock_path(home_dir);
+    let Some(_guard) = acquire_send_alert_lock(&lock_path) else {
+        warn!(
+            path = %lock_path.display(),
+            "failed to acquire send alert lock while clearing dedup state"
+        );
+        return;
+    };
+
     let Ok(mut state) = load_send_alert_state(&state_path) else {
         return;
     };
@@ -361,23 +382,33 @@ fn send_alert_state_path(home_dir: &Path) -> PathBuf {
     home_dir.join(".config").join("atm").join("state.json")
 }
 
+fn send_alert_lock_path(home_dir: &Path) -> PathBuf {
+    home_dir.join(".config").join("atm").join("state.lock")
+}
+
 fn load_send_alert_state(path: &Path) -> Result<SendAlertState, AtmError> {
     if !path.exists() {
         return Ok(SendAlertState::default());
     }
 
     let raw = fs::read_to_string(path).map_err(|error| {
-        AtmError::file_policy(format!(
-            "failed to read send alert state at {}: {error}",
-            path.display()
-        ))
+        AtmError::new(
+            crate::error::AtmErrorKind::Config,
+            format!(
+                "failed to read send alert state at {}: {error}",
+                path.display()
+            ),
+        )
         .with_source(error)
     })?;
     serde_json::from_str(&raw).map_err(|error| {
-        AtmError::file_policy(format!(
-            "failed to parse send alert state at {}: {error}",
-            path.display()
-        ))
+        AtmError::new(
+            crate::error::AtmErrorKind::Config,
+            format!(
+                "failed to parse send alert state at {}: {error}",
+                path.display()
+            ),
+        )
         .with_source(error)
     })
 }
@@ -385,10 +416,13 @@ fn load_send_alert_state(path: &Path) -> Result<SendAlertState, AtmError> {
 fn save_send_alert_state(path: &Path, state: &SendAlertState) -> Result<(), AtmError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
-            AtmError::file_policy(format!(
-                "failed to create send alert state directory {}: {error}",
-                parent.display()
-            ))
+            AtmError::new(
+                crate::error::AtmErrorKind::Config,
+                format!(
+                    "failed to create send alert state directory {}: {error}",
+                    parent.display()
+                ),
+            )
             .with_source(error)
         })?;
     }
@@ -396,18 +430,115 @@ fn save_send_alert_state(path: &Path, state: &SendAlertState) -> Result<(), AtmE
     let temp_path = path.with_extension("tmp");
     let data = serde_json::to_vec(state)?;
     fs::write(&temp_path, data).map_err(|error| {
-        AtmError::file_policy(format!(
-            "failed to write send alert state temp file {}: {error}",
-            temp_path.display()
-        ))
+        AtmError::new(
+            crate::error::AtmErrorKind::Config,
+            format!(
+                "failed to write send alert state temp file {}: {error}",
+                temp_path.display()
+            ),
+        )
         .with_source(error)
     })?;
     fs::rename(&temp_path, path).map_err(|error| {
-        AtmError::file_policy(format!(
-            "failed to replace send alert state at {}: {error}",
-            path.display()
-        ))
+        AtmError::new(
+            crate::error::AtmErrorKind::Config,
+            format!(
+                "failed to replace send alert state at {}: {error}",
+                path.display()
+            ),
+        )
         .with_source(error)
     })?;
     Ok(())
+}
+
+fn acquire_send_alert_lock(path: &Path) -> Option<SendAlertLock> {
+    if let Some(parent) = path.parent() {
+        if let Err(error) = fs::create_dir_all(parent) {
+            warn!(
+                %error,
+                path = %parent.display(),
+                "failed to create send alert lock directory"
+            );
+            return None;
+        }
+    }
+
+    for _ in 0..100 {
+        match OpenOptions::new().write(true).create_new(true).open(path) {
+            Ok(_) => {
+                return Some(SendAlertLock {
+                    path: path.to_path_buf(),
+                });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => {
+                warn!(%error, path = %path.display(), "failed to create send alert lock");
+                return None;
+            }
+        }
+    }
+
+    None
+}
+
+struct SendAlertLock {
+    path: PathBuf,
+}
+
+impl Drop for SendAlertLock {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_file(&self.path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                warn!(
+                    %error,
+                    path = %self.path.display(),
+                    "failed to remove send alert lock"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::{
+        load_send_alert_state, save_send_alert_state, send_alert_state_path, SendAlertState,
+    };
+
+    #[test]
+    fn load_send_alert_state_parse_errors_are_config_errors() {
+        let tempdir = tempdir().expect("tempdir");
+        let path = send_alert_state_path(tempdir.path());
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("state dir");
+        }
+        fs::write(&path, "{not-json").expect("state file");
+
+        let error = load_send_alert_state(&path).expect_err("malformed state");
+        assert!(error.is_config());
+    }
+
+    #[test]
+    fn save_send_alert_state_round_trips() {
+        let tempdir = tempdir().expect("tempdir");
+        let path = send_alert_state_path(tempdir.path());
+        let mut state = SendAlertState::default();
+        state
+            .missing_team_config_keys
+            .insert("teams/atm-dev/config.json".to_string());
+
+        save_send_alert_state(&path, &state).expect("save");
+        let loaded = load_send_alert_state(&path).expect("load");
+        assert_eq!(
+            loaded.missing_team_config_keys,
+            state.missing_team_config_keys
+        );
+    }
 }

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -427,7 +427,14 @@ fn save_send_alert_state(path: &Path, state: &SendAlertState) -> Result<(), AtmE
         })?;
     }
 
-    let temp_path = path.with_extension("tmp");
+    let temp_path = path.with_file_name(format!(
+        "{}.{}.{}.tmp",
+        path.file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("state"),
+        std::process::id(),
+        Uuid::new_v4()
+    ));
     let data = serde_json::to_vec(state)?;
     fs::write(&temp_path, data).map_err(|error| {
         AtmError::new(
@@ -516,7 +523,7 @@ fn evict_stale_send_alert_lock(path: &Path) -> bool {
 
 #[cfg(unix)]
 fn process_is_alive(pid: u32) -> bool {
-    let pid = match i32::try_from(pid) {
+    let pid: libc::pid_t = match pid.try_into() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -532,14 +539,17 @@ fn process_is_alive(pid: u32) -> bool {
 
 #[cfg(windows)]
 fn process_is_alive(pid: u32) -> bool {
+    use std::ptr;
+
     use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
     use windows_sys::Win32::System::Threading::{
         GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
     };
 
     // SAFETY: OpenProcess is called read-only for process liveness inspection.
-    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
-    if handle == 0 {
+    let process_id: u32 = pid;
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, process_id) };
+    if handle == ptr::null_mut() {
         return false;
     }
 
@@ -548,7 +558,7 @@ fn process_is_alive(pid: u32) -> bool {
     let ok = unsafe { GetExitCodeProcess(handle, &mut exit_code) };
     // SAFETY: handle was opened successfully above and must be closed once.
     unsafe { CloseHandle(handle) };
-    ok != 0 && exit_code == STILL_ACTIVE
+    ok != 0 && exit_code == STILL_ACTIVE as u32
 }
 
 struct SendAlertLock {

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -466,12 +466,21 @@ fn acquire_send_alert_lock(path: &Path) -> Option<SendAlertLock> {
 
     for _ in 0..100 {
         match OpenOptions::new().write(true).create_new(true).open(path) {
-            Ok(_) => {
+            Ok(mut file) => {
+                let pid = std::process::id().to_string();
+                if let Err(error) = std::io::Write::write_all(&mut file, pid.as_bytes()) {
+                    warn!(%error, path = %path.display(), "failed to write send alert lock pid");
+                    let _ = fs::remove_file(path);
+                    return None;
+                }
                 return Some(SendAlertLock {
                     path: path.to_path_buf(),
                 });
             }
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if evict_stale_send_alert_lock(path) {
+                    continue;
+                }
                 thread::sleep(Duration::from_millis(10));
             }
             Err(error) => {
@@ -482,6 +491,64 @@ fn acquire_send_alert_lock(path: &Path) -> Option<SendAlertLock> {
     }
 
     None
+}
+
+fn evict_stale_send_alert_lock(path: &Path) -> bool {
+    let Ok(raw) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(pid) = raw.trim().parse::<u32>() else {
+        return false;
+    };
+    if process_is_alive(pid) {
+        return false;
+    }
+
+    match fs::remove_file(path) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+        Err(error) => {
+            warn!(%error, path = %path.display(), pid, "failed to evict stale send alert lock");
+            false
+        }
+    }
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    let pid = match i32::try_from(pid) {
+        Ok(pid) => pid,
+        Err(_) => return false,
+    };
+    // SAFETY: libc::kill with signal 0 performs an existence/permission check
+    // only and does not deliver a signal.
+    let result = unsafe { libc::kill(pid, 0) };
+    if result == 0 {
+        return true;
+    }
+
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(windows)]
+fn process_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    // SAFETY: OpenProcess is called read-only for process liveness inspection.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle == 0 {
+        return false;
+    }
+
+    let mut exit_code = 0u32;
+    // SAFETY: handle was returned by OpenProcess and remains valid until CloseHandle below.
+    let ok = unsafe { GetExitCodeProcess(handle, &mut exit_code) };
+    // SAFETY: handle was opened successfully above and must be closed once.
+    unsafe { CloseHandle(handle) };
+    ok != 0 && exit_code == STILL_ACTIVE
 }
 
 struct SendAlertLock {
@@ -509,7 +576,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        load_send_alert_state, save_send_alert_state, send_alert_state_path, SendAlertState,
+        acquire_send_alert_lock, load_send_alert_state, process_is_alive, save_send_alert_state,
+        send_alert_lock_path, send_alert_state_path, SendAlertState,
     };
 
     #[test]
@@ -540,5 +608,26 @@ mod tests {
             loaded.missing_team_config_keys,
             state.missing_team_config_keys
         );
+    }
+
+    #[test]
+    fn process_is_alive_reports_current_process() {
+        assert!(process_is_alive(std::process::id()));
+    }
+
+    #[test]
+    fn acquire_send_alert_lock_evicts_stale_pid_lock() {
+        let tempdir = tempdir().expect("tempdir");
+        let path = send_alert_lock_path(tempdir.path());
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("lock dir");
+        }
+        fs::write(&path, u32::MAX.to_string()).expect("stale lock");
+
+        let guard = acquire_send_alert_lock(&path).expect("acquire lock");
+        let pid = fs::read_to_string(&path).expect("lock contents");
+        assert_eq!(pid.trim(), std::process::id().to_string());
+        drop(guard);
+        assert!(!path.exists());
     }
 }

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -1,18 +1,20 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Map;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::address::AgentAddress;
 use crate::config;
-use crate::error::{AtmError, AtmErrorKind};
+use crate::error::AtmError;
 use crate::home;
 use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
-use crate::schema::{MessageEnvelope, TeamConfig};
+use crate::schema::MessageEnvelope;
 use crate::types::IsoTimestamp;
 
 pub(crate) mod file_policy;
@@ -58,8 +60,16 @@ pub struct SendOutcome {
     pub summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub dry_run: bool,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct SendAlertState {
+    #[serde(default)]
+    missing_team_config_keys: BTreeSet<String>,
 }
 
 pub fn send_mail(
@@ -79,13 +89,51 @@ pub fn send_mail(
         return Err(AtmError::team_not_found(&recipient.team));
     }
 
-    let team_config = load_team_config(&team_dir)?;
-    if !team_config
-        .members
-        .iter()
-        .any(|member| member.name == recipient.agent)
-    {
-        return Err(AtmError::agent_not_found(&recipient.agent, &recipient.team));
+    let inbox_path =
+        home::inbox_path_from_home(&request.home_dir, &recipient.team, &recipient.agent)?;
+    let mut warnings = Vec::new();
+
+    match config::load_team_config(&team_dir) {
+        Ok(team_config) => {
+            clear_missing_team_config_alert(&request.home_dir, &team_dir);
+            if !team_config
+                .members
+                .iter()
+                .any(|member| member.name == recipient.agent)
+            {
+                return Err(AtmError::agent_not_found(&recipient.agent, &recipient.team));
+            }
+        }
+        Err(error) if error.is_missing_document() => {
+            if !inbox_path.exists() {
+                return Err(AtmError::missing_document(format!(
+                    "team config is missing at {} and inbox {} does not exist, so send cannot safely proceed",
+                    team_dir.join("config.json").display(),
+                    inbox_path.display()
+                ))
+                .with_recovery(
+                    "Restore config.json for the team or create the intended inbox by an approved workflow before retrying.",
+                ));
+            }
+
+            warnings.push(format!(
+                "warning: team config is missing at {}; send used existing inbox fallback for {}@{}. Restore the team config.",
+                team_dir.join("config.json").display(),
+                recipient.agent,
+                recipient.team
+            ));
+
+            if !request.dry_run {
+                notify_team_lead_missing_config(
+                    &request.home_dir,
+                    &team_dir,
+                    &sender,
+                    &recipient.team,
+                    &recipient.agent,
+                );
+            }
+        }
+        Err(error) => return Err(error),
     }
 
     let task_id = input::validate_task_id(request.task_id)?;
@@ -115,8 +163,6 @@ pub fn send_mail(
             task_id: task_id.clone(),
             extra: Map::new(),
         };
-        let inbox_path =
-            home::inbox_path_from_home(&request.home_dir, &recipient.team, &recipient.agent)?;
         mailbox::append_message(&inbox_path, &envelope)?;
     }
 
@@ -131,6 +177,7 @@ pub fn send_mail(
         task_id: task_id.clone(),
         summary: Some(summary),
         message: request.dry_run.then_some(body.clone()),
+        warnings,
         dry_run: request.dry_run,
     };
 
@@ -188,31 +235,6 @@ fn resolve_recipient(
     })
 }
 
-fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
-    let config_path = team_dir.join("config.json");
-    let raw = fs::read_to_string(&config_path).map_err(|error| {
-        AtmError::new(
-            AtmErrorKind::Config,
-            format!(
-                "failed to read team config at {}: {error}",
-                config_path.display()
-            ),
-        )
-        .with_source(error)
-    })?;
-
-    serde_json::from_str(&raw).map_err(|error| {
-        AtmError::new(
-            AtmErrorKind::Config,
-            format!(
-                "failed to parse team config at {}: {error}",
-                config_path.display()
-            ),
-        )
-        .with_source(error)
-    })
-}
-
 fn resolve_message_body(
     source: &SendMessageSource,
     current_dir: &Path,
@@ -234,4 +256,158 @@ fn resolve_message_body(
 
 fn is_false(value: &bool) -> bool {
     !*value
+}
+
+fn notify_team_lead_missing_config(
+    home_dir: &Path,
+    team_dir: &Path,
+    sender: &str,
+    team: &str,
+    recipient: &str,
+) {
+    let alert_key = missing_team_config_alert_key(team_dir);
+    if !register_missing_team_config_alert(home_dir, &alert_key) {
+        return;
+    }
+
+    let team_lead_inbox = match home::inbox_path_from_home(home_dir, team, "team-lead") {
+        Ok(path) => path,
+        Err(error) => {
+            warn!(%error, team, "failed to resolve team-lead inbox for missing-config notice");
+            return;
+        }
+    };
+
+    if !team_lead_inbox.exists() {
+        return;
+    }
+
+    let config_path = team_dir.join("config.json");
+    let timestamp = IsoTimestamp::now();
+    let mut extra = Map::new();
+    extra.insert(
+        "atmAlertKind".into(),
+        serde_json::Value::String("missing_team_config".into()),
+    );
+    extra.insert(
+        "missingConfigPath".into(),
+        serde_json::Value::String(config_path.display().to_string()),
+    );
+
+    let notice = MessageEnvelope {
+        from: sender.to_string(),
+        text: format!(
+            "ATM warning: send used existing inbox fallback for {recipient}@{team} because team config is missing at {}. Please restore config.json.",
+            config_path.display()
+        ),
+        timestamp,
+        read: false,
+        source_team: Some(team.to_string()),
+        summary: Some(format!(
+            "ATM warning: missing team config fallback used for {recipient}@{team}"
+        )),
+        message_id: Some(Uuid::new_v4()),
+        pending_ack_at: None,
+        acknowledged_at: None,
+        acknowledges_message_id: None,
+        task_id: None,
+        extra,
+    };
+
+    if let Err(error) = mailbox::append_message(&team_lead_inbox, &notice) {
+        warn!(
+            %error,
+            path = %team_lead_inbox.display(),
+            "failed to append missing-config notice to team-lead inbox"
+        );
+    }
+}
+
+fn missing_team_config_alert_key(team_dir: &Path) -> String {
+    team_dir.join("config.json").display().to_string()
+}
+
+fn register_missing_team_config_alert(home_dir: &Path, key: &str) -> bool {
+    let state_path = send_alert_state_path(home_dir);
+    let mut state = load_send_alert_state(&state_path).unwrap_or_default();
+    if state.missing_team_config_keys.contains(key) {
+        return false;
+    }
+
+    state.missing_team_config_keys.insert(key.to_string());
+    if let Err(error) = save_send_alert_state(&state_path, &state) {
+        warn!(%error, path = %state_path.display(), "failed to save send alert dedup state");
+    }
+    true
+}
+
+fn clear_missing_team_config_alert(home_dir: &Path, team_dir: &Path) {
+    let state_path = send_alert_state_path(home_dir);
+    let Ok(mut state) = load_send_alert_state(&state_path) else {
+        return;
+    };
+
+    let key = missing_team_config_alert_key(team_dir);
+    if !state.missing_team_config_keys.remove(&key) {
+        return;
+    }
+
+    if let Err(error) = save_send_alert_state(&state_path, &state) {
+        warn!(%error, path = %state_path.display(), "failed to clear send alert dedup state");
+    }
+}
+
+fn send_alert_state_path(home_dir: &Path) -> PathBuf {
+    home_dir.join(".config").join("atm").join("state.json")
+}
+
+fn load_send_alert_state(path: &Path) -> Result<SendAlertState, AtmError> {
+    if !path.exists() {
+        return Ok(SendAlertState::default());
+    }
+
+    let raw = fs::read_to_string(path).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to read send alert state at {}: {error}",
+            path.display()
+        ))
+        .with_source(error)
+    })?;
+    serde_json::from_str(&raw).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to parse send alert state at {}: {error}",
+            path.display()
+        ))
+        .with_source(error)
+    })
+}
+
+fn save_send_alert_state(path: &Path, state: &SendAlertState) -> Result<(), AtmError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to create send alert state directory {}: {error}",
+                parent.display()
+            ))
+            .with_source(error)
+        })?;
+    }
+
+    let temp_path = path.with_extension("tmp");
+    let data = serde_json::to_vec(state)?;
+    fs::write(&temp_path, data).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to write send alert state temp file {}: {error}",
+            temp_path.display()
+        ))
+        .with_source(error)
+    })?;
+    fs::rename(&temp_path, path).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to replace send alert state at {}: {error}",
+            path.display()
+        ))
+        .with_source(error)
+    })?;
+    Ok(())
 }

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -13,6 +13,9 @@ pub fn print_send_result(outcome: &SendOutcome, json: bool) -> Result<()> {
             "Sent to {}@{} [message_id: {}]",
             outcome.agent, outcome.team, outcome.message_id
         );
+        for warning in &outcome.warnings {
+            println!("{warning}");
+        }
     }
 
     Ok(())

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -166,6 +166,7 @@ impl Fixture {
                 .iter()
                 .map(|member| AgentMember {
                     name: (*member).to_string(),
+                    ..Default::default()
                 })
                 .collect(),
         };

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -353,6 +353,7 @@ impl Fixture {
                 .iter()
                 .map(|member| AgentMember {
                     name: (*member).to_string(),
+                    ..Default::default()
                 })
                 .collect(),
         };

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -393,6 +393,7 @@ impl Fixture {
                 .iter()
                 .map(|member| AgentMember {
                     name: (*member).to_string(),
+                    ..Default::default()
                 })
                 .collect(),
         };

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -142,6 +142,19 @@ fn test_read_json_output() {
 }
 
 #[test]
+fn test_read_missing_team_config_fails_with_actionable_error() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
+
+    let output = fixture.run(&["read", "--json"]);
+
+    assert!(!output.status.success());
+    let stderr = fixture.stderr(&output);
+    assert!(stderr.contains("team config is missing"));
+    assert!(stderr.contains("Restore config.json"));
+}
+
+#[test]
 fn test_read_seen_state() {
     let fixture = Fixture::new(&["arch-ctm"]);
     fixture.write_inbox(

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -148,6 +148,169 @@ fn test_send_supports_positional_message_with_file() {
         .starts_with("context first\n\nFile reference:"));
 }
 
+#[test]
+fn test_send_tolerates_invalid_team_members_when_recipient_is_valid() {
+    let fixture = Fixture::new("recipient");
+    fixture.write_raw_team_config(
+        r#"{
+            "members": [
+                {"name":"recipient"},
+                {"broken": true},
+                17
+            ]
+        }"#,
+    );
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello despite bad siblings"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let inbox = fixture.inbox_contents("recipient");
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].text, "hello despite bad siblings");
+}
+
+#[test]
+fn test_send_accepts_string_member_compatibility_form() {
+    let fixture = Fixture::new("recipient");
+    fixture.write_raw_team_config(r#"{"members":["recipient"]}"#);
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello legacy"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let inbox = fixture.inbox_contents("recipient");
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].text, "hello legacy");
+}
+
+#[test]
+fn test_send_reports_actionable_error_for_malformed_team_config() {
+    let fixture = Fixture::new("recipient");
+    fixture.write_raw_team_config(r#"{"members":[{"name":"recipient"}"#);
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello"]);
+
+    assert!(!output.status.success());
+    let stderr = fixture.stderr(&output);
+    assert!(stderr.contains("failed to parse team config"));
+    assert!(stderr.contains("config.json"));
+    assert!(stderr.contains("Repair the JSON syntax in config.json"));
+}
+
+#[test]
+fn test_send_missing_config_uses_existing_inbox_fallback_and_warns_sender() {
+    let fixture = Fixture::new("recipient");
+    fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
+    fixture.write_inbox("recipient", &[]);
+    fixture.write_inbox("team-lead", &[]);
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello fallback"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let stdout = fixture.stdout(&output);
+    assert!(stdout.contains("Sent to recipient@atm-dev"));
+    assert!(stdout.contains("warning: team config is missing"));
+
+    let inbox = fixture.inbox_contents("recipient");
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].text, "hello fallback");
+
+    let notices = fixture.inbox_contents("team-lead");
+    assert_eq!(notices.len(), 1);
+    assert!(notices[0]
+        .text
+        .contains("ATM warning: send used existing inbox fallback"));
+}
+
+#[test]
+fn test_send_missing_config_deduplicates_team_lead_notice() {
+    let fixture = Fixture::new("recipient");
+    fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
+    fixture.write_inbox("recipient", &[]);
+    fixture.write_inbox("team-lead", &[]);
+
+    let first = fixture.run(&["send", "recipient@atm-dev", "first"]);
+    assert!(first.status.success(), "stderr: {}", fixture.stderr(&first));
+
+    let second = fixture.run(&["send", "recipient@atm-dev", "second"]);
+    assert!(
+        second.status.success(),
+        "stderr: {}",
+        fixture.stderr(&second)
+    );
+
+    let notices = fixture.inbox_contents("team-lead");
+    assert_eq!(notices.len(), 1);
+}
+
+#[test]
+fn test_send_missing_config_notice_resets_after_config_is_restored() {
+    let fixture = Fixture::new("recipient");
+    fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
+    fixture.write_inbox("recipient", &[]);
+    fixture.write_inbox("team-lead", &[]);
+
+    let first = fixture.run(&["send", "recipient@atm-dev", "first"]);
+    assert!(first.status.success(), "stderr: {}", fixture.stderr(&first));
+    assert_eq!(fixture.inbox_contents("team-lead").len(), 1);
+
+    fixture.write_team_config("recipient");
+    let second = fixture.run(&["send", "recipient@atm-dev", "with config restored"]);
+    assert!(
+        second.status.success(),
+        "stderr: {}",
+        fixture.stderr(&second)
+    );
+    assert_eq!(fixture.inbox_contents("team-lead").len(), 1);
+
+    fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config again");
+    let third = fixture.run(&["send", "recipient@atm-dev", "broken again"]);
+    assert!(third.status.success(), "stderr: {}", fixture.stderr(&third));
+    assert_eq!(fixture.inbox_contents("team-lead").len(), 2);
+}
+
+#[test]
+fn test_send_missing_config_fails_when_recipient_inbox_does_not_exist() {
+    let fixture = Fixture::new("recipient");
+    fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello"]);
+
+    assert!(!output.status.success());
+    let stderr = fixture.stderr(&output);
+    assert!(stderr.contains("team config is missing"));
+    assert!(stderr.contains("cannot safely proceed"));
+    assert!(stderr.contains("Restore config.json"));
+}
+
+#[test]
+fn test_send_missing_config_does_not_block_when_team_lead_inbox_is_absent() {
+    let fixture = Fixture::new("recipient");
+    fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
+    fixture.write_inbox("recipient", &[]);
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello fallback"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let inbox = fixture.inbox_contents("recipient");
+    assert_eq!(inbox.len(), 1);
+}
+
 struct Fixture {
     tempdir: tempfile::TempDir,
 }
@@ -191,6 +354,17 @@ impl Fixture {
         .expect("write team config");
     }
 
+    fn write_raw_team_config(&self, raw: &str) {
+        let team_dir = self
+            .tempdir
+            .path()
+            .join(".claude")
+            .join("teams")
+            .join("atm-dev");
+        fs::create_dir_all(&team_dir).expect("team dir");
+        fs::write(team_dir.join("config.json"), raw).expect("write raw team config");
+    }
+
     fn inbox_path(&self, recipient: &str) -> std::path::PathBuf {
         self.tempdir
             .path()
@@ -201,12 +375,43 @@ impl Fixture {
             .join(format!("{recipient}.json"))
     }
 
+    fn write_inbox(&self, recipient: &str, messages: &[MessageEnvelope]) {
+        let inbox_path = self.inbox_path(recipient);
+        if let Some(parent) = inbox_path.parent() {
+            fs::create_dir_all(parent).expect("inbox dir");
+        }
+        let raw = if messages.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "{}\n",
+                messages
+                    .iter()
+                    .map(|message| serde_json::to_string(message).expect("json line"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        };
+        fs::write(inbox_path, raw).expect("write inbox");
+    }
+
     fn inbox_contents(&self, recipient: &str) -> Vec<MessageEnvelope> {
         let inbox_path = self.inbox_path(recipient);
         let raw = fs::read_to_string(&inbox_path).expect("inbox contents");
+        if raw.trim().is_empty() {
+            return Vec::new();
+        }
         raw.lines()
             .map(|line| serde_json::from_str(line).expect("json line"))
             .collect()
+    }
+
+    fn team_dir(&self) -> std::path::PathBuf {
+        self.tempdir
+            .path()
+            .join(".claude")
+            .join("teams")
+            .join("atm-dev")
     }
 
     fn stdout(&self, output: &std::process::Output) -> String {

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -255,6 +255,32 @@ fn test_send_missing_config_deduplicates_team_lead_notice() {
 }
 
 #[test]
+fn test_send_missing_config_deduplicates_team_lead_notice_under_concurrency() {
+    let fixture = Fixture::new("recipient");
+    fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
+    fixture.write_inbox("recipient", &[]);
+    fixture.write_inbox("team-lead", &[]);
+
+    let (first, second) = std::thread::scope(|scope| {
+        let first = scope.spawn(|| fixture.run(&["send", "recipient@atm-dev", "first"]));
+        let second = scope.spawn(|| fixture.run(&["send", "recipient@atm-dev", "second"]));
+        (
+            first.join().expect("first send"),
+            second.join().expect("second send"),
+        )
+    });
+
+    assert!(first.status.success(), "stderr: {}", fixture.stderr(&first));
+    assert!(
+        second.status.success(),
+        "stderr: {}",
+        fixture.stderr(&second)
+    );
+    let notices = fixture.inbox_contents("team-lead");
+    assert_eq!(notices.len(), 1);
+}
+
+#[test]
 fn test_send_missing_config_notice_resets_after_config_is_restored() {
     let fixture = Fixture::new("recipient");
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
@@ -345,6 +371,7 @@ impl Fixture {
         let config = TeamConfig {
             members: vec![AgentMember {
                 name: recipient.to_string(),
+                ..Default::default()
             }],
         };
         fs::write(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -257,6 +257,9 @@ Diagnostics for team config failures must preserve:
 - parser line and column when available
 - original parser cause for operator repair
 
+Sample operator-facing repair cases live in
+[`persisted-data-repair.md`](./persisted-data-repair.md).
+
 ### 5.2 Inbox Message
 
 Persisted fields used by the rewrite:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -321,6 +321,7 @@ Public entrypoint:
 - requires-ack flag
 - summary
 - rendered message body
+- warnings
 - delivery result
 
 The file-reference path may be rewritten through the file policy layer.
@@ -335,6 +336,7 @@ Normal send JSON output includes:
 - `message_id`
 - `requires_ack`
 - `task_id`
+- `warnings` when send completed in a degraded but permitted mode
 
 Dry-run send JSON output includes:
 - `action = "send"`
@@ -344,6 +346,7 @@ Dry-run send JSON output includes:
 - `dry_run = true`
 - `requires_ack`
 - `task_id`
+- `warnings` when dry-run surfaces degraded send conditions
 
 Send ordering rules:
 - resolve target address, team existence, and agent membership as one address-resolution stage before mailbox path selection

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -238,20 +238,22 @@ pub struct LogFieldMatch {
 The rewrite reuses the existing team config schema where feasible.
 
 Only a small subset is required by the retained surface:
-- team name
-- member names
-- enough member metadata to preserve round-trips
-- bridge remote host configuration needed for origin-file merge
+- member roster
+- enough member metadata to preserve round-trips when present
+- bridge remote host configuration needed for origin-file merge when present
 
 Team config loading must follow a narrow-scope recovery policy:
-- compatibility-only field additions may use deterministic defaults at the
-  schema boundary
+- compatibility-only schema drift may use deterministic defaults at the schema
+  boundary
 - malformed member records should be isolated at member scope only when the
   remaining roster is still trustworthy
+- missing `config.json` is a distinct `missing-document` condition, not a parse
+  error
 - root-document corruption or invalid root structure remains a command error
 - identity and routing fields must never be guessed to keep commands running
 
 Diagnostics for team config failures must preserve:
+- failure class when known
 - file path
 - member or collection scope when known
 - parser line and column when available
@@ -349,6 +351,15 @@ Send ordering rules:
 - validate message text inside the atomic append boundary
 - generate UUID v4 `message_id` inside the atomic append boundary
 - perform duplicate suppression and final append inside the same atomic append boundary
+
+Missing-team-config fallback is limited to `send`:
+- fallback applies only when `config.json` is missing and the target inbox
+  already exists
+- malformed `config.json` remains a command error
+- fallback must surface an actionable sender warning
+- fallback may send a best-effort repair notice to `team-lead`
+- repair notices must be deduplicated by unresolved condition so repeated sends
+  do not flood inboxes
 
 ### 6.2 Read Service
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -311,18 +311,22 @@ Public entrypoint:
 - stdin text
 - file reference
 
-`SendOutcome` contains:
-- action
-- resolved team
-- resolved recipient
-- resolved sender
-- generated message id
-- task id
-- requires-ack flag
-- summary
-- rendered message body
-- warnings
-- delivery result
+`SendOutcome` fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `action` | `&'static str` | Stable send action marker. |
+| `team` | `String` | Resolved target team. |
+| `agent` | `String` | Resolved target recipient. |
+| `sender` | `String` | Resolved sender identity. |
+| `outcome` | `&'static str` | Delivery result such as `sent` or `dry_run`. |
+| `message_id` | `Uuid` | ATM-authored UUID v4 for the send operation. |
+| `requires_ack` | `bool` | Whether the message requires acknowledgement. |
+| `task_id` | `Option<String>` | Optional task identifier persisted on the message. |
+| `summary` | `Option<String>` | Generated or caller-supplied summary text. |
+| `message` | `Option<String>` | Rendered message body for dry-run output. |
+| `warnings` | `Vec<String>` | Actionable degraded-mode warnings surfaced when send succeeds under a permitted fallback condition. |
+| `dry_run` | `bool` | Whether the send was executed as a dry run. |
 
 The file-reference path may be rewritten through the file policy layer.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,6 +243,20 @@ Only a small subset is required by the retained surface:
 - enough member metadata to preserve round-trips
 - bridge remote host configuration needed for origin-file merge
 
+Team config loading must follow a narrow-scope recovery policy:
+- compatibility-only field additions may use deterministic defaults at the
+  schema boundary
+- malformed member records should be isolated at member scope only when the
+  remaining roster is still trustworthy
+- root-document corruption or invalid root structure remains a command error
+- identity and routing fields must never be guessed to keep commands running
+
+Diagnostics for team config failures must preserve:
+- file path
+- member or collection scope when known
+- parser line and column when available
+- original parser cause for operator repair
+
 ### 5.2 Inbox Message
 
 Persisted fields used by the rewrite:
@@ -680,6 +694,9 @@ Every public error must include:
 - human-readable cause
 - recovery guidance when the user can act
 
+Persisted-data errors should additionally carry file/entity/parser context so
+CLI surfaces can report the exact failing document and scope.
+
 ## 16. Trait Policy
 
 The initial rewrite should avoid public extension traits.
@@ -693,6 +710,8 @@ If a trait becomes necessary:
 `atm-core` tests:
 - address parsing
 - config precedence
+- tolerant team-config parsing for compatibility-only schema drift
+- precise persisted-data diagnostics for non-recoverable config failures
 - bridge hostname resolution for merged inbox reads
 - settings resolution
 - hook identity resolution

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -17,8 +17,27 @@ service boundaries.
   dependency on `sc-observability`.
 - `atm-core` must keep mailbox/config/workflow/log/doctor logic reusable across
   CLI contexts.
+- `atm-core` owns persisted config/team loading policy, including compatibility
+  defaults, recovery boundaries, and precise parse diagnostics.
 
-## 3. ADR Namespace
+## 3. Config Loading Boundary
+
+Persisted config and team-document handling belongs at the `atm-core` loading
+boundary rather than in scattered command call sites.
+
+Required loading policy:
+- classify persisted-data failures as compatibility-only schema drift,
+  record-level invalid data, or document-level invalid data
+- apply defaults only for deterministic compatibility recovery
+- keep identity and routing-critical fields required unless the product docs
+  explicitly define a safe fallback
+- preserve file, entity, and parser context when converting loader failures
+  into `AtmError`
+
+This keeps tolerant parsing centralized and prevents commands from inventing
+ad hoc recovery behavior.
+
+## 4. ADR Namespace
 
 The `atm-core` crate uses the `ADR-CORE-*` namespace.
 

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -45,6 +45,17 @@ Send-specific policy remains layered above the loader:
 - deduplicated repair notifications belong to the send orchestration boundary,
   not to generic config parsing
 
+Current `AgentMember` persisted schema:
+- `name: String` required for roster membership checks
+- `agent_id: String` stored as `agentId`, default empty string
+- `agent_type: String` stored as `agentType`, default empty string
+- `model: String`, default empty string
+- `joined_at: Option<u64>` stored as `joinedAt`
+- `tmux_pane_id: String` stored as `tmuxPaneId`, default empty string
+- `cwd: String`, default empty string
+- `extra: serde_json::Map<String, serde_json::Value>` via `#[serde(flatten)]`
+  for forward-compatible Claude Code fields
+
 ## 4. ADR Namespace
 
 The `atm-core` crate uses the `ADR-CORE-*` namespace.

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -27,7 +27,7 @@ boundary rather than in scattered command call sites.
 
 Required loading policy:
 - classify persisted-data failures as compatibility-only schema drift,
-  record-level invalid data, or document-level invalid data
+  record-level invalid data, document-level invalid data, or missing-document
 - apply defaults only for deterministic compatibility recovery
 - keep identity and routing-critical fields required unless the product docs
   explicitly define a safe fallback
@@ -36,6 +36,14 @@ Required loading policy:
 
 This keeps tolerant parsing centralized and prevents commands from inventing
 ad hoc recovery behavior.
+
+Send-specific policy remains layered above the loader:
+- send may use a narrowly defined missing-document fallback when the product
+  docs explicitly allow it
+- malformed documents remain loader errors and do not automatically degrade into
+  send fallback
+- deduplicated repair notifications belong to the send orchestration boundary,
+  not to generic config parsing
 
 ## 4. ADR Namespace
 

--- a/docs/atm-core/modules/config.md
+++ b/docs/atm-core/modules/config.md
@@ -3,10 +3,17 @@
 Owns configuration discovery, precedence rules, alias and bridge-hostname
 resolution, and translation into validated core request inputs.
 
+Also owns persisted config/team loading policy:
+- deterministic compatibility defaults for documented schema drift
+- classification of record-level versus document-level parse failures
+- recovery guidance and parser-context preservation for config errors
+
 References:
 
 - Product requirements: `docs/requirements.md` §3.3, §3.4, and §4
 - `REQ-P-CONTRACT-001`
 - `REQ-P-IDENTITY-001`
+- `REQ-P-CONFIG-HEALTH-001`
+- `REQ-CORE-CONFIG-003`
 - `REQ-CORE-MAILBOX-001`
 - Migration artifact: `docs/file-migration-plan.md`

--- a/docs/atm-core/modules/config.md
+++ b/docs/atm-core/modules/config.md
@@ -5,8 +5,9 @@ resolution, and translation into validated core request inputs.
 
 Also owns persisted config/team loading policy:
 - deterministic compatibility defaults for documented schema drift
-- classification of record-level versus document-level parse failures
+- classification of missing-document, record-level, and document-level failures
 - recovery guidance and parser-context preservation for config errors
+- refusal to guess identity or routing data during recovery
 
 References:
 

--- a/docs/atm-core/modules/send.md
+++ b/docs/atm-core/modules/send.md
@@ -8,6 +8,11 @@ Also owns send-time resilience behavior that is not generic config parsing:
 - actionable sender warnings for degraded send behavior
 - best-effort deduplicated repair notifications to `team-lead`
 
+`SendOutcome.warnings` is part of the stable send API contract:
+- empty during normal sends
+- populated only when send succeeds in a degraded but permitted mode
+- contains actionable human-readable warning text for the caller to surface
+
 References:
 
 - Product requirements: `docs/requirements.md` §6 and §12

--- a/docs/atm-core/modules/send.md
+++ b/docs/atm-core/modules/send.md
@@ -3,10 +3,17 @@
 Owns send request validation, message construction, summary generation,
 ack-required/task metadata handling, and atomic inbox append orchestration.
 
+Also owns send-time resilience behavior that is not generic config parsing:
+- missing-team-config fallback when the product contract explicitly allows it
+- actionable sender warnings for degraded send behavior
+- best-effort deduplicated repair notifications to `team-lead`
+
 References:
 
 - Product requirements: `docs/requirements.md` §6 and §12
 - `REQ-P-SEND-001`
 - `REQ-P-WORKFLOW-001`
+- `REQ-P-CONFIG-HEALTH-001`
+- `REQ-CORE-SEND-001`
 - `REQ-CORE-MAILBOX-001`
 - CLI surface: `docs/atm/commands/send.md`

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -54,6 +54,11 @@ Initial crate requirement IDs:
   resolution and target-validation aspects of:
   `REQ-P-ADDRESS-001`, `REQ-P-SEND-001`, `REQ-P-READ-001`,
   `REQ-P-CLEAR-001`.
+- `REQ-CORE-CONFIG-003` `atm-core` owns persisted config/team schema recovery
+  and diagnostic policy. Satisfies the compatibility-recovery and
+  persisted-data error aspects of:
+  `REQ-P-CONFIG-HEALTH-001`, `REQ-P-ERROR-001`,
+  `REQ-P-RELIABILITY-001`.
 - `REQ-CORE-MAILBOX-001` `atm-core` owns daemon-free mailbox/store behavior.
   Satisfies the persisted mailbox I/O and mutation aspects of:
   `REQ-P-CONTRACT-001`, `REQ-P-SEND-001`, `REQ-P-READ-001`,

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -59,6 +59,11 @@ Initial crate requirement IDs:
   persisted-data error aspects of:
   `REQ-P-CONFIG-HEALTH-001`, `REQ-P-ERROR-001`,
   `REQ-P-RELIABILITY-001`.
+- `REQ-CORE-SEND-001` `atm-core` owns send-time missing-config fallback,
+  sender-warning, and repair-notification behavior above the shared config
+  loader. Satisfies the missing-config send-path aspects of:
+  `REQ-P-SEND-001`, `REQ-P-CONFIG-HEALTH-001`,
+  `REQ-P-RELIABILITY-001`.
 - `REQ-CORE-MAILBOX-001` `atm-core` owns daemon-free mailbox/store behavior.
   Satisfies the persisted mailbox I/O and mutation aspects of:
   `REQ-P-CONTRACT-001`, `REQ-P-SEND-001`, `REQ-P-READ-001`,

--- a/docs/persisted-data-repair.md
+++ b/docs/persisted-data-repair.md
@@ -1,0 +1,278 @@
+# ATM Persisted Data Repair Guide
+
+**Lifecycle**: Permanent cross-cutting document
+
+This document provides operator guidance for persisted-data failures covered by:
+
+- `REQ-P-CONFIG-HEALTH-001`
+- `REQ-P-ERROR-001`
+- `REQ-P-RELIABILITY-001`
+
+It is intentionally not the source of truth for normative behavior. Product
+requirements remain in [`requirements.md`](./requirements.md), and product
+architecture remains in [`architecture.md`](./architecture.md).
+
+## 1. Purpose
+
+ATM reads persisted mailbox, team, and config data that may be:
+
+- older than the current schema
+- partially hand-edited
+- externally generated
+- truncated or corrupted by interrupted writes
+
+The goal is not "always continue." The goal is:
+
+- continue when recovery is deterministic and low-risk
+- isolate damage at the narrowest safe scope
+- fail loudly when continuing would require guessing identity or routing data
+
+## 2. Recovery Ladder
+
+ATM should treat persisted-data issues in this order:
+
+1. Recover with a documented default when the missing data is compatibility-only
+   and the fallback does not change identity or routing semantics.
+2. Isolate or skip one invalid record when the surrounding collection is still
+   trustworthy.
+3. Fail the command when the root document is malformed or when recovery would
+   require guessing identity, membership, or routing data.
+
+All non-recoverable cases should report:
+
+- file path
+- entity scope when known
+- field name when known
+- parser detail, including line and column when available
+- a safe repair action
+
+## 3. Common Cases
+
+### 3.1 Missing Compatibility Field
+
+Example:
+
+```json
+{
+  "agentId": "arch-ctm@atm-dev",
+  "name": "arch-ctm",
+  "model": "gpt5.3-codex",
+  "joinedAt": 1770765919076,
+  "cwd": "/workspace"
+}
+```
+
+Issue:
+- legacy `AgentMember` record omits `agentType`
+
+Expected ATM behavior:
+- recover with the documented default
+- continue loading the team config
+- preserve a warning or diagnostic that compatibility recovery was used
+
+Safe repair:
+- add `"agentType": "general-purpose"` to the member record
+
+Why this is recoverable:
+- `agentType` is descriptive capability metadata
+- defaulting it does not invent membership or routing identity
+
+### 3.2 Unknown Future Field
+
+Example:
+
+```json
+{
+  "agentId": "arch-ctm@atm-dev",
+  "name": "arch-ctm",
+  "agentType": "general-purpose",
+  "model": "gpt5.3-codex",
+  "joinedAt": 1770765919076,
+  "cwd": "/workspace",
+  "futureFeature": { "enabled": true }
+}
+```
+
+Issue:
+- newer writer added a field older ATM versions do not understand
+
+Expected ATM behavior:
+- preserve the field during round-trip when possible
+- continue without warning unless the field affects a feature this binary owns
+
+Safe repair:
+- none required
+
+Why this is recoverable:
+- the data is structurally valid and forward-compatible
+
+### 3.3 Missing Identity Or Routing Field
+
+Example:
+
+```json
+{
+  "name": "arch-ctm",
+  "agentType": "general-purpose",
+  "model": "gpt5.3-codex",
+  "joinedAt": 1770765919076,
+  "cwd": "/workspace"
+}
+```
+
+Issue:
+- required identity field such as `agentId` is missing
+
+Expected ATM behavior:
+- do not invent the missing value
+- isolate the invalid member only if the surrounding roster can still be used
+- otherwise fail with a precise config error
+
+Safe repair:
+- restore the missing `agentId` field using the canonical `agent@team` value
+
+Why this is not auto-recoverable:
+- fabricating `agentId` would guess membership and routing semantics
+
+### 3.4 Wrong Type In A Member Record
+
+Example:
+
+```json
+{
+  "agentId": "arch-ctm@atm-dev",
+  "name": "arch-ctm",
+  "agentType": "general-purpose",
+  "model": "gpt5.3-codex",
+  "joinedAt": "1770765919076",
+  "cwd": "/workspace"
+}
+```
+
+Issue:
+- field type does not match the schema
+
+Expected ATM behavior:
+- do not silently coerce the value unless the product contract explicitly
+  allows that coercion
+- isolate the member if the remaining collection is trustworthy
+- include the failing field and parser detail in the diagnostic
+
+Safe repair:
+- change `"joinedAt"` to a JSON number, not a string
+
+Why this is usually not auto-recoverable:
+- generic coercions hide malformed data and make future corruption harder to
+  detect
+
+### 3.5 Malformed Root JSON
+
+Example:
+
+```json
+{
+  "teamName": "atm-dev",
+  "members": [
+    { "agentId": "arch-ctm@atm-dev", "name": "arch-ctm" }
+```
+
+Issue:
+- truncated or syntactically invalid JSON document
+
+Expected ATM behavior:
+- fail the command
+- report the file path and parser line/column
+- avoid guessing what the missing structure should have been
+
+Safe repair:
+- restore the file from a known-good copy or repair the JSON structure
+
+Why this is not recoverable:
+- the document boundary itself is untrustworthy
+
+### 3.6 Wrong Root Shape
+
+Example:
+
+```json
+[
+  {
+    "agentId": "arch-ctm@atm-dev",
+    "name": "arch-ctm",
+    "agentType": "general-purpose"
+  }
+]
+```
+
+Issue:
+- root shape is an array when ATM expects a team config object
+
+Expected ATM behavior:
+- fail the command with a structured configuration error
+- report that the root shape is invalid rather than attempting schema
+  migration by guesswork
+
+Safe repair:
+- wrap the member list in the expected team config object shape
+
+Why this is not recoverable:
+- ATM cannot safely infer omitted root-level fields or semantics
+
+### 3.7 One Invalid Member In An Otherwise Valid Team
+
+Example:
+
+```json
+{
+  "teamName": "atm-dev",
+  "members": [
+    {
+      "agentId": "arch-ctm@atm-dev",
+      "name": "arch-ctm",
+      "agentType": "general-purpose",
+      "model": "gpt5.3-codex",
+      "joinedAt": 1770765919076,
+      "cwd": "/workspace"
+    },
+    {
+      "name": "broken-member"
+    }
+  ]
+}
+```
+
+Issue:
+- one record is invalid inside an otherwise valid roster
+
+Expected ATM behavior:
+- isolate the invalid member if the loader can still trust the containing
+  collection
+- continue serving unaffected members
+- fail commands that specifically target the invalid member
+
+Safe repair:
+- repair or remove the invalid member entry
+
+Why this is only conditionally recoverable:
+- collection-level recovery is safe only when the loader can identify a single
+  bad record without guessing hidden structure
+
+## 4. Repair Principles
+
+When repairing persisted data manually:
+
+- prefer restoring known-good values over inventing new ones
+- do not rename agents or teams unless the intent is explicit
+- keep unknown fields unless the field is known to be corrupt
+- validate JSON syntax before retrying ATM commands
+- if the file may have been truncated, restore from backup before hand-editing
+
+## 5. Implementation Note
+
+This document intentionally makes operator outcomes concrete so tests can be
+written against the same cases:
+
+- compatibility-only schema drift should have positive tests
+- isolated invalid-record handling should have scoped recovery tests
+- non-recoverable document failures should have diagnostic tests that assert
+  file and parser context

--- a/docs/persisted-data-repair.md
+++ b/docs/persisted-data-repair.md
@@ -20,160 +20,101 @@ ATM reads persisted mailbox, team, and config data that may be:
 - partially hand-edited
 - externally generated
 - truncated or corrupted by interrupted writes
+- missing entirely
 
 The goal is not "always continue." The goal is:
 
 - continue when recovery is deterministic and low-risk
 - isolate damage at the narrowest safe scope
 - fail loudly when continuing would require guessing identity or routing data
+- notify the operator or `team-lead` when degraded behavior needs repair
 
 ## 2. Recovery Ladder
 
-ATM should treat persisted-data issues in this order:
+ATM should treat team-config issues in this order:
 
-1. Recover with a documented default when the missing data is compatibility-only
-   and the fallback does not change identity or routing semantics.
-2. Isolate or skip one invalid record when the surrounding collection is still
+1. Recover `compatibility-recoverable` forms with documented deterministic
+   rules.
+2. Isolate `record-invalid` entries when the surrounding document remains
    trustworthy.
-3. Fail the command when the root document is malformed or when recovery would
-   require guessing identity, membership, or routing data.
+3. Fail on `document-invalid` config with detailed repair guidance.
+4. Treat `missing-document` separately from parse failure. Only command paths
+   that explicitly support missing-document fallback may proceed.
 
 All non-recoverable cases should report:
 
+- failure class
 - file path
 - entity scope when known
-- field name when known
-- parser detail, including line and column when available
+- parser detail when available
 - a safe repair action
 
 ## 3. Common Cases
 
-### 3.1 Missing Compatibility Field
+### 3.1 Compatibility-Recoverable Member Form
 
 Example:
 
 ```json
 {
-  "agentId": "arch-ctm@atm-dev",
-  "name": "arch-ctm",
-  "model": "gpt5.3-codex",
-  "joinedAt": 1770765919076,
-  "cwd": "/workspace"
-}
-```
-
-Issue:
-- legacy `AgentMember` record omits `agentType`
-
-Expected ATM behavior:
-- recover with the documented default
-- continue loading the team config
-- preserve a warning or diagnostic that compatibility recovery was used
-
-Safe repair:
-- add `"agentType": "general-purpose"` to the member record
-
-Why this is recoverable:
-- `agentType` is descriptive capability metadata
-- defaulting it does not invent membership or routing identity
-
-### 3.2 Unknown Future Field
-
-Example:
-
-```json
-{
-  "agentId": "arch-ctm@atm-dev",
-  "name": "arch-ctm",
-  "agentType": "general-purpose",
-  "model": "gpt5.3-codex",
-  "joinedAt": 1770765919076,
-  "cwd": "/workspace",
-  "futureFeature": { "enabled": true }
-}
-```
-
-Issue:
-- newer writer added a field older ATM versions do not understand
-
-Expected ATM behavior:
-- preserve the field during round-trip when possible
-- continue without warning unless the field affects a feature this binary owns
-
-Safe repair:
-- none required
-
-Why this is recoverable:
-- the data is structurally valid and forward-compatible
-
-### 3.3 Missing Identity Or Routing Field
-
-Example:
-
-```json
-{
-  "name": "arch-ctm",
-  "agentType": "general-purpose",
-  "model": "gpt5.3-codex",
-  "joinedAt": 1770765919076,
-  "cwd": "/workspace"
-}
-```
-
-Issue:
-- required identity field such as `agentId` is missing
-
-Expected ATM behavior:
-- do not invent the missing value
-- isolate the invalid member only if the surrounding roster can still be used
-- otherwise fail with a precise config error
-
-Safe repair:
-- restore the missing `agentId` field using the canonical `agent@team` value
-
-Why this is not auto-recoverable:
-- fabricating `agentId` would guess membership and routing semantics
-
-### 3.4 Wrong Type In A Member Record
-
-Example:
-
-```json
-{
-  "agentId": "arch-ctm@atm-dev",
-  "name": "arch-ctm",
-  "agentType": "general-purpose",
-  "model": "gpt5.3-codex",
-  "joinedAt": "1770765919076",
-  "cwd": "/workspace"
-}
-```
-
-Issue:
-- field type does not match the schema
-
-Expected ATM behavior:
-- do not silently coerce the value unless the product contract explicitly
-  allows that coercion
-- isolate the member if the remaining collection is trustworthy
-- include the failing field and parser detail in the diagnostic
-
-Safe repair:
-- change `"joinedAt"` to a JSON number, not a string
-
-Why this is usually not auto-recoverable:
-- generic coercions hide malformed data and make future corruption harder to
-  detect
-
-### 3.5 Malformed Root JSON
-
-Example:
-
-```json
-{
-  "teamName": "atm-dev",
   "members": [
-    { "agentId": "arch-ctm@atm-dev", "name": "arch-ctm" }
+    "arch-ctm",
+    { "name": "team-lead" }
+  ]
+}
+```
+
+Issue:
+- the roster mixes a legacy string-member form with the canonical object form
+
+Expected ATM behavior:
+- accept both entries
+- continue loading the team config
+- avoid fabricating any extra identity or routing data
+
+Safe repair:
+- normalize the string entry to `{ "name": "arch-ctm" }`
+
+Why this is recoverable:
+- the member name is explicit and deterministic
+
+### 3.2 Invalid Member In An Otherwise Valid Team
+
+Example:
+
+```json
+{
+  "members": [
+    { "name": "arch-ctm" },
+    { "broken": true },
+    { "name": "team-lead" }
+  ]
+}
+```
+
+Issue:
+- one member record is invalid, but the root document is still structurally
+  trustworthy
+
+Expected ATM behavior:
+- isolate the invalid record
+- continue serving valid members
+- preserve a diagnostic that identifies the skipped member scope
+
+Safe repair:
+- repair the invalid entry or remove it
+
+Why this is recoverable:
+- the loader can identify the bad record without guessing hidden structure
+
+### 3.3 Malformed Root JSON
+
+Example:
+
+```json
+{
+  "members": [
+    { "name": "arch-ctm" }
 ```
 
 Issue:
@@ -181,81 +122,118 @@ Issue:
 
 Expected ATM behavior:
 - fail the command
-- report the file path and parser line/column
-- avoid guessing what the missing structure should have been
+- report the file path and parser line/column when available
+- avoid guessing missing structure
 
 Safe repair:
-- restore the file from a known-good copy or repair the JSON structure
+- restore the file from a known-good copy or repair the JSON syntax
 
 Why this is not recoverable:
 - the document boundary itself is untrustworthy
 
-### 3.6 Wrong Root Shape
+### 3.4 Wrong Root Shape
 
 Example:
 
 ```json
 [
-  {
-    "agentId": "arch-ctm@atm-dev",
-    "name": "arch-ctm",
-    "agentType": "general-purpose"
-  }
+  { "name": "arch-ctm" }
 ]
 ```
 
 Issue:
-- root shape is an array when ATM expects a team config object
+- the root value is an array when ATM expects a team config object
 
 Expected ATM behavior:
-- fail the command with a structured configuration error
-- report that the root shape is invalid rather than attempting schema
-  migration by guesswork
+- fail with a structured configuration error
+- report that the root shape is invalid
 
 Safe repair:
-- wrap the member list in the expected team config object shape
+- wrap the member list in the expected object shape:
+  `{ "members": [ ... ] }`
 
 Why this is not recoverable:
-- ATM cannot safely infer omitted root-level fields or semantics
+- ATM cannot safely infer omitted root-level semantics
 
-### 3.7 One Invalid Member In An Otherwise Valid Team
+### 3.5 Wrong `members` Type
 
 Example:
 
 ```json
 {
-  "teamName": "atm-dev",
-  "members": [
-    {
-      "agentId": "arch-ctm@atm-dev",
-      "name": "arch-ctm",
-      "agentType": "general-purpose",
-      "model": "gpt5.3-codex",
-      "joinedAt": 1770765919076,
-      "cwd": "/workspace"
-    },
-    {
-      "name": "broken-member"
-    }
-  ]
+  "members": {
+    "name": "arch-ctm"
+  }
 }
 ```
 
 Issue:
-- one record is invalid inside an otherwise valid roster
+- `members` is an object instead of an array
 
 Expected ATM behavior:
-- isolate the invalid member if the loader can still trust the containing
-  collection
-- continue serving unaffected members
-- fail commands that specifically target the invalid member
+- fail with a structured configuration error
+- include the field name in the repair guidance
 
 Safe repair:
-- repair or remove the invalid member entry
+- repair `members` so it is an array of member records
+
+Why this is not recoverable:
+- the collection boundary is wrong, so record-level isolation is not safe
+
+### 3.6 Missing Team Config During `send`
+
+Example:
+
+```text
+~/.claude/teams/atm-dev/
+  inboxes/
+    recipient.json
+```
+
+Issue:
+- `config.json` is missing entirely, but the recipient inbox already exists
+
+Expected ATM behavior:
+- treat this as `missing-document`, not as malformed JSON
+- allow `send` to proceed only because the inbox path already exists
+- surface an actionable warning to the sender
+- send a best-effort repair notification to `team-lead` when that target can be
+  resolved without guesswork
+- deduplicate repeated repair notifications while the same missing-config
+  condition remains unresolved
+
+Safe repair:
+- restore or recreate `config.json` for the team
 
 Why this is only conditionally recoverable:
-- collection-level recovery is safe only when the loader can identify a single
-  bad record without guessing hidden structure
+- delivery can proceed without guessing membership only because the inbox path
+  already exists
+
+### 3.7 Missing Team Config Without Safe Fallback
+
+Example:
+
+```text
+~/.claude/teams/atm-dev/
+  inboxes/
+    team-lead.json
+```
+
+Issue:
+- `config.json` is missing and the requested recipient inbox does not exist
+
+Expected ATM behavior:
+- fail the `send`
+- explain that the missing config could not be bypassed safely
+- tell the operator to restore team configuration or create the correct team
+  state
+
+Safe repair:
+- restore `config.json` and retry, or create the intended team/inbox state by
+  an approved workflow
+
+Why this is not recoverable:
+- creating or selecting a delivery target would require guesswork
 
 ## 4. Repair Principles
 
@@ -266,13 +244,16 @@ When repairing persisted data manually:
 - keep unknown fields unless the field is known to be corrupt
 - validate JSON syntax before retrying ATM commands
 - if the file may have been truncated, restore from backup before hand-editing
+- when ATM used missing-config fallback, repair the team config promptly so
+  future sends do not remain in degraded mode
 
 ## 5. Implementation Note
 
 This document intentionally makes operator outcomes concrete so tests can be
 written against the same cases:
 
-- compatibility-only schema drift should have positive tests
+- compatibility-recoverable forms should have positive tests
 - isolated invalid-record handling should have scoped recovery tests
-- non-recoverable document failures should have diagnostic tests that assert
-  file and parser context
+- non-recoverable document failures should assert file and parser context
+- missing-config send fallback should assert sender warning, best-effort
+  `team-lead` notification, and deduplication

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -185,6 +185,8 @@ Delete:
 Add:
 - integration tests
 - snapshot tests
+- config/schema hardening for legacy team records with deterministic recovery
+  and precise diagnostics
 - documentation polish
 
 Acceptance:
@@ -200,6 +202,8 @@ Acceptance:
 - Display bucket behavior must remain separate from the canonical two-axis workflow model.
 - Task-linked mail must be ack-required from creation time.
 - Generic logging query/follow/filter behavior should live in `sc-observability` where possible, not in ATM-specific code.
+- Persisted config/schema compatibility issues must recover at the narrowest
+  safe scope, and identity/routing fields must never be guessed.
 
 Cross-document invariants that must stay locked during implementation:
 - `taskId` implies ack-required send behavior

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -251,6 +251,9 @@ Acceptance:
 - Generic logging query/follow/filter behavior should live in `sc-observability` where possible, not in ATM-specific code.
 - Persisted config/schema compatibility issues must recover at the narrowest
   safe scope, and identity/routing fields must never be guessed.
+- Missing team config remains distinct from malformed team config; only the
+  documented send fallback may bypass it, and repeated repair notifications
+  must be deduplicated by unresolved condition.
 
 Cross-document invariants that must stay locked during implementation:
 - `taskId` implies ack-required send behavior

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -145,6 +145,34 @@ Supported optional config fields:
 - color
 - bridge remotes and hostname aliases used by origin-inbox merge
 
+### 3.3.1 Config And Schema Recovery
+
+Product requirement ID:
+- `REQ-P-CONFIG-HEALTH-001` Persisted ATM config and team JSON loading must
+  recover at the narrowest safe scope and report precise diagnostics when
+  recovery is not safe.
+
+Satisfied by:
+- `REQ-CORE-CONFIG-003` for config/team schema recovery and diagnostic policy
+- `REQ-CORE-MAILBOX-001` for mailbox record skip behavior
+
+Required recovery policy:
+- compatibility-only schema drift may be recovered with documented,
+  deterministic defaults
+- malformed records inside a larger persisted collection should be skipped or
+  quarantined individually when the rest of the document remains trustworthy
+- malformed root documents or invalid root structure must fail with structured
+  errors rather than guessed repairs
+- identity and routing semantics must never be fabricated to keep a command
+  running
+
+Required diagnostics:
+- file path
+- entity scope when known, such as member name or collection entry
+- field name when known
+- parser detail, including line and column when available
+- recovery guidance when operator action is required
+
 ### 3.4 Claude Settings Resolution
 
 The system must resolve Claude settings for file-reference policy checks.
@@ -982,6 +1010,8 @@ Satisfied by:
 
 All user-visible failures must use structured errors with recovery guidance.
 
+Persisted-data failures must preserve parser and entity context when available.
+
 Minimum error categories:
 - configuration
 - address
@@ -1018,6 +1048,10 @@ Satisfied by:
 - duplicate message ids must not be appended twice
 - read-time duplicate message ids collapse to the newest visible entry
 - corrupt records should be skipped individually when possible
+- persisted config/team schema drift should recover with deterministic defaults
+  when safe
+- persisted config/team records with missing identity or routing-critical fields
+  must fail or be isolated rather than guessed
 - missing inbox files are treated as empty inboxes
 - seen-state races must not corrupt mailbox data
 - observability emission failures must not corrupt command behavior

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -154,19 +154,30 @@ Product requirement ID:
 
 Satisfied by:
 - `REQ-CORE-CONFIG-003` for config/team schema recovery and diagnostic policy
+- `REQ-CORE-SEND-001` for send-time missing-config fallback and repair
+  notification policy
 - `REQ-CORE-MAILBOX-001` for mailbox record skip behavior
 
-Required recovery policy:
+Required persisted-data classes:
+- `compatibility-recoverable`
+- `record-invalid`
+- `document-invalid`
+- `missing-document`
+
+Required handling policy:
 - compatibility-only schema drift may be recovered with documented,
   deterministic defaults
 - malformed records inside a larger persisted collection should be skipped or
   quarantined individually when the rest of the document remains trustworthy
 - malformed root documents or invalid root structure must fail with structured
   errors rather than guessed repairs
+- missing persisted team config is a distinct `missing-document` condition and
+  must not be collapsed into generic parse corruption
 - identity and routing semantics must never be fabricated to keep a command
   running
 
 Required diagnostics:
+- failure class when known
 - file path
 - entity scope when known, such as member name or collection entry
 - field name when known
@@ -264,6 +275,8 @@ Satisfied by:
 - `REQ-ATM-CMD-001` for CLI entry, parsing, and dispatch aspects
 - `REQ-ATM-OUT-001` for human-readable and JSON output aspects
 - `REQ-CORE-CONFIG-002` for address resolution and target-validation aspects
+- `REQ-CORE-SEND-001` for send-time missing-config fallback and repair
+  notification behavior
 - `REQ-CORE-MAILBOX-001` for message creation, duplicate suppression, and
   atomic mailbox mutation aspects
 
@@ -294,7 +307,9 @@ Retired from the current implementation:
 - resolve sender identity using the defined precedence
 - resolve recipient address using the defined precedence
 - resolve roles and aliases before mailbox lookup
-- verify target team existence and target agent membership as part of address resolution before mailbox path selection
+- verify target team existence and target agent membership as part of address
+  resolution before mailbox path selection, except for the documented
+  `missing-document` fallback in §6.3.1
 - generate summary when not explicitly provided
 - enter the atomic append boundary before final inbox mutation
 - validate message text inside the atomic append boundary
@@ -317,6 +332,26 @@ Recipients use `message_id` for:
 - duplicate suppression
 - read-time duplicate collapse
 - acknowledgement targeting
+
+### 6.3.1 Missing Team Config Fallback
+
+When team `config.json` is missing, `atm send` may still proceed only when:
+- the resolved team directory exists
+- the target inbox path already exists
+- no team, agent, or routing identity must be guessed
+
+When `atm send` uses this fallback, it must:
+- surface an actionable warning to the sender that delivery used inbox fallback
+  because team config is missing
+- keep the original delivery path best-effort and non-interactive
+- send a best-effort repair notification to `team-lead` when that recipient can
+  be resolved without guesswork
+- deduplicate repeated repair notifications for the same unresolved missing-team
+  config condition so inboxes do not accumulate hundreds of identical messages
+
+When team `config.json` is malformed rather than missing:
+- `atm send` must fail with a structured configuration error
+- malformed config must not silently degrade into missing-config fallback
 
 ### 6.4 Message Source Semantics
 
@@ -1017,6 +1052,7 @@ Persisted-data failures must preserve parser and entity context when available.
 
 Minimum error categories:
 - configuration
+- missing document
 - address
 - identity resolution
 - team not found
@@ -1053,6 +1089,8 @@ Satisfied by:
 - corrupt records should be skipped individually when possible
 - persisted config/team schema drift should recover with deterministic defaults
   when safe
+- missing team config may use only the explicitly documented send fallback
+  behavior
 - persisted config/team records with missing identity or routing-critical fields
   must fail or be isolated rather than guessed
 - missing inbox files are treated as empty inboxes

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -173,6 +173,9 @@ Required diagnostics:
 - parser detail, including line and column when available
 - recovery guidance when operator action is required
 
+Operator examples and safe repair guidance live in
+[`persisted-data-repair.md`](./persisted-data-repair.md).
+
 ### 3.4 Claude Settings Resolution
 
 The system must resolve Claude settings for file-reference policy checks.


### PR DESCRIPTION
## Summary

- Missing team-config document treated as a distinct recoverable condition (not an error)
- Malformed/invalid config returns structured error with repair guidance
- Send path uses inbox-exists fallback when config is missing, with actionable sender warning
- Best-effort deduplicated repair notices to team-lead on missing-config fallback
- Isolated per-member recovery: bad entries skipped, valid members proceed
- Regression tests covering name-only, full Claude Code format, and missing-field records

## Motivation

ATM must not fail hard when team config is absent or partially corrupt across 30+ concurrent teams. This increment hardens the config loading path to be fault-tolerant with excellent diagnostic output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)