### PR TITLE
docs: harden Phase R planning contract (per-crate arch + boundaries + requirements)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,14 @@ Phase-Q supersession note:
 - for the current mail/runtime target architecture, Section 21 is
   authoritative
 
+Phase-R redesign note:
+- the Phase Q implementation is not the architectural baseline for forward
+  work
+- the Phase R redesign starts from crate-local boundary inventories and ADRs,
+  then rebuilds the implementation under lint/visibility guardrails
+- Phase R treats thin-client extension pressure, including `atm-graft`, as a
+  first-class architectural input
+
 ## 2. Crate Boundaries
 
 The post-Q product runtime is implemented by four crates:
@@ -69,13 +77,39 @@ Product-level boundary rules:
 - `atm-daemon` must not become a second business-logic crate.
 - `atm-rusqlite` must not absorb workflow or command logic; it implements store
   contracts only.
+- crate-local boundary records in `docs/<crate>/boundaries.md` are the
+  machine-readable contract used to drive architectural linting and review
+- thin-client workflow surfaces should be modeled around `send` and `receive`
+  rather than a broad command inventory
+- `ack` may remain a retained CLI/user workflow, but thin-client protocol
+  surfaces should carry it through send-shaped request data rather than a
+  separate top-level method family
 
 Crate-local boundary detail is owned by:
 
 - [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
+- [`docs/atm-core/boundaries.md`](./atm-core/boundaries.md)
 - [`docs/atm/architecture.md`](./atm/architecture.md)
+- [`docs/atm/boundaries.md`](./atm/boundaries.md)
 - [`docs/atm-daemon/architecture.md`](./atm-daemon/architecture.md)
+- [`docs/atm-daemon/boundaries.md`](./atm-daemon/boundaries.md)
 - [`docs/atm-rusqlite/architecture.md`](./atm-rusqlite/architecture.md)
+- [`docs/atm-rusqlite/boundaries.md`](./atm-rusqlite/boundaries.md)
+
+Current Phase R boundary direction:
+- shared protocol contract: `AtmProtocol` in `atm-core`
+- outbound transport boundary: `ClientTransport`
+- inbound transport boundary: `ServerTransport`
+- request routing boundary: `RequestDispatcher`
+- outbound notification boundary: `NotificationSink`
+- inbound runtime status boundary: `StatusSource`
+- watch/reconcile boundary family:
+  - `WatchEventSource`
+  - `ReconcileCoordinator`
+- current production composition ownership:
+  - `atm` is the CLI client composition root
+  - `atm-daemon` is the runtime composition root
+  - a separate composition crate remains out of scope unless an ADR opens it
 
 ### 2.3 Release Publication Boundary
 

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -8,6 +8,99 @@ It complements the product architecture in
 [`../architecture.md`](../architecture.md) and owns crate-local structure and
 service boundaries.
 
+The crate-local machine-readable boundary inventory lives in:
+- [`./boundaries.md`](./boundaries.md)
+
+## 1.1 ADRs
+
+## Shared ATM protocol lives in atm-core
+
+```yaml
+adr_id: ADR-ATM-CORE-001
+crate: atm-core
+title: Shared ATM protocol lives in atm-core
+status: accepted
+date: 2026-05-03
+deciders:
+  - team-lead
+  - arch-ctm
+tags:
+  - protocol
+  - contracts
+related_boundaries:
+  - BOUNDARY-AtmProtocol
+  - BOUNDARY-ClientTransport
+  - BOUNDARY-ServerTransport
+  - BOUNDARY-RequestDispatcher
+code_references:
+  - docs/atm-core/boundaries.md
+  - docs/atm-daemon/boundaries.md
+  - docs/atm/boundaries.md
+```
+
+Context:
+- The protocol is shared by CLI clients, daemon server/runtime, in-process
+  transport tests, and thin extension crates such as atm-graft.
+
+Decision:
+- `AtmProtocol` is owned by `atm-core`, not by `atm-daemon`.
+- `atm-core` also owns the public transport and dispatcher contracts that
+  operate over that protocol.
+
+Consequences:
+- Thin callers do not need daemon-shaped API types.
+- Client and server transports share one contract family.
+
+Alternatives considered:
+- Keep the protocol modeled as daemon API types.
+- Move the protocol into a dedicated transport crate first.
+
+Follow-up work:
+- Keep crate-local boundary records aligned with this ownership rule.
+- Enforce daemon-shaped protocol naming as a lint failure.
+
+## Ack is folded into send-shaped thin-client requests
+
+```yaml
+adr_id: ADR-ATM-CORE-002
+crate: atm-core
+title: Ack is folded into send-shaped thin-client requests
+status: accepted
+date: 2026-05-03
+deciders:
+  - team-lead
+  - arch-ctm
+tags:
+  - workflow
+  - protocol
+related_boundaries:
+  - BOUNDARY-AtmProtocol
+  - BOUNDARY-TaskStore
+code_references:
+  - docs/atm-core/boundaries.md
+  - docs/requirements.md
+```
+
+Context:
+- Thin client surfaces should expose as few methods as possible while still
+  preserving ATM workflow semantics.
+
+Decision:
+- `ack` remains a retained user workflow, but thin-client protocol surfaces
+  carry acknowledgement through send-shaped request data rather than a separate
+  top-level protocol family.
+
+Consequences:
+- Thin extensions such as atm-graft expose a smaller public surface.
+- Task-state rules still remain explicit in store and workflow boundaries.
+
+Alternatives considered:
+- Preserve a first-class top-level `ack` protocol method family.
+
+Follow-up work:
+- Keep task-state ownership explicit in `TaskStore`.
+- Align thin-client docs with the `send` / `receive` shape.
+
 ## 2. Architectural Rules
 
 - `atm-core` exposes request/result/service boundaries, not clap surfaces.
@@ -35,20 +128,26 @@ Observability release boundary rules:
 - CLI JSON output remains wire-compatible with the current retained-log output
   shape after the boundary cleanup
 
-## 2.1 Phase Q Boundary Model
+## 2.1 Phase R Boundary Model
 
-Phase Q makes `atm-core` the owner of the service-layer boundaries while the
+Phase R makes `atm-core` the owner of the service-layer boundaries while the
 daemon remains a runtime wrapper only.
 
 Required subsystem boundaries:
+- `AtmProtocol` boundary
+- `ClientTransport` boundary
+- `ServerTransport` boundary
+- `RequestDispatcher` boundary
 - `MailStore` boundary
 - `TaskStore` boundary
 - `RosterStore` boundary
 - inbox-ingress boundary
 - inbox-export boundary
 - config-ingress boundary
-- watcher/reconcile boundary
-- notifier-facing service boundary
+- `WatchEventSource` boundary
+- `ReconcileCoordinator` boundary
+- `NotificationSink` boundary
+- `StatusSource` boundary
 
 Required architectural rules:
 - business logic must live in service modules, not in concrete adapters
@@ -90,9 +189,18 @@ Privacy rule:
 
 Those belong to the `atm-daemon` crate.
 
-## 2.2 Phase Q Semantic Wrapper Policy
+Phase R redesign notes:
+- `atm-core` owns the shared `AtmProtocol` contract
+- `atm-core` owns the public boundary contracts for transport, dispatch,
+  store, ingress/export, watch/reconcile, and notification/status surfaces
+- thin-client workflow surfaces should center on `send` and `receive`
+- `ack` remains a workflow/state concern, but thin-client protocol shape
+  should carry it inside send-shaped requests rather than a separate top-level
+  method family
 
-Phase Q should keep durable identifiers and runtime-cap settings typed across
+## 2.2 Phase R Semantic Wrapper Policy
+
+Phase R should keep durable identifiers and runtime-cap settings typed across
 the service boundary.
 
 Required wrappers:

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -124,6 +124,7 @@ ownership:
 dependencies:
   allowed_dependents:
     - atm
+    - atm-daemon
     - atm-graft
   allowed_dependencies: []
   forbidden_edges: []
@@ -157,6 +158,7 @@ status:
   state: planned
   notes:
     - designed for thin callers such as atm-graft
+    - daemon-to-daemon remote delivery also depends on this outbound client boundary
 ```
 
 Purpose:
@@ -165,6 +167,152 @@ Purpose:
 Notes:
 - The public workflow surface above this boundary should stay centered on send
   and receive.
+
+## WatchEventSource
+
+```yaml
+boundary_id: BOUNDARY-WatchEventSource
+owner_package: atm-core
+owner_crate_path: atm_core
+name: WatchEventSource
+
+public:
+  trait: WatchEventSource
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - filesystem_watch_events
+    - watch_event_delivery
+  io_forbidden:
+    - sqlite
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - notify::recommended_watcher
+
+contracts:
+  request_types:
+    - watch subscription requests
+  response_types:
+    - watch event batches
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubWatchEventSource
+  forbidden_test_bypasses:
+    - notify::recommended_watcher
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-WATCH-EVENT-SOURCE-REFERENCES
+  review_gates:
+    - no_watch_io_outside_boundary
+
+status:
+  state: planned
+  notes:
+    - watch source owns event capture only, not reconcile policy
+```
+
+Purpose:
+- Owns filesystem watch event capture and delivery to the runtime reconcile layer.
+
+Notes:
+- This keeps raw watch APIs out of store, transport, and service logic.
+
+## ReconcileCoordinator
+
+```yaml
+boundary_id: BOUNDARY-ReconcileCoordinator
+owner_package: atm-core
+owner_crate_path: atm_core
+name: ReconcileCoordinator
+
+public:
+  trait: ReconcileCoordinator
+  facade: null
+
+implementation:
+  type: null
+  module: null
+  visibility: trait_only
+  constructor: none
+
+composition:
+  roots: []
+
+ownership:
+  io_owns:
+    - watch_event_coalescing
+    - ingress_reconcile_triggering
+  io_forbidden:
+    - sqlite
+    - socket_io
+    - process_spawn
+
+dependencies:
+  allowed_dependents:
+    - atm-daemon
+  allowed_dependencies: []
+  forbidden_edges: []
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - mailbox::store::observe_source_files
+    - mailbox::store::with_locked_source_files
+
+contracts:
+  request_types:
+    - reconcile requests
+  response_types:
+    - reconcile outcomes
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubReconcileCoordinator
+  forbidden_test_bypasses:
+    - mailbox::store::observe_source_files
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-RECONCILE-COORDINATOR-REFERENCES
+  review_gates:
+    - no_store_or_transport_bypass_in_reconcile
+
+status:
+  state: planned
+  notes:
+    - reconcile owns coalescing and trigger policy, not raw watch APIs
+```
+
+Purpose:
+- Owns watch-driven reconcile policy and ingress triggering above raw watch events.
+
+Notes:
+- This closes the missing watch/reconcile boundary gap in the initial Phase R set.
 
 ## ServerTransport
 

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -8,6 +8,9 @@ The `atm-core` crate owns the reusable ATM business logic, persistent-store
 contracts, and strict I/O subsystem boundaries. Product behavior remains
 defined in [`../requirements.md`](../requirements.md).
 
+The crate-local machine-readable boundary inventory lives in:
+- [`./boundaries.md`](./boundaries.md)
+
 ## 2. Ownership
 
 `atm-core` owns:
@@ -136,8 +139,8 @@ Initial crate requirement IDs:
   Satisfies:
   `REQ-P-CONTRACT-001`, `REQ-P-RELIABILITY-001`.
 - `REQ-CORE-BOUNDARY-001` `atm-core` owns the strict trait boundaries for
-  store, inbox ingress/export, config ingress, watcher/reconcile, and
-  notifier-facing service calls. Satisfies the subsystem-boundary aspects of:
+  store, protocol, transport, inbox ingress/export, config ingress,
+  watcher/reconcile, notification sink, and status-source calls. Satisfies the subsystem-boundary aspects of:
   `REQ-P-CONTRACT-001`, `REQ-P-TEST-001`.
 - `REQ-CORE-BOUNDARY-002` `atm-core` owns the typed error-model contracts used
   by service boundaries. Satisfies the structured-error aspects of:
@@ -152,11 +155,12 @@ Initial crate requirement IDs:
 - `REQ-CORE-DAEMON-002` `atm-core` owns the contract that daemon runtime
   orchestration stays outside mail business semantics. Satisfies:
   `REQ-P-CONTRACT-001`, `REQ-P-TEST-001`.
-- `REQ-CORE-TRANSPORT-001` `atm-core` owns the typed daemon API contract shared
-  by Unix domain socket, TCP/TLS, and in-process test transport. Satisfies:
+- `REQ-CORE-TRANSPORT-001` `atm-core` owns the shared `AtmProtocol` contract
+  used by client transport, server transport, and in-process test transport. Satisfies:
   `REQ-P-CONTRACT-001`, `REQ-P-TEST-001`.
-- `REQ-CORE-TRANSPORT-002` `atm-core` owns route-selection semantics between
-  local and cross-host daemon paths. Satisfies:
+- `REQ-CORE-TRANSPORT-002` `atm-core` owns the public `ClientTransport` and
+  `ServerTransport` contracts plus route-selection semantics between local and
+  cross-host daemon paths. Satisfies:
   `REQ-P-CONTRACT-001`, `REQ-P-RELIABILITY-001`.
 - `REQ-CORE-TRANSPORT-003` `atm-core` owns the typed transport timeout and
   retry semantics exposed at service boundaries. Satisfies:
@@ -212,11 +216,13 @@ The `atm-core` crate docs must remain aligned with:
 - [`../legacy-atm-message-schema.md`](../legacy-atm-message-schema.md)
 - [`../atm-error-codes.md`](../atm-error-codes.md)
 - [`../plan-phase-Q.md`](../plan-phase-Q.md)
+- [`../plan-phase-R.md`](../plan-phase-R.md)
+- [`./boundaries.md`](./boundaries.md)
 - [`./design/dedup-metadata-schema.md`](./design/dedup-metadata-schema.md)
 - [`./design/sc-observability-integration.md`](./design/sc-observability-integration.md)
 - [`./design/sc-obs-1.0-integration.md`](./design/sc-obs-1.0-integration.md)
 
-## 6. Phase Q Store And Boundary Requirements
+## 6. Phase R Store And Boundary Requirements
 
 Requirement IDs:
 - `REQ-CORE-RUNTIME-001`

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -7,8 +7,60 @@ This document defines the `atm-daemon` crate architectural boundary.
 It complements the product architecture in
 [`../architecture.md`](../architecture.md) and owns runtime composition only.
 
+The crate-local machine-readable boundary inventory lives in:
+- [`./boundaries.md`](./boundaries.md)
+
 This crate is introduced by the Phase Q implementation line and is not part of
 the current pre-Phase-Q workspace yet.
+
+## 1.1 ADRs
+
+## Daemon is the current runtime composition root
+
+```yaml
+adr_id: ADR-ATM-DAEMON-001
+crate: atm-daemon
+title: Daemon is the current runtime composition root
+status: accepted
+date: 2026-05-03
+deciders:
+  - team-lead
+  - arch-ctm
+tags:
+  - composition
+  - runtime
+related_boundaries:
+  - BOUNDARY-ServerTransport-Socket
+  - BOUNDARY-RequestDispatcher-Daemon
+  - BOUNDARY-WatchEventSource-File
+  - BOUNDARY-ReconcileCoordinator-Daemon
+code_references:
+  - docs/atm-daemon/boundaries.md
+  - docs/atm-rusqlite/boundaries.md
+```
+
+Context:
+- The current crate set has no separate composition/app crate, but the runtime
+  still needs one legal owner that can assemble concrete adapters.
+
+Decision:
+- `atm-daemon` is the production runtime composition root in the current Phase
+  R design line.
+- It may assemble concrete runtime and store adapters while remaining thin and
+  business-logic-free.
+
+Consequences:
+- The runtime has one legal place to wire concrete adapters.
+- Forbidden dependency rules can still keep CLI and thin extensions away from
+  daemon and SQLite internals.
+
+Alternatives considered:
+- Leave composition ownership unspecified.
+- Add a separate composition crate before the boundary line is stable.
+
+Follow-up work:
+- Keep adapter assembly in daemon-owned composition code only.
+- Revisit only if a later ADR extracts a dedicated composition crate.
 
 ## 2. Responsibilities
 
@@ -25,6 +77,12 @@ The `atm-daemon` crate is responsible for:
 
 The `atm-daemon` crate must remain thin.
 
+Phase R redesign notes:
+- `atm-daemon` remains runtime-oriented, not business-logic-oriented
+- `atm-daemon` is the current runtime composition root for production wiring
+- remote daemon-to-daemon client behavior uses the same shared protocol and
+  client/server transport contract family rather than a separate daemon-only API
+
 ## 3. Architectural Rules
 
 - `atm-daemon` must not reimplement `atm-core` business logic.
@@ -32,7 +90,8 @@ The `atm-daemon` crate must remain thin.
   boundary.
 - `atm-daemon` must not parse or write inbox JSONL except through the
   `atm-core` ingress/export boundaries.
-- `atm-daemon` owns one protocol with multiple transport implementations:
+- `atm-daemon` owns runtime implementations of one shared ATM protocol with
+  multiple transport implementations:
   - Unix domain socket
   - TCP/TLS
   - in-process `test-socket`

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -2,6 +2,13 @@
 
 This document captures runtime-owned concrete adapters for Phase R.
 
+Current design assumption:
+- `atm-daemon` is the production runtime composition root
+- direct dependency on `atm-rusqlite` is allowed for runtime assembly in the
+  current design line
+- `allowed_dependents: []` means no external crate should depend on these
+  daemon-private concrete adapters
+
 ## SocketServerTransportAdapter
 
 ```yaml
@@ -21,7 +28,8 @@ implementation:
   constructor: private
 
 composition:
-  roots: []
+  roots:
+    - atm_daemon::bootstrap
 
 ownership:
   io_owns:
@@ -36,6 +44,7 @@ dependencies:
   allowed_dependents: []
   allowed_dependencies:
     - atm-core
+    - atm-rusqlite
     - tokio
   forbidden_edges:
     - atm -> atm-daemon
@@ -82,6 +91,243 @@ Purpose:
 Notes:
 - Runtime composition stays in daemon-owned code, but business logic does not.
 
+## PeerClientTransportAdapter
+
+```yaml
+boundary_id: BOUNDARY-ClientTransport-Peer
+owner_package: atm-daemon
+owner_crate_path: atm_daemon
+name: PeerClientTransportAdapter
+
+public:
+  trait: ClientTransport
+  facade: null
+
+implementation:
+  type: PeerClientTransport
+  module: atm_daemon::transport::peer_client
+  visibility: private
+  constructor: private
+
+composition:
+  roots:
+    - atm_daemon::bootstrap
+
+ownership:
+  io_owns:
+    - outbound_remote_protocol_requests
+    - peer_request_deadlines
+    - peer_response_decode
+  io_forbidden:
+    - sqlite
+    - process_spawn
+
+dependencies:
+  allowed_dependents: []
+  allowed_dependencies:
+    - atm-core
+    - atm-rusqlite
+    - tokio
+  forbidden_edges:
+    - atm -> atm-daemon
+    - atm-graft -> atm-daemon
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - PeerClientTransport
+
+contracts:
+  request_types:
+    - AtmProtocol requests
+  response_types:
+    - AtmProtocol responses
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::InProcessClientTransport
+  forbidden_test_bypasses: []
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-CLIENT-TRANSPORT-PEER-EDGES
+    - LINT-BOUNDARY-CLIENT-TRANSPORT-PEER-REFERENCES
+  review_gates:
+    - no_public_impl
+    - no_public_constructor
+    - no_cli_to_daemon_edge
+
+status:
+  state: planned
+  notes:
+    - remote daemon-to-daemon delivery uses the same shared client transport family
+```
+
+Purpose:
+- Owns the daemon-side outbound client transport used for remote peer delivery.
+
+Notes:
+- This closes the design gap between the shared ClientTransport contract and daemon-to-daemon remote delivery.
+
+## FileWatchEventSourceAdapter
+
+```yaml
+boundary_id: BOUNDARY-WatchEventSource-File
+owner_package: atm-daemon
+owner_crate_path: atm_daemon
+name: FileWatchEventSourceAdapter
+
+public:
+  trait: WatchEventSource
+  facade: null
+
+implementation:
+  type: FileWatchEventSource
+  module: atm_daemon::watch::source
+  visibility: private
+  constructor: private
+
+composition:
+  roots:
+    - atm_daemon::bootstrap
+
+ownership:
+  io_owns:
+    - filesystem_watch_events
+  io_forbidden:
+    - sqlite
+    - process_spawn
+
+dependencies:
+  allowed_dependents: []
+  allowed_dependencies:
+    - atm-core
+    - atm-rusqlite
+  forbidden_edges:
+    - atm -> atm-daemon
+    - atm-graft -> atm-daemon
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - FileWatchEventSource
+    - notify::recommended_watcher
+
+contracts:
+  request_types:
+    - watch subscription requests
+  response_types:
+    - watch event batches
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubWatchEventSource
+  forbidden_test_bypasses:
+    - notify::recommended_watcher
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-WATCH-EVENT-SOURCE-FILE-EDGES
+    - LINT-BOUNDARY-WATCH-EVENT-SOURCE-FILE-REFERENCES
+  review_gates:
+    - no_public_impl
+    - no_public_constructor
+    - no_watch_io_outside_boundary
+
+status:
+  state: planned
+  notes:
+    - raw watch event capture stays runtime-private
+```
+
+Purpose:
+- Owns the runtime file-watch implementation behind the WatchEventSource contract.
+
+Notes:
+- This adapter captures events only; it does not own reconcile policy.
+
+## DaemonReconcileCoordinatorAdapter
+
+```yaml
+boundary_id: BOUNDARY-ReconcileCoordinator-Daemon
+owner_package: atm-daemon
+owner_crate_path: atm_daemon
+name: DaemonReconcileCoordinatorAdapter
+
+public:
+  trait: ReconcileCoordinator
+  facade: null
+
+implementation:
+  type: DaemonReconcileCoordinator
+  module: atm_daemon::watch::reconcile
+  visibility: private
+  constructor: private
+
+composition:
+  roots:
+    - atm_daemon::bootstrap
+
+ownership:
+  io_owns:
+    - watch_event_coalescing
+    - ingress_reconcile_triggering
+  io_forbidden:
+    - sqlite
+    - process_spawn
+
+dependencies:
+  allowed_dependents: []
+  allowed_dependencies:
+    - atm-core
+    - atm-rusqlite
+  forbidden_edges:
+    - atm -> atm-daemon
+    - atm-graft -> atm-daemon
+
+references:
+  scope: outside_owner_crate
+  forbidden:
+    - DaemonReconcileCoordinator
+
+contracts:
+  request_types:
+    - reconcile requests
+  response_types:
+    - reconcile outcomes
+  error_types:
+    - AtmError
+
+testing:
+  allowed_test_double_paths:
+    - atm_core::test_support::StubReconcileCoordinator
+  forbidden_test_bypasses: []
+
+enforcement:
+  lint_rules:
+    - LINT-BOUNDARY-RECONCILE-COORDINATOR-DAEMON-EDGES
+    - LINT-BOUNDARY-RECONCILE-COORDINATOR-DAEMON-REFERENCES
+  review_gates:
+    - no_public_impl
+    - no_public_constructor
+    - no_store_or_transport_bypass_in_reconcile
+
+status:
+  state: planned
+  notes:
+    - runtime reconcile remains separate from raw watch source implementation
+```
+
+Purpose:
+- Owns the runtime implementation of reconcile policy behind the ReconcileCoordinator contract.
+
+Notes:
+- This adapter should trigger ingress/service work without bypassing other boundaries.
+
 ## DaemonRequestDispatcherAdapter
 
 ```yaml
@@ -101,7 +347,8 @@ implementation:
   constructor: private
 
 composition:
-  roots: []
+  roots:
+    - atm_daemon::bootstrap
 
 ownership:
   io_owns:
@@ -114,6 +361,7 @@ dependencies:
   allowed_dependents: []
   allowed_dependencies:
     - atm-core
+    - atm-rusqlite
   forbidden_edges:
     - atm -> atm-daemon
     - atm-graft -> atm-daemon

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -4,13 +4,16 @@
 
 This document defines the `atm-daemon` crate requirements.
 
-The `atm-daemon` crate owns the runtime wrapper around the Phase Q ATM system.
+The `atm-daemon` crate owns the runtime wrapper around the current ATM system.
 Product behavior remains defined in [`../requirements.md`](../requirements.md).
 `atm-daemon` must satisfy those product requirements without re-owning
 `atm-core` business logic.
 
 This crate is introduced by the Phase Q implementation line. It is not present
 in the pre-Phase-Q workspace yet.
+
+The crate-local machine-readable boundary inventory lives in:
+- [`./boundaries.md`](./boundaries.md)
 
 ## 2. Ownership
 
@@ -20,6 +23,7 @@ in the pre-Phase-Q workspace yet.
 - same-host daemon API transport
 - cross-host daemon-to-daemon transport
 - runtime composition of `atm-core` service boundaries
+- runtime composition of the current concrete adapter set used in production
 - live agent status cache
 - runtime watch/reconcile loop if enabled
 - daemon-side `sc-observability` emission
@@ -104,12 +108,14 @@ The `atm-daemon` crate docs must remain aligned with:
 - [`../architecture.md`](../architecture.md)
 - [`../project-plan.md`](../project-plan.md)
 - [`../plan-phase-Q.md`](../plan-phase-Q.md)
+- [`../plan-phase-R.md`](../plan-phase-R.md)
 - [`../team-member-state.md`](../team-member-state.md)
 - [`../documentation-guidelines.md`](../documentation-guidelines.md)
 - [`../atm-core/requirements.md`](../atm-core/requirements.md)
 - [`../atm-core/architecture.md`](../atm-core/architecture.md)
+- [`./boundaries.md`](./boundaries.md)
 
-## 5. Phase Q Runtime Requirements
+## 5. Phase R Runtime Requirements
 
 Requirement IDs:
 - `REQ-DAEMON-RUNTIME-001`
@@ -164,6 +170,12 @@ Required runtime rules:
   and any retry/re-export state needed after daemon crash must be durable rather
   than RAM-only
 - daemon code must not bypass `atm-core` subsystem boundaries
+- the current Phase R baseline keeps `atm-daemon` as the runtime composition
+  root for production runtime wiring unless a later ADR extracts a separate
+  composition crate
+- remote daemon-to-daemon client behavior uses the same shared `AtmProtocol`
+  and `ClientTransport` / `ServerTransport` contract family as local runtime
+  transport
 - daemon transport/runtime adapter implementations must remain private to the
   crate or tightly-scoped internal surfaces; public callers must not depend on
   concrete socket/runtime adapter types

--- a/docs/atm-rusqlite/architecture.md
+++ b/docs/atm-rusqlite/architecture.md
@@ -7,6 +7,53 @@ This document defines the `atm-rusqlite` crate architectural boundary.
 It complements the product and `atm-core` architecture documents and owns only
 the first concrete SQLite implementation of the Phase Q store family.
 
+The crate-local machine-readable boundary inventory lives in:
+- [`./boundaries.md`](./boundaries.md)
+
+## 1.1 ADRs
+
+## Concrete SQLite adapters remain private
+
+```yaml
+adr_id: ADR-ATM-RUSQLITE-001
+crate: atm-rusqlite
+title: Concrete SQLite adapters remain private
+status: accepted
+date: 2026-05-03
+deciders:
+  - team-lead
+  - arch-ctm
+tags:
+  - privacy
+  - sqlite
+related_boundaries:
+  - BOUNDARY-MailStore-Sqlite
+  - BOUNDARY-TaskStore-Sqlite
+  - BOUNDARY-RosterStore-Sqlite
+code_references:
+  - docs/atm-rusqlite/boundaries.md
+  - docs/atm-core/boundaries.md
+```
+
+Context:
+- Direct caller access to SQLite implementation types is one of the clearest
+  architecture violations from the Phase Q line.
+
+Decision:
+- Concrete SQLite adapter types, constructors, and re-exports remain private.
+- Callers depend on `atm-core` contracts, not on concrete SQLite types.
+
+Consequences:
+- CLI and thin extension crates cannot bypass store contracts.
+- Runtime composition may still assemble the concrete adapters through the
+  legal composition owner.
+
+Alternatives considered:
+- Public concrete store types with policy enforced only by review.
+
+Follow-up work:
+- Keep forbidden dependency edges and reference checks aligned with this rule.
+
 ## 2. Architectural Rules
 
 - `atm-rusqlite` implements store contracts; it does not define them.
@@ -19,6 +66,10 @@ the first concrete SQLite implementation of the Phase Q store family.
   and `RosterStore`, not on concrete SQLite structs.
 - routine database failure handling uses typed `Result`/error-enum paths rather
   than panic/unwrap.
+- thin callers and runtime callers should depend on `atm-core` contracts
+  rather than this crate directly
+- the current production runtime composition root may depend on this crate in
+  order to assemble concrete store adapters
 
 ## 3. Store Implementation Shape
 

--- a/docs/atm-rusqlite/boundaries.md
+++ b/docs/atm-rusqlite/boundaries.md
@@ -2,8 +2,9 @@
 
 This document captures the planned concrete SQLite adapters for Phase R.
 
-Until the final composition crate is settled, the adapter records intentionally
-leave `composition.roots` empty and forbid direct dependency from caller crates.
+Current design assumption:
+- `atm-daemon::bootstrap` is the production runtime composition root
+- thin callers and extension crates must not depend on `atm-rusqlite`
 
 ## SqliteMailStoreAdapter
 
@@ -24,7 +25,8 @@ implementation:
   constructor: private
 
 composition:
-  roots: []
+  roots:
+    - atm_daemon::bootstrap
 
 ownership:
   io_owns:
@@ -35,13 +37,13 @@ ownership:
     - process_spawn
 
 dependencies:
-  allowed_dependents: []
+  allowed_dependents:
+    - atm-daemon
   allowed_dependencies:
     - atm-core
     - rusqlite
   forbidden_edges:
     - atm -> atm-rusqlite
-    - atm-daemon -> atm-rusqlite
     - atm-graft -> atm-rusqlite
 
 references:
@@ -77,7 +79,7 @@ enforcement:
 status:
   state: planned
   notes:
-    - composition root remains to be named by a Phase R ADR
+    - assembled only by the daemon runtime composition root
 ```
 
 Purpose:
@@ -105,7 +107,8 @@ implementation:
   constructor: private
 
 composition:
-  roots: []
+  roots:
+    - atm_daemon::bootstrap
 
 ownership:
   io_owns:
@@ -116,13 +119,13 @@ ownership:
     - process_spawn
 
 dependencies:
-  allowed_dependents: []
+  allowed_dependents:
+    - atm-daemon
   allowed_dependencies:
     - atm-core
     - rusqlite
   forbidden_edges:
     - atm -> atm-rusqlite
-    - atm-daemon -> atm-rusqlite
     - atm-graft -> atm-rusqlite
 
 references:
@@ -186,7 +189,8 @@ implementation:
   constructor: private
 
 composition:
-  roots: []
+  roots:
+    - atm_daemon::bootstrap
 
 ownership:
   io_owns:
@@ -197,13 +201,13 @@ ownership:
     - process_spawn
 
 dependencies:
-  allowed_dependents: []
+  allowed_dependents:
+    - atm-daemon
   allowed_dependencies:
     - atm-core
     - rusqlite
   forbidden_edges:
     - atm -> atm-rusqlite
-    - atm-daemon -> atm-rusqlite
     - atm-graft -> atm-rusqlite
 
 references:

--- a/docs/atm-rusqlite/requirements.md
+++ b/docs/atm-rusqlite/requirements.md
@@ -5,7 +5,10 @@
 This document defines the `atm-rusqlite` crate requirements.
 
 The `atm-rusqlite` crate owns the first concrete SQLite implementation of the
-Phase Q durable store boundaries defined by `atm-core`.
+durable store boundaries defined by `atm-core`.
+
+The crate-local machine-readable boundary inventory lives in:
+- [`./boundaries.md`](./boundaries.md)
 
 ## 2. Ownership
 
@@ -42,7 +45,7 @@ Initial allocation:
 
 Initial crate requirement IDs:
 
-- `REQ-RUSQLITE-STORE-001` `atm-rusqlite` must implement the Phase Q
+- `REQ-RUSQLITE-STORE-001` `atm-rusqlite` must implement the
   `MailStore`, `TaskStore`, and `RosterStore` contracts without widening those
   interfaces. Satisfies:
   `REQ-CORE-RUNTIME-001`, `REQ-CORE-STORE-001`, `REQ-CORE-STORE-002`.
@@ -64,11 +67,13 @@ The `atm-rusqlite` crate docs must remain aligned with:
 - [`../architecture.md`](../architecture.md)
 - [`../project-plan.md`](../project-plan.md)
 - [`../plan-phase-Q.md`](../plan-phase-Q.md)
+- [`../plan-phase-R.md`](../plan-phase-R.md)
 - [`../atm-core/requirements.md`](../atm-core/requirements.md)
 - [`../atm-core/architecture.md`](../atm-core/architecture.md)
 - [`../atm-error-codes.md`](../atm-error-codes.md)
+- [`./boundaries.md`](./boundaries.md)
 
-## 5. Phase Q SQLite Implementation Rules
+## 5. Phase R SQLite Implementation Rules
 
 Requirement IDs:
 - `REQ-RUSQLITE-STORE-001`
@@ -77,10 +82,12 @@ Requirement IDs:
 - `REQ-RUSQLITE-TEST-001`
 
 Required rules:
-- only `atm-rusqlite` may own direct `rusqlite` calls in the first Phase Q
+- only `atm-rusqlite` may own direct `rusqlite` calls in the first
   implementation line
 - concrete SQLite details remain private to this crate
 - callers depend on `atm-core` store traits, not on `rusqlite` types
+- the current runtime composition owner may depend on this crate in order to
+  assemble production adapters, but thin callers and extension crates must not
 - schema bootstrap must be deterministic and idempotent
 - WAL / foreign-key / explicit-transaction policy must be enforced here
 - `MailStore`, `TaskStore`, and `RosterStore` may share one internal SQLite

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -7,6 +7,9 @@ This document defines the `atm` crate architectural boundary.
 It complements the product architecture in
 [`../architecture.md`](../architecture.md) and owns only CLI-layer decisions.
 
+The crate-local machine-readable boundary inventory lives in:
+- [`./boundaries.md`](./boundaries.md)
+
 ## 2. Responsibilities
 
 The `atm` crate is responsible for:
@@ -21,6 +24,61 @@ The `atm` crate is responsible for:
   `members`
 
 The `atm` crate must remain thin.
+
+Phase R redesign notes:
+- the CLI should depend on `AtmProtocol` and `ClientTransport`, not on daemon
+  internals or SQLite adapters
+- retained user-facing workflows may still include `ack`, but thin-client
+  transport shape should stay centered on `send` and `receive`
+
+## 1.1 ADRs
+
+## CLI uses shared protocol and client transport only
+
+```yaml
+adr_id: ADR-ATM-001
+crate: atm
+title: CLI uses shared protocol and client transport only
+status: accepted
+date: 2026-05-03
+deciders:
+  - team-lead
+  - arch-ctm
+tags:
+  - protocol
+  - transport
+  - privacy
+related_boundaries:
+  - BOUNDARY-AtmProtocol
+  - BOUNDARY-ClientTransport
+  - BOUNDARY-ClientTransport-CLI
+code_references:
+  - docs/atm/boundaries.md
+  - docs/atm-core/boundaries.md
+```
+
+Context:
+- Phase Q drift showed that letting CLI reach daemon internals or SQLite
+  adapters made architecture violations easy and review expensive.
+
+Decision:
+- The CLI depends on `AtmProtocol` and `ClientTransport` only.
+- It must not depend on daemon internals or SQLite adapter crates.
+- Retained user workflows may still include `ack`, but thin-client transport
+  shape remains `send` / `receive`.
+
+Consequences:
+- CLI runtime wiring stays thin.
+- Thin extension crates can mirror the same client shape without importing CLI
+  internals.
+
+Alternatives considered:
+- Let CLI call daemon internals directly.
+- Let CLI use concrete SQLite adapters for local shortcuts.
+
+Follow-up work:
+- Enforce the forbidden dependency edges in lint.
+- Keep CLI help and request mapping aligned with the thin-client shape.
 
 ## 3. Architectural Rules
 
@@ -43,13 +101,14 @@ The `atm` crate must remain thin.
 - `atm` must not access SQLite or inbox JSONL directly
 - `atm` must not own socket protocol semantics beyond client-side request
   mapping and error presentation
-- `atm` must not auto-spawn the daemon in production
+- `atm` must own the one documented daemon auto-start path in production and
+  must not silently bypass the daemon if startup fails
 - `atm` must preserve typed runtime error identity until the rendering
   boundary instead of collapsing failures into panic/unwrap control flow
 
-## 3.1 Phase Q CLI / Runtime Split
+## 3.1 Phase R CLI / Runtime Split
 
-Phase Q keeps the CLI thin by enforcing this split:
+Phase R keeps the CLI thin by enforcing this split:
 
 - `atm` owns parse -> request mapping -> render
 - `atm-core` owns business logic and service semantics

--- a/docs/atm/boundaries.md
+++ b/docs/atm/boundaries.md
@@ -2,6 +2,10 @@
 
 This document captures CLI-owned concrete adapters for Phase R.
 
+Interpretation note:
+- `allowed_dependents: []` means no external crate should depend on the CLI's
+  private concrete adapters
+
 ## LocalSocketClientTransportAdapter
 
 ```yaml
@@ -21,7 +25,8 @@ implementation:
   constructor: private
 
 composition:
-  roots: []
+  roots:
+    - atm::bootstrap
 
 ownership:
   io_owns:

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -9,6 +9,9 @@ Product behavior remains defined in [`../requirements.md`](../requirements.md).
 `atm` must satisfy those product requirements without re-owning `atm-core`
 business logic or `atm-daemon` runtime behavior.
 
+The crate-local machine-readable boundary inventory lives in:
+- [`./boundaries.md`](./boundaries.md)
+
 ## 2. Ownership
 
 `atm` owns:
@@ -61,12 +64,12 @@ Initial crate requirement IDs:
   into `atm-core`. Satisfies the CLI bootstrap/injection aspects of:
   `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`, `REQ-P-OBS-001`.
 - `REQ-ATM-RUNTIME-001` `atm` owns CLI-to-runtime request mapping and daemon
-  client use in production while preserving in-process testability. Satisfies
-  the CLI/runtime-entry aspects of:
+  client use in production over `AtmProtocol` and `ClientTransport` while
+  preserving in-process testability. Satisfies the CLI/runtime-entry aspects of:
   `REQ-CORE-DAEMON-002`, `REQ-CORE-TEST-RUNTIME-001`.
 - `REQ-ATM-RUNTIME-002` `atm` owns production daemon-unavailable behavior and
-  must not auto-spawn the daemon. Satisfies:
-  `REQ-P-RUNTIME-001`, `REQ-CORE-DAEMON-003`.
+  the one documented daemon auto-start attempt. Satisfies:
+  `REQ-P-RUNTIME-001`, `REQ-CORE-DAEMON-001`.
 - `REQ-ATM-ERROR-001` `atm` owns CLI-side rendering/preservation of typed
   runtime errors from `atm-core` and `atm-daemon`. Satisfies:
   `REQ-CORE-BOUNDARY-002`.
@@ -121,22 +124,28 @@ The `atm` crate docs must remain aligned with:
 - [`../project-plan.md`](../project-plan.md)
 - [`../documentation-guidelines.md`](../documentation-guidelines.md)
 - [`../plan-phase-Q.md`](../plan-phase-Q.md)
+- [`../plan-phase-R.md`](../plan-phase-R.md)
+- [`./boundaries.md`](./boundaries.md)
 
-## 6. Phase Q CLI Runtime Rules
+## 6. Phase R CLI Runtime Rules
 
 Requirement ID:
 - `REQ-ATM-RUNTIME-001`
 
-Required Phase Q rules:
+Required Phase R rules:
 - in production, `atm` acts as a client of the runtime/daemon API rather than
   talking to SQLite or inbox JSONL directly
+- in production, `atm` depends on the shared `AtmProtocol` and the
+  `ClientTransport` contract rather than daemon internals
 - `atm` must not contain business logic that duplicates `atm-core`
 - `atm` test coverage must be able to use in-process harnesses rather than
   depending on daemon process spawning
 - if a direct in-process service harness exists for tests, it must not become a
   second production path with divergent semantics
-- if the daemon is unavailable in production, `atm` must fail clearly with
-  recovery guidance rather than auto-spawning or silently bypassing the daemon
+- if the daemon is unavailable in production, `atm` must:
+  - attempt the one documented daemon auto-start path
+  - retry connection once
+  - fail clearly with recovery guidance rather than silently bypassing the daemon
 - `atm doctor` remains a CLI command, but its production runtime checks may
   query daemon state through the runtime boundary
 - CLI runtime failures must preserve typed error identity until the rendering

--- a/docs/plan-phase-R.md
+++ b/docs/plan-phase-R.md
@@ -1,0 +1,254 @@
+# Phase R Task List
+
+## 1. Goal
+
+Repeat the Phase Q line properly:
+- start from the architecture skeleton
+- lock the boundary contracts in crate-local documents
+- build the lint/parser gates before substantive implementation
+- implement under those guardrails
+
+This document is the execution tracker for that work.
+
+## 2. Design Tasks
+
+### R.0.1 Boundary Model Review
+
+Status:
+- complete
+
+Required decisions:
+- name the legal composition owner
+- confirm `AtmProtocol` is the shared contract in `atm-core`
+- confirm `ClientTransport` / `ServerTransport` split
+- confirm thin-client workflow is `send` / `receive`
+- confirm `ack` is folded into `send`-shape requests for thin clients
+- confirm `NotificationSink` / `StatusSource` split
+- add the missing watch/reconcile boundary
+
+Acceptance:
+- the boundary set in crate `boundaries.md` files is stable enough to review as
+  design, not just schema
+
+### R.0.2 Cross-Boundary Ownership Review
+
+Status:
+- complete
+
+Required design clarifications:
+- where cross-store orchestration lives
+- where compatibility/recovery policy lives for:
+  - `ConfigIngress`
+  - `InboxIngress`
+  - `InboxExport`
+- where request dispatch ends and service orchestration begins
+- whether remote daemon-to-daemon client behavior depends on the same
+  `ClientTransport` boundary
+
+Acceptance:
+- each major boundary has a clear ownership line
+- no major subsystem remains “named but still fuzzy”
+
+### R.0.3 Composition Ownership Decision
+
+Status:
+- complete
+
+Decision required:
+- choose whether runtime wiring lives in:
+  - `atm-daemon`
+  - or a separate composition/app crate
+
+Acceptance:
+- the boundary inventories and crate architecture docs agree on the legal
+  composition owner
+
+## 3. Documentation Tasks
+
+### R.1.1 Boundary Inventories
+
+Status:
+- complete
+
+Artifacts:
+- `docs/atm-core/boundaries.md`
+- `docs/atm-rusqlite/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
+- `docs/atm/boundaries.md`
+
+Required follow-up:
+- revise the records after R.0 design review
+- add the missing watch/reconcile boundary
+
+Acceptance:
+- every major Phase R boundary is represented in one crate-local record
+
+### R.1.6 Documentation Hardening Loop
+
+Status:
+- complete
+
+Completed work:
+- aligned top-level architecture and project-plan docs
+- aligned crate architecture and requirements docs
+- filled the missing watch/reconcile boundary family
+- resolved the runtime composition-owner contradiction
+- added crate-local ADR records for the key Phase R decisions
+- ran repeated review/update loops over requirements, architecture, and
+  boundary records until the remaining work moved out of documentation and
+  into parser/lint or implementation execution
+
+Acceptance:
+- the documentation set is internally coherent enough to drive parser and lint
+  work without relying on unstated architectural assumptions
+
+### R.1.2 Top-Level Architecture Alignment
+
+Status:
+- complete
+
+Required updates:
+- make Phase R the active redesign line
+- explicitly reference crate-local `boundaries.md` files
+- describe:
+  - `AtmProtocol`
+  - `ClientTransport`
+  - `ServerTransport`
+  - `RequestDispatcher`
+  - `NotificationSink`
+  - `StatusSource`
+- state that thin-client workflow is `send` / `receive`
+- state that `ack` is folded into `send`-shape requests for thin clients
+
+Acceptance:
+- top-level architecture and crate boundary inventories describe the same system
+
+### R.1.3 Crate Architecture Alignment
+
+Status:
+- complete
+
+Required updates:
+- align `docs/atm-core/architecture.md`
+- align `docs/atm-daemon/architecture.md`
+- align `docs/atm-rusqlite/architecture.md`
+- align `docs/atm/architecture.md`
+
+Acceptance:
+- crate architecture docs and crate boundary inventories agree on:
+  - ownership
+  - composition
+  - dependency direction
+  - privacy rules
+
+### R.1.4 Requirements Alignment
+
+Status:
+- complete
+
+Required updates:
+- state enforceable “must” rules for:
+  - private concrete implementations
+  - no CLI-to-daemon internal dependency
+  - no CLI-to-SQLite dependency
+  - shared protocol owned by `atm-core`
+  - thin-client `send` / `receive` surface
+  - watch/reconcile ownership once named
+
+Acceptance:
+- requirements contain only rules that can be checked or reviewed concretely
+
+### R.1.5 ADR Records
+
+Status:
+- complete
+
+Required ADRs:
+- `AtmProtocol` ownership in `atm-core`
+- `ack` folded into `send`
+- split `ClientTransport` / `ServerTransport`
+- concrete implementations remain private
+- legal composition owner
+
+Acceptance:
+- each major Phase R design decision has one crate-local ADR record
+
+## 4. Downstream Execution Phases
+
+The items below are not part of the completed documentation hardening loop.
+They depend on the hardened document set above and move into parser, lint, and
+implementation execution.
+
+### R.2 Tooling
+
+### R.2.1 Boundary Parser
+
+Status:
+- in progress by `arch-inj`
+
+Scope:
+- parse crate-local boundary records
+- validate basic record structure
+
+Acceptance:
+- parser can read all current `boundaries.md` files without ambiguity
+
+### R.2.2 Lint Gates
+
+Status:
+- pending
+
+Initial lint passes:
+- schema validation
+- manifest dependency-edge checks
+- forbidden external-reference checks
+
+Deferred until after design freeze:
+- composition-root enforcement
+- deeper visibility/re-export checks
+
+Acceptance:
+- `just lint` can fail on the first hard architectural violations
+
+### R.3 Implementation
+
+### R.3.1 Skeleton First
+
+Status:
+- pending
+
+Required outcome:
+- traits/facades exist
+- private implementation shells exist
+- composition point exists
+- illegal references are already blocked by lint and visibility
+
+Acceptance:
+- the architecture can compile in skeleton form before feature behavior lands
+
+### R.3.2 Behavior Sprints
+
+Status:
+- pending
+
+Required order:
+1. protocol and transport skeleton
+2. store boundary skeleton
+3. config/inbox/notifier/watch boundaries
+4. service orchestration
+5. thin client surfaces
+
+Acceptance:
+- no feature sprint begins before the relevant boundary and lint guardrails are in place
+
+## 6. Working Rule
+
+Phase R does not advance by ad hoc implementation.
+
+Required order:
+1. design decision
+2. boundary record
+3. architecture/requirements/ADR alignment
+4. lint/parser support
+5. implementation skeleton
+6. feature behavior

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -24,6 +24,12 @@ Phase-Q supersession note:
 - the current target line is Section 21 and the detailed design in
   `docs/plan-phase-Q.md`
 
+Phase-R redesign note:
+- the next execution line is the Phase R redesign and enforcement pass tracked
+  in [`docs/plan-phase-R.md`](./plan-phase-R.md)
+- Phase R starts with boundary documents, ADR alignment, and lint/parser gates
+  before new implementation work
+
 Status:
 - Phases 0 through P have executed on the retained rewrite line.
 - Phases G and H are complete retained-command phases, closed through the
@@ -78,12 +84,28 @@ Crate-local scope detail is owned by:
 
 - [`docs/atm-core/requirements.md`](./atm-core/requirements.md)
 - [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
+- [`docs/atm-core/boundaries.md`](./atm-core/boundaries.md)
 - [`docs/atm/requirements.md`](./atm/requirements.md)
 - [`docs/atm/architecture.md`](./atm/architecture.md)
+- [`docs/atm/boundaries.md`](./atm/boundaries.md)
 - [`docs/atm-daemon/requirements.md`](./atm-daemon/requirements.md)
 - [`docs/atm-daemon/architecture.md`](./atm-daemon/architecture.md)
+- [`docs/atm-daemon/boundaries.md`](./atm-daemon/boundaries.md)
 - [`docs/atm-rusqlite/requirements.md`](./atm-rusqlite/requirements.md)
 - [`docs/atm-rusqlite/architecture.md`](./atm-rusqlite/architecture.md)
+- [`docs/atm-rusqlite/boundaries.md`](./atm-rusqlite/boundaries.md)
+
+Phase R sequencing rule:
+- no new implementation sprint begins until:
+  - the relevant boundary records exist
+  - architecture/requirements/ADR docs agree with those records
+  - the parser/lint pass for those records is in place
+- Phase R implementation proceeds in this order:
+  - boundary design
+  - document alignment
+  - lint/parser gates
+  - skeleton implementation
+  - feature behavior
 
 ## 4. Work Sequence
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -68,6 +68,10 @@ Crate-local ownership docs live under:
 - [`docs/atm-daemon/architecture.md`](./atm-daemon/architecture.md)
 - [`docs/atm-rusqlite/requirements.md`](./atm-rusqlite/requirements.md)
 - [`docs/atm-rusqlite/architecture.md`](./atm-rusqlite/architecture.md)
+- [`docs/atm-core/boundaries.md`](./atm-core/boundaries.md)
+- [`docs/atm-daemon/boundaries.md`](./atm-daemon/boundaries.md)
+- [`docs/atm-rusqlite/boundaries.md`](./atm-rusqlite/boundaries.md)
+- [`docs/atm/boundaries.md`](./atm/boundaries.md)
 
 During the cleanup/restructure phase, product requirements stay here while
 crate-local ownership is moved out of this file into the crate directories.
@@ -77,6 +81,13 @@ Phase-Q supersession note:
   the prior rewrite line
 - for mail/runtime architecture, the current authoritative direction is Section
   21
+
+Phase-R redesign note:
+- Phase R hardens the architecture by making crate-local boundary records part
+  of the enforceable contract before new implementation work proceeds
+- the thin-client extension surface should center on `send` and `receive`
+  over the shared ATM protocol, while the retained CLI may continue to expose
+  `ack` as a user-facing workflow
 
 ## 2. Scope
 


### PR DESCRIPTION
## Summary

- Per-crate architecture docs: `docs/atm/`, `docs/atm-core/`, `docs/atm-daemon/`, `docs/atm-rusqlite/`
- Per-crate boundary contracts and requirements hardened
- `docs/plan-phase-R.md` — Phase R sprint plan
- `docs/project-plan.md` updated for Phase R
- Top-level `docs/architecture.md` and `docs/requirements.md` updated

## Context

Phase R planning baseline hardened before implementation begins in `feature/pR-s0-arch-foundation`. These docs define the trait boundaries and crate contracts that `lint_boundaries.py` will enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)