### PR TITLE
docs: Phase L config semantics, team surface, and L.8 sprint plan (L.7)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,8 @@ The retained command surface is:
 - `clear`
 - `log`
 - `doctor`
+- `teams`
+- `members`
 
 ## 1.1 Documentation Structure
 
@@ -116,6 +118,13 @@ Product-level constraints that remain relevant here:
 - no runtime spawning layer
 - no separate `tail` command in the initial rewrite
 - no separate `status` command in the initial rewrite
+- the retained release-critical team recovery surface is limited to:
+  - `teams`
+  - `members`
+  - `teams add-member`
+  - `teams backup`
+  - `teams restore`
+- broader historical team lifecycle/orchestration commands remain out of scope
 
 ## 4. Core Types
 
@@ -692,6 +701,49 @@ Roster output rules:
 - show `team-lead` first among the baseline members when present
 - show extra runtime members after the baseline set
 
+### 6.8 Team Recovery Services
+
+The retained release-critical local team surface is intentionally narrow.
+
+ATM-owned public entrypoints should cover:
+- local team discovery
+- local member listing
+- local `add-member`
+- local team backup
+- local team restore
+
+Architectural rules:
+- these services are local file/config/inbox operations; they must not depend
+  on daemon orchestration or runtime spawning
+- `teams` list is discovery-oriented and should remain deterministic over the
+  ATM home directory
+- `add-member` is the retained local roster-repair path and must reject
+  duplicates before mutating config
+- `backup` snapshots current team config, inboxes, and the ATM team task
+  bucket into a timestamped snapshot directory
+- `restore` is a local recovery path and must:
+  - preserve the current team-lead entry and `leadSessionId`
+  - restore only missing non-lead members
+  - clear runtime-only restored-member state before persistence
+  - restore non-lead inboxes from the chosen snapshot
+  - recompute `.highwatermark` from the maximum restored task id
+  - support a dry-run path without making changes
+- Claude Code project task-list restoration remains separate from the retained
+  ATM team backup/restore surface
+
+### 6.9 Members Service
+
+The retained `members` surface is a local roster inspection service.
+
+Architectural rules:
+- it must succeed without daemon or hook-only state
+- it must load the roster from local team config
+- it should order members deterministically, with `team-lead` first when
+  present
+- it may surface persisted member metadata already present in config
+- later hook/session enrichment may be layered on without changing the base
+  local verification purpose of the command
+
 ## 7. Read Pipeline
 
 The read pipeline stages are:
@@ -786,6 +838,14 @@ Repo-local config identity is not retained as a runtime fallback. In the
 multi-agent model, runtime identity must come from explicit CLI override,
 hook identity, or `ATM_IDENTITY`. An obsolete `[atm].identity` field may be
 diagnosed by doctor, but it must not control sender/actor resolution.
+
+When `ATM_POST_SEND` is set for a configured post-send hook, the payload must
+contain:
+- `from`
+- `to`
+- `message_id`
+- `requires_ack`
+- optional `task_id`
 
 ### 13.2 File Policy
 
@@ -971,3 +1031,5 @@ If a trait becomes necessary:
 - send/read/ack/clear integration behavior
 - `atm log` integration behavior
 - `atm doctor` integration behavior
+- `atm teams` integration behavior
+- `atm members` integration behavior

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,10 +289,12 @@ Architectural rules:
   canonical sender identity rather than the display-oriented `from` projection
 - ATM-owned post-send hooks are sender-scoped best-effort helpers, not part of
   the atomic send boundary
+- the hook runs only after a successful non-`dry-run` send
 - relative post-send-hook paths resolve from the discovered `.atm.toml`
   directory and execute with that same directory as the working directory
 - the hook receives inherited environment plus one ATM-owned JSON payload in
   `ATM_POST_SEND`
+- hook failure or timeout never rolls back a successful send
 
 ## 5. Persisted Schema
 
@@ -846,6 +848,9 @@ contain:
 - `message_id`
 - `requires_ack`
 - optional `task_id`
+
+The post-send hook runs only after a successful non-`dry-run` send, and hook
+failure or timeout never rolls back a successful send.
 
 ### 13.2 File Policy
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,6 +76,8 @@ ATM still owns:
 - ATM-specific structured fields
 - mapping CLI filters to shared query/follow APIs
 - ATM doctor projections over shared health models
+- ATM-owned config semantics for baseline roster, alias resolution, and
+  runtime-identity precedence
 
 `sc-observability` should own as much generic functionality as possible:
 - emission
@@ -260,6 +262,29 @@ pub struct LogFieldMatch {
 }
 ```
 
+### 4.5 Identity And Alias Projection
+
+ATM must distinguish canonical routing identity from the Claude-facing sender
+projection.
+
+Architectural rules:
+- runtime identity resolves from explicit CLI override, hook identity, or
+  `ATM_IDENTITY`, not repo-local `[atm].identity`
+- ATM-owned aliases are input shorthands that resolve to canonical member names
+- same-team messages keep current canonical sender projection behavior
+- cross-team messages may project an alias-friendly sender in the persisted
+  `from` field for Claude-facing ergonomics
+- whenever cross-team alias projection is used, ATM must also persist
+  canonical sender identity in `metadata.atm.fromIdentity`
+- self-send checks, target validation, routing, and audit logic must use the
+  canonical sender identity rather than the display-oriented `from` projection
+- ATM-owned post-send hooks are sender-scoped best-effort helpers, not part of
+  the atomic send boundary
+- relative post-send-hook paths resolve from the discovered `.atm.toml`
+  directory and execute with that same directory as the working directory
+- the hook receives inherited environment plus one ATM-owned JSON payload in
+  `ATM_POST_SEND`
+
 ## 5. Persisted Schema
 
 ### 5.1 Team Config
@@ -270,6 +295,18 @@ Only a small subset is required by the retained surface:
 - member roster
 - enough member metadata to preserve round-trips when present
 - bridge remote host configuration needed for origin-file merge when present
+
+ATM config and team-launch config are distinct concerns:
+- ATM-owned config uses the `[atm]` section of `.atm.toml`
+- launcher-owned sections such as `[rmux]` and future `[scmux]` remain outside
+  the `atm-core` runtime config boundary and are ignored by ATM
+- `[atm].team_members` is the ATM-owned baseline roster for doctor/orchestration
+  checks
+- `[atm].aliases` is the ATM-owned shorthand map for canonical agent names
+- `[atm].post_send_hook` and `[atm].post_send_hook_members` are ATM-owned
+  best-effort sender-scoped automation settings
+- `[atm].identity` is obsolete in the retained multi-agent model and must not
+  participate in runtime identity resolution
 
 Team config loading must follow a narrow-scope recovery policy:
 - compatibility-only schema drift may use deterministic defaults at the schema
@@ -330,6 +367,8 @@ Forward architectural rules:
 - forward ATM-authored alert metadata, including legacy `atmAlertKind` and
   `missingConfigPath`, belongs under `metadata.atm` as
   `metadata.atm.alertKind` and `metadata.atm.missingConfigPath`
+- cross-team alias projection stores canonical sender identity in
+  `metadata.atm.fromIdentity`
 - ATM may enrich a Claude-native stored message by adding `metadata.atm`
   without rewriting the native Claude fields
 - the current live design still uses a shared inbox surface; a separate
@@ -500,6 +539,9 @@ Read/enrichment rule:
 - when a message needs ATM workflow semantics but lacks ATM-owned machine
   metadata, ATM may enrich the original stored message additively
 - enrichment must be idempotent and must not rewrite native Claude fields
+  except for the explicitly documented cross-team alias projection carve-out on
+  `from`, which also requires canonical sender identity in
+  `metadata.atm.fromIdentity`
 
 The read service derives `MessageClass` from `(ReadState, AckState)` and applies display-bucket selection to the derived class, not to raw persisted fields.
 
@@ -633,6 +675,7 @@ Public entrypoint:
 - findings
 - recommendations
 - environment override visibility
+- current team member roster from `config.json`
 - observability health
 
 `DoctorFinding` contains:
@@ -642,6 +685,12 @@ Public entrypoint:
 - remediation
 
 The report model should reuse the current doctor command’s severity/finding structure where useful, but local checks replace daemon checks.
+
+Roster output rules:
+- show all current `config.json` members in doctor output
+- show baseline `[atm].team_members` first
+- show `team-lead` first among the baseline members when present
+- show extra runtime members after the baseline set
 
 ## 7. Read Pipeline
 
@@ -703,12 +752,14 @@ Shared `sc-observability` should own record storage, filtering, and follow mecha
 The doctor pipeline stages are:
 1. resolve config and environment overrides
 2. resolve effective team and identity inputs
-3. verify local team/mailbox/config paths
-4. verify hook identity availability
-5. verify observability initialization and health
-6. verify observability query readiness for `atm log`
-7. assemble findings and recommendations
-8. render report
+3. inspect ATM config for obsolete fields such as `[atm].identity`
+4. verify local team/mailbox/config paths
+5. verify hook identity availability
+6. compare baseline `[atm].team_members` against `config.json.members`
+7. verify observability initialization and health
+8. verify observability query readiness for `atm log`
+9. assemble findings, recommendations, and ordered roster output
+10. render report
 
 ## 12. Mailbox Storage
 
@@ -730,6 +781,11 @@ The mailbox layer does not own selection policy, display buckets, output formatt
 Hook-file identity is retained because it is a current non-daemon convenience path for send/read identity resolution.
 
 Only hook identity resolution is required for the rewrite. Session-resolution paths that exist only to bridge runtime/daemon ambiguity are not required.
+
+Repo-local config identity is not retained as a runtime fallback. In the
+multi-agent model, runtime identity must come from explicit CLI override,
+hook identity, or `ATM_IDENTITY`. An obsolete `[atm].identity` field may be
+diagnosed by doctor, but it must not control sender/actor resolution.
 
 ### 13.2 File Policy
 

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -37,6 +37,20 @@ Required loading policy:
 This keeps tolerant parsing centralized and prevents commands from inventing
 ad hoc recovery behavior.
 
+ATM-owned `.atm.toml` semantics for the retained multi-agent model:
+- `atm-core` consumes the `[atm]` section only
+- `[atm].default_team` remains the shared team default
+- `[atm].team_members` is the baseline roster used for doctor and future
+  orchestration-safety checks
+- `[atm].aliases` is an ATM-owned shorthand map for canonical agent names
+- `[atm].post_send_hook` is an ATM-owned helper command definition for
+  best-effort post-send automation
+- `[atm].post_send_hook_members` is the sender-identity allowlist for that
+  helper
+- `[atm].identity` is obsolete and ignored by runtime identity resolution
+- launcher-owned sections such as `[rmux]` and future `[scmux]` are outside the
+  `atm-core` runtime boundary and are intentionally ignored
+
 Send-specific policy remains layered above the loader:
 - send may use a narrowly defined missing-document fallback when the product
   docs explicitly allow it
@@ -44,6 +58,32 @@ Send-specific policy remains layered above the loader:
   send fallback
 - deduplicated repair notifications belong to the send orchestration boundary,
   not to generic config parsing
+
+Identity-specific policy:
+- runtime identity must come from explicit override, hook identity, or
+  `ATM_IDENTITY`
+- `atm-core` must not derive a normal sender/actor identity from repo-local
+  config in the shared multi-agent checkout model
+- aliases must resolve to canonical member names before membership validation,
+  self-send checks, and mailbox lookup
+- same-team messages keep current canonical sender projection behavior
+- cross-team messages may project an alias-oriented `from` field only when
+  canonical sender identity is also persisted in `metadata.atm.fromIdentity` for
+  validation, routing, and audit use
+- post-send-hook execution is outside the atomic mailbox mutation boundary
+- a relative hook path resolves from the discovered `.atm.toml` directory and
+  executes with that same directory as working directory
+- the hook inherits process environment and receives one ATM-owned JSON
+  payload in `ATM_POST_SEND`
+- hook execution is gated by resolved sender identity membership in
+  `[atm].post_send_hook_members`
+- hook failure or timeout is best-effort only and must not convert a
+  successful send into a command failure
+- the reserved diagnostic sender `atm-identity-missing@<team>` is for
+  ATM-generated repair/diagnostic notices only
+- doctor should project the live `config.json` roster in a deterministic order:
+  baseline `[atm].team_members` first, `team-lead` first among that baseline,
+  then extra runtime members
 
 Current `AgentMember` persisted schema:
 - `name: String` required for roster membership checks

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -15,8 +15,8 @@ service boundaries.
   structure.
 - `atm-core` owns observability as an injected boundary, not as a concrete
   dependency on `sc-observability`.
-- `atm-core` must keep mailbox/config/workflow/log/doctor logic reusable across
-  CLI contexts.
+- `atm-core` must keep mailbox/config/workflow/log/doctor/team-recovery logic
+  reusable across CLI contexts.
 - `atm-core` owns persisted config/team loading policy, including compatibility
   defaults, recovery boundaries, and precise parse diagnostics.
 
@@ -75,6 +75,12 @@ Identity-specific policy:
   executes with that same directory as working directory
 - the hook inherits process environment and receives one ATM-owned JSON
   payload in `ATM_POST_SEND`
+- the `ATM_POST_SEND` payload contains:
+  - `from`
+  - `to`
+  - `message_id`
+  - `requires_ack`
+  - optional `task_id`
 - hook execution is gated by resolved sender identity membership in
   `[atm].post_send_hook_members`
 - hook failure or timeout is best-effort only and must not convert a
@@ -108,6 +114,29 @@ Architectural rule:
   fields until the migration implementation sprint lands
 - this compatibility-period carve-out is the bounded exception referenced by
   [`requirements.md` `REQ-CORE-SEND-002`](./requirements.md#6-send-alert-metadata)
+
+## 3.2 Retained Team Recovery Boundary
+
+`atm-core` owns the retained local team recovery boundary needed for initial
+release.
+
+Architectural rules:
+- the retained team surface is limited to:
+  - team discovery
+  - member listing
+  - `add-member`
+  - local team backup
+  - local team restore
+- historical orchestration-heavy team commands remain outside the retained
+  `atm-core` boundary for initial release
+- restore preserves the current team-lead record and current `leadSessionId`
+  rather than replaying stale lead-session state from backup
+- restored non-lead members must have runtime-only state cleared before they
+  are written back to local config
+- restored ATM task buckets must recompute `.highwatermark` from the maximum
+  restored task id
+- the local `members` view is config-first; richer hook/session state may be
+  layered later without changing the base recovery contract
 
 ## 4. ADR Namespace
 

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -71,6 +71,7 @@ Identity-specific policy:
   canonical sender identity is also persisted in `metadata.atm.fromIdentity` for
   validation, routing, and audit use
 - post-send-hook execution is outside the atomic mailbox mutation boundary
+- the hook runs only after a successful non-`dry-run` send
 - a relative hook path resolves from the discovered `.atm.toml` directory and
   executes with that same directory as working directory
 - the hook inherits process environment and receives one ATM-owned JSON

--- a/docs/atm-core/design/dedup-metadata-schema.md
+++ b/docs/atm-core/design/dedup-metadata-schema.md
@@ -76,10 +76,12 @@ Concrete placement and ownership map:
 - forward ATM-owned machine metadata:
   - `metadata.atm.messageId`
   - `metadata.atm.sourceTeam`
+  - `metadata.atm.fromIdentity`
   - `metadata.atm.pendingAckAt`
   - `metadata.atm.acknowledgedAt`
   - `metadata.atm.acknowledgesMessageId`
   - `metadata.atm.alertKind`
+  - `metadata.atm.missingConfigPath`
 
 Implementation guardrails:
 
@@ -181,6 +183,8 @@ Recommendation:
 - ATM read must support Claude-native, legacy ATM top-level, and future
   metadata-based messages
 - ATM may enrich a Claude-native message in place by adding `metadata.atm`
+- cross-team alias projection may also record canonical sender identity in
+  `metadata.atm.fromIdentity`
 - enrichment must be additive and idempotent
 - ATM-native inbox separation is explicitly deferred to a later version after
   the current shared inbox design is used live
@@ -189,6 +193,9 @@ Upgrade rule:
 
 - a Claude-native message may be upgraded in place by adding `metadata.atm`
 - the original Claude-owned fields remain authoritative for message content
+- exception: a cross-team alias projection may retain a Claude-facing alias in
+  `from` only when canonical sender identity is also recorded in
+  `metadata.atm.fromIdentity`
 - ATM workflow data such as ack state or ATM message identity attaches to that
   original stored message rather than moving the message into a different
   envelope format

--- a/docs/atm-core/modules/ack.md
+++ b/docs/atm-core/modules/ack.md
@@ -5,7 +5,7 @@ from pending-ack to acknowledged.
 
 References:
 
-- Product requirements: `docs/requirements.md` §8 and §12
+- Product requirements: `docs/requirements.md` §8 and §14
 - `REQ-P-ACK-001`
 - `REQ-P-WORKFLOW-001`
 - `REQ-CORE-WORKFLOW-001`

--- a/docs/atm-core/modules/clear.md
+++ b/docs/atm-core/modules/clear.md
@@ -5,7 +5,7 @@ pending-ack messages are never removed by clear.
 
 References:
 
-- Product requirements: `docs/requirements.md` §9 and §12
+- Product requirements: `docs/requirements.md` §9 and §14
 - `REQ-P-CLEAR-001`
 - `REQ-P-WORKFLOW-001`
 - `REQ-CORE-WORKFLOW-001`

--- a/docs/atm-core/modules/config.md
+++ b/docs/atm-core/modules/config.md
@@ -15,6 +15,10 @@ References:
 - `REQ-P-CONTRACT-001`
 - `REQ-P-IDENTITY-001`
 - `REQ-P-CONFIG-HEALTH-001`
+- `REQ-CORE-CONFIG-001` for `[atm].team_members`, obsolete `[atm].identity`,
+  and `post_send_hook` / `post_send_hook_members`
+- `REQ-CORE-CONFIG-002` for `[atm].aliases` resolution and canonical address
+  rewrite
 - `REQ-CORE-CONFIG-003`
 - `REQ-CORE-MAILBOX-001`
-- Migration artifact: `docs/file-migration-plan.md`
+- Migration artifact: `docs/archive/file-migration-plan.md`

--- a/docs/atm-core/modules/doctor.md
+++ b/docs/atm-core/modules/doctor.md
@@ -11,9 +11,11 @@ It must not own:
 
 References:
 
-- Product requirements: `docs/requirements.md` §11 and §13
+- Product requirements: `docs/requirements.md` §11 and §15
 - `REQ-P-DOCTOR-001`
 - `REQ-P-OBS-001`
+- `REQ-CORE-CONFIG-001` for obsolete `[atm].identity` configuration drift
+  detection and `[atm].team_members` baseline-roster checks
 - `REQ-CORE-DOCTOR-001`
 - CLI surface: `docs/atm/commands/doctor.md`
 - Supporting boundary: `docs/atm-core/modules/observability.md`

--- a/docs/atm-core/modules/log.md
+++ b/docs/atm-core/modules/log.md
@@ -12,7 +12,7 @@ It must not own:
 
 References:
 
-- Product requirements: `docs/requirements.md` §10 and §13
+- Product requirements: `docs/requirements.md` §10 and §15
 - `REQ-P-LOG-001`
 - `REQ-P-OBS-001`
 - `REQ-CORE-LOG-001`

--- a/docs/atm-core/modules/mailbox.md
+++ b/docs/atm-core/modules/mailbox.md
@@ -5,8 +5,8 @@ suppression, and origin-inbox merge primitives.
 
 References:
 
-- Product requirements: `docs/requirements.md` §3.2 and §12
+- Product requirements: `docs/requirements.md` §3.2 and §14
 - `REQ-P-CONTRACT-001`
 - `REQ-P-WORKFLOW-001`
 - `REQ-CORE-MAILBOX-001`
-- Migration artifact: `docs/file-migration-plan.md`
+- Migration artifact: `docs/archive/file-migration-plan.md`

--- a/docs/atm-core/modules/observability.md
+++ b/docs/atm-core/modules/observability.md
@@ -11,7 +11,7 @@ It must not own:
 
 References:
 
-- Product requirements: `docs/requirements.md` §3.5, §10, §11, and §13
+- Product requirements: `docs/requirements.md` §3.5, §10, §11, and §15
 - `REQ-P-LOG-001`
 - `REQ-P-DOCTOR-001`
 - `REQ-P-OBS-001`

--- a/docs/atm-core/modules/read.md
+++ b/docs/atm-core/modules/read.md
@@ -5,7 +5,7 @@ behavior, and readable result shaping for the CLI layer to render.
 
 References:
 
-- Product requirements: `docs/requirements.md` §7 and §12
+- Product requirements: `docs/requirements.md` §7 and §14
 - `REQ-P-READ-001`
 - `REQ-P-WORKFLOW-001`
 - `REQ-CORE-WORKFLOW-001`

--- a/docs/atm-core/modules/send.md
+++ b/docs/atm-core/modules/send.md
@@ -15,10 +15,15 @@ Also owns send-time resilience behavior that is not generic config parsing:
 
 References:
 
-- Product requirements: `docs/requirements.md` §6 and §12
+- Product requirements: `docs/requirements.md` §6 and §14
 - `REQ-P-SEND-001`
 - `REQ-P-WORKFLOW-001`
 - `REQ-P-CONFIG-HEALTH-001`
+- `REQ-CORE-CONFIG-001` for runtime identity precedence and obsolete
+  `[atm].identity` handling
+- `REQ-CORE-CONFIG-002` for alias rewrite and canonical target resolution
 - `REQ-CORE-SEND-001`
+- `REQ-CORE-SEND-002` for `metadata.atm.fromIdentity` placement when
+  cross-team alias projection is used
 - `REQ-CORE-MAILBOX-001`
 - CLI surface: `docs/atm/commands/send.md`

--- a/docs/atm-core/modules/team_admin.md
+++ b/docs/atm-core/modules/team_admin.md
@@ -1,0 +1,25 @@
+# `atm-core::team_admin`
+
+Owns the retained local team recovery surface:
+
+- discovered-team listing
+- local member listing
+- `add-member`
+- team backup
+- team restore
+
+It must not own:
+
+- clap parsing
+- daemon orchestration
+- runtime spawning or launch coordination
+
+References:
+
+- Product requirements: `docs/requirements.md` §12 and §13
+- `REQ-P-TEAMS-001`
+- `REQ-P-MEMBERS-001`
+- `REQ-CORE-TEAM-001`
+- CLI surfaces:
+  - `docs/atm/commands/teams.md`
+  - `docs/atm/commands/members.md`

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -212,7 +212,7 @@ Required config rules:
 - `[atm].post_send_hook_members` may define the sender-identity allowlist for
   that hook
 - `[atm].identity` is obsolete and must not participate in runtime identity
-  resolution
+  resolution; doctor should report it as configuration drift when present
 
 Required identity rules:
 - runtime identity must come from explicit command override, hook identity, or

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -50,7 +50,7 @@ Initial crate requirement IDs:
   resolution policy. Satisfies the path/config/identity aspects of:
   `REQ-P-CONTRACT-001`, `REQ-P-IDENTITY-001`, `REQ-P-DOCTOR-001`.
 - `REQ-CORE-CONFIG-002` `atm-core` owns daemon-free address parsing,
-  alias/role rewrite, and team/member validation policy. Satisfies the address
+  alias rewrite, and team/member validation policy. Satisfies the address
   resolution and target-validation aspects of:
   `REQ-P-ADDRESS-001`, `REQ-P-SEND-001`, `REQ-P-READ-001`,
   `REQ-P-CLEAR-001`.
@@ -186,3 +186,67 @@ Required boundary rules:
 
 Detailed design and implementation shape is owned by:
 - [`design/sc-observability-integration.md`](./design/sc-observability-integration.md)
+
+## 8. Config And Team Baseline Semantics
+
+Requirement ID:
+- `REQ-CORE-CONFIG-001`
+
+Required config rules:
+- `atm-core` reads ATM-owned config only from the `[atm]` section of
+  `.atm.toml`
+- `atm-core` ignores launcher-owned sections such as `[rmux]` and future
+  `[scmux]`
+- `[atm].default_team` remains the shared team default
+- `[atm].team_members` defines the baseline team roster that should always be
+  present in `config.json`
+- `[atm].aliases` may define ATM-owned shorthand names for canonical agent
+  identities
+- `[atm].post_send_hook` may define an ATM-owned helper script/command argv
+- `[atm].post_send_hook_members` may define the sender-identity allowlist for
+  that hook
+- `[atm].identity` is obsolete and must not participate in runtime identity
+  resolution
+
+Required identity rules:
+- runtime identity must come from explicit command override, hook identity, or
+  `ATM_IDENTITY`
+- if no valid runtime identity exists where a command requires one, the command
+  must fail with a structured recovery-oriented error rather than inventing a
+  normal sender identity
+- aliases are input shorthand only until ATM resolves them to canonical member
+  names
+- recipient aliases must resolve before membership validation, self-send
+  checks, and mailbox lookup
+- same-team messages keep current canonical sender projection behavior
+- cross-team messages may persist an alias-oriented `from` value for
+  Claude-facing ergonomics only when ATM also stores canonical sender identity
+  in `metadata.atm.fromIdentity`
+- canonical sender identity remains the source of truth for validation,
+  self-send checks, routing, and audit behavior
+- `post_send_hook_members` matches resolved sender identity, not model name
+- `post_send_hook` runs only after a successful non-`dry-run` send and only
+  when the resolved sender identity is included in `post_send_hook_members`
+- a relative `post_send_hook` path resolves from the discovered `.atm.toml`
+  directory, and the hook executes with that same directory as its working
+  directory
+- the hook inherits process environment and also receives one ATM-owned JSON
+  payload in `ATM_POST_SEND` with:
+  - `from`
+  - `to`
+  - `message_id`
+  - `requires_ack`
+  - optional `task_id`
+- hook failure or timeout is best-effort only and must not roll back a
+  successful send
+- the reserved sender `atm-identity-missing@<team>` is available only for
+  ATM-generated repair/diagnostic notices and must not become a general
+  identity fallback
+
+Required doctor rules:
+- `atm doctor` must flag obsolete `[atm].identity` when present
+- `atm doctor` must compare `[atm].team_members` against `config.json.members`
+- missing baseline members are findings
+- extra runtime members in `config.json` are allowed
+- doctor roster output must show all `config.json` members, with baseline
+  members first and `team-lead` first among the baseline set

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -43,6 +43,7 @@ Initial allocation:
 - `REQ-CORE-LOG-*`
 - `REQ-CORE-DOCTOR-*`
 - `REQ-CORE-OBS-*`
+- `REQ-CORE-TEAM-*`
 
 Initial crate requirement IDs:
 
@@ -89,6 +90,10 @@ Initial crate requirement IDs:
   ATM-owned event/query models above shared crates. Satisfies the ATM event,
   query-model, and health-contract aspects of:
   `REQ-P-OBS-001`.
+- `REQ-CORE-TEAM-001` `atm-core` owns the retained local team discovery,
+  roster inspection, roster repair, and backup/restore behavior. Satisfies the
+  local team-surface aspects of:
+  `REQ-P-TEAMS-001`, `REQ-P-MEMBERS-001`.
 
 ## 4. Module Ownership
 
@@ -103,6 +108,7 @@ Per-module documentation lives under:
 - [`modules/mailbox.md`](./modules/mailbox.md)
 - [`modules/config.md`](./modules/config.md)
 - [`modules/observability.md`](./modules/observability.md)
+- [`modules/team_admin.md`](./modules/team_admin.md)
 
 Each module document defines:
 
@@ -250,3 +256,35 @@ Required doctor rules:
 - extra runtime members in `config.json` are allowed
 - doctor roster output must show all `config.json` members, with baseline
   members first and `team-lead` first among the baseline set
+
+## 9. Retained Team Recovery Surface
+
+Requirement ID:
+- `REQ-CORE-TEAM-001`
+
+Required service rules:
+- `atm-core` owns the retained local team recovery surface for:
+  - discovered-team listing
+  - local member listing
+  - `add-member`
+  - team backup
+  - team restore
+- these services remain local file/config/inbox operations and must not depend
+  on daemon orchestration or runtime spawning
+- `add-member` must validate team existence and reject duplicate member names
+  before mutating local team config
+- backup must snapshot:
+  - `config.json`
+  - team inbox files
+  - the ATM team task bucket
+- restore must:
+  - preserve the current team-lead entry and current `leadSessionId`
+  - add only missing non-lead members from the snapshot
+  - clear runtime-only restored-member fields such as session or pane state
+  - restore non-lead inboxes
+  - recompute `.highwatermark` from the maximum restored task id
+  - support a dry-run path without making changes
+- malformed or missing snapshot material must fail with structured errors
+  before partial restore is committed
+- `members` must remain useful as a local roster inspection command even when
+  daemon or hook state is unavailable

--- a/docs/atm-message-schema.md
+++ b/docs/atm-message-schema.md
@@ -77,6 +77,7 @@ Forward write target for ATM-owned machine-readable fields:
 
 - `messageId`
 - `sourceTeam`
+- `fromIdentity`
 - `pendingAckAt`
 - `acknowledgedAt`
 - `acknowledgesMessageId`
@@ -106,11 +107,16 @@ Enrichment rule:
 - enrichment must be additive and idempotent
 - ATM must not rewrite native Claude fields such as `from`, `text`,
   `timestamp`, `read`, or `summary` in order to attach ATM metadata
+- exception: when cross-team alias projection is intentionally used, ATM may
+  retain the Claude-facing alias in `from` only when canonical sender identity
+  is also recorded in `metadata.atm.fromIdentity`
 
 Forward placement map:
 
 - legacy top-level `message_id` migrates to `metadata.atm.messageId`
 - legacy top-level `source_team` migrates to `metadata.atm.sourceTeam`
+- cross-team alias projection stores canonical sender identity in
+  `metadata.atm.fromIdentity`
 - legacy top-level `pendingAckAt` remains `metadata.atm.pendingAckAt`
 - legacy top-level `acknowledgedAt` remains `metadata.atm.acknowledgedAt`
 - legacy top-level `acknowledgesMessageId` remains

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -16,6 +16,8 @@ The `atm` crate is responsible for:
 - output selection and rendering
 - process exit status mapping
 - constructing and injecting the concrete observability adapter
+- maintaining the retained CLI subcommand surface, including `teams` and
+  `members`
 
 The `atm` crate must remain thin.
 
@@ -28,6 +30,8 @@ The `atm` crate must remain thin.
   `atm-core`.
 - `atm` owns the temporary pre-publish dependency wiring for a local
   `sc-observability` checkout until the shared crates are published.
+- `atm` owns the retained local recovery CLI shape for `teams` and `members`,
+  but not the underlying team/backup/restore business rules
 
 ## 4. ADR Namespace
 

--- a/docs/atm/commands/doctor.md
+++ b/docs/atm/commands/doctor.md
@@ -16,6 +16,8 @@ References:
 - `REQ-ATM-CMD-001`
 - `REQ-ATM-OUT-001`
 - `REQ-ATM-OBS-001`
+- `REQ-CORE-CONFIG-001` for obsolete `[atm].identity` configuration drift and
+  baseline `[atm].team_members` checks
 - Product architecture: `docs/architecture.md`
 - Core modules:
   - `docs/atm-core/modules/doctor.md`

--- a/docs/atm/commands/members.md
+++ b/docs/atm/commands/members.md
@@ -1,0 +1,20 @@
+# `atm members`
+
+CLI ownership for `atm members`:
+
+- flag parsing
+- conversion into `atm-core` member-list requests
+- human-readable output
+- JSON output
+
+Core roster loading and deterministic member projection remain owned by
+`atm-core`.
+
+References:
+
+- Product requirements: `docs/requirements.md` §13
+- `REQ-P-MEMBERS-001`
+- `REQ-ATM-CMD-001`
+- `REQ-ATM-OUT-001`
+- Product architecture: `docs/architecture.md`
+- Core module: `docs/atm-core/modules/team_admin.md`

--- a/docs/atm/commands/send.md
+++ b/docs/atm/commands/send.md
@@ -15,5 +15,8 @@ References:
 - `REQ-P-SEND-001`
 - `REQ-ATM-CMD-001`
 - `REQ-ATM-OUT-001`
+- `REQ-CORE-CONFIG-002` for alias rewrite before canonical target resolution
+- `REQ-CORE-SEND-002` for cross-team `from` projection with
+  `metadata.atm.fromIdentity`
 - Product architecture: `docs/architecture.md`
 - Core module: `docs/atm-core/modules/send.md`

--- a/docs/atm/commands/teams.md
+++ b/docs/atm/commands/teams.md
@@ -1,0 +1,20 @@
+# `atm teams`
+
+CLI ownership for `atm teams`:
+
+- subcommand and flag parsing for the retained local team recovery surface
+- conversion into `atm-core` team recovery requests
+- human-readable output
+- JSON output
+
+Core team discovery, roster mutation, and backup/restore behavior remains
+owned by `atm-core`.
+
+References:
+
+- Product requirements: `docs/requirements.md` §12
+- `REQ-P-TEAMS-001`
+- `REQ-ATM-CMD-001`
+- `REQ-ATM-OUT-001`
+- Product architecture: `docs/architecture.md`
+- Core module: `docs/atm-core/modules/team_admin.md`

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -43,11 +43,13 @@ Initial crate requirement IDs:
   dispatch for the retained command surface. Satisfies the CLI
   entry/parse/dispatch aspects of:
   `REQ-P-SEND-001`, `REQ-P-READ-001`, `REQ-P-ACK-001`, `REQ-P-CLEAR-001`,
-  `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`.
+  `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`, `REQ-P-TEAMS-001`,
+  `REQ-P-MEMBERS-001`.
 - `REQ-ATM-OUT-001` `atm` owns human-readable and JSON rendering for retained
   commands. Satisfies the output-shaping and rendering aspects of:
   `REQ-P-SEND-001`, `REQ-P-READ-001`, `REQ-P-ACK-001`, `REQ-P-CLEAR-001`,
-  `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`.
+  `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`, `REQ-P-TEAMS-001`,
+  `REQ-P-MEMBERS-001`.
 - `REQ-ATM-OBS-001` `atm` owns concrete observability bootstrap and injection
   into `atm-core`. Satisfies the CLI bootstrap/injection aspects of:
   `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`, `REQ-P-OBS-001`.
@@ -76,6 +78,8 @@ Per-command documentation lives under:
 - [`commands/clear.md`](./commands/clear.md)
 - [`commands/log.md`](./commands/log.md)
 - [`commands/doctor.md`](./commands/doctor.md)
+- [`commands/teams.md`](./commands/teams.md)
+- [`commands/members.md`](./commands/members.md)
 
 Each command document defines:
 

--- a/docs/claude-code-message-schema.md
+++ b/docs/claude-code-message-schema.md
@@ -61,7 +61,8 @@ Current ATM implication:
 - ATM must not invent a replacement Claude-native idle schema.
 - ATM may enrich a Claude-native message only by adding ATM-owned metadata as
   documented in [`atm-message-schema.md`](./atm-message-schema.md); it must not
-  rewrite the native Claude fields to do so.
+  rewrite the native Claude fields to do so except for the explicitly
+  documented ATM-owned cross-team alias projection carve-out on `from`.
 
 Validation rule:
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -537,18 +537,142 @@ Planned sprints:
   - dependency note:
     - uses `sc-observability = "1.0.0"` from crates.io directly
 
-- `L.4` Switch To Published crates.io Release [COMPLETE — done in K-CRATES-IO-1]
-  - completed 2026-04-06 via sprint K-CRATES-IO-1 on branch feature/pK-crates-io
-  - commit: 1ce2369f; merged to integrate/phase-K via PR #46, then to develop
-    via PR #45 at e4b8fcf
-  - the `[patch.crates-io]` override is removed; ATM uses crates.io `"1.0.0"`
+- `L.4` Public API Cleanup
+  - goal: remove raw serialization-format leakage from the `atm-core` public
+    observability boundary while preserving centralized JSON handling inside
+    `atm-core`
+  - key tasks:
+    - replace public `serde_json::Value` / `Map<String, Value>` usage in
+      observability-facing `atm-core` types with ATM-owned domain types or
+      wrappers
+    - keep JSON/JSONL parsing, validation, degradation, and repair centralized
+      in `atm-core` rather than pushing that logic into CLI or sibling crates
+    - preserve the published CLI JSON output behavior after the public type
+      cleanup
+  - closes:
+    - `INTEROP-001`
+    - `BP-003`
+
+- `L.5` Construction And Boundary Ergonomics
+  - goal: clean up the remaining release-surface ergonomics without forcing
+    speculative refactors that are not yet justified
+  - key tasks:
+    - add a structured `CliObservability` construction path (`new(...)` or an
+      equivalent minimal builder) so CLI bootstrap and tests do not assemble
+      the adapter through ad hoc wiring
+    - review the current boxed trait-object dispatch and sealed-trait pattern;
+      implement a change only when it clearly improves the release design
+    - record an explicit disposition for `DoctorCommand` injectability:
+      - optional for initial release unless a concrete testing or feature need
+        appears during implementation
+  - closes:
+    - `UX-001`
+    - `BP-004`
+    - disposition of `UX-002`
+    - disposition of `BP-001`
+    - disposition of `UNI-003`
+
+- `L.6` Release Closeout
+  - goal: finish the remaining operator-facing and release-readiness validation
+    against the published shared crate behavior
+  - key tasks:
+    - verify file sink path alignment against upstream issue `#21`
+    - rerun full ATM observability validation on the published
+      `sc-observability = "1.0.0"` release
+    - close any remaining documentation traceability gaps uncovered during the
+      Phase L consistency review
+  - result:
+    - release-ready ATM observability signoff for initial release
+
+- `L.7` Team Baseline And Identity Source Cleanup
+  - goal: align ATM config semantics with multi-agent team launches by moving
+    shared team expectations into `.atm.toml` while removing repo-local
+    identity fallback behavior and defining cross-team alias handling
+  - key tasks:
+    - add ATM-owned `team_members` support under the `[atm]` config section as
+      the baseline roster that should always be present in `config.json`
+    - retain ATM-owned `aliases` support under the `[atm]` config section for
+      shorthand addressing of canonical members, especially cross-team
+      communication with roles such as `team-lead`
+    - add ATM-owned `post_send_hook` and `post_send_hook_members` support under
+      the `[atm]` config section for short-term sender-scoped post-send
+      automation
+    - stop using `[atm].identity` as a runtime identity fallback; identity must
+      come from explicit CLI override, hook identity, or `ATM_IDENTITY`
+    - treat `[atm].identity` as an obsolete field: ignored by runtime identity
+      resolution and flagged by `atm doctor` as configuration drift that should
+      be removed
+    - keep `[atm].default_team` as the shared team default and continue to
+      ignore `[rmux]` and future `[scmux]` sections from `atm-core`
+    - update `atm doctor` to compare `[atm].team_members` against
+      `config.json.members`
+      - missing baseline members are findings
+      - extra runtime members in `config.json` are allowed
+    - update `atm doctor` roster output to show all `config.json` members with
+      baseline members first, `team-lead` first among the baseline set, and
+      extra runtime members afterward
+    - define alias resolution and projection rules:
+      - aliases are accepted as input shorthand only
+      - recipient aliases resolve immediately to canonical member names before
+        validation, self-send checks, and mailbox lookup
+      - same-team messages keep current canonical `from` behavior
+      - cross-team messages may project the sender alias in `from` for
+        Claude-facing ergonomics
+      - whenever alias-oriented `from` projection is used, canonical sender
+        identity must also be persisted in `metadata.atm.fromIdentity` and
+        must drive validation, self-send checks, routing, and audit behavior
+    - define post-send-hook rules:
+      - the hook runs only after a successful non-`dry-run` send
+      - the hook runs only when the resolved sender identity is listed in
+        `post_send_hook_members`
+      - the hook path may be relative and must resolve from the directory that
+        owns the discovered `.atm.toml`
+      - the hook must execute with that same config-root directory as its
+        working directory
+      - the hook inherits the process environment and also receives one
+        ATM-owned JSON payload in `ATM_POST_SEND`
+      - the `ATM_POST_SEND` payload must contain:
+        - `from`
+        - `to`
+        - `message_id`
+        - `requires_ack`
+        - optional `task_id`
+      - hook failure or timeout must never roll back the send; ATM reports the
+        failure as post-send-hook diagnostics only
+    - reserve `atm-identity-missing@<team>` for ATM-generated
+      repair/diagnostic notices only; it must not become a normal sender
+      identity fallback
+  - closes:
+    - config identity/source ambiguity for multi-agent shared repos
+    - baseline-roster visibility gap in `atm doctor`
+    - cross-team alias ambiguity for baseline roles such as `team-lead`
+    - missing sender-scoped post-send automation contract for repo-root helper
+      scripts
+    - duplicate permanent-member spawn planning gap for future team-lead /
+      hook-driven orchestration
+
+Recovered Phase K carry-in mapping:
+
+- `ATM-QA-K-001` and `ATM-QA-K-002` are canonical Phase L.2 work items
+- `RUST-QA-001`, `PRR-002`, and the L.1 QA traceability gap `ATM-QA-002` are
+  canonical Phase L.3 work items
+- `INTEROP-001` and duplicate `BP-003` are canonical Phase L.4 work items
+- `UX-001` and duplicate `BP-004` are canonical Phase L.5 work items
+- `UX-002`, `BP-001`, and `UNI-003` are Phase L.5 decision/disposition items;
+  each must either land as implementation work or be explicitly deferred by a
+  documented Phase L architectural ruling
+- config identity/source cleanup and baseline team roster enforcement are
+  canonical Phase L.7 work items
 
 Acceptance:
-- Phase L covers stderr console routing, fault-injected live validation, and
-  file sink path migration — all against the published crates.io release
-- the phase preserves the ATM-owned adapter boundary and does not redefine the
-  shared crate ownership split established in Phase K
-- `L.4` is already complete; `L.1` through `L.3` are the remaining sprints
+- Phase L cannot close until:
+  - `L.2` through `L.7` are complete
+  - every mapped carry-in item above is either implemented or explicitly
+    deferred by a documented Phase L architectural decision
+  - retained observability behavior is validated against the published
+    crates.io dependency `sc-observability = "1.0.0"`
+- the phase must preserve ATM’s initial-release focus on agent messaging and
+  must not absorb future hook/`schooks` orchestration concerns prematurely
 
 ## 5. Hard Rules
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2,7 +2,10 @@
 
 ## 1. Goal
 
-Implement a daemon-free ATM rewrite in this repo that preserves retained `send`, `read`, `ack`, `clear`, `log`, and `doctor` functionality.
+Implement a daemon-free ATM rewrite in this repo that preserves retained
+`send`, `read`, `ack`, `clear`, `log`, and `doctor` functionality and restores
+the minimum release-critical team recovery surface through `teams` and
+`members`.
 
 The authoritative migration document is:
 - [`docs/archive/file-migration-plan.md`](./archive/file-migration-plan.md)
@@ -19,8 +22,8 @@ Status:
 - Phases 0 through F and J are complete.
 - Phase K is complete and ready to roll forward into shared 1.0 release
   alignment work.
-- Phase L is now the latest observability follow-on phase and the next active
-  delivery focus.
+- Phase L is now the latest release-alignment and retained-surface follow-on
+  phase and the next active delivery focus.
 - Phases G and H remain retained-command phases, but their implementation work
   depends on the concrete `sc-observability` integration delivered in Phase K
   and the release-alignment work planned in Phase L.
@@ -31,7 +34,8 @@ Status:
 ## 2. Deliverables
 
 - Rust workspace with `crates/atm-core` and `crates/atm`
-- daemon-free implementation of `send`, `read`, `ack`, `clear`, `log`, and `doctor`
+- daemon-free implementation of `send`, `read`, `ack`, `clear`, `log`,
+  `doctor`, `teams`, and `members`
 - preserved non-daemon mail functionality from the current codebase
 - explicit two-axis workflow model with three display buckets
 - task-linked message metadata with mandatory ack behavior
@@ -106,7 +110,7 @@ Status summary:
 
 | Sprint | Scope | Required outcome |
 | --- | --- | --- |
-| B.1 | CLI skeleton | `atm` exposes exactly `send`, `read`, `ack`, `clear`, `log`, `doctor` as clap subcommands and all CI gates pass |
+| B.1 | CLI skeleton | `atm` exposes the initial core messaging surface: `send`, `read`, `ack`, `clear`, `log`, `doctor` |
 | B.2 | Documentation gap closure | lock the remaining send/read/clear requirements and architecture details before Phase C begins |
 
 Create:
@@ -117,7 +121,8 @@ Create:
 
 Acceptance:
 - workspace builds
-- CLI help shows `send`, `read`, `ack`, `clear`, `log`, and `doctor`
+- CLI help shows the initial core messaging surface: `send`, `read`, `ack`,
+  `clear`, `log`, and `doctor`
 - B.1 and B.2 are both complete before Phase C starts
 - requirements and architecture lock the message id, read dedupe, and clear
   eligibility semantics needed for implementation
@@ -449,23 +454,25 @@ Acceptance:
 - any generic shared-crate usability gaps discovered during implementation are
   filed upstream in `sc-observability`
 
-### Phase L: `sc-observability` 1.0 Alignment [NEXT / LATEST]
+### Phase L: 1.0 Alignment And Release Surface Cleanup [NEXT / LATEST]
 
 Status summary:
 - Phase K delivered the full sc-observability integration against a pre-publish
   local `[patch.crates-io]` override
 - Sprint K-CRATES-IO-1 (2026-04-06) removed the override and switched ATM to
   the published `sc-observability = "1.0.0"` on crates.io; CI passed on all
-  platforms; this sprint completed what was originally scoped as `L.4`
+  platforms; this sprint completed the earlier crates.io cutover work, which
+  is now tracked historically under `K-CRATES-IO-1` rather than as an open
+  Phase L sprint
 - sc-observability 1.0.0 ships issues #55 (ConsoleSink::stderr), #57 (fault
   injection), and #21 (file sink path migration) — all confirmed shipped in
   PR #58 of sc-observability
-- `L.4` is therefore COMPLETE; `L.1` through `L.3` proceed directly against
-  the published crates.io release with no local override required
+- `L.1` through `L.8` therefore proceed directly against the published
+  crates.io release with no local override required
 
 Goal:
-- adopt the three sc-observability 1.0 surface improvements (#55, #57, #21)
-  into the ATM integration layer now that the published crates are available
+- finish the published `sc-observability` 1.0 follow-on work and close the
+  remaining retained release-surface gaps required for initial ATM release
 
 Execution model:
 - this phase is implemented as a coordinated multi-sprint stream owned by
@@ -474,7 +481,8 @@ Execution model:
   review hand-offs using the `/codex-orchestration` skill
 - the Phase K adapter boundary remains the governing implementation boundary;
   Phase L refines the ATM-side integration against the final 1.0 shared crate
-  behavior rather than redefining crate ownership
+  behavior and closes retained release-surface gaps rather than redefining
+  crate ownership
 - the detailed ATM-side 1.0 follow-on decisions are documented in:
   [`docs/atm-core/design/sc-obs-1.0-integration.md`](./atm-core/design/sc-obs-1.0-integration.md)
 - all sprints use `sc-observability = "1.0.0"` from crates.io directly; no
@@ -552,6 +560,9 @@ Planned sprints:
   - closes:
     - `INTEROP-001`
     - `BP-003`
+  - dependency note:
+    - can proceed in parallel with `L.5` once the Phase K crates.io baseline
+      from `K-CRATES-IO-1` is present
 
 - `L.5` Construction And Boundary Ergonomics
   - goal: clean up the remaining release-surface ergonomics without forcing
@@ -571,6 +582,9 @@ Planned sprints:
     - disposition of `UX-002`
     - disposition of `BP-001`
     - disposition of `UNI-003`
+  - dependency note:
+    - may run in parallel with `L.4`, or immediately after it if the public
+      API cleanup changes the preferred construction boundary
 
 - `L.6` Release Closeout
   - goal: finish the remaining operator-facing and release-readiness validation
@@ -583,6 +597,9 @@ Planned sprints:
       Phase L consistency review
   - result:
     - release-ready ATM observability signoff for initial release
+  - dependency note:
+    - depends on `L.1` through `L.5` being complete so release validation runs
+      against the final observability surface
 
 - `L.7` Team Baseline And Identity Source Cleanup
   - goal: align ATM config semantics with multi-agent team launches by moving
@@ -650,8 +667,56 @@ Planned sprints:
       scripts
     - duplicate permanent-member spawn planning gap for future team-lead /
       hook-driven orchestration
+  - dependency note:
+    - independent of `L.1` through `L.3`; it may proceed in parallel once the
+      Phase L config and identity rulings are locked
 
-Recovered Phase K carry-in mapping:
+- `L.8` Retained Team Recovery Surface
+  - goal: restore the minimum `teams` and `members` command surface required
+    for initial release, backup/restore operations, and team-repair workflows
+  - key tasks:
+    - implement bare `atm teams` to list locally discovered teams under
+      `ATM_HOME`
+    - implement `atm members` as a local team-roster view suitable for restore
+      verification and operator checks without requiring daemon or hook state
+    - implement `atm teams add-member` as the retained local roster repair path
+      for missing members after restore or config drift
+    - implement `atm teams backup` as a timestamped local snapshot of
+      `config.json`, team inboxes, and the ATM team task bucket
+    - implement `atm teams restore` with a dry-run path and explicit restore
+      safety rules:
+      - preserve the current team-lead entry and `leadSessionId`
+      - restore only missing non-lead members
+      - clear runtime-only fields such as session/activity/pane state on
+        restored members
+      - restore non-lead inbox files from the chosen snapshot
+      - recompute `.highwatermark` from the maximum restored task id
+      - fail cleanly on missing or malformed backup material without partial
+        restore
+    - keep broader historical team lifecycle/orchestration commands out of
+      scope:
+      - `spawn`
+      - `join`
+      - `resume`
+      - `update-member`
+      - `remove-member`
+      - `cleanup`
+  - tests:
+    - `teams` lists discovered teams deterministically
+    - `members` lists the current local roster deterministically
+    - `add-member` rejects duplicates and creates any required local inbox
+      state atomically
+    - `backup` produces a complete snapshot of team config, inboxes, and ATM
+      task files
+    - `restore --dry-run` reports members/inboxes/tasks that would be restored
+    - `restore` preserves team-lead / `leadSessionId`, clears runtime-only
+      restored-member state, and recomputes `.highwatermark` to the maximum
+      restored task id
+  - dependency note:
+    - depends on the Phase L config semantics from `L.7`, but does not depend
+      on the observability-specific `L.1` through `L.6` work
+
+Recovered Phase K carry-in mapping and later planning carry-ins:
 
 - `ATM-QA-K-001` and `ATM-QA-K-002` are canonical Phase L.2 work items
 - `RUST-QA-001`, `PRR-002`, and the L.1 QA traceability gap `ATM-QA-002` are
@@ -662,15 +727,22 @@ Recovered Phase K carry-in mapping:
   each must either land as implementation work or be explicitly deferred by a
   documented Phase L architectural ruling
 - config identity/source cleanup and baseline team roster enforcement are
-  canonical Phase L.7 work items
+  canonical Phase L.7 work items identified by the phase-close planning review
+  on 2026-04-07 rather than by numbered Phase K implementation findings
+- the retained `teams` / `members` release-gap closure is canonical Phase L.8
+  work identified during the same release-planning review and backup/restore
+  procedure audit
 
 Acceptance:
 - Phase L cannot close until:
-  - `L.2` through `L.7` are complete
+  - `L.2` through `L.8` are complete
   - every mapped carry-in item above is either implemented or explicitly
     deferred by a documented Phase L architectural decision
   - retained observability behavior is validated against the published
     crates.io dependency `sc-observability = "1.0.0"`
+  - the retained release-critical team recovery surface (`teams`, `members`,
+    `teams add-member`, `teams backup`, `teams restore`) is implemented and
+    validated
 - the phase must preserve ATM’s initial-release focus on agent messaging and
   must not absorb future hook/`schooks` orchestration concerns prematurely
 
@@ -708,6 +780,8 @@ The rewrite is ready when:
 - `atm clear` works without daemon support
 - `atm log` works through shared observability APIs
 - `atm doctor` works as a local diagnostics command
+- `atm teams` provides the retained local team recovery surface
+- `atm members` provides retained local roster verification
 - retained non-daemon functionality is preserved or intentionally documented as changed
 - task-linked mail remains pending until acknowledged
 - the file-by-file migration plan is complete enough to implement directly
@@ -720,6 +794,10 @@ Before implementation starts, the docs should be reviewed with these checks:
   surface appears in `docs/archive/file-migration-plan.md`
 - `requirements.md`, `architecture.md`, and `read-behavior.md` agree on the two-axis model, three display buckets, and legal transitions
 - `requirements.md`, `architecture.md`, and `read-behavior.md` agree on `--since`, `--since-last-seen`, `--no-since-last-seen`, `--no-update-seen`, and `--timeout`
-- `requirements.md`, `architecture.md`, and
-  `docs/archive/file-migration-plan.md` agree on the retained command set:
-  `send`, `read`, `ack`, `clear`, `log`, `doctor`
+- `requirements.md`, `architecture.md`, `docs/atm/requirements.md`, and
+  `docs/atm/architecture.md` agree on the retained release surface:
+  `send`, `read`, `ack`, `clear`, `log`, `doctor`, `teams`, `members`
+- `docs/archive/file-migration-plan.md` remains the source of truth for the
+  initial core migration set (`send`, `read`, `ack`, `clear`, `log`,
+  `doctor`), and the release-only `teams` / `members` expansion is explicitly
+  tracked in Phase `L.8`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -4,7 +4,7 @@
 
 Product requirement ID:
 - `REQ-P-PRODUCT-001` The retained daemon-free ATM product surface consists of
-  `send`, `read`, `ack`, `clear`, `log`, and `doctor`.
+  `send`, `read`, `ack`, `clear`, `log`, `doctor`, `teams`, and `members`.
 
 Satisfied by:
 - intentionally undecomposed product requirement; this governs overall retained
@@ -21,6 +21,8 @@ The retained product surface is:
 - `atm clear`
 - `atm log`
 - `atm doctor`
+- `atm teams`
+- `atm members`
 
 The rewritten system must preserve usable non-daemon behavior already present in the retained commands unless these requirements explicitly retire or change it.
 
@@ -87,6 +89,14 @@ Satisfied by:
 - structured logging through `sc-observability`
 - log query and follow through `sc-observability`
 - local diagnostics through `atm doctor`
+- local team discovery and recovery through `atm teams`
+- local roster verification through `atm members`
+- the retained local team recovery surface:
+  - `atm teams`
+  - `atm members`
+  - `atm teams add-member`
+  - `atm teams backup`
+  - `atm teams restore`
 - task metadata carried in the mail envelope
 - JSON output mode
 - human-readable output mode
@@ -102,7 +112,9 @@ Satisfied by:
 - runtime spawning and launch commands
 - `atm status` in the initial rewrite
 - separate `atm tail` command in the initial rewrite
-- team lifecycle management outside what the retained commands need
+- team lifecycle management outside the retained local recovery surface
+  (`atm teams`, `atm members`, `atm teams add-member`, `atm teams backup`,
+  `atm teams restore`)
 
 ## 3. External Contracts
 
@@ -209,10 +221,10 @@ Required config fields:
 - default team
 
 Supported optional config fields:
-- team members baseline roster
-- aliases map
-- post-send hook
-- post-send hook member allowlist
+- `[atm].team_members`
+- `[atm].aliases`
+- `[atm].post_send_hook`
+- `[atm].post_send_hook_members`
 
 Runtime identity rules:
 - repo-local `.atm.toml` identity is not a valid runtime identity fallback for
@@ -475,7 +487,7 @@ Forward schema requirements:
 
 `message_id` is required on every message written by `atm send`.
 
-`message_id` is optional in the persisted schema (§12.1) only to support
+`message_id` is optional in the persisted schema (§14.1) only to support
 legacy messages written by older clients, but `atm send` never omits it.
 
 Recipients use `message_id` for:
@@ -994,7 +1006,7 @@ The initial doctor implementation must cover:
 - config file discovery and parse health
 - effective team resolution
 - identity resolution inputs and fallbacks
-- obsolete ATM config identity detection
+- obsolete `[atm].identity` configuration drift detection
 - baseline `[atm].team_members` coverage against `config.json.members`
 - team directory existence
 - team config existence and parse health
@@ -1030,7 +1042,153 @@ Each doctor finding must expose at least:
 
 Critical findings must cause a non-zero exit status.
 
-## 12. Message And Workflow Model
+## 12. `atm teams`
+
+Product requirement ID:
+- `REQ-P-TEAMS-001` `atm teams` must satisfy the documented retained local
+  team recovery contract.
+
+Satisfied by:
+- `REQ-ATM-CMD-001` for CLI entry, parsing, and dispatch aspects
+- `REQ-ATM-OUT-001` for human-readable and JSON output aspects
+- `REQ-CORE-TEAM-001` for local team discovery, roster mutation, and
+  backup/restore behavior
+
+### 12.1 Purpose
+
+Provide the minimum retained local team-recovery surface required for initial
+release and the documented backup/restore workflow.
+
+### 12.2 Retained Surface
+
+The retained `teams` surface for initial release is:
+- `atm teams`
+- `atm teams add-member`
+- `atm teams backup`
+- `atm teams restore`
+
+The retained surface explicitly does not include broader historical team
+orchestration commands such as:
+- `spawn`
+- `join`
+- `resume`
+- `update-member`
+- `remove-member`
+- `cleanup`
+
+### 12.3 Required Behavior
+
+Bare `atm teams` must:
+- list discovered teams under ATM home deterministically
+- expose at least team name plus enough summary information, such as member
+  count, to pick a target team for restore or repair work
+
+`atm teams add-member` must:
+- validate that the target team exists
+- reject duplicate member names
+- persist the new member entry deterministically in team config
+- create any required local inbox state atomically with the roster update
+
+`atm teams backup` must:
+- create a timestamped snapshot under the ATM team backup area
+- capture the current `config.json`
+- capture team inbox files
+- capture the ATM team task bucket
+- report the created backup path in human and JSON output
+- not claim to back up the separate Claude Code project task list
+
+`atm teams restore` must:
+- restore from the newest snapshot by default or from an explicit backup path
+- support a dry-run mode that reports members, inboxes, and tasks that would
+  be restored
+- preserve the current team-lead entry and current `leadSessionId`
+- add only missing non-lead members from the snapshot
+- clear runtime-only restored-member fields such as session, activity, and
+  pane state before persisting them
+- restore non-lead inbox files from the chosen snapshot deterministically
+- restore the ATM team task bucket and recompute `.highwatermark` from the
+  maximum restored task id
+- fail with a structured error when backup material is missing or malformed
+- avoid partial restore on validation or snapshot-load failure
+
+### 12.4 Output Contract
+
+Human output must make the performed action and target team clear.
+
+JSON output must include:
+- `action`
+- `team`
+
+`add-member` JSON output must additionally include:
+- `member`
+
+`backup` JSON output must additionally include:
+- `backup_path`
+
+`restore` JSON output must additionally include:
+- `backup_path`
+- `members_restored`
+- `inboxes_restored`
+- `tasks_restored`
+
+Dry-run `restore` JSON output must additionally include:
+- `dry_run = true`
+- `would_restore_members`
+- `would_restore_inboxes`
+- `would_restore_tasks`
+
+## 13. `atm members`
+
+Product requirement ID:
+- `REQ-P-MEMBERS-001` `atm members` must satisfy the documented local roster
+  inspection contract.
+
+Satisfied by:
+- `REQ-ATM-CMD-001` for CLI entry, parsing, and dispatch aspects
+- `REQ-ATM-OUT-001` for human-readable and JSON output aspects
+- `REQ-CORE-TEAM-001` for local roster loading and deterministic projection
+
+### 13.1 Purpose
+
+List the current local team roster for verification, recovery, and restore
+follow-up without depending on daemon-only or hook-only state.
+
+### 13.2 Supported Flags
+
+- `--team <name>`
+- `--json`
+
+### 13.3 Required Behavior
+
+`atm members` must:
+- resolve the effective team using the retained team-resolution rules
+- load the local team roster from `config.json`
+- return a structured error when the team or team config is missing
+- show all configured members deterministically, with `team-lead` first when
+  present and remaining members in stable local order
+- expose currently persisted member metadata that ATM already knows locally,
+  such as type, model, cwd, or pane id when present in config
+- remain useful without daemon or hook state
+
+Richer runtime state, such as live session or activity data, may be layered on
+later, but it is not required for the retained local release surface.
+
+### 13.4 Output Contract
+
+Human output must show:
+- team name
+- one row per member
+- enough persisted member detail to verify roster repair or restore outcomes
+
+JSON output must include:
+- `team`
+- `members`
+
+Each member object must expose at least:
+- `name`
+- persisted local member metadata when present
+
+## 14. Message And Workflow Model
 
 Product requirement ID:
 - `REQ-P-WORKFLOW-001` The message/workflow model must satisfy the documented
@@ -1040,7 +1198,7 @@ Satisfied by:
 - `REQ-CORE-WORKFLOW-001` for the canonical two-axis model and legal
   transitions
 
-### 12.1 Persisted Message Fields
+### 14.1 Persisted Message Fields
 
 Required fields:
 - `from`
@@ -1069,7 +1227,7 @@ For ATM-authored messages:
 Legacy or externally imported records may still omit `message_id`; the rewrite
 must preserve such records without inventing synthetic ids during read.
 
-### 12.2 Two-Axis Canonical Model
+### 14.2 Two-Axis Canonical Model
 
 The canonical model has two independent axes.
 
@@ -1099,7 +1257,7 @@ Derived message class for queue logic:
 
 The canonical two-axis model is distinct from the read command’s display buckets.
 
-### 12.3 Required State Transitions
+### 14.3 Required State Transitions
 
 ```text
 Send normal message
@@ -1146,7 +1304,7 @@ Disallowed transitions:
 
 The implementation must encode legal transitions in code structure, not only in comments or tests.
 
-### 12.4 Task Metadata Rule
+### 14.4 Task Metadata Rule
 
 Messages with `taskId` are task-linked messages.
 
@@ -1156,7 +1314,7 @@ Required rules:
 - a task-linked message must continue to appear in `atm read` until acknowledged
 - a task-linked message must never be removed by `atm clear` before acknowledgement
 
-## 13. Observability Requirements
+## 15. Observability Requirements
 
 Product requirement ID:
 - `REQ-P-OBS-001` ATM observability must satisfy the documented best-effort
@@ -1221,7 +1379,7 @@ Diagnostic logging rules:
 - they are explicit observability consumers
 - if shared query/health APIs are unavailable, they must fail with clear structured errors
 
-## 14. Error Requirements
+## 16. Error Requirements
 
 Product requirement ID:
 - `REQ-P-ERROR-001` Public command failures must satisfy the documented
@@ -1266,7 +1424,7 @@ Mutation failures must be fail-safe:
 - no partial read-mark updates
 - no illegal state transitions after failed persistence
 
-## 15. Reliability Requirements
+## 17. Reliability Requirements
 
 Product requirement ID:
 - `REQ-P-RELIABILITY-001` The retained command surface must satisfy the
@@ -1291,7 +1449,7 @@ Satisfied by:
 - seen-state races must not corrupt mailbox data
 - observability emission failures must not corrupt command behavior
 
-## 16. Testing Requirements
+## 18. Testing Requirements
 
 Product requirement ID:
 - `REQ-P-TEST-001` The rewrite must satisfy the documented testing obligations.
@@ -1310,6 +1468,13 @@ Because `sc-observability` is newly introduced into ATM, the rewrite must add ex
 - log query by structured field match
 - log follow/tail behavior
 - doctor observability-health reporting
+- teams list behavior over the local ATM home
+- members list behavior over local team config
+- add-member duplicate validation and inbox creation
+- backup snapshot completeness
+- restore dry-run reporting
+- restore preservation of team-lead / `leadSessionId`
+- restore recomputation of `.highwatermark` to the maximum restored task id
 - retained mail-command correctness when observability emission fails
 - clear eligibility behavior
 
@@ -1319,8 +1484,10 @@ The implementation must include:
 - CLI integration tests for `atm doctor`
 - CLI integration tests for `atm ack`
 - CLI integration tests for `atm clear`
+- CLI integration tests for `atm teams`
+- CLI integration tests for `atm members`
 
-## 17. Acceptance Criteria
+## 19. Acceptance Criteria
 
 Product requirement ID:
 - `REQ-P-ACCEPTANCE-001` The rewrite is complete only when the documented
@@ -1337,6 +1504,8 @@ The rewrite is ready when:
 - `atm clear` works without daemon support
 - `atm log` works through shared `sc-observability` APIs
 - `atm doctor` works as a local diagnostics command
+- `atm teams` provides the retained local team recovery surface
+- `atm members` provides the retained local roster verification surface
 - retained commands preserve documented non-daemon behavior
 - workflow-axis classification is correct
 - workflow-axis transitions are encoded in implementation structure

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -170,7 +170,9 @@ Required rules:
   fields such as `metadata.atm.alertKind` and
   `metadata.atm.missingConfigPath`
 - ATM may enrich a Claude-native message in place by adding ATM-owned metadata
-  without rewriting native Claude fields
+  without rewriting native Claude fields except for the explicitly documented
+  cross-team alias projection carve-out on `from`, which also requires
+  `metadata.atm.fromIdentity`
 - locally owned schema enforcement must distinguish legacy top-level UUID-based
   ATM identifiers from forward metadata-based ULID identifiers
 - write-path validation may reject wrong-format ATM-owned identifiers with
@@ -205,14 +207,31 @@ Configuration resolution order:
 
 Required config fields:
 - default team
-- identity
 
 Supported optional config fields:
-- roles map
+- team members baseline roster
 - aliases map
-- output format
-- color
-- bridge remotes and hostname aliases used by origin-inbox merge
+- post-send hook
+- post-send hook member allowlist
+
+Runtime identity rules:
+- repo-local `.atm.toml` identity is not a valid runtime identity fallback for
+  the retained multi-agent ATM model
+- runtime identity must come from:
+  - explicit command override when supported
+  - hook-file identity
+  - `ATM_IDENTITY`
+- an obsolete config `identity` field may remain temporarily for migration, but
+  ATM must ignore it for runtime identity resolution and `atm doctor` must flag
+  it for removal
+- `.atm.toml` may define `[atm].team_members` as the baseline team roster that
+  should always be present in `config.json`
+- `.atm.toml` may define `[atm].aliases` for ATM-owned shorthand addressing of
+  canonical member identities
+- `.atm.toml` may define `[atm].post_send_hook` and
+  `[atm].post_send_hook_members` for sender-scoped post-send automation
+- config sections outside ATM-owned config, such as `[rmux]` or future
+  `[scmux]`, are not ATM runtime config and must be ignored by `atm-core`
 
 ### 3.3.1 Config And Schema Recovery
 
@@ -316,20 +335,18 @@ Satisfied by:
 1. `--from`
 2. hook-file identity
 3. `ATM_IDENTITY`
-4. config identity
 
 ### 4.2 Read Identity Resolution Order
 
 1. `--as`
 2. hook-file identity
 3. `ATM_IDENTITY`
-4. config identity
 
 ### 4.3 Doctor Identity Resolution
 
 `atm doctor` uses the same config and hook-resolution paths as the retained mail commands, but it must not fail immediately only because hook identity is absent. Missing hook identity is a diagnostic finding unless identity resolution is explicitly required for a requested check.
 
-If command identity cannot be determined where required, the command must fail with a structured recovery-oriented error.
+If command identity cannot be determined where required, the command must fail with a structured recovery-oriented error. An obsolete config `identity` field may be reported as a diagnostic, but it does not count as command identity.
 
 ## 5. Address Resolution
 
@@ -338,7 +355,7 @@ Product requirement ID:
   `agent`/`agent@team` forms and precedence rules.
 
 Satisfied by:
-- `REQ-CORE-CONFIG-002` for address parsing, alias/role rewrite, and
+- `REQ-CORE-CONFIG-002` for address parsing, alias rewrite, and
   team/member validation policy
 
 Supported address forms:
@@ -352,7 +369,35 @@ Resolution order:
 
 An explicit `@team` suffix takes precedence over `--team`.
 
-Roles and aliases are resolved after splitting `agent@team`, so only the agent token is rewritten.
+Aliases are resolved after splitting `agent@team`, so only the agent token is
+rewritten.
+
+Alias rules:
+- aliases are accepted as ATM-owned input shorthand only
+- recipient aliases must resolve to canonical member names before validation,
+  self-send checks, and mailbox lookup
+- sender aliases may be accepted on input, but canonical sender identity
+  remains the routing and validation identity
+- same-team messages keep current canonical sender projection behavior
+- cross-team messages may project an alias-oriented sender in the persisted
+  `from` field only when ATM also stores canonical sender identity in
+  `metadata.atm.fromIdentity`
+
+Post-send-hook rules:
+- `post_send_hook` is an ATM-owned helper script/command path list
+- `post_send_hook_members` matches resolved sender identity, not model name
+- a relative hook path must resolve from the directory containing the
+  discovered `.atm.toml`
+- the hook must execute with that same config-root directory as its working
+  directory
+- the hook inherits the process environment and also receives one ATM-owned
+  JSON payload in `ATM_POST_SEND`
+- the `ATM_POST_SEND` payload must contain:
+  - `from`
+  - `to`
+  - `message_id`
+  - `requires_ack`
+  - optional `task_id`
 
 ## 6. `atm send`
 
@@ -394,7 +439,11 @@ Retired from the current implementation:
 
 - resolve sender identity using the defined precedence
 - resolve recipient address using the defined precedence
-- resolve roles and aliases before mailbox lookup
+- resolve aliases before mailbox lookup
+- when a cross-team alias-oriented sender is projected into `from`, also
+  persist canonical sender identity in `metadata.atm.fromIdentity` and use the
+  canonical sender identity for validation, self-send checks, routing, and
+  audit behavior
 - verify target team existence and target agent membership as part of address
   resolution before mailbox path selection, except for the documented
   `missing-document` fallback in §6.3.1
@@ -408,6 +457,10 @@ Retired from the current implementation:
 - support dry-run without mutation
 - support sender-controlled ack-required messages
 - support optional task metadata on sent messages
+- run `post_send_hook` only after successful non-`dry-run` sends and only when
+  the resolved sender identity is listed in `post_send_hook_members`
+- treat `post_send_hook` failure or timeout as best-effort diagnostics only; it
+  must not roll back or fail an already-successful send
 - write a non-null `message_id` on every ATM-authored message
 - current live write compatibility may generate top-level `message_id` values
   using UUID while the metadata-based schema is not yet implemented
@@ -941,6 +994,8 @@ The initial doctor implementation must cover:
 - config file discovery and parse health
 - effective team resolution
 - identity resolution inputs and fallbacks
+- obsolete ATM config identity detection
+- baseline `[atm].team_members` coverage against `config.json.members`
 - team directory existence
 - team config existence and parse health
 - inbox directory existence and writability
@@ -955,6 +1010,8 @@ The initial doctor implementation must cover:
 Human output must provide:
 - overall status summary
 - findings grouped by severity
+- full current member roster from `config.json`, with baseline
+  `[atm].team_members` shown first and `team-lead` first among that baseline
 - concrete remediation guidance when the user can act
 
 JSON output must provide:
@@ -962,6 +1019,7 @@ JSON output must provide:
 - findings
 - recommendations
 - environment override visibility
+- member roster
 - observability health snapshot
 
 Each doctor finding must expose at least:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -227,15 +227,15 @@ Supported optional config fields:
 - `[atm].post_send_hook_members`
 
 Runtime identity rules:
-- repo-local `.atm.toml` identity is not a valid runtime identity fallback for
-  the retained multi-agent ATM model
+- repo-local `.atm.toml` `[atm].identity` is not a valid runtime identity
+  fallback for the retained multi-agent ATM model
 - runtime identity must come from:
   - explicit command override when supported
   - hook-file identity
   - `ATM_IDENTITY`
-- an obsolete config `identity` field may remain temporarily for migration, but
-  ATM must ignore it for runtime identity resolution and `atm doctor` must flag
-  it for removal
+- an obsolete config `[atm].identity` field may remain temporarily for
+  migration, but ATM must ignore it for runtime identity resolution and
+  `atm doctor` must flag it for removal
 - `.atm.toml` may define `[atm].team_members` as the baseline team roster that
   should always be present in `config.json`
 - `.atm.toml` may define `[atm].aliases` for ATM-owned shorthand addressing of


### PR DESCRIPTION
## Summary

- Finalizes Phase L `.atm.toml` config semantics: `team_members`, `aliases`, `post_send_hook`, `post_send_hook_members`, `fromIdentity`, identity obsolescence, cross-team alias projection
- Applies architectural rulings: replaces `[core]` → `[atm]` throughout, removes unimplemented `[roles]` table, resolution order is aliases-then-literal
- Adds `ATM_POST_SEND` payload fields (`from`, `to`, `message_id`, `requires_ack`, `task_id`) to both architecture docs
- Adds L.8 teams-surface sprint entry (`atm teams`, `atm members`, `atm teams add-member`, `atm teams backup`, `atm teams restore`)
- Adds dependency notes for L.4–L.7 and carry-in origin note (2026-04-07 planning review)

## Commits

- `3c0ab1c` docs: finalize phase l config semantics
- `4654a92` docs: finalize phase L config and team surface
- `6bf2b24` docs: resolve phase L QA fix r2

## Test plan

- [ ] QA-3 (ATM-CORE-L7-QA-3) in progress — verifying ATM-QA-002/004/006/007 closure
- [ ] CI green
- [ ] QA-3 PASS → ready to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)