### PR TITLE
feat(N.4): customer-facing release surface docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,164 @@
-# atm-core
+# agent-team-mail (`atm`)
 
-Daemon-free ATM workspace for the retained `1.0` release surface.
+`agent-team-mail` is the retained `1.0` CLI and core library for local ATM
+mailbox workflows.
 
-Current target:
-- `atm` CLI
+This repository is now the source of truth for publishing:
+- `agent-team-mail`
+- `agent-team-mail-core`
+
+The installed command remains `atm`.
+
+## What `1.0` Includes
+
+The retained `1.0` release scope is the daemon-free CLI/core pair:
+- `agent-team-mail` — the `atm` CLI
+- `agent-team-mail-core` — the core Rust library used by the CLI
+
+This release line continues to consume the published `sc-observability` family
+for retained logging and health reporting:
+- `sc-observability`
+- `sc-observability-types`
+- `sc-observability-otlp`
+
+This repo does not publish the retired legacy daemon, MCP, TUI, or CI-monitor
+artifacts as part of the retained `1.0` surface.
+
+## Installation
+
+### GitHub Releases
+
+Download the latest release from
+[GitHub Releases](https://github.com/randlee/atm-core/releases).
+
+Published archives:
+
+| Platform | Archive |
+| --- | --- |
+| Linux (x86_64) | `atm_<version>_x86_64-unknown-linux-gnu.tar.gz` |
+| macOS (Intel) | `atm_<version>_x86_64-apple-darwin.tar.gz` |
+| macOS (Apple Silicon) | `atm_<version>_aarch64-apple-darwin.tar.gz` |
+| Windows (x86_64) | `atm_<version>_x86_64-pc-windows-msvc.zip` |
+
+Extract the archive and place `atm` or `atm.exe` somewhere on your `PATH`.
+
+### Homebrew
+
+```bash
+brew tap randlee/tap
+brew install randlee/tap/agent-team-mail
+```
+
+### crates.io
+
+```bash
+cargo install agent-team-mail
+```
+
+The library crate is also published as:
+
+```bash
+cargo add agent-team-mail-core
+```
+
+### winget
+
+```powershell
+winget install randlee.agent-team-mail
+```
+
+`winget` is a new required `1.0` Windows channel rather than a historical
+parity channel from the old repo. Public `winget` installability may lag by
+1-2 days after release because Microsoft reviews new submissions and updates
+before they become broadly visible.
+
+### Build From Source
+
+```bash
+git clone https://github.com/randlee/atm-core.git
+cd atm-core
+cargo install --path crates/atm --bin atm
+```
+
+## Quick Start
+
+ATM works against the local Claude team mailbox layout under `~/.claude/teams`.
+Typical flows:
+
+### Send a message
+
+```bash
+atm send teammate "Hello from ATM"
+atm send teammate@other-team "Cross-team message"
+atm send teammate "Please confirm" --requires-ack
+```
+
+### Read your mailbox
+
+```bash
+atm read
+atm read --all --no-mark
+atm read --pending-ack-only
+```
+
+### Acknowledge or clear messages
+
+```bash
+atm ack <message-id> "Acknowledged"
+atm clear
+```
+
+### Inspect health and retained logs
+
+```bash
+atm doctor
+atm log snapshot --level warn
+```
+
+### Manage teams
+
+```bash
+atm teams
+atm members my-team
+atm teams add-member my-team teammate
+atm teams backup my-team
+atm teams restore my-team --from backup.tar.gz --dry-run
+```
+
+Run `atm --help` or `atm <command> --help` for the full command surface.
+
+## CLI Surface
+
+The retained CLI includes:
 - `send`
 - `read`
 - `ack`
 - `clear`
 - `log`
 - `doctor`
-- `sc-observability` logging
-- task-linked mail metadata with mandatory ack
-- no daemon
-- no CI monitoring
-- no agent-state integration in MVP
+- `teams`
+- `members`
 
-Docs:
-- `docs/requirements.md`
-- `docs/architecture.md`
-- `docs/project-plan.md`
-- `docs/migration-map.md`
-- `docs/file-migration-plan.md`
-- `docs/read-behavior.md`
+The `teams` command also contains retained team-administration subcommands:
+- `add-member`
+- `backup`
+- `restore`
 
-Published crate/package identities:
-- `agent-team-mail-core`: daemon-free core library published from
-  `crates/atm-core`
-- `agent-team-mail`: CLI package published from `crates/atm` and installing the
-  `atm` binary
+## Configuration Notes
 
-Workspace crates:
-- `crates/atm-core`: library for config, addressing, mailbox I/O, command
-  services, diagnostics, and the observability port boundary
-- `crates/atm`: CLI binary plus the concrete `sc-observability` integration
+ATM resolves runtime identity and team context from the current CLI/config
+surface and uses the local Claude team directory layout for mailbox storage.
 
-No third first-party crate is planned for MVP. The first implementation dependency is an early `sc-observability` gap-analysis sprint to verify and close the shared query/follow/filter/health APIs needed by `atm log` and `atm doctor`.
+Useful docs in this repo:
+- [requirements.md](docs/requirements.md)
+- [architecture.md](docs/architecture.md)
+- [project-plan.md](docs/project-plan.md)
+- [WINGET_SETUP.md](docs/WINGET_SETUP.md)
+
+## Development
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```


### PR DESCRIPTION
## Sprint N.4 — Customer-Facing Release Surface Documentation

Rewrites README.md from reset-workspace language into release-facing product documentation.

**Covers:**
- Installation from all 4 channels: GitHub Releases, Homebrew, crates.io, winget
- Package identity continuity (`agent-team-mail`, `agent-team-mail-core` now published from this repo)
- Retained 1.0 daemon-free CLI/core scope
- winget as new required 1.0 Windows channel (not historical parity)
- 1-2 day winget review lag acknowledged
- Real `atm` CLI usage/getting-started section

Commit: cf911095da24463b33a4e678b7658a5337dff274

🤖 Generated with [Claude Code](https://claude.com/claude-code)