### PR TITLE
fix: FIX-PRE101-R3 error-code registry wiring + hardening (ATM-QA-007/008 blocking)

### DIFF
--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -1,3 +1,5 @@
+//! ATM config discovery, loading, normalization, and team-config parsing.
+
 pub mod aliases;
 pub mod bridge;
 pub mod discovery;
@@ -125,6 +127,7 @@ pub fn resolve_identity(_config: Option<&AtmConfig>) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+/// Resolve the active team from explicit override, environment, or config.
 pub fn resolve_team(team_override: Option<&str>, config: Option<&AtmConfig>) -> Option<String> {
     team_override
         .filter(|value| !value.is_empty())
@@ -295,6 +298,7 @@ fn parse_team_member(config_path: &Path, index: usize, entry: &Value) -> Option<
                     .map(ToOwned::to_owned)
                     .unwrap_or_else(|| format!("#{index}"));
                 warn!(
+                    code = %AtmErrorCode::WarningInvalidTeamMemberSkipped,
                     path = %config_path.display(),
                     member_index = index,
                     member = %member_label,

--- a/crates/atm-core/src/error_codes.rs
+++ b/crates/atm-core/src/error_codes.rs
@@ -38,8 +38,6 @@ pub enum AtmErrorCode {
     MailboxLockFailed,
     /// Acquiring a mailbox lock timed out.
     MailboxLockTimeout,
-    /// A malformed mailbox record was skipped.
-    MailboxRecordSkipped,
     /// Message validation failed.
     MessageValidationFailed,
     /// Serialization or deserialization failed.
@@ -109,7 +107,6 @@ impl AtmErrorCode {
             Self::MailboxWriteFailed => "ATM_MAILBOX_WRITE_FAILED",
             Self::MailboxLockFailed => "ATM_MAILBOX_LOCK_FAILED",
             Self::MailboxLockTimeout => "ATM_MAILBOX_LOCK_TIMEOUT",
-            Self::MailboxRecordSkipped => "ATM_MAILBOX_RECORD_SKIPPED",
             Self::MessageValidationFailed => "ATM_MESSAGE_VALIDATION_FAILED",
             Self::SerializationFailed => "ATM_SERIALIZATION_FAILED",
             Self::FilePolicyRejected => "ATM_FILE_POLICY_REJECTED",

--- a/crates/atm-core/src/identity/hook.rs
+++ b/crates/atm-core/src/identity/hook.rs
@@ -6,13 +6,6 @@ use crate::error::AtmError;
 
 const HOOK_FILE_TTL_SECS: f64 = 5.0;
 
-#[cfg(test)]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HookIdentity {
-    pub agent: String,
-    pub team: String,
-}
-
 #[derive(Debug, Deserialize)]
 struct HookFileData {
     agent_name: Option<String>,

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -1,8 +1,5 @@
 pub mod hook;
 
-#[cfg(test)]
-use hook::HookIdentity;
-
 use crate::config::AtmConfig;
 use crate::error::AtmError;
 
@@ -67,11 +64,11 @@ pub fn resolve_runtime_sender_identity(config: Option<&AtmConfig>) -> Result<Str
 pub fn resolve_hook_identity(
     team_override: Option<&str>,
     config: Option<&AtmConfig>,
-) -> Result<HookIdentity, AtmError> {
+) -> Result<(String, String), AtmError> {
     let agent = resolve_runtime_sender_identity(config)?;
     let team = crate::config::resolve_team(team_override, config)
         .ok_or_else(AtmError::team_unavailable)?;
-    Ok(HookIdentity { agent, team })
+    Ok((agent, team))
 }
 
 #[cfg(test)]
@@ -131,9 +128,9 @@ mod tests {
         set_env_var("ATM_IDENTITY", "arch-ctm");
         set_env_var("ATM_TEAM", "atm-dev");
 
-        let identity = resolve_hook_identity(None, None).expect("hook identity");
-        assert_eq!(identity.agent, "arch-ctm");
-        assert_eq!(identity.team, "atm-dev");
+        let (agent, team) = resolve_hook_identity(None, None).expect("hook identity");
+        assert_eq!(agent, "arch-ctm");
+        assert_eq!(team, "atm-dev");
 
         restore("ATM_IDENTITY", original_identity);
         restore("ATM_TEAM", original_team);

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -1,3 +1,5 @@
+//! Mailbox read/write helpers, compatibility parsing, and lock-scoped mutation.
+
 pub(crate) mod atomic;
 pub(crate) mod hash;
 pub(crate) mod lock;
@@ -11,7 +13,7 @@ use std::path::Path;
 use serde_json::Value;
 use tracing::warn;
 
-use crate::error::{AtmError, AtmErrorKind};
+use crate::error::{AtmError, AtmErrorCode, AtmErrorKind};
 use crate::schema::{LegacyMessageId, MessageEnvelope};
 /// Append one message to a mailbox JSONL file under the mailbox lock.
 ///
@@ -97,6 +99,7 @@ fn parse_mailbox_array(raw: &str, path: &Path) -> Result<Vec<MessageEnvelope>, A
                 Ok(None) => None,
                 Err(error) => {
                     warn!(
+                        code = %AtmErrorCode::WarningMailboxRecordSkipped,
                         line = index + 1,
                         mailbox_path = %path.display(),
                         raw_record = %value,
@@ -123,6 +126,7 @@ fn parse_mailbox_jsonl(raw: &str, path: &Path) -> Vec<MessageEnvelope> {
                 Ok(None) => None,
                 Err(error) => {
                     warn!(
+                        code = %AtmErrorCode::WarningMailboxRecordSkipped,
                         line = index + 1,
                         mailbox_path = %path.display(),
                         raw_record = %line,
@@ -169,6 +173,7 @@ fn sanitize_legacy_message_id(value: &mut Value, path: &Path, line_number: usize
 
     if serde_json::from_value::<LegacyMessageId>(raw_message_id.clone()).is_err() {
         warn!(
+            code = %AtmErrorCode::WarningMalformedAtmFieldIgnored,
             mailbox_path = %path.display(),
             line = line_number,
             field = "message_id",

--- a/crates/atm-core/src/mailbox/source.rs
+++ b/crates/atm-core/src/mailbox/source.rs
@@ -2,9 +2,11 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use tracing::warn;
+
 use crate::address::AgentAddress;
 use crate::config;
-use crate::error::{AtmError, AtmErrorKind};
+use crate::error::{AtmError, AtmErrorCode, AtmErrorKind};
 use crate::home;
 use crate::schema::MessageEnvelope;
 use crate::types::SourceIndex;
@@ -89,9 +91,20 @@ pub(crate) fn discover_origin_inboxes(
 
     let mut paths = Vec::new();
     for entry in entries {
-        let path = entry
-            .map_err(|error| origin_inbox_enumeration_error(inboxes_dir, agent, error))?
-            .path();
+        let path = match entry {
+            Ok(entry) => entry.path(),
+            Err(error) => {
+                let enumerated = origin_inbox_enumeration_error(inboxes_dir, agent, error);
+                warn!(
+                    code = %AtmErrorCode::WarningOriginInboxEntrySkipped,
+                    inbox_dir = %inboxes_dir.display(),
+                    agent,
+                    %enumerated,
+                    "failed while enumerating origin inbox entries; aborting source discovery"
+                );
+                return Err(enumerated);
+            }
+        };
         if path
             .file_name()
             .and_then(|value| value.to_str())

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -141,8 +141,8 @@ impl AtmJsonNumber {
         &self.raw
     }
 
-    fn to_json_number(&self) -> Result<serde_json::Number, AtmError> {
-        Ok(self.number.clone())
+    fn to_json_number(&self) -> serde_json::Number {
+        self.number.clone()
     }
 }
 
@@ -159,9 +159,7 @@ impl Serialize for AtmJsonNumber {
     where
         S: Serializer,
     {
-        self.to_json_number()
-            .map_err(S::Error::custom)?
-            .serialize(serializer)
+        self.to_json_number().serialize(serializer)
     }
 }
 
@@ -245,7 +243,7 @@ impl LogFieldValue {
             Self::Null => Ok(Value::Null),
             Self::Bool(value) => Ok(Value::Bool(*value)),
             Self::String(value) => Ok(Value::String(value.clone())),
-            Self::Number(value) => Ok(Value::Number(value.to_json_number()?)),
+            Self::Number(value) => Ok(Value::Number(value.to_json_number())),
             Self::Array(values) => values
                 .iter()
                 .map(Self::to_json_value)

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -157,6 +157,13 @@ pub fn send_mail(
                 recipient.agent,
                 recipient.team
             ));
+            warn!(
+                code = %AtmErrorCode::WarningMissingTeamConfigFallback,
+                config_path = %team_dir.join("config.json").display(),
+                recipient = %recipient.agent,
+                team = %recipient.team,
+                "send used existing inbox fallback; team config is missing"
+            );
 
             if !request.dry_run {
                 notify_team_lead_missing_config(

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -675,7 +675,7 @@ fn process_is_alive(pid: u32) -> bool {
     // SAFETY: OpenProcess is called read-only for process liveness inspection.
     let process_id: u32 = pid;
     let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, process_id) };
-    if handle == 0 {
+    if handle.is_null() {
         return false;
     }
 

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -13,7 +13,7 @@ use tracing::warn;
 
 use crate::address::AgentAddress;
 use crate::config;
-use crate::error::AtmError;
+use crate::error::{AtmError, AtmErrorCode};
 use crate::home;
 use crate::identity;
 use crate::mailbox;
@@ -319,7 +319,12 @@ fn notify_team_lead_missing_config(home_dir: &Path, team_dir: &Path, team: &str,
     let team_lead_inbox = match home::inbox_path_from_home(home_dir, team, "team-lead") {
         Ok(path) => path,
         Err(error) => {
-            warn!(%error, team, "failed to resolve team-lead inbox for missing-config notice");
+            warn!(
+                code = %AtmErrorCode::WarningMissingTeamConfigFallback,
+                %error,
+                team,
+                "failed to resolve team-lead inbox for missing-config notice"
+            );
             return;
         }
     };
@@ -362,6 +367,7 @@ fn notify_team_lead_missing_config(home_dir: &Path, team_dir: &Path, team: &str,
 
     if let Err(error) = mailbox::append_message(&team_lead_inbox, &notice) {
         warn!(
+            code = %AtmErrorCode::WarningMissingTeamConfigFallback,
             %error,
             path = %team_lead_inbox.display(),
             "failed to append missing-config notice to team-lead inbox"
@@ -441,6 +447,7 @@ fn register_missing_team_config_alert(home_dir: &Path, key: &str) -> bool {
     let lock_path = send_alert_lock_path(home_dir);
     let Some(_guard) = acquire_send_alert_lock(&lock_path) else {
         warn!(
+            code = %AtmErrorCode::WarningSendAlertStateDegraded,
             path = %lock_path.display(),
             "failed to acquire send alert lock; skipping team-lead notification"
         );
@@ -451,6 +458,7 @@ fn register_missing_team_config_alert(home_dir: &Path, key: &str) -> bool {
         Ok(state) => state,
         Err(error) => {
             warn!(
+                code = %AtmErrorCode::WarningSendAlertStateDegraded,
                 %error,
                 path = %state_path.display(),
                 "failed to read send state file - defaulting to empty state"
@@ -464,7 +472,12 @@ fn register_missing_team_config_alert(home_dir: &Path, key: &str) -> bool {
 
     state.missing_team_config_keys.insert(key.to_string());
     if let Err(error) = save_send_alert_state(&state_path, &state) {
-        warn!(%error, path = %state_path.display(), "failed to save send alert dedup state");
+        warn!(
+            code = %AtmErrorCode::WarningSendAlertStateDegraded,
+            %error,
+            path = %state_path.display(),
+            "failed to save send alert dedup state"
+        );
     }
     true
 }
@@ -474,6 +487,7 @@ fn clear_missing_team_config_alert(home_dir: &Path, team_dir: &Path) {
     let lock_path = send_alert_lock_path(home_dir);
     let Some(_guard) = acquire_send_alert_lock(&lock_path) else {
         warn!(
+            code = %AtmErrorCode::WarningSendAlertStateDegraded,
             path = %lock_path.display(),
             "failed to acquire send alert lock while clearing dedup state"
         );
@@ -490,7 +504,12 @@ fn clear_missing_team_config_alert(home_dir: &Path, team_dir: &Path) {
     }
 
     if let Err(error) = save_send_alert_state(&state_path, &state) {
-        warn!(%error, path = %state_path.display(), "failed to clear send alert dedup state");
+        warn!(
+            code = %AtmErrorCode::WarningSendAlertStateDegraded,
+            %error,
+            path = %state_path.display(),
+            "failed to clear send alert dedup state"
+        );
     }
 }
 
@@ -549,6 +568,7 @@ fn acquire_send_alert_lock(path: &Path) -> Option<SendAlertLock> {
         && let Err(error) = fs::create_dir_all(parent)
     {
         warn!(
+            code = %AtmErrorCode::WarningSendAlertStateDegraded,
             %error,
             path = %parent.display(),
             "failed to create send alert lock directory"
@@ -561,7 +581,12 @@ fn acquire_send_alert_lock(path: &Path) -> Option<SendAlertLock> {
             Ok(mut file) => {
                 let pid = std::process::id().to_string();
                 if let Err(error) = std::io::Write::write_all(&mut file, pid.as_bytes()) {
-                    warn!(%error, path = %path.display(), "failed to write send alert lock pid");
+                    warn!(
+                        code = %AtmErrorCode::WarningSendAlertStateDegraded,
+                        %error,
+                        path = %path.display(),
+                        "failed to write send alert lock pid"
+                    );
                     let _ = fs::remove_file(path);
                     return None;
                 }
@@ -576,7 +601,12 @@ fn acquire_send_alert_lock(path: &Path) -> Option<SendAlertLock> {
                 thread::sleep(Duration::from_millis(10));
             }
             Err(error) => {
-                warn!(%error, path = %path.display(), "failed to create send alert lock");
+                warn!(
+                    code = %AtmErrorCode::WarningSendAlertStateDegraded,
+                    %error,
+                    path = %path.display(),
+                    "failed to create send alert lock"
+                );
                 return None;
             }
         }
@@ -600,7 +630,13 @@ fn evict_stale_send_alert_lock(path: &Path) -> bool {
         Ok(()) => true,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
         Err(error) => {
-            warn!(%error, path = %path.display(), pid, "failed to evict stale send alert lock");
+            warn!(
+                code = %AtmErrorCode::WarningSendAlertStateDegraded,
+                %error,
+                path = %path.display(),
+                pid,
+                "failed to evict stale send alert lock"
+            );
             false
         }
     }
@@ -624,8 +660,6 @@ fn process_is_alive(pid: u32) -> bool {
 
 #[cfg(windows)]
 fn process_is_alive(pid: u32) -> bool {
-    use std::ptr;
-
     use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
     use windows_sys::Win32::System::Threading::{
         GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
@@ -634,7 +668,7 @@ fn process_is_alive(pid: u32) -> bool {
     // SAFETY: OpenProcess is called read-only for process liveness inspection.
     let process_id: u32 = pid;
     let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, process_id) };
-    if handle == ptr::null_mut() {
+    if handle == 0 {
         return false;
     }
 
@@ -656,6 +690,7 @@ impl Drop for SendAlertLock {
             && error.kind() != std::io::ErrorKind::NotFound
         {
             warn!(
+                code = %AtmErrorCode::WarningSendAlertStateDegraded,
                 %error,
                 path = %self.path.display(),
                 "failed to remove send alert lock"

--- a/docs/atm-core/modules/send.md
+++ b/docs/atm-core/modules/send.md
@@ -34,8 +34,10 @@ References:
 - `REQ-CORE-CONFIG-001` for runtime identity precedence and obsolete
   `[atm].identity` handling
 - `REQ-CORE-CONFIG-002` for alias rewrite and canonical target resolution
-- `REQ-CORE-SEND-001`
+- `REQ-CORE-SEND-001` for missing-config fallback and repair notification
 - `REQ-CORE-SEND-002` for `metadata.atm.fromIdentity` placement when
   cross-team alias projection is used
+- `REQ-CORE-SEND-003` for send-path message construction and append-boundary
+  behavior
 - `REQ-CORE-MAILBOX-001`
 - CLI surface: `docs/atm/commands/send.md`

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -80,7 +80,7 @@ Initial crate requirement IDs:
   of:
   `REQ-P-READ-001`, `REQ-P-ACK-001`, `REQ-P-CLEAR-001`,
   `REQ-P-WORKFLOW-001`.
-- `REQ-CORE-SEND-001` `atm-core` owns send-path message construction,
+- `REQ-CORE-SEND-003` `atm-core` owns send-path message construction,
   classification, and append-boundary behavior above the mailbox storage
   helpers. Satisfies the send-path service aspects of:
   `REQ-P-SEND-001`, `REQ-P-IDLE-001`.

--- a/docs/atm-error-codes.md
+++ b/docs/atm-error-codes.md
@@ -69,7 +69,6 @@ Error codes should describe the failure class, not a specific prose message.
 - `ATM_MAILBOX_WRITE_FAILED`
 - `ATM_MAILBOX_LOCK_FAILED`
 - `ATM_MAILBOX_LOCK_TIMEOUT`
-- `ATM_MAILBOX_RECORD_SKIPPED`
 - `ATM_MESSAGE_VALIDATION_FAILED`
 - `ATM_SERIALIZATION_FAILED`
 
@@ -137,10 +136,12 @@ Error codes should describe the failure class, not a specific prose message.
   - emitted during ATM config loading before send execution proceeds
   - requires migration guidance that explains sender- versus
     recipient-triggered hook filters and the `*` wildcard
+  - `{config_path}` resolves to the discovered `.atm.toml` path that contained
+    the retired key
   - expected output split:
     - message:
       ```text
-      error: '.atm.toml' field 'post_send_hook_members' is no longer supported.
+      error: '{config_path}' field 'post_send_hook_members' is no longer supported.
       ```
     - recovery:
       ```text

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -475,11 +475,12 @@ Post-send-hook rules:
 - when retired `post_send_hook_members` is present, ATM must fail with a
   migration-oriented error message following this template:
   ```text
-  error: '.atm.toml' field 'post_send_hook_members' is no longer supported.
+  error: '{config_path}' field 'post_send_hook_members' is no longer supported.
   Use 'post_send_hook_senders' (match on sender identity) and/or
   'post_send_hook_recipients' (match on recipient name) under [atm].
   Use '*' to match all senders or all recipients.
   ```
+- `{config_path}` is the discovered `.atm.toml` path containing the retired key
 - a relative hook path must resolve from the directory containing the
   discovered `.atm.toml`
 - the hook must execute with that same config-root directory as its working


### PR DESCRIPTION
## Summary

Final hardening round addressing 2 Blocking + 8 Important/Minor findings from QA-FINAL-RELEASE-GATE on develop @ c20f3d0. This unblocks PR #85 (develop → main, v1.0.1 release).

- **ATM-QA-007** [Blocking]: Wire `WarningMissingTeamConfigFallback` + `WarningSendAlertStateDegraded` into `send/mod.rs` warn!() calls
- **ATM-QA-008** [Blocking]: Wire `WarningMailboxRecordSkipped` + `WarningInvalidTeamMemberSkipped` + `WarningOriginInboxEntrySkipped` into mailbox/config/source warn!() calls
- **ATM-QA-009**: Update spec docs to document `{config_path}` substitution in error template
- **ATM-QA-010**: Renumber duplicate REQ-CORE-SEND-001 → REQ-CORE-SEND-003
- **ATM-QA-011**: Classify orphaned `ATM_MAILBOX_RECORD_SKIPPED`
- **BP-006**: Remove test-only `HookIdentity` named struct
- **BP-007**: Make `AtmJsonNumber::to_json_number` infallible (returns `serde_json::Number` directly)
- **BP-008**: Add `///` doc comment to `resolve_team`
- **BP-009**: Add `//!` module docs to `config/mod.rs` and `mailbox/mod.rs`
- **BP-010**: Fix Windows HANDLE comparison to use `== 0`

## Test plan
- [ ] cargo test --workspace — PASS (bd6f7aa)
- [ ] cargo clippy --workspace --all-targets -- -D warnings — PASS
- [ ] Quality-mgr targeted re-QA
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)