### PR TITLE
feat: type send outcome sender

### DIFF
--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -82,9 +82,7 @@ pub struct SendOutcome {
     pub action: &'static str,
     pub team: TeamName,
     pub agent: AgentName,
-    // Preserve the rendered sender identity surface here because cross-team
-    // sends may intentionally emit a qualified alias like `team-lead@src-gen`.
-    pub sender: String,
+    pub sender: AgentName,
     pub outcome: &'static str,
     pub message_id: LegacyMessageId,
     pub requires_ack: bool,
@@ -134,7 +132,7 @@ pub fn send_mail(
         config.as_ref(),
     )?;
     let sender_team = config::resolve_team(None, config.as_ref()).map(TeamName::from_validated);
-    let sender = display_sender_identity(
+    let display_sender = display_sender_identity(
         &canonical_sender,
         request.sender_override.as_deref(),
         sender_team.as_deref(),
@@ -217,14 +215,14 @@ pub fn send_mail(
     if !request.dry_run {
         let mut extra = Map::new();
         workflow::set_atm_message_id(&mut extra, atm_message_id);
-        if sender != canonical_sender.as_str() {
+        if display_sender != canonical_sender.as_str() {
             set_canonical_sender_metadata(
                 &mut extra,
                 &qualified_sender_identity(&canonical_sender, sender_team.as_deref()),
             );
         }
         let envelope = MessageEnvelope {
-            from: sender.clone(),
+            from: display_sender.clone(),
             text: body.clone(),
             timestamp,
             read: false,
@@ -253,7 +251,7 @@ pub fn send_mail(
         action: "send",
         team: recipient.team.clone(),
         agent: recipient.agent.clone(),
-        sender: sender.clone(),
+        sender: canonical_sender.clone(),
         outcome: if request.dry_run { "dry_run" } else { "sent" },
         message_id,
         requires_ack,

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -444,6 +444,26 @@ fn test_send_cross_team_projects_alias_and_persists_canonical_from_identity() {
 }
 
 #[test]
+fn test_send_json_reports_canonical_sender_identity() {
+    let fixture = Fixture::new("recipient");
+    fixture.write_team_config_for_team("other-team", "recipient");
+    fixture.write_atm_config("[atm]\n[atm.aliases]\nlead = \"arch-ctm\"\n");
+
+    let output = fixture.run_with_env(
+        &["send", "recipient@other-team", "hello cross-team", "--json"],
+        &[("ATM_TEAM", "atm-dev")],
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        fixture.stderr(&output)
+    );
+    let parsed = fixture.stdout_json(&output);
+    assert_eq!(parsed["sender"], "arch-ctm");
+}
+
+#[test]
 fn test_send_runs_post_send_hook_with_expected_payload() {
     let fixture = Fixture::new("recipient");
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");


### PR DESCRIPTION
## Summary
- type  as 
- update the ATM send JSON contract coverage for the typed sender field
- close the remaining non-redesign P.12 item at commit 

## Validation
- cargo test --workspace --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all --check