### PR TITLE
docs: Phase P post-merge documentation reconciliation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ Crate-local boundary detail is owned by:
 - [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
 - [`docs/atm/architecture.md`](./atm/architecture.md)
 
-### 2.4 Release Publication Boundary
+### 2.3 Release Publication Boundary
 
 The `1.0` retained-surface release is a source-repo replacement of the old
 `agent-team-mail` CLI/core publication path, not a new public package family.
@@ -123,7 +123,7 @@ Schema ownership references:
   `tools/schema_models/atm_message_schema.py` and
   `tools/schema_models/legacy_atm_message_schema.py`
 
-### 2.3 Shared Observability Boundary
+### 2.4 Shared Observability Boundary
 
 `atm-core` must not import `sc-observability` directly.
 
@@ -463,7 +463,7 @@ Diagnostics for team config failures must preserve:
 - parser line and column when available
 - original parser cause for operator repair
 
-### 13.2 Deprecated `[atm].identity`
+### 5.1.1 Deprecated `[atm].identity`
 
 `[atm].identity` remains parse-compatible only as an obsolete migration field.
 It is no longer part of runtime sender or actor resolution.
@@ -533,7 +533,7 @@ Forward architectural rules:
 - the current live design still uses a shared inbox surface; a separate
   ATM-native inbox is intentionally deferred to a later architecture phase
 
-Current-phase constraint:
+Current compatibility rule:
 
 - the current runtime send/alert write path may continue writing legacy
   top-level alert fields during the compatibility period

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1452,9 +1452,22 @@ ATM now treats mailbox access as two distinct patterns:
 This keeps non-mutating reads out of the lock path while preserving a stable
 writeback boundary for commands that actually rewrite inbox files.
 
+Executed command mapping:
+- `read` uses an unlocked observational snapshot for display selection and
+  timeout polling, then enters the shared lock+reload+recompute path only when
+  display-state mutation is actually required
+- `ack` uses an unlocked preflight to resolve the reply target and candidate
+  source message, then acquires one final sorted superset lock and re-validates
+  the pending-ack state under that lock set before writing source/reply state
+- mutating `clear` acquires the shared lock plan before its mutating reread and
+  holds it through removal computation, mailbox replacement, and workflow-state
+  updates; `clear --dry-run` remains observational only
+
 ### 18.4.3 Executed Mailbox Workflow Migration
 
-Phase P.4 executes the mailbox workflow-state migration on this branch.
+Phase P completed the mailbox workflow-state migration. P.4 delivered the
+sidecar move, and the current architecture documents the post-P.5 executed
+state.
 
 Current executed rule:
 - ATM-owned workflow durability for identified mailbox messages is written to

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1485,6 +1485,15 @@ Current executed rule:
 - `clear` classifies removable messages from the projected workflow view and
   removes matching workflow-state entries when the inbox record is deleted
 
+Current executed limitation:
+- `send` and the missing-config team-lead notice path still seed workflow state
+  via an atomic owner-routed `load -> mutate -> save` sequence instead of a
+  dedicated freshness-proving helper
+- that means the sidecar family is already the source of truth, but concurrent
+  same-recipient send-side seeding is not yet hardened to the same
+  lock/reload/recompute standard used by mailbox read/ack/clear
+- P.6 is the tracked hardening continuation for that specific gap
+
 ### 18.5 New Error Codes
 
 - `MailboxLockFailed` / `ATM_MAILBOX_LOCK_FAILED` — lock-path creation,
@@ -1566,6 +1575,10 @@ Current architectural limitation:
 - therefore the current shared-inbox rewrite path is still a compatibility
   boundary, not the ideal long-term source-of-truth architecture for ATM-local
   workflow state
+- separately, send-side workflow seeding still lacks a dedicated freshness
+  boundary across concurrent same-recipient sends; that is a post-P.5 hardening
+  gap rather than a reason to move workflow durability back into Claude-owned
+  inbox records
 
 This rule intentionally applies beyond mailbox files so future work does not
 reintroduce partial-write or torn-state risks through backup/restore or shared

--- a/docs/atm-core/modules/mailbox.md
+++ b/docs/atm-core/modules/mailbox.md
@@ -28,6 +28,15 @@ Primary ownership note:
   sender in the same inbox and append the new record in one atomic sequence
 - this behavior satisfies the sender-scoped idle-notification dedup contract
   in `docs/requirements.md` alongside `REQ-CORE-MAILBOX-001`
+- mailbox ownership stops at the Claude-owned inbox compatibility surface; a
+  mailbox append that implies workflow-sidecar seeding must hand off to the
+  workflow owner boundary rather than persisting sidecar JSON itself
+- review-sensitive corner cases for this boundary are:
+  - `read` observational snapshot differs from the eventual under-lock reread
+  - `ack` reply-target expansion requires a larger final lock set than the
+    unlocked preflight saw
+  - `clear --dry-run` must remain observational while mutating `clear` uses the
+    shared lock+reload+persist path
 
 References:
 

--- a/docs/atm-core/modules/workflow.md
+++ b/docs/atm-core/modules/workflow.md
@@ -27,6 +27,6 @@ Primary ownership note:
 
 References:
 
-- Product requirements: `docs/requirements.md` §14 and §18
+- Product requirements: `docs/requirements.md` §3.2.2, §14, and §20.2
 - Architecture: `docs/architecture.md` §5 and §18.4.3
 - Message schema: `docs/atm-message-schema.md` §3

--- a/docs/atm-core/modules/workflow.md
+++ b/docs/atm-core/modules/workflow.md
@@ -13,6 +13,17 @@ Primary ownership note:
 - callers must not shape workflow JSON directly at the command layer
 - messages without a stable ATM identity remain compatibility-only and may
   still rely on legacy inbox-local fields until a later enrichment phase lands
+- current limitation: send-side seeding still reaches this module through an
+  atomic `load -> mutate -> save` sequence, so concurrent same-recipient sends
+  are not yet protected by a dedicated freshness helper
+- P.6 is the tracked hardening item to introduce that freshness boundary
+- review-sensitive corner cases for this module are:
+  - two ATM-authored sends race to seed distinct message ids for the same
+    recipient sidecar file
+  - one sender wins the atomic rename while another must reload and preserve
+    the winning entry before adding its own
+  - malformed sidecar JSON must fail with explicit diagnostics rather than
+    silently resetting workflow state
 
 References:
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1027,7 +1027,8 @@ Tests required:
 Acceptance criteria:
 - `lock.rs` is no longer a placeholder stub
 - all mailbox read-modify-write paths hold an exclusive lock
-- `read`, `ack`, and `clear` lock their entire source-file set before reading any source inbox
+- `read`, `ack`, and `clear` use one deterministic full-source lock plan for
+  every mutating reread and writeback
 - no shared mutable structured file touched by M.1 is rewritten in place
 - concurrent `atm send` to the same inbox from two processes does not lose messages
 - CI passes on macOS, Linux, Windows
@@ -1602,7 +1603,7 @@ Phase O completion gate:
 - CI passes on all platforms
 - `integrate/phase-O` merges to `develop`
 
-### Phase P: File-I/O Ownership And Single-Write-Path Hardening [PROPOSED]
+### Phase P: File-I/O Ownership And Single-Write-Path Hardening [MERGED / HARDENING FOLLOW-UP]
 
 Status note:
 - P.1 completed on `feature/pP-s1-ownership-classification` via PR `#111`
@@ -1613,13 +1614,12 @@ Status note:
   at `git#ecb774a`
 - P.4 completed on `feature/pP-s4-claude-inbox-compat` via PR `#113`
   at `git#9d5729b`
-- P.5 closure merged to `develop` via PR `#120` at `git#ad49336`
-- until Sprint 3 reconciles the heading and requirement text, this phase
-  section intentionally mixes executed history with follow-up stabilization
-  planning
-- `integrate/phase-P` must stay fast-forwarded to `develop` before any
-  follow-up stabilization sprint starts; the current planning baseline is
-  `develop@ad49336`
+- P.5 closure gate completed on `feature/pP-s5-closure-gate` via PR `#114`
+- final Phase P integration merged to `develop` via PR `#120` at `git#ad49336`
+- this phase section now records both the executed P.1-P.5 history and the
+  remaining hardening continuation work needed before a publish-quality close
+- `integrate/phase-P` is currently rebased onto `develop@628e176`; refresh it
+  again if `develop` advances before the next hardening slice begins
 
 Goal:
 - make the retained ATM implementation production-ready by applying one
@@ -1641,25 +1641,25 @@ Non-negotiable constraints:
 
 Integration branch: `integrate/phase-P`
 
-#### P.F — Post-Merge Stabilization Sprints
+#### P.6-P.8 — Post-Merge Hardening Continuation
 
 Goal:
 - close the remaining Phase P publish-risk gaps after the merge to `develop`
 - keep follow-up work split into deterministic, reviewable sprint slices:
-  - Sprint 1: workflow-sidecar concurrency and typed boundary cleanup
-  - Sprint 2: test hygiene and observability cleanup
-  - Sprint 3: requirements/plan reconciliation
+  - P.6: workflow-sidecar concurrency and typed boundary cleanup
+  - P.7: test hygiene and observability cleanup
+  - P.8: requirements/architecture/project-plan reconciliation
 
 Planning rule:
-- each stabilization sprint must start from the latest `develop` on
+- each hardening continuation sprint must start from the latest `develop` on
   `integrate/phase-P`
-- if `develop` advances between sprints, fast-forward `integrate/phase-P`
+- if `develop` advances between sprints, refresh `integrate/phase-P` from it
   before opening the next sprint branch
 - no sprint may rely on timing-based tests, unlocked ATM-owned state rewrites,
   or new raw `String`/parse-later request surfaces for agent/team/address
   identifiers
 
-##### Sprint 1 — Workflow-Sidecar Concurrency And Typed Boundary Cleanup
+##### P.6 — Workflow-Sidecar Concurrency And Typed Boundary Cleanup
 
 Goals:
 - make workflow-sidecar seeding in `send` safe for concurrent same-recipient
@@ -1714,7 +1714,7 @@ Required coverage:
 - request-construction tests showing invalid team/agent/address input is
   rejected before command execution enters the core implementation
 
-##### Sprint 2 — Test Hygiene And Observability Cleanup
+##### P.7 — Test Hygiene And Observability Cleanup
 
 Goals:
 - remove the remaining timing-dependent and process-environment test seams
@@ -1756,11 +1756,11 @@ Required coverage:
 - read-path coverage proving malformed idle-notification JSON is observable in
   logs/diagnostics and does not panic or change mailbox state
 
-##### Sprint 3 — Requirements And Plan Reconciliation
+##### P.8 — Requirements, Architecture, And Plan Reconciliation
 
 Goals:
-- bring the written Phase P requirements and plan text into alignment with the
-  landed implementation and the follow-up sprint results
+- bring the written Phase P requirements, architecture, and plan text into
+  alignment with the landed implementation and the follow-up hardening results
 - close the remaining documentation ambiguity before a final publish decision
 
 Files expected in scope:
@@ -1776,15 +1776,16 @@ Design details:
   - `read_only`: no locks
   - `read_possible_write`: unlocked observation is allowed, but any commit must
     reload/prove freshness under the final lock set
-  - `read_modify_write`: lock before the mutating snapshot and hold through
-    commit
+  - `read_modify_write`: acquire the final lock plan before the mutating
+    snapshot and hold it through commit
 - explicitly document that `read`, `ack`, and `clear` do not all share the same
   pre-lock read behavior anymore; the requirement should describe the
   command-specific executed pattern instead of the pre-Phase-P rule
-- rename the Phase P heading from `[PROPOSED]` to a closed/executed label that
-  matches the merged state on `develop`
-- record the Sprint 1 and Sprint 2 fixes in the Phase P closure history so the
-  plan reads as executed release evidence rather than mixed proposal/history
+- keep `docs/requirements.md` and `docs/architecture.md` as the always-valid
+  enforced source of truth for the post-P.5 system state rather than a phase
+  narrative
+- record the P.6 and P.7 fixes in the Phase P closure history so the plan
+  reads as executed release evidence rather than mixed proposal/history
 
 Acceptance criteria:
 - requirements, architecture, and project-plan text all describe the same

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1706,6 +1706,30 @@ Implementation patterns:
 - keep concurrent coverage deterministic by using channels/barriers with bounded
   waits; do not use sleeps to try to overlap sends
 
+Reference shape:
+
+```rust
+// Pseudocode shape, not a final required signature.
+let envelope = mailbox::append_message(...)?;
+workflow::commit_state(home, team, recipient, |state| {
+    state.remember_initial_state(&envelope);
+})?;
+```
+
+```rust
+// Pseudocode shape for the final freshness boundary.
+workflow::commit_state(home, team, recipient, |state| {
+    let fresh = state.reload_or_validate()?;
+    fresh.remember_initial_state(&envelope);
+    Ok(())
+})?;
+```
+
+The hardening requirement is not the helper name; it is that `send` and the
+missing-config team-lead notice path must stop open-coding `load -> mutate ->
+save` against the workflow sidecar and must commit from a freshness-proven
+owner-layer boundary.
+
 Required coverage:
 - concurrent same-recipient send/send test proving two ATM-authored messages
   both seed workflow state without lost updates
@@ -1713,6 +1737,13 @@ Required coverage:
   workflow owner helper
 - request-construction tests showing invalid team/agent/address input is
   rejected before command execution enters the core implementation
+- concurrent send where one path is a normal recipient send and the other is the
+  missing-config team-lead notice path for the same workflow file family
+- contention case where one sender observes an older workflow snapshot, loses
+  the race, reloads, and recomputes without dropping the winning sender's entry
+- mixed payload case where concurrent sends differ on `requires_ack`, `task_id`,
+  and summary generation, proving the seeded sidecar state tracks the correct
+  message identity rather than whichever writer saves last
 
 ##### P.7 — Test Hygiene And Observability Cleanup
 
@@ -1747,6 +1778,22 @@ Implementation patterns:
 - malformed JSON handling should remain fail-soft for Claude-owned inbox data,
   but it must not silently disappear; trace/debug logging is required
 
+Reference shape:
+
+```rust
+// Pseudocode shape, not a required concrete helper name.
+let ready = readiness.wait_until_ready(timeout)?;
+assert!(ready);
+let records = log_tail.read_after(ready.cursor())?;
+```
+
+```rust
+let _guard = test_env::scoped_var(
+    "ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD",
+    "1",
+);
+```
+
 Required coverage:
 - deterministic log-tail readiness test with no fixed-duration sleep
 - `config/discovery.rs` tests rewritten to tempdir fixtures with no `/tmp`
@@ -1755,6 +1802,12 @@ Required coverage:
   state through scoped guard teardown
 - read-path coverage proving malformed idle-notification JSON is observable in
   logs/diagnostics and does not panic or change mailbox state
+- malformed idle-notification JSON adjacent to valid mailbox records still
+  leaves the valid records readable and classifiable
+- tempdir-backed discovery tests cover paths with spaces and nested directories
+  so platform path handling is exercised instead of assuming `/tmp` semantics
+- env-guard teardown is verified on early-return/failure paths so one test's
+  injected state cannot leak into the next test process
 
 ##### P.8 — Requirements, Architecture, And Plan Reconciliation
 
@@ -1790,6 +1843,8 @@ Design details:
 Acceptance criteria:
 - requirements, architecture, and project-plan text all describe the same
   mailbox-read taxonomy and lock acquisition model
+- the docs explicitly name the remaining P.6 send-side workflow freshness gap
+  rather than implying it is already solved
 - the Phase P heading and status note clearly show merged/executed state
 - no Phase P document still implies that the merged implementation is
   proposal-only

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1613,9 +1613,13 @@ Status note:
   at `git#ecb774a`
 - P.4 completed on `feature/pP-s4-claude-inbox-compat` via PR `#113`
   at `git#9d5729b`
-- P.5 is the active closure gate; the remaining content in this phase section is
-  now implementation history plus the final closure work, not proposal-only
-  planning guidance
+- P.5 closure merged to `develop` via PR `#120` at `git#ad49336`
+- until Sprint 3 reconciles the heading and requirement text, this phase
+  section intentionally mixes executed history with follow-up stabilization
+  planning
+- `integrate/phase-P` must stay fast-forwarded to `develop` before any
+  follow-up stabilization sprint starts; the current planning baseline is
+  `develop@ad49336`
 
 Goal:
 - make the retained ATM implementation production-ready by applying one
@@ -1636,6 +1640,158 @@ Non-negotiable constraints:
 - no tolerance for flaky tests
 
 Integration branch: `integrate/phase-P`
+
+#### P.F — Post-Merge Stabilization Sprints
+
+Goal:
+- close the remaining Phase P publish-risk gaps after the merge to `develop`
+- keep follow-up work split into deterministic, reviewable sprint slices:
+  - Sprint 1: workflow-sidecar concurrency and typed boundary cleanup
+  - Sprint 2: test hygiene and observability cleanup
+  - Sprint 3: requirements/plan reconciliation
+
+Planning rule:
+- each stabilization sprint must start from the latest `develop` on
+  `integrate/phase-P`
+- if `develop` advances between sprints, fast-forward `integrate/phase-P`
+  before opening the next sprint branch
+- no sprint may rely on timing-based tests, unlocked ATM-owned state rewrites,
+  or new raw `String`/parse-later request surfaces for agent/team/address
+  identifiers
+
+##### Sprint 1 — Workflow-Sidecar Concurrency And Typed Boundary Cleanup
+
+Goals:
+- make workflow-sidecar seeding in `send` safe for concurrent same-recipient
+  sends
+- remove the remaining raw-string request/target boundaries called out by the
+  Phase P rust-best-practices review
+
+Files expected in scope:
+- `crates/atm-core/src/send/mod.rs`
+- `crates/atm-core/src/workflow.rs`
+- `crates/atm-core/src/mailbox/source.rs`
+- `crates/atm-core/src/read/mod.rs`
+- `crates/atm-core/src/team_admin.rs`
+- `crates/atm-core/tests/mailbox_locking.rs`
+- command-layer constructors/parsers that build these request types
+
+Design details:
+- introduce one owner-layer workflow commit path for `.atm-state/workflow` that
+  proves freshness before replacing the live file
+- `send_mail(...)` and the missing-config team-lead notice path must stop using
+  unlocked `load -> mutate -> save` on workflow state
+- same-recipient send/send concurrency must either:
+  - lock the workflow sidecar and reload under that lock before persisting, or
+  - use a compare-and-swap equivalent at the workflow owner boundary
+- mailbox append plus workflow seed must be treated as one coordinated
+  persistence plan for send-owned writes; no parallel ad hoc sidecar mutation
+  path is allowed
+- request/target parsing must move to construction time for the remaining
+  boundary types:
+  - `AddMemberRequest.team` and `.member` use `TeamName` / `AgentName`
+    instead of raw `String` (`RBP-F001`)
+  - `ReadQuery.target_address` uses `Option<AgentAddress>` instead of
+    `Option<String>` (`RBP-F002`)
+  - `ResolvedTarget.agent` / `.team` carry `AgentName` / `TeamName`
+    rather than raw `String` (`RBP-F003`)
+
+Implementation patterns:
+- prefer a typed workflow helper such as
+  `workflow::with_locked_state(...)` or `workflow::commit_state(...)`
+  over reimplementing lock/CAS logic inside `send/mod.rs`
+- keep validation at the API boundary: constructors, CLI parsing, and resolver
+  outputs should carry validated newtypes rather than validating deep in the
+  implementation
+- keep concurrent coverage deterministic by using channels/barriers with bounded
+  waits; do not use sleeps to try to overlap sends
+
+Required coverage:
+- concurrent same-recipient send/send test proving two ATM-authored messages
+  both seed workflow state without lost updates
+- coverage for the missing-config team-lead notice path using the shared
+  workflow owner helper
+- request-construction tests showing invalid team/agent/address input is
+  rejected before command execution enters the core implementation
+
+##### Sprint 2 — Test Hygiene And Observability Cleanup
+
+Goals:
+- remove the remaining timing-dependent and process-environment test seams
+- stop silently discarding malformed idle-notification JSON during read-path
+  classification
+
+Files expected in scope:
+- `crates/atm/tests/log.rs`
+- `crates/atm-core/src/config/discovery.rs`
+- `crates/atm-core/src/clear/mod.rs`
+- `crates/atm-core/src/read/mod.rs`
+- any shared test fixture/helper file needed to make readiness deterministic
+
+Design details:
+- replace the fixed `thread::sleep(Duration::from_millis(250))` in log-tail
+  coverage with an explicit readiness handshake or bounded polling barrier
+- replace all hardcoded `/tmp/atm-config-root` test roots in
+  `config/discovery.rs` with `tempdir()`-backed paths
+- scope `ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD` with an RAII env guard under
+  `#[serial]` in `clear/mod.rs`
+- replace `idle_notification_sender(...).ok().and_then(...)` with explicit
+  malformed-JSON handling that preserves non-fatal behavior but emits traceable
+  diagnostics and recovery context (`RBP-F004`)
+
+Implementation patterns:
+- any new helper introduced for log-tail readiness must expose a positive-ready
+  signal; it must not sleep "long enough"
+- process-environment mutation in tests must use one repo-standard pattern:
+  shared env lock plus scoped guard plus `#[serial]`
+- malformed JSON handling should remain fail-soft for Claude-owned inbox data,
+  but it must not silently disappear; trace/debug logging is required
+
+Required coverage:
+- deterministic log-tail readiness test with no fixed-duration sleep
+- `config/discovery.rs` tests rewritten to tempdir fixtures with no `/tmp`
+  assumptions
+- `clear/mod.rs` regression showing the injected disappearing-inbox path resets
+  state through scoped guard teardown
+- read-path coverage proving malformed idle-notification JSON is observable in
+  logs/diagnostics and does not panic or change mailbox state
+
+##### Sprint 3 — Requirements And Plan Reconciliation
+
+Goals:
+- bring the written Phase P requirements and plan text into alignment with the
+  landed implementation and the follow-up sprint results
+- close the remaining documentation ambiguity before a final publish decision
+
+Files expected in scope:
+- `docs/requirements.md`
+- `docs/project-plan.md`
+- `docs/architecture.md`
+- `docs/atm-core/modules/mailbox.md`
+- `docs/atm-core/modules/workflow.md`
+
+Design details:
+- rewrite `REQ-CORE-MAILBOX-LOCK-005` so it matches the executed mutation
+  taxonomy:
+  - `read_only`: no locks
+  - `read_possible_write`: unlocked observation is allowed, but any commit must
+    reload/prove freshness under the final lock set
+  - `read_modify_write`: lock before the mutating snapshot and hold through
+    commit
+- explicitly document that `read`, `ack`, and `clear` do not all share the same
+  pre-lock read behavior anymore; the requirement should describe the
+  command-specific executed pattern instead of the pre-Phase-P rule
+- rename the Phase P heading from `[PROPOSED]` to a closed/executed label that
+  matches the merged state on `develop`
+- record the Sprint 1 and Sprint 2 fixes in the Phase P closure history so the
+  plan reads as executed release evidence rather than mixed proposal/history
+
+Acceptance criteria:
+- requirements, architecture, and project-plan text all describe the same
+  mailbox-read taxonomy and lock acquisition model
+- the Phase P heading and status note clearly show merged/executed state
+- no Phase P document still implies that the merged implementation is
+  proposal-only
 
 #### P.0 — Audited Production File-I/O Inventory
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -19,14 +19,17 @@ restructured, product docs remain in `docs/` and crate-local detail moves into
 `docs/atm/` and `docs/atm-core/`.
 
 Status:
-- Phases 0 through F and J are complete.
-- Phase K is complete and ready to roll forward into shared 1.0 release
-  alignment work.
-- Phase L is now the latest release-alignment and retained-surface follow-on
-  phase and the next active delivery focus.
-- Phases G and H remain retained-command phases, but their implementation work
-  depends on the concrete `sc-observability` integration delivered in Phase K
-  and the release-alignment work planned in Phase L.
+- Phases 0 through P have executed on the retained rewrite line.
+- Phases G and H are complete retained-command phases, closed through the
+  shared observability and release-alignment work delivered in later phases.
+- Phase K completed the shared `sc-observability` integration boundary.
+- Phase L completed the retained release-surface and team-recovery closeout.
+- Phase M completed mailbox locking and review-finding fixes.
+- Phase N completed publish-replacement and distribution-parity planning and
+  implementation merge work.
+- Phase O completed the security and hardening follow-up line.
+- Phase P implementation is merged; follow-up hardening remains open for
+  `P.6` and `P.7`, while `P.8` documentation reconciliation is complete.
 - Message schema ownership and metadata normalization are now implemented well
   enough for live shared-inbox adoption, while a separate ATM-native inbox
   remains deferred to a later version.
@@ -454,7 +457,7 @@ Acceptance:
 - any generic shared-crate usability gaps discovered during implementation are
   filed upstream in `sc-observability`
 
-### Phase L: 1.0 Alignment And Release Surface Cleanup [NEXT / LATEST]
+### Phase L: 1.0 Alignment And Release Surface Cleanup [COMPLETE]
 
 Status summary:
 - Phase K delivered the full sc-observability integration against a pre-publish
@@ -1280,7 +1283,9 @@ Acceptance criteria:
 
 ---
 
-### Phase N: Publish Replacement And Distribution Parity [PLANNED]
+### Phase N: Publish Replacement And Distribution Parity [COMPLETE]
+
+Status: COMPLETE
 
 Goal:
 - ship the retained `1.0` release from this repo as the direct replacement for
@@ -1532,7 +1537,9 @@ Phase N completion gate:
 - `winget` is explicitly documented as a new required Windows install channel,
   not as historical parity
 
-### Phase O: Security And Hardening [PLANNED]
+### Phase O: Security And Hardening [COMPLETE]
+
+Status: COMPLETE
 
 Goal:
 - close the confirmed CR001 findings that affect path safety, allocation
@@ -1659,7 +1666,7 @@ Planning rule:
   or new raw `String`/parse-later request surfaces for agent/team/address
   identifiers
 
-##### P.6 — Workflow-Sidecar Concurrency And Typed Boundary Cleanup
+##### P.6 — Workflow-Sidecar Concurrency And Typed Boundary Cleanup [PLANNED]
 
 Goals:
 - make workflow-sidecar seeding in `send` safe for concurrent same-recipient
@@ -1745,7 +1752,7 @@ Required coverage:
   and summary generation, proving the seeded sidecar state tracks the correct
   message identity rather than whichever writer saves last
 
-##### P.7 — Test Hygiene And Observability Cleanup
+##### P.7 — Test Hygiene And Observability Cleanup [PLANNED]
 
 Goals:
 - remove the remaining timing-dependent and process-environment test seams
@@ -1809,7 +1816,7 @@ Required coverage:
 - env-guard teardown is verified on early-return/failure paths so one test's
   injected state cannot leak into the next test process
 
-##### P.8 — Requirements, Architecture, And Plan Reconciliation
+##### P.8 — Requirements, Architecture, And Plan Reconciliation [COMPLETE]
 
 Goals:
 - bring the written Phase P requirements, architecture, and plan text into

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1918,6 +1918,14 @@ closed before the 1.0 release.
   - a stale-snapshot rename after late lock acquisition is forbidden even if
     the rename itself is atomic
 
+  Current limitation:
+  - mailbox read/ack/clear paths satisfy this through
+    `mailbox::store::with_locked_source_files(...)`
+  - workflow-sidecar writes performed during `send` and the missing-config
+    team-lead notice path are already atomic and owner-routed, but they do not
+    yet provide a dedicated freshness proof across concurrent same-recipient
+    sends; P.6 is the tracked hardening item for that gap
+
 - `REQ-CORE-PERSIST-ATOMIC-001B` Every shared mutable file family must have one
   documented write path and one owning helper boundary.
 
@@ -1954,6 +1962,9 @@ closed before the 1.0 release.
       `team_admin::restore::clear_restore_marker(...)`,
       `team_admin::restore::prepare_restore_workspace(...)`, and
       `team_admin::restore::cleanup_restore_workspace(...)`
+  - send-side workflow seeding must not continue indefinitely as an open-coded
+    `load -> mutate -> save` sequence in command-layer logic; P.6 exists to
+    converge that path onto a dedicated owner-layer freshness boundary
 
 - `REQ-CORE-PERSIST-ATOMIC-001C` ATM must not claim rewrite safety for
   non-cooperating external writers.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -288,11 +288,11 @@ Required rules:
 - a separate ATM-native inbox is explicitly deferred and must not be assumed by
   the current live design
 
-Current-phase migration constraint:
+Current compatibility rule:
 
-- Phase J sprint J.4 is documentation and planning only
-- existing runtime write/read behavior for legacy top-level alert fields remains
-  stable until a later implementation sprint performs the actual migration
+- existing runtime write/read behavior for legacy top-level alert fields
+  remains stable until a later compatibility-migration implementation changes
+  that persisted shape
 `REQ-P-SCHEMA-001` is owned by:
 
 - [`claude-code-message-schema.md`](./claude-code-message-schema.md)
@@ -1808,17 +1808,20 @@ closed before the 1.0 release.
   the final write step would still allow stale reads and lost updates.
 
   Required behavior:
-  - `read` may take an unlocked observational snapshot of the source inbox set,
+  - `read` is a `read_possible_write` path: it may take an unlocked
+    observational snapshot of the source inbox set,
     but if display-state mutation is needed it must re-discover the current
     source-file set, dedupe duplicate paths, sort the resulting paths
     deterministically by canonical path string, acquire the full lock set, then
     reload and recompute under that lock set before persisting
-  - `ack` may resolve the reply target and candidate source message from an
-    unlocked preflight, but it must acquire the final sorted superset lock plan
-    before the mutating source reread, then re-read and re-validate the pending
+  - `ack` uses an unlocked preflight plus one final superset lock: it may
+    resolve the reply target and candidate source message from an unlocked
+    preflight, but it must acquire the final sorted superset lock plan before
+    the mutating source reread, then re-read and re-validate the pending
     acknowledgement state under that final lock set before writing either the
     source or reply mailbox state
-  - mutating `clear` must acquire the deterministic lock set before its
+  - mutating `clear` is a full-lock-through-persist path: it must acquire the
+    deterministic lock set before its
     mutating source reread and must hold that lock set through removal
     computation, mailbox replacement, and workflow-sidecar updates; `clear
     --dry-run` remains observational and lock-free
@@ -1918,7 +1921,7 @@ closed before the 1.0 release.
   - a stale-snapshot rename after late lock acquisition is forbidden even if
     the rename itself is atomic
 
-  Current limitation:
+  Open hardening gap — `P.6` send-side workflow freshness:
   - mailbox read/ack/clear paths satisfy this through
     `mailbox::store::with_locked_source_files(...)`
   - workflow-sidecar writes performed during `send` and the missing-config

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1796,45 +1796,61 @@ closed before the 1.0 release.
 
   Read-only `read_messages` calls with no following writeback do not require locking.
 
-- `REQ-CORE-MAILBOX-LOCK-005` Multi-source mailbox commands must acquire all
-  required locks before reading any source inbox, and must do so in deterministic
-  path order.
+- `REQ-CORE-MAILBOX-LOCK-005` Multi-source mailbox commands must acquire their
+  final required lock set before any mutating source reread, and must do so in
+  deterministic path order.
 
   Rationale: `read`, `ack`, and `clear` do not operate on a single inbox file.
-  They call `load_source_files(...)`, which reads the requested inbox plus any
-  origin inboxes, compute a merged surface from those snapshots, and then write
-  one or more source files back. Taking a lock only during the final write step
-  would still allow stale reads and lost updates.
+  The executed Phase P design permits unlocked observational snapshots when no
+  mutation is committed from that snapshot, but any state-changing path must
+  reacquire the full deterministic lock set, reload fresh source files under
+  that lock set, recompute the mutation, and then persist. Locking only during
+  the final write step would still allow stale reads and lost updates.
 
   Required behavior:
-  - `read`, `ack`, and `clear` must discover their full source-file set, dedupe
-    duplicate paths, sort the resulting paths deterministically by canonical path
-    string, acquire all locks, then call `load_source_files(...)`
-  - source-file discovery must happen before any source inbox read and must use
-    the command's existing requested-inbox plus origin-inbox resolution logic
+  - `read` may take an unlocked observational snapshot of the source inbox set,
+    but if display-state mutation is needed it must re-discover the current
+    source-file set, dedupe duplicate paths, sort the resulting paths
+    deterministically by canonical path string, acquire the full lock set, then
+    reload and recompute under that lock set before persisting
+  - `ack` may resolve the reply target and candidate source message from an
+    unlocked preflight, but it must acquire the final sorted superset lock plan
+    before the mutating source reread, then re-read and re-validate the pending
+    acknowledgement state under that final lock set before writing either the
+    source or reply mailbox state
+  - mutating `clear` must acquire the deterministic lock set before its
+    mutating source reread and must hold that lock set through removal
+    computation, mailbox replacement, and workflow-sidecar updates; `clear
+    --dry-run` remains observational and lock-free
+  - final source-file discovery for a mutating path must use the command's
+    existing requested-inbox plus origin-inbox resolution logic
   - legitimately absent inbox paths at discovery time are excluded from the
     lock set rather than locked speculatively
   - source enumeration faults are not treated as absent paths; if origin inbox
     discovery cannot enumerate the candidate directory completely, the command
     must fail closed instead of continuing with a partial source set
-  - those locks must remain held through surface computation, state transition,
-    and final writeback
+  - for any mutating path, those locks must remain held through the fresh
+    surface computation, state transition, and final writeback
   - deterministic ordering must prevent deadlock when two commands contend on the
     same pair of inbox files in opposite discovery order
   - lock acquisition uses one total timeout budget for the full lock set, not a
     fresh timeout per file
   - if any lock in the set cannot be acquired, every previously acquired lock in
     that attempt must be released immediately and the command must fail without
-    reading or mutating any source inbox
+    mutating any source inbox from a partially locked snapshot
   - partial lock acquisition must never degrade into a best-effort state-changing
     command result for `read`, `ack`, or `clear`
-  - source discovery for mutation commands must fail closed: if directory
+  - the unlocked observational snapshot used by `read`, `ack`, or dry-run
+    `clear` must never be the snapshot from which a later mutating commit is
+    persisted
+  - source discovery for mutating commands must fail closed: if directory
     enumeration itself fails or if any directory entry in the candidate inbox
-    directory cannot be enumerated reliably, the command must abort before lock
-    acquisition instead of warning and continuing with a partial source set
-  - if a discovered file disappears or becomes unreadable after lock planning but
-    before or during source-file load, the command must fail as a normal
-    operator-actionable file-read error and must not persist any partial state
+    directory cannot be enumerated reliably, the command must abort before the
+    mutating reread instead of warning and continuing with a partial source set
+  - if a discovered file disappears or becomes unreadable after lock planning
+    but before or during the under-lock source-file load, the command must fail
+    as a normal operator-actionable file-read error and must not persist any
+    partial state
 
 - `REQ-CORE-MAILBOX-LOCK-006` Single-process single-threaded usage must not
   regress measurably due to lock acquisition.


### PR DESCRIPTION
## Summary

- `b4e36e7` Plan Phase P stabilization sprints
- `959b1be` Reconcile post-P.5 phase P hardening state — resolves doc contradictions
- `926b7d8` Harden Phase P follow-up documentation — adds P.6/P.7 reference pseudocode, expands corner-case coverage expectations, documents send-side workflow seeding limitation (concurrent same-recipient sends not yet hardened) across `project-plan.md`, `requirements.md`, `architecture.md`, `docs/atm-core/modules/mailbox.md`, `docs/atm-core/modules/workflow.md`

## Test plan

- [ ] Docs review — no contradictions across project-plan/requirements/architecture (arch-ctm confirmed clean pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)