### PR TITLE
L.6: Release Closeout — identity fallback removal + ATM_WARNING_IDENTITY_DRIFT

### DIFF
--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -7,6 +7,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use serde::Deserialize;
 use serde_json::Value;
 use tracing::warn;
 
@@ -27,14 +28,20 @@ pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
         )
         .with_source(error)
     })?;
-    let parsed = toml::from_str(&contents).map_err(|error| {
+    let parsed = toml::from_str::<RawConfigFile>(&contents).map_err(|error| {
         AtmError::new(
             AtmErrorKind::Config,
             format!("failed to parse config at {}: {error}", path.display()),
         )
         .with_source(error)
     })?;
-    Ok(Some(parsed))
+    let obsolete_identity_present = parsed.atm.identity.is_some() || parsed.identity.is_some();
+
+    Ok(Some(AtmConfig {
+        identity: parsed.atm.identity.or(parsed.identity),
+        default_team: parsed.atm.default_team.or(parsed.default_team),
+        obsolete_identity_present,
+    }))
 }
 
 pub fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
@@ -65,11 +72,10 @@ pub fn load_team_config(team_dir: &Path) -> Result<TeamConfig, AtmError> {
     parse_team_config(&config_path, &raw)
 }
 
-pub fn resolve_identity(config: Option<&AtmConfig>) -> Option<String> {
+pub fn resolve_identity(_config: Option<&AtmConfig>) -> Option<String> {
     env::var("ATM_IDENTITY")
         .ok()
         .filter(|value| !value.is_empty())
-        .or_else(|| config.and_then(|cfg| cfg.identity.clone()))
 }
 
 pub fn resolve_team(team_override: Option<&str>, config: Option<&AtmConfig>) -> Option<String> {
@@ -93,6 +99,24 @@ fn find_config_path(start_dir: &Path) -> Option<PathBuf> {
     }
 
     None
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawConfigFile {
+    #[serde(default)]
+    atm: RawAtmSection,
+    #[serde(default)]
+    identity: Option<String>,
+    #[serde(default)]
+    default_team: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawAtmSection {
+    #[serde(default)]
+    identity: Option<String>,
+    #[serde(default)]
+    default_team: Option<String>,
 }
 
 fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmError> {
@@ -191,13 +215,29 @@ mod tests {
         fs::create_dir_all(&nested).expect("nested dir");
         fs::write(
             root.join(".atm.toml"),
-            "identity = \"arch-ctm\"\ndefault_team = \"atm-dev\"\n",
+            "[atm]\nidentity = \"arch-ctm\"\ndefault_team = \"atm-dev\"\n",
         )
         .expect("config");
 
         let config = load_config(&nested).expect("config").expect("present");
         assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
         assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+        assert!(config.obsolete_identity_present);
+    }
+
+    #[test]
+    fn load_config_accepts_legacy_top_level_keys_for_compatibility() {
+        let root = unique_temp_dir("legacy-config");
+        fs::write(
+            root.join(".atm.toml"),
+            "identity = \"arch-ctm\"\ndefault_team = \"atm-dev\"\n",
+        )
+        .expect("config");
+
+        let config = load_config(&root).expect("config").expect("present");
+        assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
+        assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+        assert!(config.obsolete_identity_present);
     }
 
     #[test]
@@ -330,12 +370,29 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-identity".into()),
             default_team: None,
+            obsolete_identity_present: true,
         };
 
         assert_eq!(
             resolve_identity(Some(&config)).as_deref(),
             Some("env-identity")
         );
+        restore("ATM_IDENTITY", original_identity);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn identity_ignores_obsolete_config_field_when_env_missing() {
+        let original_identity = env::var_os("ATM_IDENTITY");
+        remove_env_var("ATM_IDENTITY");
+
+        let config = AtmConfig {
+            identity: Some("config-identity".into()),
+            default_team: None,
+            obsolete_identity_present: true,
+        };
+
+        assert_eq!(resolve_identity(Some(&config)), None);
         restore("ATM_IDENTITY", original_identity);
     }
 
@@ -348,6 +405,7 @@ mod tests {
         let config = AtmConfig {
             identity: None,
             default_team: Some("config-team".into()),
+            obsolete_identity_present: false,
         };
 
         assert_eq!(

--- a/crates/atm-core/src/config/types.rs
+++ b/crates/atm-core/src/config/types.rs
@@ -1,7 +1,6 @@
-use serde::Deserialize;
-
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AtmConfig {
     pub identity: Option<String>,
     pub default_team: Option<String>,
+    pub(crate) obsolete_identity_present: bool,
 }

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -3,6 +3,8 @@ pub mod report;
 
 use std::path::PathBuf;
 
+use crate::config;
+use crate::error_codes::AtmErrorCode;
 use crate::observability::ObservabilityPort;
 
 pub use report::{
@@ -21,7 +23,7 @@ pub fn run_doctor(
     query: DoctorQuery,
     observability: &dyn ObservabilityPort,
 ) -> Result<DoctorReport, crate::error::AtmError> {
-    let _ = &query.current_dir;
+    let config = config::load_config(&query.current_dir)?;
 
     let environment = health::environment_visibility(query.home_dir, query.team_override);
     let (observability_health, finding) = match observability.health() {
@@ -36,7 +38,22 @@ pub fn run_doctor(
         }
     };
 
-    let findings = vec![finding];
+    let mut findings = Vec::new();
+    if config
+        .as_ref()
+        .is_some_and(|config| config.obsolete_identity_present)
+    {
+        findings.push(DoctorFinding {
+            severity: DoctorSeverity::Warning,
+            code: AtmErrorCode::WarningIdentityDrift,
+            message: "obsolete [atm].identity is still present in .atm.toml; ATM no longer uses config identity as a runtime fallback.".to_string(),
+            remediation: Some(
+                "Remove [atm].identity from .atm.toml and set ATM_IDENTITY in the active agent environment instead."
+                    .to_string(),
+            ),
+        });
+    }
+    findings.push(finding);
     let recommendations = findings
         .iter()
         .filter_map(|finding| finding.remediation.clone())
@@ -131,10 +148,14 @@ mod tests {
         fn new() -> Self {
             let tempdir = tempfile::tempdir().expect("tempdir");
             let root = tempdir.path().to_path_buf();
+            let home_dir = root.join("atm-home");
+            let current_dir = root.join("workspace");
+            std::fs::create_dir_all(&home_dir).expect("home dir");
+            std::fs::create_dir_all(&current_dir).expect("workspace dir");
             Self {
                 _tempdir: tempdir,
-                home_dir: root.join("atm-home"),
-                current_dir: root.join("workspace"),
+                home_dir,
+                current_dir,
                 active_log_path: root.join("atm.log.jsonl"),
             }
         }
@@ -167,6 +188,38 @@ mod tests {
         assert_eq!(report.summary.status, DoctorStatus::Healthy);
         assert_eq!(report.findings[0].severity, DoctorSeverity::Info);
         assert_eq!(report.findings[0].code, AtmErrorCode::ObservabilityHealthOk);
+    }
+
+    #[test]
+    fn run_doctor_reports_obsolete_identity_drift_as_warning() {
+        let paths = TestPaths::new();
+        std::fs::write(
+            paths.current_dir.join(".atm.toml"),
+            "[atm]\nidentity = \"arch-ctm\"\n",
+        )
+        .expect("config");
+        let report = run_doctor(
+            query(&paths),
+            &StubObservability {
+                health: StubHealth::Ok(AtmObservabilityHealth {
+                    active_log_path: Some(paths.active_log_path.clone()),
+                    logging_state: AtmObservabilityHealthState::Healthy,
+                    query_state: Some(AtmObservabilityHealthState::Healthy),
+                    detail: None,
+                }),
+            },
+        )
+        .expect("doctor report");
+
+        assert_eq!(report.summary.status, DoctorStatus::Warning);
+        assert_eq!(report.findings[0].severity, DoctorSeverity::Warning);
+        assert_eq!(report.findings[0].code, AtmErrorCode::WarningIdentityDrift);
+        assert!(
+            report.findings[0]
+                .message
+                .contains("obsolete [atm].identity")
+        );
+        assert_eq!(report.findings[1].code, AtmErrorCode::ObservabilityHealthOk);
     }
 
     #[test]

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -158,9 +158,7 @@ impl AtmError {
             AtmErrorKind::Identity,
             "identity is not configured",
         )
-        .with_recovery(
-            "Set ATM_IDENTITY, configure identity in .atm.toml, or pass --from once that flag is available.",
-        )
+        .with_recovery("Set ATM_IDENTITY or provide an explicit command identity override when the command supports one.")
     }
 
     pub fn team_unavailable() -> Self {

--- a/crates/atm-core/src/error_codes.rs
+++ b/crates/atm-core/src/error_codes.rs
@@ -74,6 +74,8 @@ pub enum AtmErrorCode {
     WarningMissingTeamConfigFallback,
     /// Send alert state degraded but the command continued.
     WarningSendAlertStateDegraded,
+    /// Obsolete .atm.toml identity config is still present.
+    WarningIdentityDrift,
 }
 
 impl AtmErrorCode {
@@ -111,6 +113,7 @@ impl AtmErrorCode {
             Self::WarningOriginInboxEntrySkipped => "ATM_WARNING_ORIGIN_INBOX_ENTRY_SKIPPED",
             Self::WarningMissingTeamConfigFallback => "ATM_WARNING_MISSING_TEAM_CONFIG_FALLBACK",
             Self::WarningSendAlertStateDegraded => "ATM_WARNING_SEND_ALERT_STATE_DEGRADED",
+            Self::WarningIdentityDrift => "ATM_WARNING_IDENTITY_DRIFT",
         }
     }
 }

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -38,6 +38,7 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-agent".into()),
             default_team: None,
+            obsolete_identity_present: true,
         };
         assert_eq!(
             resolve_sender_identity(Some(&config)).expect("identity"),
@@ -49,18 +50,18 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn resolves_sender_identity_from_config_when_env_missing() {
+    fn sender_identity_does_not_fall_back_to_config_when_env_missing() {
         let original_identity = env::var_os("ATM_IDENTITY");
-        set_env_var("ATM_IDENTITY", "");
+        remove_env_var("ATM_IDENTITY");
 
         let config = AtmConfig {
             identity: Some("config-agent".into()),
             default_team: None,
+            obsolete_identity_present: true,
         };
-        assert_eq!(
-            resolve_sender_identity(Some(&config)).expect("identity"),
-            "config-agent"
-        );
+
+        let error = resolve_sender_identity(Some(&config)).expect_err("identity error");
+        assert!(error.is_identity());
 
         restore("ATM_IDENTITY", original_identity);
     }
@@ -83,20 +84,20 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn resolves_hook_identity_from_config_when_env_missing() {
+    fn hook_identity_requires_runtime_identity_when_env_missing() {
         let original_identity = env::var_os("ATM_IDENTITY");
         let original_team = env::var_os("ATM_TEAM");
-        set_env_var("ATM_IDENTITY", "");
+        remove_env_var("ATM_IDENTITY");
         set_env_var("ATM_TEAM", "");
 
         let config = AtmConfig {
             identity: Some("config-agent".into()),
             default_team: Some("config-team".into()),
+            obsolete_identity_present: true,
         };
 
-        let identity = resolve_hook_identity(None, Some(&config)).expect("hook identity");
-        assert_eq!(identity.agent, "config-agent");
-        assert_eq!(identity.team, "config-team");
+        let error = resolve_hook_identity(None, Some(&config)).expect_err("hook identity error");
+        assert!(error.is_identity());
 
         restore("ATM_IDENTITY", original_identity);
         restore("ATM_TEAM", original_team);

--- a/crates/atm/tests/doctor.rs
+++ b/crates/atm/tests/doctor.rs
@@ -73,6 +73,30 @@ fn test_doctor_reports_unavailable_observability_with_real_fault_injection() {
     assert_eq!(parsed["observability"]["query_state"], "healthy");
 }
 
+#[test]
+fn test_doctor_reports_obsolete_identity_drift_warning() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_atm_config("[atm]\nidentity = \"arch-ctm\"\n");
+
+    let output = fixture.run(&["doctor", "--json"], &[]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["summary"]["status"], "warning");
+    let findings = parsed["findings"].as_array().expect("findings array");
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["code"] == "ATM_WARNING_IDENTITY_DRIFT"),
+        "stdout: {}",
+        String::from_utf8(output.stdout.clone()).expect("stdout utf8")
+    );
+}
+
 struct Fixture {
     tempdir: tempfile::TempDir,
 }
@@ -118,6 +142,10 @@ impl Fixture {
             serde_json::to_vec(&config).expect("team config"),
         )
         .expect("write team config");
+    }
+
+    fn write_atm_config(&self, raw: &str) {
+        fs::write(self.tempdir.path().join(".atm.toml"), raw).expect("write .atm.toml");
     }
 
     fn stdout_json(&self, output: &std::process::Output) -> Value {

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -265,6 +265,22 @@ fn test_send_missing_config_uses_existing_inbox_fallback_and_warns_sender() {
 }
 
 #[test]
+fn test_send_does_not_fall_back_to_obsolete_config_identity() {
+    let fixture = Fixture::new("recipient");
+    fixture.write_atm_config("[atm]\nidentity = \"config-agent\"\n");
+
+    let output = fixture.run_without_identity(&["send", "recipient@atm-dev", "hello"]);
+
+    assert!(!output.status.success());
+    let stderr = fixture.stderr(&output);
+    assert!(
+        stderr.contains("identity is not configured"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("Set ATM_IDENTITY"), "stderr: {stderr}");
+}
+
+#[test]
 fn test_send_missing_config_deduplicates_team_lead_notice() {
     let fixture = Fixture::new("recipient");
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
@@ -392,6 +408,18 @@ impl Fixture {
             .expect("run atm")
     }
 
+    fn run_without_identity(&self, args: &[&str]) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_atm"))
+            .args(args)
+            .env("ATM_HOME", self.tempdir.path())
+            .env("ATM_CONFIG_HOME", self.tempdir.path())
+            .env_remove("ATM_IDENTITY")
+            .env("ATM_TEAM", "atm-dev")
+            .current_dir(self.tempdir.path())
+            .output()
+            .expect("run atm without identity")
+    }
+
     fn write_team_config(&self, recipient: &str) {
         let team_dir = self
             .tempdir
@@ -423,6 +451,10 @@ impl Fixture {
             .join("atm-dev");
         fs::create_dir_all(&team_dir).expect("team dir");
         fs::write(team_dir.join("config.json"), raw).expect("write raw team config");
+    }
+
+    fn write_atm_config(&self, raw: &str) {
+        fs::write(self.tempdir.path().join(".atm.toml"), raw).expect("write .atm.toml");
     }
 
     fn inbox_path(&self, recipient: &str) -> std::path::PathBuf {

--- a/docs/atm-core/design/live-observability-validation.md
+++ b/docs/atm-core/design/live-observability-validation.md
@@ -6,6 +6,61 @@ worktree. This pass closes the earlier healthy-only gap by exercising healthy,
 degraded, and unavailable observability states through the shared retained-sink
 fault injector rather than through ATM-local deterministic doubles.
 
+## Phase L.6 Rerun (2026-04-07)
+
+Phase L.6 reran the published-baseline validation after the L.4 public field
+cleanup, the L.5 construction refactor, and the release-closeout identity
+changes. The goal of this rerun was to prove that the shared observability
+surface still behaves the same on the published `1.0.0` crates while also
+confirming the new doctor drift finding for obsolete `[atm].identity`.
+
+Rerun fixtures:
+
+- clean validation fixture `ATM_HOME`:
+  `/var/folders/zk/zklzmbr52q55r1y8zv_k84k80000gn/T/tmp.MGlw9wjiob`
+- drift-check fixture `ATM_HOME`:
+  `/var/folders/zk/zklzmbr52q55r1y8zv_k84k80000gn/T/tmp.TVHup79rTM`
+
+Commands rerun on the clean fixture:
+
+1. `atm send arch-ctm@atm-dev "l6 validation seed" --json`
+2. `atm read --json`
+3. `atm doctor --json`
+4. `ATM_OBSERVABILITY_RETAINED_SINK_FAULT=degraded atm doctor --json`
+5. `ATM_OBSERVABILITY_RETAINED_SINK_FAULT=unavailable atm doctor --json`
+6. `atm log snapshot --match command=send --since 10m --limit 10 --json`
+7. `atm log filter --match command=read --json`
+
+Additional drift-check command:
+
+8. `atm doctor --json` with `.atm.toml` containing obsolete `[atm].identity`
+
+Observed results:
+
+- `atm send` succeeded and `atm read` returned one unread message from the
+  clean fixture inbox
+- healthy doctor run stayed `healthy` with `ATM_OBSERVABILITY_HEALTH_OK`
+- degraded fault-injected doctor run stayed `warning` with
+  `ATM_WARNING_OBSERVABILITY_HEALTH_DEGRADED`
+- unavailable fault-injected doctor run stayed `error` with
+  `ATM_OBSERVABILITY_HEALTH_FAILED` and exited with status `1`
+- `atm log snapshot` still returned the emitted `send` command record
+- `atm log filter` still returned the emitted `read` command record
+- the active shared file sink remained:
+  `/var/folders/zk/zklzmbr52q55r1y8zv_k84k80000gn/T/tmp.MGlw9wjiob/.local/share/logs/atm.log.jsonl`
+- the separate drift-check run returned warning status with:
+  - `ATM_WARNING_IDENTITY_DRIFT`
+  - `ATM_OBSERVABILITY_HEALTH_OK`
+
+Interpretation:
+
+- L.4 and L.5 did not change the published shared-adapter wire behavior for
+  ATM observability commands
+- L.6 closes the identity carry-forward findings without disturbing the
+  healthy/degraded/unavailable health mapping already validated in L.2
+- obsolete `[atm].identity` now surfaces as an additive doctor warning rather
+  than a runtime identity fallback
+
 ## Environment
 
 - Worktree: `feature/pL-s2-fault-injection`

--- a/docs/atm-core/design/sc-obs-1.0-integration.md
+++ b/docs/atm-core/design/sc-obs-1.0-integration.md
@@ -209,3 +209,28 @@ Dispositions:
 - `UNI-003`: deferred
   - `DoctorCommand` injectability remains out of scope for initial release
     unless implementation exposes a concrete testability or composition need
+
+## 9. L.6 Release Closeout
+
+L.6 closes the remaining release-critical operator-facing carry-forward items
+without reopening the broader `.atm.toml` planning note from `L.7`.
+
+Closes:
+- `ATM-QA-001`
+  - runtime identity no longer falls back to obsolete `.atm.toml`
+    `[atm].identity`; the retained multi-agent model now requires runtime
+    identity to come from explicit command override when supported, hook
+    identity, or `ATM_IDENTITY`
+- `ATM-QA-002`
+  - `atm doctor` now reports obsolete `[atm].identity` as
+    `ATM_WARNING_IDENTITY_DRIFT` and directs operators to remove the field and
+    set `ATM_IDENTITY` in the active environment instead
+
+Validation closeout:
+- the published `sc-observability = "1.0.0"` baseline was revalidated after
+  `L.4`, `L.5`, and `L.6`
+- healthy, degraded, and unavailable doctor states still map to the expected
+  shared-adapter health contract
+- the drift warning is additive: it does not replace the observability health
+  finding and therefore surfaces as a warning alongside healthy observability
+  when obsolete config identity is still present

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -281,7 +281,8 @@ Required identity rules:
   identity fallback
 
 Required doctor rules:
-- `atm doctor` must flag obsolete `[atm].identity` when present
+- `atm doctor` must flag obsolete `[atm].identity` when present with
+  `ATM_WARNING_IDENTITY_DRIFT`
 - `atm doctor` must compare `[atm].team_members` against `config.json.members`
 - missing baseline members are findings
 - extra runtime members in `config.json` are allowed

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -477,6 +477,12 @@ Status summary:
   - `L.3` complete on `feature/pL-s3-file-sink-migration` / PR #52 with the
     current branch tip carrying the final fix-r1 closure for the live
     validation and status-summary findings
+  - `L.4` complete on `feature/pL-s4-public-api-cleanup` at
+    `4304d825ff6dddc52ddc21e08f5d2bb3ead795dc`
+  - `L.5` complete on `feature/pL-s5-construction-ergonomics` at
+    `512dfa4d89ac71307ef7324f64dffb67d5189cc3`
+  - `L.6` complete on `feature/pL-s6-release-closeout` at the current branch
+    closeout head for this sprint
 
 Goal:
 - finish the published `sc-observability` 1.0 follow-on work and close the
@@ -630,6 +636,13 @@ Planned sprints:
   - goal: finish the remaining operator-facing and release-readiness validation
     against the published shared crate behavior
   - key tasks:
+    - close the two remaining release-critical identity carry-forward findings:
+      - `ATM-QA-001`
+        - remove obsolete config identity fallback from runtime identity
+          resolution
+      - `ATM-QA-002`
+        - add `atm doctor` drift reporting for obsolete `[atm].identity`
+          configuration
     - verify file sink path alignment against upstream issue `#21`
     - rerun full ATM observability validation on the published
       `sc-observability = "1.0.0"` release
@@ -640,8 +653,9 @@ Planned sprints:
   - dependency note:
     - depends on `L.1` through `L.5` being complete so release validation runs
       against the final observability surface
-    - distinct from `L.7`; config/identity cleanup is not part of the
-      release-closeout sprint
+    - the two release-critical identity items above were pulled forward from
+      earlier `L.7` planning because they block release signoff; the remaining
+      broader `.atm.toml` semantics work stays in `L.7`
 
 - `L.7` Team Baseline And Identity Source Cleanup
   - goal: align ATM config semantics with multi-agent team launches by moving
@@ -656,11 +670,11 @@ Planned sprints:
     - add ATM-owned `post_send_hook` and `post_send_hook_members` support under
       the `[atm]` config section for short-term sender-scoped post-send
       automation
-    - stop using `[atm].identity` as a runtime identity fallback; identity must
-      come from explicit CLI override, hook identity, or `ATM_IDENTITY`
-    - treat `[atm].identity` as an obsolete field: ignored by runtime identity
-      resolution and flagged by `atm doctor` as configuration drift that should
-      be removed
+    - historical note:
+      - the release-critical `[atm].identity` fallback removal and doctor drift
+        warning were pulled forward and closed in `L.6`
+      - the remaining `L.7` scope covers broader baseline-roster, alias, and
+        post-send-hook semantics
     - keep `[atm].default_team` as the shared team default and continue to
       ignore `[rmux]` and future `[scmux]` sections from `atm-core`
     - update `atm doctor` to compare `[atm].team_members` against

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -481,8 +481,8 @@ Status summary:
     `4304d825ff6dddc52ddc21e08f5d2bb3ead795dc`
   - `L.5` complete on `feature/pL-s5-construction-ergonomics` at
     `512dfa4d89ac71307ef7324f64dffb67d5189cc3`
-  - `L.6` complete on `feature/pL-s6-release-closeout` at the current branch
-    closeout head for this sprint
+  - `L.6` complete on `feature/pL-s6-release-closeout` / PR #56 at
+    `341e28c1f7175f9890a5a1d5606b64e0ce816d52`
 
 Goal:
 - finish the published `sc-observability` 1.0 follow-on work and close the

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1039,6 +1039,9 @@ Each doctor finding must expose at least:
 - message
 - remediation when available
 
+The obsolete config-identity finding must use:
+- `ATM_WARNING_IDENTITY_DRIFT`
+
 Critical findings must cause a non-zero exit status.
 
 ## 12. `atm teams`


### PR DESCRIPTION
## Summary

- Remove `config.identity` runtime fallback from `resolve_identity` (`crates/atm-core/src/config/mod.rs:72`) — identity now resolves: explicit CLI override → `ATM_IDENTITY` env only
- Add `ATM_WARNING_IDENTITY_DRIFT` doctor check: warns when `[atm].identity` is present in `.atm.toml`
- Live observability validation (healthy/degraded/unavailable + identity-drift) documented in `docs/atm-core/design/live-observability-validation.md` (L.6 section)
- Phase L status updated in `docs/project-plan.md`

Closes ATM-QA-001, ATM-QA-002 carry-forwards from Phase K QA.

## Test plan
- [ ] `cargo fmt --all` clean ✓
- [ ] `cargo clippy --workspace -- -D warnings` clean ✓
- [ ] All tests pass (Linux, macOS, Windows) ✓
- [ ] `resolve_identity` no longer uses `config.identity` fallback
- [ ] `atm doctor` emits `ATM_WARNING_IDENTITY_DRIFT` when `[atm].identity` present
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)