### PR TITLE
L.5: CliObservability construction ergonomics

### DIFF
--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -16,6 +16,10 @@ pub struct DoctorCommand {
 }
 
 impl DoctorCommand {
+    // L.5 disposition (UNI-003): keep DoctorCommand injectability deferred for
+    // initial release. Current service-level coverage exercises doctor behavior
+    // without introducing a wider command abstraction before a concrete need
+    // appears.
     pub fn run(self, observability: &CliObservability) -> Result<()> {
         let current_dir = std::env::current_dir()?;
         let home_dir = home::atm_home()?;

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -38,8 +38,8 @@ fn run() -> anyhow::Result<()> {
         Ok(observability) => observability,
         Err(error) => {
             let fallback = observability::CliObservability::fallback();
-            fallback.emit_fatal_error("bootstrap", error.as_ref());
-            return Err(error);
+            fallback.emit_fatal_error("bootstrap", &error);
+            return Err(error.into());
         }
     };
 

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::Result;
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::home;
 use atm_core::observability::{
@@ -117,6 +116,8 @@ impl CliObservability {
         }
     }
 
+    /// Test-only helper for injecting a synthetic observability port without
+    /// exposing the boxed inner field to production callers.
     #[cfg(test)]
     fn from_port(port: impl ObservabilityPort + Send + Sync + 'static) -> Self {
         Self {
@@ -125,7 +126,7 @@ impl CliObservability {
     }
 }
 
-pub fn init(stderr_logs: bool) -> Result<CliObservability> {
+pub fn init(stderr_logs: bool) -> Result<CliObservability, AtmError> {
     let home_dir = home::atm_home()?;
     Ok(CliObservability::new(
         &home_dir,
@@ -158,11 +159,15 @@ struct ScObservabilityAdapter {
 }
 
 // L.5 dispositions:
-// - BP-001 / UX-002 retained: boxed trait-object dispatch remains acceptable
-//   for initial release because it keeps CLI bootstrap simple without forcing a
-//   wider enum or unified observer abstraction.
-// - the sealed boundary remains in place so external crates cannot bypass the
-//   intended ATM-owned adapter contract with arbitrary ObservabilityPort impls.
+// - UX-002 retained: boxed trait-object dispatch remains acceptable for
+//   initial release because it keeps CLI bootstrap simple without forcing a
+//   wider unified observer abstraction.
+// - BP-001 retained: the sealed boundary remains in place so external crates
+//   cannot bypass the intended ATM-owned adapter contract with arbitrary
+//   ObservabilityPort impls.
+// - UNI-003 / DoctorCommand injectability: deferred — DoctorCommand does not
+//   participate in the ObservabilityPort contract; defer injectability to a
+//   future sprint unless a concrete testing or feature need appears.
 impl observability::sealed::Sealed for CliObservability {}
 impl observability::sealed::Sealed for ScObservabilityAdapter {}
 

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -31,6 +31,26 @@ enum ConsoleLogRoute {
     Stderr,
 }
 
+/// Structured CLI-owned observability construction options.
+///
+/// L.5 intentionally keeps the release surface narrow: one explicit
+/// construction entry point without introducing a broader builder or unified
+/// observer abstraction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CliObservabilityOptions {
+    pub stderr_logs: bool,
+}
+
+impl CliObservabilityOptions {
+    fn console_log_route(self) -> ConsoleLogRoute {
+        if self.stderr_logs {
+            ConsoleLogRoute::Stderr
+        } else {
+            ConsoleLogRoute::Disabled
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RetainedSinkFaultMode {
     Degraded,
@@ -53,20 +73,17 @@ impl std::fmt::Debug for CliObservability {
 }
 
 impl CliObservability {
-    fn concrete_for_home(
-        home_dir: &Path,
-        console_log_route: ConsoleLogRoute,
-    ) -> Result<Self, AtmError> {
-        let adapter = ScObservabilityAdapter::new(home_dir, console_log_route)?;
+    pub fn new(home_dir: &Path, options: CliObservabilityOptions) -> Result<Self, AtmError> {
+        let adapter = ScObservabilityAdapter::new(home_dir, options.console_log_route())?;
         Ok(Self {
             inner: Box::new(adapter),
         })
     }
 
     pub fn fallback() -> Self {
-        Self::concrete_for_home(
+        Self::new(
             &std::env::temp_dir().join("atm-bootstrap-observability"),
-            ConsoleLogRoute::Disabled,
+            CliObservabilityOptions::default(),
         )
         .unwrap_or_else(|_| Self {
             inner: Box::new(atm_core::observability::NullObservability),
@@ -99,18 +116,20 @@ impl CliObservability {
             eprintln!("{}", fatal_emit_failure_message(stage, &emit_error));
         }
     }
+
+    #[cfg(test)]
+    fn from_port(port: impl ObservabilityPort + Send + Sync + 'static) -> Self {
+        Self {
+            inner: Box::new(port),
+        }
+    }
 }
 
 pub fn init(stderr_logs: bool) -> Result<CliObservability> {
     let home_dir = home::atm_home()?;
-    let console_log_route = if stderr_logs {
-        ConsoleLogRoute::Stderr
-    } else {
-        ConsoleLogRoute::Disabled
-    };
-    Ok(CliObservability::concrete_for_home(
+    Ok(CliObservability::new(
         &home_dir,
-        console_log_route,
+        CliObservabilityOptions { stderr_logs },
     )?)
 }
 
@@ -138,6 +157,12 @@ struct ScObservabilityAdapter {
     target_category: TargetCategory,
 }
 
+// L.5 dispositions:
+// - BP-001 / UX-002 retained: boxed trait-object dispatch remains acceptable
+//   for initial release because it keeps CLI bootstrap simple without forcing a
+//   wider enum or unified observer abstraction.
+// - the sealed boundary remains in place so external crates cannot bypass the
+//   intended ATM-owned adapter contract with arbitrary ObservabilityPort impls.
 impl observability::sealed::Sealed for CliObservability {}
 impl observability::sealed::Sealed for ScObservabilityAdapter {}
 
@@ -580,7 +605,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        CliObservability, ConsoleLogRoute, fatal_emit_failure_message, level_for_outcome, log_root,
+        CliObservability, CliObservabilityOptions, fatal_emit_failure_message, level_for_outcome,
+        log_root,
     };
 
     struct FailingEmitObservability;
@@ -651,7 +677,7 @@ mod tests {
     fn concrete_adapter_emits_queries_follows_and_reports_health() {
         let tempdir = TempDir::new().expect("tempdir");
         let observability =
-            CliObservability::concrete_for_home(tempdir.path(), ConsoleLogRoute::Disabled)
+            CliObservability::new(tempdir.path(), CliObservabilityOptions::default())
                 .expect("concrete adapter");
 
         observability
@@ -733,9 +759,7 @@ mod tests {
 
     #[test]
     fn cli_observability_is_debuggable() {
-        let observability = CliObservability {
-            inner: Box::new(atm_core::observability::NullObservability),
-        };
+        let observability = CliObservability::from_port(atm_core::observability::NullObservability);
         let debug = format!("{observability:?}");
         assert!(debug.contains("CliObservability"));
     }
@@ -752,9 +776,7 @@ mod tests {
 
     #[test]
     fn emit_fatal_error_executes_secondary_failure_path_without_panicking() {
-        let observability = CliObservability {
-            inner: Box::new(FailingEmitObservability),
-        };
+        let observability = CliObservability::from_port(FailingEmitObservability);
         observability.emit_fatal_error("service", &AtmError::validation("boom"));
     }
 }

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -128,10 +128,7 @@ impl CliObservability {
 
 pub fn init(stderr_logs: bool) -> Result<CliObservability, AtmError> {
     let home_dir = home::atm_home()?;
-    Ok(CliObservability::new(
-        &home_dir,
-        CliObservabilityOptions { stderr_logs },
-    )?)
+    CliObservability::new(&home_dir, CliObservabilityOptions { stderr_logs })
 }
 
 impl ObservabilityPort for CliObservability {


### PR DESCRIPTION
## Sprint L.5 — Construction Ergonomics

Implements `CliObservability::new(home_dir, CliObservabilityOptions)` construction path per L.5 spec.

**Changes:**
- `CliObservability::new(home_dir, CliObservabilityOptions)` as the canonical constructor
- `init(...)` delegates to `new(...)` (no duplicate logic)
- `from_port` test-only helper removes direct inner-field wiring from tests
- L.5 disposition notes inline: dynamic dispatch retained, sealed boundary retained, DoctorCommand injectability deferred

**Depends on:** integrate/phase-L (L.8 + L.4 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)