### PR TITLE
N.2: Release automation port — workflows, scripts, Homebrew, winget

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -1,0 +1,174 @@
+name: Release Preflight
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version candidate (e.g. 1.0.0 or v1.0.0)"
+        required: true
+        type: string
+      run_by_agent:
+        description: "Must be 'publisher' (agent ownership assertion)"
+        required: true
+        default: "publisher"
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  RELEASE_ARTIFACT_MANIFEST: release/publish-artifacts.toml
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce publisher ownership input
+        shell: bash
+        run: |
+          set -euo pipefail
+          runner='${{ github.event.inputs.run_by_agent }}'
+          if [[ "$runner" != "publisher" ]]; then
+            echo "Preflight must be executed by publisher agent. Got run_by_agent='$runner'" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Normalize version input
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          raw='${{ github.event.inputs.version }}'
+          tag="$raw"
+          [[ "$tag" == v* ]] || tag="v${tag}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version: '$raw' (expected X.Y.Z or vX.Y.Z)" >&2
+            exit 1
+          fi
+          version="${tag#v}"
+          echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "release_version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release manifest and helper files exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "${RELEASE_ARTIFACT_MANIFEST}"
+          test -f scripts/release_gate.sh
+          test -f scripts/release_artifacts.py
+          test -f docs/release-inventory-schema.json
+
+      - name: Validate manifest coverage, preflight modes, and publish ordering
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/release_artifacts.py validate-manifest \
+            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+            --workspace-toml Cargo.toml
+          python3 scripts/release_artifacts.py validate-preflight-checks \
+            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+            --workspace-toml Cargo.toml
+          python3 scripts/release_artifacts.py validate-publish-order \
+            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+            --workspace-toml Cargo.toml
+
+      - name: Preflight guard — fail if release version already exists on crates.io
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/release_artifacts.py check-version-unpublished \
+            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+            --version '${{ steps.meta.outputs.release_version }}'
+
+      - name: Generate preflight release inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          version='${{ steps.meta.outputs.release_version }}'
+          tag='${{ steps.meta.outputs.release_tag }}'
+          commit="$(git rev-parse HEAD)"
+          generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          source_ref="${GITHUB_REF:-refs/heads/develop}"
+          mkdir -p release
+          python3 scripts/release_artifacts.py emit-inventory \
+            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+            --version "$version" \
+            --tag "$tag" \
+            --commit "$commit" \
+            --source-ref "$source_ref" \
+            --generated-at "$generated_at" \
+            --output release/release-inventory.json
+
+      - name: Validate inventory shape
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          inventory = json.loads(Path("release/release-inventory.json").read_text(encoding="utf-8"))
+          required_top = ["releaseVersion", "releaseTag", "releaseCommit", "generatedAt", "items"]
+          for field in required_top:
+              if field not in inventory:
+                  raise SystemExit(f"inventory missing required field: {field}")
+          items = inventory.get("items", [])
+          if not isinstance(items, list) or not items:
+              raise SystemExit("inventory.items must be a non-empty list")
+          for idx, item in enumerate(items):
+              for field in ["artifact", "version", "sourceRef", "publishTarget", "verifyCommands", "required"]:
+                  if field not in item:
+                      raise SystemExit(f"inventory.items[{idx}] missing {field}")
+          print("release inventory validation passed")
+          PY
+
+      - name: Validate workspace and crate versions match preflight version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.meta.outputs.release_version }}'
+          python3 - <<'PY' "$VERSION"
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          version = sys.argv[1]
+          root = Path(".")
+          root_toml = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+          workspace_version = root_toml.get("workspace", {}).get("package", {}).get("version")
+          if workspace_version != version:
+              raise SystemExit(f"workspace version mismatch: expected {version}, got {workspace_version}")
+          print("workspace version validated")
+          PY
+
+      - name: Run dependency-aware preflight crate checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t full_checks < <(
+            python3 scripts/release_artifacts.py list-preflight \
+              --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+              --mode full
+          )
+          for crate in "${full_checks[@]}"; do
+            [[ -n "$crate" ]] || continue
+            cargo package -p "$crate" --locked --no-verify
+            cargo publish --dry-run -p "$crate" --locked --no-verify
+          done
+
+          mapfile -t locked_checks < <(
+            python3 scripts/release_artifacts.py list-preflight \
+              --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+              --mode locked
+          )
+          for crate in "${locked_checks[@]}"; do
+            [[ -n "$crate" ]] || continue
+            cargo check -p "$crate" --locked
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,340 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 1.0.0 or v1.0.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  RELEASE_ARTIFACT_MANIFEST: release/publish-artifacts.toml
+
+jobs:
+  gate-and-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      release_version: ${{ steps.meta.outputs.release_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Normalize version input
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          raw='${{ github.event.inputs.version }}'
+          tag="$raw"
+          [[ "$tag" == v* ]] || tag="v${tag}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version: '$raw' (expected X.Y.Z or vX.Y.Z)" >&2
+            exit 1
+          fi
+          version="${tag#v}"
+          echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "release_version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Run release gate
+        run: scripts/release_gate.sh
+
+      - name: Ensure tag is correct or create it
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag='${{ steps.meta.outputs.release_tag }}'
+          main_sha="$(git rev-parse origin/main)"
+          remote_tag_sha="$(git ls-remote --tags origin "refs/tags/${tag}" | awk '{print $1}' || true)"
+          if [[ -n "$remote_tag_sha" ]]; then
+            if [[ "$remote_tag_sha" == "$main_sha" ]]; then
+              echo "Tag ${tag} already exists and points to origin/main (${main_sha}), skipping creation"
+              exit 0
+            fi
+            echo "Tag ${tag} exists but points to ${remote_tag_sha}, not origin/main (${main_sha})" >&2
+            exit 1
+          fi
+          git tag "$tag" origin/main
+          git push origin "$tag"
+
+  prepare-release-inventory:
+    needs: gate-and-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate-and-tag.outputs.release_tag }}
+
+      - name: Generate release inventory artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          version='${{ needs.gate-and-tag.outputs.release_version }}'
+          tag='${{ needs.gate-and-tag.outputs.release_tag }}'
+          commit="$(git rev-parse "$tag")"
+          generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          mkdir -p release
+          python3 scripts/release_artifacts.py emit-inventory \
+            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+            --version "$version" \
+            --tag "$tag" \
+            --commit "$commit" \
+            --source-ref "refs/tags/${tag}" \
+            --generated-at "$generated_at" \
+            --output release/release-inventory.json
+
+      - name: Upload release inventory artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-inventory
+          path: release/release-inventory.json
+
+  pre-publish-audit:
+    needs: [gate-and-tag, prepare-release-inventory]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate-and-tag.outputs.release_tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo package audit (core crate) + locked compile check (non-core)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t full_checks < <(
+            python3 scripts/release_artifacts.py list-preflight \
+              --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+              --mode full
+          )
+          for crate in "${full_checks[@]}"; do
+            [[ -n "$crate" ]] || continue
+            cargo package -p "$crate" --locked
+          done
+
+          mapfile -t locked_checks < <(
+            python3 scripts/release_artifacts.py list-preflight \
+              --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+              --mode locked
+          )
+          for crate in "${locked_checks[@]}"; do
+            [[ -n "$crate" ]] || continue
+            cargo check -p "$crate" --locked
+          done
+
+  publish-crates:
+    needs: [gate-and-tag, prepare-release-inventory, pre-publish-audit]
+    runs-on: ubuntu-latest
+    environment: crates-io
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate-and-tag.outputs.release_tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish crates in dependency order (idempotent)
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          version='${{ needs.gate-and-tag.outputs.release_version }}'
+
+          crate_exists() {
+            local crate="$1"
+            local version="$2"
+            cargo search "$crate" --limit 1 | grep -F "${crate} = \"${version}\"" >/dev/null
+          }
+
+          publish_if_missing() {
+            local crate="$1"
+            local wait_seconds="${2:-0}"
+            if crate_exists "$crate" "$version"; then
+              echo "${crate} ${version} already published; skipping"
+              return 0
+            fi
+            cargo publish -p "$crate" --locked
+            if [[ "$wait_seconds" -gt 0 ]]; then
+              sleep "$wait_seconds"
+            fi
+          }
+
+          while IFS='|' read -r crate wait_seconds; do
+            [[ -n "$crate" ]] || continue
+            publish_if_missing "$crate" "${wait_seconds:-0}"
+          done < <(
+            python3 scripts/release_artifacts.py list-publish-plan \
+              --manifest "${RELEASE_ARTIFACT_MANIFEST}"
+          )
+
+  build:
+    needs: gate-and-tag
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate-and-tag.outputs.release_tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Ensure cross-compilation target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build release binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin_args="$(python3 scripts/release_artifacts.py cargo-build-bin-args --manifest "${RELEASE_ARTIFACT_MANIFEST}")"
+          cargo build --release --target ${{ matrix.target }} ${bin_args}
+
+      - name: Package (unix)
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION='${{ needs.gate-and-tag.outputs.release_version }}'
+          ARCHIVE="atm_${VERSION}_${{ matrix.target }}.tar.gz"
+          cd target/${{ matrix.target }}/release
+          tar czf "../../../${ARCHIVE}" atm
+          cd ../../..
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Package (windows)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          $VERSION = '${{ needs.gate-and-tag.outputs.release_version }}'
+          $ARCHIVE = "atm_${VERSION}_${{ matrix.target }}.zip"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/atm.exe" -DestinationPath $ARCHIVE
+          echo "ARCHIVE=$ARCHIVE" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  release:
+    needs: [gate-and-tag, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate-and-tag.outputs.release_tag }}
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' \) -exec mv {} release/ \;
+          ls -la release/
+
+      - name: Generate checksums
+        working-directory: release
+        run: sha256sum * > checksums.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.gate-and-tag.outputs.release_tag }}
+          generate_release_notes: true
+          files: |
+            release/*
+
+  update-homebrew:
+    needs: [gate-and-tag, release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          repository: randlee/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Compute release tarball SHA256
+        id: sha
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag='${{ needs.gate-and-tag.outputs.release_tag }}'
+          version='${{ needs.gate-and-tag.outputs.release_version }}'
+          tarball_path="${RUNNER_TEMP:?RUNNER_TEMP is required}/release.tar.gz"
+          # Homebrew automation requires HOMEBREW_TAP_TOKEN to be configured on the atm-core repo.
+          tarball_url="https://github.com/randlee/atm-core/releases/download/${tag}/atm_${version}_aarch64-apple-darwin.tar.gz"
+          echo "tarball_url=${tarball_url}" >> "$GITHUB_OUTPUT"
+          curl -fsSL --retry 5 --retry-delay 30 --retry-all-errors -o "${tarball_path}" "${tarball_url}"
+          sha256=$(sha256sum "${tarball_path}" | awk '{print $1}')
+          echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
+
+      - name: Update Homebrew formulas
+        shell: bash
+        run: |
+          set -euo pipefail
+          version='${{ needs.gate-and-tag.outputs.release_version }}'
+          sha256='${{ steps.sha.outputs.sha256 }}'
+          tarball_url='${{ steps.sha.outputs.tarball_url }}'
+          for formula in homebrew-tap/Formula/agent-team-mail.rb homebrew-tap/Formula/atm.rb; do
+            sed -i "s|version \"[^\"]*\"|version \"${version}\"|g" "$formula"
+            sed -i "s|url \"[^\"]*\"|url \"${tarball_url}\"|g" "$formula"
+            sed -i "s|sha256 \"[^\"]*\"|sha256 \"${sha256}\"|g" "$formula"
+          done
+
+      - name: Commit and push to homebrew-tap
+        shell: bash
+        run: |
+          set -euo pipefail
+          version='${{ needs.gate-and-tag.outputs.release_version }}'
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/agent-team-mail.rb Formula/atm.rb
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: bump agent-team-mail to v${version}"
+          git push
+
+  publish-winget:
+    needs: [gate-and-tag, release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish to winget
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          # Initial bootstrap still requires a one-time manual manifest submission to microsoft/winget-pkgs.
+          identifier: randlee.agent-team-mail
+          installers-regex: 'atm_.*_x86_64-pc-windows-msvc\.zip$'
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: randlee.agent-team-mail
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Randy Lee
+PublisherUrl: https://github.com/randlee
+PackageName: agent-team-mail
+PackageUrl: https://github.com/randlee/atm-core
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/randlee/atm-core/blob/main/LICENSE
+ShortDescription: Daemon-free CLI for local agent team mail workflows
+Description: |
+  agent-team-mail is the retained daemon-free ATM CLI published from the
+  atm-core repository. It ships the `atm` binary and supports local send, read,
+  ack, clear, doctor, log, teams, and members workflows without a daemon.
+Tags:
+  - cli
+  - agent
+  - mail
+  - teams
+  - developer-tools
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.0.0/atm_1.0.0_x86_64-pc-windows-msvc.zip
+    InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/docs/WINGET_SETUP.md
+++ b/docs/WINGET_SETUP.md
@@ -1,0 +1,48 @@
+# Windows Package Manager (`winget`) Setup
+
+This document explains the retained `1.0` `winget` path for `agent-team-mail`
+published from the `atm-core` repo.
+
+## Package Identity
+
+- Package identifier: `randlee.agent-team-mail`
+- Installed binary: `atm`
+- Release source repo: `https://github.com/randlee/atm-core`
+
+## Release Model
+
+- The first `winget` release requires a one-time manual manifest submission to
+  `microsoft/winget-pkgs`.
+- After that bootstrap submission, later releases are automated by the release
+  workflow via `vedantmgoyal2009/winget-releaser@v2`.
+- No `winget`-specific repository secret is required; the default
+  `GITHUB_TOKEN` is sufficient for the workflow step.
+
+## Installer Source
+
+The workflow submits the Windows ZIP asset from the GitHub Release:
+
+- `atm_<VERSION>_x86_64-pc-windows-msvc.zip`
+
+The `winget` submission uses the ZIP asset URL and SHA256 generated from the
+GitHub Release artifacts.
+
+## Review Lag
+
+Microsoft review normally introduces a 1-2 day lag between submission and
+public `winget install` visibility. Release verification for ATM therefore
+checks submission success, not same-day installability.
+
+## First Release Bootstrap
+
+For the initial submission:
+
+1. Build and publish the GitHub Release as usual.
+2. Update the template manifest under `.winget/`.
+3. Prepare the initial three-file manifest set for `microsoft/winget-pkgs`:
+   - version manifest
+   - installer manifest
+   - locale/default-locale manifest
+4. Submit that initial manifest set to `microsoft/winget-pkgs`.
+5. After that first package exists, keep using the automated workflow step for
+   later releases.

--- a/docs/release-inventory-schema.json
+++ b/docs/release-inventory-schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randlee/atm-core/blob/main/docs/release-inventory-schema.json",
+  "title": "ATM Release Inventory",
+  "description": "Machine-readable release inventory for the retained ATM release line.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["releaseVersion", "releaseTag", "releaseCommit", "generatedAt", "items"],
+  "properties": {
+    "releaseVersion": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "releaseTag": {
+      "type": "string",
+      "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "releaseCommit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/item"
+      }
+    }
+  },
+  "$defs": {
+    "item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact", "version", "sourceRef", "publishTarget", "verifyCommands", "required"],
+      "properties": {
+        "artifact": { "type": "string", "minLength": 1 },
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "sourceRef": { "type": "string", "minLength": 1 },
+        "publishTarget": {
+          "type": "string",
+          "enum": ["crates.io", "github-release", "homebrew", "winget"]
+        },
+        "verifyCommands": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "required": { "type": "boolean" },
+        "publish": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/release/publish-artifacts.toml
+++ b/release/publish-artifacts.toml
@@ -1,0 +1,26 @@
+schema_version = 1
+
+[[crates]]
+artifact = "agent-team-mail-core"
+package = "agent-team-mail-core"
+cargo_toml = "crates/atm-core/Cargo.toml"
+required = true
+publish = true
+publish_order = 1
+preflight_check = "full"
+wait_after_publish_seconds = 60
+verify_install = false
+
+[[crates]]
+artifact = "agent-team-mail"
+package = "agent-team-mail"
+cargo_toml = "crates/atm/Cargo.toml"
+required = true
+publish = true
+publish_order = 2
+preflight_check = "locked"
+wait_after_publish_seconds = 0
+verify_install = true
+
+[[release_binaries]]
+name = "atm"

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Release artifact manifest utilities for the retained ATM release surface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+
+PREFLIGHT_FULL = "full"
+PREFLIGHT_LOCKED = "locked"
+
+
+def load_manifest(path: Path) -> dict:
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema_version") != 1:
+        raise SystemExit("unsupported manifest schema_version")
+
+    crates = data.get("crates")
+    if not isinstance(crates, list) or not crates:
+        raise SystemExit("manifest must define non-empty [[crates]]")
+    binaries = data.get("release_binaries")
+    if not isinstance(binaries, list) or not binaries:
+        raise SystemExit("manifest must define non-empty [[release_binaries]]")
+
+    required = {
+        "artifact",
+        "package",
+        "cargo_toml",
+        "required",
+        "publish",
+        "publish_order",
+        "preflight_check",
+        "wait_after_publish_seconds",
+        "verify_install",
+    }
+    seen_artifacts: set[str] = set()
+    seen_packages: set[str] = set()
+    for idx, crate in enumerate(crates):
+        if not isinstance(crate, dict):
+            raise SystemExit(f"crates[{idx}] must be a table")
+        missing = sorted(required - set(crate))
+        if missing:
+            raise SystemExit(f"crates[{idx}] missing fields: {', '.join(missing)}")
+        artifact = require_str(crate, "artifact", f"crates[{idx}]")
+        package = require_str(crate, "package", f"crates[{idx}]")
+        require_str(crate, "cargo_toml", f"crates[{idx}]")
+        mode = require_str(crate, "preflight_check", f"crates[{idx}]")
+        if mode not in {PREFLIGHT_FULL, PREFLIGHT_LOCKED}:
+            raise SystemExit(f"{artifact}: invalid preflight_check {mode!r}")
+        if artifact in seen_artifacts:
+            raise SystemExit(f"duplicate artifact {artifact}")
+        if package in seen_packages:
+            raise SystemExit(f"duplicate package {package}")
+        seen_artifacts.add(artifact)
+        seen_packages.add(package)
+
+    seen_bins: set[str] = set()
+    for idx, entry in enumerate(binaries):
+        if not isinstance(entry, dict):
+            raise SystemExit(f"release_binaries[{idx}] must be a table")
+        name = require_str(entry, "name", f"release_binaries[{idx}]")
+        if name in seen_bins:
+            raise SystemExit(f"duplicate release binary {name}")
+        seen_bins.add(name)
+
+    crates.sort(key=lambda item: (item["publish_order"], item["artifact"]))
+    return {"crates": crates, "release_binaries": binaries}
+
+
+def require_str(obj: dict, key: str, label: str) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f"{label}.{key} must be a non-empty string")
+    return value
+
+
+def cargo_search_version_exists(crate: str, version: str) -> bool:
+    result = subprocess.run(
+        ["cargo", "search", crate, "--limit", "1"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    return f'{crate} = "{version}"' in result.stdout
+
+
+def emit_inventory(args: argparse.Namespace) -> int:
+    manifest = load_manifest(Path(args.manifest))
+    generated_at = args.generated_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    items = []
+    for crate in manifest["crates"]:
+        if not crate["publish"]:
+            continue
+        verify = [f'cargo search {crate["package"]} --limit 1 | grep -F \'{crate["package"]} = "{args.version}"\'']
+        if crate["verify_install"]:
+            verify.append(f"cargo install {crate['package']} --version {args.version} --locked --force")
+        items.append(
+            {
+                "artifact": crate["artifact"],
+                "version": args.version,
+                "sourceRef": args.source_ref,
+                "publishTarget": "crates.io",
+                "required": crate["required"],
+                "publish": crate["publish"],
+                "verifyCommands": verify,
+            }
+        )
+    items.sort(key=lambda item: item["artifact"])
+    payload = {
+        "releaseVersion": args.version,
+        "releaseTag": args.tag,
+        "releaseCommit": args.commit,
+        "generatedAt": generated_at,
+        "items": items,
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+def list_cargo_tomls(args: argparse.Namespace) -> int:
+    for crate in load_manifest(Path(args.manifest))["crates"]:
+        print(crate["cargo_toml"])
+    return 0
+
+
+def list_artifacts(args: argparse.Namespace) -> int:
+    for crate in load_manifest(Path(args.manifest))["crates"]:
+        if args.publishable_only and not crate["publish"]:
+            continue
+        print(crate["artifact"])
+    return 0
+
+
+def list_preflight(args: argparse.Namespace) -> int:
+    for crate in load_manifest(Path(args.manifest))["crates"]:
+        if crate["publish"] and crate["preflight_check"] == args.mode:
+            print(crate["package"])
+    return 0
+
+
+def list_publish_plan(args: argparse.Namespace) -> int:
+    crates = [crate for crate in load_manifest(Path(args.manifest))["crates"] if crate["publish"]]
+    for crate in crates:
+        print(f'{crate["package"]}|{crate["wait_after_publish_seconds"]}')
+    return 0
+
+
+def list_release_binaries(args: argparse.Namespace) -> int:
+    for entry in load_manifest(Path(args.manifest))["release_binaries"]:
+        print(entry["name"])
+    return 0
+
+
+def cargo_build_bin_args(args: argparse.Namespace) -> int:
+    print(" ".join(f'--bin {entry["name"]}' for entry in load_manifest(Path(args.manifest))["release_binaries"]))
+    return 0
+
+
+def check_version_unpublished(args: argparse.Namespace) -> int:
+    published = []
+    for crate in load_manifest(Path(args.manifest))["crates"]:
+        if crate["publish"] and cargo_search_version_exists(crate["package"], args.version):
+            published.append(crate["artifact"])
+    if published:
+        raise SystemExit("release version already published for: " + ", ".join(sorted(published)))
+    print(f"ok: no publishable artifacts found at version {args.version}")
+    return 0
+
+
+def workspace_members(workspace_toml: Path) -> list[str]:
+    data = tomllib.loads(workspace_toml.read_text(encoding="utf-8"))
+    members = data.get("workspace", {}).get("members", [])
+    if not isinstance(members, list):
+        raise SystemExit("Cargo.toml [workspace].members must be a list")
+    return members
+
+
+def crate_name(crate_toml: Path) -> str | None:
+    data = tomllib.loads(crate_toml.read_text(encoding="utf-8"))
+    return data.get("package", {}).get("name")
+
+
+def crate_is_publishable(crate_toml: Path) -> bool:
+    data = tomllib.loads(crate_toml.read_text(encoding="utf-8"))
+    publish = data.get("package", {}).get("publish")
+    if publish is False:
+        return False
+    if isinstance(publish, list) and len(publish) == 0:
+        return False
+    return True
+
+
+def validate_manifest(args: argparse.Namespace) -> int:
+    manifest_packages = {crate["package"] for crate in load_manifest(Path(args.manifest))["crates"]}
+    workspace_toml = Path(args.workspace_toml)
+    workspace_root = workspace_toml.parent
+    missing = []
+    for member in workspace_members(workspace_toml):
+        crate_toml = workspace_root / member / "Cargo.toml"
+        if not crate_toml.exists() or not crate_is_publishable(crate_toml):
+            continue
+        name = crate_name(crate_toml)
+        if name and name not in manifest_packages:
+            missing.append(name)
+            print(f"MISSING: {name}")
+    if missing:
+        print(f"\n{len(missing)} publishable crate(s) missing from manifest.", file=sys.stderr)
+        return 1
+    print("ok: all publishable workspace crates are present in the manifest")
+    return 0
+
+
+def has_workspace_path_deps(crate_toml: Path, workspace_root: Path) -> list[str]:
+    data = tomllib.loads(crate_toml.read_text(encoding="utf-8"))
+    ws_toml = workspace_root / "Cargo.toml"
+    ws_data = tomllib.loads(ws_toml.read_text(encoding="utf-8")) if ws_toml.exists() else {}
+    workspace_deps = ws_data.get("workspace", {}).get("dependencies", {})
+    crate_dir = crate_toml.parent
+    deps: list[str] = []
+
+    def check_table(table: object) -> None:
+        if not isinstance(table, dict):
+            return
+        for dep_name, dep_spec in table.items():
+            if isinstance(dep_spec, dict):
+                if dep_spec.get("workspace") is True:
+                    ws_dep = workspace_deps.get(dep_name, {})
+                    if isinstance(ws_dep, dict) and "path" in ws_dep:
+                        deps.append(dep_name)
+                elif "path" in dep_spec:
+                    dep_path = (crate_dir / dep_spec["path"]).resolve()
+                    if dep_path.is_relative_to(workspace_root.resolve()):
+                        deps.append(dep_name)
+
+    check_table(data.get("dependencies", {}))
+    check_table(data.get("build-dependencies", {}))
+    for target_data in data.get("target", {}).values():
+        if isinstance(target_data, dict):
+            check_table(target_data.get("dependencies", {}))
+            check_table(target_data.get("build-dependencies", {}))
+    return sorted(set(deps))
+
+
+def validate_preflight_checks(args: argparse.Namespace) -> int:
+    manifest = load_manifest(Path(args.manifest))
+    workspace_root = Path(args.workspace_toml).parent
+    errors = []
+    for crate in manifest["crates"]:
+        if crate["preflight_check"] != PREFLIGHT_FULL:
+            continue
+        crate_toml = workspace_root / crate["cargo_toml"]
+        path_deps = has_workspace_path_deps(crate_toml, workspace_root)
+        if path_deps:
+            errors.append(
+                f"{crate['artifact']} has workspace path deps ({', '.join(path_deps)}) but preflight_check='full'"
+            )
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+    print("ok: all preflight_check='full' crates are genuine leaf crates")
+    return 0
+
+
+def workspace_package_map(workspace_toml: Path) -> dict[str, Path]:
+    root = workspace_toml.parent
+    mapping = {}
+    for member in workspace_members(workspace_toml):
+        crate_toml = root / member / "Cargo.toml"
+        if crate_toml.exists():
+            name = crate_name(crate_toml)
+            if name:
+                mapping[name] = crate_toml
+    return mapping
+
+
+def workspace_dependency_names(crate_toml: Path, workspace_root: Path) -> set[str]:
+    data = tomllib.loads(crate_toml.read_text(encoding="utf-8"))
+    ws_toml = workspace_root / "Cargo.toml"
+    ws_data = tomllib.loads(ws_toml.read_text(encoding="utf-8")) if ws_toml.exists() else {}
+    workspace_deps = ws_data.get("workspace", {}).get("dependencies", {})
+    workspace_packages = set(workspace_package_map(ws_toml).keys()) if ws_toml.exists() else set()
+    crate_dir = crate_toml.parent
+    deps: set[str] = set()
+
+    def resolve(dep_name: str, dep_spec: object) -> str | None:
+        if isinstance(dep_spec, str):
+            return dep_name if dep_name in workspace_packages else None
+        if not isinstance(dep_spec, dict):
+            return None
+        if dep_spec.get("workspace") is True:
+            ws_dep = workspace_deps.get(dep_name, {})
+            if isinstance(ws_dep, dict):
+                package_name = ws_dep.get("package", dep_name)
+                if "path" in ws_dep or package_name in workspace_packages:
+                    return package_name
+            return dep_name if dep_name in workspace_packages else None
+        package_name = dep_spec.get("package", dep_name)
+        if "path" in dep_spec:
+            dep_path = (crate_dir / dep_spec["path"]).resolve()
+            if dep_path.is_relative_to(workspace_root.resolve()):
+                return package_name
+        return package_name if package_name in workspace_packages else None
+
+    def collect(table: object) -> None:
+        if not isinstance(table, dict):
+            return
+        for dep_name, dep_spec in table.items():
+            package_name = resolve(dep_name, dep_spec)
+            if package_name:
+                deps.add(package_name)
+
+    collect(data.get("dependencies", {}))
+    collect(data.get("build-dependencies", {}))
+    for target_data in data.get("target", {}).values():
+        if isinstance(target_data, dict):
+            collect(target_data.get("dependencies", {}))
+            collect(target_data.get("build-dependencies", {}))
+    return deps
+
+
+def validate_publish_order(args: argparse.Namespace) -> int:
+    manifest = load_manifest(Path(args.manifest))
+    workspace_root = Path(args.workspace_toml).parent
+    publishable = [crate for crate in manifest["crates"] if crate["publish"]]
+    order = {crate["package"]: crate["publish_order"] for crate in publishable}
+    violations = []
+    for crate in publishable:
+        crate_toml = workspace_root / crate["cargo_toml"]
+        for dep_package in sorted(workspace_dependency_names(crate_toml, workspace_root)):
+            if dep_package in order and order[crate["package"]] <= order[dep_package]:
+                violations.append(
+                    f"{crate['package']} (publish_order={order[crate['package']]}) depends on "
+                    f"{dep_package} (publish_order={order[dep_package]})"
+                )
+    if violations:
+        print("publish_order violation(s):")
+        for violation in violations:
+            print(f"  - {violation}")
+        return 1
+    print("ok: publish_order matches the workspace dependency graph")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Release artifact manifest utilities")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    emit = subparsers.add_parser("emit-inventory")
+    emit.add_argument("--manifest", required=True)
+    emit.add_argument("--version", required=True)
+    emit.add_argument("--tag", required=True)
+    emit.add_argument("--commit", required=True)
+    emit.add_argument("--source-ref", required=True)
+    emit.add_argument("--generated-at")
+    emit.add_argument("--output", required=True)
+    emit.set_defaults(func=emit_inventory)
+
+    list_tomls = subparsers.add_parser("list-cargo-tomls")
+    list_tomls.add_argument("--manifest", required=True)
+    list_tomls.set_defaults(func=list_cargo_tomls)
+
+    list_items = subparsers.add_parser("list-artifacts")
+    list_items.add_argument("--manifest", required=True)
+    list_items.add_argument("--publishable-only", action="store_true")
+    list_items.set_defaults(func=list_artifacts)
+
+    list_pre = subparsers.add_parser("list-preflight")
+    list_pre.add_argument("--manifest", required=True)
+    list_pre.add_argument("--mode", required=True, choices=[PREFLIGHT_FULL, PREFLIGHT_LOCKED])
+    list_pre.set_defaults(func=list_preflight)
+
+    list_plan = subparsers.add_parser("list-publish-plan")
+    list_plan.add_argument("--manifest", required=True)
+    list_plan.set_defaults(func=list_publish_plan)
+
+    list_bins = subparsers.add_parser("list-release-binaries")
+    list_bins.add_argument("--manifest", required=True)
+    list_bins.set_defaults(func=list_release_binaries)
+
+    build_bins = subparsers.add_parser("cargo-build-bin-args")
+    build_bins.add_argument("--manifest", required=True)
+    build_bins.set_defaults(func=cargo_build_bin_args)
+
+    unpublished = subparsers.add_parser("check-version-unpublished")
+    unpublished.add_argument("--manifest", required=True)
+    unpublished.add_argument("--version", required=True)
+    unpublished.set_defaults(func=check_version_unpublished)
+
+    validate_m = subparsers.add_parser("validate-manifest")
+    validate_m.add_argument("--manifest", required=True)
+    validate_m.add_argument("--workspace-toml", required=True)
+    validate_m.set_defaults(func=validate_manifest)
+
+    validate_p = subparsers.add_parser("validate-preflight-checks")
+    validate_p.add_argument("--manifest", required=True)
+    validate_p.add_argument("--workspace-toml", required=True)
+    validate_p.set_defaults(func=validate_preflight_checks)
+
+    validate_o = subparsers.add_parser("validate-publish-order")
+    validate_o.add_argument("--manifest", required=True)
+    validate_o.add_argument("--workspace-toml", required=True)
+    validate_o.set_defaults(func=validate_publish_order)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAIN_REF="${1:-origin/main}"
+DEVELOP_REF="${2:-origin/develop}"
+
+fail() {
+  echo "release-gate: FAIL - $*" >&2
+  exit 1
+}
+
+info() {
+  echo "release-gate: $*"
+}
+
+info "fetching refs and tags"
+git fetch origin --prune --tags >/dev/null 2>&1 || fail "git fetch failed"
+
+git rev-parse --verify "$MAIN_REF" >/dev/null 2>&1 || fail "missing ref: $MAIN_REF"
+git rev-parse --verify "$DEVELOP_REF" >/dev/null 2>&1 || fail "missing ref: $DEVELOP_REF"
+
+main_sha="$(git rev-parse "$MAIN_REF")"
+develop_sha="$(git rev-parse "$DEVELOP_REF")"
+info "main=$main_sha develop=$develop_sha"
+
+ahead_count="$(git rev-list --count "${MAIN_REF}..${DEVELOP_REF}")"
+if [[ "$ahead_count" != "0" ]]; then
+  fail "$DEVELOP_REF has $ahead_count commit(s) not in $MAIN_REF (merge develop->main before release)"
+fi
+
+if ! git merge-base --is-ancestor "$DEVELOP_REF" "$MAIN_REF"; then
+  fail "$DEVELOP_REF is not an ancestor of $MAIN_REF"
+fi
+
+info "PASS - release gate checks satisfied"


### PR DESCRIPTION
## Summary
- `release/publish-artifacts.toml` with retained publish surface (agent-team-mail-core → agent-team-mail publish order)
- Ported `release-preflight.yml` and `release.yml` narrowed to CLI/core surface
- Ported `scripts/release_gate.sh` and `scripts/release_artifacts.py`
- Added `docs/release-inventory-schema.json` and `docs/WINGET_SETUP.md`
- Added `.winget/randlee.agent-team-mail.yaml` template
- Release workflow covers: crates.io ordered publish, GitHub Release (4 targets), Homebrew tap update, winget via vedantmgoyal2009/winget-releaser@v2
- HOMEBREW_TAP_TOKEN prerequisite and one-time winget bootstrap documented

## Test plan
- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Release automation files reference only retained crates (agent-team-mail-core, agent-team-mail)

Part of Phase N publish replacement. Targets `integrate/phase-N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)