### PR TITLE
feat: O.1 — input validation and allocation safety (H-1, M-2)

### DIFF
--- a/crates/atm-core/src/address.rs
+++ b/crates/atm-core/src/address.rs
@@ -21,11 +21,6 @@ impl FromStr for AgentAddress {
             Some((agent, team)) => {
                 validate_path_segment(agent, "agent")?;
                 validate_path_segment(team, "team")?;
-                if team.contains('@') {
-                    return Err(AtmError::address_parse(
-                        "address must contain at most one @ separator",
-                    ));
-                }
 
                 Ok(Self {
                     agent: agent.to_string(),
@@ -119,6 +114,8 @@ mod tests {
         assert!(AgentAddress::from_str("team/subdir").is_err());
         assert!(AgentAddress::from_str(r"team\\subdir").is_err());
         assert!(AgentAddress::from_str(".hidden").is_err());
+        assert!(AgentAddress::from_str("a..b@team").is_err());
+        assert!(AgentAddress::from_str("a...b@team").is_err());
     }
 
     #[test]

--- a/crates/atm-core/src/address.rs
+++ b/crates/atm-core/src/address.rs
@@ -19,12 +19,8 @@ impl FromStr for AgentAddress {
 
         match trimmed.split_once('@') {
             Some((agent, team)) => {
-                if agent.is_empty() {
-                    return Err(AtmError::address_parse("agent name must not be empty"));
-                }
-                if team.is_empty() {
-                    return Err(AtmError::address_parse("team name must not be empty"));
-                }
+                validate_path_segment(agent, "agent")?;
+                validate_path_segment(team, "team")?;
                 if team.contains('@') {
                     return Err(AtmError::address_parse(
                         "address must contain at most one @ separator",
@@ -36,12 +32,52 @@ impl FromStr for AgentAddress {
                     team: Some(team.to_string()),
                 })
             }
-            None => Ok(Self {
-                agent: trimmed.to_string(),
-                team: None,
-            }),
+            None => {
+                validate_path_segment(trimmed, "agent")?;
+                Ok(Self {
+                    agent: trimmed.to_string(),
+                    team: None,
+                })
+            }
         }
     }
+}
+
+fn validate_path_segment(value: &str, kind: &str) -> Result<(), AtmError> {
+    if value.is_empty() {
+        return Err(AtmError::address_parse(format!(
+            "{kind} name must not be empty"
+        )));
+    }
+
+    if value.starts_with('.') {
+        return Err(AtmError::address_parse(format!(
+            "{kind} name must not start with '.'"
+        )));
+    }
+
+    if value.contains("..") {
+        return Err(AtmError::address_parse(format!(
+            "{kind} name must not contain '..'"
+        )));
+    }
+
+    if value.contains(['/', '\\']) {
+        return Err(AtmError::address_parse(format!(
+            "{kind} name must not contain path separators"
+        )));
+    }
+
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        return Err(AtmError::address_parse(format!(
+            "{kind} name contains invalid characters"
+        )));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -74,5 +110,25 @@ mod tests {
     fn rejects_invalid_team_segment() {
         assert!(AgentAddress::from_str("arch-ctm@").is_err());
         assert!(AgentAddress::from_str("arch-ctm@atm@dev").is_err());
+    }
+
+    #[test]
+    fn rejects_path_traversal_and_separator_segments() {
+        assert!(AgentAddress::from_str("../evil").is_err());
+        assert!(AgentAddress::from_str("../../passwd").is_err());
+        assert!(AgentAddress::from_str("team/subdir").is_err());
+        assert!(AgentAddress::from_str(r"team\\subdir").is_err());
+        assert!(AgentAddress::from_str(".hidden").is_err());
+    }
+
+    #[test]
+    fn accepts_valid_segment_characters() {
+        let parsed = AgentAddress::from_str("valid-team_name.1").expect("address");
+        assert_eq!(parsed.agent, "valid-team_name.1");
+        assert_eq!(parsed.team, None);
+
+        let parsed = AgentAddress::from_str("arch-ctm@atm-dev").expect("address");
+        assert_eq!(parsed.agent, "arch-ctm");
+        assert_eq!(parsed.team.as_deref(), Some("atm-dev"));
     }
 }

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -739,12 +739,19 @@ mod tests {
 
     #[test]
     fn normalize_json_number_preserves_raw_string_for_large_exponents() {
+        // 1e63 expands to 64 chars (max allowed); 1e64 expands to 65 chars
+        // (one over limit, capped).
         assert_eq!(normalize_json_number("1e1000000000"), "1e1000000000");
         assert_eq!(normalize_json_number("1e64"), "1e64");
         assert_eq!(
             normalize_json_number("1e63"),
             format!("1{}", "0".repeat(63))
         );
+    }
+
+    #[test]
+    fn normalize_json_number_handles_point_index_zero_boundary() {
+        assert_eq!(normalize_json_number("5e-1"), "0.5");
     }
 
     #[test]

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -536,6 +536,8 @@ impl ObservabilityPort for NullObservability {
 /// This function does not panic on malformed exponents. If exponent parsing
 /// fails unexpectedly, it logs a warning and preserves the original string.
 fn normalize_json_number(raw: &str) -> String {
+    const MAX_NORMALIZED_JSON_NUMBER_LEN: usize = 64;
+
     let (negative, unsigned) = match raw.strip_prefix('-') {
         Some(rest) => (true, rest),
         None => (false, raw),
@@ -578,6 +580,21 @@ fn normalize_json_number(raw: &str) -> String {
         scale += 1;
     }
 
+    if normalized_number_len_exceeds_limit(
+        negative,
+        digits.len(),
+        scale,
+        MAX_NORMALIZED_JSON_NUMBER_LEN,
+    ) {
+        warn!(
+            code = %AtmErrorCode::WarningMalformedAtmFieldIgnored,
+            raw,
+            max_normalized_len = MAX_NORMALIZED_JSON_NUMBER_LEN,
+            "JSON number exponent too large to normalize; preserving original value"
+        );
+        return raw.to_string();
+    }
+
     let unsigned = if scale >= 0 {
         format!("{digits}{}", "0".repeat(scale as usize))
     } else {
@@ -595,6 +612,28 @@ fn normalize_json_number(raw: &str) -> String {
     } else {
         unsigned
     }
+}
+
+fn normalized_number_len_exceeds_limit(
+    negative: bool,
+    digits_len: usize,
+    scale: i64,
+    max_len: usize,
+) -> bool {
+    let unsigned_len = if scale >= 0 {
+        digits_len.saturating_add(scale as usize)
+    } else {
+        let point_index = digits_len as i64 + scale;
+        if point_index > 0 {
+            digits_len.saturating_add(1)
+        } else {
+            digits_len
+                .saturating_add((-point_index) as usize)
+                .saturating_add(2)
+        }
+    };
+    let total_len = unsigned_len.saturating_add(usize::from(negative));
+    total_len > max_len
 }
 
 #[cfg(test)]
@@ -696,6 +735,16 @@ mod tests {
     #[test]
     fn normalize_json_number_preserves_raw_string_for_malformed_exponent() {
         assert_eq!(normalize_json_number("1e-not-a-number"), "1e-not-a-number");
+    }
+
+    #[test]
+    fn normalize_json_number_preserves_raw_string_for_large_exponents() {
+        assert_eq!(normalize_json_number("1e1000000000"), "1e1000000000");
+        assert_eq!(normalize_json_number("1e64"), "1e64");
+        assert_eq!(
+            normalize_json_number("1e63"),
+            format!("1{}", "0".repeat(63))
+        );
     }
 
     #[test]

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2052,6 +2052,6 @@ closed before the 1.0 release.
   eliminated and documented.
 
   Required behavior:
-  - `observability.rs:529` — replace `.expect("valid JSON number exponent")`
+  - `observability.rs:538` — replace `.expect("valid JSON number exponent")`
     with a graceful fallback that returns the raw input string on parse failure
   - a library function must not panic on potentially untrusted input


### PR DESCRIPTION
## Summary

- **H-1**: Add path-segment validation to `AgentAddress::from_str` — rejects path separators, `..`, and traversal sequences before any path construction in `address.rs` / `home.rs`
- **M-2**: Cap `normalize_json_number` expansion to 64 chars — returns raw string + emits `warn!(code = %AtmErrorCode::WarningMalformedAtmFieldIgnored)` for large exponents

## Requirements

- REQ-SEC-001: All user-supplied team/agent name segments validated before path construction
- REQ-SEC-002: JSON number normalization must not allocate unbounded memory

## Test plan

- `AgentAddress::from_str` rejects `../evil`, `../../passwd`, names with path separators ✓
- `AgentAddress::from_str` accepts `arch-ctm`, `valid-team_name.1` ✓
- `normalize_json_number` with exponent > 64 chars returns raw string + warning ✓
- `cargo test --workspace` pass
- `cargo clippy --workspace --all-targets -- -D warnings` clean

## Context

Phase O Sprint O.1. Closes CR001 findings H-1 and M-2. PR targets `integrate/phase-O`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)