### PR TITLE
feat(L.7): atm.toml config — team_members, aliases, post_send_hook, doctor updates

### DIFF
--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -201,6 +201,12 @@ fn resolve_reply_target(
     message: &MessageEnvelope,
     current_team: &str,
 ) -> Result<(String, String), AtmError> {
+    if let Some(identity) = canonical_sender_identity(message) {
+        let parsed: AgentAddress = identity.parse()?;
+        let team = parsed.team.ok_or_else(AtmError::team_unavailable)?;
+        return Ok((parsed.agent, team));
+    }
+
     let parsed: AgentAddress = if message.from.contains('@') {
         message.from.parse()?
     } else {
@@ -215,6 +221,71 @@ fn resolve_reply_target(
 
     let team = parsed.team.ok_or_else(AtmError::team_unavailable)?;
     Ok((parsed.agent, team))
+}
+
+fn canonical_sender_identity(message: &MessageEnvelope) -> Option<String> {
+    message
+        .extra
+        .get("metadata")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|metadata| metadata.get("atm"))
+        .and_then(serde_json::Value::as_object)
+        .and_then(|atm| atm.get("fromIdentity"))
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{canonical_sender_identity, resolve_reply_target};
+    use crate::schema::MessageEnvelope;
+    use crate::types::IsoTimestamp;
+
+    fn message_with_from(from: &str) -> MessageEnvelope {
+        MessageEnvelope {
+            from: from.to_string(),
+            text: "hello".to_string(),
+            timestamp: IsoTimestamp::now(),
+            read: false,
+            source_team: Some("atm-dev".to_string()),
+            summary: None,
+            message_id: None,
+            pending_ack_at: None,
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            task_id: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    #[test]
+    fn canonical_sender_identity_reads_metadata_override() {
+        let mut message = message_with_from("lead");
+        message.extra.insert(
+            "metadata".to_string(),
+            json!({"atm": {"fromIdentity": "team-lead@src-gen"}}),
+        );
+
+        assert_eq!(
+            canonical_sender_identity(&message).as_deref(),
+            Some("team-lead@src-gen")
+        );
+    }
+
+    #[test]
+    fn resolve_reply_target_prefers_canonical_sender_identity_metadata() {
+        let mut message = message_with_from("lead");
+        message.source_team = Some("atm-dev".to_string());
+        message.extra.insert(
+            "metadata".to_string(),
+            json!({"atm": {"fromIdentity": "team-lead@src-gen"}}),
+        );
+
+        let target = resolve_reply_target(&message, "atm-dev").expect("reply target");
+        assert_eq!(target, ("team-lead".to_string(), "src-gen".to_string()));
+    }
 }
 
 fn load_source_files(

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -235,59 +235,6 @@ fn canonical_sender_identity(message: &MessageEnvelope) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-#[cfg(test)]
-mod tests {
-    use serde_json::json;
-
-    use super::{canonical_sender_identity, resolve_reply_target};
-    use crate::schema::MessageEnvelope;
-    use crate::types::IsoTimestamp;
-
-    fn message_with_from(from: &str) -> MessageEnvelope {
-        MessageEnvelope {
-            from: from.to_string(),
-            text: "hello".to_string(),
-            timestamp: IsoTimestamp::now(),
-            read: false,
-            source_team: Some("atm-dev".to_string()),
-            summary: None,
-            message_id: None,
-            pending_ack_at: None,
-            acknowledged_at: None,
-            acknowledges_message_id: None,
-            task_id: None,
-            extra: serde_json::Map::new(),
-        }
-    }
-
-    #[test]
-    fn canonical_sender_identity_reads_metadata_override() {
-        let mut message = message_with_from("lead");
-        message.extra.insert(
-            "metadata".to_string(),
-            json!({"atm": {"fromIdentity": "team-lead@src-gen"}}),
-        );
-
-        assert_eq!(
-            canonical_sender_identity(&message).as_deref(),
-            Some("team-lead@src-gen")
-        );
-    }
-
-    #[test]
-    fn resolve_reply_target_prefers_canonical_sender_identity_metadata() {
-        let mut message = message_with_from("lead");
-        message.source_team = Some("atm-dev".to_string());
-        message.extra.insert(
-            "metadata".to_string(),
-            json!({"atm": {"fromIdentity": "team-lead@src-gen"}}),
-        );
-
-        let target = resolve_reply_target(&message, "atm-dev").expect("reply target");
-        assert_eq!(target, ("team-lead".to_string(), "src-gen".to_string()));
-    }
-}
-
 fn load_source_files(
     home_dir: &Path,
     team: &str,
@@ -392,4 +339,57 @@ fn persist_source_files(source_files: &[SourceFile]) -> Result<(), AtmError> {
         mailbox::atomic::write_messages(&source.path, &source.messages)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{canonical_sender_identity, resolve_reply_target};
+    use crate::schema::MessageEnvelope;
+    use crate::types::IsoTimestamp;
+
+    fn message_with_from(from: &str) -> MessageEnvelope {
+        MessageEnvelope {
+            from: from.to_string(),
+            text: "hello".to_string(),
+            timestamp: IsoTimestamp::now(),
+            read: false,
+            source_team: Some("atm-dev".to_string()),
+            summary: None,
+            message_id: None,
+            pending_ack_at: None,
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            task_id: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    #[test]
+    fn canonical_sender_identity_reads_metadata_override() {
+        let mut message = message_with_from("lead");
+        message.extra.insert(
+            "metadata".to_string(),
+            json!({"atm": {"fromIdentity": "team-lead@src-gen"}}),
+        );
+
+        assert_eq!(
+            canonical_sender_identity(&message).as_deref(),
+            Some("team-lead@src-gen")
+        );
+    }
+
+    #[test]
+    fn resolve_reply_target_prefers_canonical_sender_identity_metadata() {
+        let mut message = message_with_from("lead");
+        message.source_team = Some("atm-dev".to_string());
+        message.extra.insert(
+            "metadata".to_string(),
+            json!({"atm": {"fromIdentity": "team-lead@src-gen"}}),
+        );
+
+        let target = resolve_reply_target(&message, "atm-dev").expect("reply target");
+        assert_eq!(target, ("team-lead".to_string(), "src-gen".to_string()));
+    }
 }

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -187,7 +187,7 @@ fn resolve_actor_identity(
     config: Option<&config::AtmConfig>,
 ) -> Result<String, AtmError> {
     if let Some(actor) = actor_override.filter(|value| !value.trim().is_empty()) {
-        return Ok(actor.to_string());
+        return Ok(config::aliases::resolve_agent(actor, config));
     }
 
     if let Some(identity) = identity::hook::read_hook_identity()? {

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -146,7 +146,7 @@ fn resolve_actor_identity(
     config: Option<&config::AtmConfig>,
 ) -> Result<String, AtmError> {
     if let Some(actor) = actor_override.filter(|value| !value.trim().is_empty()) {
-        return Ok(actor.to_string());
+        return Ok(config::aliases::resolve_agent(actor, config));
     }
 
     if let Some(identity) = identity::hook::read_hook_identity()? {

--- a/crates/atm-core/src/config/aliases.rs
+++ b/crates/atm-core/src/config/aliases.rs
@@ -1,1 +1,55 @@
-// TODO: implement config alias handling.
+use super::AtmConfig;
+
+pub fn resolve_agent(value: &str, config: Option<&AtmConfig>) -> String {
+    config
+        .and_then(|config| config.aliases.get(value))
+        .cloned()
+        .unwrap_or_else(|| value.to_string())
+}
+
+pub fn preferred_alias(canonical: &str, config: Option<&AtmConfig>) -> Option<String> {
+    config.and_then(|config| {
+        config
+            .aliases
+            .iter()
+            .find_map(|(alias, resolved)| (resolved == canonical).then(|| alias.clone()))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::{preferred_alias, resolve_agent};
+    use crate::config::AtmConfig;
+
+    #[test]
+    fn resolve_agent_returns_canonical_name_when_alias_exists() {
+        let mut aliases = BTreeMap::new();
+        aliases.insert("tl".to_string(), "team-lead".to_string());
+        let config = AtmConfig {
+            aliases,
+            ..Default::default()
+        };
+
+        assert_eq!(resolve_agent("tl", Some(&config)), "team-lead");
+        assert_eq!(resolve_agent("team-lead", Some(&config)), "team-lead");
+    }
+
+    #[test]
+    fn preferred_alias_returns_first_alias_for_canonical_name() {
+        let mut aliases = BTreeMap::new();
+        aliases.insert("lead".to_string(), "team-lead".to_string());
+        aliases.insert("tl".to_string(), "team-lead".to_string());
+        let config = AtmConfig {
+            aliases,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            preferred_alias("team-lead", Some(&config)).as_deref(),
+            Some("lead")
+        );
+        assert_eq!(preferred_alias("arch-ctm", Some(&config)), None);
+    }
+}

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -13,7 +13,7 @@ use tracing::warn;
 
 pub use types::AtmConfig;
 
-use crate::error::{AtmError, AtmErrorKind};
+use crate::error::{AtmError, AtmErrorCode, AtmErrorKind};
 use crate::schema::{AgentMember, TeamConfig};
 
 pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
@@ -163,7 +163,8 @@ fn normalize_optional_command(command: Option<Vec<String>>) -> Option<Vec<String
 
 fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmError> {
     let root: Value = serde_json::from_str(raw).map_err(|error| {
-        AtmError::new(
+        AtmError::new_with_code(
+            AtmErrorCode::ConfigTeamParseFailed,
             AtmErrorKind::Config,
             format!(
                 "failed to parse team config at {}: {error}",
@@ -175,7 +176,8 @@ fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmErr
     })?;
 
     let object = root.as_object().ok_or_else(|| {
-        AtmError::new(
+        AtmError::new_with_code(
+            AtmErrorCode::ConfigTeamParseFailed,
             AtmErrorKind::Config,
             format!(
                 "failed to parse team config at {}: root value must be a JSON object",
@@ -193,7 +195,8 @@ fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmErr
             .filter_map(|(index, entry)| parse_team_member(config_path, index, entry))
             .collect(),
         Some(_) => {
-            return Err(AtmError::new(
+            return Err(AtmError::new_with_code(
+                AtmErrorCode::ConfigTeamParseFailed,
                 AtmErrorKind::Config,
                 format!(
                     "failed to parse team config at {}: field 'members' must be a JSON array",
@@ -246,6 +249,7 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
+    use crate::error_codes::AtmErrorCode;
     use serde_json::Value;
 
     use super::{AtmConfig, load_config, parse_team_config, resolve_identity, resolve_team};
@@ -401,6 +405,7 @@ blank = ""
             .expect_err("syntax error");
 
         assert!(error.is_config());
+        assert_eq!(error.code, AtmErrorCode::ConfigTeamParseFailed);
         assert!(error.message.contains("config.json"));
         assert!(error.message.contains("EOF while parsing"));
         assert!(error.recovery.as_deref().is_some());
@@ -413,6 +418,7 @@ blank = ""
             parse_team_config(&config_path, r#"["arch-ctm"]"#).expect_err("root shape error");
 
         assert!(error.is_config());
+        assert_eq!(error.code, AtmErrorCode::ConfigTeamParseFailed);
         assert!(error.message.contains("root value must be a JSON object"));
         assert!(error.recovery.as_deref().is_some());
     }
@@ -424,6 +430,7 @@ blank = ""
             .expect_err("members shape error");
 
         assert!(error.is_config());
+        assert_eq!(error.code, AtmErrorCode::ConfigTeamParseFailed);
         assert!(
             error
                 .message

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -36,10 +36,19 @@ pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
         .with_source(error)
     })?;
     let obsolete_identity_present = parsed.atm.identity.is_some() || parsed.identity.is_some();
+    let config_root = path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
 
     Ok(Some(AtmConfig {
         identity: parsed.atm.identity.or(parsed.identity),
         default_team: parsed.atm.default_team.or(parsed.default_team),
+        team_members: normalize_string_list(parsed.atm.team_members),
+        aliases: normalize_aliases(parsed.atm.aliases),
+        post_send_hook: normalize_optional_command(parsed.atm.post_send_hook),
+        post_send_hook_members: normalize_string_list(parsed.atm.post_send_hook_members),
+        config_root,
         obsolete_identity_present,
     }))
 }
@@ -117,6 +126,39 @@ struct RawAtmSection {
     identity: Option<String>,
     #[serde(default)]
     default_team: Option<String>,
+    #[serde(default)]
+    team_members: Vec<String>,
+    #[serde(default)]
+    aliases: std::collections::BTreeMap<String, String>,
+    #[serde(default)]
+    post_send_hook: Option<Vec<String>>,
+    #[serde(default)]
+    post_send_hook_members: Vec<String>,
+}
+
+fn normalize_string_list(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn normalize_aliases(
+    aliases: std::collections::BTreeMap<String, String>,
+) -> std::collections::BTreeMap<String, String> {
+    aliases
+        .into_iter()
+        .map(|(alias, canonical)| (alias.trim().to_string(), canonical.trim().to_string()))
+        .filter(|(alias, canonical)| !alias.is_empty() && !canonical.is_empty())
+        .collect()
+}
+
+fn normalize_optional_command(command: Option<Vec<String>>) -> Option<Vec<String>> {
+    command.and_then(|values| {
+        let normalized = normalize_string_list(values);
+        (!normalized.is_empty()).then_some(normalized)
+    })
 }
 
 fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmError> {
@@ -222,6 +264,7 @@ mod tests {
         let config = load_config(&nested).expect("config").expect("present");
         assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
         assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+        assert_eq!(config.config_root, root);
         assert!(config.obsolete_identity_present);
     }
 
@@ -237,7 +280,48 @@ mod tests {
         let config = load_config(&root).expect("config").expect("present");
         assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
         assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+        assert_eq!(config.config_root, root);
         assert!(config.obsolete_identity_present);
+    }
+
+    #[test]
+    fn load_config_reads_team_members_aliases_and_post_send_hook() {
+        let root = unique_temp_dir("atm-config-surface");
+        fs::write(
+            root.join(".atm.toml"),
+            r#"[atm]
+default_team = "atm-dev"
+team_members = ["team-lead", "arch-ctm", " ", "qa"]
+post_send_hook = ["bin/hook", "notify"]
+post_send_hook_members = ["arch-ctm", "", "team-lead"]
+
+[atm.aliases]
+tl = "team-lead"
+qa = "quality-mgr"
+blank = ""
+"#,
+        )
+        .expect("config");
+
+        let config = load_config(&root).expect("config").expect("present");
+        assert_eq!(config.team_members, vec!["team-lead", "arch-ctm", "qa"]);
+        assert_eq!(
+            config.post_send_hook.as_deref(),
+            Some(&["bin/hook".to_string(), "notify".to_string()][..])
+        );
+        assert_eq!(
+            config.post_send_hook_members,
+            vec!["arch-ctm".to_string(), "team-lead".to_string()]
+        );
+        assert_eq!(
+            config.aliases.get("tl").map(String::as_str),
+            Some("team-lead")
+        );
+        assert_eq!(
+            config.aliases.get("qa").map(String::as_str),
+            Some("quality-mgr")
+        );
+        assert!(!config.aliases.contains_key("blank"));
     }
 
     #[test]
@@ -370,6 +454,11 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-identity".into()),
             default_team: None,
+            team_members: Vec::new(),
+            aliases: Default::default(),
+            post_send_hook: None,
+            post_send_hook_members: Vec::new(),
+            config_root: PathBuf::new(),
             obsolete_identity_present: true,
         };
 
@@ -389,6 +478,11 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-identity".into()),
             default_team: None,
+            team_members: Vec::new(),
+            aliases: Default::default(),
+            post_send_hook: None,
+            post_send_hook_members: Vec::new(),
+            config_root: PathBuf::new(),
             obsolete_identity_present: true,
         };
 
@@ -405,6 +499,11 @@ mod tests {
         let config = AtmConfig {
             identity: None,
             default_team: Some("config-team".into()),
+            team_members: Vec::new(),
+            aliases: Default::default(),
+            post_send_hook: None,
+            post_send_hook_members: Vec::new(),
+            config_root: PathBuf::new(),
             obsolete_identity_present: false,
         };
 

--- a/crates/atm-core/src/config/types.rs
+++ b/crates/atm-core/src/config/types.rs
@@ -1,6 +1,14 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AtmConfig {
     pub identity: Option<String>,
     pub default_team: Option<String>,
+    pub team_members: Vec<String>,
+    pub aliases: BTreeMap<String, String>,
+    pub post_send_hook: Option<Vec<String>>,
+    pub post_send_hook_members: Vec<String>,
+    pub config_root: PathBuf,
     pub(crate) obsolete_identity_present: bool,
 }

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -1,11 +1,14 @@
 pub mod health;
 pub mod report;
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use crate::config;
 use crate::error_codes::AtmErrorCode;
 use crate::observability::ObservabilityPort;
+use crate::schema::AgentMember;
+use crate::team_admin::{MemberSummary, MembersList};
 
 pub use report::{
     DoctorEnvironmentVisibility, DoctorFinding, DoctorReport, DoctorSeverity, DoctorStatus,
@@ -24,6 +27,8 @@ pub fn run_doctor(
     observability: &dyn ObservabilityPort,
 ) -> Result<DoctorReport, crate::error::AtmError> {
     let config = config::load_config(&query.current_dir)?;
+    let home_dir = query.home_dir.clone();
+    let resolved_team = config::resolve_team(query.team_override.as_deref(), config.as_ref());
 
     let environment = health::environment_visibility(query.home_dir, query.team_override);
     let (observability_health, finding) = match observability.health() {
@@ -53,6 +58,9 @@ pub fn run_doctor(
             ),
         });
     }
+    let member_roster = resolved_team
+        .as_deref()
+        .and_then(|team| load_member_roster(&home_dir, team, config.as_ref(), &mut findings));
     findings.push(finding);
     let recommendations = findings
         .iter()
@@ -85,8 +93,94 @@ pub fn run_doctor(
         findings,
         recommendations,
         environment,
+        member_roster,
         observability: observability_health,
     })
+}
+
+fn load_member_roster(
+    home_dir: &std::path::Path,
+    team: &str,
+    config: Option<&config::AtmConfig>,
+    findings: &mut Vec<DoctorFinding>,
+) -> Option<MembersList> {
+    let team_dir = crate::home::team_dir_from_home(home_dir, team).ok()?;
+    let team_config = config::load_team_config(&team_dir).ok()?;
+    let baseline = config
+        .map(|config| config.team_members.as_slice())
+        .unwrap_or(&[]);
+
+    let present = team_config
+        .members
+        .iter()
+        .map(|member| member.name.clone())
+        .collect::<BTreeSet<_>>();
+    for member in baseline {
+        if present.contains(member) {
+            continue;
+        }
+        findings.push(DoctorFinding {
+            severity: DoctorSeverity::Warning,
+            code: AtmErrorCode::WarningBaselineMemberMissing,
+            message: format!(
+                "baseline member '{member}' is missing from team config.json for '{team}'"
+            ),
+            remediation: Some(format!(
+                "Restore '{member}' in .claude/teams/{team}/config.json or remove it from [atm].team_members if it is no longer part of the baseline roster."
+            )),
+        });
+    }
+
+    Some(MembersList {
+        team: team.to_string(),
+        members: ordered_member_summaries(&team_config.members, baseline),
+    })
+}
+
+fn ordered_member_summaries(members: &[AgentMember], baseline: &[String]) -> Vec<MemberSummary> {
+    let mut ordered = Vec::new();
+    let mut included = BTreeSet::new();
+
+    if baseline.iter().any(|member| member == "team-lead")
+        && let Some(team_lead) = members.iter().find(|member| member.name == "team-lead")
+    {
+        ordered.push(member_summary(team_lead));
+        included.insert(team_lead.name.clone());
+    }
+
+    for baseline_member in baseline {
+        if baseline_member == "team-lead" {
+            continue;
+        }
+        if let Some(member) = members
+            .iter()
+            .find(|member| member.name == *baseline_member)
+        {
+            ordered.push(member_summary(member));
+            included.insert(member.name.clone());
+        }
+    }
+
+    for member in members {
+        if included.insert(member.name.clone()) {
+            ordered.push(member_summary(member));
+        }
+    }
+
+    ordered
+}
+
+fn member_summary(member: &AgentMember) -> MemberSummary {
+    MemberSummary {
+        name: member.name.clone(),
+        agent_id: member.agent_id.clone(),
+        agent_type: member.agent_type.clone(),
+        model: member.model.clone(),
+        joined_at: member.joined_at,
+        tmux_pane_id: member.tmux_pane_id.clone(),
+        cwd: member.cwd.clone(),
+        extra: member.extra.clone(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -2,7 +2,9 @@ pub mod health;
 pub mod report;
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::config;
 use crate::error_codes::AtmErrorCode;
@@ -99,16 +101,46 @@ pub fn run_doctor(
 }
 
 fn load_member_roster(
-    home_dir: &std::path::Path,
+    home_dir: &Path,
     team: &str,
     config: Option<&config::AtmConfig>,
     findings: &mut Vec<DoctorFinding>,
 ) -> Option<MembersList> {
-    let team_dir = crate::home::team_dir_from_home(home_dir, team).ok()?;
-    let team_config = config::load_team_config(&team_dir).ok()?;
+    let team_dir = match crate::home::team_dir_from_home(home_dir, team) {
+        Ok(team_dir) => team_dir,
+        Err(error) => {
+            push_doctor_error(findings, DoctorSeverity::Error, error);
+            return None;
+        }
+    };
+    if !team_dir.is_dir() {
+        findings.push(DoctorFinding {
+            severity: DoctorSeverity::Error,
+            code: AtmErrorCode::TeamNotFound,
+            message: format!(
+                "team directory is missing at {} for '{}'",
+                team_dir.display(),
+                team
+            ),
+            remediation: Some(format!(
+                "Create .claude/teams/{team} or correct ATM_HOME / --team before rerunning `atm doctor`."
+            )),
+        });
+        return None;
+    }
+
+    let team_config = match config::load_team_config(&team_dir) {
+        Ok(team_config) => team_config,
+        Err(error) => {
+            push_doctor_error(findings, DoctorSeverity::Error, error);
+            return None;
+        }
+    };
     let baseline = config
         .map(|config| config.team_members.as_slice())
         .unwrap_or(&[]);
+
+    check_inbox_directory(team, &team_dir.join("inboxes"), findings);
 
     let present = team_config
         .members
@@ -135,6 +167,70 @@ fn load_member_roster(
         team: team.to_string(),
         members: ordered_member_summaries(&team_config.members, baseline),
     })
+}
+
+fn push_doctor_error(
+    findings: &mut Vec<DoctorFinding>,
+    severity: DoctorSeverity,
+    error: crate::error::AtmError,
+) {
+    findings.push(DoctorFinding {
+        severity,
+        code: error.code,
+        message: error.message,
+        remediation: error.recovery,
+    });
+}
+
+fn check_inbox_directory(team: &str, inboxes_dir: &Path, findings: &mut Vec<DoctorFinding>) {
+    if !inboxes_dir.is_dir() {
+        findings.push(DoctorFinding {
+            severity: DoctorSeverity::Error,
+            code: AtmErrorCode::MailboxWriteFailed,
+            message: format!(
+                "inbox directory is missing at {} for '{}'",
+                inboxes_dir.display(),
+                team
+            ),
+            remediation: Some(format!(
+                "Create .claude/teams/{team}/inboxes and ensure ATM can write inbox files before rerunning `atm doctor`."
+            )),
+        });
+        return;
+    }
+
+    if let Err(error) = probe_directory_writable(inboxes_dir) {
+        findings.push(DoctorFinding {
+            severity: DoctorSeverity::Error,
+            code: AtmErrorCode::MailboxWriteFailed,
+            message: format!(
+                "inbox directory is not writable at {}: {error}",
+                inboxes_dir.display()
+            ),
+            remediation: Some(
+                "Check inbox directory permissions and ensure ATM can create and remove inbox files before rerunning `atm doctor`."
+                    .to_string(),
+            ),
+        });
+    }
+}
+
+fn probe_directory_writable(directory: &Path) -> Result<(), std::io::Error> {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let probe_path = directory.join(format!(
+        ".atm-doctor-write-probe-{}-{nonce}",
+        std::process::id()
+    ));
+    let file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&probe_path)?;
+    drop(file);
+    fs::remove_file(&probe_path)?;
+    Ok(())
 }
 
 fn ordered_member_summaries(members: &[AgentMember], baseline: &[String]) -> Vec<MemberSummary> {
@@ -194,6 +290,7 @@ mod tests {
         AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState,
         LogTailSession, ObservabilityPort,
     };
+    use crate::schema::{AgentMember, TeamConfig};
 
     enum StubHealth {
         Ok(AtmObservabilityHealth),
@@ -253,6 +350,36 @@ mod tests {
                 active_log_path: root.join("atm.log.jsonl"),
             }
         }
+
+        fn team_dir(&self) -> PathBuf {
+            self.home_dir.join(".claude").join("teams").join("atm-dev")
+        }
+
+        fn write_team_layout(&self, members: &[&str]) {
+            let team_dir = self.team_dir();
+            std::fs::create_dir_all(team_dir.join("inboxes")).expect("inboxes dir");
+            let config = TeamConfig {
+                members: members
+                    .iter()
+                    .map(|member| AgentMember {
+                        name: (*member).to_string(),
+                        ..Default::default()
+                    })
+                    .collect(),
+                ..Default::default()
+            };
+            std::fs::write(
+                team_dir.join("config.json"),
+                serde_json::to_vec(&config).expect("team config"),
+            )
+            .expect("write team config");
+        }
+
+        fn write_raw_team_config(&self, raw: &str) {
+            let team_dir = self.team_dir();
+            std::fs::create_dir_all(&team_dir).expect("team dir");
+            std::fs::write(team_dir.join("config.json"), raw).expect("write raw team config");
+        }
     }
 
     fn query(paths: &TestPaths) -> DoctorQuery {
@@ -266,6 +393,7 @@ mod tests {
     #[test]
     fn run_doctor_reports_healthy_observability() {
         let paths = TestPaths::new();
+        paths.write_team_layout(&["arch-ctm"]);
         let report = run_doctor(
             query(&paths),
             &StubObservability {
@@ -287,6 +415,7 @@ mod tests {
     #[test]
     fn run_doctor_reports_obsolete_identity_drift_as_warning() {
         let paths = TestPaths::new();
+        paths.write_team_layout(&["arch-ctm"]);
         std::fs::write(
             paths.current_dir.join(".atm.toml"),
             "[atm]\nidentity = \"arch-ctm\"\n",
@@ -319,6 +448,7 @@ mod tests {
     #[test]
     fn run_doctor_reports_degraded_observability_as_warning() {
         let paths = TestPaths::new();
+        paths.write_team_layout(&["arch-ctm"]);
         let report = run_doctor(
             query(&paths),
             &StubObservability {
@@ -343,6 +473,7 @@ mod tests {
     #[test]
     fn run_doctor_reports_unavailable_observability_as_error() {
         let paths = TestPaths::new();
+        paths.write_team_layout(&["arch-ctm"]);
         let report = run_doctor(
             query(&paths),
             &StubObservability {
@@ -367,6 +498,7 @@ mod tests {
     #[test]
     fn run_doctor_reports_observability_health_errors() {
         let paths = TestPaths::new();
+        paths.write_team_layout(&["arch-ctm"]);
         let report = run_doctor(
             query(&paths),
             &StubObservability {
@@ -391,6 +523,86 @@ mod tests {
             report.findings[0]
                 .message
                 .contains("health check transport failed")
+        );
+    }
+
+    #[test]
+    fn run_doctor_reports_missing_team_directory_as_error() {
+        let paths = TestPaths::new();
+        let report = run_doctor(
+            query(&paths),
+            &StubObservability {
+                health: StubHealth::Ok(AtmObservabilityHealth {
+                    active_log_path: Some(paths.active_log_path.clone()),
+                    logging_state: AtmObservabilityHealthState::Healthy,
+                    query_state: Some(AtmObservabilityHealthState::Healthy),
+                    detail: None,
+                }),
+            },
+        )
+        .expect("doctor report");
+
+        assert_eq!(report.summary.status, DoctorStatus::Error);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.code == AtmErrorCode::TeamNotFound),
+            "{report:#?}"
+        );
+    }
+
+    #[test]
+    fn run_doctor_reports_team_config_parse_failure_as_error() {
+        let paths = TestPaths::new();
+        paths.write_raw_team_config("{\"members\":");
+        let report = run_doctor(
+            query(&paths),
+            &StubObservability {
+                health: StubHealth::Ok(AtmObservabilityHealth {
+                    active_log_path: Some(paths.active_log_path.clone()),
+                    logging_state: AtmObservabilityHealthState::Healthy,
+                    query_state: Some(AtmObservabilityHealthState::Healthy),
+                    detail: None,
+                }),
+            },
+        )
+        .expect("doctor report");
+
+        assert_eq!(report.summary.status, DoctorStatus::Error);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.code == AtmErrorCode::ConfigTeamParseFailed),
+            "{report:#?}"
+        );
+    }
+
+    #[test]
+    fn run_doctor_reports_missing_inboxes_directory_as_error() {
+        let paths = TestPaths::new();
+        paths.write_raw_team_config(r#"{"members":[{"name":"arch-ctm"}]}"#);
+        let report = run_doctor(
+            query(&paths),
+            &StubObservability {
+                health: StubHealth::Ok(AtmObservabilityHealth {
+                    active_log_path: Some(paths.active_log_path.clone()),
+                    logging_state: AtmObservabilityHealthState::Healthy,
+                    query_state: Some(AtmObservabilityHealthState::Healthy),
+                    detail: None,
+                }),
+            },
+        )
+        .expect("doctor report");
+
+        assert_eq!(report.summary.status, DoctorStatus::Error);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.code == AtmErrorCode::MailboxWriteFailed),
+            "{report:#?}"
         );
     }
 }

--- a/crates/atm-core/src/doctor/report.rs
+++ b/crates/atm-core/src/doctor/report.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 use crate::error_codes::AtmErrorCode;
 use crate::observability::AtmObservabilityHealth;
+use crate::team_admin::MembersList;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -52,6 +53,8 @@ pub struct DoctorReport {
     pub findings: Vec<DoctorFinding>,
     pub recommendations: Vec<String>,
     pub environment: DoctorEnvironmentVisibility,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub member_roster: Option<MembersList>,
     pub observability: AtmObservabilityHealth,
 }
 

--- a/crates/atm-core/src/error_codes.rs
+++ b/crates/atm-core/src/error_codes.rs
@@ -76,6 +76,8 @@ pub enum AtmErrorCode {
     WarningSendAlertStateDegraded,
     /// Obsolete .atm.toml identity config is still present.
     WarningIdentityDrift,
+    /// A baseline team member declared in .atm.toml is missing from config.json.
+    WarningBaselineMemberMissing,
 }
 
 impl AtmErrorCode {
@@ -114,6 +116,7 @@ impl AtmErrorCode {
             Self::WarningMissingTeamConfigFallback => "ATM_WARNING_MISSING_TEAM_CONFIG_FALLBACK",
             Self::WarningSendAlertStateDegraded => "ATM_WARNING_SEND_ALERT_STATE_DEGRADED",
             Self::WarningIdentityDrift => "ATM_WARNING_IDENTITY_DRIFT",
+            Self::WarningBaselineMemberMissing => "ATM_WARNING_BASELINE_MEMBER_MISSING",
         }
     }
 }

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -38,6 +38,11 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-agent".into()),
             default_team: None,
+            team_members: Vec::new(),
+            aliases: Default::default(),
+            post_send_hook: None,
+            post_send_hook_members: Vec::new(),
+            config_root: std::path::PathBuf::new(),
             obsolete_identity_present: true,
         };
         assert_eq!(
@@ -57,6 +62,11 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-agent".into()),
             default_team: None,
+            team_members: Vec::new(),
+            aliases: Default::default(),
+            post_send_hook: None,
+            post_send_hook_members: Vec::new(),
+            config_root: std::path::PathBuf::new(),
             obsolete_identity_present: true,
         };
 
@@ -93,6 +103,11 @@ mod tests {
         let config = AtmConfig {
             identity: Some("config-agent".into()),
             default_team: Some("config-team".into()),
+            team_members: Vec::new(),
+            aliases: Default::default(),
+            post_send_hook: None,
+            post_send_hook_members: Vec::new(),
+            config_root: std::path::PathBuf::new(),
             obsolete_identity_present: true,
         };
 

--- a/crates/atm-core/src/mailbox/source.rs
+++ b/crates/atm-core/src/mailbox/source.rs
@@ -49,9 +49,10 @@ pub(crate) fn resolve_target(
         .team
         .or_else(|| config::resolve_team(team_override, config))
         .ok_or_else(AtmError::team_unavailable)?;
+    let agent = config::aliases::resolve_agent(&parsed.agent, config);
 
     Ok(ResolvedTarget {
-        agent: parsed.agent,
+        agent,
         team,
         explicit: true,
     })
@@ -104,9 +105,12 @@ pub(crate) fn discover_origin_inboxes(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use tempfile::tempdir;
 
-    use super::discover_origin_inboxes;
+    use super::{discover_origin_inboxes, resolve_target};
+    use crate::config::AtmConfig;
 
     #[test]
     fn discover_origin_inboxes_ignores_primary_and_sorts_matches() {
@@ -125,5 +129,21 @@ mod tests {
                 inboxes.join("arch-ctm.host-b.json")
             ]
         );
+    }
+
+    #[test]
+    fn resolve_target_canonicalizes_alias_before_mailbox_lookup() {
+        let mut aliases = BTreeMap::new();
+        aliases.insert("tl".to_string(), "team-lead".to_string());
+        let config = AtmConfig {
+            default_team: Some("atm-dev".to_string()),
+            aliases,
+            ..Default::default()
+        };
+
+        let target = resolve_target(Some("tl"), "arch-ctm", None, Some(&config)).expect("target");
+        assert_eq!(target.agent, "team-lead");
+        assert_eq!(target.team, "atm-dev");
+        assert!(target.explicit);
     }
 }

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -262,7 +262,7 @@ fn resolve_actor_identity(
     config: Option<&config::AtmConfig>,
 ) -> Result<String, AtmError> {
     if let Some(actor) = actor_override.filter(|value| !value.trim().is_empty()) {
-        return Ok(actor.to_string());
+        return Ok(config::aliases::resolve_agent(actor, config));
     }
 
     if let Some(identity) = identity::hook::read_hook_identity()? {

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -2,11 +2,12 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
-use serde_json::Map;
+use serde_json::{Map, json};
 use tracing::warn;
 
 use crate::address::AgentAddress;
@@ -80,12 +81,21 @@ pub fn send_mail(
     observability: &dyn ObservabilityPort,
 ) -> Result<SendOutcome, AtmError> {
     let config = config::load_config(&request.current_dir)?;
-    let sender = resolve_sender_identity(request.sender_override.as_deref(), config.as_ref())?;
+    let canonical_sender =
+        resolve_sender_identity(request.sender_override.as_deref(), config.as_ref())?;
     let recipient = resolve_recipient(
         &request.to,
         request.team_override.as_deref(),
         config.as_ref(),
     )?;
+    let sender_team = config::resolve_team(None, config.as_ref());
+    let sender = display_sender_identity(
+        &canonical_sender,
+        request.sender_override.as_deref(),
+        sender_team.as_deref(),
+        &recipient.team,
+        config.as_ref(),
+    );
 
     let team_dir = home::team_dir_from_home(&request.home_dir, &recipient.team)?;
     if !team_dir.exists() {
@@ -130,7 +140,6 @@ pub fn send_mail(
                 notify_team_lead_missing_config(
                     &request.home_dir,
                     &team_dir,
-                    &sender,
                     &recipient.team,
                     &recipient.agent,
                 );
@@ -152,24 +161,31 @@ pub fn send_mail(
     let timestamp = IsoTimestamp::now();
 
     if !request.dry_run {
+        let mut extra = Map::new();
+        if sender != canonical_sender {
+            set_canonical_sender_metadata(
+                &mut extra,
+                &qualified_sender_identity(&canonical_sender, sender_team.as_deref()),
+            );
+        }
         let envelope = MessageEnvelope {
             from: sender.clone(),
             text: body.clone(),
             timestamp,
             read: false,
-            source_team: Some(recipient.team.clone()),
+            source_team: sender_team.clone().or(Some(recipient.team.clone())),
             summary: Some(summary.clone()),
             message_id: Some(message_id),
             pending_ack_at: requires_ack.then_some(timestamp),
             acknowledged_at: None,
             acknowledges_message_id: None,
             task_id: task_id.clone(),
-            extra: Map::new(),
+            extra,
         };
         mailbox::append_message(&inbox_path, &envelope)?;
     }
 
-    let outcome = SendOutcome {
+    let mut outcome = SendOutcome {
         action: "send",
         team: recipient.team.clone(),
         agent: recipient.agent.clone(),
@@ -184,13 +200,28 @@ pub fn send_mail(
         dry_run: request.dry_run,
     };
 
+    if !request.dry_run {
+        maybe_run_post_send_hook(
+            &mut outcome.warnings,
+            config.as_ref(),
+            PostSendHookContext {
+                sender: &canonical_sender,
+                sender_team: sender_team.as_deref(),
+                recipient: &recipient,
+                message_id,
+                requires_ack,
+                task_id: task_id.as_deref(),
+            },
+        );
+    }
+
     let _ = observability.emit(CommandEvent {
         command: "send",
         action: "send",
         outcome: outcome.outcome,
         team: outcome.team.clone(),
         agent: outcome.agent.clone(),
-        sender,
+        sender: canonical_sender,
         message_id: Some(outcome.message_id),
         requires_ack: outcome.requires_ack,
         dry_run: outcome.dry_run,
@@ -208,19 +239,29 @@ struct ResolvedRecipient {
     team: String,
 }
 
+struct PostSendHookContext<'a> {
+    sender: &'a str,
+    sender_team: Option<&'a str>,
+    recipient: &'a ResolvedRecipient,
+    message_id: LegacyMessageId,
+    requires_ack: bool,
+    task_id: Option<&'a str>,
+}
+
 fn resolve_sender_identity(
     sender_override: Option<&str>,
     config: Option<&config::AtmConfig>,
 ) -> Result<String, AtmError> {
     if let Some(sender) = sender_override.filter(|value| !value.trim().is_empty()) {
-        return Ok(sender.to_string());
+        return Ok(config::aliases::resolve_agent(sender.trim(), config));
     }
 
     if let Some(identity) = identity::hook::read_hook_identity()? {
-        return Ok(identity);
+        return Ok(config::aliases::resolve_agent(&identity, config));
     }
 
     identity::resolve_sender_identity(config)
+        .map(|identity| config::aliases::resolve_agent(&identity, config))
 }
 
 fn resolve_recipient(
@@ -235,7 +276,7 @@ fn resolve_recipient(
         .ok_or_else(AtmError::team_unavailable)?;
 
     Ok(ResolvedRecipient {
-        agent: parsed.agent,
+        agent: config::aliases::resolve_agent(&parsed.agent, config),
         team,
     })
 }
@@ -263,13 +304,7 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
-fn notify_team_lead_missing_config(
-    home_dir: &Path,
-    team_dir: &Path,
-    sender: &str,
-    team: &str,
-    recipient: &str,
-) {
+fn notify_team_lead_missing_config(home_dir: &Path, team_dir: &Path, team: &str, recipient: &str) {
     let alert_key = missing_team_config_alert_key(team_dir);
     if !register_missing_team_config_alert(home_dir, &alert_key) {
         return;
@@ -300,7 +335,7 @@ fn notify_team_lead_missing_config(
     );
 
     let notice = MessageEnvelope {
-        from: sender.to_string(),
+        from: format!("atm-identity-missing@{team}"),
         text: format!(
             "ATM warning: send used existing inbox fallback for {recipient}@{team} because team config is missing at {}. Please restore config.json.",
             config_path.display()
@@ -325,6 +360,158 @@ fn notify_team_lead_missing_config(
             path = %team_lead_inbox.display(),
             "failed to append missing-config notice to team-lead inbox"
         );
+    }
+}
+
+fn display_sender_identity(
+    canonical_sender: &str,
+    sender_override: Option<&str>,
+    sender_team: Option<&str>,
+    recipient_team: &str,
+    config: Option<&config::AtmConfig>,
+) -> String {
+    let cross_team = sender_team.is_some_and(|team| team != recipient_team);
+    if !cross_team {
+        return canonical_sender.to_string();
+    }
+
+    if let Some(sender_override) = sender_override
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        && config::aliases::resolve_agent(sender_override, config) == canonical_sender
+    {
+        return sender_override.to_string();
+    }
+
+    config::aliases::preferred_alias(canonical_sender, config)
+        .unwrap_or_else(|| canonical_sender.to_string())
+}
+
+fn qualified_sender_identity(sender: &str, sender_team: Option<&str>) -> String {
+    sender_team
+        .map(|team| format!("{sender}@{team}"))
+        .unwrap_or_else(|| sender.to_string())
+}
+
+fn set_canonical_sender_metadata(extra: &mut Map<String, serde_json::Value>, canonical_from: &str) {
+    let metadata = extra
+        .entry("metadata".to_string())
+        .or_insert_with(|| serde_json::Value::Object(Map::new()));
+    if !metadata.is_object() {
+        *metadata = serde_json::Value::Object(Map::new());
+    }
+    let Some(metadata) = metadata.as_object_mut() else {
+        return;
+    };
+    let atm = metadata
+        .entry("atm".to_string())
+        .or_insert_with(|| serde_json::Value::Object(Map::new()));
+    if !atm.is_object() {
+        *atm = serde_json::Value::Object(Map::new());
+    }
+    let Some(atm) = atm.as_object_mut() else {
+        return;
+    };
+    atm.insert(
+        "fromIdentity".to_string(),
+        serde_json::Value::String(canonical_from.to_string()),
+    );
+}
+
+fn maybe_run_post_send_hook(
+    warnings: &mut Vec<String>,
+    config: Option<&config::AtmConfig>,
+    context: PostSendHookContext<'_>,
+) {
+    const POST_SEND_HOOK_TIMEOUT: Duration = Duration::from_secs(5);
+
+    let Some(config) = config else {
+        return;
+    };
+    let Some(command_argv) = config.post_send_hook.as_ref() else {
+        return;
+    };
+    if !config
+        .post_send_hook_members
+        .iter()
+        .any(|member| member == context.sender)
+    {
+        return;
+    }
+
+    let mut argv = command_argv.iter();
+    let Some(command_path) = argv.next() else {
+        return;
+    };
+    let command_path = {
+        let path = PathBuf::from(command_path);
+        if path.is_absolute() {
+            path
+        } else {
+            config.config_root.join(path)
+        }
+    };
+
+    let payload = json!({
+        "from": qualified_sender_identity(context.sender, context.sender_team),
+        "to": format!("{}@{}", context.recipient.agent, context.recipient.team),
+        "message_id": context.message_id.to_string(),
+        "requires_ack": context.requires_ack,
+        "task_id": context.task_id,
+    });
+
+    let mut command = Command::new(&command_path);
+    command
+        .args(argv)
+        .current_dir(&config.config_root)
+        .env("ATM_POST_SEND", payload.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            warnings.push(format!(
+                "warning: post-send hook failed to start from {}: {error}",
+                command_path.display()
+            ));
+            return;
+        }
+    };
+
+    let started_at = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    warnings.push(format!(
+                        "warning: post-send hook exited unsuccessfully from {} with status {status}",
+                        command_path.display()
+                    ));
+                }
+                return;
+            }
+            Ok(None) if started_at.elapsed() < POST_SEND_HOOK_TIMEOUT => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                warnings.push(format!(
+                    "warning: post-send hook timed out after {}s for {}",
+                    POST_SEND_HOOK_TIMEOUT.as_secs(),
+                    command_path.display()
+                ));
+                return;
+            }
+            Err(error) => {
+                warnings.push(format!(
+                    "warning: post-send hook status check failed for {}: {error}",
+                    command_path.display()
+                ));
+                return;
+            }
+        }
     }
 }
 

--- a/crates/atm/src/bin/atm_post_send_hook_fixture.rs
+++ b/crates/atm/src/bin/atm_post_send_hook_fixture.rs
@@ -1,0 +1,30 @@
+use std::env;
+use std::fs;
+use std::process::ExitCode;
+use std::thread;
+use std::time::Duration;
+
+fn main() -> ExitCode {
+    let mut args = env::args().skip(1);
+    let mode = match args.next() {
+        Some(mode) => mode,
+        None => return ExitCode::from(2),
+    };
+    let output_path = match args.next() {
+        Some(path) => path,
+        None => return ExitCode::from(2),
+    };
+
+    let payload = env::var("ATM_POST_SEND").unwrap_or_default();
+    let _ = fs::write(&output_path, payload);
+
+    match mode.as_str() {
+        "capture" => ExitCode::SUCCESS,
+        "fail" => ExitCode::from(3),
+        "sleep" => {
+            thread::sleep(Duration::from_secs(6));
+            ExitCode::SUCCESS
+        }
+        _ => ExitCode::from(2),
+    }
+}

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod observability;
 mod output;
+mod sc_observability_adapter;
 
 use clap::Parser;
 use clap::error::ErrorKind;

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -1,34 +1,11 @@
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::path::Path;
 
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::home;
 use atm_core::observability::{
-    self, AtmLogQuery, AtmLogRecord, AtmLogSnapshot, AtmObservabilityHealth,
-    AtmObservabilityHealthState, CommandEvent, LogFieldMap, LogFieldMatch, LogLevelFilter,
-    LogOrder, LogTailSession, ObservabilityPort,
+    self, AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, CommandEvent, LogTailSession,
+    ObservabilityPort,
 };
-use chrono::{DateTime, Utc};
-use sc_observability::{
-    ConsoleSink, JsonlFileSink, Logger, LoggerBuilder, LoggerConfig, RetainedSinkFaultInjector,
-    RetentionPolicy, RotationPolicy, SinkRegistration,
-};
-use sc_observability_types::{
-    ActionName, CorrelationId, DiagnosticInfo, Level, LogEvent, LogQuery, OutcomeLabel,
-    ProcessIdentity, QueryError, SchemaVersion, ServiceName, TargetCategory, Timestamp,
-};
-use serde_json::Map;
-use time::OffsetDateTime;
-
-const ATM_SERVICE_NAME: &str = "atm";
-const ATM_COMMAND_TARGET: &str = "atm.command";
-const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAINED_SINK_FAULT";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ConsoleLogRoute {
-    Disabled,
-    Stderr,
-}
 
 /// Structured CLI-owned observability construction options.
 ///
@@ -40,21 +17,6 @@ pub struct CliObservabilityOptions {
     pub stderr_logs: bool,
 }
 
-impl CliObservabilityOptions {
-    fn console_log_route(self) -> ConsoleLogRoute {
-        if self.stderr_logs {
-            ConsoleLogRoute::Stderr
-        } else {
-            ConsoleLogRoute::Disabled
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RetainedSinkFaultMode {
-    Degraded,
-    Unavailable,
-}
 /// ATM CLI observability handle.
 ///
 /// Clone is intentionally not derived; see rationale below.
@@ -73,9 +35,11 @@ impl std::fmt::Debug for CliObservability {
 
 impl CliObservability {
     pub fn new(home_dir: &Path, options: CliObservabilityOptions) -> Result<Self, AtmError> {
-        let adapter = ScObservabilityAdapter::new(home_dir, options.console_log_route())?;
         Ok(Self {
-            inner: Box::new(adapter),
+            inner: crate::sc_observability_adapter::new_sc_observability_adapter(
+                home_dir,
+                options.stderr_logs,
+            )?,
         })
     }
 
@@ -149,12 +113,6 @@ impl ObservabilityPort for CliObservability {
     }
 }
 
-struct ScObservabilityAdapter {
-    logger: Logger,
-    service_name: ServiceName,
-    target_category: TargetCategory,
-}
-
 // L.5 dispositions:
 // - UX-002 retained: boxed trait-object dispatch remains acceptable for
 //   initial release because it keeps CLI bootstrap simple without forcing a
@@ -162,461 +120,33 @@ struct ScObservabilityAdapter {
 // - BP-001 retained: the sealed boundary remains in place so external crates
 //   cannot bypass the intended ATM-owned adapter contract with arbitrary
 //   ObservabilityPort impls.
-// - UNI-003 / DoctorCommand injectability: deferred — DoctorCommand does not
+// - UNI-003 retained as a defer decision: DoctorCommand injectability does not
 //   participate in the ObservabilityPort contract; defer injectability to a
 //   future sprint unless a concrete testing or feature need appears.
 impl observability::sealed::Sealed for CliObservability {}
-impl observability::sealed::Sealed for ScObservabilityAdapter {}
-
-impl ScObservabilityAdapter {
-    fn new(home_dir: &Path, console_log_route: ConsoleLogRoute) -> Result<Self, AtmError> {
-        let service_name = ServiceName::new(ATM_SERVICE_NAME).map_err(|source| {
-            AtmError::observability_bootstrap("failed to validate ATM service name")
-                .with_source(source)
-        })?;
-        let target_category = TargetCategory::new(ATM_COMMAND_TARGET).map_err(|source| {
-            AtmError::observability_bootstrap("failed to validate ATM observability target")
-                .with_source(source)
-        })?;
-        let mut config = LoggerConfig::default_for(service_name.clone(), log_root(home_dir));
-        // ATM CLI owns stdout/stderr UX by default; only opt into a shared
-        // console sink when the CLI routing rule explicitly selects one.
-        config.enable_console_sink = false;
-        let mut builder = Logger::builder(config).map_err(|source| {
-            AtmError::observability_bootstrap("failed to initialize shared observability logger")
-                .with_source(source)
-        })?;
-        if console_log_route == ConsoleLogRoute::Stderr {
-            builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
-        }
-        if let Some(mode) = retained_sink_fault_mode()? {
-            register_retained_sink_fault(&mut builder, home_dir, mode);
-        }
-        let logger = builder.build();
-
-        Ok(Self {
-            logger,
-            service_name,
-            target_category,
-        })
-    }
-}
-
-impl ObservabilityPort for ScObservabilityAdapter {
-    fn emit(&self, event: CommandEvent) -> Result<(), AtmError> {
-        let event = map_command_event(&self.service_name, &self.target_category, event)?;
-        self.logger.emit(event).map_err(|source| {
-            let code = source.diagnostic().code.as_str().to_string();
-            AtmError::observability_emit(format!("shared observability emit failed ({code})"))
-                .with_source(source)
-        })
-    }
-
-    fn query(&self, req: AtmLogQuery) -> Result<AtmLogSnapshot, AtmError> {
-        let query = map_query(&self.service_name, &self.target_category, req)?;
-        let snapshot = self.logger.query(&query).map_err(map_query_error)?;
-        map_snapshot(snapshot)
-    }
-
-    fn follow(&self, req: AtmLogQuery) -> Result<LogTailSession, AtmError> {
-        let query = map_query(&self.service_name, &self.target_category, req)?;
-        let mut session = self
-            .logger
-            .follow(query)
-            .map_err(|source| map_follow_error("start", source))?;
-        Ok(LogTailSession::from_poller(move || {
-            let snapshot = session
-                .poll()
-                .map_err(|source| map_follow_error("poll", source))?;
-            map_snapshot(snapshot)
-        }))
-    }
-
-    fn health(&self) -> Result<AtmObservabilityHealth, AtmError> {
-        let report = self.logger.health();
-        let query_state = report
-            .query
-            .as_ref()
-            .map(|query| map_query_state(query.state));
-        let query_detail = report
-            .query
-            .as_ref()
-            .and_then(|query| query.last_error.clone().map(render_diagnostic_summary));
-        Ok(AtmObservabilityHealth {
-            active_log_path: Some(report.active_log_path),
-            logging_state: map_logging_state(report.state),
-            query_state,
-            detail: report
-                .last_error
-                .map(render_diagnostic_summary)
-                .or(query_detail),
-        })
-    }
-}
-
-fn log_root(home_dir: &Path) -> PathBuf {
-    home_dir.join(".local").join("share")
-}
-
-fn fault_injection_log_path(home_dir: &Path) -> PathBuf {
-    log_root(home_dir)
-        .join("logs")
-        .join("atm-fault-injection.log.jsonl")
-}
 
 fn fatal_emit_failure_message(stage: &str, emit_error: &AtmError) -> String {
     format!("ATM fatal diagnostic emission failed during {stage}: {emit_error}")
-}
-
-fn retained_sink_fault_mode() -> Result<Option<RetainedSinkFaultMode>, AtmError> {
-    // WARNING: production-reachable diagnostic seam. Phase L intentionally
-    // keeps this env hook available so live degraded/unavailable validation
-    // can exercise the real shared adapter before initial release.
-    let Some(value) = std::env::var(ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV)
-        .ok()
-        .map(|value| value.trim().to_ascii_lowercase())
-        .filter(|value| !value.is_empty())
-    else {
-        return Ok(None);
-    };
-
-    match value.as_str() {
-        "degraded" => Ok(Some(RetainedSinkFaultMode::Degraded)),
-        "unavailable" => Ok(Some(RetainedSinkFaultMode::Unavailable)),
-        _ => Err(AtmError::observability_bootstrap(format!(
-            "invalid {ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV} value `{value}`; use `degraded` or `unavailable`"
-        ))),
-    }
-}
-
-fn register_retained_sink_fault(
-    builder: &mut LoggerBuilder,
-    home_dir: &Path,
-    mode: RetainedSinkFaultMode,
-) {
-    let injector = RetainedSinkFaultInjector::new();
-    let sink = Arc::new(JsonlFileSink::new(
-        fault_injection_log_path(home_dir),
-        RotationPolicy::default(),
-        RetentionPolicy::default(),
-    ));
-    builder.register_sink(SinkRegistration::new(injector.wrap(sink)));
-
-    match mode {
-        RetainedSinkFaultMode::Degraded => injector.force_degraded(),
-        RetainedSinkFaultMode::Unavailable => injector.force_unavailable(),
-    }
-}
-
-fn map_command_event(
-    service_name: &ServiceName,
-    target_category: &TargetCategory,
-    event: CommandEvent,
-) -> Result<LogEvent, AtmError> {
-    let schema_version =
-        SchemaVersion::new(sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION)
-            .map_err(|source| {
-                AtmError::observability_emit("failed to validate ATM observability schema version")
-                    .with_source(source)
-            })?;
-    let action = ActionName::new(event.action).map_err(|source| {
-        AtmError::observability_emit("failed to validate ATM observability action")
-            .with_source(source)
-    })?;
-    let request_id = event
-        .message_id
-        .map(|value| CorrelationId::new(value.to_string()))
-        .transpose()
-        .map_err(|source| {
-            AtmError::observability_emit("failed to validate ATM observability request id")
-                .with_source(source)
-        })?;
-    let correlation_id = event
-        .task_id
-        .as_deref()
-        .map(CorrelationId::new)
-        .transpose()
-        .map_err(|source| {
-            AtmError::observability_emit("failed to validate ATM observability correlation id")
-                .with_source(source)
-        })?;
-    let outcome = OutcomeLabel::new(event.outcome).map_err(|source| {
-        AtmError::observability_emit("failed to validate ATM observability outcome label")
-            .with_source(source)
-    })?;
-
-    // emit path: builds sc_observability_types fields directly; exempt from
-    // REQ-CORE-OBS-001 centralization per architect ruling (outputs to foreign type)
-    let mut fields = Map::new();
-    fields.insert(
-        "command".to_string(),
-        serde_json::Value::String(event.command.to_string()),
-    );
-    fields.insert(
-        "team".to_string(),
-        serde_json::Value::String(event.team.clone()),
-    );
-    fields.insert(
-        "agent".to_string(),
-        serde_json::Value::String(event.agent.clone()),
-    );
-    fields.insert(
-        "sender".to_string(),
-        serde_json::Value::String(event.sender.clone()),
-    );
-    fields.insert(
-        "requires_ack".to_string(),
-        serde_json::Value::Bool(event.requires_ack),
-    );
-    fields.insert(
-        "dry_run".to_string(),
-        serde_json::Value::Bool(event.dry_run),
-    );
-    if let Some(message_id) = event.message_id {
-        fields.insert(
-            "message_id".to_string(),
-            serde_json::Value::String(message_id.to_string()),
-        );
-    }
-    if let Some(task_id) = &event.task_id {
-        fields.insert(
-            "task_id".to_string(),
-            serde_json::Value::String(task_id.clone()),
-        );
-    }
-    if let Some(error_code) = event.error_code {
-        fields.insert(
-            "error_code".to_string(),
-            serde_json::Value::String(error_code.to_string()),
-        );
-    }
-    if let Some(error_message) = &event.error_message {
-        fields.insert(
-            "error_message".to_string(),
-            serde_json::Value::String(error_message.clone()),
-        );
-    }
-
-    Ok(LogEvent {
-        version: schema_version,
-        timestamp: Timestamp::now_utc(),
-        level: level_for_outcome(event.outcome),
-        service: service_name.clone(),
-        target: target_category.clone(),
-        action,
-        message: Some(format!(
-            "ATM command {} completed with outcome {}",
-            event.command, event.outcome
-        )),
-        identity: ProcessIdentity::default(),
-        trace: None,
-        request_id,
-        correlation_id,
-        outcome: Some(outcome),
-        diagnostic: None,
-        state_transition: None,
-        fields,
-    })
-}
-
-fn map_query(
-    service_name: &ServiceName,
-    target_category: &TargetCategory,
-    req: AtmLogQuery,
-) -> Result<LogQuery, AtmError> {
-    let field_matches = req
-        .field_matches
-        .into_iter()
-        .map(map_field_match)
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(LogQuery {
-        service: Some(service_name.clone()),
-        levels: req.levels.into_iter().map(map_level).collect(),
-        target: Some(target_category.clone()),
-        action: None,
-        request_id: None,
-        correlation_id: None,
-        since: req.since.map(map_timestamp).transpose()?,
-        until: req.until.map(map_timestamp).transpose()?,
-        field_matches,
-        limit: req.limit,
-        order: map_order(req.order),
-    })
-}
-
-fn map_field_match(
-    field_match: LogFieldMatch,
-) -> Result<sc_observability_types::LogFieldMatch, AtmError> {
-    let key = field_match.key.as_str().to_string();
-    let value = serde_json::to_value(&field_match.value).map_err(|source| {
-        AtmError::observability_query("failed to encode ATM log field match value")
-            .with_source(source)
-    })?;
-
-    Ok(sc_observability_types::LogFieldMatch::equals(key, value))
-}
-
-fn map_snapshot(snapshot: sc_observability_types::LogSnapshot) -> Result<AtmLogSnapshot, AtmError> {
-    let records = snapshot
-        .events
-        .into_iter()
-        .map(map_record)
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(AtmLogSnapshot {
-        records,
-        truncated: snapshot.truncated,
-    })
-}
-
-fn map_record(event: LogEvent) -> Result<AtmLogRecord, AtmError> {
-    let fields = serde_json::from_value::<LogFieldMap>(serde_json::Value::Object(event.fields))
-        .map_err(|source| {
-            AtmError::observability_query("failed to project shared log fields into ATM types")
-                .with_source(source)
-        })?;
-    Ok(AtmLogRecord {
-        timestamp: map_timestamp_back(event.timestamp)?,
-        severity: map_level_back(event.level),
-        service: event.service.to_string(),
-        target: Some(event.target.to_string()),
-        action: Some(event.action.to_string()),
-        message: event.message,
-        fields,
-    })
-}
-
-fn map_timestamp(timestamp: atm_core::types::IsoTimestamp) -> Result<Timestamp, AtmError> {
-    let datetime = timestamp.into_inner();
-    let nanos = datetime.timestamp_nanos_opt().ok_or_else(|| {
-        AtmError::observability_query("ATM timestamp could not be converted to nanoseconds")
-    })?;
-    let offset = OffsetDateTime::from_unix_timestamp_nanos(nanos.into()).map_err(|source| {
-        AtmError::observability_query("failed to convert ATM timestamp to shared timestamp")
-            .with_source(source)
-    })?;
-    Ok(Timestamp::from(offset))
-}
-
-fn map_timestamp_back(timestamp: Timestamp) -> Result<atm_core::types::IsoTimestamp, AtmError> {
-    let offset: OffsetDateTime = timestamp.into();
-    let datetime = DateTime::<Utc>::from_timestamp(offset.unix_timestamp(), offset.nanosecond())
-        .ok_or_else(|| {
-            AtmError::observability_query(
-                "shared observability timestamp could not be converted to chrono",
-            )
-        })?;
-    Ok(datetime.into())
-}
-
-fn map_level(level: LogLevelFilter) -> Level {
-    match level {
-        LogLevelFilter::Trace => Level::Trace,
-        LogLevelFilter::Debug => Level::Debug,
-        LogLevelFilter::Info => Level::Info,
-        LogLevelFilter::Warn => Level::Warn,
-        LogLevelFilter::Error => Level::Error,
-    }
-}
-
-fn map_level_back(level: Level) -> LogLevelFilter {
-    match level {
-        Level::Trace => LogLevelFilter::Trace,
-        Level::Debug => LogLevelFilter::Debug,
-        Level::Info => LogLevelFilter::Info,
-        Level::Warn => LogLevelFilter::Warn,
-        Level::Error => LogLevelFilter::Error,
-    }
-}
-
-fn map_order(order: LogOrder) -> sc_observability_types::LogOrder {
-    match order {
-        LogOrder::NewestFirst => sc_observability_types::LogOrder::NewestFirst,
-        LogOrder::OldestFirst => sc_observability_types::LogOrder::OldestFirst,
-    }
-}
-
-fn map_logging_state(
-    state: sc_observability_types::LoggingHealthState,
-) -> AtmObservabilityHealthState {
-    match state {
-        sc_observability_types::LoggingHealthState::Healthy => AtmObservabilityHealthState::Healthy,
-        sc_observability_types::LoggingHealthState::DegradedDropping => {
-            AtmObservabilityHealthState::Degraded
-        }
-        sc_observability_types::LoggingHealthState::Unavailable => {
-            AtmObservabilityHealthState::Unavailable
-        }
-    }
-}
-
-fn map_query_state(state: sc_observability_types::QueryHealthState) -> AtmObservabilityHealthState {
-    match state {
-        sc_observability_types::QueryHealthState::Healthy => AtmObservabilityHealthState::Healthy,
-        sc_observability_types::QueryHealthState::Degraded => AtmObservabilityHealthState::Degraded,
-        sc_observability_types::QueryHealthState::Unavailable => {
-            AtmObservabilityHealthState::Unavailable
-        }
-    }
-}
-
-fn level_for_outcome(outcome: &str) -> Level {
-    match outcome {
-        "ok" | "sent" | "dry_run" => Level::Info,
-        "timeout" => Level::Warn,
-        "error" | "failed" => Level::Error,
-        other => {
-            tracing::warn!(
-                outcome = other,
-                "unknown ATM command outcome for observability level"
-            );
-            Level::Warn
-        }
-    }
-}
-
-fn map_query_error(source: QueryError) -> AtmError {
-    let code = source.code().as_str().to_string();
-    AtmError::observability_query(format!("shared observability query failed ({code})"))
-        .with_source(source)
-}
-
-fn map_follow_error(phase: &str, source: QueryError) -> AtmError {
-    let code = source.code().as_str().to_string();
-    AtmError::observability_follow(format!(
-        "shared observability follow {phase} failed ({code})"
-    ))
-    .with_source(source)
-}
-
-fn render_diagnostic_summary(summary: sc_observability_types::DiagnosticSummary) -> String {
-    match summary.code {
-        Some(code) => format!("{}: {}", code.as_str(), summary.message),
-        None => summary.message,
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use atm_core::error::AtmError;
     use atm_core::observability::{
-        AtmLogQuery, LogLevelFilter, LogMode, LogOrder, ObservabilityPort,
+        AtmLogQuery, AtmObservabilityHealth, AtmObservabilityHealthState, CommandEvent,
+        LogLevelFilter, LogMode, LogOrder, LogTailSession, ObservabilityPort,
     };
-    use sc_observability_types::Level;
     use serial_test::serial;
     use tempfile::TempDir;
 
-    use super::{
-        CliObservability, CliObservabilityOptions, fatal_emit_failure_message, level_for_outcome,
-        log_root,
-    };
+    use super::{CliObservability, CliObservabilityOptions, fatal_emit_failure_message};
 
     struct FailingEmitObservability;
 
     impl atm_core::observability::sealed::Sealed for FailingEmitObservability {}
 
     impl ObservabilityPort for FailingEmitObservability {
-        fn emit(&self, _event: atm_core::observability::CommandEvent) -> Result<(), AtmError> {
+        fn emit(&self, _event: CommandEvent) -> Result<(), AtmError> {
             Err(AtmError::observability_emit("synthetic emit failure"))
         }
 
@@ -627,24 +157,20 @@ mod tests {
             Ok(atm_core::observability::AtmLogSnapshot::default())
         }
 
-        fn follow(
-            &self,
-            _req: AtmLogQuery,
-        ) -> Result<atm_core::observability::LogTailSession, AtmError> {
-            Ok(atm_core::observability::LogTailSession::empty())
+        fn follow(&self, _req: AtmLogQuery) -> Result<LogTailSession, AtmError> {
+            Ok(LogTailSession::empty())
         }
 
-        fn health(&self) -> Result<atm_core::observability::AtmObservabilityHealth, AtmError> {
-            Ok(atm_core::observability::AtmObservabilityHealth {
+        fn health(&self) -> Result<AtmObservabilityHealth, AtmError> {
+            Ok(AtmObservabilityHealth {
                 active_log_path: None,
-                logging_state: atm_core::observability::AtmObservabilityHealthState::Unavailable,
-                query_state: Some(
-                    atm_core::observability::AtmObservabilityHealthState::Unavailable,
-                ),
+                logging_state: AtmObservabilityHealthState::Unavailable,
+                query_state: Some(AtmObservabilityHealthState::Unavailable),
                 detail: Some("synthetic".to_string()),
             })
         }
     }
+
     fn query(order: LogOrder) -> AtmLogQuery {
         AtmLogQuery {
             mode: LogMode::Snapshot,
@@ -657,8 +183,8 @@ mod tests {
         }
     }
 
-    fn event(message_id: Option<&str>) -> atm_core::observability::CommandEvent {
-        atm_core::observability::CommandEvent {
+    fn event(message_id: Option<&str>) -> CommandEvent {
+        CommandEvent {
             command: "send",
             action: "send",
             outcome: "sent",
@@ -701,17 +227,21 @@ mod tests {
         );
 
         let health = observability.health().expect("health");
-        assert_eq!(
-            health.logging_state,
-            atm_core::observability::AtmObservabilityHealthState::Healthy
-        );
+        assert_eq!(health.logging_state, AtmObservabilityHealthState::Healthy);
         assert_eq!(
             health.query_state,
-            Some(atm_core::observability::AtmObservabilityHealthState::Healthy)
+            Some(AtmObservabilityHealthState::Healthy)
         );
         assert_eq!(
             health.active_log_path,
-            Some(log_root(tempdir.path()).join("logs").join("atm.log.jsonl"))
+            Some(
+                tempdir
+                    .path()
+                    .join(".local")
+                    .join("share")
+                    .join("logs")
+                    .join("atm.log.jsonl")
+            )
         );
         assert!(health.detail.is_none());
 
@@ -736,27 +266,6 @@ mod tests {
             }),
             "follow poll should include the newly emitted record even if the shared tail surface also returns the prior backlog entry"
         );
-    }
-
-    #[test]
-    fn unknown_outcome_maps_to_warn() {
-        assert_eq!(level_for_outcome("future-outcome"), Level::Warn);
-    }
-
-    #[test]
-    fn level_for_outcome_matches_documented_outcomes() {
-        let cases = [
-            ("ok", Level::Info),
-            ("sent", Level::Info),
-            ("dry_run", Level::Info),
-            ("timeout", Level::Warn),
-            ("error", Level::Error),
-            ("failed", Level::Error),
-        ];
-
-        for (outcome, expected) in cases {
-            assert_eq!(level_for_outcome(outcome), expected, "outcome={outcome}");
-        }
     }
 
     #[test]

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -200,6 +200,14 @@ pub fn print_doctor_result(report: &DoctorReport, json: bool) -> Result<()> {
         }
     }
 
+    if let Some(roster) = &report.member_roster {
+        println!();
+        println!("Members: {}", roster.team);
+        for member in &roster.members {
+            println!("  - {}", member.name);
+        }
+    }
+
     if !report.recommendations.is_empty() {
         println!();
         println!("Recommendations:");

--- a/crates/atm/src/sc_observability_adapter.rs
+++ b/crates/atm/src/sc_observability_adapter.rs
@@ -1,0 +1,511 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use atm_core::error::AtmError;
+use atm_core::observability::{
+    self, AtmLogQuery, AtmLogRecord, AtmLogSnapshot, AtmObservabilityHealth,
+    AtmObservabilityHealthState, CommandEvent, LogFieldMap, LogFieldMatch, LogLevelFilter,
+    LogOrder, LogTailSession, ObservabilityPort,
+};
+use chrono::{DateTime, Utc};
+use sc_observability::{
+    ConsoleSink, JsonlFileSink, Logger, LoggerBuilder, LoggerConfig, RetainedSinkFaultInjector,
+    RetentionPolicy, RotationPolicy, SinkRegistration,
+};
+use sc_observability_types::{
+    ActionName, CorrelationId, DiagnosticInfo, Level, LogEvent, LogQuery, OutcomeLabel,
+    ProcessIdentity, QueryError, SchemaVersion, ServiceName, TargetCategory, Timestamp,
+};
+use serde_json::Map;
+use time::OffsetDateTime;
+
+const ATM_SERVICE_NAME: &str = "atm";
+const ATM_COMMAND_TARGET: &str = "atm.command";
+const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAINED_SINK_FAULT";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConsoleLogRoute {
+    Disabled,
+    Stderr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetainedSinkFaultMode {
+    Degraded,
+    Unavailable,
+}
+
+pub(crate) fn new_sc_observability_adapter(
+    home_dir: &Path,
+    stderr_logs: bool,
+) -> Result<Box<dyn ObservabilityPort + Send + Sync>, AtmError> {
+    let console_log_route = if stderr_logs {
+        ConsoleLogRoute::Stderr
+    } else {
+        ConsoleLogRoute::Disabled
+    };
+    Ok(Box::new(ScObservabilityAdapter::new(
+        home_dir,
+        console_log_route,
+    )?))
+}
+
+struct ScObservabilityAdapter {
+    logger: Logger,
+    service_name: ServiceName,
+    target_category: TargetCategory,
+}
+
+impl observability::sealed::Sealed for ScObservabilityAdapter {}
+
+impl ScObservabilityAdapter {
+    fn new(home_dir: &Path, console_log_route: ConsoleLogRoute) -> Result<Self, AtmError> {
+        let service_name = ServiceName::new(ATM_SERVICE_NAME).map_err(|source| {
+            AtmError::observability_bootstrap("failed to validate ATM service name")
+                .with_source(source)
+        })?;
+        let target_category = TargetCategory::new(ATM_COMMAND_TARGET).map_err(|source| {
+            AtmError::observability_bootstrap("failed to validate ATM observability target")
+                .with_source(source)
+        })?;
+        let mut config = LoggerConfig::default_for(service_name.clone(), log_root(home_dir));
+        // ATM CLI owns stdout/stderr UX by default; only opt into a shared
+        // console sink when the CLI routing rule explicitly selects one.
+        config.enable_console_sink = false;
+        let mut builder = Logger::builder(config).map_err(|source| {
+            AtmError::observability_bootstrap("failed to initialize shared observability logger")
+                .with_source(source)
+        })?;
+        if console_log_route == ConsoleLogRoute::Stderr {
+            builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
+        }
+        if let Some(mode) = retained_sink_fault_mode()? {
+            register_retained_sink_fault(&mut builder, home_dir, mode);
+        }
+        let logger = builder.build();
+
+        Ok(Self {
+            logger,
+            service_name,
+            target_category,
+        })
+    }
+}
+
+impl ObservabilityPort for ScObservabilityAdapter {
+    fn emit(&self, event: CommandEvent) -> Result<(), AtmError> {
+        let event = map_command_event(&self.service_name, &self.target_category, event)?;
+        self.logger.emit(event).map_err(|source| {
+            let code = source.diagnostic().code.as_str().to_string();
+            AtmError::observability_emit(format!("shared observability emit failed ({code})"))
+                .with_source(source)
+        })
+    }
+
+    fn query(&self, req: AtmLogQuery) -> Result<AtmLogSnapshot, AtmError> {
+        let query = map_query(&self.service_name, &self.target_category, req)?;
+        let snapshot = self.logger.query(&query).map_err(map_query_error)?;
+        map_snapshot(snapshot)
+    }
+
+    fn follow(&self, req: AtmLogQuery) -> Result<LogTailSession, AtmError> {
+        let query = map_query(&self.service_name, &self.target_category, req)?;
+        let mut session = self
+            .logger
+            .follow(query)
+            .map_err(|source| map_follow_error("start", source))?;
+        Ok(LogTailSession::from_poller(move || {
+            let snapshot = session
+                .poll()
+                .map_err(|source| map_follow_error("poll", source))?;
+            map_snapshot(snapshot)
+        }))
+    }
+
+    fn health(&self) -> Result<AtmObservabilityHealth, AtmError> {
+        let report = self.logger.health();
+        let query_state = report
+            .query
+            .as_ref()
+            .map(|query| map_query_state(query.state));
+        let query_detail = report
+            .query
+            .as_ref()
+            .and_then(|query| query.last_error.clone().map(render_diagnostic_summary));
+        Ok(AtmObservabilityHealth {
+            active_log_path: Some(report.active_log_path),
+            logging_state: map_logging_state(report.state),
+            query_state,
+            detail: report
+                .last_error
+                .map(render_diagnostic_summary)
+                .or(query_detail),
+        })
+    }
+}
+
+fn log_root(home_dir: &Path) -> PathBuf {
+    home_dir.join(".local").join("share")
+}
+
+fn fault_injection_log_path(home_dir: &Path) -> PathBuf {
+    log_root(home_dir)
+        .join("logs")
+        .join("atm-fault-injection.log.jsonl")
+}
+
+fn retained_sink_fault_mode() -> Result<Option<RetainedSinkFaultMode>, AtmError> {
+    // WARNING: production-reachable diagnostic seam. Phase L intentionally
+    // keeps this env hook available so live degraded/unavailable validation
+    // can exercise the real shared adapter before initial release.
+    let Some(value) = std::env::var(ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV)
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+
+    match value.as_str() {
+        "degraded" => Ok(Some(RetainedSinkFaultMode::Degraded)),
+        "unavailable" => Ok(Some(RetainedSinkFaultMode::Unavailable)),
+        _ => Err(AtmError::observability_bootstrap(format!(
+            "invalid {ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV} value `{value}`; use `degraded` or `unavailable`"
+        ))),
+    }
+}
+
+fn register_retained_sink_fault(
+    builder: &mut LoggerBuilder,
+    home_dir: &Path,
+    mode: RetainedSinkFaultMode,
+) {
+    let injector = RetainedSinkFaultInjector::new();
+    let sink = Arc::new(JsonlFileSink::new(
+        fault_injection_log_path(home_dir),
+        RotationPolicy::default(),
+        RetentionPolicy::default(),
+    ));
+    builder.register_sink(SinkRegistration::new(injector.wrap(sink)));
+
+    match mode {
+        RetainedSinkFaultMode::Degraded => injector.force_degraded(),
+        RetainedSinkFaultMode::Unavailable => injector.force_unavailable(),
+    }
+}
+
+fn map_command_event(
+    service_name: &ServiceName,
+    target_category: &TargetCategory,
+    event: CommandEvent,
+) -> Result<LogEvent, AtmError> {
+    let schema_version =
+        SchemaVersion::new(sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION)
+            .map_err(|source| {
+                AtmError::observability_emit("failed to validate ATM observability schema version")
+                    .with_source(source)
+            })?;
+    let action = ActionName::new(event.action).map_err(|source| {
+        AtmError::observability_emit("failed to validate ATM observability action")
+            .with_source(source)
+    })?;
+    let request_id = event
+        .message_id
+        .map(|value| CorrelationId::new(value.to_string()))
+        .transpose()
+        .map_err(|source| {
+            AtmError::observability_emit("failed to validate ATM observability request id")
+                .with_source(source)
+        })?;
+    let correlation_id = event
+        .task_id
+        .as_deref()
+        .map(CorrelationId::new)
+        .transpose()
+        .map_err(|source| {
+            AtmError::observability_emit("failed to validate ATM observability correlation id")
+                .with_source(source)
+        })?;
+    let outcome = OutcomeLabel::new(event.outcome).map_err(|source| {
+        AtmError::observability_emit("failed to validate ATM observability outcome label")
+            .with_source(source)
+    })?;
+
+    // emit path: builds sc_observability_types fields directly; exempt from
+    // REQ-CORE-OBS-001 centralization per architect ruling (outputs to foreign type)
+    let mut fields = Map::new();
+    fields.insert(
+        "command".to_string(),
+        serde_json::Value::String(event.command.to_string()),
+    );
+    fields.insert(
+        "team".to_string(),
+        serde_json::Value::String(event.team.clone()),
+    );
+    fields.insert(
+        "agent".to_string(),
+        serde_json::Value::String(event.agent.clone()),
+    );
+    fields.insert(
+        "sender".to_string(),
+        serde_json::Value::String(event.sender.clone()),
+    );
+    fields.insert(
+        "requires_ack".to_string(),
+        serde_json::Value::Bool(event.requires_ack),
+    );
+    fields.insert(
+        "dry_run".to_string(),
+        serde_json::Value::Bool(event.dry_run),
+    );
+    if let Some(message_id) = event.message_id {
+        fields.insert(
+            "message_id".to_string(),
+            serde_json::Value::String(message_id.to_string()),
+        );
+    }
+    if let Some(task_id) = &event.task_id {
+        fields.insert(
+            "task_id".to_string(),
+            serde_json::Value::String(task_id.clone()),
+        );
+    }
+    if let Some(error_code) = event.error_code {
+        fields.insert(
+            "error_code".to_string(),
+            serde_json::Value::String(error_code.to_string()),
+        );
+    }
+    if let Some(error_message) = &event.error_message {
+        fields.insert(
+            "error_message".to_string(),
+            serde_json::Value::String(error_message.clone()),
+        );
+    }
+
+    Ok(LogEvent {
+        version: schema_version,
+        timestamp: Timestamp::now_utc(),
+        level: level_for_outcome(event.outcome),
+        service: service_name.clone(),
+        target: target_category.clone(),
+        action,
+        message: Some(format!(
+            "ATM command {} completed with outcome {}",
+            event.command, event.outcome
+        )),
+        identity: ProcessIdentity::default(),
+        trace: None,
+        request_id,
+        correlation_id,
+        outcome: Some(outcome),
+        diagnostic: None,
+        state_transition: None,
+        fields,
+    })
+}
+
+fn map_query(
+    service_name: &ServiceName,
+    target_category: &TargetCategory,
+    req: AtmLogQuery,
+) -> Result<LogQuery, AtmError> {
+    let field_matches = req
+        .field_matches
+        .into_iter()
+        .map(map_field_match)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(LogQuery {
+        service: Some(service_name.clone()),
+        levels: req.levels.into_iter().map(map_level).collect(),
+        target: Some(target_category.clone()),
+        action: None,
+        request_id: None,
+        correlation_id: None,
+        since: req.since.map(map_timestamp).transpose()?,
+        until: req.until.map(map_timestamp).transpose()?,
+        field_matches,
+        limit: req.limit,
+        order: map_order(req.order),
+    })
+}
+
+fn map_field_match(
+    field_match: LogFieldMatch,
+) -> Result<sc_observability_types::LogFieldMatch, AtmError> {
+    let key = field_match.key.as_str().to_string();
+    let value = serde_json::to_value(&field_match.value).map_err(|source| {
+        AtmError::observability_query("failed to encode ATM log field match value")
+            .with_source(source)
+    })?;
+
+    Ok(sc_observability_types::LogFieldMatch::equals(key, value))
+}
+
+fn map_snapshot(snapshot: sc_observability_types::LogSnapshot) -> Result<AtmLogSnapshot, AtmError> {
+    let records = snapshot
+        .events
+        .into_iter()
+        .map(map_record)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(AtmLogSnapshot {
+        records,
+        truncated: snapshot.truncated,
+    })
+}
+
+fn map_record(event: LogEvent) -> Result<AtmLogRecord, AtmError> {
+    let fields = serde_json::from_value::<LogFieldMap>(serde_json::Value::Object(event.fields))
+        .map_err(|source| {
+            AtmError::observability_query("failed to project shared log fields into ATM types")
+                .with_source(source)
+        })?;
+    Ok(AtmLogRecord {
+        timestamp: map_timestamp_back(event.timestamp)?,
+        severity: map_level_back(event.level),
+        service: event.service.to_string(),
+        target: Some(event.target.to_string()),
+        action: Some(event.action.to_string()),
+        message: event.message,
+        fields,
+    })
+}
+
+fn map_timestamp(timestamp: atm_core::types::IsoTimestamp) -> Result<Timestamp, AtmError> {
+    let datetime = timestamp.into_inner();
+    let nanos = datetime.timestamp_nanos_opt().ok_or_else(|| {
+        AtmError::observability_query("ATM timestamp could not be converted to nanoseconds")
+    })?;
+    let offset = OffsetDateTime::from_unix_timestamp_nanos(nanos.into()).map_err(|source| {
+        AtmError::observability_query("failed to convert ATM timestamp to shared timestamp")
+            .with_source(source)
+    })?;
+    Ok(Timestamp::from(offset))
+}
+
+fn map_timestamp_back(timestamp: Timestamp) -> Result<atm_core::types::IsoTimestamp, AtmError> {
+    let offset: OffsetDateTime = timestamp.into();
+    let datetime = DateTime::<Utc>::from_timestamp(offset.unix_timestamp(), offset.nanosecond())
+        .ok_or_else(|| {
+            AtmError::observability_query(
+                "shared observability timestamp could not be converted to chrono",
+            )
+        })?;
+    Ok(datetime.into())
+}
+
+fn map_level(level: LogLevelFilter) -> Level {
+    match level {
+        LogLevelFilter::Trace => Level::Trace,
+        LogLevelFilter::Debug => Level::Debug,
+        LogLevelFilter::Info => Level::Info,
+        LogLevelFilter::Warn => Level::Warn,
+        LogLevelFilter::Error => Level::Error,
+    }
+}
+
+fn map_level_back(level: Level) -> LogLevelFilter {
+    match level {
+        Level::Trace => LogLevelFilter::Trace,
+        Level::Debug => LogLevelFilter::Debug,
+        Level::Info => LogLevelFilter::Info,
+        Level::Warn => LogLevelFilter::Warn,
+        Level::Error => LogLevelFilter::Error,
+    }
+}
+
+fn map_order(order: LogOrder) -> sc_observability_types::LogOrder {
+    match order {
+        LogOrder::NewestFirst => sc_observability_types::LogOrder::NewestFirst,
+        LogOrder::OldestFirst => sc_observability_types::LogOrder::OldestFirst,
+    }
+}
+
+fn map_logging_state(
+    state: sc_observability_types::LoggingHealthState,
+) -> AtmObservabilityHealthState {
+    match state {
+        sc_observability_types::LoggingHealthState::Healthy => AtmObservabilityHealthState::Healthy,
+        sc_observability_types::LoggingHealthState::DegradedDropping => {
+            AtmObservabilityHealthState::Degraded
+        }
+        sc_observability_types::LoggingHealthState::Unavailable => {
+            AtmObservabilityHealthState::Unavailable
+        }
+    }
+}
+
+fn map_query_state(state: sc_observability_types::QueryHealthState) -> AtmObservabilityHealthState {
+    match state {
+        sc_observability_types::QueryHealthState::Healthy => AtmObservabilityHealthState::Healthy,
+        sc_observability_types::QueryHealthState::Degraded => AtmObservabilityHealthState::Degraded,
+        sc_observability_types::QueryHealthState::Unavailable => {
+            AtmObservabilityHealthState::Unavailable
+        }
+    }
+}
+
+fn level_for_outcome(outcome: &str) -> Level {
+    match outcome {
+        "ok" | "sent" | "dry_run" => Level::Info,
+        "timeout" => Level::Warn,
+        "error" | "failed" => Level::Error,
+        other => {
+            tracing::warn!(
+                outcome = other,
+                "unknown ATM command outcome for observability level"
+            );
+            Level::Warn
+        }
+    }
+}
+
+fn map_query_error(source: QueryError) -> AtmError {
+    let code = source.code().as_str().to_string();
+    AtmError::observability_query(format!("shared observability query failed ({code})"))
+        .with_source(source)
+}
+
+fn map_follow_error(phase: &str, source: QueryError) -> AtmError {
+    let code = source.code().as_str().to_string();
+    AtmError::observability_follow(format!(
+        "shared observability follow {phase} failed ({code})"
+    ))
+    .with_source(source)
+}
+
+fn render_diagnostic_summary(summary: sc_observability_types::DiagnosticSummary) -> String {
+    match summary.code {
+        Some(code) => format!("{}: {}", code.as_str(), summary.message),
+        None => summary.message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sc_observability_types::Level;
+
+    use super::level_for_outcome;
+
+    #[test]
+    fn unknown_outcome_maps_to_warn() {
+        assert_eq!(level_for_outcome("future-outcome"), Level::Warn);
+    }
+
+    #[test]
+    fn level_for_outcome_matches_documented_outcomes() {
+        let cases = [
+            ("ok", Level::Info),
+            ("sent", Level::Info),
+            ("dry_run", Level::Info),
+            ("timeout", Level::Warn),
+            ("error", Level::Error),
+            ("failed", Level::Error),
+        ];
+
+        for (outcome, expected) in cases {
+            assert_eq!(level_for_outcome(outcome), expected, "outcome={outcome}");
+        }
+    }
+}

--- a/crates/atm/tests/doctor.rs
+++ b/crates/atm/tests/doctor.rs
@@ -149,14 +149,75 @@ fn test_doctor_reports_member_roster_with_baseline_ordering() {
     assert_eq!(members[3]["name"], "temp-worker");
 }
 
+#[test]
+fn test_doctor_reports_missing_team_directory_finding() {
+    let fixture = Fixture::empty();
+
+    let output = fixture.run(&["doctor", "--json"], &[]);
+
+    assert!(!output.status.success());
+    let parsed = fixture.stdout_json(&output);
+    let findings = parsed["findings"].as_array().expect("findings array");
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["code"] == "ATM_TEAM_NOT_FOUND"),
+        "stdout: {}",
+        String::from_utf8(output.stdout.clone()).expect("stdout utf8")
+    );
+}
+
+#[test]
+fn test_doctor_reports_team_config_parse_failure_finding() {
+    let fixture = Fixture::empty();
+    fixture.write_raw_team_config("{\"members\":");
+
+    let output = fixture.run(&["doctor", "--json"], &[]);
+
+    assert!(!output.status.success());
+    let parsed = fixture.stdout_json(&output);
+    let findings = parsed["findings"].as_array().expect("findings array");
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["code"] == "ATM_CONFIG_TEAM_PARSE_FAILED"),
+        "stdout: {}",
+        String::from_utf8(output.stdout.clone()).expect("stdout utf8")
+    );
+}
+
+#[test]
+fn test_doctor_reports_missing_inboxes_directory_finding() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fs::remove_dir_all(fixture.team_dir().join("inboxes")).expect("remove inboxes dir");
+
+    let output = fixture.run(&["doctor", "--json"], &[]);
+
+    assert!(!output.status.success());
+    let parsed = fixture.stdout_json(&output);
+    let findings = parsed["findings"].as_array().expect("findings array");
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["code"] == "ATM_MAILBOX_WRITE_FAILED"),
+        "stdout: {}",
+        String::from_utf8(output.stdout.clone()).expect("stdout utf8")
+    );
+}
+
 struct Fixture {
     tempdir: tempfile::TempDir,
 }
 
 impl Fixture {
+    fn empty() -> Self {
+        Self {
+            tempdir: tempfile::tempdir().expect("tempdir"),
+        }
+    }
+
     fn new(members: &[&str]) -> Self {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let fixture = Self { tempdir };
+        let fixture = Self::empty();
         fixture.write_team_config(members);
         fixture
     }
@@ -179,6 +240,7 @@ impl Fixture {
     fn write_team_config(&self, members: &[&str]) {
         let team_dir = self.team_dir();
         fs::create_dir_all(&team_dir).expect("team dir");
+        fs::create_dir_all(team_dir.join("inboxes")).expect("inboxes dir");
         let config = TeamConfig {
             members: members
                 .iter()
@@ -198,6 +260,12 @@ impl Fixture {
 
     fn write_atm_config(&self, raw: &str) {
         fs::write(self.tempdir.path().join(".atm.toml"), raw).expect("write .atm.toml");
+    }
+
+    fn write_raw_team_config(&self, raw: &str) {
+        let team_dir = self.team_dir();
+        fs::create_dir_all(&team_dir).expect("team dir");
+        fs::write(team_dir.join("config.json"), raw).expect("write raw team config");
     }
 
     fn stdout_json(&self, output: &std::process::Output) -> Value {

--- a/crates/atm/tests/doctor.rs
+++ b/crates/atm/tests/doctor.rs
@@ -97,6 +97,58 @@ fn test_doctor_reports_obsolete_identity_drift_warning() {
     );
 }
 
+#[test]
+fn test_doctor_reports_missing_baseline_team_member() {
+    let fixture = Fixture::new(&["team-lead", "arch-ctm"]);
+    fixture.write_atm_config(
+        "[atm]\ndefault_team = \"atm-dev\"\nteam_members = [\"team-lead\", \"arch-ctm\", \"qa\"]\n",
+    );
+
+    let output = fixture.run(&["doctor", "--json"], &[]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    let findings = parsed["findings"].as_array().expect("findings array");
+    assert!(
+        findings.iter().any(|finding| {
+            finding["code"] == "ATM_WARNING_BASELINE_MEMBER_MISSING"
+                && finding["message"]
+                    .as_str()
+                    .is_some_and(|message| message.contains("qa"))
+        }),
+        "stdout: {}",
+        String::from_utf8(output.stdout.clone()).expect("stdout utf8")
+    );
+}
+
+#[test]
+fn test_doctor_reports_member_roster_with_baseline_ordering() {
+    let fixture = Fixture::new(&["qa", "team-lead", "arch-ctm", "temp-worker"]);
+    fixture.write_atm_config(
+        "[atm]\ndefault_team = \"atm-dev\"\nteam_members = [\"arch-ctm\", \"team-lead\", \"qa\"]\n",
+    );
+
+    let output = fixture.run(&["doctor", "--json"], &[]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    let members = parsed["member_roster"]["members"]
+        .as_array()
+        .expect("member roster array");
+    assert_eq!(members[0]["name"], "team-lead");
+    assert_eq!(members[1]["name"], "arch-ctm");
+    assert_eq!(members[2]["name"], "qa");
+    assert_eq!(members[3]["name"], "temp-worker");
+}
+
 struct Fixture {
     tempdir: tempfile::TempDir,
 }

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
@@ -257,6 +258,7 @@ fn test_send_missing_config_uses_existing_inbox_fallback_and_warns_sender() {
 
     let notices = fixture.inbox_contents("team-lead");
     assert_eq!(notices.len(), 1);
+    assert_eq!(notices[0].from, "atm-identity-missing@atm-dev");
     assert!(
         notices[0]
             .text
@@ -384,6 +386,105 @@ fn test_send_missing_config_does_not_block_when_team_lead_inbox_is_absent() {
     assert_eq!(inbox.len(), 1);
 }
 
+#[test]
+fn test_send_resolves_recipient_alias_before_membership_validation() {
+    let fixture = Fixture::new("team-lead");
+    fixture.write_atm_config("[atm]\n[atm.aliases]\ntl = \"team-lead\"\n");
+
+    let output = fixture.run(&["send", "tl@atm-dev", "hello alias"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let inbox = fixture.inbox_contents("team-lead");
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].text, "hello alias");
+}
+
+#[test]
+fn test_send_cross_team_projects_alias_and_persists_canonical_from_identity() {
+    let fixture = Fixture::new("recipient");
+    fixture.write_team_config_for_team("other-team", "recipient");
+    fixture.write_atm_config("[atm]\n[atm.aliases]\nlead = \"arch-ctm\"\n");
+
+    let output = fixture.run_with_env(
+        &["send", "recipient@other-team", "hello cross-team"],
+        &[("ATM_TEAM", "atm-dev")],
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let inbox = fixture.inbox_contents_in_team("other-team", "recipient");
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].from, "lead");
+    assert_eq!(
+        inbox[0].extra["metadata"]["atm"]["fromIdentity"],
+        "arch-ctm@atm-dev"
+    );
+}
+
+#[test]
+fn test_send_runs_post_send_hook_with_expected_payload() {
+    let fixture = Fixture::new("recipient");
+    let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
+    fixture.write_atm_config(&format!(
+        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_members = ['arch-ctm']\n",
+        hook_path.display(),
+        payload_path.display()
+    ));
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello hook"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
+    assert_eq!(payload["from"], "arch-ctm@atm-dev");
+    assert_eq!(payload["to"], "recipient@atm-dev");
+    assert_eq!(payload["requires_ack"], false);
+    assert!(payload["message_id"].as_str().is_some());
+    assert!(payload.get("task_id").is_some());
+}
+
+#[test]
+fn test_send_post_send_hook_failure_does_not_roll_back_send() {
+    let fixture = Fixture::new("recipient");
+    let (hook_path, payload_path) = fixture.install_hook_fixture("fail");
+    fixture.write_atm_config(&format!(
+        "[atm]\npost_send_hook = ['{}', 'fail', '{}']\npost_send_hook_members = ['arch-ctm']\n",
+        hook_path.display(),
+        payload_path.display()
+    ));
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello failed hook", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid send json");
+    let warnings = parsed["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings.iter().any(|warning| warning
+            .as_str()
+            .is_some_and(|warning| warning.contains("post-send hook exited unsuccessfully"))),
+        "stdout: {}",
+        fixture.stdout(&output)
+    );
+    let inbox = fixture.inbox_contents("recipient");
+    assert_eq!(inbox.len(), 1);
+}
+
 struct Fixture {
     tempdir: tempfile::TempDir,
 }
@@ -397,15 +498,7 @@ impl Fixture {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_atm"))
-            .args(args)
-            .env("ATM_HOME", self.tempdir.path())
-            .env("ATM_CONFIG_HOME", self.tempdir.path())
-            .env("ATM_IDENTITY", "arch-ctm")
-            .env("ATM_TEAM", "atm-dev")
-            .current_dir(self.tempdir.path())
-            .output()
-            .expect("run atm")
+        self.run_with_env(args, &[])
     }
 
     fn run_without_identity(&self, args: &[&str]) -> std::process::Output {
@@ -420,13 +513,27 @@ impl Fixture {
             .expect("run atm without identity")
     }
 
+    fn run_with_env(&self, args: &[&str], extra_env: &[(&str, &str)]) -> std::process::Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_atm"));
+        command
+            .args(args)
+            .env("ATM_HOME", self.tempdir.path())
+            .env("ATM_CONFIG_HOME", self.tempdir.path())
+            .env("ATM_IDENTITY", "arch-ctm")
+            .env("ATM_TEAM", "atm-dev")
+            .current_dir(self.tempdir.path());
+        for (key, value) in extra_env {
+            command.env(key, value);
+        }
+        command.output().expect("run atm")
+    }
+
     fn write_team_config(&self, recipient: &str) {
-        let team_dir = self
-            .tempdir
-            .path()
-            .join(".claude")
-            .join("teams")
-            .join("atm-dev");
+        self.write_team_config_for_team("atm-dev", recipient);
+    }
+
+    fn write_team_config_for_team(&self, team: &str, recipient: &str) {
+        let team_dir = self.tempdir.path().join(".claude").join("teams").join(team);
         fs::create_dir_all(&team_dir).expect("team dir");
         let config = TeamConfig {
             members: vec![AgentMember {
@@ -458,11 +565,15 @@ impl Fixture {
     }
 
     fn inbox_path(&self, recipient: &str) -> std::path::PathBuf {
+        self.inbox_path_in_team("atm-dev", recipient)
+    }
+
+    fn inbox_path_in_team(&self, team: &str, recipient: &str) -> std::path::PathBuf {
         self.tempdir
             .path()
             .join(".claude")
             .join("teams")
-            .join("atm-dev")
+            .join(team)
             .join("inboxes")
             .join(format!("{recipient}.json"))
     }
@@ -488,7 +599,11 @@ impl Fixture {
     }
 
     fn inbox_contents(&self, recipient: &str) -> Vec<MessageEnvelope> {
-        let inbox_path = self.inbox_path(recipient);
+        self.inbox_contents_in_team("atm-dev", recipient)
+    }
+
+    fn inbox_contents_in_team(&self, team: &str, recipient: &str) -> Vec<MessageEnvelope> {
+        let inbox_path = self.inbox_path_in_team(team, recipient);
         let raw = fs::read_to_string(&inbox_path).expect("inbox contents");
         if raw.trim().is_empty() {
             return Vec::new();
@@ -504,6 +619,29 @@ impl Fixture {
             .join(".claude")
             .join("teams")
             .join("atm-dev")
+    }
+
+    fn install_hook_fixture(&self, mode: &str) -> (PathBuf, PathBuf) {
+        let fixture_binary = PathBuf::from(env!("CARGO_BIN_EXE_atm_post_send_hook_fixture"));
+        let hook_dir = self.tempdir.path().join("bin");
+        fs::create_dir_all(&hook_dir).expect("hook dir");
+        let hook_path = hook_dir.join(fixture_binary.file_name().expect("hook binary filename"));
+        fs::copy(&fixture_binary, &hook_path).expect("copy hook fixture");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = fs::metadata(&hook_path)
+                .expect("hook metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&hook_path, permissions).expect("hook permissions");
+        }
+        let payload_path = self.tempdir.path().join(format!("{mode}-payload.json"));
+        (
+            PathBuf::from("bin").join(hook_path.file_name().expect("copied hook binary filename")),
+            payload_path,
+        )
     }
 
     fn stdout(&self, output: &std::process::Output) -> String {

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -483,6 +483,8 @@ Status summary:
     `512dfa4d89ac71307ef7324f64dffb67d5189cc3`
   - `L.6` complete on `feature/pL-s6-release-closeout` / PR #56 at
     `341e28c1f7175f9890a5a1d5606b64e0ce816d52`
+  - `L.7` complete on `feature/pL-s-atm-toml-config` / PR #58 at
+    `f0fe9d571db74a030705ac971fe484fb1c350094`
 
 Goal:
 - finish the published `sc-observability` 1.0 follow-on work and close the

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -484,7 +484,7 @@ Status summary:
   - `L.6` complete on `feature/pL-s6-release-closeout` / PR #56 at
     `341e28c1f7175f9890a5a1d5606b64e0ce816d52`
   - `L.7` complete on `feature/pL-s-atm-toml-config` / PR #58 at
-    `f0fe9d571db74a030705ac971fe484fb1c350094`
+    `70242203dc1130e4b0fa1cfc9268c54314c38d42`
 
 Goal:
 - finish the published `sc-observability` 1.0 follow-on work and close the


### PR DESCRIPTION
## Sprint L.7 — ATM-owned config surface

Implements the `.atm.toml` runtime config features documented in Phase L requirements/architecture.

## Deliverables

- `[atm].team_members` loading and doctor baseline-member findings
- `[atm].aliases` loading and recipient alias resolution before send validation/mailbox lookup
- Cross-team alias-friendly sender projection with `metadata.atm.fromIdentity` persistence
- `[atm].post_send_hook` and `post_send_hook_members` with config-root-relative execution and `ATM_POST_SEND` payload
- Best-effort hook failure handling (no send rollback)
- Reserved repair sender `atm-identity-missing@<team>` for missing-config notices (ARCH-CR-003)
- Doctor member-roster output with baseline-first ordering, team-lead first among baseline (ARCH-CR-004)
- Ack reply-target resolution prefers `metadata.atm.fromIdentity` when present
- Integration coverage: alias send, doctor roster/finding behavior, post-send hook success/failure

## Validation

`cargo fmt`, `cargo test --workspace`, `cargo clippy -- -D warnings` all PASS at `f0fe9d5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)