### PR TITLE
docs: Phase R boundary inventories and planning baseline

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -639,7 +639,14 @@ Supersession note:
 
 Public entrypoint:
 
-`send::send_mail(request: SendRequest, observability: &dyn ObservabilityPort) -> Result<SendOutcome, AtmError>`
+`send::send_mail_via_store(request: SendRequest, store: &dyn SendStore, ingress: &dyn InboxIngress, exporter: &dyn InboxExport, observability: &dyn ObservabilityPort) -> Result<SendOutcome, AtmError>`
+
+Phase Q note:
+- Q.2 replaced the earlier `send_mail(request, observability)` entrypoint with
+  `send_mail_via_store(...)`
+- the store, ingress, and exporter parameters make the SQLite-first write,
+  ingest-before-export, and projection/export boundaries explicit at the public
+  service seam
 
 `SendRequest` contains:
 - home directory
@@ -667,7 +674,8 @@ Public entrypoint:
 | `agent` | `String` | Resolved target recipient. |
 | `sender` | `String` | Resolved sender identity. |
 | `outcome` | `&'static str` | Delivery result such as `sent` or `dry_run`. |
-| `message_id` | `Uuid` | ATM-authored UUID v4 for the send operation. |
+| `message_id` | `LegacyMessageId` | ATM-authored legacy UUID bridge identity for the send operation. |
+| `atm_message_id` | `AtmMessageId` | Canonical ATM ULID carried in SQLite and `metadata.atm.messageId`. |
 | `requires_ack` | `bool` | Whether the message requires acknowledgement. |
 | `task_id` | `Option<String>` | Optional task identifier persisted on the message. |
 | `summary` | `Option<String>` | Generated or caller-supplied summary text. |
@@ -685,14 +693,21 @@ Normal send JSON output includes:
 - `agent`
 - `outcome`
 - `message_id`
+- `atm_message_id`
 - `requires_ack`
 - `task_id`
 - `warnings` when send completed in a degraded but permitted mode
+
+For the ATM-authored inbox wire shape, the top-level legacy `message_id` is
+omitted; that legacy field appears only in compatibility-mode sends. The
+canonical send identity is `atm_message_id`, with the legacy UUID bridge
+retained only where older consumers still require it.
 
 Dry-run send JSON output includes:
 - `action = "send"`
 - `agent`
 - `team`
+- `atm_message_id`
 - `message`
 - `dry_run = true`
 - `requires_ack`
@@ -822,7 +837,7 @@ The CLI JSON output mirrors the current contract:
 
 Public entrypoint:
 
-`ack::ack_mail(request: AckRequest, observability: &dyn ObservabilityPort) -> Result<AckOutcome, AtmError>`
+`ack::ack_mail<S>(request: AckRequest, store: &S, observability: &dyn ObservabilityPort) -> Result<AckOutcome, AtmError> where S: AckStore`
 
 `AckRequest` contains:
 - home directory
@@ -840,6 +855,9 @@ Public entrypoint:
 - optional task id from the acknowledged message
 - reply target
 - reply message id
+  `AckOutcome.reply_message_id` remains `LegacyMessageId` for CLI/output
+  compatibility even though SQLite and `metadata.atm.messageId` carry the
+  canonical `AtmMessageId`
 - reply text
 - warnings: Vec<String>
 - Phase Q addition: `warnings` carries best-effort post-send-hook diagnostics
@@ -847,7 +865,9 @@ Public entrypoint:
 
 The ack service is responsible for the legal transition from `(Read, PendingAck)` to `(Read, Acknowledged)` plus the reply append.
 
-When the source message came from an origin inbox file in the merged surface, the acknowledgement writeback must update that source file atomically rather than projecting the change onto a different inbox file.
+Phase Q supersedes the legacy source-file writeback rule: SQLite is the
+authoritative durable store for ack state, while inbox/file-surface projection
+is deferred to the Q.4 export/runtime path.
 
 ### 6.4 Clear Service
 
@@ -964,7 +984,9 @@ Roster output rules:
 - show extra runtime members after the baseline set
 - snapshot `~/.claude/teams/*/inboxes/*.lock` at doctor start and end; any lock
   path present in both snapshots is stale and should surface as
-  `ATM_WARNING_STALE_MAILBOX_LOCK` with `rm -f <path>` recovery guidance
+  `ATM_WARNING_STALE_MAILBOX_LOCK` with recovery guidance that explicitly marks
+  the lock as a transitional compatibility diagnostic rather than a Phase Q
+  mail-correctness dependency
 
 ### 6.8 Team Recovery Services
 
@@ -984,19 +1006,21 @@ Architectural rules:
   ATM home directory
 - `add-member` is the retained local roster-repair path and must reject
   duplicates before mutating config
-- `backup` snapshots current team config, inboxes, and the ATM team task
-  bucket into a timestamped snapshot directory
+- `backup` snapshots current team config, the ATM-owned `.atm-state` tree
+  (including SQLite durable state and workflow compatibility state), inboxes,
+  and the ATM team task bucket into a timestamped snapshot directory
 - inbox backup excludes transient mailbox `*.lock` sentinels, dotfiles, and
   restore markers
 - `restore` is a local recovery path and must:
   - preserve the current team-lead entry and `leadSessionId`
   - restore only missing non-lead members
   - clear runtime-only restored-member state before persistence
+  - restore the ATM-owned `.atm-state` tree from the chosen snapshot when
+    present
   - restore non-lead inboxes from the chosen snapshot
-  - sweep stale mailbox `*.lock` sentinels before restored inbox files are copied in
-  - treat stale-sentinel sweep as result-bearing: if that cleanup hits a
-    read-only-filesystem failure, restore must stop and surface
-    `MailboxLockReadOnlyFilesystem` instead of warning and continuing
+  - treat stale mailbox `*.lock` sentinels as compatibility-only diagnostics;
+    restore must not require sweeping them in order to restore durable ATM
+    state or inbox compatibility files
   - recompute `.highwatermark` from the maximum restored task id
   - support a dry-run path without making changes
 - Claude Code project task-list restoration remains separate from the retained
@@ -1295,6 +1319,7 @@ Required families:
 - identity
 - team not found
 - agent not found
+- store
 - mailbox read
 - mailbox write
 - file policy
@@ -2124,6 +2149,8 @@ Auto-start path:
 - if the daemon is absent, the CLI/runtime path may perform exactly one
   auto-start attempt
 - after one auto-start attempt, the CLI/runtime path retries connect once
+- daemon startup waits at most `10s` for control-state publication
+  (`AUTO_START_PUBLISH_TIMEOUT`)
 - if the daemon remains unavailable, the command fails with a typed actionable
   error
 - there is no silent fallback from the production path to direct SQLite or
@@ -2385,11 +2412,13 @@ The daemon runtime must use one documented operational contract.
 Required architectural defaults:
 - graceful shutdown drain deadline: `5s`
 - force-cancel deadline: `10s` total
+- daemon auto-start publish deadline: `10s`
+  (`AUTO_START_PUBLISH_TIMEOUT`)
 - same-host daemon request deadline: `3s`
 - per-leg TCP/TLS connect deadline: `5s`
 - per-leg TCP/TLS read/write deadline: `5s`
 - total remote retry budget: `30s`
-- SQLite `busy_timeout`: `1500ms`
+- SQLite `busy_timeout`: `5000ms`
 - ingest batch processing slice: `2s`
 - doctor health query deadline: `3s`
 
@@ -2414,19 +2443,9 @@ Phase Q test architecture must keep:
 - core service logic testable in-process
 - transport/watch/runtime logic testable through fakes or harnesses
 - daemon process spawning out of the core test path
-- subprocess integration tests isolated from developer ATM filesystem and
-  identity state by temp-owned config/runtime roots and test-only fixture
-  identifiers
-- explicit production-compatibility exceptions for `ATM_TEAM`,
-  `ATM_IDENTITY`, and reserved role names such as `team-lead` only when those
-  values are the subject under test
 
 If a capability cannot be tested without real daemon spawning, that is treated
 as a design smell rather than the default approach.
-
-The authoritative architectural fitness rules that enforce these test-isolation
-constraints live in `.claude/agents/arch-qa.md` as `RULE-008`, `RULE-009`,
-`RULE-010`, and `RULE-011`.
 
 ### 21.8 Lock Elimination
 

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -1,0 +1,898 @@
+# ATM-Core Boundary Inventory
+
+This document is the initial Phase R boundary inventory for `atm-core`.
+
+Contract-owner records intentionally use:
+- `implementation.type: null`
+- `implementation.module: null`
+- `implementation.visibility: trait_only`
+- `implementation.constructor: none`
+
+That means `atm-core` owns the public contract and semantics, but not a default
+concrete adapter in this crate.
+
+## AtmProtocol
+
+```yaml
+boundary_id: BOUNDARY-AtmProtocol
+owner_package: atm-core
+owner_crate_path: atm_core
+name: AtmProtocol
+
+public:
+  trait: null
+  facade: AtmProtocol
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - protocol_request_types
+    - protocol_response_types
+    - frame_payload_contract
+  io_forbidden:
+    - socket_io
+    - sqlite
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm
+    - atm-daemon
+    - atm-graft
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: global
+  forbidden:
+    - daemon_api
+    - DaemonRequestEnvelope
+    - DaemonResponseEnvelope
+
+contracts:
+  request_types:
+    - SendRequest
+    - ReceiveRequest
+  response_types:
+    - SendResponse
+    - ReceiveResponse
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths: []
+  forbidden_test_bypasses: []
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-ATM-PROTOCOL-NAMING
+  review_gates:
+    - no_daemon_shaped_protocol_types
+
+status:
+  state: planned
+  notes:
+    - ack is represented inside send-shape request data, not as a top-level protocol family
+```
+
+Purpose:
+- Owns the shared ATM request/response contract used by local CLI, daemon, and
+  thin extension clients.
+
+Notes:
+- This is the first boundary updated explicitly for `atm-graft`.
+
+## ClientTransport
+
+```yaml
+boundary_id: BOUNDARY-ClientTransport
+owner_package: atm-core
+owner_crate_path: atm_core
+name: ClientTransport
+
+public:
+  trait: ClientTransport
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - outbound_protocol_requests
+    - request_deadlines
+    - response_decoding
+  io_forbidden:
+    - sqlite
+    - inbox_jsonl
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm
+    - atm-graft
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - atm_daemon::client
+
+contracts:
+  request_types:
+    - AtmProtocol requests
+  response_types:
+    - AtmProtocol responses
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InProcessClientTransport
+  forbidden_test_bypasses:
+    - atm_daemon::client
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-CLIENT-TRANSPORT-REFERENCES
+  review_gates:
+    - no_cli_to_daemon_internal_edge
+
+status:
+  state: planned
+  notes:
+    - designed for thin callers such as atm-graft
+```
+
+Purpose:
+- Owns the outbound ATM request path from thin clients into a server/runtime.
+
+Notes:
+- The public workflow surface above this boundary should stay centered on send
+  and receive.
+
+## ServerTransport
+
+```yaml
+boundary_id: BOUNDARY-ServerTransport
+owner_package: atm-core
+owner_crate_path: atm_core
+name: ServerTransport
+
+public:
+  trait: ServerTransport
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - listener_accept_loop
+    - framed_request_receive
+    - framed_response_send
+  io_forbidden:
+    - sqlite
+    - inbox_jsonl
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - rusqlite::Connection
+
+contracts:
+  request_types:
+    - AtmProtocol requests
+  response_types:
+    - AtmProtocol responses
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InProcessServerTransport
+  forbidden_test_bypasses: []
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-SERVER-TRANSPORT-REFERENCES
+  review_gates:
+    - no_server_business_logic
+
+status:
+  state: planned
+  notes:
+    - server transports stay runtime-only and are not exposed to thin client crates
+```
+
+Purpose:
+- Owns inbound ATM request serving and response framing for runtime hosts.
+
+Notes:
+- Listener/runtime code should remain thin and dispatch through RequestDispatcher.
+
+## RequestDispatcher
+
+```yaml
+boundary_id: BOUNDARY-RequestDispatcher
+owner_package: atm-core
+owner_crate_path: atm_core
+name: RequestDispatcher
+
+public:
+  trait: RequestDispatcher
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - protocol_request_routing
+  io_forbidden:
+    - socket_io
+    - sqlite
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - tokio::net::TcpListener
+    - tokio::net::UnixListener
+
+contracts:
+  request_types:
+    - AtmProtocol requests
+  response_types:
+    - AtmProtocol responses
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubRequestDispatcher
+  forbidden_test_bypasses: []
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-DISPATCHER-REFERENCES
+  review_gates:
+    - no_socket_specific_dispatch_logic
+
+status:
+  state: planned
+  notes:
+    - dispatcher is a service boundary, not a socket adapter
+```
+
+Purpose:
+- Owns routing of typed protocol requests to the correct service handlers.
+
+Notes:
+- Transport-specific listeners should not embed request-family logic.
+
+## MailStore
+
+```yaml
+boundary_id: BOUNDARY-MailStore
+owner_package: atm-core
+owner_crate_path: atm_core
+name: MailStore
+
+public:
+  trait: MailStore
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - message_lifecycle_state
+    - mailbox_projection_state
+  io_forbidden:
+    - socket_io
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm-rusqlite
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - SqliteMailStore
+    - RusqliteStore
+    - rusqlite::Connection
+
+contracts:
+  request_types:
+    - MailStore method inputs
+  response_types:
+    - atm-core mailbox DTOs
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InMemoryMailStore
+  forbidden_test_bypasses:
+    - rusqlite::Connection
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-MAILSTORE-REFERENCES
+  review_gates:
+    - no_concrete_store_leakage
+
+status:
+  state: planned
+  notes:
+    - mail state remains distinct from task and roster state
+```
+
+Purpose:
+- Owns durable message lifecycle and mailbox-facing state.
+
+Notes:
+- This stays the canonical durable truth behind send and receive workflows.
+
+## TaskStore
+
+```yaml
+boundary_id: BOUNDARY-TaskStore
+owner_package: atm-core
+owner_crate_path: atm_core
+name: TaskStore
+
+public:
+  trait: TaskStore
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - task_state
+    - task_message_linkage
+  io_forbidden:
+    - socket_io
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm-rusqlite
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - SqliteTaskStore
+    - rusqlite::Connection
+
+contracts:
+  request_types:
+    - TaskStore method inputs
+  response_types:
+    - atm-core task DTOs
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InMemoryTaskStore
+  forbidden_test_bypasses:
+    - rusqlite::Connection
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-TASKSTORE-REFERENCES
+  review_gates:
+    - no_concrete_store_leakage
+
+status:
+  state: planned
+  notes:
+    - ack-specific state changes belong here even when ack is modeled through send
+```
+
+Purpose:
+- Owns durable task-domain state and task/message linkage.
+
+Notes:
+- `ack` is not a top-level public method, but it still mutates task state.
+
+## RosterStore
+
+```yaml
+boundary_id: BOUNDARY-RosterStore
+owner_package: atm-core
+owner_crate_path: atm_core
+name: RosterStore
+
+public:
+  trait: RosterStore
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - durable_roster_state
+    - member_routing_metadata
+  io_forbidden:
+    - socket_io
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm-rusqlite
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - SqliteRosterStore
+    - rusqlite::Connection
+
+contracts:
+  request_types:
+    - RosterStore method inputs
+  response_types:
+    - atm-core roster DTOs
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InMemoryRosterStore
+  forbidden_test_bypasses:
+    - rusqlite::Connection
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-ROSTERSTORE-REFERENCES
+  review_gates:
+    - no_concrete_store_leakage
+
+status:
+  state: planned
+  notes:
+    - live status belongs elsewhere; this boundary owns durable roster truth only
+```
+
+Purpose:
+- Owns durable roster state and routing-relevant member metadata.
+
+Notes:
+- Runtime status remains outside durable roster ownership.
+
+## ConfigIngress
+
+```yaml
+boundary_id: BOUNDARY-ConfigIngress
+owner_package: atm-core
+owner_crate_path: atm_core
+name: ConfigIngress
+
+public:
+  trait: ConfigIngress
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - persisted_config_loading
+    - config_document_validation
+  io_forbidden:
+    - sqlite
+    - socket_io
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - load_team_config
+    - std::fs::read_to_string
+
+contracts:
+  request_types:
+    - config load requests
+  response_types:
+    - typed ATM config models
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubConfigIngress
+  forbidden_test_bypasses:
+    - std::fs::read_to_string
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-CONFIG-INGRESS-REFERENCES
+  review_gates:
+    - no_direct_config_parser_calls
+
+status:
+  state: planned
+  notes:
+    - this boundary replaces direct command/service calls into a concrete parser module
+```
+
+Purpose:
+- Owns loading and validating persisted ATM/team configuration into typed models.
+
+Notes:
+- This is one of the main explicit corrections to the Phase Q leakage.
+
+## InboxIngress
+
+```yaml
+boundary_id: BOUNDARY-InboxIngress
+owner_package: atm-core
+owner_crate_path: atm_core
+name: InboxIngress
+
+public:
+  trait: InboxIngress
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - inbound_mailbox_import
+    - compatibility_surface_translation
+  io_forbidden:
+    - sqlite
+    - socket_io
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - mailbox::store::observe_source_files
+
+contracts:
+  request_types:
+    - ingress scan requests
+  response_types:
+    - typed ingress result models
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubInboxIngress
+  forbidden_test_bypasses:
+    - mailbox::store::observe_source_files
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-INBOX-INGRESS-REFERENCES
+  review_gates:
+    - no_direct_mailbox_helper_calls
+
+status:
+  state: planned
+  notes:
+    - watcher-driven reconcile should call this boundary rather than store helpers directly
+```
+
+Purpose:
+- Owns import from compatibility/shared inbox surfaces into ATM-owned state.
+
+Notes:
+- The import path stays separate from durable store ownership.
+
+## InboxExport
+
+```yaml
+boundary_id: BOUNDARY-InboxExport
+owner_package: atm-core
+owner_crate_path: atm_core
+name: InboxExport
+
+public:
+  trait: InboxExport
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - outbound_mailbox_projection
+    - compatibility_surface_translation
+  io_forbidden:
+    - sqlite
+    - socket_io
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - mailbox::store::with_locked_source_files
+    - mailbox::store::commit_source_files
+
+contracts:
+  request_types:
+    - export write requests
+  response_types:
+    - typed export result models
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubInboxExport
+  forbidden_test_bypasses:
+    - mailbox::store::with_locked_source_files
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-INBOX-EXPORT-REFERENCES
+  review_gates:
+    - no_direct_mailbox_helper_calls
+
+status:
+  state: planned
+  notes:
+    - send and receive state transitions should reach compatibility files through this boundary only
+```
+
+Purpose:
+- Owns projection of ATM-owned state back to compatibility/shared inbox surfaces.
+
+Notes:
+- This is the write-facing sibling of InboxIngress, not a general store boundary.
+
+## NotificationSink
+
+```yaml
+boundary_id: BOUNDARY-NotificationSink
+owner_package: atm-core
+owner_crate_path: atm_core
+name: NotificationSink
+
+public:
+  trait: NotificationSink
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - outbound_notification_delivery
+  io_forbidden:
+    - sqlite
+    - socket_io
+
+dependencies:
+  allowed_dependents:
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - std::process::Command
+    - maybe_run_post_send_hook
+
+contracts:
+  request_types:
+    - notification payload requests
+  response_types:
+    - notification delivery results
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubNotificationSink
+  forbidden_test_bypasses:
+    - std::process::Command
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-NOTIFICATION-SINK-REFERENCES
+  review_gates:
+    - no_direct_process_spawn
+
+status:
+  state: planned
+  notes:
+    - a thin extension crate should never need to reach into process-spawn internals
+```
+
+Purpose:
+- Owns outward delivery of notifications, hooks, or plugin-facing events.
+
+Notes:
+- This replaces direct `Command::new` use in business-flow code.
+
+## StatusSource
+
+```yaml
+boundary_id: BOUNDARY-StatusSource
+owner_package: atm-core
+owner_crate_path: atm_core
+name: StatusSource
+
+public:
+  trait: StatusSource
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - inbound_runtime_status_updates
+  io_forbidden:
+    - sqlite
+    - socket_io
+
+dependencies:
+  allowed_dependents:
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden: []
+
+contracts:
+  request_types:
+    - status update notifications
+  response_types:
+    - status snapshots
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubStatusSource
+  forbidden_test_bypasses: []
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-STATUS-SOURCE-REFERENCES
+  review_gates:
+    - no_status_leakage_into_roster_store
+
+status:
+  state: planned
+  notes:
+    - live status remains separate from durable roster truth
+```
+
+Purpose:
+- Owns inbound runtime status/activity updates before they become ATM-visible state.
+
+Notes:
+- This stays distinct from `RosterStore` to avoid durable/live-state collapse.

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -171,11 +171,6 @@ Initial crate requirement IDs:
 - `REQ-CORE-DOCTOR-002` `atm-core` owns the daemon-health query contract
   consumed by `atm doctor`. Satisfies:
   `REQ-P-DOCTOR-001`, `REQ-P-OBS-001`.
-- `REQ-CORE-TEST-001` `atm-core` owns the workspace subprocess-isolation rule
-  for ATM tests, including test-only fixture identifiers and narrow
-  production-compatibility carve-outs for env-read and role-significant cases.
-  Satisfies:
-  `REQ-P-TEST-001`.
 - `REQ-CORE-TEST-RUNTIME-001` `atm-core` owns the rule that core correctness is
   testable in process without daemon spawning. Satisfies:
   `REQ-P-TEST-001`.
@@ -504,32 +499,3 @@ Required service rules:
   before partial restore is committed
 - `members` must remain useful as a local roster inspection command even when
   daemon or hook state is unavailable
-
-## 10. Test Subprocess Isolation
-
-Requirement ID:
-- `REQ-CORE-TEST-001`
-
-See also:
-- [`../requirements.md`](../requirements.md) §18.1
-- [`../cross-platform-guidelines.md`](../cross-platform-guidelines.md) §Test Subprocess Isolation
-
-Required service rules:
-- tests use test-only fixture constants for all team, agent, and
-  role-significant names
-- ATM subprocess tests provision temp-owned `ATM_HOME` and
-  `ATM_CONFIG_HOME`
-- tests that exercise team-directory discovery also provision `ATM_TEAMS_DIR`
-- subprocess tests pass `ATM_*` vars per-command rather than through ambient
-  process state
-- direct-call tests use explicit `team_override` / `actor_override` inputs or
-  TempDir-scoped config; `team_override: None` with an empty or unrelated
-  current directory is a violation
-- test fixtures write all required config to TempDir-owned state and do not
-  read repo `.atm.toml` or live mailbox directories
-- the raw literal `team-lead` may appear only behind a named role constant
-  when the production role itself is semantically required
-- tests that validate `ATM_TEAM` or `ATM_IDENTITY` reads may set those
-  variables explicitly, but only inside the isolated subprocess harness
-- ambient reuse of developer workstation ATM home, team, or identity state is
-  forbidden

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -1,0 +1,158 @@
+# ATM-Daemon Boundary Inventory
+
+This document captures runtime-owned concrete adapters for Phase R.
+
+## SocketServerTransportAdapter
+
+```yaml
+boundary_id: BOUNDARY-ServerTransport-Socket
+owner_package: atm-daemon
+owner_crate_path: atm_daemon
+name: SocketServerTransportAdapter
+
+public:
+  trait: ServerTransport
+  facade: null
+
+implementation:
+  type: LocalSocketServerTransport
+  module: atm_daemon::transport::local_socket
+  visibility: private
+  constructor: private
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - listener_accept_loop
+    - framed_request_receive
+    - framed_response_send
+  io_forbidden:
+    - sqlite
+    - process_spawn
+
+dependencies:
+  allowed_dependents: []
+  allowed_dependencies:
+    - atm-core
+    - tokio
+  forbidden_edges:
+    - atm -> atm-daemon
+    - atm-graft -> atm-daemon
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - LocalSocketServerTransport
+    - tokio::net::UnixListener
+
+contracts:
+  request_types:
+    - AtmProtocol requests
+  response_types:
+    - AtmProtocol responses
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InProcessServerTransport
+  forbidden_test_bypasses:
+    - tokio::net::UnixListener
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-SERVER-TRANSPORT-SOCKET-EDGES
+    - LINT-BOUNDARY-SERVER-TRANSPORT-SOCKET-REFERENCES
+  review_gates:
+    - no_public_impl
+    - no_public_constructor
+    - no_cli_to_daemon_edge
+
+status:
+  state: planned
+  notes:
+    - thin clients must stop at ClientTransport and AtmProtocol
+```
+
+Purpose:
+- Owns the runtime listener implementation for the ServerTransport contract.
+
+Notes:
+- Runtime composition stays in daemon-owned code, but business logic does not.
+
+## DaemonRequestDispatcherAdapter
+
+```yaml
+boundary_id: BOUNDARY-RequestDispatcher-Daemon
+owner_package: atm-daemon
+owner_crate_path: atm_daemon
+name: DaemonRequestDispatcherAdapter
+
+public:
+  trait: RequestDispatcher
+  facade: null
+
+implementation:
+  type: DaemonRequestDispatcher
+  module: atm_daemon::dispatcher
+  visibility: private
+  constructor: private
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - runtime_request_routing
+  io_forbidden:
+    - sqlite
+    - process_spawn
+
+dependencies:
+  allowed_dependents: []
+  allowed_dependencies:
+    - atm-core
+  forbidden_edges:
+    - atm -> atm-daemon
+    - atm-graft -> atm-daemon
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - DaemonRequestDispatcher
+
+contracts:
+  request_types:
+    - AtmProtocol requests
+  response_types:
+    - AtmProtocol responses
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubRequestDispatcher
+  forbidden_test_bypasses: []
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-REQUEST-DISPATCHER-DAEMON-EDGES
+    - LINT-BOUNDARY-REQUEST-DISPATCHER-DAEMON-REFERENCES
+  review_gates:
+    - no_public_impl
+    - no_public_constructor
+    - no_socket_specific_business_logic
+
+status:
+  state: planned
+  notes:
+    - dispatcher remains thin and runtime-owned
+```
+
+Purpose:
+- Owns the runtime dispatcher implementation that routes protocol requests into core services.
+
+Notes:
+- This adapter exists to keep transport loops and service logic separate.

--- a/docs/atm-error-codes.md
+++ b/docs/atm-error-codes.md
@@ -168,7 +168,22 @@ Error codes should describe the failure class, not a specific prose message.
   - must not be downgraded to a warning because the old key is ambiguous under
     the redesigned contract
 
-#### 5.8.2 `ATM_WARNING_HOOK_SKIPPED`
+#### 5.8.2 `ATM_CONFIG_RETIRED_LEGACY_HOOK_KEYS`
+
+- code: `ATM_CONFIG_RETIRED_LEGACY_HOOK_KEYS`
+- description: `.atm.toml` still uses the retired flat legacy post-send-hook
+  filter keys
+- HTTP status: `400 Bad Request`
+- context:
+  - emitted during ATM config loading before send execution proceeds
+  - requires migration guidance that explains the recipient-scoped
+    `[[atm.post_send_hooks]]` rule shape
+  - flat legacy keys are ambiguous because they attempted to split sender and
+    recipient filtering outside the new one-rule-per-recipient contract
+  - must not be downgraded to a warning because the config cannot be safely
+    interpreted under the current hook model
+
+#### 5.8.3 `ATM_WARNING_HOOK_SKIPPED`
 
 - code: `ATM_WARNING_HOOK_SKIPPED`
 - description: retired for the hook filter non-match path; retained only as a
@@ -184,7 +199,7 @@ Error codes should describe the failure class, not a specific prose message.
   - actual caller-visible hook warnings now live only under
     `ATM_WARNING_HOOK_EXECUTION_FAILED`
 
-#### 5.8.3 `ATM_WARNING_HOOK_EXECUTION_FAILED`
+#### 5.8.4 `ATM_WARNING_HOOK_EXECUTION_FAILED`
 
 - code: `ATM_WARNING_HOOK_EXECUTION_FAILED`
 - description: a configured post-send hook failed to start, exited non-zero,
@@ -221,19 +236,28 @@ Error codes should describe the failure class, not a specific prose message.
     - message:
       ```text
       error: mailbox lock {operation} failed for {lock_path}: filesystem is read-only.
+      ```
+    - recovery:
+      ```text
+      Remount or move the ATM home to a writable filesystem, then retry the ATM command.
+      ```
 
-### 5.10 Phase Q Reserved Families
+### 5.10 Phase Q Runtime Families
 
-The following families are reserved for the Phase Q runtime line and must be
-materialized in `crates/atm-core/src/error_codes.rs` when the implementation
-lands.
+The following families are part of the Phase Q runtime line. Store codes are
+already materialized in `crates/atm-core/src/error_codes.rs`; the remaining
+families stay documented here as the shared contract for the later runtime
+surface.
 
 #### 5.10.1 Store
 
+- `ATM_STORE_OPEN_FAILED`
 - `ATM_STORE_BOOTSTRAP_FAILED`
-- `ATM_STORE_SCHEMA_FAILED`
+- `ATM_STORE_MIGRATION_FAILED`
+- `ATM_STORE_QUERY_FAILED`
+- `ATM_STORE_BUSY`
+- `ATM_STORE_CONSTRAINT_VIOLATION`
 - `ATM_STORE_TRANSACTION_FAILED`
-- `ATM_STORE_BUSY_TIMEOUT`
 
 #### 5.10.2 Ingest / Export
 
@@ -259,11 +283,6 @@ lands.
 - `ATM_DAEMON_SIGNAL_RELOAD_FAILED`
 - `ATM_DAEMON_UNAVAILABLE`
 - `ATM_DAEMON_CLIENT_TIMEOUT`
-      ```
-    - recovery:
-      ```text
-      Remount or move the ATM home to a writable filesystem, then retry the ATM command.
-      ```
   - drop-time best-effort cleanup may log the code as a warning because the
     mailbox command has already succeeded, but public acquisition/sweep paths
     must return the structured error directly
@@ -279,7 +298,7 @@ Required mapping rules:
 
 | `AtmErrorKind` | Default `AtmErrorCode` | Additional implemented codes in the same kind |
 | --- | --- | --- |
-| `Config` | `ATM_CONFIG_PARSE_FAILED` | `ATM_CONFIG_HOME_UNAVAILABLE`, `ATM_CONFIG_RETIRED_HOOK_MEMBERS_KEY`, `ATM_CONFIG_TEAM_PARSE_FAILED` |
+| `Config` | `ATM_CONFIG_PARSE_FAILED` | `ATM_CONFIG_HOME_UNAVAILABLE`, `ATM_CONFIG_RETIRED_HOOK_MEMBERS_KEY`, `ATM_CONFIG_RETIRED_LEGACY_HOOK_KEYS`, `ATM_CONFIG_TEAM_PARSE_FAILED` |
 | `MissingDocument` | `ATM_CONFIG_TEAM_MISSING` | none |
 | `Address` | `ATM_ADDRESS_PARSE_FAILED` | none |
 | `Identity` | `ATM_IDENTITY_UNAVAILABLE` | none |
@@ -292,11 +311,16 @@ Required mapping rules:
 | `Validation` | `ATM_MESSAGE_VALIDATION_FAILED` | `ATM_ACK_INVALID_STATE`, `ATM_CLEAR_INVALID_STATE` |
 | `Serialization` | `ATM_SERIALIZATION_FAILED` | none |
 | `Timeout` | `ATM_WAIT_TIMEOUT` | none |
+| `Store` | `ATM_STORE_QUERY_FAILED` | `ATM_STORE_OPEN_FAILED`, `ATM_STORE_BOOTSTRAP_FAILED`, `ATM_STORE_MIGRATION_FAILED`, `ATM_STORE_BUSY`, `ATM_STORE_CONSTRAINT_VIOLATION`, `ATM_STORE_TRANSACTION_FAILED` |
 | `ObservabilityEmit` | `ATM_OBSERVABILITY_EMIT_FAILED` | none |
 | `ObservabilityBootstrap` | `ATM_OBSERVABILITY_BOOTSTRAP_FAILED` | none |
 | `ObservabilityQuery` | `ATM_OBSERVABILITY_QUERY_FAILED` | none |
 | `ObservabilityFollow` | `ATM_OBSERVABILITY_FOLLOW_FAILED` | none |
 | `ObservabilityHealth` | `ATM_OBSERVABILITY_HEALTH_FAILED` | `ATM_OBSERVABILITY_HEALTH_OK`, `ATM_WARNING_OBSERVABILITY_HEALTH_DEGRADED` |
+
+Store-facing rusqlite layers classify persistence failures first, then command
+adapters preserve those codes under the caller-visible `AtmErrorKind::Store`
+coarse kind.
 
 ## 7. Recoverability Classification
 
@@ -358,13 +382,17 @@ Classification rules:
 | `ATM_WARNING_MISSING_TEAM_CONFIG_FALLBACK` | `warning_only` |
 | `ATM_WARNING_SEND_ALERT_STATE_DEGRADED` | `warning_only` |
 | `ATM_CONFIG_RETIRED_HOOK_MEMBERS_KEY` | `operator_actionable` |
+| `ATM_CONFIG_RETIRED_LEGACY_HOOK_KEYS` | `operator_actionable` |
 | `ATM_WARNING_HOOK_SKIPPED` | `warning_only` |
 | `ATM_WARNING_HOOK_EXECUTION_FAILED` | `warning_only` |
 | `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM` | `operator_actionable` |
+| `ATM_STORE_OPEN_FAILED` | `operator_actionable` |
 | `ATM_STORE_BOOTSTRAP_FAILED` | `operator_actionable` |
-| `ATM_STORE_SCHEMA_FAILED` | `fail_closed` |
+| `ATM_STORE_MIGRATION_FAILED` | `operator_actionable` |
+| `ATM_STORE_QUERY_FAILED` | `operator_actionable` |
+| `ATM_STORE_BUSY` | `retryable` |
+| `ATM_STORE_CONSTRAINT_VIOLATION` | `fail_closed` |
 | `ATM_STORE_TRANSACTION_FAILED` | `retryable` |
-| `ATM_STORE_BUSY_TIMEOUT` | `retryable` |
 | `ATM_INGEST_FAILED` | `operator_actionable` |
 | `ATM_WARNING_INGEST_BACKPRESSURE` | `warning_only` |
 | `ATM_WARNING_INGEST_RECORD_SKIPPED` | `warning_only` |

--- a/docs/atm-rusqlite/architecture.md
+++ b/docs/atm-rusqlite/architecture.md
@@ -43,7 +43,7 @@ Architectural rule:
 - enforcement of:
   - `journal_mode = WAL`
   - `foreign_keys = ON`
-  - `busy_timeout = 1500ms`
+  - `busy_timeout = 5000ms`
   - explicit transactions for mutating operations
 
 `atm-rusqlite` does not own:
@@ -62,7 +62,7 @@ Rules:
 - ATM-owned `AtmErrorCode` remains the public code vocabulary
 - the crate must not invent local ad hoc error-code strings
 - connection open/configuration is not complete until `journal_mode = WAL`,
-  `foreign_keys = ON`, and `busy_timeout = 1500ms` have all been enforced
+  `foreign_keys = ON`, and `busy_timeout = 5000ms` have all been enforced
 - `SQLITE_BUSY` must map to a typed retry-able ATM store error rather than
   leaking as a raw driver failure
 - `SQLITE_BUSY_SNAPSHOT` must map to a typed retry-able or replay-required ATM

--- a/docs/atm-rusqlite/boundaries.md
+++ b/docs/atm-rusqlite/boundaries.md
@@ -1,0 +1,249 @@
+# ATM-Rusqlite Boundary Inventory
+
+This document captures the planned concrete SQLite adapters for Phase R.
+
+Until the final composition crate is settled, the adapter records intentionally
+leave `composition.roots` empty and forbid direct dependency from caller crates.
+
+## SqliteMailStoreAdapter
+
+```yaml
+boundary_id: BOUNDARY-MailStore-Sqlite
+owner_package: atm-rusqlite
+owner_crate_path: atm_rusqlite
+name: SqliteMailStoreAdapter
+
+public:
+  trait: MailStore
+  facade: null
+
+implementation:
+  type: SqliteMailStore
+  module: atm_rusqlite::mail_store
+  visibility: private
+  constructor: private
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - sqlite
+    - mailbox_state_persistence
+  io_forbidden:
+    - socket_io
+    - process_spawn
+
+dependencies:
+  allowed_dependents: []
+  allowed_dependencies:
+    - atm-core
+    - rusqlite
+  forbidden_edges:
+    - atm -> atm-rusqlite
+    - atm-daemon -> atm-rusqlite
+    - atm-graft -> atm-rusqlite
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - SqliteMailStore
+    - SqliteMailStore::open
+    - rusqlite::Connection
+
+contracts:
+  request_types:
+    - MailStore method inputs
+  response_types:
+    - atm-core mailbox DTOs
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InMemoryMailStore
+  forbidden_test_bypasses:
+    - rusqlite::Connection
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-MAILSTORE-SQLITE-EDGES
+    - LINT-BOUNDARY-MAILSTORE-SQLITE-REFERENCES
+  review_gates:
+    - no_public_impl
+    - no_public_constructor
+    - no_public_reexport
+
+status:
+  state: planned
+  notes:
+    - composition root remains to be named by a Phase R ADR
+```
+
+Purpose:
+- Owns the SQLite-backed implementation of the MailStore contract.
+
+Notes:
+- Caller crates should know only the MailStore trait, never this concrete type.
+
+## SqliteTaskStoreAdapter
+
+```yaml
+boundary_id: BOUNDARY-TaskStore-Sqlite
+owner_package: atm-rusqlite
+owner_crate_path: atm_rusqlite
+name: SqliteTaskStoreAdapter
+
+public:
+  trait: TaskStore
+  facade: null
+
+implementation:
+  type: SqliteTaskStore
+  module: atm_rusqlite::task_store
+  visibility: private
+  constructor: private
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - sqlite
+    - task_state_persistence
+  io_forbidden:
+    - socket_io
+    - process_spawn
+
+dependencies:
+  allowed_dependents: []
+  allowed_dependencies:
+    - atm-core
+    - rusqlite
+  forbidden_edges:
+    - atm -> atm-rusqlite
+    - atm-daemon -> atm-rusqlite
+    - atm-graft -> atm-rusqlite
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - SqliteTaskStore
+    - SqliteTaskStore::open
+    - rusqlite::Connection
+
+contracts:
+  request_types:
+    - TaskStore method inputs
+  response_types:
+    - atm-core task DTOs
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InMemoryTaskStore
+  forbidden_test_bypasses:
+    - rusqlite::Connection
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-TASKSTORE-SQLITE-EDGES
+    - LINT-BOUNDARY-TASKSTORE-SQLITE-REFERENCES
+  review_gates:
+    - no_public_impl
+    - no_public_constructor
+    - no_public_reexport
+
+status:
+  state: planned
+  notes:
+    - ack-related task transitions still resolve through send-shape workflows, not a separate public ack API
+```
+
+Purpose:
+- Owns the SQLite-backed implementation of the TaskStore contract.
+
+Notes:
+- This remains separate from mail and roster persistence to preserve ownership clarity.
+
+## SqliteRosterStoreAdapter
+
+```yaml
+boundary_id: BOUNDARY-RosterStore-Sqlite
+owner_package: atm-rusqlite
+owner_crate_path: atm_rusqlite
+name: SqliteRosterStoreAdapter
+
+public:
+  trait: RosterStore
+  facade: null
+
+implementation:
+  type: SqliteRosterStore
+  module: atm_rusqlite::roster_store
+  visibility: private
+  constructor: private
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - sqlite
+    - durable_roster_persistence
+  io_forbidden:
+    - socket_io
+    - process_spawn
+
+dependencies:
+  allowed_dependents: []
+  allowed_dependencies:
+    - atm-core
+    - rusqlite
+  forbidden_edges:
+    - atm -> atm-rusqlite
+    - atm-daemon -> atm-rusqlite
+    - atm-graft -> atm-rusqlite
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - SqliteRosterStore
+    - SqliteRosterStore::open
+    - rusqlite::Connection
+
+contracts:
+  request_types:
+    - RosterStore method inputs
+  response_types:
+    - atm-core roster DTOs
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InMemoryRosterStore
+  forbidden_test_bypasses:
+    - rusqlite::Connection
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-ROSTERSTORE-SQLITE-EDGES
+    - LINT-BOUNDARY-ROSTERSTORE-SQLITE-REFERENCES
+  review_gates:
+    - no_public_impl
+    - no_public_constructor
+    - no_public_reexport
+
+status:
+  state: planned
+  notes:
+    - durable roster truth remains distinct from live status caches
+```
+
+Purpose:
+- Owns the SQLite-backed implementation of the RosterStore contract.
+
+Notes:
+- Thin extensions such as atm-graft must not depend on this crate directly.

--- a/docs/atm/boundaries.md
+++ b/docs/atm/boundaries.md
@@ -1,0 +1,86 @@
+# ATM Boundary Inventory
+
+This document captures CLI-owned concrete adapters for Phase R.
+
+## LocalSocketClientTransportAdapter
+
+```yaml
+boundary_id: BOUNDARY-ClientTransport-CLI
+owner_package: atm
+owner_crate_path: atm
+name: LocalSocketClientTransportAdapter
+
+public:
+  trait: ClientTransport
+  facade: null
+
+implementation:
+  type: LocalSocketClientTransport
+  module: atm::transport::local_socket
+  visibility: private
+  constructor: private
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - outbound_local_socket_requests
+    - client_request_deadlines
+    - response_decode
+  io_forbidden:
+    - sqlite
+    - process_spawn_for_notifications
+
+dependencies:
+  allowed_dependents: []
+  allowed_dependencies:
+    - atm-core
+    - tokio
+  forbidden_edges:
+    - atm -> atm-daemon
+    - atm -> atm-rusqlite
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - LocalSocketClientTransport
+    - atm_daemon::client
+    - rusqlite::Connection
+
+contracts:
+  request_types:
+    - AtmProtocol requests
+  response_types:
+    - AtmProtocol responses
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InProcessClientTransport
+  forbidden_test_bypasses:
+    - atm_daemon::client
+    - rusqlite::Connection
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-CLIENT-TRANSPORT-CLI-EDGES
+    - LINT-BOUNDARY-CLIENT-TRANSPORT-CLI-REFERENCES
+  review_gates:
+    - no_public_impl
+    - no_public_constructor
+    - no_cli_to_daemon_edge
+    - no_cli_to_sqlite_edge
+
+status:
+  state: planned
+  notes:
+    - thin extension clients such as atm-graft may reuse the contract shape without depending on atm internals
+```
+
+Purpose:
+- Owns the CLI-local implementation of the ClientTransport contract.
+
+Notes:
+- The CLI stays thin: parse, map request, call transport, render response.

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -41,9 +41,7 @@ fn set_home_env(cmd: &mut assert_cmd::Command, temp_dir: &TempDir) {
 
 Before declaring dev work complete, grep all integration test files:
 ```bash
-grep -rn 'ATM_HOME' crates/atm/tests/ || echo "FAIL: Missing ATM_HOME in test helpers"
 grep -rn 'ATM_CONFIG_HOME' crates/atm/tests/ || echo "FAIL: Missing ATM_CONFIG_HOME in test helpers"
-grep -rn 'ATM_TEAMS_DIR' crates/atm/tests/ || echo "FAIL: Missing ATM_TEAMS_DIR where team discovery is exercised"
 grep -rn 'env(\"HOME\"' crates/atm/tests/
 ```
 
@@ -122,54 +120,6 @@ grep -rn "'/tmp/" crates/ && echo "FAIL: Found /tmp hardcoding" || echo "OK"
 
 - Check env vars with `std::env::var()`, not by reading `/proc` or shell config files.
 - For test isolation, set env vars per-command with `cmd.env("KEY", "value")` rather than `std::env::set_var()` which is global and causes race conditions in parallel tests.
-
-## Test Subprocess Isolation
-
-See also:
-- [`requirements.md`](./requirements.md) `REQ-CORE-TEST-001`
-- [`.claude/agents/arch-qa.md`](../.claude/agents/arch-qa.md) `RULE-011`
-
-Subprocess-style ATM tests must not reuse developer workstation config or
-identity state.
-
-Required pattern:
-- create one `TempDir` per test fixture
-- point `ATM_HOME` at that temp-owned runtime root
-- point `ATM_CONFIG_HOME` at that temp-owned config root
-- point `ATM_TEAMS_DIR` at a temp-owned teams directory when the test depends
-  on team discovery
-- pass environment overrides with `cmd.env(...)` on each spawned command
-
-Use explicit test-only names for team and agent fixtures:
-- `TEST_TEAM = "test-team"`
-- `TEST_SENDER = "test-sender"`
-- `TEST_RECIPIENT = "test-recipient"`
-- `TEST_LEAD = "test-lead"`
-
-Reserved production names may still matter in a few tests:
-- `ATM_TEAM` and `ATM_IDENTITY` may be set explicitly when the test is proving
-  production env-read behavior
-- `team-lead` may be used when the role itself is semantically significant,
-  but the raw literal should be centralized behind one constant such as
-  `ROLE_TEAM_LEAD`
-
-Avoid:
-- raw `atm-dev` / `arch-*` literals in generic test fixtures
-- `std::env::set_var()` in integration tests
-- reading or writing the developer's real ATM home during tests
-
-Recommended helper shape:
-
-```rust
-let env = TestEnvBuilder::new().build().expect("test env");
-let mut cmd = assert_cmd::cargo::cargo_bin_cmd!("atm");
-// TestEnvBuilder provides filesystem isolation only. Tests still set
-// ATM_IDENTITY and ATM_TEAM explicitly when the command under test needs them.
-cmd.envs(env.env_map.iter())
-    .env("ATM_IDENTITY", TEST_SENDER)
-    .env("ATM_TEAM", TEST_TEAM)
-    .current_dir(&env.cwd);
-```
 
 ## Line Endings
 

--- a/docs/plan-phase-Q.md
+++ b/docs/plan-phase-Q.md
@@ -709,7 +709,7 @@ Implementation details:
   - TCP/TLS connect `5s`
   - TCP/TLS read/write `5s`
   - remote retry budget `30s`
-  - SQLite `busy_timeout` `1500ms`
+  - SQLite `busy_timeout` `5000ms`
   - ingest batch slice `2s`
   - doctor query `3s`
 - resource caps:
@@ -733,6 +733,9 @@ Acceptance:
 - `read` and `clear` no longer require mailbox rewrite correctness
 - lock contention on inbox files does not block SQLite-owned state transitions
 - existing CLI output remains compatible
+- ack hook post-send payload includes roster-backed `recipient_pane_id` when
+  known; when roster truth leaves it `NULL`/absent, the hook still fires with
+  `recipient_pane_id` omitted instead of failing the successful ack transition
 - tests cover:
   - mixed imported legacy + forward ATM rows
   - repeated `read` after external Claude append

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2482,6 +2482,9 @@ Integration branch:
 
 ### Q.0 — Boundary Cleanup And Debt Retirement
 
+Status:
+- complete on `feature/pQ-s0-debt-retirement` at `01a252a`
+
 Scope:
 - align the existing codebase with the Phase Q target shape before store and
   daemon work begin
@@ -2519,31 +2522,6 @@ Acceptance:
 - shorthand and object-form `config.json` member parsing follow the same
   validation expectations where both remain supported
 - the codebase is simpler to migrate after Q.0 than before Q.0
-
-### Q.RULES-DOC-1 — Test Isolation Rules Formalization [COMPLETE]
-
-Objective:
-- formalize the architectural and requirements contracts for test subprocess
-  isolation before the broader Phase Q enforcement sweep turns those findings
-  into active merge blockers
-
-Delivered in:
-- commit `7649712fc5ffc3576f4c410a01b7ed2866d2f112`
-
-Deliverables:
-- `RULE-008` through `RULE-011` defined in `.claude/agents/arch-qa.md`
-- `REQ-CORE-TEST-001` added to product and crate requirements
-- `docs/cross-platform-guidelines.md` updated with test subprocess isolation
-  guidance
-- `crates/atm/tests/support/mod.rs` added with test-only constants and a
-  `TestEnvBuilder` scaffold
-
-Acceptance:
-- test subprocess isolation rules are explicit and auditable in the rule,
-  requirement, and architecture docs
-- blocking enforcement leaves room for explicit production-compatibility tests
-  that must exercise `ATM_TEAM`, `ATM_IDENTITY`, or role-significant names
-  such as `team-lead`
 
 ### Q.1 — Store And Boundary Foundation
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1364,6 +1364,8 @@ Bare `atm teams` must:
 `atm teams backup` must:
 - create a timestamped snapshot under the ATM team backup area
 - capture the current `config.json`
+- capture the ATM-owned `.atm-state` tree, including SQLite durable state
+  (`mail.db`) and workflow compatibility state when present
 - capture team inbox files, excluding transient `*.lock` sentinels, dotfiles,
   and restore markers
 - capture the ATM team task bucket
@@ -1378,9 +1380,10 @@ Bare `atm teams` must:
 - add only missing non-lead members from the snapshot
 - clear runtime-only restored-member fields such as session, activity, and
   pane state before persisting them
+- restore the ATM-owned `.atm-state` tree from the chosen snapshot when present
 - restore non-lead inbox files from the chosen snapshot deterministically
-- sweep stale inbox `*.lock` sentinels before copying restored inbox files as a
-  self-heal step
+- treat stale inbox `*.lock` sentinels as transitional compatibility
+  diagnostics rather than a restore correctness gate
 - restore the ATM team task bucket and recompute `.highwatermark` from the
   maximum restored task id
 - fail with a structured error when backup material is missing or malformed
@@ -1764,8 +1767,6 @@ Product requirement ID:
 Satisfied by:
 - intentionally undecomposed product requirement; this governs workspace-level
   test coverage expectations rather than a single crate-local requirement ID
-- `REQ-CORE-TEST-001` for subprocess-isolation, fixture-naming, and explicit
-  production-compatibility carve-out rules
 
 Because `sc-observability` is newly introduced into ATM, the rewrite must add explicit test coverage for:
 - ATM event emission through the observability port boundary
@@ -1795,33 +1796,6 @@ The implementation must include:
 - CLI integration tests for `atm clear`
 - CLI integration tests for `atm teams`
 - CLI integration tests for `atm members`
-
-### 18.1 Subprocess Isolation
-
-- `REQ-CORE-TEST-001` ATM test subprocesses must isolate filesystem and
-  environment state and must not hardcode production-like team or agent
-  identities except in explicit production-compatibility tests.
-
-  See also:
-  - [`cross-platform-guidelines.md`](./cross-platform-guidelines.md) §Test Subprocess Isolation
-
-  Required behavior:
-  - (a) tests use test-only fixture constants for all team, agent, and
-    role-significant names rather than raw repo-significant production names
-  - (b) subprocess tests provision isolated `ATM_HOME`, `ATM_CONFIG_HOME`, and
-    `ATM_TEAMS_DIR` as needed and pass `ATM_*` vars per-command rather than
-    through ambient process state
-  - (c) direct-call tests use explicit `team_override` / `actor_override`
-    inputs or TempDir-scoped config; `team_override: None` with an empty or
-    unrelated current directory is a violation
-  - (d) test fixtures write all required config to TempDir-owned state and do
-    not read repo `.atm.toml` or live mailbox directories
-  - tests that need the semantic role represented by `team-lead` centralize
-    that raw literal behind one named constant
-  - tests may set `ATM_TEAM` or `ATM_IDENTITY` when validating production
-    env-read behavior, but only inside the isolated subprocess harness
-  - ambient reuse of a developer workstation ATM home, team, or identity is
-    forbidden
 
 ## 19. Acceptance Criteria
 

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,140 @@
+# Templates
+
+This folder contains `sc-compose` templates for crate architecture ADRs and
+boundary inventories.
+
+Recommended document layout per crate:
+- `docs/<crate>/architecture.md`
+  - hand-written crate architecture document
+  - contains one or more rendered ADR records from `architecture-adr.md.j2`
+- `docs/<crate>/boundaries.md`
+  - hand-written boundary inventory document
+  - contains one rendered boundary record per major trait/facade from
+    `boundary-record.md.j2`
+
+The intended default workflow is:
+- keep crate documents mostly hand-written
+- render one ADR record per major architectural decision
+- render one boundary record per major trait/facade
+- paste those records into the crate-local docs
+
+This keeps the docs readable while giving the parser and lint tooling a stable,
+machine-authoritative schema.
+
+## Boundary Record Template
+
+Use `boundary-record.md.j2` inside `docs/<crate>/boundaries.md`.
+
+The YAML block is the authoritative machine-readable contract for:
+- public trait/facade
+- concrete implementation
+- visibility
+- composition roots
+- forbidden dependencies and references
+- lint/review enforcement
+
+Semantics:
+- `owner_package` is the Cargo package name, e.g. `atm-rusqlite`
+- `owner_crate_path` is the Rust crate/module path root, e.g. `atm_rusqlite`
+- `allowed_dependents` means crates allowed to depend on the owner package
+- `allowed_dependencies` means crates the owner package may depend on directly
+- `references.scope` should normally be `outside_owner_crate`, so forbidden
+  references are interpreted as external-bypass checks rather than global bans
+- `implementation.visibility: private` and `implementation.constructor: private`
+  mean no public struct, no public constructor, and no public re-export
+
+### Render One Boundary Record
+
+```bash
+_VARS=$(mktemp)
+cat > "$_VARS" <<'JSON'
+{
+  "boundary_name": "MailStore",
+  "boundary_id": "BOUNDARY-MailStore",
+  "owner_package": "atm-rusqlite",
+  "owner_crate_path": "atm_rusqlite",
+  "public_trait": "MailStore",
+  "public_facade": "null",
+  "impl_type": "SqliteMailStore",
+  "impl_module": "atm_rusqlite::mail_store",
+  "impl_visibility": "private",
+  "impl_constructor": "private",
+  "composition_roots": "    - atm_app::compose",
+  "io_owns": "    - sqlite",
+  "io_forbidden": "    - config_json\n    - sockets\n    - process_spawn",
+  "allowed_dependents": "    - atm-app",
+  "allowed_dependencies": "    - atm-core\n    - rusqlite",
+  "forbidden_edges": "    - atm -> atm-rusqlite\n    - atm-daemon -> atm-rusqlite",
+  "references_scope": "outside_owner_crate",
+  "forbidden_references": "    - SqliteMailStore\n    - SqliteMailStore::open\n    - rusqlite::Connection",
+  "request_types": "    - MailStore method inputs",
+  "response_types": "    - atm-core store DTOs",
+  "error_types": "    - AtmError",
+  "allowed_test_double_paths": "    - atm_core::test_support::InMemoryMailStore",
+  "forbidden_test_bypasses": "    - rusqlite::Connection",
+  "lint_rules": "    - LINT-BOUNDARY-001\n    - LINT-BOUNDARY-002",
+  "review_gates": "    - no_public_impl\n    - no_public_constructor\n    - no_forbidden_imports",
+  "state": "planned",
+  "status_notes": "    - none",
+  "purpose": "- Owns durable mailbox state access.",
+  "notes": "- Used by lint tooling as the crate-local source of truth."
+}
+JSON
+
+sc-compose render \
+  --root docs/templates \
+  --file boundary-record.md.j2 \
+  --var-file "$_VARS"
+
+rm -f "$_VARS"
+```
+
+## Architecture ADR Template
+
+Use `architecture-adr.md.j2` inside `docs/<crate>/architecture.md`.
+
+The YAML block is the authoritative machine-readable record for:
+- decision identity and status
+- related boundaries
+- code/module references
+- downstream follow-up work
+
+### Render One ADR Record
+
+```bash
+_VARS=$(mktemp)
+cat > "$_VARS" <<'JSON'
+{
+  "adr_title": "Strict trait boundaries are mechanically enforced",
+  "adr_id": "ADR-ATM-RUSQLITE-001",
+  "crate": "atm-rusqlite",
+  "status": "accepted",
+  "date": "2026-05-04",
+  "deciders": "  - team-lead\n  - arch-ctm",
+  "tags": "  - boundaries\n  - lint\n  - privacy",
+  "related_boundaries": "  - BOUNDARY-MailStore\n  - BOUNDARY-TaskStore\n  - BOUNDARY-RosterStore",
+  "code_references": "  - crates/atm-rusqlite/src/lib.rs\n  - crates/atm-rusqlite/src/mail_store.rs",
+  "context": "- Phase Q drift showed that prose-only architecture was not enough to prevent concrete SQLite leakage.",
+  "decision": "- All crate boundaries must be documented in machine-parsable records, and concrete implementations remain private behind the documented trait/facade.",
+  "consequences": "- Lint and review can enforce forbidden references directly from crate-local boundary records.",
+  "alternatives_considered": "- Keep boundary rules only in top-level architecture prose.\n- Infer boundary contracts from code instead of documenting them explicitly.",
+  "follow_up_work": "- Populate `docs/atm-rusqlite/boundaries.md` for each major boundary.\n- Wire lint checks to read those records."
+}
+JSON
+
+sc-compose render \
+  --root docs/templates \
+  --file architecture-adr.md.j2 \
+  --var-file "$_VARS"
+
+rm -f "$_VARS"
+```
+
+### Notes
+
+- The YAML block inside each rendered record is the authoritative machine
+  contract for parsers and tooling.
+- The prose below the YAML is for human explanation and migration notes.
+- The older `boundary-section.md.j2` and `crate-boundary-architecture.md.j2`
+  templates are retained as transitional scaffolds, but the preferred pattern
+  is `architecture.md` + `boundaries.md` with one rendered record per section.

--- a/docs/templates/architecture-adr.md.j2
+++ b/docs/templates/architecture-adr.md.j2
@@ -1,0 +1,53 @@
+---
+name: architecture-adr
+version: 1.0.0
+description: Machine-parsable ADR template for crate architecture decisions with code references.
+format: markdown
+required_variables:
+  - adr_title
+  - adr_id
+  - crate
+  - status
+  - date
+  - deciders
+  - tags
+  - related_boundaries
+  - code_references
+  - context
+  - decision
+  - consequences
+  - alternatives_considered
+  - follow_up_work
+---
+## {{ adr_title }}
+
+```yaml
+adr_id: {{ adr_id }}
+crate: {{ crate }}
+title: {{ adr_title }}
+status: {{ status }}
+date: {{ date }}
+deciders:
+{{ deciders }}
+tags:
+{{ tags }}
+related_boundaries:
+{{ related_boundaries }}
+code_references:
+{{ code_references }}
+```
+
+Context:
+{{ context }}
+
+Decision:
+{{ decision }}
+
+Consequences:
+{{ consequences }}
+
+Alternatives considered:
+{{ alternatives_considered }}
+
+Follow-up work:
+{{ follow_up_work }}

--- a/docs/templates/boundary-record.md.j2
+++ b/docs/templates/boundary-record.md.j2
@@ -1,0 +1,108 @@
+---
+name: boundary-record
+version: 1.0.0
+description: Per-boundary machine-parsable record for crate boundary inventories and lint enforcement.
+format: markdown
+required_variables:
+  - boundary_name
+  - boundary_id
+  - owner_package
+  - owner_crate_path
+  - public_trait
+  - public_facade
+  - impl_type
+  - impl_module
+  - impl_visibility
+  - impl_constructor
+  - composition_roots
+  - io_owns
+  - io_forbidden
+  - allowed_dependents
+  - allowed_dependencies
+  - forbidden_edges
+  - references_scope
+  - forbidden_references
+  - request_types
+  - response_types
+  - error_types
+  - allowed_test_double_paths
+  - forbidden_test_bypasses
+  - lint_rules
+  - review_gates
+  - state
+  - status_notes
+  - purpose
+  - notes
+---
+## {{ boundary_name }}
+
+```yaml
+boundary_id: {{ boundary_id }}
+owner_package: {{ owner_package }}
+owner_crate_path: {{ owner_crate_path }}
+name: {{ boundary_name }}
+
+public:
+  trait: {{ public_trait }}
+  facade: {{ public_facade }}
+
+implementation:
+  type: {{ impl_type }}
+  module: {{ impl_module }}
+  visibility: {{ impl_visibility }}
+  constructor: {{ impl_constructor }}
+
+composition:
+  roots:
+{{ composition_roots }}
+
+ownership:
+  io_owns:
+{{ io_owns }}
+  io_forbidden:
+{{ io_forbidden }}
+
+dependencies:
+  allowed_dependents:
+{{ allowed_dependents }}
+  allowed_dependencies:
+{{ allowed_dependencies }}
+  forbidden_edges:
+{{ forbidden_edges }}
+
+references:
+  scope: {{ references_scope }}
+  forbidden:
+{{ forbidden_references }}
+
+contracts:
+  request_types:
+{{ request_types }}
+  response_types:
+{{ response_types }}
+  error_types:
+{{ error_types }}
+
+testing:
+  allowed_test_double_paths:
+{{ allowed_test_double_paths }}
+  forbidden_test_bypasses:
+{{ forbidden_test_bypasses }}
+
+enforcement:
+  lint_rules:
+{{ lint_rules }}
+  review_gates:
+{{ review_gates }}
+
+status:
+  state: {{ state }}
+  notes:
+{{ status_notes }}
+```
+
+Purpose:
+{{ purpose }}
+
+Notes:
+{{ notes }}

--- a/docs/templates/boundary-section.md.j2
+++ b/docs/templates/boundary-section.md.j2
@@ -1,0 +1,85 @@
+---
+name: boundary-section
+version: 1.0.0
+description: Per-boundary architecture section template for strict trait/facade enforcement.
+format: markdown
+required_variables:
+  - boundary_name
+  - purpose
+  - public_trait
+  - impl_type
+  - impl_module
+  - visibility
+  - constructor_path
+  - allowed_instantiation
+  - forbidden_instantiation
+  - allowed_dependencies
+  - forbidden_dependencies
+  - forbidden_references
+  - io_owns
+  - io_not_owns
+  - request_types
+  - response_types
+  - error_types
+  - test_seam
+  - test_bypass_forbidden
+  - compile_time_enforcement
+  - lint_enforcement
+  - review_gate
+---
+### {{ boundary_name }}
+
+Purpose:
+{{ purpose }}
+
+Public boundary:
+- Trait/facade: `{{ public_trait }}`
+
+Concrete implementation:
+- Type: `{{ impl_type }}`
+- Crate/module: `{{ impl_module }}`
+- Visibility: {{ visibility }}
+
+Construction:
+- Constructor path: `{{ constructor_path }}`
+- Instantiation allowed only in:
+{{ allowed_instantiation }}
+- Instantiation forbidden in:
+{{ forbidden_instantiation }}
+
+Allowed dependencies:
+{{ allowed_dependencies }}
+
+Forbidden dependencies:
+{{ forbidden_dependencies }}
+
+Forbidden references:
+{{ forbidden_references }}
+
+I/O ownership:
+- owns:
+{{ io_owns }}
+- does not own:
+{{ io_not_owns }}
+
+Input/output contract:
+- request types:
+{{ request_types }}
+- response types:
+{{ response_types }}
+- error types:
+{{ error_types }}
+
+Test seam:
+- tests use:
+{{ test_seam }}
+- tests must not bypass the boundary via:
+{{ test_bypass_forbidden }}
+
+Enforcement:
+- compile-time:
+{{ compile_time_enforcement }}
+- lint/CI:
+{{ lint_enforcement }}
+- review gate:
+{{ review_gate }}

--- a/docs/templates/crate-boundary-architecture.md.j2
+++ b/docs/templates/crate-boundary-architecture.md.j2
@@ -1,0 +1,137 @@
+---
+name: crate-boundary-architecture
+version: 1.0.0
+description: Crate architecture template for strict trait boundaries, private implementations, and composition-root enforcement.
+format: markdown
+required_variables:
+  - crate_name
+  - crate_path
+  - crate_purpose
+  - allowed_inbound_dependencies
+  - allowed_outbound_dependencies
+  - forbidden_dependencies
+  - composition_roots
+  - boundary_summary_rows
+  - boundary_sections
+  - enforcement_checks
+  - open_questions
+---
+# {{ crate_name }} Architecture
+
+Crate path:
+- `{{ crate_path }}`
+
+Purpose:
+- {{ crate_purpose }}
+
+## Dependency Contract
+
+Allowed inbound dependencies:
+{{ allowed_inbound_dependencies }}
+
+Allowed outbound dependencies:
+{{ allowed_outbound_dependencies }}
+
+Forbidden dependencies and references:
+{{ forbidden_dependencies }}
+
+## Composition Roots
+
+Only these modules/crates may instantiate concrete implementations:
+{{ composition_roots }}
+
+## Boundary Inventory
+
+| Boundary | Public Trait/Facade | Concrete Implementation | Owner | Private | Composition Root |
+|---|---|---|---|---|---|
+{{ boundary_summary_rows }}
+
+## Boundary Details
+
+{{ boundary_sections }}
+
+## Enforcement
+
+The following checks must fail CI when violated:
+{{ enforcement_checks }}
+
+## Open Questions
+
+{{ open_questions }}
+
+---
+
+## Boundary Section Template
+
+Copy this section once per boundary if hand-editing the crate document:
+
+```md
+### <Boundary Name>
+
+Purpose:
+- <one sentence about what this boundary owns>
+
+Public boundary:
+- Trait/facade: `<TraitName>`
+
+Concrete implementation:
+- Type: `<ImplTypeName>`
+- Crate/module: `<crate>::<module>`
+- Visibility: `private` | `pub(crate)` by documented exception | `public by architectural exception`
+
+Construction:
+- Constructor path: `<fn/path>` or `private constructor only`
+- Instantiation allowed only in:
+  - `<composition root path>`
+- Instantiation forbidden in:
+  - `<caller crate/module>`
+  - `<caller crate/module>`
+
+Allowed dependencies:
+- may depend on:
+  - `<crate/module>`
+  - `<crate/module>`
+
+Forbidden dependencies:
+- must not depend on:
+  - `<crate/module>`
+  - `<crate/module>`
+
+Forbidden references:
+- callers must not reference:
+  - `<ImplTypeName>`
+  - `<constructor fn>`
+  - `<helper module path>`
+  - `<forbidden concrete crate/type>`
+
+I/O ownership:
+- owns:
+  - `<sqlite | config.json parsing | socket I/O | process spawning | inbox write | ...>`
+- does not own:
+  - `<business logic categories it must not absorb>`
+
+Input/output contract:
+- request types:
+  - `<TypeName>`
+- response types:
+  - `<TypeName>`
+- error types:
+  - `<TypeName>`
+
+Test seam:
+- tests use:
+  - `<fake impl | in-memory impl | test transport>`
+- tests must not bypass the boundary via:
+  - `<forbidden helper or concrete impl>`
+
+Enforcement:
+- compile-time:
+  - `<private impl>`
+  - `<private constructor>`
+  - `<crate visibility restriction>`
+- lint/CI:
+  - `<forbidden dependency edge rule>`
+  - `<forbidden import/symbol rule>`
+- review gate:
+  - `<what is an automatic blocker>`
+```


### PR DESCRIPTION
## Summary

- Copies Phase Q docs baseline into feature/pR-planning for Phase R redesign
- Adds per-crate boundary inventory files (`docs/atm/boundaries.md`, `docs/atm-core/boundaries.md`, `docs/atm-daemon/boundaries.md`, `docs/atm-rusqlite/boundaries.md`)
- Adds boundary doc templates (`docs/templates/`) for use in Phase R sprint design

## Context

Phase R is a redo of Phase Q with correct architecture:
- No `atm` CLI dependency on `atm-daemon` or `atm-rusqlite`
- All subsections of `atm-daemon` behind strict traits (MailStore, TaskStore, etc.)
- IPC client extracted from daemon crate — CLI talks only through IPC transport

This PR establishes the planning baseline for review before implementation begins in `feature/pR-s0-arch-foundation`.

## Target

Targets `develop` — planning docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)