### PR TITLE
feat(J.3): centralize message_id surface canonicalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "thiserror",
  "toml",
  "tracing",
+ "ulid",
  "uuid",
  "windows-sys 0.59.0",
 ]
@@ -271,13 +272,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -472,6 +485,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,9 +523,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -689,7 +746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -823,6 +880,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand",
+ "serde",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,7 +914,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -953,6 +1021,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1191,6 +1269,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -15,6 +15,7 @@ tracing.workspace = true
 libc = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"
+ulid = { version = "1.2.1", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -176,7 +176,7 @@ pub fn ack_mail(
         team,
         agent: actor.clone(),
         sender: actor,
-        message_id: Some(request.message_id.into()),
+        message_id: Some(request.message_id),
         requires_ack: false,
         dry_run: false,
         task_id: source_task_id,
@@ -306,6 +306,9 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
+    // Read is the only surface that applies receiver-side idle-notification
+    // collapse. Ack must preserve the full merged message surface and only
+    // canonicalize legacy top-level message_id collisions.
     let mut latest_for_id: HashMap<LegacyMessageId, (IsoTimestamp, usize)> = HashMap::new();
     for (index, message) in messages.iter().enumerate() {
         if let Some(message_id) = message.envelope.message_id {

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 use serde_json::Map;
 use tracing::{trace, warn};
-use uuid::Uuid;
 
 use crate::address::AgentAddress;
 use crate::config;
@@ -15,7 +14,7 @@ use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
-use crate::schema::MessageEnvelope;
+use crate::schema::{LegacyMessageId, MessageEnvelope};
 use crate::send::{input, summary};
 use crate::types::IsoTimestamp;
 
@@ -25,7 +24,7 @@ pub struct AckRequest {
     pub current_dir: PathBuf,
     pub actor_override: Option<String>,
     pub team_override: Option<String>,
-    pub message_id: Uuid,
+    pub message_id: LegacyMessageId,
     pub reply_body: String,
 }
 
@@ -34,11 +33,11 @@ pub struct AckOutcome {
     pub action: &'static str,
     pub team: String,
     pub agent: String,
-    pub message_id: Uuid,
+    pub message_id: LegacyMessageId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
     pub reply_target: String,
-    pub reply_message_id: Uuid,
+    pub reply_message_id: LegacyMessageId,
     pub reply_text: String,
 }
 
@@ -135,7 +134,7 @@ pub fn ack_mail(
 
     let ack_timestamp = IsoTimestamp::now();
     let reply_text = input::validate_message_text(request.reply_body)?;
-    let reply_message_id = Uuid::new_v4();
+    let reply_message_id = LegacyMessageId::new();
     let source_task_id = source_message.envelope.task_id.clone();
     let reply_message = MessageEnvelope {
         from: actor.clone(),
@@ -177,7 +176,7 @@ pub fn ack_mail(
         team,
         agent: actor.clone(),
         sender: actor,
-        message_id: Some(request.message_id),
+        message_id: Some(request.message_id.into()),
         requires_ack: false,
         dry_run: false,
         task_id: source_task_id,
@@ -307,7 +306,7 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
-    let mut latest_for_id: HashMap<Uuid, (IsoTimestamp, usize)> = HashMap::new();
+    let mut latest_for_id: HashMap<LegacyMessageId, (IsoTimestamp, usize)> = HashMap::new();
     for (index, message) in messages.iter().enumerate() {
         if let Some(message_id) = message.envelope.message_id {
             latest_for_id

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -12,6 +11,7 @@ use crate::error::{AtmError, AtmErrorKind};
 use crate::home;
 use crate::identity;
 use crate::mailbox;
+use crate::mailbox::surface::dedupe_legacy_message_id_surface;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
 use crate::schema::{LegacyMessageId, MessageEnvelope};
@@ -306,32 +306,11 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
-    let mut latest_for_id: HashMap<LegacyMessageId, (IsoTimestamp, usize)> = HashMap::new();
-    for (index, message) in messages.iter().enumerate() {
-        if let Some(message_id) = message.envelope.message_id {
-            latest_for_id
-                .entry(message_id)
-                .and_modify(|entry| {
-                    if message.envelope.timestamp > entry.0
-                        || (message.envelope.timestamp == entry.0 && index > entry.1)
-                    {
-                        *entry = (message.envelope.timestamp, index);
-                    }
-                })
-                .or_insert((message.envelope.timestamp, index));
-        }
-    }
-
-    messages
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, message)| match message.envelope.message_id {
-            Some(message_id) => latest_for_id
-                .get(&message_id)
-                .and_then(|(_, keep_index)| (*keep_index == index).then_some(message)),
-            None => Some(message),
-        })
-        .collect()
+    dedupe_legacy_message_id_surface(
+        messages,
+        |message| message.envelope.message_id,
+        |message| message.envelope.timestamp,
+    )
 }
 
 fn update_source_message(

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -278,6 +278,9 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
+    // Clear intentionally does not apply read-surface idle-notification dedup.
+    // Cleanup decisions must inspect the raw merged surface after legacy
+    // message_id canonicalization only.
     let mut latest_for_id: HashMap<LegacyMessageId, (crate::types::IsoTimestamp, usize)> =
         HashMap::new();
     for (index, message) in messages.iter().enumerate() {

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -14,9 +14,10 @@ use crate::error::{AtmError, AtmErrorKind};
 use crate::home;
 use crate::identity;
 use crate::mailbox;
+use crate::mailbox::surface::dedupe_legacy_message_id_surface;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
-use crate::schema::{LegacyMessageId, MessageEnvelope};
+use crate::schema::MessageEnvelope;
 use crate::types::MessageClass;
 
 #[derive(Debug, Clone)]
@@ -278,33 +279,11 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
-    let mut latest_for_id: HashMap<LegacyMessageId, (crate::types::IsoTimestamp, usize)> =
-        HashMap::new();
-    for (index, message) in messages.iter().enumerate() {
-        if let Some(message_id) = message.envelope.message_id {
-            latest_for_id
-                .entry(message_id)
-                .and_modify(|entry| {
-                    if message.envelope.timestamp > entry.0
-                        || (message.envelope.timestamp == entry.0 && index > entry.1)
-                    {
-                        *entry = (message.envelope.timestamp, index);
-                    }
-                })
-                .or_insert((message.envelope.timestamp, index));
-        }
-    }
-
-    messages
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, message)| match message.envelope.message_id {
-            Some(message_id) => latest_for_id
-                .get(&message_id)
-                .and_then(|(_, keep_index)| (*keep_index == index).then_some(message)),
-            None => Some(message),
-        })
-        .collect()
+    dedupe_legacy_message_id_surface(
+        messages,
+        |message| message.envelope.message_id,
+        |message| message.envelope.timestamp,
+    )
 }
 
 fn cutoff_timestamp(

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -7,7 +7,6 @@ use chrono::{DateTime, TimeDelta, Utc};
 use serde::Serialize;
 use serde_json::Value;
 use tracing::warn;
-use uuid::Uuid;
 
 use crate::address::AgentAddress;
 use crate::config;
@@ -17,7 +16,7 @@ use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
-use crate::schema::MessageEnvelope;
+use crate::schema::{LegacyMessageId, MessageEnvelope};
 use crate::types::MessageClass;
 
 #[derive(Debug, Clone)]
@@ -279,7 +278,8 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
-    let mut latest_for_id: HashMap<Uuid, (crate::types::IsoTimestamp, usize)> = HashMap::new();
+    let mut latest_for_id: HashMap<LegacyMessageId, (crate::types::IsoTimestamp, usize)> =
+        HashMap::new();
     for (index, message) in messages.iter().enumerate() {
         if let Some(message_id) = message.envelope.message_id {
             latest_for_id

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use tracing::warn;
 
 use crate::error::{AtmError, AtmErrorKind};
-use crate::schema::MessageEnvelope;
+use crate::schema::{LegacyMessageId, MessageEnvelope};
 
 pub fn append_message(path: &Path, envelope: &MessageEnvelope) -> Result<(), AtmError> {
     let mut messages = read_messages(path)?;
@@ -60,7 +60,7 @@ pub fn read_messages(path: &Path) -> Result<Vec<MessageEnvelope>, AtmError> {
         }
     }
 
-    let mut last_indices = HashMap::new();
+    let mut last_indices: HashMap<LegacyMessageId, usize> = HashMap::new();
     for (index, message) in messages.iter().enumerate() {
         if let Some(message_id) = message.message_id {
             last_indices.insert(message_id, index);
@@ -154,7 +154,7 @@ mod tests {
             read: false,
             source_team: Some("atm-dev".into()),
             summary: None,
-            message_id: Some(message_id),
+            message_id: Some(message_id.into()),
             pending_ack_at: None,
             acknowledged_at: None,
             acknowledges_message_id: None,

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod atomic;
 pub(crate) mod hash;
 pub(crate) mod lock;
 pub(crate) mod store;
+pub(crate) mod surface;
 
 use std::collections::HashMap;
 use std::fs;

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -3,11 +3,11 @@ pub(crate) mod hash;
 pub(crate) mod lock;
 pub(crate) mod store;
 
-use std::collections::HashMap;
 use std::fs;
 use std::io::BufRead;
 use std::path::Path;
 
+use serde_json::Value;
 use tracing::warn;
 
 use crate::error::{AtmError, AtmErrorKind};
@@ -50,31 +50,55 @@ pub fn read_messages(path: &Path) -> Result<Vec<MessageEnvelope>, AtmError> {
             continue;
         }
 
-        match serde_json::from_str::<MessageEnvelope>(&line) {
-            Ok(message) => messages.push(message),
+        match parse_mailbox_record(&line, path, index + 1) {
+            Ok(Some(message)) => messages.push(message),
+            Ok(None) => {}
             Err(error) => warn!(
                 line = index + 1,
+                mailbox_path = %path.display(),
                 %error,
                 "skipping malformed mailbox record"
             ),
         }
     }
 
-    let mut last_indices: HashMap<LegacyMessageId, usize> = HashMap::new();
-    for (index, message) in messages.iter().enumerate() {
-        if let Some(message_id) = message.message_id {
-            last_indices.insert(message_id, index);
-        }
+    Ok(messages)
+}
+
+fn parse_mailbox_record(
+    line: &str,
+    path: &Path,
+    line_number: usize,
+) -> Result<Option<MessageEnvelope>, serde_json::Error> {
+    let mut value = serde_json::from_str::<Value>(line)?;
+    sanitize_legacy_message_id(&mut value, path, line_number);
+    serde_json::from_value::<MessageEnvelope>(value).map(Some)
+}
+
+fn sanitize_legacy_message_id(value: &mut Value, path: &Path, line_number: usize) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    let Some(raw_message_id) = object.get("message_id").cloned() else {
+        return;
+    };
+
+    if raw_message_id.is_null() {
+        return;
     }
 
-    Ok(messages
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, message)| match message.message_id {
-            Some(message_id) => (last_indices.get(&message_id) == Some(&index)).then_some(message),
-            None => Some(message),
-        })
-        .collect())
+    if serde_json::from_value::<LegacyMessageId>(raw_message_id.clone()).is_err() {
+        warn!(
+            mailbox_path = %path.display(),
+            line = line_number,
+            field = "message_id",
+            expected_format = "UUID",
+            raw_value = %raw_message_id,
+            "treating malformed ATM-owned field as absent during mailbox read"
+        );
+        object.remove("message_id");
+    }
 }
 
 #[cfg(test)]
@@ -118,7 +142,7 @@ mod tests {
     }
 
     #[test]
-    fn read_messages_deduplicates_by_message_id_last_wins() {
+    fn read_messages_preserves_duplicate_message_ids_for_surface_canonicalization() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("dedupe.jsonl");
         let message_id = Uuid::new_v4();
@@ -138,8 +162,32 @@ mod tests {
         fs::write(&path, contents).expect("write");
 
         let messages = read_messages(&path).expect("read");
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].text, "first");
+        assert_eq!(messages[1].text, "second");
+    }
+
+    #[test]
+    fn read_messages_treats_malformed_legacy_message_id_as_absent() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("malformed-message-id.jsonl");
+        let contents = serde_json::json!({
+            "from": "team-lead",
+            "text": "valid body",
+            "timestamp": "2026-03-30T00:00:00Z",
+            "read": false,
+            "message_id": "01JABCDEF0123456789ABCDEF0"
+        });
+        fs::write(
+            &path,
+            format!("{}\n", serde_json::to_string(&contents).expect("json")),
+        )
+        .expect("write");
+
+        let messages = read_messages(&path).expect("read");
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].text, "second");
+        assert_eq!(messages[0].text, "valid body");
+        assert!(messages[0].message_id.is_none());
     }
 
     fn sample_message(message_id: Uuid, body: &str) -> MessageEnvelope {

--- a/crates/atm-core/src/mailbox/surface.rs
+++ b/crates/atm-core/src/mailbox/surface.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+
+use crate::schema::LegacyMessageId;
+use crate::types::IsoTimestamp;
+
+/// Canonicalize a merged mailbox surface by the legacy top-level `message_id`
+/// owned by docs/atm-message-schema.md §2. For read/ack/clear, the newest
+/// message for a given LegacyMessageId wins; equal timestamps fall back to the
+/// later merged-surface position.
+pub(crate) fn dedupe_legacy_message_id_surface<T, FId, FTs>(
+    messages: Vec<T>,
+    mut legacy_message_id: FId,
+    mut timestamp: FTs,
+) -> Vec<T>
+where
+    FId: FnMut(&T) -> Option<LegacyMessageId>,
+    FTs: FnMut(&T) -> IsoTimestamp,
+{
+    let mut latest_for_id: HashMap<LegacyMessageId, (IsoTimestamp, usize)> = HashMap::new();
+    for (index, message) in messages.iter().enumerate() {
+        if let Some(message_id) = legacy_message_id(message) {
+            latest_for_id
+                .entry(message_id)
+                .and_modify(|entry| {
+                    let message_timestamp = timestamp(message);
+                    if message_timestamp > entry.0
+                        || (message_timestamp == entry.0 && index > entry.1)
+                    {
+                        *entry = (message_timestamp, index);
+                    }
+                })
+                .or_insert((timestamp(message), index));
+        }
+    }
+
+    messages
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, message)| match legacy_message_id(&message) {
+            Some(message_id) => latest_for_id
+                .get(&message_id)
+                .and_then(|(_, keep_index)| (*keep_index == index).then_some(message)),
+            None => Some(message),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use crate::schema::LegacyMessageId;
+    use crate::types::IsoTimestamp;
+
+    use super::dedupe_legacy_message_id_surface;
+
+    #[derive(Clone)]
+    struct SurfaceRecord {
+        message_id: Option<LegacyMessageId>,
+        timestamp: IsoTimestamp,
+        body: &'static str,
+    }
+
+    #[test]
+    fn dedupe_legacy_message_id_surface_keeps_newest_timestamp() {
+        let message_id = LegacyMessageId::new();
+        let messages = vec![
+            SurfaceRecord {
+                message_id: Some(message_id),
+                timestamp: iso("2026-04-04T10:00:00Z"),
+                body: "older",
+            },
+            SurfaceRecord {
+                message_id: Some(message_id),
+                timestamp: iso("2026-04-04T10:00:01Z"),
+                body: "newer",
+            },
+        ];
+
+        let deduped = dedupe_legacy_message_id_surface(
+            messages,
+            |message| message.message_id,
+            |message| message.timestamp,
+        );
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].body, "newer");
+    }
+
+    #[test]
+    fn dedupe_legacy_message_id_surface_keeps_later_position_on_timestamp_tie() {
+        let message_id = LegacyMessageId::new();
+        let timestamp = iso("2026-04-04T10:00:00Z");
+        let messages = vec![
+            SurfaceRecord {
+                message_id: Some(message_id),
+                timestamp,
+                body: "first",
+            },
+            SurfaceRecord {
+                message_id: Some(message_id),
+                timestamp,
+                body: "second",
+            },
+        ];
+
+        let deduped = dedupe_legacy_message_id_surface(
+            messages,
+            |message| message.message_id,
+            |message| message.timestamp,
+        );
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].body, "second");
+    }
+
+    fn iso(value: &str) -> IsoTimestamp {
+        IsoTimestamp::from_datetime(
+            chrono::DateTime::parse_from_rfc3339(value)
+                .expect("timestamp")
+                .with_timezone(&Utc),
+        )
+    }
+}

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
-use uuid::Uuid;
 
 use crate::error::AtmError;
+use crate::schema::LegacyMessageId;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct CommandEvent {
@@ -11,7 +11,7 @@ pub struct CommandEvent {
     pub team: String,
     pub agent: String,
     pub sender: String,
-    pub message_id: Option<Uuid>,
+    pub message_id: Option<LegacyMessageId>,
     pub requires_ack: bool,
     pub dry_run: bool,
     pub task_id: Option<String>,

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -17,8 +17,9 @@ use crate::error::{AtmError, AtmErrorKind};
 use crate::home;
 use crate::identity;
 use crate::mailbox;
+use crate::mailbox::surface::dedupe_legacy_message_id_surface;
 use crate::observability::{CommandEvent, ObservabilityPort};
-use crate::schema::{LegacyMessageId, MessageEnvelope};
+use crate::schema::MessageEnvelope;
 use crate::types::{AckActivationMode, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection};
 
 #[derive(Debug, Clone)]
@@ -387,32 +388,11 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
-    let mut latest_for_id: HashMap<LegacyMessageId, (IsoTimestamp, usize)> = HashMap::new();
-    for (index, message) in messages.iter().enumerate() {
-        if let Some(message_id) = message.envelope.message_id {
-            latest_for_id
-                .entry(message_id)
-                .and_modify(|entry| {
-                    if message.envelope.timestamp > entry.0
-                        || (message.envelope.timestamp == entry.0 && index > entry.1)
-                    {
-                        *entry = (message.envelope.timestamp, index);
-                    }
-                })
-                .or_insert((message.envelope.timestamp, index));
-        }
-    }
-
-    let deduped = messages
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, message)| match message.envelope.message_id {
-            Some(message_id) => latest_for_id
-                .get(&message_id)
-                .and_then(|(_, keep_index)| (*keep_index == index).then_some(message)),
-            None => Some(message),
-        })
-        .collect::<Vec<_>>();
+    let deduped = dedupe_legacy_message_id_surface(
+        messages,
+        |message| message.envelope.message_id,
+        |message| message.envelope.timestamp,
+    );
 
     let latest_idle_for_sender = messages_from_idle_sender(&deduped);
 

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -8,8 +8,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
+use serde_json::Value;
 use tracing::warn;
-use uuid::Uuid;
 
 use crate::address::AgentAddress;
 use crate::config;
@@ -18,7 +18,7 @@ use crate::home;
 use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
-use crate::schema::MessageEnvelope;
+use crate::schema::{LegacyMessageId, MessageEnvelope};
 use crate::types::{AckActivationMode, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection};
 
 #[derive(Debug, Clone)]
@@ -387,7 +387,7 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
 }
 
 fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
-    let mut latest_for_id: HashMap<Uuid, (IsoTimestamp, usize)> = HashMap::new();
+    let mut latest_for_id: HashMap<LegacyMessageId, (IsoTimestamp, usize)> = HashMap::new();
     for (index, message) in messages.iter().enumerate() {
         if let Some(message_id) = message.envelope.message_id {
             latest_for_id
@@ -403,7 +403,7 @@ fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage>
         }
     }
 
-    messages
+    let deduped = messages
         .into_iter()
         .enumerate()
         .filter_map(|(index, message)| match message.envelope.message_id {
@@ -412,7 +412,65 @@ fn dedupe_sourced_messages(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage>
                 .and_then(|(_, keep_index)| (*keep_index == index).then_some(message)),
             None => Some(message),
         })
+        .collect::<Vec<_>>();
+
+    let latest_idle_for_sender = messages_from_idle_sender(&deduped);
+
+    deduped
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, message)| {
+            dedupe_idle_notifications(index, &message, &latest_idle_for_sender).then_some(message)
+        })
         .collect()
+}
+
+fn dedupe_idle_notifications(
+    index: usize,
+    message: &SourcedMessage,
+    latest_idle_for_sender: &HashMap<String, usize>,
+) -> bool {
+    if !is_unread_idle_notification(&message.envelope) {
+        return true;
+    }
+
+    idle_sender(&message.envelope)
+        .and_then(|sender| latest_idle_for_sender.get(&sender))
+        .map(|keep_index| *keep_index == index)
+        .unwrap_or(true)
+}
+
+fn messages_from_idle_sender(messages: &[SourcedMessage]) -> HashMap<String, usize> {
+    let mut latest_idle_for_sender = HashMap::new();
+
+    for (index, message) in messages.iter().enumerate() {
+        if !is_unread_idle_notification(&message.envelope) {
+            continue;
+        }
+
+        if let Some(sender) = idle_sender(&message.envelope) {
+            latest_idle_for_sender
+                .entry(sender)
+                .and_modify(|keep_index| *keep_index = index)
+                .or_insert(index);
+        }
+    }
+
+    latest_idle_for_sender
+}
+
+fn is_unread_idle_notification(message: &MessageEnvelope) -> bool {
+    !message.read
+        && serde_json::from_str::<Value>(&message.text)
+            .ok()
+            .map(|value| value.get("type").and_then(Value::as_str) == Some("idle_notification"))
+            .unwrap_or(false)
+}
+
+fn idle_sender(message: &MessageEnvelope) -> Option<String> {
+    serde_json::from_str::<Value>(&message.text)
+        .ok()
+        .and_then(|value| value.get("from").and_then(Value::as_str).map(str::to_string))
 }
 
 fn classify_all(messages: Vec<SourcedMessage>) -> Vec<ClassifiedMessage> {

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -1,8 +1,129 @@
+use std::fmt;
+
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use ulid::Ulid;
 use uuid::Uuid;
 
 use crate::types::IsoTimestamp;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LegacyMessageId(Uuid);
+
+impl LegacyMessageId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    pub fn into_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+impl From<Uuid> for LegacyMessageId {
+    fn from(value: Uuid) -> Self {
+        Self(value)
+    }
+}
+
+impl From<LegacyMessageId> for Uuid {
+    fn from(value: LegacyMessageId) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for LegacyMessageId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AtmMessageId(Ulid);
+
+impl AtmMessageId {
+    pub fn new() -> Self {
+        Self(Ulid::new())
+    }
+
+    pub fn into_ulid(self) -> Ulid {
+        self.0
+    }
+
+    pub fn timestamp(self) -> IsoTimestamp {
+        let datetime: DateTime<Utc> = self.0.datetime().into();
+        IsoTimestamp::from_datetime(datetime)
+    }
+
+    pub fn new_with_timestamp() -> (Self, IsoTimestamp) {
+        let message_id = Self::new();
+        let timestamp = message_id.timestamp();
+        (message_id, timestamp)
+    }
+}
+
+impl From<Ulid> for AtmMessageId {
+    fn from(value: Ulid) -> Self {
+        Self(value)
+    }
+}
+
+impl From<AtmMessageId> for Ulid {
+    fn from(value: AtmMessageId) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for AtmMessageId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AtmMetadataFields {
+    #[serde(rename = "messageId", skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<AtmMessageId>,
+
+    #[serde(rename = "sourceTeam", skip_serializing_if = "Option::is_none")]
+    pub source_team: Option<String>,
+
+    #[serde(rename = "pendingAckAt", skip_serializing_if = "Option::is_none")]
+    pub pending_ack_at: Option<IsoTimestamp>,
+
+    #[serde(rename = "acknowledgedAt", skip_serializing_if = "Option::is_none")]
+    pub acknowledged_at: Option<IsoTimestamp>,
+
+    #[serde(
+        rename = "acknowledgesMessageId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub acknowledges_message_id: Option<AtmMessageId>,
+
+    #[serde(rename = "alertKind", skip_serializing_if = "Option::is_none")]
+    pub alert_kind: Option<String>,
+
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct MessageMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub atm: Option<AtmMetadataFields>,
+
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForwardMetadataEnvelope {
+    pub timestamp: IsoTimestamp,
+    pub metadata: MessageMetadata,
+}
 
 /// Persisted inbox superset used by ATM.
 ///
@@ -31,7 +152,7 @@ pub struct MessageEnvelope {
     pub summary: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<Uuid>,
+    pub message_id: Option<LegacyMessageId>,
 
     #[serde(rename = "pendingAckAt", skip_serializing_if = "Option::is_none")]
     pub pending_ack_at: Option<IsoTimestamp>,
@@ -43,7 +164,7 @@ pub struct MessageEnvelope {
         rename = "acknowledgesMessageId",
         skip_serializing_if = "Option::is_none"
     )]
-    pub acknowledges_message_id: Option<Uuid>,
+    pub acknowledges_message_id: Option<LegacyMessageId>,
 
     #[serde(rename = "taskId", skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
@@ -56,7 +177,7 @@ pub struct MessageEnvelope {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PendingAck {
-    pub message_id: Uuid,
+    pub message_id: LegacyMessageId,
     pub from: String,
     pub acked: bool,
     pub acked_at: Option<IsoTimestamp>,
@@ -69,7 +190,10 @@ mod tests {
 
     use chrono::Utc;
 
-    use super::{IsoTimestamp, MessageEnvelope, PendingAck, Uuid};
+    use super::{
+        AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, IsoTimestamp, LegacyMessageId,
+        MessageEnvelope, MessageMetadata, PendingAck,
+    };
 
     #[test]
     fn message_envelope_round_trips_with_current_inbox_shape() {
@@ -87,7 +211,7 @@ mod tests {
             read: false,
             source_team: Some("atm-dev".into()),
             summary: Some("hello".into()),
-            message_id: Some(Uuid::new_v4()),
+            message_id: Some(LegacyMessageId::new()),
             pending_ack_at: Some(IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
                     .single()
@@ -142,7 +266,7 @@ mod tests {
     #[test]
     fn pending_ack_round_trips() {
         let pending_ack = PendingAck {
-            message_id: Uuid::new_v4(),
+            message_id: LegacyMessageId::new(),
             from: "team-lead".into(),
             acked: true,
             acked_at: Some(IsoTimestamp::from_datetime(
@@ -156,5 +280,35 @@ mod tests {
         let decoded: PendingAck = serde_json::from_str(&encoded).expect("decode");
 
         assert_eq!(decoded, pending_ack);
+    }
+
+    #[test]
+    fn forward_metadata_envelope_uses_atm_message_id() {
+        let (message_id, timestamp) = AtmMessageId::new_with_timestamp();
+        let envelope = ForwardMetadataEnvelope {
+            timestamp,
+            metadata: MessageMetadata {
+                atm: Some(AtmMetadataFields {
+                    message_id: Some(message_id),
+                    source_team: Some("atm-dev".into()),
+                    pending_ack_at: None,
+                    acknowledged_at: None,
+                    acknowledges_message_id: None,
+                    alert_kind: None,
+                    extra: Map::new(),
+                }),
+                extra: Map::new(),
+            },
+        };
+
+        let encoded = serde_json::to_string(&envelope).expect("encode");
+        let decoded: ForwardMetadataEnvelope = serde_json::from_str(&encoded).expect("decode");
+        assert_eq!(decoded, envelope);
+    }
+
+    #[test]
+    fn atm_message_id_timestamp_matches_derived_timestamp() {
+        let (message_id, timestamp) = AtmMessageId::new_with_timestamp();
+        assert_eq!(message_id.timestamp(), timestamp);
     }
 }

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -10,6 +10,7 @@ use crate::types::IsoTimestamp;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
+/// UUID-based compatibility identifier for legacy top-level ATM `message_id`.
 pub struct LegacyMessageId(Uuid);
 
 impl LegacyMessageId {
@@ -19,6 +20,12 @@ impl LegacyMessageId {
 
     pub fn into_uuid(self) -> Uuid {
         self.0
+    }
+}
+
+impl Default for LegacyMessageId {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -42,6 +49,7 @@ impl fmt::Display for LegacyMessageId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
+/// ULID-based forward ATM identifier for `metadata.atm.messageId`.
 pub struct AtmMessageId(Ulid);
 
 impl AtmMessageId {
@@ -65,6 +73,12 @@ impl AtmMessageId {
     }
 }
 
+impl Default for AtmMessageId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<Ulid> for AtmMessageId {
     fn from(value: Ulid) -> Self {
         Self(value)
@@ -84,6 +98,7 @@ impl fmt::Display for AtmMessageId {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+/// ATM-owned machine metadata planned for the forward `metadata.atm` namespace.
 pub struct AtmMetadataFields {
     #[serde(rename = "messageId", skip_serializing_if = "Option::is_none")]
     pub message_id: Option<AtmMessageId>,
@@ -111,6 +126,7 @@ pub struct AtmMetadataFields {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+/// Top-level metadata container preserving ATM-owned and foreign metadata keys.
 pub struct MessageMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub atm: Option<AtmMetadataFields>,
@@ -120,6 +136,7 @@ pub struct MessageMetadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Minimal forward-schema projection used to validate metadata/timestamp rules.
 pub struct ForwardMetadataEnvelope {
     pub timestamp: IsoTimestamp,
     pub metadata: MessageMetadata,

--- a/crates/atm-core/src/schema/mod.rs
+++ b/crates/atm-core/src/schema/mod.rs
@@ -5,5 +5,8 @@ pub mod settings;
 pub mod team_config;
 
 pub use agent_member::AgentMember;
-pub use inbox_message::{MessageEnvelope, PendingAck};
+pub use inbox_message::{
+    AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, LegacyMessageId, MessageEnvelope,
+    MessageMetadata, PendingAck,
+};
 pub use team_config::TeamConfig;

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -17,7 +17,7 @@ use crate::home;
 use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
-use crate::schema::MessageEnvelope;
+use crate::schema::{LegacyMessageId, MessageEnvelope};
 use crate::types::IsoTimestamp;
 
 pub(crate) mod file_policy;
@@ -55,7 +55,7 @@ pub struct SendOutcome {
     pub agent: String,
     pub sender: String,
     pub outcome: &'static str,
-    pub message_id: Uuid,
+    pub message_id: LegacyMessageId,
     pub requires_ack: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
@@ -148,7 +148,7 @@ pub fn send_mail(
         &recipient.team,
     )?;
     let summary = summary::build_summary(&body, request.summary_override);
-    let message_id = Uuid::new_v4();
+    let message_id = LegacyMessageId::new();
     let timestamp = IsoTimestamp::now();
 
     if !request.dry_run {
@@ -191,7 +191,7 @@ pub fn send_mail(
         team: outcome.team.clone(),
         agent: outcome.agent.clone(),
         sender,
-        message_id: Some(outcome.message_id),
+        message_id: Some(outcome.message_id.into()),
         requires_ack: outcome.requires_ack,
         dry_run: outcome.dry_run,
         task_id,
@@ -309,7 +309,7 @@ fn notify_team_lead_missing_config(
         summary: Some(format!(
             "ATM warning: missing team config fallback used for {recipient}@{team}"
         )),
-        message_id: Some(Uuid::new_v4()),
+        message_id: Some(LegacyMessageId::new()),
         pending_ack_at: None,
         acknowledged_at: None,
         acknowledges_message_id: None,

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -191,7 +191,7 @@ pub fn send_mail(
         team: outcome.team.clone(),
         agent: outcome.agent.clone(),
         sender,
-        message_id: Some(outcome.message_id.into()),
+        message_id: Some(outcome.message_id),
         requires_ack: outcome.requires_ack,
         dry_run: outcome.dry_run,
         task_id,

--- a/crates/atm/src/commands/ack.rs
+++ b/crates/atm/src/commands/ack.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use atm_core::ack::{self, AckRequest};
 use atm_core::home;
+use atm_core::schema::LegacyMessageId;
 use clap::Args;
 use uuid::Uuid;
 
@@ -35,7 +36,7 @@ impl AckCommand {
                 current_dir,
                 actor_override: self.actor,
                 team_override: self.team,
-                message_id,
+                message_id: LegacyMessageId::from(message_id),
                 reply_body: self.reply,
             },
             observability,

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::process::Command;
 
-use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
+use atm_core::schema::{AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig};
 use atm_core::types::IsoTimestamp;
 use chrono::{Duration, Utc};
 use serde_json::Value;
@@ -55,7 +55,10 @@ fn test_ack_transitions_pending_ack_and_appends_reply() {
     assert_eq!(replies.len(), 1);
     assert_eq!(replies[0].text, "received and starting");
     assert_eq!(replies[0].from, "arch-ctm");
-    assert_eq!(replies[0].acknowledges_message_id, Some(message_id));
+    assert_eq!(
+        replies[0].acknowledges_message_id,
+        Some(LegacyMessageId::from(message_id))
+    );
 }
 
 #[test]
@@ -263,7 +266,7 @@ impl Fixture {
             read,
             source_team: Some("atm-dev".into()),
             summary: None,
-            message_id: Some(message_id),
+            message_id: Some(LegacyMessageId::from(message_id)),
             pending_ack_at: pending_offset
                 .map(|offset| IsoTimestamp::from_datetime(timestamp + offset)),
             acknowledged_at: acknowledged_offset

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -1,11 +1,10 @@
 use std::fs;
 use std::process::Command;
 
-use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
+use atm_core::schema::{AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig};
 use atm_core::types::IsoTimestamp;
 use chrono::{Duration, Utc};
 use serde_json::Value;
-use uuid::Uuid;
 
 #[test]
 fn test_clear_default_removes_only_read_and_acknowledged() {
@@ -449,7 +448,7 @@ impl Fixture {
             read,
             source_team: Some("atm-dev".into()),
             summary: None,
-            message_id: Some(Uuid::new_v4()),
+            message_id: Some(LegacyMessageId::new()),
             pending_ack_at: pending_ack_at.map(Into::into),
             acknowledged_at: acknowledged_at.map(Into::into),
             acknowledges_message_id: None,

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -1,11 +1,13 @@
 use std::fs;
 use std::process::Command;
 
-use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
+use atm_core::schema::{
+    AgentMember, AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, LegacyMessageId,
+    MessageEnvelope, MessageMetadata, TeamConfig,
+};
 use atm_core::types::IsoTimestamp;
 use chrono::{TimeZone, Utc};
 use serde_json::Value;
-use uuid::Uuid;
 
 #[test]
 fn test_read_own_inbox_default() {
@@ -312,6 +314,84 @@ fn test_read_from_filter() {
 }
 
 #[test]
+fn test_read_deduplicates_unread_idle_notifications_per_sender() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[
+            fixture.message(
+                "daemon",
+                &idle_notification_text("team-lead", "available"),
+                false,
+                None,
+                None,
+                0,
+            ),
+            fixture.message(
+                "daemon",
+                &idle_notification_text("team-lead", "available"),
+                false,
+                None,
+                None,
+                1,
+            ),
+            fixture.message("team-lead", "normal unread", false, None, None, 2),
+        ],
+    );
+
+    let output = fixture.run(&["read", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 2);
+    assert_eq!(parsed["bucket_counts"]["unread"], 2);
+    let messages = parsed["messages"].as_array().expect("messages array");
+    assert_eq!(messages[0]["text"], "normal unread");
+    assert!(
+        messages
+            .iter()
+            .filter(|message| message["text"] == idle_notification_text("team-lead", "available"))
+            .count()
+            == 1
+    );
+}
+
+#[test]
+fn test_forward_metadata_message_id_timestamp_matches_persisted_timestamp() {
+    let (message_id, timestamp) = AtmMessageId::new_with_timestamp();
+    let envelope = ForwardMetadataEnvelope {
+        timestamp,
+        metadata: MessageMetadata {
+            atm: Some(AtmMetadataFields {
+                message_id: Some(message_id),
+                source_team: Some("atm-dev".into()),
+                pending_ack_at: None,
+                acknowledged_at: None,
+                acknowledges_message_id: None,
+                alert_kind: None,
+                extra: serde_json::Map::new(),
+            }),
+            extra: serde_json::Map::new(),
+        },
+    };
+
+    assert_eq!(
+        envelope
+            .metadata
+            .atm
+            .expect("atm metadata")
+            .message_id
+            .expect("message id")
+            .timestamp(),
+        envelope.timestamp
+    );
+}
+
+#[test]
 fn test_read_mutual_exclusion() {
     let fixture = Fixture::new(&["arch-ctm"]);
 
@@ -485,7 +565,7 @@ impl Fixture {
             read,
             source_team: Some("atm-dev".into()),
             summary: None,
-            message_id: Some(Uuid::new_v4()),
+            message_id: Some(LegacyMessageId::new()),
             pending_ack_at: pending_ack_offset
                 .map(|offset| IsoTimestamp::from_datetime(self.timestamp(offset))),
             acknowledged_at: acknowledged_offset
@@ -495,4 +575,16 @@ impl Fixture {
             extra: serde_json::Map::new(),
         }
     }
+}
+
+fn idle_notification_text(from: &str, idle_reason: &str) -> String {
+    // Claude Code owns the idle-notification payload shape in the text field.
+    // Keep this fixture aligned with docs/claude-code-message-schema.md.
+    serde_json::json!({
+        "type": "idle_notification",
+        "from": from,
+        "timestamp": "2026-03-30T00:00:00Z",
+        "idleReason": idle_reason,
+    })
+    .to_string()
 }

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -361,6 +361,117 @@ fn test_read_deduplicates_unread_idle_notifications_per_sender() {
 }
 
 #[test]
+fn test_read_deduplicates_idle_notifications_per_sender_only() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[
+            fixture.message(
+                "daemon",
+                &idle_notification_text("sender-a", "available"),
+                false,
+                None,
+                None,
+                0,
+            ),
+            fixture.message(
+                "daemon",
+                &idle_notification_text("sender-a", "available"),
+                false,
+                None,
+                None,
+                1,
+            ),
+            fixture.message(
+                "daemon",
+                &idle_notification_text("sender-b", "available"),
+                false,
+                None,
+                None,
+                2,
+            ),
+            fixture.message(
+                "daemon",
+                &idle_notification_text("sender-b", "available"),
+                false,
+                None,
+                None,
+                3,
+            ),
+        ],
+    );
+
+    let output = fixture.run(&["read", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    let messages = parsed["messages"].as_array().expect("messages array");
+    assert_eq!(messages.len(), 2);
+    assert_eq!(parsed["bucket_counts"]["unread"], 2);
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|message| message["text"] == idle_notification_text("sender-a", "available"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|message| message["text"] == idle_notification_text("sender-b", "available"))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn test_read_keeps_read_idle_notifications_visible() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[
+            fixture.message(
+                "daemon",
+                &idle_notification_text("team-lead", "available"),
+                true,
+                None,
+                None,
+                0,
+            ),
+            fixture.message(
+                "daemon",
+                &idle_notification_text("team-lead", "available"),
+                true,
+                None,
+                None,
+                1,
+            ),
+        ],
+    );
+
+    let output = fixture.run(&["read", "--all", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    let messages = parsed["messages"].as_array().expect("messages array");
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|message| message["text"] == idle_notification_text("team-lead", "available"))
+            .count(),
+        2
+    );
+}
+
+#[test]
 fn test_forward_metadata_message_id_timestamp_matches_persisted_timestamp() {
     let (message_id, timestamp) = AtmMessageId::new_with_timestamp();
     let envelope = ForwardMetadataEnvelope {

--- a/docs/atm-core/design/dedup-metadata-schema.md
+++ b/docs/atm-core/design/dedup-metadata-schema.md
@@ -303,8 +303,11 @@ Expected usage:
 
 Current implementation:
 
-- read/ack/clear deduplicate merged surfaces by `message_id` with last-wins
-  behavior
+- `crates/atm-core/src/mailbox/surface.rs::dedupe_legacy_message_id_surface`
+  is the single implementation used by read/ack/clear
+- the key is the legacy ATM-authored top-level `message_id`
+- collision handling keeps the newest message by timestamp; equal timestamps
+  fall back to the later merged-surface position
 
 Purpose:
 


### PR DESCRIPTION
## Summary
- Centralizes legacy `message_id` surface dedup for read, ack, and clear into `crates/atm-core/src/mailbox/surface.rs`
- Single `LegacyMessageId(Uuid)`-based dedup contract, last-wins collision behavior preserved
- Design doc updated to point to canonical implementation location and schema ownership
- Merges J.2 (AtmMessageId/LegacyMessageId newtypes + idle dedup) as base

## Test plan
- [ ] `cargo test` workspace pass (atm-core 47/47, read 19/19, clear 8/8, ack 4/4, send 15/15)
- [ ] No duplicated `dedupe_sourced_messages` logic across commands
- [ ] Dedup uses `LegacyMessageId(Uuid)` — no raw String/Uuid at call sites

## References
- Design: `docs/atm-core/design/dedup-metadata-schema.md` §3.1, §4.3
- Schema: `docs/atm-message-schema.md` §2

🤖 Generated with [Claude Code](https://claude.com/claude-code)