### PR TITLE
fix: restore atm-nudge-xml-1.py post-send hook

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -4,7 +4,7 @@ identity = "team-lead"
 
 [[atm.post_send_hooks]]
 recipient = "arch-ctm"
-command = ["scripts/atm-nudge.py", "arch-ctm"]
+command = ["atm-nudge-xml-1.py", "arch-ctm"]
 
 [plugins.atm-agent-mcp]
 codex_bin = "codex"


### PR DESCRIPTION
## Summary

- Reverts `.atm.toml` hook command back to `atm-nudge-xml-1.py` which was working before PR #148 changed it to `scripts/atm-nudge.py`
- `atm-nudge-xml-1.py` has the validated CTA payload wording required for unattended Codex sessions

## Test plan

- [ ] `atm send arch-ctm` fires hook without permission error
- [ ] Codex pane receives correct XML nudge with `execute the assigned task` / `busy="after-current-task"` wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)