### PR TITLE
L.1: --stderr-logs global flag for ConsoleSink routing

### DIFF
--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -25,11 +25,22 @@ use crate::observability::CliObservability;
     disable_help_subcommand = true
 )]
 pub struct Cli {
+    /// Route retained observability console logs to stderr.
+    ///
+    /// ATM owns normal command stdout output; this flag opts the shared
+    /// console sink into stderr so retained diagnostics do not pollute stdout.
+    #[arg(long = "stderr-logs", global = true)]
+    stderr_logs: bool,
+
     #[command(subcommand)]
     command: Command,
 }
 
 impl Cli {
+    pub fn stderr_logs(&self) -> bool {
+        self.stderr_logs
+    }
+
     pub fn run(self, observability: &CliObservability) -> Result<()> {
         self.command.run(observability)
     }

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -17,15 +17,6 @@ fn main() {
 }
 
 fn run() -> anyhow::Result<()> {
-    let observability = match observability::init() {
-        Ok(observability) => observability,
-        Err(error) => {
-            let fallback = observability::CliObservability::fallback();
-            fallback.emit_fatal_error("bootstrap", error.as_ref());
-            return Err(error);
-        }
-    };
-
     let cli = match commands::Cli::try_parse() {
         Ok(cli) => cli,
         Err(error) => {
@@ -37,8 +28,18 @@ fn run() -> anyhow::Result<()> {
                 return Ok(());
             }
             let validation_error = atm_core::error::AtmError::validation(error.to_string());
-            observability.emit_fatal_error("parse", &validation_error);
+            observability::CliObservability::fallback()
+                .emit_fatal_error("parse", &validation_error);
             return Err(error.into());
+        }
+    };
+
+    let observability = match observability::init(cli.stderr_logs()) {
+        Ok(observability) => observability,
+        Err(error) => {
+            let fallback = observability::CliObservability::fallback();
+            fallback.emit_fatal_error("bootstrap", error.as_ref());
+            return Err(error);
         }
     };
 

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::Result;
 use atm_core::error::{AtmError, AtmErrorCode};
@@ -9,8 +10,7 @@ use atm_core::observability::{
     LogTailSession, ObservabilityPort,
 };
 use chrono::{DateTime, Utc};
-use sc_observability::Logger;
-use sc_observability::LoggerConfig;
+use sc_observability::{ConsoleSink, Logger, LoggerConfig, SinkRegistration};
 use sc_observability_types::{
     ActionName, CorrelationId, DiagnosticInfo, Level, LogEvent, LogQuery, OutcomeLabel,
     ProcessIdentity, QueryError, SchemaVersion, ServiceName, TargetCategory, Timestamp,
@@ -21,23 +21,35 @@ use time::OffsetDateTime;
 const ATM_SERVICE_NAME: &str = "atm";
 const ATM_COMMAND_TARGET: &str = "atm.command";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConsoleLogRoute {
+    Disabled,
+    Stderr,
+}
+
 pub struct CliObservability {
     inner: Box<dyn ObservabilityPort + Send + Sync>,
 }
 
 impl CliObservability {
-    fn concrete_for_home(home_dir: &Path) -> Result<Self, AtmError> {
-        let adapter = ScObservabilityAdapter::new(home_dir)?;
+    fn concrete_for_home(
+        home_dir: &Path,
+        console_log_route: ConsoleLogRoute,
+    ) -> Result<Self, AtmError> {
+        let adapter = ScObservabilityAdapter::new(home_dir, console_log_route)?;
         Ok(Self {
             inner: Box::new(adapter),
         })
     }
 
     pub fn fallback() -> Self {
-        Self::concrete_for_home(&std::env::temp_dir().join("atm-bootstrap-observability"))
-            .unwrap_or_else(|_| Self {
-                inner: Box::new(atm_core::observability::NullObservability),
-            })
+        Self::concrete_for_home(
+            &std::env::temp_dir().join("atm-bootstrap-observability"),
+            ConsoleLogRoute::Disabled,
+        )
+        .unwrap_or_else(|_| Self {
+            inner: Box::new(atm_core::observability::NullObservability),
+        })
     }
 
     pub fn emit_fatal_error(&self, stage: &'static str, error: &(dyn std::error::Error + 'static)) {
@@ -72,12 +84,20 @@ impl CliObservability {
     }
 }
 
-pub fn init() -> Result<CliObservability> {
+pub fn init(stderr_logs: bool) -> Result<CliObservability> {
     let home_dir = home::atm_home()?;
     if let Some(override_health) = test_health_override(&home_dir) {
         return Ok(override_health);
     }
-    Ok(CliObservability::concrete_for_home(&home_dir)?)
+    let console_log_route = if stderr_logs {
+        ConsoleLogRoute::Stderr
+    } else {
+        ConsoleLogRoute::Disabled
+    };
+    Ok(CliObservability::concrete_for_home(
+        &home_dir,
+        console_log_route,
+    )?)
 }
 
 impl ObservabilityPort for CliObservability {
@@ -113,7 +133,7 @@ impl observability::sealed::Sealed for ScObservabilityAdapter {}
 impl observability::sealed::Sealed for StaticHealthObservability {}
 
 impl ScObservabilityAdapter {
-    fn new(home_dir: &Path) -> Result<Self, AtmError> {
+    fn new(home_dir: &Path, console_log_route: ConsoleLogRoute) -> Result<Self, AtmError> {
         let service_name = ServiceName::new(ATM_SERVICE_NAME).map_err(|source| {
             AtmError::observability_bootstrap("failed to validate ATM service name")
                 .with_source(source)
@@ -123,13 +143,17 @@ impl ScObservabilityAdapter {
                 .with_source(source)
         })?;
         let mut config = LoggerConfig::default_for(service_name.clone(), log_root(home_dir));
-        // ATM CLI owns stdout/stderr UX; retain logs via the shared file sink by default.
+        // ATM CLI owns stdout/stderr UX by default; only opt into a shared
+        // console sink when the CLI routing rule explicitly selects one.
         config.enable_console_sink = false;
-
-        let logger = Logger::new(config).map_err(|source| {
+        let mut builder = Logger::builder(config).map_err(|source| {
             AtmError::observability_bootstrap("failed to initialize shared observability logger")
                 .with_source(source)
         })?;
+        if console_log_route == ConsoleLogRoute::Stderr {
+            builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
+        }
+        let logger = builder.build();
 
         Ok(Self {
             logger,
@@ -542,7 +566,7 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
-    use super::{CliObservability, level_for_outcome, log_root};
+    use super::{CliObservability, ConsoleLogRoute, level_for_outcome, log_root};
 
     fn query(order: LogOrder) -> AtmLogQuery {
         AtmLogQuery {
@@ -578,7 +602,8 @@ mod tests {
     fn concrete_adapter_emits_queries_follows_and_reports_health() {
         let tempdir = TempDir::new().expect("tempdir");
         let observability =
-            CliObservability::concrete_for_home(tempdir.path()).expect("concrete adapter");
+            CliObservability::concrete_for_home(tempdir.path(), ConsoleLogRoute::Disabled)
+                .expect("concrete adapter");
 
         observability
             .emit(event(Some("550e8400-e29b-41d4-a716-446655440000")))

--- a/crates/atm/tests/log.rs
+++ b/crates/atm/tests/log.rs
@@ -218,6 +218,55 @@ fn test_invalid_send_logs_error_code_and_exits_nonzero() {
     );
 }
 
+#[test]
+fn test_send_stdout_remains_clean_without_stderr_logs() {
+    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello stdout", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["agent"], "recipient");
+    assert_eq!(parsed["team"], "atm-dev");
+    assert!(
+        fixture.stderr(&output).trim().is_empty(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+}
+
+#[test]
+fn test_send_routes_retained_console_logs_to_stderr_when_requested() {
+    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
+
+    let output = fixture.run(&[
+        "--stderr-logs",
+        "send",
+        "recipient@atm-dev",
+        "hello stderr",
+        "--json",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["agent"], "recipient");
+    assert_eq!(parsed["team"], "atm-dev");
+
+    let stderr = fixture.stderr(&output);
+    assert!(
+        stderr.contains("atm.command send ATM command send completed with outcome sent"),
+        "stderr: {stderr}"
+    );
+}
+
 struct Fixture {
     tempdir: tempfile::TempDir,
 }

--- a/docs/atm-core/design/sc-obs-1.0-integration.md
+++ b/docs/atm-core/design/sc-obs-1.0-integration.md
@@ -31,26 +31,33 @@ shared 1.0 crate behavior.
 
 ## 3. Stderr Routing Strategy (`#55`)
 
-Current ATM behavior uses the shared console sink conservatively because normal
-CLI command output must remain under ATM control.
+`L.1` is complete.
 
-Required Phase L direction:
+ATM now keeps retained console logging disabled by default and exposes one
+explicit CLI routing switch:
 
-- `CliObservability` should support a retained-log console route that targets
-  stderr through `ConsoleSink::stderr()`
-- ATM must preserve the distinction between:
-  - normal command output rendered by ATM CLI code
-  - retained/shared console log output emitted by the observability adapter
-- stderr routing must not leak shared sink behavior into `atm-core`; it remains
-  an `atm` adapter concern
+- `--stderr-logs`
 
-Expected implementation shape:
+When present, the `atm` crate wires `ConsoleSink::stderr()` into the shared
+logger builder. When absent, ATM leaves the shared console sink disabled so
+normal command stdout output remains unchanged.
 
-- add a CLI-facing selection rule:
-  - explicit `--stderr`, or
-  - a documented TTY-aware routing policy
-- keep stdout behavior unchanged unless the routing rule selects stderr
-- verify both output paths in integration tests
+Rationale:
+
+- the routing decision stays entirely inside the `atm` crate
+- `atm-core` still exposes only the ATM-owned `ObservabilityPort` boundary
+- stderr is opt-in, so scripted stdout consumers keep the same behavior unless
+  they explicitly request retained console output
+- the switch is straightforward to test in integration coverage
+
+Implementation notes:
+
+- `CliObservability` now uses `Logger::builder(...)` so the CLI adapter can
+  register `ConsoleSink::stderr()` without changing `atm-core`
+- stdout command rendering remains owned by ATM output code
+- integration tests cover both:
+  - default mode: stdout command output stays clean and stderr remains empty
+  - `--stderr-logs`: retained console output is emitted on stderr
 
 This change is useful for:
 
@@ -98,15 +105,6 @@ Required Phase L direction:
 
 ## 6. Dependency Strategy
 
-Implementation sprints `L.1` through `L.3` continue to use the local
-`[patch.crates-io]` override strategy described in:
-
-- [`../dev/pre-publish-deps.md`](../dev/pre-publish-deps.md)
-
-Final adoption rule:
-
-- `L.4` is the only sprint that removes the local override and switches ATM to
-  crates.io `sc-observability = "^1.0.0"`
-
-This keeps all pre-publish testing aligned with the real shared code while
-making the final release-cut transition explicit and auditable.
+ATM now consumes the published `sc-observability = "^1.0.0"` release. Phase L
+continues from that published baseline rather than the earlier local
+`[patch.crates-io]` pre-publish strategy.


### PR DESCRIPTION
## Sprint L.1 — stderr routing via --stderr-logs flag

Implements global `--stderr-logs` flag that wires `ConsoleSink::stderr()` through the CLI adapter only. stdout default preserved. No sc-observability types leak into atm-core.

### Deliverables
- `--stderr-logs` global flag added to CLI argument parser
- `ConsoleSink::stderr()` wired through CLI adapter when flag is set
- stdout default preserved when flag is absent
- stdout/stderr integration coverage added
- `docs/atm-core/design/sc-obs-1.0-integration.md` §3 updated with completed routing rule and rationale

### Commit
a84ef5767813a9f604f84d697874cee74e5689e4

### Acceptance
- `cargo test --workspace` PASS
- `cargo clippy --workspace -- -D warnings` PASS
- No sc-observability types in atm-core
- stdout/stderr routing verified by integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)