### PR TITLE
fix(P.10): close mailbox lock sentinel gaps (GAP-1 sweep predicate + GAP-2 read-only FS)

### DIFF
--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -218,6 +218,23 @@ impl AtmError {
         )
     }
 
+    pub fn mailbox_lock_read_only_filesystem(
+        operation: &'static str,
+        path: &std::path::Path,
+    ) -> Self {
+        Self::new_with_code(
+            AtmErrorCode::MailboxLockReadOnlyFilesystem,
+            AtmErrorKind::MailboxLock,
+            format!(
+                "mailbox lock {operation} failed for {}: filesystem is read-only",
+                path.display()
+            ),
+        )
+        .with_recovery(
+            "Remount or move the ATM home to a writable filesystem, then retry the ATM command.",
+        )
+    }
+
     pub fn mailbox_lock_timeout(path: &std::path::Path) -> Self {
         Self::new_with_code(
             AtmErrorCode::MailboxLockTimeout,

--- a/crates/atm-core/src/error_codes.rs
+++ b/crates/atm-core/src/error_codes.rs
@@ -38,6 +38,8 @@ pub enum AtmErrorCode {
     MailboxWriteFailed,
     /// Acquiring or releasing a mailbox lock failed.
     MailboxLockFailed,
+    /// The mailbox lock path lives on a read-only filesystem.
+    MailboxLockReadOnlyFilesystem,
     /// Acquiring a mailbox lock timed out.
     MailboxLockTimeout,
     /// Message validation failed.
@@ -111,6 +113,7 @@ impl AtmErrorCode {
             Self::MailboxReadFailed => "ATM_MAILBOX_READ_FAILED",
             Self::MailboxWriteFailed => "ATM_MAILBOX_WRITE_FAILED",
             Self::MailboxLockFailed => "ATM_MAILBOX_LOCK_FAILED",
+            Self::MailboxLockReadOnlyFilesystem => "ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM",
             Self::MailboxLockTimeout => "ATM_MAILBOX_LOCK_TIMEOUT",
             Self::MessageValidationFailed => "ATM_MESSAGE_VALIDATION_FAILED",
             Self::SerializationFailed => "ATM_SERIALIZATION_FAILED",

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -650,15 +650,19 @@ fn canonical_lock_key(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::{OsStr, OsString};
     use std::io;
+    use std::sync::{Mutex, OnceLock};
     use std::time::{Duration, Instant};
 
+    use serial_test::serial;
     use tempfile::tempdir;
 
     use super::{
         DEFAULT_LOCK_TIMEOUT, FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE, StaleLockSentinelEviction,
         acquire, acquire_many_sorted, default_lock_timeout, evict_stale_lock_sentinel,
-        is_lock_contention_error, sentinel_path, sweep_stale_lock_sentinels,
+        is_lock_contention_error, is_lock_sentinel_candidate, sentinel_path,
+        sweep_stale_lock_sentinels,
     };
     use crate::error::AtmErrorCode;
 
@@ -684,12 +688,14 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn sentinel_path_appends_lock_suffix() {
         let path = PathBuf::from("team-lead.json");
         assert_eq!(sentinel_path(&path), PathBuf::from("team-lead.json.lock"));
     }
 
     #[test]
+    #[serial]
     fn acquire_creates_sentinel_file() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join("arch-ctm.json");
@@ -700,6 +706,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn dropping_guard_removes_sentinel_file() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join("arch-ctm.json");
@@ -714,6 +721,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn dropping_guard_skips_removal_when_sentinel_path_rotates() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join("arch-ctm.json");
@@ -731,6 +739,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn evict_stale_lock_sentinel_removes_dead_pid_file() {
         let tempdir = tempdir().expect("tempdir");
         let sentinel = tempdir.path().join("arch-ctm.json.lock");
@@ -744,6 +753,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn sweep_stale_lock_sentinels_removes_only_lock_files_with_dead_pids() {
         let tempdir = tempdir().expect("tempdir");
         let lock_path = tempdir.path().join("arch-ctm.json.lock");
@@ -759,6 +769,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn sweep_stale_lock_sentinels_removes_rotated_dead_pid_sentinels_only() {
         let tempdir = tempdir().expect("tempdir");
         let rotated = tempdir.path().join("arch-ctm.json.lock.old");
@@ -777,6 +788,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn sweep_stale_lock_sentinels_skips_malformed_rotated_sentinels() {
         let tempdir = tempdir().expect("tempdir");
         let rotated = tempdir.path().join("arch-ctm.json.lock.old");
@@ -789,6 +801,18 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn is_lock_sentinel_candidate_rejects_partial_lock_suffixes() {
+        assert!(!is_lock_sentinel_candidate(&PathBuf::from(
+            "inbox.json.lockold",
+        )));
+        assert!(!is_lock_sentinel_candidate(&PathBuf::from(
+            "inbox.locksmith.json",
+        )));
+    }
+
+    #[test]
+    #[serial]
     fn acquire_many_sorted_dedupes_and_sorts_paths() {
         let tempdir = tempdir().expect("tempdir");
         let a = tempdir.path().join("dir").join("..").join("b.json");
@@ -805,6 +829,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn acquire_reports_mailbox_lock_timeout_code() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join("arch-ctm.json");
@@ -815,6 +840,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn acquire_many_sorted_releases_prior_guards_on_failure() {
         let tempdir = tempdir().expect("tempdir");
         let free = tempdir.path().join("free.json");
@@ -832,6 +858,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn acquire_many_sorted_uses_total_timeout_budget() {
         let tempdir = tempdir().expect("tempdir");
         let first = tempdir.path().join("first.json");
@@ -846,6 +873,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn sort_unique_paths_dedupes_same_canonical_path() {
         let tempdir = tempdir().expect("tempdir");
         let real = tempdir.path().join("arch-ctm.json");
@@ -864,6 +892,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn acquire_many_sorted_orders_paths_deterministically() {
         let tempdir = tempdir().expect("tempdir");
         let a = tempdir.path().join("c.json");
@@ -878,17 +907,20 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn default_lock_timeout_uses_default_without_override() {
         assert_eq!(default_lock_timeout(), DEFAULT_LOCK_TIMEOUT);
     }
 
     #[test]
+    #[serial]
     fn would_block_is_classified_as_lock_contention() {
         let error = io::Error::from(io::ErrorKind::WouldBlock);
         assert!(is_lock_contention_error(&error));
     }
 
     #[test]
+    #[serial]
     fn acquire_reports_read_only_filesystem_for_open_failure() {
         let _readonly = ReadOnlyFilesystemGuard::set("open");
         let tempdir = tempdir().expect("tempdir");
@@ -901,6 +933,21 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn acquire_reports_read_only_filesystem_for_open_failure_via_env_var_seam() {
+        let _env_lock = env_lock().lock().expect("env lock");
+        let _guard = EnvGuard::set_raw("ATM_TEST_FORCE_LOCK_READONLY_FS", "open");
+        let tempdir = tempdir().expect("tempdir");
+        let inbox = tempdir.path().join("arch-ctm.json");
+
+        let error = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect_err("read-only open");
+
+        assert_eq!(error.code, AtmErrorCode::MailboxLockReadOnlyFilesystem);
+        assert!(error.message.contains("mailbox lock open failed"));
+    }
+
+    #[test]
+    #[serial]
     fn acquire_reports_read_only_filesystem_for_owner_record_write_failure() {
         let _readonly = ReadOnlyFilesystemGuard::set("write_owner");
         let tempdir = tempdir().expect("tempdir");
@@ -917,6 +964,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn sweep_reports_read_only_filesystem_for_stale_sentinel_removal() {
         let _readonly = ReadOnlyFilesystemGuard::set("remove");
         let tempdir = tempdir().expect("tempdir");
@@ -930,6 +978,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn dropping_guard_tolerates_read_only_cleanup_failure() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join("arch-ctm.json");
@@ -940,6 +989,45 @@ mod tests {
         drop(guard);
 
         assert!(sentinel.exists());
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set_raw(key: &'static str, value: &str) -> Self {
+            let original = std::env::var_os(key);
+            set_env_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                Some(value) => set_env_var(self.key, value),
+                None => remove_env_var(self.key),
+            }
+        }
+    }
+
+    fn set_env_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
+        // SAFETY: this test module uses #[serial] before mutating the process
+        // environment, so these mutations are serialized within this process.
+        unsafe { std::env::set_var(key, value) }
+    }
+
+    fn remove_env_var<K: AsRef<OsStr>>(key: K) {
+        // SAFETY: this test module uses #[serial] before mutating the process
+        // environment, so these mutations are serialized within this process.
+        unsafe { std::env::remove_var(key) }
     }
 
     use std::path::PathBuf;

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -61,7 +61,7 @@ impl Drop for MailboxLockGuard {
             && error.kind() != io::ErrorKind::NotFound
         {
             warn!(
-                code = %AtmErrorCode::MailboxLockFailed,
+                code = %mailbox_lock_error_code(&error),
                 %error,
                 target_path = %self.target_path.display(),
                 lock_path = %self.lock_path.display(),
@@ -114,20 +114,29 @@ pub(crate) fn acquire(path: &Path, timeout: Duration) -> Result<MailboxLockGuard
     let deadline = Instant::now() + timeout;
     let in_process_guard = acquire_in_process_lock(path, deadline)?;
     if let Some(parent) = lock_path.parent() {
-        fs::create_dir_all(parent).map_err(|error| {
-            AtmError::mailbox_lock(format!(
-                "failed to create mailbox lock directory {}: {error}",
-                parent.display()
-            ))
-            .with_recovery(
-                "Ensure the mailbox directory exists and is writable before retrying the ATM command.",
-            )
-            .with_source(error)
-        })?;
+        fs::create_dir_all(parent)
+            .map_err(|error| mailbox_lock_path_error("create", parent, error))?;
     }
 
     loop {
-        let _ = evict_stale_lock_sentinel(&lock_path);
+        match evict_stale_lock_sentinel(&lock_path) {
+            Ok(_) => {}
+            Err(error) if is_readonly_filesystem_error(&error) => {
+                return Err(mailbox_lock_path_error(
+                    "remove stale sentinel",
+                    &lock_path,
+                    error,
+                ));
+            }
+            Err(error) => {
+                warn!(
+                    code = %mailbox_lock_error_code(&error),
+                    %error,
+                    lock_path = %lock_path.display(),
+                    "failed to evict stale mailbox lock sentinel during acquisition"
+                );
+            }
+        }
         let file = open_lock_file(&lock_path)?;
         match try_lock_exclusive(&file, &lock_path) {
             Ok(()) => {
@@ -188,11 +197,27 @@ pub(crate) fn sweep_stale_lock_sentinels(dir: &Path) -> Result<usize, AtmError> 
     let mut removed = 0usize;
     for entry in entries.filter_map(Result::ok) {
         let path = entry.path();
-        if path.extension().and_then(|ext| ext.to_str()) != Some("lock") {
+        if !is_lock_sentinel_candidate(&path) {
             continue;
         }
-        if evict_stale_lock_sentinel(&path) {
-            removed += 1;
+        match evict_stale_lock_sentinel(&path) {
+            Ok(StaleLockSentinelEviction::Removed) => removed += 1,
+            Ok(StaleLockSentinelEviction::Skipped) => {}
+            Err(error) if is_readonly_filesystem_error(&error) => {
+                return Err(mailbox_lock_path_error(
+                    "remove stale sentinel",
+                    &path,
+                    error,
+                ));
+            }
+            Err(error) => {
+                warn!(
+                    code = %mailbox_lock_error_code(&error),
+                    %error,
+                    lock_path = %path.display(),
+                    "failed to evict stale mailbox lock sentinel during sweep"
+                );
+            }
         }
     }
 
@@ -236,22 +261,17 @@ fn try_lock_exclusive(file: &File, lock_path: &Path) -> io::Result<()> {
 }
 
 fn open_lock_file(lock_path: &Path) -> Result<File, AtmError> {
+    if let Some(error) = forced_readonly_filesystem_error("open") {
+        return Err(mailbox_lock_path_error("open", lock_path, error));
+    }
+
     OpenOptions::new()
         .create(true)
         .truncate(false)
         .read(true)
         .write(true)
         .open(lock_path)
-        .map_err(|error| {
-            AtmError::mailbox_lock(format!(
-                "failed to open mailbox lock {}: {error}",
-                lock_path.display()
-            ))
-            .with_recovery(
-                "Ensure the mailbox lock file path is writable and not blocked by permissions before retrying the ATM command.",
-            )
-            .with_source(error)
-        })
+        .map_err(|error| mailbox_lock_path_error("open", lock_path, error))
 }
 
 fn write_lock_owner_record(
@@ -259,27 +279,20 @@ fn write_lock_owner_record(
     lock_path: &Path,
     owner_record: &LockOwnerRecord,
 ) -> Result<(), AtmError> {
-    file.set_len(0).map_err(|error| {
-        AtmError::mailbox_lock(format!(
-            "failed to reset mailbox lock {} before writing owner record: {error}",
-            lock_path.display()
-        ))
-        .with_recovery(
-            "Check mailbox lock-file permissions and filesystem health before retrying the ATM command.",
-        )
-        .with_source(error)
-    })?;
+    if let Some(error) = forced_readonly_filesystem_error("write_owner") {
+        return Err(mailbox_lock_path_error(
+            "write owner record",
+            lock_path,
+            error,
+        ));
+    }
+
+    file.set_len(0)
+        .map_err(|error| mailbox_lock_path_error("write owner record", lock_path, error))?;
     let mut writer = file;
-    writer.write_all(owner_record.encode().as_bytes()).map_err(|error| {
-        AtmError::mailbox_lock(format!(
-            "failed to write mailbox lock owner record to {}: {error}",
-            lock_path.display()
-        ))
-        .with_recovery(
-            "Check mailbox lock-file permissions and filesystem health before retrying the ATM command.",
-        )
-        .with_source(error)
-    })
+    writer
+        .write_all(owner_record.encode().as_bytes())
+        .map_err(|error| mailbox_lock_path_error("write owner record", lock_path, error))
 }
 
 fn remove_active_lock_sentinel(lock_path: &Path, owner_record: &LockOwnerRecord) -> io::Result<()> {
@@ -332,36 +345,42 @@ fn lock_file_identity_from_path(path: &Path) -> io::Result<LockFileIdentity> {
     Handle::from_path(path)
 }
 
-fn evict_stale_lock_sentinel(lock_path: &Path) -> bool {
-    let Ok(raw) = fs::read_to_string(lock_path) else {
-        return false;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StaleLockSentinelEviction {
+    Removed,
+    Skipped,
+}
+
+fn evict_stale_lock_sentinel(lock_path: &Path) -> io::Result<StaleLockSentinelEviction> {
+    let raw = match fs::read_to_string(lock_path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(StaleLockSentinelEviction::Skipped);
+        }
+        Err(_) => return Ok(StaleLockSentinelEviction::Skipped),
     };
     let Some(pid) = parse_lock_owner_pid(&raw) else {
-        return false;
+        return Ok(StaleLockSentinelEviction::Skipped);
     };
     if process_is_alive(pid) {
-        return false;
+        return Ok(StaleLockSentinelEviction::Skipped);
     }
 
     match remove_lock_sentinel_with_retry(lock_path) {
-        Ok(()) => true,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => true,
-        Err(error) => {
-            warn!(
-                code = %AtmErrorCode::MailboxLockFailed,
-                %error,
-                lock_path = %lock_path.display(),
-                pid,
-                "failed to evict stale mailbox lock sentinel"
-            );
-            false
+        Ok(()) => Ok(StaleLockSentinelEviction::Removed),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            Ok(StaleLockSentinelEviction::Removed)
         }
+        Err(error) => Err(error),
     }
 }
 
 fn remove_lock_sentinel_with_retry(lock_path: &Path) -> io::Result<()> {
     let mut last_error = None;
     for attempt in 0..REMOVE_RETRY_ATTEMPTS {
+        if let Some(error) = forced_readonly_filesystem_error("remove") {
+            return Err(error);
+        }
         match fs::remove_file(lock_path) {
             Ok(()) => return Ok(()),
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
@@ -379,6 +398,10 @@ fn remove_lock_sentinel_with_retry(lock_path: &Path) -> io::Result<()> {
 }
 
 fn should_retry_remove_lock_sentinel(error: &io::Error) -> bool {
+    if is_readonly_filesystem_error(error) {
+        return false;
+    }
+
     if error.kind() == io::ErrorKind::PermissionDenied {
         return true;
     }
@@ -397,6 +420,93 @@ fn should_retry_remove_lock_sentinel(error: &io::Error) -> bool {
     {
         false
     }
+}
+
+fn is_lock_sentinel_candidate(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".lock") || name.contains(".lock."))
+}
+
+fn mailbox_lock_error_code(error: &io::Error) -> AtmErrorCode {
+    if is_readonly_filesystem_error(error) {
+        AtmErrorCode::MailboxLockReadOnlyFilesystem
+    } else {
+        AtmErrorCode::MailboxLockFailed
+    }
+}
+
+fn mailbox_lock_path_error(
+    operation: &'static str,
+    lock_path: &Path,
+    error: io::Error,
+) -> AtmError {
+    if is_readonly_filesystem_error(&error) {
+        AtmError::mailbox_lock_read_only_filesystem(operation, lock_path).with_source(error)
+    } else {
+        AtmError::mailbox_lock(format!(
+            "failed to {operation} mailbox lock {}: {error}",
+            lock_path.display()
+        ))
+        .with_recovery(
+            "Check mailbox lock-file permissions, parent-directory writability, and filesystem health before retrying the ATM command.",
+        )
+        .with_source(error)
+    }
+}
+
+fn is_readonly_filesystem_error(error: &io::Error) -> bool {
+    #[cfg(windows)]
+    {
+        matches!(
+            error.raw_os_error(),
+            Some(code) if code == windows_sys::Win32::Foundation::ERROR_WRITE_PROTECT as i32
+        )
+    }
+
+    #[cfg(not(windows))]
+    {
+        matches!(error.raw_os_error(), Some(code) if code == libc::EROFS)
+    }
+}
+
+fn forced_readonly_filesystem_error(operation: &'static str) -> Option<io::Error> {
+    #[cfg(test)]
+    if forced_readonly_filesystem_test_override() == Some(operation) {
+        return Some(io::Error::from_raw_os_error(
+            readonly_filesystem_raw_os_error(),
+        ));
+    }
+
+    let forced = std::env::var("ATM_TEST_FORCE_LOCK_READONLY_FS").ok()?;
+    if forced != operation {
+        return None;
+    }
+
+    Some(io::Error::from_raw_os_error(
+        readonly_filesystem_raw_os_error(),
+    ))
+}
+
+#[cfg(test)]
+thread_local! {
+    static FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE: std::cell::Cell<Option<&'static str>> =
+        const { std::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+fn forced_readonly_filesystem_test_override() -> Option<&'static str> {
+    FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE.with(|operation| operation.get())
+}
+
+#[cfg(windows)]
+const fn readonly_filesystem_raw_os_error() -> i32 {
+    windows_sys::Win32::Foundation::ERROR_WRITE_PROTECT as i32
+}
+
+#[cfg(not(windows))]
+const fn readonly_filesystem_raw_os_error() -> i32 {
+    libc::EROFS
 }
 
 fn is_lock_contention_error(error: &io::Error) -> bool {
@@ -546,11 +656,32 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        DEFAULT_LOCK_TIMEOUT, acquire, acquire_many_sorted, default_lock_timeout,
-        evict_stale_lock_sentinel, is_lock_contention_error, sentinel_path,
-        sweep_stale_lock_sentinels,
+        DEFAULT_LOCK_TIMEOUT, FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE, StaleLockSentinelEviction,
+        acquire, acquire_many_sorted, default_lock_timeout, evict_stale_lock_sentinel,
+        is_lock_contention_error, sentinel_path, sweep_stale_lock_sentinels,
     };
     use crate::error::AtmErrorCode;
+
+    struct ReadOnlyFilesystemGuard {
+        original: Option<&'static str>,
+    }
+
+    impl ReadOnlyFilesystemGuard {
+        fn set(operation: &'static str) -> Self {
+            let original = FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE.with(|cell| {
+                let original = cell.get();
+                cell.set(Some(operation));
+                original
+            });
+            Self { original }
+        }
+    }
+
+    impl Drop for ReadOnlyFilesystemGuard {
+        fn drop(&mut self) {
+            FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE.with(|cell| cell.set(self.original));
+        }
+    }
 
     #[test]
     fn sentinel_path_appends_lock_suffix() {
@@ -605,7 +736,10 @@ mod tests {
         let sentinel = tempdir.path().join("arch-ctm.json.lock");
         std::fs::write(&sentinel, u32::MAX.to_string()).expect("stale sentinel");
 
-        assert!(evict_stale_lock_sentinel(&sentinel));
+        assert_eq!(
+            evict_stale_lock_sentinel(&sentinel).expect("evict"),
+            StaleLockSentinelEviction::Removed
+        );
         assert!(!sentinel.exists());
     }
 
@@ -622,6 +756,36 @@ mod tests {
         assert_eq!(removed, 1);
         assert!(!lock_path.exists());
         assert!(inbox_path.exists());
+    }
+
+    #[test]
+    fn sweep_stale_lock_sentinels_removes_rotated_dead_pid_sentinels_only() {
+        let tempdir = tempdir().expect("tempdir");
+        let rotated = tempdir.path().join("arch-ctm.json.lock.old");
+        let live_rotated = tempdir.path().join("team-lead.json.lock.replaced");
+        let unrelated = tempdir.path().join("locksmith.txt");
+        std::fs::write(&rotated, u32::MAX.to_string()).expect("stale rotated");
+        std::fs::write(&live_rotated, std::process::id().to_string()).expect("live rotated");
+        std::fs::write(&unrelated, u32::MAX.to_string()).expect("unrelated");
+
+        let removed = sweep_stale_lock_sentinels(tempdir.path()).expect("sweep");
+
+        assert_eq!(removed, 1);
+        assert!(!rotated.exists());
+        assert!(live_rotated.exists());
+        assert!(unrelated.exists());
+    }
+
+    #[test]
+    fn sweep_stale_lock_sentinels_skips_malformed_rotated_sentinels() {
+        let tempdir = tempdir().expect("tempdir");
+        let rotated = tempdir.path().join("arch-ctm.json.lock.old");
+        std::fs::write(&rotated, "not-a-pid").expect("malformed");
+
+        let removed = sweep_stale_lock_sentinels(tempdir.path()).expect("sweep");
+
+        assert_eq!(removed, 0);
+        assert!(rotated.exists());
     }
 
     #[test]
@@ -722,6 +886,60 @@ mod tests {
     fn would_block_is_classified_as_lock_contention() {
         let error = io::Error::from(io::ErrorKind::WouldBlock);
         assert!(is_lock_contention_error(&error));
+    }
+
+    #[test]
+    fn acquire_reports_read_only_filesystem_for_open_failure() {
+        let _readonly = ReadOnlyFilesystemGuard::set("open");
+        let tempdir = tempdir().expect("tempdir");
+        let inbox = tempdir.path().join("arch-ctm.json");
+
+        let error = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect_err("read-only open");
+
+        assert_eq!(error.code, AtmErrorCode::MailboxLockReadOnlyFilesystem);
+        assert!(error.message.contains("mailbox lock open failed"));
+    }
+
+    #[test]
+    fn acquire_reports_read_only_filesystem_for_owner_record_write_failure() {
+        let _readonly = ReadOnlyFilesystemGuard::set("write_owner");
+        let tempdir = tempdir().expect("tempdir");
+        let inbox = tempdir.path().join("arch-ctm.json");
+
+        let error = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect_err("read-only write");
+
+        assert_eq!(error.code, AtmErrorCode::MailboxLockReadOnlyFilesystem);
+        assert!(
+            error
+                .message
+                .contains("mailbox lock write owner record failed")
+        );
+    }
+
+    #[test]
+    fn sweep_reports_read_only_filesystem_for_stale_sentinel_removal() {
+        let _readonly = ReadOnlyFilesystemGuard::set("remove");
+        let tempdir = tempdir().expect("tempdir");
+        let rotated = tempdir.path().join("arch-ctm.json.lock.old");
+        std::fs::write(&rotated, u32::MAX.to_string()).expect("stale rotated");
+
+        let error = sweep_stale_lock_sentinels(tempdir.path()).expect_err("read-only remove");
+
+        assert_eq!(error.code, AtmErrorCode::MailboxLockReadOnlyFilesystem);
+        assert!(rotated.exists());
+    }
+
+    #[test]
+    fn dropping_guard_tolerates_read_only_cleanup_failure() {
+        let tempdir = tempdir().expect("tempdir");
+        let inbox = tempdir.path().join("arch-ctm.json");
+        let sentinel = sentinel_path(&inbox);
+        let guard = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect("lock");
+        let _readonly = ReadOnlyFilesystemGuard::set("remove");
+
+        drop(guard);
+
+        assert!(sentinel.exists());
     }
 
     use std::path::PathBuf;

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -16,12 +16,6 @@ use super::{PostSendHookContext, qualified_sender_identity};
 const POST_SEND_HOOK_TIMEOUT: Duration = Duration::from_secs(5);
 const POST_SEND_HOOK_MAX_STDOUT_BYTES: usize = 8 * 1024;
 
-#[derive(Debug, Clone, Copy)]
-struct PostSendHookMatch {
-    sender: bool,
-    recipient: bool,
-}
-
 #[derive(Debug, Deserialize)]
 struct PostSendHookResult {
     level: PostSendHookResultLevel,
@@ -47,52 +41,35 @@ pub(super) fn maybe_run_post_send_hook(
     let Some(config) = config else {
         return;
     };
-    let Some(command_argv) = config.post_send_hook.as_ref() else {
-        return;
-    };
 
-    let sender_filters_configured = !config.post_send_hook_senders.is_empty();
-    let recipient_filters_configured = !config.post_send_hook_recipients.is_empty();
-    let hook_match = PostSendHookMatch {
-        sender: matches_hook_axis(&config.post_send_hook_senders, context.sender),
-        recipient: matches_hook_axis(&config.post_send_hook_recipients, &context.recipient.agent),
-    };
-    if !hook_match.sender && !hook_match.recipient {
-        if !sender_filters_configured && !recipient_filters_configured {
-            debug!(
-                sender = context.sender,
-                recipient = %context.recipient.agent,
-                recipient_team = %context.recipient.team,
-                "post-send hook disabled because no sender or recipient filters are configured"
-            );
-            return;
-        }
+    let matching_rules: Vec<_> = config
+        .post_send_hooks
+        .iter()
+        .filter(|rule| hook_matches_recipient(&rule.recipient, &context.recipient.agent))
+        .collect();
 
+    if matching_rules.is_empty() {
         debug!(
             sender = context.sender,
             recipient = %context.recipient.agent,
             recipient_team = %context.recipient.team,
-            sender_filters = %display_filter_list(&config.post_send_hook_senders),
-            recipient_filters = %display_filter_list(&config.post_send_hook_recipients),
-            sender_match = hook_match.sender,
-            recipient_match = hook_match.recipient,
-            "post-send hook did not match configured sender or recipient filters"
+            "post-send hook had no matching recipient rules"
         );
         return;
     }
 
-    debug!(
-        sender = context.sender,
-        recipient = %context.recipient.agent,
-        recipient_team = %context.recipient.team,
-        sender_filters = %display_filter_list(&config.post_send_hook_senders),
-        recipient_filters = %display_filter_list(&config.post_send_hook_recipients),
-        sender_match = hook_match.sender,
-        recipient_match = hook_match.recipient,
-        "post-send hook matched"
-    );
+    for rule in matching_rules {
+        execute_post_send_hook(warnings, config, rule, &context);
+    }
+}
 
-    let mut argv = command_argv.iter();
+fn execute_post_send_hook(
+    warnings: &mut Vec<String>,
+    config: &config::AtmConfig,
+    rule: &config::types::PostSendHookRule,
+    context: &PostSendHookContext<'_>,
+) {
+    let mut argv = rule.command.iter();
     let Some(command_path) = argv.next() else {
         return;
     };
@@ -101,14 +78,23 @@ pub(super) fn maybe_run_post_send_hook(
         "from": qualified_sender_identity(context.sender, context.sender_team),
         "to": format!("{}@{}", context.recipient.agent, context.recipient.team),
         "sender": context.sender,
-        "recipient": context.recipient.agent.as_str(),
-        "team": context.recipient.team.as_str(),
+        "recipient": context.recipient.agent,
+        "team": context.recipient.team,
         "message_id": context.message_id.to_string(),
         "requires_ack": context.requires_ack,
     });
     if let Some(task_id) = context.task_id {
         payload["task_id"] = Value::String(task_id.to_string());
     }
+
+    debug!(
+        sender = context.sender,
+        recipient = %context.recipient.agent,
+        recipient_team = %context.recipient.team,
+        hook_recipient = %rule.recipient,
+        hook_path = %command_path.display(),
+        "post-send hook matched recipient rule"
+    );
 
     let mut command = Command::new(&command_path);
     command
@@ -122,7 +108,7 @@ pub(super) fn maybe_run_post_send_hook(
         Ok(child) => child,
         Err(error) => {
             let warning = format!(
-                "warning: post-send hook failed to start from {}: {error}. Check that post_send_hook in .atm.toml points to a valid executable.",
+                "warning: post-send hook failed to start from {}: {error}. Check that the hook command in .atm.toml points to a valid executable.",
                 command_path.display()
             );
             warn!(
@@ -130,6 +116,7 @@ pub(super) fn maybe_run_post_send_hook(
                 sender = context.sender,
                 recipient = %context.recipient.agent,
                 recipient_team = %context.recipient.team,
+                hook_recipient = %rule.recipient,
                 hook_path = %command_path.display(),
                 %error,
                 "post-send hook failed to start"
@@ -158,6 +145,7 @@ pub(super) fn maybe_run_post_send_hook(
                         sender = context.sender,
                         recipient = %context.recipient.agent,
                         recipient_team = %context.recipient.team,
+                        hook_recipient = %rule.recipient,
                         hook_path = %command_path.display(),
                         %status,
                         "post-send hook exited unsuccessfully"
@@ -186,6 +174,7 @@ pub(super) fn maybe_run_post_send_hook(
                     sender = context.sender,
                     recipient = %context.recipient.agent,
                     recipient_team = %context.recipient.team,
+                    hook_recipient = %rule.recipient,
                     hook_path = %command_path.display(),
                     timeout_seconds = POST_SEND_HOOK_TIMEOUT.as_secs(),
                     "post-send hook timed out"
@@ -209,6 +198,7 @@ pub(super) fn maybe_run_post_send_hook(
                     sender = context.sender,
                     recipient = %context.recipient.agent,
                     recipient_team = %context.recipient.team,
+                    hook_recipient = %rule.recipient,
                     hook_path = %command_path.display(),
                     %error,
                     "post-send hook status check failed"
@@ -222,35 +212,15 @@ pub(super) fn maybe_run_post_send_hook(
 
 fn resolve_command_path(config: &config::AtmConfig, command_path: &str) -> PathBuf {
     let path = PathBuf::from(command_path);
-    if path.is_absolute() || !command_path_contains_path_separator(command_path) {
+    if path.is_absolute() || !config::discovery::command_looks_like_path(command_path) {
         path
     } else {
         config.config_root.join(path)
     }
 }
 
-fn command_path_contains_path_separator(command_path: &str) -> bool {
-    command_path.contains('/') || command_path.contains('\\')
-}
-
-fn matches_hook_axis(filters: &[String], candidate: &str) -> bool {
-    hook_filter_matches(filters, candidate)
-}
-
-fn hook_filter_matches(filters: &[String], candidate: &str) -> bool {
-    filters
-        .iter()
-        .any(|filter| filter == "*" || filter == candidate)
-}
-
-/// Render filters exactly as operators configure them so skip diagnostics make
-/// it clear when a trigger axis is effectively disabled.
-fn display_filter_list(filters: &[String]) -> String {
-    if filters.is_empty() {
-        "(not configured)".to_string()
-    } else {
-        filters.join(", ")
-    }
+fn hook_matches_recipient(configured: &str, candidate: &str) -> bool {
+    configured == "*" || configured == candidate
 }
 
 fn spawn_post_send_hook_stdout_reader(
@@ -283,7 +253,8 @@ fn finish_post_send_hook_stdout_capture(
     match stdout_reader.join() {
         Ok(Ok(stdout)) => Some(stdout),
         Ok(Err(error)) => {
-            warn!(code = %AtmErrorCode::WarningHookExecutionFailed,
+            warn!(
+                code = %AtmErrorCode::WarningHookExecutionFailed,
                 hook_path = %command_path.display(),
                 %error,
                 "post-send hook stdout capture failed"
@@ -291,7 +262,8 @@ fn finish_post_send_hook_stdout_capture(
             None
         }
         Err(_) => {
-            warn!(code = %AtmErrorCode::WarningHookExecutionFailed,
+            warn!(
+                code = %AtmErrorCode::WarningHookExecutionFailed,
                 hook_path = %command_path.display(),
                 "post-send hook stdout capture panicked"
             );
@@ -400,80 +372,21 @@ fn hook_result_log_level(level: PostSendHookResultLevel) -> Level {
 
 #[cfg(test)]
 mod tests {
-    use std::env;
     use std::path::Path;
 
     use serde_json::json;
     use tracing::Level;
 
     use super::{
-        POST_SEND_HOOK_MAX_STDOUT_BYTES, PostSendHookResultLevel,
-        command_path_contains_path_separator, hook_filter_matches, hook_result_log_level,
-        matches_hook_axis, parse_post_send_hook_result, resolve_command_path,
+        POST_SEND_HOOK_MAX_STDOUT_BYTES, PostSendHookResultLevel, hook_matches_recipient,
+        hook_result_log_level, parse_post_send_hook_result,
     };
 
-    fn test_config_root() -> std::path::PathBuf {
-        env::temp_dir().join("atm-config-root")
-    }
-
     #[test]
-    fn hook_filter_matches_exact_and_wildcard_values() {
-        assert!(hook_filter_matches(&["arch-ctm".to_string()], "arch-ctm"));
-        assert!(hook_filter_matches(&["*".to_string()], "arch-ctm"));
-        assert!(!hook_filter_matches(&["team-lead".to_string()], "arch-ctm"));
-    }
-
-    #[test]
-    fn matches_hook_axis_treats_empty_filter_list_as_no_match() {
-        assert!(!matches_hook_axis(&[], "arch-ctm"));
-    }
-
-    #[test]
-    fn command_path_contains_path_separator_matches_path_like_commands_only() {
-        assert!(command_path_contains_path_separator("scripts/hook.sh"));
-        assert!(command_path_contains_path_separator(r"scripts\hook.bat"));
-        assert!(!command_path_contains_path_separator("bash"));
-    }
-
-    #[test]
-    fn resolve_command_path_preserves_absolute_paths() {
-        let config = crate::config::AtmConfig {
-            config_root: test_config_root(),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            resolve_command_path(&config, "/usr/local/bin/hook"),
-            Path::new("/usr/local/bin/hook")
-        );
-    }
-
-    #[test]
-    fn resolve_command_path_joins_relative_paths_with_separators_under_config_root() {
-        let config = crate::config::AtmConfig {
-            config_root: test_config_root(),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            resolve_command_path(&config, "scripts/hook.sh"),
-            test_config_root().join("scripts/hook.sh")
-        );
-    }
-
-    #[test]
-    fn resolve_command_path_preserves_bare_command_names_for_path_lookup() {
-        let config = crate::config::AtmConfig {
-            config_root: test_config_root(),
-            ..Default::default()
-        };
-
-        assert_eq!(resolve_command_path(&config, "bash"), Path::new("bash"));
-    }
-
-    #[test]
-    fn display_filter_list_renders_empty_as_not_configured() {
-        assert_eq!(super::display_filter_list(&[]), "(not configured)");
+    fn hook_matches_recipient_exact_and_wildcard_values() {
+        assert!(hook_matches_recipient("arch-ctm", "arch-ctm"));
+        assert!(hook_matches_recipient("*", "arch-ctm"));
+        assert!(!hook_matches_recipient("team-lead", "arch-ctm"));
     }
 
     #[test]

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
+use serde_json::Value;
 
 #[test]
 fn test_send_creates_inbox_file() {
@@ -124,6 +125,19 @@ fn test_send_requires_ack() {
     let inbox = fixture.inbox_contents("recipient");
     assert_eq!(inbox.len(), 1);
     assert!(inbox[0].pending_ack_at.is_some());
+    let atm_message_id = inbox[0].extra["metadata"]["atm"]["messageId"]
+        .as_str()
+        .expect("atm message id");
+    let workflow = fixture.workflow_state_contents("atm-dev", "recipient");
+    assert!(
+        workflow["messages"][format!("atm:{atm_message_id}")]["read"].is_null()
+            || workflow["messages"][format!("atm:{atm_message_id}")]["read"] == false
+    );
+    assert!(
+        workflow["messages"][format!("atm:{atm_message_id}")]["pendingAckAt"]
+            .as_str()
+            .is_some()
+    );
 }
 
 #[test]
@@ -434,7 +448,7 @@ fn test_send_runs_post_send_hook_with_expected_payload() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_senders = ['arch-ctm']\n",
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'capture', '{}']\n",
         hook_path.display(),
         payload_path.display()
     ));
@@ -450,13 +464,11 @@ fn test_send_runs_post_send_hook_with_expected_payload() {
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
     assert_eq!(payload["from"], "arch-ctm@atm-dev");
     assert_eq!(payload["to"], "recipient@atm-dev");
-    assert_eq!(payload["sender"], "arch-ctm");
-    assert_eq!(payload["recipient"], "recipient");
-    assert_eq!(payload["team"], "atm-dev");
     assert_eq!(payload["requires_ack"], false);
     assert!(payload["message_id"].as_str().is_some());
     assert!(payload.get("task_id").is_none());
-    assert!(payload.get("hook_match").is_none());
+    assert_eq!(payload["sender"], "arch-ctm");
+    assert_eq!(payload["recipient"], "recipient");
 }
 
 #[test]
@@ -464,7 +476,7 @@ fn test_send_post_send_hook_failure_does_not_roll_back_send() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("fail");
     fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'fail', '{}']\npost_send_hook_senders = ['arch-ctm']\n",
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'fail', '{}']\n",
         hook_path.display(),
         payload_path.display()
     ));
@@ -491,16 +503,16 @@ fn test_send_post_send_hook_failure_does_not_roll_back_send() {
 }
 
 #[test]
-fn test_send_non_matching_hook_filters_are_silent() {
+fn test_send_post_send_hook_non_match_is_silent() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_senders = ['team-lead']\npost_send_hook_recipients = ['quality-mgr']\n",
+        "[[atm.post_send_hooks]]\nrecipient = 'quality-mgr'\ncommand = ['{}', 'capture', '{}']\n",
         hook_path.display(),
         payload_path.display()
     ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello skipped hook"]);
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello unmatched hook"]);
 
     assert!(
         output.status.success(),
@@ -508,73 +520,67 @@ fn test_send_non_matching_hook_filters_are_silent() {
         fixture.stderr(&output)
     );
     assert!(!payload_path.exists(), "hook payload unexpectedly created");
-    assert!(
-        fixture.stderr(&output).is_empty(),
-        "stderr: {}",
-        fixture.stderr(&output)
-    );
+    assert_eq!(fixture.stderr(&output), "");
     let inbox = fixture.inbox_contents("recipient");
     assert_eq!(inbox.len(), 1);
 }
 
 #[test]
-fn test_send_non_matching_hook_filters_are_silent_in_json_mode() {
+fn test_send_runs_post_send_hook_for_wildcard_recipient() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_senders = ['team-lead']\npost_send_hook_recipients = ['quality-mgr']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '*'\ncommand = ['{}', 'capture', '{}']\n",
         hook_path.display(),
         payload_path.display()
     ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello skipped hook", "--json"]);
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello wildcard hook"]);
 
     assert!(
         output.status.success(),
         "stderr: {}",
         fixture.stderr(&output)
     );
-    assert!(!payload_path.exists(), "hook payload unexpectedly created");
-    assert!(
-        fixture.stderr(&output).is_empty(),
-        "stderr: {}",
-        fixture.stderr(&output)
-    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
+    assert_eq!(payload["recipient"], "recipient");
 }
 
 #[test]
-fn test_send_recipient_only_non_matching_hook_filter_is_silent() {
+fn test_send_runs_multiple_matching_post_send_hooks_in_config_order() {
     let fixture = Fixture::new("recipient");
-    let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
-    fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_recipients = ['quality-mgr']\n",
-        hook_path.display(),
-        payload_path.display()
-    ));
+    let order_path = fixture.tempdir.path().join("hook-order.log");
+    fixture.install_executable_script(
+        "scripts/append-order.py",
+        &format!(
+            "#!/usr/bin/env python3\nimport sys\nfrom pathlib import Path\nPath(r\"{}\").open(\"a\", encoding=\"utf-8\").write(sys.argv[1] + \"\\n\")\n",
+            order_path.display()
+        ),
+    );
+    fixture.write_atm_config(
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['python3', 'scripts/append-order.py', 'recipient']\n\n[[atm.post_send_hooks]]\nrecipient = '*'\ncommand = ['python3', 'scripts/append-order.py', 'wildcard']\n",
+    );
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello skipped hook"]);
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello multiple hooks"]);
 
     assert!(
         output.status.success(),
         "stderr: {}",
         fixture.stderr(&output)
     );
-    assert!(!payload_path.exists(), "hook payload unexpectedly created");
-    assert!(
-        fixture.stderr(&output).is_empty(),
-        "stderr: {}",
-        fixture.stderr(&output)
-    );
-    let inbox = fixture.inbox_contents("recipient");
-    assert_eq!(inbox.len(), 1);
+    let hook_order = fs::read_to_string(order_path)
+        .expect("hook order log")
+        .replace("\r\n", "\n");
+    assert_eq!(hook_order, "recipient\nwildcard\n");
 }
 
 #[test]
-fn test_send_runs_post_send_hook_when_recipient_matches_filter() {
+fn test_send_runs_post_send_hook_when_recipient_matches_rule() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_recipients = ['recipient']\n",
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'capture', '{}']\n",
         hook_path.display(),
         payload_path.display()
     ));
@@ -588,41 +594,15 @@ fn test_send_runs_post_send_hook_when_recipient_matches_filter() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["sender"], "arch-ctm");
     assert_eq!(payload["recipient"], "recipient");
-    assert_eq!(payload["team"], "atm-dev");
-    assert!(payload.get("hook_match").is_none());
 }
 
 #[test]
-fn test_send_runs_post_send_hook_once_when_sender_and_recipient_both_match() {
-    let fixture = Fixture::new("recipient");
-    let (hook_path, counter_path) = fixture.install_hook_fixture("count");
-    fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'count', '{}']\npost_send_hook_senders = ['arch-ctm']\npost_send_hook_recipients = ['recipient']\n",
-        hook_path.display(),
-        counter_path.display()
-    ));
-
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello both filters"]);
-
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        fixture.stderr(&output)
-    );
-    assert_eq!(
-        fs::read_to_string(counter_path).expect("counter").trim(),
-        "1"
-    );
-}
-
-#[test]
-fn test_send_runs_post_send_hook_for_multiline_message_when_sender_matches() {
+fn test_send_runs_post_send_hook_for_multiline_message_when_rule_matches() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_senders = ['arch-ctm']\n",
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'capture', '{}']\n",
         hook_path.display(),
         payload_path.display()
     ));
@@ -650,7 +630,7 @@ fn test_send_ignores_post_send_hook_configured_only_in_core_section() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[core]\ndefault_team = 'atm-dev'\nidentity = 'team-lead'\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_senders = ['arch-ctm']\npost_send_hook_recipients = ['recipient']\n",
+        "[core]\ndefault_team = 'atm-dev'\nidentity = 'team-lead'\npost_send_hook = ['{}', 'capture', '{}']\n",
         hook_path.display(),
         payload_path.display()
     ));
@@ -672,7 +652,7 @@ fn test_send_post_send_hook_receives_only_configured_positional_args() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture-meta");
     fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture-meta', '{}']\npost_send_hook_senders = ['arch-ctm']\n",
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'capture-meta', '{}']\n",
         hook_path.display(),
         payload_path.display()
     ));
@@ -688,23 +668,25 @@ fn test_send_post_send_hook_receives_only_configured_positional_args() {
         serde_json::from_slice(&fs::read(payload_path).expect("hook meta")).expect("json");
     assert_eq!(captured["args"], serde_json::json!([]));
     assert_eq!(captured["payload"]["to"], "recipient@atm-dev");
-    assert_eq!(captured["payload"]["sender"], "arch-ctm");
-    assert_eq!(captured["payload"]["recipient"], "recipient");
-    assert_eq!(captured["payload"]["team"], "atm-dev");
-    assert!(captured["payload"].get("hook_match").is_none());
 }
 
+#[cfg(unix)]
 #[test]
-fn test_send_runs_post_send_hook_when_sender_filter_is_wildcard() {
+fn test_send_runs_post_send_hook_with_relative_script_command() {
     let fixture = Fixture::new("recipient");
-    let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
-    fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_senders = ['*']\n",
-        hook_path.display(),
-        payload_path.display()
-    ));
+    let payload_path = fixture.tempdir.path().join("relative-hook.json");
+    fixture.install_executable_script(
+        "scripts/record-hook.sh",
+        &format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$ATM_POST_SEND\" > '{}'\n",
+            payload_path.display()
+        ),
+    );
+    fixture.write_atm_config(
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['scripts/record-hook.sh']\n",
+    );
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello wildcard sender"]);
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello relative script"]);
 
     assert!(
         output.status.success(),
@@ -713,23 +695,26 @@ fn test_send_runs_post_send_hook_when_sender_filter_is_wildcard() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["sender"], "arch-ctm");
     assert_eq!(payload["recipient"], "recipient");
-    assert_eq!(payload["team"], "atm-dev");
-    assert!(payload.get("hook_match").is_none());
 }
 
+#[cfg(unix)]
 #[test]
-fn test_send_runs_post_send_hook_when_recipient_filter_is_wildcard() {
+fn test_send_runs_post_send_hook_with_bare_bash_command() {
     let fixture = Fixture::new("recipient");
-    let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
-    fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_recipients = ['*']\n",
-        hook_path.display(),
-        payload_path.display()
-    ));
+    let payload_path = fixture.tempdir.path().join("bash-hook.json");
+    fixture.install_executable_script(
+        "scripts/record-hook.sh",
+        &format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$ATM_POST_SEND\" > '{}'\n",
+            payload_path.display()
+        ),
+    );
+    fixture.write_atm_config(
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['bash', 'scripts/record-hook.sh']\n",
+    );
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello wildcard recipient"]);
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello bare bash"]);
 
     assert!(
         output.status.success(),
@@ -738,35 +723,25 @@ fn test_send_runs_post_send_hook_when_recipient_filter_is_wildcard() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["sender"], "arch-ctm");
     assert_eq!(payload["recipient"], "recipient");
-    assert_eq!(payload["team"], "atm-dev");
-    assert!(payload.get("hook_match").is_none());
 }
 
 #[test]
-fn test_send_runs_post_send_hook_with_bare_binary_command_via_path() {
+fn test_send_runs_post_send_hook_with_python_command() {
     let fixture = Fixture::new("recipient");
-    let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
-    let hook_bin_name = hook_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .expect("hook binary filename");
-    fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\npost_send_hook_recipients = ['recipient']\n",
-        hook_bin_name,
-        payload_path.display()
-    ));
-
-    let existing_path = std::env::var_os("PATH").unwrap_or_default();
-    let mut path_entries = vec![fixture.tempdir.path().join("bin")];
-    path_entries.extend(std::env::split_paths(&existing_path));
-    let path_value = std::env::join_paths(path_entries).expect("PATH");
-    let path_string = path_value.to_string_lossy().into_owned();
-    let output = fixture.run_with_env(
-        &["send", "recipient@atm-dev", "hello bare path hook"],
-        &[("PATH", path_string.as_str())],
+    let payload_path = fixture.tempdir.path().join("python-hook.json");
+    fixture.install_executable_script(
+        "scripts/record_hook.py",
+        &format!(
+            "#!/usr/bin/env python3\nimport os\nfrom pathlib import Path\nPath(r\"{}\").write_text(os.environ['ATM_POST_SEND'])\n",
+            payload_path.display()
+        ),
     );
+    fixture.write_atm_config(
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['python3', 'scripts/record_hook.py']\n",
+    );
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello python hook"]);
 
     assert!(
         output.status.success(),
@@ -775,41 +750,13 @@ fn test_send_runs_post_send_hook_with_bare_binary_command_via_path() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["sender"], "arch-ctm");
     assert_eq!(payload["recipient"], "recipient");
-    assert_eq!(payload["team"], "atm-dev");
-    assert!(payload.get("hook_match").is_none());
-}
-
-#[test]
-fn test_send_does_not_run_post_send_hook_when_filter_lists_are_empty() {
-    let fixture = Fixture::new("recipient");
-    let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
-    fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'capture', '{}']\n",
-        hook_path.display(),
-        payload_path.display()
-    ));
-
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello empty filters"]);
-
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        fixture.stderr(&output)
-    );
-    assert!(!payload_path.exists(), "hook payload unexpectedly created");
-    assert_eq!(fixture.stderr(&output), "");
-    let inbox = fixture.inbox_contents("recipient");
-    assert_eq!(inbox.len(), 1);
 }
 
 #[test]
 fn test_send_rejects_retired_post_send_hook_members_config() {
     let fixture = Fixture::new("recipient");
-    fixture.write_atm_config(
-        "[atm]\npost_send_hook = ['bin/hook']\npost_send_hook_members = ['team-lead']\n",
-    );
+    fixture.write_atm_config("[atm]\npost_send_hook_members = ['team-lead']\n");
 
     let output = fixture.run(&["send", "recipient@atm-dev", "hello retired"]);
 
@@ -817,7 +764,46 @@ fn test_send_rejects_retired_post_send_hook_members_config() {
     let stderr = fixture.stderr(&output);
     assert!(stderr.contains("post_send_hook_members"));
     assert!(stderr.contains(".atm.toml"));
-    assert!(stderr.contains("Use 'post_send_hook_senders' (match on sender identity) and/or 'post_send_hook_recipients' (match on recipient name) under [atm]. Use '*' to match all senders or all recipients."));
+    assert!(stderr.contains("[[atm.post_send_hooks]]"));
+}
+
+#[test]
+fn test_send_rejects_legacy_post_send_filter_shape() {
+    let fixture = Fixture::new("recipient");
+    fixture.write_atm_config(
+        "[atm]\npost_send_hook = ['bin/hook']\npost_send_hook_recipients = ['recipient']\n",
+    );
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello retired"]);
+
+    assert!(!output.status.success());
+    let stderr = fixture.stderr(&output);
+    assert!(stderr.contains("retired post-send hook keys"));
+    assert!(stderr.contains("[[atm.post_send_hooks]]"));
+}
+
+#[test]
+fn test_send_rejects_post_send_hook_with_empty_recipient() {
+    let fixture = Fixture::new("recipient");
+    fixture.write_atm_config("[[atm.post_send_hooks]]\nrecipient = '   '\ncommand = ['bash']\n");
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello invalid hook"]);
+
+    assert!(!output.status.success());
+    let stderr = fixture.stderr(&output);
+    assert!(stderr.contains("recipient must not be empty"));
+}
+
+#[test]
+fn test_send_rejects_post_send_hook_with_empty_command() {
+    let fixture = Fixture::new("recipient");
+    fixture.write_atm_config("[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = []\n");
+
+    let output = fixture.run(&["send", "recipient@atm-dev", "hello invalid hook"]);
+
+    assert!(!output.status.success());
+    let stderr = fixture.stderr(&output);
+    assert!(stderr.contains("command must not be empty"));
 }
 
 #[test]
@@ -825,7 +811,7 @@ fn test_send_ignores_invalid_hook_result_stdout() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("result-invalid");
     fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'result-invalid', '{}']\npost_send_hook_senders = ['arch-ctm']\n",
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'result-invalid', '{}']\n",
         hook_path.display(),
         payload_path.display()
     ));
@@ -847,7 +833,7 @@ fn test_send_logs_structured_hook_result_stdout() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("result-debug");
     fixture.write_atm_config(&format!(
-        "[atm]\npost_send_hook = ['{}', 'result-debug', '{}']\npost_send_hook_senders = ['arch-ctm']\n",
+        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'result-debug', '{}']\n",
         hook_path.display(),
         payload_path.display()
     ));
@@ -892,9 +878,9 @@ fn test_send_help_mentions_post_send_hook_config() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
-    assert!(stdout.contains("post_send_hook"));
-    assert!(stdout.contains("post_send_hook_senders"));
-    assert!(stdout.contains("post_send_hook_recipients"));
+    assert!(stdout.contains("[[atm.post_send_hooks]]"));
+    assert!(stdout.contains("recipient = \"name-or-*\""));
+    assert!(stdout.contains("command = [\"argv\", ...]"));
     assert!(stdout.contains("ATM_LOG=debug"));
     assert!(stdout.contains(".atm.toml"));
 }
@@ -1035,6 +1021,21 @@ impl Fixture {
             .join("atm-dev")
     }
 
+    fn workflow_state_contents(&self, team: &str, agent: &str) -> Value {
+        let raw = fs::read_to_string(
+            self.tempdir
+                .path()
+                .join(".claude")
+                .join("teams")
+                .join(team)
+                .join(".atm-state")
+                .join("workflow")
+                .join(format!("{agent}.json")),
+        )
+        .expect("workflow state contents");
+        serde_json::from_str(&raw).expect("workflow json")
+    }
+
     fn install_hook_fixture(&self, mode: &str) -> (PathBuf, PathBuf) {
         let fixture_binary = PathBuf::from(env!("CARGO_BIN_EXE_atm_post_send_hook_fixture"));
         let hook_dir = self.tempdir.path().join("bin");
@@ -1056,6 +1057,23 @@ impl Fixture {
             PathBuf::from("bin").join(hook_path.file_name().expect("copied hook binary filename")),
             payload_path,
         )
+    }
+
+    fn install_executable_script(&self, relative_path: &str, body: &str) -> PathBuf {
+        let path = self.tempdir.path().join(relative_path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("script dir");
+        }
+        fs::write(&path, body).expect("write script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = fs::metadata(&path).expect("script metadata").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&path, permissions).expect("script permissions");
+        }
+        path
     }
 
     fn stdout(&self, output: &std::process::Output) -> String {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -934,6 +934,9 @@ Architectural rules:
   - clear runtime-only restored-member state before persistence
   - restore non-lead inboxes from the chosen snapshot
   - sweep stale mailbox `*.lock` sentinels before restored inbox files are copied in
+  - treat stale-sentinel sweep as result-bearing: if that cleanup hits a
+    read-only-filesystem failure, restore must stop and surface
+    `MailboxLockReadOnlyFilesystem` instead of warning and continuing
   - recompute `.highwatermark` from the maximum restored task id
   - support a dry-run path without making changes
 - Claude Code project task-list restoration remains separate from the retained
@@ -1414,7 +1417,12 @@ Call-graph decisions:
   the caller rather than logging and continuing
 - pre-acquisition stale eviction inside `acquire(...)` propagates the
   read-only diagnostic when the cleanup path hits it, because subsequent owner
-  record writes cannot succeed on the same mount
+  record writes cannot succeed on the same mount; this early-exit happens
+  before any later `try_lock_exclusive()` attempt
+- each retry iteration must classify raw OS errors before consulting the
+  timeout budget: `EROFS` / `ERROR_WRITE_PROTECT` exits immediately as
+  `MailboxLockReadOnlyFilesystem`, while non-contention path failures such as
+  `ENOSPC`, `EMFILE`, and `ESTALE` exit immediately as `MailboxLockFailed`
 - `MailboxLockGuard::drop` still warns only, because the successful mailbox
   mutation has already completed and `Drop` cannot change the command result
 
@@ -1731,6 +1739,8 @@ exist with no detection mechanism.
 
 Key properties:
 - crash at steps 2-6: config.json unchanged, extra inbox files harmless, marker signals re-run
+- read-only failure during the pre-copy stale-sentinel sweep aborts before live
+  inbox replacement begins, preserving the pre-restore team state
 - crash at step 7: config write is itself atomic via the existing `write_team_config(...)`
   temp-file + rename path, so no partial config write is possible
 - crash at step 8: config is written, stale marker cleaned up by next doctor/restore run

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1338,6 +1338,97 @@ duplicates what `fs2` already provides correctly.
   other tools that bypass ATM locking are outside the protection boundary. This
   is an accepted limitation for the ATM shared-inbox model.
 
+### 18.3.1 Stale-Sentinel Sweep Predicate
+
+The current `path.extension() == "lock"` filter is too narrow because it misses
+rotated sentinels such as `inbox.json.lock.old`. The executed P.10 design must
+match only filenames that still carry the sentinel suffix chain:
+
+```rust
+let is_lock_sentinel_candidate = path
+    .file_name()
+    .and_then(|name| name.to_str())
+    .is_some_and(|name| name.ends_with(".lock") || name.contains(".lock."));
+```
+
+Why this exact predicate:
+- `ends_with(".lock")` preserves the ordinary live sentinel path
+- `contains(".lock.")` catches rotated forms such as `.lock.old` and
+  `.lock.replaced`
+- basename-only matching avoids broad false positives from parent directories
+- rejecting generic `contains("lock")` avoids matching unrelated files such as
+  `locksmith.txt`
+
+Eviction remains conservative:
+- read the candidate contents as the documented `pid[:token]` owner record
+- if parsing fails, leave the file in place
+- if `process_is_alive(pid)` is true, leave the file in place
+- only then attempt removal
+
+This is still best-effort cleanup, not a second ownership protocol. The actual
+authority boundary remains the later `fs2` advisory lock plus the existing
+`lock_path_matches_file(...)` identity recheck after acquisition.
+
+Platform note:
+- Windows may not permit renaming a live locked sentinel the same way Unix
+  does, so the broadened sweep is not a live-handoff mechanism
+- the predicate exists to clean up crash leftovers, repair leftovers, or
+  externally rotated sentinel artifacts that otherwise evade the old exact
+  `.lock` extension test
+
+### 18.3.2 Read-Only Filesystem Classification
+
+P.10 should add a dedicated read-only-filesystem mailbox-lock code instead of
+overloading the generic non-contention lock failure bucket.
+
+Required platform mapping:
+- Linux: `libc::EROFS` (`30`)
+- macOS: `libc::EROFS` (`30`)
+- Windows: `windows_sys::Win32::Foundation::ERROR_WRITE_PROTECT` (`19`)
+
+The classification helper belongs at the lock-path error-conversion boundary,
+not duplicated ad hoc at individual call sites. The intended shape is:
+
+```rust
+fn is_readonly_filesystem_error(error: &io::Error) -> bool
+```
+
+and then a shared mapper such as:
+
+```rust
+fn mailbox_lock_path_error(
+    operation: &'static str,
+    lock_path: &Path,
+    error: io::Error,
+) -> AtmError
+```
+
+Call-graph decisions:
+- `open_lock_file(...)` maps read-only failures directly to
+  `MailboxLockReadOnlyFilesystem`
+- `write_lock_owner_record(...)` maps both truncate and write failures through
+  the same helper
+- `remove_lock_sentinel_with_retry(...)` explicitly does not retry read-only
+  failures before the current permission-denied/backoff logic
+- public `sweep_stale_lock_sentinels(...)` surfaces the read-only diagnostic to
+  the caller rather than logging and continuing
+- pre-acquisition stale eviction inside `acquire(...)` propagates the
+  read-only diagnostic when the cleanup path hits it, because subsequent owner
+  record writes cannot succeed on the same mount
+- `MailboxLockGuard::drop` still warns only, because the successful mailbox
+  mutation has already completed and `Drop` cannot change the command result
+
+Recommended recovery text:
+- message includes the attempted operation and lock path
+- recovery tells the operator to remount or move the ATM home to a writable
+  filesystem before retrying, not merely to wait for another process
+
+Reason for a new code instead of enriching `MailboxLockFailed`:
+- read-only filesystem state is a stable, operator-actionable class with
+  different remediation from ACL failures or transient path I/O
+- the retry policy must branch on this distinction
+- QA and integration tests need a stable machine-readable contract for it
+
 ### 18.4 Integration: Single-File Helper + Multi-File Lock Set
 
 `append_message` is a true single-file read-modify-write and should use one shared helper:
@@ -1498,6 +1589,10 @@ Current executed limitation:
 
 - `MailboxLockFailed` / `ATM_MAILBOX_LOCK_FAILED` — lock-path creation,
   open, or acquisition failed for a non-contention filesystem or OS reason
+- `MailboxLockReadOnlyFilesystem`
+  / `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM` — the lock path or lock sentinel
+  lives on a read-only filesystem, so ATM cannot create, update, or remove the
+  required mailbox-lock artifact
 - `MailboxLockTimeout` / `ATM_MAILBOX_LOCK_TIMEOUT` — lock not acquired within timeout
 - New `AtmErrorKind::MailboxLock` variant in `error.rs`
 

--- a/docs/atm-error-codes.md
+++ b/docs/atm-error-codes.md
@@ -195,6 +195,38 @@ Error codes should describe the failure class, not a specific prose message.
   - may be accompanied by lower-level OS/process details and any structured
     hook result that was successfully parsed before failure
 
+### 5.9 Mailbox Lock Read-Only Filesystem
+
+- `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`
+
+#### 5.9.1 `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`
+
+- code: `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`
+- description: ATM could not create, update, or remove the mailbox lock
+  sentinel because the underlying filesystem is read-only
+- HTTP status: `500 Internal Server Error`
+- context:
+  - emitted for lock-path `open`, owner-record truncate/write, or stale-sentinel
+    removal when the underlying OS reports a read-only filesystem
+  - this is more specific than `ATM_MAILBOX_LOCK_FAILED` because the operator
+    remediation is to restore writability or move the ATM home, not to wait for
+    lock contention or adjust discretionary permissions
+  - required platform classification:
+    - Linux/macOS: raw OS error `EROFS` (`30`)
+    - Windows: raw OS error `ERROR_WRITE_PROTECT` (`19`)
+  - required output split:
+    - message:
+      ```text
+      error: mailbox lock {operation} failed for {lock_path}: filesystem is read-only.
+      ```
+    - recovery:
+      ```text
+      Remount or move the ATM home to a writable filesystem, then retry the ATM command.
+      ```
+  - drop-time best-effort cleanup may log the code as a warning because the
+    mailbox command has already succeeded, but public acquisition/sweep paths
+    must return the structured error directly
+
 ## 6. Mapping Rules
 
 Required mapping rules:
@@ -212,7 +244,7 @@ Required mapping rules:
 | `Identity` | `ATM_IDENTITY_UNAVAILABLE` | none |
 | `TeamNotFound` | `ATM_TEAM_NOT_FOUND` | `ATM_TEAM_UNAVAILABLE` |
 | `AgentNotFound` | `ATM_AGENT_NOT_FOUND` | none |
-| `MailboxLock` | `ATM_MAILBOX_LOCK_FAILED` | `ATM_MAILBOX_LOCK_TIMEOUT` |
+| `MailboxLock` | `ATM_MAILBOX_LOCK_FAILED` | `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`, `ATM_MAILBOX_LOCK_TIMEOUT` |
 | `MailboxRead` | `ATM_MAILBOX_READ_FAILED` | none |
 | `MailboxWrite` | `ATM_MAILBOX_WRITE_FAILED` | none |
 | `FilePolicy` | `ATM_FILE_POLICY_REJECTED` | `ATM_FILE_REFERENCE_REWRITE_FAILED` |

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1978,6 +1978,11 @@ Test simulation pattern:
   - `ATM_TEST_FORCE_LOCK_READONLY_FS=open`
   - `ATM_TEST_FORCE_LOCK_READONLY_FS=write_owner`
   - `ATM_TEST_FORCE_LOCK_READONLY_FS=remove`
+- operation scoping is strict:
+  - `open` affects only the lock open/create path; owner-record write and
+    sentinel removal continue to execute normally
+  - `write_owner` affects only owner-record truncate/write
+  - `remove` affects only stale-sentinel removal / cleanup
 - the seam must synthesize the platform-correct raw OS error so the production
   classification logic is what the tests exercise
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -30,6 +30,8 @@ Status:
 - Phase O completed the security and hardening follow-up line.
 - Phase P implementation is merged; follow-up hardening remains open for
   `P.6` and `P.7`, while `P.8` documentation reconciliation is complete.
+  `P.9` is an arch-ctm design review of the two residual lock-sentinel gaps.
+  `P.10` implements the hardened fix from P.9's recommendations.
 - Message schema ownership and metadata normalization are now implemented well
   enough for live shared-inbox adoption, while a separate ATM-native inbox
   remains deferred to a later version.
@@ -1855,6 +1857,109 @@ Acceptance criteria:
 - the Phase P heading and status note clearly show merged/executed state
 - no Phase P document still implies that the merged implementation is
   proposal-only
+
+##### P.9 — Lock Sentinel Gap: Detailed Design And Doc Updates [PLANNED]
+
+Goals:
+- produce a complete, implementation-ready design for the P.10 coding sprint
+- update `docs/requirements.md` and `docs/architecture.md` to reflect the
+  planned GAP-1 and GAP-2 changes before a single line of implementation code
+  is written
+- the design output becomes the authoritative specification arch-ctm follows
+  in P.10
+
+Files expected in scope:
+- `docs/requirements.md` (add/update lock sentinel requirements for GAP-1 and GAP-2)
+- `docs/architecture.md` (update lock design section to reflect sweep predicate change and EROFS error path)
+- `docs/atm-error-codes.md` (define MailboxLockReadOnlyFilesystem or document enriched MailboxLockFailed)
+- `docs/project-plan.md` §P.10 (populate design details from this review)
+- `crates/atm-core/src/mailbox/lock.rs` (read-only analysis only; no code changes)
+
+Design details:
+
+**GAP-1 — Renamed sentinel not swept by `sweep_stale_lock_sentinels`**
+
+`sweep_stale_lock_sentinels` matches files with extension `.lock`
+(`path.extension() == Some("lock")`). A sentinel that has been externally
+renamed (e.g., `inbox.json.lock.old`) has extension `old` and is silently
+skipped. The orphaned file is inert — no flock is held on it — but it
+accumulates on disk indefinitely.
+
+Fix: broaden the sweep predicate to match any file whose name contains
+`.lock` as a component (e.g., ends with `.lock` or contains `.lock.`),
+or match by the full sentinel-path pattern (`{base}.lock{optional-suffix}`).
+The sweep must not remove active sentinel files (those whose owning PID is
+still alive).
+
+**GAP-2 — Read-only filesystem surfaces as generic `MailboxLockFailed`**
+
+If the filesystem becomes read-only after a sentinel is created, both
+`remove_active_lock_sentinel` in Drop and `evict_stale_lock_sentinel` in
+the acquire loop fail with `EROFS`. `EROFS` is not handled by
+`should_retry_remove_lock_sentinel` (only `PermissionDenied` and Windows
+sharing-violation are retried), so the error surfaces immediately. The
+flock is released by the kernel, but the sentinel cannot be removed and
+`open_lock_file` (create=true) also fails — the lock mechanism breaks
+completely on a read-only filesystem.
+
+Fix: detect `EROFS` (and the Windows equivalent `ERROR_WRITE_PROTECT`) in
+`open_lock_file`, `remove_lock_sentinel_with_retry`, and
+`evict_stale_lock_sentinel`, and surface a dedicated
+`AtmErrorCode::MailboxLockReadOnlyFilesystem` with a recovery message that
+names the filesystem path and advises on remounting. The behavior must
+remain fail-soft where the flock is already released (no liveness
+regression); the improvement is diagnostic clarity only.
+
+Implementation patterns:
+- GAP-1 fix must not change sweep behavior for normally-named `.lock` files
+- GAP-2 fix must not retry `EROFS` — it is permanent until remount; return
+  the specific error immediately after the first attempt
+- add `AtmErrorCode::MailboxLockReadOnlyFilesystem` to `error_codes.rs` and
+  `docs/atm-error-codes.md`
+
+Required coverage:
+- sweep test: sentinel renamed to `.lock.old` is matched and evicted when
+  its PID is dead; active `.lock.old` for a live PID is not removed
+- EROFS test (simulated via `EPERM` or a read-only tempdir mount): confirms
+  that `MailboxLockReadOnlyFilesystem` error code is returned and message
+  includes the path
+
+P.9 deliverables (design sprint — no implementation code):
+1. Updated `docs/requirements.md`: add or update lock sentinel requirements
+   covering the sweep predicate contract (GAP-1) and read-only filesystem
+   behavior (GAP-2)
+2. Updated `docs/architecture.md`: update the lock design section to describe
+   the broadened sweep predicate, the EROFS detection call graph, and the
+   new/enriched error code
+3. Updated `docs/atm-error-codes.md`: define `MailboxLockReadOnlyFilesystem`
+   (or document the enriched `MailboxLockFailed` decision with rationale)
+4. Populated `docs/project-plan.md` §P.10 design details: the exact Rust
+   expressions, OS error codes, test simulation pattern, and call-graph
+   decisions that arch-ctm will implement in P.10
+5. ATM message to team-lead with the five design-question answers and a
+   summary of all document changes made
+
+##### P.10 — Lock Sentinel Gap Implementation [PLANNED]
+
+Goals:
+- implement the hardened fixes for GAP-1 and GAP-2 as specified by the P.9
+  design review output from arch-ctm
+
+Files expected in scope:
+- `crates/atm-core/src/mailbox/lock.rs`
+- `crates/atm-core/src/error_codes.rs`
+- `docs/atm-error-codes.md`
+
+Design details:
+- implementation spec will be populated from arch-ctm's P.9 review findings
+  before this sprint opens; do not begin coding until P.9 findings are
+  incorporated here
+
+Planning rule:
+- P.10 branch opens from `integrate/phase-P` after P.9 findings are reviewed
+  and accepted by team-lead
+- the P.9 review output must be merged into this plan section before the
+  dev-template assignment is sent
 
 #### P.0 — Audited Production File-I/O Inventory
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -29,9 +29,9 @@ Status:
   implementation merge work.
 - Phase O completed the security and hardening follow-up line.
 - Phase P implementation is merged; follow-up hardening remains open for
-  `P.6` and `P.7`, while `P.8` documentation reconciliation is complete.
-  `P.9` is an arch-ctm design review of the two residual lock-sentinel gaps.
-  `P.10` implements the hardened fix from P.9's recommendations.
+  `P.6`, `P.7`, and `P.10`, while `P.8` documentation reconciliation and the
+  `P.9` lock-sentinel design review are complete. `P.10` implements the
+  hardened fix from P.9's recommendations.
 - Message schema ownership and metadata normalization are now implemented well
   enough for live shared-inbox adoption, while a separate ATM-native inbox
   remains deferred to a later version.
@@ -1858,108 +1858,151 @@ Acceptance criteria:
 - no Phase P document still implies that the merged implementation is
   proposal-only
 
-##### P.9 — Lock Sentinel Gap: Detailed Design And Doc Updates [PLANNED]
+##### P.9 — Lock Sentinel Gap: Detailed Design And Doc Updates [COMPLETE]
 
 Goals:
 - produce a complete, implementation-ready design for the P.10 coding sprint
-- update `docs/requirements.md` and `docs/architecture.md` to reflect the
-  planned GAP-1 and GAP-2 changes before a single line of implementation code
-  is written
-- the design output becomes the authoritative specification arch-ctm follows
-  in P.10
+- update `docs/requirements.md`, `docs/architecture.md`, and
+  `docs/atm-error-codes.md` so the production contract is settled before code
+  changes begin
+- make the design output itself the authoritative specification for P.10
 
-Files expected in scope:
-- `docs/requirements.md` (add/update lock sentinel requirements for GAP-1 and GAP-2)
-- `docs/architecture.md` (update lock design section to reflect sweep predicate change and EROFS error path)
-- `docs/atm-error-codes.md` (define MailboxLockReadOnlyFilesystem or document enriched MailboxLockFailed)
-- `docs/project-plan.md` §P.10 (populate design details from this review)
-- `crates/atm-core/src/mailbox/lock.rs` (read-only analysis only; no code changes)
+Files in scope:
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-error-codes.md`
+- `docs/project-plan.md`
+- `crates/atm-core/src/mailbox/lock.rs` (read-only analysis only; no code
+  changes in P.9)
 
-Design details:
+Design outcomes:
+- GAP-1 uses a conservative basename predicate instead of
+  `path.extension() == "lock"`
+- GAP-2 uses a dedicated
+  `AtmErrorCode::MailboxLockReadOnlyFilesystem`
+  / `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`
+  instead of overloading `MailboxLockFailed`
+- read-only filesystem classification is based on raw OS error codes, not
+  generic `PermissionDenied` handling
+- read-only failures surface directly from public sweep/acquire paths and do
+  not enter retry loops
+- drop-time cleanup remains warn-only because the mailbox mutation has already
+  completed successfully
 
-**GAP-1 — Renamed sentinel not swept by `sweep_stale_lock_sentinels`**
+P.9 deliverables:
+1. Updated `docs/requirements.md` with explicit GAP-1 and GAP-2 lock
+   requirements
+2. Updated `docs/architecture.md` with the final sweep predicate, call-graph
+   decisions, and error-code rationale
+3. Updated `docs/atm-error-codes.md` with
+   `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`
+4. Populated `docs/project-plan.md` §P.10 with the exact implementation
+   contract
+5. ATM status report to `team-lead` with the five design-question answers and
+   a summary of the doc changes
 
-`sweep_stale_lock_sentinels` matches files with extension `.lock`
-(`path.extension() == Some("lock")`). A sentinel that has been externally
-renamed (e.g., `inbox.json.lock.old`) has extension `old` and is silently
-skipped. The orphaned file is inert — no flock is held on it — but it
-accumulates on disk indefinitely.
-
-Fix: broaden the sweep predicate to match any file whose name contains
-`.lock` as a component (e.g., ends with `.lock` or contains `.lock.`),
-or match by the full sentinel-path pattern (`{base}.lock{optional-suffix}`).
-The sweep must not remove active sentinel files (those whose owning PID is
-still alive).
-
-**GAP-2 — Read-only filesystem surfaces as generic `MailboxLockFailed`**
-
-If the filesystem becomes read-only after a sentinel is created, both
-`remove_active_lock_sentinel` in Drop and `evict_stale_lock_sentinel` in
-the acquire loop fail with `EROFS`. `EROFS` is not handled by
-`should_retry_remove_lock_sentinel` (only `PermissionDenied` and Windows
-sharing-violation are retried), so the error surfaces immediately. The
-flock is released by the kernel, but the sentinel cannot be removed and
-`open_lock_file` (create=true) also fails — the lock mechanism breaks
-completely on a read-only filesystem.
-
-Fix: detect `EROFS` (and the Windows equivalent `ERROR_WRITE_PROTECT`) in
-`open_lock_file`, `remove_lock_sentinel_with_retry`, and
-`evict_stale_lock_sentinel`, and surface a dedicated
-`AtmErrorCode::MailboxLockReadOnlyFilesystem` with a recovery message that
-names the filesystem path and advises on remounting. The behavior must
-remain fail-soft where the flock is already released (no liveness
-regression); the improvement is diagnostic clarity only.
-
-Implementation patterns:
-- GAP-1 fix must not change sweep behavior for normally-named `.lock` files
-- GAP-2 fix must not retry `EROFS` — it is permanent until remount; return
-  the specific error immediately after the first attempt
-- add `AtmErrorCode::MailboxLockReadOnlyFilesystem` to `error_codes.rs` and
-  `docs/atm-error-codes.md`
-
-Required coverage:
-- sweep test: sentinel renamed to `.lock.old` is matched and evicted when
-  its PID is dead; active `.lock.old` for a live PID is not removed
-- EROFS test (simulated via `EPERM` or a read-only tempdir mount): confirms
-  that `MailboxLockReadOnlyFilesystem` error code is returned and message
-  includes the path
-
-P.9 deliverables (design sprint — no implementation code):
-1. Updated `docs/requirements.md`: add or update lock sentinel requirements
-   covering the sweep predicate contract (GAP-1) and read-only filesystem
-   behavior (GAP-2)
-2. Updated `docs/architecture.md`: update the lock design section to describe
-   the broadened sweep predicate, the EROFS detection call graph, and the
-   new/enriched error code
-3. Updated `docs/atm-error-codes.md`: define `MailboxLockReadOnlyFilesystem`
-   (or document the enriched `MailboxLockFailed` decision with rationale)
-4. Populated `docs/project-plan.md` §P.10 design details: the exact Rust
-   expressions, OS error codes, test simulation pattern, and call-graph
-   decisions that arch-ctm will implement in P.10
-5. ATM message to team-lead with the five design-question answers and a
-   summary of all document changes made
-
-##### P.10 — Lock Sentinel Gap Implementation [PLANNED]
+##### P.10 — Lock Sentinel Residual Gap Closure [PLANNED]
 
 Goals:
-- implement the hardened fixes for GAP-1 and GAP-2 as specified by the P.9
-  design review output from arch-ctm
+- implement the hardened fixes for GAP-1 and GAP-2 exactly as specified by the
+  completed P.9 design output
+- close the remaining mailbox-lock residual risks without broadening scope into
+  unrelated refactors
 
 Files expected in scope:
 - `crates/atm-core/src/mailbox/lock.rs`
+- `crates/atm-core/src/error.rs`
 - `crates/atm-core/src/error_codes.rs`
-- `docs/atm-error-codes.md`
+- docs already updated in P.9
 
-Design details:
-- implementation spec will be populated from arch-ctm's P.9 review findings
-  before this sprint opens; do not begin coding until P.9 findings are
-  incorporated here
+Exact GAP-1 predicate:
 
-Planning rule:
-- P.10 branch opens from `integrate/phase-P` after P.9 findings are reviewed
-  and accepted by team-lead
-- the P.9 review output must be merged into this plan section before the
-  dev-template assignment is sent
+```rust
+let is_lock_sentinel_candidate = path
+    .file_name()
+    .and_then(|name| name.to_str())
+    .is_some_and(|name| name.ends_with(".lock") || name.contains(".lock."));
+```
+
+Why this expression:
+- `ends_with(".lock")` keeps the ordinary live sentinel path
+- `contains(".lock.")` catches rotated artifacts such as `.lock.old` and
+  `.lock.replaced`
+- basename-only matching avoids matching parent directories
+- generic `contains("lock")` is forbidden because it creates unrelated-file
+  false positives
+
+Exact GAP-2 platform classification:
+- Linux: `libc::EROFS` (`30`)
+- macOS: `libc::EROFS` (`30`)
+- Windows: `windows_sys::Win32::Foundation::ERROR_WRITE_PROTECT as i32` (`19`)
+
+Recommended helper shape:
+
+```rust
+fn is_readonly_filesystem_error(error: &io::Error) -> bool
+```
+
+```rust
+fn mailbox_lock_path_error(
+    operation: &'static str,
+    lock_path: &Path,
+    error: io::Error,
+) -> AtmError
+```
+
+Required call-graph decisions:
+- `open_lock_file(...)` maps read-only failures to
+  `MailboxLockReadOnlyFilesystem`
+- `write_lock_owner_record(...)` maps both truncate and write failures through
+  the same helper
+- `remove_lock_sentinel_with_retry(...)` checks read-only first and returns the
+  error immediately instead of entering the permission-denied retry loop
+- `evict_stale_lock_sentinel(...)` must become result-bearing enough for public
+  sweep/acquire call sites to surface read-only failures instead of only
+  warning
+- `MailboxLockGuard::drop` keeps warning-only cleanup on read-only failure
+
+Recommended result-shape change:
+- change stale-sentinel eviction from a bare `bool` outcome to a richer result
+  that distinguishes:
+  - removed
+  - skipped (live owner / malformed / not found)
+  - failed (`io::Error`)
+
+Test simulation pattern:
+- do not require a real read-only mount
+- add a deterministic synthetic seam patterned after
+  `ATM_TEST_FORCE_LOCK_NON_CONTENTION_ERROR`
+- recommended env var contract:
+  - `ATM_TEST_FORCE_LOCK_READONLY_FS=open`
+  - `ATM_TEST_FORCE_LOCK_READONLY_FS=write_owner`
+  - `ATM_TEST_FORCE_LOCK_READONLY_FS=remove`
+- the seam must synthesize the platform-correct raw OS error so the production
+  classification logic is what the tests exercise
+
+Required coverage:
+- unit: rotated sentinel names such as `inbox.json.lock.old` are considered
+  sweep candidates, while unrelated filenames are ignored
+- unit: malformed rotated sentinel contents are skipped, not deleted
+- unit: read-only `open` returns
+  `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`
+- unit: read-only owner-record write returns
+  `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`
+- unit: read-only sentinel removal is not retried as permission-denied
+- unit or focused integration: public stale-sentinel sweep surfaces the
+  read-only error instead of logging and continuing
+- regression: drop-time cleanup remains non-fatal even when read-only cleanup
+  fails after a successful command
+
+Acceptance criteria:
+- no rotated stale sentinel escapes the sweep solely because it no longer ends
+  with the literal `.lock` extension
+- read-only filesystem failures are machine-readable and operator-distinct from
+  contention and generic path I/O
+- retry loops are reserved for genuine contention or documented transient
+  sharing failures, not persistent read-only mounts
+- tests remain deterministic and mount-free
 
 #### P.0 — Audited Production File-I/O Inventory
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1902,6 +1902,16 @@ closed before the 1.0 release.
     lock handle; rotated-name sweeping exists to clean up post-crash or
     externally renamed artifacts, not to coordinate live-lock handoff
 
+  Acceptance Criteria:
+  - positive predicate cases: `inbox.json.lock`, `inbox.json.lock.old`, and
+    `inbox.json.lock.replaced` are all treated as stale-sentinel candidates
+  - negative predicate cases: malformed or unrelated names such as
+    `inbox.json.lockold`, `locksmith.txt`, and `inbox.locksmith.json` are not
+    treated as stale-sentinel candidates
+  - malformed rotated candidates that do match the filename predicate but do
+    not contain a parseable `pid[:token]` owner record remain in place and are
+    not deleted speculatively
+
 - `REQ-CORE-MAILBOX-LOCK-009` Read-only filesystem failures on the mailbox-lock
   path must surface as a dedicated non-contention diagnostic.
 
@@ -1917,6 +1927,10 @@ closed before the 1.0 release.
     operator guidance stay consistent
   - read-only filesystem errors must not participate in the lock-contention
     retry loop and must not be retried by sentinel-removal backoff logic
+  - on every lock-acquisition retry iteration, read-only-filesystem
+    classification must run before any timeout-budget decision; a classified
+    `EROFS` / `ERROR_WRITE_PROTECT` failure must never fall through to
+    `MailboxLockTimeout`
   - mutation-path failures caused by a read-only filesystem must return
     `MailboxLockReadOnlyFilesystem`
     / `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`, not `MailboxLockFailed` or
@@ -1925,9 +1939,25 @@ closed before the 1.0 release.
     path plus the specific attempted operation (`open`, `write owner record`,
     or `remove stale sentinel`) so operators can distinguish remount/media
     failures from ACL or contention issues
+  - other non-contention lock-path filesystem failures, including `ENOSPC`,
+    `EMFILE`, and `ESTALE`, remain `MailboxLockFailed` and are not retried
   - best-effort drop-time cleanup remains warn-only because the command has
     already completed, but public sweep or acquisition paths must surface the
     read-only diagnosis instead of silently suppressing it
+
+  Acceptance Criteria:
+  - `ATM_TEST_FORCE_LOCK_READONLY_FS=open` injects a synthetic platform-correct
+    read-only-filesystem error into the lock open/create path only; owner-record
+    write and sentinel-removal paths continue to run normally
+  - `ATM_TEST_FORCE_LOCK_READONLY_FS=write_owner` injects a synthetic
+    read-only-filesystem error into the owner-record truncate/write path only
+  - `ATM_TEST_FORCE_LOCK_READONLY_FS=remove` injects a synthetic
+    read-only-filesystem error into the stale-sentinel removal path only
+  - when the seam is unset or set to any other value, no synthetic read-only
+    filesystem failure is injected
+  - read-only failures injected through any of the three seam values surface as
+    `MailboxLockReadOnlyFilesystem`
+    / `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`, never as `MailboxLockTimeout`
 
 ### 20.2 Shared Mutable File Atomicity
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1877,6 +1877,58 @@ closed before the 1.0 release.
   - operator recovery guidance must distinguish "wait and retry" from
     "repair filesystem/permissions state"
 
+- `REQ-CORE-MAILBOX-LOCK-008` Stale-lock sweeping must identify rotated lock
+  sentinels conservatively and must evict only verifiable orphaned candidates.
+
+  Required behavior:
+  - candidate matching is based on the basename, not the full path
+  - the accepted sentinel predicate is:
+    `file_name.ends_with(".lock") || file_name.contains(".lock.")`
+  - the sweep must not use `path.extension() == "lock"` because that misses
+    rotated sentinels such as `inbox.json.lock.old`
+  - the sweep must not broaden to arbitrary substring matching such as
+    `contains("lock")`; non-sentinel files like `locksmith.txt` must not be
+    considered
+  - a matched candidate is evictable only when its contents parse as the
+    documented `pid[:token]` owner record format and `process_is_alive(pid)`
+    returns false
+  - malformed or unreadable candidate contents are treated as non-evictable and
+    must be left in place for explicit operator cleanup instead of speculative
+    deletion
+  - the sweep is a best-effort stale-artifact cleanup path, not a second lock
+    authority; it must not claim ownership without the existing advisory-lock
+    acquisition succeeding afterward
+  - Windows rename semantics must not be assumed to match Unix for a live held
+    lock handle; rotated-name sweeping exists to clean up post-crash or
+    externally renamed artifacts, not to coordinate live-lock handoff
+
+- `REQ-CORE-MAILBOX-LOCK-009` Read-only filesystem failures on the mailbox-lock
+  path must surface as a dedicated non-contention diagnostic.
+
+  Required behavior:
+  - ATM must classify read-only filesystem errors by raw OS error code rather
+    than treating them as generic permission failures
+  - the required platform mappings are:
+    - Linux: `EROFS` (`30`)
+    - macOS: `EROFS` (`30`)
+    - Windows: `ERROR_WRITE_PROTECT` (`19`)
+  - the same classification helper must be used for lock-path open/create,
+    owner-record truncate/write, and sentinel removal so retry behavior and
+    operator guidance stay consistent
+  - read-only filesystem errors must not participate in the lock-contention
+    retry loop and must not be retried by sentinel-removal backoff logic
+  - mutation-path failures caused by a read-only filesystem must return
+    `MailboxLockReadOnlyFilesystem`
+    / `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`, not `MailboxLockFailed` or
+    `MailboxLockTimeout`
+  - the structured error message and recovery guidance must include the lock
+    path plus the specific attempted operation (`open`, `write owner record`,
+    or `remove stale sentinel`) so operators can distinguish remount/media
+    failures from ACL or contention issues
+  - best-effort drop-time cleanup remains warn-only because the command has
+    already completed, but public sweep or acquisition paths must surface the
+    read-only diagnosis instead of silently suppressing it
+
 ### 20.2 Shared Mutable File Atomicity
 
 - `REQ-CORE-PERSIST-ATOMIC-001` Every shared mutable ATM-owned structured state


### PR DESCRIPTION
## Summary

- **GAP-1**: Replace `.extension() == Some("lock")` sweep predicate with `is_lock_sentinel_candidate()` that also matches rotated sentinels (`.lock.old`, `.lock.bak`, etc.)
- **GAP-2**: Detect read-only filesystem errors (EROFS=30 Linux/macOS, ERROR_WRITE_PROTECT=19 Windows) and surface as `AtmErrorCode::MailboxLockReadOnlyFilesystem` — early-exit before timeout budget in `acquire()`, propagated from `sweep_stale_lock_sentinels()` as `Result<usize, AtmError>`
- New test seam: `ATM_TEST_FORCE_LOCK_READONLY_FS=open|write_owner|remove` (operation-scoped, deterministic)
- Docs: P.9 design sprint additions to requirements.md, architecture.md, atm-error-codes.md, project-plan.md

**Branch**: `feature/pP-s10-lock-sentinel-impl` at git#11ce312  
**Design spec**: P.9 docs (REQ-CORE-MAILBOX-LOCK-008/009, arch §18.3)  
**Validation**: `cargo test -p agent-team-mail-core mailbox::lock` — 20 passed

> **Note**: Needs sync with `integrate/phase-P` to pick up P.7 hook.rs changes — in progress.

## Test plan

- [ ] CI passes on all three platforms (Linux, macOS, Windows)
- [ ] `cargo test -p agent-team-mail-core mailbox::lock` — all lock tests pass
- [ ] `ATM_TEST_FORCE_LOCK_READONLY_FS=open` triggers `MailboxLockReadOnlyFilesystem` error
- [ ] `ATM_TEST_FORCE_LOCK_READONLY_FS=remove` in `sweep_stale_lock_sentinels` returns Err
- [ ] Sweep predicate catches `.lock.old` rotated sentinels
- [ ] QA: req-qa, arch-qa, rust-qa-agent pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)