### PR TITLE
feat: formalize test isolation rules RULE-008–011 (Q.RULES-DOC-1)

### DIFF
--- a/.claude/agents/arch-qa.md
+++ b/.claude/agents/arch-qa.md
@@ -93,6 +93,77 @@ Severity: IMPORTANT
 `sysinfo::System::new_all()` is expensive and must not appear in synchronous hot
 paths such as registration handlers or similar request paths.
 
+### RULE-008: No production team literals in test code
+Severity: CRITICAL
+
+Tests must not hardcode production-like ATM team names in fixtures, subprocess
+arguments, expected output, JSON blobs, or on-disk layout setup.
+
+Required pattern:
+- use test-only constants such as `TEST_TEAM`
+- route shared subprocess setup through a helper such as
+  `crates/atm/tests/support/mod.rs`
+
+Allowed narrow exceptions:
+- tests where a specific production team name is the subject under test
+- references to environment variable names such as `ATM_TEAM`
+
+Flag repo-significant team literals such as `atm-dev` unless the test clearly
+documents why production compatibility requires the real value.
+
+### RULE-009: No production agent identity literals in test code
+Severity: CRITICAL
+
+Tests must not hardcode production-like ATM agent identities in fixtures,
+subprocess arguments, expected output, JSON blobs, or on-disk layout setup.
+
+Required pattern:
+- use test-only constants such as `TEST_SENDER`, `TEST_RECIPIENT`, and
+  `TEST_LEAD`
+
+Allowed narrow exceptions:
+- tests where a specific production identity is the subject under test
+- references to environment variable names such as `ATM_IDENTITY`
+
+Flag repo-significant identities such as `arch-ctm` unless the test clearly
+documents why compatibility requires the real value.
+
+### RULE-010: Role-significant names must be centralized constants
+Severity: CRITICAL
+
+When a test needs the semantic role represented by a reserved name such as
+`team-lead`, the raw literal must be centralized behind one named constant and
+all other test code must consume that constant.
+
+Required pattern:
+- define one constant such as `ROLE_TEAM_LEAD = "team-lead"`
+- use the constant everywhere a role-significant name is required
+
+This preserves coverage for production semantics while preventing unreviewed
+copy/paste spread of reserved names across the test tree.
+
+### RULE-011: Subprocess tests must isolate ATM env and filesystem state
+Severity: CRITICAL
+
+Tests that spawn ATM subprocesses must provision isolated ATM runtime and
+config paths under a temp directory and must pass environment overrides on the
+spawned command rather than mutating ambient process state.
+
+Required behavior:
+- provide isolated `ATM_HOME`
+- provide isolated `ATM_CONFIG_HOME`
+- provide isolated `ATM_TEAMS_DIR` when the test relies on team-directory
+  resolution
+- use per-command environment assignment rather than `std::env::set_var()`
+
+Allowed narrow exceptions:
+- tests that intentionally validate production reads of `ATM_TEAM` or
+  `ATM_IDENTITY` may set those variables explicitly, but only inside the
+  isolated subprocess harness
+
+Ambient reuse of a developer workstation ATM home, team, or identity is a
+blocking failure.
+
 ## Evaluation Process
 
 1. Read the input JSON.

--- a/.claude/agents/arch-qa.md
+++ b/.claude/agents/arch-qa.md
@@ -156,6 +156,9 @@ Required behavior:
   resolution
 - use per-command environment assignment rather than `std::env::set_var()`
 
+See also:
+- `docs/cross-platform-guidelines.md` §Test Subprocess Isolation
+
 Allowed narrow exceptions:
 - tests that intentionally validate production reads of `ATM_TEAM` or
   `ATM_IDENTITY` may set those variables explicitly, but only inside the

--- a/crates/atm/tests/support/mod.rs
+++ b/crates/atm/tests/support/mod.rs
@@ -1,0 +1,113 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+use serde_json::json;
+use tempfile::TempDir;
+
+pub const TEST_TEAM: &str = "test-team";
+pub const TEST_SENDER: &str = "test-sender";
+pub const TEST_RECIPIENT: &str = "test-recipient";
+pub const TEST_LEAD: &str = "test-lead";
+pub const ROLE_TEAM_LEAD: &str = "team-lead";
+
+#[derive(Debug)]
+pub struct TestEnv {
+    pub tempdir: TempDir,
+    pub env_map: BTreeMap<String, String>,
+    pub cwd: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct TestEnvBuilder {
+    team: String,
+    members: Vec<String>,
+    cwd_name: String,
+}
+
+impl TestEnvBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn team(mut self, team: impl Into<String>) -> Self {
+        self.team = team.into();
+        self
+    }
+
+    pub fn members<I, S>(mut self, members: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.members = members.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn cwd_name(mut self, cwd_name: impl Into<String>) -> Self {
+        self.cwd_name = cwd_name.into();
+        self
+    }
+
+    pub fn build(self) -> io::Result<TestEnv> {
+        let tempdir = tempfile::tempdir()?;
+        let atm_home = tempdir.path().join("atm-home");
+        let atm_config_home = tempdir.path().join("config-home");
+        let atm_teams_dir = atm_config_home.join(".claude").join("teams");
+        let team_dir = atm_teams_dir.join(&self.team);
+        let inboxes_dir = team_dir.join("inboxes");
+        let workflow_dir = team_dir.join(".atm-state").join("workflow");
+        let db_dir = atm_home.join("db");
+        let cwd = tempdir.path().join(&self.cwd_name);
+
+        fs::create_dir_all(&atm_home)?;
+        fs::create_dir_all(&inboxes_dir)?;
+        fs::create_dir_all(&workflow_dir)?;
+        fs::create_dir_all(&db_dir)?;
+        fs::create_dir_all(&cwd)?;
+
+        let config_path = team_dir.join("config.json");
+        let members = self
+            .members
+            .into_iter()
+            .map(|name| json!({ "name": name }))
+            .collect::<Vec<_>>();
+        fs::write(config_path, serde_json::to_vec_pretty(&json!({ "members": members }))?)?;
+
+        let env_map = BTreeMap::from([
+            (
+                "ATM_HOME".to_string(),
+                atm_home.to_string_lossy().into_owned(),
+            ),
+            (
+                "ATM_CONFIG_HOME".to_string(),
+                atm_config_home.to_string_lossy().into_owned(),
+            ),
+            (
+                "ATM_TEAMS_DIR".to_string(),
+                atm_teams_dir.to_string_lossy().into_owned(),
+            ),
+        ]);
+
+        Ok(TestEnv {
+            tempdir,
+            env_map,
+            cwd,
+        })
+    }
+}
+
+impl Default for TestEnvBuilder {
+    fn default() -> Self {
+        Self {
+            team: TEST_TEAM.to_string(),
+            members: vec![
+                TEST_SENDER.to_string(),
+                TEST_RECIPIENT.to_string(),
+                TEST_LEAD.to_string(),
+            ],
+            cwd_name: "cwd".to_string(),
+        }
+    }
+}

--- a/crates/atm/tests/support/mod.rs
+++ b/crates/atm/tests/support/mod.rs
@@ -98,6 +98,10 @@ impl TestEnvBuilder {
     }
 }
 
+/// Default fixtures use `TEST_LEAD` instead of the reserved `ROLE_TEAM_LEAD`
+/// string so generic tests do not silently depend on production role naming.
+/// Tests that must exercise `team-lead` semantics should opt in explicitly by
+/// using `ROLE_TEAM_LEAD`.
 impl Default for TestEnvBuilder {
     fn default() -> Self {
         Self {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2414,9 +2414,18 @@ Phase Q test architecture must keep:
 - core service logic testable in-process
 - transport/watch/runtime logic testable through fakes or harnesses
 - daemon process spawning out of the core test path
+- subprocess integration tests isolated from developer ATM filesystem and
+  identity state by temp-owned config/runtime roots and test-only fixture
+  identifiers
+- explicit production-compatibility exceptions for `ATM_TEAM`,
+  `ATM_IDENTITY`, and reserved role names such as `team-lead` only when those
+  values are the subject under test
 
 If a capability cannot be tested without real daemon spawning, that is treated
 as a design smell rather than the default approach.
+
+The authoritative architectural fitness rules that enforce these test-isolation
+constraints live in `.claude/agents/arch-qa.md`.
 
 ### 21.8 Lock Elimination
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2425,7 +2425,8 @@ If a capability cannot be tested without real daemon spawning, that is treated
 as a design smell rather than the default approach.
 
 The authoritative architectural fitness rules that enforce these test-isolation
-constraints live in `.claude/agents/arch-qa.md`.
+constraints live in `.claude/agents/arch-qa.md` as `RULE-008`, `RULE-009`,
+`RULE-010`, and `RULE-011`.
 
 ### 21.8 Lock Elimination
 

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -510,13 +510,23 @@ Required service rules:
 Requirement ID:
 - `REQ-CORE-TEST-001`
 
+See also:
+- [`../requirements.md`](../requirements.md) §18.1
+- [`../cross-platform-guidelines.md`](../cross-platform-guidelines.md) §Test Subprocess Isolation
+
 Required service rules:
-- ATM subprocess tests must provision temp-owned `ATM_HOME` and
+- tests use test-only fixture constants for all team, agent, and
+  role-significant names
+- ATM subprocess tests provision temp-owned `ATM_HOME` and
   `ATM_CONFIG_HOME`
-- tests that exercise team-directory discovery must also provision
-  `ATM_TEAMS_DIR`
-- shared fixture names must come from explicit test-only constants such as
-  `TEST_TEAM`, `TEST_SENDER`, `TEST_RECIPIENT`, and `TEST_LEAD`
+- tests that exercise team-directory discovery also provision `ATM_TEAMS_DIR`
+- subprocess tests pass `ATM_*` vars per-command rather than through ambient
+  process state
+- direct-call tests use explicit `team_override` / `actor_override` inputs or
+  TempDir-scoped config; `team_override: None` with an empty or unrelated
+  current directory is a violation
+- test fixtures write all required config to TempDir-owned state and do not
+  read repo `.atm.toml` or live mailbox directories
 - the raw literal `team-lead` may appear only behind a named role constant
   when the production role itself is semantically required
 - tests that validate `ATM_TEAM` or `ATM_IDENTITY` reads may set those

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -171,6 +171,11 @@ Initial crate requirement IDs:
 - `REQ-CORE-DOCTOR-002` `atm-core` owns the daemon-health query contract
   consumed by `atm doctor`. Satisfies:
   `REQ-P-DOCTOR-001`, `REQ-P-OBS-001`.
+- `REQ-CORE-TEST-001` `atm-core` owns the workspace subprocess-isolation rule
+  for ATM tests, including test-only fixture identifiers and narrow
+  production-compatibility carve-outs for env-read and role-significant cases.
+  Satisfies:
+  `REQ-P-TEST-001`.
 - `REQ-CORE-TEST-RUNTIME-001` `atm-core` owns the rule that core correctness is
   testable in process without daemon spawning. Satisfies:
   `REQ-P-TEST-001`.
@@ -499,3 +504,22 @@ Required service rules:
   before partial restore is committed
 - `members` must remain useful as a local roster inspection command even when
   daemon or hook state is unavailable
+
+## 10. Test Subprocess Isolation
+
+Requirement ID:
+- `REQ-CORE-TEST-001`
+
+Required service rules:
+- ATM subprocess tests must provision temp-owned `ATM_HOME` and
+  `ATM_CONFIG_HOME`
+- tests that exercise team-directory discovery must also provision
+  `ATM_TEAMS_DIR`
+- shared fixture names must come from explicit test-only constants such as
+  `TEST_TEAM`, `TEST_SENDER`, `TEST_RECIPIENT`, and `TEST_LEAD`
+- the raw literal `team-lead` may appear only behind a named role constant
+  when the production role itself is semantically required
+- tests that validate `ATM_TEAM` or `ATM_IDENTITY` reads may set those
+  variables explicitly, but only inside the isolated subprocess harness
+- ambient reuse of developer workstation ATM home, team, or identity state is
+  forbidden

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -121,6 +121,48 @@ grep -rn "'/tmp/" crates/ && echo "FAIL: Found /tmp hardcoding" || echo "OK"
 - Check env vars with `std::env::var()`, not by reading `/proc` or shell config files.
 - For test isolation, set env vars per-command with `cmd.env("KEY", "value")` rather than `std::env::set_var()` which is global and causes race conditions in parallel tests.
 
+## Test Subprocess Isolation
+
+Subprocess-style ATM tests must not reuse developer workstation config or
+identity state.
+
+Required pattern:
+- create one `TempDir` per test fixture
+- point `ATM_HOME` at that temp-owned runtime root
+- point `ATM_CONFIG_HOME` at that temp-owned config root
+- point `ATM_TEAMS_DIR` at a temp-owned teams directory when the test depends
+  on team discovery
+- pass environment overrides with `cmd.env(...)` on each spawned command
+
+Use explicit test-only names for team and agent fixtures:
+- `TEST_TEAM = "test-team"`
+- `TEST_SENDER = "test-sender"`
+- `TEST_RECIPIENT = "test-recipient"`
+- `TEST_LEAD = "test-lead"`
+
+Reserved production names may still matter in a few tests:
+- `ATM_TEAM` and `ATM_IDENTITY` may be set explicitly when the test is proving
+  production env-read behavior
+- `team-lead` may be used when the role itself is semantically significant,
+  but the raw literal should be centralized behind one constant such as
+  `ROLE_TEAM_LEAD`
+
+Avoid:
+- raw `atm-dev` / `arch-*` literals in generic test fixtures
+- `std::env::set_var()` in integration tests
+- reading or writing the developer's real ATM home during tests
+
+Recommended helper shape:
+
+```rust
+let env = TestEnvBuilder::new().build().expect("test env");
+let mut cmd = assert_cmd::cargo::cargo_bin_cmd!("atm");
+cmd.envs(env.env_map.iter())
+    .env("ATM_IDENTITY", TEST_SENDER)
+    .env("ATM_TEAM", TEST_TEAM)
+    .current_dir(&env.cwd);
+```
+
 ## Line Endings
 
 - Rust's `fs::read_to_string()` returns platform-native line endings.

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -41,7 +41,9 @@ fn set_home_env(cmd: &mut assert_cmd::Command, temp_dir: &TempDir) {
 
 Before declaring dev work complete, grep all integration test files:
 ```bash
+grep -rn 'ATM_HOME' crates/atm/tests/ || echo "FAIL: Missing ATM_HOME in test helpers"
 grep -rn 'ATM_CONFIG_HOME' crates/atm/tests/ || echo "FAIL: Missing ATM_CONFIG_HOME in test helpers"
+grep -rn 'ATM_TEAMS_DIR' crates/atm/tests/ || echo "FAIL: Missing ATM_TEAMS_DIR where team discovery is exercised"
 grep -rn 'env(\"HOME\"' crates/atm/tests/
 ```
 
@@ -123,6 +125,10 @@ grep -rn "'/tmp/" crates/ && echo "FAIL: Found /tmp hardcoding" || echo "OK"
 
 ## Test Subprocess Isolation
 
+See also:
+- [`requirements.md`](./requirements.md) `REQ-CORE-TEST-001`
+- [`.claude/agents/arch-qa.md`](../.claude/agents/arch-qa.md) `RULE-011`
+
 Subprocess-style ATM tests must not reuse developer workstation config or
 identity state.
 
@@ -157,6 +163,8 @@ Recommended helper shape:
 ```rust
 let env = TestEnvBuilder::new().build().expect("test env");
 let mut cmd = assert_cmd::cargo::cargo_bin_cmd!("atm");
+// TestEnvBuilder provides filesystem isolation only. Tests still set
+// ATM_IDENTITY and ATM_TEAM explicitly when the command under test needs them.
 cmd.envs(env.env_map.iter())
     .env("ATM_IDENTITY", TEST_SENDER)
     .env("ATM_TEAM", TEST_TEAM)

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2520,6 +2520,31 @@ Acceptance:
   validation expectations where both remain supported
 - the codebase is simpler to migrate after Q.0 than before Q.0
 
+### Q.RULES-DOC-1 — Test Isolation Rules Formalization [COMPLETE]
+
+Objective:
+- formalize the architectural and requirements contracts for test subprocess
+  isolation before the broader Phase Q enforcement sweep turns those findings
+  into active merge blockers
+
+Delivered in:
+- commit `7649712fc5ffc3576f4c410a01b7ed2866d2f112`
+
+Deliverables:
+- `RULE-008` through `RULE-011` defined in `.claude/agents/arch-qa.md`
+- `REQ-CORE-TEST-001` added to product and crate requirements
+- `docs/cross-platform-guidelines.md` updated with test subprocess isolation
+  guidance
+- `crates/atm/tests/support/mod.rs` added with test-only constants and a
+  `TestEnvBuilder` scaffold
+
+Acceptance:
+- test subprocess isolation rules are explicit and auditable in the rule,
+  requirement, and architecture docs
+- blocking enforcement leaves room for explicit production-compatibility tests
+  that must exercise `ATM_TEAM`, `ATM_IDENTITY`, or role-significant names
+  such as `team-lead`
+
 ### Q.1 — Store And Boundary Foundation
 
 Scope:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1764,6 +1764,8 @@ Product requirement ID:
 Satisfied by:
 - intentionally undecomposed product requirement; this governs workspace-level
   test coverage expectations rather than a single crate-local requirement ID
+- `REQ-CORE-TEST-001` for subprocess-isolation, fixture-naming, and explicit
+  production-compatibility carve-out rules
 
 Because `sc-observability` is newly introduced into ATM, the rewrite must add explicit test coverage for:
 - ATM event emission through the observability port boundary
@@ -1793,6 +1795,25 @@ The implementation must include:
 - CLI integration tests for `atm clear`
 - CLI integration tests for `atm teams`
 - CLI integration tests for `atm members`
+
+### 18.1 Subprocess Isolation
+
+- `REQ-CORE-TEST-001` ATM test subprocesses must isolate filesystem and
+  environment state and must not hardcode production-like team or agent
+  identities except in explicit production-compatibility tests.
+
+  Required behavior:
+  - subprocess-style tests provision temp-owned `ATM_HOME` and
+    `ATM_CONFIG_HOME`
+  - tests that rely on team-directory discovery also provision `ATM_TEAMS_DIR`
+  - tests use test-only fixture constants for team and agent names rather than
+    raw repo-significant production names
+  - tests that need the semantic role represented by `team-lead` centralize
+    that raw literal behind one named constant
+  - tests may set `ATM_TEAM` or `ATM_IDENTITY` when validating production
+    env-read behavior, but only inside the isolated subprocess harness
+  - ambient reuse of a developer workstation ATM home, team, or identity is
+    forbidden
 
 ## 19. Acceptance Criteria
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1802,12 +1802,20 @@ The implementation must include:
   environment state and must not hardcode production-like team or agent
   identities except in explicit production-compatibility tests.
 
+  See also:
+  - [`cross-platform-guidelines.md`](./cross-platform-guidelines.md) §Test Subprocess Isolation
+
   Required behavior:
-  - subprocess-style tests provision temp-owned `ATM_HOME` and
-    `ATM_CONFIG_HOME`
-  - tests that rely on team-directory discovery also provision `ATM_TEAMS_DIR`
-  - tests use test-only fixture constants for team and agent names rather than
-    raw repo-significant production names
+  - (a) tests use test-only fixture constants for all team, agent, and
+    role-significant names rather than raw repo-significant production names
+  - (b) subprocess tests provision isolated `ATM_HOME`, `ATM_CONFIG_HOME`, and
+    `ATM_TEAMS_DIR` as needed and pass `ATM_*` vars per-command rather than
+    through ambient process state
+  - (c) direct-call tests use explicit `team_override` / `actor_override`
+    inputs or TempDir-scoped config; `team_override: None` with an empty or
+    unrelated current directory is a violation
+  - (d) test fixtures write all required config to TempDir-owned state and do
+    not read repo `.atm.toml` or live mailbox directories
   - tests that need the semantic role represented by `team-lead` centralize
     that raw literal behind one named constant
   - tests may set `ATM_TEAM` or `ATM_IDENTITY` when validating production


### PR DESCRIPTION
## Summary

- Adds RULE-008 through RULE-011 to `.claude/agents/arch-qa.md` (blocking severity, arch fitness rules for test isolation)
- Adds `REQ-CORE-TEST-001` to `docs/requirements.md` and `docs/atm-core/requirements.md` with architecture/test-isolation cross-references
- Adds subprocess-isolation guidance to `docs/cross-platform-guidelines.md`
- Adds `crates/atm/tests/support/mod.rs` with `TEST_TEAM`, `TEST_SENDER`, `TEST_RECIPIENT`, `TEST_LEAD`, `ROLE_TEAM_LEAD` constants and `TestEnvBuilder` scaffold

## Rules added

- **RULE-008**: No production team literals in test code
- **RULE-009**: No production agent identity literals in test code
- **RULE-010**: Role-significant names must be centralized constants
- **RULE-011**: Subprocess tests must isolate ATM env and filesystem state

## Validation

`cargo fmt --check`, `cargo build --tests`, `cargo clippy --tests` all PASS at `7649712`.

## Test plan

- [ ] req-qa: REQ-CORE-TEST-001 present and complete
- [ ] arch-qa: RULE-008–011 consistent with RULE-001–007; no arch violations in support/mod.rs
- [ ] rust-qa-agent: cargo test --workspace passes; TestEnvBuilder compiles
- [ ] rust-best-practices-agent: TestEnvBuilder struct design idiomatic

🤖 Generated with [Claude Code](https://claude.com/claude-code)