### PR TITLE
docs: Phase O plan + CR001 analysis + security requirements

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1593,3 +1593,28 @@ Phase M builds on the already-landed L.7 runtime surface
 (`team_members`, `aliases`, `post_send_hook`, doctor identity drift warning).
 Phase M does not re-open that feature set; it only adds the remaining concurrency,
 restore, and code-review hardening needed for 1.0.
+
+### 20.6 Security Boundaries (Phase O)
+
+Phase O adds three architecture-level hardening decisions:
+
+1. **Address validation is the trust boundary for path construction**
+   - team and agent names must be validated before any helper constructs
+     `{ATM_HOME}/.claude/teams/{team}` or `{agent}.json`
+   - `address.rs` and `home.rs` together form the boundary; downstream code
+     must not attempt ad hoc sanitization after path joins are already built
+
+2. **PID-file locking remains conservative by design**
+   - the send-alert lock uses a PID-file-style stale-lock check
+   - PID reuse is an accepted limitation: a reused PID can make a stale lock
+     look alive, so ATM may conservatively preserve that stale lock until
+     timeout or manual cleanup
+   - this limitation favors false-alive availability loss over false-dead lock
+     eviction
+
+3. **Atomic writes must use collision-proof temp names**
+   - temp files for atomic replacement must use UUID-based suffixes instead of
+     timestamp-only suffixes
+   - this keeps same-process rapid writes to the same target path from
+     colliding on the temp-file name while preserving the target basename for
+     operator debugging

--- a/docs/atm-core/modules/send.md
+++ b/docs/atm-core/modules/send.md
@@ -9,6 +9,10 @@ Also owns send-time resilience behavior that is not generic config parsing:
 - best-effort deduplicated repair notifications to `team-lead`
 - post-send-hook trigger evaluation, payload construction, and diagnostics
 
+Accepted limitations in this module:
+- missing-config repair notifications are best-effort and effectively at-most-once across crash windows because dedup state is recorded before the team-lead inbox append
+- send-alert stale-lock eviction uses PID-only liveness checks, so PID reuse can conservatively preserve a stale lock until manual cleanup or timeout
+
 `SendOutcome.warnings` is part of the stable send API contract:
 - empty during normal sends
 - populated only when send succeeds in a degraded but permitted mode

--- a/docs/code-review-cr001-analysis.md
+++ b/docs/code-review-cr001-analysis.md
@@ -1,0 +1,168 @@
+# Code Review CR001 Analysis
+
+## Executive Summary
+
+- Total findings: 4 confirmed, 5 accepted-limitations, 3 false-positives
+- Highest-risk confirmed findings:
+  - `H-1` path traversal through unsanitized `team` / `agent` segments
+  - `M-2` unbounded allocation in `normalize_json_number(...)` for large exponents
+  - `C-1` temp-file naming is not collision-proof for concurrent same-path writes in one PID
+- Recommended phase scope:
+  - Phase 1: fix `H-1` and `M-2` first because they combine untrusted input with filesystem or allocation risk
+  - Phase 2: fix `C-1` and `H-2` as small correctness/hardening changes
+  - Leave accepted limitations documented unless product requirements change
+
+## Finding Analysis
+
+### C-1 — Temp File Name Collision
+
+**Verdict**: CONFIRMED
+
+**Root cause**: `crates/atm-core/src/persistence.rs` builds temp paths as `.{file}.tmp.{pid}.{timestamp_nanos}`. There is no counter, random suffix, or UUID in the name. `Utc::now().timestamp_nanos_opt().unwrap_or_default()` makes the `None -> 0` fallback explicit, although `Utc::now()` should normally stay in-range. The real issue is that two writes for the same target path from the same PID can still pick the same timestamp-based suffix.
+
+**Risk in practice**: Low-to-moderate. Several call sites are already lock-protected, which narrows the window, but `atomic_write_bytes(...)` is a general helper and the collision prevention is not complete. The repo already depends on `uuid`, so a collision-proof suffix is available without adding a dependency.
+
+**Recommended action**: Switch temp naming to a guaranteed-unique suffix, for example `Uuid::new_v4()` or a per-process atomic counter. Keep the target basename in the temp filename for debuggability, but stop relying on timestamp uniqueness.
+
+### C-2 — Stale Envelope Fallback After Re-Lock
+
+**Verdict**: FALSE-POSITIVE
+
+**Root cause**: `read_mail(...)` re-locks, reloads `source_files`, rebuilds `selected`, and only then constructs `output_messages`. The fallback to `selected_message.envelope` is reached only if the reloaded `source_files` no longer contain the exact `source_path + source_index` tuple that was just rebuilt from the same `source_files`. Under the current implementation that tuple is stable: `apply_display_mutations(...)` mutates envelopes in place and does not reorder or remove elements.
+
+**Risk in practice**: Negligible. The fallback is defensive code, not a real stale-snapshot path under current control flow. If the lookup fails, a deeper invariant has already been broken elsewhere.
+
+**Recommended action**: No bug fix required. Optional cleanup later: replace the fallback with a debug assertion or explicit invariant comment if the team wants the defensive branch to be more obviously unreachable.
+
+### H-1 — Path Traversal Via Unsanitized Team / Agent Names
+
+**Verdict**: CONFIRMED
+
+**Root cause**: `AgentAddress::from_str(...)` in `crates/atm-core/src/address.rs` only rejects empty segments and multiple `@` separators. `team_dir_from_home(...)` and `inbox_path_from_home(...)` in `crates/atm-core/src/home.rs` then join the raw `team` and `agent` strings directly into filesystem paths. There is no downstream sanitization or canonical-root enforcement.
+
+**Risk in practice**: High for correctness and medium for security. ATM is a local CLI, so the attacker model is narrower than a network service, but this still allows crafted input like `../other-team` to escape the intended `.claude/teams` subtree.
+
+**Recommended action**: Add validated newtypes or a shared validator for team/member path segments. Reject path separators, `..`, empty segments, and platform-specific path escapes before any path construction.
+
+### H-2 — Spin Loop After Repeated Successful Stale-Lock Eviction
+
+**Verdict**: CONFIRMED
+
+**Root cause**: In `acquire_send_alert_lock(...)`, the `AlreadyExists` branch does `if evict_stale_send_alert_lock(path) { continue; }` and only sleeps in the `false` branch. If a stale lock can be evicted repeatedly, the loop can re-enter without backoff.
+
+**Risk in practice**: Low, but real. In the common case, one successful eviction is followed by a successful `create_new(...)` and the loop exits. The busy-loop only shows up under unusual churn or adversarial recreation of stale lock files.
+
+**Recommended action**: Add a small sleep or bounded backoff even after successful eviction, or restructure the loop so every `AlreadyExists` turn yields at least once.
+
+### H-3 — PID Reuse In Stale-Lock Detection
+
+**Verdict**: ACCEPTED-LIMITATION
+
+**Root cause**: `process_is_alive(...)` uses PID-only liveness checks (`kill(pid, 0)` on Unix, `OpenProcess(...)` on Windows). This cannot distinguish “the original lock owner is still alive” from “that PID now belongs to some unrelated process.” The review note’s exact failure mode is slightly off: PID reuse causes a false-alive outcome, not a false-dead eviction. ATM will conservatively keep the lock rather than incorrectly evicting a live one.
+
+**Risk in practice**: Low and availability-only. The effect is a stale lock that may survive until manual cleanup or timeout, not corrupted state.
+
+**Recommended action**: Keep the current behavior as an accepted limitation, but document that PID-only stale-lock detection is conservative and may preserve a stale lock if the PID has been reused.
+
+### H-4 — TOCTOU Window Between Lock Drop And Reacquire In `ack_mail`
+
+**Verdict**: ACCEPTED-LIMITATION
+
+**Root cause**: `ack_mail(...)` intentionally drops the initial actor-source lock set before acquiring the full superset that includes the reply inbox. The source already documents the reason in code comments, and `docs/architecture.md` section `18.4.1` explains the two-phase locking pattern and the post-reacquire revalidation.
+
+**Risk in practice**: Low and already mitigated. The unlock gap is real, but the function re-discovers source paths, reloads state, and revalidates pending-ack state before mutating anything.
+
+**Recommended action**: No code change required. Existing architecture documentation is sufficient.
+
+### H-5 — Infallible `team_dir_from_home(...)` / `inbox_path_from_home(...)` Return `Result`
+
+**Verdict**: ACCEPTED-LIMITATION
+
+**Root cause**: The helpers in `crates/atm-core/src/home.rs` are currently infallible after `home_dir` resolution, but they intentionally keep a `Result<PathBuf, AtmError>` shape. The doc comments already state why: callers share one path-construction contract and the helper may grow validation later.
+
+**Risk in practice**: Low. This is API-shape overhead, not a correctness bug.
+
+**Recommended action**: No change required. The existing doc comments already record the rationale.
+
+### M-1 — Blocking Lock Acquisition In Hot Polling Loop
+
+**Verdict**: FALSE-POSITIVE
+
+**Root cause**: The polling path is fully synchronous. `read_mail(...)` is a sync function, `read::wait::wait_for_eligible_message(...)` uses `std::thread::sleep`, and there is no async executor in this call path. The repo has a `tokio` dependency in the workspace, but not in ATM’s `read` execution path.
+
+**Risk in practice**: None under the current architecture. The code blocks a thread, not an async runtime.
+
+**Recommended action**: No fix required. Revisit only if `atm-core` grows an async public API.
+
+### M-2 — Unbounded Allocation In `normalize_json_number(...)`
+
+**Verdict**: CONFIRMED
+
+**Root cause**: `normalize_json_number(...)` builds strings with `"0".repeat(scale as usize)` for non-negative exponents and `"0".repeat((-point_index) as usize)` for large negative scales. The exponent is parsed from user-supplied JSON-number text into `i64`, and there is no size cap before allocation.
+
+**Risk in practice**: Moderate. The panic was already removed, but a large exponent such as `1e1000000000` can still drive extremely large allocations or OOM behavior.
+
+**Recommended action**: Cap the expansion length. If the normalized form would exceed a reasonable bound, return the raw string unchanged and emit a warning instead of allocating.
+
+### M-3 — Full Clone Of Message Vec On Every Poll Tick
+
+**Verdict**: ACCEPTED-LIMITATION
+
+**Root cause**: `selected_after_filters(...)` and `select_messages(...)` clone vectors in the polling path (`messages.to_vec()`). This keeps the selection pipeline simple and ownership-friendly, but it does duplicate work every 100ms while waiting.
+
+**Risk in practice**: Low. ATM mailbox surfaces are local and usually small; this is a throughput trade-off, not a correctness defect. If very large mailboxes become normal, the cost could become noticeable.
+
+**Recommended action**: Keep as-is for now. Consider borrowing-based filter/selection helpers only if real mailbox sizes make polling costs measurable.
+
+### M-4 — Dedup-Before-Append Crash Window For Team-Lead Repair Notification
+
+**Verdict**: ACCEPTED-LIMITATION
+
+**Root cause**: `notify_team_lead_missing_config(...)` records the dedup key through `register_missing_team_config_alert(...)` before appending the notice to the `team-lead` inbox. A crash in between can permanently suppress that notification until the config is restored and the dedup state is cleared.
+
+**Risk in practice**: Low and aligned with the documented delivery model. The requirements and repair docs already say these notifications are best-effort and deduplicated, not guaranteed delivery.
+
+**Recommended action**: Keep the current behavior, but document the implied at-most-once semantics explicitly so operators understand that crash recovery favors duplicate suppression over guaranteed resend.
+
+### M-5 — Inconsistent Sort Keys Across Origin Inbox Discovery
+
+**Verdict**: FALSE-POSITIVE
+
+**Root cause**: `discover_origin_inboxes(...)` sorts the origin-only list with `paths.sort()`, but `discover_source_paths(...)` immediately re-sorts the combined primary+origin list with `sort_by_key(|path| path.to_string_lossy().into_owned())`. The externally consumed ordering is therefore the second sort, not the first.
+
+**Risk in practice**: Negligible. For ATM-created paths, the final ordering is stable and the first sort is just redundant work. The two functions do not expose conflicting orderings for the same final result.
+
+**Recommended action**: No correctness fix required. Optional cleanup later: remove the redundant first sort or align both helpers to one canonical ordering style.
+
+## Fix Plan
+
+Confirmed findings only:
+
+1. `H-1` — Path-segment validation for team/agent names
+   - Effort: medium
+   - Suggested sprint grouping: Security and path-hardening sprint
+   - Dependencies: none
+
+2. `M-2` — Cap or short-circuit large exponent normalization
+   - Effort: small
+   - Suggested sprint grouping: Observability hardening sprint
+   - Dependencies: none
+
+3. `C-1` — Collision-proof temp-file naming in persistence helpers
+   - Effort: small
+   - Suggested sprint grouping: Filesystem durability / persistence sprint
+   - Dependencies: none
+
+4. `H-2` — Add backoff after successful stale-lock eviction
+   - Effort: trivial
+   - Suggested sprint grouping: Send-alert lock hardening sprint
+   - Dependencies: none
+
+Recommended grouping:
+
+- Sprint A: `H-1` + `M-2`
+  - highest user-controlled input risk
+- Sprint B: `C-1` + `H-2`
+  - low-risk hardening changes with small code surface
+
+No dependency chain blocks those sprints from running independently, but Sprint A should land first because it closes the most externally exposed risk.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1533,3 +1533,74 @@ Phase N completion gate:
   - `winget`
 - `winget` is explicitly documented as a new required Windows install channel,
   not as historical parity
+
+### Phase O: Security And Hardening [PLANNED]
+
+Goal:
+- close the confirmed CR001 findings that affect path safety, allocation
+  bounds, temp-file collision resistance, and send-alert lock behavior before
+  the next post-`1.0.1` hardening cycle begins
+
+Status summary:
+- CR001 confirmed four follow-up fixes that were intentionally left out of the
+  immediate release gate because they need small but focused design + test work
+- Phase O groups those fixes into one input-safety sprint and one
+  filesystem/lock-hardening sprint
+- accepted limitations from CR001 remain documented separately and are not
+  re-opened by this phase
+
+Integration branch: `integrate/phase-O`
+
+#### O.1 — Input Validation And Allocation Safety
+
+Goal:
+- close the two highest-risk confirmed CR001 findings by tightening the trust
+  boundary around path construction and bounding JSON-number normalization
+
+Deliverables:
+- `H-1`: add validated newtypes or one shared validator for team/agent path
+  segments
+  - reject path separators, `..`, empty segments, and platform-specific escapes
+    before any path construction in `address.rs` and `home.rs`
+- `M-2`: cap `normalize_json_number(...)` expansion length
+  - if the normalized form would exceed 64 characters, return the raw string
+    unchanged and emit `warn!` with
+    `code = %AtmErrorCode::WarningMalformedAtmFieldIgnored`
+
+Acceptance criteria:
+- `AgentAddress::from_str(...)` rejects `../evil`, `../../passwd`, and names
+  containing path separators
+- `normalize_json_number(...)` with exponent expansion over 64 characters
+  returns the raw string unchanged and emits the documented warning
+- `cargo test --workspace` passes
+- `cargo clippy --workspace --all-targets -- -D warnings` is clean
+
+#### O.2 — Filesystem Durability And Lock Hardening
+
+Goal:
+- close the remaining confirmed CR001 findings in persistence temp naming and
+  send-alert stale-lock handling
+
+Deliverables:
+- `C-1`: replace the timestamp-nanos temp-file suffix in `persistence.rs` with
+  `Uuid::new_v4()` while keeping the target basename for debuggability
+- `H-2`: add sleep/backoff after successful stale-lock eviction in
+  `acquire_send_alert_lock(...)` so every `AlreadyExists` turn yields at least
+  once
+
+Acceptance criteria:
+- `atomic_write_bytes(...)` uses UUID-based temp names
+- `acquire_send_alert_lock(...)` sleeps on every `AlreadyExists` iteration,
+  regardless of whether stale-lock eviction succeeded
+- `cargo test --workspace` passes
+- `cargo clippy --workspace --all-targets -- -D warnings` is clean
+
+Phase O completion gate:
+- O.1 and O.2 are both merged to `integrate/phase-O`
+- all four confirmed CR001 findings are resolved:
+  - `H-1`
+  - `M-2`
+  - `C-1`
+  - `H-2`
+- CI passes on all platforms
+- `integrate/phase-O` merges to `develop`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -202,6 +202,42 @@ Required canonical paths:
 - `{ATM_HOME}/.config/atm/state.json`
 - `{ATM_HOME}/.config/atm/share/{team}/`
 
+### 3.1.1 Security And Durability Boundaries
+
+Product requirement IDs:
+- `REQ-SEC-001` All user-supplied team and agent name segments must be
+  validated before path construction.
+- `REQ-SEC-002` JSON number normalization must not allocate unbounded memory.
+- `REQ-DURABILITY-001` Atomic-write temp file names must be globally unique
+  within a process.
+
+Required behavior:
+- valid team/agent path-segment characters are limited to:
+  - alphanumeric
+  - hyphen
+  - underscore
+  - period
+- team/agent segments must reject:
+  - empty strings
+  - path separators
+  - `..` sequences
+  - consecutive periods
+  - leading periods
+  - platform-specific path escapes that could break out of the intended ATM
+    home subtree
+- validation must happen before any path construction in address parsing or
+  home/path helpers
+- JSON number normalization must cap exponent-driven string expansion at 64
+  characters
+- if exponent expansion would exceed 64 characters, ATM must:
+  - return the original raw numeric string unchanged
+  - emit a structured warning using
+    `AtmErrorCode::WarningMalformedAtmFieldIgnored`
+- atomic persistence helpers must use temp-file names that are unique for each
+  write attempt targeting the same destination path from the same process
+- timestamp-only temp-file suffixes are not sufficient for the durability
+  contract because rapid same-process writes can collide
+
 ### 3.2 Team Mail Store
 
 Per-team layout:


### PR DESCRIPTION
## Summary

- Add `docs/code-review-cr001-analysis.md` — root-cause verdicts for all 12 CR001 findings (4 confirmed, 5 accepted-limitations, 3 false-positives)
- Add Phase O to `docs/project-plan.md` — two-sprint security/hardening phase (O.1: input validation + allocation safety, O.2: filesystem durability + lock hardening)
- Add REQ-SEC-001, REQ-SEC-002, REQ-DURABILITY-001 to `docs/requirements.md`
- Add security boundaries section to `docs/architecture.md`
- Update `docs/atm-core/modules/send.md` with accepted-limitation documentation (PID reuse, at-most-once notifications)

No code changes — documentation and planning only.

## Context

Closes the planning gate for Phase O. Confirmed findings to be fixed in O.1 + O.2 sprints: H-1 (path traversal), M-2 (OOM in normalize_json_number), C-1 (temp file collision), H-2 (spin-loop backoff).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)