### PR TITLE
docs: plan Phase N publish replacement and distribution parity

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,26 @@ Release-process ownership rules:
   and must be ported into this repo with source-of-truth paths updated to the
   new repo layout and retained crate list
 
+Release infrastructure notes:
+- Homebrew continues to use the shared `randlee/homebrew-tap` repository and
+  existing `Formula/agent-team-mail.rb` / `Formula/atm.rb` formulas
+- `HOMEBREW_TAP_TOKEN` is a required secret for the `atm-core` repo before the
+  ported Homebrew update automation can run successfully
+- `winget` uses the same `randlee` publisher namespace proven in
+  `claude-history`; the retained CLI package ID for this repo is
+  `randlee.agent-team-mail`
+- the ported `winget` flow uses the default GitHub workflow token and does not
+  introduce a separate `winget`-specific secret requirement
+- the release workflow should use
+  `vedantmgoyal2009/winget-releaser@v2` against the Windows ZIP release asset
+  and its SHA256 rather than inventing repo-specific manifest plumbing first
+- the initial `winget` manifest submission is a one-time manual bootstrap
+  action; recurring releases are workflow-driven after the package exists in
+  `microsoft/winget-pkgs`
+- release verification must treat `winget` submission success and manifest
+  generation as the immediate release signal because Microsoft review normally
+  delays public installability by 1-2 days
+
 Schema ownership references:
 
 - Claude Code-native message schema:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,10 +63,13 @@ Architectural rules:
   names `atm` or `atm-core`
 - crate identity continuity for downstream users is preserved by package-name
   replacement while keeping the CLI binary name `atm`
-- GitHub Releases and Homebrew remain release channels owned by the same source
-  repo release workflow family
-- `winget` is not part of historical channel parity for this replacement and
-  must not be added implicitly to the `1.0` release architecture
+- historical parity channels remain:
+  - crates.io
+  - GitHub Releases
+  - Homebrew
+- `winget` is not part of historical parity, but it is required in the new
+  release architecture because Windows installation must be first-class for
+  `1.0` without Rust tooling or manual archive extraction
 
 Release-process ownership rules:
 - release automation is repo-owned infrastructure, not ad hoc operator
@@ -78,6 +81,7 @@ Release-process ownership rules:
   - release-gate script/helpers
   - release inventory generation and verification
   - Homebrew formula update automation
+  - `winget` manifest/update automation and verification
 - the `publisher` agent instructions are part of the release-control surface
   and must be ported into this repo with source-of-truth paths updated to the
   new repo layout and retained crate list

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,38 @@ Crate-local boundary detail is owned by:
 - [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
 - [`docs/atm/architecture.md`](./atm/architecture.md)
 
+### 2.4 Release Publication Boundary
+
+The `1.0` retained-surface release is a source-repo replacement of the old
+`agent-team-mail` CLI/core publication path, not a new public package family.
+
+Architectural rules:
+- this repo becomes the source of truth for publishing:
+  - `agent-team-mail`
+  - `agent-team-mail-core`
+- this repo does not publish its retained CLI/core release under the crate
+  names `atm` or `atm-core`
+- crate identity continuity for downstream users is preserved by package-name
+  replacement while keeping the CLI binary name `atm`
+- GitHub Releases and Homebrew remain release channels owned by the same source
+  repo release workflow family
+- `winget` is not part of historical channel parity for this replacement and
+  must not be added implicitly to the `1.0` release architecture
+
+Release-process ownership rules:
+- release automation is repo-owned infrastructure, not ad hoc operator
+  procedure
+- the new repo must own:
+  - release artifact manifest
+  - preflight workflow
+  - release workflow
+  - release-gate script/helpers
+  - release inventory generation and verification
+  - Homebrew formula update automation
+- the `publisher` agent instructions are part of the release-control surface
+  and must be ported into this repo with source-of-truth paths updated to the
+  new repo layout and retained crate list
+
 Schema ownership references:
 
 - Claude Code-native message schema:

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1270,6 +1270,14 @@ Status summary:
   GitHub Releases, and Homebrew automation
 - the old repo does not contain `winget` release automation, so this repo must
   add it as new release infrastructure rather than porting it directly
+- `team-lead` has confirmed the shared account-level publish infrastructure:
+  - Homebrew tap remains `randlee/homebrew-tap`
+  - `HOMEBREW_TAP_TOKEN` exists in account secrets but is not yet configured on
+    `atm-core`
+  - `winget` has a proven reference implementation in `randlee/claude-history`
+    using `vedantmgoyal2009/winget-releaser@v2`
+  - `winget` uses the default GitHub workflow token and does not require an
+    additional repo secret
 - this repo currently has only CI and no equivalent release-manifest,
   preflight, release, or publisher-agent infrastructure
 - the new repo currently uses local crate names (`atm`, `atm-core`) that are
@@ -1320,6 +1328,8 @@ Goal:
 
 Deliverables:
 - add `release/publish-artifacts.toml` as the new release artifact manifest
+- add the missing `HOMEBREW_TAP_TOKEN` GitHub secret to `atm-core` as a
+  one-time prerequisite before the Homebrew update job is expected to pass
 - port and adapt:
   - `.github/workflows/release-preflight.yml`
   - `.github/workflows/release.yml`
@@ -1347,8 +1357,18 @@ Deliverables:
   - manifest generation or update path
   - release-version and asset-URL wiring
   - SHA256 update from the released Windows archive
-  - publish/submit step appropriate to the chosen `winget` repository flow
-  - post-publish verification that the released version is visible to `winget`
+  - `vedantmgoyal2009/winget-releaser@v2` workflow step targeting package ID
+    `randlee.agent-team-mail`
+  - use the Windows ZIP asset from the GitHub Release as the installer source
+  - one-time initial manifest submission procedure for the first release
+  - recurring submission flow for later releases after the package exists in
+    `microsoft/winget-pkgs`
+  - no additional `winget` secret beyond the default workflow `GITHUB_TOKEN`
+  - verification of submission success rather than same-day installability
+- port/reference the proven `claude-history` winget materials:
+  - `.winget/randlee.claude-history.yaml`
+  - `docs/WINGET_SETUP.md`
+  - the `winget` step in `.github/workflows/release.yml`
 
 Acceptance criteria:
 - this repo has release-preflight and release workflows with no missing helper
@@ -1361,6 +1381,9 @@ Acceptance criteria:
   Homebrew update steps without references to removed daemon/TUI/MCP artifacts
 - release automation includes a concrete `winget` update/publish path for the
   retained Windows CLI install surface
+- `N.2` explicitly records the Homebrew secret prerequisite and the one-time
+  `winget` bootstrap requirement so the workflow design does not assume either
+  exists magically
 
 #### N.3 — Publisher Agent Port
 
@@ -1385,6 +1408,14 @@ Deliverables:
   - `winget`
 - update the inventory and verification expectations so the publisher does not
   expect daemon, MCP, TUI, or CI monitor outputs from this repo
+- document in the publisher agent:
+  - that `HOMEBREW_TAP_TOKEN` must exist on `atm-core` before Homebrew release
+    automation can run
+  - that the first `winget` release requires a one-time manual manifest
+    submission
+  - that later `winget` releases are workflow-driven
+  - that Microsoft review introduces a normal 1-2 day delay before `winget`
+    installability is observable
 
 Acceptance criteria:
 - `.claude/agents/publisher.md` exists in this repo
@@ -1447,11 +1478,15 @@ Deliverables:
   - GitHub Releases
   - Homebrew
   - `winget`
+- verify that `winget` readiness proof checks successful submission/manifests,
+  not immediate public installability
 
 Acceptance criteria:
 - all dry-run packaging and publishability checks succeed from this repo
 - the release inventory matches the retained release scope exactly
 - no retained release doc or workflow step depends on removed legacy crates
+- `N.5` explicitly acknowledges the 1-2 day Microsoft review lag so release
+  operators do not treat normal `winget` review delay as a failed publish
 
 Phase N completion gate:
 - package identities are switched to the legacy crates.io names

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1249,3 +1249,206 @@ Acceptance criteria:
   - `send` reports synthetic non-contention lock-path failure as `MailboxLockFailed`
 - `M-LF-005` remains explicitly advisory unless a helper extraction is needed to
   land the blocking/important fixes
+
+---
+
+### Phase N: Publish Replacement And Distribution Parity [PLANNED]
+
+Goal:
+- ship the retained `1.0` release from this repo as the direct replacement for
+  the historical `agent-team-mail` CLI/core release line
+- preserve the historical release channels that actually existed for the old
+  repo:
+  - crates.io
+  - GitHub Releases
+  - Homebrew
+- explicitly exclude `winget` from parity scope because it was not part of the
+  prior release system
+
+Status summary:
+- the old repo already contains the release source of truth for crates.io,
+  GitHub Releases, and Homebrew automation
+- this repo currently has only CI and no equivalent release-manifest,
+  preflight, release, or publisher-agent infrastructure
+- the new repo currently uses local crate names (`atm`, `atm-core`) that are
+  not the intended public replacement identities
+
+#### N.1 — Package Identity And Manifest Replacement
+
+Goal:
+- convert the retained publishable crates in this repo to the legacy package
+  identities expected by downstream users
+
+Deliverables:
+- rename `crates/atm/Cargo.toml` package name from `atm` to
+  `agent-team-mail`
+- rename `crates/atm-core/Cargo.toml` package name from `atm-core` to
+  `agent-team-mail-core`
+- keep the CLI binary name `atm`
+- set both publishable crates to the intended `1.0.0` release version
+- replace the CLI path-only core dependency with an explicit versioned
+  dependency on `agent-team-mail-core`
+- add release-grade package metadata to both publishable manifests:
+  - description
+  - repository
+  - homepage
+  - readme
+  - keywords
+  - categories
+- ensure the publishable crate surface excludes test-only fixture binaries and
+  other non-release executables
+- audit release dependency features so production releases do not ship
+  test-oriented features unless explicitly intended
+
+Acceptance criteria:
+- `cargo package -p agent-team-mail-core --locked` succeeds
+- `cargo package -p agent-team-mail --locked` succeeds
+- `cargo publish --dry-run -p agent-team-mail-core --locked --no-verify`
+  succeeds
+- `cargo publish --dry-run -p agent-team-mail --locked --no-verify` succeeds
+- only the retained release binary `atm` is part of the publishable CLI
+  install surface
+
+#### N.2 — Release Automation Port
+
+Goal:
+- port the old repo’s release automation into this repo, narrowed to the
+  retained CLI/core release surface plus continued shared-family dependency
+  verification
+
+Deliverables:
+- add `release/publish-artifacts.toml` as the new release artifact manifest
+- port and adapt:
+  - `.github/workflows/release-preflight.yml`
+  - `.github/workflows/release.yml`
+  - `scripts/release_gate.sh`
+  - `scripts/release_artifacts.py`
+  - release inventory schema/supporting release docs needed by the workflows
+- define the retained publishable artifact set in
+  `release/publish-artifacts.toml`:
+  - `agent-team-mail-core`
+  - `agent-team-mail`
+- define the retained binary artifact set for GitHub Releases:
+  - `atm`
+- keep crates.io publish ordering explicit:
+  - `agent-team-mail-core` before `agent-team-mail`
+- keep GitHub Release asset packaging for the supported platform targets:
+  - `x86_64-unknown-linux-gnu`
+  - `x86_64-apple-darwin`
+  - `aarch64-apple-darwin`
+  - `x86_64-pc-windows-msvc`
+- port Homebrew update automation for the formulas already managed by the old
+  release workflow:
+  - `Formula/agent-team-mail.rb`
+  - `Formula/atm.rb`
+
+Acceptance criteria:
+- this repo has release-preflight and release workflows with no missing helper
+  files or schema dependencies
+- the release artifact manifest is the single source of truth for publishable
+  crates and release binaries in this repo
+- preflight validates version alignment, artifact inventory, and dependency
+  ordering from this repo layout
+- release workflow produces retained `atm` archives, crates publish order, and
+  Homebrew update steps without references to removed daemon/TUI/MCP artifacts
+
+#### N.3 — Publisher Agent Port
+
+Goal:
+- port the release-orchestration agent instructions into this repo so release
+  execution remains controlled by the same hardened operating procedure
+
+Deliverables:
+- create `.claude/agents/publisher.md` in this repo
+- port the old `publisher` agent instructions and update all source-of-truth
+  references to this repo’s files and workflows
+- keep the hard rules around:
+  - tag creation only by workflow
+  - no manual `v*` tag pushes
+  - develop -> main release gate ordering
+  - required preflight and release workflow dispatch steps
+- narrow the retained artifact/channel assumptions to this repo’s actual
+  publish surface:
+  - crates.io
+  - GitHub Releases
+  - Homebrew
+- update the inventory and verification expectations so the publisher does not
+  expect daemon, MCP, TUI, CI monitor, or `winget` outputs from this repo
+
+Acceptance criteria:
+- `.claude/agents/publisher.md` exists in this repo
+- publisher source-of-truth paths resolve to files that exist in this repo
+- publisher instructions enumerate the retained artifact set and release
+  channels accurately
+- publisher instructions explicitly state that `winget` is not part of parity
+  scope for this replacement phase
+
+#### N.4 — Customer-Facing Release Surface Documentation
+
+Goal:
+- make the replacement release understandable to downstream users and package
+  consumers before `1.0` ships
+
+Deliverables:
+- rewrite `README.md` from reset-workspace language into release-facing product
+  documentation
+- document installation from:
+  - GitHub Releases
+  - Homebrew
+  - crates.io
+- state that `agent-team-mail` and `agent-team-mail-core` are now published
+  from this repo
+- explain that the retained `1.0` replacement scope covers the daemon-free
+  CLI/core pair and continues to consume the published `sc-observability`
+  family
+- explicitly state that `winget` is not part of replacement parity scope
+
+Acceptance criteria:
+- `README.md` matches the retained release surface and actual distribution
+  channels
+- customer-facing install instructions no longer describe this repo as a reset
+  workspace
+- release docs do not promise `winget` or non-retained legacy crates
+
+#### N.5 — Final Release Readiness Proof
+
+Goal:
+- prove that the retained replacement release can be published and installed
+  from this repo before the real `1.0` publish run starts
+
+Deliverables:
+- run and record:
+  - `cargo fmt --all --check`
+  - `cargo clippy --workspace --all-targets -- -D warnings`
+  - `cargo test --workspace`
+  - `cargo package -p agent-team-mail-core --locked`
+  - `cargo package -p agent-team-mail --locked`
+  - `cargo publish --dry-run -p agent-team-mail-core --locked --no-verify`
+  - `cargo publish --dry-run -p agent-team-mail --locked --no-verify`
+- perform one install smoke test against the packaged/publishable CLI artifact
+  surface to confirm `atm` is the installed entrypoint
+- verify that the release inventory and post-publish verification expectations
+  cover only the retained parity channels:
+  - crates.io
+  - GitHub Releases
+  - Homebrew
+
+Acceptance criteria:
+- all dry-run packaging and publishability checks succeed from this repo
+- the release inventory matches the retained parity scope exactly
+- no retained release doc or workflow step depends on `winget` or removed
+  legacy crates
+
+Phase N completion gate:
+- package identities are switched to the legacy crates.io names
+- release automation is present in this repo and references the retained
+  artifact set correctly
+- `.claude/agents/publisher.md` is ported and accurate for this repo
+- customer-facing docs reflect the retained replacement release
+- preflight and release dry-runs are clean for the retained publishable crates
+- parity channels confirmed:
+  - crates.io
+  - GitHub Releases
+  - Homebrew
+- non-parity channels explicitly confirmed out of scope:
+  - `winget`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1262,12 +1262,14 @@ Goal:
   - crates.io
   - GitHub Releases
   - Homebrew
-- explicitly exclude `winget` from parity scope because it was not part of the
-  prior release system
+- add `winget` as a required new `1.0` channel so Windows users can install
+  without Rust tooling or manual archive extraction
 
 Status summary:
 - the old repo already contains the release source of truth for crates.io,
   GitHub Releases, and Homebrew automation
+- the old repo does not contain `winget` release automation, so this repo must
+  add it as new release infrastructure rather than porting it directly
 - this repo currently has only CI and no equivalent release-manifest,
   preflight, release, or publisher-agent infrastructure
 - the new repo currently uses local crate names (`atm`, `atm-core`) that are
@@ -1314,7 +1316,7 @@ Acceptance criteria:
 Goal:
 - port the old repo’s release automation into this repo, narrowed to the
   retained CLI/core release surface plus continued shared-family dependency
-  verification
+  verification and the new required `winget` channel
 
 Deliverables:
 - add `release/publish-artifacts.toml` as the new release artifact manifest
@@ -1341,6 +1343,12 @@ Deliverables:
   release workflow:
   - `Formula/agent-team-mail.rb`
   - `Formula/atm.rb`
+- add `winget` release automation for the retained CLI package:
+  - manifest generation or update path
+  - release-version and asset-URL wiring
+  - SHA256 update from the released Windows archive
+  - publish/submit step appropriate to the chosen `winget` repository flow
+  - post-publish verification that the released version is visible to `winget`
 
 Acceptance criteria:
 - this repo has release-preflight and release workflows with no missing helper
@@ -1351,6 +1359,8 @@ Acceptance criteria:
   ordering from this repo layout
 - release workflow produces retained `atm` archives, crates publish order, and
   Homebrew update steps without references to removed daemon/TUI/MCP artifacts
+- release automation includes a concrete `winget` update/publish path for the
+  retained Windows CLI install surface
 
 #### N.3 — Publisher Agent Port
 
@@ -1372,16 +1382,17 @@ Deliverables:
   - crates.io
   - GitHub Releases
   - Homebrew
+  - `winget`
 - update the inventory and verification expectations so the publisher does not
-  expect daemon, MCP, TUI, CI monitor, or `winget` outputs from this repo
+  expect daemon, MCP, TUI, or CI monitor outputs from this repo
 
 Acceptance criteria:
 - `.claude/agents/publisher.md` exists in this repo
 - publisher source-of-truth paths resolve to files that exist in this repo
 - publisher instructions enumerate the retained artifact set and release
   channels accurately
-- publisher instructions explicitly state that `winget` is not part of parity
-  scope for this replacement phase
+- publisher instructions distinguish historical parity channels from the new
+  required `winget` channel for Windows installation
 
 #### N.4 — Customer-Facing Release Surface Documentation
 
@@ -1396,19 +1407,22 @@ Deliverables:
   - GitHub Releases
   - Homebrew
   - crates.io
+  - `winget`
 - state that `agent-team-mail` and `agent-team-mail-core` are now published
   from this repo
 - explain that the retained `1.0` replacement scope covers the daemon-free
   CLI/core pair and continues to consume the published `sc-observability`
   family
-- explicitly state that `winget` is not part of replacement parity scope
+- explain that `winget` is a new required `1.0` Windows channel rather than a
+  historical parity channel
 
 Acceptance criteria:
 - `README.md` matches the retained release surface and actual distribution
   channels
 - customer-facing install instructions no longer describe this repo as a reset
   workspace
-- release docs do not promise `winget` or non-retained legacy crates
+- release docs promise only retained legacy crates and the actual supported
+  install channels, including `winget`
 
 #### N.5 — Final Release Readiness Proof
 
@@ -1428,16 +1442,16 @@ Deliverables:
 - perform one install smoke test against the packaged/publishable CLI artifact
   surface to confirm `atm` is the installed entrypoint
 - verify that the release inventory and post-publish verification expectations
-  cover only the retained parity channels:
+  cover the retained release channels:
   - crates.io
   - GitHub Releases
   - Homebrew
+  - `winget`
 
 Acceptance criteria:
 - all dry-run packaging and publishability checks succeed from this repo
-- the release inventory matches the retained parity scope exactly
-- no retained release doc or workflow step depends on `winget` or removed
-  legacy crates
+- the release inventory matches the retained release scope exactly
+- no retained release doc or workflow step depends on removed legacy crates
 
 Phase N completion gate:
 - package identities are switched to the legacy crates.io names
@@ -1446,9 +1460,10 @@ Phase N completion gate:
 - `.claude/agents/publisher.md` is ported and accurate for this repo
 - customer-facing docs reflect the retained replacement release
 - preflight and release dry-runs are clean for the retained publishable crates
-- parity channels confirmed:
+- retained release channels confirmed:
   - crates.io
   - GitHub Releases
   - Homebrew
-- non-parity channels explicitly confirmed out of scope:
   - `winget`
+- `winget` is explicitly documented as a new required Windows install channel,
+  not as historical parity

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -142,6 +142,10 @@ Product requirement ID:
   therefore a required additional release channel even though it was not part
   of the historical `agent-team-mail` release system.
 
+- `REQ-P-RELEASE-006` Release prerequisites that depend on account-level
+  distribution infrastructure must be made explicit in the repo-owned release
+  plan before `1.0` release automation is considered complete.
+
 Required behavior:
 - the `1.0` release must publish the retained CLI and core crates under the
   legacy crates.io package names:
@@ -156,6 +160,19 @@ Required behavior:
 - `winget` is not a historical release channel for `agent-team-mail`, but it
   is a required new `1.0` release channel so normal Windows users can install
   ATM without Rust tooling or manual zip handling
+- Homebrew release automation depends on the existing `randlee/homebrew-tap`
+  tap and requires `HOMEBREW_TAP_TOKEN` to be configured in `atm-core` GitHub
+  secrets before the release workflow can update formulas from this repo
+- `winget` release automation uses the `randlee` namespace with package ID
+  `randlee.agent-team-mail`
+- the first `winget` release requires a one-time manual manifest submission to
+  `microsoft/winget-pkgs`; after that initial submission, later releases may
+  be automated from this repo
+- `winget` release automation must not require a repo-specific secret beyond
+  the default GitHub workflow token
+- release readiness proof for `winget` must validate successful submission or
+  manifest update dispatch; it cannot require same-day installability because
+  Microsoft review introduces a normal 1-2 day publication lag
 
 ## 3. External Contracts
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -137,6 +137,11 @@ Product requirement ID:
   workflows, artifact manifest, supporting scripts, and `publisher` agent
   instructions.
 
+- `REQ-P-RELEASE-005` Windows installation must be first-class for `1.0`
+  without requiring Rust tooling or manual archive extraction; `winget` is
+  therefore a required additional release channel even though it was not part
+  of the historical `agent-team-mail` release system.
+
 Required behavior:
 - the `1.0` release must publish the retained CLI and core crates under the
   legacy crates.io package names:
@@ -148,11 +153,9 @@ Required behavior:
   - crates.io
   - GitHub Releases
   - Homebrew
-- `winget` is not a historical release channel for `agent-team-mail` and is
-  therefore not required for channel-parity acceptance in this replacement
-  phase
-- any future `winget` support is additive follow-on work and must not be
-  inferred as part of the `1.0` parity scope
+- `winget` is not a historical release channel for `agent-team-mail`, but it
+  is a required new `1.0` release channel so normal Windows users can install
+  ATM without Rust tooling or manual zip handling
 
 ## 3. External Contracts
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -116,6 +116,44 @@ Satisfied by:
   (`atm teams`, `atm members`, `atm teams add-member`, `atm teams backup`,
   `atm teams restore`)
 
+### 2.3 Release Distribution Scope
+
+Product requirement ID:
+- `REQ-P-RELEASE-001` The `1.0` retained-surface release must replace the
+  previously published `agent-team-mail` CLI/core distribution channels from
+  this repo without requiring downstream users to adopt new crate identities.
+
+- `REQ-P-RELEASE-002` Channel parity for the replacement release is limited to
+  the historical release channels that actually existed for the old repo:
+  crates.io, GitHub Releases, and Homebrew.
+
+- `REQ-P-RELEASE-003` Crate/package identity continuity must be preserved by
+  publishing the retained CLI/core replacement under the legacy package names
+  `agent-team-mail` and `agent-team-mail-core` while keeping the installed CLI
+  binary name `atm`.
+
+- `REQ-P-RELEASE-004` This repo must own the release-process control surface
+  needed to ship and verify the replacement release, including the release
+  workflows, artifact manifest, supporting scripts, and `publisher` agent
+  instructions.
+
+Required behavior:
+- the `1.0` release must publish the retained CLI and core crates under the
+  legacy crates.io package names:
+  - `agent-team-mail`
+  - `agent-team-mail-core`
+- the `atm` binary name remains the installed CLI entrypoint
+- the release channels that were already part of the historical
+  `agent-team-mail` release system and must be replaced from this repo are:
+  - crates.io
+  - GitHub Releases
+  - Homebrew
+- `winget` is not a historical release channel for `agent-team-mail` and is
+  therefore not required for channel-parity acceptance in this replacement
+  phase
+- any future `winget` support is additive follow-on work and must not be
+  inferred as part of the `1.0` parity scope
+
 ## 3. External Contracts
 
 Product requirement ID:


### PR DESCRIPTION
## Summary

- Adds Phase N to `docs/project-plan.md`: 5-sprint plan for replacing the legacy `agent-team-mail` release line from this repo
- Updates `docs/requirements.md` and `docs/architecture.md` with publish-replacement contracts
- Captures shared infrastructure details confirmed with team-lead:
  - Retained channels: crates.io, GitHub Releases, Homebrew (`randlee/homebrew-tap`, formulas already exist)
  - winget as required new 1.0 Windows channel via `vedantmgoyal2009/winget-releaser@v2` (proven on `randlee/claude-history`, package ID `randlee.agent-team-mail`, no extra secret beyond `GITHUB_TOKEN`)
  - `HOMEBREW_TAP_TOKEN` prerequisite documented for N.2 (not yet set on atm-core)
  - N.5 verification checks submission success, not same-day installability (1-2 day Microsoft review lag noted)

## Sprints

| Sprint | Title |
|--------|-------|
| N.1 | Package Identity & Manifest Replacement (`atm` → `agent-team-mail`, `atm-core` → `agent-team-mail-core`, v1.0.0) |
| N.2 | Release Automation Port (release-preflight, release workflow, publish-artifacts.toml, Homebrew, winget) |
| N.3 | Publisher Agent Port (`.claude/agents/publisher.md` scoped to retained surface) |
| N.4 | Customer-Facing Release Surface Documentation (README rewrite) |
| N.5 | Final Release Readiness Proof (dry-run packaging + publishability, install smoke test) |

## Test plan

- [ ] Verify Phase N sprint specs are coherent and acceptance criteria are testable
- [ ] Confirm `HOMEBREW_TAP_TOKEN` is added to atm-core secrets before N.2 begins
- [ ] No code changes in this PR — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)