### PR TITLE
L.4: ATM-owned public field model (LogFieldKey, AtmJsonNumber, LogFieldValue, LogFieldMap)

### DIFF
--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -218,7 +218,7 @@ impl LogFieldValue {
     ///
     /// Returns [`AtmError`] when a nested field key or JSON number fails ATM
     /// validation.
-    pub fn from_json_value(value: Value) -> Result<Self, AtmError> {
+    pub(crate) fn from_json_value(value: Value) -> Result<Self, AtmError> {
         match value {
             Value::Null => Ok(Self::Null),
             Value::Bool(value) => Ok(Self::Bool(value)),
@@ -239,7 +239,7 @@ impl LogFieldValue {
     ///
     /// Returns [`AtmError`] when a nested ATM-owned JSON number cannot be
     /// materialized as a JSON value.
-    pub fn to_json_value(&self) -> Result<Value, AtmError> {
+    pub(crate) fn to_json_value(&self) -> Result<Value, AtmError> {
         match self {
             Self::Null => Ok(Value::Null),
             Self::Bool(value) => Ok(Value::Bool(*value)),
@@ -298,7 +298,7 @@ impl LogFieldMap {
     /// # Errors
     ///
     /// Returns [`AtmError`] when a nested key or value fails ATM validation.
-    pub fn from_json_map(values: Map<String, Value>) -> Result<Self, AtmError> {
+    pub(crate) fn from_json_map(values: Map<String, Value>) -> Result<Self, AtmError> {
         let entries = values
             .into_iter()
             .map(|(key, value)| {

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -2,7 +2,9 @@
 
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
+use serde::de::Error as DeError;
+use serde::ser::{Error as SerError, SerializeMap};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Map, Value};
 
 use crate::error::{AtmError, AtmErrorCode};
@@ -49,13 +51,262 @@ pub enum LogOrder {
     OldestFirst,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
-pub struct LogFieldMatch {
-    pub key: String,
-    pub value: Value,
+/// ATM-owned field-key type for observability query and record projections.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LogFieldKey(String);
+
+impl LogFieldKey {
+    pub fn new(value: impl Into<String>) -> Result<Self, AtmError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(AtmError::validation("ATM log field key must not be empty"));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+impl Serialize for LogFieldKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for LogFieldKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(D::Error::custom)
+    }
+}
+
+/// ATM-owned validated JSON-number representation for the observability
+/// boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AtmJsonNumber(String);
+
+impl AtmJsonNumber {
+    pub fn new(value: impl Into<String>) -> Result<Self, AtmError> {
+        let value = value.into();
+        let parsed: Value = serde_json::from_str(&value).map_err(|source| {
+            AtmError::validation(format!("invalid ATM JSON number `{value}`")).with_source(source)
+        })?;
+        match parsed {
+            Value::Number(_) => Ok(Self(value)),
+            _ => Err(AtmError::validation(format!(
+                "invalid ATM JSON number `{value}`"
+            ))),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn to_json_number(&self) -> Result<serde_json::Number, AtmError> {
+        let parsed: Value = serde_json::from_str(&self.0).map_err(|source| {
+            AtmError::validation(format!("invalid ATM JSON number `{}`", self.0))
+                .with_source(source)
+        })?;
+        match parsed {
+            Value::Number(number) => Ok(number),
+            _ => Err(AtmError::validation(format!(
+                "invalid ATM JSON number `{}`",
+                self.0
+            ))),
+        }
+    }
+}
+
+impl Serialize for AtmJsonNumber {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_json_number()
+            .map_err(S::Error::custom)?
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for AtmJsonNumber {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        match value {
+            Value::Number(number) => Self::new(number.to_string()).map_err(D::Error::custom),
+            _ => Err(D::Error::custom("expected a JSON number")),
+        }
+    }
+}
+
+/// ATM-owned recursive JSON-value wrapper used by the observability boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LogFieldValue {
+    Null,
+    Bool(bool),
+    String(String),
+    Number(AtmJsonNumber),
+    Array(Vec<LogFieldValue>),
+    Object(LogFieldMap),
+}
+
+impl LogFieldValue {
+    pub fn null() -> Self {
+        Self::Null
+    }
+
+    pub fn bool(value: bool) -> Self {
+        Self::Bool(value)
+    }
+
+    pub fn string(value: impl Into<String>) -> Self {
+        Self::String(value.into())
+    }
+
+    pub fn number(value: AtmJsonNumber) -> Self {
+        Self::Number(value)
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::String(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    fn from_json_value(value: Value) -> Result<Self, AtmError> {
+        match value {
+            Value::Null => Ok(Self::Null),
+            Value::Bool(value) => Ok(Self::Bool(value)),
+            Value::String(value) => Ok(Self::String(value)),
+            Value::Number(value) => Ok(Self::Number(AtmJsonNumber::new(value.to_string())?)),
+            Value::Array(values) => values
+                .into_iter()
+                .map(Self::from_json_value)
+                .collect::<Result<Vec<_>, _>>()
+                .map(Self::Array),
+            Value::Object(values) => LogFieldMap::from_json_map(values).map(Self::Object),
+        }
+    }
+
+    fn to_json_value(&self) -> Result<Value, AtmError> {
+        match self {
+            Self::Null => Ok(Value::Null),
+            Self::Bool(value) => Ok(Value::Bool(*value)),
+            Self::String(value) => Ok(Value::String(value.clone())),
+            Self::Number(value) => Ok(Value::Number(value.to_json_number()?)),
+            Self::Array(values) => values
+                .iter()
+                .map(Self::to_json_value)
+                .collect::<Result<Vec<_>, _>>()
+                .map(Value::Array),
+            Self::Object(values) => values.to_json_map().map(Value::Object),
+        }
+    }
+}
+
+impl Serialize for LogFieldValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_json_value()
+            .map_err(S::Error::custom)?
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LogFieldValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        Self::from_json_value(value).map_err(D::Error::custom)
+    }
+}
+
+/// ATM-owned map wrapper used by public observability record projections.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LogFieldMap {
+    entries: Vec<(LogFieldKey, LogFieldValue)>,
+}
+
+impl LogFieldMap {
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn get(&self, key: &str) -> Option<&LogFieldValue> {
+        self.entries
+            .iter()
+            .find_map(|(entry_key, entry_value)| (entry_key.as_str() == key).then_some(entry_value))
+    }
+
+    fn from_json_map(values: Map<String, Value>) -> Result<Self, AtmError> {
+        let entries = values
+            .into_iter()
+            .map(|(key, value)| {
+                Ok((
+                    LogFieldKey::new(key)?,
+                    LogFieldValue::from_json_value(value)?,
+                ))
+            })
+            .collect::<Result<Vec<_>, AtmError>>()?;
+        Ok(Self { entries })
+    }
+
+    fn to_json_map(&self) -> Result<Map<String, Value>, AtmError> {
+        self.entries
+            .iter()
+            .try_fold(Map::new(), |mut map, (key, value)| {
+                map.insert(key.as_str().to_string(), value.to_json_value()?);
+                Ok(map)
+            })
+    }
+}
+
+impl Serialize for LogFieldMap {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.entries.len()))?;
+        for (key, value) in &self.entries {
+            map.serialize_entry(key.as_str(), value)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for LogFieldMap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let values = Map::<String, Value>::deserialize(deserializer)?;
+        Self::from_json_map(values).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct LogFieldMatch {
+    pub key: LogFieldKey,
+    pub value: LogFieldValue,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AtmLogQuery {
     pub mode: LogMode,
     pub levels: Vec<LogLevelFilter>,
@@ -66,7 +317,7 @@ pub struct AtmLogQuery {
     pub order: LogOrder,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AtmLogRecord {
     pub timestamp: IsoTimestamp,
     pub severity: LogLevelFilter,
@@ -74,7 +325,7 @@ pub struct AtmLogRecord {
     pub target: Option<String>,
     pub action: Option<String>,
     pub message: Option<String>,
-    pub fields: Map<String, Value>,
+    pub fields: LogFieldMap,
 }
 
 #[derive(Debug, Clone, Default, Serialize, PartialEq)]

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -56,10 +56,19 @@ pub enum LogOrder {
 pub struct LogFieldKey(String);
 
 impl LogFieldKey {
+    /// Construct a validated ATM log-field key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AtmError`] when the provided key is empty or whitespace-only.
     pub fn new(value: impl Into<String>) -> Result<Self, AtmError> {
         let value = value.into();
         if value.trim().is_empty() {
-            return Err(AtmError::validation("ATM log field key must not be empty"));
+            return Err(
+                AtmError::validation("ATM log field key must not be empty").with_recovery(
+                    "Provide a non-empty field key when building ATM log queries or records.",
+                ),
+            );
         }
         Ok(Self(value))
     }
@@ -90,41 +99,59 @@ impl<'de> Deserialize<'de> for LogFieldKey {
 
 /// ATM-owned validated JSON-number representation for the observability
 /// boundary.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct AtmJsonNumber(String);
+#[derive(Debug, Clone)]
+pub struct AtmJsonNumber {
+    raw: String,
+    number: serde_json::Number,
+    normalized: String,
+}
 
 impl AtmJsonNumber {
+    /// Construct a validated ATM JSON number from a raw numeric string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AtmError`] when the input is not a valid RFC 8259 JSON
+    /// number. Non-JSON values such as `NaN` and `Infinity` are rejected.
     pub fn new(value: impl Into<String>) -> Result<Self, AtmError> {
         let value = value.into();
         let parsed: Value = serde_json::from_str(&value).map_err(|source| {
-            AtmError::validation(format!("invalid ATM JSON number `{value}`")).with_source(source)
+            AtmError::validation(format!("invalid ATM JSON number `{value}`"))
+                .with_recovery(
+                    "Provide a valid RFC 8259 JSON number such as `1`, `-2.5`, or `6.02e23`.",
+                )
+                .with_source(source)
         })?;
         match parsed {
-            Value::Number(_) => Ok(Self(value)),
-            _ => Err(AtmError::validation(format!(
-                "invalid ATM JSON number `{value}`"
-            ))),
+            Value::Number(number) => Ok(Self {
+                raw: value.clone(),
+                number,
+                normalized: normalize_json_number(&value),
+            }),
+            _ => Err(
+                AtmError::validation(format!("invalid ATM JSON number `{value}`")).with_recovery(
+                    "Provide a valid RFC 8259 JSON number such as `1`, `-2.5`, or `6.02e23`.",
+                ),
+            ),
         }
     }
 
     pub fn as_str(&self) -> &str {
-        &self.0
+        &self.raw
     }
 
     fn to_json_number(&self) -> Result<serde_json::Number, AtmError> {
-        let parsed: Value = serde_json::from_str(&self.0).map_err(|source| {
-            AtmError::validation(format!("invalid ATM JSON number `{}`", self.0))
-                .with_source(source)
-        })?;
-        match parsed {
-            Value::Number(number) => Ok(number),
-            _ => Err(AtmError::validation(format!(
-                "invalid ATM JSON number `{}`",
-                self.0
-            ))),
-        }
+        Ok(self.number.clone())
     }
 }
+
+impl PartialEq for AtmJsonNumber {
+    fn eq(&self, other: &Self) -> bool {
+        self.normalized == other.normalized
+    }
+}
+
+impl Eq for AtmJsonNumber {}
 
 impl Serialize for AtmJsonNumber {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -185,7 +212,13 @@ impl LogFieldValue {
         }
     }
 
-    fn from_json_value(value: Value) -> Result<Self, AtmError> {
+    /// Convert a serde_json value into the ATM-owned field-value wrapper.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AtmError`] when a nested field key or JSON number fails ATM
+    /// validation.
+    pub fn from_json_value(value: Value) -> Result<Self, AtmError> {
         match value {
             Value::Null => Ok(Self::Null),
             Value::Bool(value) => Ok(Self::Bool(value)),
@@ -200,7 +233,13 @@ impl LogFieldValue {
         }
     }
 
-    fn to_json_value(&self) -> Result<Value, AtmError> {
+    /// Convert the ATM-owned field-value wrapper into a serde_json value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AtmError`] when a nested ATM-owned JSON number cannot be
+    /// materialized as a JSON value.
+    pub fn to_json_value(&self) -> Result<Value, AtmError> {
         match self {
             Self::Null => Ok(Value::Null),
             Self::Bool(value) => Ok(Value::Bool(*value)),
@@ -254,7 +293,12 @@ impl LogFieldMap {
             .find_map(|(entry_key, entry_value)| (entry_key.as_str() == key).then_some(entry_value))
     }
 
-    fn from_json_map(values: Map<String, Value>) -> Result<Self, AtmError> {
+    /// Convert a serde_json object into the ATM-owned field-map wrapper.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AtmError`] when a nested key or value fails ATM validation.
+    pub fn from_json_map(values: Map<String, Value>) -> Result<Self, AtmError> {
         let entries = values
             .into_iter()
             .map(|(key, value)| {
@@ -268,6 +312,9 @@ impl LogFieldMap {
     }
 
     fn to_json_map(&self) -> Result<Map<String, Value>, AtmError> {
+        // Duplicate keys collapse with a last-wins policy when projected back
+        // into JSON. Serialize uses the same helper so the policy is
+        // consistent across both outbound paths.
         self.entries
             .iter()
             .try_fold(Map::new(), |mut map, (key, value)| {
@@ -282,9 +329,10 @@ impl Serialize for LogFieldMap {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(Some(self.entries.len()))?;
-        for (key, value) in &self.entries {
-            map.serialize_entry(key.as_str(), value)?;
+        let json_map = self.to_json_map().map_err(S::Error::custom)?;
+        let mut map = serializer.serialize_map(Some(json_map.len()))?;
+        for (key, value) in json_map {
+            map.serialize_entry(&key, &value)?;
         }
         map.end()
     }
@@ -471,11 +519,67 @@ impl ObservabilityPort for NullObservability {
     }
 }
 
+fn normalize_json_number(raw: &str) -> String {
+    let (negative, unsigned) = match raw.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, raw),
+    };
+    let (base, exponent) = match unsigned.find(['e', 'E']) {
+        Some(index) => (
+            &unsigned[..index],
+            unsigned[index + 1..]
+                .parse::<i64>()
+                .expect("valid JSON number exponent"),
+        ),
+        None => (unsigned, 0),
+    };
+    let (integer, fraction) = match base.split_once('.') {
+        Some((integer, fraction)) => (integer, fraction),
+        None => (base, ""),
+    };
+
+    let mut digits = format!("{integer}{fraction}");
+    let mut scale = exponent - fraction.len() as i64;
+
+    let trimmed = digits.trim_start_matches('0');
+    digits = if trimmed.is_empty() {
+        "0".to_string()
+    } else {
+        trimmed.to_string()
+    };
+    if digits == "0" {
+        return "0".to_string();
+    }
+
+    while digits.ends_with('0') {
+        digits.pop();
+        scale += 1;
+    }
+
+    let unsigned = if scale >= 0 {
+        format!("{digits}{}", "0".repeat(scale as usize))
+    } else {
+        let point_index = digits.len() as i64 + scale;
+        if point_index > 0 {
+            let point_index = point_index as usize;
+            format!("{}.{}", &digits[..point_index], &digits[point_index..])
+        } else {
+            format!("0.{}{}", "0".repeat((-point_index) as usize), digits)
+        }
+    };
+
+    if negative {
+        format!("-{unsigned}")
+    } else {
+        unsigned
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        AtmLogQuery, AtmObservabilityHealthState, LogLevelFilter, LogMode, LogOrder,
-        NullObservability, ObservabilityPort,
+        AtmJsonNumber, AtmLogQuery, AtmObservabilityHealthState, LogFieldKey, LogFieldMap,
+        LogFieldValue, LogLevelFilter, LogMode, LogOrder, NullObservability, ObservabilityPort,
     };
     use serde_json::json;
 
@@ -535,5 +639,104 @@ mod tests {
             serde_json::from_value::<LogMode>(json!("tail")).unwrap(),
             LogMode::Tail
         );
+    }
+
+    #[test]
+    fn atm_json_number_rejects_non_json_numeric_values() {
+        assert!(AtmJsonNumber::new("NaN").is_err());
+        assert!(AtmJsonNumber::new("Infinity").is_err());
+        assert!(AtmJsonNumber::new("-Infinity").is_err());
+    }
+
+    #[test]
+    fn atm_json_number_accepts_valid_json_numbers() {
+        for raw in ["1", "1.5", "-42", "6.02e23", "1e-6"] {
+            let number = AtmJsonNumber::new(raw).expect("valid number");
+            let encoded = serde_json::to_string(&number).expect("serialize");
+            let decoded: AtmJsonNumber = serde_json::from_str(&encoded).expect("deserialize");
+            assert_eq!(decoded, number, "number `{raw}` should round-trip");
+        }
+    }
+
+    #[test]
+    fn atm_json_number_equality_is_value_based() {
+        assert_eq!(
+            AtmJsonNumber::new("1").expect("one"),
+            AtmJsonNumber::new("1.0").expect("one point zero")
+        );
+        assert_eq!(
+            AtmJsonNumber::new("1").expect("one"),
+            AtmJsonNumber::new("1e0").expect("scientific")
+        );
+    }
+
+    #[test]
+    fn log_field_key_round_trips_through_json() {
+        let key = LogFieldKey::new("task_id").expect("key");
+        let encoded = serde_json::to_string(&key).expect("encode");
+        let decoded: LogFieldKey = serde_json::from_str(&encoded).expect("decode");
+        assert_eq!(decoded, key);
+    }
+
+    #[test]
+    fn log_field_value_variants_round_trip_through_json() {
+        let object: LogFieldMap = serde_json::from_value(json!({
+            "nested": true,
+            "answer": 42
+        }))
+        .expect("object");
+        let cases = vec![
+            LogFieldValue::Null,
+            LogFieldValue::Bool(true),
+            LogFieldValue::String("hello".to_string()),
+            LogFieldValue::Number(AtmJsonNumber::new("1.0").expect("number")),
+            LogFieldValue::Array(vec![
+                LogFieldValue::String("a".to_string()),
+                LogFieldValue::Bool(false),
+            ]),
+            LogFieldValue::Object(object),
+        ];
+
+        for case in cases {
+            let encoded = serde_json::to_value(&case).expect("encode value");
+            let decoded: LogFieldValue = serde_json::from_value(encoded).expect("decode value");
+            assert_eq!(decoded, case);
+        }
+    }
+
+    #[test]
+    fn log_field_map_round_trips_with_last_key_wins() {
+        let map = LogFieldMap {
+            entries: vec![
+                (
+                    LogFieldKey::new("dup").expect("key"),
+                    LogFieldValue::String("first".to_string()),
+                ),
+                (
+                    LogFieldKey::new("stable").expect("key"),
+                    LogFieldValue::Bool(true),
+                ),
+                (
+                    LogFieldKey::new("dup").expect("key"),
+                    LogFieldValue::String("second".to_string()),
+                ),
+            ],
+        };
+
+        let encoded = serde_json::to_value(&map).expect("encode map");
+        assert_eq!(
+            encoded,
+            json!({
+                "dup": "second",
+                "stable": true
+            })
+        );
+
+        let decoded: LogFieldMap = serde_json::from_value(encoded).expect("decode map");
+        assert_eq!(
+            decoded.get("dup").and_then(LogFieldValue::as_str),
+            Some("second")
+        );
+        assert_eq!(decoded.get("stable"), Some(&LogFieldValue::Bool(true)));
     }
 }

--- a/crates/atm/src/commands/log.rs
+++ b/crates/atm/src/commands/log.rs
@@ -3,11 +3,11 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use atm_core::observability::{
-    AtmLogQuery, LogFieldMatch, LogLevelFilter, LogMode, LogOrder, ObservabilityPort,
+    AtmJsonNumber, AtmLogQuery, LogFieldKey, LogFieldMatch, LogFieldValue, LogLevelFilter, LogMode,
+    LogOrder, ObservabilityPort,
 };
 use atm_core::types::IsoTimestamp;
 use clap::{Args, Subcommand, ValueEnum};
-use serde_json::Value;
 
 use crate::observability::CliObservability;
 use crate::output;
@@ -181,28 +181,22 @@ fn parse_match_expression(raw: &str) -> Result<LogFieldMatch> {
     }
 
     Ok(LogFieldMatch {
-        key: key.to_string(),
+        key: LogFieldKey::new(key.to_string())?,
         value: parse_match_value(value),
     })
 }
 
-fn parse_match_value(raw: &str) -> Value {
+fn parse_match_value(raw: &str) -> LogFieldValue {
     if raw.eq_ignore_ascii_case("true") {
-        Value::Bool(true)
+        LogFieldValue::bool(true)
     } else if raw.eq_ignore_ascii_case("false") {
-        Value::Bool(false)
+        LogFieldValue::bool(false)
     } else if raw.eq_ignore_ascii_case("null") {
-        Value::Null
-    } else if let Ok(number) = raw.parse::<i64>() {
-        Value::Number(number.into())
-    } else if let Ok(number) = raw.parse::<u64>() {
-        Value::Number(number.into())
-    } else if let Ok(number) = raw.parse::<f64>() {
-        serde_json::Number::from_f64(number)
-            .map(Value::Number)
-            .unwrap_or_else(|| Value::String(raw.to_string()))
+        LogFieldValue::null()
+    } else if let Ok(number) = AtmJsonNumber::new(raw.to_string()) {
+        LogFieldValue::number(number)
     } else {
-        Value::String(raw.to_string())
+        LogFieldValue::string(raw.to_string())
     }
 }
 

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -420,7 +420,7 @@ fn map_field_match(
     field_match: LogFieldMatch,
 ) -> Result<sc_observability_types::LogFieldMatch, AtmError> {
     let key = field_match.key.as_str().to_string();
-    let value = serde_json::to_value(&field_match.value).map_err(|source| {
+    let value = field_match.value.to_json_value().map_err(|source| {
         AtmError::observability_query("failed to encode ATM log field match value")
             .with_source(source)
     })?;
@@ -441,11 +441,10 @@ fn map_snapshot(snapshot: sc_observability_types::LogSnapshot) -> Result<AtmLogS
 }
 
 fn map_record(event: LogEvent) -> Result<AtmLogRecord, AtmError> {
-    let fields = serde_json::from_value::<LogFieldMap>(serde_json::Value::Object(event.fields))
-        .map_err(|source| {
-            AtmError::observability_query("failed to project shared log fields into ATM types")
-                .with_source(source)
-        })?;
+    let fields = LogFieldMap::from_json_map(event.fields).map_err(|source| {
+        AtmError::observability_query("failed to project shared log fields into ATM types")
+            .with_source(source)
+    })?;
     Ok(AtmLogRecord {
         timestamp: map_timestamp_back(event.timestamp)?,
         severity: map_level_back(event.level),

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -318,6 +318,8 @@ fn map_command_event(
             .with_source(source)
     })?;
 
+    // emit path: builds sc_observability_types fields directly; exempt from
+    // REQ-CORE-OBS-001 centralization per architect ruling (outputs to foreign type)
     let mut fields = Map::new();
     fields.insert(
         "command".to_string(),
@@ -420,7 +422,7 @@ fn map_field_match(
     field_match: LogFieldMatch,
 ) -> Result<sc_observability_types::LogFieldMatch, AtmError> {
     let key = field_match.key.as_str().to_string();
-    let value = field_match.value.to_json_value().map_err(|source| {
+    let value = serde_json::to_value(&field_match.value).map_err(|source| {
         AtmError::observability_query("failed to encode ATM log field match value")
             .with_source(source)
     })?;
@@ -441,10 +443,11 @@ fn map_snapshot(snapshot: sc_observability_types::LogSnapshot) -> Result<AtmLogS
 }
 
 fn map_record(event: LogEvent) -> Result<AtmLogRecord, AtmError> {
-    let fields = LogFieldMap::from_json_map(event.fields).map_err(|source| {
-        AtmError::observability_query("failed to project shared log fields into ATM types")
-            .with_source(source)
-    })?;
+    let fields = serde_json::from_value::<LogFieldMap>(serde_json::Value::Object(event.fields))
+        .map_err(|source| {
+            AtmError::observability_query("failed to project shared log fields into ATM types")
+                .with_source(source)
+        })?;
     Ok(AtmLogRecord {
         timestamp: map_timestamp_back(event.timestamp)?,
         severity: map_level_back(event.level),

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -6,8 +6,8 @@ use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::home;
 use atm_core::observability::{
     self, AtmLogQuery, AtmLogRecord, AtmLogSnapshot, AtmObservabilityHealth,
-    AtmObservabilityHealthState, CommandEvent, LogFieldMatch, LogLevelFilter, LogOrder,
-    LogTailSession, ObservabilityPort,
+    AtmObservabilityHealthState, CommandEvent, LogFieldMap, LogFieldMatch, LogLevelFilter,
+    LogOrder, LogTailSession, ObservabilityPort,
 };
 use chrono::{DateTime, Utc};
 use sc_observability::{
@@ -419,16 +419,13 @@ fn map_query(
 fn map_field_match(
     field_match: LogFieldMatch,
 ) -> Result<sc_observability_types::LogFieldMatch, AtmError> {
-    if field_match.key.trim().is_empty() {
-        return Err(AtmError::observability_query(
-            "ATM log field match key must not be empty",
-        ));
-    }
+    let key = field_match.key.as_str().to_string();
+    let value = serde_json::to_value(&field_match.value).map_err(|source| {
+        AtmError::observability_query("failed to encode ATM log field match value")
+            .with_source(source)
+    })?;
 
-    Ok(sc_observability_types::LogFieldMatch::equals(
-        field_match.key,
-        field_match.value,
-    ))
+    Ok(sc_observability_types::LogFieldMatch::equals(key, value))
 }
 
 fn map_snapshot(snapshot: sc_observability_types::LogSnapshot) -> Result<AtmLogSnapshot, AtmError> {
@@ -444,6 +441,11 @@ fn map_snapshot(snapshot: sc_observability_types::LogSnapshot) -> Result<AtmLogS
 }
 
 fn map_record(event: LogEvent) -> Result<AtmLogRecord, AtmError> {
+    let fields = serde_json::from_value::<LogFieldMap>(serde_json::Value::Object(event.fields))
+        .map_err(|source| {
+            AtmError::observability_query("failed to project shared log fields into ATM types")
+                .with_source(source)
+        })?;
     Ok(AtmLogRecord {
         timestamp: map_timestamp_back(event.timestamp)?,
         severity: map_level_back(event.level),
@@ -451,7 +453,7 @@ fn map_record(event: LogEvent) -> Result<AtmLogRecord, AtmError> {
         target: Some(event.target.to_string()),
         action: Some(event.action.to_string()),
         message: event.message,
-        fields: event.fields,
+        fields,
     })
 }
 
@@ -661,8 +663,11 @@ mod tests {
         assert_eq!(initial.records[0].service, "atm");
         assert_eq!(initial.records[0].action.as_deref(), Some("send"));
         assert_eq!(
-            initial.records[0].fields["command"],
-            serde_json::Value::String("send".to_string())
+            initial.records[0]
+                .fields
+                .get("command")
+                .and_then(atm_core::observability::LogFieldValue::as_str),
+            Some("send")
         );
 
         let health = observability.health().expect("health");
@@ -693,10 +698,11 @@ mod tests {
         let followed = follow.poll().expect("follow poll");
         assert!(
             followed.records.iter().any(|record| {
-                record.fields.get("message_id")
-                    == Some(&serde_json::Value::String(
-                        "550e8400-e29b-41d4-a716-446655440001".to_string(),
-                    ))
+                record
+                    .fields
+                    .get("message_id")
+                    .and_then(atm_core::observability::LogFieldValue::as_str)
+                    == Some("550e8400-e29b-41d4-a716-446655440001")
             }),
             "follow poll should include the newly emitted record even if the shared tail surface also returns the prior backlog entry"
         );

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -299,8 +299,9 @@ Architectural rules:
 
 ### 4.5 Observability Construction Contract
 
-`CliObservability` should expose one structured construction path for initial
-release:
+`CliObservability` (atm crate) should expose one structured construction path
+for initial release, and `CliObservabilityOptions` is also owned by the `atm`
+crate:
 
 ```rust
 pub struct CliObservabilityOptions {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -269,9 +269,59 @@ pub struct LogFieldMatch {
     pub key: LogFieldKey,
     pub value: LogFieldValue,
 }
+
+pub struct LogFieldMap(BTreeMap<LogFieldKey, LogFieldValue>);
+
+pub struct AtmJsonNumber(String);
+
+pub enum LogFieldValue {
+    Null,
+    Bool(bool),
+    String(String),
+    Number(AtmJsonNumber),
+    Array(Vec<LogFieldValue>),
+    Object(LogFieldMap),
+}
 ```
 
-### 4.5 Identity And Alias Projection
+Architectural rules:
+- `LogFieldKey` replaces raw field-name strings at the public observability
+  boundary
+- `AtmJsonNumber` replaces raw numeric `serde_json` values at the public
+  observability boundary
+- `LogFieldValue` and `LogFieldMap` replace raw `serde_json::Value` /
+  `Map<String, Value>` in `LogFieldMatch` and `AtmLogRecord`
+- these ATM-owned types must serialize to the same JSON shape the CLI exposes
+  today; the boundary cleanup is a Rust API cleanup, not a CLI wire-format
+  redesign
+- conversion to and from raw `serde_json` values remains centralized inside
+  `atm-core`
+
+### 4.5 Observability Construction Contract
+
+`CliObservability` should expose one structured construction path for initial
+release:
+
+```rust
+pub struct CliObservabilityOptions {
+    pub stderr_logs: bool,
+}
+
+impl CliObservability {
+    pub fn new(home_dir: &Path, options: CliObservabilityOptions) -> Result<Self, AtmError>;
+}
+```
+
+Architectural rules:
+- the top-level `init(stderr_logs)` helper may remain as a CLI convenience, but
+  it should delegate to `CliObservability::new(...)`
+- dynamic dispatch via `Box<dyn ObservabilityPort + Send + Sync>` remains
+  acceptable for initial release
+- the current sealed-trait pattern remains acceptable for initial release
+- `DoctorCommand` injectability is explicitly deferred unless implementation
+  surfaces a concrete need
+
+### 4.6 Identity And Alias Projection
 
 ATM must distinguish canonical routing identity from the Claude-facing sender
 projection.

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -114,6 +114,22 @@ Current `AgentMember` persisted schema:
 - `extra: serde_json::Map<String, serde_json::Value>` via `#[serde(flatten)]`
   for forward-compatible Claude Code fields
 
+Observability boundary note:
+- `AgentMember.extra` is intentionally out of scope for the L.4 observability
+  field-model cleanup
+- L.4 only replaces raw JSON types on observability-facing public types such as
+  `AtmLogRecord.fields` and `LogFieldMatch`
+- `AgentMember.extra` remains a round-trip preservation mechanism for
+  Claude Code config fields rather than part of the retained-log API surface
+
+Sealed-trait note:
+- the sealed `ObservabilityPort` boundary prevents arbitrary external crates
+  from implementing ATM's injected observability contract and bypassing the
+  intended adapter split between `atm-core` and `atm`
+- this decision should be revisited only if a concrete alternative materially
+  simplifies first-party construction or testing without weakening those
+  crate-boundary guarantees
+
 ## 3.1 Send Alert Metadata Boundary
 
 ATM-authored alert metadata belongs to the send/schema boundary in `atm-core`.

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -20,6 +20,17 @@ service boundaries.
 - `atm-core` owns persisted config/team loading policy, including compatibility
   defaults, recovery boundaries, and precise parse diagnostics.
 
+Observability release boundary rules:
+- raw `serde_json::Value` / `serde_json::Map` remain internal translation types
+  only; they are not part of the public observability contract
+- the public L.4 field model uses:
+  - `LogFieldKey`
+  - `AtmJsonNumber`
+  - `LogFieldValue`
+  - `LogFieldMap`
+- CLI JSON output remains wire-compatible with the current retained-log output
+  shape after the boundary cleanup
+
 ## 3. Config Loading Boundary
 
 Persisted config and team-document handling belongs at the `atm-core` loading

--- a/docs/atm-core/design/sc-obs-1.0-integration.md
+++ b/docs/atm-core/design/sc-obs-1.0-integration.md
@@ -165,6 +165,19 @@ Implementation contract:
 - update `LogFieldMatch` and `AtmLogRecord.fields` to use that field model
 - keep all raw `serde_json` parsing and adapter translation inside `atm-core`
 - preserve the current CLI JSON output shape for retained-log commands
+- `AgentMember.extra` remains explicitly out of scope for L.4 because it uses
+  `#[serde(flatten)]` for round-trip preservation of Claude Code fields rather
+  than the observability-facing field model
+
+`AtmJsonNumber` contract:
+- `AtmJsonNumber` accepts any valid JSON number allowed by RFC 8259
+- `AtmJsonNumber` must reject non-JSON numeric values such as `NaN`,
+  `Infinity`, and `-Infinity`
+- its constructor returns `Result<AtmJsonNumber, AtmError>`
+
+Closes:
+- `INTEROP-001`
+- `BP-003`
 
 ## 8. L.5 Construction Ergonomics
 
@@ -177,3 +190,22 @@ Implementation contract:
   implementation surfaces a concrete defect
 - keep `DoctorCommand` injectability deferred for initial release unless a
   concrete need appears during implementation
+
+Closes:
+- `UX-001`
+- `BP-004`
+
+Dispositions:
+- `UX-002`: retained
+  - dynamic dispatch via `Box<dyn ObservabilityPort + Send + Sync>` remains
+    acceptable for initial release because it keeps the CLI bootstrap surface
+    simple without weakening the ATM-owned boundary
+- `BP-001`: retained
+  - the current sealed-trait pattern remains in place because it prevents
+    arbitrary external `ObservabilityPort` implementations from bypassing the
+    intended ATM adapter boundary; this should be revisited only if an
+    alternative clearly reduces construction complexity or materially improves
+    first-party testing without weakening crate-boundary guarantees
+- `UNI-003`: deferred
+  - `DoctorCommand` injectability remains out of scope for initial release
+    unless implementation exposes a concrete testability or composition need

--- a/docs/atm-core/design/sc-obs-1.0-integration.md
+++ b/docs/atm-core/design/sc-obs-1.0-integration.md
@@ -105,3 +105,30 @@ Required Phase L direction:
 ATM now consumes the published `sc-observability = "1.0.0"` release. Phase L
 continues from that published baseline rather than the earlier local
 `[patch.crates-io]` pre-publish strategy.
+
+## 7. L.4 Public Boundary Cleanup
+
+L.4 is a Rust API cleanup sprint, not a CLI JSON redesign.
+
+Implementation contract:
+- replace public raw `serde_json::Value` / `serde_json::Map` usage with the
+  ATM-owned field model:
+  - `LogFieldKey`
+  - `AtmJsonNumber`
+  - `LogFieldValue`
+  - `LogFieldMap`
+- update `LogFieldMatch` and `AtmLogRecord.fields` to use that field model
+- keep all raw `serde_json` parsing and adapter translation inside `atm-core`
+- preserve the current CLI JSON output shape for retained-log commands
+
+## 8. L.5 Construction Ergonomics
+
+L.5 is a construction-contract cleanup sprint.
+
+Implementation contract:
+- add `CliObservability::new(home_dir, CliObservabilityOptions)`
+- keep `init(...)` only as a delegating CLI bootstrap helper
+- keep dynamic dispatch and the current sealed-trait pattern unless
+  implementation surfaces a concrete defect
+- keep `DoctorCommand` injectability deferred for initial release unless a
+  concrete need appears during implementation

--- a/docs/atm-core/design/sc-observability-integration.md
+++ b/docs/atm-core/design/sc-observability-integration.md
@@ -1,5 +1,13 @@
 # `sc-observability` Integration Plan
 
+Status note:
+
+- this document is the historical Phase K integration baseline
+- current release-alignment decisions for the published 1.0 surface now live in
+  [`sc-obs-1.0-integration.md`](./sc-obs-1.0-integration.md)
+- when the two documents differ on current-state details, the Phase L 1.0 note
+  is authoritative
+
 ## 1. Purpose
 
 This document defines the production implementation plan for integrating
@@ -129,7 +137,7 @@ pub struct AtmLogRecord {
     pub target: Option<String>,
     pub action: Option<String>,
     pub message: Option<String>,
-    pub fields: serde_json::Map<String, serde_json::Value>,
+    pub fields: LogFieldMap,
 }
 
 pub struct AtmLogSnapshot {

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -175,6 +175,9 @@ Required boundary rules:
 - `atm-core` owns the injected observability boundary used by retained command
   services
 - `atm-core` must not depend on concrete `sc-observability` crate types
+- the public `atm-core` observability boundary must not expose
+  `serde_json::Value`, `serde_json::Map`, or other serialization-format types
+  directly
 - the boundary must cover emit, query, follow, and health rather than
   remaining emit-only
 - ATM-owned projected request/result types must be defined in `atm-core` for:
@@ -190,8 +193,32 @@ Required boundary rules:
 - the corresponding source-of-truth code registry must live in one source file
   and match [`../atm-error-codes.md`](../atm-error-codes.md)
 
+Required public field-model rules:
+- `LogFieldKey` is the validated ATM-owned field-name type used by retained-log
+  queries and projected records
+- `AtmJsonNumber` is the validated ATM-owned representation for JSON numeric
+  literals at the observability boundary
+- `LogFieldValue` is the ATM-owned recursive value model with variants for:
+  - null
+  - bool
+  - string
+  - number (`AtmJsonNumber`)
+  - array of `LogFieldValue`
+  - object (`LogFieldMap`)
+- `LogFieldMap` is the ATM-owned map type used by `AtmLogRecord.fields`
+- `LogFieldMatch` must use `LogFieldKey` + `LogFieldValue`
+- `AtmLogRecord.fields` must use `LogFieldMap`
+- serialization of these ATM-owned types must preserve the current CLI JSON
+  wire shape for retained-log commands
+- conversion to and from raw `serde_json` values must remain centralized inside
+  `atm-core`
+
 Detailed design and implementation shape is owned by:
 - [`design/sc-observability-integration.md`](./design/sc-observability-integration.md)
+  for the historical Phase K boundary expansion rationale
+- [`design/sc-obs-1.0-integration.md`](./design/sc-obs-1.0-integration.md)
+  for the active Phase L release-alignment decisions, including the L.4 public
+  boundary cleanup
 
 ## 8. Config And Team Baseline Semantics
 

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -208,6 +208,10 @@ Required public field-model rules:
 - `LogFieldMap` is the ATM-owned map type used by `AtmLogRecord.fields`
 - `LogFieldMatch` must use `LogFieldKey` + `LogFieldValue`
 - `AtmLogRecord.fields` must use `LogFieldMap`
+- `AtmJsonNumber` must accept any valid RFC 8259 JSON number and reject
+  non-JSON numeric values such as `NaN`, `Infinity`, and `-Infinity`
+- construction of `AtmJsonNumber` must return
+  `Result<AtmJsonNumber, AtmError>`
 - serialization of these ATM-owned types must preserve the current CLI JSON
   wire shape for retained-log commands
 - conversion to and from raw `serde_json` values must remain centralized inside

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -28,8 +28,11 @@ The `atm` crate must remain thin.
 - `atm` owns mapping of CLI flags to `atm-core` request structs.
 - `atm` owns bootstrap of shared observability implementations used by
   `atm-core`.
-- `atm` owns the temporary pre-publish dependency wiring for a local
-  `sc-observability` checkout until the shared crates are published.
+- `atm` owns the concrete published-crate bootstrap against
+  `sc-observability = "1.0.0"`.
+- `atm` owns the structured construction contract for the concrete adapter:
+  `CliObservability::new(home_dir, CliObservabilityOptions)`.
+- `atm` may retain `init(...)` only as a delegating helper.
 - `atm` owns the retained local recovery CLI shape for `teams` and `members`,
   but not the underlying team/backup/restore business rules
 

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -58,10 +58,13 @@ Initial crate requirement IDs:
 
 - initializing the concrete shared logger once per CLI process
 - mapping ATM env/config decisions into shared logger configuration
-- consuming `sc-observability` from a local checkout in developer/CI builds
-  until publish is complete, without hardcoding user-specific absolute paths
-- switching to versioned published crate dependencies once the shared workspace
-  is released
+- consuming the published `sc-observability = "1.0.0"` crate baseline rather
+  than a local pre-publish checkout
+- exposing one structured construction contract for the concrete adapter:
+  - `CliObservability::new(home_dir, CliObservabilityOptions)`
+- keeping `init(...)` only as a delegating CLI bootstrap helper
+- retaining dynamic dispatch and the current sealed-trait pattern unless
+  implementation surfaces a concrete defect
 - logging CLI bootstrap, parse, and terminal command failures with stable
   ATM-owned error codes before exit
 - using the single ATM-owned code registry defined by

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -551,15 +551,31 @@ Planned sprints:
     `atm-core`
   - key tasks:
     - replace public `serde_json::Value` / `Map<String, Value>` usage in
-      observability-facing `atm-core` types with ATM-owned domain types or
-      wrappers
+      observability-facing `atm-core` types with the ATM-owned field model:
+      - `LogFieldKey`
+      - `AtmJsonNumber`
+      - `LogFieldValue`
+      - `LogFieldMap`
+    - update `LogFieldMatch` to use `LogFieldKey` + `LogFieldValue`
+    - update `AtmLogRecord.fields` to use `LogFieldMap`
     - keep JSON/JSONL parsing, validation, degradation, and repair centralized
       in `atm-core` rather than pushing that logic into CLI or sibling crates
+    - keep all raw `serde_json` translation at the `atm-core` boundary edge;
+      CLI and sibling crates must not need to manipulate raw retained-log JSON
+      values directly
     - preserve the published CLI JSON output behavior after the public type
       cleanup
   - closes:
     - `INTEROP-001`
     - `BP-003`
+  - tests:
+    - unit coverage for `LogFieldKey`, `AtmJsonNumber`, `LogFieldValue`, and
+      `LogFieldMap` serde/validation behavior
+    - unit coverage for adapter mapping between ATM-owned field types and the
+      shared query/result values
+    - integration coverage proving CLI JSON output remains stable for
+      `atm log snapshot --json`, `atm log filter --json`, and
+      `atm log tail --json`
   - dependency note:
     - can proceed in parallel with `L.5` once the Phase K crates.io baseline
       from `K-CRATES-IO-1` is present
@@ -568,13 +584,17 @@ Planned sprints:
   - goal: clean up the remaining release-surface ergonomics without forcing
     speculative refactors that are not yet justified
   - key tasks:
-    - add a structured `CliObservability` construction path (`new(...)` or an
-      equivalent minimal builder) so CLI bootstrap and tests do not assemble
-      the adapter through ad hoc wiring
-    - review the current boxed trait-object dispatch and sealed-trait pattern;
-      implement a change only when it clearly improves the release design
-    - record an explicit disposition for `DoctorCommand` injectability:
-      - optional for initial release unless a concrete testing or feature need
+    - add a structured construction API:
+      - `CliObservability::new(home_dir, CliObservabilityOptions)`
+    - keep `init(...)` only as a delegating CLI bootstrap helper
+    - define `CliObservabilityOptions` as the single supported construction
+      contract for production bootstrap and tests
+    - keep dynamic dispatch (`Box<dyn ObservabilityPort + Send + Sync>`) unless
+      implementation proves a concrete release defect
+    - keep the current sealed-trait pattern unless implementation proves a
+      concrete encapsulation defect
+    - record the explicit disposition for `DoctorCommand` injectability:
+      - deferred for initial release unless a concrete testing or feature need
         appears during implementation
   - closes:
     - `UX-001`
@@ -582,6 +602,10 @@ Planned sprints:
     - disposition of `UX-002`
     - disposition of `BP-001`
     - disposition of `UNI-003`
+  - tests:
+    - constructor coverage for default bootstrap and stderr-routing bootstrap
+    - no-regression coverage for existing `atm doctor` / `atm log` bootstrap
+      behavior after the construction refactor
   - dependency note:
     - may run in parallel with `L.4`, or immediately after it if the public
       API cleanup changes the preferred construction boundary
@@ -600,6 +624,8 @@ Planned sprints:
   - dependency note:
     - depends on `L.1` through `L.5` being complete so release validation runs
       against the final observability surface
+    - distinct from `L.7`; config/identity cleanup is not part of the
+      release-closeout sprint
 
 - `L.7` Team Baseline And Identity Source Cleanup
   - goal: align ATM config semantics with multi-agent team launches by moving

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -321,9 +321,8 @@ Required integration rules:
   `sc-observability` APIs can own the behavior
 - `atm-core` must keep the shared crates behind an ATM-owned injected boundary
 - `atm` owns the concrete shared-crate bootstrap and dependency wiring
-- until `sc-observability` is published, local and CI builds may consume the
-  shared crates from a local checkout, but committed ATM docs/scripts must not
-  hardcode user-specific absolute paths
+- the active release baseline uses the published
+  `sc-observability = "1.0.0"` crates.io dependency
 - the same pinned Rust toolchain must be used locally and in CI across ATM and
   `sc-*` repos
 - the concrete integration work is planned in Phase K of


### PR DESCRIPTION
## Summary
- Replace public `serde_json::Value`/`Map<String,Value>` in atm-core observability boundary with ATM-owned domain types (`LogFieldKey`, `AtmJsonNumber`, `LogFieldValue`, `LogFieldMap`)
- CLI log parser/adapter translates through the new types; all JSON handling remains centralized in atm-core
- CLI JSON wire shape preserved (`atm send`, `atm read`, `atm doctor --json`, `atm log snapshot --json` output unchanged)
- Closes INTEROP-001 and BP-003

## Test plan
- [ ] `cargo fmt --all` clean
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] All tests pass on Linux, macOS, Windows
- [ ] CLI JSON output verified unchanged after boundary cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)