### PR TITLE
fix: move ATM inbox machine fields into metadata.atm (PP-S10-A)

### DIFF
--- a/crates/atm-core/src/mailbox/atomic.rs
+++ b/crates/atm-core/src/mailbox/atomic.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use crate::error::{AtmError, AtmErrorKind};
 use crate::persistence;
 use crate::schema::MessageEnvelope;
+use crate::schema::inbox_message::to_shared_inbox_value;
 
 /// Atomically replace one mailbox JSONL file from fully serialized records.
 ///
@@ -25,7 +26,8 @@ use crate::schema::MessageEnvelope;
 pub fn write_messages(path: &Path, messages: &[MessageEnvelope]) -> Result<(), AtmError> {
     let mut bytes = Vec::new();
     for message in messages {
-        serde_json::to_writer(&mut bytes, message)?;
+        let encoded = to_shared_inbox_value(message)?;
+        serde_json::to_writer(&mut bytes, &encoded)?;
         bytes.push(b'\n');
     }
 

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 use tracing::warn;
 
 use crate::error::{AtmError, AtmErrorCode, AtmErrorKind};
+use crate::schema::inbox_message::hydrate_legacy_fields_from_metadata;
 use crate::schema::{LegacyMessageId, MessageEnvelope};
 
 const MAX_MAILBOX_READ_BYTES: u64 = 10 * 1024 * 1024;
@@ -205,6 +206,7 @@ fn parse_mailbox_value(
     path: &Path,
     line_number: usize,
 ) -> Result<Option<MessageEnvelope>, serde_json::Error> {
+    hydrate_legacy_fields_from_metadata(value);
     sanitize_legacy_message_id(value, path, line_number);
     serde_json::from_value::<MessageEnvelope>(value.take()).map(Some)
 }
@@ -264,6 +266,20 @@ mod tests {
         assert!(raw.contains("\"text\":\"first\""));
         let read_back = read_messages(&path).expect("read back");
         assert_eq!(read_back, vec![envelope]);
+    }
+
+    #[test]
+    fn append_message_serializes_metadata_atm_without_top_level_machine_fields() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("append-message-metadata.jsonl");
+        let envelope = sample_message(Uuid::new_v4(), "first");
+
+        append_message(&path, &envelope).expect("append");
+
+        let raw = fs::read_to_string(&path).expect("raw contents");
+        assert!(raw.contains("\"metadata\":{\"atm\":{"));
+        assert!(!raw.contains("\"message_id\""));
+        assert!(!raw.contains("\"source_team\""));
     }
 
     #[test]
@@ -426,6 +442,27 @@ mod tests {
     }
 
     #[test]
+    fn read_messages_hydrates_fields_from_metadata_atm() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("metadata-atm.json");
+        fs::write(
+            &path,
+            r#"{"from":"team-lead","text":"hello","timestamp":"2026-03-30T00:00:00Z","read":false,"summary":"hello","metadata":{"atm":{"messageId":"01JQYVB6W51Q2E7E6T3Y4Q9N2M","sourceTeam":"atm-dev","pendingAckAt":"2026-03-30T00:00:01Z","taskId":"TASK-123"}}}"#,
+        )
+        .expect("write");
+
+        let messages = read_messages(&path).expect("read");
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].message_id.is_some());
+        assert_eq!(messages[0].source_team.as_deref(), Some("atm-dev"));
+        assert!(messages[0].pending_ack_at.is_some());
+        assert_eq!(
+            messages[0].task_id.as_ref().map(|task_id| task_id.as_str()),
+            Some("TASK-123")
+        );
+    }
+
+    #[test]
     fn append_message_preserves_both_records_under_concurrent_writers() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("append-message-concurrent.jsonl");
@@ -454,6 +491,24 @@ mod tests {
     }
 
     fn sample_message(message_id: Uuid, body: &str) -> MessageEnvelope {
+        let mut extra = serde_json::Map::new();
+        let mut metadata = serde_json::Map::new();
+        let mut atm = serde_json::Map::new();
+        atm.insert(
+            "messageId".to_string(),
+            serde_json::Value::String(
+                crate::schema::LegacyMessageId::from(message_id)
+                    .into_atm_message_id()
+                    .to_string(),
+            ),
+        );
+        atm.insert(
+            "sourceTeam".to_string(),
+            serde_json::Value::String("atm-dev".to_string()),
+        );
+        metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
+        extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
+
         MessageEnvelope {
             from: "arch-ctm".into(),
             text: body.into(),
@@ -470,7 +525,7 @@ mod tests {
             acknowledged_at: None,
             acknowledges_message_id: None,
             task_id: None,
-            extra: serde_json::Map::new(),
+            extra,
         }
     }
 }

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -178,6 +178,21 @@ mod tests {
     }
 
     fn sample_message(from: &str, text: &str) -> MessageEnvelope {
+        let message_id = LegacyMessageId::from(Uuid::new_v4());
+        let mut extra = serde_json::Map::new();
+        let mut metadata = serde_json::Map::new();
+        let mut atm = serde_json::Map::new();
+        atm.insert(
+            "messageId".to_string(),
+            serde_json::Value::String(message_id.into_atm_message_id().to_string()),
+        );
+        atm.insert(
+            "sourceTeam".to_string(),
+            serde_json::Value::String("atm-dev".to_string()),
+        );
+        metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
+        extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
+
         MessageEnvelope {
             from: from.to_string(),
             text: text.to_string(),
@@ -185,12 +200,12 @@ mod tests {
             read: false,
             source_team: Some("atm-dev".to_string()),
             summary: None,
-            message_id: Some(LegacyMessageId::from(Uuid::new_v4())),
+            message_id: Some(message_id),
             pending_ack_at: None,
             acknowledged_at: None,
             acknowledges_message_id: None,
             task_id: None,
-            extra: serde_json::Map::new(),
+            extra,
         }
     }
 }

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -1,8 +1,12 @@
+//! Shared inbox compatibility schema for Claude-native envelopes plus ATM metadata.
+
 use std::fmt;
+use std::io;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use tracing::warn;
 use ulid::Ulid;
 use uuid::Uuid;
 
@@ -243,7 +247,12 @@ fn ensure_object<'a>(parent: &'a mut Map<String, Value>, key: &str) -> &'a mut M
 }
 
 pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, serde_json::Error> {
-    let mut value = serde_json::to_value(message)?;
+    let mut value = serde_json::to_value(message).map_err(|error| {
+        serde_json::Error::io(io::Error::other(format!(
+            "failed to serialize shared inbox envelope for {} at {:?}: {error}",
+            message.from, message.timestamp
+        )))
+    })?;
     let object = value
         .as_object_mut()
         .expect("message envelope serializes to object");
@@ -312,55 +321,75 @@ pub(crate) fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
         .and_then(Value::as_object)
         .and_then(|metadata| metadata.get("atm"))
         .and_then(Value::as_object)
-        .cloned()
     else {
         return;
     };
 
-    if !object.contains_key("message_id") {
-        if let Some(raw) = atm.get("messageId").and_then(Value::as_str) {
-            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
-                object.insert(
-                    "message_id".to_string(),
-                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-                );
+    let message_id = if object.contains_key("message_id") {
+        None
+    } else if let Some(raw) = atm.get("messageId").and_then(Value::as_str) {
+        match raw.parse::<AtmMessageId>() {
+            Ok(message_id) => Some(Value::String(
+                LegacyMessageId::from_atm_message_id(message_id).to_string(),
+            )),
+            Err(error) => {
+                warn!(%error, raw, "ignoring malformed metadata.atm.messageId");
+                None
             }
         }
-    }
+    } else {
+        None
+    };
 
-    if !object.contains_key("source_team") {
-        if let Some(value) = atm.get("sourceTeam") {
-            object.insert("source_team".to_string(), value.clone());
-        }
-    }
-
-    if !object.contains_key("pendingAckAt") {
-        if let Some(value) = atm.get("pendingAckAt") {
-            object.insert("pendingAckAt".to_string(), value.clone());
-        }
-    }
-
-    if !object.contains_key("acknowledgedAt") {
-        if let Some(value) = atm.get("acknowledgedAt") {
-            object.insert("acknowledgedAt".to_string(), value.clone());
-        }
-    }
-
-    if !object.contains_key("acknowledgesMessageId") {
-        if let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str) {
-            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
-                object.insert(
-                    "acknowledgesMessageId".to_string(),
-                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+    let source_team = (!object.contains_key("source_team"))
+        .then(|| atm.get("sourceTeam").cloned())
+        .flatten();
+    let pending_ack_at = (!object.contains_key("pendingAckAt"))
+        .then(|| atm.get("pendingAckAt").cloned())
+        .flatten();
+    let acknowledged_at = (!object.contains_key("acknowledgedAt"))
+        .then(|| atm.get("acknowledgedAt").cloned())
+        .flatten();
+    let acknowledges_message_id = if object.contains_key("acknowledgesMessageId") {
+        None
+    } else if let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str) {
+        match raw.parse::<AtmMessageId>() {
+            Ok(message_id) => Some(Value::String(
+                LegacyMessageId::from_atm_message_id(message_id).to_string(),
+            )),
+            Err(error) => {
+                warn!(
+                    %error,
+                    raw,
+                    "ignoring malformed metadata.atm.acknowledgesMessageId"
                 );
+                None
             }
         }
-    }
+    } else {
+        None
+    };
+    let task_id = (!object.contains_key("taskId"))
+        .then(|| atm.get("taskId").cloned())
+        .flatten();
 
-    if !object.contains_key("taskId") {
-        if let Some(value) = atm.get("taskId") {
-            object.insert("taskId".to_string(), value.clone());
-        }
+    if let Some(value) = message_id {
+        object.insert("message_id".to_string(), value);
+    }
+    if let Some(value) = source_team {
+        object.insert("source_team".to_string(), value);
+    }
+    if let Some(value) = pending_ack_at {
+        object.insert("pendingAckAt".to_string(), value);
+    }
+    if let Some(value) = acknowledged_at {
+        object.insert("acknowledgedAt".to_string(), value);
+    }
+    if let Some(value) = acknowledges_message_id {
+        object.insert("acknowledgesMessageId".to_string(), value);
+    }
+    if let Some(value) = task_id {
+        object.insert("taskId".to_string(), value);
     }
 }
 
@@ -587,6 +616,50 @@ mod tests {
     }
 
     #[test]
+    fn shared_inbox_write_shape_moves_ack_machine_fields_into_metadata() {
+        let acknowledged_at = IsoTimestamp::from_datetime(
+            Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 2)
+                .single()
+                .expect("timestamp"),
+        );
+        let envelope = MessageEnvelope {
+            from: "arch-ctm".into(),
+            text: "ack reply".into(),
+            timestamp: IsoTimestamp::from_datetime(
+                Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                    .single()
+                    .expect("timestamp"),
+            ),
+            read: false,
+            source_team: Some("atm-dev".into()),
+            summary: Some("ack reply".into()),
+            message_id: Some(LegacyMessageId::new()),
+            pending_ack_at: None,
+            acknowledged_at: Some(acknowledged_at),
+            acknowledges_message_id: Some(LegacyMessageId::new()),
+            task_id: None,
+            extra: Map::new(),
+        };
+
+        let encoded = to_shared_inbox_value(&envelope).expect("encode");
+        let object = encoded.as_object().expect("object");
+        assert!(!object.contains_key("acknowledgedAt"));
+        assert!(!object.contains_key("acknowledgesMessageId"));
+
+        let atm = object
+            .get("metadata")
+            .and_then(Value::as_object)
+            .and_then(|metadata| metadata.get("atm"))
+            .and_then(Value::as_object)
+            .expect("metadata.atm");
+        assert_eq!(
+            atm.get("acknowledgedAt"),
+            Some(&json!("2026-03-30T00:00:02Z"))
+        );
+        assert!(atm["acknowledgesMessageId"].as_str().is_some());
+    }
+
+    #[test]
     fn metadata_fields_hydrate_legacy_internal_shape() {
         let mut value = json!({
             "from": "arch-ctm",
@@ -609,5 +682,76 @@ mod tests {
         assert!(object.contains_key("message_id"));
         assert_eq!(object.get("source_team"), Some(&json!("atm-dev")));
         assert_eq!(object.get("taskId"), Some(&json!("TASK-123")));
+    }
+
+    #[test]
+    fn metadata_fields_hydrate_legacy_ack_fields() {
+        let mut value = json!({
+            "from": "arch-ctm",
+            "text": "ack reply",
+            "timestamp": "2026-03-30T00:00:00Z",
+            "read": false,
+            "metadata": {
+                "atm": {
+                    "acknowledgedAt": "2026-03-30T00:00:02Z",
+                    "acknowledgesMessageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M"
+                }
+            }
+        });
+
+        hydrate_legacy_fields_from_metadata(&mut value);
+        let object = value.as_object().expect("object");
+        assert_eq!(
+            object.get("acknowledgedAt"),
+            Some(&json!("2026-03-30T00:00:02Z"))
+        );
+        assert!(object["acknowledgesMessageId"].as_str().is_some());
+    }
+
+    #[test]
+    fn hydrate_legacy_fields_ignores_malformed_metadata_without_panic() {
+        let mut value = json!({
+            "from": "arch-ctm",
+            "text": "hello",
+            "timestamp": "2026-03-30T00:00:00Z",
+            "read": false,
+            "metadata": {
+                "atm": {
+                    "messageId": "not-a-ulid",
+                    "acknowledgesMessageId": "also-not-a-ulid"
+                }
+            }
+        });
+
+        hydrate_legacy_fields_from_metadata(&mut value);
+        let object = value.as_object().expect("object");
+        assert!(!object.contains_key("message_id"));
+        assert!(!object.contains_key("acknowledgesMessageId"));
+    }
+
+    #[test]
+    fn hydrate_legacy_fields_handles_partially_migrated_envelope() {
+        let mut value = json!({
+            "from": "arch-ctm",
+            "text": "hello",
+            "timestamp": "2026-03-30T00:00:00Z",
+            "read": false,
+            "source_team": "legacy-team",
+            "metadata": {
+                "atm": {
+                    "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
+                    "pendingAckAt": "2026-03-30T00:00:01Z"
+                }
+            }
+        });
+
+        hydrate_legacy_fields_from_metadata(&mut value);
+        let object = value.as_object().expect("object");
+        assert_eq!(object.get("source_team"), Some(&json!("legacy-team")));
+        assert!(object["message_id"].as_str().is_some());
+        assert_eq!(
+            object.get("pendingAckAt"),
+            Some(&json!("2026-03-30T00:00:01Z"))
+        );
     }
 }

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -18,8 +18,16 @@ impl LegacyMessageId {
         Self(Uuid::new_v4())
     }
 
+    pub fn from_atm_message_id(value: AtmMessageId) -> Self {
+        Self(Uuid::from_bytes(value.into_ulid().to_bytes()))
+    }
+
     pub fn into_uuid(self) -> Uuid {
         self.0
+    }
+
+    pub fn into_atm_message_id(self) -> AtmMessageId {
+        AtmMessageId::from(Ulid::from_bytes(self.0.into_bytes()))
     }
 }
 
@@ -134,6 +142,9 @@ pub struct AtmMetadataFields {
     )]
     pub acknowledges_message_id: Option<AtmMessageId>,
 
+    #[serde(rename = "taskId", skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<TaskId>,
+
     #[serde(rename = "alertKind", skip_serializing_if = "Option::is_none")]
     pub alert_kind: Option<String>,
 
@@ -221,16 +232,149 @@ pub struct PendingAck {
     pub acked_at: Option<IsoTimestamp>,
 }
 
+fn ensure_object<'a>(parent: &'a mut Map<String, Value>, key: &str) -> &'a mut Map<String, Value> {
+    let entry = parent
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !entry.is_object() {
+        *entry = Value::Object(Map::new());
+    }
+    entry.as_object_mut().expect("entry forced to object")
+}
+
+pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, serde_json::Error> {
+    let mut value = serde_json::to_value(message)?;
+    let object = value
+        .as_object_mut()
+        .expect("message envelope serializes to object");
+    let message_id = object.remove("message_id").and_then(|value| match value {
+        Value::String(_) => message
+            .message_id
+            .map(LegacyMessageId::into_atm_message_id)
+            .map(|message_id| Value::String(message_id.to_string())),
+        _ => None,
+    });
+    let source_team = object.remove("source_team");
+    let pending_ack_at = object.remove("pendingAckAt");
+    let acknowledged_at = object.remove("acknowledgedAt");
+    let acknowledges_message_id =
+        object
+            .remove("acknowledgesMessageId")
+            .and_then(|value| match value {
+                Value::String(_) => message
+                    .acknowledges_message_id
+                    .map(LegacyMessageId::into_atm_message_id)
+                    .map(|message_id| Value::String(message_id.to_string())),
+                _ => None,
+            });
+    let task_id = object.remove("taskId");
+    let alert_kind = object.remove("atmAlertKind");
+    let missing_config_path = object.remove("missingConfigPath");
+
+    let metadata = ensure_object(object, "metadata");
+    let atm = ensure_object(metadata, "atm");
+
+    if let Some(value) = message_id {
+        atm.entry("messageId".to_string()).or_insert(value);
+    }
+    if let Some(value) = source_team {
+        atm.entry("sourceTeam".to_string()).or_insert(value);
+    }
+    if let Some(value) = pending_ack_at {
+        atm.entry("pendingAckAt".to_string()).or_insert(value);
+    }
+    if let Some(value) = acknowledged_at {
+        atm.entry("acknowledgedAt".to_string()).or_insert(value);
+    }
+    if let Some(value) = acknowledges_message_id {
+        atm.entry("acknowledgesMessageId".to_string())
+            .or_insert(value);
+    }
+    if let Some(value) = task_id {
+        atm.entry("taskId".to_string()).or_insert(value);
+    }
+    if let Some(value) = alert_kind {
+        atm.entry("alertKind".to_string()).or_insert(value);
+    }
+    if let Some(value) = missing_config_path {
+        atm.entry("missingConfigPath".to_string()).or_insert(value);
+    }
+
+    Ok(value)
+}
+
+pub(crate) fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    let Some(atm) = object
+        .get("metadata")
+        .and_then(Value::as_object)
+        .and_then(|metadata| metadata.get("atm"))
+        .and_then(Value::as_object)
+        .cloned()
+    else {
+        return;
+    };
+
+    if !object.contains_key("message_id") {
+        if let Some(raw) = atm.get("messageId").and_then(Value::as_str) {
+            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
+                object.insert(
+                    "message_id".to_string(),
+                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+                );
+            }
+        }
+    }
+
+    if !object.contains_key("source_team") {
+        if let Some(value) = atm.get("sourceTeam") {
+            object.insert("source_team".to_string(), value.clone());
+        }
+    }
+
+    if !object.contains_key("pendingAckAt") {
+        if let Some(value) = atm.get("pendingAckAt") {
+            object.insert("pendingAckAt".to_string(), value.clone());
+        }
+    }
+
+    if !object.contains_key("acknowledgedAt") {
+        if let Some(value) = atm.get("acknowledgedAt") {
+            object.insert("acknowledgedAt".to_string(), value.clone());
+        }
+    }
+
+    if !object.contains_key("acknowledgesMessageId") {
+        if let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str) {
+            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
+                object.insert(
+                    "acknowledgesMessageId".to_string(),
+                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+                );
+            }
+        }
+    }
+
+    if !object.contains_key("taskId") {
+        if let Some(value) = atm.get("taskId") {
+            object.insert("taskId".to_string(), value.clone());
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::TimeZone;
-    use serde_json::{Map, json};
+    use serde_json::{Map, Value, json};
 
     use chrono::Utc;
 
     use super::{
         AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, IsoTimestamp, LegacyMessageId,
-        MessageEnvelope, MessageMetadata, PendingAck,
+        MessageEnvelope, MessageMetadata, PendingAck, hydrate_legacy_fields_from_metadata,
+        to_shared_inbox_value,
     };
 
     #[test]
@@ -347,6 +491,7 @@ mod tests {
                     pending_ack_at: None,
                     acknowledged_at: None,
                     acknowledges_message_id: None,
+                    task_id: None,
                     alert_kind: None,
                     missing_config_path: None,
                     extra: Map::new(),
@@ -396,5 +541,73 @@ mod tests {
         let (message_id, _) = AtmMessageId::new_with_timestamp();
         let parsed: AtmMessageId = message_id.to_string().parse().expect("parse atm id");
         assert_eq!(parsed, message_id);
+    }
+
+    #[test]
+    fn shared_inbox_write_shape_moves_machine_fields_into_metadata() {
+        let envelope = MessageEnvelope {
+            from: "arch-ctm".into(),
+            text: "hello".into(),
+            timestamp: IsoTimestamp::from_datetime(
+                Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                    .single()
+                    .expect("timestamp"),
+            ),
+            read: false,
+            source_team: Some("atm-dev".into()),
+            summary: Some("hello".into()),
+            message_id: Some(LegacyMessageId::new()),
+            pending_ack_at: Some(IsoTimestamp::from_datetime(
+                Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
+                    .single()
+                    .expect("timestamp"),
+            )),
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            task_id: Some("TASK-123".parse().expect("task id")),
+            extra: Map::new(),
+        };
+
+        let encoded = to_shared_inbox_value(&envelope).expect("encode");
+        let object = encoded.as_object().expect("object");
+        assert!(!object.contains_key("message_id"));
+        assert!(!object.contains_key("source_team"));
+        assert!(!object.contains_key("pendingAckAt"));
+        assert!(!object.contains_key("taskId"));
+
+        let atm = object
+            .get("metadata")
+            .and_then(Value::as_object)
+            .and_then(|metadata| metadata.get("atm"))
+            .and_then(Value::as_object)
+            .expect("metadata.atm");
+        assert!(atm.contains_key("messageId"));
+        assert_eq!(atm.get("sourceTeam"), Some(&json!("atm-dev")));
+        assert_eq!(atm.get("taskId"), Some(&json!("TASK-123")));
+    }
+
+    #[test]
+    fn metadata_fields_hydrate_legacy_internal_shape() {
+        let mut value = json!({
+            "from": "arch-ctm",
+            "text": "hello",
+            "timestamp": "2026-03-30T00:00:00Z",
+            "read": false,
+            "summary": "hello",
+            "metadata": {
+                "atm": {
+                    "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
+                    "sourceTeam": "atm-dev",
+                    "pendingAckAt": "2026-03-30T00:00:01Z",
+                    "taskId": "TASK-123"
+                }
+            }
+        });
+
+        hydrate_legacy_fields_from_metadata(&mut value);
+        let object = value.as_object().expect("object");
+        assert!(object.contains_key("message_id"));
+        assert_eq!(object.get("source_team"), Some(&json!("atm-dev")));
+        assert_eq!(object.get("taskId"), Some(&json!("TASK-123")));
     }
 }

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -213,7 +213,11 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
     assert!(
         arch_workflow["messages"][format!("legacy:{pending_message_id}")]["acknowledgedAt"]
             .as_str()
-            .is_some(),
+            .is_some()
+            || arch_workflow["messages"]
+                [format!("atm:{}", pending_message_id.into_atm_message_id())]["acknowledgedAt"]
+                .as_str()
+                .is_some(),
         "pending message was not acknowledged in workflow state: {arch_workflow:?}"
     );
     let qa_inbox = ack_fixture.inbox_contents("qa");
@@ -1133,52 +1137,45 @@ fn hydrate_legacy_fields_from_metadata(value: &mut serde_json::Value) {
         return;
     };
 
-    if !object.contains_key("message_id") {
-        if let Some(raw) = atm.get("messageId").and_then(serde_json::Value::as_str) {
-            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
-                object.insert(
-                    "message_id".to_string(),
-                    serde_json::Value::String(
-                        LegacyMessageId::from_atm_message_id(message_id).to_string(),
-                    ),
-                );
-            }
-        }
+    if !object.contains_key("message_id")
+        && let Some(raw) = atm.get("messageId").and_then(serde_json::Value::as_str)
+        && let Ok(message_id) = raw.parse::<AtmMessageId>()
+    {
+        object.insert(
+            "message_id".to_string(),
+            serde_json::Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+        );
     }
-    if !object.contains_key("source_team") {
-        if let Some(value) = atm.get("sourceTeam") {
-            object.insert("source_team".to_string(), value.clone());
-        }
+    if !object.contains_key("source_team")
+        && let Some(value) = atm.get("sourceTeam")
+    {
+        object.insert("source_team".to_string(), value.clone());
     }
-    if !object.contains_key("pendingAckAt") {
-        if let Some(value) = atm.get("pendingAckAt") {
-            object.insert("pendingAckAt".to_string(), value.clone());
-        }
+    if !object.contains_key("pendingAckAt")
+        && let Some(value) = atm.get("pendingAckAt")
+    {
+        object.insert("pendingAckAt".to_string(), value.clone());
     }
-    if !object.contains_key("acknowledgedAt") {
-        if let Some(value) = atm.get("acknowledgedAt") {
-            object.insert("acknowledgedAt".to_string(), value.clone());
-        }
+    if !object.contains_key("acknowledgedAt")
+        && let Some(value) = atm.get("acknowledgedAt")
+    {
+        object.insert("acknowledgedAt".to_string(), value.clone());
     }
-    if !object.contains_key("acknowledgesMessageId") {
-        if let Some(raw) = atm
+    if !object.contains_key("acknowledgesMessageId")
+        && let Some(raw) = atm
             .get("acknowledgesMessageId")
             .and_then(serde_json::Value::as_str)
-        {
-            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
-                object.insert(
-                    "acknowledgesMessageId".to_string(),
-                    serde_json::Value::String(
-                        LegacyMessageId::from_atm_message_id(message_id).to_string(),
-                    ),
-                );
-            }
-        }
+        && let Ok(message_id) = raw.parse::<AtmMessageId>()
+    {
+        object.insert(
+            "acknowledgesMessageId".to_string(),
+            serde_json::Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+        );
     }
-    if !object.contains_key("taskId") {
-        if let Some(value) = atm.get("taskId") {
-            object.insert("taskId".to_string(), value.clone());
-        }
+    if !object.contains_key("taskId")
+        && let Some(value) = atm.get("taskId")
+    {
+        object.insert("taskId".to_string(), value.clone());
     }
 }
 

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -10,7 +10,7 @@ use atm_core::clear::{ClearQuery, clear_mail};
 use atm_core::error::AtmErrorCode;
 use atm_core::observability::NullObservability;
 use atm_core::read::{ReadQuery, read_mail};
-use atm_core::schema::{AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig};
+use atm_core::schema::{AgentMember, AtmMessageId, LegacyMessageId, MessageEnvelope, TeamConfig};
 use atm_core::send::{SendMessageSource, SendRequest, send_mail};
 use atm_core::types::{AckActivationMode, IsoTimestamp, ReadSelection};
 use chrono::Utc;
@@ -1089,7 +1089,11 @@ fn message_atm_id(message: &MessageEnvelope) -> String {
 fn read_jsonl(path: std::path::PathBuf) -> Vec<MessageEnvelope> {
     let raw = fs::read_to_string(path).expect("inbox contents");
     raw.lines()
-        .map(|line| serde_json::from_str(line).expect("json line"))
+        .map(|line| {
+            let mut value: serde_json::Value = serde_json::from_str(line).expect("json line");
+            hydrate_legacy_fields_from_metadata(&mut value);
+            serde_json::from_value(value).expect("message envelope")
+        })
         .collect()
 }
 
@@ -1113,6 +1117,69 @@ fn sentinel_path(path: &std::path::Path) -> std::path::PathBuf {
     let mut os = path.as_os_str().to_os_string();
     os.push(".lock");
     std::path::PathBuf::from(os)
+}
+
+fn hydrate_legacy_fields_from_metadata(value: &mut serde_json::Value) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    let Some(atm) = object
+        .get("metadata")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|metadata| metadata.get("atm"))
+        .and_then(serde_json::Value::as_object)
+        .cloned()
+    else {
+        return;
+    };
+
+    if !object.contains_key("message_id") {
+        if let Some(raw) = atm.get("messageId").and_then(serde_json::Value::as_str) {
+            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
+                object.insert(
+                    "message_id".to_string(),
+                    serde_json::Value::String(
+                        LegacyMessageId::from_atm_message_id(message_id).to_string(),
+                    ),
+                );
+            }
+        }
+    }
+    if !object.contains_key("source_team") {
+        if let Some(value) = atm.get("sourceTeam") {
+            object.insert("source_team".to_string(), value.clone());
+        }
+    }
+    if !object.contains_key("pendingAckAt") {
+        if let Some(value) = atm.get("pendingAckAt") {
+            object.insert("pendingAckAt".to_string(), value.clone());
+        }
+    }
+    if !object.contains_key("acknowledgedAt") {
+        if let Some(value) = atm.get("acknowledgedAt") {
+            object.insert("acknowledgedAt".to_string(), value.clone());
+        }
+    }
+    if !object.contains_key("acknowledgesMessageId") {
+        if let Some(raw) = atm
+            .get("acknowledgesMessageId")
+            .and_then(serde_json::Value::as_str)
+        {
+            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
+                object.insert(
+                    "acknowledgesMessageId".to_string(),
+                    serde_json::Value::String(
+                        LegacyMessageId::from_atm_message_id(message_id).to_string(),
+                    ),
+                );
+            }
+        }
+    }
+    if !object.contains_key("taskId") {
+        if let Some(value) = atm.get("taskId") {
+            object.insert("taskId".to_string(), value.clone());
+        }
+    }
 }
 
 fn pending_ack_message(

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -382,44 +382,42 @@ fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
         return;
     };
 
-    if !object.contains_key("message_id") {
-        if let Some(raw) = atm.get("messageId").and_then(Value::as_str) {
-            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
-                object.insert(
-                    "message_id".to_string(),
-                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-                );
-            }
-        }
+    if !object.contains_key("message_id")
+        && let Some(raw) = atm.get("messageId").and_then(Value::as_str)
+        && let Ok(message_id) = raw.parse::<AtmMessageId>()
+    {
+        object.insert(
+            "message_id".to_string(),
+            Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+        );
     }
-    if !object.contains_key("source_team") {
-        if let Some(value) = atm.get("sourceTeam") {
-            object.insert("source_team".to_string(), value.clone());
-        }
+    if !object.contains_key("source_team")
+        && let Some(value) = atm.get("sourceTeam")
+    {
+        object.insert("source_team".to_string(), value.clone());
     }
-    if !object.contains_key("pendingAckAt") {
-        if let Some(value) = atm.get("pendingAckAt") {
-            object.insert("pendingAckAt".to_string(), value.clone());
-        }
+    if !object.contains_key("pendingAckAt")
+        && let Some(value) = atm.get("pendingAckAt")
+    {
+        object.insert("pendingAckAt".to_string(), value.clone());
     }
-    if !object.contains_key("acknowledgedAt") {
-        if let Some(value) = atm.get("acknowledgedAt") {
-            object.insert("acknowledgedAt".to_string(), value.clone());
-        }
+    if !object.contains_key("acknowledgedAt")
+        && let Some(value) = atm.get("acknowledgedAt")
+    {
+        object.insert("acknowledgedAt".to_string(), value.clone());
     }
-    if !object.contains_key("acknowledgesMessageId") {
-        if let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str) {
-            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
-                object.insert(
-                    "acknowledgesMessageId".to_string(),
-                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-                );
-            }
-        }
+    if !object.contains_key("acknowledgesMessageId")
+        && let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str)
+        && let Ok(message_id) = raw.parse::<AtmMessageId>()
+    {
+        object.insert(
+            "acknowledgesMessageId".to_string(),
+            Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+        );
     }
-    if !object.contains_key("taskId") {
-        if let Some(value) = atm.get("taskId") {
-            object.insert("taskId".to_string(), value.clone());
-        }
+    if !object.contains_key("taskId")
+        && let Some(value) = atm.get("taskId")
+    {
+        object.insert("taskId".to_string(), value.clone());
     }
 }

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::process::Command;
 
-use atm_core::schema::{AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig};
+use atm_core::schema::{AgentMember, AtmMessageId, LegacyMessageId, MessageEnvelope, TeamConfig};
 use atm_core::types::IsoTimestamp;
 use chrono::{Duration, Utc};
 use serde_json::Value;
@@ -70,6 +70,13 @@ fn test_ack_transitions_pending_ack_and_appends_reply() {
         replies[0].acknowledges_message_id,
         Some(LegacyMessageId::from(message_id))
     );
+    let raw_replies = fixture.inbox_json_lines("team-lead");
+    assert!(
+        raw_replies[0]["metadata"]["atm"]["acknowledgesMessageId"]
+            .as_str()
+            .is_some()
+    );
+    assert!(raw_replies[0].get("acknowledgesMessageId").is_none());
 }
 
 #[test]
@@ -259,6 +266,17 @@ impl Fixture {
     fn inbox_contents(&self, agent: &str) -> Vec<MessageEnvelope> {
         let raw = fs::read_to_string(self.inbox_path(agent)).expect("inbox contents");
         raw.lines()
+            .map(|line| {
+                let mut value: Value = serde_json::from_str(line).expect("json line");
+                hydrate_legacy_fields_from_metadata(&mut value);
+                serde_json::from_value(value).expect("message envelope")
+            })
+            .collect()
+    }
+
+    fn inbox_json_lines(&self, agent: &str) -> Vec<Value> {
+        let raw = fs::read_to_string(self.inbox_path(agent)).expect("inbox contents");
+        raw.lines()
             .map(|line| serde_json::from_str(line).expect("json line"))
             .collect()
     }
@@ -286,7 +304,11 @@ impl Fixture {
         let raw = fs::read_to_string(self.origin_inbox_path(agent, origin))
             .expect("origin inbox contents");
         raw.lines()
-            .map(|line| serde_json::from_str(line).expect("json line"))
+            .map(|line| {
+                let mut value: Value = serde_json::from_str(line).expect("json line");
+                hydrate_legacy_fields_from_metadata(&mut value);
+                serde_json::from_value(value).expect("message envelope")
+            })
             .collect()
     }
 
@@ -342,6 +364,62 @@ impl Fixture {
             acknowledges_message_id: None,
             task_id: None,
             extra: serde_json::Map::new(),
+        }
+    }
+}
+
+fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    let Some(atm) = object
+        .get("metadata")
+        .and_then(Value::as_object)
+        .and_then(|metadata| metadata.get("atm"))
+        .and_then(Value::as_object)
+        .cloned()
+    else {
+        return;
+    };
+
+    if !object.contains_key("message_id") {
+        if let Some(raw) = atm.get("messageId").and_then(Value::as_str) {
+            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
+                object.insert(
+                    "message_id".to_string(),
+                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+                );
+            }
+        }
+    }
+    if !object.contains_key("source_team") {
+        if let Some(value) = atm.get("sourceTeam") {
+            object.insert("source_team".to_string(), value.clone());
+        }
+    }
+    if !object.contains_key("pendingAckAt") {
+        if let Some(value) = atm.get("pendingAckAt") {
+            object.insert("pendingAckAt".to_string(), value.clone());
+        }
+    }
+    if !object.contains_key("acknowledgedAt") {
+        if let Some(value) = atm.get("acknowledgedAt") {
+            object.insert("acknowledgedAt".to_string(), value.clone());
+        }
+    }
+    if !object.contains_key("acknowledgesMessageId") {
+        if let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str) {
+            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
+                object.insert(
+                    "acknowledgesMessageId".to_string(),
+                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+                );
+            }
+        }
+    }
+    if !object.contains_key("taskId") {
+        if let Some(value) = atm.get("taskId") {
+            object.insert("taskId".to_string(), value.clone());
         }
     }
 }

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -753,6 +753,7 @@ fn test_forward_metadata_message_id_timestamp_matches_persisted_timestamp() {
                 pending_ack_at: None,
                 acknowledged_at: None,
                 acknowledges_message_id: None,
+                task_id: None,
                 alert_kind: None,
                 missing_config_path: None,
                 extra: serde_json::Map::new(),

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use atm_core::schema::{AgentMember, MessageEnvelope, TeamConfig};
+use atm_core::schema::{AgentMember, AtmMessageId, LegacyMessageId, MessageEnvelope, TeamConfig};
 use serde_json::Value;
 
 #[test]
@@ -29,6 +29,12 @@ fn test_send_creates_inbox_file() {
     assert_eq!(inbox[0].text, "hello from test");
     assert_eq!(inbox[0].from, "arch-ctm");
     assert!(inbox[0].message_id.is_some());
+    let raw = fixture.inbox_json_lines("recipient");
+    assert_eq!(raw.len(), 1);
+    assert!(raw[0]["metadata"]["atm"]["messageId"].as_str().is_some());
+    assert_eq!(raw[0]["metadata"]["atm"]["sourceTeam"], "atm-dev");
+    assert!(raw[0].get("message_id").is_none());
+    assert!(raw[0].get("source_team").is_none());
 }
 
 #[test]
@@ -125,6 +131,9 @@ fn test_send_requires_ack() {
     let inbox = fixture.inbox_contents("recipient");
     assert_eq!(inbox.len(), 1);
     assert!(inbox[0].pending_ack_at.is_some());
+    let raw = fixture.inbox_json_lines("recipient");
+    assert!(raw[0]["metadata"]["atm"]["pendingAckAt"].as_str().is_some());
+    assert!(raw[0].get("pendingAckAt").is_none());
     let atm_message_id = inbox[0].extra["metadata"]["atm"]["messageId"]
         .as_str()
         .expect("atm message id");
@@ -161,6 +170,9 @@ fn test_send_persists_task_id() {
     let inbox = fixture.inbox_contents("recipient");
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].task_id.as_deref(), Some("TASK-123"));
+    let raw = fixture.inbox_json_lines("recipient");
+    assert_eq!(raw[0]["metadata"]["atm"]["taskId"], "TASK-123");
+    assert!(raw[0].get("taskId").is_none());
 }
 
 #[test]
@@ -1022,7 +1034,26 @@ impl Fixture {
         self.inbox_contents_in_team("atm-dev", recipient)
     }
 
+    fn inbox_json_lines(&self, recipient: &str) -> Vec<Value> {
+        self.inbox_json_lines_in_team("atm-dev", recipient)
+    }
+
     fn inbox_contents_in_team(&self, team: &str, recipient: &str) -> Vec<MessageEnvelope> {
+        let inbox_path = self.inbox_path_in_team(team, recipient);
+        let raw = fs::read_to_string(&inbox_path).expect("inbox contents");
+        if raw.trim().is_empty() {
+            return Vec::new();
+        }
+        raw.lines()
+            .map(|line| {
+                let mut value: Value = serde_json::from_str(line).expect("json line");
+                hydrate_legacy_fields_from_metadata(&mut value);
+                serde_json::from_value(value).expect("message envelope")
+            })
+            .collect()
+    }
+
+    fn inbox_json_lines_in_team(&self, team: &str, recipient: &str) -> Vec<Value> {
         let inbox_path = self.inbox_path_in_team(team, recipient);
         let raw = fs::read_to_string(&inbox_path).expect("inbox contents");
         if raw.trim().is_empty() {
@@ -1106,5 +1137,66 @@ impl Fixture {
 
     fn stderr(&self, output: &std::process::Output) -> String {
         String::from_utf8(output.stderr.clone()).expect("stderr utf8")
+    }
+}
+
+fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    let Some(atm) = object
+        .get("metadata")
+        .and_then(Value::as_object)
+        .and_then(|metadata| metadata.get("atm"))
+        .and_then(Value::as_object)
+        .cloned()
+    else {
+        return;
+    };
+
+    if !object.contains_key("message_id") {
+        if let Some(raw) = atm.get("messageId").and_then(Value::as_str) {
+            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
+                object.insert(
+                    "message_id".to_string(),
+                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+                );
+            }
+        }
+    }
+
+    if !object.contains_key("source_team") {
+        if let Some(value) = atm.get("sourceTeam") {
+            object.insert("source_team".to_string(), value.clone());
+        }
+    }
+
+    if !object.contains_key("pendingAckAt") {
+        if let Some(value) = atm.get("pendingAckAt") {
+            object.insert("pendingAckAt".to_string(), value.clone());
+        }
+    }
+
+    if !object.contains_key("acknowledgedAt") {
+        if let Some(value) = atm.get("acknowledgedAt") {
+            object.insert("acknowledgedAt".to_string(), value.clone());
+        }
+    }
+
+    if !object.contains_key("acknowledgesMessageId") {
+        if let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str) {
+            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
+                object.insert(
+                    "acknowledgesMessageId".to_string(),
+                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+                );
+            }
+        }
+    }
+
+    if !object.contains_key("taskId") {
+        if let Some(value) = atm.get("taskId") {
+            object.insert("taskId".to_string(), value.clone());
+        }
     }
 }

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -1154,49 +1154,47 @@ fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
         return;
     };
 
-    if !object.contains_key("message_id") {
-        if let Some(raw) = atm.get("messageId").and_then(Value::as_str) {
-            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
-                object.insert(
-                    "message_id".to_string(),
-                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-                );
-            }
-        }
+    if !object.contains_key("message_id")
+        && let Some(raw) = atm.get("messageId").and_then(Value::as_str)
+        && let Ok(message_id) = raw.parse::<AtmMessageId>()
+    {
+        object.insert(
+            "message_id".to_string(),
+            Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+        );
     }
 
-    if !object.contains_key("source_team") {
-        if let Some(value) = atm.get("sourceTeam") {
-            object.insert("source_team".to_string(), value.clone());
-        }
+    if !object.contains_key("source_team")
+        && let Some(value) = atm.get("sourceTeam")
+    {
+        object.insert("source_team".to_string(), value.clone());
     }
 
-    if !object.contains_key("pendingAckAt") {
-        if let Some(value) = atm.get("pendingAckAt") {
-            object.insert("pendingAckAt".to_string(), value.clone());
-        }
+    if !object.contains_key("pendingAckAt")
+        && let Some(value) = atm.get("pendingAckAt")
+    {
+        object.insert("pendingAckAt".to_string(), value.clone());
     }
 
-    if !object.contains_key("acknowledgedAt") {
-        if let Some(value) = atm.get("acknowledgedAt") {
-            object.insert("acknowledgedAt".to_string(), value.clone());
-        }
+    if !object.contains_key("acknowledgedAt")
+        && let Some(value) = atm.get("acknowledgedAt")
+    {
+        object.insert("acknowledgedAt".to_string(), value.clone());
     }
 
-    if !object.contains_key("acknowledgesMessageId") {
-        if let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str) {
-            if let Ok(message_id) = raw.parse::<AtmMessageId>() {
-                object.insert(
-                    "acknowledgesMessageId".to_string(),
-                    Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-                );
-            }
-        }
+    if !object.contains_key("acknowledgesMessageId")
+        && let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str)
+        && let Ok(message_id) = raw.parse::<AtmMessageId>()
+    {
+        object.insert(
+            "acknowledgesMessageId".to_string(),
+            Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
+        );
     }
 
-    if !object.contains_key("taskId") {
-        if let Some(value) = atm.get("taskId") {
-            object.insert("taskId".to_string(), value.clone());
-        }
+    if !object.contains_key("taskId")
+        && let Some(value) = atm.get("taskId")
+    {
+        object.insert("taskId".to_string(), value.clone());
     }
 }

--- a/docs/atm-message-schema.md
+++ b/docs/atm-message-schema.md
@@ -142,7 +142,7 @@ Identifier rules:
   preserve the message when the Claude-native envelope is still usable, and
   treat the malformed ATM-owned field as absent for ATM semantics
 
-## 4. ATM-Interpreted Shared Or De Facto Fields
+## 4. ATM-Interpreted Shared Fields And Forward Write Rule
 
 ATM currently interprets the following field when present:
 
@@ -167,6 +167,17 @@ Current evidence note:
 
 - `taskId` is documented and interpreted by ATM, but it was not present in the
   current live `atm-dev` inbox data sampled during this design sprint
+
+Forward write rule:
+
+- ATM-authored shared-inbox writes must keep the Claude-native top level intact
+- ATM machine fields, including `taskId`, must be written under `metadata.atm`
+- legacy top-level ATM fields remain read-compatible only
+- forward writes must not emit legacy top-level ATM machine fields
+
+Forward placement map addition:
+
+- legacy top-level `taskId` migrates to `metadata.atm.taskId`
 
 ## 5. ATM-Specific Alert Metadata
 

--- a/docs/lock-release-gate.md
+++ b/docs/lock-release-gate.md
@@ -1,0 +1,109 @@
+# Lock Release Gate
+
+Branch: `feature/pP-s10-schema-lock-fix`
+
+Scope: `PP-S10-B` release gate only. This is not another hardening sprint.
+
+Verdict: `PASS` for interim release use.
+
+## Checklist
+
+- [x] Stale/orphaned lock artifact does not wedge command flow.
+- [x] Write contention fails or recovers in bounded time.
+- [x] Read-only paths work under contention.
+- [x] Crash/restart-style stale lock recovery does not rely solely on the 5-minute cron sweep.
+- [x] `send -> ack -> clear` remains operable after a lock fault.
+
+## Evidence
+
+### 1. Stale/orphaned lock artifact does not wedge command flow
+
+Evidence:
+- `crates/atm-core/src/mailbox/lock.rs`
+  - `acquire(...)` calls `evict_stale_lock_sentinel(...)` on each acquisition attempt before waiting on contention.
+  - `sweep_stale_lock_sentinels(...)` exists as secondary cleanup, not the only recovery path.
+- unit tests in `crates/atm-core/src/mailbox/lock.rs`
+  - `evict_stale_lock_sentinel_removes_dead_pid_file`
+  - `sweep_stale_lock_sentinels_removes_only_lock_files_with_dead_pids`
+  - `sweep_stale_lock_sentinels_removes_rotated_dead_pid_sentinels_only`
+  - `sweep_stale_lock_sentinels_skips_malformed_rotated_sentinels`
+
+Assessment:
+- Dead-PID stale sentinels are removed inline on acquisition, so an orphaned sentinel is not left to block progress until cron runs.
+
+### 2. Write contention fails or recovers in bounded time
+
+Evidence:
+- `cargo test -p agent-team-mail-core --test mailbox_locking --quiet`
+- integration tests in `crates/atm-core/tests/mailbox_locking.rs`
+  - `send_times_out_under_bounded_lock_contention`
+  - `send_reports_non_contention_lock_failures_without_timeout`
+  - `concurrent_ack_on_overlapping_inbox_sets_completes_without_deadlock`
+  - `concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss`
+- unit tests in `crates/atm-core/src/mailbox/lock.rs`
+  - `acquire_reports_mailbox_lock_timeout_code`
+  - `acquire_many_sorted_uses_total_timeout_budget`
+  - `acquire_many_sorted_releases_prior_guards_on_failure`
+
+Assessment:
+- Mutating paths either complete or return `MailboxLockTimeout` / `MailboxLockFailed` within a bounded window.
+
+### 3. Read-only paths work under contention
+
+Evidence:
+- `cargo test -p agent-team-mail-core --test mailbox_locking --quiet`
+- integration tests in `crates/atm-core/tests/mailbox_locking.rs`
+  - `clear_dry_run_does_not_wait_on_mailbox_lock`
+  - `read_possible_write_only_locks_when_display_mutation_is_required`
+
+Assessment:
+- Dry-run clear stays non-blocking under contention.
+- Read only acquires locks when display mutation is required; no-mutation reads remain operable while a lock is held.
+
+### 4. Crash/restart-style recovery does not rely solely on the cron sweep
+
+Evidence:
+- `crates/atm-core/src/mailbox/lock.rs`
+  - `acquire(...)` performs inline stale-sentinel eviction before retrying contention.
+  - `evict_stale_lock_sentinel(...)` distinguishes dead-PID sentinels from live holders.
+- unit tests in `crates/atm-core/src/mailbox/lock.rs`
+  - `evict_stale_lock_sentinel_removes_dead_pid_file`
+  - `dropping_guard_tolerates_read_only_cleanup_failure`
+
+Assessment:
+- There is no dedicated kill-holder integration test in this gate.
+- However, the runtime recovery path is not cron-only: a new command attempts stale-sentinel eviction itself before waiting on the lock.
+- That is sufficient for an interim release gate, but it remains weaker than the future SQLite replacement.
+
+### 5. `send -> ack -> clear` remains operable after a lock fault
+
+Evidence:
+- `cargo test -p agent-team-mail-core --test mailbox_locking --quiet`
+- integration tests in `crates/atm-core/tests/mailbox_locking.rs`
+  - `concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss`
+  - `multi_source_read_and_clear_complete_without_deadlock`
+  - `clear_remove_locked_inbox_seam_fails_closed_without_mutating_surviving_state`
+
+Assessment:
+- Command flow remains operable through mixed send/ack/clear activity.
+- Failure paths fail closed without corrupting surviving state.
+
+## Schema-Fix Regression Note
+
+The `PP-S10-A` schema fix did not modify mailbox lock code. After that change, the lock suite still passed:
+
+- `cargo test -p agent-team-mail-core --test mailbox_locking --quiet`
+
+I attempted a direct `origin/develop` comparison run, but clean `develop` currently fails to compile due unrelated `send/hook.rs` config-field errors. So this gate establishes:
+
+- no observed lock regression from the schema fix on this branch
+- no clean same-suite `develop` baseline is currently available
+
+## Release Decision
+
+`PASS` for interim release use.
+
+Reason:
+- the current Phase P line shows bounded lock behavior, inline stale-sentinel recovery, non-blocking read-only paths, and mixed command operability under contention
+- this is good enough to relieve the present lock problem as an interim release
+- it does not change the longer-term direction away from mailbox-lock-centered correctness

--- a/docs/plan-pP-lock-atm-bugs.md
+++ b/docs/plan-pP-lock-atm-bugs.md
@@ -1,0 +1,135 @@
+# Phase P Lock + ATM Context Plan
+
+## Goal
+
+Document the two active Phase P blockers so implementation can move directly to
+a bounded sprint instead of reopening architecture debate during QA.
+
+Bugs covered:
+- lock requirements violation on the current mailbox write path
+- ATM-authored message schema breaking Claude context injection
+
+## Bug 1: Lock Requirements Violation
+
+### Root Cause
+
+Phase P improved mailbox locking, stale-sentinel handling, and timeout
+behavior, but the current line still encodes mailbox locks as part of the
+runtime correctness model. That does not satisfy the stricter operational
+requirement that stale/orphaned locks stop being a product-blocking failure.
+
+Current state:
+- `read_only` paths can avoid locks
+- mutating mailbox paths still depend on lock acquisition
+- the system still relies on stale-lock recovery behavior, including the
+  5-minute cron sweep, rather than eliminating lock dependence
+
+### Affected Files / Paths
+
+- `crates/atm-core/src/mailbox/lock.rs`
+- `crates/atm-core/src/mailbox/mod.rs`
+- `crates/atm-core/src/mailbox/store.rs`
+- `crates/atm-core/tests/mailbox_locking.rs`
+- `docs/requirements.md`
+- `docs/architecture.md`
+
+### Fix Approach
+
+Short term:
+- treat this as a release gate, not another hardening sprint
+- prove whether `integrate/phase-P` is good enough as an interim lock-relief
+  release
+
+Gate criteria:
+- stale/orphaned lock artifact does not wedge command flow
+- write contention fails or recovers in bounded time
+- read-only paths still work under contention
+- crash/restart style recovery works without relying solely on the cron sweep
+- `send -> ack -> clear` remains operable after the fault
+
+If the gate passes:
+- Phase P can ship as an interim release only
+
+If the gate fails:
+- stop investing in mailbox-lock architecture and move directly to the
+  SQLite-backed replacement phase
+
+### Acceptance Criteria
+
+- explicit release-gate checklist exists in `docs/project-plan.md`
+- missing deterministic lock tests are added
+- `develop` and `integrate/phase-P` are both run against the same gate
+- release decision is PASS/FAIL, not another open-ended stabilization loop
+
+## Bug 2: ATM Context Injection Broken
+
+### Root Cause
+
+ATM-authored messages are being written to the shared Claude inbox with
+ATM-owned machine fields at the top level. Claude-native teammate delivery
+works, and Claude-native plus `metadata.atm` also works, but ATM top-level
+fields break the context-injection path.
+
+Proven behavior:
+- native Claude envelope works
+- native Claude envelope plus `metadata.atm` works
+- ATM-authored top-level fields such as `message_id`, `source_team`, and
+  `pendingAckAt` are the compatibility break
+
+### Affected Files / Paths
+
+- `crates/atm-core/src/send/mod.rs`
+- `crates/atm-core/src/ack/mod.rs`
+- `crates/atm-core/src/schema/inbox_message.rs`
+- mailbox compatibility helpers that serialize or project ATM-authored inbox
+  records
+- `tools/schema_models/claude_code_message_schema.py`
+- `tools/schema_models/atm_message_schema.py`
+- `tools/schema_models/test_schema_models.py`
+- `docs/claude-code-message-schema.md`
+- `docs/atm-message-schema.md`
+
+### Fix Approach
+
+Forward write rule:
+- shared Claude inbox top level stays Claude-native only
+- ATM-owned machine fields move under `metadata.atm`
+
+Required migrations for ATM-authored writes:
+- `message_id` -> `metadata.atm.messageId`
+- `source_team` -> `metadata.atm.sourceTeam`
+- `pendingAckAt` -> `metadata.atm.pendingAckAt`
+- `acknowledgedAt` -> `metadata.atm.acknowledgedAt`
+- `acknowledgesMessageId` -> `metadata.atm.acknowledgesMessageId`
+- `taskId` -> `metadata.atm.taskId`
+
+Compatibility rule:
+- legacy top-level ATM fields remain read-compatible during transition
+- forward writes must not emit those fields at the top level
+
+Validation rule:
+- top-level envelope must validate against
+  `ClaudeCodeInboxMessage`
+- ATM-authored inbox messages with metadata must validate against
+  `AtmMetadataEnvelope`
+
+### Acceptance Criteria
+
+- ATM-authored `send` and `ack` writes produce Claude-native top-level fields
+  plus optional `metadata.atm`
+- schema-model tests fail if ATM machine fields leak to the top level
+- QA reviews the schema fix change set itself
+- QA also reviews the final comparison-run evidence; comparison review is
+  PASS/FAIL, not authorization for more code churn
+
+## Sprint Recommendation
+
+Open one bounded implementation sprint from `integrate/phase-P`:
+- fix the ATM inbox schema bug first
+- run the lock release gate without expanding scope
+- send the schema change set and the gate evidence to QA
+
+Do not:
+- reopen broader mailbox architecture redesign inside this sprint
+- use the gate as cover for another general stabilization cycle
+- mix the later SQLite SSOT work into this sprint

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1913,6 +1913,9 @@ Files expected in scope:
 - `crates/atm-core/src/mailbox/lock.rs`
 - `crates/atm-core/src/error.rs`
 - `crates/atm-core/src/error_codes.rs`
+- `crates/atm-core/src/ack/mod.rs`
+- `crates/atm-core/src/send/mod.rs`
+- `crates/atm-core/src/schema/inbox_message.rs`
 - docs already updated in P.9
 
 Exact GAP-1 predicate:

--- a/tools/schema_models/atm_message_schema.py
+++ b/tools/schema_models/atm_message_schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, StringConstraints
+from pydantic import BaseModel, ConfigDict, StringConstraints, model_validator
 
 from .claude_code_message_schema import ClaudeCodeInboxMessage
 
@@ -42,6 +42,7 @@ class AtmMetadataFields(BaseModel):
     pendingAckAt: str | None = None
     acknowledgedAt: str | None = None
     acknowledgesMessageId: UlidString | None = None
+    taskId: str | None = None
     alertKind: str | None = None
 
 
@@ -59,6 +60,28 @@ class AtmMetadataEnvelope(ClaudeCodeInboxMessage):
     model_config = ConfigDict(extra="allow")
 
     metadata: MessageMetadata | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_top_level_atm_machine_fields(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+
+        forbidden = {
+            "message_id",
+            "source_team",
+            "pendingAckAt",
+            "acknowledgedAt",
+            "acknowledgesMessageId",
+            "taskId",
+        }
+        leaked = sorted(forbidden.intersection(value.keys()))
+        if leaked:
+            raise ValueError(
+                "ATM machine fields must not appear at top level for forward writes: "
+                + ", ".join(leaked)
+            )
+        return value
 
 
 class AtmMissingTeamConfigAlertMessage(AtmInboxMessage):

--- a/tools/schema_models/test_schema_models.py
+++ b/tools/schema_models/test_schema_models.py
@@ -113,6 +113,7 @@ class SchemaModelTests(unittest.TestCase):
                 "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
                 "sourceTeam": "atm-dev",
                 "pendingAckAt": "2026-04-04T18:49:59.525Z",
+                "taskId": "TASK-123",
             }
         )
         self.assertEqual(metadata.sourceTeam, "atm-dev")
@@ -128,12 +129,34 @@ class SchemaModelTests(unittest.TestCase):
                     "atm": {
                         "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
                         "sourceTeam": "atm-dev",
+                        "taskId": "TASK-123",
                     }
                 },
             }
         )
         self.assertIsInstance(envelope.metadata, MessageMetadata)
         self.assertEqual(envelope.metadata.atm.sourceTeam, "atm-dev")
+        self.assertEqual(envelope.metadata.atm.taskId, "TASK-123")
+
+    def test_forward_metadata_rejects_top_level_atm_machine_fields(self) -> None:
+        """Write-path: top-level ATM machine fields are forbidden on forward inbox writes."""
+
+        with self.assertRaises(Exception):
+            AtmMetadataEnvelope.model_validate(
+                {
+                    "from": "team-lead",
+                    "text": "ping",
+                    "timestamp": "2026-04-04T18:49:59.525Z",
+                    "read": True,
+                    "summary": "ping",
+                    "message_id": "81286baa-e783-4f0c-bfea-82d070750fae",
+                    "metadata": {
+                        "atm": {
+                            "sourceTeam": "atm-dev",
+                        }
+                    },
+                }
+            )
 
     def test_legacy_top_level_message_id_rejects_ulid(self) -> None:
         """Write-path: guards docs/atm-message-schema.md legacy top-level UUID placement."""


### PR DESCRIPTION
## Summary
- Moves ATM-owned machine fields from top-level Claude inbox messages to `metadata.atm.*`
- Forward write path now uses Claude-native top-level envelope only
- Legacy top-level fields remain read-compatible during migration

## Fields migrated
`message_id` → `metadata.atm.messageId`, `source_team` → `metadata.atm.sourceTeam`, `pendingAckAt`, `acknowledgedAt`, `acknowledgesMessageId`, `taskId`

## Test plan
- [ ] `cargo test` passes
- [ ] Schema-model tests fail if ATM machine fields appear at top level on write path
- [ ] Legacy read path handles old top-level format without error

Part of Phase P — PP-S10-A schema fix. PP-S10-B (lock gate) follows on this same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)