### PR TITLE
fix: close Phase P RBP cleanup findings

### DIFF
--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -16,7 +16,7 @@ use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
 use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
 use crate::send::{input, summary};
-use crate::types::{AgentName, IsoTimestamp, TeamName};
+use crate::types::{AgentName, IsoTimestamp, TaskId, TeamName};
 use crate::workflow;
 
 /// Parameters for acknowledging one pending-ack mailbox message.
@@ -38,7 +38,7 @@ pub struct AckOutcome {
     pub agent: AgentName,
     pub message_id: LegacyMessageId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
+    pub task_id: Option<TaskId>,
     pub reply_target: String,
     pub reply_message_id: LegacyMessageId,
     pub reply_text: String,

--- a/crates/atm-core/src/config/discovery.rs
+++ b/crates/atm-core/src/config/discovery.rs
@@ -4,21 +4,23 @@ use std::path::{Path, PathBuf};
 
 use crate::address::validate_path_segment;
 use crate::error::{AtmError, AtmErrorKind};
+use crate::types::AgentName;
 
-use super::types::PostSendHookRule;
+use super::RawPostSendHookRule;
+use super::types::{HookRecipient, PostSendHookRule};
 
 /// Normalize recipient hook rules relative to the declaring config directory.
 ///
 /// Path-like `command[0]` values resolve from `config_root`. Bare executable
 /// names remain unchanged so the OS can resolve them through `PATH`.
-pub fn normalize_post_send_hooks(
-    hooks: Vec<PostSendHookRule>,
+pub(super) fn normalize_post_send_hooks(
+    hooks: Vec<RawPostSendHookRule>,
     config_root: &Path,
 ) -> Result<Vec<PostSendHookRule>, AtmError> {
     hooks.into_iter()
         .map(|mut hook| {
-            hook.recipient = hook.recipient.trim().to_string();
-            if hook.recipient.is_empty() {
+            let recipient = hook.recipient.trim();
+            if recipient.is_empty() {
                 return Err(AtmError::new(
                     AtmErrorKind::Config,
                     "post-send hook recipient must not be empty".to_string(),
@@ -27,13 +29,16 @@ pub fn normalize_post_send_hooks(
                     "Set [[atm.post_send_hooks]].recipient to one concrete recipient name or '*'.",
                 ));
             }
-            if hook.recipient != "*" {
-                validate_path_segment(&hook.recipient, "hook recipient").map_err(|error| {
+            let recipient = if recipient == "*" {
+                HookRecipient::Wildcard
+            } else {
+                validate_path_segment(recipient, "hook recipient").map_err(|error| {
                     AtmError::new(AtmErrorKind::Config, error.message).with_recovery(
                         "Use one concrete recipient name or '*' in [[atm.post_send_hooks]].recipient.",
                     )
                 })?;
-            }
+                HookRecipient::Named(AgentName::from_validated(recipient))
+            };
 
             let Some(program) = hook.command.first_mut() else {
                 return Err(AtmError::new(
@@ -73,7 +78,10 @@ pub fn normalize_post_send_hooks(
                     })?
                     .to_string();
             }
-            Ok(hook)
+            Ok(PostSendHookRule {
+                recipient,
+                command: hook.command,
+            })
         })
         .collect()
 }
@@ -89,7 +97,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{command_looks_like_path, normalize_post_send_hooks};
-    use crate::config::types::PostSendHookRule;
+    use crate::config::RawPostSendHookRule;
+    use crate::config::types::HookRecipient;
 
     fn config_root_fixture() -> (tempfile::TempDir, PathBuf) {
         let tempdir = tempdir().expect("tempdir");
@@ -101,7 +110,7 @@ mod tests {
     #[test]
     fn normalize_post_send_hooks_resolves_relative_script_commands() {
         let (_tempdir, config_root) = config_root_fixture();
-        let hooks = vec![PostSendHookRule {
+        let hooks = vec![RawPostSendHookRule {
             recipient: "team-lead".into(),
             command: vec!["scripts/atm-nudge.sh".into(), "team-lead".into()],
         }];
@@ -115,12 +124,16 @@ mod tests {
                 .display()
                 .to_string()
         );
+        assert_eq!(
+            hooks[0].recipient,
+            HookRecipient::Named("team-lead".parse().expect("recipient"))
+        );
     }
 
     #[test]
     fn normalize_post_send_hooks_keeps_bare_executables_for_path_lookup() {
         let (_tempdir, config_root) = config_root_fixture();
-        let hooks = vec![PostSendHookRule {
+        let hooks = vec![RawPostSendHookRule {
             recipient: "*".into(),
             command: vec!["bash".into(), "-lc".into(), "echo hi".into()],
         }];
@@ -128,6 +141,7 @@ mod tests {
         let hooks = normalize_post_send_hooks(hooks, &config_root).expect("hooks");
 
         assert_eq!(hooks[0].command[0], "bash");
+        assert_eq!(hooks[0].recipient, HookRecipient::Wildcard);
     }
 
     #[test]
@@ -142,7 +156,7 @@ mod tests {
     fn normalize_post_send_hooks_preserves_absolute_paths() {
         let (_tempdir, config_root) = config_root_fixture();
         let absolute = config_root.join("absolute hook.cmd");
-        let hooks = vec![PostSendHookRule {
+        let hooks = vec![RawPostSendHookRule {
             recipient: "*".into(),
             command: vec![absolute.display().to_string()],
         }];
@@ -156,7 +170,7 @@ mod tests {
     fn normalize_post_send_hooks_rejects_empty_recipient() {
         let (_tempdir, config_root) = config_root_fixture();
         let error = normalize_post_send_hooks(
-            vec![PostSendHookRule {
+            vec![RawPostSendHookRule {
                 recipient: "   ".into(),
                 command: vec!["bash".into()],
             }],
@@ -171,7 +185,7 @@ mod tests {
     fn normalize_post_send_hooks_rejects_invalid_recipient_selector() {
         let (_tempdir, config_root) = config_root_fixture();
         let error = normalize_post_send_hooks(
-            vec![PostSendHookRule {
+            vec![RawPostSendHookRule {
                 recipient: "bad/name".into(),
                 command: vec!["bash".into()],
             }],
@@ -190,7 +204,7 @@ mod tests {
     fn normalize_post_send_hooks_rejects_empty_command_array() {
         let (_tempdir, config_root) = config_root_fixture();
         let error = normalize_post_send_hooks(
-            vec![PostSendHookRule {
+            vec![RawPostSendHookRule {
                 recipient: "team-lead".into(),
                 command: Vec::new(),
             }],
@@ -205,7 +219,7 @@ mod tests {
     fn normalize_post_send_hooks_rejects_blank_program_name() {
         let (_tempdir, config_root) = config_root_fixture();
         let error = normalize_post_send_hooks(
-            vec![PostSendHookRule {
+            vec![RawPostSendHookRule {
                 recipient: "team-lead".into(),
                 command: vec!["   ".into(), "arg".into()],
             }],

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -18,6 +18,7 @@ pub use types::AtmConfig;
 
 use crate::error::{AtmError, AtmErrorCode, AtmErrorKind};
 use crate::schema::{AgentMember, TeamConfig};
+use crate::types::TeamName;
 use discovery::normalize_post_send_hooks;
 
 /// Load `.atm.toml` by walking upward from `start_dir`.
@@ -69,7 +70,22 @@ pub fn load_config(start_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
 
     Ok(Some(AtmConfig {
         identity: parsed.atm.identity.or(parsed.identity),
-        default_team: parsed.atm.default_team.or(parsed.default_team),
+        default_team: parsed
+            .atm
+            .default_team
+            .or(parsed.default_team)
+            .map(|team| {
+                team.parse::<TeamName>().map_err(|error| {
+                    AtmError::new(
+                        AtmErrorKind::Config,
+                        format!("invalid default team in {}: {}", path.display(), error.message),
+                    )
+                    .with_recovery(
+                        "Use a valid ATM team name in [atm].default_team or default_team without path separators or surrounding whitespace.",
+                    )
+                })
+            })
+            .transpose()?,
         team_members: normalize_string_list(parsed.atm.team_members),
         aliases: normalize_aliases(parsed.atm.aliases),
         post_send_hooks: normalize_post_send_hooks(parsed.atm.post_send_hooks, &config_root)?,
@@ -132,7 +148,7 @@ pub fn resolve_team(team_override: Option<&str>, config: Option<&AtmConfig>) -> 
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
         .or_else(|| env::var("ATM_TEAM").ok().filter(|value| !value.is_empty()))
-        .or_else(|| config.and_then(|cfg| cfg.default_team.clone()))
+        .or_else(|| config.and_then(|cfg| cfg.default_team.as_ref().map(ToString::to_string)))
 }
 
 fn find_config_path(start_dir: &Path) -> Option<PathBuf> {
@@ -171,7 +187,14 @@ struct RawAtmSection {
     #[serde(default)]
     aliases: std::collections::BTreeMap<String, String>,
     #[serde(default)]
-    post_send_hooks: Vec<types::PostSendHookRule>,
+    post_send_hooks: Vec<RawPostSendHookRule>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawPostSendHookRule {
+    recipient: String,
+    command: Vec<String>,
 }
 
 fn reject_legacy_post_send_hook_keys(path: &Path, raw_toml: &TomlValue) -> Result<(), AtmError> {
@@ -316,6 +339,7 @@ fn parse_team_member(config_path: &Path, index: usize, entry: &Value) -> Option<
 
 #[cfg(test)]
 mod tests {
+    use crate::config::types::HookRecipient;
     use crate::error_codes::AtmErrorCode;
     use serde_json::Value;
     use std::env;
@@ -387,7 +411,10 @@ blank = ""
         let config = load_config(&root).expect("config").expect("present");
         assert_eq!(config.team_members, vec!["team-lead", "arch-ctm", "qa"]);
         assert_eq!(config.post_send_hooks.len(), 2);
-        assert_eq!(config.post_send_hooks[0].recipient, "team-lead");
+        assert_eq!(
+            config.post_send_hooks[0].recipient,
+            HookRecipient::Named("team-lead".parse().expect("recipient"))
+        );
         assert_eq!(
             config.post_send_hooks[0].command,
             vec![
@@ -395,7 +422,7 @@ blank = ""
                 "team-lead".to_string()
             ]
         );
-        assert_eq!(config.post_send_hooks[1].recipient, "*");
+        assert_eq!(config.post_send_hooks[1].recipient, HookRecipient::Wildcard);
         assert_eq!(
             config.post_send_hooks[1].command,
             vec!["bash".to_string(), "-lc".to_string(), "echo hi".to_string()]
@@ -655,7 +682,7 @@ post_send_hook_recipients = ["team-lead"]
         set_env_var("ATM_TEAM", "env-team");
 
         let config = AtmConfig {
-            default_team: Some("config-team".into()),
+            default_team: Some("config-team".parse().expect("team")),
             ..Default::default()
         };
 

--- a/crates/atm-core/src/config/types.rs
+++ b/crates/atm-core/src/config/types.rs
@@ -1,5 +1,8 @@
 use std::collections::BTreeMap;
+use std::fmt;
 use std::path::PathBuf;
+
+use crate::types::{AgentName, TeamName};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AtmConfig {
@@ -13,7 +16,7 @@ pub struct AtmConfig {
     /// present. Migration path: remove `[atm].identity` from `.atm.toml` and
     /// inject `ATM_IDENTITY` in the active agent environment.
     pub identity: Option<String>,
-    pub default_team: Option<String>,
+    pub default_team: Option<TeamName>,
     pub team_members: Vec<String>,
     pub aliases: BTreeMap<String, String>,
     pub post_send_hooks: Vec<PostSendHookRule>,
@@ -21,9 +24,29 @@ pub struct AtmConfig {
     pub(crate) obsolete_identity_present: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookRecipient {
+    Wildcard,
+    Named(AgentName),
+}
+
+impl HookRecipient {
+    pub fn matches(&self, candidate: &AgentName) -> bool {
+        matches!(self, Self::Wildcard) || matches!(self, Self::Named(name) if name == candidate)
+    }
+}
+
+impl fmt::Display for HookRecipient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Wildcard => f.write_str("*"),
+            Self::Named(name) => name.fmt(f),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PostSendHookRule {
-    pub recipient: String,
+    pub recipient: HookRecipient,
     pub command: Vec<String>,
 }

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -197,19 +197,27 @@ impl AtmError {
     }
 
     pub fn validation(message: impl Into<String>) -> Self {
-        Self::new(AtmErrorKind::Validation, message)
+        Self::new(AtmErrorKind::Validation, message).with_recovery(
+            "Correct the invalid ATM input or mailbox state, then retry the command with a valid target or argument.",
+        )
     }
 
     pub fn missing_document(message: impl Into<String>) -> Self {
-        Self::new(AtmErrorKind::MissingDocument, message)
+        Self::new(AtmErrorKind::MissingDocument, message).with_recovery(
+            "Restore the missing ATM document or recreate it through the documented team-management workflow before retrying.",
+        )
     }
 
     pub fn file_policy(message: impl Into<String>) -> Self {
-        Self::new(AtmErrorKind::FilePolicy, message)
+        Self::new(AtmErrorKind::FilePolicy, message).with_recovery(
+            "Update the referenced file, path, or policy inputs so they satisfy ATM file-policy rules before retrying the command.",
+        )
     }
 
     pub fn mailbox_read(message: impl Into<String>) -> Self {
-        Self::new(AtmErrorKind::MailboxRead, message)
+        Self::new(AtmErrorKind::MailboxRead, message).with_recovery(
+            "Check ATM_HOME, mailbox file permissions, and mailbox JSON syntax before retrying the ATM command.",
+        )
     }
 
     pub fn mailbox_lock(message: impl Into<String>) -> Self {
@@ -219,7 +227,7 @@ impl AtmError {
     }
 
     pub fn mailbox_lock_read_only_filesystem(
-        operation: &'static str,
+        operation: impl fmt::Display,
         path: &std::path::Path,
     ) -> Self {
         Self::new_with_code(
@@ -231,7 +239,7 @@ impl AtmError {
             ),
         )
         .with_recovery(
-            "Remount or move the ATM home to a writable filesystem, then retry the ATM command.",
+            "Remount the filesystem read-write or point ATM at a writable home with ATM_HOME or --home, then retry the ATM command.",
         )
     }
 
@@ -288,7 +296,7 @@ impl fmt::Display for AtmError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.message)?;
         if let Some(recovery) = &self.recovery {
-            write!(f, " Recovery: {recovery}")?;
+            write!(f, "\n  Recovery: {recovery}")?;
         }
         Ok(())
     }

--- a/crates/atm-core/src/error_codes.rs
+++ b/crates/atm-core/src/error_codes.rs
@@ -4,8 +4,9 @@
 //! degraded-warning diagnostics emitted by ATM.
 
 use std::fmt;
+use std::str::FromStr;
 
-use serde::Serialize;
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Stable ATM error and warning codes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -145,6 +146,62 @@ impl AtmErrorCode {
     }
 }
 
+impl FromStr for AtmErrorCode {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "ATM_CONFIG_HOME_UNAVAILABLE" => Ok(Self::ConfigHomeUnavailable),
+            "ATM_CONFIG_PARSE_FAILED" => Ok(Self::ConfigParseFailed),
+            "ATM_CONFIG_RETIRED_HOOK_MEMBERS_KEY" => Ok(Self::ConfigRetiredHookMembersKey),
+            "ATM_CONFIG_RETIRED_LEGACY_HOOK_KEYS" => Ok(Self::ConfigRetiredLegacyHookKeys),
+            "ATM_CONFIG_TEAM_PARSE_FAILED" => Ok(Self::ConfigTeamParseFailed),
+            "ATM_CONFIG_TEAM_MISSING" => Ok(Self::ConfigTeamMissing),
+            "ATM_IDENTITY_UNAVAILABLE" => Ok(Self::IdentityUnavailable),
+            "ATM_ADDRESS_PARSE_FAILED" => Ok(Self::AddressParseFailed),
+            "ATM_TEAM_UNAVAILABLE" => Ok(Self::TeamUnavailable),
+            "ATM_TEAM_NOT_FOUND" => Ok(Self::TeamNotFound),
+            "ATM_AGENT_NOT_FOUND" => Ok(Self::AgentNotFound),
+            "ATM_MAILBOX_READ_FAILED" => Ok(Self::MailboxReadFailed),
+            "ATM_MAILBOX_WRITE_FAILED" => Ok(Self::MailboxWriteFailed),
+            "ATM_MAILBOX_LOCK_FAILED" => Ok(Self::MailboxLockFailed),
+            "ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM" => Ok(Self::MailboxLockReadOnlyFilesystem),
+            "ATM_MAILBOX_LOCK_TIMEOUT" => Ok(Self::MailboxLockTimeout),
+            "ATM_MESSAGE_VALIDATION_FAILED" => Ok(Self::MessageValidationFailed),
+            "ATM_SERIALIZATION_FAILED" => Ok(Self::SerializationFailed),
+            "ATM_FILE_POLICY_REJECTED" => Ok(Self::FilePolicyRejected),
+            "ATM_FILE_REFERENCE_REWRITE_FAILED" => Ok(Self::FileReferenceRewriteFailed),
+            "ATM_WAIT_TIMEOUT" => Ok(Self::WaitTimeout),
+            "ATM_ACK_INVALID_STATE" => Ok(Self::AckInvalidState),
+            "ATM_CLEAR_INVALID_STATE" => Ok(Self::ClearInvalidState),
+            "ATM_OBSERVABILITY_EMIT_FAILED" => Ok(Self::ObservabilityEmitFailed),
+            "ATM_OBSERVABILITY_QUERY_FAILED" => Ok(Self::ObservabilityQueryFailed),
+            "ATM_OBSERVABILITY_FOLLOW_FAILED" => Ok(Self::ObservabilityFollowFailed),
+            "ATM_OBSERVABILITY_HEALTH_FAILED" => Ok(Self::ObservabilityHealthFailed),
+            "ATM_OBSERVABILITY_BOOTSTRAP_FAILED" => Ok(Self::ObservabilityBootstrapFailed),
+            "ATM_OBSERVABILITY_HEALTH_OK" => Ok(Self::ObservabilityHealthOk),
+            "ATM_WARNING_INVALID_TEAM_MEMBER_SKIPPED" => Ok(Self::WarningInvalidTeamMemberSkipped),
+            "ATM_WARNING_MAILBOX_RECORD_SKIPPED" => Ok(Self::WarningMailboxRecordSkipped),
+            "ATM_WARNING_MALFORMED_ATM_FIELD_IGNORED" => Ok(Self::WarningMalformedAtmFieldIgnored),
+            "ATM_WARNING_OBSERVABILITY_HEALTH_DEGRADED" => {
+                Ok(Self::WarningObservabilityHealthDegraded)
+            }
+            "ATM_WARNING_ORIGIN_INBOX_ENTRY_SKIPPED" => Ok(Self::WarningOriginInboxEntrySkipped),
+            "ATM_WARNING_MISSING_TEAM_CONFIG_FALLBACK" => {
+                Ok(Self::WarningMissingTeamConfigFallback)
+            }
+            "ATM_WARNING_SEND_ALERT_STATE_DEGRADED" => Ok(Self::WarningSendAlertStateDegraded),
+            "ATM_WARNING_IDENTITY_DRIFT" => Ok(Self::WarningIdentityDrift),
+            "ATM_WARNING_BASELINE_MEMBER_MISSING" => Ok(Self::WarningBaselineMemberMissing),
+            "ATM_WARNING_RESTORE_IN_PROGRESS" => Ok(Self::WarningRestoreInProgress),
+            "ATM_WARNING_STALE_MAILBOX_LOCK" => Ok(Self::WarningStaleMailboxLock),
+            "ATM_WARNING_HOOK_SKIPPED" => Ok(Self::WarningHookSkipped),
+            "ATM_WARNING_HOOK_EXECUTION_FAILED" => Ok(Self::WarningHookExecutionFailed),
+            _ => Err("unknown ATM error code"),
+        }
+    }
+}
+
 impl fmt::Display for AtmErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
@@ -157,5 +214,30 @@ impl Serialize for AtmErrorCode {
         S: serde::Serializer,
     {
         serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for AtmErrorCode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AtmErrorCode;
+
+    #[test]
+    fn error_code_round_trips_through_json_string() {
+        let encoded =
+            serde_json::to_string(&AtmErrorCode::MailboxLockReadOnlyFilesystem).expect("serialize");
+        assert_eq!(encoded, "\"ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM\"");
+
+        let decoded: AtmErrorCode = serde_json::from_str(&encoded).expect("deserialize");
+        assert_eq!(decoded, AtmErrorCode::MailboxLockReadOnlyFilesystem);
     }
 }

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -146,7 +146,7 @@ mod tests {
 
         let config = AtmConfig {
             identity: Some("config-agent".into()),
-            default_team: Some("config-team".into()),
+            default_team: Some("config-team".parse().expect("team")),
             obsolete_identity_present: true,
             ..Default::default()
         };

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -23,6 +23,47 @@ const RETRY_INTERVAL: Duration = Duration::from_millis(50);
 const REMOVE_RETRY_INTERVAL: Duration = Duration::from_millis(10);
 const REMOVE_RETRY_ATTEMPTS: usize = 20;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LockOperation {
+    CreateDirectory,
+    Open,
+    WriteOwnerRecord,
+    Remove,
+    RemoveStaleSentinel,
+}
+
+impl LockOperation {
+    const fn test_override_token(self) -> &'static str {
+        match self {
+            Self::CreateDirectory => "create_directory",
+            Self::Open => "open",
+            Self::WriteOwnerRecord => "write_owner",
+            Self::Remove => "remove",
+            Self::RemoveStaleSentinel => "remove_stale_sentinel",
+        }
+    }
+}
+
+impl std::fmt::Display for LockOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::CreateDirectory => "create",
+            Self::Open => "open",
+            Self::WriteOwnerRecord => "write owner record",
+            Self::Remove => "remove",
+            Self::RemoveStaleSentinel => "remove stale sentinel",
+        })
+    }
+}
+
+/// Canonical in-process registry key for one mailbox lock target.
+///
+/// The key uses the canonical path when available and otherwise falls back to
+/// the provided path. This mirrors `sort_unique_paths()` so the in-process
+/// registry and multi-lock planner share the same identity semantics.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CanonicalLockKey(String);
+
 pub(crate) fn default_lock_timeout() -> Duration {
     if let Some(timeout) = debug_timeout_override() {
         return timeout;
@@ -37,7 +78,7 @@ pub(crate) struct MailboxLockGuard {
     lock_path: PathBuf,
     file: Option<File>,
     owner_record: LockOwnerRecord,
-    _in_process_guard: Option<InProcessMailboxLockGuard>,
+    _in_process_guard: InProcessMailboxLockGuard,
 }
 
 impl Drop for MailboxLockGuard {
@@ -114,8 +155,9 @@ pub(crate) fn acquire(path: &Path, timeout: Duration) -> Result<MailboxLockGuard
     let deadline = Instant::now() + timeout;
     let in_process_guard = acquire_in_process_lock(path, deadline)?;
     if let Some(parent) = lock_path.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|error| mailbox_lock_path_error("create", parent, error))?;
+        fs::create_dir_all(parent).map_err(|error| {
+            mailbox_lock_path_error(LockOperation::CreateDirectory, parent, error)
+        })?;
     }
 
     loop {
@@ -123,7 +165,7 @@ pub(crate) fn acquire(path: &Path, timeout: Duration) -> Result<MailboxLockGuard
             Ok(_) => {}
             Err(error) if is_readonly_filesystem_error(&error) => {
                 return Err(mailbox_lock_path_error(
-                    "remove stale sentinel",
+                    LockOperation::RemoveStaleSentinel,
                     &lock_path,
                     error,
                 ));
@@ -155,7 +197,7 @@ pub(crate) fn acquire(path: &Path, timeout: Duration) -> Result<MailboxLockGuard
                     lock_path,
                     file: Some(file),
                     owner_record,
-                    _in_process_guard: Some(in_process_guard),
+                    _in_process_guard: in_process_guard,
                 });
             }
             Err(error) if is_lock_contention_error(&error) && Instant::now() >= deadline => {
@@ -181,6 +223,14 @@ pub(crate) fn acquire(path: &Path, timeout: Duration) -> Result<MailboxLockGuard
     }
 }
 
+/// Sweep one mailbox directory for stale `.lock` sentinels.
+///
+/// # Errors
+///
+/// Returns [`AtmError`] only when directory enumeration fails or when stale
+/// sentinel cleanup hits a read-only filesystem. Other per-sentinel eviction
+/// failures are logged and skipped so recovery commands can continue scanning
+/// the rest of the mailbox directory.
 pub(crate) fn sweep_stale_lock_sentinels(dir: &Path) -> Result<usize, AtmError> {
     if !dir.exists() {
         return Ok(0);
@@ -205,7 +255,7 @@ pub(crate) fn sweep_stale_lock_sentinels(dir: &Path) -> Result<usize, AtmError> 
             Ok(StaleLockSentinelEviction::Skipped) => {}
             Err(error) if is_readonly_filesystem_error(&error) => {
                 return Err(mailbox_lock_path_error(
-                    "remove stale sentinel",
+                    LockOperation::RemoveStaleSentinel,
                     &path,
                     error,
                 ));
@@ -261,8 +311,12 @@ fn try_lock_exclusive(file: &File, lock_path: &Path) -> io::Result<()> {
 }
 
 fn open_lock_file(lock_path: &Path) -> Result<File, AtmError> {
-    if let Some(error) = forced_readonly_filesystem_error("open") {
-        return Err(mailbox_lock_path_error("open", lock_path, error));
+    if let Some(error) = forced_readonly_filesystem_error(LockOperation::Open) {
+        return Err(mailbox_lock_path_error(
+            LockOperation::Open,
+            lock_path,
+            error,
+        ));
     }
 
     OpenOptions::new()
@@ -271,7 +325,7 @@ fn open_lock_file(lock_path: &Path) -> Result<File, AtmError> {
         .read(true)
         .write(true)
         .open(lock_path)
-        .map_err(|error| mailbox_lock_path_error("open", lock_path, error))
+        .map_err(|error| mailbox_lock_path_error(LockOperation::Open, lock_path, error))
 }
 
 fn write_lock_owner_record(
@@ -279,20 +333,21 @@ fn write_lock_owner_record(
     lock_path: &Path,
     owner_record: &LockOwnerRecord,
 ) -> Result<(), AtmError> {
-    if let Some(error) = forced_readonly_filesystem_error("write_owner") {
+    if let Some(error) = forced_readonly_filesystem_error(LockOperation::WriteOwnerRecord) {
         return Err(mailbox_lock_path_error(
-            "write owner record",
+            LockOperation::WriteOwnerRecord,
             lock_path,
             error,
         ));
     }
 
-    file.set_len(0)
-        .map_err(|error| mailbox_lock_path_error("write owner record", lock_path, error))?;
+    file.set_len(0).map_err(|error| {
+        mailbox_lock_path_error(LockOperation::WriteOwnerRecord, lock_path, error)
+    })?;
     let mut writer = file;
     writer
         .write_all(owner_record.encode().as_bytes())
-        .map_err(|error| mailbox_lock_path_error("write owner record", lock_path, error))
+        .map_err(|error| mailbox_lock_path_error(LockOperation::WriteOwnerRecord, lock_path, error))
 }
 
 fn remove_active_lock_sentinel(lock_path: &Path, owner_record: &LockOwnerRecord) -> io::Result<()> {
@@ -378,7 +433,7 @@ fn evict_stale_lock_sentinel(lock_path: &Path) -> io::Result<StaleLockSentinelEv
 fn remove_lock_sentinel_with_retry(lock_path: &Path) -> io::Result<()> {
     let mut last_error = None;
     for attempt in 0..REMOVE_RETRY_ATTEMPTS {
-        if let Some(error) = forced_readonly_filesystem_error("remove") {
+        if let Some(error) = forced_readonly_filesystem_error(LockOperation::Remove) {
             return Err(error);
         }
         match fs::remove_file(lock_path) {
@@ -394,7 +449,7 @@ fn remove_lock_sentinel_with_retry(lock_path: &Path) -> io::Result<()> {
         }
     }
 
-    Err(last_error.unwrap_or_else(|| io::Error::other("lock sentinel removal failed")))
+    Err(last_error.expect("last_error must be Some after retry exhaustion"))
 }
 
 fn should_retry_remove_lock_sentinel(error: &io::Error) -> bool {
@@ -437,7 +492,7 @@ fn mailbox_lock_error_code(error: &io::Error) -> AtmErrorCode {
 }
 
 fn mailbox_lock_path_error(
-    operation: &'static str,
+    operation: LockOperation,
     lock_path: &Path,
     error: io::Error,
 ) -> AtmError {
@@ -456,6 +511,9 @@ fn mailbox_lock_path_error(
 }
 
 fn is_readonly_filesystem_error(error: &io::Error) -> bool {
+    // Keep this predicate in sync with `readonly_filesystem_raw_os_error()`.
+    // Tests inject the raw OS code through that helper and expect this logic to
+    // classify the injected error as read-only on every supported platform.
     #[cfg(windows)]
     {
         matches!(
@@ -470,7 +528,7 @@ fn is_readonly_filesystem_error(error: &io::Error) -> bool {
     }
 }
 
-fn forced_readonly_filesystem_error(operation: &'static str) -> Option<io::Error> {
+fn forced_readonly_filesystem_error(operation: LockOperation) -> Option<io::Error> {
     #[cfg(test)]
     if forced_readonly_filesystem_test_override() == Some(operation) {
         return Some(io::Error::from_raw_os_error(
@@ -479,24 +537,13 @@ fn forced_readonly_filesystem_error(operation: &'static str) -> Option<io::Error
     }
 
     let forced = std::env::var("ATM_TEST_FORCE_LOCK_READONLY_FS").ok()?;
-    if forced != operation {
+    if forced != operation.test_override_token() {
         return None;
     }
 
     Some(io::Error::from_raw_os_error(
         readonly_filesystem_raw_os_error(),
     ))
-}
-
-#[cfg(test)]
-thread_local! {
-    static FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE: std::cell::Cell<Option<&'static str>> =
-        const { std::cell::Cell::new(None) };
-}
-
-#[cfg(test)]
-fn forced_readonly_filesystem_test_override() -> Option<&'static str> {
-    FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE.with(|operation| operation.get())
 }
 
 #[cfg(windows)]
@@ -553,6 +600,9 @@ struct LockOwnerRecord {
 
 impl LockOwnerRecord {
     fn new(pid: u32) -> Self {
+        // Relaxed is sufficient because the token only needs process-local
+        // uniqueness for sentinel ownership records; it does not synchronize any
+        // shared memory access across threads.
         static NEXT_LOCK_TOKEN: AtomicU64 = AtomicU64::new(1);
         Self {
             pid,
@@ -571,6 +621,11 @@ fn parse_lock_owner_pid(raw: &str) -> Option<u32> {
         .map_or_else(|| raw.trim().parse().ok(), |(pid, _)| pid.parse().ok())
 }
 
+/// Process-local lock state used to serialize repeated lock attempts on the
+/// same mailbox path before the advisory file lock is reached.
+///
+/// The `held` boolean tracks only whether this process currently owns the local
+/// gate. The outer registry keeps one shared state per canonical mailbox path.
 #[derive(Debug)]
 struct InProcessMailboxLockState {
     held: Mutex<bool>,
@@ -584,7 +639,13 @@ struct InProcessMailboxLockGuard {
 
 impl Drop for InProcessMailboxLockGuard {
     fn drop(&mut self) {
-        let mut held = self.state.held.lock().expect("in-process lock poisoned");
+        // If the mutex is poisoned during teardown, prefer releasing the local
+        // gate over panicking in Drop and aborting the process.
+        let mut held = self
+            .state
+            .held
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         *held = false;
         self.state.wake.notify_one();
     }
@@ -595,11 +656,15 @@ fn acquire_in_process_lock(
     deadline: Instant,
 ) -> Result<InProcessMailboxLockGuard, AtmError> {
     let key = canonical_lock_key(path);
-    let state = in_process_lock_state(key);
+    let state = in_process_lock_state(key)?;
     let mut held = state
         .held
         .lock()
-        .map_err(|_| AtmError::mailbox_lock("in-process mailbox lock state poisoned"))?;
+        .map_err(|_| {
+            AtmError::mailbox_lock("in-process mailbox lock state poisoned").with_recovery(
+                "Retry the ATM command. If the error persists, restart the current ATM process so the in-process mailbox lock gate is rebuilt.",
+            )
+        })?;
     loop {
         if !*held {
             *held = true;
@@ -614,7 +679,11 @@ fn acquire_in_process_lock(
         let (next_held, wait_result) = state
             .wake
             .wait_timeout(held, remaining)
-            .map_err(|_| AtmError::mailbox_lock("in-process mailbox lock wait poisoned"))?;
+            .map_err(|_| {
+                AtmError::mailbox_lock("in-process mailbox lock wait poisoned").with_recovery(
+                    "Retry the ATM command. If the error persists, restart the current ATM process so the in-process mailbox lock gate is rebuilt.",
+                )
+            })?;
         held = next_held;
         if wait_result.timed_out() && *held {
             return Err(AtmError::mailbox_lock_timeout(path));
@@ -622,15 +691,25 @@ fn acquire_in_process_lock(
     }
 }
 
-fn in_process_lock_state(key: String) -> Arc<InProcessMailboxLockState> {
+fn in_process_lock_state(
+    key: CanonicalLockKey,
+) -> Result<Arc<InProcessMailboxLockState>, AtmError> {
     static REGISTRY: OnceLock<
-        Mutex<std::collections::HashMap<String, Arc<InProcessMailboxLockState>>>,
+        Mutex<std::collections::HashMap<CanonicalLockKey, Arc<InProcessMailboxLockState>>>,
     > = OnceLock::new();
+    // A coarse process-wide registry mutex is acceptable here because mailbox
+    // lock acquisition already goes through retry sleeps and filesystem I/O; the
+    // registry only guards short-lived HashMap access before threads block on
+    // the per-path condvar.
     let registry = REGISTRY.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
     let mut registry = registry
         .lock()
-        .expect("in-process mailbox lock registry poisoned");
-    registry
+        .map_err(|_| {
+            AtmError::mailbox_lock("in-process mailbox lock registry poisoned").with_recovery(
+                "Retry the ATM command. If the error persists, restart the current ATM process so the in-process mailbox lock registry is rebuilt.",
+            )
+        })?;
+    Ok(registry
         .entry(key)
         .or_insert_with(|| {
             Arc::new(InProcessMailboxLockState {
@@ -638,14 +717,44 @@ fn in_process_lock_state(key: String) -> Arc<InProcessMailboxLockState> {
                 wake: Condvar::new(),
             })
         })
-        .clone()
+        .clone())
 }
 
-fn canonical_lock_key(path: &Path) -> String {
-    fs::canonicalize(path)
-        .unwrap_or_else(|_| path.to_path_buf())
-        .to_string_lossy()
-        .into_owned()
+fn canonical_lock_key(path: &Path) -> CanonicalLockKey {
+    CanonicalLockKey(
+        fs::canonicalize(path)
+            .unwrap_or_else(|_| path.to_path_buf())
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+#[cfg(test)]
+mod readonly_test_override {
+    use std::cell::Cell;
+
+    use super::LockOperation;
+
+    thread_local! {
+        static OVERRIDE: Cell<Option<LockOperation>> = const { Cell::new(None) };
+    }
+
+    pub(super) fn get() -> Option<LockOperation> {
+        OVERRIDE.with(|operation| operation.get())
+    }
+
+    pub(super) fn set(operation: Option<LockOperation>) -> Option<LockOperation> {
+        OVERRIDE.with(|cell| {
+            let original = cell.get();
+            cell.set(operation);
+            original
+        })
+    }
+}
+
+#[cfg(test)]
+fn forced_readonly_filesystem_test_override() -> Option<LockOperation> {
+    readonly_test_override::get()
 }
 
 #[cfg(test)]
@@ -659,31 +768,27 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        DEFAULT_LOCK_TIMEOUT, FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE, StaleLockSentinelEviction,
-        acquire, acquire_many_sorted, default_lock_timeout, evict_stale_lock_sentinel,
-        is_lock_contention_error, is_lock_sentinel_candidate, sentinel_path,
-        sweep_stale_lock_sentinels,
+        DEFAULT_LOCK_TIMEOUT, LockOperation, StaleLockSentinelEviction, acquire,
+        acquire_many_sorted, default_lock_timeout, evict_stale_lock_sentinel,
+        is_lock_contention_error, is_lock_sentinel_candidate, readonly_test_override,
+        sentinel_path, sweep_stale_lock_sentinels,
     };
     use crate::error::AtmErrorCode;
 
     struct ReadOnlyFilesystemGuard {
-        original: Option<&'static str>,
+        original: Option<LockOperation>,
     }
 
     impl ReadOnlyFilesystemGuard {
-        fn set(operation: &'static str) -> Self {
-            let original = FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE.with(|cell| {
-                let original = cell.get();
-                cell.set(Some(operation));
-                original
-            });
+        fn set(operation: LockOperation) -> Self {
+            let original = readonly_test_override::set(Some(operation));
             Self { original }
         }
     }
 
     impl Drop for ReadOnlyFilesystemGuard {
         fn drop(&mut self) {
-            FORCED_READONLY_FILESYSTEM_TEST_OVERRIDE.with(|cell| cell.set(self.original));
+            readonly_test_override::set(self.original);
         }
     }
 
@@ -922,7 +1027,7 @@ mod tests {
     #[test]
     #[serial]
     fn acquire_reports_read_only_filesystem_for_open_failure() {
-        let _readonly = ReadOnlyFilesystemGuard::set("open");
+        let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::Open);
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join("arch-ctm.json");
 
@@ -949,7 +1054,7 @@ mod tests {
     #[test]
     #[serial]
     fn acquire_reports_read_only_filesystem_for_owner_record_write_failure() {
-        let _readonly = ReadOnlyFilesystemGuard::set("write_owner");
+        let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::WriteOwnerRecord);
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join("arch-ctm.json");
 
@@ -966,7 +1071,7 @@ mod tests {
     #[test]
     #[serial]
     fn sweep_reports_read_only_filesystem_for_stale_sentinel_removal() {
-        let _readonly = ReadOnlyFilesystemGuard::set("remove");
+        let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::Remove);
         let tempdir = tempdir().expect("tempdir");
         let rotated = tempdir.path().join("arch-ctm.json.lock.old");
         std::fs::write(&rotated, u32::MAX.to_string()).expect("stale rotated");
@@ -984,7 +1089,7 @@ mod tests {
         let inbox = tempdir.path().join("arch-ctm.json");
         let sentinel = sentinel_path(&inbox);
         let guard = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect("lock");
-        let _readonly = ReadOnlyFilesystemGuard::set("remove");
+        let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::Remove);
 
         drop(guard);
 

--- a/crates/atm-core/src/mailbox/source.rs
+++ b/crates/atm-core/src/mailbox/source.rs
@@ -254,7 +254,7 @@ mod tests {
         let mut aliases = BTreeMap::new();
         aliases.insert("tl".to_string(), "team-lead".to_string());
         let config = AtmConfig {
-            default_team: Some("atm-dev".to_string()),
+            default_team: Some("atm-dev".parse().expect("team")),
             aliases,
             ..Default::default()
         };

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -10,7 +10,7 @@ use tracing::warn;
 
 use crate::error::{AtmError, AtmErrorCode};
 use crate::schema::LegacyMessageId;
-use crate::types::IsoTimestamp;
+use crate::types::{IsoTimestamp, TaskId};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct CommandEvent {
@@ -23,7 +23,7 @@ pub struct CommandEvent {
     pub message_id: Option<LegacyMessageId>,
     pub requires_ack: bool,
     pub dry_run: bool,
-    pub task_id: Option<String>,
+    pub task_id: Option<TaskId>,
     pub error_code: Option<AtmErrorCode>,
     pub error_message: Option<String>,
 }

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -6,7 +6,7 @@ use serde_json::{Map, Value};
 use ulid::Ulid;
 use uuid::Uuid;
 
-use crate::types::IsoTimestamp;
+use crate::types::{IsoTimestamp, TaskId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -205,7 +205,7 @@ pub struct MessageEnvelope {
     pub acknowledges_message_id: Option<LegacyMessageId>,
 
     #[serde(rename = "taskId", skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
+    pub task_id: Option<TaskId>,
 
     // Preserve unknown producer-owned fields so ATM does not accidentally
     // redefine external schemas by dropping or rewriting them.
@@ -257,7 +257,7 @@ mod tests {
             )),
             acknowledged_at: None,
             acknowledges_message_id: None,
-            task_id: Some("TASK-123".into()),
+            task_id: Some("TASK-123".parse().expect("task id")),
             extra: Map::new(),
         };
 

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -302,6 +302,21 @@ mod tests {
     }
 
     #[test]
+    fn blank_task_id_is_rejected() {
+        let json = json!({
+            "from": "team-lead",
+            "text": "hello",
+            "timestamp": "2026-03-30T00:00:00Z",
+            "read": false,
+            "taskId": "   "
+        });
+
+        let error = serde_json::from_value::<MessageEnvelope>(json).expect_err("blank task id");
+
+        assert!(error.to_string().contains("task id must not be blank"));
+    }
+
+    #[test]
     fn pending_ack_round_trips() {
         let pending_ack = PendingAck {
             message_id: LegacyMessageId::new(),

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -6,9 +6,12 @@ use std::time::{Duration, Instant};
 
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
-use tracing::{Level, debug, error, info, warn};
+#[cfg(test)]
+use tracing::Level;
+use tracing::{debug, error, info, warn};
 
 use crate::config;
+use crate::config::types::HookRecipient;
 use crate::error::AtmErrorCode;
 
 use super::{PostSendHookContext, qualified_sender_identity};
@@ -50,7 +53,7 @@ pub(super) fn maybe_run_post_send_hook(
 
     if matching_rules.is_empty() {
         debug!(
-            sender = context.sender,
+            sender = %context.sender,
             recipient = %context.recipient.agent,
             recipient_team = %context.recipient.team,
             "post-send hook had no matching recipient rules"
@@ -75,9 +78,9 @@ fn execute_post_send_hook(
     };
     let command_path = resolve_command_path(config, command_path);
     let mut payload = json!({
-        "from": qualified_sender_identity(context.sender, context.sender_team),
+        "from": qualified_sender_identity(context.sender, context.sender_team.map(|team| team.as_str())),
         "to": format!("{}@{}", context.recipient.agent, context.recipient.team),
-        "sender": context.sender,
+        "sender": context.sender.as_str(),
         "recipient": context.recipient.agent,
         "team": context.recipient.team,
         "message_id": context.message_id.to_string(),
@@ -88,7 +91,7 @@ fn execute_post_send_hook(
     }
 
     debug!(
-        sender = context.sender,
+        sender = %context.sender,
         recipient = %context.recipient.agent,
         recipient_team = %context.recipient.team,
         hook_recipient = %rule.recipient,
@@ -113,7 +116,7 @@ fn execute_post_send_hook(
             );
             warn!(
                 code = %AtmErrorCode::WarningHookExecutionFailed,
-                sender = context.sender,
+                sender = %context.sender,
                 recipient = %context.recipient.agent,
                 recipient_team = %context.recipient.team,
                 hook_recipient = %rule.recipient,
@@ -142,7 +145,7 @@ fn execute_post_send_hook(
                     );
                     warn!(
                         code = %AtmErrorCode::WarningHookExecutionFailed,
-                        sender = context.sender,
+                        sender = %context.sender,
                         recipient = %context.recipient.agent,
                         recipient_team = %context.recipient.team,
                         hook_recipient = %rule.recipient,
@@ -171,7 +174,7 @@ fn execute_post_send_hook(
                 );
                 warn!(
                     code = %AtmErrorCode::WarningHookExecutionFailed,
-                    sender = context.sender,
+                    sender = %context.sender,
                     recipient = %context.recipient.agent,
                     recipient_team = %context.recipient.team,
                     hook_recipient = %rule.recipient,
@@ -195,7 +198,7 @@ fn execute_post_send_hook(
                 );
                 warn!(
                     code = %AtmErrorCode::WarningHookExecutionFailed,
-                    sender = context.sender,
+                    sender = %context.sender,
                     recipient = %context.recipient.agent,
                     recipient_team = %context.recipient.team,
                     hook_recipient = %rule.recipient,
@@ -219,8 +222,8 @@ fn resolve_command_path(config: &config::AtmConfig, command_path: &str) -> PathB
     }
 }
 
-fn hook_matches_recipient(configured: &str, candidate: &str) -> bool {
-    configured == "*" || configured == candidate
+fn hook_matches_recipient(configured: &HookRecipient, candidate: &crate::types::AgentName) -> bool {
+    configured.matches(candidate)
 }
 
 fn spawn_post_send_hook_stdout_reader(
@@ -331,36 +334,36 @@ fn log_post_send_hook_result(command_path: &Path, result: PostSendHookResult) {
     } = result;
     let fields = Value::Object(fields);
 
-    match hook_result_log_level(level) {
-        Level::DEBUG => debug!(
+    match level {
+        PostSendHookResultLevel::Debug => debug!(
             hook_path = %command_path.display(),
             hook_result_message = %message,
             hook_result_fields = %fields,
             "post-send hook reported result"
         ),
-        Level::INFO => info!(
+        PostSendHookResultLevel::Info => info!(
             hook_path = %command_path.display(),
             hook_result_message = %message,
             hook_result_fields = %fields,
             "post-send hook reported result"
         ),
-        Level::WARN => warn!(
+        PostSendHookResultLevel::Warn => warn!(
             code = %AtmErrorCode::WarningHookExecutionFailed,
             hook_path = %command_path.display(),
             hook_result_message = %message,
             hook_result_fields = %fields,
             "post-send hook reported warning"
         ),
-        Level::ERROR => error!(
+        PostSendHookResultLevel::Error => error!(
             hook_path = %command_path.display(),
             hook_result_message = %message,
             hook_result_fields = %fields,
             "post-send hook reported error"
         ),
-        _ => unreachable!("all tracing levels are covered"),
     }
 }
 
+#[cfg(test)]
 fn hook_result_log_level(level: PostSendHookResultLevel) -> Level {
     match level {
         PostSendHookResultLevel::Debug => Level::DEBUG,
@@ -381,12 +384,22 @@ mod tests {
         POST_SEND_HOOK_MAX_STDOUT_BYTES, PostSendHookResultLevel, hook_matches_recipient,
         hook_result_log_level, parse_post_send_hook_result,
     };
+    use crate::config::types::HookRecipient;
 
     #[test]
     fn hook_matches_recipient_exact_and_wildcard_values() {
-        assert!(hook_matches_recipient("arch-ctm", "arch-ctm"));
-        assert!(hook_matches_recipient("*", "arch-ctm"));
-        assert!(!hook_matches_recipient("team-lead", "arch-ctm"));
+        assert!(hook_matches_recipient(
+            &HookRecipient::Named("arch-ctm".parse().expect("recipient")),
+            &"arch-ctm".parse().expect("candidate")
+        ));
+        assert!(hook_matches_recipient(
+            &HookRecipient::Wildcard,
+            &"arch-ctm".parse().expect("candidate")
+        ));
+        assert!(!hook_matches_recipient(
+            &HookRecipient::Named("team-lead".parse().expect("recipient")),
+            &"arch-ctm".parse().expect("candidate")
+        ));
     }
 
     #[test]

--- a/crates/atm-core/src/send/input.rs
+++ b/crates/atm-core/src/send/input.rs
@@ -1,6 +1,7 @@
 use std::io::Read;
 
 use crate::error::{AtmError, AtmErrorKind};
+use crate::types::TaskId;
 
 /// Read a message body from stdin.
 ///
@@ -46,12 +47,6 @@ pub fn validate_message_text(message: impl Into<String>) -> Result<String, AtmEr
 /// Returns [`AtmError`] with
 /// [`crate::error_codes::AtmErrorCode::MessageValidationFailed`] when a task id
 /// is present but blank.
-pub fn validate_task_id(task_id: Option<String>) -> Result<Option<String>, AtmError> {
-    match task_id {
-        Some(task_id) if task_id.trim().is_empty() => {
-            Err(AtmError::validation("task id must not be blank"))
-        }
-        Some(task_id) => Ok(Some(task_id)),
-        None => Ok(None),
-    }
+pub fn validate_task_id(task_id: Option<TaskId>) -> Result<Option<TaskId>, AtmError> {
+    Ok(task_id)
 }

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -14,7 +14,7 @@ use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
-use crate::types::{AgentName, TeamName};
+use crate::types::{AgentName, TaskId, TeamName};
 use crate::workflow;
 
 mod alert_state;
@@ -43,7 +43,7 @@ pub struct SendRequest {
     pub message_source: SendMessageSource,
     pub summary_override: Option<String>,
     pub requires_ack: bool,
-    pub task_id: Option<String>,
+    pub task_id: Option<TaskId>,
     pub dry_run: bool,
 }
 
@@ -58,7 +58,7 @@ impl SendRequest {
         message_source: SendMessageSource,
         summary_override: Option<String>,
         requires_ack: bool,
-        task_id: Option<String>,
+        task_id: Option<TaskId>,
         dry_run: bool,
     ) -> Result<Self, AtmError> {
         Ok(Self {
@@ -82,12 +82,14 @@ pub struct SendOutcome {
     pub action: &'static str,
     pub team: TeamName,
     pub agent: AgentName,
+    // Preserve the rendered sender identity surface here because cross-team
+    // sends may intentionally emit a qualified alias like `team-lead@src-gen`.
     pub sender: String,
     pub outcome: &'static str,
     pub message_id: LegacyMessageId,
     pub requires_ack: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
+    pub task_id: Option<TaskId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -122,14 +124,16 @@ pub fn send_mail(
     observability: &dyn ObservabilityPort,
 ) -> Result<SendOutcome, AtmError> {
     let config = config::load_config(&request.current_dir)?;
-    let canonical_sender =
-        identity::resolve_sender_identity(request.sender_override.as_deref(), config.as_ref())?;
+    let canonical_sender = AgentName::from_validated(identity::resolve_sender_identity(
+        request.sender_override.as_deref(),
+        config.as_ref(),
+    )?);
     let recipient = resolve_recipient(
         &request.to,
         request.team_override.as_deref(),
         config.as_ref(),
     )?;
-    let sender_team = config::resolve_team(None, config.as_ref());
+    let sender_team = config::resolve_team(None, config.as_ref()).map(TeamName::from_validated);
     let sender = display_sender_identity(
         &canonical_sender,
         request.sender_override.as_deref(),
@@ -213,7 +217,7 @@ pub fn send_mail(
     if !request.dry_run {
         let mut extra = Map::new();
         workflow::set_atm_message_id(&mut extra, atm_message_id);
-        if sender != canonical_sender {
+        if sender != canonical_sender.as_str() {
             set_canonical_sender_metadata(
                 &mut extra,
                 &qualified_sender_identity(&canonical_sender, sender_team.as_deref()),
@@ -226,6 +230,7 @@ pub fn send_mail(
             read: false,
             source_team: sender_team
                 .clone()
+                .map(|team| team.to_string())
                 .or_else(|| Some(recipient.team.to_string())),
             summary: Some(summary.clone()),
             message_id: Some(message_id),
@@ -265,11 +270,11 @@ pub fn send_mail(
             config.as_ref(),
             PostSendHookContext {
                 sender: &canonical_sender,
-                sender_team: sender_team.as_deref(),
+                sender_team: sender_team.as_ref(),
                 recipient: &recipient,
                 message_id,
                 requires_ack,
-                task_id: task_id.as_deref(),
+                task_id: task_id.as_ref(),
             },
         );
     }
@@ -280,7 +285,7 @@ pub fn send_mail(
         outcome: outcome.outcome,
         team: outcome.team.to_string(),
         agent: outcome.agent.to_string(),
-        sender: canonical_sender,
+        sender: canonical_sender.to_string(),
         message_id: Some(outcome.message_id),
         requires_ack: outcome.requires_ack,
         dry_run: outcome.dry_run,
@@ -300,12 +305,12 @@ pub(super) struct ResolvedRecipient {
 
 #[derive(Clone, Copy)]
 pub(super) struct PostSendHookContext<'a> {
-    sender: &'a str,
-    sender_team: Option<&'a str>,
+    sender: &'a AgentName,
+    sender_team: Option<&'a TeamName>,
     recipient: &'a ResolvedRecipient,
     message_id: LegacyMessageId,
     requires_ack: bool,
-    task_id: Option<&'a str>,
+    task_id: Option<&'a TaskId>,
 }
 
 fn resolve_recipient(
@@ -450,7 +455,7 @@ fn append_mailbox_message_and_seed_workflow(
 }
 
 fn display_sender_identity(
-    canonical_sender: &str,
+    canonical_sender: &AgentName,
     sender_override: Option<&str>,
     sender_team: Option<&str>,
     recipient_team: &str,
@@ -464,16 +469,16 @@ fn display_sender_identity(
     if let Some(sender_override) = sender_override
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        && config::aliases::resolve_agent(sender_override, config) == canonical_sender
+        && config::aliases::resolve_agent(sender_override, config) == canonical_sender.as_str()
     {
         return sender_override.to_string();
     }
 
-    config::aliases::preferred_alias(canonical_sender, config)
+    config::aliases::preferred_alias(canonical_sender.as_str(), config)
         .unwrap_or_else(|| canonical_sender.to_string())
 }
 
-pub(super) fn qualified_sender_identity(sender: &str, sender_team: Option<&str>) -> String {
+pub(super) fn qualified_sender_identity(sender: &AgentName, sender_team: Option<&str>) -> String {
     sender_team
         .map(|team| format!("{sender}@{team}"))
         .unwrap_or_else(|| sender.to_string())

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -158,6 +158,65 @@ impl PartialEq<&str> for TeamName {
     }
 }
 
+/// Validated ATM task id carried across command, schema, and hook boundaries.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TaskId(String);
+
+impl TaskId {
+    /// Borrow the wrapped task id as `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the wrapper and return the inner owned task id.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl FromStr for TaskId {
+    type Err = AtmError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(
+                AtmError::validation("task id must not be blank").with_recovery(
+                    "Provide a non-empty --task-id value or omit --task-id for non-task messages.",
+                ),
+            );
+        }
+        Ok(Self(trimmed.to_string()))
+    }
+}
+
+impl From<TaskId> for String {
+    fn from(value: TaskId) -> Self {
+        value.0
+    }
+}
+
+impl AsRef<str> for TaskId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for TaskId {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for TaskId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Index of one message within its source mailbox file.
 #[derive(
     Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::address::validate_path_segment;
 use crate::error::AtmError;
@@ -159,7 +159,7 @@ impl PartialEq<&str> for TeamName {
 }
 
 /// Validated ATM task id carried across command, schema, and hook boundaries.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct TaskId(String);
 
@@ -191,6 +191,16 @@ impl FromStr for TaskId {
     }
 }
 
+impl<'de> Deserialize<'de> for TaskId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 impl From<TaskId> for String {
     fn from(value: TaskId) -> Self {
         value.0
@@ -214,6 +224,18 @@ impl Deref for TaskId {
 impl fmt::Display for TaskId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TaskId;
+
+    #[test]
+    fn task_id_rejects_blank_deserialization() {
+        let error = serde_json::from_str::<TaskId>("\"   \"").expect_err("blank task id");
+
+        assert!(error.to_string().contains("task id must not be blank"));
     }
 }
 

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -235,7 +235,7 @@ fn concurrent_same_recipient_sends_preserve_mixed_payloads_and_workflow_state() 
     let plain_request = fixture.send_request("team-lead", "arch-ctm@atm-dev", "plain payload");
     let mut task_request = fixture.send_request("qa", "arch-ctm@atm-dev", "task payload");
     task_request.requires_ack = true;
-    task_request.task_id = Some("TASK-123".to_string());
+    task_request.task_id = Some("TASK-123".parse().expect("task id"));
     task_request.summary_override = Some("manual summary".to_string());
 
     for (label, request) in [("plain", plain_request), ("task", task_request)] {

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use atm_core::home;
 use atm_core::send::{self, SendMessageSource, SendRequest};
+use atm_core::types::TaskId;
 use clap::Args;
 
 use crate::observability::CliObservability;
@@ -39,7 +40,7 @@ pub struct SendCommand {
     requires_ack: bool,
 
     #[arg(long = "task-id")]
-    task_id: Option<String>,
+    task_id: Option<TaskId>,
 
     #[arg(long)]
     dry_run: bool,

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -419,7 +419,7 @@ fn map_command_event(
     if let Some(task_id) = &event.task_id {
         fields.insert(
             "task_id".to_string(),
-            serde_json::Value::String(task_id.clone()),
+            serde_json::Value::String(task_id.to_string()),
         );
     }
     if let Some(error_code) = event.error_code {

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -197,7 +197,7 @@ mod tests {
             message_id: message_id.map(|value| value.parse().expect("legacy message id")),
             requires_ack: false,
             dry_run: false,
-            task_id: Some("TASK-1".to_string()),
+            task_id: Some("TASK-1".parse().expect("task id")),
             error_code: None,
             error_message: None,
         }

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -19,7 +19,7 @@ fn test_ack_transitions_pending_ack_and_appends_reply() {
         None,
         message_id,
     );
-    message.task_id = Some("TASK-123".into());
+    message.task_id = Some("TASK-123".parse().expect("task id"));
     fixture.write_inbox("arch-ctm", &[message]);
 
     let output = fixture.run(&[


### PR DESCRIPTION
## Summary

- Implements all blocking and important RBP findings from the Phase P full rust-best-practices review
- `AtmErrorCode` now derives `Deserialize` with round-trip serde test
- `TaskId` is a validated newtype across send/schema/observability surfaces
- Post-send hook recipients typed via `HookRecipient { Wildcard, Named(AgentName) }`
- `default_team` typed via `TeamName` newtype in config
- Mailbox lock operations enum-backed (`LockOperation` enum)
- Poison/recovery handling tightened; `with_recovery()` chains added to missing constructors
- Readonly/sweep contracts clarified
- Scope notes: full ack/clear typestate elimination deferred (boundary at user-selected message); `SendOutcome.sender` kept as legacy string surface (documented)

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all --check` passes
- [ ] QA-pP-s11: req-qa, arch-qa, rust-qa-agent, rust-best-practices-agent, rust-service-hardening-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)