### PR TITLE
N.2-fix-r1: release.yml job ordering, inventory validation, fault-injection removal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,75 @@ jobs:
             --generated-at "$generated_at" \
             --output release/release-inventory.json
 
+      - name: Validate generated release inventory against schema constraints
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          schema_path = Path("docs/release-inventory-schema.json")
+          inventory_path = Path("release/release-inventory.json")
+
+          schema = json.loads(schema_path.read_text(encoding="utf-8"))
+          inventory = json.loads(inventory_path.read_text(encoding="utf-8"))
+
+          required_top = ["releaseVersion", "releaseTag", "releaseCommit", "generatedAt", "items"]
+          for field in required_top:
+              if field not in inventory:
+                  raise SystemExit(f"inventory missing required top-level field: {field}")
+
+          items = inventory.get("items", [])
+          if not isinstance(items, list) or not items:
+              raise SystemExit("inventory.items must be a non-empty array")
+
+          required_item = ["artifact", "version", "sourceRef", "publishTarget", "verifyCommands", "required"]
+          artifacts = []
+          for idx, item in enumerate(items):
+              if not isinstance(item, dict):
+                  raise SystemExit(f"inventory.items[{idx}] must be an object")
+              for field in required_item:
+                  if field not in item:
+                      raise SystemExit(f"inventory.items[{idx}] missing required field: {field}")
+              verify = item["verifyCommands"]
+              if not isinstance(verify, list) or not verify:
+                  raise SystemExit(f"inventory.items[{idx}].verifyCommands must be non-empty")
+              if not isinstance(item["required"], bool):
+                  raise SystemExit(f"inventory.items[{idx}].required must be boolean")
+              artifacts.append(item["artifact"])
+              publish = item.get("publish", True)
+              if not isinstance(publish, bool):
+                  raise SystemExit(f"inventory.items[{idx}].publish must be boolean when present")
+              if not publish:
+                  waiver_reason = item.get("waiver_reason")
+                  if not isinstance(waiver_reason, str) or not waiver_reason.strip():
+                      raise SystemExit(
+                          f"inventory.items[{idx}] sets publish=false but waiver_reason is missing/empty"
+                      )
+              waiver = item.get("waiver")
+              if waiver is not None:
+                  for wf in ["approver", "reason", "gateCheck"]:
+                      if not str(waiver.get(wf, "")).strip():
+                          raise SystemExit(
+                              f"inventory.items[{idx}].waiver.{wf} must be present and non-empty"
+                          )
+
+          if len(artifacts) != len(set(artifacts)):
+              raise SystemExit("inventory has duplicate artifact entries")
+          if artifacts != sorted(artifacts):
+              raise SystemExit("inventory items must be sorted by artifact for deterministic ordering")
+
+          item_required = set(schema["$defs"]["item"]["required"])
+          missing = set(required_item) - item_required
+          if missing:
+              raise SystemExit(
+                  f"schema missing required item fields: {', '.join(sorted(missing))}"
+              )
+
+          print("release inventory validation passed")
+          PY
+
       - name: Upload release inventory artifact
         uses: actions/upload-artifact@v4
         with:
@@ -243,7 +312,7 @@ jobs:
           path: ${{ env.ARCHIVE }}
 
   release:
-    needs: [gate-and-tag, build]
+    needs: [gate-and-tag, build, publish-crates]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -23,7 +23,7 @@ atm-core = { package = "agent-team-mail-core", version = "1.0.0", path = "../atm
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
-sc-observability = { version = "1.0.0", features = ["fault-injection"] }
+sc-observability = "1.0.0"
 sc-observability-types = "1.0.0"
 serde_json.workspace = true
 time = "0.3"
@@ -31,5 +31,6 @@ tracing.workspace = true
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+sc-observability = { version = "1.0.0", features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"

--- a/crates/atm/src/sc_observability_adapter.rs
+++ b/crates/atm/src/sc_observability_adapter.rs
@@ -15,12 +15,13 @@ use atm_core::observability::{
 };
 use chrono::{DateTime, Utc};
 use sc_observability::{
-    ConsoleSink, JsonlFileSink, Logger, LoggerBuilder, LoggerConfig, RetainedSinkFaultInjector,
-    RetentionPolicy, RotationPolicy, SinkRegistration,
+    ConsoleSink, JsonlFileSink, LogSink, Logger, LoggerBuilder, LoggerConfig, RetentionPolicy,
+    RotationPolicy, SinkRegistration,
 };
 use sc_observability_types::{
-    ActionName, CorrelationId, DiagnosticInfo, Level, LogEvent, LogQuery, OutcomeLabel,
-    ProcessIdentity, QueryError, SchemaVersion, ServiceName, TargetCategory, Timestamp,
+    ActionName, CorrelationId, DiagnosticInfo, Level, LogEvent, LogQuery, LogSinkError,
+    OutcomeLabel, ProcessIdentity, QueryError, SchemaVersion, ServiceName, SinkHealth,
+    SinkHealthState, TargetCategory, Timestamp,
 };
 use serde_json::Map;
 use time::OffsetDateTime;
@@ -186,17 +187,47 @@ fn register_retained_sink_fault(
     home_dir: &Path,
     mode: RetainedSinkFaultMode,
 ) {
-    let injector = RetainedSinkFaultInjector::new();
     let sink = Arc::new(JsonlFileSink::new(
         fault_injection_log_path(home_dir),
         RotationPolicy::default(),
         RetentionPolicy::default(),
     ));
-    builder.register_sink(SinkRegistration::new(injector.wrap(sink)));
+    builder.register_sink(SinkRegistration::new(Arc::new(
+        RetainedSinkHealthOverride::new(sink, mode),
+    )));
+}
 
-    match mode {
-        RetainedSinkFaultMode::Degraded => injector.force_degraded(),
-        RetainedSinkFaultMode::Unavailable => injector.force_unavailable(),
+struct RetainedSinkHealthOverride {
+    inner: Arc<dyn LogSink>,
+    mode: RetainedSinkFaultMode,
+}
+
+impl RetainedSinkHealthOverride {
+    fn new(inner: Arc<dyn LogSink>, mode: RetainedSinkFaultMode) -> Self {
+        Self { inner, mode }
+    }
+
+    fn forced_state(&self) -> SinkHealthState {
+        match self.mode {
+            RetainedSinkFaultMode::Degraded => SinkHealthState::DegradedDropping,
+            RetainedSinkFaultMode::Unavailable => SinkHealthState::Unavailable,
+        }
+    }
+}
+
+impl LogSink for RetainedSinkHealthOverride {
+    fn write(&self, event: &LogEvent) -> Result<(), LogSinkError> {
+        self.inner.write(event)
+    }
+
+    fn flush(&self) -> Result<(), LogSinkError> {
+        self.inner.flush()
+    }
+
+    fn health(&self) -> SinkHealth {
+        let mut health = self.inner.health();
+        health.state = self.forced_state();
+        health
     }
 }
 


### PR DESCRIPTION
## Summary

- ATM-QA-003: Add `publish-crates` to GitHub Release job `needs:` in release.yml — ensures release binary upload waits on crates.io publish
- ATM-QA-004: Restore generated-inventory validation block (Python) ported from old repo release.yml:216-283
- ATM-QA-005: Remove `sc-observability/fault-injection` feature from `crates/atm/Cargo.toml` production deps; replaced with ATM-local retained-sink health override; test path preserved

## Test plan

- [ ] `cargo fmt --all --check` passes
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] release.yml GitHub Release job has `needs: [publish-crates]`
- [ ] Inventory validation block present in release.yml
- [ ] No `fault-injection` in production Cargo deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)