### PR TITLE
feat: Phase M.1 — mailbox locking (fs2 advisory locks)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "fs2",
  "libc",
  "serde",
  "serde_json",
@@ -247,6 +248,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures-core"
@@ -1045,6 +1056,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"
 ulid = { version = "1.2.1", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
+fs2 = "0.4"
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -143,6 +143,18 @@ pub fn ack_mail(
         mailbox::lock::acquire_many_sorted(final_write_paths, mailbox::lock::DEFAULT_LOCK_TIMEOUT)?;
     let mut source_files = load_source_files(&actor_source_paths)?;
     let source_message = find_source_message(&source_files, request.message_id, &actor, &team)?;
+    match (
+        state::derive_read_state(&source_message.envelope),
+        state::derive_ack_state(&source_message.envelope),
+    ) {
+        (crate::types::ReadState::Read, crate::types::AckState::PendingAck) => {}
+        _ => {
+            return Err(AtmError::validation(format!(
+                "message {} is not in the (read, pending_ack) state",
+                request.message_id
+            )));
+        }
+    }
     update_source_message(&mut source_files, &source_message, ack_timestamp)?;
 
     append_reply_message(&mut source_files, &reply_inbox_path, reply_message)?;
@@ -330,8 +342,13 @@ fn append_reply_message(
 
     source_files.push(SourceFile {
         path: reply_inbox_path.to_path_buf(),
-        messages: vec![reply_message],
+        messages: mailbox::read_messages(reply_inbox_path)?,
     });
+    source_files
+        .last_mut()
+        .expect("reply inbox source file just pushed")
+        .messages
+        .push(reply_message);
     source_files.sort_by(|left, right| left.path.cmp(&right.path));
     Ok(())
 }

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -10,7 +10,9 @@ use crate::error::AtmError;
 use crate::home;
 use crate::identity;
 use crate::mailbox;
-use crate::mailbox::source::{SourceFile, SourcedMessage, discover_origin_inboxes};
+use crate::mailbox::source::{
+    SourceFile, SourcedMessage, discover_source_paths, load_source_files,
+};
 use crate::mailbox::surface::dedupe_legacy_message_id_surface;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
@@ -63,35 +65,17 @@ pub fn ack_mail(
         return Err(AtmError::agent_not_found(&actor, &team));
     }
 
-    let mut source_files = load_source_files(&request.home_dir, &team, &actor)?;
+    let actor_source_paths = discover_source_paths(&request.home_dir, &team, &actor)?;
+    let initial_locks = mailbox::lock::acquire_many_sorted(
+        actor_source_paths.clone(),
+        mailbox::lock::DEFAULT_LOCK_TIMEOUT,
+    )?;
+    let mut source_files = load_source_files(&actor_source_paths)?;
     // Ack intentionally does not apply read-surface idle-notification dedup.
     // It must preserve the raw merged surface after legacy message_id
     // canonicalization so acknowledgement lookup does not depend on read-only
     // inbox clutter policy.
-    let source_message = dedupe_legacy_message_id_surface(
-        merged_surface(&source_files),
-        |message: &SourcedMessage| message.envelope.message_id,
-        |message: &SourcedMessage| message.envelope.timestamp,
-    )
-    .into_iter()
-    .filter_map(|message| match message.envelope.message_id {
-        Some(_) => Some(message),
-        None => {
-            trace!(
-                source_path = %message.source_path.display(),
-                source_index = message.source_index,
-                "skipping source message without message_id during ack lookup"
-            );
-            None
-        }
-    })
-    .find(|message| message.envelope.message_id == Some(request.message_id))
-    .ok_or_else(|| {
-        AtmError::validation(format!(
-            "message {} was not found in {}@{}",
-            request.message_id, actor, team
-        ))
-    })?;
+    let source_message = find_source_message(&source_files, request.message_id, &actor, &team)?;
 
     match (
         state::derive_read_state(&source_message.envelope),
@@ -146,10 +130,27 @@ pub fn ack_mail(
         extra: Map::new(),
     };
 
-    update_source_message(&mut source_files, &source_message, ack_timestamp)?;
-
     let reply_inbox_path =
         home::inbox_path_from_home(&request.home_dir, &reply_team, &reply_agent)?;
+    let final_write_paths = if actor_source_paths
+        .iter()
+        .any(|path| path == &reply_inbox_path)
+    {
+        actor_source_paths.clone()
+    } else {
+        let mut final_paths = actor_source_paths.clone();
+        final_paths.push(reply_inbox_path.clone());
+        final_paths
+    };
+    drop(initial_locks);
+    let _final_locks = mailbox::lock::acquire_many_sorted(
+        final_write_paths.clone(),
+        mailbox::lock::DEFAULT_LOCK_TIMEOUT,
+    )?;
+    source_files = load_source_files(&actor_source_paths)?;
+    let source_message = find_source_message(&source_files, request.message_id, &actor, &team)?;
+    update_source_message(&mut source_files, &source_message, ack_timestamp)?;
+
     append_reply_message(&mut source_files, &reply_inbox_path, reply_message)?;
     persist_source_files(&source_files)?;
 
@@ -235,31 +236,6 @@ fn canonical_sender_identity(message: &MessageEnvelope) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-fn load_source_files(
-    home_dir: &Path,
-    team: &str,
-    agent: &str,
-) -> Result<Vec<SourceFile>, AtmError> {
-    let inbox_path = home::inbox_path_from_home(home_dir, team, agent)?;
-    let inboxes_dir = inbox_path
-        .parent()
-        .ok_or_else(|| AtmError::mailbox_read("inbox path has no parent directory"))?;
-    let inboxes_dir = inboxes_dir.to_path_buf();
-
-    let mut paths = vec![inbox_path];
-    paths.extend(discover_origin_inboxes(&inboxes_dir, agent)?);
-
-    let mut sources = Vec::with_capacity(paths.len());
-    for path in paths {
-        sources.push(SourceFile {
-            messages: mailbox::read_messages(&path)?,
-            path,
-        });
-    }
-
-    Ok(sources)
-}
-
 fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
     source_files
         .iter()
@@ -276,6 +252,38 @@ fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {
                 })
         })
         .collect()
+}
+
+fn find_source_message(
+    source_files: &[SourceFile],
+    message_id: LegacyMessageId,
+    actor: &str,
+    team: &str,
+) -> Result<SourcedMessage, AtmError> {
+    dedupe_legacy_message_id_surface(
+        merged_surface(source_files),
+        |message: &SourcedMessage| message.envelope.message_id,
+        |message: &SourcedMessage| message.envelope.timestamp,
+    )
+    .into_iter()
+    .filter_map(|message| match message.envelope.message_id {
+        Some(_) => Some(message),
+        None => {
+            trace!(
+                source_path = %message.source_path.display(),
+                source_index = message.source_index,
+                "skipping source message without message_id during ack lookup"
+            );
+            None
+        }
+    })
+    .find(|message| message.envelope.message_id == Some(message_id))
+    .ok_or_else(|| {
+        AtmError::validation(format!(
+            "message {} was not found in {}@{}",
+            message_id, actor, team
+        ))
+    })
 }
 
 fn update_source_message(

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -346,7 +346,7 @@ fn append_reply_message(
     });
     source_files
         .last_mut()
-        .expect("reply inbox source file just pushed")
+        .ok_or_else(|| AtmError::mailbox_write("reply inbox source file disappeared after push"))?
         .messages
         .push(reply_message);
     source_files.sort_by(|left, right| left.path.cmp(&right.path));

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -66,16 +66,13 @@ pub fn ack_mail(
     }
 
     let actor_source_paths = discover_source_paths(&request.home_dir, &team, &actor)?;
-    let initial_locks = mailbox::lock::acquire_many_sorted(
-        actor_source_paths.clone(),
-        mailbox::lock::DEFAULT_LOCK_TIMEOUT,
-    )?;
-    let mut source_files = load_source_files(&actor_source_paths)?;
+    let preflight_source_files = load_source_files(&actor_source_paths)?;
     // Ack intentionally does not apply read-surface idle-notification dedup.
     // It must preserve the raw merged surface after legacy message_id
     // canonicalization so acknowledgement lookup does not depend on read-only
     // inbox clutter policy.
-    let source_message = find_source_message(&source_files, request.message_id, &actor, &team)?;
+    let source_message =
+        find_source_message(&preflight_source_files, request.message_id, &actor, &team)?;
 
     match (
         state::derive_read_state(&source_message.envelope),
@@ -142,12 +139,9 @@ pub fn ack_mail(
         final_paths.push(reply_inbox_path.clone());
         final_paths
     };
-    drop(initial_locks);
-    let _final_locks = mailbox::lock::acquire_many_sorted(
-        final_write_paths.clone(),
-        mailbox::lock::DEFAULT_LOCK_TIMEOUT,
-    )?;
-    source_files = load_source_files(&actor_source_paths)?;
+    let _final_locks =
+        mailbox::lock::acquire_many_sorted(final_write_paths, mailbox::lock::DEFAULT_LOCK_TIMEOUT)?;
+    let mut source_files = load_source_files(&actor_source_paths)?;
     let source_message = find_source_message(&source_files, request.message_id, &actor, &team)?;
     update_source_message(&mut source_files, &source_message, ack_timestamp)?;
 

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -76,11 +76,8 @@ pub fn clear_mail(
         return Err(AtmError::agent_not_found(&target.agent, &target.team));
     }
 
-    let mut source_files = load_source_files(&discover_source_paths(
-        &query.home_dir,
-        &target.team,
-        &target.agent,
-    )?)?;
+    let source_paths = discover_source_paths(&query.home_dir, &target.team, &target.agent)?;
+    let mut source_files = load_source_files(&source_paths)?;
     // Clear intentionally does not apply read-surface idle-notification dedup.
     // Cleanup decisions must inspect the raw merged surface after legacy
     // message_id canonicalization only.
@@ -105,7 +102,6 @@ pub fn clear_mail(
         .collect::<HashSet<_>>();
 
     if !query.dry_run {
-        let source_paths = discover_source_paths(&query.home_dir, &target.team, &target.agent)?;
         let _locks = mailbox::lock::acquire_many_sorted(
             source_paths.clone(),
             mailbox::lock::DEFAULT_LOCK_TIMEOUT,

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use chrono::{DateTime, TimeDelta, Utc};
@@ -11,7 +11,9 @@ use crate::error::AtmError;
 use crate::home;
 use crate::identity;
 use crate::mailbox;
-use crate::mailbox::source::{SourceFile, SourcedMessage, discover_origin_inboxes, resolve_target};
+use crate::mailbox::source::{
+    SourceFile, SourcedMessage, discover_source_paths, load_source_files, resolve_target,
+};
 use crate::mailbox::surface::dedupe_legacy_message_id_surface;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
@@ -74,7 +76,11 @@ pub fn clear_mail(
         return Err(AtmError::agent_not_found(&target.agent, &target.team));
     }
 
-    let mut source_files = load_source_files(&query.home_dir, &target.team, &target.agent)?;
+    let mut source_files = load_source_files(&discover_source_paths(
+        &query.home_dir,
+        &target.team,
+        &target.agent,
+    )?)?;
     // Clear intentionally does not apply read-surface idle-notification dedup.
     // Cleanup decisions must inspect the raw merged surface after legacy
     // message_id canonicalization only.
@@ -99,6 +105,23 @@ pub fn clear_mail(
         .collect::<HashSet<_>>();
 
     if !query.dry_run {
+        let source_paths = discover_source_paths(&query.home_dir, &target.team, &target.agent)?;
+        let _locks = mailbox::lock::acquire_many_sorted(
+            source_paths.clone(),
+            mailbox::lock::DEFAULT_LOCK_TIMEOUT,
+        )?;
+        source_files = load_source_files(&source_paths)?;
+        let merged = dedupe_legacy_message_id_surface(
+            merged_surface(&source_files),
+            |message: &SourcedMessage| message.envelope.message_id,
+            |message: &SourcedMessage| message.envelope.timestamp,
+        );
+        let removable = merged
+            .iter()
+            .filter(|message| is_clearable(message, cutoff, query.idle_only))
+            .map(|message| (message.source_path.clone(), message.source_index))
+            .collect::<HashSet<_>>();
+
         apply_removals(&mut source_files, &removable);
         persist_source_files(&source_files)?;
     }
@@ -154,31 +177,6 @@ fn resolve_actor_identity(
     }
 
     identity::resolve_sender_identity(config)
-}
-
-fn load_source_files(
-    home_dir: &Path,
-    team: &str,
-    agent: &str,
-) -> Result<Vec<SourceFile>, AtmError> {
-    let inbox_path = home::inbox_path_from_home(home_dir, team, agent)?;
-    let inboxes_dir = inbox_path
-        .parent()
-        .ok_or_else(|| AtmError::mailbox_read("inbox path has no parent directory"))?;
-    let inboxes_dir = inboxes_dir.to_path_buf();
-
-    let mut paths = vec![inbox_path];
-    paths.extend(discover_origin_inboxes(&inboxes_dir, agent)?);
-
-    let mut sources = Vec::with_capacity(paths.len());
-    for path in paths {
-        sources.push(SourceFile {
-            messages: mailbox::read_messages(&path)?,
-            path,
-        });
-    }
-
-    Ok(sources)
 }
 
 fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -101,43 +101,53 @@ pub fn clear_mail(
         .map(|message| (message.source_path.clone(), message.source_index))
         .collect::<HashSet<_>>();
 
-    if !query.dry_run {
+    let (removed_total, remaining_total, removed_by_class) = if query.dry_run {
+        (
+            removable.len(),
+            merged.len().saturating_sub(removable.len()),
+            removed_by_class,
+        )
+    } else {
         let _locks = mailbox::lock::acquire_many_sorted(
             source_paths.clone(),
             mailbox::lock::DEFAULT_LOCK_TIMEOUT,
         )?;
+        maybe_remove_locked_source_file_for_test(&source_paths)?;
         source_files = load_source_files(&source_paths)?;
         let merged = dedupe_legacy_message_id_surface(
             merged_surface(&source_files),
             |message: &SourcedMessage| message.envelope.message_id,
             |message: &SourcedMessage| message.envelope.timestamp,
         );
+        let mut locked_removed_by_class = RemovedByClass::default();
         let removable = merged
             .iter()
             .filter(|message| is_clearable(message, cutoff, query.idle_only))
+            .inspect(|message| {
+                count_removed(
+                    &mut locked_removed_by_class,
+                    state::classify_message(&message.envelope),
+                )
+            })
             .map(|message| (message.source_path.clone(), message.source_index))
             .collect::<HashSet<_>>();
 
         apply_removals(&mut source_files, &removable);
         persist_source_files(&source_files)?;
-    }
-
-    let remaining_total = if query.dry_run {
-        merged.len().saturating_sub(removable.len())
-    } else {
-        dedupe_legacy_message_id_surface(
+        let remaining_total = dedupe_legacy_message_id_surface(
             merged_surface(&source_files),
             |message: &SourcedMessage| message.envelope.message_id,
             |message: &SourcedMessage| message.envelope.timestamp,
         )
-        .len()
+        .len();
+        (removable.len(), remaining_total, locked_removed_by_class)
     };
 
     let outcome = ClearOutcome {
         action: "clear",
         team: target.team,
         agent: target.agent,
-        removed_total: removable.len(),
+        removed_total,
         remaining_total,
         removed_by_class,
     };
@@ -222,6 +232,23 @@ fn is_idle_notification(message: &MessageEnvelope) -> bool {
         .ok()
         .map(|value| value.get("type").and_then(Value::as_str) == Some("idle_notification"))
         .unwrap_or(false)
+}
+
+fn maybe_remove_locked_source_file_for_test(source_paths: &[PathBuf]) -> Result<(), AtmError> {
+    if std::env::var_os("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD").is_none() {
+        return Ok(());
+    }
+
+    let Some(path) = source_paths.first() else {
+        return Ok(());
+    };
+    std::fs::remove_file(path).map_err(|error| {
+        AtmError::mailbox_write(format!(
+            "failed to remove locked inbox {} during test injection: {error}",
+            path.display()
+        ))
+        .with_source(error)
+    })
 }
 
 fn count_removed(counts: &mut RemovedByClass, class: MessageClass) {

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -301,7 +301,7 @@ impl AtmErrorKind {
             Self::Identity => AtmErrorCode::IdentityUnavailable,
             Self::TeamNotFound => AtmErrorCode::TeamNotFound,
             Self::AgentNotFound => AtmErrorCode::AgentNotFound,
-            Self::MailboxLock => AtmErrorCode::MailboxWriteFailed,
+            Self::MailboxLock => AtmErrorCode::MailboxLockFailed,
             Self::MailboxRead => AtmErrorCode::MailboxReadFailed,
             Self::MailboxWrite => AtmErrorCode::MailboxWriteFailed,
             Self::FilePolicy => AtmErrorCode::FilePolicyRejected,
@@ -342,6 +342,10 @@ mod tests {
         assert_eq!(
             AtmError::observability_health("health failed").code,
             AtmErrorCode::ObservabilityHealthFailed
+        );
+        assert_eq!(
+            AtmError::mailbox_lock("lock failed").code,
+            AtmErrorCode::MailboxLockFailed
         );
     }
 }

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -12,6 +12,7 @@ pub(crate) enum AtmErrorKind {
     Identity,
     TeamNotFound,
     AgentNotFound,
+    MailboxLock,
     MailboxRead,
     MailboxWrite,
     FilePolicy,
@@ -81,6 +82,10 @@ impl AtmError {
 
     pub fn is_mailbox_read(&self) -> bool {
         self.kind == AtmErrorKind::MailboxRead
+    }
+
+    pub fn is_mailbox_lock(&self) -> bool {
+        self.kind == AtmErrorKind::MailboxLock
     }
 
     pub fn is_mailbox_write(&self) -> bool {
@@ -202,6 +207,26 @@ impl AtmError {
         Self::new(AtmErrorKind::MailboxRead, message)
     }
 
+    pub fn mailbox_lock(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::MailboxLock, message).with_recovery(
+            "Retry after other ATM mailbox activity completes, or wait for the competing process to release its mailbox lock.",
+        )
+    }
+
+    pub fn mailbox_lock_timeout(path: &std::path::Path) -> Self {
+        Self::new_with_code(
+            AtmErrorCode::MailboxLockTimeout,
+            AtmErrorKind::MailboxLock,
+            format!(
+                "timed out waiting for mailbox lock on {}",
+                path.display()
+            ),
+        )
+        .with_recovery(
+            "Retry after the competing ATM process finishes, or investigate whether another process is holding the mailbox lock unexpectedly.",
+        )
+    }
+
     pub fn mailbox_write(message: impl Into<String>) -> Self {
         Self::new(AtmErrorKind::MailboxWrite, message)
     }
@@ -276,6 +301,7 @@ impl AtmErrorKind {
             Self::Identity => AtmErrorCode::IdentityUnavailable,
             Self::TeamNotFound => AtmErrorCode::TeamNotFound,
             Self::AgentNotFound => AtmErrorCode::AgentNotFound,
+            Self::MailboxLock => AtmErrorCode::MailboxWriteFailed,
             Self::MailboxRead => AtmErrorCode::MailboxReadFailed,
             Self::MailboxWrite => AtmErrorCode::MailboxWriteFailed,
             Self::FilePolicy => AtmErrorCode::FilePolicyRejected,

--- a/crates/atm-core/src/error_codes.rs
+++ b/crates/atm-core/src/error_codes.rs
@@ -32,6 +32,8 @@ pub enum AtmErrorCode {
     MailboxReadFailed,
     /// Writing a mailbox failed.
     MailboxWriteFailed,
+    /// Acquiring a mailbox lock timed out.
+    MailboxLockTimeout,
     /// A malformed mailbox record was skipped.
     MailboxRecordSkipped,
     /// Message validation failed.
@@ -94,6 +96,7 @@ impl AtmErrorCode {
             Self::AgentNotFound => "ATM_AGENT_NOT_FOUND",
             Self::MailboxReadFailed => "ATM_MAILBOX_READ_FAILED",
             Self::MailboxWriteFailed => "ATM_MAILBOX_WRITE_FAILED",
+            Self::MailboxLockTimeout => "ATM_MAILBOX_LOCK_TIMEOUT",
             Self::MailboxRecordSkipped => "ATM_MAILBOX_RECORD_SKIPPED",
             Self::MessageValidationFailed => "ATM_MESSAGE_VALIDATION_FAILED",
             Self::SerializationFailed => "ATM_SERIALIZATION_FAILED",

--- a/crates/atm-core/src/error_codes.rs
+++ b/crates/atm-core/src/error_codes.rs
@@ -32,6 +32,8 @@ pub enum AtmErrorCode {
     MailboxReadFailed,
     /// Writing a mailbox failed.
     MailboxWriteFailed,
+    /// Acquiring or releasing a mailbox lock failed.
+    MailboxLockFailed,
     /// Acquiring a mailbox lock timed out.
     MailboxLockTimeout,
     /// A malformed mailbox record was skipped.
@@ -96,6 +98,7 @@ impl AtmErrorCode {
             Self::AgentNotFound => "ATM_AGENT_NOT_FOUND",
             Self::MailboxReadFailed => "ATM_MAILBOX_READ_FAILED",
             Self::MailboxWriteFailed => "ATM_MAILBOX_WRITE_FAILED",
+            Self::MailboxLockFailed => "ATM_MAILBOX_LOCK_FAILED",
             Self::MailboxLockTimeout => "ATM_MAILBOX_LOCK_TIMEOUT",
             Self::MailboxRecordSkipped => "ATM_MAILBOX_RECORD_SKIPPED",
             Self::MessageValidationFailed => "ATM_MESSAGE_VALIDATION_FAILED",

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -4,6 +4,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use fs2::FileExt;
+use tracing::warn;
 
 use crate::error::AtmError;
 
@@ -12,32 +13,63 @@ const RETRY_INTERVAL: Duration = Duration::from_millis(50);
 
 #[derive(Debug)]
 pub(crate) struct MailboxLockGuard {
-    #[allow(dead_code)]
     target_path: PathBuf,
-    #[allow(dead_code)]
     lock_path: PathBuf,
     file: File,
 }
 
 impl Drop for MailboxLockGuard {
     fn drop(&mut self) {
-        let _ = self.file.unlock();
+        if let Err(error) = self.file.unlock() {
+            warn!(
+                %error,
+                target_path = %self.target_path.display(),
+                lock_path = %self.lock_path.display(),
+                "failed to release mailbox lock"
+            );
+        }
     }
 }
 
+/// Return the sentinel lock-file path for a mailbox file.
+///
+/// # Errors
+///
+/// This helper does not return errors.
 pub(crate) fn sentinel_path(path: &Path) -> PathBuf {
     let mut os = path.as_os_str().to_os_string();
     os.push(".lock");
     PathBuf::from(os)
 }
 
+/// Sort and deduplicate mailbox paths by canonical filesystem identity.
+///
+/// # Errors
+///
+/// This helper does not return errors. Canonicalization failures fall back to
+/// the original path string for sorting and deduplication.
 pub(crate) fn sort_unique_paths(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
-    let mut paths = paths.into_iter().collect::<Vec<_>>();
-    paths.sort_by_key(|path| path.to_string_lossy().into_owned());
-    paths.dedup_by(|left, right| left == right);
-    paths
+    let mut paths = paths
+        .into_iter()
+        .map(|path| {
+            let key = fs::canonicalize(&path)
+                .unwrap_or_else(|_| path.clone())
+                .to_string_lossy()
+                .into_owned();
+            (key, path)
+        })
+        .collect::<Vec<_>>();
+    paths.sort_by(|left, right| left.0.cmp(&right.0));
+    paths.dedup_by(|left, right| left.0 == right.0);
+    paths.into_iter().map(|(_, path)| path).collect()
 }
 
+/// Acquire the advisory lock for one mailbox path.
+///
+/// # Errors
+///
+/// Returns [`AtmError`] when the lock sentinel cannot be created/opened or when
+/// acquisition times out before the configured deadline.
 pub(crate) fn acquire(path: &Path, timeout: Duration) -> Result<MailboxLockGuard, AtmError> {
     let lock_path = sentinel_path(path);
     if let Some(parent) = lock_path.parent() {
@@ -84,6 +116,12 @@ pub(crate) fn acquire(path: &Path, timeout: Duration) -> Result<MailboxLockGuard
     }
 }
 
+/// Acquire one sorted, deduplicated lock set under a single total timeout budget.
+///
+/// # Errors
+///
+/// Returns [`AtmError`] when any mailbox lock cannot be acquired before the
+/// total timeout expires. Previously acquired guards are released on failure.
 pub(crate) fn acquire_many_sorted(
     paths: impl IntoIterator<Item = PathBuf>,
     timeout: Duration,
@@ -105,9 +143,12 @@ pub(crate) fn acquire_many_sorted(
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
     use tempfile::tempdir;
 
     use super::{DEFAULT_LOCK_TIMEOUT, acquire, acquire_many_sorted, sentinel_path};
+    use crate::error::AtmErrorCode;
 
     #[test]
     fn sentinel_path_appends_lock_suffix() {
@@ -128,14 +169,90 @@ mod tests {
     #[test]
     fn acquire_many_sorted_dedupes_and_sorts_paths() {
         let tempdir = tempdir().expect("tempdir");
-        let a = tempdir.path().join("b.json");
+        let a = tempdir.path().join("dir").join("..").join("b.json");
         let b = tempdir.path().join("a.json");
+        std::fs::create_dir_all(tempdir.path().join("dir")).expect("dir");
+        std::fs::write(tempdir.path().join("b.json"), "").expect("b");
+        std::fs::write(&b, "").expect("a");
 
         let guards =
             acquire_many_sorted(vec![a.clone(), b.clone(), a.clone()], DEFAULT_LOCK_TIMEOUT)
                 .expect("locks");
 
         assert_eq!(guards.len(), 2);
+    }
+
+    #[test]
+    fn acquire_reports_mailbox_lock_timeout_code() {
+        let tempdir = tempdir().expect("tempdir");
+        let inbox = tempdir.path().join("arch-ctm.json");
+        let _first = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect("first lock");
+
+        let error = acquire(&inbox, Duration::from_millis(10)).expect_err("timeout");
+        assert_eq!(error.code, AtmErrorCode::MailboxLockTimeout);
+    }
+
+    #[test]
+    fn acquire_many_sorted_releases_prior_guards_on_failure() {
+        let tempdir = tempdir().expect("tempdir");
+        let free = tempdir.path().join("free.json");
+        let blocked = tempdir.path().join("blocked.json");
+        let _blocked_guard = acquire(&blocked, DEFAULT_LOCK_TIMEOUT).expect("blocked");
+
+        let error = acquire_many_sorted(
+            vec![free.clone(), blocked.clone()],
+            Duration::from_millis(10),
+        )
+        .expect_err("lock failure");
+        assert_eq!(error.code, AtmErrorCode::MailboxLockTimeout);
+
+        let _free_guard = acquire(&free, DEFAULT_LOCK_TIMEOUT).expect("free lock released");
+    }
+
+    #[test]
+    fn acquire_many_sorted_uses_total_timeout_budget() {
+        let tempdir = tempdir().expect("tempdir");
+        let first = tempdir.path().join("first.json");
+        let blocked = tempdir.path().join("blocked.json");
+        let _blocked_guard = acquire(&blocked, DEFAULT_LOCK_TIMEOUT).expect("blocked");
+
+        let started = Instant::now();
+        let _ = acquire_many_sorted(vec![first, blocked], Duration::from_millis(50))
+            .expect_err("timeout");
+
+        assert!(started.elapsed() < Duration::from_millis(250));
+    }
+
+    #[test]
+    fn sort_unique_paths_dedupes_same_canonical_path() {
+        let tempdir = tempdir().expect("tempdir");
+        let real = tempdir.path().join("arch-ctm.json");
+        std::fs::write(&real, "").expect("write");
+        let alternate = tempdir
+            .path()
+            .join("nested")
+            .join("..")
+            .join("arch-ctm.json");
+        std::fs::create_dir_all(tempdir.path().join("nested")).expect("nested");
+
+        let sorted = super::sort_unique_paths(vec![real.clone(), alternate]);
+
+        assert_eq!(sorted.len(), 1);
+        assert_eq!(sorted[0], real);
+    }
+
+    #[test]
+    fn acquire_many_sorted_orders_paths_deterministically() {
+        let tempdir = tempdir().expect("tempdir");
+        let a = tempdir.path().join("c.json");
+        let b = tempdir.path().join("a.json");
+        let c = tempdir.path().join("b.json");
+        for path in [&a, &b, &c] {
+            std::fs::write(path, "").expect("file");
+        }
+
+        let sorted = super::sort_unique_paths(vec![a, b.clone(), c]);
+        assert_eq!(sorted[0], b);
     }
 
     use std::path::PathBuf;

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -1,1 +1,142 @@
-//! Internal mailbox locking helpers reserved for future implementation.
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+
+use crate::error::AtmError;
+
+pub(crate) const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
+const RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Debug)]
+pub(crate) struct MailboxLockGuard {
+    #[allow(dead_code)]
+    target_path: PathBuf,
+    #[allow(dead_code)]
+    lock_path: PathBuf,
+    file: File,
+}
+
+impl Drop for MailboxLockGuard {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+pub(crate) fn sentinel_path(path: &Path) -> PathBuf {
+    let mut os = path.as_os_str().to_os_string();
+    os.push(".lock");
+    PathBuf::from(os)
+}
+
+pub(crate) fn sort_unique_paths(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut paths = paths.into_iter().collect::<Vec<_>>();
+    paths.sort_by_key(|path| path.to_string_lossy().into_owned());
+    paths.dedup_by(|left, right| left == right);
+    paths
+}
+
+pub(crate) fn acquire(path: &Path, timeout: Duration) -> Result<MailboxLockGuard, AtmError> {
+    let lock_path = sentinel_path(path);
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AtmError::mailbox_lock(format!(
+                "failed to create mailbox lock directory {}: {error}",
+                parent.display()
+            ))
+            .with_source(error)
+        })?;
+    }
+
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| {
+            AtmError::mailbox_lock(format!(
+                "failed to open mailbox lock {}: {error}",
+                lock_path.display()
+            ))
+            .with_source(error)
+        })?;
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => {
+                return Ok(MailboxLockGuard {
+                    target_path: path.to_path_buf(),
+                    lock_path,
+                    file,
+                });
+            }
+            Err(error) if Instant::now() >= deadline => {
+                return Err(AtmError::mailbox_lock_timeout(path).with_source(error));
+            }
+            Err(_) => {
+                thread::sleep(RETRY_INTERVAL);
+            }
+        }
+    }
+}
+
+pub(crate) fn acquire_many_sorted(
+    paths: impl IntoIterator<Item = PathBuf>,
+    timeout: Duration,
+) -> Result<Vec<MailboxLockGuard>, AtmError> {
+    let paths = sort_unique_paths(paths);
+    let deadline = Instant::now() + timeout;
+    let mut guards = Vec::with_capacity(paths.len());
+
+    for path in paths {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(AtmError::mailbox_lock_timeout(&path));
+        }
+        guards.push(acquire(&path, remaining)?);
+    }
+
+    Ok(guards)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::{DEFAULT_LOCK_TIMEOUT, acquire, acquire_many_sorted, sentinel_path};
+
+    #[test]
+    fn sentinel_path_appends_lock_suffix() {
+        let path = PathBuf::from("team-lead.json");
+        assert_eq!(sentinel_path(&path), PathBuf::from("team-lead.json.lock"));
+    }
+
+    #[test]
+    fn acquire_creates_sentinel_file() {
+        let tempdir = tempdir().expect("tempdir");
+        let inbox = tempdir.path().join("arch-ctm.json");
+
+        let _guard = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect("lock");
+
+        assert!(sentinel_path(&inbox).exists());
+    }
+
+    #[test]
+    fn acquire_many_sorted_dedupes_and_sorts_paths() {
+        let tempdir = tempdir().expect("tempdir");
+        let a = tempdir.path().join("b.json");
+        let b = tempdir.path().join("a.json");
+
+        let guards =
+            acquire_many_sorted(vec![a.clone(), b.clone(), a.clone()], DEFAULT_LOCK_TIMEOUT)
+                .expect("locks");
+
+        assert_eq!(guards.len(), 2);
+    }
+
+    use std::path::PathBuf;
+}

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -127,6 +127,8 @@ fn sanitize_legacy_message_id(value: &mut Value, path: &Path, line_number: usize
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
 
     use chrono::{TimeZone, Utc};
     use tempfile::TempDir;
@@ -211,6 +213,34 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].text, "valid body");
         assert!(messages[0].message_id.is_none());
+    }
+
+    #[test]
+    fn append_message_preserves_both_records_under_concurrent_writers() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("append-message-concurrent.jsonl");
+        let barrier = Arc::new(Barrier::new(3));
+
+        let mut handles = Vec::new();
+        for body in ["first", "second"] {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                let envelope = sample_message(Uuid::new_v4(), body);
+                barrier.wait();
+                append_message(&path, &envelope).expect("append");
+            }));
+        }
+
+        barrier.wait();
+        for handle in handles {
+            handle.join().expect("thread");
+        }
+
+        let messages = read_messages(&path).expect("read");
+        assert_eq!(messages.len(), 2);
+        assert!(messages.iter().any(|message| message.text == "first"));
+        assert!(messages.iter().any(|message| message.text == "second"));
     }
 
     fn sample_message(message_id: Uuid, body: &str) -> MessageEnvelope {

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -21,8 +21,23 @@ pub(crate) fn temp_file_suffix() -> String {
 }
 
 pub fn append_message(path: &Path, envelope: &MessageEnvelope) -> Result<(), AtmError> {
+    locked_read_modify_write(path, lock::DEFAULT_LOCK_TIMEOUT, |messages| {
+        messages.push(envelope.clone());
+        Ok(())
+    })
+}
+
+pub(crate) fn locked_read_modify_write<F>(
+    path: &Path,
+    timeout: std::time::Duration,
+    mutate: F,
+) -> Result<(), AtmError>
+where
+    F: FnOnce(&mut Vec<MessageEnvelope>) -> Result<(), AtmError>,
+{
+    let _guard = lock::acquire(path, timeout)?;
     let mut messages = read_messages(path)?;
-    messages.push(envelope.clone());
+    mutate(&mut messages)?;
     atomic::write_messages(path, &messages)
 }
 

--- a/crates/atm-core/src/mailbox/source.rs
+++ b/crates/atm-core/src/mailbox/source.rs
@@ -154,7 +154,7 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::{discover_origin_inboxes, resolve_target};
+    use super::{discover_origin_inboxes, load_source_files, resolve_target};
     use crate::config::AtmConfig;
 
     #[test]
@@ -190,5 +190,17 @@ mod tests {
         assert_eq!(target.agent, "team-lead");
         assert_eq!(target.team, "atm-dev");
         assert!(target.explicit);
+    }
+
+    #[test]
+    fn load_source_files_reports_disappearing_mailbox() {
+        let tempdir = tempdir().expect("tempdir");
+        let path = tempdir.path().join("arch-ctm.json");
+        std::fs::write(&path, "").expect("mailbox");
+        std::fs::remove_file(&path).expect("remove");
+
+        let error = load_source_files(&[path]).expect_err("missing mailbox");
+        assert!(error.is_mailbox_read());
+        assert!(error.message.contains("disappeared"));
     }
 }

--- a/crates/atm-core/src/mailbox/source.rs
+++ b/crates/atm-core/src/mailbox/source.rs
@@ -6,6 +6,7 @@ use tracing::warn;
 use crate::address::AgentAddress;
 use crate::config;
 use crate::error::{AtmError, AtmErrorKind};
+use crate::home;
 use crate::schema::MessageEnvelope;
 
 #[derive(Debug, Clone)]
@@ -101,6 +102,50 @@ pub(crate) fn discover_origin_inboxes(
 
     paths.sort();
     Ok(paths)
+}
+
+pub(crate) fn discover_source_paths(
+    home_dir: &Path,
+    team: &str,
+    agent: &str,
+) -> Result<Vec<PathBuf>, AtmError> {
+    let inbox_path = home::inbox_path_from_home(home_dir, team, agent)?;
+    let inboxes_dir = inbox_path
+        .parent()
+        .ok_or_else(|| AtmError::mailbox_read("inbox path has no parent directory"))?;
+    let inboxes_dir = inboxes_dir.to_path_buf();
+
+    let mut paths = Vec::new();
+    if inbox_path.exists() {
+        paths.push(inbox_path);
+    }
+    paths.extend(discover_origin_inboxes(&inboxes_dir, agent)?);
+    paths.sort_by_key(|path| path.to_string_lossy().into_owned());
+    paths.dedup();
+    Ok(paths)
+}
+
+pub(crate) fn load_source_files(paths: &[PathBuf]) -> Result<Vec<SourceFile>, AtmError> {
+    let mut sources = Vec::with_capacity(paths.len());
+    for path in paths {
+        if !path.exists() {
+            return Err(AtmError::mailbox_read(format!(
+                "mailbox file disappeared before locked read completed: {}",
+                path.display()
+            ))
+            .with_recovery(
+                "Retry after the competing ATM operation completes, or verify the team inbox files still exist.",
+            ));
+        }
+
+        let messages = super::read_messages(path)?;
+        sources.push(SourceFile {
+            path: path.clone(),
+            messages,
+        });
+    }
+
+    Ok(sources)
 }
 
 #[cfg(test)]

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -107,11 +107,8 @@ pub fn read_mail(
         None
     };
 
-    let mut source_files = load_source_files(&discover_source_paths(
-        &query.home_dir,
-        &target.team,
-        &target.agent,
-    )?)?;
+    let mut source_paths = discover_source_paths(&query.home_dir, &target.team, &target.agent)?;
+    let mut source_files = load_source_files(&source_paths)?;
     let mut classified_all = classify_all(apply_idle_notification_dedup(
         dedupe_legacy_message_id_surface(
             merged_surface(&source_files),
@@ -150,11 +147,8 @@ pub fn read_mail(
         )?;
 
         if wait_satisfied {
-            source_files = load_source_files(&discover_source_paths(
-                &query.home_dir,
-                &target.team,
-                &target.agent,
-            )?)?;
+            source_paths = discover_source_paths(&query.home_dir, &target.team, &target.agent)?;
+            source_files = load_source_files(&source_paths)?;
             classified_all = classify_all(apply_idle_notification_dedup(
                 dedupe_legacy_message_id_surface(
                     merged_surface(&source_files),
@@ -190,7 +184,6 @@ pub fn read_mail(
     let mutation_applied = if timed_out || selected.is_empty() {
         false
     } else {
-        let source_paths = discover_source_paths(&query.home_dir, &target.team, &target.agent)?;
         let _locks = mailbox::lock::acquire_many_sorted(
             source_paths.clone(),
             mailbox::lock::DEFAULT_LOCK_TIMEOUT,

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod state;
 pub(crate) mod wait;
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use serde::Serialize;
 use serde_json::Value;
@@ -14,7 +14,9 @@ use crate::error::AtmError;
 use crate::home;
 use crate::identity;
 use crate::mailbox;
-use crate::mailbox::source::{SourceFile, SourcedMessage, discover_origin_inboxes, resolve_target};
+use crate::mailbox::source::{
+    SourceFile, SourcedMessage, discover_source_paths, load_source_files, resolve_target,
+};
 use crate::mailbox::surface::dedupe_legacy_message_id_surface;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::schema::MessageEnvelope;
@@ -105,7 +107,11 @@ pub fn read_mail(
         None
     };
 
-    let mut source_files = load_source_files(&query.home_dir, &target.team, &target.agent)?;
+    let mut source_files = load_source_files(&discover_source_paths(
+        &query.home_dir,
+        &target.team,
+        &target.agent,
+    )?)?;
     let mut classified_all = classify_all(apply_idle_notification_dedup(
         dedupe_legacy_message_id_surface(
             merged_surface(&source_files),
@@ -130,11 +136,11 @@ pub fn read_mail(
             || {
                 Ok(apply_idle_notification_dedup(
                     dedupe_legacy_message_id_surface(
-                        merged_surface(&load_source_files(
+                        merged_surface(&load_source_files(&discover_source_paths(
                             &query.home_dir,
                             &target.team,
                             &target.agent,
-                        )?),
+                        )?)?),
                         |message: &SourcedMessage| message.envelope.message_id,
                         |message: &SourcedMessage| message.envelope.timestamp,
                     ),
@@ -144,7 +150,11 @@ pub fn read_mail(
         )?;
 
         if wait_satisfied {
-            source_files = load_source_files(&query.home_dir, &target.team, &target.agent)?;
+            source_files = load_source_files(&discover_source_paths(
+                &query.home_dir,
+                &target.team,
+                &target.agent,
+            )?)?;
             classified_all = classify_all(apply_idle_notification_dedup(
                 dedupe_legacy_message_id_surface(
                     merged_surface(&source_files),
@@ -180,6 +190,39 @@ pub fn read_mail(
     let mutation_applied = if timed_out || selected.is_empty() {
         false
     } else {
+        let source_paths = discover_source_paths(&query.home_dir, &target.team, &target.agent)?;
+        let _locks = mailbox::lock::acquire_many_sorted(
+            source_paths.clone(),
+            mailbox::lock::DEFAULT_LOCK_TIMEOUT,
+        )?;
+        source_files = load_source_files(&source_paths)?;
+        classified_all = classify_all(apply_idle_notification_dedup(
+            dedupe_legacy_message_id_surface(
+                merged_surface(&source_files),
+                |message: &SourcedMessage| message.envelope.message_id,
+                |message: &SourcedMessage| message.envelope.timestamp,
+            ),
+        ));
+        bucket_counts = bucket_counts_for(&classified_all);
+        filtered = apply_filters(
+            classified_all.clone(),
+            query.sender_filter.as_deref(),
+            query.timestamp_filter,
+        );
+        selected = select_messages(&filtered, query.selection_mode, seen_watermark);
+        selected.sort_by(|left, right| {
+            right
+                .envelope
+                .timestamp
+                .cmp(&left.envelope.timestamp)
+                .then_with(|| right.envelope.message_id.cmp(&left.envelope.message_id))
+                .then_with(|| right.source_index.cmp(&left.source_index))
+        });
+
+        if let Some(limit) = query.limit {
+            selected.truncate(limit);
+        }
+
         apply_display_mutations(
             &mut source_files,
             &selected,
@@ -270,29 +313,6 @@ fn resolve_actor_identity(
     }
 
     identity::resolve_sender_identity(config)
-}
-
-fn load_source_files(
-    home_dir: &Path,
-    team: &str,
-    agent: &str,
-) -> Result<Vec<SourceFile>, AtmError> {
-    let inbox_path = home::inbox_path_from_home(home_dir, team, agent)?;
-    let inboxes_dir = inbox_path
-        .parent()
-        .ok_or_else(|| AtmError::mailbox_read("inbox path has no parent directory"))?;
-    let inboxes_dir = inboxes_dir.to_path_buf();
-
-    let mut paths = vec![inbox_path];
-    paths.extend(discover_origin_inboxes(&inboxes_dir, agent)?);
-
-    let mut sources = Vec::with_capacity(paths.len());
-    for path in paths {
-        let messages = mailbox::read_messages(&path)?;
-        sources.push(SourceFile { path, messages });
-    }
-
-    Ok(sources)
 }
 
 fn merged_surface(source_files: &[SourceFile]) -> Vec<SourcedMessage> {

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -1,0 +1,181 @@
+use std::fs;
+use std::sync::{Arc, Barrier, mpsc};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use atm_core::ack::{AckRequest, ack_mail};
+use atm_core::observability::NullObservability;
+use atm_core::schema::{AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig};
+use atm_core::types::IsoTimestamp;
+use chrono::Utc;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+#[test]
+fn concurrent_ack_on_overlapping_inbox_sets_completes_without_deadlock() {
+    let fixture = Fixture::new();
+    let observability = Arc::new(NullObservability);
+    let barrier = Arc::new(Barrier::new(3));
+    let (tx, rx) = mpsc::channel();
+
+    let arch_request = fixture.ack_request("arch-ctm", fixture.arch_message_id, "ack from arch");
+    let qa_request = fixture.ack_request("qa", fixture.qa_message_id, "ack from qa");
+
+    let started = Instant::now();
+    for (label, request) in [("arch", arch_request), ("qa", qa_request)] {
+        let barrier = Arc::clone(&barrier);
+        let tx = tx.clone();
+        let observability = Arc::clone(&observability);
+        thread::spawn(move || {
+            barrier.wait();
+            tx.send((label, ack_mail(request, observability.as_ref())))
+                .expect("send result");
+        });
+    }
+    drop(tx);
+
+    barrier.wait();
+    let first = rx
+        .recv_timeout(Duration::from_secs(4))
+        .expect("first ack result");
+    let second = rx
+        .recv_timeout(Duration::from_secs(4))
+        .expect("second ack result");
+
+    assert!(
+        first.1.is_ok(),
+        "first ack failed for {}: {:?}",
+        first.0,
+        first.1
+    );
+    assert!(
+        second.1.is_ok(),
+        "second ack failed for {}: {:?}; arch inbox: {:?}; qa inbox: {:?}",
+        second.0,
+        second.1,
+        fixture.inbox_contents("arch-ctm"),
+        fixture.inbox_contents("qa")
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(4),
+        "overlapping ack operations exceeded the deadlock budget"
+    );
+
+    let arch_inbox = fixture.inbox_contents("arch-ctm");
+    let qa_inbox = fixture.inbox_contents("qa");
+    assert!(
+        arch_inbox
+            .iter()
+            .any(|message| message.text == "ack from qa")
+    );
+    assert!(
+        qa_inbox
+            .iter()
+            .any(|message| message.text == "ack from arch")
+    );
+}
+
+struct Fixture {
+    tempdir: TempDir,
+    arch_message_id: LegacyMessageId,
+    qa_message_id: LegacyMessageId,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
+        fs::create_dir_all(team_dir.join("inboxes")).expect("inboxes");
+
+        let config = TeamConfig {
+            members: ["team-lead", "arch-ctm", "qa"]
+                .into_iter()
+                .map(|name| AgentMember {
+                    name: name.to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        fs::write(
+            team_dir.join("config.json"),
+            serde_json::to_vec(&config).expect("team config"),
+        )
+        .expect("write team config");
+
+        let arch_message_id = LegacyMessageId::from(Uuid::new_v4());
+        let qa_message_id = LegacyMessageId::from(Uuid::new_v4());
+
+        write_inbox(
+            &team_dir.join("inboxes").join("arch-ctm.json"),
+            &[message("qa", &arch_message_id, "arch pending")],
+        );
+        write_inbox(
+            &team_dir.join("inboxes").join("qa.json"),
+            &[message("arch-ctm", &qa_message_id, "qa pending")],
+        );
+
+        Self {
+            tempdir,
+            arch_message_id,
+            qa_message_id,
+        }
+    }
+
+    fn ack_request(
+        &self,
+        actor: &str,
+        message_id: LegacyMessageId,
+        reply_body: &str,
+    ) -> AckRequest {
+        AckRequest {
+            home_dir: self.tempdir.path().to_path_buf(),
+            current_dir: self.tempdir.path().to_path_buf(),
+            actor_override: Some(actor.to_string()),
+            team_override: Some("atm-dev".to_string()),
+            message_id,
+            reply_body: reply_body.to_string(),
+        }
+    }
+
+    fn inbox_contents(&self, agent: &str) -> Vec<MessageEnvelope> {
+        let path = self
+            .tempdir
+            .path()
+            .join(".claude")
+            .join("teams")
+            .join("atm-dev")
+            .join("inboxes")
+            .join(format!("{agent}.json"));
+        let raw = fs::read_to_string(path).expect("inbox contents");
+        raw.lines()
+            .map(|line| serde_json::from_str(line).expect("json line"))
+            .collect()
+    }
+}
+
+fn write_inbox(path: &std::path::Path, messages: &[MessageEnvelope]) {
+    let raw = messages
+        .iter()
+        .map(|message| serde_json::to_string(message).expect("json line"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(path, format!("{raw}\n")).expect("write inbox");
+}
+
+fn message(from: &str, message_id: &LegacyMessageId, text: &str) -> MessageEnvelope {
+    MessageEnvelope {
+        from: from.to_string(),
+        text: text.to_string(),
+        timestamp: IsoTimestamp::from_datetime(Utc::now()),
+        read: true,
+        source_team: Some("atm-dev".to_string()),
+        summary: None,
+        message_id: Some(message_id.clone()),
+        pending_ack_at: Some(IsoTimestamp::from_datetime(Utc::now())),
+        acknowledged_at: None,
+        acknowledges_message_id: None,
+        task_id: None,
+        extra: serde_json::Map::new(),
+    }
+}

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -171,7 +171,7 @@ fn message(from: &str, message_id: &LegacyMessageId, text: &str) -> MessageEnvel
         read: true,
         source_team: Some("atm-dev".to_string()),
         summary: None,
-        message_id: Some(message_id.clone()),
+        message_id: Some(*message_id),
         pending_ack_at: Some(IsoTimestamp::from_datetime(Utc::now())),
         acknowledged_at: None,
         acknowledges_message_id: None,

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -360,6 +360,36 @@ fn test_clear_removes_from_origin_inbox_file() {
     assert_eq!(fixture.origin_inbox_contents("arch-ctm", "host-a").len(), 0);
 }
 
+#[test]
+fn test_clear_reports_graceful_error_when_locked_inbox_disappears_before_load() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[fixture.message(
+            "team-lead",
+            "read",
+            true,
+            None,
+            None,
+            Utc::now() - Duration::days(3),
+        )],
+    );
+
+    let output = fixture.run_with_env(
+        &["clear", "--json"],
+        &[("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD", "1")],
+    );
+
+    assert!(!output.status.success());
+    assert!(
+        fixture
+            .stderr(&output)
+            .contains("mailbox file disappeared before locked read completed"),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+}
+
 struct Fixture {
     tempdir: tempfile::TempDir,
 }
@@ -373,15 +403,22 @@ impl Fixture {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_atm"))
+        self.run_with_env(args, &[])
+    }
+
+    fn run_with_env(&self, args: &[&str], extra_env: &[(&str, &str)]) -> std::process::Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_atm"));
+        command
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
             .env("ATM_IDENTITY", "arch-ctm")
             .env("ATM_TEAM", "atm-dev")
-            .current_dir(self.tempdir.path())
-            .output()
-            .expect("run atm")
+            .current_dir(self.tempdir.path());
+        for (key, value) in extra_env {
+            command.env(key, value);
+        }
+        command.output().expect("run atm")
     }
 
     fn write_team_config(&self, members: &[&str]) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1248,8 +1248,8 @@ requested inbox plus any origin inboxes before writing back. To make those paths
 concurrency-safe, Phase M needs a second abstraction:
 
 ```rust
-pub fn acquire_many_sorted<'a>(
-    paths: impl IntoIterator<Item = &'a Path>,
+pub fn acquire_many_sorted(
+    paths: impl IntoIterator<Item = PathBuf>,
     timeout: Duration,
 ) -> Result<Vec<MailboxLockGuard>, AtmError>
 ```

--- a/docs/atm-error-codes.md
+++ b/docs/atm-error-codes.md
@@ -67,6 +67,7 @@ Error codes should describe the failure class, not a specific prose message.
 
 - `ATM_MAILBOX_READ_FAILED`
 - `ATM_MAILBOX_WRITE_FAILED`
+- `ATM_MAILBOX_LOCK_FAILED`
 - `ATM_MAILBOX_RECORD_SKIPPED`
 - `ATM_MESSAGE_VALIDATION_FAILED`
 - `ATM_SERIALIZATION_FAILED`


### PR DESCRIPTION
## Summary
- Add `fs2` advisory locking for mailbox files
- Implement `locked_read_modify_write` for `append_message`
- Deterministic sorted multi-lock acquisition for `read`, `ack`, `clear`
- Shared source-path discovery/load helpers
- `MailboxLockTimeout` error code wiring

## Sprint
ATM-CORE-M-S1 | Phase M.1 — Mailbox Locking

## Validation
cargo fmt --all ✓ | cargo test --workspace ✓ | cargo clippy -D warnings ✓ | git diff --check ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)