### PR TITLE
fix(K.4-FIX-R1): BP-001/002/003 — duration parse, level map, error encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "time",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -15,6 +15,7 @@ sc-observability = "1.0.0"
 sc-observability-types = "1.0.0"
 serde_json.workspace = true
 time = "0.3"
+tracing.workspace = true
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/atm/src/commands/log.rs
+++ b/crates/atm/src/commands/log.rs
@@ -205,7 +205,15 @@ fn parse_relative_duration(raw: &str) -> Result<IsoTimestamp> {
         bail!("invalid relative duration '{raw}'; expected forms like 30s, 15m, 2h, or 7d");
     }
 
-    let (amount, unit) = raw.split_at(raw.len() - 1);
+    let (amount, unit) = raw
+        .char_indices()
+        .next_back()
+        .map(|(index, _)| (&raw[..index], &raw[index..]))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "invalid relative duration '{raw}'; expected forms like 30s, 15m, 2h, or 7d"
+            )
+        })?;
     let amount: i64 = amount.parse().with_context(|| {
         format!("invalid relative duration '{raw}'; duration amount must be an integer")
     })?;
@@ -219,4 +227,18 @@ fn parse_relative_duration(raw: &str) -> Result<IsoTimestamp> {
     };
 
     Ok((chrono::Utc::now() - delta).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_relative_duration;
+
+    #[test]
+    fn parse_relative_duration_rejects_multibyte_suffix_without_panicking() {
+        let error = parse_relative_duration("10µ").expect_err("invalid unit");
+        assert!(
+            error.to_string().contains("supported units are s, m, h, d"),
+            "error: {error}"
+        );
+    }
 }

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -88,10 +88,8 @@ impl ObservabilityPort for ScObservabilityAdapter {
         let event = map_command_event(&self.service_name, event)?;
         self.logger.emit(event).map_err(|source| {
             let code = source.diagnostic().code.as_str().to_string();
-            AtmError::observability_emit(format!(
-                "shared observability emit failed ({code}): {source}"
-            ))
-            .with_source(source)
+            AtmError::observability_emit(format!("shared observability emit failed ({code})"))
+                .with_source(source)
         })
     }
 
@@ -353,23 +351,29 @@ fn map_query_state(state: sc_observability_types::QueryHealthState) -> AtmObserv
 
 fn level_for_outcome(outcome: &str) -> Level {
     match outcome {
+        "ok" | "sent" | "dry_run" => Level::Info,
         "timeout" => Level::Warn,
-        _ => Level::Info,
+        "error" | "failed" => Level::Error,
+        other => {
+            tracing::warn!(
+                outcome = other,
+                "unknown ATM command outcome for observability level"
+            );
+            Level::Warn
+        }
     }
 }
 
 fn map_query_error(source: QueryError) -> AtmError {
     let code = source.code().as_str().to_string();
-    AtmError::observability_query(format!(
-        "shared observability query failed ({code}): {source}"
-    ))
-    .with_source(source)
+    AtmError::observability_query(format!("shared observability query failed ({code})"))
+        .with_source(source)
 }
 
 fn map_follow_error(phase: &str, source: QueryError) -> AtmError {
     let code = source.code().as_str().to_string();
     AtmError::observability_follow(format!(
-        "shared observability follow {phase} failed ({code}): {source}"
+        "shared observability follow {phase} failed ({code})"
     ))
     .with_source(source)
 }
@@ -386,10 +390,11 @@ mod tests {
     use atm_core::observability::{
         AtmLogQuery, LogLevelFilter, LogMode, LogOrder, ObservabilityPort,
     };
+    use sc_observability_types::Level;
     use serial_test::serial;
     use tempfile::TempDir;
 
-    use super::{CliObservability, log_root};
+    use super::{CliObservability, level_for_outcome, log_root};
 
     fn query(order: LogOrder) -> AtmLogQuery {
         AtmLogQuery {
@@ -476,5 +481,10 @@ mod tests {
             )
         );
         assert!(health.detail.is_none());
+    }
+
+    #[test]
+    fn unknown_outcome_maps_to_warn() {
+        assert_eq!(level_for_outcome("future-outcome"), Level::Warn);
     }
 }


### PR DESCRIPTION
## Phase K Sprint K.4 — fix-r1

Commit: 430adcd484b3254722755bf4378a1731093245b4

Addresses 3 findings from ATM-CORE-K4-QA-1:

- **[BP-003]** `parse_relative_duration`: char-boundary-safe suffix stripping — no more `split_at` panic risk on multi-byte UTF-8
- **[BP-001]** `level_for_outcome()`: unknown command outcomes now warn instead of silently mapping to Info
- **[BP-002]** emit/query/follow error paths: removed double-encoded source text (`.context(format!("...: {}", e))` → `.context("...")`)

### Merge gate
- QA: ATM-CORE-K4-FIX-R1-QA (pending)
- CI: pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)