### PR TITLE
chore: remove [patch.crates-io] override — sc-observability 1.0.0 live on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,8 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "sc-observability"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f574cd3a66eb9d5a6780c747086617c58907e02729d258e771efb4d6f076e8df"
 dependencies = [
  "sc-observability-types",
  "serde_json",
@@ -611,6 +613,8 @@ dependencies = [
 [[package]]
 name = "sc-observability-types"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e42c54a18a4c86d92e4ebaee8d7f06620fd5c9908eb1946b47da24f9778753d"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,3 @@ anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tokio = { version = "1", features = ["rt"] }
-
-# Pre-publish CI override: sc-observability 1.0 is not yet on crates.io.
-# This committed git-source patch lets CI resolve the dependency without a
-# local sibling checkout. Remove this section in Sprint L.4 when switching to
-# the published crates.io ^1.0.0 release. See docs/atm-core/dev/pre-publish-deps.md.
-[patch.crates-io]
-sc-observability = { git = "https://github.com/randlee/sc-observability", rev = "bcae027394e01b689bd8e38af720e76dda644931" }
-sc-observability-types = { git = "https://github.com/randlee/sc-observability", rev = "bcae027394e01b689bd8e38af720e76dda644931" }

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -12,8 +12,8 @@ use chrono::{DateTime, Utc};
 use sc_observability::Logger;
 use sc_observability::LoggerConfig;
 use sc_observability_types::{
-    ActionName, DiagnosticInfo, Level, LogEvent, LogQuery, ProcessIdentity, QueryError,
-    ServiceName, TargetCategory, Timestamp,
+    ActionName, CorrelationId, DiagnosticInfo, Level, LogEvent, LogQuery, OutcomeLabel,
+    ProcessIdentity, QueryError, SchemaVersion, ServiceName, TargetCategory, Timestamp,
 };
 use serde_json::Map;
 use time::OffsetDateTime;
@@ -233,12 +233,7 @@ fn test_health_override(home_dir: &Path) -> Option<CliObservability> {
         .filter(|value| !value.is_empty());
 
     Some(CliObservability::static_health(AtmObservabilityHealth {
-        active_log_path: Some(
-            log_root(home_dir)
-                .join("atm")
-                .join("logs")
-                .join("atm.log.jsonl"),
-        ),
+        active_log_path: Some(log_root(home_dir).join("logs").join("atm.log.jsonl")),
         logging_state,
         query_state: Some(query_state),
         detail,
@@ -250,8 +245,35 @@ fn map_command_event(
     target_category: &TargetCategory,
     event: CommandEvent,
 ) -> Result<LogEvent, AtmError> {
+    let schema_version =
+        SchemaVersion::new(sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION)
+            .map_err(|source| {
+                AtmError::observability_emit("failed to validate ATM observability schema version")
+                    .with_source(source)
+            })?;
     let action = ActionName::new(event.action).map_err(|source| {
         AtmError::observability_emit("failed to validate ATM observability action")
+            .with_source(source)
+    })?;
+    let request_id = event
+        .message_id
+        .map(|value| CorrelationId::new(value.to_string()))
+        .transpose()
+        .map_err(|source| {
+            AtmError::observability_emit("failed to validate ATM observability request id")
+                .with_source(source)
+        })?;
+    let correlation_id = event
+        .task_id
+        .as_deref()
+        .map(CorrelationId::new)
+        .transpose()
+        .map_err(|source| {
+            AtmError::observability_emit("failed to validate ATM observability correlation id")
+                .with_source(source)
+        })?;
+    let outcome = OutcomeLabel::new(event.outcome).map_err(|source| {
+        AtmError::observability_emit("failed to validate ATM observability outcome label")
             .with_source(source)
     })?;
 
@@ -306,7 +328,7 @@ fn map_command_event(
     }
 
     Ok(LogEvent {
-        version: sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION.to_string(),
+        version: schema_version,
         timestamp: Timestamp::now_utc(),
         level: level_for_outcome(event.outcome),
         service: service_name.clone(),
@@ -318,9 +340,9 @@ fn map_command_event(
         )),
         identity: ProcessIdentity::default(),
         trace: None,
-        request_id: event.message_id.map(|value| value.to_string()),
-        correlation_id: event.task_id.clone(),
-        outcome: Some(event.outcome.to_string()),
+        request_id,
+        correlation_id,
+        outcome: Some(outcome),
         diagnostic: None,
         state_transition: None,
         fields,
@@ -584,12 +606,7 @@ mod tests {
         );
         assert_eq!(
             health.active_log_path,
-            Some(
-                log_root(tempdir.path())
-                    .join("atm")
-                    .join("logs")
-                    .join("atm.log.jsonl"),
-            )
+            Some(log_root(tempdir.path()).join("logs").join("atm.log.jsonl"))
         );
         assert!(health.detail.is_none());
 

--- a/docs/atm-core/dev/pre-publish-deps.md
+++ b/docs/atm-core/dev/pre-publish-deps.md
@@ -13,58 +13,28 @@ This strategy applies only to the pre-publish period for:
 Committed ATM source must target the real crate names and must not hardcode a
 developer-specific filesystem path.
 
-## 2. Local Developer Strategy
+## 2. Publication Status
 
-Local developer builds may point the shared crates at a sibling checkout using
-an uncommitted `[patch.crates-io]` section in the root `Cargo.toml`.
+`sc-observability` `1.0.0` and `sc-observability-types` `1.0.0` are now
+published on crates.io.
 
-Example local-only patch:
+The temporary pre-publish override strategy is complete:
 
-```toml
-[patch.crates-io]
-sc-observability = { path = "../sc-observability/crates/sc-observability" }
-sc-observability-types = { path = "../sc-observability/crates/sc-observability-types" }
-```
+- the committed root `[patch.crates-io]` override has been removed
+- workspace and crate manifests should use the published crates.io packages
+  directly
+- no branch should reintroduce the old git-source override unless a new,
+  explicitly documented pre-publish exception is approved
 
-Required rules:
+## 3. Current Dependency Rule
 
-- the patch must point to a sibling checkout such as `../sc-observability`
-- the patch must remain a local developer edit and must not be committed
-- no committed docs, manifests, or scripts may require an absolute path such as
-  `/Users/...`
+ATM must depend on the published crates.io packages directly:
 
-Developers who want a stashable helper file may keep the same snippet in an
-ignored file such as `Cargo.local.toml` and apply it locally as needed. That
-helper file is ignored by this repo and must not be referenced by committed CI
-steps.
+- `sc-observability = "1.0.0"` (or a later approved released version)
+- `sc-observability-types = "1.0.0"` (or a later approved released version)
 
-## 3. CI Strategy Before Publication
-
-Integration branches (`integrate/phase-K` and later) use a committed
-git-source `[patch.crates-io]` in the root `Cargo.toml` so that CI runners
-can resolve `sc-observability` without a local sibling checkout.
-
-Example (what is committed on `integrate/phase-K`):
-
-```toml
-[patch.crates-io]
-sc-observability = { git = "https://github.com/randlee/sc-observability", rev = "<sha>" }
-sc-observability-types = { git = "https://github.com/randlee/sc-observability", rev = "<sha>" }
-```
-
-Required rules:
-
-- use a pinned `rev` so builds are reproducible; update the rev when picking
-  up new upstream sc-observability commits (e.g. between Phase L sprints)
-- the git URL must be the public GitHub remote — no local paths
-- this committed patch is only appropriate on integration/feature branches;
-  it must not appear on `develop` or `main`
-- remove this section entirely in Sprint L.4 when switching to the published
-  crates.io `^1.0.0` release
-
-Local developer builds may still override the git source with a local sibling
-path for faster iteration (see §2 above); the local override takes precedence
-over the committed git source when both are present.
+`Cargo.lock` should therefore resolve both shared crates from crates.io rather
+than git or a local path.
 
 ## 4. Toolchain Alignment
 


### PR DESCRIPTION
## Summary

- Remove `[patch.crates-io]` git-source override from workspace `Cargo.toml` (sc-observability 1.0.0 is now published on crates.io)
- Update `docs/atm-core/dev/pre-publish-deps.md` to reflect pre-publish strategy is complete
- Refresh `Cargo.lock` — resolves sc-observability + sc-observability-types from crates.io
- Adapt `crates/atm/src/observability.rs` to published sc-observability 1.0.0 API and default log path layout

## Validation

- `cargo update --workspace` — Cargo.lock updated to crates.io sources
- `cargo test --workspace` — PASS
- `cargo clippy --workspace -- -D warnings` — PASS

## Context

Sprint `ATM-CORE-K-CRATES-IO-1` — final sprint of Phase K. After this merges to `integrate/phase-K`, PR #45 (`integrate/phase-K → develop`) is ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)