### PR TITLE
chore: ignore sc session artifacts and compose logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ Cargo.toml.ci
 # Contains mutation testing data
 **/mutants.out*/
 
+# Local session artifacts and compose logs from sc tooling
+.sc/sessions/
+.sc-compose/logs/
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore


### PR DESCRIPTION
## Summary
- add repo-local ATM nudge hook script with XML task call-to-action payloads
- wire .atm.toml post-send hooks to the repo script for team-lead and arch-ctm
- ignore local .sc session artifacts and sc-compose logs, and remove the tracked log file from git

## Validation
- python3 -m py_compile scripts/atm-nudge.py
- ATM_POST_SEND sample invocation of scripts/atm-nudge.py returned 0
