### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -115,9 +115,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -420,9 +420,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1010,9 +1010,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -1028,11 +1028,11 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1041,7 +1041,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1322,6 +1322,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -420,9 +420,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1010,9 +1010,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -1028,11 +1028,11 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1041,7 +1041,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1322,6 +1322,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/atm-core", "crates/atm"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.3"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/atm-core", "crates/atm"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -19,7 +19,7 @@ name = "atm"
 path = "src/main.rs"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.0" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -19,7 +19,7 @@ name = "atm"
 path = "src/main.rs"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.0.4" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/atm/tests/version_alignment.rs
+++ b/crates/atm/tests/version_alignment.rs
@@ -1,0 +1,56 @@
+/// Verifies that the version field on the agent-team-mail-core path dependency
+/// in crates/atm/Cargo.toml matches the workspace version, and that Cargo.lock
+/// records the same version for both crates.
+///
+/// crates.io rejects a publish if path deps lack a version field, and it must
+/// match the published crate version. This test catches mismatches at CI time.
+#[test]
+fn atm_core_dep_version_matches_workspace_version() {
+    let workspace_toml = include_str!("../../../Cargo.toml");
+    let atm_toml = include_str!("../Cargo.toml");
+    let cargo_lock = include_str!("../../../Cargo.lock");
+
+    let workspace_version = workspace_toml
+        .lines()
+        .find(|l| l.starts_with("version = "))
+        .and_then(|l| l.split('"').nth(1))
+        .expect("workspace version not found in Cargo.toml");
+
+    // Verify dep version field matches workspace version
+    let dep_version = atm_toml
+        .lines()
+        .find(|l| l.contains("agent-team-mail-core") && l.contains("version"))
+        .and_then(|l| l.split("version").nth(1)?.split('"').nth(1))
+        .expect(
+            "version field missing on agent-team-mail-core dep in crates/atm/Cargo.toml \
+             — add version = \"x.y.z\" matching the workspace version",
+        );
+
+    assert_eq!(
+        workspace_version, dep_version,
+        "crates/atm/Cargo.toml agent-team-mail-core dep version ({dep_version}) \
+         does not match workspace version ({workspace_version})"
+    );
+
+    // Verify Cargo.lock records the same version for agent-team-mail and agent-team-mail-core
+    for crate_name in ["agent-team-mail", "agent-team-mail-core"] {
+        let lock_version = cargo_lock
+            .split("\n[[package]]")
+            .find(|chunk| {
+                chunk.contains(&format!("name = \"{crate_name}\""))
+            })
+            .and_then(|chunk| {
+                chunk
+                    .lines()
+                    .find(|l| l.starts_with("version = "))
+                    .and_then(|l| l.split('"').nth(1))
+            })
+            .unwrap_or_else(|| panic!("{crate_name} not found in Cargo.lock"));
+
+        assert_eq!(
+            workspace_version, lock_version,
+            "Cargo.lock version for {crate_name} ({lock_version}) \
+             does not match workspace version ({workspace_version}) — run `cargo generate-lockfile`"
+        );
+    }
+}

--- a/crates/atm/tests/version_alignment.rs
+++ b/crates/atm/tests/version_alignment.rs
@@ -36,9 +36,7 @@ fn atm_core_dep_version_matches_workspace_version() {
     for crate_name in ["agent-team-mail", "agent-team-mail-core"] {
         let lock_version = cargo_lock
             .split("\n[[package]]")
-            .find(|chunk| {
-                chunk.contains(&format!("name = \"{crate_name}\""))
-            })
+            .find(|chunk| chunk.contains(&format!("name = \"{crate_name}\"")))
             .and_then(|chunk| {
                 chunk
                     .lines()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1032,17 +1032,14 @@ The mailbox layer does not own selection policy, display buckets, output formatt
 
 When `ATM_POST_SEND` is set for a configured post-send hook, the payload must
 contain:
+- `sender`
+- `recipient`
+- `team`
 - `from`
 - `to`
 - `message_id`
 - `requires_ack`
 - optional `task_id` when present
-- `hook_match.sender`
-  boolean — true if the sender filter axis matched, false otherwise
-- `hook_match.recipient`
-  boolean — true if the recipient filter axis matched, false otherwise
-- omitted or empty sender/recipient lists therefore produce `hook_match`
-  values of `false`; only `*` represents an unconditional match
 
 The post-send hook runs only after a successful non-`dry-run` send, executes
 once when sender or recipient matching succeeds, may optionally emit one


### PR DESCRIPTION
## Summary
- Bumps workspace version from 1.0.3 → 1.1.0
- Adds `version = "1.1.0"` to `agent-team-mail-core` path dep in `crates/atm/Cargo.toml`
- Merges develop → integration branch (brings in version_alignment regression test + arch doc fix)
- `cargo test --test version_alignment` passes at 1.1.0

## Test plan
- [ ] CI green
- [ ] version_alignment test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)