### PR TITLE
fix: normalize add-member tmux schema (#102)

### DIFF
--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::address::validate_path_segment;
@@ -265,15 +265,22 @@ pub fn add_member(request: AddMemberRequest) -> Result<AddMemberOutcome, AtmErro
     let inbox_path = home::inbox_path_from_home(&request.home_dir, &request.team, &request.member)?;
     let created_inbox = ensure_inbox_exists(&inbox_path)?;
 
+    let normalized_tmux_pane_id = normalize_tmux_pane_id(request.tmux_pane_id.as_deref())?;
+    let mut extra = serde_json::Map::new();
+    if normalized_tmux_pane_id.is_some() {
+        extra.insert("backendType".to_string(), json!("tmux"));
+        extra.insert("isActive".to_string(), json!(true));
+    }
+
     config.members.push(AgentMember {
         name: request.member.clone(),
         agent_id: format!("{}@{}", request.member, request.team),
         agent_type: request.agent_type,
         model: request.model,
         joined_at: Some(Utc::now().timestamp_millis() as u64),
-        tmux_pane_id: request.tmux_pane_id.unwrap_or_default(),
+        tmux_pane_id: normalized_tmux_pane_id.unwrap_or_default(),
         cwd: request.cwd.display().to_string(),
-        extra: serde_json::Map::new(),
+        extra,
     });
 
     if let Err(error) = write_team_config(&team_dir, &config) {
@@ -841,6 +848,7 @@ fn recompute_highwatermark(tasks_dir: &Path) -> Result<usize, AtmError> {
 fn clear_runtime_member_state(member: &mut AgentMember) {
     member.tmux_pane_id.clear();
     for key in [
+        "backendType",
         "sessionId",
         "activity",
         "status",
@@ -852,6 +860,27 @@ fn clear_runtime_member_state(member: &mut AgentMember) {
     ] {
         member.extra.remove(key);
     }
+}
+
+fn normalize_tmux_pane_id(pane_id: Option<&str>) -> Result<Option<String>, AtmError> {
+    let Some(raw) = pane_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+
+    if let Some(rest) = raw.strip_prefix('%') {
+        if !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_digit()) {
+            return Ok(Some(raw.to_string()));
+        }
+    } else if raw.chars().all(|ch| ch.is_ascii_digit()) {
+        return Ok(Some(format!("%{raw}")));
+    }
+
+    Err(AtmError::validation(format!(
+        "tmux pane id '{raw}' must use the tmux pane format '%<number>' or a bare numeric pane id",
+    ))
+    .with_recovery(
+        "Pass `--pane-id $(tmux display-message -p '#{pane_id}')` or a bare numeric pane id when registering a tmux-backed member.",
+    ))
 }
 
 fn restore_marker_path(team_dir: &Path) -> PathBuf {
@@ -990,6 +1019,58 @@ mod tests {
         .expect_err("invalid team");
 
         assert_eq!(error.code, AtmErrorCode::AddressParseFailed);
+    }
+
+    #[test]
+    fn add_member_normalizes_tmux_shape_when_pane_is_provided() {
+        let tempdir = tempdir().expect("tempdir");
+        write_team_config(tempdir.path(), "atm-dev");
+
+        add_member(AddMemberRequest {
+            home_dir: tempdir.path().to_path_buf(),
+            team: "atm-dev".to_string(),
+            member: "arch-ctm".to_string(),
+            agent_type: "worker".to_string(),
+            model: "gpt-5".to_string(),
+            cwd: tempdir.path().to_path_buf(),
+            tmux_pane_id: Some("7".to_string()),
+        })
+        .expect("add member");
+
+        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
+        let config: TeamConfig = serde_json::from_slice(
+            &std::fs::read(team_dir.join("config.json")).expect("read config"),
+        )
+        .expect("parse config");
+        let member = config
+            .members
+            .iter()
+            .find(|member| member.name == "arch-ctm")
+            .expect("member");
+
+        assert_eq!(member.tmux_pane_id, "%7");
+        assert_eq!(member.extra["backendType"], serde_json::json!("tmux"));
+        assert_eq!(member.extra["isActive"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn add_member_rejects_non_canonical_tmux_target_syntax() {
+        let tempdir = tempdir().expect("tempdir");
+        write_team_config(tempdir.path(), "atm-dev");
+
+        let error = add_member(AddMemberRequest {
+            home_dir: tempdir.path().to_path_buf(),
+            team: "atm-dev".to_string(),
+            member: "arch-ctm".to_string(),
+            agent_type: "worker".to_string(),
+            model: "gpt-5".to_string(),
+            cwd: tempdir.path().to_path_buf(),
+            tmux_pane_id: Some("session:1.2".to_string()),
+        })
+        .expect_err("invalid pane id");
+
+        assert_eq!(error.code, AtmErrorCode::MessageValidationFailed);
+        assert!(error.message.contains("tmux pane id"));
     }
 
     #[test]

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -39,7 +39,10 @@ struct AddMemberCommand {
     #[arg(long)]
     cwd: Option<PathBuf>,
 
-    #[arg(long = "pane-id")]
+    #[arg(
+        long = "pane-id",
+        help = "tmux pane id in '%<number>' form or a bare numeric pane id"
+    )]
     pane_id: Option<String>,
 
     #[arg(long)]

--- a/crates/atm/tests/team_recovery.rs
+++ b/crates/atm/tests/team_recovery.rs
@@ -99,6 +99,63 @@ fn test_add_member_rejects_duplicates_and_creates_inbox_state() {
 }
 
 #[test]
+fn test_add_member_normalizes_tmux_member_shape() {
+    let fixture = Fixture::new();
+    fixture.write_team_config_value("atm-dev", json!({"members":[{"name":"team-lead"}]}));
+
+    let added = fixture.run(&[
+        "teams",
+        "add-member",
+        "atm-dev",
+        "arch-ctm",
+        "--agent-type",
+        "general-purpose",
+        "--model",
+        "sonnet",
+        "--pane-id",
+        "12",
+        "--json",
+    ]);
+    assert!(added.status.success(), "stderr: {}", fixture.stderr(&added));
+
+    let config = fixture.read_team_config_value("atm-dev");
+    let member = config["members"]
+        .as_array()
+        .expect("members")
+        .iter()
+        .find(|member| member["name"] == "arch-ctm")
+        .expect("arch-ctm member");
+    assert_eq!(member["tmuxPaneId"], "%12");
+    assert_eq!(member["backendType"], "tmux");
+    assert_eq!(member["isActive"], true);
+}
+
+#[test]
+fn test_add_member_rejects_non_canonical_tmux_target_syntax() {
+    let fixture = Fixture::new();
+    fixture.write_team_config_value("atm-dev", json!({"members":[{"name":"team-lead"}]}));
+
+    let output = fixture.run(&[
+        "teams",
+        "add-member",
+        "atm-dev",
+        "arch-ctm",
+        "--agent-type",
+        "general-purpose",
+        "--model",
+        "sonnet",
+        "--pane-id",
+        "session:1.2",
+    ]);
+    assert!(!output.status.success());
+    assert!(
+        fixture.stderr(&output).contains("tmux pane id"),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+}
+
+#[test]
 fn test_add_member_rolls_back_inbox_when_config_write_fails() {
     let fixture = Fixture::new();
     fixture.write_team_config_value("atm-dev", json!({"members":[{"name":"team-lead"}]}));

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -912,6 +912,10 @@ Architectural rules:
   ATM home directory
 - `add-member` is the retained local roster-repair path and must reject
   duplicates before mutating config
+- when `add-member` registers a tmux-backed member, it should persist
+  `tmuxPaneId` in canonical `%<number>` form and set `backendType = "tmux"`
+  plus `isActive = true`; unsupported tmux target syntax should fail fast
+  instead of being guessed into a routing handle
 - `backup` snapshots current team config, inboxes, and the ATM team task
   bucket into a timestamped snapshot directory
 - `restore` is a local recovery path and must:

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -135,6 +135,15 @@ Current `AgentMember` persisted schema:
 - `extra: serde_json::Map<String, serde_json::Value>` via `#[serde(flatten)]`
   for forward-compatible Claude Code fields
 
+ATM-owned member normalization rules:
+- `agentId`, `name`, `agentType`, `model`, and `cwd` are the persisted routing
+  identity fields ATM writes during `teams add-member`
+- tmux-backed members use canonical `tmuxPaneId` values in `%<number>` form
+- when ATM writes a tmux-backed member, it also sets `backendType = "tmux"` and
+  `isActive = true` in `extra`
+- unsupported tmux target syntax such as `session:window.pane` must be rejected
+  rather than guessed into a pane handle
+
 Observability boundary note:
 - `AgentMember.extra` is intentionally out of scope for the L.4 observability
   field-model cleanup

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -339,6 +339,11 @@ Required service rules:
   on daemon orchestration or runtime spawning
 - `add-member` must validate team existence and reject duplicate member names
   before mutating local team config
+- when `add-member` receives a pane id, it must persist `tmuxPaneId` in
+  canonical tmux `%<number>` form, set `backendType = "tmux"`, and mark the
+  member `isActive = true`
+- `add-member` must reject unsupported tmux target syntax such as
+  `session:window.pane` rather than guessing a pane handle
 - backup must snapshot:
   - `config.json`
   - team inbox files

--- a/docs/atm/commands/teams.md
+++ b/docs/atm/commands/teams.md
@@ -10,6 +10,10 @@ CLI ownership for `atm teams`:
 Core team discovery, roster mutation, and backup/restore behavior remains
 owned by `atm-core`.
 
+CLI note:
+- `teams add-member --pane-id` accepts tmux pane ids in `%<number>` form or a
+  bare numeric pane id that ATM canonicalizes to `%<number>`
+
 References:
 
 - Product requirements: `docs/requirements.md` §12

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1279,6 +1279,13 @@ Bare `atm teams` must:
 - validate that the target team exists
 - reject duplicate member names
 - persist the new member entry deterministically in team config
+- write `tmuxPaneId` in canonical tmux `%<number>` form when `--pane-id` is
+  provided; bare numeric pane ids may be normalized to that form, but
+  `session:window.pane` target syntax must be rejected rather than guessed
+- set `backendType = "tmux"` and `isActive = true` on the persisted member
+  record when `--pane-id` is provided
+- preserve `name`, `agentId`, `agentType`, `model`, and `cwd` as the
+  persisted routing identity fields written by ATM
 - create any required local inbox state atomically with the roster update
 
 `atm teams backup` must:


### PR DESCRIPTION
## Summary

- Canonicalizes tmux pane IDs to `%<number>` format in `add-member`
- Rejects unsupported `session:window.pane` syntax with clear error
- Writes `backendType='tmux'` and `isActive=true` for tmux-backed members
- Clears `backendType` on restore to avoid stale state
- Updates docs and tests for the member-routing contract

Fixes #102

## Test plan

- [ ] `cargo test` passes
- [ ] `cargo clippy` clean
- [ ] `atm teams add-member` with `%id` format succeeds
- [ ] `atm teams add-member` with `session:window.pane` format errors
- [ ] Windows CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)