### PR TITLE
build: port lint framework into Phase R foundation (pR-s0)

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,5 @@
+# Rust baseline false positives.
+ser
+de
+
+# Add project-specific false positives here if codespell reports any.

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = ./.git,./target,./.just/logs,./Cargo.lock
+ignore-words = .codespellignore
+quiet-level = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,42 @@ on:
     branches: [develop, main]
 
 jobs:
+  just-lint:
+    name: Just lint (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+          components: clippy, rustfmt
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@cargo-shear
+
+      - name: Install codespell
+        run: python -m pip install codespell
+
+      - name: Run just lint
+        run: just lint
+
   fmt:
     name: Format check
     runs-on: ubuntu-latest
@@ -95,4 +131,6 @@ jobs:
         run: cargo build --verbose
 
       - name: Run tests
+        env:
+          ATM_TEST_RECV_TIMEOUT_SECS: "60"
         run: cargo test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ Cargo.toml.ci
 # Local session artifacts and compose logs from sc tooling
 .sc/sessions/
 .sc-compose/logs/
+.just/logs/
+.just/tests/__pycache__/
+.just/__pycache__/
 
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can

--- a/.just/check_line_counts.py
+++ b/.just/check_line_counts.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+from lint_common import classify_rust_test_scope
+from lint_common import discover_repo_root
+from lint_common import is_code_line
+from lint_common import load_lint_config
+
+
+@dataclass(frozen=True)
+class LineLimitConfig:
+    max_total_lines: int | None = None
+    max_production_lines: int | None = 1000
+    max_scoped_code_lines: int | None = None
+    exclusions: dict[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class FileCounts:
+    crate_name: str
+    path: str
+    total_lines: int
+    production_lines: int
+    test_lines: int
+
+    @property
+    def scoped_code_lines(self) -> int:
+        return self.production_lines + self.test_lines
+
+
+@dataclass(frozen=True)
+class CrateTotals:
+    crate_name: str
+    total_lines: int
+    production_lines: int
+    test_lines: int
+
+    @property
+    def scoped_code_lines(self) -> int:
+        return self.production_lines + self.test_lines
+
+
+def classify_lines(lines: list[str]) -> tuple[int, int]:
+    test_scope = classify_rust_test_scope(lines)
+    production_lines = 0
+    test_lines = 0
+    for line, in_test_scope in zip(lines, test_scope, strict=True):
+        if not is_code_line(line):
+            continue
+        if in_test_scope:
+            test_lines += 1
+        else:
+            production_lines += 1
+    return production_lines, test_lines
+
+
+def load_config(repo_root: Path) -> LineLimitConfig:
+    config = load_lint_config(repo_root).get("line_counts", {})
+    if not isinstance(config, dict):
+        raise SystemExit("[line_counts] must be a TOML table")
+
+    def parse_limit(name: str) -> int | None:
+        value = config.get(name)
+        if value in (None, 0):
+            return None
+        if not isinstance(value, int) or value < 0:
+            raise SystemExit(f"[line_counts].{name} must be a non-negative integer")
+        return value
+
+    exclusions = config.get("exclusions", {})
+    if not isinstance(exclusions, dict):
+        raise SystemExit("[line_counts.exclusions] must be a TOML table")
+
+    return LineLimitConfig(
+        max_total_lines=parse_limit("max_total_lines"),
+        max_production_lines=parse_limit("max_production_lines"),
+        max_scoped_code_lines=parse_limit("max_scoped_code_lines"),
+        exclusions={str(path): str(reason) for path, reason in exclusions.items()},
+    )
+
+
+def collect_file_counts(repo_root: Path, config: LineLimitConfig) -> list[FileCounts]:
+    results: list[FileCounts] = []
+    for path in sorted((repo_root / "crates").rglob("*.rs")):
+        rel = path.relative_to(repo_root)
+        rel_posix = rel.as_posix()
+        if "/tests/" in rel_posix:
+            continue
+        if "/src/" not in rel_posix:
+            continue
+        if config.exclusions and rel_posix in config.exclusions:
+            continue
+
+        lines = path.read_text(encoding="utf-8").splitlines()
+        production_lines, test_lines = classify_lines(lines)
+        results.append(
+            FileCounts(
+                crate_name=rel.parts[1],
+                path=rel_posix,
+                total_lines=len(lines),
+                production_lines=production_lines,
+                test_lines=test_lines,
+            )
+        )
+    return results
+
+
+def crate_totals(counts: list[FileCounts]) -> list[CrateTotals]:
+    totals: dict[str, CrateTotals] = {}
+    for count in counts:
+        previous = totals.get(
+            count.crate_name,
+            CrateTotals(
+                crate_name=count.crate_name,
+                total_lines=0,
+                production_lines=0,
+                test_lines=0,
+            ),
+        )
+        totals[count.crate_name] = CrateTotals(
+            crate_name=count.crate_name,
+            total_lines=previous.total_lines + count.total_lines,
+            production_lines=previous.production_lines + count.production_lines,
+            test_lines=previous.test_lines + count.test_lines,
+        )
+    return [totals[name] for name in sorted(totals)]
+
+
+def format_table(counts: list[FileCounts]) -> list[str]:
+    if not counts:
+        return ["no eligible source files found"]
+
+    crate_width = max(len("crate"), max(len(item.crate_name) for item in counts))
+    file_width = max(len("file"), max(len(Path(item.path).relative_to(f"crates/{item.crate_name}").as_posix()) for item in counts))
+    total_width = max(len("total"), max(len(str(item.total_lines)) for item in counts))
+    prod_width = max(len("prod"), max(len(str(item.production_lines)) for item in counts))
+    test_width = max(len("test"), max(len(str(item.test_lines)) for item in counts))
+    scoped_width = max(len("prod+test"), max(len(str(item.scoped_code_lines)) for item in counts))
+
+    header = (
+        f"{'crate':<{crate_width}}  "
+        f"{'file':<{file_width}}  "
+        f"{'total':>{total_width}}  "
+        f"{'prod':>{prod_width}}  "
+        f"{'test':>{test_width}}  "
+        f"{'prod+test':>{scoped_width}}"
+    )
+    divider = "-" * len(header)
+    rows = [header, divider]
+
+    grouped: dict[str, list[FileCounts]] = {}
+    for item in counts:
+        grouped.setdefault(item.crate_name, []).append(item)
+
+    for crate_name in sorted(grouped):
+        crate_rows = grouped[crate_name]
+        for item in crate_rows:
+            file_name = Path(item.path).relative_to(f"crates/{crate_name}").as_posix()
+            rows.append(
+                f"{crate_name:<{crate_width}}  "
+                f"{file_name:<{file_width}}  "
+                f"{item.total_lines:>{total_width}}  "
+                f"{item.production_lines:>{prod_width}}  "
+                f"{item.test_lines:>{test_width}}  "
+                f"{item.scoped_code_lines:>{scoped_width}}"
+            )
+        totals = crate_totals(crate_rows)[0]
+        rows.append(
+            f"{crate_name:<{crate_width}}  "
+            f"{'TOTAL':<{file_width}}  "
+            f"{totals.total_lines:>{total_width}}  "
+            f"{totals.production_lines:>{prod_width}}  "
+            f"{totals.test_lines:>{test_width}}  "
+            f"{totals.scoped_code_lines:>{scoped_width}}"
+        )
+        rows.append("")
+
+    return rows[:-1] if rows and rows[-1] == "" else rows
+
+
+def evaluate_limits(counts: list[FileCounts], config: LineLimitConfig) -> list[str]:
+    failures: list[str] = []
+    for item in counts:
+        if config.max_total_lines is not None and item.total_lines > config.max_total_lines:
+            failures.append(
+                f"{item.path}: total={item.total_lines} exceeds limit {config.max_total_lines}"
+            )
+        if (
+            config.max_production_lines is not None
+            and item.production_lines > config.max_production_lines
+        ):
+            failures.append(
+                f"{item.path}: prod={item.production_lines} exceeds limit {config.max_production_lines}"
+            )
+        if (
+            config.max_scoped_code_lines is not None
+            and item.scoped_code_lines > config.max_scoped_code_lines
+        ):
+            failures.append(
+                f"{item.path}: prod+test={item.scoped_code_lines} exceeds limit {config.max_scoped_code_lines}"
+            )
+    return failures
+
+
+def limit_summary(config: LineLimitConfig) -> str:
+    parts: list[str] = []
+    if config.max_total_lines is not None:
+        parts.append(f"total<={config.max_total_lines}")
+    if config.max_production_lines is not None:
+        parts.append(f"prod<={config.max_production_lines}")
+    if config.max_scoped_code_lines is not None:
+        parts.append(f"prod+test<={config.max_scoped_code_lines}")
+    return ", ".join(parts) if parts else "no active limits"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check Rust file size limits by crate.")
+    parser.add_argument("--root", help="Repo root to inspect.")
+    return parser.parse_args(argv[1:])
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = discover_repo_root(args.root)
+    config = load_config(repo_root)
+    counts = collect_file_counts(repo_root, config)
+    failures = evaluate_limits(counts, config)
+
+    if failures:
+        print("RULE-003 violation: source file size limits exceeded.")
+        print(f"active limits: {limit_summary(config)}")
+        print("files over limit:")
+        for failure in failures:
+            print(failure)
+        print("")
+        print("per-crate line counts:")
+        for line in format_table(counts):
+            print(line)
+        print("")
+        if config.exclusions:
+            print("temporary exclusions:")
+            for path, reason in config.exclusions.items():
+                print(f"- {path} ({reason})")
+        print(f"errors: {len(failures)}")
+        return 1
+
+    print("RULE-003 check passed: source file size limits satisfied.")
+    print(f"active limits: {limit_summary(config)}")
+    print("per-crate line counts:")
+    for line in format_table(counts):
+        print(line)
+    if config.exclusions:
+        print("")
+        print("temporary exclusions:")
+        for path, reason in config.exclusions.items():
+            print(f"- {path} ({reason})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.just/check_test_identity_literals.py
+++ b/.just/check_test_identity_literals.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+from lint_common import LintDirectivePolicy
+from lint_common import classify_rust_test_scope
+from lint_common import discover_repo_root
+from lint_common import is_code_line
+from lint_common import line_is_suppressed
+from lint_common import load_lint_config
+
+
+LINT_NAME = "identities"
+DIRECTIVE_POLICY = LintDirectivePolicy(
+    tool_key=LINT_NAME,
+    aliases=("rule-008", "rule-009"),
+)
+
+
+@dataclass(frozen=True)
+class IdentityViolation:
+    path: str
+    line_number: int
+    line: str
+
+    def render(self) -> str:
+        return f"{self.path}:{self.line_number}: {self.line}"
+
+
+def load_forbidden_literals(repo_root: Path) -> tuple[str, ...]:
+    config = load_lint_config(repo_root).get("identities", {})
+    if not isinstance(config, dict):
+        raise SystemExit("[identities] must be a TOML table")
+    literals = config.get("forbidden_literals")
+    if not isinstance(literals, list) or not all(isinstance(item, str) for item in literals):
+        raise SystemExit("[identities].forbidden_literals must be an array of strings")
+    return tuple(literals)
+
+
+def iter_rust_files(repo_root: Path) -> list[Path]:
+    return sorted((repo_root / "crates").rglob("*.rs"))
+
+
+def file_scope(path: Path, lines: list[str]) -> list[bool]:
+    rel_posix = path.as_posix()
+    if "/tests/" in rel_posix:
+        return [True] * len(lines)
+    if "/src/" in rel_posix:
+        return classify_rust_test_scope(lines)
+    return [False] * len(lines)
+
+
+def collect_identity_violations(
+    repo_root: Path,
+    *,
+    forbidden_literals: tuple[str, ...],
+) -> list[IdentityViolation]:
+    violations: list[IdentityViolation] = []
+    for abs_path in iter_rust_files(repo_root):
+        rel_path = abs_path.relative_to(repo_root)
+        lines = abs_path.read_text(encoding="utf-8").splitlines()
+        scope = file_scope(rel_path, lines)
+
+        for line_number, (line, in_test_scope) in enumerate(zip(lines, scope, strict=True), start=1):
+            if not in_test_scope:
+                continue
+            if not is_code_line(line):
+                continue
+            if not any(literal in line for literal in forbidden_literals):
+                continue
+            if line_is_suppressed(line_number, lines, DIRECTIVE_POLICY):
+                continue
+            violations.append(
+                IdentityViolation(
+                    path=rel_path.as_posix(),
+                    line_number=line_number,
+                    line=line.strip(),
+                )
+            )
+
+    return violations
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check test and cfg(test) Rust code for forbidden production identity literals."
+    )
+    parser.add_argument("--root", help="Repo root to inspect.")
+    return parser.parse_args(argv[1:])
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = discover_repo_root(args.root)
+    forbidden_literals = load_forbidden_literals(repo_root)
+    violations = collect_identity_violations(
+        repo_root,
+        forbidden_literals=forbidden_literals,
+    )
+
+    if violations:
+        print("RULE-008/RULE-009 violation: raw production literals found in test/cfg(test) Rust code.")
+        print("Use test constants, centralized reserved-role constants, or explicit lint suppressions.")
+        for violation in violations:
+            print(violation.render())
+        print(f"total violations: {len(violations)}")
+        return 1
+
+    print("RULE-008/RULE-009 check passed: no disallowed raw production literals found in test scope.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.just/check_test_identity_literals.py
+++ b/.just/check_test_identity_literals.py
@@ -12,6 +12,7 @@ from lint_common import discover_repo_root
 from lint_common import is_code_line
 from lint_common import line_is_suppressed
 from lint_common import load_lint_config
+from lint_common import workspace_crate_section_lines
 
 
 LINT_NAME = "identities"
@@ -101,6 +102,9 @@ def main(argv: list[str]) -> int:
         repo_root,
         forbidden_literals=forbidden_literals,
     )
+
+    for line in workspace_crate_section_lines(repo_root):
+        print(line)
 
     if violations:
         print("RULE-008/RULE-009 violation: raw production literals found in test/cfg(test) Rust code.")

--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -6,6 +6,8 @@ import sys
 import tomllib
 from pathlib import Path
 
+from lint_common import workspace_crate_section_lines
+
 
 def fail(message: str) -> None:
     raise SystemExit(message)
@@ -164,6 +166,8 @@ def main() -> int:
     validate_lockfile(repo_root, workspace_version)
     validate_winget_manifest(repo_root, workspace_version)
     validate_homebrew_release_wiring(repo_root)
+    for line in workspace_crate_section_lines(repo_root):
+        print(line)
     print(success_message(workspace_version))
     return 0
 

--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -150,6 +150,13 @@ def validate_homebrew_release_wiring(repo_root: Path) -> None:
             )
 
 
+def success_message(workspace_version: str) -> str:
+    return (
+        f"version sync check passed: workspace_version={workspace_version}; "
+        "workspace, crate pin, Cargo.lock, winget, and Homebrew release wiring are aligned."
+    )
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parent.parent
     workspace_version = validate_workspace_version(repo_root)
@@ -157,10 +164,7 @@ def main() -> int:
     validate_lockfile(repo_root, workspace_version)
     validate_winget_manifest(repo_root, workspace_version)
     validate_homebrew_release_wiring(repo_root)
-    print(
-        "version sync check passed: workspace, crate pin, Cargo.lock, winget, "
-        "and Homebrew release wiring are aligned."
-    )
+    print(success_message(workspace_version))
     return 0
 
 

--- a/.just/check_version_sync.py
+++ b/.just/check_version_sync.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def extract_version_from_url(url: str) -> str | None:
+    match = re.search(r"/download/v(?P<version>\d+\.\d+\.\d+)/", url)
+    if match:
+        return match.group("version")
+    match = re.search(r"[_-](?P<version>\d+\.\d+\.\d+)[_/]", url)
+    if match:
+        return match.group("version")
+    return None
+
+
+def validate_workspace_version(repo_root: Path) -> str:
+    cargo_toml = tomllib.loads(read_text(repo_root / "Cargo.toml"))
+    workspace_version = cargo_toml.get("workspace", {}).get("package", {}).get("version")
+    if not workspace_version:
+        fail("workspace version missing from Cargo.toml")
+    return workspace_version
+
+
+def validate_crate_versions(repo_root: Path, workspace_version: str) -> None:
+    manifests = sorted((repo_root / "crates").glob("*/Cargo.toml"))
+    if not manifests:
+        fail("no crate manifests found under crates/")
+
+    manifest_texts = {path: read_text(path) for path in manifests}
+    for path, text in manifest_texts.items():
+        if "version.workspace = true" not in text:
+            fail(f"{path.relative_to(repo_root)} must use version.workspace = true")
+
+    atm_toml_path = repo_root / "crates" / "atm" / "Cargo.toml"
+    atm_text = manifest_texts.get(atm_toml_path)
+    if atm_text is None:
+        fail("crates/atm/Cargo.toml missing")
+
+    dep_match = re.search(
+        r'agent-team-mail-core".*?version\s*=\s*"(?P<version>\d+\.\d+\.\d+)"',
+        atm_text,
+    )
+    if dep_match is None:
+        fail("crates/atm/Cargo.toml is missing the agent-team-mail-core path dependency version pin")
+    dep_version = dep_match.group("version")
+    if dep_version != workspace_version:
+        fail(
+            "crates/atm/Cargo.toml agent-team-mail-core dependency version "
+            f"({dep_version}) does not match workspace version ({workspace_version})"
+        )
+
+
+def validate_lockfile(repo_root: Path, workspace_version: str) -> None:
+    lock = tomllib.loads(read_text(repo_root / "Cargo.lock"))
+    packages = lock.get("package", [])
+    versions: dict[str, str] = {}
+    workspace_packages: set[str] = set()
+    for manifest_path in sorted((repo_root / "crates").glob("*/Cargo.toml")):
+        manifest = tomllib.loads(read_text(manifest_path))
+        package_name = manifest.get("package", {}).get("name")
+        if isinstance(package_name, str):
+            workspace_packages.add(package_name)
+    for package in packages:
+        name = package.get("name")
+        version = package.get("version")
+        if name in workspace_packages:
+            versions[name] = version
+
+    for package_name in sorted(workspace_packages):
+        version = versions.get(package_name)
+        if version is None:
+            fail(f"{package_name} missing from Cargo.lock")
+        if version != workspace_version:
+            fail(
+                f"Cargo.lock version for {package_name} ({version}) "
+                f"does not match workspace version ({workspace_version})"
+            )
+
+
+def validate_winget_manifest(repo_root: Path, workspace_version: str) -> None:
+    manifest_path = repo_root / ".winget" / "randlee.agent-team-mail.yaml"
+    text = read_text(manifest_path)
+
+    version_match = re.search(r"^PackageVersion:\s*(?P<version>\d+\.\d+\.\d+)\s*$", text, re.MULTILINE)
+    if version_match is None:
+        fail(f"{manifest_path.relative_to(repo_root)} is missing PackageVersion")
+    package_version = version_match.group("version")
+    if package_version != workspace_version:
+        fail(
+            f"{manifest_path.relative_to(repo_root)} PackageVersion ({package_version}) "
+            f"does not match workspace version ({workspace_version})"
+        )
+
+    manifest_version_match = re.search(
+        r"^ManifestVersion:\s*(?P<version>\d+\.\d+\.\d+)\s*$",
+        text,
+        re.MULTILINE,
+    )
+    if manifest_version_match is None:
+        fail(f"{manifest_path.relative_to(repo_root)} is missing ManifestVersion")
+    manifest_version = manifest_version_match.group("version")
+    if manifest_version != workspace_version:
+        fail(
+            f"{manifest_path.relative_to(repo_root)} ManifestVersion ({manifest_version}) "
+            f"does not match workspace version ({workspace_version})"
+        )
+
+    installer_match = re.search(r"^\s*InstallerUrl:\s*(?P<url>\S+)\s*$", text, re.MULTILINE)
+    if installer_match is None:
+        fail(f"{manifest_path.relative_to(repo_root)} is missing InstallerUrl")
+    installer_url = installer_match.group("url")
+    installer_version = extract_version_from_url(installer_url)
+    if installer_version != workspace_version:
+        fail(
+            f"{manifest_path.relative_to(repo_root)} InstallerUrl version ({installer_version}) "
+            f"does not match workspace version ({workspace_version})"
+        )
+
+
+def validate_homebrew_release_wiring(repo_root: Path) -> None:
+    workflow_path = repo_root / ".github" / "workflows" / "release.yml"
+    text = read_text(workflow_path)
+
+    required_fragments = (
+        "update-homebrew:",
+        "repository: randlee/homebrew-tap",
+        "for formula in homebrew-tap/Formula/agent-team-mail.rb homebrew-tap/Formula/atm.rb; do",
+        'version=\'${{ needs.gate-and-tag.outputs.release_version }}\'',
+        'tarball_url="https://github.com/randlee/atm-core/releases/download/${tag}/atm_${version}_aarch64-apple-darwin.tar.gz"',
+        'sed -i "s|version \\"[^\\"]*\\"|version \\"${version}\\"|g" "$formula"',
+    )
+
+    for fragment in required_fragments:
+        if fragment not in text:
+            fail(
+                ".github/workflows/release.yml no longer guarantees Homebrew formulas "
+                f"are updated from the shared release version: missing {fragment!r}"
+            )
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    workspace_version = validate_workspace_version(repo_root)
+    validate_crate_versions(repo_root, workspace_version)
+    validate_lockfile(repo_root, workspace_version)
+    validate_winget_manifest(repo_root, workspace_version)
+    validate_homebrew_release_wiring(repo_root)
+    print(
+        "version sync check passed: workspace, crate pin, Cargo.lock, winget, "
+        "and Homebrew release wiring are aligned."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -19,3 +19,7 @@ max_scoped_code_lines = 0
 "crates/atm-core/src/mailbox/lock.rs" = "Q.6 split pending"
 "crates/atm-core/src/read/mod.rs" = "Q.6 split pending"
 "crates/atm-rusqlite/src/tests.rs" = "Q.6 split pending"
+
+[cargo_shear.allowed_empty_files]
+
+[cargo_shear.allowed_unlinked_files]

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -1,0 +1,21 @@
+[identities]
+forbidden_literals = [
+  "team-lead",
+  "arch-ctm",
+  "arch-qa",
+  "arch-inj",
+  "arch-obs",
+  "quality-mgr",
+  "publisher",
+  "atm-dev",
+]
+
+[line_counts]
+max_total_lines = 0
+max_production_lines = 1000
+max_scoped_code_lines = 0
+
+[line_counts.exclusions]
+"crates/atm-core/src/mailbox/lock.rs" = "Q.6 split pending"
+"crates/atm-core/src/read/mod.rs" = "Q.6 split pending"
+"crates/atm-rusqlite/src/tests.rs" = "Q.6 split pending"

--- a/.just/lint_boundaries.py
+++ b/.just/lint_boundaries.py
@@ -13,6 +13,7 @@ from lint_common import discover_repo_root
 from lint_common import is_comment_line
 from lint_common import monotonic_now
 from lint_common import print_report
+from lint_common import render_table
 from lint_common import workspace_crate_section_lines
 
 
@@ -1030,6 +1031,62 @@ def build_summary(violations: list[BoundaryViolation], record_count: int) -> str
     return f"boundary rules violated ({len(violations)} findings across {record_count} records)"
 
 
+def boundary_doc_section_lines(repo_root: Path, records: list[BoundaryRecord]) -> list[str]:
+    record_counts_by_doc: dict[str, dict[str, int]] = {}
+    for doc_path in boundary_docs(repo_root):
+        record_counts_by_doc[doc_path.relative_to(repo_root).as_posix()] = {
+            "records": 0,
+            "active": 0,
+            "planned": 0,
+            "retired": 0,
+        }
+
+    for record in records:
+        if record.source_path.is_absolute():
+            doc_key = record.source_path.relative_to(repo_root).as_posix()
+        else:
+            doc_key = record.source_path.as_posix()
+        counts = record_counts_by_doc.setdefault(
+            doc_key,
+            {"records": 0, "active": 0, "planned": 0, "retired": 0},
+        )
+        counts["records"] += 1
+        if record.status_state in counts:
+            counts[record.status_state] += 1
+
+    rows: list[dict[str, str]] = []
+    for doc_display in sorted(record_counts_by_doc):
+        counts = record_counts_by_doc[doc_display]
+        rows.append(
+            {
+                "doc": doc_display,
+                "records": str(counts["records"]),
+                "active": str(counts["active"]),
+                "planned": str(counts["planned"]),
+                "retired": str(counts["retired"]),
+            }
+        )
+
+    lines = ["boundary docs analyzed:"]
+    lines.extend(
+        render_table(
+            rows,
+            [
+                ("doc", "doc"),
+                ("records", "records"),
+                ("active", "active"),
+                ("planned", "planned"),
+                ("retired", "retired"),
+            ],
+        )
+    )
+    lines.append("")
+    lines.append(f"boundary doc count: {len(rows)}")
+    lines.append(f"boundary records validated: {len(records)}")
+    lines.append("")
+    return lines
+
+
 def run(repo_root: Path) -> int:
     started_at = datetime.now(timezone.utc)
     started_monotonic = monotonic_now()
@@ -1048,9 +1105,7 @@ def run(repo_root: Path) -> int:
     duration_seconds = monotonic_now() - started_monotonic
     findings = [violation.render() for violation in violations]
     transcript_lines = workspace_crate_section_lines(repo_root)
-    transcript_lines.append(f"boundary docs analyzed: {len(boundary_docs(repo_root))}")
-    transcript_lines.append(f"boundary records validated: {len(records)}")
-    transcript_lines.append("")
+    transcript_lines.extend(boundary_doc_section_lines(repo_root, records))
     transcript_lines.extend(findings or ["no boundary violations found"])
     report = build_report(
         lint_name=LINT_NAME,

--- a/.just/lint_boundaries.py
+++ b/.just/lint_boundaries.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import argparse
+import re
+import sys
+
+from lint_common import build_report
+from lint_common import discover_repo_root
+from lint_common import monotonic_now
+from lint_common import print_report
+
+
+LINT_NAME = "boundaries"
+RUSQLITE_ALLOWED_MANIFEST = Path("crates/atm-rusqlite/Cargo.toml")
+RUSQLITE_ALLOWED_SOURCE_ROOT = Path("crates/atm-rusqlite")
+ATM_CORE_MANIFEST = Path("crates/atm-core/Cargo.toml")
+ATM_RUSQLITE_PACKAGE = "atm-rusqlite"
+ATM_RUSQLITE_ALLOWED_SECTIONS = {"dev-dependencies"}
+BOUNDARY_DOC_GLOB = "docs/*/boundaries.md"
+YAML_FENCE_START = "```yaml"
+YAML_FENCE_END = "```"
+SOURCE_IMPORT_PATTERNS = (
+    re.compile(r"\brusqlite::"),
+    re.compile(r"\buse\s+rusqlite\b"),
+    re.compile(r"\bextern\s+crate\s+rusqlite\b"),
+)
+REQUIRED_BOUNDARY_FIELDS = (
+    ("boundary_id",),
+    ("owner_package",),
+    ("owner_crate_path",),
+    ("name",),
+    ("implementation", "visibility"),
+    ("implementation", "constructor"),
+    ("dependencies", "forbidden_edges"),
+    ("references", "scope"),
+    ("references", "forbidden"),
+    ("enforcement", "lint_rules"),
+    ("status", "state"),
+)
+ENFORCED_RECORD_STATES = {"active"}
+
+
+@dataclass(frozen=True)
+class BoundaryViolation:
+    location: str
+    message: str
+
+    def render(self) -> str:
+        return f"{self.location}: {self.message}"
+
+
+@dataclass(frozen=True)
+class BoundaryRecord:
+    boundary_id: str
+    owner_package: str
+    owner_crate_path: str
+    status_state: str
+    forbidden_edges: tuple[str, ...]
+    source_path: Path
+    start_line: int
+    raw: dict[str, object]
+
+    @property
+    def is_enforced(self) -> bool:
+        return self.status_state.lower() in ENFORCED_RECORD_STATES
+
+
+def dependency_sections(manifest: dict) -> list[tuple[str, dict]]:
+    sections: list[tuple[str, dict]] = []
+    for section_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+        dependencies = manifest.get(section_name)
+        if isinstance(dependencies, dict):
+            sections.append((section_name, dependencies))
+
+    targets = manifest.get("target", {})
+    if isinstance(targets, dict):
+        for target_name, target in targets.items():
+            if not isinstance(target, dict):
+                continue
+            for section_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+                dependencies = target.get(section_name)
+                if isinstance(dependencies, dict):
+                    sections.append((f"target.{target_name}.{section_name}", dependencies))
+
+    return sections
+
+
+def dependency_package_name(dependency_name: str, dependency: object) -> str:
+    if isinstance(dependency, str):
+        return dependency_name
+    if isinstance(dependency, dict):
+        package_name = dependency.get("package")
+        if isinstance(package_name, str):
+            return package_name
+    return dependency_name
+
+
+def workspace_manifests(repo_root: Path) -> list[Path]:
+    return sorted((repo_root / "crates").glob("*/Cargo.toml"))
+
+
+def rust_sources(repo_root: Path) -> list[Path]:
+    return sorted((repo_root / "crates").glob("**/*.rs"))
+
+
+def boundary_docs(repo_root: Path) -> list[Path]:
+    return sorted(repo_root.glob(BOUNDARY_DOC_GLOB))
+
+
+def tomllib_load(path: Path) -> dict:
+    import tomllib
+
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def yaml_scalar(value: str) -> object:
+    stripped = value.strip()
+    if stripped == "null":
+        return None
+    if stripped == "[]":
+        return []
+    if stripped.lower() == "true":
+        return True
+    if stripped.lower() == "false":
+        return False
+    return stripped
+
+
+def leading_spaces(text: str) -> int:
+    return len(text) - len(text.lstrip(" "))
+
+
+def next_content_line(lines: list[tuple[int, str]], start_index: int) -> tuple[int, str] | None:
+    for index in range(start_index, len(lines)):
+        line_number, text = lines[index]
+        if text.strip():
+            return line_number, text
+    return None
+
+
+def parse_yaml_list(lines: list[tuple[int, str]], start_index: int, indent: int) -> tuple[list[object], int]:
+    items: list[object] = []
+    index = start_index
+    while index < len(lines):
+        _line_number, text = lines[index]
+        if not text.strip():
+            index += 1
+            continue
+        current_indent = leading_spaces(text)
+        if current_indent < indent:
+            break
+        if current_indent > indent:
+            raise ValueError(f"unexpected indentation in list item: {text!r}")
+        stripped = text.strip()
+        if not stripped.startswith("- "):
+            break
+        items.append(yaml_scalar(stripped[2:]))
+        index += 1
+    return items, index
+
+
+def parse_yaml_mapping(lines: list[tuple[int, str]], start_index: int, indent: int) -> tuple[dict[str, object], int]:
+    mapping: dict[str, object] = {}
+    index = start_index
+    while index < len(lines):
+        _line_number, text = lines[index]
+        if not text.strip():
+            index += 1
+            continue
+
+        current_indent = leading_spaces(text)
+        if current_indent < indent:
+            break
+        if current_indent > indent:
+            raise ValueError(f"unexpected indentation in mapping: {text!r}")
+
+        stripped = text.strip()
+        if stripped.startswith("- "):
+            raise ValueError(f"unexpected list item in mapping: {text!r}")
+        if ":" not in stripped:
+            raise ValueError(f"expected key/value pair: {text!r}")
+
+        key, remainder = stripped.split(":", 1)
+        remainder = remainder.strip()
+        index += 1
+
+        if remainder:
+            mapping[key] = yaml_scalar(remainder)
+            continue
+
+        next_line = next_content_line(lines, index)
+        if next_line is None:
+            mapping[key] = {}
+            continue
+
+        _next_line_number, next_text = next_line
+        next_indent = leading_spaces(next_text)
+        if next_indent <= current_indent:
+            mapping[key] = {}
+            continue
+
+        if next_text.strip().startswith("- "):
+            value, index = parse_yaml_list(lines, index, next_indent)
+        else:
+            value, index = parse_yaml_mapping(lines, index, next_indent)
+        mapping[key] = value
+
+    return mapping, index
+
+
+def parse_simple_yaml_document(text: str) -> dict[str, object]:
+    lines = [(line_number, line) for line_number, line in enumerate(text.splitlines(), start=1)]
+    mapping, _ = parse_yaml_mapping(lines, 0, 0)
+    return mapping
+
+
+def extract_yaml_blocks(path: Path) -> list[tuple[int, str]]:
+    blocks: list[tuple[int, str]] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    in_block = False
+    start_line = 0
+    buffer: list[str] = []
+    for line_number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not in_block and stripped == YAML_FENCE_START:
+            in_block = True
+            start_line = line_number + 1
+            buffer = []
+            continue
+        if in_block and stripped == YAML_FENCE_END:
+            blocks.append((start_line, "\n".join(buffer)))
+            in_block = False
+            buffer = []
+            continue
+        if in_block:
+            buffer.append(line)
+    return blocks
+
+
+def nested_get(data: dict[str, object], path: tuple[str, ...]) -> object | None:
+    current: object = data
+    for segment in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(segment)
+    return current
+
+
+def validate_boundary_record_data(data: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+    for path in REQUIRED_BOUNDARY_FIELDS:
+        value = nested_get(data, path)
+        if value is None:
+            errors.append(f"missing required field: {'.'.join(path)}")
+            continue
+        if isinstance(value, str) and not value.strip():
+            errors.append(f"missing required field: {'.'.join(path)}")
+
+    public_trait = nested_get(data, ("public", "trait"))
+    public_facade = nested_get(data, ("public", "facade"))
+    if public_trait is None and public_facade is None:
+        errors.append("missing required field: public.(trait|facade)")
+    return errors
+
+
+def boundary_record_from_data(
+    *,
+    data: dict[str, object],
+    source_path: Path,
+    start_line: int,
+) -> BoundaryRecord:
+    forbidden_edges = nested_get(data, ("dependencies", "forbidden_edges"))
+    if not isinstance(forbidden_edges, list):
+        forbidden_edges = []
+    status_state = nested_get(data, ("status", "state"))
+    if not isinstance(status_state, str):
+        status_state = "planned"
+    boundary_id = nested_get(data, ("boundary_id",))
+    owner_package = nested_get(data, ("owner_package",))
+    owner_crate_path = nested_get(data, ("owner_crate_path",))
+    if not isinstance(boundary_id, str) or not isinstance(owner_package, str) or not isinstance(owner_crate_path, str):
+        raise ValueError("boundary record missing required identifying fields")
+    return BoundaryRecord(
+        boundary_id=boundary_id,
+        owner_package=owner_package,
+        owner_crate_path=owner_crate_path,
+        status_state=status_state,
+        forbidden_edges=tuple(str(edge) for edge in forbidden_edges),
+        source_path=source_path,
+        start_line=start_line,
+        raw=data,
+    )
+
+
+def parse_boundary_records(repo_root: Path) -> tuple[list[BoundaryRecord], list[BoundaryViolation]]:
+    records: list[BoundaryRecord] = []
+    violations: list[BoundaryViolation] = []
+    for doc_path in boundary_docs(repo_root):
+        rel_doc = doc_path.relative_to(repo_root).as_posix()
+        for start_line, yaml_text in extract_yaml_blocks(doc_path):
+            try:
+                data = parse_simple_yaml_document(yaml_text)
+            except ValueError as error:
+                violations.append(BoundaryViolation(f"{rel_doc}:{start_line}", f"invalid boundary YAML: {error}"))
+                continue
+
+            record_errors = validate_boundary_record_data(data)
+            if record_errors:
+                for error in record_errors:
+                    violations.append(BoundaryViolation(f"{rel_doc}:{start_line}", error))
+                continue
+
+            try:
+                records.append(
+                    boundary_record_from_data(
+                        data=data,
+                        source_path=doc_path.relative_to(repo_root),
+                        start_line=start_line,
+                    )
+                )
+            except ValueError as error:
+                violations.append(BoundaryViolation(f"{rel_doc}:{start_line}", str(error)))
+    return records, violations
+
+
+def crate_manifest_aliases(manifest_path: Path) -> set[str]:
+    manifest = tomllib_load(manifest_path)
+    package = manifest.get("package", {})
+    package_name = package.get("name")
+    aliases = {manifest_path.parent.name}
+    if isinstance(package_name, str):
+        aliases.add(package_name)
+    return aliases
+
+
+def manifest_by_alias(repo_root: Path) -> dict[str, Path]:
+    aliases: dict[str, Path] = {}
+    for manifest_path in workspace_manifests(repo_root):
+        for alias in crate_manifest_aliases(manifest_path):
+            aliases[alias] = manifest_path
+    return aliases
+
+
+def collect_forbidden_edge_violations(
+    repo_root: Path,
+    records: list[BoundaryRecord],
+) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+    alias_map = manifest_by_alias(repo_root)
+    for record in records:
+        if not record.is_enforced:
+            continue
+        for edge in record.forbidden_edges:
+            if "->" not in edge:
+                rel_doc = record.source_path.as_posix()
+                violations.append(
+                    BoundaryViolation(
+                        f"{rel_doc}:{record.start_line}",
+                        f"{record.boundary_id} has invalid forbidden edge {edge!r}",
+                    )
+                )
+                continue
+            left_alias, right_alias = (part.strip() for part in edge.split("->", 1))
+            left_manifest = alias_map.get(left_alias)
+            if left_manifest is None:
+                continue
+            manifest = tomllib_load(left_manifest)
+            rel_manifest_path = left_manifest.relative_to(repo_root)
+            rel_manifest = rel_manifest_path.as_posix()
+            for section_name, dependencies in dependency_sections(manifest):
+                for dependency_name, dependency in dependencies.items():
+                    package_name = dependency_package_name(dependency_name, dependency)
+                    dependency_aliases = {dependency_name, package_name}
+                    if right_alias in dependency_aliases:
+                        violations.append(
+                            BoundaryViolation(
+                                f"{rel_manifest} [{section_name}]",
+                                f"{record.boundary_id} forbids edge {left_alias} -> {right_alias}",
+                            )
+                        )
+    return violations
+
+
+def collect_boundary_violations(repo_root: Path) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+    boundary_records, record_violations = parse_boundary_records(repo_root)
+    violations.extend(record_violations)
+    violations.extend(collect_forbidden_edge_violations(repo_root, boundary_records))
+
+    for manifest_path in workspace_manifests(repo_root):
+        manifest = tomllib_load(manifest_path)
+        rel_manifest_path = manifest_path.relative_to(repo_root)
+        rel_manifest = rel_manifest_path.as_posix()
+        for section_name, dependencies in dependency_sections(manifest):
+            for dependency_name, dependency in dependencies.items():
+                package_name = dependency_package_name(dependency_name, dependency)
+                if package_name == "rusqlite" and rel_manifest_path != RUSQLITE_ALLOWED_MANIFEST:
+                    violations.append(
+                        BoundaryViolation(
+                            f"{rel_manifest} [{section_name}]",
+                            "only crates/atm-rusqlite may depend on rusqlite",
+                        )
+                    )
+
+                if (
+                    rel_manifest_path == ATM_CORE_MANIFEST
+                    and package_name == ATM_RUSQLITE_PACKAGE
+                    and section_name not in ATM_RUSQLITE_ALLOWED_SECTIONS
+                ):
+                    violations.append(
+                        BoundaryViolation(
+                            f"{rel_manifest} [{section_name}]",
+                            "atm-core may reference atm-rusqlite only in dev-dependencies",
+                        )
+                    )
+
+    allowed_source_root = (repo_root / RUSQLITE_ALLOWED_SOURCE_ROOT).resolve()
+    for source_path in rust_sources(repo_root):
+        if allowed_source_root in source_path.resolve().parents:
+            continue
+        rel_source = source_path.relative_to(repo_root).as_posix()
+        text = source_path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if any(pattern.search(line) for pattern in SOURCE_IMPORT_PATTERNS):
+                violations.append(
+                    BoundaryViolation(
+                        f"{rel_source}:{line_number}",
+                        "only crates/atm-rusqlite source may import rusqlite directly",
+                    )
+                )
+
+    return dedupe_violations(violations)
+
+
+def dedupe_violations(violations: list[BoundaryViolation]) -> list[BoundaryViolation]:
+    unique: dict[tuple[str, str], BoundaryViolation] = {}
+    for violation in violations:
+        unique[(violation.location, violation.message)] = violation
+    return list(unique.values())
+
+
+def build_summary(violations: list[BoundaryViolation]) -> str:
+    if not violations:
+        return "boundary rules satisfied"
+    return f"boundary rules violated ({len(violations)} findings)"
+
+
+def run(repo_root: Path) -> int:
+    started_at = datetime.now(timezone.utc)
+    started_monotonic = monotonic_now()
+    violations = collect_boundary_violations(repo_root)
+    duration_seconds = monotonic_now() - started_monotonic
+    findings = [violation.render() for violation in violations]
+    transcript_lines = findings or ["no boundary violations found"]
+    report = build_report(
+        lint_name=LINT_NAME,
+        repo_root=repo_root,
+        passed=not violations,
+        summary=build_summary(violations),
+        findings=findings,
+        transcript_lines=transcript_lines,
+        started_at=started_at,
+        duration_seconds=duration_seconds,
+    )
+    print_report(report, repo_root=repo_root, preview_limit=4, direct_threshold=4)
+    return 0 if report.passed else 1
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Check crate and source boundary rules.")
+    parser.add_argument("--root", help="Repo root to inspect.")
+    args = parser.parse_args(argv[1:])
+    repo_root = discover_repo_root(args.root)
+    return run(repo_root)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.just/lint_boundaries.py
+++ b/.just/lint_boundaries.py
@@ -13,6 +13,7 @@ from lint_common import discover_repo_root
 from lint_common import is_comment_line
 from lint_common import monotonic_now
 from lint_common import print_report
+from lint_common import workspace_crate_section_lines
 
 
 LINT_NAME = "boundaries"
@@ -1046,7 +1047,11 @@ def run(repo_root: Path) -> int:
 
     duration_seconds = monotonic_now() - started_monotonic
     findings = [violation.render() for violation in violations]
-    transcript_lines = findings or [f"validated {len(records)} boundary records"]
+    transcript_lines = workspace_crate_section_lines(repo_root)
+    transcript_lines.append(f"boundary docs analyzed: {len(boundary_docs(repo_root))}")
+    transcript_lines.append(f"boundary records validated: {len(records)}")
+    transcript_lines.append("")
+    transcript_lines.extend(findings or ["no boundary violations found"])
     report = build_report(
         lint_name=LINT_NAME,
         repo_root=repo_root,

--- a/.just/lint_boundaries.py
+++ b/.just/lint_boundaries.py
@@ -10,24 +10,19 @@ import sys
 
 from lint_common import build_report
 from lint_common import discover_repo_root
+from lint_common import is_comment_line
 from lint_common import monotonic_now
 from lint_common import print_report
 
 
 LINT_NAME = "boundaries"
-RUSQLITE_ALLOWED_MANIFEST = Path("crates/atm-rusqlite/Cargo.toml")
-RUSQLITE_ALLOWED_SOURCE_ROOT = Path("crates/atm-rusqlite")
-ATM_CORE_MANIFEST = Path("crates/atm-core/Cargo.toml")
-ATM_RUSQLITE_PACKAGE = "atm-rusqlite"
-ATM_RUSQLITE_ALLOWED_SECTIONS = {"dev-dependencies"}
 BOUNDARY_DOC_GLOB = "docs/*/boundaries.md"
 YAML_FENCE_START = "```yaml"
 YAML_FENCE_END = "```"
-SOURCE_IMPORT_PATTERNS = (
-    re.compile(r"\brusqlite::"),
-    re.compile(r"\buse\s+rusqlite\b"),
-    re.compile(r"\bextern\s+crate\s+rusqlite\b"),
-)
+RUSQLITE_ALLOWED_MANIFEST = Path("crates/atm-rusqlite/Cargo.toml")
+ATM_CORE_MANIFEST = Path("crates/atm-core/Cargo.toml")
+ATM_RUSQLITE_PACKAGE = "atm-rusqlite"
+ATM_RUSQLITE_ALLOWED_SECTIONS = {"dev-dependencies"}
 REQUIRED_BOUNDARY_FIELDS = (
     ("boundary_id",),
     ("owner_package",),
@@ -35,13 +30,36 @@ REQUIRED_BOUNDARY_FIELDS = (
     ("name",),
     ("implementation", "visibility"),
     ("implementation", "constructor"),
+    ("dependencies", "allowed_dependents"),
+    ("dependencies", "allowed_dependencies"),
     ("dependencies", "forbidden_edges"),
     ("references", "scope"),
     ("references", "forbidden"),
+    ("testing", "allowed_test_double_paths"),
+    ("testing", "forbidden_test_bypasses"),
     ("enforcement", "lint_rules"),
+    ("enforcement", "review_gates"),
     ("status", "state"),
 )
-ENFORCED_RECORD_STATES = {"active"}
+VISIBILITY_VALUES = {"private", "pub(crate)", "public", "trait_only"}
+CONSTRUCTOR_VALUES = {"private", "pub(crate)", "public", "none"}
+REFERENCE_SCOPE_VALUES = {"global", "outside_owner_crate"}
+STATE_VALUES = {"planned", "active", "retired"}
+PACKAGE_NAME_RE = re.compile(r"^[a-z0-9]+(?:[.-][a-z0-9]+)*$")
+CRATE_PATH_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+RUST_PATH_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$")
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+FORBIDDEN_EDGE_RE = re.compile(
+    r"^(?P<left>[a-z0-9]+(?:[.-][a-z0-9]+)*)\s*->\s*(?P<right>[a-z0-9]+(?:[.-][a-z0-9]+)*)$"
+)
+SOURCE_IMPORT_PATTERNS = (
+    re.compile(r"\brusqlite::"),
+    re.compile(r"\buse\s+rusqlite\b"),
+    re.compile(r"\bextern\s+crate\s+rusqlite\b"),
+)
+PUBLIC_TYPE_TEMPLATE = r"^\s*pub(?:\([^)]*\))?\s+(?:struct|enum|type)\s+{name}\b"
+PUBLIC_REEXPORT_TEMPLATE = r"^\s*pub(?:\([^)]*\))?\s+use\b.*\b{name}\b"
+PUBLIC_FUNCTION_RE = re.compile(r"^\s*pub(?:\([^)]*\))?\s+fn\s+[A-Za-z_][A-Za-z0-9_]*\b")
 
 
 @dataclass(frozen=True)
@@ -58,15 +76,49 @@ class BoundaryRecord:
     boundary_id: str
     owner_package: str
     owner_crate_path: str
-    status_state: str
+    name: str
+    public_trait: str | None
+    public_facade: str | None
+    implementation_type: str | None
+    implementation_module: str | None
+    implementation_visibility: str
+    implementation_constructor: str
+    composition_roots: tuple[str, ...]
+    allowed_dependents: tuple[str, ...]
+    allowed_dependencies: tuple[str, ...]
     forbidden_edges: tuple[str, ...]
+    references_scope: str
+    forbidden_references: tuple[str, ...]
+    allowed_test_double_paths: tuple[str, ...]
+    forbidden_test_bypasses: tuple[str, ...]
+    lint_rules: tuple[str, ...]
+    review_gates: tuple[str, ...]
+    status_state: str
     source_path: Path
     start_line: int
     raw: dict[str, object]
 
     @property
-    def is_enforced(self) -> bool:
-        return self.status_state.lower() in ENFORCED_RECORD_STATES
+    def is_active(self) -> bool:
+        return self.status_state == "active"
+
+    @property
+    def location(self) -> str:
+        return f"{self.source_path.as_posix()}:{self.start_line} [{self.boundary_id}]"
+
+
+@dataclass(frozen=True)
+class ManifestInfo:
+    path: Path
+    package_name: str
+    crate_dir_name: str
+    crate_path_name: str
+
+    @property
+    def aliases(self) -> tuple[str, ...]:
+        aliases = {self.package_name, self.crate_dir_name}
+        aliases.add(self.crate_path_name)
+        return tuple(sorted(aliases))
 
 
 def dependency_sections(manifest: dict) -> list[tuple[str, dict]]:
@@ -104,7 +156,14 @@ def workspace_manifests(repo_root: Path) -> list[Path]:
 
 
 def rust_sources(repo_root: Path) -> list[Path]:
-    return sorted((repo_root / "crates").glob("**/*.rs"))
+    return sorted((repo_root / "crates").glob("*/src/**/*.rs"))
+
+
+def rust_test_sources_for_crate(info: ManifestInfo) -> list[Path]:
+    tests_root = info.path.parent / "tests"
+    if not tests_root.exists():
+        return []
+    return sorted(tests_root.glob("**/*.rs"))
 
 
 def boundary_docs(repo_root: Path) -> list[Path]:
@@ -146,7 +205,7 @@ def parse_yaml_list(lines: list[tuple[int, str]], start_index: int, indent: int)
     items: list[object] = []
     index = start_index
     while index < len(lines):
-        _line_number, text = lines[index]
+        line_number, text = lines[index]
         if not text.strip():
             index += 1
             continue
@@ -154,7 +213,7 @@ def parse_yaml_list(lines: list[tuple[int, str]], start_index: int, indent: int)
         if current_indent < indent:
             break
         if current_indent > indent:
-            raise ValueError(f"unexpected indentation in list item: {text!r}")
+            raise ValueError(f"unexpected indentation in list item at line {line_number}: {text!r}")
         stripped = text.strip()
         if not stripped.startswith("- "):
             break
@@ -167,7 +226,7 @@ def parse_yaml_mapping(lines: list[tuple[int, str]], start_index: int, indent: i
     mapping: dict[str, object] = {}
     index = start_index
     while index < len(lines):
-        _line_number, text = lines[index]
+        line_number, text = lines[index]
         if not text.strip():
             index += 1
             continue
@@ -176,13 +235,13 @@ def parse_yaml_mapping(lines: list[tuple[int, str]], start_index: int, indent: i
         if current_indent < indent:
             break
         if current_indent > indent:
-            raise ValueError(f"unexpected indentation in mapping: {text!r}")
+            raise ValueError(f"unexpected indentation in mapping at line {line_number}: {text!r}")
 
         stripped = text.strip()
         if stripped.startswith("- "):
-            raise ValueError(f"unexpected list item in mapping: {text!r}")
+            raise ValueError(f"unexpected list item in mapping at line {line_number}: {text!r}")
         if ":" not in stripped:
-            raise ValueError(f"expected key/value pair: {text!r}")
+            raise ValueError(f"expected key/value pair at line {line_number}: {text!r}")
 
         key, remainder = stripped.split(":", 1)
         remainder = remainder.strip()
@@ -197,7 +256,7 @@ def parse_yaml_mapping(lines: list[tuple[int, str]], start_index: int, indent: i
             mapping[key] = {}
             continue
 
-        _next_line_number, next_text = next_line
+        next_line_number, next_text = next_line
         next_indent = leading_spaces(next_text)
         if next_indent <= current_indent:
             mapping[key] = {}
@@ -250,7 +309,21 @@ def nested_get(data: dict[str, object], path: tuple[str, ...]) -> object | None:
     return current
 
 
-def validate_boundary_record_data(data: dict[str, object]) -> list[str]:
+def as_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def as_string_list(value: object) -> list[str] | None:
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return [str(item) for item in value]
+    return None
+
+
+def validate_required_fields(data: dict[str, object]) -> list[str]:
     errors: list[str] = []
     for path in REQUIRED_BOUNDARY_FIELDS:
         value = nested_get(data, path)
@@ -267,114 +340,448 @@ def validate_boundary_record_data(data: dict[str, object]) -> list[str]:
     return errors
 
 
-def boundary_record_from_data(
+def validate_package_name(value: str, *, field_name: str) -> str | None:
+    if not PACKAGE_NAME_RE.match(value):
+        return f"invalid {field_name}: {value!r}"
+    return None
+
+
+def validate_rust_path(value: str, *, field_name: str) -> str | None:
+    if not RUST_PATH_RE.match(value):
+        return f"invalid {field_name}: {value!r}"
+    return None
+
+
+def validate_identifier(value: str, *, field_name: str) -> str | None:
+    if not IDENTIFIER_RE.match(value):
+        return f"invalid {field_name}: {value!r}"
+    return None
+
+
+def validate_list_field(
+    data: dict[str, object],
+    path: tuple[str, ...],
+    *,
+    field_name: str,
+    allow_empty: bool = True,
+) -> tuple[list[str], list[str]]:
+    value = nested_get(data, path)
+    rendered = as_string_list(value)
+    if rendered is None:
+        return [], [f"{field_name} must be a list of strings"]
+    if not allow_empty and not rendered:
+        return rendered, [f"{field_name} must not be empty"]
+    return rendered, []
+
+
+def build_boundary_record(
     *,
     data: dict[str, object],
     source_path: Path,
     start_line: int,
-) -> BoundaryRecord:
-    forbidden_edges = nested_get(data, ("dependencies", "forbidden_edges"))
-    if not isinstance(forbidden_edges, list):
-        forbidden_edges = []
-    status_state = nested_get(data, ("status", "state"))
-    if not isinstance(status_state, str):
-        status_state = "planned"
-    boundary_id = nested_get(data, ("boundary_id",))
-    owner_package = nested_get(data, ("owner_package",))
-    owner_crate_path = nested_get(data, ("owner_crate_path",))
-    if not isinstance(boundary_id, str) or not isinstance(owner_package, str) or not isinstance(owner_crate_path, str):
-        raise ValueError("boundary record missing required identifying fields")
-    return BoundaryRecord(
+) -> tuple[BoundaryRecord | None, list[BoundaryViolation]]:
+    base_location = f"{source_path.as_posix()}:{start_line}"
+    errors = validate_required_fields(data)
+
+    boundary_id = as_string(nested_get(data, ("boundary_id",)))
+    owner_package = as_string(nested_get(data, ("owner_package",)))
+    owner_crate_path = as_string(nested_get(data, ("owner_crate_path",)))
+    name = as_string(nested_get(data, ("name",)))
+    public_trait = as_string(nested_get(data, ("public", "trait")))
+    public_facade = as_string(nested_get(data, ("public", "facade")))
+    implementation_type = as_string(nested_get(data, ("implementation", "type")))
+    implementation_module = as_string(nested_get(data, ("implementation", "module")))
+    implementation_visibility = as_string(nested_get(data, ("implementation", "visibility")))
+    implementation_constructor = as_string(nested_get(data, ("implementation", "constructor")))
+    references_scope = as_string(nested_get(data, ("references", "scope")))
+    status_state = as_string(nested_get(data, ("status", "state")))
+
+    composition_roots, composition_errors = validate_list_field(
+        data,
+        ("composition", "roots"),
+        field_name="composition.roots",
+    )
+    allowed_dependents, allowed_dependent_errors = validate_list_field(
+        data,
+        ("dependencies", "allowed_dependents"),
+        field_name="dependencies.allowed_dependents",
+    )
+    allowed_dependencies, allowed_dependency_errors = validate_list_field(
+        data,
+        ("dependencies", "allowed_dependencies"),
+        field_name="dependencies.allowed_dependencies",
+    )
+    forbidden_edges, forbidden_edge_errors = validate_list_field(
+        data,
+        ("dependencies", "forbidden_edges"),
+        field_name="dependencies.forbidden_edges",
+    )
+    forbidden_references, forbidden_reference_errors = validate_list_field(
+        data,
+        ("references", "forbidden"),
+        field_name="references.forbidden",
+    )
+    allowed_test_double_paths, test_double_errors = validate_list_field(
+        data,
+        ("testing", "allowed_test_double_paths"),
+        field_name="testing.allowed_test_double_paths",
+    )
+    forbidden_test_bypasses, test_bypass_errors = validate_list_field(
+        data,
+        ("testing", "forbidden_test_bypasses"),
+        field_name="testing.forbidden_test_bypasses",
+    )
+    lint_rules, lint_rule_errors = validate_list_field(
+        data,
+        ("enforcement", "lint_rules"),
+        field_name="enforcement.lint_rules",
+        allow_empty=False,
+    )
+    review_gates, review_gate_errors = validate_list_field(
+        data,
+        ("enforcement", "review_gates"),
+        field_name="enforcement.review_gates",
+        allow_empty=False,
+    )
+
+    errors.extend(
+        composition_errors
+        + allowed_dependent_errors
+        + allowed_dependency_errors
+        + forbidden_edge_errors
+        + forbidden_reference_errors
+        + test_double_errors
+        + test_bypass_errors
+        + lint_rule_errors
+        + review_gate_errors
+    )
+
+    for label, value in (
+        ("boundary_id", boundary_id),
+        ("owner_package", owner_package),
+        ("name", name),
+    ):
+        if value is None:
+            continue
+        error = validate_package_name(value, field_name=label) if label == "owner_package" else None
+        if error:
+            errors.append(error)
+
+    if owner_crate_path is not None:
+        error = validate_identifier(owner_crate_path, field_name="owner_crate_path")
+        if error:
+            errors.append(error)
+    if public_trait is not None:
+        error = validate_identifier(public_trait, field_name="public.trait")
+        if error:
+            errors.append(error)
+    if public_facade is not None:
+        error = validate_identifier(public_facade, field_name="public.facade")
+        if error:
+            errors.append(error)
+    if implementation_type is not None:
+        error = validate_identifier(implementation_type, field_name="implementation.type")
+        if error:
+            errors.append(error)
+    if implementation_module is not None:
+        error = validate_rust_path(implementation_module, field_name="implementation.module")
+        if error:
+            errors.append(error)
+
+    if implementation_visibility is not None and implementation_visibility not in VISIBILITY_VALUES:
+        errors.append(
+            "implementation.visibility must be one of: "
+            + ", ".join(sorted(VISIBILITY_VALUES))
+        )
+    if implementation_constructor is not None and implementation_constructor not in CONSTRUCTOR_VALUES:
+        errors.append(
+            "implementation.constructor must be one of: "
+            + ", ".join(sorted(CONSTRUCTOR_VALUES))
+        )
+    if references_scope is not None and references_scope not in REFERENCE_SCOPE_VALUES:
+        errors.append("references.scope must be one of: " + ", ".join(sorted(REFERENCE_SCOPE_VALUES)))
+    if status_state is not None and status_state not in STATE_VALUES:
+        errors.append("status.state must be one of: " + ", ".join(sorted(STATE_VALUES)))
+
+    if public_trait is None and public_facade is None:
+        errors.append("one of public.trait or public.facade must be provided")
+
+    if implementation_visibility == "trait_only":
+        if implementation_type is not None:
+            errors.append("implementation.type must be null when implementation.visibility is trait_only")
+        if implementation_module is not None:
+            errors.append("implementation.module must be null when implementation.visibility is trait_only")
+        if implementation_constructor != "none":
+            errors.append("implementation.constructor must be none when implementation.visibility is trait_only")
+    else:
+        if implementation_type is None:
+            errors.append("implementation.type is required for concrete boundaries")
+        if implementation_module is None:
+            errors.append("implementation.module is required for concrete boundaries")
+
+    for path_name in composition_roots:
+        error = validate_rust_path(path_name, field_name="composition.roots entry")
+        if error:
+            errors.append(error)
+    for path_name in allowed_test_double_paths:
+        error = validate_rust_path(path_name, field_name="testing.allowed_test_double_paths entry")
+        if error:
+            errors.append(error)
+    for path_name in forbidden_test_bypasses:
+        error = validate_rust_path(path_name, field_name="testing.forbidden_test_bypasses entry")
+        if error:
+            errors.append(error)
+    for ref_name in forbidden_references:
+        if "::" not in ref_name:
+            error = validate_identifier(ref_name, field_name="references.forbidden entry")
+        else:
+            error = validate_rust_path(ref_name, field_name="references.forbidden entry")
+        if error:
+            errors.append(error)
+    for rule_name in lint_rules:
+        error = validate_identifier(rule_name.replace("-", "_"), field_name="enforcement.lint_rules entry")
+        if error:
+            errors.append(f"invalid enforcement.lint_rules entry: {rule_name!r}")
+    for gate_name in review_gates:
+        error = validate_identifier(gate_name.replace("-", "_"), field_name="enforcement.review_gates entry")
+        if error:
+            errors.append(f"invalid enforcement.review_gates entry: {gate_name!r}")
+    for edge in forbidden_edges:
+        match = FORBIDDEN_EDGE_RE.match(edge)
+        if match is None:
+            errors.append(f"invalid dependencies.forbidden_edges entry: {edge!r}")
+        else:
+            left_alias = match.group("left")
+            right_alias = match.group("right")
+            if left_alias == right_alias:
+                errors.append(f"invalid dependencies.forbidden_edges self-edge: {edge!r}")
+
+    if owner_package and source_path.parent.name != owner_package:
+        errors.append(
+            f"document path owner mismatch: docs/{source_path.parent.name}/boundaries.md declares owner_package {owner_package!r}"
+        )
+
+    if owner_package and composition_roots:
+        owner_crate_prefix = owner_crate_path or ""
+        allowed_dependent_set = set(allowed_dependents)
+        for root in composition_roots:
+            crate_prefix = root.split("::", 1)[0]
+            if crate_prefix != owner_crate_prefix and crate_prefix.replace("_", "-") not in allowed_dependent_set:
+                errors.append(
+                    f"composition root {root!r} must also appear in dependencies.allowed_dependents"
+                )
+
+    if errors:
+        identifier = boundary_id or name or "unknown-boundary"
+        return None, [BoundaryViolation(base_location, f"[{identifier}] {error}") for error in errors]
+
+    assert boundary_id is not None
+    assert owner_package is not None
+    assert owner_crate_path is not None
+    assert name is not None
+    assert implementation_visibility is not None
+    assert implementation_constructor is not None
+    assert references_scope is not None
+    assert status_state is not None
+
+    record = BoundaryRecord(
         boundary_id=boundary_id,
         owner_package=owner_package,
         owner_crate_path=owner_crate_path,
+        name=name,
+        public_trait=public_trait,
+        public_facade=public_facade,
+        implementation_type=implementation_type,
+        implementation_module=implementation_module,
+        implementation_visibility=implementation_visibility,
+        implementation_constructor=implementation_constructor,
+        composition_roots=tuple(composition_roots),
+        allowed_dependents=tuple(allowed_dependents),
+        allowed_dependencies=tuple(allowed_dependencies),
+        forbidden_edges=tuple(forbidden_edges),
+        references_scope=references_scope,
+        forbidden_references=tuple(forbidden_references),
+        allowed_test_double_paths=tuple(allowed_test_double_paths),
+        forbidden_test_bypasses=tuple(forbidden_test_bypasses),
+        lint_rules=tuple(lint_rules),
+        review_gates=tuple(review_gates),
         status_state=status_state,
-        forbidden_edges=tuple(str(edge) for edge in forbidden_edges),
         source_path=source_path,
         start_line=start_line,
         raw=data,
     )
+    return record, []
 
 
 def parse_boundary_records(repo_root: Path) -> tuple[list[BoundaryRecord], list[BoundaryViolation]]:
     records: list[BoundaryRecord] = []
     violations: list[BoundaryViolation] = []
     for doc_path in boundary_docs(repo_root):
-        rel_doc = doc_path.relative_to(repo_root).as_posix()
+        rel_doc = doc_path.relative_to(repo_root)
         for start_line, yaml_text in extract_yaml_blocks(doc_path):
             try:
                 data = parse_simple_yaml_document(yaml_text)
             except ValueError as error:
-                violations.append(BoundaryViolation(f"{rel_doc}:{start_line}", f"invalid boundary YAML: {error}"))
-                continue
-
-            record_errors = validate_boundary_record_data(data)
-            if record_errors:
-                for error in record_errors:
-                    violations.append(BoundaryViolation(f"{rel_doc}:{start_line}", error))
-                continue
-
-            try:
-                records.append(
-                    boundary_record_from_data(
-                        data=data,
-                        source_path=doc_path.relative_to(repo_root),
-                        start_line=start_line,
-                    )
+                violations.append(
+                    BoundaryViolation(f"{rel_doc.as_posix()}:{start_line}", f"invalid boundary YAML: {error}")
                 )
-            except ValueError as error:
-                violations.append(BoundaryViolation(f"{rel_doc}:{start_line}", str(error)))
+                continue
+            record, record_errors = build_boundary_record(
+                data=data,
+                source_path=rel_doc,
+                start_line=start_line,
+            )
+            violations.extend(record_errors)
+            if record is not None:
+                records.append(record)
     return records, violations
 
 
-def crate_manifest_aliases(manifest_path: Path) -> set[str]:
-    manifest = tomllib_load(manifest_path)
-    package = manifest.get("package", {})
-    package_name = package.get("name")
-    aliases = {manifest_path.parent.name}
-    if isinstance(package_name, str):
-        aliases.add(package_name)
-    return aliases
-
-
-def manifest_by_alias(repo_root: Path) -> dict[str, Path]:
-    aliases: dict[str, Path] = {}
+def manifest_info(repo_root: Path) -> list[ManifestInfo]:
+    infos: list[ManifestInfo] = []
     for manifest_path in workspace_manifests(repo_root):
-        for alias in crate_manifest_aliases(manifest_path):
-            aliases[alias] = manifest_path
+        manifest = tomllib_load(manifest_path)
+        package = manifest.get("package", {})
+        package_name = package.get("name")
+        if not isinstance(package_name, str):
+            continue
+        lib = manifest.get("lib", {})
+        lib_name = lib.get("name") if isinstance(lib, dict) else None
+        crate_path_name = lib_name if isinstance(lib_name, str) else manifest_path.parent.name.replace("-", "_")
+        infos.append(
+            ManifestInfo(
+                path=manifest_path,
+                package_name=package_name,
+                crate_dir_name=manifest_path.parent.name,
+                crate_path_name=crate_path_name,
+            )
+        )
+    return infos
+
+
+def manifest_by_alias(repo_root: Path) -> dict[str, ManifestInfo]:
+    aliases: dict[str, ManifestInfo] = {}
+    for info in manifest_info(repo_root):
+        for alias in info.aliases:
+            aliases[alias] = info
     return aliases
 
 
-def collect_forbidden_edge_violations(
-    repo_root: Path,
-    records: list[BoundaryRecord],
-) -> list[BoundaryViolation]:
+def source_files_for_crate(info: ManifestInfo) -> list[Path]:
+    crate_root = info.path.parent / "src"
+    if not crate_root.exists():
+        return []
+    return sorted(crate_root.glob("**/*.rs"))
+
+
+def dedupe_violations(violations: list[BoundaryViolation]) -> list[BoundaryViolation]:
+    unique: dict[tuple[str, str], BoundaryViolation] = {}
+    for violation in violations:
+        unique[(violation.location, violation.message)] = violation
+    return sorted(unique.values(), key=lambda item: (item.location, item.message))
+
+
+def collect_duplicate_record_violations(records: list[BoundaryRecord]) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+    by_id: dict[str, BoundaryRecord] = {}
+    by_owner_name: dict[tuple[str, str], BoundaryRecord] = {}
+    for record in records:
+        existing = by_id.get(record.boundary_id)
+        if existing is not None:
+            violations.append(
+                BoundaryViolation(
+                    record.location,
+                    f"duplicate boundary_id {record.boundary_id!r}; first declared at {existing.location}",
+                )
+            )
+        else:
+            by_id[record.boundary_id] = record
+
+        key = (record.owner_package, record.name)
+        existing_owner_name = by_owner_name.get(key)
+        if existing_owner_name is not None:
+            violations.append(
+                BoundaryViolation(
+                    record.location,
+                    f"duplicate boundary name {record.name!r} for owner_package {record.owner_package!r}; first declared at {existing_owner_name.location}",
+                )
+            )
+        else:
+            by_owner_name[key] = record
+    return violations
+
+
+def collect_manifest_consistency_violations(repo_root: Path, records: list[BoundaryRecord]) -> list[BoundaryViolation]:
     violations: list[BoundaryViolation] = []
     alias_map = manifest_by_alias(repo_root)
     for record in records:
-        if not record.is_enforced:
+        info = alias_map.get(record.owner_package)
+        if info is None:
             continue
-        for edge in record.forbidden_edges:
-            if "->" not in edge:
-                rel_doc = record.source_path.as_posix()
-                violations.append(
-                    BoundaryViolation(
-                        f"{rel_doc}:{record.start_line}",
-                        f"{record.boundary_id} has invalid forbidden edge {edge!r}",
-                    )
+        if record.owner_crate_path != info.crate_path_name:
+            violations.append(
+                BoundaryViolation(
+                    record.location,
+                    f"owner_crate_path {record.owner_crate_path!r} does not match workspace crate path {info.crate_path_name!r}",
                 )
+            )
+    return violations
+
+
+def collect_allowed_dependent_violations(repo_root: Path, records: list[BoundaryRecord]) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+    infos = manifest_info(repo_root)
+    records_by_owner: dict[str, list[BoundaryRecord]] = {}
+    for record in records:
+        records_by_owner.setdefault(record.owner_package, []).append(record)
+
+    for owner_package, owner_records in records_by_owner.items():
+        owner_info = next((info for info in infos if owner_package in info.aliases), None)
+        if owner_info is None:
+            continue
+        allowed = {alias for record in owner_records for alias in record.allowed_dependents}
+        for depender_info in infos:
+            if depender_info.path == owner_info.path:
                 continue
-            left_alias, right_alias = (part.strip() for part in edge.split("->", 1))
+            manifest = tomllib_load(depender_info.path)
+            for section_name, dependencies in dependency_sections(manifest):
+                if "dev-dependencies" in section_name:
+                    continue
+                for dependency_name, dependency in dependencies.items():
+                    package_name = dependency_package_name(dependency_name, dependency)
+                    if package_name != owner_info.package_name:
+                        continue
+                    depender_aliases = {depender_info.package_name, depender_info.crate_dir_name}
+                    if depender_aliases.isdisjoint(allowed):
+                        rel_manifest = depender_info.path.relative_to(repo_root).as_posix()
+                        violations.append(
+                            BoundaryViolation(
+                                f"{rel_manifest} [{section_name}]",
+                                f"{owner_package} allows dependents {sorted(allowed)!r}; found unexpected dependent {depender_info.package_name!r}",
+                            )
+                        )
+    return violations
+
+
+def collect_forbidden_edge_violations(repo_root: Path, records: list[BoundaryRecord]) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+    alias_map = manifest_by_alias(repo_root)
+    for record in records:
+        for edge in record.forbidden_edges:
+            match = FORBIDDEN_EDGE_RE.match(edge)
+            if match is None:
+                continue
+            left_alias = match.group("left")
+            right_alias = match.group("right")
             left_manifest = alias_map.get(left_alias)
             if left_manifest is None:
                 continue
-            manifest = tomllib_load(left_manifest)
-            rel_manifest_path = left_manifest.relative_to(repo_root)
-            rel_manifest = rel_manifest_path.as_posix()
+            manifest = tomllib_load(left_manifest.path)
+            rel_manifest = left_manifest.path.relative_to(repo_root).as_posix()
             for section_name, dependencies in dependency_sections(manifest):
                 for dependency_name, dependency in dependencies.items():
                     package_name = dependency_package_name(dependency_name, dependency)
-                    dependency_aliases = {dependency_name, package_name}
+                    dependency_aliases = {dependency_name, package_name, package_name.replace("-", "_")}
                     if right_alias in dependency_aliases:
                         violations.append(
                             BoundaryViolation(
@@ -385,12 +792,176 @@ def collect_forbidden_edge_violations(
     return violations
 
 
-def collect_boundary_violations(repo_root: Path) -> list[BoundaryViolation]:
-    violations: list[BoundaryViolation] = []
-    boundary_records, record_violations = parse_boundary_records(repo_root)
-    violations.extend(record_violations)
-    violations.extend(collect_forbidden_edge_violations(repo_root, boundary_records))
+def compile_reference_pattern(reference: str) -> re.Pattern[str]:
+    escaped = re.escape(reference)
+    return re.compile(rf"(?<![A-Za-z0-9_]){escaped}(?![A-Za-z0-9_])")
 
+
+def resolve_module_file(repo_root: Path, module_path: str) -> list[Path]:
+    crate_prefix, *segments = module_path.split("::")
+    info = manifest_by_alias(repo_root).get(crate_prefix)
+    if info is None:
+        return []
+    src_root = info.path.parent / "src"
+    if not src_root.exists():
+        return []
+    if not segments:
+        candidates = [src_root / "lib.rs", src_root / "main.rs"]
+    else:
+        module_rel = Path(*segments)
+        candidates = [src_root / f"{module_rel}.rs", src_root / module_rel / "mod.rs"]
+    return [path for path in candidates if path.exists()]
+
+
+def exempt_reference_files(repo_root: Path, record: BoundaryRecord) -> set[Path]:
+    files: set[Path] = set()
+    alias_map = manifest_by_alias(repo_root)
+    owner_info = alias_map.get(record.owner_package)
+    if owner_info is not None:
+        files.update(path.resolve() for path in source_files_for_crate(owner_info))
+    for root in record.composition_roots:
+        files.update(path.resolve() for path in resolve_module_file(repo_root, root))
+    return files
+
+
+def collect_reference_violations(repo_root: Path, records: list[BoundaryRecord]) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+    source_paths = rust_sources(repo_root)
+    for record in records:
+        exempt_files = exempt_reference_files(repo_root, record) if record.references_scope == "outside_owner_crate" else set()
+        compiled_patterns = [(reference, compile_reference_pattern(reference)) for reference in record.forbidden_references]
+        if not compiled_patterns:
+            continue
+        for source_path in source_paths:
+            if source_path.resolve() in exempt_files:
+                continue
+            rel_source = source_path.relative_to(repo_root).as_posix()
+            for line_number, line in enumerate(source_path.read_text(encoding="utf-8").splitlines(), start=1):
+                if is_comment_line(line):
+                    continue
+                for reference, pattern in compiled_patterns:
+                    if pattern.search(line):
+                        violations.append(
+                            BoundaryViolation(
+                                f"{rel_source}:{line_number}",
+                                f"{record.boundary_id} forbids external reference {reference!r}",
+                            )
+                        )
+    return violations
+
+
+def collect_test_bypass_violations(repo_root: Path, records: list[BoundaryRecord]) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+    alias_map = manifest_by_alias(repo_root)
+    for record in records:
+        owner_info = alias_map.get(record.owner_package)
+        if owner_info is None:
+            continue
+        test_sources = rust_test_sources_for_crate(owner_info)
+        compiled_patterns = [
+            (reference, compile_reference_pattern(reference)) for reference in record.forbidden_test_bypasses
+        ]
+        if not compiled_patterns:
+            continue
+        for source_path in test_sources:
+            rel_source = source_path.relative_to(repo_root).as_posix()
+            for line_number, line in enumerate(source_path.read_text(encoding="utf-8").splitlines(), start=1):
+                if is_comment_line(line):
+                    continue
+                for reference, pattern in compiled_patterns:
+                    if pattern.search(line):
+                        violations.append(
+                            BoundaryViolation(
+                                f"{rel_source}:{line_number}",
+                                f"{record.boundary_id} forbids test bypass reference {reference!r}",
+                            )
+                        )
+    return violations
+
+
+def find_public_type_violations(record: BoundaryRecord, source_path: Path, repo_root: Path) -> list[BoundaryViolation]:
+    if record.implementation_type is None:
+        return []
+    pattern = re.compile(PUBLIC_TYPE_TEMPLATE.format(name=re.escape(record.implementation_type)))
+    rel_source = source_path.relative_to(repo_root).as_posix()
+    violations: list[BoundaryViolation] = []
+    for line_number, line in enumerate(source_path.read_text(encoding="utf-8").splitlines(), start=1):
+        if pattern.search(line):
+            violations.append(
+                BoundaryViolation(
+                    f"{rel_source}:{line_number}",
+                    f"{record.boundary_id} requires private implementation.type {record.implementation_type!r}",
+                )
+            )
+    return violations
+
+
+def find_public_reexport_violations(record: BoundaryRecord, source_path: Path, repo_root: Path) -> list[BoundaryViolation]:
+    if record.implementation_type is None:
+        return []
+    pattern = re.compile(PUBLIC_REEXPORT_TEMPLATE.format(name=re.escape(record.implementation_type)))
+    rel_source = source_path.relative_to(repo_root).as_posix()
+    violations: list[BoundaryViolation] = []
+    for line_number, line in enumerate(source_path.read_text(encoding="utf-8").splitlines(), start=1):
+        if pattern.search(line):
+            violations.append(
+                BoundaryViolation(
+                    f"{rel_source}:{line_number}",
+                    f"{record.boundary_id} forbids public re-export of {record.implementation_type!r}",
+                )
+            )
+    return violations
+
+
+def find_public_constructor_violations(record: BoundaryRecord, source_path: Path, repo_root: Path) -> list[BoundaryViolation]:
+    if record.implementation_type is None:
+        return []
+    lines = source_path.read_text(encoding="utf-8").splitlines()
+    rel_source = source_path.relative_to(repo_root).as_posix()
+    violations: list[BoundaryViolation] = []
+    inside_impl = False
+    brace_depth = 0
+    impl_pattern = re.compile(rf"\bimpl(?:<[^>]+>)?(?:\s+[A-Za-z0-9_:<>, ]+)?\s+{re.escape(record.implementation_type)}\b")
+    for line_number, line in enumerate(lines, start=1):
+        if not inside_impl and impl_pattern.search(line):
+            inside_impl = True
+            brace_depth = line.count("{") - line.count("}")
+        elif inside_impl:
+            brace_depth += line.count("{") - line.count("}")
+            if PUBLIC_FUNCTION_RE.search(line):
+                violations.append(
+                    BoundaryViolation(
+                        f"{rel_source}:{line_number}",
+                        f"{record.boundary_id} forbids public constructor/helper methods on {record.implementation_type!r}",
+                    )
+                )
+            if brace_depth <= 0:
+                inside_impl = False
+                brace_depth = 0
+    return violations
+
+
+def collect_active_implementation_violations(repo_root: Path, records: list[BoundaryRecord]) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+    alias_map = manifest_by_alias(repo_root)
+    for record in records:
+        if not record.is_active or record.implementation_visibility == "trait_only":
+            continue
+        owner_info = alias_map.get(record.owner_package)
+        if owner_info is None:
+            continue
+        source_files = source_files_for_crate(owner_info)
+        for source_path in source_files:
+            if record.implementation_visibility == "private":
+                violations.extend(find_public_type_violations(record, source_path, repo_root))
+                violations.extend(find_public_reexport_violations(record, source_path, repo_root))
+            if record.implementation_constructor == "private":
+                violations.extend(find_public_constructor_violations(record, source_path, repo_root))
+    return violations
+
+
+def collect_special_case_violations(repo_root: Path) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
     for manifest_path in workspace_manifests(repo_root):
         manifest = tomllib_load(manifest_path)
         rel_manifest_path = manifest_path.relative_to(repo_root)
@@ -405,7 +976,6 @@ def collect_boundary_violations(repo_root: Path) -> list[BoundaryViolation]:
                             "only crates/atm-rusqlite may depend on rusqlite",
                         )
                     )
-
                 if (
                     rel_manifest_path == ATM_CORE_MANIFEST
                     and package_name == ATM_RUSQLITE_PACKAGE
@@ -418,13 +988,16 @@ def collect_boundary_violations(repo_root: Path) -> list[BoundaryViolation]:
                         )
                     )
 
-    allowed_source_root = (repo_root / RUSQLITE_ALLOWED_SOURCE_ROOT).resolve()
+    allowed_manifest = repo_root / RUSQLITE_ALLOWED_MANIFEST
+    allowed_source_root = allowed_manifest.parent / "src"
     for source_path in rust_sources(repo_root):
-        if allowed_source_root in source_path.resolve().parents:
+        if allowed_source_root.exists() and allowed_source_root.resolve() in source_path.resolve().parents:
             continue
         rel_source = source_path.relative_to(repo_root).as_posix()
         text = source_path.read_text(encoding="utf-8")
         for line_number, line in enumerate(text.splitlines(), start=1):
+            if is_comment_line(line):
+                continue
             if any(pattern.search(line) for pattern in SOURCE_IMPORT_PATTERNS):
                 violations.append(
                     BoundaryViolation(
@@ -432,35 +1005,53 @@ def collect_boundary_violations(repo_root: Path) -> list[BoundaryViolation]:
                         "only crates/atm-rusqlite source may import rusqlite directly",
                     )
                 )
+    return violations
 
+
+def collect_boundary_violations(repo_root: Path) -> list[BoundaryViolation]:
+    records, parse_violations = parse_boundary_records(repo_root)
+    violations: list[BoundaryViolation] = []
+    violations.extend(parse_violations)
+    violations.extend(collect_duplicate_record_violations(records))
+    violations.extend(collect_manifest_consistency_violations(repo_root, records))
+    violations.extend(collect_allowed_dependent_violations(repo_root, records))
+    violations.extend(collect_forbidden_edge_violations(repo_root, records))
+    violations.extend(collect_reference_violations(repo_root, records))
+    violations.extend(collect_test_bypass_violations(repo_root, records))
+    violations.extend(collect_active_implementation_violations(repo_root, records))
+    violations.extend(collect_special_case_violations(repo_root))
     return dedupe_violations(violations)
 
 
-def dedupe_violations(violations: list[BoundaryViolation]) -> list[BoundaryViolation]:
-    unique: dict[tuple[str, str], BoundaryViolation] = {}
-    for violation in violations:
-        unique[(violation.location, violation.message)] = violation
-    return list(unique.values())
-
-
-def build_summary(violations: list[BoundaryViolation]) -> str:
+def build_summary(violations: list[BoundaryViolation], record_count: int) -> str:
     if not violations:
-        return "boundary rules satisfied"
-    return f"boundary rules violated ({len(violations)} findings)"
+        return f"boundary rules satisfied ({record_count} records)"
+    return f"boundary rules violated ({len(violations)} findings across {record_count} records)"
 
 
 def run(repo_root: Path) -> int:
     started_at = datetime.now(timezone.utc)
     started_monotonic = monotonic_now()
-    violations = collect_boundary_violations(repo_root)
+    records, parse_violations = parse_boundary_records(repo_root)
+    violations = parse_violations.copy()
+    violations.extend(collect_duplicate_record_violations(records))
+    violations.extend(collect_manifest_consistency_violations(repo_root, records))
+    violations.extend(collect_allowed_dependent_violations(repo_root, records))
+    violations.extend(collect_forbidden_edge_violations(repo_root, records))
+    violations.extend(collect_reference_violations(repo_root, records))
+    violations.extend(collect_test_bypass_violations(repo_root, records))
+    violations.extend(collect_active_implementation_violations(repo_root, records))
+    violations.extend(collect_special_case_violations(repo_root))
+    violations = dedupe_violations(violations)
+
     duration_seconds = monotonic_now() - started_monotonic
     findings = [violation.render() for violation in violations]
-    transcript_lines = findings or ["no boundary violations found"]
+    transcript_lines = findings or [f"validated {len(records)} boundary records"]
     report = build_report(
         lint_name=LINT_NAME,
         repo_root=repo_root,
         passed=not violations,
-        summary=build_summary(violations),
+        summary=build_summary(violations, len(records)),
         findings=findings,
         transcript_lines=transcript_lines,
         started_at=started_at,
@@ -471,7 +1062,7 @@ def run(repo_root: Path) -> int:
 
 
 def main(argv: list[str]) -> int:
-    parser = argparse.ArgumentParser(description="Check crate and source boundary rules.")
+    parser = argparse.ArgumentParser(description="Check boundary inventory schema and enforcement rules.")
     parser.add_argument("--root", help="Repo root to inspect.")
     args = parser.parse_args(argv[1:])
     repo_root = discover_repo_root(args.root)

--- a/.just/lint_cargo_deny.py
+++ b/.just/lint_cargo_deny.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 
 from lint_common import discover_repo_root
+from lint_common import workspace_crate_section_lines
 
 
 DEPRECATED_CONFIG_LINES = (
@@ -53,6 +54,9 @@ def main(argv: list[str]) -> int:
     if shutil.which("cargo-deny") is None:
         print("cargo-deny is not installed; install it to run this lint", file=sys.stderr)
         return 2
+
+    for line in workspace_crate_section_lines(repo_root):
+        print(line)
 
     runtime_config = build_runtime_config(repo_root)
     completed = subprocess.run(

--- a/.just/lint_cargo_deny.py
+++ b/.just/lint_cargo_deny.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from lint_common import discover_repo_root
+
+
+DEPRECATED_CONFIG_LINES = (
+    "vulnerability = ",
+    "unlicensed = ",
+)
+
+
+def build_command(repo_root: Path, config_path: Path) -> list[str]:
+    return [
+        "cargo-deny",
+        "check",
+        "--config",
+        str(config_path),
+        "advisories",
+        "bans",
+        "licenses",
+        "sources",
+    ]
+
+
+def build_runtime_config(repo_root: Path) -> Path:
+    source_path = repo_root / "deny.toml"
+    text = source_path.read_text(encoding="utf-8")
+    filtered_lines = [
+        line
+        for line in text.splitlines()
+        if not any(line.lstrip().startswith(prefix) for prefix in DEPRECATED_CONFIG_LINES)
+    ]
+    temp_dir = Path(tempfile.mkdtemp(prefix="atm-lint-deny-"))
+    runtime_path = temp_dir / "deny.toml"
+    runtime_path.write_text("\n".join(filtered_lines).rstrip() + "\n", encoding="utf-8")
+    return runtime_path
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Run cargo-deny with the repo policy.")
+    parser.add_argument("--root", help="Repo root to inspect.")
+    args = parser.parse_args(argv[1:])
+    repo_root = discover_repo_root(args.root)
+
+    if shutil.which("cargo-deny") is None:
+        print("cargo-deny is not installed; install it to run this lint", file=sys.stderr)
+        return 2
+
+    runtime_config = build_runtime_config(repo_root)
+    completed = subprocess.run(
+        build_command(repo_root, runtime_config),
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if completed.stdout:
+        print(completed.stdout, end="")
+    if completed.stderr:
+        print(completed.stderr, end="", file=sys.stderr)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/lint_cargo_shear.py
+++ b/.just/lint_cargo_shear.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+from dataclasses import dataclass
 import argparse
 from pathlib import Path
 import shutil
@@ -8,10 +9,179 @@ import subprocess
 import sys
 
 from lint_common import discover_repo_root
+from lint_common import load_lint_config
+
+
+ERROR_SECTIONS = {"unlinked_files", "empty_files"}
+
+
+@dataclass(frozen=True)
+class ShearSection:
+    name: str
+    header: str
+    body_lines: tuple[str, ...]
+    file_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ShearPolicyFinding:
+    section_name: str
+    file_path: str
+    reason: str
 
 
 def build_command(repo_root: Path) -> list[str]:
     return ["cargo-shear"]
+
+
+def parse_sections(stdout: str) -> list[ShearSection]:
+    sections: list[ShearSection] = []
+    current_name: str | None = None
+    current_body: list[str] = []
+    current_header = ""
+
+    for line in stdout.splitlines():
+        if line.startswith("shear/"):
+            if current_name is not None:
+                sections.append(
+                    ShearSection(
+                        name=current_name,
+                        header=current_header,
+                        body_lines=tuple(current_body),
+                        file_paths=tuple(extract_file_paths(current_body)),
+                    )
+                )
+            current_name = line.split("/", 1)[1].strip()
+            current_header = line.strip()
+            current_body = []
+            continue
+        if current_name is not None:
+            current_body.append(line)
+
+    if current_name is not None:
+        sections.append(
+            ShearSection(
+                name=current_name,
+                header=current_header,
+                body_lines=tuple(current_body),
+                file_paths=tuple(extract_file_paths(current_body)),
+            )
+        )
+    return sections
+
+
+def extract_file_paths(body_lines: list[str] | tuple[str, ...]) -> list[str]:
+    paths: list[str] = []
+    for line in body_lines:
+        stripped = line.strip()
+        if not stripped.startswith("│ "):
+            continue
+        candidate = stripped[2:].strip()
+        if not candidate:
+            continue
+        if "/" not in candidate and "\\" not in candidate:
+            continue
+        paths.append(candidate.replace("\\", "/"))
+    return paths
+
+
+def package_to_crate_dir(repo_root: Path) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    crates_dir = repo_root / "crates"
+    if not crates_dir.exists():
+        return mapping
+    for manifest_path in sorted(crates_dir.glob("*/Cargo.toml")):
+        text = manifest_path.read_text(encoding="utf-8")
+        package_name = None
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("name = "):
+                package_name = stripped.split("=", 1)[1].strip().strip('"')
+                break
+        if package_name:
+            mapping[package_name] = manifest_path.parent.name
+    return mapping
+
+
+def load_policy_config(repo_root: Path) -> dict[str, dict[str, str]]:
+    config = load_lint_config(repo_root)
+    cargo_shear = config.get("cargo_shear", {})
+    if not isinstance(cargo_shear, dict):
+        return {"allowed_empty_files": {}, "allowed_unlinked_files": {}}
+
+    def table(name: str) -> dict[str, str]:
+        value = cargo_shear.get(name, {})
+        if not isinstance(value, dict):
+            return {}
+        normalized: dict[str, str] = {}
+        for key, reason in value.items():
+            if isinstance(key, str) and isinstance(reason, str):
+                normalized[key.replace("\\", "/")] = reason
+        return normalized
+
+    return {
+        "allowed_empty_files": table("allowed_empty_files"),
+        "allowed_unlinked_files": table("allowed_unlinked_files"),
+    }
+
+
+def evaluate_policy(sections: list[ShearSection], policy: dict[str, dict[str, str]]) -> tuple[list[ShearPolicyFinding], list[str]]:
+    findings: list[ShearPolicyFinding] = []
+    downgraded: list[str] = []
+
+    for section in sections:
+        if section.name not in ERROR_SECTIONS:
+            continue
+        allowed = (
+            policy["allowed_empty_files"]
+            if section.name == "empty_files"
+            else policy["allowed_unlinked_files"]
+        )
+        for file_path in section.file_paths:
+            reason = allowed.get(file_path)
+            if reason is not None:
+                downgraded.append(
+                    f"{section.name}: downgraded {file_path} ({reason})"
+                )
+                continue
+            findings.append(
+                ShearPolicyFinding(
+                    section_name=section.name,
+                    file_path=file_path,
+                    reason=f"{section.name} must be fixed or explicitly downgraded in .just/lint-config.toml",
+                )
+            )
+    return findings, downgraded
+
+
+def render_policy_findings(findings: list[ShearPolicyFinding]) -> list[str]:
+    rendered: list[str] = []
+    for finding in findings:
+        rendered.append(
+            f"shear policy error: {finding.file_path} [{finding.section_name}] {finding.reason}"
+        )
+    return rendered
+
+
+def annotate_sections(sections: list[ShearSection], repo_root: Path) -> list[str]:
+    crate_map = package_to_crate_dir(repo_root)
+    rendered: list[str] = []
+    for section in sections:
+        if not section.file_paths:
+            continue
+        crate_name = infer_package_name(section.body_lines)
+        crate_dir = crate_map.get(crate_name, crate_name)
+        for path in section.file_paths:
+            rendered.append(f"shear note: crates/{crate_dir}/{path} [{section.name}]")
+    return rendered
+
+
+def infer_package_name(body_lines: tuple[str, ...]) -> str:
+    for line in body_lines:
+        stripped = line.strip()
+        if " in `" in stripped and stripped.endswith("`"):
+            return stripped.split(" in `", 1)[1][:-1]
+    return "unknown-package"
 
 
 def main(argv: list[str]) -> int:
@@ -31,11 +201,40 @@ def main(argv: list[str]) -> int:
         text=True,
         encoding="utf-8",
     )
-    if completed.stdout:
-        print(completed.stdout, end="")
+
+    stdout = completed.stdout
+    sections = parse_sections(stdout)
+    policy = load_policy_config(repo_root)
+    policy_findings, downgraded = evaluate_policy(sections, policy)
+
+    if completed.returncode != 0:
+        if stdout:
+            print(stdout, end="")
+        if completed.stderr:
+            print(completed.stderr, end="", file=sys.stderr)
+        return completed.returncode
+
+    if policy_findings:
+        for line in render_policy_findings(policy_findings):
+            print(line)
+        for line in annotate_sections(sections, repo_root):
+            if any(f.file_path in line for f in policy_findings):
+                print(line)
+        if downgraded:
+            for line in downgraded:
+                print(line)
+        if stdout:
+            print(stdout, end="")
+        return 1
+
+    if downgraded:
+        for line in downgraded:
+            print(line)
+    if stdout:
+        print(stdout, end="")
     if completed.stderr:
         print(completed.stderr, end="", file=sys.stderr)
-    return completed.returncode
+    return 0
 
 
 if __name__ == "__main__":

--- a/.just/lint_cargo_shear.py
+++ b/.just/lint_cargo_shear.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+from lint_common import discover_repo_root
+
+
+def build_command(repo_root: Path) -> list[str]:
+    return ["cargo-shear"]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Run cargo-shear for dependency pruning checks.")
+    parser.add_argument("--root", help="Repo root to inspect.")
+    args = parser.parse_args(argv[1:])
+    repo_root = discover_repo_root(args.root)
+
+    if shutil.which("cargo-shear") is None:
+        print("cargo-shear is not installed; install it to run this lint", file=sys.stderr)
+        return 2
+
+    completed = subprocess.run(
+        build_command(repo_root),
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if completed.stdout:
+        print(completed.stdout, end="")
+    if completed.stderr:
+        print(completed.stderr, end="", file=sys.stderr)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/lint_cargo_shear.py
+++ b/.just/lint_cargo_shear.py
@@ -10,6 +10,7 @@ import sys
 
 from lint_common import discover_repo_root
 from lint_common import load_lint_config
+from lint_common import workspace_crate_section_lines
 
 
 ERROR_SECTIONS = {"unlinked_files", "empty_files"}
@@ -193,6 +194,9 @@ def main(argv: list[str]) -> int:
     if shutil.which("cargo-shear") is None:
         print("cargo-shear is not installed; install it to run this lint", file=sys.stderr)
         return 2
+
+    for line in workspace_crate_section_lines(repo_root):
+        print(line)
 
     completed = subprocess.run(
         build_command(repo_root),

--- a/.just/lint_codespell.py
+++ b/.just/lint_codespell.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+
+from lint_common import discover_repo_root
+
+
+def build_command(repo_root: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-c",
+        "import sys; from codespell_lib import _script_main; sys.exit(_script_main())",
+    ]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Run codespell with the repo policy.")
+    parser.add_argument("--root", help="Repo root to inspect.")
+    args = parser.parse_args(argv[1:])
+    repo_root = discover_repo_root(args.root)
+
+    completed = subprocess.run(
+        build_command(repo_root),
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if completed.stdout:
+        print(completed.stdout, end="")
+    if completed.stderr:
+        print(completed.stderr, end="", file=sys.stderr)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/lint_codespell.py
+++ b/.just/lint_codespell.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 
 from lint_common import discover_repo_root
+from lint_common import workspace_crate_section_lines
 
 
 def build_command(repo_root: Path) -> list[str]:
@@ -22,6 +23,9 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--root", help="Repo root to inspect.")
     args = parser.parse_args(argv[1:])
     repo_root = discover_repo_root(args.root)
+
+    for line in workspace_crate_section_lines(repo_root):
+        print(line)
 
     completed = subprocess.run(
         build_command(repo_root),

--- a/.just/lint_common.py
+++ b/.just/lint_common.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+import time
+import tomllib
+
+
+LOG_DIR = Path(".just/logs")
+CONFIG_PATH = Path(".just/lint-config.toml")
+TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
+LINT_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+DIRECTIVE_RE = re.compile(
+    r"(?P<label>(?:lint-[A-Za-z0-9._-]+|rule-\d{3}|lint-all))\s*:\s*"
+    r"(?P<action>allow-next-line|allow-start|allow-end)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class LintReport:
+    lint_name: str
+    passed: bool
+    summary: str
+    findings: list[str]
+    transcript: list[str]
+    duration_seconds: float
+    log_path: Path
+
+
+@dataclass(frozen=True)
+class LintDirectivePolicy:
+    tool_key: str
+    aliases: tuple[str, ...] = ()
+
+    @property
+    def labels(self) -> set[str]:
+        labels = {"lint-all", f"lint-{self.tool_key.lower()}"}
+        labels.update(alias.lower() for alias in self.aliases)
+        return labels
+
+
+def discover_repo_root(explicit_root: str | None = None) -> Path:
+    if explicit_root is not None:
+        return Path(explicit_root).resolve()
+    return Path(__file__).resolve().parent.parent
+
+
+def load_lint_config(repo_root: Path) -> dict:
+    config_path = repo_root / CONFIG_PATH
+    return tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+
+def lint_slug(lint_name: str) -> str:
+    slug = LINT_NAME_RE.sub("-", lint_name.strip().lower()).strip("-")
+    return slug or "lint"
+
+
+def make_log_path(repo_root: Path, lint_name: str, started_at: datetime | None = None) -> Path:
+    timestamp = (started_at or datetime.now(timezone.utc)).strftime(TIMESTAMP_FORMAT)
+    return repo_root / LOG_DIR / f"{timestamp}-{lint_slug(lint_name)}.log"
+
+
+def write_log(log_path: Path, transcript: list[str]) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    text = "\n".join(transcript).rstrip()
+    if text:
+        text += "\n"
+    log_path.write_text(text, encoding="utf-8")
+
+
+def format_duration(duration_seconds: float) -> str:
+    if duration_seconds < 1:
+        return f"{duration_seconds:.2f}s"
+    return f"{duration_seconds:.1f}s"
+
+
+def relative_log_path(repo_root: Path, log_path: Path) -> str:
+    try:
+        return log_path.relative_to(repo_root).as_posix()
+    except ValueError:
+        return log_path.as_posix()
+
+
+def build_transcript_header(
+    *,
+    lint_name: str,
+    repo_root: Path,
+    started_at: datetime,
+    duration_seconds: float,
+    summary: str,
+) -> list[str]:
+    return [
+        f"lint: {lint_name}",
+        f"repo_root: {repo_root}",
+        f"started_at_utc: {started_at.isoformat()}",
+        f"duration: {format_duration(duration_seconds)}",
+        f"summary: {summary}",
+        "",
+    ]
+
+
+def build_report(
+    *,
+    lint_name: str,
+    repo_root: Path,
+    passed: bool,
+    summary: str,
+    findings: list[str],
+    transcript_lines: list[str],
+    started_at: datetime,
+    duration_seconds: float,
+) -> LintReport:
+    log_path = make_log_path(repo_root, lint_name, started_at)
+    transcript = build_transcript_header(
+        lint_name=lint_name,
+        repo_root=repo_root,
+        started_at=started_at,
+        duration_seconds=duration_seconds,
+        summary=summary,
+    )
+    transcript.extend(transcript_lines)
+    write_log(log_path, transcript)
+    return LintReport(
+        lint_name=lint_name,
+        passed=passed,
+        summary=summary,
+        findings=findings,
+        transcript=transcript,
+        duration_seconds=duration_seconds,
+        log_path=log_path,
+    )
+
+
+def print_report(
+    report: LintReport,
+    *,
+    repo_root: Path,
+    preview_limit: int = 2,
+    direct_threshold: int = 3,
+) -> None:
+    if report.passed:
+        print(f"{report.lint_name} passed [{format_duration(report.duration_seconds)}]")
+        return
+
+    print(f"{report.lint_name} failed")
+    preview = report.findings[:preview_limit]
+    if len(report.findings) <= direct_threshold:
+        preview = report.findings
+
+    for finding in preview:
+        print(f"  {finding}")
+
+    log_display = relative_log_path(repo_root, report.log_path)
+    if len(report.findings) > direct_threshold:
+        print(f"  [{len(report.findings)}] errors in {log_display}")
+    else:
+        print(f"  full log: {log_display}")
+
+
+def monotonic_now() -> float:
+    return time.perf_counter()
+
+
+def is_comment_line(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith(("//", "///", "//!", "/*", "*", "*/"))
+
+
+def is_comment_or_empty(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return True
+    return is_comment_line(line)
+
+
+def is_code_line(line: str) -> bool:
+    return not is_comment_or_empty(line)
+
+
+def matching_directive_actions(line: str, policy: LintDirectivePolicy) -> list[str]:
+    actions: list[str] = []
+    for match in DIRECTIVE_RE.finditer(line):
+        label = match.group("label").lower()
+        if label in policy.labels:
+            actions.append(match.group("action").lower())
+    return actions
+
+
+def line_has_allow_next_line(
+    line_number: int,
+    lines: list[str],
+    policy: LintDirectivePolicy,
+) -> bool:
+    if line_number <= 1:
+        return False
+    index = line_number - 2
+    while index >= 0:
+        line = lines[index]
+        actions = matching_directive_actions(line, policy)
+        if "allow-next-line" in actions:
+            return True
+        if not is_comment_line(line):
+            return False
+        index -= 1
+    return False
+
+
+def line_is_inside_allow_block(
+    line_number: int,
+    lines: list[str],
+    policy: LintDirectivePolicy,
+) -> bool:
+    allow_depth = 0
+    for line in lines[: line_number - 1]:
+        for action in matching_directive_actions(line, policy):
+            if action == "allow-start":
+                allow_depth += 1
+            elif action == "allow-end":
+                allow_depth = max(0, allow_depth - 1)
+    return allow_depth > 0
+
+
+def line_is_suppressed(
+    line_number: int,
+    lines: list[str],
+    policy: LintDirectivePolicy,
+) -> bool:
+    return line_has_allow_next_line(line_number, lines, policy) or line_is_inside_allow_block(
+        line_number,
+        lines,
+        policy,
+    )
+
+
+def classify_rust_test_scope(
+    lines: list[str],
+    *,
+    treat_all_lines_as_test: bool = False,
+) -> list[bool]:
+    if treat_all_lines_as_test:
+        return [True] * len(lines)
+
+    scope: list[bool] = []
+    cfg_test_pending = False
+    cfg_test_attribute_active = False
+    test_block_depth: int | None = None
+    brace_balance = 0
+
+    for line in lines:
+        stripped = line.strip()
+
+        if "#[cfg(test)]" in stripped:
+            cfg_test_pending = True
+            cfg_test_attribute_active = True
+            scope.append(True)
+            continue
+
+        if cfg_test_pending and stripped.startswith("#[") and stripped.endswith("]"):
+            scope.append(True)
+            continue
+
+        current_scope_is_test = test_block_depth is not None or cfg_test_pending
+        scope.append(current_scope_is_test)
+
+        open_braces = line.count("{")
+        close_braces = line.count("}")
+
+        if cfg_test_pending and open_braces > 0:
+            brace_balance = open_braces - close_braces
+            test_block_depth = max(brace_balance, 0)
+            cfg_test_pending = False
+            cfg_test_attribute_active = False
+        elif cfg_test_pending and stripped.endswith(";"):
+            cfg_test_pending = False
+            cfg_test_attribute_active = False
+        elif test_block_depth is not None:
+            brace_balance += open_braces - close_braces
+            test_block_depth = max(brace_balance, 0)
+            if test_block_depth == 0:
+                test_block_depth = None
+        elif cfg_test_attribute_active and stripped and not stripped.startswith("#["):
+            cfg_test_pending = False
+            cfg_test_attribute_active = False
+
+    return scope

--- a/.just/lint_common.py
+++ b/.just/lint_common.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import re
 import time
 import tomllib
+from typing import Callable
 
 
 LOG_DIR = Path(".just/logs")
@@ -43,6 +44,14 @@ class LintDirectivePolicy:
         return labels
 
 
+@dataclass(frozen=True)
+class WorkspaceCrate:
+    crate_dir: str
+    package_name: str
+    crate_path_name: str
+    manifest_path: str
+
+
 def discover_repo_root(explicit_root: str | None = None) -> Path:
     if explicit_root is not None:
         return Path(explicit_root).resolve()
@@ -52,6 +61,91 @@ def discover_repo_root(explicit_root: str | None = None) -> Path:
 def load_lint_config(repo_root: Path) -> dict:
     config_path = repo_root / CONFIG_PATH
     return tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+
+def workspace_crates(repo_root: Path) -> list[WorkspaceCrate]:
+    crates: list[WorkspaceCrate] = []
+    for manifest_path in sorted((repo_root / "crates").glob("*/Cargo.toml")):
+        manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+        package = manifest.get("package", {})
+        package_name = package.get("name")
+        if not isinstance(package_name, str):
+            continue
+        lib = manifest.get("lib", {})
+        lib_name = lib.get("name") if isinstance(lib, dict) else None
+        crate_path_name = lib_name if isinstance(lib_name, str) else manifest_path.parent.name.replace("-", "_")
+        crates.append(
+            WorkspaceCrate(
+                crate_dir=manifest_path.parent.name,
+                package_name=package_name,
+                crate_path_name=crate_path_name,
+                manifest_path=manifest_path.relative_to(repo_root).as_posix(),
+            )
+        )
+    return crates
+
+
+def render_table(
+    rows: list[dict[str, str]],
+    columns: list[tuple[str, str]],
+) -> list[str]:
+    if not rows:
+        return []
+    widths: dict[str, int] = {}
+    for key, header in columns:
+        widths[key] = len(header)
+        for row in rows:
+            widths[key] = max(widths[key], len(row.get(key, "")))
+
+    header_line = "  " + "  ".join(header.ljust(widths[key]) for key, header in columns)
+    divider_line = "  " + "  ".join("-" * widths[key] for key, _header in columns)
+    body_lines = [
+        "  " + "  ".join(row.get(key, "").ljust(widths[key]) for key, _header in columns)
+        for row in rows
+    ]
+    return [header_line, divider_line, *body_lines]
+
+
+def render_workspace_crate_table(
+    repo_root: Path,
+    *,
+    extra_columns: list[tuple[str, str, Callable[[WorkspaceCrate], str]]] | None = None,
+) -> list[str]:
+    crates = workspace_crates(repo_root)
+    rows: list[dict[str, str]] = []
+    for crate in crates:
+        row = {
+            "crate": crate.crate_dir,
+            "package": crate.package_name,
+            "crate_path": crate.crate_path_name,
+            "manifest": crate.manifest_path,
+        }
+        if extra_columns:
+            for key, _header, value_fn in extra_columns:
+                row[key] = value_fn(crate)
+        rows.append(row)
+
+    columns: list[tuple[str, str]] = [
+        ("crate", "crate"),
+        ("package", "package"),
+        ("crate_path", "crate_path"),
+        ("manifest", "manifest"),
+    ]
+    if extra_columns:
+        columns.extend((key, header) for key, header, _value_fn in extra_columns)
+    return render_table(rows, columns)
+
+
+def workspace_crate_section_lines(
+    repo_root: Path,
+    *,
+    title: str = "crates analyzed:",
+    extra_columns: list[tuple[str, str, Callable[[WorkspaceCrate], str]]] | None = None,
+) -> list[str]:
+    lines = [title]
+    lines.extend(render_workspace_crate_table(repo_root, extra_columns=extra_columns))
+    lines.append("")
+    return lines
 
 
 def lint_slug(lint_name: str) -> str:

--- a/.just/lint_manifests.py
+++ b/.just/lint_manifests.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import argparse
+import sys
+
+from lint_common import build_report
+from lint_common import discover_repo_root
+from lint_common import monotonic_now
+from lint_common import print_report
+
+
+LINT_NAME = "manifests"
+REQUIRED_WORKSPACE_FIELDS = (
+    "version",
+    "edition",
+    "rust-version",
+    "authors",
+    "license",
+    "repository",
+    "homepage",
+)
+
+
+@dataclass(frozen=True)
+class ManifestViolation:
+    location: str
+    message: str
+
+    def render(self) -> str:
+        return f"{self.location}: {self.message}"
+
+
+def tomllib_load(path: Path) -> dict:
+    import tomllib
+
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def workspace_version(repo_root: Path) -> str:
+    manifest = tomllib_load(repo_root / "Cargo.toml")
+    package = manifest.get("workspace", {}).get("package", {})
+    version = package.get("version")
+    if not isinstance(version, str):
+        raise SystemExit("workspace.package.version missing from Cargo.toml")
+    return version
+
+
+def member_manifests(repo_root: Path) -> list[Path]:
+    return sorted((repo_root / "crates").glob("*/Cargo.toml"))
+
+
+def dependency_sections(manifest: dict) -> list[tuple[str, dict]]:
+    sections: list[tuple[str, dict]] = []
+    for section_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+        dependencies = manifest.get(section_name)
+        if isinstance(dependencies, dict):
+            sections.append((section_name, dependencies))
+
+    targets = manifest.get("target", {})
+    if isinstance(targets, dict):
+        for target_name, target in targets.items():
+            if not isinstance(target, dict):
+                continue
+            for section_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+                dependencies = target.get(section_name)
+                if isinstance(dependencies, dict):
+                    sections.append((f"target.{target_name}.{section_name}", dependencies))
+    return sections
+
+
+def collect_manifest_violations(repo_root: Path) -> list[ManifestViolation]:
+    violations: list[ManifestViolation] = []
+    version = workspace_version(repo_root)
+
+    for manifest_path in member_manifests(repo_root):
+        manifest = tomllib_load(manifest_path)
+        rel_manifest = str(manifest_path.relative_to(repo_root))
+        package = manifest.get("package", {})
+        if not isinstance(package, dict):
+            violations.append(ManifestViolation(rel_manifest, "missing [package] table"))
+            continue
+
+        for field in REQUIRED_WORKSPACE_FIELDS:
+            field_value = package.get(field)
+            if not (isinstance(field_value, dict) and field_value.get("workspace") is True):
+                violations.append(
+                    ManifestViolation(rel_manifest, f"set [package].{field}.workspace = true")
+                )
+
+        for section_name, dependencies in dependency_sections(manifest):
+            for dependency_name, dependency in dependencies.items():
+                if not isinstance(dependency, dict):
+                    continue
+                dependency_path = dependency.get("path")
+                if not isinstance(dependency_path, str):
+                    continue
+                pinned_version = dependency.get("version")
+                if pinned_version != version:
+                    violations.append(
+                        ManifestViolation(
+                            f"{rel_manifest} [{section_name}.{dependency_name}]",
+                            f'path dependency version must match workspace version "{version}"',
+                        )
+                    )
+
+    return violations
+
+
+def build_summary(violations: list[ManifestViolation]) -> str:
+    if not violations:
+        return "manifest policy satisfied"
+    return f"manifest policy violated ({len(violations)} findings)"
+
+
+def run(repo_root: Path) -> int:
+    started_at = datetime.now(timezone.utc)
+    started_monotonic = monotonic_now()
+    violations = collect_manifest_violations(repo_root)
+    duration_seconds = monotonic_now() - started_monotonic
+    findings = [violation.render() for violation in violations]
+    transcript_lines = findings or ["no manifest violations found"]
+    report = build_report(
+        lint_name=LINT_NAME,
+        repo_root=repo_root,
+        passed=not violations,
+        summary=build_summary(violations),
+        findings=findings,
+        transcript_lines=transcript_lines,
+        started_at=started_at,
+        duration_seconds=duration_seconds,
+    )
+    print_report(report, repo_root=repo_root, preview_limit=4, direct_threshold=4)
+    return 0 if report.passed else 1
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Check Cargo manifest policy rules.")
+    parser.add_argument("--root", help="Repo root to inspect.")
+    args = parser.parse_args(argv[1:])
+    repo_root = discover_repo_root(args.root)
+    return run(repo_root)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.just/lint_manifests.py
+++ b/.just/lint_manifests.py
@@ -11,6 +11,7 @@ from lint_common import build_report
 from lint_common import discover_repo_root
 from lint_common import monotonic_now
 from lint_common import print_report
+from lint_common import workspace_crate_section_lines
 
 
 LINT_NAME = "manifests"
@@ -122,7 +123,8 @@ def run(repo_root: Path) -> int:
     violations = collect_manifest_violations(repo_root)
     duration_seconds = monotonic_now() - started_monotonic
     findings = [violation.render() for violation in violations]
-    transcript_lines = findings or ["no manifest violations found"]
+    transcript_lines = workspace_crate_section_lines(repo_root)
+    transcript_lines.extend(findings or ["no manifest violations found"])
     report = build_report(
         lint_name=LINT_NAME,
         repo_root=repo_root,

--- a/.just/lint_manifests.py
+++ b/.just/lint_manifests.py
@@ -54,6 +54,10 @@ def member_manifests(repo_root: Path) -> list[Path]:
     return sorted((repo_root / "crates").glob("*/Cargo.toml"))
 
 
+def relative_manifest_display(manifest_path: Path, repo_root: Path) -> str:
+    return manifest_path.relative_to(repo_root).as_posix()
+
+
 def dependency_sections(manifest: dict) -> list[tuple[str, dict]]:
     sections: list[tuple[str, dict]] = []
     for section_name in ("dependencies", "dev-dependencies", "build-dependencies"):
@@ -79,7 +83,7 @@ def collect_manifest_violations(repo_root: Path) -> list[ManifestViolation]:
 
     for manifest_path in member_manifests(repo_root):
         manifest = tomllib_load(manifest_path)
-        rel_manifest = str(manifest_path.relative_to(repo_root))
+        rel_manifest = relative_manifest_display(manifest_path, repo_root)
         package = manifest.get("package", {})
         if not isinstance(package, dict):
             violations.append(ManifestViolation(rel_manifest, "missing [package] table"))

--- a/.just/print_help.py
+++ b/.just/print_help.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SECTIONS = (
+    (
+        "General",
+        (
+            ("help", "Show this help."),
+            ("build", "Build the full workspace."),
+            ("test", "Run the full workspace test suite."),
+            ("clean", "Remove workspace build artifacts."),
+            ("ci", "Run the local CI-equivalent command set."),
+        ),
+    ),
+    (
+        "Formatting",
+        (
+            ("fmt", "Check Rust formatting."),
+            ("fmt check", "Check Rust formatting."),
+            ("fmt write", "Format the Rust workspace in place."),
+            ("fmt apply", "Format the Rust workspace in place."),
+        ),
+    ),
+    (
+        "Lint",
+        (
+            ("lint", "Run the full repo lint suite."),
+            ("lint fmt", "Run only the format check."),
+            ("lint clippy", "Run only Clippy with warnings denied."),
+            ("lint deny", "Run cargo-deny advisories/bans/source checks."),
+            ("lint shear", "Run cargo-shear unused-dependency checks."),
+            ("lint boundaries", "Run the crate/source boundary checks."),
+            ("lint manifests", "Run the Cargo manifest policy checks."),
+            ("lint version", "Run only the version alignment checks."),
+            ("lint identities", "Run only the RULE-008 identity literal guard."),
+            ("lint lines", "Run only the RULE-003 line-count guard."),
+            ("lint spell", "Run the spelling/content check."),
+            ("lint pytests", "Run the Python lint-tool unit tests."),
+        ),
+    ),
+)
+
+
+def render_help(repo_name: str) -> str:
+    lines = [
+        f"{repo_name} task runner",
+        "",
+        "Usage:",
+        "  just <recipe>",
+        "",
+    ]
+    width = max(len(name) for _, recipes in SECTIONS for name, _ in recipes)
+    for section_name, recipes in SECTIONS:
+        lines.append(f"{section_name}:")
+        for name, description in recipes:
+            lines.append(f"  {name.ljust(width)}  {description}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    repo_name = Path(__file__).resolve().parent.parent.name
+    print(render_help(repo_name), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.just/run_fmt.py
+++ b/.just/run_fmt.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+FMT_STEPS = {
+    "write": ["just", "_fmt-write"],
+    "apply": ["just", "_fmt-write"],
+    "check": ["just", "_fmt-check"],
+}
+
+
+def resolve_command(mode: str) -> list[str] | None:
+    return FMT_STEPS.get(mode)
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    mode = argv[1] if len(argv) > 1 else "check"
+
+    command = resolve_command(mode)
+    if command is None:
+        valid = ", ".join(FMT_STEPS.keys())
+        print(f"unknown fmt mode: {mode}", file=sys.stderr)
+        print(f"expected one of: {valid}", file=sys.stderr)
+        return 2
+
+    completed = subprocess.run(command, cwd=repo_root)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -65,10 +65,7 @@ def build_tasks(repo_root: Path) -> dict[str, LintTask]:
         "boundaries": LintTask("boundaries", [python_executable, str(repo_root / ".just/lint_boundaries.py")]),
         "manifests": LintTask("manifests", [python_executable, str(repo_root / ".just/lint_manifests.py")]),
         "spell": LintTask("spell", [python_executable, str(repo_root / ".just/lint_codespell.py")]),
-        "pytests": LintTask(
-            "pytests",
-            [python_executable, "-m", "unittest", "discover", "-s", str(repo_root / ".just/tests"), "-p", "test_*.py"],
-        ),
+        "pytests": LintTask("pytests", [python_executable, str(repo_root / ".just/run_pytests.py")]),
     }
 
 

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -36,6 +36,8 @@ COUNT_PATTERNS = (
     ("errors:", "errors"),
 )
 FILE_FINDING_RE = re.compile(r"^[A-Za-z0-9_.-]+/.*:\d+:")
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+ERROR_MARKER_RE = re.compile(r"(?<![A-Za-z0-9_])(error|failed|traceback|exception)(?![A-Za-z0-9_])")
 
 
 @dataclass(frozen=True)
@@ -83,8 +85,12 @@ def resolve_task_names(target: str) -> list[str]:
     return [target]
 
 
+def strip_ansi(text: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", text)
+
+
 def interesting_lines(output: str) -> list[str]:
-    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    lines = [strip_ansi(line).strip() for line in output.splitlines() if line.strip()]
     filtered = [line for line in lines if not line.startswith(("python ", "python3 ", "cargo "))]
     return filtered or lines
 
@@ -93,10 +99,7 @@ def prioritize_error_lines(lines: list[str]) -> list[str]:
     error_lines = [
         line
         for line in lines
-        if any(
-            token in line.lower()
-            for token in ("error", "failed", "traceback", "exception", "could not")
-        )
+        if ERROR_MARKER_RE.search(line.lower()) or "could not" in line.lower()
     ]
     return error_lines or lines
 

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import argparse
+import subprocess
+import sys
+import time
+
+from lint_common import discover_repo_root
+from lint_common import format_duration
+from lint_common import make_log_path
+from lint_common import relative_log_path
+from lint_common import write_log
+
+
+PYTHON_LINT_ORDER = (
+    "version",
+    "boundaries",
+    "manifests",
+    "identities",
+    "lines",
+    "spell",
+    "pytests",
+)
+CARGO_LINT_ORDER = ("fmt", "clippy", "deny", "shear")
+HIGH_VOLUME_LINTS = {"identities", "lines"}
+COUNT_PATTERNS = (
+    ("total violations:", "violations"),
+    ("errors:", "errors"),
+)
+
+
+@dataclass(frozen=True)
+class LintTask:
+    name: str
+    command: list[str]
+
+
+@dataclass(frozen=True)
+class LintResult:
+    task: LintTask
+    returncode: int
+    stdout: str
+    stderr: str
+    duration_seconds: float
+    log_path: Path
+
+
+def build_tasks(repo_root: Path) -> dict[str, LintTask]:
+    python_executable = sys.executable
+    return {
+        "fmt": LintTask("fmt", ["just", "_lint-fmt"]),
+        "clippy": LintTask("clippy", ["just", "_lint-clippy"]),
+        "deny": LintTask("deny", [python_executable, str(repo_root / ".just/lint_cargo_deny.py")]),
+        "shear": LintTask("shear", [python_executable, str(repo_root / ".just/lint_cargo_shear.py")]),
+        "version": LintTask("version", [python_executable, str(repo_root / ".just/check_version_sync.py")]),
+        "identities": LintTask(
+            "identities", [python_executable, str(repo_root / ".just/check_test_identity_literals.py")]
+        ),
+        "lines": LintTask("lines", [python_executable, str(repo_root / ".just/check_line_counts.py")]),
+        "boundaries": LintTask("boundaries", [python_executable, str(repo_root / ".just/lint_boundaries.py")]),
+        "manifests": LintTask("manifests", [python_executable, str(repo_root / ".just/lint_manifests.py")]),
+        "spell": LintTask("spell", [python_executable, str(repo_root / ".just/lint_codespell.py")]),
+        "pytests": LintTask(
+            "pytests",
+            [python_executable, "-m", "unittest", "discover", "-s", str(repo_root / ".just/tests"), "-p", "test_*.py"],
+        ),
+    }
+
+
+def resolve_task_names(target: str) -> list[str]:
+    if target == "all":
+        return [*CARGO_LINT_ORDER, *PYTHON_LINT_ORDER]
+    valid = {"all", *CARGO_LINT_ORDER, *PYTHON_LINT_ORDER}
+    if target not in valid:
+        valid_display = ", ".join(sorted(valid))
+        raise ValueError(f"unknown lint target: {target}; expected one of: {valid_display}")
+    return [target]
+
+
+def interesting_lines(output: str) -> list[str]:
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    filtered = [line for line in lines if not line.startswith(("python ", "python3 ", "cargo "))]
+    return filtered or lines
+
+
+def prioritize_error_lines(lines: list[str]) -> list[str]:
+    error_lines = [
+        line
+        for line in lines
+        if any(
+            token in line.lower()
+            for token in ("error", "failed", "traceback", "exception", "could not")
+        )
+    ]
+    return error_lines or lines
+
+
+def extract_count(lines: list[str]) -> int | None:
+    for line in reversed(lines):
+        lowered = line.lower()
+        for prefix, _label in COUNT_PATTERNS:
+            if prefix in lowered:
+                trailing = lowered.split(prefix, 1)[1].strip()
+                if trailing.isdigit():
+                    return int(trailing)
+        if lowered.startswith("[") and "] errors in " in lowered:
+            count = lowered.split("]", 1)[0].lstrip("[")
+            if count.isdigit():
+                return int(count)
+    return None
+
+
+def build_transcript(task: LintTask, result: LintResult, repo_root: Path) -> list[str]:
+    return [
+        f"lint: {task.name}",
+        f"repo_root: {repo_root}",
+        f"recorded_at_utc: {datetime.now(timezone.utc).isoformat()}",
+        f"duration: {format_duration(result.duration_seconds)}",
+        f"command: {' '.join(task.command)}",
+        f"exit_code: {result.returncode}",
+        "",
+        "stdout:",
+        result.stdout.rstrip(),
+        "",
+        "stderr:",
+        result.stderr.rstrip(),
+    ]
+
+
+def run_task(task: LintTask, repo_root: Path) -> LintResult:
+    started_at = datetime.now(timezone.utc)
+    start_time = time.perf_counter()
+    completed = subprocess.run(
+        task.command,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    duration_seconds = time.perf_counter() - start_time
+    log_path = make_log_path(repo_root, task.name, started_at)
+    result = LintResult(
+        task=task,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        duration_seconds=duration_seconds,
+        log_path=log_path,
+    )
+    write_log(log_path, build_transcript(task, result, repo_root))
+    return result
+
+
+def print_result(result: LintResult, repo_root: Path) -> None:
+    if result.returncode == 0:
+        print(f"{result.task.name} passed [{format_duration(result.duration_seconds)}]")
+        return
+
+    lines = interesting_lines("\n".join((result.stdout, result.stderr)))
+    log_display = relative_log_path(repo_root, result.log_path)
+    print(f"{result.task.name} failed")
+    if result.task.name in HIGH_VOLUME_LINTS:
+        preview = lines[:2]
+        for line in preview:
+            print(f"  {line}")
+        count = extract_count(lines)
+        if count is not None:
+            print(f"  [{count}] errors in {log_display}")
+        else:
+            print(f"  full log: {log_display}")
+        return
+
+    preview = lines[:4]
+    preview = prioritize_error_lines(lines)[:4]
+    for line in preview:
+        print(f"  {line}")
+    print(f"  full log: {log_display}")
+
+
+def run_parallel(tasks: list[LintTask], repo_root: Path) -> list[LintResult]:
+    with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
+        futures = [executor.submit(run_task, task, repo_root) for task in tasks]
+        return [future.result() for future in futures]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Run repo lint targets.")
+    parser.add_argument("target", nargs="?", default="all")
+    parser.add_argument("--root", help="Repo root to inspect.")
+    args = parser.parse_args(argv[1:])
+    repo_root = discover_repo_root(args.root)
+    target = args.target
+    try:
+        task_names = resolve_task_names(target)
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 2
+
+    tasks = build_tasks(repo_root)
+    selected_tasks = [tasks[name] for name in task_names]
+
+    cargo_tasks = [task for task in selected_tasks if task.name in CARGO_LINT_ORDER]
+    python_tasks = [task for task in selected_tasks if task.name in PYTHON_LINT_ORDER]
+    results: list[LintResult] = []
+
+    for task in cargo_tasks:
+        result = run_task(task, repo_root)
+        print_result(result, repo_root)
+        results.append(result)
+
+    if python_tasks:
+        for result in run_parallel(python_tasks, repo_root):
+            print_result(result, repo_root)
+            results.append(result)
+
+    failures = [result for result in results if result.returncode != 0]
+    if failures:
+        print(f"lint failed: {len(failures)} check(s) failed")
+        return 1
+
+    print(f"lint passed: {len(results)} check(s) succeeded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 import argparse
+import re
 import subprocess
 import sys
 import time
@@ -29,10 +30,12 @@ PYTHON_LINT_ORDER = (
 )
 CARGO_LINT_ORDER = ("fmt", "clippy", "deny", "shear")
 HIGH_VOLUME_LINTS = {"identities", "lines"}
+CRATE_INVENTORY_LINTS = {"fmt", "clippy", "boundaries", "manifests"}
 COUNT_PATTERNS = (
     ("total violations:", "violations"),
     ("errors:", "errors"),
 )
+FILE_FINDING_RE = re.compile(r"^[A-Za-z0-9_.-]+/.*:\d+:")
 
 
 @dataclass(frozen=True)
@@ -113,6 +116,31 @@ def extract_count(lines: list[str]) -> int | None:
     return None
 
 
+def preview_lines_for_task(task_name: str, lines: list[str]) -> list[str]:
+    if task_name != "identities":
+        return lines
+
+    filtered: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped == "crates analyzed:":
+            continue
+        if "crate_path" in stripped and "manifest" in stripped:
+            continue
+        if "Cargo.toml" in stripped:
+            continue
+        if stripped.lower().startswith("rule-"):
+            filtered.append(stripped)
+            continue
+        if FILE_FINDING_RE.match(stripped):
+            filtered.append(stripped)
+            continue
+
+    return filtered or lines
+
+
 def build_transcript(task: LintTask, result: LintResult, repo_root: Path) -> list[str]:
     transcript = [
         f"lint: {task.name}",
@@ -123,7 +151,7 @@ def build_transcript(task: LintTask, result: LintResult, repo_root: Path) -> lis
         f"exit_code: {result.returncode}",
         "",
     ]
-    if task.name == "fmt":
+    if task.name in CRATE_INVENTORY_LINTS:
         transcript.extend(workspace_crate_section_lines(repo_root))
     transcript.extend(
         [
@@ -170,7 +198,7 @@ def print_result(result: LintResult, repo_root: Path) -> None:
     log_display = relative_log_path(repo_root, result.log_path)
     print(f"{result.task.name} failed")
     if result.task.name in HIGH_VOLUME_LINTS:
-        preview = lines[:2]
+        preview = preview_lines_for_task(result.task.name, lines)[:2]
         for line in preview:
             print(f"  {line}")
         count = extract_count(lines)

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -14,6 +14,7 @@ from lint_common import discover_repo_root
 from lint_common import format_duration
 from lint_common import make_log_path
 from lint_common import relative_log_path
+from lint_common import workspace_crate_section_lines
 from lint_common import write_log
 
 
@@ -113,7 +114,7 @@ def extract_count(lines: list[str]) -> int | None:
 
 
 def build_transcript(task: LintTask, result: LintResult, repo_root: Path) -> list[str]:
-    return [
+    transcript = [
         f"lint: {task.name}",
         f"repo_root: {repo_root}",
         f"recorded_at_utc: {datetime.now(timezone.utc).isoformat()}",
@@ -121,12 +122,19 @@ def build_transcript(task: LintTask, result: LintResult, repo_root: Path) -> lis
         f"command: {' '.join(task.command)}",
         f"exit_code: {result.returncode}",
         "",
-        "stdout:",
-        result.stdout.rstrip(),
-        "",
-        "stderr:",
-        result.stderr.rstrip(),
     ]
+    if task.name == "fmt":
+        transcript.extend(workspace_crate_section_lines(repo_root))
+    transcript.extend(
+        [
+            "stdout:",
+            result.stdout.rstrip(),
+            "",
+            "stderr:",
+            result.stderr.rstrip(),
+        ]
+    )
+    return transcript
 
 
 def run_task(task: LintTask, repo_root: Path) -> LintResult:

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -153,6 +153,12 @@ def build_transcript(task: LintTask, result: LintResult, repo_root: Path) -> lis
     ]
     if task.name in CRATE_INVENTORY_LINTS:
         transcript.extend(workspace_crate_section_lines(repo_root))
+    if task.name == "boundaries":
+        from lint_boundaries import boundary_doc_section_lines
+        from lint_boundaries import parse_boundary_records
+
+        records, _violations = parse_boundary_records(repo_root)
+        transcript.extend(boundary_doc_section_lines(repo_root, records))
     transcript.extend(
         [
             "stdout:",

--- a/.just/run_pytests.py
+++ b/.just/run_pytests.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from collections import Counter
+import importlib.util
+from pathlib import Path
+import argparse
+import sys
+import unittest
+
+from lint_common import discover_repo_root
+
+
+def flatten_suite(suite: unittest.TestSuite) -> list[unittest.TestCase]:
+    tests: list[unittest.TestCase] = []
+    for item in suite:
+        if isinstance(item, unittest.TestSuite):
+            tests.extend(flatten_suite(item))
+        else:
+            tests.append(item)
+    return tests
+
+
+def fixture_name(test: unittest.TestCase) -> str:
+    test_id = test.id()
+    parts = test_id.split(".")
+    if len(parts) >= 3:
+        return ".".join(parts[:-1])
+    return test_id
+
+
+def count_fixtures(suite: unittest.TestSuite) -> list[tuple[str, int]]:
+    counter: Counter[str] = Counter()
+    for test in flatten_suite(suite):
+        counter[fixture_name(test)] += 1
+    return sorted(counter.items())
+
+
+def print_fixture_summary(fixture_counts: list[tuple[str, int]]) -> None:
+    print("pytests fixture counts:")
+    for fixture, count in fixture_counts:
+        print(f"  {fixture}: {count}")
+    print(f"pytests fixtures total: {len(fixture_counts)}")
+
+
+def build_suite(repo_root: Path) -> unittest.TestSuite:
+    loader = unittest.defaultTestLoader
+    suite = unittest.TestSuite()
+    for test_path in sorted((repo_root / ".just/tests").glob("test_*.py")):
+        spec = importlib.util.spec_from_file_location(test_path.stem, test_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"unable to load test module from {test_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        suite.addTests(loader.loadTestsFromModule(module))
+    return suite
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Run lint-tool Python unit tests with fixture summary output.")
+    parser.add_argument("--root", help="Repo root to inspect.")
+    args = parser.parse_args(argv[1:])
+    repo_root = discover_repo_root(args.root)
+
+    suite = build_suite(repo_root)
+    fixture_counts = count_fixtures(suite)
+    print_fixture_summary(fixture_counts)
+    runner = unittest.TextTestRunner(stream=sys.stdout, verbosity=1)
+    result = runner.run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/tests/test_check_line_counts.py
+++ b/.just/tests/test_check_line_counts.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from check_line_counts import FileCounts
+from check_line_counts import LineLimitConfig
+from check_line_counts import classify_lines
+from check_line_counts import evaluate_limits
+from check_line_counts import format_table
+from check_line_counts import limit_summary
+
+
+class CheckLineCountsTests(unittest.TestCase):
+    def test_classify_lines_separates_cfg_test_block_lines(self) -> None:
+        lines = [
+            "pub fn production() {",
+            '    println!(\"prod\");',
+            "}",
+            "",
+            "#[cfg(test)]",
+            "mod tests {",
+            "    use super::*;",
+            "",
+            "    #[test]",
+            "    fn example() {",
+            "        production();",
+            "    }",
+            "}",
+        ]
+
+        production_lines, test_lines = classify_lines(lines)
+
+        self.assertEqual(production_lines, 3)
+        self.assertEqual(test_lines, 8)
+
+    def test_classify_lines_counts_comments_inside_correct_scope(self) -> None:
+        lines = [
+            "// prod comment",
+            "pub fn production() {}",
+            "#[cfg(test)]",
+            "mod tests {",
+            "    // test comment",
+            "    #[test]",
+            "    fn example() {}",
+            "}",
+        ]
+
+        production_lines, test_lines = classify_lines(lines)
+
+        self.assertEqual(production_lines, 1)
+        self.assertEqual(test_lines, 5)
+
+    def test_evaluate_limits_uses_configured_metrics(self) -> None:
+        counts = [
+            FileCounts(
+                crate_name="atm-core",
+                path="crates/atm-core/src/example.rs",
+                total_lines=1200,
+                production_lines=1001,
+                test_lines=20,
+            )
+        ]
+        config = LineLimitConfig(
+            max_total_lines=1100,
+            max_production_lines=1000,
+            max_scoped_code_lines=1010,
+        )
+
+        failures = evaluate_limits(counts, config)
+
+        self.assertEqual(len(failures), 3)
+        self.assertIn("total=1200 exceeds limit 1100", failures[0])
+        self.assertIn("prod=1001 exceeds limit 1000", failures[1])
+        self.assertIn("prod+test=1021 exceeds limit 1010", failures[2])
+
+    def test_format_table_includes_crate_totals(self) -> None:
+        counts = [
+            FileCounts(
+                crate_name="atm-core",
+                path="crates/atm-core/src/a.rs",
+                total_lines=10,
+                production_lines=8,
+                test_lines=1,
+            ),
+            FileCounts(
+                crate_name="atm-core",
+                path="crates/atm-core/src/b.rs",
+                total_lines=20,
+                production_lines=15,
+                test_lines=3,
+            ),
+            FileCounts(
+                crate_name="atm",
+                path="crates/atm/src/main.rs",
+                total_lines=5,
+                production_lines=4,
+                test_lines=0,
+            ),
+        ]
+
+        table = format_table(counts)
+        joined = "\n".join(table)
+
+        self.assertIn("crate", table[0])
+        self.assertIn("prod+test", table[0])
+        self.assertIn("atm-core", joined)
+        self.assertIn("src/a.rs", joined)
+        self.assertIn("src/b.rs", joined)
+        self.assertIn("TOTAL", joined)
+        self.assertIn("30", joined)
+        self.assertIn("23", joined)
+        self.assertIn("4", joined)
+
+    def test_limit_summary_only_lists_enabled_limits(self) -> None:
+        config = LineLimitConfig(
+            max_total_lines=None,
+            max_production_lines=1000,
+            max_scoped_code_lines=1200,
+        )
+
+        self.assertEqual(limit_summary(config), "prod<=1000, prod+test<=1200")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_check_test_identity_literals.py
+++ b/.just/tests/test_check_test_identity_literals.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from check_test_identity_literals import collect_identity_violations
+from check_test_identity_literals import load_forbidden_literals
+
+
+LINT_CONFIG = """\
+[identities]
+forbidden_literals = [
+  "team-lead",
+  "arch-ctm",
+  "quality-mgr",
+]
+"""
+
+
+class CheckTestIdentityLiteralsTests(unittest.TestCase):
+    def write_repo(self, repo_root: Path) -> None:
+        (repo_root / ".just").mkdir()
+        (repo_root / ".just/lint-config.toml").write_text(LINT_CONFIG, encoding="utf-8")
+        (repo_root / "crates/atm-core/src").mkdir(parents=True)
+        (repo_root / "crates/atm-core/tests").mkdir(parents=True)
+
+    def test_load_forbidden_literals_reads_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+
+            literals = load_forbidden_literals(repo_root)
+
+            self.assertEqual(literals, ("team-lead", "arch-ctm", "quality-mgr"))
+
+    def test_collect_identity_violations_flags_test_scope_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/src/example.rs").write_text(
+                """\
+pub fn production() {
+    let role = "team-lead";
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn example() {
+        let role = "team-lead";
+    }
+}
+""",
+                encoding="utf-8",
+            )
+
+            violations = collect_identity_violations(
+                repo_root,
+                forbidden_literals=load_forbidden_literals(repo_root),
+            )
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].line_number, 9)
+
+    def test_collect_identity_violations_respects_shared_suppressions(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/tests/example.rs").write_text(
+                """\
+// lint-identities: allow-next-line
+let _ = "team-lead";
+// rule-009: allow-start
+let _ = "arch-ctm";
+// lint-identities: allow-end
+let _ = "quality-mgr";
+""",
+                encoding="utf-8",
+            )
+
+            violations = collect_identity_violations(
+                repo_root,
+                forbidden_literals=load_forbidden_literals(repo_root),
+            )
+
+            self.assertEqual([violation.line_number for violation in violations], [6])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_check_version_sync.py
+++ b/.just/tests/test_check_version_sync.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from check_version_sync import validate_crate_versions
+from check_version_sync import validate_lockfile
+
+
+ROOT_MANIFEST = """\
+[workspace]
+members = ["crates/atm", "crates/atm-core", "crates/atm-daemon", "crates/atm-rusqlite"]
+resolver = "2"
+
+[workspace.package]
+version = "1.1.2"
+"""
+
+
+def crate_manifest(name: str, extra: str = "") -> str:
+    return f"""\
+[package]
+name = "{name}"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+{extra}
+"""
+
+
+class CheckVersionSyncTests(unittest.TestCase):
+    def write_repo(self, repo_root: Path) -> None:
+        (repo_root / "Cargo.toml").write_text(ROOT_MANIFEST, encoding="utf-8")
+        crates_dir = repo_root / "crates"
+        for crate_name, package_name in (
+            ("atm", "agent-team-mail"),
+            ("atm-core", "agent-team-mail-core"),
+            ("atm-daemon", "agent-team-mail-daemon"),
+            ("atm-rusqlite", "agent-team-mail-rusqlite"),
+        ):
+            crate_dir = crates_dir / crate_name
+            crate_dir.mkdir(parents=True)
+            extra = ""
+            if crate_name == "atm":
+                extra = '\n[dependencies]\natm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2" }\n'
+            (crate_dir / "Cargo.toml").write_text(crate_manifest(package_name, extra=extra), encoding="utf-8")
+
+    def test_validate_crate_versions_checks_all_member_manifests(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            manifest = repo_root / "crates/atm-rusqlite/Cargo.toml"
+            manifest.write_text(manifest.read_text(encoding="utf-8").replace("version.workspace = true\n", ""), encoding="utf-8")
+
+            with self.assertRaises(SystemExit) as error:
+                validate_crate_versions(repo_root, "1.1.2")
+
+            message = str(error.exception).replace("\\", "/")
+            self.assertIn("crates/atm-rusqlite/Cargo.toml must use version.workspace = true", message)
+
+    def test_validate_lockfile_checks_all_workspace_packages(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "Cargo.lock").write_text(
+                """\
+version = 3
+
+[[package]]
+name = "agent-team-mail"
+version = "1.1.2"
+
+[[package]]
+name = "agent-team-mail-core"
+version = "1.1.2"
+
+[[package]]
+name = "agent-team-mail-daemon"
+version = "1.1.2"
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit) as error:
+                validate_lockfile(repo_root, "1.1.2")
+
+            self.assertIn("agent-team-mail-rusqlite missing from Cargo.lock", str(error.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_check_version_sync.py
+++ b/.just/tests/test_check_version_sync.py
@@ -12,6 +12,7 @@ if str(JUST_DIR) not in sys.path:
 
 from check_version_sync import validate_crate_versions
 from check_version_sync import validate_lockfile
+from check_version_sync import success_message
 
 
 ROOT_MANIFEST = """\
@@ -96,6 +97,12 @@ version = "1.1.2"
                 validate_lockfile(repo_root, "1.1.2")
 
             self.assertIn("agent-team-mail-rusqlite missing from Cargo.lock", str(error.exception))
+
+    def test_success_message_includes_workspace_version(self) -> None:
+        self.assertEqual(
+            success_message("1.1.2"),
+            "version sync check passed: workspace_version=1.1.2; workspace, crate pin, Cargo.lock, winget, and Homebrew release wiring are aligned.",
+        )
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_lint_boundaries.py
+++ b/.just/tests/test_lint_boundaries.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from lint_boundaries import collect_boundary_violations
+from lint_boundaries import parse_boundary_records
+from lint_boundaries import parse_simple_yaml_document
+
+
+ROOT_MANIFEST = """\
+[workspace]
+members = ["crates/atm-core", "crates/atm-rusqlite", "crates/atm"]
+resolver = "2"
+
+[workspace.package]
+version = "1.1.2"
+edition = "2024"
+rust-version = "1.94.1"
+authors = ["atm-core contributors"]
+license = "MIT OR Apache-2.0"
+repository = "https://example.invalid/repo"
+homepage = "https://example.invalid/repo"
+"""
+
+BASE_BOUNDARY_DOC = """\
+# Example Boundaries
+
+## SqliteMailStoreAdapter
+
+```yaml
+boundary_id: BOUNDARY-MailStore-Sqlite
+owner_package: atm-rusqlite
+owner_crate_path: atm_rusqlite
+name: SqliteMailStoreAdapter
+
+public:
+  trait: MailStore
+  facade: null
+
+implementation:
+  type: SqliteMailStore
+  module: atm_rusqlite::mail_store
+  visibility: private
+  constructor: private
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - sqlite
+  io_forbidden:
+    - socket_io
+
+dependencies:
+  allowed_dependents: []
+  allowed_dependencies:
+    - atm-core
+    - rusqlite
+  forbidden_edges:
+    - atm -> atm-rusqlite
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - SqliteMailStore
+    - rusqlite::Connection
+
+contracts:
+  request_types:
+    - MailStore inputs
+  response_types:
+    - MailStore outputs
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InMemoryMailStore
+  forbidden_test_bypasses:
+    - rusqlite::Connection
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-MAILSTORE-SQLITE-EDGES
+  review_gates:
+    - no_public_impl
+
+status:
+  state: planned
+  notes: []
+```
+"""
+
+
+class LintBoundariesTests(unittest.TestCase):
+    def write_repo(self, repo_root: Path) -> None:
+        (repo_root / "Cargo.toml").write_text(ROOT_MANIFEST, encoding="utf-8")
+        for crate_name in ("atm-core", "atm-rusqlite", "atm"):
+            crate_dir = repo_root / "crates" / crate_name
+            crate_dir.mkdir(parents=True)
+            (crate_dir / "src").mkdir()
+            (crate_dir / "src/lib.rs").write_text("pub fn example() {}\n", encoding="utf-8")
+        (repo_root / "docs" / "atm-rusqlite").mkdir(parents=True)
+
+    def write_manifests(self, repo_root: Path, *, atm_dependencies: str = "atm-core = { path = \"../atm-core\", version = \"1.1.2\" }\n") -> None:
+        (repo_root / "crates/atm-core/Cargo.toml").write_text(
+            """\
+[package]
+name = "agent-team-mail-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dev-dependencies]
+atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }
+""",
+            encoding="utf-8",
+        )
+        (repo_root / "crates/atm-rusqlite/Cargo.toml").write_text(
+            """\
+[package]
+name = "atm-rusqlite"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+rusqlite = "0.37"
+atm-core = { path = "../atm-core", version = "1.1.2" }
+""",
+            encoding="utf-8",
+        )
+        (repo_root / "crates/atm/Cargo.toml").write_text(
+            f"""\
+[package]
+name = "agent-team-mail"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+{atm_dependencies}""",
+            encoding="utf-8",
+        )
+
+    def test_parse_simple_yaml_document_reads_nested_lists(self) -> None:
+        document = textwrap.dedent(
+            """\
+            boundary_id: BOUNDARY-Test
+            dependencies:
+              forbidden_edges:
+                - atm -> atm-rusqlite
+            status:
+              state: planned
+            """
+        )
+        parsed = parse_simple_yaml_document(document)
+        self.assertEqual(parsed["boundary_id"], "BOUNDARY-Test")
+        self.assertEqual(parsed["dependencies"]["forbidden_edges"], ["atm -> atm-rusqlite"])
+        self.assertEqual(parsed["status"]["state"], "planned")
+
+    def test_parse_boundary_records_accepts_planned_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+
+            records, violations = parse_boundary_records(repo_root)
+            self.assertEqual(violations, [])
+            self.assertEqual(len(records), 1)
+            self.assertEqual(records[0].boundary_id, "BOUNDARY-MailStore-Sqlite")
+            self.assertFalse(records[0].is_enforced)
+
+    def test_parse_boundary_records_flags_missing_required_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            broken_doc = BASE_BOUNDARY_DOC.replace("owner_crate_path: atm_rusqlite\n", "")
+            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(broken_doc, encoding="utf-8")
+
+            _records, violations = parse_boundary_records(repo_root)
+            rendered = [violation.render() for violation in violations]
+            self.assertTrue(
+                any(item.endswith("missing required field: owner_crate_path") for item in rendered),
+                rendered,
+            )
+
+    def test_collect_boundary_violations_accepts_allowed_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+            (repo_root / "crates/atm-rusqlite/src/lib.rs").write_text("use rusqlite::Connection;\n", encoding="utf-8")
+
+            self.assertEqual(collect_boundary_violations(repo_root), [])
+
+    def test_collect_boundary_violations_flags_direct_rusqlite_dependency(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+            (repo_root / "crates/atm-core/Cargo.toml").write_text(
+                """\
+[package]
+name = "agent-team-mail-core"
+
+[dependencies]
+rusqlite = "0.37"
+""",
+                encoding="utf-8",
+            )
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+            self.assertIn(
+                "crates/atm-core/Cargo.toml [dependencies]: only crates/atm-rusqlite may depend on rusqlite",
+                rendered,
+            )
+
+    def test_collect_boundary_violations_flags_rusqlite_source_import_outside_store(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+            (repo_root / "crates/atm/src/lib.rs").write_text("use rusqlite::Connection;\n", encoding="utf-8")
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+            self.assertIn(
+                "crates/atm/src/lib.rs:1: only crates/atm-rusqlite source may import rusqlite directly",
+                rendered,
+            )
+
+    def test_collect_boundary_violations_flags_non_dev_atm_core_edge(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+            (repo_root / "crates/atm-core/Cargo.toml").write_text(
+                """\
+[package]
+name = "agent-team-mail-core"
+
+[dependencies]
+atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }
+""",
+                encoding="utf-8",
+            )
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+            self.assertIn(
+                "crates/atm-core/Cargo.toml [dependencies]: atm-core may reference atm-rusqlite only in dev-dependencies",
+                rendered,
+            )
+
+    def test_collect_boundary_violations_ignores_planned_forbidden_edges(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(
+                repo_root,
+                atm_dependencies="atm-rusqlite = { path = \"../atm-rusqlite\", version = \"1.1.2\" }\n",
+            )
+            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+            self.assertNotIn(
+                "crates/atm/Cargo.toml [dependencies]: BOUNDARY-MailStore-Sqlite forbids edge atm -> atm-rusqlite",
+                rendered,
+            )
+
+    def test_collect_boundary_violations_flags_active_forbidden_edges(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(
+                repo_root,
+                atm_dependencies="atm-rusqlite = { path = \"../atm-rusqlite\", version = \"1.1.2\" }\n",
+            )
+            active_doc = BASE_BOUNDARY_DOC.replace("state: planned", "state: active")
+            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(active_doc, encoding="utf-8")
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+            self.assertIn(
+                "crates/atm/Cargo.toml [dependencies]: BOUNDARY-MailStore-Sqlite forbids edge atm -> atm-rusqlite",
+                rendered,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_lint_boundaries.py
+++ b/.just/tests/test_lint_boundaries.py
@@ -18,7 +18,7 @@ from lint_boundaries import parse_simple_yaml_document
 
 ROOT_MANIFEST = """\
 [workspace]
-members = ["crates/atm-core", "crates/atm-rusqlite", "crates/atm"]
+members = ["crates/atm-core", "crates/atm-rusqlite", "crates/atm", "crates/atm-daemon"]
 resolver = "2"
 
 [workspace.package]
@@ -53,7 +53,8 @@ implementation:
   constructor: private
 
 composition:
-  roots: []
+  roots:
+    - atm_daemon::bootstrap
 
 ownership:
   io_owns:
@@ -62,17 +63,20 @@ ownership:
     - socket_io
 
 dependencies:
-  allowed_dependents: []
+  allowed_dependents:
+    - atm-daemon
   allowed_dependencies:
     - atm-core
     - rusqlite
   forbidden_edges:
     - atm -> atm-rusqlite
+    - atm-graft -> atm-rusqlite
 
 references:
   scope: outside_owner_crate
   forbidden:
     - SqliteMailStore
+    - SqliteMailStore::open
     - rusqlite::Connection
 
 contracts:
@@ -105,14 +109,21 @@ status:
 class LintBoundariesTests(unittest.TestCase):
     def write_repo(self, repo_root: Path) -> None:
         (repo_root / "Cargo.toml").write_text(ROOT_MANIFEST, encoding="utf-8")
-        for crate_name in ("atm-core", "atm-rusqlite", "atm"):
+        for crate_name in ("atm-core", "atm-rusqlite", "atm", "atm-daemon"):
             crate_dir = repo_root / "crates" / crate_name
             crate_dir.mkdir(parents=True)
             (crate_dir / "src").mkdir()
             (crate_dir / "src/lib.rs").write_text("pub fn example() {}\n", encoding="utf-8")
-        (repo_root / "docs" / "atm-rusqlite").mkdir(parents=True)
+        for doc_name in ("atm-core", "atm-rusqlite", "atm", "atm-daemon"):
+            (repo_root / "docs" / doc_name).mkdir(parents=True)
 
-    def write_manifests(self, repo_root: Path, *, atm_dependencies: str = "atm-core = { path = \"../atm-core\", version = \"1.1.2\" }\n") -> None:
+    def write_manifests(
+        self,
+        repo_root: Path,
+        *,
+        atm_dependencies: str = 'atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2" }\n',
+        atm_rusqlite_dependencies: str = 'rusqlite = "0.37"\natm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2" }\n',
+    ) -> None:
         (repo_root / "crates/atm-core/Cargo.toml").write_text(
             """\
 [package]
@@ -125,13 +136,16 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lib]
+name = "atm_core"
+
 [dev-dependencies]
 atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }
 """,
             encoding="utf-8",
         )
         (repo_root / "crates/atm-rusqlite/Cargo.toml").write_text(
-            """\
+            f"""\
 [package]
 name = "atm-rusqlite"
 version.workspace = true
@@ -142,10 +156,11 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lib]
+name = "atm_rusqlite"
+
 [dependencies]
-rusqlite = "0.37"
-atm-core = { path = "../atm-core", version = "1.1.2" }
-""",
+{atm_rusqlite_dependencies}""",
             encoding="utf-8",
         )
         (repo_root / "crates/atm/Cargo.toml").write_text(
@@ -160,10 +175,37 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[lib]
+name = "atm"
+
 [dependencies]
 {atm_dependencies}""",
             encoding="utf-8",
         )
+        (repo_root / "crates/atm-daemon/Cargo.toml").write_text(
+            """\
+[package]
+name = "atm-daemon"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lib]
+name = "atm_daemon"
+
+[dependencies]
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2" }
+atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }
+""",
+            encoding="utf-8",
+        )
+
+    def write_doc(self, repo_root: Path, crate_name: str, text: str = BASE_BOUNDARY_DOC) -> None:
+        (repo_root / "docs" / crate_name / "boundaries.md").write_text(text, encoding="utf-8")
 
     def test_parse_simple_yaml_document_reads_nested_lists(self) -> None:
         document = textwrap.dedent(
@@ -186,13 +228,13 @@ homepage.workspace = true
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
             self.write_manifests(repo_root)
-            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+            self.write_doc(repo_root, "atm-rusqlite")
 
             records, violations = parse_boundary_records(repo_root)
             self.assertEqual(violations, [])
             self.assertEqual(len(records), 1)
             self.assertEqual(records[0].boundary_id, "BOUNDARY-MailStore-Sqlite")
-            self.assertFalse(records[0].is_enforced)
+            self.assertFalse(records[0].is_active)
 
     def test_parse_boundary_records_flags_missing_required_field(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -200,31 +242,102 @@ homepage.workspace = true
             self.write_repo(repo_root)
             self.write_manifests(repo_root)
             broken_doc = BASE_BOUNDARY_DOC.replace("owner_crate_path: atm_rusqlite\n", "")
-            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(broken_doc, encoding="utf-8")
+            self.write_doc(repo_root, "atm-rusqlite", broken_doc)
 
             _records, violations = parse_boundary_records(repo_root)
             rendered = [violation.render() for violation in violations]
             self.assertTrue(
-                any(item.endswith("missing required field: owner_crate_path") for item in rendered),
+                any("missing required field: owner_crate_path" in item for item in rendered),
                 rendered,
             )
+
+    def test_parse_boundary_records_flags_invalid_edge_syntax(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            broken_doc = BASE_BOUNDARY_DOC.replace("- atm -> atm-rusqlite", "- atm => atm-rusqlite")
+            self.write_doc(repo_root, "atm-rusqlite", broken_doc)
+
+            _records, violations = parse_boundary_records(repo_root)
+            rendered = [violation.render() for violation in violations]
+            self.assertTrue(
+                any("invalid dependencies.forbidden_edges entry" in item for item in rendered),
+                rendered,
+            )
+
+    def test_parse_boundary_records_flags_doc_owner_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            self.write_doc(repo_root, "atm", BASE_BOUNDARY_DOC)
+
+            _records, violations = parse_boundary_records(repo_root)
+            rendered = [violation.render() for violation in violations]
+            self.assertTrue(any("document path owner mismatch" in item for item in rendered), rendered)
 
     def test_collect_boundary_violations_accepts_allowed_layout(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
             self.write_manifests(repo_root)
-            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+            self.write_doc(repo_root, "atm-rusqlite")
             (repo_root / "crates/atm-rusqlite/src/lib.rs").write_text("use rusqlite::Connection;\n", encoding="utf-8")
 
             self.assertEqual(collect_boundary_violations(repo_root), [])
+
+    def test_collect_boundary_violations_flags_duplicate_boundary_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            self.write_doc(repo_root, "atm-rusqlite")
+            self.write_doc(repo_root, "atm-daemon", BASE_BOUNDARY_DOC.replace("owner_package: atm-rusqlite", "owner_package: atm-daemon").replace("owner_crate_path: atm_rusqlite", "owner_crate_path: atm_daemon"))
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+            self.assertTrue(any("duplicate boundary_id" in item for item in rendered), rendered)
+
+    def test_collect_boundary_violations_flags_owner_crate_path_mismatch_for_existing_crate(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            broken_doc = BASE_BOUNDARY_DOC.replace("owner_crate_path: atm_rusqlite", "owner_crate_path: bad_path")
+            self.write_doc(repo_root, "atm-rusqlite", broken_doc)
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+            self.assertTrue(any("does not match workspace crate path" in item for item in rendered), rendered)
+
+    def test_collect_boundary_violations_flags_unexpected_allowed_dependent(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root, atm_dependencies='atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }\n')
+            self.write_doc(repo_root, "atm-rusqlite")
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+            self.assertTrue(any("found unexpected dependent" in item for item in rendered), rendered)
+
+    def test_collect_boundary_violations_flags_forbidden_edge_even_when_planned(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root, atm_dependencies='atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }\n')
+            self.write_doc(repo_root, "atm-rusqlite")
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+            self.assertIn(
+                "crates/atm/Cargo.toml [dependencies]: BOUNDARY-MailStore-Sqlite forbids edge atm -> atm-rusqlite",
+                rendered,
+            )
 
     def test_collect_boundary_violations_flags_direct_rusqlite_dependency(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
             self.write_manifests(repo_root)
-            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+            self.write_doc(repo_root, "atm-rusqlite")
             (repo_root / "crates/atm-core/Cargo.toml").write_text(
                 """\
 [package]
@@ -247,7 +360,7 @@ rusqlite = "0.37"
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
             self.write_manifests(repo_root)
-            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+            self.write_doc(repo_root, "atm-rusqlite")
             (repo_root / "crates/atm/src/lib.rs").write_text("use rusqlite::Connection;\n", encoding="utf-8")
 
             rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
@@ -261,7 +374,7 @@ rusqlite = "0.37"
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
             self.write_manifests(repo_root)
-            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+            self.write_doc(repo_root, "atm-rusqlite")
             (repo_root / "crates/atm-core/Cargo.toml").write_text(
                 """\
 [package]
@@ -279,38 +392,58 @@ atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }
                 rendered,
             )
 
-    def test_collect_boundary_violations_ignores_planned_forbidden_edges(self) -> None:
+    def test_collect_boundary_violations_flags_forbidden_reference_outside_owner(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
-            self.write_manifests(
-                repo_root,
-                atm_dependencies="atm-rusqlite = { path = \"../atm-rusqlite\", version = \"1.1.2\" }\n",
-            )
-            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(BASE_BOUNDARY_DOC, encoding="utf-8")
+            self.write_manifests(repo_root)
+            self.write_doc(repo_root, "atm-rusqlite")
+            (repo_root / "crates/atm-core/src/lib.rs").write_text("pub fn demo() { let _ = SqliteMailStore::open(); }\n", encoding="utf-8")
 
             rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
-            self.assertNotIn(
-                "crates/atm/Cargo.toml [dependencies]: BOUNDARY-MailStore-Sqlite forbids edge atm -> atm-rusqlite",
-                rendered,
-            )
+            self.assertTrue(any("forbids external reference 'SqliteMailStore::open'" in item for item in rendered), rendered)
 
-    def test_collect_boundary_violations_flags_active_forbidden_edges(self) -> None:
+    def test_collect_boundary_violations_allows_composition_root_reference(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
-            self.write_manifests(
-                repo_root,
-                atm_dependencies="atm-rusqlite = { path = \"../atm-rusqlite\", version = \"1.1.2\" }\n",
+            self.write_manifests(repo_root)
+            self.write_doc(repo_root, "atm-rusqlite")
+            (repo_root / "crates/atm-daemon/src/bootstrap.rs").write_text(
+                "pub fn build() { let _ = SqliteMailStore::open(); }\n",
+                encoding="utf-8",
             )
+
+            rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
+            self.assertFalse(any("SqliteMailStore::open" in item for item in rendered), rendered)
+
+    def test_collect_boundary_violations_flags_active_public_impl_and_constructor(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
             active_doc = BASE_BOUNDARY_DOC.replace("state: planned", "state: active")
-            (repo_root / "docs/atm-rusqlite/boundaries.md").write_text(active_doc, encoding="utf-8")
+            self.write_doc(repo_root, "atm-rusqlite", active_doc)
+            (repo_root / "crates/atm-rusqlite/src/lib.rs").write_text(
+                textwrap.dedent(
+                    """\
+                    pub struct SqliteMailStore;
+                    pub use self::SqliteMailStore as ExportedStore;
+
+                    impl SqliteMailStore {
+                        pub fn open() -> Self {
+                            Self
+                        }
+                    }
+                    """
+                ),
+                encoding="utf-8",
+            )
 
             rendered = [violation.render() for violation in collect_boundary_violations(repo_root)]
-            self.assertIn(
-                "crates/atm/Cargo.toml [dependencies]: BOUNDARY-MailStore-Sqlite forbids edge atm -> atm-rusqlite",
-                rendered,
-            )
+            self.assertTrue(any("requires private implementation.type" in item for item in rendered), rendered)
+            self.assertTrue(any("forbids public re-export" in item for item in rendered), rendered)
+            self.assertTrue(any("forbids public constructor/helper methods" in item for item in rendered), rendered)
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_lint_boundaries.py
+++ b/.just/tests/test_lint_boundaries.py
@@ -12,6 +12,7 @@ if str(JUST_DIR) not in sys.path:
     sys.path.insert(0, str(JUST_DIR))
 
 from lint_boundaries import collect_boundary_violations
+from lint_boundaries import boundary_doc_section_lines
 from lint_boundaries import parse_boundary_records
 from lint_boundaries import parse_simple_yaml_document
 
@@ -235,6 +236,31 @@ atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }
             self.assertEqual(len(records), 1)
             self.assertEqual(records[0].boundary_id, "BOUNDARY-MailStore-Sqlite")
             self.assertFalse(records[0].is_active)
+
+    def test_boundary_doc_section_lines_reports_per_doc_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.write_manifests(repo_root)
+            self.write_doc(repo_root, "atm-rusqlite")
+            self.write_doc(
+                repo_root,
+                "atm-core",
+                BASE_BOUNDARY_DOC.replace("owner_package: atm-rusqlite", "owner_package: atm-core").replace(
+                    "owner_crate_path: atm_rusqlite", "owner_crate_path: atm_core"
+                ),
+            )
+
+            records, violations = parse_boundary_records(repo_root)
+            self.assertEqual(violations, [])
+
+            lines = boundary_doc_section_lines(repo_root, records)
+            joined = "\n".join(lines)
+            self.assertIn("boundary docs analyzed:", joined)
+            self.assertIn("docs/atm-core/boundaries.md", joined)
+            self.assertIn("docs/atm-rusqlite/boundaries.md", joined)
+            self.assertIn("boundary doc count: 2", joined)
+            self.assertIn("boundary records validated: 2", joined)
 
     def test_parse_boundary_records_flags_missing_required_field(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/.just/tests/test_lint_common.py
+++ b/.just/tests/test_lint_common.py
@@ -19,6 +19,9 @@ from lint_common import line_is_suppressed
 from lint_common import load_lint_config
 from lint_common import make_log_path
 from lint_common import relative_log_path
+from lint_common import render_workspace_crate_table
+from lint_common import workspace_crate_section_lines
+from lint_common import workspace_crates
 
 
 class LintCommonTests(unittest.TestCase):
@@ -64,6 +67,91 @@ class LintCommonTests(unittest.TestCase):
             config = load_lint_config(repo_root)
 
             self.assertEqual(config["identities"]["forbidden_literals"], ["team-lead"])
+
+    def test_workspace_crates_reads_package_and_crate_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            crates_dir = repo_root / "crates"
+            atm_core_dir = crates_dir / "atm-core"
+            atm_core_dir.mkdir(parents=True)
+            (atm_core_dir / "Cargo.toml").write_text(
+                """\
+[package]
+name = "agent-team-mail-core"
+version = "1.1.2"
+
+[lib]
+name = "atm_core"
+""",
+                encoding="utf-8",
+            )
+            atm_dir = crates_dir / "atm"
+            atm_dir.mkdir(parents=True)
+            (atm_dir / "Cargo.toml").write_text(
+                """\
+[package]
+name = "agent-team-mail"
+version = "1.1.2"
+""",
+                encoding="utf-8",
+            )
+
+            crates = workspace_crates(repo_root)
+
+            self.assertEqual(
+                [(crate.crate_dir, crate.package_name, crate.crate_path_name) for crate in crates],
+                [
+                    ("atm", "agent-team-mail", "atm"),
+                    ("atm-core", "agent-team-mail-core", "atm_core"),
+                ],
+            )
+
+    def test_render_workspace_crate_table_supports_extra_columns(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            crate_dir = repo_root / "crates" / "atm-core"
+            crate_dir.mkdir(parents=True)
+            (crate_dir / "Cargo.toml").write_text(
+                """\
+[package]
+name = "agent-team-mail-core"
+version = "1.1.2"
+
+[lib]
+name = "atm_core"
+""",
+                encoding="utf-8",
+            )
+
+            lines = render_workspace_crate_table(
+                repo_root,
+                extra_columns=[("lint_mode", "lint_mode", lambda _crate: "check")],
+            )
+
+            self.assertIn("crate", lines[0])
+            self.assertIn("lint_mode", lines[0])
+            self.assertTrue(any("atm-core" in line and "check" in line for line in lines))
+
+    def test_workspace_crate_section_lines_wraps_table(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            crate_dir = repo_root / "crates" / "atm-core"
+            crate_dir.mkdir(parents=True)
+            (crate_dir / "Cargo.toml").write_text(
+                """\
+[package]
+name = "agent-team-mail-core"
+version = "1.1.2"
+""",
+                encoding="utf-8",
+            )
+
+            lines = workspace_crate_section_lines(repo_root, title="inventory:")
+
+            self.assertEqual(lines[0], "inventory:")
+            self.assertIn("crate", lines[1])
+            self.assertIn("manifest", lines[1])
+            self.assertEqual(lines[-1], "")
 
     def test_line_is_suppressed_supports_tool_key_and_rule_aliases(self) -> None:
         lines = [

--- a/.just/tests/test_lint_common.py
+++ b/.just/tests/test_lint_common.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from lint_common import build_report
+from lint_common import classify_rust_test_scope
+from lint_common import LintDirectivePolicy
+from lint_common import lint_slug
+from lint_common import line_is_suppressed
+from lint_common import load_lint_config
+from lint_common import make_log_path
+from lint_common import relative_log_path
+
+
+class LintCommonTests(unittest.TestCase):
+    def test_lint_slug_normalizes_names(self) -> None:
+        self.assertEqual(lint_slug("Rule 8 / identities"), "rule-8-identities")
+
+    def test_build_report_writes_log(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            started_at = datetime(2026, 5, 4, 3, 15, 0, tzinfo=timezone.utc)
+            report = build_report(
+                lint_name="manifests",
+                repo_root=repo_root,
+                passed=True,
+                summary="manifest policy satisfied",
+                findings=[],
+                transcript_lines=["no manifest violations found"],
+                started_at=started_at,
+                duration_seconds=0.42,
+            )
+
+            self.assertTrue(report.log_path.is_file())
+            self.assertIn("summary: manifest policy satisfied", report.log_path.read_text(encoding="utf-8"))
+            self.assertEqual(relative_log_path(repo_root, report.log_path), ".just/logs/20260504031500-manifests.log")
+
+    def test_make_log_path_uses_timestamp_and_slug(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            started_at = datetime(2026, 5, 4, 3, 16, 0, tzinfo=timezone.utc)
+            path = make_log_path(repo_root, "Boundary Check", started_at)
+            self.assertEqual(path, repo_root / ".just/logs/20260504031600-boundary-check.log")
+
+    def test_load_lint_config_reads_repo_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            just_dir = repo_root / ".just"
+            just_dir.mkdir()
+            (just_dir / "lint-config.toml").write_text(
+                "[identities]\nforbidden_literals = [\"team-lead\"]\n",
+                encoding="utf-8",
+            )
+
+            config = load_lint_config(repo_root)
+
+            self.assertEqual(config["identities"]["forbidden_literals"], ["team-lead"])
+
+    def test_line_is_suppressed_supports_tool_key_and_rule_aliases(self) -> None:
+        lines = [
+            "// lint-identities: allow-next-line",
+            "let _ = \"team-lead\";",
+            "// rule-009: allow-start",
+            "let _ = \"arch-ctm\";",
+            "// lint-identities: allow-end",
+            "let _ = \"quality-mgr\";",
+        ]
+        policy = LintDirectivePolicy(tool_key="identities", aliases=("rule-008", "rule-009"))
+
+        self.assertTrue(line_is_suppressed(2, lines, policy))
+        self.assertTrue(line_is_suppressed(4, lines, policy))
+        self.assertFalse(line_is_suppressed(6, lines, policy))
+
+    def test_line_is_suppressed_supports_multiline_comment_directives(self) -> None:
+        lines = [
+            "/* lint-identities: allow-start */",
+            "let _ = \"team-lead\";",
+            "* lint-identities: allow-end",
+            "let _ = \"arch-ctm\";",
+        ]
+        policy = LintDirectivePolicy(tool_key="identities", aliases=("rule-008", "rule-009"))
+
+        self.assertTrue(line_is_suppressed(2, lines, policy))
+        self.assertFalse(line_is_suppressed(4, lines, policy))
+
+    def test_classify_rust_test_scope_marks_cfg_test_block_only(self) -> None:
+        lines = [
+            "pub fn production() {}",
+            "#[cfg(test)]",
+            "mod tests {",
+            "    #[test]",
+            "    fn example() {}",
+            "}",
+        ]
+
+        scope = classify_rust_test_scope(lines)
+
+        self.assertEqual(scope, [False, True, True, True, True, True])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_lint_external_tools.py
+++ b/.just/tests/test_lint_external_tools.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from lint_cargo_deny import build_command as build_cargo_deny_command
+from lint_cargo_deny import build_runtime_config
+from lint_cargo_shear import build_command as build_cargo_shear_command
+from lint_codespell import build_command as build_codespell_command
+
+
+class ExternalLintToolTests(unittest.TestCase):
+    def test_build_cargo_deny_command_targets_workspace_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            config_path = repo_root / "deny.runtime.toml"
+            self.assertEqual(
+                build_cargo_deny_command(repo_root, config_path),
+                [
+                    "cargo-deny",
+                    "check",
+                    "--config",
+                    str(config_path),
+                    "advisories",
+                    "bans",
+                    "licenses",
+                    "sources",
+                ],
+            )
+
+    def test_build_runtime_config_strips_deprecated_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            (repo_root / "deny.toml").write_text(
+                """\
+[advisories]
+vulnerability = "deny"
+yanked = "deny"
+
+[licenses]
+unlicensed = "deny"
+allow = ["MIT"]
+""",
+                encoding="utf-8",
+            )
+
+            runtime_path = build_runtime_config(repo_root)
+            text = runtime_path.read_text(encoding="utf-8")
+
+            self.assertNotIn('vulnerability = "deny"', text)
+            self.assertNotIn('unlicensed = "deny"', text)
+            self.assertIn('yanked = "deny"', text)
+            self.assertIn('allow = ["MIT"]', text)
+
+    def test_build_cargo_shear_command_targets_workspace_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.assertEqual(
+                build_cargo_shear_command(repo_root),
+                ["cargo-shear"],
+            )
+
+    def test_build_codespell_command_uses_repo_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            command = build_codespell_command(repo_root)
+            self.assertEqual(command[:2], [sys.executable, "-c"])
+            self.assertIn("codespell_lib", command[2])
+            self.assertEqual(len(command), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_lint_external_tools.py
+++ b/.just/tests/test_lint_external_tools.py
@@ -12,7 +12,11 @@ if str(JUST_DIR) not in sys.path:
 
 from lint_cargo_deny import build_command as build_cargo_deny_command
 from lint_cargo_deny import build_runtime_config
+from lint_cargo_shear import annotate_sections
 from lint_cargo_shear import build_command as build_cargo_shear_command
+from lint_cargo_shear import evaluate_policy
+from lint_cargo_shear import load_policy_config
+from lint_cargo_shear import parse_sections
 from lint_codespell import build_command as build_codespell_command
 
 
@@ -65,6 +69,123 @@ allow = ["MIT"]
             self.assertEqual(
                 build_cargo_shear_command(repo_root),
                 ["cargo-shear"],
+            )
+
+    def test_parse_sections_extracts_warning_files(self) -> None:
+        stdout = """\
+shear/unlinked_files
+
+  ⚠ 1 unlinked file in `agent-team-mail`
+  │ tests/support/mod.rs
+  help: delete this file
+
+shear/empty_files
+
+  ⚠ 2 empty files in `agent-team-mail-core`
+  │ src/model_registry.rs
+  │ src/schema/settings.rs
+"""
+        sections = parse_sections(stdout)
+        self.assertEqual([section.name for section in sections], ["unlinked_files", "empty_files"])
+        self.assertEqual(sections[0].file_paths, ("tests/support/mod.rs",))
+        self.assertEqual(
+            sections[1].file_paths,
+            ("src/model_registry.rs", "src/schema/settings.rs"),
+        )
+
+    def test_evaluate_policy_promotes_unapproved_warning_files_to_errors(self) -> None:
+        stdout = """\
+shear/unlinked_files
+
+  ⚠ 1 unlinked file in `agent-team-mail`
+  │ tests/support/mod.rs
+"""
+        sections = parse_sections(stdout)
+        findings, downgraded = evaluate_policy(
+            sections,
+            {"allowed_empty_files": {}, "allowed_unlinked_files": {}},
+        )
+        self.assertEqual(downgraded, [])
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].section_name, "unlinked_files")
+        self.assertEqual(findings[0].file_path, "tests/support/mod.rs")
+
+    def test_evaluate_policy_downgrades_allowlisted_files(self) -> None:
+        stdout = """\
+shear/empty_files
+
+  ⚠ 1 empty file in `agent-team-mail-core`
+  │ src/model_registry.rs
+"""
+        sections = parse_sections(stdout)
+        findings, downgraded = evaluate_policy(
+            sections,
+            {
+                "allowed_empty_files": {"src/model_registry.rs": "planned stub"},
+                "allowed_unlinked_files": {},
+            },
+        )
+        self.assertEqual(findings, [])
+        self.assertEqual(
+            downgraded,
+            ["empty_files: downgraded src/model_registry.rs (planned stub)"],
+        )
+
+    def test_load_policy_config_normalizes_windows_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            just_dir = repo_root / ".just"
+            just_dir.mkdir()
+            (just_dir / "lint-config.toml").write_text(
+                """\
+[cargo_shear.allowed_empty_files]
+"src\\\\model_registry.rs" = "planned stub"
+
+[cargo_shear.allowed_unlinked_files]
+"tests\\\\support\\\\mod.rs" = "legacy pending"
+""",
+                encoding="utf-8",
+            )
+
+            policy = load_policy_config(repo_root)
+            self.assertEqual(
+                policy["allowed_empty_files"]["src/model_registry.rs"],
+                "planned stub",
+            )
+            self.assertEqual(
+                policy["allowed_unlinked_files"]["tests/support/mod.rs"],
+                "legacy pending",
+            )
+
+    def test_annotate_sections_uses_crate_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            for crate_name, package_name in (
+                ("atm", "agent-team-mail"),
+                ("atm-core", "agent-team-mail-core"),
+            ):
+                crate_dir = repo_root / "crates" / crate_name
+                crate_dir.mkdir(parents=True)
+                (crate_dir / "Cargo.toml").write_text(
+                    f"""\
+[package]
+name = "{package_name}"
+version = "1.1.2"
+""",
+                    encoding="utf-8",
+                )
+
+            sections = parse_sections(
+                """\
+shear/unlinked_files
+
+  ⚠ 1 unlinked file in `agent-team-mail`
+  │ tests/support/mod.rs
+"""
+            )
+            self.assertEqual(
+                annotate_sections(sections, repo_root),
+                ["shear note: crates/atm/tests/support/mod.rs [unlinked_files]"],
             )
 
     def test_build_codespell_command_uses_repo_config(self) -> None:

--- a/.just/tests/test_lint_manifests.py
+++ b/.just/tests/test_lint_manifests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from pathlib import PureWindowsPath
 import sys
 import tempfile
 import unittest
@@ -11,6 +12,7 @@ if str(JUST_DIR) not in sys.path:
     sys.path.insert(0, str(JUST_DIR))
 
 from lint_manifests import collect_manifest_violations
+from lint_manifests import relative_manifest_display
 
 
 ROOT_MANIFEST = """\
@@ -46,6 +48,15 @@ serde = "1"
 
 
 class LintManifestsTests(unittest.TestCase):
+    def test_relative_manifest_display_uses_posix_separators(self) -> None:
+        repo_root = PureWindowsPath(r"D:\a\atm-core\atm-core")
+        manifest_path = PureWindowsPath(r"D:\a\atm-core\atm-core\crates\atm-core\Cargo.toml")
+
+        self.assertEqual(
+            relative_manifest_display(manifest_path, repo_root),
+            "crates/atm-core/Cargo.toml",
+        )
+
     def write_repo(self, repo_root: Path) -> None:
         (repo_root / "Cargo.toml").write_text(ROOT_MANIFEST, encoding="utf-8")
         crate_dir = repo_root / "crates/atm-core"

--- a/.just/tests/test_lint_manifests.py
+++ b/.just/tests/test_lint_manifests.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from lint_manifests import collect_manifest_violations
+
+
+ROOT_MANIFEST = """\
+[workspace]
+members = ["crates/atm-core", "crates/atm"]
+resolver = "2"
+
+[workspace.package]
+version = "1.1.2"
+edition = "2024"
+rust-version = "1.94.1"
+authors = ["atm-core contributors"]
+license = "MIT OR Apache-2.0"
+repository = "https://example.invalid/repo"
+homepage = "https://example.invalid/repo"
+"""
+
+
+GOOD_MEMBER = """\
+[package]
+name = "agent-team-mail-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+serde = "1"
+"""
+
+
+class LintManifestsTests(unittest.TestCase):
+    def write_repo(self, repo_root: Path) -> None:
+        (repo_root / "Cargo.toml").write_text(ROOT_MANIFEST, encoding="utf-8")
+        crate_dir = repo_root / "crates/atm-core"
+        crate_dir.mkdir(parents=True)
+        (crate_dir / "Cargo.toml").write_text(GOOD_MEMBER, encoding="utf-8")
+
+    def test_collect_manifest_violations_accepts_workspace_inheritance(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            self.assertEqual(collect_manifest_violations(repo_root), [])
+
+    def test_collect_manifest_violations_flags_missing_workspace_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            manifest_path = repo_root / "crates/atm-core/Cargo.toml"
+            manifest_path.write_text(GOOD_MEMBER.replace("homepage.workspace = true\n", ""), encoding="utf-8")
+
+            violations = collect_manifest_violations(repo_root)
+            rendered = [violation.render() for violation in violations]
+            self.assertIn("crates/atm-core/Cargo.toml: set [package].homepage.workspace = true", rendered)
+
+    def test_collect_manifest_violations_flags_mismatched_internal_path_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            (repo_root / "Cargo.toml").write_text(ROOT_MANIFEST.replace('"crates/atm"]', '"crates/atm", "crates/atm-core"]'), encoding="utf-8")
+            atm_core_dir = repo_root / "crates/atm-core"
+            atm_core_dir.mkdir(parents=True)
+            (atm_core_dir / "Cargo.toml").write_text(GOOD_MEMBER, encoding="utf-8")
+            atm_dir = repo_root / "crates/atm"
+            atm_dir.mkdir(parents=True)
+            (atm_dir / "Cargo.toml").write_text(
+                """\
+[package]
+name = "agent-team-mail"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+atm-core = { path = "../atm-core", version = "9.9.9" }
+""",
+                encoding="utf-8",
+            )
+
+            violations = collect_manifest_violations(repo_root)
+            rendered = [violation.render() for violation in violations]
+            self.assertIn(
+                'crates/atm/Cargo.toml [dependencies.atm-core]: path dependency version must match workspace version "1.1.2"',
+                rendered,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_print_help.py
+++ b/.just/tests/test_print_help.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from print_help import render_help
+
+
+class PrintHelpTests(unittest.TestCase):
+    def test_render_help_mentions_new_lint_entries(self) -> None:
+        output = render_help("atm-core")
+        self.assertIn("lint boundaries", output)
+        self.assertIn("lint manifests", output)
+        self.assertIn("lint pytests", output)
+        self.assertIn("fmt apply", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_run_fmt.py
+++ b/.just/tests/test_run_fmt.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from run_fmt import resolve_command
+
+
+class RunFmtTests(unittest.TestCase):
+    def test_resolve_command_accepts_aliases(self) -> None:
+        self.assertEqual(resolve_command("check"), ["just", "_fmt-check"])
+        self.assertEqual(resolve_command("write"), ["just", "_fmt-write"])
+        self.assertEqual(resolve_command("apply"), ["just", "_fmt-write"])
+
+    def test_resolve_command_rejects_unknown_mode(self) -> None:
+        self.assertIsNone(resolve_command("unknown"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_run_lint.py
+++ b/.just/tests/test_run_lint.py
@@ -15,6 +15,7 @@ from run_lint import build_transcript
 from run_lint import extract_count
 from run_lint import LintResult
 from run_lint import LintTask
+from run_lint import preview_lines_for_task
 from run_lint import prioritize_error_lines
 from run_lint import resolve_task_names
 
@@ -63,7 +64,7 @@ class RunLintTests(unittest.TestCase):
             self.assertEqual(tasks["spell"].command[-1], str(repo_root / ".just/lint_codespell.py"))
             self.assertEqual(tasks["pytests"].command[-1], str(repo_root / ".just/run_pytests.py"))
 
-    def test_build_transcript_adds_crate_inventory_for_fmt(self) -> None:
+    def test_build_transcript_adds_crate_inventory_for_crate_scoped_lints(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)
             crate_dir = repo_root / "crates" / "atm-core"
@@ -76,21 +77,41 @@ version = "1.1.2"
 """,
                 encoding="utf-8",
             )
-            result = LintResult(
-                task=LintTask("fmt", ["just", "_lint-fmt"]),
-                returncode=0,
-                stdout="",
-                stderr="",
-                duration_seconds=0.2,
-                log_path=repo_root / ".just/logs/example.log",
-            )
+            for lint_name in ("fmt", "clippy", "boundaries", "manifests"):
+                result = LintResult(
+                    task=LintTask(lint_name, ["just", f"_lint-{lint_name}"]),
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                    duration_seconds=0.2,
+                    log_path=repo_root / ".just/logs/example.log",
+                )
 
-            transcript = build_transcript(result.task, result, repo_root)
+                transcript = build_transcript(result.task, result, repo_root)
 
-            self.assertIn("crates analyzed:", transcript)
-            joined = "\n".join(transcript)
-            self.assertIn("crate_path", joined)
-            self.assertIn("atm-core", joined)
+                self.assertIn("crates analyzed:", transcript)
+                joined = "\n".join(transcript)
+                self.assertIn("crate_path", joined)
+                self.assertIn("atm-core", joined)
+
+    def test_preview_lines_for_identities_skips_inventory_rows(self) -> None:
+        lines = [
+            "crates analyzed:",
+            "crate     package               crate_path  manifest",
+            "atm       agent-team-mail       atm         crates/atm/Cargo.toml",
+            "atm-core  agent-team-mail-core  atm_core    crates/atm-core/Cargo.toml",
+            "RULE-008/RULE-009 violation: raw production literals found in test/cfg(test) Rust code.",
+            "crates/atm/tests/ack.rs:28: let fixture = Fixture::new(&[\"arch-ctm\", \"team-lead\"]);",
+            "total violations: 880",
+        ]
+
+        self.assertEqual(
+            preview_lines_for_task("identities", lines),
+            [
+                "RULE-008/RULE-009 violation: raw production literals found in test/cfg(test) Rust code.",
+                "crates/atm/tests/ack.rs:28: let fixture = Fixture::new(&[\"arch-ctm\", \"team-lead\"]);",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_run_lint.py
+++ b/.just/tests/test_run_lint.py
@@ -113,6 +113,104 @@ version = "1.1.2"
             ],
         )
 
+    def test_build_transcript_adds_boundary_doc_inventory_for_boundaries(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            crate_dir = repo_root / "crates" / "atm-core"
+            crate_dir.mkdir(parents=True)
+            (crate_dir / "Cargo.toml").write_text(
+                """\
+[package]
+name = "agent-team-mail-core"
+version = "1.1.2"
+""",
+                encoding="utf-8",
+            )
+            docs_dir = repo_root / "docs" / "atm-core"
+            docs_dir.mkdir(parents=True)
+            (docs_dir / "boundaries.md").write_text(
+                """\
+# Boundaries
+
+```yaml
+boundary_id: BOUNDARY-Test
+owner_package: atm-core
+owner_crate_path: atm_core
+name: TestBoundary
+
+public:
+  trait: TestTrait
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - sqlite
+  io_forbidden:
+    - sockets
+
+dependencies:
+  allowed_dependents:
+    - atm
+  allowed_dependencies:
+    - atm-core
+  forbidden_edges:
+    - atm -> atm-rusqlite
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - TestImpl
+
+contracts:
+  request_types: []
+  response_types: []
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::tests::TestDouble
+  forbidden_test_bypasses:
+    - rusqlite::Connection
+
+enforcement:
+  lint_rules:
+    - LINT_BOUNDARY_TEST
+  review_gates:
+    - no_public_impl
+
+status:
+  state: planned
+  notes: []
+```
+""",
+                encoding="utf-8",
+            )
+            result = LintResult(
+                task=LintTask("boundaries", ["just", "_lint-boundaries"]),
+                returncode=0,
+                stdout="boundaries passed [0.10s]\n",
+                stderr="",
+                duration_seconds=0.2,
+                log_path=repo_root / ".just/logs/example.log",
+            )
+
+            transcript = build_transcript(result.task, result, repo_root)
+            joined = "\n".join(transcript)
+
+            self.assertIn("boundary docs analyzed:", joined)
+            self.assertIn("docs/atm-core/boundaries.md", joined)
+            self.assertIn("boundary records validated: 1", joined)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.just/tests/test_run_lint.py
+++ b/.just/tests/test_run_lint.py
@@ -18,6 +18,7 @@ from run_lint import LintTask
 from run_lint import preview_lines_for_task
 from run_lint import prioritize_error_lines
 from run_lint import resolve_task_names
+from run_lint import strip_ansi
 
 
 class RunLintTests(unittest.TestCase):
@@ -50,6 +51,21 @@ class RunLintTests(unittest.TestCase):
             [
                 "error[E0432]: unresolved import `uuid`",
                 "could not compile `agent-team-mail`",
+            ],
+        )
+
+    def test_strip_ansi_and_prioritize_error_lines_handles_colored_cargo_output(self) -> None:
+        lines = [
+            strip_ansi("\x1b[1m\x1b[92m  Downloaded\x1b[0m thiserror v2.0.18"),
+            strip_ansi("\x1b[1m\x1b[91merror[E0308]: mismatched types\x1b[0m"),
+            strip_ansi("\x1b[1m\x1b[91merror:\x1b[0m could not compile `agent-team-mail`"),
+        ]
+
+        self.assertEqual(
+            prioritize_error_lines(lines),
+            [
+                "error[E0308]: mismatched types",
+                "error: could not compile `agent-team-mail`",
             ],
         )
 

--- a/.just/tests/test_run_lint.py
+++ b/.just/tests/test_run_lint.py
@@ -11,7 +11,10 @@ if str(JUST_DIR) not in sys.path:
     sys.path.insert(0, str(JUST_DIR))
 
 from run_lint import build_tasks
+from run_lint import build_transcript
 from run_lint import extract_count
+from run_lint import LintResult
+from run_lint import LintTask
 from run_lint import prioritize_error_lines
 from run_lint import resolve_task_names
 
@@ -59,6 +62,35 @@ class RunLintTests(unittest.TestCase):
             self.assertEqual(tasks["shear"].command[-1], str(repo_root / ".just/lint_cargo_shear.py"))
             self.assertEqual(tasks["spell"].command[-1], str(repo_root / ".just/lint_codespell.py"))
             self.assertEqual(tasks["pytests"].command[-1], str(repo_root / ".just/run_pytests.py"))
+
+    def test_build_transcript_adds_crate_inventory_for_fmt(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            crate_dir = repo_root / "crates" / "atm-core"
+            crate_dir.mkdir(parents=True)
+            (crate_dir / "Cargo.toml").write_text(
+                """\
+[package]
+name = "agent-team-mail-core"
+version = "1.1.2"
+""",
+                encoding="utf-8",
+            )
+            result = LintResult(
+                task=LintTask("fmt", ["just", "_lint-fmt"]),
+                returncode=0,
+                stdout="",
+                stderr="",
+                duration_seconds=0.2,
+                log_path=repo_root / ".just/logs/example.log",
+            )
+
+            transcript = build_transcript(result.task, result, repo_root)
+
+            self.assertIn("crates analyzed:", transcript)
+            joined = "\n".join(transcript)
+            self.assertIn("crate_path", joined)
+            self.assertIn("atm-core", joined)
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_run_lint.py
+++ b/.just/tests/test_run_lint.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from run_lint import build_tasks
+from run_lint import extract_count
+from run_lint import prioritize_error_lines
+from run_lint import resolve_task_names
+
+
+class RunLintTests(unittest.TestCase):
+    def test_resolve_task_names_all_includes_new_targets(self) -> None:
+        names = resolve_task_names("all")
+        self.assertIn("boundaries", names)
+        self.assertIn("manifests", names)
+        self.assertIn("deny", names)
+        self.assertIn("shear", names)
+        self.assertIn("spell", names)
+        self.assertIn("pytests", names)
+
+    def test_resolve_task_names_rejects_unknown_target(self) -> None:
+        with self.assertRaises(ValueError):
+            resolve_task_names("unknown")
+
+    def test_extract_count_understands_total_violations(self) -> None:
+        self.assertEqual(extract_count(["total violations: 58"]), 58)
+
+    def test_prioritize_error_lines_prefers_actual_failures(self) -> None:
+        lines = [
+            "Updating crates.io index",
+            "Downloaded crate",
+            "error[E0432]: unresolved import `uuid`",
+            "could not compile `agent-team-mail`",
+        ]
+
+        self.assertEqual(
+            prioritize_error_lines(lines),
+            [
+                "error[E0432]: unresolved import `uuid`",
+                "could not compile `agent-team-mail`",
+            ],
+        )
+
+    def test_build_tasks_contains_expected_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            tasks = build_tasks(repo_root)
+            self.assertEqual(tasks["boundaries"].command[-1], str(repo_root / ".just/lint_boundaries.py"))
+            self.assertEqual(tasks["manifests"].command[-1], str(repo_root / ".just/lint_manifests.py"))
+            self.assertEqual(tasks["deny"].command[-1], str(repo_root / ".just/lint_cargo_deny.py"))
+            self.assertEqual(tasks["shear"].command[-1], str(repo_root / ".just/lint_cargo_shear.py"))
+            self.assertEqual(tasks["spell"].command[-1], str(repo_root / ".just/lint_codespell.py"))
+            self.assertEqual(tasks["pytests"].command[-1], "test_*.py")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_run_lint.py
+++ b/.just/tests/test_run_lint.py
@@ -58,7 +58,7 @@ class RunLintTests(unittest.TestCase):
             self.assertEqual(tasks["deny"].command[-1], str(repo_root / ".just/lint_cargo_deny.py"))
             self.assertEqual(tasks["shear"].command[-1], str(repo_root / ".just/lint_cargo_shear.py"))
             self.assertEqual(tasks["spell"].command[-1], str(repo_root / ".just/lint_codespell.py"))
-            self.assertEqual(tasks["pytests"].command[-1], "test_*.py")
+            self.assertEqual(tasks["pytests"].command[-1], str(repo_root / ".just/run_pytests.py"))
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_run_pytests.py
+++ b/.just/tests/test_run_pytests.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+import sys
+import tempfile
+import textwrap
+import unittest
+from unittest import mock
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from run_pytests import build_suite
+from run_pytests import count_fixtures
+from run_pytests import print_fixture_summary
+
+
+class RunPytestsTests(unittest.TestCase):
+    def write_test_file(self, root: Path, name: str, body: str) -> None:
+        tests_dir = root / ".just" / "tests"
+        tests_dir.mkdir(parents=True, exist_ok=True)
+        (tests_dir / name).write_text(body, encoding="utf-8")
+
+    def test_count_fixtures_reports_testcase_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_test_file(
+                repo_root,
+                "test_sample.py",
+                textwrap.dedent(
+                    """\
+                    import unittest
+
+                    class AlphaTests(unittest.TestCase):
+                        def test_one(self):
+                            pass
+
+                        def test_two(self):
+                            pass
+
+                    class BetaTests(unittest.TestCase):
+                        def test_three(self):
+                            pass
+                    """
+                ),
+            )
+
+            suite = build_suite(repo_root)
+            self.assertEqual(
+                count_fixtures(suite),
+                [
+                    ("test_sample.AlphaTests", 2),
+                    ("test_sample.BetaTests", 1),
+                ],
+            )
+
+    def test_print_fixture_summary_includes_total(self) -> None:
+        buffer = StringIO()
+        with mock.patch("sys.stdout", buffer):
+            print_fixture_summary([("test_alpha.AlphaTests", 2), ("test_beta.BetaTests", 1)])
+
+        self.assertEqual(
+            buffer.getvalue(),
+            "pytests fixture counts:\n"
+            "  test_alpha.AlphaTests: 2\n"
+            "  test_beta.BetaTests: 1\n"
+            "pytests fixtures total: 2\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.0.0
+PackageVersion: 1.1.2
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.0.0/atm_1.0.0_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.1.2/atm_1.1.2_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.0.0
+ManifestVersion: 1.1.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,6 @@ dependencies = [
 name = "agent-team-mail-core"
 version = "1.1.2"
 dependencies = [
- "anyhow",
  "chrono",
  "fs2",
  "libc",
@@ -34,7 +33,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
- "thiserror",
  "toml",
  "tracing",
  "ulid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,7 @@ homepage = "https://github.com/randlee/atm-core"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "2.0"
 anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-tokio = { version = "1", features = ["rt"] }
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/Justfile
+++ b/Justfile
@@ -66,7 +66,7 @@ _lint-spell:
 
 [private]
 _lint-pytests:
-    {{python_cmd}} -m unittest discover -s .just/tests -p "test_*.py"
+    {{python_cmd}} .just/run_pytests.py
 
 # Build the full workspace.
 build:

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,89 @@
+set windows-shell := ["pwsh", "-NoLogo", "-Command"]
+
+python_cmd := if os_family() == "windows" { "python" } else { "python3" }
+
+# Show the curated repo task help.
+default: help
+
+# Show the curated repo task help.
+help:
+    {{python_cmd}} .just/print_help.py
+
+[private]
+_fmt-write:
+    cargo fmt --all
+
+[private]
+_fmt-check:
+    cargo fmt --all --check
+
+# Format the Rust workspace or run the formatting gate.
+fmt mode='check':
+    {{python_cmd}} .just/run_fmt.py {{mode}}
+
+[private]
+_lint-fmt:
+    @just fmt check
+
+[private]
+_lint-clippy:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+[private]
+_lint-deny:
+    {{python_cmd}} .just/lint_cargo_deny.py
+
+[private]
+_lint-shear:
+    {{python_cmd}} .just/lint_cargo_shear.py
+
+[private]
+_lint-boundaries:
+    {{python_cmd}} .just/lint_boundaries.py
+
+[private]
+_lint-manifests:
+    {{python_cmd}} .just/lint_manifests.py
+
+# Verify crate/release versions stay aligned.
+[private]
+_lint-version:
+    {{python_cmd}} .just/check_version_sync.py
+
+# Enforce RULE-008 for test and cfg(test) code.
+[private]
+_lint-identities:
+    {{python_cmd}} .just/check_test_identity_literals.py
+
+# Enforce RULE-003 source file size limits.
+[private]
+_lint-lines:
+    {{python_cmd}} .just/check_line_counts.py
+
+[private]
+_lint-spell:
+    {{python_cmd}} .just/lint_codespell.py
+
+[private]
+_lint-pytests:
+    {{python_cmd}} -m unittest discover -s .just/tests -p "test_*.py"
+
+# Build the full workspace.
+build:
+    cargo build --workspace
+
+# Run the full workspace test suite.
+test:
+    cargo build --workspace
+    cargo test --workspace
+
+# Remove workspace build artifacts.
+clean:
+    cargo clean
+
+# Run the repo lint suite.
+lint target='all':
+    {{python_cmd}} .just/run_lint.py {{target}}
+
+# Run the local CI-equivalent command set.
+ci: lint test

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -19,8 +19,6 @@ name = "atm_core"
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-thiserror.workspace = true
-anyhow.workspace = true
 tracing.workspace = true
 libc = "0.2"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -29,9 +29,9 @@ serde_json.workspace = true
 time = "0.3"
 tracing.workspace = true
 tracing-subscriber.workspace = true
-uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 sc-observability = { version = "1.0.0", features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"
+uuid = { version = "1", features = ["v4"] }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,28 @@
+[graph]
+all-features = false
+no-default-features = false
+
+[advisories]
+vulnerability = "deny"
+yanked = "deny"
+ignore = []
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[licenses]
+unlicensed = "deny"
+allow = [
+  "Apache-2.0",
+  "MIT",
+  "Unicode-3.0",
+  "Zlib",
+]


### PR DESCRIPTION
## Summary

- Ports `.just/` lint tooling from Phase Q (`feature/pQ-lint-tools`) into Phase R sprint 0 foundation
- CI `just-lint` job wired to `integrate/phase-R` pipeline
- `deny.toml` and codespell config carried forward
- **New**: first boundary-record parser pass in `lint_boundaries.py` — validates `docs/*/boundaries.md` schema and enforces active-state forbidden-edge constraints
- Fixes surfaced by new lint: winget version wiring matches workspace `1.1.2`, removed stale `shear` deps (`thiserror`/`anyhow`/`tokio`), moved `uuid` to `dev-dependencies`

## Validation

- `python3 -m unittest discover -s .just/tests -p test_*.py` — PASS
- `just lint boundaries` — PASS
- `just lint pytests` — PASS
- `cargo test --workspace --quiet` — PASS
- Full `just lint` fails only on existing RULE-008 backlog (880 findings, pre-existing); boundaries/version/shear all green

## Context

Phase R is a redo of Phase Q with correct architecture. This sprint establishes the lint enforcement baseline before implementation begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)