### PR TITLE
L.8: Team recovery minimum surface

### DIFF
--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -140,7 +140,10 @@ fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmErr
         }
     };
 
-    Ok(TeamConfig { members })
+    let mut extra = object.clone();
+    extra.remove("members");
+
+    Ok(TeamConfig { members, extra })
 }
 
 fn parse_team_member(config_path: &Path, index: usize, entry: &Value) -> Option<AgentMember> {
@@ -177,6 +180,8 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
+    use serde_json::Value;
+
     use super::{AtmConfig, load_config, parse_team_config, resolve_identity, resolve_team};
 
     #[test]
@@ -207,6 +212,7 @@ mod tests {
         assert_eq!(config.members.len(), 2);
         assert_eq!(config.members[0].name, "arch-ctm");
         assert_eq!(config.members[1].name, "team-lead");
+        assert!(config.extra.is_empty());
     }
 
     #[test]
@@ -221,6 +227,7 @@ mod tests {
         assert_eq!(config.members.len(), 2);
         assert_eq!(config.members[0].name, "arch-ctm");
         assert_eq!(config.members[1].name, "team-lead");
+        assert!(config.extra.is_empty());
     }
 
     #[test]
@@ -235,6 +242,7 @@ mod tests {
         assert_eq!(config.members.len(), 2);
         assert_eq!(config.members[0].name, "arch-ctm");
         assert_eq!(config.members[1].name, "team-lead");
+        assert!(config.extra.is_empty());
     }
 
     #[test]
@@ -243,6 +251,23 @@ mod tests {
         let config = parse_team_config(&config_path, r#"{}"#).expect("team config");
 
         assert!(config.members.is_empty());
+        assert!(config.extra.is_empty());
+    }
+
+    #[test]
+    fn parse_team_config_preserves_root_extra_fields() {
+        let config_path = temp_config_path();
+        let config = parse_team_config(
+            &config_path,
+            r#"{"leadSessionId":"lead-123","members":[{"name":"team-lead"}]}"#,
+        )
+        .expect("team config");
+
+        assert_eq!(config.members.len(), 1);
+        assert_eq!(
+            config.extra["leadSessionId"],
+            Value::String("lead-123".to_string())
+        );
     }
 
     #[test]

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -30,6 +30,8 @@ pub mod read;
 pub mod schema;
 /// Mailbox send workflows and request/response models.
 pub mod send;
+/// Retained local team discovery, roster repair, and backup/restore workflows.
+pub mod team_admin;
 /// Internal text-formatting helpers used by ATM core surfaces.
 pub(crate) mod text;
 /// Shared enums and semantic newtypes used across ATM core workflows.

--- a/crates/atm-core/src/schema/team_config.rs
+++ b/crates/atm-core/src/schema/team_config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 use super::agent_member::AgentMember;
 
@@ -6,4 +7,7 @@ use super::agent_member::AgentMember;
 pub struct TeamConfig {
     #[serde(default)]
     pub members: Vec<AgentMember>,
+
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
 }

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -19,6 +19,7 @@ pub struct TeamSummary {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct TeamsList {
+    pub action: &'static str,
     pub teams: Vec<TeamSummary>,
 }
 
@@ -111,7 +112,10 @@ pub struct RestoreOutcome {
 pub fn list_teams(home_dir: PathBuf) -> Result<TeamsList, AtmError> {
     let teams_root = teams_root_from_home(&home_dir);
     if !teams_root.exists() {
-        return Ok(TeamsList { teams: Vec::new() });
+        return Ok(TeamsList {
+            action: "list",
+            teams: Vec::new(),
+        });
     }
 
     let mut teams = Vec::new();
@@ -154,7 +158,10 @@ pub fn list_teams(home_dir: PathBuf) -> Result<TeamsList, AtmError> {
     }
 
     teams.sort_by(|a, b| a.name.cmp(&b.name));
-    Ok(TeamsList { teams })
+    Ok(TeamsList {
+        action: "list",
+        teams,
+    })
 }
 
 pub fn list_members(query: MembersQuery) -> Result<MembersList, AtmError> {
@@ -453,6 +460,14 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), AtmError> {
             ))
             .with_source(error)
         })?;
+    }
+
+    // Test seam for deterministic rollback coverage in integration tests.
+    if std::env::var_os("ATM_TEST_FAIL_TEAM_CONFIG_WRITE").is_some() {
+        return Err(AtmError::file_policy(format!(
+            "forced team config write failure for {}",
+            path.display()
+        )));
     }
 
     let temp_path = path.with_file_name(format!(

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -1,0 +1,725 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::Serialize;
+use serde_json::Value;
+use tracing::warn;
+
+use crate::config::{load_config, load_team_config, resolve_team};
+use crate::error::AtmError;
+use crate::home;
+use crate::schema::{AgentMember, TeamConfig};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TeamSummary {
+    pub name: String,
+    pub member_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TeamsList {
+    pub teams: Vec<TeamSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct MemberSummary {
+    pub name: String,
+    pub agent_id: String,
+    pub agent_type: String,
+    pub model: String,
+    pub joined_at: Option<u64>,
+    pub tmux_pane_id: String,
+    pub cwd: String,
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct MembersList {
+    pub team: String,
+    pub members: Vec<MemberSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MembersQuery {
+    pub home_dir: PathBuf,
+    pub current_dir: PathBuf,
+    pub team_override: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AddMemberRequest {
+    pub home_dir: PathBuf,
+    pub team: String,
+    pub member: String,
+    pub agent_type: String,
+    pub model: String,
+    pub cwd: PathBuf,
+    pub tmux_pane_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AddMemberOutcome {
+    pub action: &'static str,
+    pub team: String,
+    pub member: String,
+    pub created_inbox: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct BackupRequest {
+    pub home_dir: PathBuf,
+    pub team: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BackupOutcome {
+    pub action: &'static str,
+    pub team: String,
+    pub backup_path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct RestoreRequest {
+    pub home_dir: PathBuf,
+    pub team: String,
+    pub from: Option<PathBuf>,
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RestorePlan {
+    pub action: &'static str,
+    pub team: String,
+    pub backup_path: PathBuf,
+    pub dry_run: bool,
+    pub would_restore_members: Vec<String>,
+    pub would_restore_inboxes: Vec<String>,
+    pub would_restore_tasks: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RestoreOutcome {
+    pub action: &'static str,
+    pub team: String,
+    pub backup_path: PathBuf,
+    pub members_restored: usize,
+    pub inboxes_restored: usize,
+    pub tasks_restored: usize,
+}
+
+pub fn list_teams(home_dir: PathBuf) -> Result<TeamsList, AtmError> {
+    let teams_root = teams_root_from_home(&home_dir);
+    if !teams_root.exists() {
+        return Ok(TeamsList { teams: Vec::new() });
+    }
+
+    let mut teams = Vec::new();
+    for entry in fs::read_dir(&teams_root).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to read teams directory {}: {error}",
+            teams_root.display()
+        ))
+        .with_source(error)
+    })? {
+        let entry = entry.map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to read teams directory entry under {}: {error}",
+                teams_root.display()
+            ))
+            .with_source(error)
+        })?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        if entry.file_name().to_string_lossy().starts_with('.') {
+            continue;
+        }
+        if !path.join("config.json").is_file() {
+            continue;
+        }
+
+        match load_team_config(&path) {
+            Ok(config) => teams.push(TeamSummary {
+                name: entry.file_name().to_string_lossy().to_string(),
+                member_count: config.members.len(),
+            }),
+            Err(error) => warn!(
+                path = %path.display(),
+                %error,
+                "skipping malformed team config while listing teams"
+            ),
+        }
+    }
+
+    teams.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(TeamsList { teams })
+}
+
+pub fn list_members(query: MembersQuery) -> Result<MembersList, AtmError> {
+    let config = load_config(&query.current_dir)?;
+    let team = resolve_team(query.team_override.as_deref(), config.as_ref())
+        .ok_or_else(AtmError::team_unavailable)?;
+    let team_dir = home::team_dir_from_home(&query.home_dir, &team)?;
+    if !team_dir.exists() {
+        return Err(AtmError::team_not_found(&team));
+    }
+    let config = load_team_config(&team_dir)?;
+
+    let mut members = Vec::with_capacity(config.members.len());
+    if let Some(team_lead) = config
+        .members
+        .iter()
+        .find(|member| member.name == "team-lead")
+    {
+        members.push(member_summary(team_lead));
+    }
+    for member in &config.members {
+        if member.name == "team-lead" {
+            continue;
+        }
+        members.push(member_summary(member));
+    }
+
+    Ok(MembersList { team, members })
+}
+
+pub fn add_member(request: AddMemberRequest) -> Result<AddMemberOutcome, AtmError> {
+    let team_dir = home::team_dir_from_home(&request.home_dir, &request.team)?;
+    if !team_dir.exists() {
+        return Err(AtmError::team_not_found(&request.team));
+    }
+
+    let mut config = load_team_config(&team_dir)?;
+    if config
+        .members
+        .iter()
+        .any(|member| member.name == request.member)
+    {
+        return Err(AtmError::validation(format!(
+            "member '{}' already exists in team '{}'",
+            request.member, request.team
+        )));
+    }
+
+    let inbox_path = home::inbox_path_from_home(&request.home_dir, &request.team, &request.member)?;
+    let created_inbox = ensure_inbox_exists(&inbox_path)?;
+
+    config.members.push(AgentMember {
+        name: request.member.clone(),
+        agent_id: format!("{}@{}", request.member, request.team),
+        agent_type: request.agent_type,
+        model: request.model,
+        joined_at: Some(Utc::now().timestamp_millis() as u64),
+        tmux_pane_id: request.tmux_pane_id.unwrap_or_default(),
+        cwd: request.cwd.display().to_string(),
+        extra: serde_json::Map::new(),
+    });
+
+    if let Err(error) = write_team_config(&team_dir, &config) {
+        if created_inbox {
+            let _ = fs::remove_file(&inbox_path);
+        }
+        return Err(error);
+    }
+
+    Ok(AddMemberOutcome {
+        action: "add-member",
+        team: request.team,
+        member: request.member,
+        created_inbox,
+    })
+}
+
+pub fn backup_team(request: BackupRequest) -> Result<BackupOutcome, AtmError> {
+    let team_dir = home::team_dir_from_home(&request.home_dir, &request.team)?;
+    if !team_dir.exists() {
+        return Err(AtmError::team_not_found(&request.team));
+    }
+
+    let config_path = team_dir.join("config.json");
+    if !config_path.is_file() {
+        return Err(AtmError::missing_document(format!(
+            "team config is missing at {}",
+            config_path.display()
+        )));
+    }
+
+    let backup_dir = backup_root_from_home(&request.home_dir, &request.team).join(timestamp_dir());
+    fs::create_dir_all(backup_dir.join("inboxes")).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to create backup directory {}: {error}",
+            backup_dir.display()
+        ))
+        .with_source(error)
+    })?;
+
+    fs::copy(&config_path, backup_dir.join("config.json")).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to copy {} into backup {}: {error}",
+            config_path.display(),
+            backup_dir.display()
+        ))
+        .with_source(error)
+    })?;
+
+    copy_regular_files(&team_dir.join("inboxes"), &backup_dir.join("inboxes"))?;
+    copy_regular_files(
+        &tasks_dir_from_home(&request.home_dir, &request.team),
+        &backup_dir.join("tasks"),
+    )?;
+
+    Ok(BackupOutcome {
+        action: "backup",
+        team: request.team,
+        backup_path: backup_dir,
+    })
+}
+
+pub fn restore_team(
+    request: RestoreRequest,
+) -> Result<Result<RestoreOutcome, RestorePlan>, AtmError> {
+    let team_dir = home::team_dir_from_home(&request.home_dir, &request.team)?;
+    if !team_dir.exists() {
+        return Err(AtmError::team_not_found(&request.team));
+    }
+    let current_config = load_team_config(&team_dir)?;
+    let backup_dir = locate_backup_dir(&request.home_dir, &request.team, request.from.as_deref())?;
+    let backup_config = load_team_config(&backup_dir)?;
+
+    let members_to_restore = backup_config
+        .members
+        .iter()
+        .filter(|member| member.name != "team-lead")
+        .filter(|member| {
+            !current_config
+                .members
+                .iter()
+                .any(|existing| existing.name == member.name)
+        })
+        .map(|member| member.name.clone())
+        .collect::<Vec<_>>();
+
+    let mut inboxes_to_restore = list_backup_inboxes(&backup_dir)?;
+    inboxes_to_restore.retain(|name| name != "team-lead.json");
+    let tasks_to_restore = count_numeric_task_files(&backup_dir.join("tasks"))?;
+
+    if request.dry_run {
+        return Ok(Err(RestorePlan {
+            action: "restore",
+            team: request.team,
+            backup_path: backup_dir,
+            dry_run: true,
+            would_restore_members: members_to_restore,
+            would_restore_inboxes: inboxes_to_restore,
+            would_restore_tasks: tasks_to_restore,
+        }));
+    }
+
+    let mut updated_config = current_config.clone();
+    for member in &backup_config.members {
+        if member.name == "team-lead" {
+            continue;
+        }
+        if updated_config
+            .members
+            .iter()
+            .any(|existing| existing.name == member.name)
+        {
+            continue;
+        }
+        let mut restored = member.clone();
+        clear_runtime_member_state(&mut restored);
+        updated_config.members.push(restored);
+    }
+    if let Some(value) = current_config.extra.get("leadSessionId") {
+        updated_config
+            .extra
+            .insert("leadSessionId".to_string(), value.clone());
+    }
+
+    let inboxes_dir = team_dir.join("inboxes");
+    fs::create_dir_all(&inboxes_dir).map_err(|error| {
+        AtmError::mailbox_write(format!(
+            "failed to create inbox directory {}: {error}",
+            inboxes_dir.display()
+        ))
+        .with_source(error)
+    })?;
+    for inbox_name in &inboxes_to_restore {
+        let from = backup_dir.join("inboxes").join(inbox_name);
+        let to = inboxes_dir.join(inbox_name);
+        fs::copy(&from, &to).map_err(|error| {
+            AtmError::mailbox_write(format!(
+                "failed to restore inbox {} from {}: {error}",
+                to.display(),
+                from.display()
+            ))
+            .with_source(error)
+        })?;
+    }
+
+    let tasks_dir = tasks_dir_from_home(&request.home_dir, &request.team);
+    restore_task_bucket(&backup_dir.join("tasks"), &tasks_dir)?;
+    recompute_highwatermark(&tasks_dir)?;
+    write_team_config(&team_dir, &updated_config)?;
+
+    Ok(Ok(RestoreOutcome {
+        action: "restore",
+        team: request.team,
+        backup_path: backup_dir,
+        members_restored: members_to_restore.len(),
+        inboxes_restored: inboxes_to_restore.len(),
+        tasks_restored: tasks_to_restore,
+    }))
+}
+
+fn member_summary(member: &AgentMember) -> MemberSummary {
+    MemberSummary {
+        name: member.name.clone(),
+        agent_id: member.agent_id.clone(),
+        agent_type: member.agent_type.clone(),
+        model: member.model.clone(),
+        joined_at: member.joined_at,
+        tmux_pane_id: member.tmux_pane_id.clone(),
+        cwd: member.cwd.clone(),
+        extra: member.extra.clone(),
+    }
+}
+
+fn teams_root_from_home(home_dir: &Path) -> PathBuf {
+    home_dir.join(".claude").join("teams")
+}
+
+fn backup_root_from_home(home_dir: &Path, team: &str) -> PathBuf {
+    teams_root_from_home(home_dir).join(".backups").join(team)
+}
+
+fn tasks_dir_from_home(home_dir: &Path, team: &str) -> PathBuf {
+    home_dir.join(".claude").join("tasks").join(team)
+}
+
+fn timestamp_dir() -> String {
+    let now = Utc::now();
+    format!(
+        "{}{:09}Z",
+        now.format("%Y%m%dT%H%M%S"),
+        now.timestamp_subsec_nanos()
+    )
+}
+
+fn ensure_inbox_exists(inbox_path: &Path) -> Result<bool, AtmError> {
+    if inbox_path.exists() {
+        return Ok(false);
+    }
+
+    if let Some(parent) = inbox_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AtmError::mailbox_write(format!(
+                "failed to create inbox directory {}: {error}",
+                parent.display()
+            ))
+            .with_source(error)
+        })?;
+    }
+
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(inbox_path)
+        .map_err(|error| {
+            AtmError::mailbox_write(format!(
+                "failed to create inbox {}: {error}",
+                inbox_path.display()
+            ))
+            .with_source(error)
+        })?;
+    Ok(true)
+}
+
+fn write_team_config(team_dir: &Path, config: &TeamConfig) -> Result<(), AtmError> {
+    let config_path = team_dir.join("config.json");
+    let encoded = serde_json::to_vec_pretty(config).map_err(AtmError::from)?;
+    atomic_write(&config_path, &encoded)
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), AtmError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to create parent directory {}: {error}",
+                parent.display()
+            ))
+            .with_source(error)
+        })?;
+    }
+
+    let temp_path = path.with_file_name(format!(
+        ".{}.tmp.{}.{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("config"),
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    fs::write(&temp_path, bytes).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to write temporary file {}: {error}",
+            temp_path.display()
+        ))
+        .with_source(error)
+    })?;
+    fs::rename(&temp_path, path).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to atomically replace {}: {error}",
+            path.display()
+        ))
+        .with_source(error)
+    })?;
+    Ok(())
+}
+
+fn copy_regular_files(src: &Path, dst: &Path) -> Result<(), AtmError> {
+    if !src.exists() {
+        return Ok(());
+    }
+    fs::create_dir_all(dst).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to create destination directory {}: {error}",
+            dst.display()
+        ))
+        .with_source(error)
+    })?;
+
+    let mut entries = fs::read_dir(src)
+        .map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to read source directory {}: {error}",
+                src.display()
+            ))
+            .with_source(error)
+        })?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_file())
+        .collect::<Vec<_>>();
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        fs::copy(&from, &to).map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to copy {} to {}: {error}",
+                from.display(),
+                to.display()
+            ))
+            .with_source(error)
+        })?;
+    }
+
+    Ok(())
+}
+
+fn locate_backup_dir(
+    home_dir: &Path,
+    team: &str,
+    explicit: Option<&Path>,
+) -> Result<PathBuf, AtmError> {
+    if let Some(path) = explicit {
+        if !path.is_dir() {
+            return Err(AtmError::missing_document(format!(
+                "backup directory not found: {}",
+                path.display()
+            )));
+        }
+        return Ok(path.to_path_buf());
+    }
+
+    let root = backup_root_from_home(home_dir, team);
+    if !root.exists() {
+        return Err(AtmError::missing_document(format!(
+            "no backup found for team '{}'",
+            team
+        )));
+    }
+    let mut entries = fs::read_dir(&root)
+        .map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to read backup directory {}: {error}",
+                root.display()
+            ))
+            .with_source(error)
+        })?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    entries.sort();
+    entries
+        .pop()
+        .ok_or_else(|| AtmError::missing_document(format!("no backup found for team '{}'", team)))
+}
+
+fn list_backup_inboxes(backup_dir: &Path) -> Result<Vec<String>, AtmError> {
+    let inbox_dir = backup_dir.join("inboxes");
+    if !inbox_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut names = fs::read_dir(&inbox_dir)
+        .map_err(|error| {
+            AtmError::mailbox_read(format!(
+                "failed to read backup inbox directory {}: {error}",
+                inbox_dir.display()
+            ))
+            .with_source(error)
+        })?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_file())
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    names.sort();
+    Ok(names)
+}
+
+fn count_numeric_task_files(tasks_dir: &Path) -> Result<usize, AtmError> {
+    if !tasks_dir.exists() {
+        return Ok(0);
+    }
+    let count = fs::read_dir(tasks_dir)
+        .map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to read task directory {}: {error}",
+                tasks_dir.display()
+            ))
+            .with_source(error)
+        })?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path.extension().and_then(|ext| ext.to_str()) == Some("json")
+                && path
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .and_then(|stem| stem.parse::<u64>().ok())
+                    .is_some()
+        })
+        .count();
+    Ok(count)
+}
+
+fn restore_task_bucket(src: &Path, dst: &Path) -> Result<(), AtmError> {
+    if !src.exists() {
+        fs::create_dir_all(dst).map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to create task directory {}: {error}",
+                dst.display()
+            ))
+            .with_source(error)
+        })?;
+        return Ok(());
+    }
+
+    let staging = dst.with_file_name(format!(
+        ".{}.restore.{}",
+        dst.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("tasks"),
+        std::process::id()
+    ));
+    if staging.exists() {
+        fs::remove_dir_all(&staging).map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to clear task staging directory {}: {error}",
+                staging.display()
+            ))
+            .with_source(error)
+        })?;
+    }
+    copy_regular_files(src, &staging)?;
+
+    if dst.exists() {
+        fs::remove_dir_all(dst).map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to clear existing task directory {}: {error}",
+                dst.display()
+            ))
+            .with_source(error)
+        })?;
+    }
+    if let Some(parent) = dst.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to create task parent directory {}: {error}",
+                parent.display()
+            ))
+            .with_source(error)
+        })?;
+    }
+    fs::rename(&staging, dst).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to install restored task directory {}: {error}",
+            dst.display()
+        ))
+        .with_source(error)
+    })?;
+    Ok(())
+}
+
+fn recompute_highwatermark(tasks_dir: &Path) -> Result<usize, AtmError> {
+    fs::create_dir_all(tasks_dir).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to create task directory {}: {error}",
+            tasks_dir.display()
+        ))
+        .with_source(error)
+    })?;
+
+    let max_id = fs::read_dir(tasks_dir)
+        .map_err(|error| {
+            AtmError::file_policy(format!(
+                "failed to read task directory {}: {error}",
+                tasks_dir.display()
+            ))
+            .with_source(error)
+        })?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file() && path.extension().and_then(|ext| ext.to_str()) == Some("json")
+        })
+        .filter_map(|path| {
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .and_then(|stem| stem.parse::<usize>().ok())
+        })
+        .max()
+        .unwrap_or(0);
+
+    fs::write(tasks_dir.join(".highwatermark"), format!("{max_id}\n")).map_err(|error| {
+        AtmError::file_policy(format!(
+            "failed to write {}: {error}",
+            tasks_dir.join(".highwatermark").display()
+        ))
+        .with_source(error)
+    })?;
+    Ok(max_id)
+}
+
+fn clear_runtime_member_state(member: &mut AgentMember) {
+    member.tmux_pane_id.clear();
+    for key in [
+        "sessionId",
+        "activity",
+        "status",
+        "lastAliveAt",
+        "processId",
+        "isActive",
+        "lastActive",
+        "paneId",
+    ] {
+        member.extra.remove(key);
+    }
+}

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -322,9 +323,16 @@ pub fn restore_team(request: RestoreRequest) -> Result<RestoreResult, AtmError> 
         })
         .map(|member| member.name.clone())
         .collect::<Vec<_>>();
+    let members_to_restore_set = members_to_restore.iter().cloned().collect::<BTreeSet<_>>();
 
     let mut inboxes_to_restore = list_backup_inboxes(&backup_dir)?;
-    inboxes_to_restore.retain(|name| name != "team-lead.json");
+    inboxes_to_restore.retain(|name| {
+        if name == "team-lead.json" {
+            return false;
+        }
+        name.strip_suffix(".json")
+            .is_some_and(|member| members_to_restore_set.contains(member))
+    });
     let tasks_to_restore = count_numeric_task_files(&backup_dir.join("tasks"))?;
 
     if request.dry_run {
@@ -447,6 +455,7 @@ fn ensure_inbox_exists(inbox_path: &Path) -> Result<bool, AtmError> {
                 parent.display()
             ))
             .with_source(error)
+            .with_recovery("Check inbox directory permissions and rerun the team recovery command.")
         })?;
     }
 
@@ -460,6 +469,7 @@ fn ensure_inbox_exists(inbox_path: &Path) -> Result<bool, AtmError> {
                 inbox_path.display()
             ))
             .with_source(error)
+            .with_recovery("Check inbox permissions and rerun the team recovery command.")
         })?;
     Ok(true)
 }
@@ -478,6 +488,7 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), AtmError> {
                 parent.display()
             ))
             .with_source(error)
+            .with_recovery("Check config directory permissions and rerun the operation.")
         })?;
     }
 
@@ -486,7 +497,10 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), AtmError> {
         return Err(AtmError::file_policy(format!(
             "forced team config write failure for {}",
             path.display()
-        )));
+        ))
+        .with_recovery(
+            "Unset ATM_TEST_FAIL_TEAM_CONFIG_WRITE or rerun without the injected test failure.",
+        ));
     }
 
     let temp_path = path.with_file_name(format!(
@@ -503,6 +517,7 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), AtmError> {
             temp_path.display()
         ))
         .with_source(error)
+        .with_recovery("Check config directory permissions and available disk space, then retry.")
     })?;
     fs::rename(&temp_path, path).map_err(|error| {
         AtmError::file_policy(format!(
@@ -510,6 +525,7 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), AtmError> {
             path.display()
         ))
         .with_source(error)
+        .with_recovery("Check config file permissions and rerun the operation.")
     })?;
     Ok(())
 }
@@ -524,6 +540,7 @@ fn copy_regular_files(src: &Path, dst: &Path) -> Result<(), AtmError> {
             dst.display()
         ))
         .with_source(error)
+        .with_recovery("Check destination directory permissions and retry the copy.")
     })?;
 
     let mut entries = fs::read_dir(src)
@@ -533,6 +550,7 @@ fn copy_regular_files(src: &Path, dst: &Path) -> Result<(), AtmError> {
                 src.display()
             ))
             .with_source(error)
+            .with_recovery("Check source directory permissions and retry the copy.")
         })?
         .filter_map(Result::ok)
         .filter(|entry| entry.path().is_file())
@@ -549,6 +567,7 @@ fn copy_regular_files(src: &Path, dst: &Path) -> Result<(), AtmError> {
                 to.display()
             ))
             .with_source(error)
+            .with_recovery("Check source and destination permissions and retry the copy.")
         })?;
     }
 
@@ -584,6 +603,7 @@ fn locate_backup_dir(
                 root.display()
             ))
             .with_source(error)
+            .with_recovery("Check backup directory permissions or pass an explicit --from path.")
         })?
         .filter_map(Result::ok)
         .map(|entry| entry.path())
@@ -608,6 +628,7 @@ fn list_backup_inboxes(backup_dir: &Path) -> Result<Vec<String>, AtmError> {
                 inbox_dir.display()
             ))
             .with_source(error)
+            .with_recovery("Check backup inbox permissions and retry the restore.")
         })?
         .filter_map(Result::ok)
         .filter(|entry| entry.path().is_file())
@@ -628,6 +649,7 @@ fn count_numeric_task_files(tasks_dir: &Path) -> Result<usize, AtmError> {
                 tasks_dir.display()
             ))
             .with_source(error)
+            .with_recovery("Check task directory permissions and retry the restore.")
         })?
         .filter_map(Result::ok)
         .map(|entry| entry.path())
@@ -652,6 +674,7 @@ fn restore_task_bucket(src: &Path, dst: &Path) -> Result<(), AtmError> {
                 dst.display()
             ))
             .with_source(error)
+            .with_recovery("Check task directory permissions and rerun the restore.")
         })?;
         return Ok(());
     }
@@ -670,6 +693,7 @@ fn restore_task_bucket(src: &Path, dst: &Path) -> Result<(), AtmError> {
                 staging.display()
             ))
             .with_source(error)
+            .with_recovery("Check task staging directory permissions and rerun the restore.")
         })?;
     }
     copy_regular_files(src, &staging)?;
@@ -681,6 +705,7 @@ fn restore_task_bucket(src: &Path, dst: &Path) -> Result<(), AtmError> {
                 dst.display()
             ))
             .with_source(error)
+            .with_recovery("Check task directory permissions and rerun the restore.")
         })?;
     }
     if let Some(parent) = dst.parent() {
@@ -690,6 +715,7 @@ fn restore_task_bucket(src: &Path, dst: &Path) -> Result<(), AtmError> {
                 parent.display()
             ))
             .with_source(error)
+            .with_recovery("Check task parent directory permissions and rerun the restore.")
         })?;
     }
     fs::rename(&staging, dst).map_err(|error| {
@@ -698,6 +724,7 @@ fn restore_task_bucket(src: &Path, dst: &Path) -> Result<(), AtmError> {
             dst.display()
         ))
         .with_source(error)
+        .with_recovery("Check task directory permissions and rerun the restore.")
     })?;
     Ok(())
 }
@@ -709,6 +736,7 @@ fn recompute_highwatermark(tasks_dir: &Path) -> Result<usize, AtmError> {
             tasks_dir.display()
         ))
         .with_source(error)
+        .with_recovery("Check task directory permissions and rerun the restore.")
     })?;
 
     let max_id = fs::read_dir(tasks_dir)
@@ -718,6 +746,7 @@ fn recompute_highwatermark(tasks_dir: &Path) -> Result<usize, AtmError> {
                 tasks_dir.display()
             ))
             .with_source(error)
+            .with_recovery("Check task directory permissions and rerun the restore.")
         })?
         .filter_map(Result::ok)
         .map(|entry| entry.path())
@@ -738,6 +767,7 @@ fn recompute_highwatermark(tasks_dir: &Path) -> Result<usize, AtmError> {
             tasks_dir.join(".highwatermark").display()
         ))
         .with_source(error)
+        .with_recovery("Check task directory permissions and rerun the restore.")
     })?;
     Ok(max_id)
 }

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -19,7 +19,8 @@ pub struct TeamSummary {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct TeamsList {
-    pub action: &'static str,
+    pub action: String,
+    pub team: String,
     pub teams: Vec<TeamSummary>,
 }
 
@@ -109,11 +110,20 @@ pub struct RestoreOutcome {
     pub tasks_restored: usize,
 }
 
-pub fn list_teams(home_dir: PathBuf) -> Result<TeamsList, AtmError> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RestoreResult {
+    DryRun(RestorePlan),
+    Applied(RestoreOutcome),
+}
+
+pub fn list_teams(home_dir: PathBuf, current_dir: PathBuf) -> Result<TeamsList, AtmError> {
+    let config = load_config(&current_dir)?;
+    let current_team = resolve_team(None, config.as_ref()).unwrap_or_default();
     let teams_root = teams_root_from_home(&home_dir);
     if !teams_root.exists() {
         return Ok(TeamsList {
-            action: "list",
+            action: "list".to_string(),
+            team: current_team,
             teams: Vec::new(),
         });
     }
@@ -125,6 +135,7 @@ pub fn list_teams(home_dir: PathBuf) -> Result<TeamsList, AtmError> {
             teams_root.display()
         ))
         .with_source(error)
+        .with_recovery("Check ATM_HOME and ensure the teams directory is readable.")
     })? {
         let entry = entry.map_err(|error| {
             AtmError::file_policy(format!(
@@ -132,6 +143,7 @@ pub fn list_teams(home_dir: PathBuf) -> Result<TeamsList, AtmError> {
                 teams_root.display()
             ))
             .with_source(error)
+            .with_recovery("Check ATM_HOME and ensure the teams directory is readable.")
         })?;
         let path = entry.path();
         if !path.is_dir() {
@@ -159,7 +171,8 @@ pub fn list_teams(home_dir: PathBuf) -> Result<TeamsList, AtmError> {
 
     teams.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(TeamsList {
-        action: "list",
+        action: "list".to_string(),
+        team: current_team,
         teams,
     })
 }
@@ -228,7 +241,9 @@ pub fn add_member(request: AddMemberRequest) -> Result<AddMemberOutcome, AtmErro
         if created_inbox {
             let _ = fs::remove_file(&inbox_path);
         }
-        return Err(error);
+        return Err(
+            error.with_recovery("Check team config permissions and rerun `atm teams add-member`.")
+        );
     }
 
     Ok(AddMemberOutcome {
@@ -260,6 +275,7 @@ pub fn backup_team(request: BackupRequest) -> Result<BackupOutcome, AtmError> {
             backup_dir.display()
         ))
         .with_source(error)
+        .with_recovery("Check backup directory permissions under ATM_HOME and retry the backup.")
     })?;
 
     fs::copy(&config_path, backup_dir.join("config.json")).map_err(|error| {
@@ -269,6 +285,7 @@ pub fn backup_team(request: BackupRequest) -> Result<BackupOutcome, AtmError> {
             backup_dir.display()
         ))
         .with_source(error)
+        .with_recovery("Check source and backup directory permissions and retry the backup.")
     })?;
 
     copy_regular_files(&team_dir.join("inboxes"), &backup_dir.join("inboxes"))?;
@@ -284,9 +301,7 @@ pub fn backup_team(request: BackupRequest) -> Result<BackupOutcome, AtmError> {
     })
 }
 
-pub fn restore_team(
-    request: RestoreRequest,
-) -> Result<Result<RestoreOutcome, RestorePlan>, AtmError> {
+pub fn restore_team(request: RestoreRequest) -> Result<RestoreResult, AtmError> {
     let team_dir = home::team_dir_from_home(&request.home_dir, &request.team)?;
     if !team_dir.exists() {
         return Err(AtmError::team_not_found(&request.team));
@@ -313,7 +328,7 @@ pub fn restore_team(
     let tasks_to_restore = count_numeric_task_files(&backup_dir.join("tasks"))?;
 
     if request.dry_run {
-        return Ok(Err(RestorePlan {
+        return Ok(RestoreResult::DryRun(RestorePlan {
             action: "restore",
             team: request.team,
             backup_path: backup_dir,
@@ -353,6 +368,7 @@ pub fn restore_team(
             inboxes_dir.display()
         ))
         .with_source(error)
+        .with_recovery("Check inbox directory permissions and rerun `atm teams restore`.")
     })?;
     for inbox_name in &inboxes_to_restore {
         let from = backup_dir.join("inboxes").join(inbox_name);
@@ -364,15 +380,18 @@ pub fn restore_team(
                 from.display()
             ))
             .with_source(error)
+            .with_recovery("Check inbox permissions and backup integrity, then rerun the restore.")
         })?;
     }
 
     let tasks_dir = tasks_dir_from_home(&request.home_dir, &request.team);
     restore_task_bucket(&backup_dir.join("tasks"), &tasks_dir)?;
     recompute_highwatermark(&tasks_dir)?;
-    write_team_config(&team_dir, &updated_config)?;
+    write_team_config(&team_dir, &updated_config).map_err(|error| {
+        error.with_recovery("Check team config permissions and rerun `atm teams restore`.")
+    })?;
 
-    Ok(Ok(RestoreOutcome {
+    Ok(RestoreResult::Applied(RestoreOutcome {
         action: "restore",
         team: request.team,
         backup_path: backup_dir,

--- a/crates/atm/src/commands/members.rs
+++ b/crates/atm/src/commands/members.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use atm_core::home;
+use atm_core::team_admin::{self, MembersQuery};
+use clap::Args;
+
+use crate::observability::CliObservability;
+use crate::output;
+
+#[derive(Debug, Args)]
+pub struct MembersCommand {
+    #[arg(long)]
+    team: Option<String>,
+
+    #[arg(long)]
+    json: bool,
+}
+
+impl MembersCommand {
+    pub fn run(self, _observability: &CliObservability) -> Result<()> {
+        let home_dir = home::atm_home()?;
+        let current_dir = std::env::current_dir()?;
+        let outcome = team_admin::list_members(MembersQuery {
+            home_dir,
+            current_dir,
+            team_override: self.team,
+        })?;
+        output::print_members_result(&outcome, self.json)
+    }
+}

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -5,15 +5,19 @@ pub mod ack;
 pub mod clear;
 pub mod doctor;
 pub mod log;
+pub mod members;
 pub mod read;
 pub mod send;
+pub mod teams;
 
 pub use ack::AckCommand;
 pub use clear::ClearCommand;
 pub use doctor::DoctorCommand;
 pub use log::LogCommand;
+pub use members::MembersCommand;
 pub use read::ReadCommand;
 pub use send::SendCommand;
+pub use teams::TeamsCommand;
 
 use crate::observability::CliObservability;
 
@@ -54,6 +58,8 @@ enum Command {
     Clear(ClearCommand),
     Log(LogCommand),
     Doctor(DoctorCommand),
+    Teams(TeamsCommand),
+    Members(MembersCommand),
 }
 
 impl Command {
@@ -65,6 +71,8 @@ impl Command {
             Self::Clear(command) => command.run(observability),
             Self::Log(command) => command.run(observability),
             Self::Doctor(command) => command.run(observability),
+            Self::Teams(command) => command.run(observability),
+            Self::Members(command) => command.run(observability),
         }
     }
 }

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use atm_core::home;
-use atm_core::team_admin::{self, AddMemberRequest, BackupRequest, RestoreRequest};
+use atm_core::team_admin::{self, AddMemberRequest, BackupRequest, RestoreRequest, RestoreResult};
 use clap::{Args, Subcommand};
 
 use crate::observability::CliObservability;
@@ -72,7 +72,7 @@ impl TeamsCommand {
         let home_dir = home::atm_home()?;
         match self.command {
             None => {
-                let outcome = team_admin::list_teams(home_dir)?;
+                let outcome = team_admin::list_teams(home_dir, std::env::current_dir()?)?;
                 output::print_teams_result(&outcome, self.json)
             }
             Some(TeamsSubcommand::AddMember(command)) => command.run(home_dir),
@@ -119,8 +119,8 @@ impl RestoreCommand {
             from: self.from,
             dry_run: self.dry_run,
         })? {
-            Ok(outcome) => output::print_restore_result(&outcome, self.json),
-            Err(plan) => output::print_restore_plan(&plan, self.json),
+            RestoreResult::Applied(outcome) => output::print_restore_result(&outcome, self.json),
+            RestoreResult::DryRun(plan) => output::print_restore_plan(&plan, self.json),
         }
     }
 }

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -1,0 +1,126 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use atm_core::home;
+use atm_core::team_admin::{self, AddMemberRequest, BackupRequest, RestoreRequest};
+use clap::{Args, Subcommand};
+
+use crate::observability::CliObservability;
+use crate::output;
+
+#[derive(Debug, Args)]
+pub struct TeamsCommand {
+    #[command(subcommand)]
+    command: Option<TeamsSubcommand>,
+
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Subcommand)]
+enum TeamsSubcommand {
+    AddMember(AddMemberCommand),
+    Backup(BackupCommand),
+    Restore(RestoreCommand),
+}
+
+#[derive(Debug, Args)]
+struct AddMemberCommand {
+    team: String,
+    member: String,
+
+    #[arg(long, default_value = "general-purpose")]
+    agent_type: String,
+
+    #[arg(long, default_value = "unknown")]
+    model: String,
+
+    #[arg(long)]
+    cwd: Option<PathBuf>,
+
+    #[arg(long = "pane-id")]
+    pane_id: Option<String>,
+
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct BackupCommand {
+    team: String,
+
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct RestoreCommand {
+    team: String,
+
+    #[arg(long)]
+    from: Option<PathBuf>,
+
+    #[arg(long = "dry-run")]
+    dry_run: bool,
+
+    #[arg(long)]
+    json: bool,
+}
+
+impl TeamsCommand {
+    pub fn run(self, _observability: &CliObservability) -> Result<()> {
+        let home_dir = home::atm_home()?;
+        match self.command {
+            None => {
+                let outcome = team_admin::list_teams(home_dir)?;
+                output::print_teams_result(&outcome, self.json)
+            }
+            Some(TeamsSubcommand::AddMember(command)) => command.run(home_dir),
+            Some(TeamsSubcommand::Backup(command)) => command.run(home_dir),
+            Some(TeamsSubcommand::Restore(command)) => command.run(home_dir),
+        }
+    }
+}
+
+impl AddMemberCommand {
+    fn run(self, home_dir: PathBuf) -> Result<()> {
+        let cwd = match self.cwd {
+            Some(path) => path,
+            None => std::env::current_dir()?,
+        };
+        let outcome = team_admin::add_member(AddMemberRequest {
+            home_dir,
+            team: self.team,
+            member: self.member,
+            agent_type: self.agent_type,
+            model: self.model,
+            cwd,
+            tmux_pane_id: self.pane_id,
+        })?;
+        output::print_add_member_result(&outcome, self.json)
+    }
+}
+
+impl BackupCommand {
+    fn run(self, home_dir: PathBuf) -> Result<()> {
+        let outcome = team_admin::backup_team(BackupRequest {
+            home_dir,
+            team: self.team,
+        })?;
+        output::print_backup_result(&outcome, self.json)
+    }
+}
+
+impl RestoreCommand {
+    fn run(self, home_dir: PathBuf) -> Result<()> {
+        match team_admin::restore_team(RestoreRequest {
+            home_dir,
+            team: self.team,
+            from: self.from,
+            dry_run: self.dry_run,
+        })? {
+            Ok(outcome) => output::print_restore_result(&outcome, self.json),
+            Err(plan) => output::print_restore_plan(&plan, self.json),
+        }
+    }
+}

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -5,6 +5,9 @@ use atm_core::doctor::{DoctorReport, DoctorSeverity, DoctorStatus};
 use atm_core::observability::{AtmLogRecord, AtmLogSnapshot};
 use atm_core::read::ReadOutcome;
 use atm_core::send::SendOutcome;
+use atm_core::team_admin::{
+    AddMemberOutcome, BackupOutcome, MembersList, RestoreOutcome, RestorePlan, TeamsList,
+};
 use atm_core::types::DisplayBucket;
 
 pub fn print_send_result(outcome: &SendOutcome, json: bool) -> Result<()> {
@@ -208,6 +211,99 @@ pub fn print_doctor_result(report: &DoctorReport, json: bool) -> Result<()> {
     Ok(())
 }
 
+pub fn print_teams_result(outcome: &TeamsList, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+        return Ok(());
+    }
+
+    if outcome.teams.is_empty() {
+        println!("No teams found");
+        return Ok(());
+    }
+
+    println!("Teams:");
+    for team in &outcome.teams {
+        println!("  {} ({})", team.name, team.member_count);
+    }
+    Ok(())
+}
+
+pub fn print_members_result(outcome: &MembersList, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+        return Ok(());
+    }
+
+    println!("Team: {}", outcome.team);
+    if outcome.members.is_empty() {
+        println!("  No members");
+        return Ok(());
+    }
+
+    for member in &outcome.members {
+        println!(
+            "  {} | type={} model={} cwd={} pane={}",
+            member.name,
+            empty_dash(&member.agent_type),
+            empty_dash(&member.model),
+            empty_dash(&member.cwd),
+            empty_dash(&member.tmux_pane_id)
+        );
+    }
+    Ok(())
+}
+
+pub fn print_add_member_result(outcome: &AddMemberOutcome, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+    } else {
+        println!(
+            "Added member {} to {} (created_inbox: {})",
+            outcome.member, outcome.team, outcome.created_inbox
+        );
+    }
+    Ok(())
+}
+
+pub fn print_backup_result(outcome: &BackupOutcome, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+    } else {
+        println!("Backup created: {}", outcome.backup_path.display());
+    }
+    Ok(())
+}
+
+pub fn print_restore_plan(plan: &RestorePlan, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(plan)?);
+        return Ok(());
+    }
+
+    println!(
+        "Dry run — would restore from: {}",
+        plan.backup_path.display()
+    );
+    println!("  Members: {}", plan.would_restore_members.join(", "));
+    println!("  Inboxes: {}", plan.would_restore_inboxes.join(", "));
+    println!("  Tasks: {}", plan.would_restore_tasks);
+    Ok(())
+}
+
+pub fn print_restore_result(outcome: &RestoreOutcome, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+    } else {
+        println!("Restored from: {}", outcome.backup_path.display());
+        println!(
+            "  members={} inboxes={} tasks={}",
+            outcome.members_restored, outcome.inboxes_restored, outcome.tasks_restored
+        );
+    }
+    Ok(())
+}
+
 fn print_bucket(outcome: &ReadOutcome, bucket: DisplayBucket, label: &str) {
     let messages = outcome
         .messages
@@ -236,6 +332,10 @@ fn print_bucket(outcome: &ReadOutcome, bucket: DisplayBucket, label: &str) {
             println!("  message_id: {message_id}");
         }
     }
+}
+
+fn empty_dash(value: &str) -> &str {
+    if value.is_empty() { "-" } else { value }
 }
 
 fn print_log_record_line(record: &AtmLogRecord) {

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -172,6 +172,7 @@ impl Fixture {
                     ..Default::default()
                 })
                 .collect(),
+            ..Default::default()
         };
         fs::write(
             team_dir.join("config.json"),

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -357,6 +357,7 @@ impl Fixture {
                     ..Default::default()
                 })
                 .collect(),
+            ..Default::default()
         };
         fs::write(
             team_dir.join("config.json"),

--- a/crates/atm/tests/doctor.rs
+++ b/crates/atm/tests/doctor.rs
@@ -65,6 +65,7 @@ impl Fixture {
                     ..Default::default()
                 })
                 .collect(),
+            ..Default::default()
         };
         fs::write(
             team_dir.join("config.json"),

--- a/crates/atm/tests/log.rs
+++ b/crates/atm/tests/log.rs
@@ -335,6 +335,7 @@ impl Fixture {
                     ..Default::default()
                 })
                 .collect(),
+            ..Default::default()
         };
         fs::write(
             team_dir.join("config.json"),

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -676,6 +676,7 @@ impl Fixture {
                     ..Default::default()
                 })
                 .collect(),
+            ..Default::default()
         };
         fs::write(
             team_dir.join("config.json"),

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -377,6 +377,7 @@ impl Fixture {
                 name: recipient.to_string(),
                 ..Default::default()
             }],
+            ..Default::default()
         };
         fs::write(
             team_dir.join("config.json"),

--- a/crates/atm/tests/team_recovery.rs
+++ b/crates/atm/tests/team_recovery.rs
@@ -315,6 +315,68 @@ fn test_restore_preserves_team_lead_and_recomputes_highwatermark() {
     assert_eq!(fixture.read_highwatermark("atm-dev"), "82");
 }
 
+#[test]
+fn test_restore_does_not_overwrite_existing_member_inbox() {
+    let fixture = Fixture::new();
+    fixture.write_team_config_value(
+        "atm-dev",
+        json!({
+            "leadSessionId":"lead-current",
+            "members":[
+                {"name":"team-lead","agentType":"lead","cwd":"/repo"},
+                {"name":"existing","agentType":"worker","cwd":"/repo"}
+            ]
+        }),
+    );
+    fixture.write_inbox("atm-dev", "existing", "keep existing inbox");
+
+    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T030405000000000Z");
+    fixture.write_json(
+        backup_dir.join("config.json"),
+        &json!({
+            "leadSessionId":"lead-backup",
+            "members":[
+                {"name":"team-lead","agentType":"lead","cwd":"/backup"},
+                {"name":"existing","agentType":"worker","cwd":"/backup"},
+                {"name":"arch-ctm","agentType":"general-purpose","cwd":"/repo"}
+            ]
+        }),
+    );
+    fixture.write_inbox_at(
+        backup_dir.join("inboxes").join("existing.json"),
+        "team-lead",
+        "do not overwrite existing inbox",
+    );
+    fixture.write_inbox_at(
+        backup_dir.join("inboxes").join("arch-ctm.json"),
+        "team-lead",
+        "restore new member inbox",
+    );
+
+    let output = fixture.run(&[
+        "teams",
+        "restore",
+        "atm-dev",
+        "--from",
+        backup_dir.to_str().expect("utf8"),
+        "--json",
+    ]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let existing_inbox =
+        fs::read_to_string(fixture.inbox_path("atm-dev", "existing")).expect("existing inbox");
+    assert!(existing_inbox.contains("keep existing inbox"));
+    assert!(!existing_inbox.contains("do not overwrite existing inbox"));
+
+    let restored_inbox =
+        fs::read_to_string(fixture.inbox_path("atm-dev", "arch-ctm")).expect("restored inbox");
+    assert!(restored_inbox.contains("restore new member inbox"));
+}
+
 struct Fixture {
     tempdir: tempfile::TempDir,
 }

--- a/crates/atm/tests/team_recovery.rs
+++ b/crates/atm/tests/team_recovery.rs
@@ -23,6 +23,7 @@ fn test_teams_lists_discovered_teams_deterministically() {
 
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["action"], "list");
+    assert_eq!(parsed["team"], "atm-dev");
     let teams = parsed["teams"].as_array().expect("teams array");
     assert_eq!(teams.len(), 2);
     assert_eq!(teams[0]["name"], "atm-dev");

--- a/crates/atm/tests/team_recovery.rs
+++ b/crates/atm/tests/team_recovery.rs
@@ -22,6 +22,7 @@ fn test_teams_lists_discovered_teams_deterministically() {
     );
 
     let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["action"], "list");
     let teams = parsed["teams"].as_array().expect("teams array");
     assert_eq!(teams.len(), 2);
     assert_eq!(teams[0]["name"], "atm-dev");
@@ -94,6 +95,45 @@ fn test_add_member_rejects_duplicates_and_creates_inbox_state() {
 
     let config = fixture.read_team_config_value("atm-dev");
     assert_eq!(config["members"].as_array().expect("members").len(), 2);
+}
+
+#[test]
+fn test_add_member_rolls_back_inbox_when_config_write_fails() {
+    let fixture = Fixture::new();
+    fixture.write_team_config_value("atm-dev", json!({"members":[{"name":"team-lead"}]}));
+
+    let output = fixture.run_with_env(
+        &[
+            "teams",
+            "add-member",
+            "atm-dev",
+            "arch-ctm",
+            "--agent-type",
+            "general-purpose",
+            "--model",
+            "sonnet",
+            "--json",
+        ],
+        &[("ATM_TEST_FAIL_TEAM_CONFIG_WRITE", "1")],
+    );
+    assert!(
+        !output.status.success(),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        fixture
+            .stderr(&output)
+            .contains("forced team config write failure"),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    assert!(!fixture.inbox_path("atm-dev", "arch-ctm").exists());
+
+    let config = fixture.read_team_config_value("atm-dev");
+    let members = config["members"].as_array().expect("members");
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0]["name"], "team-lead");
 }
 
 #[test]
@@ -290,12 +330,20 @@ impl Fixture {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_atm"))
+        self.run_with_env(args, &[])
+    }
+
+    fn run_with_env(&self, args: &[&str], extra_env: &[(&str, &str)]) -> std::process::Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_atm"));
+        command
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
-            .current_dir(self.tempdir.path())
-            .output()
-            .expect("run atm")
+            .env("ATM_CONFIG_HOME", self.tempdir.path())
+            .current_dir(self.tempdir.path());
+        for (key, value) in extra_env {
+            command.env(key, value);
+        }
+        command.output().expect("run atm")
     }
 
     fn write_team_config_value(&self, team: &str, value: Value) {

--- a/crates/atm/tests/team_recovery.rs
+++ b/crates/atm/tests/team_recovery.rs
@@ -1,0 +1,402 @@
+use std::fs;
+use std::process::Command;
+
+use atm_core::schema::MessageEnvelope;
+use chrono::Utc;
+use serde_json::{Value, json};
+
+#[test]
+fn test_teams_lists_discovered_teams_deterministically() {
+    let fixture = Fixture::new();
+    fixture.write_team_config_value("zeta", json!({"members":[{"name":"team-lead"}]}));
+    fixture.write_team_config_value(
+        "atm-dev",
+        json!({"members":[{"name":"team-lead"},{"name":"arch-ctm"}]}),
+    );
+
+    let output = fixture.run(&["teams", "--json"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let parsed = fixture.stdout_json(&output);
+    let teams = parsed["teams"].as_array().expect("teams array");
+    assert_eq!(teams.len(), 2);
+    assert_eq!(teams[0]["name"], "atm-dev");
+    assert_eq!(teams[0]["member_count"], 2);
+    assert_eq!(teams[1]["name"], "zeta");
+}
+
+#[test]
+fn test_members_lists_current_roster_deterministically() {
+    let fixture = Fixture::new();
+    fixture.write_team_config_value(
+        "atm-dev",
+        json!({
+            "members": [
+                {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"},
+                {"name":"team-lead","agentType":"lead","model":"opus","cwd":"/repo","tmuxPaneId":"%1"},
+                {"name":"qa","agentType":"qa","model":"haiku","cwd":"/repo"}
+            ]
+        }),
+    );
+
+    let output = fixture.run(&["members", "--json"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let parsed = fixture.stdout_json(&output);
+    let members = parsed["members"].as_array().expect("members array");
+    assert_eq!(members[0]["name"], "team-lead");
+    assert_eq!(members[1]["name"], "arch-ctm");
+    assert_eq!(members[2]["name"], "qa");
+    assert_eq!(members[0]["tmux_pane_id"], "%1");
+}
+
+#[test]
+fn test_add_member_rejects_duplicates_and_creates_inbox_state() {
+    let fixture = Fixture::new();
+    fixture.write_team_config_value("atm-dev", json!({"members":[{"name":"team-lead"}]}));
+
+    let added = fixture.run(&[
+        "teams",
+        "add-member",
+        "atm-dev",
+        "arch-ctm",
+        "--agent-type",
+        "general-purpose",
+        "--model",
+        "sonnet",
+        "--json",
+    ]);
+    assert!(added.status.success(), "stderr: {}", fixture.stderr(&added));
+    let parsed = fixture.stdout_json(&added);
+    assert_eq!(parsed["action"], "add-member");
+    assert_eq!(parsed["member"], "arch-ctm");
+    assert_eq!(parsed["created_inbox"], true);
+    assert!(fixture.inbox_path("atm-dev", "arch-ctm").is_file());
+
+    let config = fixture.read_team_config_value("atm-dev");
+    assert_eq!(config["members"].as_array().expect("members").len(), 2);
+
+    let duplicate = fixture.run(&["teams", "add-member", "atm-dev", "arch-ctm"]);
+    assert!(!duplicate.status.success());
+    assert!(
+        fixture.stderr(&duplicate).contains("already exists"),
+        "stderr: {}",
+        fixture.stderr(&duplicate)
+    );
+
+    let config = fixture.read_team_config_value("atm-dev");
+    assert_eq!(config["members"].as_array().expect("members").len(), 2);
+}
+
+#[test]
+fn test_backup_captures_config_inboxes_and_tasks() {
+    let fixture = Fixture::new();
+    fixture.write_team_config_value(
+        "atm-dev",
+        json!({"leadSessionId":"lead-1","members":[{"name":"team-lead"},{"name":"arch-ctm"}]}),
+    );
+    fixture.write_inbox("atm-dev", "arch-ctm", "backup me");
+    fixture.write_task("atm-dev", 7, json!({"id":"7","status":"open"}));
+    fixture.write_highwatermark("atm-dev", "7\n");
+
+    let output = fixture.run(&["teams", "backup", "atm-dev", "--json"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let parsed = fixture.stdout_json(&output);
+    let backup_path = parsed["backup_path"].as_str().expect("backup path");
+    let backup_dir = std::path::Path::new(backup_path);
+    assert!(backup_dir.join("config.json").is_file());
+    assert!(backup_dir.join("inboxes").join("arch-ctm.json").is_file());
+    assert!(backup_dir.join("tasks").join("7.json").is_file());
+    assert!(backup_dir.join("tasks").join(".highwatermark").is_file());
+}
+
+#[test]
+fn test_restore_dry_run_reports_members_inboxes_and_tasks() {
+    let fixture = Fixture::new();
+    fixture.write_team_config_value(
+        "atm-dev",
+        json!({"leadSessionId":"lead-current","members":[{"name":"team-lead"}]}),
+    );
+
+    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T010203000000000Z");
+    fixture.write_json(
+        backup_dir.join("config.json"),
+        &json!({
+            "leadSessionId":"lead-backup",
+            "members":[
+                {"name":"team-lead"},
+                {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+            ]
+        }),
+    );
+    fixture.write_inbox_at(
+        backup_dir.join("inboxes").join("arch-ctm.json"),
+        "team-lead",
+        "restored",
+    );
+    fixture.write_json(
+        backup_dir.join("tasks").join("80.json"),
+        &json!({"id":"80","status":"open"}),
+    );
+
+    let output = fixture.run(&[
+        "teams",
+        "restore",
+        "atm-dev",
+        "--from",
+        backup_dir.to_str().expect("utf8"),
+        "--dry-run",
+        "--json",
+    ]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["dry_run"], true);
+    assert_eq!(parsed["would_restore_members"][0], "arch-ctm");
+    assert_eq!(parsed["would_restore_inboxes"][0], "arch-ctm.json");
+    assert_eq!(parsed["would_restore_tasks"], 1);
+}
+
+#[test]
+fn test_restore_preserves_team_lead_and_recomputes_highwatermark() {
+    let fixture = Fixture::new();
+    fixture.write_team_config_value(
+        "atm-dev",
+        json!({
+            "leadSessionId":"lead-current",
+            "members":[
+                {"name":"team-lead","model":"current-lead","agentType":"lead","cwd":"/repo"},
+                {"name":"existing","model":"existing","agentType":"worker","cwd":"/repo"}
+            ]
+        }),
+    );
+    fixture.write_inbox("atm-dev", "team-lead", "keep me");
+    fixture.write_task("atm-dev", 75, json!({"id":"75","status":"stale"}));
+    fixture.write_highwatermark("atm-dev", "75\n");
+
+    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T020304000000000Z");
+    fixture.write_json(
+        backup_dir.join("config.json"),
+        &json!({
+            "leadSessionId":"lead-backup",
+            "members":[
+                {"name":"team-lead","model":"backup-lead","agentType":"lead","cwd":"/backup"},
+                {
+                    "name":"arch-ctm",
+                    "agentId":"arch-ctm@atm-dev",
+                    "agentType":"general-purpose",
+                    "model":"sonnet",
+                    "cwd":"/repo",
+                    "tmuxPaneId":"%9",
+                    "sessionId":"session-123",
+                    "activity":"idle"
+                }
+            ]
+        }),
+    );
+    fixture.write_inbox_at(
+        backup_dir.join("inboxes").join("team-lead.json"),
+        "arch-ctm",
+        "do not restore",
+    );
+    fixture.write_inbox_at(
+        backup_dir.join("inboxes").join("arch-ctm.json"),
+        "team-lead",
+        "restore worker inbox",
+    );
+    fixture.write_json(
+        backup_dir.join("tasks").join("80.json"),
+        &json!({"id":"80","status":"open"}),
+    );
+    fixture.write_json(
+        backup_dir.join("tasks").join("82.json"),
+        &json!({"id":"82","status":"done"}),
+    );
+    fixture.write_text(backup_dir.join("tasks").join(".highwatermark"), "1\n");
+
+    let output = fixture.run(&[
+        "teams",
+        "restore",
+        "atm-dev",
+        "--from",
+        backup_dir.to_str().expect("utf8"),
+        "--json",
+    ]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["members_restored"], 1);
+    assert_eq!(parsed["inboxes_restored"], 1);
+    assert_eq!(parsed["tasks_restored"], 2);
+
+    let config = fixture.read_team_config_value("atm-dev");
+    assert_eq!(config["leadSessionId"], "lead-current");
+    assert_eq!(config["members"][0]["name"], "team-lead");
+    assert_eq!(config["members"][0]["model"], "current-lead");
+
+    let restored = config["members"]
+        .as_array()
+        .expect("members")
+        .iter()
+        .find(|member| member["name"] == "arch-ctm")
+        .expect("restored member");
+    assert_eq!(restored["tmuxPaneId"], "");
+    assert!(restored.get("sessionId").is_none());
+    assert!(restored.get("activity").is_none());
+
+    let team_lead_inbox =
+        fs::read_to_string(fixture.inbox_path("atm-dev", "team-lead")).expect("team-lead inbox");
+    assert!(team_lead_inbox.contains("keep me"));
+    let restored_inbox =
+        fs::read_to_string(fixture.inbox_path("atm-dev", "arch-ctm")).expect("restored inbox");
+    assert!(restored_inbox.contains("restore worker inbox"));
+    assert_eq!(fixture.read_highwatermark("atm-dev"), "82");
+}
+
+struct Fixture {
+    tempdir: tempfile::TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            tempdir.path().join(".atm.toml"),
+            "default_team = \"atm-dev\"\n",
+        )
+        .expect("config");
+        Self { tempdir }
+    }
+
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_atm"))
+            .args(args)
+            .env("ATM_HOME", self.tempdir.path())
+            .current_dir(self.tempdir.path())
+            .output()
+            .expect("run atm")
+    }
+
+    fn write_team_config_value(&self, team: &str, value: Value) {
+        self.write_json(self.team_dir(team).join("config.json"), &value);
+    }
+
+    fn read_team_config_value(&self, team: &str) -> Value {
+        serde_json::from_slice(
+            &fs::read(self.team_dir(team).join("config.json")).expect("config json"),
+        )
+        .expect("team config json")
+    }
+
+    fn write_inbox(&self, team: &str, member: &str, text: &str) {
+        self.write_inbox_at(self.inbox_path(team, member), "team-lead", text);
+    }
+
+    fn write_inbox_at(&self, path: std::path::PathBuf, from: &str, text: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("inbox dir");
+        }
+        let envelope = MessageEnvelope {
+            from: from.to_string(),
+            text: text.to_string(),
+            timestamp: atm_core::types::IsoTimestamp::from_datetime(Utc::now()),
+            read: false,
+            source_team: Some("atm-dev".to_string()),
+            summary: None,
+            message_id: None,
+            pending_ack_at: None,
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            task_id: None,
+            extra: serde_json::Map::new(),
+        };
+        let raw = serde_json::to_string(&envelope).expect("envelope");
+        fs::write(path, format!("{raw}\n")).expect("write inbox");
+    }
+
+    fn write_task(&self, team: &str, id: usize, value: Value) {
+        self.write_json(self.tasks_dir(team).join(format!("{id}.json")), &value);
+    }
+
+    fn write_highwatermark(&self, team: &str, value: &str) {
+        self.write_text(self.tasks_dir(team).join(".highwatermark"), value);
+    }
+
+    fn read_highwatermark(&self, team: &str) -> String {
+        fs::read_to_string(self.tasks_dir(team).join(".highwatermark"))
+            .expect("highwatermark")
+            .trim()
+            .to_string()
+    }
+
+    fn make_backup_dir(&self, team: &str, stamp: &str) -> std::path::PathBuf {
+        let path = self
+            .tempdir
+            .path()
+            .join(".claude")
+            .join("teams")
+            .join(".backups")
+            .join(team)
+            .join(stamp);
+        fs::create_dir_all(path.join("inboxes")).expect("backup inbox dir");
+        fs::create_dir_all(path.join("tasks")).expect("backup task dir");
+        path
+    }
+
+    fn write_json(&self, path: std::path::PathBuf, value: &Value) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("json dir");
+        }
+        fs::write(path, serde_json::to_vec_pretty(value).expect("json")).expect("write json");
+    }
+
+    fn write_text(&self, path: std::path::PathBuf, value: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("text dir");
+        }
+        fs::write(path, value).expect("write text");
+    }
+
+    fn stdout_json(&self, output: &std::process::Output) -> Value {
+        serde_json::from_slice(&output.stdout).expect("valid json")
+    }
+
+    fn stderr(&self, output: &std::process::Output) -> String {
+        String::from_utf8(output.stderr.clone()).expect("stderr utf8")
+    }
+
+    fn team_dir(&self, team: &str) -> std::path::PathBuf {
+        self.tempdir.path().join(".claude").join("teams").join(team)
+    }
+
+    fn inbox_path(&self, team: &str, member: &str) -> std::path::PathBuf {
+        self.team_dir(team)
+            .join("inboxes")
+            .join(format!("{member}.json"))
+    }
+
+    fn tasks_dir(&self, team: &str) -> std::path::PathBuf {
+        self.tempdir.path().join(".claude").join("tasks").join(team)
+    }
+}


### PR DESCRIPTION
## Sprint L.8 — Team Recovery Minimum Surface

Implements the retained `atm teams` / `atm members` minimum recovery surface:

- `atm teams` (list)
- `atm members`
- `atm teams add-member` (with inbox creation + rollback on failure)
- `atm teams backup` (config/inboxes/tasks)
- `atm teams restore` (skips team-lead overwrite, preserves `leadSessionId`, clears runtime-only state, restores inboxes/tasks, recomputes `.highwatermark`)

Core implementation in `atm_core::team_admin` with config-root extra-field preservation. Integration tests in `crates/atm/tests/team_recovery.rs` covering list/add-member/backup/restore semantics.

Commit: 4daaf08

🤖 Generated with [Claude Code](https://claude.com/claude-code)