### PR TITLE
fix: always call TeamCreate on session ID match path after compaction

### DIFF
--- a/.claude/skills/restore-team-communications/SKILL.md
+++ b/.claude/skills/restore-team-communications/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: restore-team-communications
+description: >
+  Repair Claude teammate routing after same-session compaction or resume when
+  atm-dev still exists on disk and the saved leadSessionId still matches the
+  current SESSION_ID, but SendMessage or teammate reachability is broken.
+---
+
+# Restore Team Communications
+
+Use this skill only when all of these are true:
+- `ATM_IDENTITY=team-lead`
+- `SESSION_ID` still matches `leadSessionId` in
+  `~/.claude/teams/atm-dev/config.json`
+- the team directory still exists on disk
+- Claude teammate communication is broken or suspect after compaction or resume
+
+Do not use this skill for fresh startup or after `clear`. If the current
+`SESSION_ID` does not match `leadSessionId`, use `/team-lead` and follow the
+full restore procedure instead.
+
+## Step 0 — Prove Whether Repair Is Needed
+
+First, try normal Claude-to-Claude communication before changing anything:
+
+```text
+SendMessage(to="<claude-teammate>", message="ping: verify atm-dev communications path")
+```
+
+If the message is delivered and acknowledged, stop. No repair is needed.
+
+Do not read inbox files, session files, or tmux panes directly on this path.
+
+## Step 1 — Back Up Current State
+
+Back up before any destructive recovery:
+
+```bash
+atm teams backup atm-dev
+BACKUP_PATH=$(ls -td ~/.claude/teams/.backups/atm-dev/*/ | head -1)
+cp -r ~/.claude/tasks/agent-team-mail/ "$BACKUP_PATH/tasks-cc"
+echo "CC task list backed up to $BACKUP_PATH/tasks-cc"
+```
+
+## Step 2 — Remove Broken Team Registration
+
+Clear both live Claude routing state and the persisted team directory:
+
+```text
+TeamDelete
+```
+
+```bash
+rm -rf ~/.claude/teams/atm-dev
+```
+
+If `TeamDelete` reports no active team name, proceed. That means live routing
+was already absent.
+
+## Step 3 — Recreate Team And Restore ATM State
+
+Recreate the team:
+
+```text
+TeamCreate(team_name="atm-dev", description="ATM development team", agent_type="team-lead")
+```
+
+Then restore from the most recent backup:
+
+```bash
+atm teams restore atm-dev --from "$BACKUP_PATH"
+```
+
+If required members are missing after restore, add them before verification.
+
+## Step 4 — Verify Both Communication Layers
+
+Repair is not complete until all checks pass:
+
+1. `SendMessage` to another Claude teammate.
+2. `atm send` to a non-Claude model.
+3. `atm send` to Codex and verify the nudge fires.
+
+For Codex-directed ATM sends, the nudge must include a clear call to action, not
+just a passive unread-mail announcement. Preferred structured nudge payload:
+
+```text
+<atm><action>read atm</action><action>ack <TASK-ID></action><action>execute assigned task</action><when idle="immediate" busy="after-current-task"/><console announce="concise" pause="false"/></atm>
+```
+
+Fallback plain-text wording:
+
+```text
+read atm for task <TASK-ID> and complete it before stopping
+```
+
+If the task is queued behind active work, use a queued-task nudge instead of an
+interruptive one.
+
+## Step 5 — Resume Work Quietly
+
+If the repair succeeded:
+- do not broadcast internal restore diagnostics over ATM
+- send only the minimum teammate message needed to resume work
+- return to normal project coordination
+
+If the repair failed, stop and report the exact failed verification step.

--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -9,7 +9,9 @@ description: >
 
 # Team Lead Skill
 
-Trigger: run at the start of every session where `ATM_IDENTITY=team-lead`.
+Trigger: run at the start of every fresh session where `ATM_IDENTITY=team-lead`.
+Do not use this skill for same-session compaction or resume unless the session id
+has changed.
 
 ## Step 0 — Confirm Identity
 
@@ -28,13 +30,14 @@ Get the current session id from the `SessionStart` hook output in context
 python3 -c "import json; print(json.load(open('/Users/randlee/.claude/teams/atm-dev/config.json'))['leadSessionId'])"
 ```
 
-- Match: the team is already initialized for this session, so no full ATM
-  restore is needed. Before reading `docs/project-plan.md`, run
-  `TeamCreate(team_name="atm-dev", description="ATM development team", agent_type="team-lead")`
-  once to re-establish Claude Code's in-memory team routing if context
-  compaction wiped it. This is a communications repair step, not a destructive
-  restore.
-- Mismatch or missing config: follow the full restore procedure in
+- Match: the current session already matches the persisted team state. Proceed to
+  reading `docs/project-plan.md` and outputting project status. Stay silent in
+  ATM unless teammate action is required. If teammate communications are broken
+  despite a match, stop and use `/restore-team-communications` instead of the
+  full restore flow.
+- Mismatch or missing config: this is the normal startup or `clear` case where
+  the live `SESSION_ID` changed and the saved `leadSessionId` no longer
+  matches. Follow the full restore procedure in
   `.claude/skills/team-lead/backup-and-restore-team.md`.
 
 ## Team-Lead Responsibilities
@@ -46,6 +49,7 @@ After initialization, use these repo-local skills to coordinate work:
 | `/phase-orchestration` | Orchestrate a multi-sprint phase with fresh scrum-masters |
 | `/codex-orchestration` | Run phases where arch-ctm is sole dev, with pipelined QA via quality-mgr |
 | `/quality-management-gh` | Multi-pass QA on GitHub PRs; CI monitoring; findings/final quality reports |
+| `/restore-team-communications` | Repair same-session Claude teammate routing after compaction or resume without invoking full startup/clear restore |
 
 Additional orchestration guides live in `.claude/skills/*/SKILL.md`.
 

--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -28,8 +28,12 @@ Get the current session id from the `SessionStart` hook output in context
 python3 -c "import json; print(json.load(open('/Users/randlee/.claude/teams/atm-dev/config.json'))['leadSessionId'])"
 ```
 
-- Match: the team is already initialized for this session. Proceed directly to
-  reading `docs/project-plan.md` and outputting project status.
+- Match: the team is already initialized for this session, so no full ATM
+  restore is needed. Before reading `docs/project-plan.md`, run
+  `TeamCreate(team_name="atm-dev", description="ATM development team", agent_type="team-lead")`
+  once to re-establish Claude Code's in-memory team routing if context
+  compaction wiped it. This is a communications repair step, not a destructive
+  restore.
 - Mismatch or missing config: follow the full restore procedure in
   `.claude/skills/team-lead/backup-and-restore-team.md`.
 

--- a/.claude/skills/team-lead/backup-and-restore-team.md
+++ b/.claude/skills/team-lead/backup-and-restore-team.md
@@ -45,6 +45,11 @@ TeamCreate(team_name="atm-dev", description="ATM development team", agent_type="
 
 Verify that the returned team name is exactly `atm-dev`. If it is not, stop.
 
+Note: this same `TeamCreate` call is also required on the Step 1 fast path when
+the session id still matches but Claude Code's in-memory routing was wiped by
+context compaction. In that case it repairs teammate communications without
+doing the destructive backup/delete/restore sequence above.
+
 ## Step 5 — Restore Team Members And Inboxes
 
 ```bash

--- a/.claude/skills/team-lead/backup-and-restore-team.md
+++ b/.claude/skills/team-lead/backup-and-restore-team.md
@@ -1,7 +1,13 @@
 # Team Backup And Restore Procedure
 
 Follow this procedure when Step 1 of the `team-lead` skill detects a session id
-mismatch and a full team restore is required.
+mismatch and a full team restore is required. This is the startup or `clear`
+path where the live `SESSION_ID` changed and no longer matches
+`leadSessionId`.
+
+Do not use this procedure for same-session compaction or resume when the
+session id still matches. Use `/restore-team-communications` for that lighter
+repair path.
 
 ## Step 2 — Backup Current State
 
@@ -45,10 +51,10 @@ TeamCreate(team_name="atm-dev", description="ATM development team", agent_type="
 
 Verify that the returned team name is exactly `atm-dev`. If it is not, stop.
 
-Note: this same `TeamCreate` call is also required on the Step 1 fast path when
-the session id still matches but Claude Code's in-memory routing was wiped by
-context compaction. In that case it repairs teammate communications without
-doing the destructive backup/delete/restore sequence above.
+Note: `/restore-team-communications` reuses this same `TeamCreate` primitive
+when communications are broken after compaction or resume, but that path should
+prove the failure first and avoid this destructive backup/delete/restore flow
+unless the lighter repair fails.
 
 ## Step 5 — Restore Team Members And Inboxes
 
@@ -108,6 +114,11 @@ atm inbox
 atm gh pr list
 ```
 
+Communication verification is also mandatory:
+1. `SendMessage` to another Claude teammate to prove Claude-side routing works.
+2. `atm send` to a non-Claude model to prove ATM mailbox routing works.
+3. `atm send` to Codex and confirm the Codex-side nudge fires.
+
 ## Step 8 — Read Project Context
 
 1. Read `docs/project-plan.md`.
@@ -124,11 +135,18 @@ atm gh pr list
 atm send arch-ctm "New session (session-id: <SESSION_ID>). Team atm-dev restored. Please acknowledge and confirm status."
 ```
 
-If no response arrives within about 60 seconds, nudge via tmux:
+If no response arrives within about 60 seconds, nudge via tmux. Preferred
+structured nudge payload when task metadata is available:
+
+```text
+<atm><action>read atm</action><action>ack <TASK-ID></action><action>execute assigned task</action><when idle="immediate" busy="after-current-task"/><console announce="concise" pause="false"/></atm>
+```
+
+Fallback plain-text nudge:
 
 ```bash
 tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_title}'
-tmux send-keys -t <pane-id> "You have unread ATM messages. Run: atm read --team atm-dev" Enter
+tmux send-keys -t <pane-id> "read atm for task <TASK-ID> and complete it before stopping" Enter
 ```
 
 ## Common Failure Modes


### PR DESCRIPTION
## Summary

- Fix `team-lead` SKILL.md Step 1 fast path — session ID match now calls `TeamCreate` before reading project-plan.md
- Adds note to `backup-and-restore-team.md` Step 4 clarifying TeamCreate is required even on fast path after compaction
- Root cause: Claude Code in-memory team routing is wiped on context compaction; session ID match in config does not imply active routing

## Why

After compaction, `SendMessage` routing to `quality-mgr` and other teammates fails silently with "No agent named X is currently addressable" because `TeamCreate` was never called in the new session. The fast path (session ID match) incorrectly skipped `TeamCreate`, assuming the team was already initialized.

## Test plan

- [ ] Start new session after compaction with `ATM_IDENTITY=team-lead`
- [ ] Verify `TeamCreate` is called before reading project-plan.md (even on session ID match)
- [ ] Verify `SendMessage` routes correctly to `quality-mgr` after restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)