### PR TITLE
fix: simplify inbox schema compatibility and remove UUID/ULID dual path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 1.1.1
+
+- preserve Claude inbox files in JSON array format during ATM shared-inbox writes
+  so ATM-authored messages inject into live Claude sessions correctly
+- keep ATM machine metadata under `metadata.atm` for supported fields while
+  leaving alert fields on their current top-level compatibility shape for this
+  sprint
+- keep forward `metadata.atm.messageId` values as real ULIDs assigned by ATM
+  send/ack flows rather than deriving them from legacy UUID compatibility ids

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/atm-core", "crates/atm"]
 resolver = "2"
 
 [workspace.package]
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/atm-core", "crates/atm"]
 resolver = "2"
 
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -179,11 +179,11 @@ pub fn ack_mail(
     let mut reply_extra = Map::new();
     workflow::set_atm_message_id(&mut reply_extra, reply_atm_message_id);
     let reply_message = MessageEnvelope {
-        from: actor.to_string(),
+        from: actor.clone(),
         text: reply_text.clone(),
         timestamp: ack_timestamp,
         read: false,
-        source_team: Some(team.to_string()),
+        source_team: Some(team.clone()),
         summary: Some(summary::build_summary(&reply_text, None)),
         message_id: Some(reply_message_id),
         pending_ack_at: None,
@@ -344,13 +344,14 @@ fn resolve_reply_target(
     }
 
     let parsed: AgentAddress = if message.from.contains('@') {
-        message.from.parse()?
+        message.from.as_str().parse()?
     } else {
         AgentAddress {
-            agent: message.from.clone(),
+            agent: message.from.to_string(),
             team: message
                 .source_team
                 .clone()
+                .map(Into::into)
                 .or_else(|| Some(current_team.to_string())),
         }
     };
@@ -503,15 +504,15 @@ mod tests {
 
     use super::{canonical_sender_identity, resolve_reply_target};
     use crate::schema::MessageEnvelope;
-    use crate::types::IsoTimestamp;
+    use crate::types::{AgentName, IsoTimestamp, TeamName};
 
     fn message_with_from(from: &str) -> MessageEnvelope {
         MessageEnvelope {
-            from: from.to_string(),
+            from: from.parse::<AgentName>().expect("agent"),
             text: "hello".to_string(),
             timestamp: IsoTimestamp::now(),
             read: false,
-            source_team: Some("atm-dev".to_string()),
+            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
             summary: None,
             message_id: None,
             pending_ack_at: None,
@@ -539,7 +540,7 @@ mod tests {
     #[test]
     fn resolve_reply_target_prefers_canonical_sender_identity_metadata() {
         let mut message = message_with_from("lead");
-        message.source_team = Some("atm-dev".to_string());
+        message.source_team = Some("atm-dev".parse::<TeamName>().expect("team"));
         message.extra.insert(
             "metadata".to_string(),
             json!({"atm": {"fromIdentity": "team-lead@src-gen"}}),

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -335,12 +335,12 @@ fn resolve_reply_target(
     current_team: &str,
 ) -> Result<(AgentName, TeamName), AtmError> {
     if let Some(identity) = canonical_sender_identity(message) {
-        let parsed: AgentAddress = identity.parse()?;
-        let team = parsed.team.ok_or_else(AtmError::team_unavailable)?;
-        return Ok((
-            AgentName::from_validated(parsed.agent),
-            TeamName::from_validated(team),
-        ));
+        let team = message
+            .source_team
+            .clone()
+            .or_else(|| Some(current_team.parse().expect("validated team")))
+            .ok_or_else(AtmError::team_unavailable)?;
+        return Ok((identity, team));
     }
 
     let parsed: AgentAddress = if message.from.contains('@') {
@@ -363,7 +363,7 @@ fn resolve_reply_target(
     ))
 }
 
-fn canonical_sender_identity(message: &MessageEnvelope) -> Option<String> {
+fn canonical_sender_identity(message: &MessageEnvelope) -> Option<AgentName> {
     message
         .extra
         .get("metadata")
@@ -371,8 +371,8 @@ fn canonical_sender_identity(message: &MessageEnvelope) -> Option<String> {
         .and_then(|metadata| metadata.get("atm"))
         .and_then(serde_json::Value::as_object)
         .and_then(|atm| atm.get("fromIdentity"))
-        .and_then(serde_json::Value::as_str)
-        .map(ToOwned::to_owned)
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
 }
 
 fn merged_surface(
@@ -528,12 +528,12 @@ mod tests {
         let mut message = message_with_from("lead");
         message.extra.insert(
             "metadata".to_string(),
-            json!({"atm": {"fromIdentity": "team-lead@src-gen"}}),
+            json!({"atm": {"fromIdentity": "team-lead"}}),
         );
 
         assert_eq!(
             canonical_sender_identity(&message).as_deref(),
-            Some("team-lead@src-gen")
+            Some("team-lead")
         );
     }
 
@@ -543,7 +543,7 @@ mod tests {
         message.source_team = Some("atm-dev".parse::<TeamName>().expect("team"));
         message.extra.insert(
             "metadata".to_string(),
-            json!({"atm": {"fromIdentity": "team-lead@src-gen"}}),
+            json!({"atm": {"fromIdentity": "team-lead"}}),
         );
 
         let target = resolve_reply_target(&message, "atm-dev").expect("reply target");
@@ -551,7 +551,7 @@ mod tests {
             target,
             (
                 "team-lead".parse().expect("agent"),
-                "src-gen".parse().expect("team"),
+                "atm-dev".parse().expect("team"),
             )
         );
     }

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -325,59 +325,6 @@ mod tests {
     use std::{panic, panic::AssertUnwindSafe};
 
     use serial_test::serial;
-    use tempfile::tempdir;
-
-    use super::{ClearQuery, clear_mail};
-    use crate::observability::NullObservability;
-    use crate::schema::{AgentMember, TeamConfig};
-
-    #[test]
-    #[serial]
-    fn locked_clear_source_removal_reports_disappearing_mailbox() {
-        let _env_lock = env_lock().lock().expect("env lock");
-        let tempdir = tempdir().expect("tempdir");
-        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
-        let inboxes_dir = team_dir.join("inboxes");
-        std::fs::create_dir_all(&inboxes_dir).expect("inboxes");
-        let config = TeamConfig {
-            members: vec![AgentMember {
-                name: "arch-ctm".to_string(),
-                ..Default::default()
-            }],
-            ..Default::default()
-        };
-        std::fs::write(
-            team_dir.join("config.json"),
-            serde_json::to_vec(&config).expect("team config"),
-        )
-        .expect("write config");
-        std::fs::write(inboxes_dir.join("arch-ctm.json"), "").expect("mailbox");
-        let error = {
-            let _guard = EnvGuard::set_raw("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD", "1");
-            clear_mail(
-                ClearQuery {
-                    home_dir: tempdir.path().to_path_buf(),
-                    current_dir: tempdir.path().to_path_buf(),
-                    actor_override: Some("arch-ctm".parse().expect("actor")),
-                    target_address: None,
-                    team_override: Some("atm-dev".parse().expect("team")),
-                    older_than: None,
-                    idle_only: false,
-                    dry_run: false,
-                },
-                &NullObservability,
-            )
-            .expect_err("missing mailbox")
-        };
-
-        assert!(error.is_mailbox_read());
-        assert!(error.message.contains("disappeared"));
-        assert!(
-            std::env::var_os("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD").is_none(),
-            "scoped env guard leaked after failure path"
-        );
-    }
-
     #[test]
     #[serial]
     fn env_guard_restores_original_value_after_panic() {

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -337,7 +337,7 @@ fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmErr
 fn parse_team_member(config_path: &Path, index: usize, entry: &Value) -> Option<AgentMember> {
     match entry {
         Value::String(name) => Some(AgentMember {
-            name: name.clone(),
+            name: AgentName::from_validated(name.clone()),
             ..Default::default()
         }),
         _ => match serde_json::from_value::<AgentMember>(entry.clone()) {

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -336,10 +336,23 @@ fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmErr
 
 fn parse_team_member(config_path: &Path, index: usize, entry: &Value) -> Option<AgentMember> {
     match entry {
-        Value::String(name) => Some(AgentMember {
-            name: AgentName::from_validated(name.clone()),
-            ..Default::default()
-        }),
+        Value::String(name) => match name.parse::<AgentName>() {
+            Ok(name) => Some(AgentMember {
+                name,
+                ..Default::default()
+            }),
+            Err(error) => {
+                warn!(
+                    code = %AtmErrorCode::WarningInvalidTeamMemberSkipped,
+                    path = %config_path.display(),
+                    member_index = index,
+                    member = %name,
+                    %error,
+                    "skipping invalid team member record"
+                );
+                None
+            }
+        },
         _ => match serde_json::from_value::<AgentMember>(entry.clone()) {
             Ok(member) => Some(member),
             Err(error) => {

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -337,10 +337,7 @@ fn parse_team_config(config_path: &Path, raw: &str) -> Result<TeamConfig, AtmErr
 fn parse_team_member(config_path: &Path, index: usize, entry: &Value) -> Option<AgentMember> {
     match entry {
         Value::String(name) => match name.parse::<AgentName>() {
-            Ok(name) => Some(AgentMember {
-                name,
-                ..Default::default()
-            }),
+            Ok(name) => Some(AgentMember::with_name(name)),
             Err(error) => {
                 warn!(
                     code = %AtmErrorCode::WarningInvalidTeamMemberSkipped,

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -363,7 +363,7 @@ fn member_summary(member: &AgentMember) -> MemberSummary {
     MemberSummary {
         name: AgentName::from_validated(member.name.clone()),
         agent_id: member.agent_id.clone(),
-        agent_type: member.agent_type.clone(),
+        agent_type: member.agent_type.to_string(),
         model: member.model.clone(),
         joined_at: member.joined_at,
         tmux_pane_id: member.tmux_pane_id.clone(),

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -166,7 +166,10 @@ fn load_member_roster(
         .map(|member| member.name.clone())
         .collect::<BTreeSet<_>>();
     for member in baseline {
-        if present.contains(member.as_str()) {
+        if present
+            .iter()
+            .any(|present_member| present_member == &member.as_str())
+        {
             continue;
         }
         findings.push(DoctorFinding {
@@ -381,6 +384,7 @@ mod tests {
         LogTailSession, ObservabilityPort,
     };
     use crate::schema::{AgentMember, TeamConfig};
+    use crate::types::AgentName;
 
     enum StubHealth {
         Ok(AtmObservabilityHealth),
@@ -452,7 +456,7 @@ mod tests {
                 members: members
                     .iter()
                     .map(|member| AgentMember {
-                        name: (*member).to_string(),
+                        name: AgentName::from_validated(*member),
                         ..Default::default()
                     })
                     .collect(),

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -455,10 +455,7 @@ mod tests {
             let config = TeamConfig {
                 members: members
                     .iter()
-                    .map(|member| AgentMember {
-                        name: AgentName::from_validated(*member),
-                        ..Default::default()
-                    })
+                    .map(|member| AgentMember::with_name(AgentName::from_validated(*member)))
                     .collect(),
                 ..Default::default()
             };

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -317,13 +317,21 @@ impl StdError for AtmError {
 
 impl From<serde_json::Error> for AtmError {
     fn from(source: serde_json::Error) -> Self {
-        Self::new(AtmErrorKind::Serialization, format!("json error: {source}")).with_source(source)
+        Self::new(AtmErrorKind::Serialization, format!("json error: {source}"))
+            .with_recovery(
+                "Inspect the JSON payload for structural errors and verify the schema matches the expected format.",
+            )
+            .with_source(source)
     }
 }
 
 impl From<toml::de::Error> for AtmError {
     fn from(source: toml::de::Error) -> Self {
-        Self::new(AtmErrorKind::Config, format!("toml error: {source}")).with_source(source)
+        Self::new(AtmErrorKind::Config, format!("toml error: {source}"))
+            .with_recovery(
+                "Inspect the TOML file for syntax errors and verify all required fields are present.",
+            )
+            .with_source(source)
     }
 }
 

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -160,6 +160,9 @@ impl AtmError {
             AtmErrorKind::Address,
             format!("address parse failed: {}", message.into()),
         )
+        .with_recovery(
+            "Correct the ATM address format and retry with a valid <agent> or <agent>@<team> target.",
+        )
     }
 
     pub fn identity_unavailable() -> Self {

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -111,6 +111,8 @@ mod tests {
         workflow_state_path_from_home,
     };
 
+    // Serializes process-environment mutation inside this test module. This is
+    // process-local only; it does not coordinate with other test processes.
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))

--- a/crates/atm-core/src/mailbox/atomic.rs
+++ b/crates/atm-core/src/mailbox/atomic.rs
@@ -1,21 +1,23 @@
 use std::path::Path;
 
+use serde_json::Value;
+
 use crate::error::{AtmError, AtmErrorKind};
 use crate::persistence;
 use crate::schema::MessageEnvelope;
 use crate::schema::inbox_message::to_shared_inbox_value;
 
-/// Atomically replace one mailbox JSONL file from fully serialized records.
+/// Atomically replace one shared inbox file from fully serialized records.
 ///
-/// ATM serializes every envelope into one temp file, fsyncs that temp file, and
-/// then performs same-filesystem replacement through the shared persistence
-/// helper. On Linux, a successful return means the file contents and renamed
-/// directory entry were durably published after the parent-directory fsync. On
-/// macOS, ATM performs the same parent-directory sync call, but APFS durability
-/// semantics may still differ from Linux after power loss. On Windows, the
-/// shared helper returns `Ok(())` after temp-file fsync plus rename without an
-/// additional parent-directory sync because the standard library does not
-/// expose a portable directory-sync operation there.
+/// ATM serializes every envelope into one JSON array document, fsyncs that temp
+/// file, and then performs same-filesystem replacement through the shared
+/// persistence helper. On Linux, a successful return means the file contents
+/// and renamed directory entry were durably published after the
+/// parent-directory fsync. On macOS, ATM performs the same parent-directory
+/// sync call, but APFS durability semantics may still differ from Linux after
+/// power loss. On Windows, the shared helper returns `Ok(())` after temp-file
+/// fsync plus rename without an additional parent-directory sync because the
+/// standard library does not expose a portable directory-sync operation there.
 ///
 /// # Errors
 ///
@@ -24,12 +26,12 @@ use crate::schema::inbox_message::to_shared_inbox_value;
 /// serialization fails or the mailbox temp-file write, fsync, rename, or
 /// parent-directory durability step cannot be completed.
 pub fn write_messages(path: &Path, messages: &[MessageEnvelope]) -> Result<(), AtmError> {
-    let mut bytes = Vec::new();
+    let mut encoded = Vec::<Value>::with_capacity(messages.len());
     for message in messages {
-        let encoded = to_shared_inbox_value(message)?;
-        serde_json::to_writer(&mut bytes, &encoded)?;
-        bytes.push(b'\n');
+        encoded.push(to_shared_inbox_value(message)?);
     }
+    let mut bytes = serde_json::to_vec_pretty(&encoded)?;
+    bytes.push(b'\n');
 
     persistence::atomic_write_bytes(
         path,

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -249,7 +249,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::schema::MessageEnvelope;
-    use crate::types::IsoTimestamp;
+    use crate::types::{AgentName, IsoTimestamp, TeamName};
 
     use super::{MAX_MAILBOX_READ_BYTES, append_message, locked_read_modify_write, read_messages};
     use crate::mailbox::lock;
@@ -495,12 +495,15 @@ mod tests {
     }
 
     fn sample_message(message_id: Uuid, body: &str) -> MessageEnvelope {
+        let legacy_message_id = crate::schema::LegacyMessageId::from(message_id);
+        let atm_message_id = legacy_message_id.into_lossy_atm_message_id_approximation();
+        let message_id = crate::schema::LegacyMessageId::from_atm_message_id(atm_message_id);
         let mut extra = serde_json::Map::new();
         let mut metadata = serde_json::Map::new();
         let mut atm = serde_json::Map::new();
         atm.insert(
             "messageId".to_string(),
-            serde_json::Value::String(crate::schema::AtmMessageId::new().to_string()),
+            serde_json::Value::String(atm_message_id.to_string()),
         );
         atm.insert(
             "sourceTeam".to_string(),
@@ -510,7 +513,7 @@ mod tests {
         extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
 
         MessageEnvelope {
-            from: "arch-ctm".into(),
+            from: "arch-ctm".parse::<AgentName>().expect("agent"),
             text: body.into(),
             timestamp: IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
@@ -518,9 +521,9 @@ mod tests {
                     .expect("timestamp"),
             ),
             read: false,
-            source_team: Some("atm-dev".into()),
+            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
             summary: None,
-            message_id: Some(message_id.into()),
+            message_id: Some(message_id),
             pending_ack_at: None,
             acknowledged_at: None,
             acknowledges_message_id: None,

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -496,7 +496,7 @@ mod tests {
 
     fn sample_message(message_id: Uuid, body: &str) -> MessageEnvelope {
         let legacy_message_id = crate::schema::LegacyMessageId::from(message_id);
-        let atm_message_id = legacy_message_id.into_lossy_atm_message_id_approximation();
+        let atm_message_id = legacy_message_id.into_atm_message_id();
         let message_id = crate::schema::LegacyMessageId::from_atm_message_id(atm_message_id);
         let mut extra = serde_json::Map::new();
         let mut metadata = serde_json::Map::new();

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -18,7 +18,7 @@ use crate::schema::inbox_message::hydrate_legacy_fields_from_metadata;
 use crate::schema::{LegacyMessageId, MessageEnvelope};
 
 const MAX_MAILBOX_READ_BYTES: u64 = 10 * 1024 * 1024;
-/// Append one message to a mailbox JSONL file under the mailbox lock.
+/// Append one message to a shared inbox file under the mailbox lock.
 ///
 /// Production send flows use the same lock discipline through
 /// `mailbox::store::append_mailbox_message_and_seed_workflow()`. This helper is
@@ -72,7 +72,7 @@ where
     store::commit_mailbox_state(path, &messages)
 }
 
-/// Read all valid mailbox records from a mailbox JSONL file.
+/// Read all valid mailbox records from one shared inbox file.
 ///
 /// # Errors
 ///
@@ -255,15 +255,17 @@ mod tests {
     use crate::mailbox::lock;
 
     #[test]
-    fn append_message_persists_one_jsonl_record() {
+    fn append_message_persists_one_array_record() {
         let tempdir = TempDir::new().expect("tempdir");
-        let path = tempdir.path().join("append-message.jsonl");
+        let path = tempdir.path().join("append-message.json");
         let envelope = sample_message(Uuid::new_v4(), "first");
 
         append_message(&path, &envelope).expect("append");
 
         let raw = fs::read_to_string(&path).expect("raw contents");
-        assert!(raw.contains("\"text\":\"first\""));
+        let values: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("json array");
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0]["text"], "first");
         let read_back = read_messages(&path).expect("read back");
         assert_eq!(read_back, vec![envelope]);
     }
@@ -271,21 +273,23 @@ mod tests {
     #[test]
     fn append_message_serializes_metadata_atm_without_top_level_machine_fields() {
         let tempdir = TempDir::new().expect("tempdir");
-        let path = tempdir.path().join("append-message-metadata.jsonl");
+        let path = tempdir.path().join("append-message-metadata.json");
         let envelope = sample_message(Uuid::new_v4(), "first");
 
         append_message(&path, &envelope).expect("append");
 
         let raw = fs::read_to_string(&path).expect("raw contents");
-        assert!(raw.contains("\"metadata\":{\"atm\":{"));
-        assert!(!raw.contains("\"message_id\""));
-        assert!(!raw.contains("\"source_team\""));
+        let values: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("json array");
+        let object = values[0].as_object().expect("message object");
+        assert!(object.contains_key("metadata"));
+        assert!(!object.contains_key("message_id"));
+        assert!(!object.contains_key("source_team"));
     }
 
     #[test]
     fn locked_read_modify_write_reads_mutates_and_rewrites_under_lock() {
         let tempdir = TempDir::new().expect("tempdir");
-        let path = tempdir.path().join("locked-rmw.jsonl");
+        let path = tempdir.path().join("locked-rmw.json");
         let first = sample_message(Uuid::new_v4(), "first");
         append_message(&path, &first).expect("seed");
 
@@ -306,7 +310,7 @@ mod tests {
     #[test]
     fn append_message_removes_lock_sentinel_after_write() {
         let tempdir = TempDir::new().expect("tempdir");
-        let path = tempdir.path().join("append-removes-lock.jsonl");
+        let path = tempdir.path().join("append-removes-lock.json");
 
         append_message(&path, &sample_message(Uuid::new_v4(), "first")).expect("append");
 
@@ -316,7 +320,7 @@ mod tests {
     #[test]
     fn append_message_cleans_preexisting_stale_lock_sentinel() {
         let tempdir = TempDir::new().expect("tempdir");
-        let path = tempdir.path().join("append-cleans-stale-lock.jsonl");
+        let path = tempdir.path().join("append-cleans-stale-lock.json");
         fs::write(lock::sentinel_path(&path), u32::MAX.to_string()).expect("stale lock");
 
         append_message(&path, &sample_message(Uuid::new_v4(), "first")).expect("append");
@@ -465,7 +469,7 @@ mod tests {
     #[test]
     fn append_message_preserves_both_records_under_concurrent_writers() {
         let tempdir = TempDir::new().expect("tempdir");
-        let path = tempdir.path().join("append-message-concurrent.jsonl");
+        let path = tempdir.path().join("append-message-concurrent.json");
         let barrier = Arc::new(Barrier::new(3));
 
         let mut handles = Vec::new();

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -500,11 +500,7 @@ mod tests {
         let mut atm = serde_json::Map::new();
         atm.insert(
             "messageId".to_string(),
-            serde_json::Value::String(
-                crate::schema::LegacyMessageId::from(message_id)
-                    .into_atm_message_id()
-                    .to_string(),
-            ),
+            serde_json::Value::String(crate::schema::AtmMessageId::new().to_string()),
         );
         atm.insert(
             "sourceTeam".to_string(),

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -55,46 +55,50 @@ where
     I: IntoIterator<Item = PathBuf>,
     F: FnOnce(&[PathBuf], &mut Vec<SourceFile>) -> Result<T, AtmError>,
 {
+    with_locked_source_files_hook(
+        home_dir,
+        team,
+        agent,
+        extra_write_paths,
+        timeout,
+        |_| Ok(()),
+        body,
+    )
+}
+
+fn with_locked_source_files_hook<T, I, H, F>(
+    home_dir: &Path,
+    team: &str,
+    agent: &str,
+    extra_write_paths: I,
+    timeout: Duration,
+    before_load: H,
+    body: F,
+) -> Result<T, AtmError>
+where
+    I: IntoIterator<Item = PathBuf>,
+    H: FnOnce(&[PathBuf]) -> Result<(), AtmError>,
+    F: FnOnce(&[PathBuf], &mut Vec<SourceFile>) -> Result<T, AtmError>,
+{
     let source_paths = discover_source_paths(home_dir, team, agent)?;
     let mut write_paths = source_paths.clone();
     write_paths.extend(extra_write_paths);
     let _locks = lock::acquire_many_sorted(write_paths, timeout)?;
     let source_paths = rediscover_and_validate_source_paths(&source_paths, home_dir, team, agent)?;
-    maybe_remove_locked_source_file_for_test(&source_paths)?;
+    before_load(&source_paths)?;
     let mut source_files = load_source_files(&source_paths)?;
     body(&source_paths, &mut source_files)
-}
-
-fn maybe_remove_locked_source_file_for_test(source_paths: &[PathBuf]) -> Result<(), AtmError> {
-    if std::env::var_os("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD").is_none() {
-        return Ok(());
-    }
-
-    let Some(path) = source_paths.first() else {
-        return Ok(());
-    };
-
-    std::fs::remove_file(path).map_err(|error| {
-        AtmError::mailbox_write(format!(
-            "failed to remove locked inbox {} during test injection: {error}",
-            path.display()
-        ))
-        .with_recovery(
-            "Clear ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD or restore the missing inbox file before retrying the injected test path.",
-        )
-        .with_source(error)
-    })
 }
 
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
 
-    use super::{commit_mailbox_state, commit_source_files};
+    use super::{commit_mailbox_state, commit_source_files, with_locked_source_files_hook};
     use crate::mailbox::read_messages;
     use crate::mailbox::source::SourceFile;
-    use crate::schema::{AtmMessageId, MessageEnvelope};
-    use crate::types::IsoTimestamp;
+    use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
+    use crate::types::{AgentName, IsoTimestamp, TeamName};
 
     #[test]
     fn commit_mailbox_state_rewrites_mailbox_array_with_only_new_messages() {
@@ -177,13 +181,56 @@ mod tests {
         assert!(!later_path.exists());
     }
 
+    #[test]
+    fn injected_before_load_hook_can_fail_closed_without_production_env_seam() {
+        let tempdir = tempdir().expect("tempdir");
+        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
+        let inbox_dir = team_dir.join("inboxes");
+        std::fs::create_dir_all(&inbox_dir).expect("inbox dir");
+        std::fs::write(
+            team_dir.join("config.json"),
+            serde_json::json!({
+                "members": [{"name": "arch-ctm"}, {"name": "team-lead"}]
+            })
+            .to_string(),
+        )
+        .expect("config");
+        let inbox_path = inbox_dir.join("arch-ctm.json");
+        commit_mailbox_state(&inbox_path, &[sample_message("team-lead", "hello")]).expect("seed");
+
+        let error = with_locked_source_files_hook(
+            tempdir.path(),
+            "atm-dev",
+            "arch-ctm",
+            std::iter::empty::<std::path::PathBuf>(),
+            std::time::Duration::from_secs(1),
+            |paths| {
+                let path = paths.first().expect("first path");
+                std::fs::remove_file(path).map_err(|source| {
+                    crate::error::AtmError::mailbox_write(format!(
+                        "failed to remove locked inbox {} during test injection: {source}",
+                        path.display()
+                    ))
+                    .with_source(source)
+                })
+            },
+            |_paths, _source_files| Ok(()),
+        )
+        .expect_err("hook failure");
+
+        assert!(error.is_mailbox_read());
+        assert!(!inbox_path.exists());
+    }
+
     fn sample_message(from: &str, text: &str) -> MessageEnvelope {
+        let atm_message_id = AtmMessageId::new();
+        let message_id = LegacyMessageId::from_atm_message_id(atm_message_id);
         let mut extra = serde_json::Map::new();
         let mut metadata = serde_json::Map::new();
         let mut atm = serde_json::Map::new();
         atm.insert(
             "messageId".to_string(),
-            serde_json::Value::String(AtmMessageId::new().to_string()),
+            serde_json::Value::String(atm_message_id.to_string()),
         );
         atm.insert(
             "sourceTeam".to_string(),
@@ -193,13 +240,13 @@ mod tests {
         extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
 
         MessageEnvelope {
-            from: from.to_string(),
+            from: from.parse::<AgentName>().expect("agent name"),
             text: text.to_string(),
             timestamp: IsoTimestamp::now(),
             read: false,
-            source_team: Some("atm-dev".to_string()),
+            source_team: Some("atm-dev".parse::<TeamName>().expect("team name")),
             summary: None,
-            message_id: Some(crate::schema::LegacyMessageId::new()),
+            message_id: Some(message_id),
             pending_ack_at: None,
             acknowledged_at: None,
             acknowledges_message_id: None,

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -89,12 +89,11 @@ fn maybe_remove_locked_source_file_for_test(source_paths: &[PathBuf]) -> Result<
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
-    use uuid::Uuid;
 
     use super::{commit_mailbox_state, commit_source_files};
     use crate::mailbox::read_messages;
     use crate::mailbox::source::SourceFile;
-    use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
+    use crate::schema::{AtmMessageId, MessageEnvelope};
     use crate::types::IsoTimestamp;
 
     #[test]
@@ -200,7 +199,7 @@ mod tests {
             read: false,
             source_team: Some("atm-dev".to_string()),
             summary: None,
-            message_id: Some(message_id),
+            message_id: Some(crate::schema::LegacyMessageId::new()),
             pending_ack_at: None,
             acknowledged_at: None,
             acknowledges_message_id: None,

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -94,7 +94,7 @@ mod tests {
     use super::{commit_mailbox_state, commit_source_files};
     use crate::mailbox::read_messages;
     use crate::mailbox::source::SourceFile;
-    use crate::schema::{LegacyMessageId, MessageEnvelope};
+    use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
     use crate::types::IsoTimestamp;
 
     #[test]
@@ -179,13 +179,12 @@ mod tests {
     }
 
     fn sample_message(from: &str, text: &str) -> MessageEnvelope {
-        let message_id = LegacyMessageId::from(Uuid::new_v4());
         let mut extra = serde_json::Map::new();
         let mut metadata = serde_json::Map::new();
         let mut atm = serde_json::Map::new();
         atm.insert(
             "messageId".to_string(),
-            serde_json::Value::String(message_id.into_atm_message_id().to_string()),
+            serde_json::Value::String(AtmMessageId::new().to_string()),
         );
         atm.insert(
             "sourceTeam".to_string(),

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -98,7 +98,7 @@ mod tests {
     use crate::types::IsoTimestamp;
 
     #[test]
-    fn commit_mailbox_state_rewrites_mailbox_jsonl_with_only_new_messages() {
+    fn commit_mailbox_state_rewrites_mailbox_array_with_only_new_messages() {
         let tempdir = tempdir().expect("tempdir");
         let path = tempdir.path().join("arch-ctm.json");
         std::fs::write(&path, "{\"stale\":true}\n").expect("seed mailbox");
@@ -111,7 +111,8 @@ mod tests {
 
         let raw = std::fs::read_to_string(&path).expect("mailbox contents");
         assert!(!raw.contains("stale"));
-        assert_eq!(raw.lines().count(), 2);
+        let encoded: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("json array");
+        assert_eq!(encoded.len(), 2);
         assert!(raw.ends_with('\n'));
         assert_eq!(read_messages(&path).expect("read mailbox"), messages);
     }

--- a/crates/atm-core/src/persistence.rs
+++ b/crates/atm-core/src/persistence.rs
@@ -180,6 +180,8 @@ mod tests {
     use super::{atomic_write_bytes, temp_path_for_atomic_write};
     use crate::error::AtmErrorKind;
 
+    // Serializes process-environment mutation inside this test module. This is
+    // process-local only; it does not coordinate with other test processes.
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -696,18 +696,19 @@ mod tests {
     use crate::mailbox::source::SourcedMessage;
     use crate::schema::{LegacyMessageId, MessageEnvelope};
     use crate::types::{
-        AckActivationMode, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection,
+        AckActivationMode, AgentName, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection,
+        TeamName,
     };
     use crate::workflow;
 
     fn sourced_message(index: usize, text: &str) -> SourcedMessage {
         SourcedMessage {
             envelope: MessageEnvelope {
-                from: "team-lead".to_string(),
+                from: "team-lead".parse::<AgentName>().expect("agent"),
                 text: text.to_string(),
                 timestamp: IsoTimestamp::now(),
                 read: false,
-                source_team: Some("atm-dev".to_string()),
+                source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
                 summary: None,
                 message_id: Some(LegacyMessageId::new()),
                 pending_ack_at: None,

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -1,7 +1,76 @@
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use crate::types::AgentName;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AgentType {
+    GeneralPurpose,
+    Plan,
+    Lead,
+    Qa,
+    Worker,
+    Unknown(String),
+}
+
+impl Default for AgentType {
+    fn default() -> Self {
+        Self::Unknown(String::new())
+    }
+}
+
+impl From<String> for AgentType {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "general-purpose" => Self::GeneralPurpose,
+            "plan" => Self::Plan,
+            "lead" => Self::Lead,
+            "qa" => Self::Qa,
+            "worker" => Self::Worker,
+            _ => Self::Unknown(value),
+        }
+    }
+}
+
+impl From<AgentType> for String {
+    fn from(value: AgentType) -> Self {
+        match value {
+            AgentType::GeneralPurpose => "general-purpose".to_string(),
+            AgentType::Plan => "plan".to_string(),
+            AgentType::Lead => "lead".to_string(),
+            AgentType::Qa => "qa".to_string(),
+            AgentType::Worker => "worker".to_string(),
+            AgentType::Unknown(value) => value,
+        }
+    }
+}
+
+impl Serialize for AgentType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&String::from(self.clone()))
+    }
+}
+
+impl<'de> Deserialize<'de> for AgentType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::from(String::deserialize(deserializer)?))
+    }
+}
+
+impl fmt::Display for AgentType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&String::from(self.clone()))
+    }
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -12,7 +81,7 @@ pub struct AgentMember {
     pub agent_id: String,
 
     #[serde(default)]
-    pub agent_type: String,
+    pub agent_type: AgentType,
 
     #[serde(default)]
     pub model: String,
@@ -32,7 +101,7 @@ pub struct AgentMember {
 
 #[cfg(test)]
 mod tests {
-    use super::AgentMember;
+    use super::{AgentMember, AgentType};
     use crate::types::AgentName;
 
     #[test]
@@ -41,7 +110,7 @@ mod tests {
 
         assert_eq!(member.name, AgentName::from_validated("arch-ctm"));
         assert!(member.agent_id.is_empty());
-        assert!(member.agent_type.is_empty());
+        assert_eq!(member.agent_type, AgentType::Unknown(String::new()));
         assert!(member.model.is_empty());
         assert_eq!(member.joined_at, None);
         assert!(member.tmux_pane_id.is_empty());
@@ -65,7 +134,7 @@ mod tests {
         let member: AgentMember = serde_json::from_str(raw).expect("member");
         assert_eq!(member.agent_id, "arch-ctm@atm-dev");
         assert_eq!(member.name, AgentName::from_validated("arch-ctm"));
-        assert_eq!(member.agent_type, "general-purpose");
+        assert_eq!(member.agent_type, AgentType::GeneralPurpose);
         assert_eq!(member.model, "claude-sonnet-4-5");
         assert_eq!(member.joined_at, Some(1770765919076));
         assert_eq!(member.tmux_pane_id, "%1");
@@ -83,7 +152,7 @@ mod tests {
             serde_json::from_str(r#"{"name":"arch-ctm","agentType":"plan"}"#).expect("member");
 
         assert_eq!(member.name, AgentName::from_validated("arch-ctm"));
-        assert_eq!(member.agent_type, "plan");
+        assert_eq!(member.agent_type, AgentType::Plan);
         assert!(member.agent_id.is_empty());
         assert!(member.model.is_empty());
         assert_eq!(member.joined_at, None);

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -105,8 +105,7 @@ pub struct AgentMember {
     #[serde(default)]
     pub tmux_pane_id: String,
 
-    /// Working directory path for the agent process. Opaque passthrough from
-    /// external tmux session state.
+    /// Retained working directory path for the agent process, copied from `config.json` roster state.
     #[serde(default)]
     pub cwd: String,
 

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use tracing::warn;
 
 use crate::types::AgentName;
 
@@ -30,7 +31,13 @@ impl From<String> for AgentType {
             "lead" => Self::Lead,
             "qa" => Self::Qa,
             "worker" => Self::Worker,
-            _ => Self::Unknown(value),
+            _ => {
+                warn!(
+                    raw_agent_type = %value,
+                    "unknown agent_type preserved as opaque compatibility value"
+                );
+                Self::Unknown(value)
+            }
         }
     }
 }
@@ -72,23 +79,27 @@ impl fmt::Display for AgentType {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentMember {
     pub name: AgentName,
 
+    /// Retained external compatibility field for the full runtime-scoped agent
+    /// identifier (for example `arch-ctm@atm-dev`).
     #[serde(default)]
     pub agent_id: String,
 
     #[serde(default)]
     pub agent_type: AgentType,
 
+    /// Retained provider/model label copied from `config.json` roster state.
     #[serde(default)]
     pub model: String,
 
     #[serde(default)]
     pub joined_at: Option<u64>,
 
+    /// Retained tmux pane identifier copied from `config.json` roster state.
     #[serde(default)]
     pub tmux_pane_id: String,
 
@@ -97,6 +108,21 @@ pub struct AgentMember {
 
     #[serde(flatten)]
     pub extra: Map<String, Value>,
+}
+
+impl AgentMember {
+    pub fn with_name(name: AgentName) -> Self {
+        Self {
+            name,
+            agent_id: String::new(),
+            agent_type: AgentType::default(),
+            model: String::new(),
+            joined_at: None,
+            tmux_pane_id: String::new(),
+            cwd: String::new(),
+            extra: Map::new(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -1,10 +1,12 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
+use crate::types::AgentName;
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentMember {
-    pub name: String,
+    pub name: AgentName,
 
     #[serde(default)]
     pub agent_id: String,
@@ -31,12 +33,13 @@ pub struct AgentMember {
 #[cfg(test)]
 mod tests {
     use super::AgentMember;
+    use crate::types::AgentName;
 
     #[test]
     fn parse_name_only_record_defaults_optional_fields() {
         let member: AgentMember = serde_json::from_str(r#"{"name":"arch-ctm"}"#).expect("member");
 
-        assert_eq!(member.name, "arch-ctm");
+        assert_eq!(member.name, AgentName::from_validated("arch-ctm"));
         assert!(member.agent_id.is_empty());
         assert!(member.agent_type.is_empty());
         assert!(member.model.is_empty());
@@ -61,7 +64,7 @@ mod tests {
 
         let member: AgentMember = serde_json::from_str(raw).expect("member");
         assert_eq!(member.agent_id, "arch-ctm@atm-dev");
-        assert_eq!(member.name, "arch-ctm");
+        assert_eq!(member.name, AgentName::from_validated("arch-ctm"));
         assert_eq!(member.agent_type, "general-purpose");
         assert_eq!(member.model, "claude-sonnet-4-5");
         assert_eq!(member.joined_at, Some(1770765919076));
@@ -79,7 +82,7 @@ mod tests {
         let member: AgentMember =
             serde_json::from_str(r#"{"name":"arch-ctm","agentType":"plan"}"#).expect("member");
 
-        assert_eq!(member.name, "arch-ctm");
+        assert_eq!(member.name, AgentName::from_validated("arch-ctm"));
         assert_eq!(member.agent_type, "plan");
         assert!(member.agent_id.is_empty());
         assert!(member.model.is_empty());

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -7,7 +7,6 @@ use tracing::warn;
 use crate::types::AgentName;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum AgentType {
     GeneralPurpose,
     Plan,
@@ -84,11 +83,14 @@ impl fmt::Display for AgentType {
 pub struct AgentMember {
     pub name: AgentName,
 
-    /// Retained external compatibility field for the full runtime-scoped agent
-    /// identifier (for example `arch-ctm@atm-dev`).
+    /// Compound `agent@team` address as supplied by the external Claude Code
+    /// agent-team API. Opaque passthrough — format is owned externally and not
+    /// validated as an ATM path segment.
     #[serde(default)]
     pub agent_id: String,
 
+    /// Agent type as deserialized from Claude Code agent-team config. ATM
+    /// reads but does not write config.json — no round-trip concern.
     #[serde(default)]
     pub agent_type: AgentType,
 
@@ -103,6 +105,8 @@ pub struct AgentMember {
     #[serde(default)]
     pub tmux_pane_id: String,
 
+    /// Working directory path for the agent process. Opaque passthrough from
+    /// external tmux session state.
     #[serde(default)]
     pub cwd: String,
 

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -1,16 +1,15 @@
 //! Shared inbox compatibility schema for Claude-native envelopes plus ATM metadata.
 
-use std::fmt;
-use std::io;
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use std::fmt;
 use tracing::warn;
 use ulid::Ulid;
 use uuid::Uuid;
 
-use crate::types::{IsoTimestamp, TaskId, TeamName};
+use crate::error::AtmError;
+use crate::types::{AgentName, IsoTimestamp, TaskId, TeamName};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -35,7 +34,12 @@ impl LegacyMessageId {
         self.0
     }
 
-    pub fn into_atm_message_id(self) -> AtmMessageId {
+    /// Convert a legacy compatibility UUID into a best-effort ULID approximation.
+    ///
+    /// This mapping is intentionally lossy. `from_atm_message_id` normalizes the
+    /// source ULID into a UUID v4-compatible byte pattern, so reversing the
+    /// process cannot recover the original ULID exactly.
+    pub fn into_lossy_atm_message_id_approximation(self) -> AtmMessageId {
         AtmMessageId::from(Ulid::from_bytes(self.0.into_bytes()))
     }
 }
@@ -139,6 +143,9 @@ pub struct AtmMetadataFields {
     #[serde(rename = "sourceTeam", skip_serializing_if = "Option::is_none")]
     pub source_team: Option<TeamName>,
 
+    #[serde(rename = "fromIdentity", skip_serializing_if = "Option::is_none")]
+    pub from_identity: Option<String>,
+
     #[serde(rename = "pendingAckAt", skip_serializing_if = "Option::is_none")]
     pub pending_ack_at: Option<IsoTimestamp>,
 
@@ -195,7 +202,7 @@ pub struct MessageEnvelope {
     // Claude Code-native fields. Do not change these as if ATM owned the
     // native schema; update the owning schema docs first if the external
     // contract changes.
-    pub from: String,
+    pub from: AgentName,
     pub text: String,
     pub timestamp: IsoTimestamp,
     pub read: bool,
@@ -204,7 +211,7 @@ pub struct MessageEnvelope {
     // message schema. Historical provenance analysis in this design sprint
     // confirmed these persisted fields are ATM-added rather than Claude-native.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_team: Option<String>,
+    pub source_team: Option<TeamName>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
@@ -236,7 +243,7 @@ pub struct MessageEnvelope {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PendingAck {
     pub message_id: LegacyMessageId,
-    pub from: String,
+    pub from: AgentName,
     pub acked: bool,
     pub acked_at: Option<IsoTimestamp>,
 }
@@ -248,19 +255,28 @@ fn ensure_object<'a>(parent: &'a mut Map<String, Value>, key: &str) -> &'a mut M
     if !entry.is_object() {
         *entry = Value::Object(Map::new());
     }
-    entry.as_object_mut().expect("entry forced to object")
+    let Some(entry) = entry.as_object_mut() else {
+        unreachable!("entry was just normalized into an object")
+    };
+    entry
 }
 
-pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, serde_json::Error> {
+pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, AtmError> {
     let mut value = serde_json::to_value(message).map_err(|error| {
-        serde_json::Error::io(io::Error::other(format!(
+        AtmError::mailbox_write(format!(
             "failed to serialize shared inbox envelope for {} at {:?}: {error}",
             message.from, message.timestamp
-        )))
+        ))
+        .with_source(error)
     })?;
     let object = value
         .as_object_mut()
-        .expect("message envelope serializes to object");
+        .ok_or_else(|| {
+            AtmError::mailbox_write(format!(
+                "failed to serialize shared inbox envelope for {} at {:?}: envelope did not encode as a JSON object",
+                message.from, message.timestamp
+            ))
+        })?;
     let _ = object.remove("message_id");
     let source_team = object.remove("source_team");
     let pending_ack_at = object.remove("pendingAckAt");
@@ -271,13 +287,11 @@ pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, 
             .and_then(|value| match value {
                 Value::String(_) => message
                     .acknowledges_message_id
-                    .map(LegacyMessageId::into_atm_message_id)
+                    .map(LegacyMessageId::into_lossy_atm_message_id_approximation)
                     .map(|message_id| Value::String(message_id.to_string())),
                 _ => None,
             });
     let task_id = object.remove("taskId");
-    let _ = object.get("atmAlertKind");
-    let _ = object.get("missingConfigPath");
 
     let metadata = ensure_object(object, "metadata");
     let atm = ensure_object(metadata, "atm");
@@ -299,6 +313,19 @@ pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, 
         atm.entry("taskId".to_string()).or_insert(value);
     }
     Ok(value)
+}
+
+impl MessageEnvelope {
+    pub fn atm_message_id(&self) -> Option<AtmMessageId> {
+        self.extra
+            .get("metadata")
+            .and_then(Value::as_object)
+            .and_then(|metadata| metadata.get("atm"))
+            .and_then(Value::as_object)
+            .and_then(|atm| atm.get("messageId"))
+            .and_then(Value::as_str)
+            .and_then(|value| value.parse().ok())
+    }
 }
 
 pub fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
@@ -401,7 +428,7 @@ mod tests {
         // Claude-native schema. Ownership is documented in
         // docs/legacy-atm-message-schema.md and docs/atm-message-schema.md.
         let envelope = MessageEnvelope {
-            from: "arch-ctm".into(),
+            from: "arch-ctm".parse().expect("agent"),
             text: "hello".into(),
             timestamp: IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
@@ -409,7 +436,7 @@ mod tests {
                     .expect("timestamp"),
             ),
             read: false,
-            source_team: Some("atm-dev".into()),
+            source_team: Some("atm-dev".parse().expect("team")),
             summary: Some("hello".into()),
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: Some(IsoTimestamp::from_datetime(
@@ -482,7 +509,7 @@ mod tests {
     fn pending_ack_round_trips() {
         let pending_ack = PendingAck {
             message_id: LegacyMessageId::new(),
-            from: "team-lead".into(),
+            from: "team-lead".parse().expect("agent"),
             acked: true,
             acked_at: Some(IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
@@ -506,6 +533,7 @@ mod tests {
                 atm: Some(AtmMetadataFields {
                     message_id: Some(message_id),
                     source_team: Some("atm-dev".parse().expect("team name")),
+                    from_identity: None,
                     pending_ack_at: None,
                     acknowledged_at: None,
                     acknowledges_message_id: None,
@@ -564,7 +592,7 @@ mod tests {
     #[test]
     fn shared_inbox_write_shape_moves_machine_fields_into_metadata() {
         let envelope = MessageEnvelope {
-            from: "arch-ctm".into(),
+            from: "arch-ctm".parse().expect("agent"),
             text: "hello".into(),
             timestamp: IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
@@ -572,7 +600,7 @@ mod tests {
                     .expect("timestamp"),
             ),
             read: false,
-            source_team: Some("atm-dev".into()),
+            source_team: Some("atm-dev".parse().expect("team")),
             summary: Some("hello".into()),
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: Some(IsoTimestamp::from_datetime(
@@ -612,7 +640,7 @@ mod tests {
                 .expect("timestamp"),
         );
         let envelope = MessageEnvelope {
-            from: "arch-ctm".into(),
+            from: "arch-ctm".parse().expect("agent"),
             text: "ack reply".into(),
             timestamp: IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
@@ -620,7 +648,7 @@ mod tests {
                     .expect("timestamp"),
             ),
             read: false,
-            source_team: Some("atm-dev".into()),
+            source_team: Some("atm-dev".parse().expect("team")),
             summary: Some("ack reply".into()),
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: None,

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -23,7 +23,12 @@ impl LegacyMessageId {
     }
 
     pub fn from_atm_message_id(value: AtmMessageId) -> Self {
-        Self(Uuid::from_bytes(value.into_ulid().to_bytes()))
+        let mut bytes = value.into_ulid().to_bytes();
+        // Preserve a deterministic bridge for legacy read/ack flows while
+        // normalizing the bytes into a structurally valid UUID v4 shape.
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+        Self(Uuid::from_bytes(bytes))
     }
 
     pub fn into_uuid(self) -> Uuid {
@@ -296,7 +301,7 @@ pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, 
     Ok(value)
 }
 
-pub(crate) fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
+pub fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
     let Some(object) = value.as_object_mut() else {
         return;
     };

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -144,7 +144,7 @@ pub struct AtmMetadataFields {
     pub source_team: Option<TeamName>,
 
     #[serde(rename = "fromIdentity", skip_serializing_if = "Option::is_none")]
-    pub from_identity: Option<String>,
+    pub from_identity: Option<AgentName>,
 
     #[serde(rename = "pendingAckAt", skip_serializing_if = "Option::is_none")]
     pub pending_ack_at: Option<IsoTimestamp>,
@@ -165,7 +165,7 @@ pub struct AtmMetadataFields {
     pub alert_kind: Option<String>,
 
     #[serde(rename = "missingConfigPath", skip_serializing_if = "Option::is_none")]
-    pub missing_config_path: Option<String>,
+    pub missing_config_path: Option<std::path::PathBuf>,
 
     #[serde(flatten)]
     pub extra: Map<String, Value>,
@@ -277,6 +277,9 @@ pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, 
                 message.from, message.timestamp
             ))
         })?;
+    // The legacy UUID `message_id` is stripped here but deliberately not
+    // forwarded. Forwarded ATM message ids must remain ULID-authored per
+    // architecture §5.2 rather than being derived from compatibility UUIDs.
     let _ = object.remove("message_id");
     let source_team = object.remove("source_team");
     let pending_ack_at = object.remove("pendingAckAt");
@@ -287,6 +290,9 @@ pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, 
             .and_then(|value| match value {
                 Value::String(_) => message
                     .acknowledges_message_id
+                    // This forwarding path is lossy: the top-level field is a
+                    // legacy UUID, so the shared inbox export can only emit a
+                    // ULID approximation rather than the original ATM ULID.
                     .map(LegacyMessageId::into_lossy_atm_message_id_approximation)
                     .map(|message_id| Value::String(message_id.to_string())),
                 _ => None,

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -22,24 +22,15 @@ impl LegacyMessageId {
     }
 
     pub fn from_atm_message_id(value: AtmMessageId) -> Self {
-        let mut bytes = value.into_ulid().to_bytes();
-        // Preserve a deterministic bridge for legacy read/ack flows while
-        // normalizing the bytes into a structurally valid UUID v4 shape.
-        bytes[6] = (bytes[6] & 0x0f) | 0x40;
-        bytes[8] = (bytes[8] & 0x3f) | 0x80;
-        Self(Uuid::from_bytes(bytes))
+        Self(Uuid::from_bytes(value.into_ulid().to_bytes()))
     }
 
     pub fn into_uuid(self) -> Uuid {
         self.0
     }
 
-    /// Convert a legacy compatibility UUID into a best-effort ULID approximation.
-    ///
-    /// This mapping is intentionally lossy. `from_atm_message_id` normalizes the
-    /// source ULID into a UUID v4-compatible byte pattern, so reversing the
-    /// process cannot recover the original ULID exactly.
-    pub fn into_lossy_atm_message_id_approximation(self) -> AtmMessageId {
+    /// Reinterpret the raw UUID bytes as an ATM message ULID without mutation.
+    pub fn into_atm_message_id(self) -> AtmMessageId {
         AtmMessageId::from(Ulid::from_bytes(self.0.into_bytes()))
     }
 }
@@ -134,6 +125,17 @@ impl fmt::Display for AtmMessageId {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+/// ATM-owned semantic discriminator for alert-class metadata.
+pub struct AlertKind(String);
+
+impl AlertKind {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 /// ATM-owned machine metadata planned for the forward `metadata.atm` namespace.
 pub struct AtmMetadataFields {
@@ -162,7 +164,7 @@ pub struct AtmMetadataFields {
     pub task_id: Option<TaskId>,
 
     #[serde(rename = "alertKind", skip_serializing_if = "Option::is_none")]
-    pub alert_kind: Option<String>,
+    pub alert_kind: Option<AlertKind>,
 
     // This advisory diagnostic field preserves platform-native path encoding
     // (including backslashes on Windows) rather than normalizing JSON output to
@@ -293,10 +295,10 @@ pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, 
             .and_then(|value| match value {
                 Value::String(_) => message
                     .acknowledges_message_id
-                    // This forwarding path is lossy: the top-level field is a
-                    // legacy UUID, so the shared inbox export can only emit a
-                    // ULID approximation rather than the original ATM ULID.
-                    .map(LegacyMessageId::into_lossy_atm_message_id_approximation)
+                    // This forwarding path preserves the legacy UUID bytes
+                    // exactly, but the resulting shared-inbox value is still a
+                    // compatibility reinterpretation of those bytes as a ULID.
+                    .map(LegacyMessageId::into_atm_message_id)
                     .map(|message_id| Value::String(message_id.to_string())),
                 _ => None,
             });

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -256,13 +256,7 @@ pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, 
     let object = value
         .as_object_mut()
         .expect("message envelope serializes to object");
-    let message_id = object.remove("message_id").and_then(|value| match value {
-        Value::String(_) => message
-            .message_id
-            .map(LegacyMessageId::into_atm_message_id)
-            .map(|message_id| Value::String(message_id.to_string())),
-        _ => None,
-    });
+    let _ = object.remove("message_id");
     let source_team = object.remove("source_team");
     let pending_ack_at = object.remove("pendingAckAt");
     let acknowledged_at = object.remove("acknowledgedAt");
@@ -277,15 +271,12 @@ pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, 
                 _ => None,
             });
     let task_id = object.remove("taskId");
-    let alert_kind = object.remove("atmAlertKind");
-    let missing_config_path = object.remove("missingConfigPath");
+    let _ = object.get("atmAlertKind");
+    let _ = object.get("missingConfigPath");
 
     let metadata = ensure_object(object, "metadata");
     let atm = ensure_object(metadata, "atm");
 
-    if let Some(value) = message_id {
-        atm.entry("messageId".to_string()).or_insert(value);
-    }
     if let Some(value) = source_team {
         atm.entry("sourceTeam".to_string()).or_insert(value);
     }
@@ -302,13 +293,6 @@ pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, 
     if let Some(value) = task_id {
         atm.entry("taskId".to_string()).or_insert(value);
     }
-    if let Some(value) = alert_kind {
-        atm.entry("alertKind".to_string()).or_insert(value);
-    }
-    if let Some(value) = missing_config_path {
-        atm.entry("missingConfigPath".to_string()).or_insert(value);
-    }
-
     Ok(value)
 }
 
@@ -610,7 +594,7 @@ mod tests {
             .and_then(|metadata| metadata.get("atm"))
             .and_then(Value::as_object)
             .expect("metadata.atm");
-        assert!(atm.contains_key("messageId"));
+        assert!(!atm.contains_key("messageId"));
         assert_eq!(atm.get("sourceTeam"), Some(&json!("atm-dev")));
         assert_eq!(atm.get("taskId"), Some(&json!("TASK-123")));
     }

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -125,14 +125,56 @@ impl fmt::Display for AtmMessageId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 /// ATM-owned semantic discriminator for alert-class metadata.
-pub struct AlertKind(String);
+pub enum AlertKind {
+    MissingTeamConfig,
+    Unknown(String),
+}
 
 impl AlertKind {
     pub fn as_str(&self) -> &str {
-        &self.0
+        match self {
+            Self::MissingTeamConfig => "missing_team_config",
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+impl From<String> for AlertKind {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "missing_team_config" => Self::MissingTeamConfig,
+            _ => Self::Unknown(value),
+        }
+    }
+}
+
+impl From<AlertKind> for String {
+    fn from(value: AlertKind) -> Self {
+        match value {
+            AlertKind::MissingTeamConfig => "missing_team_config".to_string(),
+            AlertKind::Unknown(value) => value,
+        }
+    }
+}
+
+impl Serialize for AlertKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for AlertKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::from(String::deserialize(deserializer)?))
     }
 }
 
@@ -428,10 +470,29 @@ mod tests {
     use chrono::Utc;
 
     use super::{
-        AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, IsoTimestamp, LegacyMessageId,
-        MessageEnvelope, MessageMetadata, PendingAck, hydrate_legacy_fields_from_metadata,
-        to_shared_inbox_value,
+        AlertKind, AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, IsoTimestamp,
+        LegacyMessageId, MessageEnvelope, MessageMetadata, PendingAck,
+        hydrate_legacy_fields_from_metadata, to_shared_inbox_value,
     };
+
+    #[test]
+    fn alert_kind_round_trips_known_and_unknown_wire_values() {
+        let known: AlertKind =
+            serde_json::from_str(r#""missing_team_config""#).expect("known alert kind");
+        assert_eq!(known, AlertKind::MissingTeamConfig);
+        assert_eq!(
+            serde_json::to_string(&known).expect("encode known"),
+            r#""missing_team_config""#
+        );
+
+        let unknown: AlertKind =
+            serde_json::from_str(r#""future_alert_kind""#).expect("unknown alert kind");
+        assert_eq!(unknown, AlertKind::Unknown("future_alert_kind".to_string()));
+        assert_eq!(
+            serde_json::to_string(&unknown).expect("encode unknown"),
+            r#""future_alert_kind""#
+        );
+    }
 
     #[test]
     fn message_envelope_round_trips_with_current_inbox_shape() {

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -164,6 +164,9 @@ pub struct AtmMetadataFields {
     #[serde(rename = "alertKind", skip_serializing_if = "Option::is_none")]
     pub alert_kind: Option<String>,
 
+    // This advisory diagnostic field preserves platform-native path encoding
+    // (including backslashes on Windows) rather than normalizing JSON output to
+    // forward-slash-only form.
     #[serde(rename = "missingConfigPath", skip_serializing_if = "Option::is_none")]
     pub missing_config_path: Option<std::path::PathBuf>,
 

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -126,7 +126,6 @@ impl fmt::Display for AtmMessageId {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
 /// ATM-owned semantic discriminator for alert-class metadata.
 pub enum AlertKind {
     MissingTeamConfig,

--- a/crates/atm-core/src/schema/mod.rs
+++ b/crates/atm-core/src/schema/mod.rs
@@ -7,6 +7,6 @@ pub mod team_config;
 pub use agent_member::AgentMember;
 pub use inbox_message::{
     AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, LegacyMessageId, MessageEnvelope,
-    MessageMetadata, PendingAck,
+    MessageMetadata, PendingAck, hydrate_legacy_fields_from_metadata,
 };
 pub use team_config::TeamConfig;

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -220,14 +220,11 @@ pub fn send_mail(
             );
         }
         let envelope = MessageEnvelope {
-            from: display_sender.clone(),
+            from: display_sender.parse().expect("display sender is valid"),
             text: body.clone(),
             timestamp,
             read: false,
-            source_team: sender_team
-                .clone()
-                .map(|team| team.to_string())
-                .or_else(|| Some(recipient.team.to_string())),
+            source_team: sender_team.clone().or_else(|| Some(recipient.team.clone())),
             summary: Some(summary.clone()),
             message_id: Some(message_id),
             pending_ack_at: requires_ack.then_some(timestamp),
@@ -397,14 +394,16 @@ fn notify_team_lead_missing_config(
     );
 
     let notice = MessageEnvelope {
-        from: format!("atm-identity-missing@{team}"),
+        from: "atm-identity-missing"
+            .parse()
+            .expect("system sender is valid"),
         text: format!(
             "ATM warning: send used existing inbox fallback for {recipient}@{team} because team config is missing at {}. Please restore config.json.",
             config_path.display()
         ),
         timestamp,
         read: false,
-        source_team: Some(team.to_string()),
+        source_team: Some(team.parse().expect("team name")),
         summary: Some(format!(
             "ATM warning: missing team config fallback used for {recipient}@{team}"
         )),

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -214,10 +214,7 @@ pub fn send_mail(
         let mut extra = Map::new();
         workflow::set_atm_message_id(&mut extra, atm_message_id);
         if display_sender != canonical_sender.as_str() {
-            set_canonical_sender_metadata(
-                &mut extra,
-                &qualified_sender_identity(&canonical_sender, sender_team.as_deref()),
-            );
+            set_canonical_sender_metadata(&mut extra, &canonical_sender);
         }
         let envelope = MessageEnvelope {
             from: display_sender.parse().expect("display sender is valid"),
@@ -487,7 +484,10 @@ pub(super) fn qualified_sender_identity(sender: &AgentName, sender_team: Option<
         .unwrap_or_else(|| sender.to_string())
 }
 
-fn set_canonical_sender_metadata(extra: &mut Map<String, serde_json::Value>, canonical_from: &str) {
+fn set_canonical_sender_metadata(
+    extra: &mut Map<String, serde_json::Value>,
+    canonical_from: &AgentName,
+) {
     let metadata = extra
         .entry("metadata".to_string())
         .or_insert_with(|| serde_json::Value::Object(Map::new()));
@@ -508,7 +508,7 @@ fn set_canonical_sender_metadata(extra: &mut Map<String, serde_json::Value>, can
     };
     atm.insert(
         "fromIdentity".to_string(),
-        serde_json::Value::String(canonical_from.to_string()),
+        serde_json::to_value(canonical_from).expect("AgentName serializes"),
     );
 }
 

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -319,7 +319,7 @@ pub fn add_member(request: AddMemberRequest) -> Result<AddMemberOutcome, AtmErro
     }
 
     config.members.push(AgentMember {
-        name: request.member.to_string(),
+        name: request.member.clone(),
         agent_id: format!("{}@{}", request.member, request.team),
         agent_type: request.agent_type,
         model: request.model,

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -321,7 +321,7 @@ pub fn add_member(request: AddMemberRequest) -> Result<AddMemberOutcome, AtmErro
     config.members.push(AgentMember {
         name: request.member.clone(),
         agent_id: format!("{}@{}", request.member, request.team),
-        agent_type: request.agent_type,
+        agent_type: request.agent_type.into(),
         model: request.model,
         joined_at: Some(Utc::now().timestamp_millis() as u64),
         tmux_pane_id: normalized_tmux_pane_id.unwrap_or_default(),
@@ -419,7 +419,7 @@ fn member_summary(member: &AgentMember) -> MemberSummary {
     MemberSummary {
         name: AgentName::from_validated(member.name.clone()),
         agent_id: member.agent_id.clone(),
-        agent_type: member.agent_type.clone(),
+        agent_type: member.agent_type.to_string(),
         model: member.model.clone(),
         joined_at: member.joined_at,
         tmux_pane_id: member.tmux_pane_id.clone(),

--- a/crates/atm-core/src/team_admin/restore.rs
+++ b/crates/atm-core/src/team_admin/restore.rs
@@ -42,8 +42,11 @@ pub(super) fn restore_team(request: RestoreRequest) -> Result<RestoreResult, Atm
         if name == "team-lead.json" {
             return false;
         }
-        name.strip_suffix(".json")
-            .is_some_and(|member| members_to_restore_set.contains(member))
+        name.strip_suffix(".json").is_some_and(|member| {
+            members_to_restore_set
+                .iter()
+                .any(|restored_member| restored_member == &member)
+        })
     });
     let tasks_to_restore = count_numeric_task_files(&backup_dir.join("tasks"))?;
 

--- a/crates/atm-core/src/team_admin/restore.rs
+++ b/crates/atm-core/src/team_admin/restore.rs
@@ -599,11 +599,11 @@ mod tests {
 
     fn write_inbox(path: &Path, text: &str) {
         let envelope = crate::schema::MessageEnvelope {
-            from: "team-lead".to_string(),
+            from: "team-lead".parse().expect("agent"),
             text: text.to_string(),
             timestamp: crate::types::IsoTimestamp::from_datetime(Utc::now()),
             read: false,
-            source_team: Some("atm-dev".to_string()),
+            source_team: Some("atm-dev".parse().expect("team")),
             summary: None,
             message_id: None,
             pending_ack_at: None,

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -33,7 +33,7 @@ impl From<DateTime<Utc>> for IsoTimestamp {
 }
 
 /// Canonical ATM agent/member name at a public API boundary.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct AgentName(String);
 
@@ -48,8 +48,18 @@ impl AgentName {
         self.0
     }
 
+    /// Construct from a value that has already passed `validate_path_segment`
+    /// or came from a trusted internal deserialization context.
+    ///
+    /// Raw untrusted strings must go through `FromStr` or `Deserialize`.
     pub(crate) fn from_validated(value: impl Into<String>) -> Self {
         Self(value.into())
+    }
+}
+
+impl Default for AgentName {
+    fn default() -> Self {
+        Self("<default-agent-name>".to_string())
     }
 }
 

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -57,12 +57,6 @@ impl AgentName {
     }
 }
 
-impl Default for AgentName {
-    fn default() -> Self {
-        Self("<default-agent-name>".to_string())
-    }
-}
-
 impl FromStr for AgentName {
     type Err = AtmError;
 

--- a/crates/atm-core/src/workflow.rs
+++ b/crates/atm-core/src/workflow.rs
@@ -260,15 +260,15 @@ mod tests {
         set_atm_message_id, workflow_key,
     };
     use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
-    use crate::types::IsoTimestamp;
+    use crate::types::{AgentName, IsoTimestamp, TeamName};
 
     fn sample_message() -> MessageEnvelope {
         MessageEnvelope {
-            from: "team-lead".to_string(),
+            from: "team-lead".parse::<AgentName>().expect("agent"),
             text: "hello".to_string(),
             timestamp: IsoTimestamp::now(),
             read: false,
-            source_team: Some("atm-dev".to_string()),
+            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
             summary: None,
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: None,

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 
 // Test-side ceiling guard only; production lock timeout defaults to 5s per
 // architecture §18.3.
-const NON_BLOCKING_LOCK_BUDGET: Duration = Duration::from_secs(2);
+const TEST_LOCK_BUDGET_CEILING: Duration = Duration::from_secs(2);
 
 #[test]
 #[serial]
@@ -219,10 +219,8 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
         arch_workflow["messages"][format!("legacy:{pending_message_id}")]["acknowledgedAt"]
             .as_str()
             .is_some()
-            || arch_workflow["messages"][format!(
-                "atm:{}",
-                pending_message_id.into_lossy_atm_message_id_approximation()
-            )]["acknowledgedAt"]
+            || arch_workflow["messages"]
+                [format!("atm:{}", pending_message_id.into_atm_message_id())]["acknowledgedAt"]
                 .as_str()
                 .is_some(),
         "pending message was not acknowledged in workflow state: {arch_workflow:?}"
@@ -579,7 +577,7 @@ fn send_times_out_under_bounded_lock_contention() {
 
     assert_eq!(error.code, AtmErrorCode::MailboxLockTimeout);
     assert!(
-        started.elapsed() < NON_BLOCKING_LOCK_BUDGET,
+        started.elapsed() < TEST_LOCK_BUDGET_CEILING,
         "retain only a coarse non-blocking budget here; recv_timeout-based tests above already cover deadlock detection"
     );
 }
@@ -616,7 +614,7 @@ fn clear_dry_run_does_not_wait_on_mailbox_lock() {
     assert_eq!(outcome.removed_total, 0);
     assert_eq!(outcome.remaining_total, 1);
     assert!(
-        started.elapsed() < NON_BLOCKING_LOCK_BUDGET,
+        started.elapsed() < TEST_LOCK_BUDGET_CEILING,
         "retain only a coarse non-blocking budget here; recv_timeout-based tests above already cover deadlock detection"
     );
 }
@@ -681,7 +679,7 @@ fn read_possible_write_only_locks_when_display_mutation_is_required() {
     assert_eq!(outcome.count, 1);
     assert_eq!(outcome.messages[0].envelope.text, "already read");
     assert!(
-        started.elapsed() < NON_BLOCKING_LOCK_BUDGET,
+        started.elapsed() < TEST_LOCK_BUDGET_CEILING,
         "retain only a coarse non-blocking budget here; recv_timeout-based tests above already cover deadlock detection"
     );
 }
@@ -794,7 +792,7 @@ fn send_reports_non_contention_lock_failures_without_timeout() {
 
     assert_eq!(error.code, AtmErrorCode::MailboxLockFailed);
     assert!(
-        started.elapsed() < NON_BLOCKING_LOCK_BUDGET,
+        started.elapsed() < TEST_LOCK_BUDGET_CEILING,
         "retain only a coarse non-blocking budget here; recv_timeout-based tests above already cover deadlock detection"
     );
 }
@@ -1128,7 +1126,7 @@ fn pending_ack_message(
     let mut extra = serde_json::Map::new();
     let mut metadata = serde_json::Map::new();
     let mut atm = serde_json::Map::new();
-    let atm_message_id = message_id.into_lossy_atm_message_id_approximation();
+    let atm_message_id = message_id.into_atm_message_id();
     atm.insert(
         "messageId".to_string(),
         serde_json::Value::String(atm_message_id.to_string()),
@@ -1165,7 +1163,7 @@ fn read_message(from: &str, text: &str, message_id: LegacyMessageId) -> MessageE
     let mut extra = serde_json::Map::new();
     let mut metadata = serde_json::Map::new();
     let mut atm = serde_json::Map::new();
-    let atm_message_id = message_id.into_lossy_atm_message_id_approximation();
+    let atm_message_id = message_id.into_atm_message_id();
     atm.insert(
         "messageId".to_string(),
         serde_json::Value::String(atm_message_id.to_string()),
@@ -1202,7 +1200,7 @@ fn unread_message(from: &str, text: &str, message_id: LegacyMessageId) -> Messag
     let mut extra = serde_json::Map::new();
     let mut metadata = serde_json::Map::new();
     let mut atm = serde_json::Map::new();
-    let atm_message_id = message_id.into_lossy_atm_message_id_approximation();
+    let atm_message_id = message_id.into_atm_message_id();
     atm.insert(
         "messageId".to_string(),
         serde_json::Value::String(atm_message_id.to_string()),

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -1092,9 +1092,21 @@ fn message_atm_id(message: &MessageEnvelope) -> String {
 
 fn read_jsonl(path: std::path::PathBuf) -> Vec<MessageEnvelope> {
     let raw = fs::read_to_string(path).expect("inbox contents");
-    raw.lines()
-        .map(|line| {
-            let mut value: serde_json::Value = serde_json::from_str(line).expect("json line");
+    if raw.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let values: Vec<serde_json::Value> = match raw.chars().find(|ch| !ch.is_whitespace()) {
+        Some('[') => serde_json::from_str(&raw).expect("json array"),
+        _ => raw
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("json line"))
+            .collect(),
+    };
+
+    values
+        .into_iter()
+        .map(|mut value| {
             hydrate_legacy_fields_from_metadata(&mut value);
             serde_json::from_value(value).expect("message envelope")
         })
@@ -1102,18 +1114,26 @@ fn read_jsonl(path: std::path::PathBuf) -> Vec<MessageEnvelope> {
 }
 
 fn find_inbox_json_line(raw: &str, text: &str) -> serde_json::Value {
-    raw.lines()
-        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("json line"))
+    let values: Vec<serde_json::Value> = if raw.trim().is_empty() {
+        Vec::new()
+    } else {
+        match raw.chars().find(|ch| !ch.is_whitespace()) {
+            Some('[') => serde_json::from_str(raw).expect("json array"),
+            _ => raw
+                .lines()
+                .map(|line| serde_json::from_str(line).expect("json line"))
+                .collect(),
+        }
+    };
+
+    values
+        .into_iter()
         .find(|line| line["text"] == text)
         .expect("matching inbox json line")
 }
 
 fn write_inbox(path: &std::path::Path, messages: &[MessageEnvelope]) {
-    let raw = messages
-        .iter()
-        .map(|message| serde_json::to_string(message).expect("json line"))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let raw = serde_json::to_string_pretty(messages).expect("json array");
     fs::write(path, format!("{raw}\n")).expect("write inbox");
 }
 
@@ -1185,6 +1205,20 @@ fn pending_ack_message(
     message_id: LegacyMessageId,
     source_team: &str,
 ) -> MessageEnvelope {
+    let mut extra = serde_json::Map::new();
+    let mut metadata = serde_json::Map::new();
+    let mut atm = serde_json::Map::new();
+    atm.insert(
+        "messageId".to_string(),
+        serde_json::Value::String(message_id.into_atm_message_id().to_string()),
+    );
+    atm.insert(
+        "sourceTeam".to_string(),
+        serde_json::Value::String(source_team.to_string()),
+    );
+    metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
+    extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
+
     MessageEnvelope {
         from: from.to_string(),
         text: text.to_string(),
@@ -1197,11 +1231,25 @@ fn pending_ack_message(
         acknowledged_at: None,
         acknowledges_message_id: None,
         task_id: None,
-        extra: serde_json::Map::new(),
+        extra,
     }
 }
 
 fn read_message(from: &str, text: &str, message_id: LegacyMessageId) -> MessageEnvelope {
+    let mut extra = serde_json::Map::new();
+    let mut metadata = serde_json::Map::new();
+    let mut atm = serde_json::Map::new();
+    atm.insert(
+        "messageId".to_string(),
+        serde_json::Value::String(message_id.into_atm_message_id().to_string()),
+    );
+    atm.insert(
+        "sourceTeam".to_string(),
+        serde_json::Value::String("atm-dev".to_string()),
+    );
+    metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
+    extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
+
     MessageEnvelope {
         from: from.to_string(),
         text: text.to_string(),
@@ -1214,11 +1262,25 @@ fn read_message(from: &str, text: &str, message_id: LegacyMessageId) -> MessageE
         acknowledged_at: None,
         acknowledges_message_id: None,
         task_id: None,
-        extra: serde_json::Map::new(),
+        extra,
     }
 }
 
 fn unread_message(from: &str, text: &str, message_id: LegacyMessageId) -> MessageEnvelope {
+    let mut extra = serde_json::Map::new();
+    let mut metadata = serde_json::Map::new();
+    let mut atm = serde_json::Map::new();
+    atm.insert(
+        "messageId".to_string(),
+        serde_json::Value::String(message_id.into_atm_message_id().to_string()),
+    );
+    atm.insert(
+        "sourceTeam".to_string(),
+        serde_json::Value::String("atm-dev".to_string()),
+    );
+    metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
+    extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
+
     MessageEnvelope {
         from: from.to_string(),
         text: text.to_string(),
@@ -1231,6 +1293,6 @@ fn unread_message(from: &str, text: &str, message_id: LegacyMessageId) -> Messag
         acknowledged_at: None,
         acknowledges_message_id: None,
         task_id: None,
-        extra: serde_json::Map::new(),
+        extra,
     }
 }

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -22,7 +22,7 @@ use serial_test::serial;
 use tempfile::TempDir;
 use uuid::Uuid;
 
-const NON_BLOCKING_LOCK_BUDGET: Duration = Duration::from_secs(10);
+const NON_BLOCKING_LOCK_BUDGET: Duration = Duration::from_secs(2);
 
 #[test]
 #[serial]
@@ -728,6 +728,10 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
         atm_message_id
     );
     assert_eq!(physical_after["read"], false);
+    assert!(
+        !sentinel_path(&fixture.primary_inbox_path("arch-ctm")).exists(),
+        "read-only ULID sidecar path must not leave a lock sentinel behind",
+    );
 
     let workflow = fixture.workflow_state_contents("arch-ctm");
     assert_eq!(

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -802,6 +802,8 @@ enum CommandOp {
     Clear(ClearQuery, Arc<NullObservability>),
 }
 
+// Serializes process-environment mutation inside this test module. This is
+// process-local only; it does not coordinate with other test processes.
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     // These tests mutate process-global environment variables while exercising
@@ -1041,10 +1043,7 @@ fn create_team_with_config(home_dir: &std::path::Path, team: &str, members: &[&s
     let config = TeamConfig {
         members: members
             .iter()
-            .map(|name| AgentMember {
-                name: (*name).parse().expect("agent"),
-                ..Default::default()
-            })
+            .map(|name| AgentMember::with_name((*name).parse().expect("agent")))
             .collect(),
         ..Default::default()
     };

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -22,6 +22,8 @@ use serial_test::serial;
 use tempfile::TempDir;
 use uuid::Uuid;
 
+// Test-side ceiling guard only; production lock timeout defaults to 5s per
+// architecture §18.3.
 const NON_BLOCKING_LOCK_BUDGET: Duration = Duration::from_secs(2);
 
 #[test]
@@ -1042,7 +1044,7 @@ fn create_team_with_config(home_dir: &std::path::Path, team: &str, members: &[&s
         members: members
             .iter()
             .map(|name| AgentMember {
-                name: (*name).to_string(),
+                name: (*name).parse().expect("agent"),
                 ..Default::default()
             })
             .collect(),

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -10,7 +10,9 @@ use atm_core::clear::{ClearQuery, clear_mail};
 use atm_core::error::AtmErrorCode;
 use atm_core::observability::NullObservability;
 use atm_core::read::{ReadQuery, read_mail};
-use atm_core::schema::{AgentMember, AtmMessageId, LegacyMessageId, MessageEnvelope, TeamConfig};
+use atm_core::schema::{
+    AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig, hydrate_legacy_fields_from_metadata,
+};
 use atm_core::send::{SendMessageSource, SendRequest, send_mail};
 use atm_core::types::{AckActivationMode, IsoTimestamp, ReadSelection};
 use chrono::Utc;
@@ -1141,62 +1143,6 @@ fn sentinel_path(path: &std::path::Path) -> std::path::PathBuf {
     let mut os = path.as_os_str().to_os_string();
     os.push(".lock");
     std::path::PathBuf::from(os)
-}
-
-fn hydrate_legacy_fields_from_metadata(value: &mut serde_json::Value) {
-    let Some(object) = value.as_object_mut() else {
-        return;
-    };
-    let Some(atm) = object
-        .get("metadata")
-        .and_then(serde_json::Value::as_object)
-        .and_then(|metadata| metadata.get("atm"))
-        .and_then(serde_json::Value::as_object)
-        .cloned()
-    else {
-        return;
-    };
-
-    if !object.contains_key("message_id")
-        && let Some(raw) = atm.get("messageId").and_then(serde_json::Value::as_str)
-        && let Ok(message_id) = raw.parse::<AtmMessageId>()
-    {
-        object.insert(
-            "message_id".to_string(),
-            serde_json::Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-        );
-    }
-    if !object.contains_key("source_team")
-        && let Some(value) = atm.get("sourceTeam")
-    {
-        object.insert("source_team".to_string(), value.clone());
-    }
-    if !object.contains_key("pendingAckAt")
-        && let Some(value) = atm.get("pendingAckAt")
-    {
-        object.insert("pendingAckAt".to_string(), value.clone());
-    }
-    if !object.contains_key("acknowledgedAt")
-        && let Some(value) = atm.get("acknowledgedAt")
-    {
-        object.insert("acknowledgedAt".to_string(), value.clone());
-    }
-    if !object.contains_key("acknowledgesMessageId")
-        && let Some(raw) = atm
-            .get("acknowledgesMessageId")
-            .and_then(serde_json::Value::as_str)
-        && let Ok(message_id) = raw.parse::<AtmMessageId>()
-    {
-        object.insert(
-            "acknowledgesMessageId".to_string(),
-            serde_json::Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-        );
-    }
-    if !object.contains_key("taskId")
-        && let Some(value) = atm.get("taskId")
-    {
-        object.insert("taskId".to_string(), value.clone());
-    }
 }
 
 fn pending_ack_message(

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -11,10 +11,11 @@ use atm_core::error::AtmErrorCode;
 use atm_core::observability::NullObservability;
 use atm_core::read::{ReadQuery, read_mail};
 use atm_core::schema::{
-    AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig, hydrate_legacy_fields_from_metadata,
+    AgentMember, AtmMessageId, LegacyMessageId, MessageEnvelope, TeamConfig,
+    hydrate_legacy_fields_from_metadata,
 };
 use atm_core::send::{SendMessageSource, SendRequest, send_mail};
-use atm_core::types::{AckActivationMode, IsoTimestamp, ReadSelection};
+use atm_core::types::{AckActivationMode, AgentName, IsoTimestamp, ReadSelection, TeamName};
 use chrono::Utc;
 use fs2::FileExt;
 use serial_test::serial;
@@ -216,8 +217,10 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
         arch_workflow["messages"][format!("legacy:{pending_message_id}")]["acknowledgedAt"]
             .as_str()
             .is_some()
-            || arch_workflow["messages"]
-                [format!("atm:{}", pending_message_id.into_atm_message_id())]["acknowledgedAt"]
+            || arch_workflow["messages"][format!(
+                "atm:{}",
+                pending_message_id.into_lossy_atm_message_id_approximation()
+            )]["acknowledgedAt"]
                 .as_str()
                 .is_some(),
         "pending message was not acknowledged in workflow state: {arch_workflow:?}"
@@ -395,7 +398,8 @@ fn missing_config_notice_seeds_team_lead_workflow_state() {
 
     let notices = fixture.inbox_contents_for_team("broken-dev", "team-lead");
     let notice = notices.first().expect("missing-config notice");
-    assert_eq!(notice.from, "atm-identity-missing@broken-dev");
+    assert_eq!(notice.from, "atm-identity-missing");
+    assert_eq!(notice.source_team.as_deref(), Some("broken-dev"));
     let workflow = fixture.workflow_state_contents_for_team("broken-dev", "team-lead");
     let notice_atm_id = message_atm_id(notice);
     assert!(
@@ -734,48 +738,6 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
 
 #[test]
 #[serial]
-fn clear_remove_locked_inbox_seam_fails_closed_without_mutating_surviving_state() {
-    let _env_lock = env_lock().lock().expect("env lock");
-    let _fault = EnvGuard::set_raw("ATM_TEST_REMOVE_LOCKED_INBOX_BEFORE_LOAD", "1");
-    let fixture = Fixture::new();
-    let observability = NullObservability;
-    let origin_message_id = LegacyMessageId::from(Uuid::new_v4());
-    fixture.write_origin_inbox(
-        "arch-ctm",
-        "zzz",
-        &[read_message("qa", "origin read a", origin_message_id)],
-    );
-    fixture.write_workflow_state(
-        "arch-ctm",
-        serde_json::json!({
-            "messages": {
-                format!("legacy:{origin_message_id}"): {
-                    "read": true
-                }
-            }
-        }),
-    );
-    let before_origin = fs::read_to_string(fixture.origin_inbox_path("arch-ctm", "zzz"))
-        .expect("origin inbox before");
-    let before_workflow =
-        fs::read_to_string(fixture.workflow_state_path("arch-ctm")).expect("workflow before");
-
-    let error = clear_mail(fixture.clear_query("arch-ctm"), &observability).expect_err("fault");
-
-    assert!(error.is_mailbox_read());
-    assert_eq!(
-        fs::read_to_string(fixture.origin_inbox_path("arch-ctm", "zzz"))
-            .expect("origin inbox after"),
-        before_origin
-    );
-    assert_eq!(
-        fs::read_to_string(fixture.workflow_state_path("arch-ctm")).expect("workflow after"),
-        before_workflow
-    );
-}
-
-#[test]
-#[serial]
 fn clear_fails_closed_on_synthetic_source_discovery_fault() {
     let _env_lock = env_lock().lock().expect("env lock");
     let _fault = EnvGuard::set_raw("ATM_TEST_FORCE_SOURCE_DISCOVERY_FAULT", "1");
@@ -838,6 +800,10 @@ enum CommandOp {
 
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    // These tests mutate process-global environment variables while exercising
+    // mailbox lock behavior. Keep a single process-wide mutex in addition to
+    // #[serial] so a poisoned lock fails the suite closed instead of silently
+    // continuing with inconsistent shared state.
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
@@ -888,8 +854,8 @@ impl Fixture {
         let tempdir = tempfile::tempdir().expect("tempdir");
         create_team_with_config(tempdir.path(), "atm-dev", &["team-lead", "arch-ctm", "qa"]);
 
-        let arch_message_id = LegacyMessageId::from(Uuid::new_v4());
-        let qa_message_id = LegacyMessageId::from(Uuid::new_v4());
+        let arch_message_id = LegacyMessageId::from_atm_message_id(AtmMessageId::new());
+        let qa_message_id = LegacyMessageId::from_atm_message_id(AtmMessageId::new());
 
         let fixture = Self {
             tempdir,
@@ -1086,8 +1052,10 @@ fn create_team_with_config(home_dir: &std::path::Path, team: &str, members: &[&s
 }
 
 fn message_atm_id(message: &MessageEnvelope) -> String {
-    message.extra["metadata"]["atm"]["messageId"]
-        .as_str()
+    message
+        .atm_message_id()
+        .map(|message_id| message_id.to_string())
+        .as_deref()
         .expect("atm message id")
         .to_string()
 }
@@ -1154,9 +1122,10 @@ fn pending_ack_message(
     let mut extra = serde_json::Map::new();
     let mut metadata = serde_json::Map::new();
     let mut atm = serde_json::Map::new();
+    let atm_message_id = message_id.into_lossy_atm_message_id_approximation();
     atm.insert(
         "messageId".to_string(),
-        serde_json::Value::String(message_id.into_atm_message_id().to_string()),
+        serde_json::Value::String(atm_message_id.to_string()),
     );
     atm.insert(
         "sourceTeam".to_string(),
@@ -1164,13 +1133,18 @@ fn pending_ack_message(
     );
     metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
     extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
+    assert_eq!(
+        LegacyMessageId::from_atm_message_id(message_atm_id_from_extra(&extra).expect("atm id")),
+        message_id,
+        "mailbox fixture metadata.atm.messageId must match legacy message_id",
+    );
 
     MessageEnvelope {
-        from: from.to_string(),
+        from: from.parse::<AgentName>().expect("agent"),
         text: text.to_string(),
         timestamp: IsoTimestamp::from_datetime(Utc::now()),
         read: true,
-        source_team: Some(source_team.to_string()),
+        source_team: Some(source_team.parse::<TeamName>().expect("team")),
         summary: None,
         message_id: Some(message_id),
         pending_ack_at: Some(IsoTimestamp::from_datetime(Utc::now())),
@@ -1185,9 +1159,10 @@ fn read_message(from: &str, text: &str, message_id: LegacyMessageId) -> MessageE
     let mut extra = serde_json::Map::new();
     let mut metadata = serde_json::Map::new();
     let mut atm = serde_json::Map::new();
+    let atm_message_id = message_id.into_lossy_atm_message_id_approximation();
     atm.insert(
         "messageId".to_string(),
-        serde_json::Value::String(message_id.into_atm_message_id().to_string()),
+        serde_json::Value::String(atm_message_id.to_string()),
     );
     atm.insert(
         "sourceTeam".to_string(),
@@ -1195,13 +1170,18 @@ fn read_message(from: &str, text: &str, message_id: LegacyMessageId) -> MessageE
     );
     metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
     extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
+    assert_eq!(
+        LegacyMessageId::from_atm_message_id(message_atm_id_from_extra(&extra).expect("atm id")),
+        message_id,
+        "mailbox fixture metadata.atm.messageId must match legacy message_id",
+    );
 
     MessageEnvelope {
-        from: from.to_string(),
+        from: from.parse::<AgentName>().expect("agent"),
         text: text.to_string(),
         timestamp: IsoTimestamp::from_datetime(Utc::now()),
         read: true,
-        source_team: Some("atm-dev".to_string()),
+        source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
         summary: None,
         message_id: Some(message_id),
         pending_ack_at: None,
@@ -1216,9 +1196,10 @@ fn unread_message(from: &str, text: &str, message_id: LegacyMessageId) -> Messag
     let mut extra = serde_json::Map::new();
     let mut metadata = serde_json::Map::new();
     let mut atm = serde_json::Map::new();
+    let atm_message_id = message_id.into_lossy_atm_message_id_approximation();
     atm.insert(
         "messageId".to_string(),
-        serde_json::Value::String(message_id.into_atm_message_id().to_string()),
+        serde_json::Value::String(atm_message_id.to_string()),
     );
     atm.insert(
         "sourceTeam".to_string(),
@@ -1226,13 +1207,18 @@ fn unread_message(from: &str, text: &str, message_id: LegacyMessageId) -> Messag
     );
     metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
     extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
+    assert_eq!(
+        LegacyMessageId::from_atm_message_id(message_atm_id_from_extra(&extra).expect("atm id")),
+        message_id,
+        "mailbox fixture metadata.atm.messageId must match legacy message_id",
+    );
 
     MessageEnvelope {
-        from: from.to_string(),
+        from: from.parse::<AgentName>().expect("agent"),
         text: text.to_string(),
         timestamp: IsoTimestamp::from_datetime(Utc::now()),
         read: false,
-        source_team: Some("atm-dev".to_string()),
+        source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
         summary: None,
         message_id: Some(message_id),
         pending_ack_at: None,
@@ -1241,4 +1227,17 @@ fn unread_message(from: &str, text: &str, message_id: LegacyMessageId) -> Messag
         task_id: None,
         extra,
     }
+}
+
+fn message_atm_id_from_extra(
+    extra: &serde_json::Map<String, serde_json::Value>,
+) -> Option<AtmMessageId> {
+    extra
+        .get("metadata")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|metadata| metadata.get("atm"))
+        .and_then(serde_json::Value::as_object)
+        .and_then(|atm| atm.get("messageId"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(|value| value.parse().ok())
 }

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -19,7 +19,7 @@ name = "atm"
 path = "src/main.rs"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.0" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.1" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -19,7 +19,7 @@ name = "atm"
 path = "src/main.rs"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.1" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -332,7 +332,7 @@ impl Fixture {
             members: members
                 .iter()
                 .map(|member| AgentMember {
-                    name: (*member).to_string(),
+                    name: (*member).parse().expect("agent"),
                     ..Default::default()
                 })
                 .collect(),

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::process::Command;
 
-use atm_core::schema::{AgentMember, AtmMessageId, LegacyMessageId, MessageEnvelope, TeamConfig};
+use atm_core::schema::{
+    AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig, hydrate_legacy_fields_from_metadata,
+};
 use atm_core::types::IsoTimestamp;
 use chrono::{Duration, Utc};
 use serde_json::Value;
@@ -493,59 +495,5 @@ impl Fixture {
             task_id: None,
             extra: serde_json::Map::new(),
         }
-    }
-}
-
-fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
-    let Some(object) = value.as_object_mut() else {
-        return;
-    };
-    let Some(atm) = object
-        .get("metadata")
-        .and_then(Value::as_object)
-        .and_then(|metadata| metadata.get("atm"))
-        .and_then(Value::as_object)
-        .cloned()
-    else {
-        return;
-    };
-
-    if !object.contains_key("message_id")
-        && let Some(raw) = atm.get("messageId").and_then(Value::as_str)
-        && let Ok(message_id) = raw.parse::<AtmMessageId>()
-    {
-        object.insert(
-            "message_id".to_string(),
-            Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-        );
-    }
-    if !object.contains_key("source_team")
-        && let Some(value) = atm.get("sourceTeam")
-    {
-        object.insert("source_team".to_string(), value.clone());
-    }
-    if !object.contains_key("pendingAckAt")
-        && let Some(value) = atm.get("pendingAckAt")
-    {
-        object.insert("pendingAckAt".to_string(), value.clone());
-    }
-    if !object.contains_key("acknowledgedAt")
-        && let Some(value) = atm.get("acknowledgedAt")
-    {
-        object.insert("acknowledgedAt".to_string(), value.clone());
-    }
-    if !object.contains_key("acknowledgesMessageId")
-        && let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str)
-        && let Ok(message_id) = raw.parse::<AtmMessageId>()
-    {
-        object.insert(
-            "acknowledgesMessageId".to_string(),
-            Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-        );
-    }
-    if !object.contains_key("taskId")
-        && let Some(value) = atm.get("taskId")
-    {
-        object.insert("taskId".to_string(), value.clone());
     }
 }

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -7,6 +7,20 @@ use chrono::{Duration, Utc};
 use serde_json::Value;
 use uuid::Uuid;
 
+fn parse_inbox_values(raw: &str) -> Vec<Value> {
+    if raw.trim().is_empty() {
+        return Vec::new();
+    }
+
+    match raw.chars().find(|ch| !ch.is_whitespace()) {
+        Some('[') => serde_json::from_str(raw).expect("json array"),
+        _ => raw
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("json line"))
+            .collect(),
+    }
+}
+
 #[test]
 fn test_ack_transitions_pending_ack_and_appends_reply() {
     let fixture = Fixture::new(&["arch-ctm", "team-lead"]);
@@ -249,12 +263,15 @@ impl Fixture {
         if let Some(parent) = inbox_path.parent() {
             fs::create_dir_all(parent).expect("inbox dir");
         }
-        let raw = messages
+        let values: Vec<Value> = messages
             .iter()
-            .map(|message| serde_json::to_string(message).expect("json line"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        fs::write(inbox_path, format!("{raw}\n")).expect("write inbox");
+            .map(|message| serde_json::to_value(message).expect("json value"))
+            .collect();
+        fs::write(
+            inbox_path,
+            serde_json::to_string_pretty(&values).expect("json array"),
+        )
+        .expect("write inbox");
     }
 
     fn inbox_path(&self, agent: &str) -> std::path::PathBuf {
@@ -265,9 +282,9 @@ impl Fixture {
 
     fn inbox_contents(&self, agent: &str) -> Vec<MessageEnvelope> {
         let raw = fs::read_to_string(self.inbox_path(agent)).expect("inbox contents");
-        raw.lines()
-            .map(|line| {
-                let mut value: Value = serde_json::from_str(line).expect("json line");
+        parse_inbox_values(&raw)
+            .into_iter()
+            .map(|mut value| {
                 hydrate_legacy_fields_from_metadata(&mut value);
                 serde_json::from_value(value).expect("message envelope")
             })
@@ -276,9 +293,7 @@ impl Fixture {
 
     fn inbox_json_lines(&self, agent: &str) -> Vec<Value> {
         let raw = fs::read_to_string(self.inbox_path(agent)).expect("inbox contents");
-        raw.lines()
-            .map(|line| serde_json::from_str(line).expect("json line"))
-            .collect()
+        parse_inbox_values(&raw)
     }
 
     fn write_origin_inbox(&self, agent: &str, origin: &str, messages: &[MessageEnvelope]) {
@@ -286,12 +301,15 @@ impl Fixture {
         if let Some(parent) = inbox_path.parent() {
             fs::create_dir_all(parent).expect("origin inbox dir");
         }
-        let raw = messages
+        let values: Vec<Value> = messages
             .iter()
-            .map(|message| serde_json::to_string(message).expect("json line"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        fs::write(inbox_path, format!("{raw}\n")).expect("write origin inbox");
+            .map(|message| serde_json::to_value(message).expect("json value"))
+            .collect();
+        fs::write(
+            inbox_path,
+            serde_json::to_string_pretty(&values).expect("json array"),
+        )
+        .expect("write origin inbox");
     }
 
     fn origin_inbox_path(&self, agent: &str, origin: &str) -> std::path::PathBuf {
@@ -303,9 +321,9 @@ impl Fixture {
     fn origin_inbox_contents(&self, agent: &str, origin: &str) -> Vec<MessageEnvelope> {
         let raw = fs::read_to_string(self.origin_inbox_path(agent, origin))
             .expect("origin inbox contents");
-        raw.lines()
-            .map(|line| {
-                let mut value: Value = serde_json::from_str(line).expect("json line");
+        parse_inbox_values(&raw)
+            .into_iter()
+            .map(|mut value| {
                 hydrate_legacy_fields_from_metadata(&mut value);
                 serde_json::from_value(value).expect("message envelope")
             })

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -331,10 +331,7 @@ impl Fixture {
         let config = TeamConfig {
             members: members
                 .iter()
-                .map(|member| AgentMember {
-                    name: (*member).parse().expect("agent"),
-                    ..Default::default()
-                })
+                .map(|member| AgentMember::with_name((*member).parse().expect("agent")))
                 .collect(),
             ..Default::default()
         };

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use atm_core::schema::{
     AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig, hydrate_legacy_fields_from_metadata,
 };
-use atm_core::types::IsoTimestamp;
+use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use chrono::{Duration, Utc};
 use serde_json::Value;
 use uuid::Uuid;
@@ -480,11 +480,11 @@ impl Fixture {
     ) -> MessageEnvelope {
         let timestamp = Utc::now() - Duration::minutes(30);
         MessageEnvelope {
-            from: from.to_string(),
+            from: from.parse::<AgentName>().expect("agent"),
             text: text.to_string(),
             timestamp: timestamp.into(),
             read,
-            source_team: Some("atm-dev".into()),
+            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
             summary: None,
             message_id: Some(LegacyMessageId::from(message_id)),
             pending_ack_at: pending_offset

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -448,7 +448,7 @@ impl Fixture {
             members: members
                 .iter()
                 .map(|member| AgentMember {
-                    name: (*member).to_string(),
+                    name: (*member).parse().expect("agent"),
                     ..Default::default()
                 })
                 .collect(),

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::process::Command;
 
 use atm_core::schema::{AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig};
-use atm_core::types::IsoTimestamp;
+use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use chrono::{Duration, Utc};
 use serde_json::Value;
 
@@ -572,11 +572,11 @@ impl Fixture {
         timestamp: chrono::DateTime<Utc>,
     ) -> MessageEnvelope {
         MessageEnvelope {
-            from: from.to_string(),
+            from: from.parse::<AgentName>().expect("agent"),
             text: text.to_string(),
             timestamp: timestamp.into(),
             read,
-            source_team: Some("atm-dev".into()),
+            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
             summary: None,
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: pending_ack_at.map(Into::into),

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -447,10 +447,7 @@ impl Fixture {
         let config = TeamConfig {
             members: members
                 .iter()
-                .map(|member| AgentMember {
-                    name: (*member).parse().expect("agent"),
-                    ..Default::default()
-                })
+                .map(|member| AgentMember::with_name((*member).parse().expect("agent")))
                 .collect(),
             ..Default::default()
         };

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -6,6 +6,20 @@ use atm_core::types::IsoTimestamp;
 use chrono::{Duration, Utc};
 use serde_json::Value;
 
+fn parse_inbox_values(raw: &str) -> Vec<Value> {
+    if raw.trim().is_empty() {
+        return Vec::new();
+    }
+
+    match raw.chars().find(|ch| !ch.is_whitespace()) {
+        Some('[') => serde_json::from_str(raw).expect("json array"),
+        _ => raw
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("json line"))
+            .collect(),
+    }
+}
+
 #[test]
 fn test_clear_default_removes_only_read_and_acknowledged() {
     let fixture = Fixture::new(&["arch-ctm"]);
@@ -452,12 +466,15 @@ impl Fixture {
         if let Some(parent) = inbox_path.parent() {
             fs::create_dir_all(parent).expect("inbox dir");
         }
-        let raw = messages
+        let values: Vec<Value> = messages
             .iter()
-            .map(|message| serde_json::to_string(message).expect("json line"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        fs::write(inbox_path, format!("{raw}\n")).expect("write inbox");
+            .map(|message| serde_json::to_value(message).expect("json value"))
+            .collect();
+        fs::write(
+            inbox_path,
+            serde_json::to_string_pretty(&values).expect("json array"),
+        )
+        .expect("write inbox");
     }
 
     fn inbox_path(&self, agent: &str) -> std::path::PathBuf {
@@ -468,8 +485,9 @@ impl Fixture {
 
     fn inbox_contents(&self, agent: &str) -> Vec<MessageEnvelope> {
         let raw = fs::read_to_string(self.inbox_path(agent)).expect("inbox contents");
-        raw.lines()
-            .map(|line| serde_json::from_str(line).expect("json line"))
+        parse_inbox_values(&raw)
+            .into_iter()
+            .map(|value| serde_json::from_value(value).expect("message envelope"))
             .collect()
     }
 
@@ -502,12 +520,15 @@ impl Fixture {
         if let Some(parent) = inbox_path.parent() {
             fs::create_dir_all(parent).expect("origin inbox dir");
         }
-        let raw = messages
+        let values: Vec<Value> = messages
             .iter()
-            .map(|message| serde_json::to_string(message).expect("json line"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        fs::write(inbox_path, format!("{raw}\n")).expect("write origin inbox");
+            .map(|message| serde_json::to_value(message).expect("json value"))
+            .collect();
+        fs::write(
+            inbox_path,
+            serde_json::to_string_pretty(&values).expect("json array"),
+        )
+        .expect("write origin inbox");
     }
 
     fn origin_inbox_path(&self, agent: &str, origin: &str) -> std::path::PathBuf {
@@ -519,8 +540,9 @@ impl Fixture {
     fn origin_inbox_contents(&self, agent: &str, origin: &str) -> Vec<MessageEnvelope> {
         let raw = fs::read_to_string(self.origin_inbox_path(agent, origin))
             .expect("origin inbox contents");
-        raw.lines()
-            .map(|line| serde_json::from_str(line).expect("json line"))
+        parse_inbox_values(&raw)
+            .into_iter()
+            .map(|value| serde_json::from_value(value).expect("message envelope"))
             .collect()
     }
 

--- a/crates/atm/tests/doctor.rs
+++ b/crates/atm/tests/doctor.rs
@@ -308,7 +308,7 @@ impl Fixture {
             members: members
                 .iter()
                 .map(|member| AgentMember {
-                    name: (*member).to_string(),
+                    name: (*member).parse().expect("agent"),
                     ..Default::default()
                 })
                 .collect(),

--- a/crates/atm/tests/doctor.rs
+++ b/crates/atm/tests/doctor.rs
@@ -307,10 +307,7 @@ impl Fixture {
         let config = TeamConfig {
             members: members
                 .iter()
-                .map(|member| AgentMember {
-                    name: (*member).parse().expect("agent"),
-                    ..Default::default()
-                })
+                .map(|member| AgentMember::with_name((*member).parse().expect("agent")))
                 .collect(),
             ..Default::default()
         };

--- a/crates/atm/tests/log.rs
+++ b/crates/atm/tests/log.rs
@@ -333,10 +333,7 @@ impl Fixture {
         let config = TeamConfig {
             members: members
                 .iter()
-                .map(|member| AgentMember {
-                    name: (*member).parse().expect("agent"),
-                    ..Default::default()
-                })
+                .map(|member| AgentMember::with_name((*member).parse().expect("agent")))
                 .collect(),
             ..Default::default()
         };

--- a/crates/atm/tests/log.rs
+++ b/crates/atm/tests/log.rs
@@ -334,7 +334,7 @@ impl Fixture {
             members: members
                 .iter()
                 .map(|member| AgentMember {
-                    name: (*member).to_string(),
+                    name: (*member).parse().expect("agent"),
                     ..Default::default()
                 })
                 .collect(),

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -9,6 +9,20 @@ use atm_core::types::IsoTimestamp;
 use chrono::{TimeZone, Utc};
 use serde_json::Value;
 
+fn parse_inbox_values(raw: &str) -> Vec<Value> {
+    if raw.trim().is_empty() {
+        return Vec::new();
+    }
+
+    match raw.chars().find(|ch| !ch.is_whitespace()) {
+        Some('[') => serde_json::from_str(raw).expect("json array"),
+        _ => raw
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("json line"))
+            .collect(),
+    }
+}
+
 #[test]
 fn test_read_own_inbox_default() {
     let fixture = Fixture::new(&["arch-ctm", "recipient"]);
@@ -879,12 +893,15 @@ impl Fixture {
         if let Some(parent) = inbox_path.parent() {
             fs::create_dir_all(parent).expect("inbox dir");
         }
-        let raw = messages
+        let values: Vec<Value> = messages
             .iter()
-            .map(|message| serde_json::to_string(message).expect("json line"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        fs::write(inbox_path, format!("{raw}\n")).expect("write inbox");
+            .map(|message| serde_json::to_value(message).expect("json value"))
+            .collect();
+        fs::write(
+            inbox_path,
+            serde_json::to_string_pretty(&values).expect("json array"),
+        )
+        .expect("write inbox");
     }
 
     fn write_raw_inbox(&self, agent: &str, raw: &str) {
@@ -908,12 +925,15 @@ impl Fixture {
         if let Some(parent) = inbox_path.parent() {
             fs::create_dir_all(parent).expect("origin inbox dir");
         }
-        let raw = messages
+        let values: Vec<Value> = messages
             .iter()
-            .map(|message| serde_json::to_string(message).expect("json line"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        fs::write(inbox_path, format!("{raw}\n")).expect("write origin inbox");
+            .map(|message| serde_json::to_value(message).expect("json value"))
+            .collect();
+        fs::write(
+            inbox_path,
+            serde_json::to_string_pretty(&values).expect("json array"),
+        )
+        .expect("write origin inbox");
     }
 
     fn read_seen_state(&self, agent: &str) -> Option<chrono::DateTime<Utc>> {
@@ -938,8 +958,9 @@ impl Fixture {
 
     fn inbox_contents(&self, agent: &str) -> Vec<MessageEnvelope> {
         let raw = fs::read_to_string(self.inbox_path(agent)).expect("inbox contents");
-        raw.lines()
-            .map(|line| serde_json::from_str(line).expect("json line"))
+        parse_inbox_values(&raw)
+            .into_iter()
+            .map(|value| serde_json::from_value(value).expect("message envelope"))
             .collect()
     }
 

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -5,7 +5,7 @@ use atm_core::schema::{
     AgentMember, AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, LegacyMessageId,
     MessageEnvelope, MessageMetadata, TeamConfig,
 };
-use atm_core::types::IsoTimestamp;
+use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use chrono::{TimeZone, Utc};
 use serde_json::Value;
 
@@ -764,6 +764,7 @@ fn test_forward_metadata_message_id_timestamp_matches_persisted_timestamp() {
             atm: Some(AtmMetadataFields {
                 message_id: Some(message_id),
                 source_team: Some("atm-dev".parse().expect("team")),
+                from_identity: None,
                 pending_ack_at: None,
                 acknowledged_at: None,
                 acknowledges_message_id: None,
@@ -1007,11 +1008,11 @@ impl Fixture {
         timestamp_offset: i64,
     ) -> MessageEnvelope {
         MessageEnvelope {
-            from: from.to_string(),
+            from: from.parse::<AgentName>().expect("agent"),
             text: text.to_string(),
             timestamp: IsoTimestamp::from_datetime(self.timestamp(timestamp_offset)),
             read,
-            source_team: Some("atm-dev".into()),
+            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
             summary: None,
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: pending_ack_offset

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -876,7 +876,7 @@ impl Fixture {
             members: members
                 .iter()
                 .map(|member| AgentMember {
-                    name: (*member).to_string(),
+                    name: (*member).parse().expect("agent"),
                     ..Default::default()
                 })
                 .collect(),

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -875,10 +875,7 @@ impl Fixture {
         let config = TeamConfig {
             members: members
                 .iter()
-                .map(|member| AgentMember {
-                    name: (*member).parse().expect("agent"),
-                    ..Default::default()
-                })
+                .map(|member| AgentMember::with_name((*member).parse().expect("agent")))
                 .collect(),
             ..Default::default()
         };

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -770,7 +770,7 @@ fn test_forward_metadata_message_id_timestamp_matches_persisted_timestamp() {
                 acknowledges_message_id: None,
                 task_id: None,
                 alert_kind: None,
-                missing_config_path: None,
+                missing_config_path: None::<std::path::PathBuf>,
                 extra: serde_json::Map::new(),
             }),
             extra: serde_json::Map::new(),

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -986,10 +986,7 @@ impl Fixture {
         let team_dir = self.tempdir.path().join(".claude").join("teams").join(team);
         fs::create_dir_all(&team_dir).expect("team dir");
         let config = TeamConfig {
-            members: vec![AgentMember {
-                name: recipient.parse().expect("agent"),
-                ..Default::default()
-            }],
+            members: vec![AgentMember::with_name(recipient.parse().expect("agent"))],
             ..Default::default()
         };
         fs::write(

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -5,6 +5,20 @@ use std::process::Command;
 use atm_core::schema::{AgentMember, AtmMessageId, LegacyMessageId, MessageEnvelope, TeamConfig};
 use serde_json::Value;
 
+fn parse_inbox_values(raw: &str) -> Vec<Value> {
+    if raw.trim().is_empty() {
+        return Vec::new();
+    }
+
+    match raw.chars().find(|ch| !ch.is_whitespace()) {
+        Some('[') => serde_json::from_str(raw).expect("json array"),
+        _ => raw
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("json line"))
+            .collect(),
+    }
+}
+
 #[test]
 fn test_send_creates_inbox_file() {
     let fixture = Fixture::new("recipient");
@@ -1015,18 +1029,11 @@ impl Fixture {
         if let Some(parent) = inbox_path.parent() {
             fs::create_dir_all(parent).expect("inbox dir");
         }
-        let raw = if messages.is_empty() {
-            String::new()
-        } else {
-            format!(
-                "{}\n",
-                messages
-                    .iter()
-                    .map(|message| serde_json::to_string(message).expect("json line"))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            )
-        };
+        let values: Vec<Value> = messages
+            .iter()
+            .map(|message| serde_json::to_value(message).expect("json value"))
+            .collect();
+        let raw = serde_json::to_string_pretty(&values).expect("json array");
         fs::write(inbox_path, raw).expect("write inbox");
     }
 
@@ -1041,12 +1048,9 @@ impl Fixture {
     fn inbox_contents_in_team(&self, team: &str, recipient: &str) -> Vec<MessageEnvelope> {
         let inbox_path = self.inbox_path_in_team(team, recipient);
         let raw = fs::read_to_string(&inbox_path).expect("inbox contents");
-        if raw.trim().is_empty() {
-            return Vec::new();
-        }
-        raw.lines()
-            .map(|line| {
-                let mut value: Value = serde_json::from_str(line).expect("json line");
+        parse_inbox_values(&raw)
+            .into_iter()
+            .map(|mut value| {
                 hydrate_legacy_fields_from_metadata(&mut value);
                 serde_json::from_value(value).expect("message envelope")
             })
@@ -1056,12 +1060,7 @@ impl Fixture {
     fn inbox_json_lines_in_team(&self, team: &str, recipient: &str) -> Vec<Value> {
         let inbox_path = self.inbox_path_in_team(team, recipient);
         let raw = fs::read_to_string(&inbox_path).expect("inbox contents");
-        if raw.trim().is_empty() {
-            return Vec::new();
-        }
-        raw.lines()
-            .map(|line| serde_json::from_str(line).expect("json line"))
-            .collect()
+        parse_inbox_values(&raw)
     }
 
     fn team_dir(&self) -> std::path::PathBuf {

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -301,7 +301,8 @@ fn test_send_missing_config_uses_existing_inbox_fallback_and_warns_sender() {
 
     let notices = fixture.inbox_contents("team-lead");
     assert_eq!(notices.len(), 1);
-    assert_eq!(notices[0].from, "atm-identity-missing@atm-dev");
+    assert_eq!(notices[0].from, "atm-identity-missing");
+    assert_eq!(notices[0].source_team.as_deref(), Some("atm-dev"));
     assert!(
         notices[0]
             .text

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -468,7 +468,7 @@ fn test_send_cross_team_projects_alias_and_persists_canonical_from_identity() {
     assert_eq!(inbox[0].from, "lead");
     assert_eq!(
         inbox[0].extra["metadata"]["atm"]["fromIdentity"],
-        "arch-ctm@atm-dev"
+        "arch-ctm"
     );
 }
 

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -987,7 +987,7 @@ impl Fixture {
         fs::create_dir_all(&team_dir).expect("team dir");
         let config = TeamConfig {
             members: vec![AgentMember {
-                name: recipient.to_string(),
+                name: recipient.parse().expect("agent"),
                 ..Default::default()
             }],
             ..Default::default()

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -2,7 +2,9 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use atm_core::schema::{AgentMember, AtmMessageId, LegacyMessageId, MessageEnvelope, TeamConfig};
+use atm_core::schema::{
+    AgentMember, MessageEnvelope, TeamConfig, hydrate_legacy_fields_from_metadata,
+};
 use serde_json::Value;
 
 fn parse_inbox_values(raw: &str) -> Vec<Value> {
@@ -1137,64 +1139,5 @@ impl Fixture {
 
     fn stderr(&self, output: &std::process::Output) -> String {
         String::from_utf8(output.stderr.clone()).expect("stderr utf8")
-    }
-}
-
-fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
-    let Some(object) = value.as_object_mut() else {
-        return;
-    };
-    let Some(atm) = object
-        .get("metadata")
-        .and_then(Value::as_object)
-        .and_then(|metadata| metadata.get("atm"))
-        .and_then(Value::as_object)
-        .cloned()
-    else {
-        return;
-    };
-
-    if !object.contains_key("message_id")
-        && let Some(raw) = atm.get("messageId").and_then(Value::as_str)
-        && let Ok(message_id) = raw.parse::<AtmMessageId>()
-    {
-        object.insert(
-            "message_id".to_string(),
-            Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-        );
-    }
-
-    if !object.contains_key("source_team")
-        && let Some(value) = atm.get("sourceTeam")
-    {
-        object.insert("source_team".to_string(), value.clone());
-    }
-
-    if !object.contains_key("pendingAckAt")
-        && let Some(value) = atm.get("pendingAckAt")
-    {
-        object.insert("pendingAckAt".to_string(), value.clone());
-    }
-
-    if !object.contains_key("acknowledgedAt")
-        && let Some(value) = atm.get("acknowledgedAt")
-    {
-        object.insert("acknowledgedAt".to_string(), value.clone());
-    }
-
-    if !object.contains_key("acknowledgesMessageId")
-        && let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str)
-        && let Ok(message_id) = raw.parse::<AtmMessageId>()
-    {
-        object.insert(
-            "acknowledgesMessageId".to_string(),
-            Value::String(LegacyMessageId::from_atm_message_id(message_id).to_string()),
-        );
-    }
-
-    if !object.contains_key("taskId")
-        && let Some(value) = atm.get("taskId")
-    {
-        object.insert("taskId".to_string(), value.clone());
     }
 }

--- a/crates/atm/tests/team_recovery.rs
+++ b/crates/atm/tests/team_recovery.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::process::Command;
 
 use atm_core::schema::MessageEnvelope;
+use atm_core::types::{AgentName, TeamName};
 use chrono::Utc;
 use serde_json::{Value, json};
 
@@ -979,11 +980,11 @@ impl Fixture {
             fs::create_dir_all(parent).expect("inbox dir");
         }
         let envelope = MessageEnvelope {
-            from: from.to_string(),
+            from: from.parse::<AgentName>().expect("agent"),
             text: text.to_string(),
             timestamp: atm_core::types::IsoTimestamp::from_datetime(Utc::now()),
             read: false,
-            source_team: Some("atm-dev".to_string()),
+            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
             summary: None,
             message_id: None,
             pending_ack_at: None,


### PR DESCRIPTION
## Summary

- Removes legacy UUID/ULID dual-path compatibility code from inbox schema
- Fixes compile error in `mailbox/store.rs` test helper (`store.rs:203`)
- Removes unused imports (`store.rs:92,97`)
- Removes duplicate `hydrate_legacy_fields_from_metadata` from `mailbox_locking.rs` in favor of production helper
- Cleans up inbox compatibility helpers in `schema/inbox_message.rs`

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo test -p agent-team-mail-core --test mailbox_locking`
- [x] `cargo test -p agent-team-mail --test send`
- [x] `cargo test -p agent-team-mail --test ack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)