### PR TITLE
Phase O: Security and Hardening (H-1, M-2, C-1, H-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -126,9 +126,9 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -373,12 +373,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -397,9 +397,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -419,9 +419,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -572,9 +572,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -672,9 +672,9 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1049,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1059,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1072,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/atm-core", "crates/atm"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tokio = { version = "1", features = ["rt"] }
+uuid = { version = "1", features = ["serde", "v4"] }

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -26,7 +26,7 @@ libc = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"
 ulid = { version = "1.2.1", features = ["serde"] }
-uuid = { version = "1", features = ["serde", "v4"] }
+uuid.workspace = true
 fs2 = "0.4"
 
 [dev-dependencies]

--- a/crates/atm-core/src/address.rs
+++ b/crates/atm-core/src/address.rs
@@ -19,29 +19,60 @@ impl FromStr for AgentAddress {
 
         match trimmed.split_once('@') {
             Some((agent, team)) => {
-                if agent.is_empty() {
-                    return Err(AtmError::address_parse("agent name must not be empty"));
-                }
-                if team.is_empty() {
-                    return Err(AtmError::address_parse("team name must not be empty"));
-                }
-                if team.contains('@') {
-                    return Err(AtmError::address_parse(
-                        "address must contain at most one @ separator",
-                    ));
-                }
+                validate_path_segment(agent, "agent")?;
+                validate_path_segment(team, "team")?;
 
                 Ok(Self {
                     agent: agent.to_string(),
                     team: Some(team.to_string()),
                 })
             }
-            None => Ok(Self {
-                agent: trimmed.to_string(),
-                team: None,
-            }),
+            None => {
+                validate_path_segment(trimmed, "agent")?;
+                Ok(Self {
+                    agent: trimmed.to_string(),
+                    team: None,
+                })
+            }
         }
     }
+}
+
+fn validate_path_segment(value: &str, kind: &str) -> Result<(), AtmError> {
+    if value.is_empty() {
+        return Err(AtmError::address_parse(format!(
+            "{kind} name must not be empty"
+        )));
+    }
+
+    if value.starts_with('.') {
+        return Err(AtmError::address_parse(format!(
+            "{kind} name must not start with '.'"
+        )));
+    }
+
+    if value.contains("..") {
+        return Err(AtmError::address_parse(format!(
+            "{kind} name must not contain '..'"
+        )));
+    }
+
+    if value.contains(['/', '\\']) {
+        return Err(AtmError::address_parse(format!(
+            "{kind} name must not contain path separators"
+        )));
+    }
+
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        return Err(AtmError::address_parse(format!(
+            "{kind} name contains invalid characters"
+        )));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -74,5 +105,27 @@ mod tests {
     fn rejects_invalid_team_segment() {
         assert!(AgentAddress::from_str("arch-ctm@").is_err());
         assert!(AgentAddress::from_str("arch-ctm@atm@dev").is_err());
+    }
+
+    #[test]
+    fn rejects_path_traversal_and_separator_segments() {
+        assert!(AgentAddress::from_str("../evil").is_err());
+        assert!(AgentAddress::from_str("../../passwd").is_err());
+        assert!(AgentAddress::from_str("team/subdir").is_err());
+        assert!(AgentAddress::from_str(r"team\\subdir").is_err());
+        assert!(AgentAddress::from_str(".hidden").is_err());
+        assert!(AgentAddress::from_str("a..b@team").is_err());
+        assert!(AgentAddress::from_str("a...b@team").is_err());
+    }
+
+    #[test]
+    fn accepts_valid_segment_characters() {
+        let parsed = AgentAddress::from_str("valid-team_name.1").expect("address");
+        assert_eq!(parsed.agent, "valid-team_name.1");
+        assert_eq!(parsed.team, None);
+
+        let parsed = AgentAddress::from_str("arch-ctm@atm-dev").expect("address");
+        assert_eq!(parsed.agent, "arch-ctm");
+        assert_eq!(parsed.team.as_deref(), Some("atm-dev"));
     }
 }

--- a/crates/atm-core/src/address.rs
+++ b/crates/atm-core/src/address.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::str::FromStr;
 
 use crate::error::AtmError;
@@ -38,7 +39,16 @@ impl FromStr for AgentAddress {
     }
 }
 
-fn validate_path_segment(value: &str, kind: &str) -> Result<(), AtmError> {
+impl fmt::Display for AgentAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.team {
+            Some(team) => write!(f, "{}@{}", self.agent, team),
+            None => f.write_str(&self.agent),
+        }
+    }
+}
+
+pub(crate) fn validate_path_segment(value: &str, kind: &str) -> Result<(), AtmError> {
     if value.is_empty() {
         return Err(AtmError::address_parse(format!(
             "{kind} name must not be empty"
@@ -127,5 +137,21 @@ mod tests {
         let parsed = AgentAddress::from_str("arch-ctm@atm-dev").expect("address");
         assert_eq!(parsed.agent, "arch-ctm");
         assert_eq!(parsed.team.as_deref(), Some("atm-dev"));
+    }
+
+    #[test]
+    fn display_round_trips_bare_and_qualified_addresses() {
+        assert_eq!(
+            AgentAddress::from_str("arch-ctm")
+                .expect("address")
+                .to_string(),
+            "arch-ctm"
+        );
+        assert_eq!(
+            AgentAddress::from_str("arch-ctm@atm-dev")
+                .expect("address")
+                .to_string(),
+            "arch-ctm@atm-dev"
+        );
     }
 }

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -443,6 +443,36 @@ mod tests {
     }
 
     #[test]
+    fn run_doctor_reports_invalid_team_override_as_address_error() {
+        let paths = TestPaths::new();
+        let report = run_doctor(
+            DoctorQuery {
+                home_dir: paths.home_dir.clone(),
+                current_dir: paths.current_dir.clone(),
+                team_override: Some("../evil".into()),
+            },
+            &StubObservability {
+                health: StubHealth::Ok(AtmObservabilityHealth {
+                    active_log_path: Some(paths.active_log_path.clone()),
+                    logging_state: AtmObservabilityHealthState::Healthy,
+                    query_state: Some(AtmObservabilityHealthState::Healthy),
+                    detail: None,
+                }),
+            },
+        )
+        .expect("doctor report");
+
+        assert!(report.member_roster.is_none());
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.code == AtmErrorCode::AddressParseFailed),
+            "{report:#?}"
+        );
+    }
+
+    #[test]
     fn run_doctor_reports_obsolete_identity_drift_as_warning() {
         let paths = TestPaths::new();
         paths.write_team_layout(&["arch-ctm"]);

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
+use crate::address::validate_path_segment;
 use crate::error::AtmError;
 
 /// Resolve the ATM home directory for the current process.
@@ -42,10 +43,12 @@ pub fn inbox_path(team: &str, agent: &str) -> Result<PathBuf, AtmError> {
 ///
 /// # Errors
 ///
-/// This helper is currently infallible after `home_dir` resolution. The
-/// `Result` shape is retained so callers can share one path-construction
-/// contract with helpers that may grow validation in the future.
+/// Returns [`AtmError`] with
+/// [`crate::error_codes::AtmErrorCode::AddressParseFailed`] when `team`
+/// contains path traversal, path separators, or other invalid path-segment
+/// characters.
 pub fn team_dir_from_home(home_dir: &Path, team: &str) -> Result<PathBuf, AtmError> {
+    validate_path_segment(team, "team")?;
     Ok(home_dir.join(".claude").join("teams").join(team))
 }
 
@@ -53,10 +56,12 @@ pub fn team_dir_from_home(home_dir: &Path, team: &str) -> Result<PathBuf, AtmErr
 ///
 /// # Errors
 ///
-/// This helper is currently infallible after `home_dir` resolution. The
-/// `Result` shape is retained so callers can share one path-construction
-/// contract with helpers that may grow validation in the future.
+/// Returns [`AtmError`] with
+/// [`crate::error_codes::AtmErrorCode::AddressParseFailed`] when `team` or
+/// `agent` contains path traversal, path separators, or other invalid
+/// path-segment characters.
 pub fn inbox_path_from_home(home_dir: &Path, team: &str, agent: &str) -> Result<PathBuf, AtmError> {
+    validate_path_segment(agent, "agent")?;
     Ok(team_dir_from_home(home_dir, team)?
         .join("inboxes")
         .join(format!("{agent}.json")))
@@ -81,7 +86,7 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use super::{atm_home, inbox_path, team_dir};
+    use super::{atm_home, inbox_path, inbox_path_from_home, team_dir, team_dir_from_home};
 
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -181,5 +186,24 @@ mod tests {
                 .join("inboxes")
                 .join("arch-ctm.json")
         );
+    }
+
+    #[test]
+    fn team_dir_from_home_rejects_path_traversal_segments() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let error = team_dir_from_home(tempdir.path(), "../evil").expect_err("invalid team");
+
+        assert!(error.is_address());
+        assert!(error.message.contains("team name"));
+    }
+
+    #[test]
+    fn inbox_path_from_home_rejects_path_traversal_segments() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let error =
+            inbox_path_from_home(tempdir.path(), "atm-dev", "../evil").expect_err("invalid agent");
+
+        assert!(error.is_address());
+        assert!(error.message.contains("agent name"));
     }
 }

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -1,7 +1,7 @@
 /// Acknowledgement workflows for ack-required mailbox messages.
 pub mod ack;
-/// Internal agent-address parsing and normalization helpers.
-pub(crate) mod address;
+/// Public agent-address parsing and normalization helpers.
+pub mod address;
 /// Mailbox cleanup workflows for read and acknowledged messages.
 pub mod clear;
 /// Internal configuration discovery and resolution helpers.

--- a/crates/atm-core/src/mailbox/source.rs
+++ b/crates/atm-core/src/mailbox/source.rs
@@ -300,4 +300,22 @@ mod tests {
         assert!(error.is_mailbox_lock());
         assert!(error.message.contains("source path set changed"));
     }
+
+    #[test]
+    fn discover_source_paths_rejects_invalid_team_segment() {
+        let tempdir = tempdir().expect("tempdir");
+        let error =
+            super::discover_source_paths(tempdir.path(), "../evil", "arch-ctm").expect_err("team");
+
+        assert!(error.is_address());
+    }
+
+    #[test]
+    fn discover_source_paths_rejects_invalid_agent_segment() {
+        let tempdir = tempdir().expect("tempdir");
+        let error =
+            super::discover_source_paths(tempdir.path(), "atm-dev", "../evil").expect_err("agent");
+
+        assert!(error.is_address());
+    }
 }

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -536,6 +536,7 @@ impl ObservabilityPort for NullObservability {
 /// This function does not panic on malformed exponents. If exponent parsing
 /// fails unexpectedly, it logs a warning and preserves the original string.
 fn normalize_json_number(raw: &str) -> String {
+    const MAX_ABS_NORMALIZED_JSON_EXPONENT: i64 = 128;
     const MAX_NORMALIZED_JSON_NUMBER_LEN: usize = 64;
 
     let (negative, unsigned) = match raw.strip_prefix('-') {
@@ -557,13 +558,35 @@ fn normalize_json_number(raw: &str) -> String {
         },
         None => (unsigned, 0),
     };
+    if !(-MAX_ABS_NORMALIZED_JSON_EXPONENT..=MAX_ABS_NORMALIZED_JSON_EXPONENT).contains(&exponent) {
+        warn!(
+            code = %AtmErrorCode::WarningMalformedAtmFieldIgnored,
+            raw,
+            exponent,
+            max_abs_exponent = MAX_ABS_NORMALIZED_JSON_EXPONENT,
+            "JSON number exponent exceeds supported normalization range; preserving original value"
+        );
+        return raw.to_string();
+    }
     let (integer, fraction) = match base.split_once('.') {
         Some((integer, fraction)) => (integer, fraction),
         None => (base, ""),
     };
 
     let mut digits = format!("{integer}{fraction}");
-    let mut scale = exponent - fraction.len() as i64;
+    let mut scale = match exponent.checked_sub(fraction.len() as i64) {
+        Some(scale) => scale,
+        None => {
+            warn!(
+                code = %AtmErrorCode::WarningMalformedAtmFieldIgnored,
+                raw,
+                exponent,
+                fraction_len = fraction.len(),
+                "JSON number exponent scaling overflowed; preserving original value"
+            );
+            return raw.to_string();
+        }
+    };
 
     let trimmed = digits.trim_start_matches('0');
     digits = if trimmed.is_empty() {
@@ -577,7 +600,17 @@ fn normalize_json_number(raw: &str) -> String {
 
     while digits.ends_with('0') {
         digits.pop();
-        scale += 1;
+        scale = match scale.checked_add(1) {
+            Some(scale) => scale,
+            None => {
+                warn!(
+                    code = %AtmErrorCode::WarningMalformedAtmFieldIgnored,
+                    raw,
+                    "JSON number exponent normalization overflowed; preserving original value"
+                );
+                return raw.to_string();
+            }
+        };
     }
 
     if normalized_number_len_exceeds_limit(
@@ -752,6 +785,22 @@ mod tests {
     #[test]
     fn normalize_json_number_handles_point_index_zero_boundary() {
         assert_eq!(normalize_json_number("5e-1"), "0.5");
+    }
+
+    #[test]
+    fn normalize_json_number_preserves_raw_string_for_min_i64_exponent() {
+        assert_eq!(
+            normalize_json_number("1.0e-9223372036854775808"),
+            "1.0e-9223372036854775808"
+        );
+    }
+
+    #[test]
+    fn normalize_json_number_preserves_raw_string_for_max_i64_exponent() {
+        assert_eq!(
+            normalize_json_number("10e9223372036854775807"),
+            "10e9223372036854775807"
+        );
     }
 
     #[test]

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -536,6 +536,8 @@ impl ObservabilityPort for NullObservability {
 /// This function does not panic on malformed exponents. If exponent parsing
 /// fails unexpectedly, it logs a warning and preserves the original string.
 fn normalize_json_number(raw: &str) -> String {
+    const MAX_NORMALIZED_JSON_NUMBER_LEN: usize = 64;
+
     let (negative, unsigned) = match raw.strip_prefix('-') {
         Some(rest) => (true, rest),
         None => (false, raw),
@@ -578,6 +580,21 @@ fn normalize_json_number(raw: &str) -> String {
         scale += 1;
     }
 
+    if normalized_number_len_exceeds_limit(
+        negative,
+        digits.len(),
+        scale,
+        MAX_NORMALIZED_JSON_NUMBER_LEN,
+    ) {
+        warn!(
+            code = %AtmErrorCode::WarningMalformedAtmFieldIgnored,
+            raw,
+            max_normalized_len = MAX_NORMALIZED_JSON_NUMBER_LEN,
+            "JSON number exponent too large to normalize; preserving original value"
+        );
+        return raw.to_string();
+    }
+
     let unsigned = if scale >= 0 {
         format!("{digits}{}", "0".repeat(scale as usize))
     } else {
@@ -595,6 +612,28 @@ fn normalize_json_number(raw: &str) -> String {
     } else {
         unsigned
     }
+}
+
+fn normalized_number_len_exceeds_limit(
+    negative: bool,
+    digits_len: usize,
+    scale: i64,
+    max_len: usize,
+) -> bool {
+    let unsigned_len = if scale >= 0 {
+        digits_len.saturating_add(scale as usize)
+    } else {
+        let point_index = digits_len as i64 + scale;
+        if point_index > 0 {
+            digits_len.saturating_add(1)
+        } else {
+            digits_len
+                .saturating_add((-point_index) as usize)
+                .saturating_add(2)
+        }
+    };
+    let total_len = unsigned_len.saturating_add(usize::from(negative));
+    total_len > max_len
 }
 
 #[cfg(test)]
@@ -696,6 +735,23 @@ mod tests {
     #[test]
     fn normalize_json_number_preserves_raw_string_for_malformed_exponent() {
         assert_eq!(normalize_json_number("1e-not-a-number"), "1e-not-a-number");
+    }
+
+    #[test]
+    fn normalize_json_number_preserves_raw_string_for_large_exponents() {
+        // 1e63 expands to 64 chars (max allowed); 1e64 expands to 65 chars
+        // (one over limit, capped).
+        assert_eq!(normalize_json_number("1e1000000000"), "1e1000000000");
+        assert_eq!(normalize_json_number("1e64"), "1e64");
+        assert_eq!(
+            normalize_json_number("1e63"),
+            format!("1{}", "0".repeat(63))
+        );
+    }
+
+    #[test]
+    fn normalize_json_number_handles_point_index_zero_boundary() {
+        assert_eq!(normalize_json_number("5e-1"), "0.5");
     }
 
     #[test]

--- a/crates/atm-core/src/persistence.rs
+++ b/crates/atm-core/src/persistence.rs
@@ -1,10 +1,9 @@
 use std::fs::{self, File};
 use std::io::Write;
-use std::path::Path;
-
-use chrono::Utc;
+use std::path::{Path, PathBuf};
 
 use crate::error::{AtmError, AtmErrorKind};
+use uuid::Uuid;
 
 /// Atomically replace one shared mutable ATM-owned state file.
 ///
@@ -36,14 +35,7 @@ pub(crate) fn atomic_write_bytes(
         })?;
     }
 
-    let temp_path = path.with_file_name(format!(
-        ".{}.tmp.{}.{}",
-        path.file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or(label),
-        std::process::id(),
-        Utc::now().timestamp_nanos_opt().unwrap_or_default()
-    ));
+    let temp_path = temp_path_for_atomic_write(path, label);
 
     {
         let mut file = File::create(&temp_path).map_err(|error| {
@@ -91,6 +83,17 @@ pub(crate) fn atomic_write_bytes(
     })?;
     sync_parent_directory(path, kind, label, recovery)?;
     Ok(())
+}
+
+fn temp_path_for_atomic_write(path: &Path, label: &str) -> PathBuf {
+    path.with_file_name(format!(
+        ".{}.tmp.{}.{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(label),
+        std::process::id(),
+        Uuid::new_v4()
+    ))
 }
 
 pub(crate) fn atomic_write_string(
@@ -174,7 +177,7 @@ mod tests {
     use serial_test::serial;
     use tempfile::tempdir;
 
-    use super::atomic_write_bytes;
+    use super::{atomic_write_bytes, temp_path_for_atomic_write};
     use crate::error::AtmErrorKind;
 
     fn env_lock() -> &'static Mutex<()> {
@@ -230,6 +233,31 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(&path).expect("state file"),
             r#"{"value":2}"#
+        );
+    }
+
+    #[test]
+    fn atomic_write_temp_paths_are_unique_across_rapid_writes() {
+        let tempdir = tempdir().expect("tempdir");
+        let path = tempdir.path().join("state.json");
+
+        let first = temp_path_for_atomic_write(&path, "state file");
+        let second = temp_path_for_atomic_write(&path, "state file");
+
+        assert_ne!(first, second);
+        assert!(
+            first
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains(".tmp.")
+        );
+        assert!(
+            second
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains(".tmp.")
         );
     }
 

--- a/crates/atm-core/src/read/seen_state.rs
+++ b/crates/atm-core/src/read/seen_state.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::address::validate_path_segment;
 use crate::error::{AtmError, AtmErrorKind};
 use crate::persistence;
 use crate::types::IsoTimestamp;
@@ -16,7 +17,7 @@ pub fn load_seen_watermark(
     team: &str,
     agent: &str,
 ) -> Result<Option<IsoTimestamp>, AtmError> {
-    let path = seen_state_path(home_dir, team, agent);
+    let path = seen_state_path(home_dir, team, agent)?;
     if !path.exists() {
         return Ok(None);
     }
@@ -59,7 +60,7 @@ pub fn save_seen_watermark(
     agent: &str,
     timestamp: IsoTimestamp,
 ) -> Result<(), AtmError> {
-    let path = seen_state_path(home_dir, team, agent);
+    let path = seen_state_path(home_dir, team, agent)?;
     persistence::atomic_write_string(
         &path,
         &timestamp.into_inner().to_rfc3339(),
@@ -69,13 +70,15 @@ pub fn save_seen_watermark(
     )
 }
 
-fn seen_state_path(home_dir: &Path, team: &str, agent: &str) -> PathBuf {
-    home_dir
+fn seen_state_path(home_dir: &Path, team: &str, agent: &str) -> Result<PathBuf, AtmError> {
+    validate_path_segment(team, "team")?;
+    validate_path_segment(agent, "agent")?;
+    Ok(home_dir
         .join(".claude")
         .join("teams")
         .join(team)
         .join(".seen")
-        .join(agent)
+        .join(agent))
 }
 
 #[cfg(test)]
@@ -107,5 +110,30 @@ mod tests {
         let loaded = load_seen_watermark(tempdir.path(), "atm-dev", "arch-ctm").expect("load");
 
         assert_eq!(loaded, Some(timestamp));
+    }
+
+    #[test]
+    fn load_seen_state_rejects_invalid_team_segment() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let error =
+            load_seen_watermark(tempdir.path(), "../evil", "arch-ctm").expect_err("invalid team");
+
+        assert!(error.is_address());
+    }
+
+    #[test]
+    fn save_seen_state_rejects_invalid_agent_segment() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let timestamp = IsoTimestamp::from_datetime(
+            chrono::Utc
+                .with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                .single()
+                .expect("timestamp"),
+        );
+
+        let error = save_seen_watermark(tempdir.path(), "atm-dev", "../evil", timestamp)
+            .expect_err("invalid agent");
+
+        assert!(error.is_address());
     }
 }

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -598,6 +598,7 @@ fn acquire_send_alert_lock(path: &Path) -> Option<SendAlertLock> {
             }
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                 if evict_stale_send_alert_lock(path) {
+                    thread::sleep(Duration::from_millis(10));
                     continue;
                 }
                 thread::sleep(Duration::from_millis(10));

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -42,7 +42,7 @@ pub struct SendRequest {
     pub home_dir: PathBuf,
     pub current_dir: PathBuf,
     pub sender_override: Option<AgentName>,
-    pub to: String,
+    pub to: AgentAddress,
     pub team_override: Option<TeamName>,
     pub message_source: SendMessageSource,
     pub summary_override: Option<String>,
@@ -277,18 +277,18 @@ pub(super) struct PostSendHookContext<'a> {
 }
 
 fn resolve_recipient(
-    target_address: &str,
+    target_address: &AgentAddress,
     team_override: Option<&str>,
     config: Option<&config::AtmConfig>,
 ) -> Result<ResolvedRecipient, AtmError> {
-    let parsed: AgentAddress = target_address.parse()?;
-    let team = parsed
+    let team = target_address
         .team
+        .clone()
         .or_else(|| config::resolve_team(team_override, config))
         .ok_or_else(AtmError::team_unavailable)?;
 
     Ok(ResolvedRecipient {
-        agent: config::aliases::resolve_agent(&parsed.agent, config),
+        agent: config::aliases::resolve_agent(&target_address.agent, config),
         team,
     })
 }

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use serde_json::Value;
 use tracing::warn;
 
+use crate::address::validate_path_segment;
 use crate::config::{load_config, load_team_config, resolve_team};
 use crate::error::{AtmError, AtmErrorCode, AtmErrorKind};
 use crate::home;
@@ -312,7 +313,7 @@ pub fn backup_team(request: BackupRequest) -> Result<BackupOutcome, AtmError> {
         )));
     }
 
-    let backup_dir = backup_root_from_home(&request.home_dir, &request.team).join(timestamp_dir());
+    let backup_dir = backup_root_from_home(&request.home_dir, &request.team)?.join(timestamp_dir());
     fs::create_dir_all(backup_dir.join("inboxes")).map_err(|error| {
         AtmError::file_policy(format!(
             "failed to create backup directory {}: {error}",
@@ -334,7 +335,7 @@ pub fn backup_team(request: BackupRequest) -> Result<BackupOutcome, AtmError> {
 
     copy_regular_files(&team_dir.join("inboxes"), &backup_dir.join("inboxes"))?;
     copy_regular_files(
-        &tasks_dir_from_home(&request.home_dir, &request.team),
+        &tasks_dir_from_home(&request.home_dir, &request.team)?,
         &backup_dir.join("tasks"),
     )?;
 
@@ -466,7 +467,7 @@ pub fn restore_team(request: RestoreRequest) -> Result<RestoreResult, AtmError> 
         })?;
     }
 
-    let tasks_dir = tasks_dir_from_home(&request.home_dir, &request.team);
+    let tasks_dir = tasks_dir_from_home(&request.home_dir, &request.team)?;
     restore_task_bucket(&backup_dir.join("tasks"), &tasks_dir)?;
     recompute_highwatermark(&tasks_dir)?;
     write_team_config(&team_dir, &updated_config).map_err(|error| {
@@ -520,12 +521,14 @@ fn teams_root_from_home(home_dir: &Path) -> PathBuf {
     home_dir.join(".claude").join("teams")
 }
 
-fn backup_root_from_home(home_dir: &Path, team: &str) -> PathBuf {
-    teams_root_from_home(home_dir).join(".backups").join(team)
+fn backup_root_from_home(home_dir: &Path, team: &str) -> Result<PathBuf, AtmError> {
+    validate_path_segment(team, "team")?;
+    Ok(teams_root_from_home(home_dir).join(".backups").join(team))
 }
 
-fn tasks_dir_from_home(home_dir: &Path, team: &str) -> PathBuf {
-    home_dir.join(".claude").join("tasks").join(team)
+fn tasks_dir_from_home(home_dir: &Path, team: &str) -> Result<PathBuf, AtmError> {
+    validate_path_segment(team, "team")?;
+    Ok(home_dir.join(".claude").join("tasks").join(team))
 }
 
 fn timestamp_dir() -> String {
@@ -653,7 +656,7 @@ fn locate_backup_dir(
         return Ok(path.to_path_buf());
     }
 
-    let root = backup_root_from_home(home_dir, team);
+    let root = backup_root_from_home(home_dir, team)?;
     if !root.exists() {
         return Err(AtmError::missing_document(format!(
             "no backup found for team '{}'",
@@ -929,4 +932,107 @@ fn clear_restore_marker(team_dir: &Path) -> Result<(), AtmError> {
         .with_source(error)
         .with_recovery("Remove the stale restore marker after verifying the restored team state.")
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::{
+        AddMemberRequest, BackupRequest, RestoreRequest, add_member, backup_root_from_home,
+        backup_team, restore_team, tasks_dir_from_home,
+    };
+    use crate::error_codes::AtmErrorCode;
+    use crate::schema::TeamConfig;
+
+    fn write_team_config(home_dir: &std::path::Path, team: &str) {
+        let team_dir = home_dir.join(".claude").join("teams").join(team);
+        std::fs::create_dir_all(&team_dir).expect("team dir");
+        std::fs::write(
+            team_dir.join("config.json"),
+            serde_json::to_vec(&TeamConfig::default()).expect("serialize config"),
+        )
+        .expect("write config");
+    }
+
+    #[test]
+    fn add_member_rejects_invalid_member_segment() {
+        let tempdir = tempdir().expect("tempdir");
+        write_team_config(tempdir.path(), "atm-dev");
+
+        let error = add_member(AddMemberRequest {
+            home_dir: tempdir.path().to_path_buf(),
+            team: "atm-dev".to_string(),
+            member: "../evil".to_string(),
+            agent_type: "worker".to_string(),
+            model: "gpt-5".to_string(),
+            cwd: tempdir.path().to_path_buf(),
+            tmux_pane_id: None,
+        })
+        .expect_err("invalid member");
+
+        assert_eq!(error.code, AtmErrorCode::AddressParseFailed);
+    }
+
+    #[test]
+    fn add_member_rejects_invalid_team_segment() {
+        let tempdir = tempdir().expect("tempdir");
+
+        let error = add_member(AddMemberRequest {
+            home_dir: tempdir.path().to_path_buf(),
+            team: "../evil".to_string(),
+            member: "arch-ctm".to_string(),
+            agent_type: "worker".to_string(),
+            model: "gpt-5".to_string(),
+            cwd: tempdir.path().to_path_buf(),
+            tmux_pane_id: None,
+        })
+        .expect_err("invalid team");
+
+        assert_eq!(error.code, AtmErrorCode::AddressParseFailed);
+    }
+
+    #[test]
+    fn backup_team_rejects_invalid_team_segment() {
+        let tempdir = tempdir().expect("tempdir");
+
+        let error = backup_team(BackupRequest {
+            home_dir: tempdir.path().to_path_buf(),
+            team: "../evil".to_string(),
+        })
+        .expect_err("invalid team");
+
+        assert_eq!(error.code, AtmErrorCode::AddressParseFailed);
+    }
+
+    #[test]
+    fn restore_team_rejects_invalid_team_segment() {
+        let tempdir = tempdir().expect("tempdir");
+
+        let error = restore_team(RestoreRequest {
+            home_dir: tempdir.path().to_path_buf(),
+            team: "../evil".to_string(),
+            from: None,
+            dry_run: false,
+        })
+        .expect_err("invalid team");
+
+        assert_eq!(error.code, AtmErrorCode::AddressParseFailed);
+    }
+
+    #[test]
+    fn backup_root_from_home_rejects_invalid_team_segment() {
+        let tempdir = tempdir().expect("tempdir");
+        let error = backup_root_from_home(tempdir.path(), "../evil").expect_err("invalid team");
+
+        assert_eq!(error.code, AtmErrorCode::AddressParseFailed);
+    }
+
+    #[test]
+    fn tasks_dir_from_home_rejects_invalid_team_segment() {
+        let tempdir = tempdir().expect("tempdir");
+        let error = tasks_dir_from_home(tempdir.path(), "../evil").expect_err("invalid team");
+
+        assert_eq!(error.code, AtmErrorCode::AddressParseFailed);
+    }
 }

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -6,6 +6,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use atm_core::ack::{AckRequest, ack_mail};
+use atm_core::address::AgentAddress;
 use atm_core::clear::{ClearQuery, clear_mail};
 use atm_core::error::AtmErrorCode;
 use atm_core::observability::NullObservability;
@@ -563,7 +564,7 @@ impl Fixture {
             home_dir: self.tempdir.path().to_path_buf(),
             current_dir: self.tempdir.path().to_path_buf(),
             sender_override: Some(sender.into()),
-            to: to.to_string(),
+            to: to.parse::<AgentAddress>().expect("address"),
             team_override: Some("atm-dev".into()),
             message_source: SendMessageSource::Inline(text.to_string()),
             summary_override: None,

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use atm_core::address::AgentAddress;
 use atm_core::home;
 use atm_core::send::{self, SendMessageSource, SendRequest};
 use atm_core::types::{AgentName, TeamName};
@@ -55,13 +56,14 @@ impl SendCommand {
         let current_dir = std::env::current_dir()?;
         let home_dir = home::atm_home()?;
         let message_source = self.build_message_source()?;
+        let to: AgentAddress = self.to.parse()?;
 
         let outcome = send::send_mail(
             SendRequest {
                 home_dir,
                 current_dir,
                 sender_override: self.from.map(AgentName::from),
-                to: self.to,
+                to,
                 team_override: self.team.map(TeamName::from),
                 message_source,
                 summary_override: self.summary,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1557,10 +1557,10 @@ identity resolution order.
 
 ### 20.3 normalize_json_number Panic Removal
 
-`observability.rs` currently contains `.expect("valid JSON number exponent")` in
-`normalize_json_number(...)` at the exponent parse site. Phase M replaces that panic
-with graceful fallback: on parse failure, return the raw string unchanged and emit
-`tracing::warn!`. A library function must not panic on potentially untrusted input.
+`normalize_json_number(...)` must not panic on untrusted numeric text. Phase M
+replaces the old panic path with graceful fallback: on exponent parse failure or
+unsupported exponent range, return the raw string unchanged and emit `tracing::warn!`.
+A library function must not panic on potentially untrusted input.
 
 ### 20.4 Error-Surface Audit Methodology
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2052,6 +2052,6 @@ closed before the 1.0 release.
   eliminated and documented.
 
   Required behavior:
-  - `observability.rs:529` — replace `.expect("valid JSON number exponent")`
+  - `observability.rs:538` — replace `.expect("valid JSON number exponent")`
     with a graceful fallback that returns the raw input string on parse failure
   - a library function must not panic on potentially untrusted input

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2052,6 +2052,6 @@ closed before the 1.0 release.
   eliminated and documented.
 
   Required behavior:
-  - `observability.rs:538` — replace `.expect("valid JSON number exponent")`
-    with a graceful fallback that returns the raw input string on parse failure
+  - `normalize_json_number(...)` must return the raw input string on exponent
+    parse failure or unsupported exponent range instead of panicking
   - a library function must not panic on potentially untrusted input


### PR DESCRIPTION
## Summary

Phase O security and hardening — two sprints, both QA-verified and CI-green.

- **O.1 (H-1, M-2)**: Input validation and allocation safety
  - `AgentAddress::from_str` now rejects path traversal (`../evil`, `../../passwd`), path separators, and consecutive periods
  - `normalize_json_number` caps expansion at 64 chars; returns raw + emits `warn!(code=WarningMalformedAtmFieldIgnored)` for large exponents
  - Satisfies REQ-SEC-001, REQ-SEC-002

- **O.2 (C-1, H-2)**: Filesystem durability and lock hardening
  - Atomic write temp suffix replaced: `timestamp_nanos` → `Uuid::new_v4()` (collision-proof)
  - `acquire_send_alert_lock` spin-loop now sleeps on every `AlreadyExists` regardless of eviction outcome
  - `uuid` hoisted to workspace dependency
  - Satisfies REQ-DURABILITY-001

## QA

| Sprint | Run | Verdict |
|--------|-----|---------|
| O.1 | R1 | FAIL (5 findings) |
| O.1 | R2 (post-FIX-R1) | **PASS** |
| O.2 | R1 | FAIL (uuid not workspace dep) |
| O.2 | R2 (post-FIX-R1) | **PASS** |

243 tests passing, clippy clean, all 5 CI checks green on macOS/Ubuntu/Windows.

## Test plan
- [ ] CI passes on this PR
- [ ] User reviews and approves merge to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)