### PR TITLE
N.1: Package identity rename + v1.0.0 + metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,44 @@
 version = 4
 
 [[package]]
+name = "agent-team-mail"
+version = "1.0.0"
+dependencies = [
+ "agent-team-mail-core",
+ "anyhow",
+ "chrono",
+ "clap",
+ "sc-observability",
+ "sc-observability-types",
+ "serde_json",
+ "serial_test",
+ "tempfile",
+ "time",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-team-mail-core"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "fs2",
+ "libc",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tempfile",
+ "thiserror",
+ "toml",
+ "tracing",
+ "ulid",
+ "uuid",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,44 +104,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "atm"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "atm-core",
- "chrono",
- "clap",
- "sc-observability",
- "sc-observability-types",
- "serde_json",
- "serial_test",
- "tempfile",
- "time",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "atm-core"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "fs2",
- "libc",
- "serde",
- "serde_json",
- "serial_test",
- "tempfile",
- "thiserror",
- "toml",
- "tracing",
- "ulid",
- "uuid",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "autocfg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,13 @@ members = ["crates/atm-core", "crates/atm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/randlee/atm-core"
+homepage = "https://github.com/randlee/atm-core"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # atm-core
 
-Minimal ATM reset workspace.
+Daemon-free ATM workspace for the retained `1.0` release surface.
 
 Current target:
 - `atm` CLI
@@ -24,8 +24,15 @@ Docs:
 - `docs/file-migration-plan.md`
 - `docs/read-behavior.md`
 
-Crates planned for MVP:
-- `crates/atm-core`: library for config, addressing, mailbox I/O, command services, diagnostics, and the observability port boundary
+Published crate/package identities:
+- `agent-team-mail-core`: daemon-free core library published from
+  `crates/atm-core`
+- `agent-team-mail`: CLI package published from `crates/atm` and installing the
+  `atm` binary
+
+Workspace crates:
+- `crates/atm-core`: library for config, addressing, mailbox I/O, command
+  services, diagnostics, and the observability port boundary
 - `crates/atm`: CLI binary plus the concrete `sc-observability` integration
 
 No third first-party crate is planned for MVP. The first implementation dependency is an early `sc-observability` gap-analysis sprint to verify and close the shared query/follow/filter/health APIs needed by `atm log` and `atm doctor`.

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -1,10 +1,20 @@
 [package]
-name = "atm-core"
+name = "agent-team-mail-core"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Daemon-free core library for local agent team mail workflows."
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/agent-team-mail-core"
+readme = "../../README.md"
+keywords = ["agent", "mail", "workflow", "teams", "local"]
+categories = ["command-line-utilities", "development-tools"]
+
+[lib]
+name = "atm_core"
 
 [dependencies]
 serde.workspace = true

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -1,13 +1,25 @@
 [package]
-name = "atm"
+name = "agent-team-mail"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Daemon-free CLI for local agent team mail workflows."
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/agent-team-mail"
+readme = "../../README.md"
+keywords = ["agent", "mail", "cli", "teams", "workflow"]
+categories = ["command-line-utilities", "development-tools"]
+exclude = ["src/bin/atm_post_send_hook_fixture.rs"]
+
+[[bin]]
+name = "atm"
+path = "src/main.rs"
 
 [dependencies]
-atm-core = { path = "../atm-core" }
+atm-core = { package = "agent-team-mail-core", version = "1.0.0", path = "../atm-core" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1280,8 +1280,9 @@ Status summary:
     additional repo secret
 - this repo currently has only CI and no equivalent release-manifest,
   preflight, release, or publisher-agent infrastructure
-- the new repo currently uses local crate names (`atm`, `atm-core`) that are
-  not the intended public replacement identities
+- the source paths remain `crates/atm` and `crates/atm-core`, but the
+  publishable package identities for this release line must be
+  `agent-team-mail` and `agent-team-mail-core`
 
 #### N.1 — Package Identity And Manifest Replacement
 


### PR DESCRIPTION
## Summary
- Rename package identities to `agent-team-mail` / `agent-team-mail-core`
- Bump workspace version to `1.0.0`
- CLI entrypoint remains `atm` binary
- Release metadata (description, license, repository, keywords) in both publishable manifests
- Fixture binary excluded from published package surface
- Phase N status line corrected in docs/project-plan.md

## Test plan
- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes

Part of Phase N publish replacement. Targets `integrate/phase-N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)