### PR TITLE
fix: pass explicit release-tag to winget-releaser action (#121)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,4 +406,5 @@ jobs:
           # Initial bootstrap still requires a one-time manual manifest submission to microsoft/winget-pkgs.
           identifier: randlee.agent-team-mail
           installers-regex: 'atm_.*_x86_64-pc-windows-msvc\.zip$'
+          release-tag: ${{ needs.gate-and-tag.outputs.release_tag }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixes `publish-winget` job 404 failure introduced by winget-releaser inferring `releases/tags/main` instead of the actual release tag
- Adds `release-tag: ${{ needs.gate-and-tag.outputs.release_tag }}` so the action always targets the correct tag (e.g. `v1.0.4`)

## Root cause
`vedantmgoyal2009/winget-releaser@v2` defaults to `GITHUB_REF` (branch = `main`) when `release-tag` is omitted on a `workflow_dispatch` run, causing a 404.

Closes #121

## Test plan
- [ ] CI green on this PR
- [ ] `publish-winget` job succeeds on next release run

🤖 Generated with [Claude Code](https://claude.com/claude-code)