### PR TITLE
build: add just task runner and lint guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,33 @@ on:
     branches: [develop, main]
 
 jobs:
+  just-lint:
+    name: Just lint (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+          components: clippy, rustfmt
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Run just lint
+        run: just lint
+
   fmt:
     name: Format check
     runs-on: ubuntu-latest

--- a/.just/check_line_counts.py
+++ b/.just/check_line_counts.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+MAX_NON_TEST_LINES = 1000
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    failures: list[tuple[str, int]] = []
+
+    for path in sorted((repo_root / "crates").rglob("*.rs")):
+        rel = path.relative_to(repo_root)
+        rel_posix = rel.as_posix()
+        if "/tests/" in rel_posix:
+            continue
+        if "/src/" not in rel_posix:
+            continue
+
+        line_count = sum(1 for _ in path.open("r", encoding="utf-8"))
+        if line_count > MAX_NON_TEST_LINES:
+            failures.append((rel_posix, line_count))
+
+    if failures:
+        print(f"RULE-003 violation: source files exceed {MAX_NON_TEST_LINES} lines.")
+        for path, line_count in failures:
+            print(f"{path}: {line_count} lines")
+        return 1
+
+    print(f"RULE-003 check passed: all source files are <= {MAX_NON_TEST_LINES} lines.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/.just/check_test_identity_literals.py
+++ b/.just/check_test_identity_literals.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+FORBIDDEN_LITERALS = ("team-lead", "arch-ctm", "atm-dev", "quality-mgr")
+
+ALLOWED_PATTERNS = (
+    re.compile(r"\b(?:pub\s+)?const\s+(?:ROLE_TEAM_LEAD|TEST_[A-Z0-9_]+)\b"),
+    re.compile(r"\b(?:ROLE_TEAM_LEAD|TEST_[A-Z0-9_]+)\b"),
+    re.compile(r"\bATM_(?:TEAM|IDENTITY)\b"),
+)
+
+
+def is_test_scope(path: Path, text: str) -> bool:
+    return "/tests/" in path.as_posix() or "#[cfg(test)]" in text or "mod tests" in text
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    crate_root = repo_root / "crates"
+    failures: list[tuple[str, int, str]] = []
+
+    for path in sorted(crate_root.rglob("*.rs")):
+        rel = path.relative_to(repo_root)
+        text = path.read_text(encoding="utf-8")
+        if not is_test_scope(rel, text):
+            continue
+
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if not any(literal in line for literal in FORBIDDEN_LITERALS):
+                continue
+            if any(pattern.search(line) for pattern in ALLOWED_PATTERNS):
+                continue
+            failures.append((rel.as_posix(), line_number, line.strip()))
+
+    if failures:
+        print("RULE-008 violation: raw production identity literals found in test/cfg(test) code.")
+        print("Use approved constants or explicit ATM_TEAM/ATM_IDENTITY env-var tests instead.")
+        for path, line_number, line in failures:
+            print(f"{path}:{line_number}: {line}")
+        print(f"total violations: {len(failures)}")
+        return 1
+
+    print("RULE-008 check passed: no disallowed raw production identity literals found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def extract_version_from_url(url: str) -> str | None:
+    match = re.search(r"/download/v(?P<version>\d+\.\d+\.\d+)/", url)
+    if match:
+        return match.group("version")
+    match = re.search(r"[_-](?P<version>\d+\.\d+\.\d+)[_/]", url)
+    if match:
+        return match.group("version")
+    return None
+
+
+def validate_workspace_version(repo_root: Path) -> str:
+    cargo_toml = tomllib.loads(read_text(repo_root / "Cargo.toml"))
+    workspace_version = cargo_toml.get("workspace", {}).get("package", {}).get("version")
+    if not workspace_version:
+        fail("workspace version missing from Cargo.toml")
+    return workspace_version
+
+
+def validate_crate_versions(repo_root: Path, workspace_version: str) -> None:
+    atm_toml_path = repo_root / "crates" / "atm" / "Cargo.toml"
+    atm_core_toml_path = repo_root / "crates" / "atm-core" / "Cargo.toml"
+    atm_text = read_text(atm_toml_path)
+    atm_core_text = read_text(atm_core_toml_path)
+
+    for path, text in ((atm_toml_path, atm_text), (atm_core_toml_path, atm_core_text)):
+        if "version.workspace = true" not in text:
+            fail(f"{path.relative_to(repo_root)} must use version.workspace = true")
+
+    dep_match = re.search(
+        r'agent-team-mail-core".*?version\s*=\s*"(?P<version>\d+\.\d+\.\d+)"',
+        atm_text,
+    )
+    if dep_match is None:
+        fail("crates/atm/Cargo.toml is missing the agent-team-mail-core path dependency version pin")
+    dep_version = dep_match.group("version")
+    if dep_version != workspace_version:
+        fail(
+            "crates/atm/Cargo.toml agent-team-mail-core dependency version "
+            f"({dep_version}) does not match workspace version ({workspace_version})"
+        )
+
+
+def validate_lockfile(repo_root: Path, workspace_version: str) -> None:
+    lock = tomllib.loads(read_text(repo_root / "Cargo.lock"))
+    packages = lock.get("package", [])
+    versions: dict[str, str] = {}
+    for package in packages:
+        name = package.get("name")
+        version = package.get("version")
+        if name in {"agent-team-mail", "agent-team-mail-core"}:
+            versions[name] = version
+
+    for package_name in ("agent-team-mail", "agent-team-mail-core"):
+        version = versions.get(package_name)
+        if version is None:
+            fail(f"{package_name} missing from Cargo.lock")
+        if version != workspace_version:
+            fail(
+                f"Cargo.lock version for {package_name} ({version}) "
+                f"does not match workspace version ({workspace_version})"
+            )
+
+
+def validate_winget_manifest(repo_root: Path, workspace_version: str) -> None:
+    manifest_path = repo_root / ".winget" / "randlee.agent-team-mail.yaml"
+    text = read_text(manifest_path)
+
+    version_match = re.search(r"^PackageVersion:\s*(?P<version>\d+\.\d+\.\d+)\s*$", text, re.MULTILINE)
+    if version_match is None:
+        fail(f"{manifest_path.relative_to(repo_root)} is missing PackageVersion")
+    package_version = version_match.group("version")
+    if package_version != workspace_version:
+        fail(
+            f"{manifest_path.relative_to(repo_root)} PackageVersion ({package_version}) "
+            f"does not match workspace version ({workspace_version})"
+        )
+
+    manifest_version_match = re.search(
+        r"^ManifestVersion:\s*(?P<version>\d+\.\d+\.\d+)\s*$",
+        text,
+        re.MULTILINE,
+    )
+    if manifest_version_match is None:
+        fail(f"{manifest_path.relative_to(repo_root)} is missing ManifestVersion")
+    manifest_version = manifest_version_match.group("version")
+    if manifest_version != workspace_version:
+        fail(
+            f"{manifest_path.relative_to(repo_root)} ManifestVersion ({manifest_version}) "
+            f"does not match workspace version ({workspace_version})"
+        )
+
+    installer_match = re.search(r"^\s*InstallerUrl:\s*(?P<url>\S+)\s*$", text, re.MULTILINE)
+    if installer_match is None:
+        fail(f"{manifest_path.relative_to(repo_root)} is missing InstallerUrl")
+    installer_url = installer_match.group("url")
+    installer_version = extract_version_from_url(installer_url)
+    if installer_version != workspace_version:
+        fail(
+            f"{manifest_path.relative_to(repo_root)} InstallerUrl version ({installer_version}) "
+            f"does not match workspace version ({workspace_version})"
+        )
+
+
+def validate_homebrew_release_wiring(repo_root: Path) -> None:
+    workflow_path = repo_root / ".github" / "workflows" / "release.yml"
+    text = read_text(workflow_path)
+
+    required_fragments = (
+        "update-homebrew:",
+        "repository: randlee/homebrew-tap",
+        "for formula in homebrew-tap/Formula/agent-team-mail.rb homebrew-tap/Formula/atm.rb; do",
+        'version=\'${{ needs.gate-and-tag.outputs.release_version }}\'',
+        'tarball_url="https://github.com/randlee/atm-core/releases/download/${tag}/atm_${version}_aarch64-apple-darwin.tar.gz"',
+        'sed -i "s|version \\"[^\\"]*\\"|version \\"${version}\\"|g" "$formula"',
+    )
+
+    for fragment in required_fragments:
+        if fragment not in text:
+            fail(
+                ".github/workflows/release.yml no longer guarantees Homebrew formulas "
+                f"are updated from the shared release version: missing {fragment!r}"
+            )
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    workspace_version = validate_workspace_version(repo_root)
+    validate_crate_versions(repo_root, workspace_version)
+    validate_lockfile(repo_root, workspace_version)
+    validate_winget_manifest(repo_root, workspace_version)
+    validate_homebrew_release_wiring(repo_root)
+    print(
+        "version sync check passed: workspace, crate pin, Cargo.lock, winget, "
+        "and Homebrew release wiring are aligned."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.just/print_help.py
+++ b/.just/print_help.py
@@ -4,19 +4,37 @@ from __future__ import annotations
 from pathlib import Path
 
 
-RECIPES = (
-    ("help", "Show this help."),
-    ("fmt", "Format the Rust workspace in place."),
-    ("fmt-check", "Check Rust formatting."),
-    ("clippy", "Run Clippy with warnings denied."),
-    ("version-check", "Verify crate, lockfile, winget, and Homebrew release wiring stay aligned."),
-    ("lint-identities", "Enforce RULE-008 for raw production identity literals in test scope."),
-    ("lint-lines", "Enforce RULE-003 source file size limits."),
-    ("lint", "Run the full repo lint suite."),
-    ("build", "Build the full workspace."),
-    ("test", "Run the full workspace test suite."),
-    ("clean", "Remove workspace build artifacts."),
-    ("ci", "Run the local CI-equivalent command set."),
+SECTIONS = (
+    (
+        "General",
+        (
+            ("help", "Show this help."),
+            ("build", "Build the full workspace."),
+            ("test", "Run the full workspace test suite."),
+            ("clean", "Remove workspace build artifacts."),
+            ("ci", "Run the local CI-equivalent command set."),
+        ),
+    ),
+    (
+        "Formatting",
+        (
+            ("fmt", "Check Rust formatting."),
+            ("fmt check", "Check Rust formatting."),
+            ("fmt write", "Format the Rust workspace in place."),
+            ("fmt apply", "Format the Rust workspace in place."),
+        ),
+    ),
+    (
+        "Lint",
+        (
+            ("lint", "Run the full repo lint suite."),
+            ("lint fmt", "Run only the format check."),
+            ("lint clippy", "Run only Clippy with warnings denied."),
+            ("lint version", "Run only the version alignment checks."),
+            ("lint identities", "Run only the RULE-008 identity literal guard."),
+            ("lint lines", "Run only the RULE-003 line-count guard."),
+        ),
+    ),
 )
 
 
@@ -27,10 +45,12 @@ def main() -> int:
     print("Usage:")
     print("  just <recipe>")
     print()
-    print("Recipes:")
-    width = max(len(name) for name, _ in RECIPES)
-    for name, description in RECIPES:
-        print(f"  {name.ljust(width)}  {description}")
+    width = max(len(name) for _, recipes in SECTIONS for name, _ in recipes)
+    for section_name, recipes in SECTIONS:
+        print(f"{section_name}:")
+        for name, description in recipes:
+            print(f"  {name.ljust(width)}  {description}")
+        print()
     return 0
 
 

--- a/.just/print_help.py
+++ b/.just/print_help.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+RECIPES = (
+    ("help", "Show this help."),
+    ("fmt", "Format the Rust workspace in place."),
+    ("fmt-check", "Check Rust formatting."),
+    ("clippy", "Run Clippy with warnings denied."),
+    ("version-check", "Verify crate, lockfile, winget, and Homebrew release wiring stay aligned."),
+    ("lint-identities", "Enforce RULE-008 for raw production identity literals in test scope."),
+    ("lint-lines", "Enforce RULE-003 source file size limits."),
+    ("lint", "Run the full repo lint suite."),
+    ("build", "Build the full workspace."),
+    ("test", "Run the full workspace test suite."),
+    ("clean", "Remove workspace build artifacts."),
+    ("ci", "Run the local CI-equivalent command set."),
+)
+
+
+def main() -> int:
+    repo_name = Path(__file__).resolve().parent.parent.name
+    print(f"{repo_name} task runner")
+    print()
+    print("Usage:")
+    print("  just <recipe>")
+    print()
+    print("Recipes:")
+    width = max(len(name) for name, _ in RECIPES)
+    for name, description in RECIPES:
+        print(f"  {name.ljust(width)}  {description}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.just/run_fmt.py
+++ b/.just/run_fmt.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+FMT_STEPS = {
+    "write": "just _fmt-write",
+    "apply": "just _fmt-write",
+    "check": "just _fmt-check",
+}
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    mode = argv[1] if len(argv) > 1 else "check"
+
+    command = FMT_STEPS.get(mode)
+    if command is None:
+        valid = ", ".join(FMT_STEPS.keys())
+        print(f"unknown fmt mode: {mode}", file=sys.stderr)
+        print(f"expected one of: {valid}", file=sys.stderr)
+        return 2
+
+    completed = subprocess.run(command, shell=True, cwd=repo_root)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+LINT_STEPS = {
+    "fmt": "just _lint-fmt",
+    "clippy": "just _lint-clippy",
+    "version": "just _lint-version",
+    "identities": "just _lint-identities",
+    "lines": "just _lint-lines",
+}
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    target = argv[1] if len(argv) > 1 else "all"
+
+    if target == "all":
+        commands = [LINT_STEPS[name] for name in ("fmt", "clippy", "version", "identities", "lines")]
+    else:
+        command = LINT_STEPS.get(target)
+        if command is None:
+            valid = ", ".join(["all", *LINT_STEPS.keys()])
+            print(f"unknown lint target: {target}", file=sys.stderr)
+            print(f"expected one of: {valid}", file=sys.stderr)
+            return 2
+        commands = [command]
+
+    for command in commands:
+        completed = subprocess.run(command, shell=True, cwd=repo_root)
+        if completed.returncode != 0:
+            return completed.returncode
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.0.0
+PackageVersion: 1.1.2
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.0.0/atm_1.0.0_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.1.2/atm_1.1.2_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.0.0
+ManifestVersion: 1.1.2

--- a/Justfile
+++ b/Justfile
@@ -9,28 +9,39 @@ default: help
 help:
     {{python_cmd}} .just/print_help.py
 
-# Format the Rust workspace in place.
-fmt:
+[private]
+_fmt-write:
     cargo fmt --all
 
-# Check Rust formatting.
-fmt-check:
+[private]
+_fmt-check:
     cargo fmt --all --check
 
-# Run Clippy with warnings denied.
-clippy:
+# Format the Rust workspace or run the formatting gate.
+fmt mode='check':
+    {{python_cmd}} .just/run_fmt.py {{mode}}
+
+[private]
+_lint-fmt:
+    @just fmt check
+
+[private]
+_lint-clippy:
     cargo clippy --workspace --all-targets -- -D warnings
 
 # Verify crate/release versions stay aligned.
-version-check:
+[private]
+_lint-version:
     {{python_cmd}} .just/check_version_sync.py
 
 # Enforce RULE-008 for test and cfg(test) code.
-lint-identities:
+[private]
+_lint-identities:
     {{python_cmd}} .just/check_test_identity_literals.py
 
 # Enforce RULE-003 source file size limits.
-lint-lines:
+[private]
+_lint-lines:
     {{python_cmd}} .just/check_line_counts.py
 
 # Build the full workspace.
@@ -46,7 +57,8 @@ clean:
     cargo clean
 
 # Run the repo lint suite.
-lint: fmt-check clippy version-check lint-identities lint-lines
+lint target='all':
+    {{python_cmd}} .just/run_lint.py {{target}}
 
 # Run the local CI-equivalent command set.
 ci: lint test

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,52 @@
+set windows-shell := ["pwsh", "-NoLogo", "-Command"]
+
+python_cmd := if os_family() == "windows" { "python" } else { "python3" }
+
+# Show the curated repo task help.
+default: help
+
+# Show the curated repo task help.
+help:
+    {{python_cmd}} .just/print_help.py
+
+# Format the Rust workspace in place.
+fmt:
+    cargo fmt --all
+
+# Check Rust formatting.
+fmt-check:
+    cargo fmt --all --check
+
+# Run Clippy with warnings denied.
+clippy:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Verify crate/release versions stay aligned.
+version-check:
+    {{python_cmd}} .just/check_version_sync.py
+
+# Enforce RULE-008 for test and cfg(test) code.
+lint-identities:
+    {{python_cmd}} .just/check_test_identity_literals.py
+
+# Enforce RULE-003 source file size limits.
+lint-lines:
+    {{python_cmd}} .just/check_line_counts.py
+
+# Build the full workspace.
+build:
+    cargo build --workspace
+
+# Run the full workspace test suite.
+test:
+    cargo test --workspace
+
+# Remove workspace build artifacts.
+clean:
+    cargo clean
+
+# Run the repo lint suite.
+lint: fmt-check clippy version-check lint-identities lint-lines
+
+# Run the local CI-equivalent command set.
+ci: lint test


### PR DESCRIPTION
## Summary

- Adds `just` task runner with `Justfile` and `.just/` helper scripts
- `just lint` runs fmt-check, clippy, RULE-008 identity literal guard, RULE-003 source file size guard
- `just lint [fmt|clippy|identities|lines|version]` for individual checks
- `just fmt` defaults to check mode; `just fmt write` for mutation
- CI job `just-lint` runs on ubuntu/macos/windows via `taiki-e/install-action@just`
- Scope: RULE-003 enforces ≤1000 lines for all `/src/*.rs` files; RULE-008 flags raw production identity literals in test/cfg(test) code

## Test plan
- [ ] `just lint` exits 0 on clean workspace
- [ ] `just lint identities` catches raw production literals in test code
- [ ] `just lint lines` catches source files > 1000 lines
- [ ] CI job runs on all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)