### PR TITLE
feat(P.7): test hygiene and observability cleanup

### DIFF
--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -313,6 +313,7 @@ fn apply_removals(source_files: &mut [SourceFile], removable: &HashSet<(PathBuf,
 #[cfg(test)]
 mod tests {
     use std::ffi::{OsStr, OsString};
+    use std::sync::{Mutex, OnceLock};
 
     use serial_test::serial;
     use tempfile::tempdir;
@@ -325,6 +326,7 @@ mod tests {
     #[test]
     #[serial]
     fn locked_clear_source_removal_reports_disappearing_mailbox() {
+        let _env_lock = env_lock().lock().expect("env lock");
         let tempdir = tempdir().expect("tempdir");
         let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
         let inboxes_dir = team_dir.join("inboxes");
@@ -342,25 +344,35 @@ mod tests {
         )
         .expect("write config");
         std::fs::write(inboxes_dir.join("arch-ctm.json"), "").expect("mailbox");
-        let _guard = EnvGuard::set_raw("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD", "1");
-
-        let error = clear_mail(
-            ClearQuery {
-                home_dir: tempdir.path().to_path_buf(),
-                current_dir: tempdir.path().to_path_buf(),
-                actor_override: Some("arch-ctm".into()),
-                target_address: None,
-                team_override: Some(TeamName::from("atm-dev")),
-                older_than: None,
-                idle_only: false,
-                dry_run: false,
-            },
-            &NullObservability,
-        )
-        .expect_err("missing mailbox");
+        let error = {
+            let _guard = EnvGuard::set_raw("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD", "1");
+            clear_mail(
+                ClearQuery {
+                    home_dir: tempdir.path().to_path_buf(),
+                    current_dir: tempdir.path().to_path_buf(),
+                    actor_override: Some("arch-ctm".into()),
+                    target_address: None,
+                    team_override: Some(TeamName::from("atm-dev")),
+                    older_than: None,
+                    idle_only: false,
+                    dry_run: false,
+                },
+                &NullObservability,
+            )
+            .expect_err("missing mailbox")
+        };
 
         assert!(error.is_mailbox_read());
         assert!(error.message.contains("disappeared"));
+        assert!(
+            std::env::var_os("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD").is_none(),
+            "scoped env guard leaked after failure path"
+        );
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
     }
 
     struct EnvGuard {

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use chrono::{DateTime, TimeDelta, Utc};
 use serde::Serialize;
 use serde_json::Value;
+use tracing::debug;
 
 use crate::address::AgentAddress;
 use crate::config;
@@ -281,10 +282,20 @@ fn is_idle_notification(message: &MessageEnvelope) -> bool {
     // Claude Code currently defines idle notifications as JSON encoded in the
     // native `text` field. Do not replace this with an ATM-local schema here;
     // any ownership change must be documented in docs/claude-code-message-schema.md.
-    serde_json::from_str::<Value>(&message.text)
-        .ok()
-        .map(|value| value.get("type").and_then(Value::as_str) == Some("idle_notification"))
-        .unwrap_or(false)
+    match serde_json::from_str::<Value>(&message.text) {
+        Ok(value) => value.get("type").and_then(Value::as_str) == Some("idle_notification"),
+        Err(error) => {
+            if message.text.contains("idle_notification") {
+                debug!(
+                    %error,
+                    recovery = "Repair or remove the malformed Claude idle-notification JSON. ATM clear will continue treating the record as a normal mailbox message.",
+                    message_text = %message.text,
+                    "ignoring malformed idle-notification JSON while classifying clear surface"
+                );
+            }
+            false
+        }
+    }
 }
 
 fn count_removed(counts: &mut RemovedByClass, class: MessageClass) {
@@ -314,6 +325,7 @@ fn apply_removals(source_files: &mut [SourceFile], removable: &HashSet<(PathBuf,
 mod tests {
     use std::ffi::{OsStr, OsString};
     use std::sync::{Mutex, OnceLock};
+    use std::{panic, panic::AssertUnwindSafe};
 
     use serial_test::serial;
     use tempfile::tempdir;
@@ -368,6 +380,28 @@ mod tests {
             std::env::var_os("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD").is_none(),
             "scoped env guard leaked after failure path"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn env_guard_restores_original_value_after_panic() {
+        let _env_lock = env_lock().lock().expect("env lock");
+        set_env_var("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD", "original");
+
+        let result = panic::catch_unwind(AssertUnwindSafe(|| {
+            let _guard = EnvGuard::set_raw("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD", "1");
+            panic!("boom");
+        }));
+
+        assert!(
+            result.is_err(),
+            "panic should propagate through catch_unwind"
+        );
+        assert_eq!(
+            std::env::var_os("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD"),
+            Some(OsString::from("original"))
+        );
+        remove_env_var("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD");
     }
 
     fn env_lock() -> &'static Mutex<()> {

--- a/crates/atm-core/src/config/discovery.rs
+++ b/crates/atm-core/src/config/discovery.rs
@@ -84,20 +84,29 @@ pub fn command_looks_like_path(program: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
+
+    use tempfile::tempdir;
 
     use super::{command_looks_like_path, normalize_post_send_hooks};
     use crate::config::types::PostSendHookRule;
 
+    fn config_root_fixture() -> (tempfile::TempDir, PathBuf) {
+        let tempdir = tempdir().expect("tempdir");
+        let config_root = tempdir.path().join("atm config root").join("nested");
+        std::fs::create_dir_all(&config_root).expect("config root");
+        (tempdir, config_root)
+    }
+
     #[test]
     fn normalize_post_send_hooks_resolves_relative_script_commands() {
-        let config_root = Path::new("/tmp/atm-config-root");
+        let (_tempdir, config_root) = config_root_fixture();
         let hooks = vec![PostSendHookRule {
             recipient: "team-lead".into(),
             command: vec!["scripts/atm-nudge.sh".into(), "team-lead".into()],
         }];
 
-        let hooks = normalize_post_send_hooks(hooks, config_root).expect("hooks");
+        let hooks = normalize_post_send_hooks(hooks, &config_root).expect("hooks");
 
         assert_eq!(
             hooks[0].command[0],
@@ -110,13 +119,13 @@ mod tests {
 
     #[test]
     fn normalize_post_send_hooks_keeps_bare_executables_for_path_lookup() {
+        let (_tempdir, config_root) = config_root_fixture();
         let hooks = vec![PostSendHookRule {
             recipient: "*".into(),
             command: vec!["bash".into(), "-lc".into(), "echo hi".into()],
         }];
 
-        let hooks =
-            normalize_post_send_hooks(hooks, Path::new("/tmp/atm-config-root")).expect("hooks");
+        let hooks = normalize_post_send_hooks(hooks, &config_root).expect("hooks");
 
         assert_eq!(hooks[0].command[0], "bash");
     }
@@ -131,26 +140,27 @@ mod tests {
 
     #[test]
     fn normalize_post_send_hooks_preserves_absolute_paths() {
+        let (_tempdir, config_root) = config_root_fixture();
         let absolute = PathBuf::from("/usr/local/bin/hook");
         let hooks = vec![PostSendHookRule {
             recipient: "*".into(),
             command: vec![absolute.display().to_string()],
         }];
 
-        let hooks =
-            normalize_post_send_hooks(hooks, Path::new("/tmp/atm-config-root")).expect("hooks");
+        let hooks = normalize_post_send_hooks(hooks, &config_root).expect("hooks");
 
         assert_eq!(hooks[0].command[0], absolute.display().to_string());
     }
 
     #[test]
     fn normalize_post_send_hooks_rejects_empty_recipient() {
+        let (_tempdir, config_root) = config_root_fixture();
         let error = normalize_post_send_hooks(
             vec![PostSendHookRule {
                 recipient: "   ".into(),
                 command: vec!["bash".into()],
             }],
-            Path::new("/tmp/atm-config-root"),
+            &config_root,
         )
         .expect_err("empty recipient should fail");
 
@@ -159,12 +169,13 @@ mod tests {
 
     #[test]
     fn normalize_post_send_hooks_rejects_invalid_recipient_selector() {
+        let (_tempdir, config_root) = config_root_fixture();
         let error = normalize_post_send_hooks(
             vec![PostSendHookRule {
                 recipient: "bad/name".into(),
                 command: vec!["bash".into()],
             }],
-            Path::new("/tmp/atm-config-root"),
+            &config_root,
         )
         .expect_err("invalid recipient should fail");
 
@@ -177,12 +188,13 @@ mod tests {
 
     #[test]
     fn normalize_post_send_hooks_rejects_empty_command_array() {
+        let (_tempdir, config_root) = config_root_fixture();
         let error = normalize_post_send_hooks(
             vec![PostSendHookRule {
                 recipient: "team-lead".into(),
                 command: Vec::new(),
             }],
-            Path::new("/tmp/atm-config-root"),
+            &config_root,
         )
         .expect_err("empty command should fail");
 
@@ -191,12 +203,13 @@ mod tests {
 
     #[test]
     fn normalize_post_send_hooks_rejects_blank_program_name() {
+        let (_tempdir, config_root) = config_root_fixture();
         let error = normalize_post_send_hooks(
             vec![PostSendHookRule {
                 recipient: "team-lead".into(),
                 command: vec!["   ".into(), "arg".into()],
             }],
-            Path::new("/tmp/atm-config-root"),
+            &config_root,
         )
         .expect_err("blank program should fail");
 

--- a/crates/atm-core/src/config/discovery.rs
+++ b/crates/atm-core/src/config/discovery.rs
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn normalize_post_send_hooks_preserves_absolute_paths() {
         let (_tempdir, config_root) = config_root_fixture();
-        let absolute = PathBuf::from("/usr/local/bin/hook");
+        let absolute = config_root.join("absolute hook.cmd");
         let hooks = vec![PostSendHookRule {
             recipient: "*".into(),
             command: vec![absolute.display().to_string()],

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -321,6 +321,7 @@ mod tests {
     use std::env;
     use std::fs;
     use std::path::PathBuf;
+    use tempfile::tempdir;
 
     use super::{AtmConfig, load_config, parse_team_config, resolve_identity, resolve_team};
 
@@ -683,7 +684,12 @@ post_send_hook_recipients = ["team-lead"]
     }
 
     fn temp_config_path() -> PathBuf {
-        env::temp_dir().join("config.json")
+        let tempdir = tempdir().expect("tempdir");
+        let root = tempdir.path().to_path_buf();
+        let nested = root.join("atm config root").join("nested config dir");
+        fs::create_dir_all(&nested).expect("nested config dir");
+        std::mem::forget(tempdir);
+        nested.join("config.json")
     }
 
     fn restore(key: &str, value: Option<std::ffi::OsString>) {

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -652,3 +652,92 @@ fn transition_displayed_message(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::Map;
+
+    use super::{ReadQuery, idle_notification_sender, selected_after_filters};
+    use crate::mailbox::source::SourcedMessage;
+    use crate::schema::{LegacyMessageId, MessageEnvelope};
+    use crate::types::{
+        AckActivationMode, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection,
+    };
+    use crate::workflow;
+
+    fn sourced_message(index: usize, text: &str) -> SourcedMessage {
+        SourcedMessage {
+            envelope: MessageEnvelope {
+                from: "team-lead".to_string(),
+                text: text.to_string(),
+                timestamp: IsoTimestamp::now(),
+                read: false,
+                source_team: Some("atm-dev".to_string()),
+                summary: None,
+                message_id: Some(LegacyMessageId::new()),
+                pending_ack_at: None,
+                acknowledged_at: None,
+                acknowledges_message_id: None,
+                task_id: None,
+                extra: Map::new(),
+            },
+            source_path: PathBuf::from("arch-ctm.json"),
+            source_index: index.into(),
+        }
+    }
+
+    #[test]
+    fn idle_notification_sender_returns_none_for_malformed_json() {
+        let message = sourced_message(0, r#"{"type":"idle_notification","from":"team-lead""#);
+
+        assert_eq!(idle_notification_sender(&message.envelope), None);
+    }
+
+    #[test]
+    fn malformed_idle_notification_adjacent_to_valid_records_remains_readable_and_classifiable() {
+        let workflow_state = workflow::WorkflowStateFile::default();
+        let messages = vec![
+            sourced_message(0, r#"{"type":"idle_notification","from":"team-lead""#),
+            sourced_message(1, "normal unread"),
+        ];
+        let query = ReadQuery {
+            home_dir: PathBuf::new(),
+            current_dir: PathBuf::new(),
+            actor_override: None,
+            target_address: None,
+            team_override: None,
+            selection_mode: ReadSelection::All,
+            seen_state_filter: false,
+            seen_state_update: false,
+            ack_activation_mode: AckActivationMode::ReadOnly,
+            limit: None,
+            sender_filter: None,
+            timestamp_filter: None,
+            timeout_secs: None,
+        };
+
+        let selected = std::panic::catch_unwind(|| {
+            selected_after_filters(&messages, &workflow_state, &query, None)
+        })
+        .expect("malformed idle notification should not panic");
+
+        assert_eq!(selected.len(), 2);
+        let valid = selected
+            .iter()
+            .find(|message| message.envelope.text == "normal unread")
+            .expect("valid record");
+        assert_eq!(valid.class, MessageClass::Unread);
+        assert_eq!(valid.bucket, DisplayBucket::Unread);
+
+        let malformed = selected
+            .iter()
+            .find(|message| {
+                message.envelope.text == r#"{"type":"idle_notification","from":"team-lead""#
+            })
+            .expect("malformed record");
+        assert_eq!(malformed.class, MessageClass::Unread);
+        assert_eq!(malformed.bucket, DisplayBucket::Unread);
+    }
+}

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 use serde_json::Value;
+use tracing::debug;
 
 use crate::address::AgentAddress;
 use crate::config;
@@ -405,18 +406,36 @@ fn idle_sender(message: &MessageEnvelope) -> Option<String> {
 }
 
 fn idle_notification_sender(message: &MessageEnvelope) -> Option<String> {
-    serde_json::from_str::<Value>(&message.text)
-        .ok()
-        .and_then(|value| {
-            (value.get("type").and_then(Value::as_str) == Some("idle_notification"))
-                .then(|| {
-                    value
-                        .get("from")
-                        .and_then(Value::as_str)
-                        .map(str::to_string)
-                })
-                .flatten()
-        })
+    let value = match serde_json::from_str::<Value>(&message.text) {
+        Ok(value) => value,
+        Err(error) => {
+            if message.text.contains("idle_notification") {
+                debug!(
+                    %error,
+                    recovery = "Repair or remove the malformed Claude idle-notification JSON. ATM will continue treating the record as a normal mailbox message.",
+                    message_text = %message.text,
+                    "ignoring malformed idle-notification JSON while classifying read surface"
+                );
+            }
+            return None;
+        }
+    };
+
+    if value.get("type").and_then(Value::as_str) != Some("idle_notification") {
+        return None;
+    }
+
+    match value.get("from").and_then(Value::as_str) {
+        Some(sender) => Some(sender.to_string()),
+        None => {
+            debug!(
+                recovery = "Ensure Claude idle-notification payloads include a string `from` field. ATM will continue treating the record as a normal mailbox message.",
+                message_text = %message.text,
+                "ignoring malformed idle-notification payload missing string `from`"
+            );
+            None
+        }
+    }
 }
 
 fn classify_all(

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -425,9 +425,10 @@ mod tests {
             ..Default::default()
         };
 
+        let abs = std::env::temp_dir().join("hook");
         assert_eq!(
-            resolve_command_path(&config, "/usr/local/bin/hook"),
-            Path::new("/usr/local/bin/hook")
+            resolve_command_path(&config, abs.to_str().unwrap()),
+            abs.as_path()
         );
     }
 

--- a/crates/atm/tests/log.rs
+++ b/crates/atm/tests/log.rs
@@ -1,8 +1,7 @@
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
-use std::sync::mpsc;
-use std::thread;
+use std::sync::mpsc::{self, Receiver};
 use std::time::Duration;
 
 use atm_core::schema::{AgentMember, TeamConfig};
@@ -137,7 +136,7 @@ fn test_log_filter_combines_level_and_match() {
 #[test]
 fn test_log_tail_streams_new_records() {
     let fixture = Fixture::new(&["arch-ctm", "recipient"]);
-    let child = fixture.spawn(&[
+    let mut tail = fixture.spawn_tail(&[
         "log",
         "tail",
         "--match",
@@ -146,23 +145,14 @@ fn test_log_tail_streams_new_records() {
         "--poll-interval-ms",
         "25",
     ]);
+    fixture.send("recipient@atm-dev", "tail readiness barrier");
+    let ready = tail.read_record();
+    assert_eq!(ready["fields"]["command"], "send");
 
-    // Known timing dependency: give the spawned tail process enough time to
-    // initialize before sending the log-producing command. TODO(v1.1.0): replace
-    // this sleep with a deterministic tail-readiness probe tracked in a follow-up issue.
-    thread::sleep(Duration::from_millis(250));
     fixture.send("recipient@atm-dev", "hello tail");
-
-    let records = fixture.read_tail_records(child, 1);
-    assert!(
-        !records.is_empty(),
-        "tail should produce at least one record"
-    );
-    assert!(
-        records
-            .iter()
-            .any(|record| record["fields"]["command"] == "send")
-    );
+    let record = tail.read_record();
+    assert_eq!(record["fields"]["command"], "send");
+    tail.finish();
 }
 
 #[test]
@@ -290,8 +280,8 @@ impl Fixture {
             .expect("run atm")
     }
 
-    fn spawn(&self, args: &[&str]) -> std::process::Child {
-        Command::new(env!("CARGO_BIN_EXE_atm"))
+    fn spawn_tail(&self, args: &[&str]) -> TailReader {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_atm"))
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
@@ -301,17 +291,10 @@ impl Fixture {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .expect("spawn atm")
-    }
-
-    fn read_tail_records(
-        &self,
-        mut child: std::process::Child,
-        count: usize,
-    ) -> Vec<serde_json::Value> {
+            .expect("spawn atm");
         let stdout = child.stdout.take().expect("tail stdout");
         let (tx, rx) = mpsc::channel();
-        thread::spawn(move || {
+        std::thread::spawn(move || {
             let mut reader = BufReader::new(stdout);
             loop {
                 let mut line = String::new();
@@ -326,23 +309,7 @@ impl Fixture {
                 }
             }
         });
-        let mut records = Vec::new();
-
-        while records.len() < count {
-            let line = rx.recv_timeout(Duration::from_secs(5)).unwrap_or_else(|_| {
-                let _ = child.kill();
-                panic!("tail timed out before producing enough output");
-            });
-            if line.trim().is_empty() {
-                continue;
-            }
-            records.push(serde_json::from_str(line.trim()).expect("json line"));
-        }
-
-        child.kill().expect("kill tail");
-        let _ = child.wait_with_output().expect("tail output");
-
-        records
+        TailReader { child, rx }
     }
 
     fn send(&self, target: &str, body: &str) {
@@ -397,5 +364,33 @@ impl Fixture {
 
     fn stderr(&self, output: &std::process::Output) -> String {
         String::from_utf8(output.stderr.clone()).expect("stderr utf8")
+    }
+}
+
+struct TailReader {
+    child: std::process::Child,
+    rx: Receiver<String>,
+}
+
+impl TailReader {
+    fn read_record(&mut self) -> serde_json::Value {
+        loop {
+            let line = self
+                .rx
+                .recv_timeout(Duration::from_secs(5))
+                .unwrap_or_else(|_| {
+                    let _ = self.child.kill();
+                    panic!("tail timed out before producing enough output");
+                });
+            if line.trim().is_empty() {
+                continue;
+            }
+            return serde_json::from_str(line.trim()).expect("json line");
+        }
+    }
+
+    fn finish(mut self) {
+        self.child.kill().expect("kill tail");
+        let _ = self.child.wait_with_output().expect("tail output");
     }
 }

--- a/crates/atm/tests/log.rs
+++ b/crates/atm/tests/log.rs
@@ -145,9 +145,7 @@ fn test_log_tail_streams_new_records() {
         "--poll-interval-ms",
         "25",
     ]);
-    fixture.send("recipient@atm-dev", "tail readiness barrier");
-    let ready = tail.read_record();
-    assert_eq!(ready["fields"]["command"], "send");
+    fixture.wait_for_tail_ready(&mut tail, "recipient@atm-dev");
 
     fixture.send("recipient@atm-dev", "hello tail");
     let record = tail.read_record();
@@ -312,6 +310,18 @@ impl Fixture {
         TailReader { child, rx }
     }
 
+    fn wait_for_tail_ready(&self, tail: &mut TailReader, target: &str) {
+        for attempt in 0..20 {
+            self.send(target, &format!("tail readiness barrier {attempt}"));
+            if let Some(record) = tail.try_read_record(Duration::from_millis(250)) {
+                assert_eq!(record["fields"]["command"], "send");
+                return;
+            }
+        }
+
+        panic!("tail never produced a readiness record after repeated barrier sends");
+    }
+
     fn send(&self, target: &str, body: &str) {
         let output = self.run(&["send", target, body, "--json"]);
         assert!(output.status.success(), "stderr: {}", self.stderr(&output));
@@ -373,20 +383,29 @@ struct TailReader {
 }
 
 impl TailReader {
-    fn read_record(&mut self) -> serde_json::Value {
+    fn try_read_record(&mut self, timeout: Duration) -> Option<serde_json::Value> {
         loop {
-            let line = self
-                .rx
-                .recv_timeout(Duration::from_secs(5))
-                .unwrap_or_else(|_| {
+            let line = match self.rx.recv_timeout(timeout) {
+                Ok(line) => line,
+                Err(mpsc::RecvTimeoutError::Timeout) => return None,
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
                     let _ = self.child.kill();
-                    panic!("tail timed out before producing enough output");
-                });
+                    panic!("tail exited before producing enough output");
+                }
+            };
             if line.trim().is_empty() {
                 continue;
             }
-            return serde_json::from_str(line.trim()).expect("json line");
+            return Some(serde_json::from_str(line.trim()).expect("json line"));
         }
+    }
+
+    fn read_record(&mut self) -> serde_json::Value {
+        self.try_read_record(Duration::from_secs(5))
+            .unwrap_or_else(|| {
+                let _ = self.child.kill();
+                panic!("tail timed out before producing enough output");
+            })
     }
 
     fn finish(mut self) {

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -658,6 +658,90 @@ fn test_read_keeps_read_and_unread_idle_notifications_from_different_files() {
 }
 
 #[test]
+fn test_read_logs_malformed_idle_notification_json_without_dropping_valid_records() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    fixture.write_inbox(
+        "arch-ctm",
+        &[
+            fixture.message(
+                "daemon",
+                r#"{"type":"idle_notification","from":"team-lead""#,
+                false,
+                None,
+                None,
+                0,
+            ),
+            fixture.message("team-lead", "normal unread", false, None, None, 1),
+        ],
+    );
+
+    let output = fixture.run_with_env(
+        &["--stderr-logs", "read", "--all", "--no-mark", "--json"],
+        &[("ATM_LOG", "debug")],
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["count"], 2);
+    let messages = parsed["messages"].as_array().expect("messages array");
+    assert!(
+        messages
+            .iter()
+            .any(|message| message["text"] == "normal unread")
+    );
+    assert!(
+        messages.iter().any(|message| {
+            message["text"] == r#"{"type":"idle_notification","from":"team-lead""#
+        })
+    );
+    let stderr = fixture.stderr(&output);
+    assert!(
+        stderr.contains("ignoring malformed idle-notification JSON while classifying read surface"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_read_logs_idle_notification_missing_sender_without_changing_mailbox_state() {
+    let fixture = Fixture::new(&["arch-ctm"]);
+    let malformed = serde_json::json!({
+        "type": "idle_notification",
+        "timestamp": "2026-03-30T00:00:00Z",
+        "idleReason": "available"
+    })
+    .to_string();
+    fixture.write_inbox(
+        "arch-ctm",
+        &[
+            fixture.message("daemon", &malformed, false, None, None, 0),
+            fixture.message("team-lead", "normal unread", false, None, None, 1),
+        ],
+    );
+    let before = fixture.inbox_contents("arch-ctm");
+
+    let output = fixture.run_with_env(
+        &["--stderr-logs", "read", "--all", "--no-mark", "--json"],
+        &[("ATM_LOG", "debug")],
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    assert_eq!(fixture.inbox_contents("arch-ctm"), before);
+    let stderr = fixture.stderr(&output);
+    assert!(
+        stderr.contains("ignoring malformed idle-notification payload missing string `from`"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_forward_metadata_message_id_timestamp_matches_persisted_timestamp() {
     let (message_id, timestamp) = AtmMessageId::new_with_timestamp();
     let envelope = ForwardMetadataEnvelope {
@@ -753,12 +837,17 @@ impl Fixture {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
+        self.run_with_env(args, &[])
+    }
+
+    fn run_with_env(&self, args: &[&str], extra_env: &[(&str, &str)]) -> std::process::Output {
         Command::new(env!("CARGO_BIN_EXE_atm"))
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
             .env("ATM_IDENTITY", "arch-ctm")
             .env("ATM_TEAM", "atm-dev")
+            .envs(extra_env.iter().copied())
             .current_dir(self.tempdir.path())
             .output()
             .expect("run atm")


### PR DESCRIPTION
## Summary

- Replaces fixed `thread::sleep(250ms)` in log-tail coverage with an explicit readiness barrier/reader — no timing-dependent tests remain
- Moves all `config/discovery.rs` tests from hardcoded `/tmp/atm-config-root` to `tempdir()`-backed paths with spaces and nested directories
- Scopes `ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD` with RAII env guard + teardown verification under `#[serial]` in `clear/mod.rs`
- Adds explicit malformed idle-notification JSON diagnostics without dropping valid mailbox records (RBP-F004)

## Test plan

- [ ] `cargo test --workspace` — PASS (validated by arch-ctm at 26925b3)
- [ ] `cargo clippy --workspace -- -D warnings` — PASS
- [ ] `cargo fmt --all --check` — PASS
- [ ] QA gate: req-qa, arch-qa, rust-qa-agent, flaky-test-qa

Part of Phase P post-merge hardening. Targets `integrate/phase-P`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)