### PR TITLE
fix: add RAII guard + #[serial] to prevent Windows CI env var leak

### DIFF
--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -580,6 +580,7 @@ fn normalize_tmux_pane_id(pane_id: Option<&str>) -> Result<Option<String>, AtmEr
 
 #[cfg(test)]
 mod tests {
+    use serial_test::serial;
     use tempfile::tempdir;
 
     use super::{
@@ -637,6 +638,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn add_member_normalizes_tmux_shape_when_pane_is_provided() {
         let tempdir = tempdir().expect("tempdir");
         write_team_config(tempdir.path(), "atm-dev");

--- a/crates/atm-core/src/team_admin/restore.rs
+++ b/crates/atm-core/src/team_admin/restore.rs
@@ -620,16 +620,44 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
-    fn with_env_var_serial<T>(key: &str, value: &str, body: impl FnOnce() -> T) -> T {
+    fn with_env_var_serial<T>(key: &'static str, value: &str, body: impl FnOnce() -> T) -> T {
         let _guard = env_lock().lock().expect("env lock");
+        let _env_guard = EnvGuard::set_raw(key, value);
+        body()
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set_raw(key: &'static str, value: &str) -> Self {
+            let original = std::env::var_os(key);
+            set_env_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                Some(value) => set_env_var(self.key, value),
+                None => remove_env_var(self.key),
+            }
+        }
+    }
+
+    fn set_env_var<K: AsRef<std::ffi::OsStr>, V: AsRef<std::ffi::OsStr>>(key: K, value: V) {
         // SAFETY: restore tests that mutate process environment run under
         // `serial_test` and hold the shared env lock for the full mutation
         // window.
         unsafe { std::env::set_var(key, value) };
-        let result = body();
+    }
+
+    fn remove_env_var<K: AsRef<std::ffi::OsStr>>(key: K) {
         // SAFETY: same serialization guarantee as above.
         unsafe { std::env::remove_var(key) };
-        result
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes `ATM_TEST_FAIL_TEAM_CONFIG_WRITE` env var leaking between parallel tests on Windows
- Adds RAII EnvGuard + `#[serial]` to `team_admin/restore.rs` fault injection tests
- Unblocks PR #120 Windows CI failure

## Context
Windows CI on PR #120 failed with `add_member_normalizes_tmux_shape_when_pane_is_provided` getting a spurious `FilePolicyRejected` error. Root cause: another test sets the fault injection env var without a RAII guard, which leaked on Windows. This commit (git#a86ab1c) applies the same pattern as FTQ-004 fix.

Fixes: #120 CI (Test windows-latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)