### PR TITLE
feat(J.4): ATM alert metadata migration plan to metadata.atm

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -313,10 +313,24 @@ Forward architectural rules:
 - new ATM-only machine-readable data belongs in `metadata.atm`
 - legacy top-level ATM fields remain read-compatible but are deprecated for new
   write behavior
+- forward ATM-authored alert metadata, including legacy `atmAlertKind` and
+  `missingConfigPath`, belongs under `metadata.atm` as
+  `metadata.atm.alertKind` and `metadata.atm.missingConfigPath`
 - ATM may enrich a Claude-native stored message by adding `metadata.atm`
   without rewriting the native Claude fields
 - the current live design still uses a shared inbox surface; a separate
   ATM-native inbox is intentionally deferred to a later architecture phase
+
+Current-phase constraint:
+
+- the current runtime send/alert write path may continue writing legacy
+  top-level alert fields during the compatibility period
+- the metadata.atm alert placement defined above is the forward architectural
+  target and must not be partially implemented without the corresponding
+  migration sprint and tests
+- the owning design rationale for this migration remains
+  [`atm-core/design/dedup-metadata-schema.md`](./atm-core/design/dedup-metadata-schema.md)
+  §2.2 and §3.3
 
 Canonical read and ack axes are derived from persisted fields and not serialized separately.
 

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -56,6 +56,17 @@ Current `AgentMember` persisted schema:
 - `extra: serde_json::Map<String, serde_json::Value>` via `#[serde(flatten)]`
   for forward-compatible Claude Code fields
 
+## 3.1 Send Alert Metadata Boundary
+
+ATM-authored alert metadata belongs to the send/schema boundary in `atm-core`.
+
+Architectural rule:
+- forward ATM-authored alert metadata lives under `metadata.atm`
+- legacy top-level alert fields such as `atmAlertKind` and
+  `missingConfigPath` remain read-compatible only
+- the current runtime send path may continue emitting the legacy top-level
+  fields until the migration implementation sprint lands
+
 ## 4. ADR Namespace
 
 The `atm-core` crate uses the `ADR-CORE-*` namespace.

--- a/docs/atm-core/design/dedup-metadata-schema.md
+++ b/docs/atm-core/design/dedup-metadata-schema.md
@@ -348,6 +348,13 @@ Schema dependency:
 - ATM-owned `atmAlertKind`
 - ATM-owned `missingConfigPath`
 
+See also:
+
+- [`../../atm-message-schema.md`](../../atm-message-schema.md) §3 forward
+  placement map
+- [`../../atm-message-schema.md`](../../atm-message-schema.md) §5
+  ATM-Specific Alert Metadata
+
 ## 4. Existing Implementation Review
 
 ### 4.1 PR #18: idle-notification-dedup
@@ -381,6 +388,9 @@ Needs update:
   to `metadata.atm` in the forward schema
 - future ATM alert fields should use explicit ATM-owned naming rather than
   unqualified shared names such as `error_code`
+- see [`../../atm-message-schema.md`](../../atm-message-schema.md) §3 forward
+  placement map and §5 ATM-Specific Alert Metadata for the J.4 alert-field
+  migration specification
 
 ### 4.3 Current `atm-core` merge-surface dedup
 

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -64,6 +64,11 @@ Initial crate requirement IDs:
   loader. Satisfies the missing-config send-path aspects of:
   `REQ-P-SEND-001`, `REQ-P-CONFIG-HEALTH-001`,
   `REQ-P-RELIABILITY-001`.
+- `REQ-CORE-SEND-002` `atm-core` owns ATM-authored alert metadata placement,
+  compatibility reads, and degradation rules across write/read paths. Satisfies
+  the alert-metadata schema and sender-side dedup aspects of:
+  `REQ-P-SCHEMA-001`, `REQ-P-CONFIG-HEALTH-001`,
+  `REQ-P-RELIABILITY-001`.
 - `REQ-CORE-MAILBOX-001` `atm-core` owns daemon-free mailbox/store behavior.
   Satisfies the persisted mailbox I/O and mutation aspects of:
   `REQ-P-CONTRACT-001`, `REQ-P-SEND-001`, `REQ-P-READ-001`,
@@ -114,3 +119,32 @@ The `atm-core` crate docs must remain aligned with:
 - [`../architecture.md`](../architecture.md)
 - [`../project-plan.md`](../project-plan.md)
 - [`../documentation-guidelines.md`](../documentation-guidelines.md)
+- [`../atm-message-schema.md`](../atm-message-schema.md)
+- [`../legacy-atm-message-schema.md`](../legacy-atm-message-schema.md)
+- [`./design/dedup-metadata-schema.md`](./design/dedup-metadata-schema.md)
+
+## 6. Send Alert Metadata
+
+Requirement ID:
+- `REQ-CORE-SEND-002`
+
+Required write-path rules:
+- ATM-authored alert field writes must use ATM-owned `metadata.atm` fields
+- forward alert writes must target `metadata.atm.alertKind` and
+  `metadata.atm.missingConfigPath` or a later explicitly documented
+  `metadata.atm` field
+- new ATM-only alert top-level fields must be rejected with a descriptive
+  validation error on the write path
+
+Required read-path rules:
+- ATM read must accept legacy top-level alert fields such as `atmAlertKind` and
+  `missingConfigPath`
+- ATM read must also accept forward `metadata.atm` alert fields
+- malformed ATM-owned alert metadata must degrade gracefully, emit warning
+  diagnostics, and never cause the message to be dropped when the
+  Claude-native envelope remains usable
+
+Forward migration rule:
+- legacy top-level `atmAlertKind` migrates to `metadata.atm.alertKind`
+- legacy top-level `missingConfigPath` migrates to
+  `metadata.atm.missingConfigPath`

--- a/docs/atm-message-schema.md
+++ b/docs/atm-message-schema.md
@@ -115,7 +115,9 @@ Forward placement map:
 - legacy top-level `acknowledgesMessageId` remains
   `metadata.atm.acknowledgesMessageId`
 - legacy ATM alert fields such as `atmAlertKind` migrate to
-  `metadata.atm.alertKind` or a later explicitly documented ATM-owned field
+  `metadata.atm.alertKind`
+- legacy top-level `missingConfigPath` migrates to
+  `metadata.atm.missingConfigPath`
 
 Identifier rules:
 
@@ -172,6 +174,8 @@ Current design ruling:
 - ATM-authored back-channel alerts may use ATM-prefixed fields during the
   legacy compatibility period
 - forward ATM alert metadata should move under `metadata.atm`
+- `atmAlertKind` migrates to `metadata.atm.alertKind`
+- `missingConfigPath` migrates to `metadata.atm.missingConfigPath`
 - new ATM-only fields should remain clearly ATM-owned until a broader shared
   schema is explicitly approved
 

--- a/docs/legacy-atm-message-schema.md
+++ b/docs/legacy-atm-message-schema.md
@@ -33,7 +33,8 @@ Observed historical ATM-only fields used for alerts and repair notices:
 
 These fields are accepted for backward compatibility with historical inbox
 data. They are not the forward schema contract for newly-authored ATM machine
-metadata.
+metadata, which belongs under `metadata.atm` in
+[`atm-message-schema.md`](./atm-message-schema.md).
 
 ## 3. Read Compatibility Rule
 
@@ -53,3 +54,6 @@ This schema is deprecated for write:
 - existing historical fields remain readable
 - migration to metadata-based ATM machine fields is documented in
   [`atm-message-schema.md`](./atm-message-schema.md)
+- legacy top-level `atmAlertKind` and `missingConfigPath` remain read-compatible
+  during the migration period and must not be removed from compatibility docs
+  before the forward metadata migration is complete

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -308,6 +308,9 @@ Planned sprints:
 - `J.4` ATM Alert Metadata Migration Plan
   - migrate the design for ATM-authored repair notices from ad hoc top-level
     fields toward `metadata.atm`
+  - explicitly preserve legacy top-level `atmAlertKind` and
+    `missingConfigPath` as read-compatible until the runtime migration sprint
+    lands
   - keep current alert writes/read-compat behavior stable until the migration
     sprint lands
   - acceptance: requirements and architecture specify the forward metadata

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -163,6 +163,10 @@ Required rules:
 - new ATM-only machine-readable fields must not be added as new top-level inbox
   fields
 - forward ATM machine-readable fields must live in `metadata.atm`
+- forward ATM-authored alert and repair metadata, including legacy
+  `atmAlertKind` and `missingConfigPath`, must migrate to `metadata.atm`
+  fields such as `metadata.atm.alertKind` and
+  `metadata.atm.missingConfigPath`
 - ATM may enrich a Claude-native message in place by adding ATM-owned metadata
   without rewriting native Claude fields
 - locally owned schema enforcement must distinguish legacy top-level UUID-based
@@ -174,11 +178,20 @@ Required rules:
 - a separate ATM-native inbox is explicitly deferred and must not be assumed by
   the current live design
 
+Current-phase migration constraint:
+
+- Phase J sprint J.4 is documentation and planning only
+- existing runtime write/read behavior for legacy top-level alert fields remains
+  stable until a later implementation sprint performs the actual migration
+
 `REQ-P-SCHEMA-001` is owned by:
 
 - [`claude-code-message-schema.md`](./claude-code-message-schema.md)
 - [`atm-message-schema.md`](./atm-message-schema.md)
 - [`legacy-atm-message-schema.md`](./legacy-atm-message-schema.md)
+- [`atm-core/design/dedup-metadata-schema.md`](./atm-core/design/dedup-metadata-schema.md)
+  §2.2 and §3.3 for forward ATM alert-field placement and sender-side dedup
+  semantics
 
 ### 3.3 Configuration Resolution
 


### PR DESCRIPTION
## Summary
- Updates requirements, architecture, and legacy schema docs to specify `metadata.atm` as forward target for ATM-authored alert fields (`atmAlertKind`, `missingConfigPath`, future alert fields)
- Legacy top-level `atmAlertKind` and `missingConfigPath` remain listed as read-compatible in `legacy-atm-message-schema.md`
- Runtime alert write/read behavior unchanged (doc/spec only sprint)
- Cross-references added between alert migration plan and `dedup-metadata-schema.md` §2.2 / §3.3
- Merges J.3 (surface canonicalization) as base

## Test plan
- [ ] `cargo test` workspace pass (47/47 atm-core, read 19/19, clear 8/8, ack 4/4, send 15/15)
- [ ] No runtime alert write code changed
- [ ] `metadata.atm.alertKind` named as forward target in requirements/architecture

## References
- Design: `docs/atm-core/design/dedup-metadata-schema.md` §2.2.1, §2.2.2, §3.3, §4.2
- ATM schema: `docs/atm-message-schema.md` §5
- Legacy schema: `docs/legacy-atm-message-schema.md` §2

🤖 Generated with [Claude Code](https://claude.com/claude-code)