### PR TITLE
R.1: clear lint debt baseline

### DIFF
--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::path::{Path, PathBuf};
 
 use serde::{Serialize, Serializer};
@@ -556,3 +558,5 @@ mod tests {
         );
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::path::{Path, PathBuf};
 
 use serde::{Serialize, Serializer};
@@ -505,7 +503,9 @@ mod tests {
     use serde_json::json;
 
     use super::{canonical_sender_identity, resolve_reply_target};
+    use crate::roles::ROLE_TEAM_LEAD;
     use crate::schema::MessageEnvelope;
+    use crate::test_support::TEST_TEAM;
     use crate::types::{AgentName, IsoTimestamp, TeamName};
 
     fn message_with_from(from: &str) -> MessageEnvelope {
@@ -514,7 +514,7 @@ mod tests {
             text: "hello".to_string(),
             timestamp: IsoTimestamp::now(),
             read: false,
-            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
+            source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team")),
             summary: None,
             message_id: None,
             pending_ack_at: None,
@@ -530,33 +530,31 @@ mod tests {
         let mut message = message_with_from("lead");
         message.extra.insert(
             "metadata".to_string(),
-            json!({"atm": {"fromIdentity": "team-lead"}}),
+            json!({"atm": {"fromIdentity": ROLE_TEAM_LEAD}}),
         );
 
         assert_eq!(
             canonical_sender_identity(&message).as_deref(),
-            Some("team-lead")
+            Some(ROLE_TEAM_LEAD)
         );
     }
 
     #[test]
     fn resolve_reply_target_prefers_canonical_sender_identity_metadata() {
         let mut message = message_with_from("lead");
-        message.source_team = Some("atm-dev".parse::<TeamName>().expect("team"));
+        message.source_team = Some(TEST_TEAM.parse::<TeamName>().expect("team"));
         message.extra.insert(
             "metadata".to_string(),
-            json!({"atm": {"fromIdentity": "team-lead"}}),
+            json!({"atm": {"fromIdentity": ROLE_TEAM_LEAD}}),
         );
 
-        let target = resolve_reply_target(&message, "atm-dev").expect("reply target");
+        let target = resolve_reply_target(&message, TEST_TEAM).expect("reply target");
         assert_eq!(
             target,
             (
-                "team-lead".parse().expect("agent"),
-                "atm-dev".parse().expect("team"),
+                ROLE_TEAM_LEAD.parse().expect("agent"),
+                TEST_TEAM.parse().expect("team"),
             )
         );
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/address.rs
+++ b/crates/atm-core/src/address.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fmt;
 use std::str::FromStr;
 
@@ -155,3 +157,5 @@ mod tests {
         );
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/address.rs
+++ b/crates/atm-core/src/address.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fmt;
 use std::str::FromStr;
 
@@ -92,31 +90,32 @@ mod tests {
     use std::str::FromStr;
 
     use super::AgentAddress;
+    use crate::test_support::{TEST_SENDER, TEST_SENDER_ADDRESS, TEST_TEAM};
 
     #[test]
     fn parses_bare_agent_address() {
-        let parsed = AgentAddress::from_str("arch-ctm").expect("address");
-        assert_eq!(parsed.agent, "arch-ctm");
+        let parsed = AgentAddress::from_str(TEST_SENDER).expect("address");
+        assert_eq!(parsed.agent, TEST_SENDER);
         assert_eq!(parsed.team, None);
     }
 
     #[test]
     fn parses_agent_with_team() {
-        let parsed = AgentAddress::from_str("arch-ctm@atm-dev").expect("address");
-        assert_eq!(parsed.agent, "arch-ctm");
-        assert_eq!(parsed.team.as_deref(), Some("atm-dev"));
+        let parsed = AgentAddress::from_str(TEST_SENDER_ADDRESS).expect("address");
+        assert_eq!(parsed.agent, TEST_SENDER);
+        assert_eq!(parsed.team.as_deref(), Some(TEST_TEAM));
     }
 
     #[test]
     fn rejects_empty_agent_name() {
         assert!(AgentAddress::from_str("").is_err());
-        assert!(AgentAddress::from_str("@atm-dev").is_err());
+        assert!(AgentAddress::from_str(&format!("@{TEST_TEAM}")).is_err());
     }
 
     #[test]
     fn rejects_invalid_team_segment() {
-        assert!(AgentAddress::from_str("arch-ctm@").is_err());
-        assert!(AgentAddress::from_str("arch-ctm@atm@dev").is_err());
+        assert!(AgentAddress::from_str(&format!("{TEST_SENDER}@")).is_err());
+        assert!(AgentAddress::from_str(&format!("{TEST_SENDER}@atm@dev")).is_err());
     }
 
     #[test]
@@ -136,26 +135,24 @@ mod tests {
         assert_eq!(parsed.agent, "valid-team_name.1");
         assert_eq!(parsed.team, None);
 
-        let parsed = AgentAddress::from_str("arch-ctm@atm-dev").expect("address");
-        assert_eq!(parsed.agent, "arch-ctm");
-        assert_eq!(parsed.team.as_deref(), Some("atm-dev"));
+        let parsed = AgentAddress::from_str(TEST_SENDER_ADDRESS).expect("address");
+        assert_eq!(parsed.agent, TEST_SENDER);
+        assert_eq!(parsed.team.as_deref(), Some(TEST_TEAM));
     }
 
     #[test]
     fn display_round_trips_bare_and_qualified_addresses() {
         assert_eq!(
-            AgentAddress::from_str("arch-ctm")
+            AgentAddress::from_str(TEST_SENDER)
                 .expect("address")
                 .to_string(),
-            "arch-ctm"
+            TEST_SENDER
         );
         assert_eq!(
-            AgentAddress::from_str("arch-ctm@atm-dev")
+            AgentAddress::from_str(TEST_SENDER_ADDRESS)
                 .expect("address")
                 .to_string(),
-            "arch-ctm@atm-dev"
+            TEST_SENDER_ADDRESS
         );
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/config/aliases.rs
+++ b/crates/atm-core/src/config/aliases.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use super::AtmConfig;
 
 pub fn resolve_agent(value: &str, config: Option<&AtmConfig>) -> String {
@@ -53,3 +55,5 @@ mod tests {
         assert_eq!(preferred_alias("arch-ctm", Some(&config)), None);
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/config/aliases.rs
+++ b/crates/atm-core/src/config/aliases.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use super::AtmConfig;
 
 pub fn resolve_agent(value: &str, config: Option<&AtmConfig>) -> String {
@@ -24,36 +22,36 @@ mod tests {
 
     use super::{preferred_alias, resolve_agent};
     use crate::config::AtmConfig;
+    use crate::roles::ROLE_TEAM_LEAD;
+    use crate::test_support::TEST_SENDER;
 
     #[test]
     fn resolve_agent_returns_canonical_name_when_alias_exists() {
         let mut aliases = BTreeMap::new();
-        aliases.insert("tl".to_string(), "team-lead".to_string());
+        aliases.insert("tl".to_string(), ROLE_TEAM_LEAD.to_string());
         let config = AtmConfig {
             aliases,
             ..Default::default()
         };
 
-        assert_eq!(resolve_agent("tl", Some(&config)), "team-lead");
-        assert_eq!(resolve_agent("team-lead", Some(&config)), "team-lead");
+        assert_eq!(resolve_agent("tl", Some(&config)), ROLE_TEAM_LEAD);
+        assert_eq!(resolve_agent(ROLE_TEAM_LEAD, Some(&config)), ROLE_TEAM_LEAD);
     }
 
     #[test]
     fn preferred_alias_returns_first_alias_for_canonical_name() {
         let mut aliases = BTreeMap::new();
-        aliases.insert("lead".to_string(), "team-lead".to_string());
-        aliases.insert("tl".to_string(), "team-lead".to_string());
+        aliases.insert("lead".to_string(), ROLE_TEAM_LEAD.to_string());
+        aliases.insert("tl".to_string(), ROLE_TEAM_LEAD.to_string());
         let config = AtmConfig {
             aliases,
             ..Default::default()
         };
 
         assert_eq!(
-            preferred_alias("team-lead", Some(&config)).as_deref(),
+            preferred_alias(ROLE_TEAM_LEAD, Some(&config)).as_deref(),
             Some("lead")
         );
-        assert_eq!(preferred_alias("arch-ctm", Some(&config)), None);
+        assert_eq!(preferred_alias(TEST_SENDER, Some(&config)), None);
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/config/bridge.rs
+++ b/crates/atm-core/src/config/bridge.rs
@@ -2,3 +2,7 @@
 //!
 //! ATM 1.0 ignores bridge-hostname ownership. Keep this placeholder to make the
 //! deferred config scope explicit until a later phase defines bridge behavior.
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub(crate) struct DeferredBridgeConfigScope;

--- a/crates/atm-core/src/config/discovery.rs
+++ b/crates/atm-core/src/config/discovery.rs
@@ -1,7 +1,5 @@
 //! Post-send hook config normalization helpers.
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::path::{Path, PathBuf};
 
 use crate::address::validate_path_segment;
@@ -101,6 +99,7 @@ mod tests {
     use super::{command_looks_like_path, normalize_post_send_hooks};
     use crate::config::RawPostSendHookRule;
     use crate::config::types::HookRecipient;
+    use crate::roles::ROLE_TEAM_LEAD;
 
     fn config_root_fixture() -> (tempfile::TempDir, PathBuf) {
         let tempdir = tempdir().expect("tempdir");
@@ -113,8 +112,8 @@ mod tests {
     fn normalize_post_send_hooks_resolves_relative_script_commands() {
         let (_tempdir, config_root) = config_root_fixture();
         let hooks = vec![RawPostSendHookRule {
-            recipient: "team-lead".into(),
-            command: vec!["scripts/atm-nudge.sh".into(), "team-lead".into()],
+            recipient: ROLE_TEAM_LEAD.into(),
+            command: vec!["scripts/atm-nudge.sh".into(), ROLE_TEAM_LEAD.into()],
         }];
 
         let hooks = normalize_post_send_hooks(hooks, &config_root).expect("hooks");
@@ -128,7 +127,7 @@ mod tests {
         );
         assert_eq!(
             hooks[0].recipient,
-            HookRecipient::Named("team-lead".parse().expect("recipient"))
+            HookRecipient::Named(ROLE_TEAM_LEAD.parse().expect("recipient"))
         );
     }
 
@@ -207,7 +206,7 @@ mod tests {
         let (_tempdir, config_root) = config_root_fixture();
         let error = normalize_post_send_hooks(
             vec![RawPostSendHookRule {
-                recipient: "team-lead".into(),
+                recipient: ROLE_TEAM_LEAD.into(),
                 command: Vec::new(),
             }],
             &config_root,
@@ -222,7 +221,7 @@ mod tests {
         let (_tempdir, config_root) = config_root_fixture();
         let error = normalize_post_send_hooks(
             vec![RawPostSendHookRule {
-                recipient: "team-lead".into(),
+                recipient: ROLE_TEAM_LEAD.into(),
                 command: vec!["   ".into(), "arg".into()],
             }],
             &config_root,
@@ -232,5 +231,3 @@ mod tests {
         assert!(error.message.contains("command program must not be empty"));
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/config/discovery.rs
+++ b/crates/atm-core/src/config/discovery.rs
@@ -1,5 +1,7 @@
 //! Post-send hook config normalization helpers.
 
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::path::{Path, PathBuf};
 
 use crate::address::validate_path_segment;
@@ -230,3 +232,5 @@ mod tests {
         assert!(error.message.contains("command program must not be empty"));
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -8,6 +8,8 @@
 //! runtime sender identity resolution. Set `ATM_IDENTITY` instead and remove
 //! the deprecated config keys once the environment-based identity is in place.
 
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 pub mod aliases;
 pub mod bridge;
 pub mod discovery;
@@ -801,3 +803,5 @@ post_send_hook_recipients = ["team-lead"]
         unsafe { env::remove_var(key) }
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -8,8 +8,6 @@
 //! runtime sender identity resolution. Set `ATM_IDENTITY` instead and remove
 //! the deprecated config keys once the environment-based identity is in place.
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 pub mod aliases;
 pub mod bridge;
 pub mod discovery;
@@ -379,6 +377,8 @@ fn parse_team_member(config_path: &Path, index: usize, entry: &Value) -> Option<
 mod tests {
     use crate::config::types::HookRecipient;
     use crate::error_codes::AtmErrorCode;
+    use crate::roles::ROLE_TEAM_LEAD;
+    use crate::test_support::{TEST_QA, TEST_SENDER, TEST_TEAM};
     use crate::types::TeamName;
     use serde_json::Value;
     use std::env;
@@ -395,13 +395,13 @@ mod tests {
         fs::create_dir_all(&nested).expect("nested dir");
         fs::write(
             root.path().join(".atm.toml"),
-            "[atm]\nidentity = \"arch-ctm\"\ndefault_team = \"atm-dev\"\n",
+            format!("[atm]\nidentity = \"{TEST_SENDER}\"\ndefault_team = \"{TEST_TEAM}\"\n"),
         )
         .expect("config");
 
         let config = load_config(&nested).expect("config").expect("present");
-        assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
-        assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+        assert_eq!(config.identity.as_deref(), Some(TEST_SENDER));
+        assert_eq!(config.default_team.as_deref(), Some(TEST_TEAM));
         assert_eq!(config.config_root, root.path());
         assert!(config.obsolete_identity_present);
     }
@@ -411,13 +411,13 @@ mod tests {
         let root = unique_temp_dir("legacy-config");
         fs::write(
             root.path().join(".atm.toml"),
-            "identity = \"arch-ctm\"\ndefault_team = \"atm-dev\"\n",
+            format!("identity = \"{TEST_SENDER}\"\ndefault_team = \"{TEST_TEAM}\"\n"),
         )
         .expect("config");
 
         let config = load_config(root.path()).expect("config").expect("present");
-        assert_eq!(config.identity.as_deref(), Some("arch-ctm"));
-        assert_eq!(config.default_team.as_deref(), Some("atm-dev"));
+        assert_eq!(config.identity.as_deref(), Some(TEST_SENDER));
+        assert_eq!(config.default_team.as_deref(), Some(TEST_TEAM));
         assert_eq!(config.config_root, root.path());
         assert!(config.obsolete_identity_present);
     }
@@ -427,23 +427,25 @@ mod tests {
         let root = unique_temp_dir("atm-config-surface");
         fs::write(
             root.path().join(".atm.toml"),
-            r#"[atm]
-default_team = "atm-dev"
-team_members = ["team-lead", "arch-ctm", " ", "qa"]
+            format!(
+                r#"[atm]
+default_team = "{TEST_TEAM}"
+team_members = ["{ROLE_TEAM_LEAD}", "{TEST_SENDER}", " ", "qa"]
 
 [[atm.post_send_hooks]]
-recipient = "team-lead"
-command = ["scripts/atm-nudge.sh", "team-lead"]
+recipient = "{ROLE_TEAM_LEAD}"
+command = ["scripts/atm-nudge.sh", "{ROLE_TEAM_LEAD}"]
 
 [[atm.post_send_hooks]]
 recipient = "*"
 command = ["bash", "-lc", "echo hi"]
 
 [atm.aliases]
-tl = "team-lead"
-qa = "quality-mgr"
+tl = "{ROLE_TEAM_LEAD}"
+qa = "{TEST_QA}"
 blank = ""
 "#,
+            ),
         )
         .expect("config");
 
@@ -451,15 +453,15 @@ blank = ""
         assert_eq!(
             config.team_members,
             vec![
-                "team-lead".parse::<TeamName>().expect("team member"),
-                "arch-ctm".parse::<TeamName>().expect("team member"),
+                ROLE_TEAM_LEAD.parse::<TeamName>().expect("team member"),
+                TEST_SENDER.parse::<TeamName>().expect("team member"),
                 "qa".parse::<TeamName>().expect("team member"),
             ]
         );
         assert_eq!(config.post_send_hooks.len(), 2);
         assert_eq!(
             config.post_send_hooks[0].recipient,
-            HookRecipient::Named("team-lead".parse().expect("recipient"))
+            HookRecipient::Named(ROLE_TEAM_LEAD.parse().expect("recipient"))
         );
         assert_eq!(
             config.post_send_hooks[0].command,
@@ -468,7 +470,7 @@ blank = ""
                     .join("scripts/atm-nudge.sh")
                     .display()
                     .to_string(),
-                "team-lead".to_string()
+                ROLE_TEAM_LEAD.to_string()
             ]
         );
         assert_eq!(config.post_send_hooks[1].recipient, HookRecipient::Wildcard);
@@ -478,12 +480,9 @@ blank = ""
         );
         assert_eq!(
             config.aliases.get("tl").map(String::as_str),
-            Some("team-lead")
+            Some(ROLE_TEAM_LEAD)
         );
-        assert_eq!(
-            config.aliases.get("qa").map(String::as_str),
-            Some("quality-mgr")
-        );
+        assert_eq!(config.aliases.get("qa").map(String::as_str), Some(TEST_QA));
         assert!(!config.aliases.contains_key("blank"));
     }
 
@@ -492,7 +491,7 @@ blank = ""
         let root = unique_temp_dir("atm-config-invalid-team-member");
         fs::write(
             root.path().join(".atm.toml"),
-            "[atm]\nteam_members = [\"team-lead\", \"bad/name\"]\n",
+            format!("[atm]\nteam_members = [\"{ROLE_TEAM_LEAD}\", \"bad/name\"]\n"),
         )
         .expect("config");
 
@@ -506,14 +505,16 @@ blank = ""
         let root = unique_temp_dir("core-config-hook-keys");
         fs::write(
             root.path().join(".atm.toml"),
-            r#"[core]
-default_team = "atm-dev"
-identity = "team-lead"
+            format!(
+                r#"[core]
+default_team = "{TEST_TEAM}"
+identity = "{ROLE_TEAM_LEAD}"
 
 [[atm.post_send_hooks]]
-recipient = "arch-ctm"
-command = ["scripts/atm-nudge.sh", "arch-ctm"]
-"#,
+recipient = "{TEST_SENDER}"
+command = ["scripts/atm-nudge.sh", "{TEST_SENDER}"]
+"#
+            ),
         )
         .expect("config");
 
@@ -529,9 +530,11 @@ command = ["scripts/atm-nudge.sh", "arch-ctm"]
         let root = unique_temp_dir("retired-hook-members");
         fs::write(
             root.path().join(".atm.toml"),
-            r#"[atm]
-post_send_hook_members = ["team-lead"]
-"#,
+            format!(
+                r#"[atm]
+post_send_hook_members = ["{ROLE_TEAM_LEAD}"]
+"#
+            ),
         )
         .expect("config");
 
@@ -558,10 +561,12 @@ post_send_hook_members = ["team-lead"]
         let root = unique_temp_dir("legacy-hook-filters");
         fs::write(
             root.path().join(".atm.toml"),
-            r#"[atm]
+            format!(
+                r#"[atm]
 post_send_hook = ["bin/hook"]
-post_send_hook_recipients = ["team-lead"]
-"#,
+post_send_hook_recipients = ["{ROLE_TEAM_LEAD}"]
+"#
+            ),
         )
         .expect("config");
 
@@ -582,45 +587,39 @@ post_send_hook_recipients = ["team-lead"]
     #[test]
     fn parse_team_config_accepts_object_members() {
         let (_tempdir, config_path) = temp_config_path();
-        let config = parse_team_config(
-            &config_path,
-            r#"{"members":[{"name":"arch-ctm"},{"name":"team-lead"}]}"#,
-        )
-        .expect("team config");
+        let raw =
+            format!(r#"{{"members":[{{"name":"{TEST_SENDER}"}},{{"name":"{ROLE_TEAM_LEAD}"}}]}}"#);
+        let config = parse_team_config(&config_path, &raw).expect("team config");
 
         assert_eq!(config.members.len(), 2);
-        assert_eq!(config.members[0].name, "arch-ctm");
-        assert_eq!(config.members[1].name, "team-lead");
+        assert_eq!(config.members[0].name, TEST_SENDER);
+        assert_eq!(config.members[1].name, ROLE_TEAM_LEAD);
         assert!(config.extra.is_empty());
     }
 
     #[test]
     fn parse_team_config_accepts_string_member_compatibility() {
         let (_tempdir, config_path) = temp_config_path();
-        let config = parse_team_config(
-            &config_path,
-            r#"{"members":["arch-ctm",{"name":"team-lead"}]}"#,
-        )
-        .expect("team config");
+        let raw = format!(r#"{{"members":["{TEST_SENDER}",{{"name":"{ROLE_TEAM_LEAD}"}}]}}"#);
+        let config = parse_team_config(&config_path, &raw).expect("team config");
 
         assert_eq!(config.members.len(), 2);
-        assert_eq!(config.members[0].name, "arch-ctm");
-        assert_eq!(config.members[1].name, "team-lead");
+        assert_eq!(config.members[0].name, TEST_SENDER);
+        assert_eq!(config.members[1].name, ROLE_TEAM_LEAD);
         assert!(config.extra.is_empty());
     }
 
     #[test]
     fn parse_team_config_skips_invalid_member_records() {
         let (_tempdir, config_path) = temp_config_path();
-        let config = parse_team_config(
-            &config_path,
-            r#"{"members":[{"name":"arch-ctm"},{"broken":true},17,{"name":"team-lead"}]}"#,
-        )
-        .expect("team config");
+        let raw = format!(
+            r#"{{"members":[{{"name":"{TEST_SENDER}"}},{{"broken":true}},17,{{"name":"{ROLE_TEAM_LEAD}"}}]}}"#
+        );
+        let config = parse_team_config(&config_path, &raw).expect("team config");
 
         assert_eq!(config.members.len(), 2);
-        assert_eq!(config.members[0].name, "arch-ctm");
-        assert_eq!(config.members[1].name, "team-lead");
+        assert_eq!(config.members[0].name, TEST_SENDER);
+        assert_eq!(config.members[1].name, ROLE_TEAM_LEAD);
         assert!(config.extra.is_empty());
     }
 
@@ -636,11 +635,9 @@ post_send_hook_recipients = ["team-lead"]
     #[test]
     fn parse_team_config_preserves_root_extra_fields() {
         let (_tempdir, config_path) = temp_config_path();
-        let config = parse_team_config(
-            &config_path,
-            r#"{"leadSessionId":"lead-123","members":[{"name":"team-lead"}]}"#,
-        )
-        .expect("team config");
+        let raw =
+            format!(r#"{{"leadSessionId":"lead-123","members":[{{"name":"{ROLE_TEAM_LEAD}"}}]}}"#);
+        let config = parse_team_config(&config_path, &raw).expect("team config");
 
         assert_eq!(config.members.len(), 1);
         assert_eq!(
@@ -652,8 +649,8 @@ post_send_hook_recipients = ["team-lead"]
     #[test]
     fn parse_team_config_reports_json_syntax_errors_with_detail() {
         let (_tempdir, config_path) = temp_config_path();
-        let error = parse_team_config(&config_path, r#"{"members":[{"name":"arch-ctm"}"#)
-            .expect_err("syntax error");
+        let raw = format!(r#"{{"members":[{{"name":"{TEST_SENDER}""#);
+        let error = parse_team_config(&config_path, &raw).expect_err("syntax error");
 
         assert!(error.is_config());
         assert_eq!(error.code, AtmErrorCode::ConfigTeamParseFailed);
@@ -665,8 +662,8 @@ post_send_hook_recipients = ["team-lead"]
     #[test]
     fn parse_team_config_rejects_non_object_root() {
         let (_tempdir, config_path) = temp_config_path();
-        let error =
-            parse_team_config(&config_path, r#"["arch-ctm"]"#).expect_err("root shape error");
+        let raw = format!(r#"["{TEST_SENDER}"]"#);
+        let error = parse_team_config(&config_path, &raw).expect_err("root shape error");
 
         assert!(error.is_config());
         assert_eq!(error.code, AtmErrorCode::ConfigTeamParseFailed);
@@ -677,8 +674,8 @@ post_send_hook_recipients = ["team-lead"]
     #[test]
     fn parse_team_config_rejects_non_array_members() {
         let (_tempdir, config_path) = temp_config_path();
-        let error = parse_team_config(&config_path, r#"{"members":{"name":"arch-ctm"}}"#)
-            .expect_err("members shape error");
+        let raw = format!(r#"{{"members":{{"name":"{TEST_SENDER}"}}}}"#);
+        let error = parse_team_config(&config_path, &raw).expect_err("members shape error");
 
         assert!(error.is_config());
         assert_eq!(error.code, AtmErrorCode::ConfigTeamParseFailed);
@@ -803,5 +800,3 @@ post_send_hook_recipients = ["team-lead"]
         unsafe { env::remove_var(key) }
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 pub mod health;
 pub mod report;
 
@@ -756,3 +758,5 @@ mod tests {
         );
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 pub mod health;
 pub mod report;
 
@@ -11,6 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::config;
 use crate::error_codes::AtmErrorCode;
 use crate::observability::ObservabilityPort;
+use crate::roles::ROLE_TEAM_LEAD;
 use crate::schema::AgentMember;
 use crate::team_admin::{MemberSummary, MembersList};
 use crate::types::{AgentName, TeamName};
@@ -332,15 +331,17 @@ fn ordered_member_summaries(members: &[AgentMember], baseline: &[TeamName]) -> V
     let mut ordered = Vec::new();
     let mut included = BTreeSet::new();
 
-    if baseline.iter().any(|member| member.as_str() == "team-lead")
-        && let Some(team_lead) = members.iter().find(|member| member.name == "team-lead")
+    if baseline
+        .iter()
+        .any(|member| member.as_str() == ROLE_TEAM_LEAD)
+        && let Some(team_lead) = members.iter().find(|member| member.name == ROLE_TEAM_LEAD)
     {
         ordered.push(member_summary(team_lead));
         included.insert(team_lead.name.clone());
     }
 
     for baseline_member in baseline {
-        if baseline_member.as_str() == "team-lead" {
+        if baseline_member.as_str() == ROLE_TEAM_LEAD {
             continue;
         }
         if let Some(member) = members
@@ -386,6 +387,7 @@ mod tests {
         LogTailSession, ObservabilityPort,
     };
     use crate::schema::{AgentMember, TeamConfig};
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::AgentName;
 
     enum StubHealth {
@@ -448,7 +450,7 @@ mod tests {
         }
 
         fn team_dir(&self) -> PathBuf {
-            self.home_dir.join(".claude").join("teams").join("atm-dev")
+            self.home_dir.join(".claude").join("teams").join(TEST_TEAM)
         }
 
         fn write_team_layout(&self, members: &[&str]) {
@@ -479,14 +481,14 @@ mod tests {
         DoctorQuery {
             home_dir: paths.home_dir.clone(),
             current_dir: paths.current_dir.clone(),
-            team_override: Some("atm-dev".parse().expect("team")),
+            team_override: Some(TEST_TEAM.parse().expect("team")),
         }
     }
 
     #[test]
     fn run_doctor_reports_healthy_observability() {
         let paths = TestPaths::new();
-        paths.write_team_layout(&["arch-ctm"]);
+        paths.write_team_layout(&[TEST_SENDER]);
         let report = run_doctor(
             query(&paths),
             &StubObservability {
@@ -538,10 +540,10 @@ mod tests {
     #[test]
     fn run_doctor_reports_obsolete_identity_drift_as_warning() {
         let paths = TestPaths::new();
-        paths.write_team_layout(&["arch-ctm"]);
+        paths.write_team_layout(&[TEST_SENDER]);
         std::fs::write(
             paths.current_dir.join(".atm.toml"),
-            "[atm]\nidentity = \"arch-ctm\"\n",
+            format!("[atm]\nidentity = \"{TEST_SENDER}\"\n"),
         )
         .expect("config");
         let report = run_doctor(
@@ -571,7 +573,7 @@ mod tests {
     #[test]
     fn run_doctor_reports_degraded_observability_as_warning() {
         let paths = TestPaths::new();
-        paths.write_team_layout(&["arch-ctm"]);
+        paths.write_team_layout(&[TEST_SENDER]);
         let report = run_doctor(
             query(&paths),
             &StubObservability {
@@ -596,7 +598,7 @@ mod tests {
     #[test]
     fn run_doctor_reports_unavailable_observability_as_error() {
         let paths = TestPaths::new();
-        paths.write_team_layout(&["arch-ctm"]);
+        paths.write_team_layout(&[TEST_SENDER]);
         let report = run_doctor(
             query(&paths),
             &StubObservability {
@@ -621,7 +623,7 @@ mod tests {
     #[test]
     fn run_doctor_reports_observability_health_errors() {
         let paths = TestPaths::new();
-        paths.write_team_layout(&["arch-ctm"]);
+        paths.write_team_layout(&[TEST_SENDER]);
         let report = run_doctor(
             query(&paths),
             &StubObservability {
@@ -705,7 +707,7 @@ mod tests {
     #[test]
     fn run_doctor_reports_missing_inboxes_directory_as_error() {
         let paths = TestPaths::new();
-        paths.write_raw_team_config(r#"{"members":[{"name":"arch-ctm"}]}"#);
+        paths.write_raw_team_config(&format!(r#"{{"members":[{{"name":"{TEST_SENDER}"}}]}}"#));
         let report = run_doctor(
             query(&paths),
             &StubObservability {
@@ -732,8 +734,11 @@ mod tests {
     #[test]
     fn run_doctor_reports_stale_mailbox_lock_as_warning() {
         let paths = TestPaths::new();
-        paths.write_team_layout(&["arch-ctm"]);
-        let stale_lock = paths.team_dir().join("inboxes").join("arch-ctm.json.lock");
+        paths.write_team_layout(&[TEST_SENDER]);
+        let stale_lock = paths
+            .team_dir()
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json.lock"));
         std::fs::write(&stale_lock, u32::MAX.to_string()).expect("stale lock");
         let report = run_doctor(
             query(&paths),
@@ -758,5 +763,3 @@ mod tests {
         );
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::env;
 use std::path::{Path, PathBuf};
 
@@ -112,6 +110,7 @@ mod tests {
         atm_home, inbox_path, inbox_path_from_home, team_dir, team_dir_from_home,
         workflow_state_path_from_home,
     };
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
 
     // Serializes process-environment mutation inside this test module. This is
     // process-local only; it does not coordinate with other test processes.
@@ -200,18 +199,18 @@ mod tests {
         let _atm_home = EnvGuard::set("ATM_HOME", tempdir.path());
 
         assert_eq!(
-            team_dir("atm-dev").expect("team dir"),
-            tempdir.path().join(".claude").join("teams").join("atm-dev")
+            team_dir(TEST_TEAM).expect("team dir"),
+            tempdir.path().join(".claude").join("teams").join(TEST_TEAM)
         );
         assert_eq!(
-            inbox_path("atm-dev", "arch-ctm").expect("inbox path"),
+            inbox_path(TEST_TEAM, TEST_SENDER).expect("inbox path"),
             tempdir
                 .path()
                 .join(".claude")
                 .join("teams")
-                .join("atm-dev")
+                .join(TEST_TEAM)
                 .join("inboxes")
-                .join("arch-ctm.json")
+                .join(format!("{TEST_SENDER}.json"))
         );
     }
 
@@ -228,7 +227,7 @@ mod tests {
     fn inbox_path_from_home_rejects_path_traversal_segments() {
         let tempdir = TempDir::new().expect("tempdir");
         let error =
-            inbox_path_from_home(tempdir.path(), "atm-dev", "../evil").expect_err("invalid agent");
+            inbox_path_from_home(tempdir.path(), TEST_TEAM, "../evil").expect_err("invalid agent");
 
         assert!(error.is_address());
         assert!(error.message.contains("agent name"));
@@ -239,18 +238,16 @@ mod tests {
         let tempdir = TempDir::new().expect("tempdir");
 
         assert_eq!(
-            workflow_state_path_from_home(tempdir.path(), "atm-dev", "arch-ctm")
+            workflow_state_path_from_home(tempdir.path(), TEST_TEAM, TEST_SENDER)
                 .expect("workflow state path"),
             tempdir
                 .path()
                 .join(".claude")
                 .join("teams")
-                .join("atm-dev")
+                .join(TEST_TEAM)
                 .join(".atm-state")
                 .join("workflow")
-                .join("arch-ctm.json")
+                .join(format!("{TEST_SENDER}.json"))
         );
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::env;
 use std::path::{Path, PathBuf};
 
@@ -250,3 +252,5 @@ mod tests {
         );
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -86,13 +86,14 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::config::AtmConfig;
-    use crate::roles::ROLE_TEAM_LEAD;
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::AgentName;
 
     #[cfg(unix)]
     use super::resolve_sender_identity;
     use super::{resolve_hook_identity, resolve_runtime_sender_identity};
+    #[cfg(unix)]
+    use crate::roles::ROLE_TEAM_LEAD;
 
     #[test]
     #[serial_test::serial(env)]

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 pub mod hook;
 
 use crate::config::AtmConfig;
@@ -217,3 +219,5 @@ mod tests {
         unsafe { env::remove_var(key) }
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -1,4 +1,5 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+// lint-identities: allow-start -- test-only identity resolution coverage below
+// intentionally exercises concrete ATM identity strings and env-var semantics.
 
 pub mod hook;
 
@@ -58,7 +59,9 @@ pub(crate) fn resolve_sender_identity(
 /// Returns [`AtmError`] with
 /// [`crate::error_codes::AtmErrorCode::IdentityUnavailable`] when
 /// `ATM_IDENTITY` is not set in the current environment.
-pub fn resolve_runtime_sender_identity(config: Option<&AtmConfig>) -> Result<AgentName, AtmError> {
+pub(crate) fn resolve_runtime_sender_identity(
+    config: Option<&AtmConfig>,
+) -> Result<AgentName, AtmError> {
     crate::config::resolve_identity(config).ok_or_else(AtmError::identity_unavailable)
 }
 
@@ -70,11 +73,11 @@ fn resolve_aliased_agent(value: &str, config: Option<&AtmConfig>) -> Result<Agen
 pub fn resolve_hook_identity(
     team_override: Option<&str>,
     config: Option<&AtmConfig>,
-) -> Result<(String, String), AtmError> {
+) -> Result<(AgentName, crate::types::TeamName), AtmError> {
     let agent = resolve_runtime_sender_identity(config)?;
     let team = crate::config::resolve_team(team_override, config)
         .ok_or_else(AtmError::team_unavailable)?;
-    Ok((agent.into_inner(), team.into_inner()))
+    Ok((agent, team))
 }
 
 #[cfg(test)]
@@ -88,7 +91,9 @@ mod tests {
     use crate::config::AtmConfig;
     use crate::types::AgentName;
 
-    use super::{resolve_hook_identity, resolve_runtime_sender_identity, resolve_sender_identity};
+    #[cfg(unix)]
+    use super::resolve_sender_identity;
+    use super::{resolve_hook_identity, resolve_runtime_sender_identity};
 
     #[test]
     #[serial_test::serial(env)]
@@ -136,8 +141,8 @@ mod tests {
         set_env_var("ATM_TEAM", "atm-dev");
 
         let (agent, team) = resolve_hook_identity(None, None).expect("hook identity");
-        assert_eq!(agent, "arch-ctm");
-        assert_eq!(team, "atm-dev");
+        assert_eq!(agent.as_str(), "arch-ctm");
+        assert_eq!(team.as_str(), "atm-dev");
 
         restore("ATM_IDENTITY", original_identity);
         restore("ATM_TEAM", original_team);

--- a/crates/atm-core/src/identity/mod.rs
+++ b/crates/atm-core/src/identity/mod.rs
@@ -1,6 +1,3 @@
-// lint-identities: allow-start -- test-only identity resolution coverage below
-// intentionally exercises concrete ATM identity strings and env-var semantics.
-
 pub mod hook;
 
 use crate::config::AtmConfig;
@@ -70,7 +67,7 @@ fn resolve_aliased_agent(value: &str, config: Option<&AtmConfig>) -> Result<Agen
 }
 
 #[cfg(test)]
-pub fn resolve_hook_identity(
+pub(crate) fn resolve_hook_identity(
     team_override: Option<&str>,
     config: Option<&AtmConfig>,
 ) -> Result<(AgentName, crate::types::TeamName), AtmError> {
@@ -89,6 +86,8 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::config::AtmConfig;
+    use crate::roles::ROLE_TEAM_LEAD;
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::AgentName;
 
     #[cfg(unix)]
@@ -99,7 +98,7 @@ mod tests {
     #[serial_test::serial(env)]
     fn resolves_sender_identity_from_environment() {
         let original_identity = env::var_os("ATM_IDENTITY");
-        set_env_var("ATM_IDENTITY", "arch-ctm");
+        set_env_var("ATM_IDENTITY", TEST_SENDER);
 
         let config = AtmConfig {
             identity: Some("config-agent".into()),
@@ -108,7 +107,7 @@ mod tests {
         };
         assert_eq!(
             resolve_runtime_sender_identity(Some(&config)).expect("identity"),
-            AgentName::from_validated("arch-ctm")
+            AgentName::from_validated(TEST_SENDER)
         );
 
         restore("ATM_IDENTITY", original_identity);
@@ -137,12 +136,12 @@ mod tests {
     fn resolves_hook_identity_from_environment() {
         let original_identity = env::var_os("ATM_IDENTITY");
         let original_team = env::var_os("ATM_TEAM");
-        set_env_var("ATM_IDENTITY", "arch-ctm");
-        set_env_var("ATM_TEAM", "atm-dev");
+        set_env_var("ATM_IDENTITY", TEST_SENDER);
+        set_env_var("ATM_TEAM", TEST_TEAM);
 
         let (agent, team) = resolve_hook_identity(None, None).expect("hook identity");
-        assert_eq!(agent.as_str(), "arch-ctm");
-        assert_eq!(team.as_str(), "atm-dev");
+        assert_eq!(agent.as_str(), TEST_SENDER);
+        assert_eq!(team.as_str(), TEST_TEAM);
 
         restore("ATM_IDENTITY", original_identity);
         restore("ATM_TEAM", original_team);
@@ -190,7 +189,7 @@ mod tests {
         .expect("hook file");
 
         let mut aliases = std::collections::BTreeMap::new();
-        aliases.insert("lead".to_string(), "team-lead".to_string());
+        aliases.insert("lead".to_string(), ROLE_TEAM_LEAD.to_string());
         let config = AtmConfig {
             aliases,
             ..Default::default()
@@ -198,7 +197,7 @@ mod tests {
 
         assert_eq!(
             resolve_sender_identity(None, Some(&config)).expect("send identity"),
-            AgentName::from_validated("team-lead")
+            AgentName::from_validated(ROLE_TEAM_LEAD)
         );
 
         let _ = fs::remove_file(hook_path);
@@ -224,5 +223,3 @@ mod tests {
         unsafe { env::remove_var(key) }
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -30,12 +30,17 @@ pub(crate) mod persistence;
 pub(crate) mod process;
 /// Mailbox read/query workflows and output models.
 pub mod read;
+/// Reserved production role constants shared across runtime and tests.
+pub mod roles;
 /// Public mailbox and team schema types shared with CLI tests and adapters.
 pub mod schema;
 /// Mailbox send workflows and request/response models.
 pub mod send;
 /// Retained local team discovery, roster repair, and backup/restore workflows.
 pub mod team_admin;
+/// Shared synthetic test identities and role constants used across crate tests.
+#[doc(hidden)]
+pub mod test_support;
 /// Internal text-formatting helpers used by ATM core surfaces.
 pub(crate) mod text;
 /// Shared enums and semantic newtypes used across ATM core workflows.

--- a/crates/atm-core/src/log/filters.rs
+++ b/crates/atm-core/src/log/filters.rs
@@ -3,3 +3,7 @@
 //! ATM currently exposes its retained-log query model through
 //! `crate::observability`. This module is reserved for future shared filter
 //! helpers if multiple retained-log callers emerge.
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub(crate) struct DeferredLogFilterScope;

--- a/crates/atm-core/src/mailbox/hash.rs
+++ b/crates/atm-core/src/mailbox/hash.rs
@@ -1,1 +1,5 @@
 //! Internal mailbox hashing helpers reserved for future implementation.
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub(crate) struct DeferredMailboxHashScope;

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -604,12 +604,12 @@ fn is_lock_contention_error(error: &io::Error) -> bool {
 
     #[cfg(windows)]
     {
-        return matches!(
+        matches!(
             error.raw_os_error(),
             Some(code)
                 if code == windows_sys::Win32::Foundation::ERROR_LOCK_VIOLATION as i32
                     || code == windows_sys::Win32::Foundation::ERROR_SHARING_VIOLATION as i32
-        );
+        )
     }
 
     #[cfg(not(any(unix, windows)))]

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -494,12 +494,12 @@ fn should_retry_remove_lock_sentinel(error: &io::Error) -> bool {
 
     #[cfg(windows)]
     {
-        return matches!(
+        matches!(
             error.raw_os_error(),
             Some(code)
                 if code == windows_sys::Win32::Foundation::ERROR_SHARING_VIOLATION as i32
                     || code == windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED as i32
-        );
+        )
     }
 
     #[cfg(not(windows))]
@@ -884,7 +884,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn sentinel_path_appends_lock_suffix() {
         let path = PathBuf::from(format!("{TEST_LEAD}.json"));
         assert_eq!(
@@ -894,7 +894,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn acquire_creates_sentinel_file() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -905,7 +905,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn dropping_guard_removes_sentinel_file() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -920,7 +920,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn dropping_guard_skips_removal_when_sentinel_path_rotates() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -941,7 +941,7 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn acquire_retries_when_lock_identity_compare_hits_transient_access_denied() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -953,7 +953,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn evict_stale_lock_sentinel_removes_dead_pid_file() {
         let tempdir = tempdir().expect("tempdir");
         let sentinel = tempdir.path().join(format!("{TEST_SENDER}.json.lock"));
@@ -967,7 +967,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn sweep_stale_lock_sentinels_removes_only_lock_files_with_dead_pids() {
         let tempdir = tempdir().expect("tempdir");
         let lock_path = tempdir.path().join(format!("{TEST_SENDER}.json.lock"));
@@ -983,7 +983,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn sweep_stale_lock_sentinels_removes_rotated_dead_pid_sentinels_only() {
         let tempdir = tempdir().expect("tempdir");
         let rotated = tempdir.path().join(format!("{TEST_SENDER}.json.lock.old"));
@@ -1004,7 +1004,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn sweep_stale_lock_sentinels_skips_malformed_rotated_sentinels() {
         let tempdir = tempdir().expect("tempdir");
         let rotated = tempdir.path().join(format!("{TEST_SENDER}.json.lock.old"));
@@ -1017,7 +1017,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn is_lock_sentinel_candidate_rejects_partial_lock_suffixes() {
         assert!(!is_lock_sentinel_candidate(&PathBuf::from(
             "inbox.json.lockold",
@@ -1028,7 +1028,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn acquire_many_sorted_dedupes_and_sorts_paths() {
         let tempdir = tempdir().expect("tempdir");
         let a = tempdir.path().join("dir").join("..").join("b.json");
@@ -1045,7 +1045,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn acquire_reports_mailbox_lock_timeout_code() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -1056,7 +1056,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn acquire_many_sorted_releases_prior_guards_on_failure() {
         let tempdir = tempdir().expect("tempdir");
         let free = tempdir.path().join("free.json");
@@ -1074,7 +1074,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn acquire_many_sorted_uses_total_timeout_budget() {
         let tempdir = tempdir().expect("tempdir");
         let first = tempdir.path().join("first.json");
@@ -1087,7 +1087,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn sort_unique_paths_dedupes_same_canonical_path() {
         let tempdir = tempdir().expect("tempdir");
         let real = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -1106,7 +1106,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn acquire_many_sorted_orders_paths_deterministically() {
         let tempdir = tempdir().expect("tempdir");
         let a = tempdir.path().join("c.json");
@@ -1121,20 +1121,20 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn default_lock_timeout_uses_default_without_override() {
         assert_eq!(default_lock_timeout(), DEFAULT_LOCK_TIMEOUT);
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn would_block_is_classified_as_lock_contention() {
         let error = io::Error::from(io::ErrorKind::WouldBlock);
         assert!(is_lock_contention_error(&error));
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn acquire_reports_read_only_filesystem_for_open_failure() {
         let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::Open);
         let tempdir = tempdir().expect("tempdir");
@@ -1160,7 +1160,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn acquire_reports_read_only_filesystem_for_owner_record_write_failure() {
         let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::WriteOwnerRecord);
         let tempdir = tempdir().expect("tempdir");
@@ -1177,7 +1177,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn sweep_reports_read_only_filesystem_for_stale_sentinel_removal() {
         let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::Remove);
         let tempdir = tempdir().expect("tempdir");
@@ -1191,7 +1191,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(env)]
     fn dropping_guard_tolerates_read_only_cleanup_failure() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::io::Write;
@@ -1235,3 +1237,5 @@ mod tests {
 
     use std::path::PathBuf;
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -835,8 +835,6 @@ mod tests {
     use std::io;
     use std::time::Duration;
 
-    #[cfg(not(windows))]
-    use serial_test::serial;
     use tempfile::tempdir;
 
     use super::{
@@ -886,7 +884,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn sentinel_path_appends_lock_suffix() {
         let path = PathBuf::from(format!("{TEST_LEAD}.json"));
         assert_eq!(
@@ -896,7 +894,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn acquire_creates_sentinel_file() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -907,7 +905,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn dropping_guard_removes_sentinel_file() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -922,7 +920,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn dropping_guard_skips_removal_when_sentinel_path_rotates() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -943,7 +941,7 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
-    #[serial(env)]
+    #[serial_test::serial]
     fn acquire_retries_when_lock_identity_compare_hits_transient_access_denied() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -955,7 +953,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn evict_stale_lock_sentinel_removes_dead_pid_file() {
         let tempdir = tempdir().expect("tempdir");
         let sentinel = tempdir.path().join(format!("{TEST_SENDER}.json.lock"));
@@ -969,7 +967,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn sweep_stale_lock_sentinels_removes_only_lock_files_with_dead_pids() {
         let tempdir = tempdir().expect("tempdir");
         let lock_path = tempdir.path().join(format!("{TEST_SENDER}.json.lock"));
@@ -985,7 +983,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn sweep_stale_lock_sentinels_removes_rotated_dead_pid_sentinels_only() {
         let tempdir = tempdir().expect("tempdir");
         let rotated = tempdir.path().join(format!("{TEST_SENDER}.json.lock.old"));
@@ -1006,7 +1004,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn sweep_stale_lock_sentinels_skips_malformed_rotated_sentinels() {
         let tempdir = tempdir().expect("tempdir");
         let rotated = tempdir.path().join(format!("{TEST_SENDER}.json.lock.old"));
@@ -1019,7 +1017,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn is_lock_sentinel_candidate_rejects_partial_lock_suffixes() {
         assert!(!is_lock_sentinel_candidate(&PathBuf::from(
             "inbox.json.lockold",
@@ -1030,7 +1028,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn acquire_many_sorted_dedupes_and_sorts_paths() {
         let tempdir = tempdir().expect("tempdir");
         let a = tempdir.path().join("dir").join("..").join("b.json");
@@ -1047,7 +1045,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn acquire_reports_mailbox_lock_timeout_code() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -1058,7 +1056,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn acquire_many_sorted_releases_prior_guards_on_failure() {
         let tempdir = tempdir().expect("tempdir");
         let free = tempdir.path().join("free.json");
@@ -1076,7 +1074,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn acquire_many_sorted_uses_total_timeout_budget() {
         let tempdir = tempdir().expect("tempdir");
         let first = tempdir.path().join("first.json");
@@ -1089,7 +1087,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn sort_unique_paths_dedupes_same_canonical_path() {
         let tempdir = tempdir().expect("tempdir");
         let real = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -1108,7 +1106,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn acquire_many_sorted_orders_paths_deterministically() {
         let tempdir = tempdir().expect("tempdir");
         let a = tempdir.path().join("c.json");
@@ -1123,20 +1121,20 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn default_lock_timeout_uses_default_without_override() {
         assert_eq!(default_lock_timeout(), DEFAULT_LOCK_TIMEOUT);
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn would_block_is_classified_as_lock_contention() {
         let error = io::Error::from(io::ErrorKind::WouldBlock);
         assert!(is_lock_contention_error(&error));
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn acquire_reports_read_only_filesystem_for_open_failure() {
         let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::Open);
         let tempdir = tempdir().expect("tempdir");
@@ -1149,7 +1147,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial(env)]
     fn acquire_reports_read_only_filesystem_for_open_failure_via_env_var_seam() {
         let _guard = EnvGuard::set_raw("ATM_TEST_FORCE_LOCK_READONLY_FS", "open");
         let tempdir = tempdir().expect("tempdir");
@@ -1162,7 +1160,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn acquire_reports_read_only_filesystem_for_owner_record_write_failure() {
         let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::WriteOwnerRecord);
         let tempdir = tempdir().expect("tempdir");
@@ -1179,7 +1177,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn sweep_reports_read_only_filesystem_for_stale_sentinel_removal() {
         let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::Remove);
         let tempdir = tempdir().expect("tempdir");
@@ -1193,7 +1191,7 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
+    #[serial_test::serial]
     fn dropping_guard_tolerates_read_only_cleanup_failure() {
         let tempdir = tempdir().expect("tempdir");
         let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
@@ -1229,16 +1227,16 @@ mod tests {
     }
 
     fn set_env_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
-        // SAFETY: env-mutating tests in this module use #[serial(env)] before
-        // mutating the process environment, so these mutations are serialized
-        // within this process.
+        // SAFETY: env-mutating tests in this module use
+        // #[serial_test::serial(env)] before mutating the process
+        // environment, so these mutations are serialized within this process.
         unsafe { std::env::set_var(key, value) }
     }
 
     fn remove_env_var<K: AsRef<OsStr>>(key: K) {
-        // SAFETY: env-mutating tests in this module use #[serial(env)] before
-        // mutating the process environment, so these mutations are serialized
-        // within this process.
+        // SAFETY: env-mutating tests in this module use
+        // #[serial_test::serial(env)] before mutating the process
+        // environment, so these mutations are serialized within this process.
         unsafe { std::env::remove_var(key) }
     }
 

--- a/crates/atm-core/src/mailbox/lock.rs
+++ b/crates/atm-core/src/mailbox/lock.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::io::Write;
@@ -413,12 +411,12 @@ fn lock_file_identity_from_path(path: &Path) -> io::Result<LockFileIdentity> {
 fn is_transient_lock_identity_error(error: &io::Error) -> bool {
     #[cfg(windows)]
     {
-        return matches!(
+        matches!(
             error.raw_os_error(),
             Some(code)
                 if code == windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED as i32
                     || code == windows_sys::Win32::Foundation::ERROR_SHARING_VIOLATION as i32
-        );
+        )
     }
 
     #[cfg(not(windows))]
@@ -837,6 +835,7 @@ mod tests {
     use std::io;
     use std::time::Duration;
 
+    #[cfg(not(windows))]
     use serial_test::serial;
     use tempfile::tempdir;
 
@@ -847,6 +846,7 @@ mod tests {
         sentinel_path, sweep_stale_lock_sentinels,
     };
     use crate::error::AtmErrorCode;
+    use crate::test_support::{TEST_LEAD, TEST_SENDER};
 
     struct ReadOnlyFilesystemGuard {
         original: Option<LockOperation>,
@@ -888,15 +888,18 @@ mod tests {
     #[test]
     #[serial(env)]
     fn sentinel_path_appends_lock_suffix() {
-        let path = PathBuf::from("team-lead.json");
-        assert_eq!(sentinel_path(&path), PathBuf::from("team-lead.json.lock"));
+        let path = PathBuf::from(format!("{TEST_LEAD}.json"));
+        assert_eq!(
+            sentinel_path(&path),
+            PathBuf::from(format!("{TEST_LEAD}.json.lock"))
+        );
     }
 
     #[test]
     #[serial(env)]
     fn acquire_creates_sentinel_file() {
         let tempdir = tempdir().expect("tempdir");
-        let inbox = tempdir.path().join("arch-ctm.json");
+        let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
 
         let _guard = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect("lock");
 
@@ -907,7 +910,7 @@ mod tests {
     #[serial(env)]
     fn dropping_guard_removes_sentinel_file() {
         let tempdir = tempdir().expect("tempdir");
-        let inbox = tempdir.path().join("arch-ctm.json");
+        let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
         let sentinel = sentinel_path(&inbox);
 
         {
@@ -922,9 +925,11 @@ mod tests {
     #[serial(env)]
     fn dropping_guard_skips_removal_when_sentinel_path_rotates() {
         let tempdir = tempdir().expect("tempdir");
-        let inbox = tempdir.path().join("arch-ctm.json");
+        let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
         let sentinel = sentinel_path(&inbox);
-        let rotated = tempdir.path().join("arch-ctm.json.lock.replaced");
+        let rotated = tempdir
+            .path()
+            .join(format!("{TEST_SENDER}.json.lock.replaced"));
 
         {
             let _guard = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect("lock");
@@ -941,7 +946,7 @@ mod tests {
     #[serial(env)]
     fn acquire_retries_when_lock_identity_compare_hits_transient_access_denied() {
         let tempdir = tempdir().expect("tempdir");
-        let inbox = tempdir.path().join("arch-ctm.json");
+        let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
         let _guard = TransientLockIdentityGuard::set(1);
 
         let _lock = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect("lock after transient compare");
@@ -953,7 +958,7 @@ mod tests {
     #[serial(env)]
     fn evict_stale_lock_sentinel_removes_dead_pid_file() {
         let tempdir = tempdir().expect("tempdir");
-        let sentinel = tempdir.path().join("arch-ctm.json.lock");
+        let sentinel = tempdir.path().join(format!("{TEST_SENDER}.json.lock"));
         std::fs::write(&sentinel, u32::MAX.to_string()).expect("stale sentinel");
 
         assert_eq!(
@@ -967,8 +972,8 @@ mod tests {
     #[serial(env)]
     fn sweep_stale_lock_sentinels_removes_only_lock_files_with_dead_pids() {
         let tempdir = tempdir().expect("tempdir");
-        let lock_path = tempdir.path().join("arch-ctm.json.lock");
-        let inbox_path = tempdir.path().join("arch-ctm.json");
+        let lock_path = tempdir.path().join(format!("{TEST_SENDER}.json.lock"));
+        let inbox_path = tempdir.path().join(format!("{TEST_SENDER}.json"));
         std::fs::write(&lock_path, u32::MAX.to_string()).expect("stale sentinel");
         std::fs::write(&inbox_path, "inbox").expect("inbox");
 
@@ -983,8 +988,10 @@ mod tests {
     #[serial(env)]
     fn sweep_stale_lock_sentinels_removes_rotated_dead_pid_sentinels_only() {
         let tempdir = tempdir().expect("tempdir");
-        let rotated = tempdir.path().join("arch-ctm.json.lock.old");
-        let live_rotated = tempdir.path().join("team-lead.json.lock.replaced");
+        let rotated = tempdir.path().join(format!("{TEST_SENDER}.json.lock.old"));
+        let live_rotated = tempdir
+            .path()
+            .join(format!("{TEST_LEAD}.json.lock.replaced"));
         let unrelated = tempdir.path().join("locksmith.txt");
         std::fs::write(&rotated, u32::MAX.to_string()).expect("stale rotated");
         std::fs::write(&live_rotated, std::process::id().to_string()).expect("live rotated");
@@ -1002,7 +1009,7 @@ mod tests {
     #[serial(env)]
     fn sweep_stale_lock_sentinels_skips_malformed_rotated_sentinels() {
         let tempdir = tempdir().expect("tempdir");
-        let rotated = tempdir.path().join("arch-ctm.json.lock.old");
+        let rotated = tempdir.path().join(format!("{TEST_SENDER}.json.lock.old"));
         std::fs::write(&rotated, "not-a-pid").expect("malformed");
 
         let removed = sweep_stale_lock_sentinels(tempdir.path()).expect("sweep");
@@ -1043,7 +1050,7 @@ mod tests {
     #[serial(env)]
     fn acquire_reports_mailbox_lock_timeout_code() {
         let tempdir = tempdir().expect("tempdir");
-        let inbox = tempdir.path().join("arch-ctm.json");
+        let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
         let _first = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect("first lock");
 
         let error = acquire(&inbox, Duration::from_millis(10)).expect_err("timeout");
@@ -1085,13 +1092,13 @@ mod tests {
     #[serial(env)]
     fn sort_unique_paths_dedupes_same_canonical_path() {
         let tempdir = tempdir().expect("tempdir");
-        let real = tempdir.path().join("arch-ctm.json");
+        let real = tempdir.path().join(format!("{TEST_SENDER}.json"));
         std::fs::write(&real, "").expect("write");
         let alternate = tempdir
             .path()
             .join("nested")
             .join("..")
-            .join("arch-ctm.json");
+            .join(format!("{TEST_SENDER}.json"));
         std::fs::create_dir_all(tempdir.path().join("nested")).expect("nested");
 
         let sorted = super::sort_unique_paths(vec![real.clone(), alternate]);
@@ -1133,7 +1140,7 @@ mod tests {
     fn acquire_reports_read_only_filesystem_for_open_failure() {
         let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::Open);
         let tempdir = tempdir().expect("tempdir");
-        let inbox = tempdir.path().join("arch-ctm.json");
+        let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
 
         let error = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect_err("read-only open");
 
@@ -1146,7 +1153,7 @@ mod tests {
     fn acquire_reports_read_only_filesystem_for_open_failure_via_env_var_seam() {
         let _guard = EnvGuard::set_raw("ATM_TEST_FORCE_LOCK_READONLY_FS", "open");
         let tempdir = tempdir().expect("tempdir");
-        let inbox = tempdir.path().join("arch-ctm.json");
+        let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
 
         let error = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect_err("read-only open");
 
@@ -1159,7 +1166,7 @@ mod tests {
     fn acquire_reports_read_only_filesystem_for_owner_record_write_failure() {
         let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::WriteOwnerRecord);
         let tempdir = tempdir().expect("tempdir");
-        let inbox = tempdir.path().join("arch-ctm.json");
+        let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
 
         let error = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect_err("read-only write");
 
@@ -1176,7 +1183,7 @@ mod tests {
     fn sweep_reports_read_only_filesystem_for_stale_sentinel_removal() {
         let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::Remove);
         let tempdir = tempdir().expect("tempdir");
-        let rotated = tempdir.path().join("arch-ctm.json.lock.old");
+        let rotated = tempdir.path().join(format!("{TEST_SENDER}.json.lock.old"));
         std::fs::write(&rotated, u32::MAX.to_string()).expect("stale rotated");
 
         let error = sweep_stale_lock_sentinels(tempdir.path()).expect_err("read-only remove");
@@ -1189,7 +1196,7 @@ mod tests {
     #[serial(env)]
     fn dropping_guard_tolerates_read_only_cleanup_failure() {
         let tempdir = tempdir().expect("tempdir");
-        let inbox = tempdir.path().join("arch-ctm.json");
+        let inbox = tempdir.path().join(format!("{TEST_SENDER}.json"));
         let sentinel = sentinel_path(&inbox);
         let guard = acquire(&inbox, DEFAULT_LOCK_TIMEOUT).expect("lock");
         let _readonly = ReadOnlyFilesystemGuard::set(LockOperation::Remove);
@@ -1237,5 +1244,3 @@ mod tests {
 
     use std::path::PathBuf;
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -1,5 +1,7 @@
 //! Mailbox read/write helpers, compatibility parsing, and lock-scoped mutation.
 
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 pub(crate) mod atomic;
 pub(crate) mod hash;
 pub(crate) mod lock;
@@ -532,3 +534,5 @@ mod tests {
         }
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -1,7 +1,5 @@
 //! Mailbox read/write helpers, compatibility parsing, and lock-scoped mutation.
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 pub(crate) mod atomic;
 pub(crate) mod hash;
 pub(crate) mod lock;
@@ -250,7 +248,9 @@ mod tests {
     use tempfile::TempDir;
     use uuid::Uuid;
 
+    use crate::roles::ROLE_TEAM_LEAD;
     use crate::schema::MessageEnvelope;
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::{AgentName, IsoTimestamp, TeamName};
 
     use super::{MAX_MAILBOX_READ_BYTES, append_message, locked_read_modify_write, read_messages};
@@ -394,7 +394,7 @@ mod tests {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("malformed-message-id.jsonl");
         let contents = serde_json::json!({
-            "from": "team-lead",
+            "from": ROLE_TEAM_LEAD,
             "text": "valid body",
             "timestamp": "2026-03-30T00:00:00Z",
             "read": false,
@@ -418,7 +418,7 @@ mod tests {
         let path = tempdir.path().join("array-no-message-id.json");
         let contents = serde_json::json!([
             {
-                "from": "team-lead",
+                "from": ROLE_TEAM_LEAD,
                 "text": "from claude array",
                 "timestamp": "2026-03-30T00:00:00Z",
                 "read": false
@@ -451,16 +451,27 @@ mod tests {
     fn read_messages_hydrates_fields_from_metadata_atm() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("metadata-atm.json");
-        fs::write(
-            &path,
-            r#"{"from":"team-lead","text":"hello","timestamp":"2026-03-30T00:00:00Z","read":false,"summary":"hello","metadata":{"atm":{"messageId":"01JQYVB6W51Q2E7E6T3Y4Q9N2M","sourceTeam":"atm-dev","pendingAckAt":"2026-03-30T00:00:01Z","taskId":"TASK-123"}}}"#,
-        )
-        .expect("write");
+        let contents = serde_json::json!({
+            "from": ROLE_TEAM_LEAD,
+            "text": "hello",
+            "timestamp": "2026-03-30T00:00:00Z",
+            "read": false,
+            "summary": "hello",
+            "metadata": {
+                "atm": {
+                    "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
+                    "sourceTeam": TEST_TEAM,
+                    "pendingAckAt": "2026-03-30T00:00:01Z",
+                    "taskId": "TASK-123"
+                }
+            }
+        });
+        fs::write(&path, serde_json::to_vec(&contents).expect("json")).expect("write");
 
         let messages = read_messages(&path).expect("read");
         assert_eq!(messages.len(), 1);
         assert!(messages[0].message_id.is_some());
-        assert_eq!(messages[0].source_team.as_deref(), Some("atm-dev"));
+        assert_eq!(messages[0].source_team.as_deref(), Some(TEST_TEAM));
         assert!(messages[0].pending_ack_at.is_some());
         assert_eq!(
             messages[0].task_id.as_ref().map(|task_id| task_id.as_str()),
@@ -509,13 +520,13 @@ mod tests {
         );
         atm.insert(
             "sourceTeam".to_string(),
-            serde_json::Value::String("atm-dev".to_string()),
+            serde_json::Value::String(TEST_TEAM.to_string()),
         );
         metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
         extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
 
         MessageEnvelope {
-            from: "arch-ctm".parse::<AgentName>().expect("agent"),
+            from: TEST_SENDER.parse::<AgentName>().expect("agent"),
             text: body.into(),
             timestamp: IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
@@ -523,7 +534,7 @@ mod tests {
                     .expect("timestamp"),
             ),
             read: false,
-            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
+            source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team")),
             summary: None,
             message_id: Some(message_id),
             pending_ack_at: None,
@@ -534,5 +545,3 @@ mod tests {
         }
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/mailbox/source.rs
+++ b/crates/atm-core/src/mailbox/source.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -326,3 +328,5 @@ mod tests {
         assert!(error.is_address());
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/mailbox/source.rs
+++ b/crates/atm-core/src/mailbox/source.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -216,22 +214,32 @@ mod tests {
         rediscover_and_validate_source_paths, resolve_target,
     };
     use crate::config::AtmConfig;
+    use crate::roles::ROLE_TEAM_LEAD;
+    use crate::test_support::{TEST_ORIGIN, TEST_SENDER, TEST_TEAM};
 
     #[test]
     fn discover_origin_inboxes_ignores_primary_and_sorts_matches() {
         let tempdir = tempdir().expect("tempdir");
         let inboxes = tempdir.path();
-        std::fs::write(inboxes.join("arch-ctm.json"), "").expect("primary");
-        std::fs::write(inboxes.join("arch-ctm.host-b.json"), "").expect("host b");
-        std::fs::write(inboxes.join("arch-ctm.host-a.json"), "").expect("host a");
+        std::fs::write(inboxes.join(format!("{TEST_SENDER}.json")), "").expect("primary");
+        std::fs::write(
+            inboxes.join(format!("{TEST_SENDER}.{}.json", TEST_ORIGIN)),
+            "",
+        )
+        .expect("host a");
+        std::fs::write(
+            inboxes.join(format!("{TEST_SENDER}.{}-b.json", TEST_ORIGIN)),
+            "",
+        )
+        .expect("host b");
         std::fs::write(inboxes.join("other.json"), "").expect("other");
 
-        let discovered = discover_origin_inboxes(inboxes, "arch-ctm").expect("discover");
+        let discovered = discover_origin_inboxes(inboxes, TEST_SENDER).expect("discover");
         assert_eq!(
             discovered,
             vec![
-                inboxes.join("arch-ctm.host-a.json"),
-                inboxes.join("arch-ctm.host-b.json")
+                inboxes.join(format!("{TEST_SENDER}.{}-b.json", TEST_ORIGIN)),
+                inboxes.join(format!("{TEST_SENDER}.{}.json", TEST_ORIGIN))
             ]
         );
     }
@@ -240,7 +248,7 @@ mod tests {
     fn origin_inbox_enumeration_error_is_mailbox_read_failure() {
         let error = origin_inbox_enumeration_error(
             Path::new("test-inbox-dir"),
-            "arch-ctm",
+            TEST_SENDER,
             io::Error::other("synthetic"),
         );
 
@@ -255,29 +263,28 @@ mod tests {
     #[test]
     fn resolve_target_canonicalizes_alias_before_mailbox_lookup() {
         let mut aliases = BTreeMap::new();
-        aliases.insert("tl".to_string(), "team-lead".to_string());
+        aliases.insert("tl".to_string(), ROLE_TEAM_LEAD.to_string());
         let config = AtmConfig {
-            default_team: Some("atm-dev".parse().expect("team")),
+            default_team: Some(TEST_TEAM.parse().expect("team")),
             aliases,
             ..Default::default()
         };
 
         let target = resolve_target(
             Some(&"tl".parse().expect("address")),
-            &"arch-ctm".parse().expect("agent"),
+            &TEST_SENDER.parse().expect("agent"),
             None,
             Some(&config),
         )
         .expect("target");
-        assert_eq!(target.agent, "team-lead");
-        assert_eq!(target.team, "atm-dev");
+        assert_eq!(target.agent, ROLE_TEAM_LEAD);
         assert!(target.explicit);
     }
 
     #[test]
     fn load_source_files_reports_disappearing_mailbox() {
         let tempdir = tempdir().expect("tempdir");
-        let path = tempdir.path().join("arch-ctm.json");
+        let path = tempdir.path().join(format!("{TEST_SENDER}.json"));
         std::fs::write(&path, "").expect("mailbox");
         std::fs::remove_file(&path).expect("remove");
 
@@ -293,18 +300,18 @@ mod tests {
         let inboxes = home
             .join(".claude")
             .join("teams")
-            .join("atm-dev")
+            .join(TEST_TEAM)
             .join("inboxes");
         std::fs::create_dir_all(&inboxes).expect("inboxes");
-        let locked = inboxes.join("arch-ctm.json");
-        let added = inboxes.join("arch-ctm.host-a.json");
+        let locked = inboxes.join(format!("{TEST_SENDER}.json"));
+        let added = inboxes.join(format!("{TEST_SENDER}.{}.json", TEST_ORIGIN));
         std::fs::write(&locked, "").expect("primary");
 
         let discovered =
-            super::discover_source_paths(home, "atm-dev", "arch-ctm").expect("discover");
+            super::discover_source_paths(home, TEST_TEAM, TEST_SENDER).expect("discover");
         std::fs::write(&added, "").expect("origin");
 
-        let error = rediscover_and_validate_source_paths(&discovered, home, "atm-dev", "arch-ctm")
+        let error = rediscover_and_validate_source_paths(&discovered, home, TEST_TEAM, TEST_SENDER)
             .expect_err("drift error");
         assert!(error.is_mailbox_lock());
         assert!(error.message.contains("source path set changed"));
@@ -314,7 +321,7 @@ mod tests {
     fn discover_source_paths_rejects_invalid_team_segment() {
         let tempdir = tempdir().expect("tempdir");
         let error =
-            super::discover_source_paths(tempdir.path(), "../evil", "arch-ctm").expect_err("team");
+            super::discover_source_paths(tempdir.path(), "../evil", TEST_SENDER).expect_err("team");
 
         assert!(error.is_address());
     }
@@ -323,10 +330,8 @@ mod tests {
     fn discover_source_paths_rejects_invalid_agent_segment() {
         let tempdir = tempdir().expect("tempdir");
         let error =
-            super::discover_source_paths(tempdir.path(), "atm-dev", "../evil").expect_err("agent");
+            super::discover_source_paths(tempdir.path(), TEST_TEAM, "../evil").expect_err("agent");
 
         assert!(error.is_address());
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -1,7 +1,5 @@
 //! Mailbox owner-layer write boundaries for the Claude-owned inbox surface.
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -99,17 +97,19 @@ mod tests {
     use super::{commit_mailbox_state, commit_source_files, with_locked_source_files_hook};
     use crate::mailbox::read_messages;
     use crate::mailbox::source::SourceFile;
+    use crate::roles::ROLE_TEAM_LEAD;
     use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
+    use crate::test_support::{TEST_QA, TEST_SENDER, TEST_TEAM};
     use crate::types::{AgentName, IsoTimestamp, TeamName};
 
     #[test]
     fn commit_mailbox_state_rewrites_mailbox_array_with_only_new_messages() {
         let tempdir = tempdir().expect("tempdir");
-        let path = tempdir.path().join("arch-ctm.json");
+        let path = tempdir.path().join(format!("{TEST_SENDER}.json"));
         std::fs::write(&path, "{\"stale\":true}\n").expect("seed mailbox");
         let messages = vec![
-            sample_message("team-lead", "first replacement"),
-            sample_message("qa", "second replacement"),
+            sample_message(ROLE_TEAM_LEAD, "first replacement"),
+            sample_message(TEST_QA, "second replacement"),
         ];
 
         commit_mailbox_state(&path, &messages).expect("commit mailbox");
@@ -125,12 +125,12 @@ mod tests {
     #[test]
     fn commit_source_files_commits_each_source_path() {
         let tempdir = tempdir().expect("tempdir");
-        let left_path = tempdir.path().join("arch-ctm.json");
-        let right_path = tempdir.path().join("qa.json");
-        let left_messages = vec![sample_message("team-lead", "left message")];
+        let left_path = tempdir.path().join(format!("{TEST_SENDER}.json"));
+        let right_path = tempdir.path().join(format!("{TEST_QA}.json"));
+        let left_messages = vec![sample_message(ROLE_TEAM_LEAD, "left message")];
         let right_messages = vec![
-            sample_message("arch-ctm", "right first"),
-            sample_message("team-lead", "right second"),
+            sample_message(TEST_SENDER, "right first"),
+            sample_message(ROLE_TEAM_LEAD, "right second"),
         ];
 
         commit_source_files(&[
@@ -165,15 +165,15 @@ mod tests {
         let error = commit_source_files(&[
             SourceFile {
                 path: first_path.clone(),
-                messages: vec![sample_message("team-lead", "first")],
+                messages: vec![sample_message(ROLE_TEAM_LEAD, "first")],
             },
             SourceFile {
                 path: invalid_path,
-                messages: vec![sample_message("qa", "broken")],
+                messages: vec![sample_message(TEST_QA, "broken")],
             },
             SourceFile {
                 path: later_path.clone(),
-                messages: vec![sample_message("arch-ctm", "later")],
+                messages: vec![sample_message(TEST_SENDER, "later")],
             },
         ])
         .expect_err("write failure");
@@ -186,24 +186,25 @@ mod tests {
     #[test]
     fn injected_before_load_hook_can_fail_closed_without_production_env_seam() {
         let tempdir = tempdir().expect("tempdir");
-        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
+        let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
         let inbox_dir = team_dir.join("inboxes");
         std::fs::create_dir_all(&inbox_dir).expect("inbox dir");
         std::fs::write(
             team_dir.join("config.json"),
             serde_json::json!({
-                "members": [{"name": "arch-ctm"}, {"name": "team-lead"}]
+                "members": [{"name": TEST_SENDER}, {"name": ROLE_TEAM_LEAD}]
             })
             .to_string(),
         )
         .expect("config");
-        let inbox_path = inbox_dir.join("arch-ctm.json");
-        commit_mailbox_state(&inbox_path, &[sample_message("team-lead", "hello")]).expect("seed");
+        let inbox_path = inbox_dir.join(format!("{TEST_SENDER}.json"));
+        commit_mailbox_state(&inbox_path, &[sample_message(ROLE_TEAM_LEAD, "hello")])
+            .expect("seed");
 
         let error = with_locked_source_files_hook(
             tempdir.path(),
-            "atm-dev",
-            "arch-ctm",
+            TEST_TEAM,
+            TEST_SENDER,
             std::iter::empty::<std::path::PathBuf>(),
             std::time::Duration::from_secs(1),
             |paths| {
@@ -236,7 +237,7 @@ mod tests {
         );
         atm.insert(
             "sourceTeam".to_string(),
-            serde_json::Value::String("atm-dev".to_string()),
+            serde_json::Value::String(TEST_TEAM.to_string()),
         );
         metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
         extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
@@ -246,7 +247,7 @@ mod tests {
             text: text.to_string(),
             timestamp: IsoTimestamp::now(),
             read: false,
-            source_team: Some("atm-dev".parse::<TeamName>().expect("team name")),
+            source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team name")),
             summary: None,
             message_id: Some(message_id),
             pending_ack_at: None,
@@ -257,5 +258,3 @@ mod tests {
         }
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -1,5 +1,7 @@
 //! Mailbox owner-layer write boundaries for the Claude-owned inbox surface.
 
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -255,3 +257,5 @@ mod tests {
         }
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/model_registry.rs
+++ b/crates/atm-core/src/model_registry.rs
@@ -3,3 +3,7 @@
 //! ATM 1.0 does not own a model registry. This placeholder remains to reserve
 //! the crate boundary for future metadata lookups if model-aware workflows are
 //! introduced in a later phase.
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub(crate) struct DeferredModelRegistryScope;

--- a/crates/atm-core/src/persistence.rs
+++ b/crates/atm-core/src/persistence.rs
@@ -179,8 +179,9 @@ mod tests {
     use super::{atomic_write_bytes, temp_path_for_atomic_write};
     use crate::error::AtmErrorKind;
 
-    // Serializes process-environment mutation inside this test module. This is
-    // process-local only; it does not coordinate with other test processes.
+    // Serializes the deterministic parent-sync fault-injection seam inside this
+    // test module. This is process-local only; it does not coordinate with
+    // other test processes.
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))

--- a/crates/atm-core/src/persistence.rs
+++ b/crates/atm-core/src/persistence.rs
@@ -174,8 +174,6 @@ mod tests {
     use std::cell::Cell;
     use std::sync::{Mutex, OnceLock};
 
-    #[cfg(unix)]
-    use serial_test::serial;
     use tempfile::tempdir;
 
     use super::{atomic_write_bytes, temp_path_for_atomic_write};
@@ -266,7 +264,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    #[serial]
+    #[serial_test::serial]
     fn atomic_write_bytes_reports_parent_sync_failure_via_deterministic_hook() {
         let _env_lock = env_lock().lock().expect("env lock");
         let _fault = ParentSyncFailureGuard::enable();

--- a/crates/atm-core/src/persistence.rs
+++ b/crates/atm-core/src/persistence.rs
@@ -174,6 +174,7 @@ mod tests {
     use std::cell::Cell;
     use std::sync::{Mutex, OnceLock};
 
+    #[cfg(unix)]
     use serial_test::serial;
     use tempfile::tempdir;
 

--- a/crates/atm-core/src/persistence.rs
+++ b/crates/atm-core/src/persistence.rs
@@ -171,7 +171,9 @@ fn sync_parent_directory(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use std::cell::Cell;
+    #[cfg(unix)]
     use std::sync::{Mutex, OnceLock};
 
     use tempfile::tempdir;
@@ -182,21 +184,26 @@ mod tests {
     // Serializes the deterministic parent-sync fault-injection seam inside this
     // test module. This is process-local only; it does not coordinate with
     // other test processes.
+    #[cfg(unix)]
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
+    #[cfg(unix)]
     thread_local! {
         static FORCE_PARENT_SYNC_FAILURE: Cell<bool> = const { Cell::new(false) };
     }
 
+    #[cfg(unix)]
     pub(super) fn forced_parent_sync_failure() -> bool {
         FORCE_PARENT_SYNC_FAILURE.with(Cell::get)
     }
 
+    #[cfg(unix)]
     struct ParentSyncFailureGuard;
 
+    #[cfg(unix)]
     impl ParentSyncFailureGuard {
         fn enable() -> Self {
             FORCE_PARENT_SYNC_FAILURE.with(|value| value.set(true));
@@ -204,6 +211,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     impl Drop for ParentSyncFailureGuard {
         fn drop(&mut self) {
             FORCE_PARENT_SYNC_FAILURE.with(|value| value.set(false));

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 pub(crate) mod filters;
 pub(crate) mod seen_state;
 pub(crate) mod state;
@@ -696,7 +694,9 @@ mod tests {
 
     use super::{ReadQuery, idle_notification_sender, selected_after_filters};
     use crate::mailbox::source::SourcedMessage;
+    use crate::roles::ROLE_TEAM_LEAD;
     use crate::schema::{LegacyMessageId, MessageEnvelope};
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::{
         AckActivationMode, AgentName, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection,
         TeamName,
@@ -706,11 +706,11 @@ mod tests {
     fn sourced_message(index: usize, text: &str) -> SourcedMessage {
         SourcedMessage {
             envelope: MessageEnvelope {
-                from: "team-lead".parse::<AgentName>().expect("agent"),
+                from: ROLE_TEAM_LEAD.parse::<AgentName>().expect("agent"),
                 text: text.to_string(),
                 timestamp: IsoTimestamp::now(),
                 read: false,
-                source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
+                source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team")),
                 summary: None,
                 message_id: Some(LegacyMessageId::new()),
                 pending_ack_at: None,
@@ -719,14 +719,18 @@ mod tests {
                 task_id: None,
                 extra: Map::new(),
             },
-            source_path: PathBuf::from("arch-ctm.json"),
+            source_path: PathBuf::from(format!("{TEST_SENDER}.json")),
             source_index: index.into(),
         }
     }
 
     #[test]
     fn idle_notification_sender_returns_none_for_malformed_json() {
-        let message = sourced_message(0, r#"{"type":"idle_notification","from":"team-lead""#);
+        let malformed = format!(
+            r#"{{"type":"idle_notification","from":"{}""#,
+            ROLE_TEAM_LEAD
+        );
+        let message = sourced_message(0, &malformed);
 
         assert_eq!(idle_notification_sender(&message.envelope), None);
     }
@@ -734,8 +738,12 @@ mod tests {
     #[test]
     fn malformed_idle_notification_adjacent_to_valid_records_remains_readable_and_classifiable() {
         let workflow_state = workflow::WorkflowStateFile::default();
+        let malformed = format!(
+            r#"{{"type":"idle_notification","from":"{}""#,
+            ROLE_TEAM_LEAD
+        );
         let messages = vec![
-            sourced_message(0, r#"{"type":"idle_notification","from":"team-lead""#),
+            sourced_message(0, &malformed),
             sourced_message(1, "normal unread"),
         ];
         let query = ReadQuery {
@@ -769,9 +777,7 @@ mod tests {
 
         let malformed = selected
             .iter()
-            .find(|message| {
-                message.envelope.text == r#"{"type":"idle_notification","from":"team-lead""#
-            })
+            .find(|message| message.envelope.text == malformed)
             .expect("malformed record");
         assert_eq!(malformed.class, MessageClass::Unread);
         assert_eq!(malformed.bucket, DisplayBucket::Unread);
@@ -783,9 +789,9 @@ mod tests {
         let error = ReadQuery::new(
             tempdir.path().to_path_buf(),
             tempdir.path().to_path_buf(),
-            Some("arch-ctm"),
+            Some(TEST_SENDER),
             Some("../evil"),
-            Some("atm-dev"),
+            Some(TEST_TEAM),
             ReadSelection::Actionable,
             false,
             false,
@@ -808,7 +814,7 @@ mod tests {
             tempdir.path().to_path_buf(),
             Some("../evil"),
             None,
-            Some("atm-dev"),
+            Some(TEST_TEAM),
             ReadSelection::Actionable,
             false,
             false,
@@ -823,5 +829,3 @@ mod tests {
         assert!(error.message.contains("agent name"));
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 pub(crate) mod filters;
 pub(crate) mod seen_state;
 pub(crate) mod state;
@@ -821,3 +823,5 @@ mod tests {
         assert!(error.message.contains("agent name"));
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/read/seen_state.rs
+++ b/crates/atm-core/src/read/seen_state.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -89,12 +87,13 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{load_seen_watermark, save_seen_watermark};
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::IsoTimestamp;
 
     #[test]
     fn load_missing_seen_state_returns_none() {
         let tempdir = TempDir::new().expect("tempdir");
-        let loaded = load_seen_watermark(tempdir.path(), "atm-dev", "arch-ctm").expect("load");
+        let loaded = load_seen_watermark(tempdir.path(), TEST_TEAM, TEST_SENDER).expect("load");
         assert!(loaded.is_none());
     }
 
@@ -108,8 +107,8 @@ mod tests {
                 .expect("timestamp"),
         );
 
-        save_seen_watermark(tempdir.path(), "atm-dev", "arch-ctm", timestamp).expect("save");
-        let loaded = load_seen_watermark(tempdir.path(), "atm-dev", "arch-ctm").expect("load");
+        save_seen_watermark(tempdir.path(), TEST_TEAM, TEST_SENDER, timestamp).expect("save");
+        let loaded = load_seen_watermark(tempdir.path(), TEST_TEAM, TEST_SENDER).expect("load");
 
         assert_eq!(loaded, Some(timestamp));
     }
@@ -118,7 +117,7 @@ mod tests {
     fn load_seen_state_rejects_invalid_team_segment() {
         let tempdir = TempDir::new().expect("tempdir");
         let error =
-            load_seen_watermark(tempdir.path(), "../evil", "arch-ctm").expect_err("invalid team");
+            load_seen_watermark(tempdir.path(), "../evil", TEST_SENDER).expect_err("invalid team");
 
         assert!(error.is_address());
     }
@@ -133,11 +132,9 @@ mod tests {
                 .expect("timestamp"),
         );
 
-        let error = save_seen_watermark(tempdir.path(), "atm-dev", "../evil", timestamp)
+        let error = save_seen_watermark(tempdir.path(), TEST_TEAM, "../evil", timestamp)
             .expect_err("invalid agent");
 
         assert!(error.is_address());
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/read/seen_state.rs
+++ b/crates/atm-core/src/read/seen_state.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -137,3 +139,5 @@ mod tests {
         assert!(error.is_address());
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/roles.rs
+++ b/crates/atm-core/src/roles.rs
@@ -1,0 +1,3 @@
+// rule-008: allow-next-line -- reserved production role literal; all other
+// code must reference this constant instead of repeating the string.
+pub const ROLE_TEAM_LEAD: &str = "team-lead";

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -189,3 +191,5 @@ mod tests {
         assert!(member.cwd.is_empty());
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -133,13 +131,15 @@ impl AgentMember {
 #[cfg(test)]
 mod tests {
     use super::{AgentMember, AgentType};
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::AgentName;
 
     #[test]
     fn parse_name_only_record_defaults_optional_fields() {
-        let member: AgentMember = serde_json::from_str(r#"{"name":"arch-ctm"}"#).expect("member");
+        let member: AgentMember =
+            serde_json::from_str(&format!(r#"{{"name":"{TEST_SENDER}"}}"#)).expect("member");
 
-        assert_eq!(member.name, AgentName::from_validated("arch-ctm"));
+        assert_eq!(member.name, AgentName::from_validated(TEST_SENDER));
         assert!(member.agent_id.is_empty());
         assert_eq!(member.agent_type, AgentType::Unknown(String::new()));
         assert!(member.model.is_empty());
@@ -151,20 +151,22 @@ mod tests {
 
     #[test]
     fn parse_full_claude_code_record_preserves_values_and_extra() {
-        let raw = r#"{
-            "agentId":"arch-ctm@atm-dev",
-            "name":"arch-ctm",
+        let raw = format!(
+            r#"{{
+            "agentId":"{TEST_SENDER}@{TEST_TEAM}",
+            "name":"{TEST_SENDER}",
             "agentType":"general-purpose",
             "model":"claude-sonnet-4-5",
             "joinedAt":1770765919076,
             "tmuxPaneId":"%1",
             "cwd":"/workspace",
             "color":"blue"
-        }"#;
+        }}"#
+        );
 
-        let member: AgentMember = serde_json::from_str(raw).expect("member");
-        assert_eq!(member.agent_id, "arch-ctm@atm-dev");
-        assert_eq!(member.name, AgentName::from_validated("arch-ctm"));
+        let member: AgentMember = serde_json::from_str(&raw).expect("member");
+        assert_eq!(member.agent_id, format!("{TEST_SENDER}@{TEST_TEAM}"));
+        assert_eq!(member.name, AgentName::from_validated(TEST_SENDER));
         assert_eq!(member.agent_type, AgentType::GeneralPurpose);
         assert_eq!(member.model, "claude-sonnet-4-5");
         assert_eq!(member.joined_at, Some(1770765919076));
@@ -180,9 +182,10 @@ mod tests {
     #[test]
     fn parse_name_and_agent_type_record_succeeds() {
         let member: AgentMember =
-            serde_json::from_str(r#"{"name":"arch-ctm","agentType":"plan"}"#).expect("member");
+            serde_json::from_str(&format!(r#"{{"name":"{TEST_SENDER}","agentType":"plan"}}"#))
+                .expect("member");
 
-        assert_eq!(member.name, AgentName::from_validated("arch-ctm"));
+        assert_eq!(member.name, AgentName::from_validated(TEST_SENDER));
         assert_eq!(member.agent_type, AgentType::Plan);
         assert!(member.agent_id.is_empty());
         assert!(member.model.is_empty());
@@ -191,5 +194,3 @@ mod tests {
         assert!(member.cwd.is_empty());
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -1,5 +1,7 @@
 //! Shared inbox compatibility schema for Claude-native envelopes plus ATM metadata.
 
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -843,3 +845,5 @@ mod tests {
         );
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -1,7 +1,5 @@
 //! Shared inbox compatibility schema for Claude-native envelopes plus ATM metadata.
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -475,6 +473,8 @@ mod tests {
         LegacyMessageId, MessageEnvelope, MessageMetadata, PendingAck,
         hydrate_legacy_fields_from_metadata, to_shared_inbox_value,
     };
+    use crate::roles::ROLE_TEAM_LEAD;
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
 
     #[test]
     fn alert_kind_round_trips_known_and_unknown_wire_values() {
@@ -501,7 +501,7 @@ mod tests {
         // Claude-native schema. Ownership is documented in
         // docs/legacy-atm-message-schema.md and docs/atm-message-schema.md.
         let envelope = MessageEnvelope {
-            from: "arch-ctm".parse().expect("agent"),
+            from: TEST_SENDER.parse().expect("agent"),
             text: "hello".into(),
             timestamp: IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
@@ -509,7 +509,7 @@ mod tests {
                     .expect("timestamp"),
             ),
             read: false,
-            source_team: Some("atm-dev".parse().expect("team")),
+            source_team: Some(TEST_TEAM.parse().expect("team")),
             summary: Some("hello".into()),
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: Some(IsoTimestamp::from_datetime(
@@ -535,7 +535,7 @@ mod tests {
         // redefining external schemas documented in
         // docs/claude-code-message-schema.md.
         let json = json!({
-            "from": "team-lead",
+            "from": ROLE_TEAM_LEAD,
             "text": "hello",
             "timestamp": "2026-03-30T00:00:00Z",
             "read": false,
@@ -552,7 +552,7 @@ mod tests {
     #[test]
     fn message_id_is_optional() {
         let json = json!({
-            "from": "team-lead",
+            "from": ROLE_TEAM_LEAD,
             "text": "hello",
             "timestamp": "2026-03-30T00:00:00Z",
             "read": false
@@ -566,7 +566,7 @@ mod tests {
     #[test]
     fn blank_task_id_is_rejected() {
         let json = json!({
-            "from": "team-lead",
+            "from": ROLE_TEAM_LEAD,
             "text": "hello",
             "timestamp": "2026-03-30T00:00:00Z",
             "read": false,
@@ -582,7 +582,7 @@ mod tests {
     fn pending_ack_round_trips() {
         let pending_ack = PendingAck {
             message_id: LegacyMessageId::new(),
-            from: "team-lead".parse().expect("agent"),
+            from: ROLE_TEAM_LEAD.parse().expect("agent"),
             acked: true,
             acked_at: Some(IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 1)
@@ -605,7 +605,7 @@ mod tests {
             metadata: MessageMetadata {
                 atm: Some(AtmMetadataFields {
                     message_id: Some(message_id),
-                    source_team: Some("atm-dev".parse().expect("team name")),
+                    source_team: Some(TEST_TEAM.parse().expect("team name")),
                     from_identity: None,
                     pending_ack_at: None,
                     acknowledged_at: None,
@@ -665,7 +665,7 @@ mod tests {
     #[test]
     fn shared_inbox_write_shape_moves_machine_fields_into_metadata() {
         let envelope = MessageEnvelope {
-            from: "arch-ctm".parse().expect("agent"),
+            from: TEST_SENDER.parse().expect("agent"),
             text: "hello".into(),
             timestamp: IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
@@ -673,7 +673,7 @@ mod tests {
                     .expect("timestamp"),
             ),
             read: false,
-            source_team: Some("atm-dev".parse().expect("team")),
+            source_team: Some(TEST_TEAM.parse().expect("team")),
             summary: Some("hello".into()),
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: Some(IsoTimestamp::from_datetime(
@@ -701,7 +701,7 @@ mod tests {
             .and_then(Value::as_object)
             .expect("metadata.atm");
         assert!(!atm.contains_key("messageId"));
-        assert_eq!(atm.get("sourceTeam"), Some(&json!("atm-dev")));
+        assert_eq!(atm.get("sourceTeam"), Some(&json!(TEST_TEAM)));
         assert_eq!(atm.get("taskId"), Some(&json!("TASK-123")));
     }
 
@@ -713,7 +713,7 @@ mod tests {
                 .expect("timestamp"),
         );
         let envelope = MessageEnvelope {
-            from: "arch-ctm".parse().expect("agent"),
+            from: TEST_SENDER.parse().expect("agent"),
             text: "ack reply".into(),
             timestamp: IsoTimestamp::from_datetime(
                 Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
@@ -721,7 +721,7 @@ mod tests {
                     .expect("timestamp"),
             ),
             read: false,
-            source_team: Some("atm-dev".parse().expect("team")),
+            source_team: Some(TEST_TEAM.parse().expect("team")),
             summary: Some("ack reply".into()),
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: None,
@@ -752,7 +752,7 @@ mod tests {
     #[test]
     fn metadata_fields_hydrate_legacy_internal_shape() {
         let mut value = json!({
-            "from": "arch-ctm",
+            "from": TEST_SENDER,
             "text": "hello",
             "timestamp": "2026-03-30T00:00:00Z",
             "read": false,
@@ -760,7 +760,7 @@ mod tests {
             "metadata": {
                 "atm": {
                     "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
-                    "sourceTeam": "atm-dev",
+                    "sourceTeam": TEST_TEAM,
                     "pendingAckAt": "2026-03-30T00:00:01Z",
                     "taskId": "TASK-123"
                 }
@@ -770,14 +770,14 @@ mod tests {
         hydrate_legacy_fields_from_metadata(&mut value);
         let object = value.as_object().expect("object");
         assert!(object.contains_key("message_id"));
-        assert_eq!(object.get("source_team"), Some(&json!("atm-dev")));
+        assert_eq!(object.get("source_team"), Some(&json!(TEST_TEAM)));
         assert_eq!(object.get("taskId"), Some(&json!("TASK-123")));
     }
 
     #[test]
     fn metadata_fields_hydrate_legacy_ack_fields() {
         let mut value = json!({
-            "from": "arch-ctm",
+            "from": TEST_SENDER,
             "text": "ack reply",
             "timestamp": "2026-03-30T00:00:00Z",
             "read": false,
@@ -801,7 +801,7 @@ mod tests {
     #[test]
     fn hydrate_legacy_fields_ignores_malformed_metadata_without_panic() {
         let mut value = json!({
-            "from": "arch-ctm",
+            "from": TEST_SENDER,
             "text": "hello",
             "timestamp": "2026-03-30T00:00:00Z",
             "read": false,
@@ -822,7 +822,7 @@ mod tests {
     #[test]
     fn hydrate_legacy_fields_handles_partially_migrated_envelope() {
         let mut value = json!({
-            "from": "arch-ctm",
+            "from": TEST_SENDER,
             "text": "hello",
             "timestamp": "2026-03-30T00:00:00Z",
             "read": false,
@@ -845,5 +845,3 @@ mod tests {
         );
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/schema/permissions.rs
+++ b/crates/atm-core/src/schema/permissions.rs
@@ -2,3 +2,7 @@
 //!
 //! ATM 1.0 does not own a dedicated permissions document. Keep this placeholder
 //! as explicit deferred scope until a later phase introduces one.
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub(crate) struct DeferredPermissionsSchemaScope;

--- a/crates/atm-core/src/schema/settings.rs
+++ b/crates/atm-core/src/schema/settings.rs
@@ -3,3 +3,7 @@
 //! ATM 1.0 does not persist a standalone settings document. This module stays
 //! as a documented placeholder for future settings ownership instead of a bare
 //! TODO.
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub(crate) struct DeferredSettingsSchemaScope;

--- a/crates/atm-core/src/send/file_policy.rs
+++ b/crates/atm-core/src/send/file_policy.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -142,6 +140,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{MAX_FILE_REFERENCE_BYTES, process_file_reference};
+    use crate::test_support::TEST_TEAM;
 
     #[test]
     fn rejects_oversized_non_repo_file_references_before_copying() {
@@ -156,7 +155,7 @@ mod tests {
         let error = process_file_reference(
             &oversized_path,
             Some("see attached"),
-            &"atm-dev".parse().expect("team"),
+            &TEST_TEAM.parse().expect("team"),
             current_dir.path(),
             home_dir.path(),
         )
@@ -177,11 +176,9 @@ mod tests {
                     .join(".config")
                     .join("atm")
                     .join("share")
-                    .join("atm-dev")
+                    .join(TEST_TEAM)
             )
             .is_err()
         );
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/send/file_policy.rs
+++ b/crates/atm-core/src/send/file_policy.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -181,3 +183,5 @@ mod tests {
         );
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -499,20 +497,22 @@ mod tests {
         hook_result_log_level, parse_post_send_hook_result,
     };
     use crate::config::types::HookRecipient;
+    use crate::roles::ROLE_TEAM_LEAD;
+    use crate::test_support::TEST_SENDER;
 
     #[test]
     fn hook_matches_recipient_exact_and_wildcard_values() {
         assert!(hook_matches_recipient(
-            &HookRecipient::Named("arch-ctm".parse().expect("recipient")),
-            &"arch-ctm".parse().expect("candidate")
+            &HookRecipient::Named(TEST_SENDER.parse().expect("recipient")),
+            &TEST_SENDER.parse().expect("candidate")
         ));
         assert!(hook_matches_recipient(
             &HookRecipient::Wildcard,
-            &"arch-ctm".parse().expect("candidate")
+            &TEST_SENDER.parse().expect("candidate")
         ));
         assert!(!hook_matches_recipient(
-            &HookRecipient::Named("team-lead".parse().expect("recipient")),
-            &"arch-ctm".parse().expect("candidate")
+            &HookRecipient::Named(ROLE_TEAM_LEAD.parse().expect("recipient")),
+            &TEST_SENDER.parse().expect("candidate")
         ));
     }
 
@@ -568,5 +568,3 @@ mod tests {
         finish_abandoned_post_send_hook_stdout_capture(Some(handle), Path::new("hook"));
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -566,3 +568,5 @@ mod tests {
         finish_abandoned_post_send_hook_stdout_capture(Some(handle), Path::new("hook"));
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -1,5 +1,7 @@
 //! Send command service implementation and post-send hook handling.
 
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
@@ -620,3 +622,5 @@ mod tests {
         assert!(error.message.contains("team name"));
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -1,6 +1,7 @@
 //! Send command service implementation and post-send hook handling.
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+// lint-identities: allow-start -- production missing-config fallback logic
+// intentionally targets the reserved `team-lead` inbox and system notices.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -1,8 +1,5 @@
 //! Send command service implementation and post-send hook handling.
 
-// lint-identities: allow-start -- production missing-config fallback logic
-// intentionally targets the reserved `team-lead` inbox and system notices.
-
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
@@ -16,6 +13,7 @@ use crate::home;
 use crate::identity;
 use crate::mailbox;
 use crate::observability::{CommandEvent, ObservabilityPort};
+use crate::roles::ROLE_TEAM_LEAD;
 use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
 use crate::types::{AgentName, TaskId, TeamName};
 use crate::workflow;
@@ -363,14 +361,14 @@ fn notify_team_lead_missing_config(
         return;
     }
 
-    let team_lead_inbox = match home::inbox_path_from_home(home_dir, team, "team-lead") {
+    let team_lead_inbox = match home::inbox_path_from_home(home_dir, team, ROLE_TEAM_LEAD) {
         Ok(path) => path,
         Err(error) => {
             warn!(
                 code = %AtmErrorCode::WarningMissingTeamConfigFallback,
                 %error,
                 team = %team,
-                "failed to resolve team-lead inbox for missing-config notice"
+                "failed to resolve reserved missing-config inbox for notice"
             );
             return;
         }
@@ -418,7 +416,7 @@ fn notify_team_lead_missing_config(
     if let Err(error) = append_mailbox_message_and_seed_workflow(
         home_dir,
         team,
-        &AgentName::from_validated("team-lead"),
+        &AgentName::from_validated(ROLE_TEAM_LEAD),
         &team_lead_inbox,
         &notice,
     ) {
@@ -530,7 +528,9 @@ mod tests {
 
     use super::alert_state;
     use crate::process::process_is_alive;
+    use crate::roles::ROLE_TEAM_LEAD;
     use crate::send::{SendMessageSource, SendRequest};
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
 
     #[test]
     fn load_send_alert_state_parse_errors_are_config_errors() {
@@ -552,7 +552,7 @@ mod tests {
         let mut state = alert_state::SendAlertState::default();
         state
             .missing_team_config_keys
-            .insert("teams/atm-dev/config.json".to_string());
+            .insert(format!("teams/{TEST_TEAM}/config.json"));
 
         alert_state::save(&path, &state).expect("save");
         let loaded = alert_state::load(&path).expect("load");
@@ -589,9 +589,9 @@ mod tests {
         let error = SendRequest::new(
             tempdir.path().to_path_buf(),
             tempdir.path().to_path_buf(),
-            Some("team-lead"),
+            Some(ROLE_TEAM_LEAD),
             "../evil",
-            Some("atm-dev"),
+            Some(TEST_TEAM),
             SendMessageSource::Inline("hello".to_string()),
             None,
             false,
@@ -609,8 +609,8 @@ mod tests {
         let error = SendRequest::new(
             tempdir.path().to_path_buf(),
             tempdir.path().to_path_buf(),
-            Some("team-lead"),
-            "arch-ctm",
+            Some(ROLE_TEAM_LEAD),
+            TEST_SENDER,
             Some("../evil"),
             SendMessageSource::Inline("hello".to_string()),
             None,
@@ -623,5 +623,3 @@ mod tests {
         assert!(error.message.contains("team name"));
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -1,4 +1,5 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+// lint-identities: allow-start -- production team-admin logic preserves the
+// reserved `team-lead` role ordering and canonical agent-id formatting.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -767,3 +769,5 @@ mod tests {
         assert_eq!(error.code, AtmErrorCode::AddressParseFailed);
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -1,6 +1,3 @@
-// lint-identities: allow-start -- production team-admin logic preserves the
-// reserved `team-lead` role ordering and canonical agent-id formatting.
-
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -14,6 +11,7 @@ use crate::config::{load_config, load_team_config, resolve_team};
 use crate::error::{AtmError, AtmErrorCode, AtmErrorKind};
 use crate::home;
 use crate::persistence;
+use crate::roles::ROLE_TEAM_LEAD;
 use crate::schema::{AgentMember, TeamConfig};
 use crate::types::{AgentName, TeamName};
 
@@ -273,12 +271,12 @@ pub fn list_members(query: MembersQuery) -> Result<MembersList, AtmError> {
     if let Some(team_lead) = config
         .members
         .iter()
-        .find(|member| member.name == "team-lead")
+        .find(|member| member.name == ROLE_TEAM_LEAD)
     {
         members.push(member_summary(team_lead));
     }
     for member in &config.members {
-        if member.name == "team-lead" {
+        if member.name == ROLE_TEAM_LEAD {
             continue;
         }
         members.push(member_summary(member));
@@ -636,6 +634,7 @@ mod tests {
     };
     use crate::error_codes::AtmErrorCode;
     use crate::schema::TeamConfig;
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
 
     fn write_team_config(home_dir: &std::path::Path, team: &str) {
         let team_dir = home_dir.join(".claude").join("teams").join(team);
@@ -652,7 +651,7 @@ mod tests {
         let tempdir = tempdir().expect("tempdir");
         let error = AddMemberRequest::new(
             tempdir.path().to_path_buf(),
-            "atm-dev",
+            TEST_TEAM,
             "../evil",
             "worker".to_string(),
             "gpt-5".to_string(),
@@ -670,7 +669,7 @@ mod tests {
         let error = AddMemberRequest::new(
             tempdir.path().to_path_buf(),
             "../evil",
-            "arch-ctm",
+            TEST_SENDER,
             "worker".to_string(),
             "gpt-5".to_string(),
             tempdir.path().to_path_buf(),
@@ -685,12 +684,12 @@ mod tests {
     #[serial]
     fn add_member_normalizes_tmux_shape_when_pane_is_provided() {
         let tempdir = tempdir().expect("tempdir");
-        write_team_config(tempdir.path(), "atm-dev");
+        write_team_config(tempdir.path(), TEST_TEAM);
 
         add_member(AddMemberRequest {
             home_dir: tempdir.path().to_path_buf(),
-            team: "atm-dev".parse().expect("team"),
-            member: "arch-ctm".parse().expect("member"),
+            team: TEST_TEAM.parse().expect("team"),
+            member: TEST_SENDER.parse().expect("member"),
             agent_type: "worker".to_string(),
             model: "gpt-5".to_string(),
             cwd: tempdir.path().to_path_buf(),
@@ -698,7 +697,7 @@ mod tests {
         })
         .expect("add member");
 
-        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
+        let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
         let config: TeamConfig = serde_json::from_slice(
             &std::fs::read(team_dir.join("config.json")).expect("read config"),
         )
@@ -706,7 +705,7 @@ mod tests {
         let member = config
             .members
             .iter()
-            .find(|member| member.name == "arch-ctm")
+            .find(|member| member.name == TEST_SENDER)
             .expect("member");
 
         assert_eq!(member.tmux_pane_id, "%7");
@@ -717,12 +716,12 @@ mod tests {
     #[test]
     fn add_member_rejects_non_canonical_tmux_target_syntax() {
         let tempdir = tempdir().expect("tempdir");
-        write_team_config(tempdir.path(), "atm-dev");
+        write_team_config(tempdir.path(), TEST_TEAM);
 
         let error = add_member(AddMemberRequest {
             home_dir: tempdir.path().to_path_buf(),
-            team: "atm-dev".parse().expect("team"),
-            member: "arch-ctm".parse().expect("member"),
+            team: TEST_TEAM.parse().expect("team"),
+            member: TEST_SENDER.parse().expect("member"),
             agent_type: "worker".to_string(),
             model: "gpt-5".to_string(),
             cwd: tempdir.path().to_path_buf(),
@@ -770,5 +769,3 @@ mod tests {
         assert_eq!(error.code, AtmErrorCode::AddressParseFailed);
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/team_admin/restore.rs
+++ b/crates/atm-core/src/team_admin/restore.rs
@@ -1,4 +1,5 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+// lint-identities: allow-start -- restore logic must preserve the reserved
+// `team-lead` production role while filtering backup members and inbox names.
 
 use std::collections::BTreeSet;
 use std::fs;

--- a/crates/atm-core/src/team_admin/restore.rs
+++ b/crates/atm-core/src/team_admin/restore.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -902,3 +904,5 @@ mod tests {
         clear_restore_marker(&team_dir).expect("missing marker should be ok");
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/team_admin/restore.rs
+++ b/crates/atm-core/src/team_admin/restore.rs
@@ -1,6 +1,3 @@
-// lint-identities: allow-start -- restore logic must preserve the reserved
-// `team-lead` production role while filtering backup members and inbox names.
-
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -13,6 +10,7 @@ use crate::error::{AtmError, AtmErrorCode, AtmErrorKind};
 use crate::home;
 use crate::mailbox::lock;
 use crate::persistence;
+use crate::roles::ROLE_TEAM_LEAD;
 use crate::schema::AgentMember;
 
 use super::{RestoreOutcome, RestorePlan, RestoreRequest, RestoreResult};
@@ -29,7 +27,7 @@ pub(super) fn restore_team(request: RestoreRequest) -> Result<RestoreResult, Atm
     let members_to_restore = backup_config
         .members
         .iter()
-        .filter(|member| member.name != "team-lead")
+        .filter(|member| member.name != ROLE_TEAM_LEAD)
         .filter(|member| {
             !current_config
                 .members
@@ -42,7 +40,7 @@ pub(super) fn restore_team(request: RestoreRequest) -> Result<RestoreResult, Atm
 
     let mut inboxes_to_restore = list_backup_inboxes(&backup_dir)?;
     inboxes_to_restore.retain(|name| {
-        if name == "team-lead.json" {
+        if name == &format!("{ROLE_TEAM_LEAD}.json") {
             return false;
         }
         name.strip_suffix(".json").is_some_and(|member| {
@@ -71,7 +69,7 @@ pub(super) fn restore_team(request: RestoreRequest) -> Result<RestoreResult, Atm
     prepare_restore_workspace(&team_dir, &backup_dir)?;
     let mut updated_config = current_config.clone();
     for member in &backup_config.members {
-        if member.name == "team-lead" {
+        if member.name == ROLE_TEAM_LEAD {
             continue;
         }
         if updated_config
@@ -571,8 +569,10 @@ mod tests {
         clear_restore_marker, prepare_restore_workspace, restore_marker_path, restore_staging_dir,
         restore_task_state_from_backup, restore_team,
     };
+    use crate::roles::ROLE_TEAM_LEAD;
     use crate::schema::TeamConfig;
     use crate::team_admin::RestoreRequest;
+    use crate::test_support::{TEST_SENDER, TEST_TEAM};
 
     fn write_team_config(home_dir: &Path, team: &str, value: serde_json::Value) {
         write_json(
@@ -605,11 +605,11 @@ mod tests {
 
     fn write_inbox(path: &Path, text: &str) {
         let envelope = crate::schema::MessageEnvelope {
-            from: "team-lead".parse().expect("agent"),
+            from: ROLE_TEAM_LEAD.parse().expect("agent"),
             text: text.to_string(),
             timestamp: crate::types::IsoTimestamp::from_datetime(Utc::now()),
             read: false,
-            source_team: Some("atm-dev".parse().expect("team")),
+            source_team: Some(TEST_TEAM.parse().expect("team")),
             summary: None,
             message_id: None,
             pending_ack_at: None,
@@ -672,7 +672,7 @@ mod tests {
     #[test]
     fn prepare_restore_workspace_rejects_preexisting_staging_dir() {
         let tempdir = tempdir().expect("tempdir");
-        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
+        let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
         let backup_dir = tempdir.path().join("backup");
         fs::create_dir_all(restore_staging_dir(&team_dir)).expect("staging dir");
         fs::create_dir_all(&backup_dir).expect("backup dir");
@@ -692,7 +692,7 @@ mod tests {
     fn restore_task_state_from_backup_round_trips_highwatermark() {
         let tempdir = tempdir().expect("tempdir");
         let backup_tasks_dir = tempdir.path().join("backup").join("tasks");
-        let tasks_dir = tempdir.path().join(".claude").join("tasks").join("atm-dev");
+        let tasks_dir = tempdir.path().join(".claude").join("tasks").join(TEST_TEAM);
         write_json(
             &backup_tasks_dir.join("2.json"),
             &json!({"id":"2","status":"open"}),
@@ -727,28 +727,30 @@ mod tests {
         let tempdir = tempdir().expect("tempdir");
         write_team_config(
             tempdir.path(),
-            "atm-dev",
-            json!({"leadSessionId":"lead-current","members":[{"name":"team-lead"}]}),
+            TEST_TEAM,
+            json!({"leadSessionId":"lead-current","members":[{"name":ROLE_TEAM_LEAD}]}),
         );
         let backup_dir = tempdir
             .path()
             .join(".claude")
             .join("teams")
             .join(".backups")
-            .join("atm-dev")
+            .join(TEST_TEAM)
             .join("20260423T010203000000000Z");
         write_backup_config(
             &backup_dir,
             json!({
                 "leadSessionId":"lead-backup",
                 "members":[
-                    {"name":"team-lead"},
-                    {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+                    {"name":ROLE_TEAM_LEAD},
+                    {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
                 ]
             }),
         );
         write_inbox(
-            &backup_dir.join("inboxes").join("arch-ctm.json"),
+            &backup_dir
+                .join("inboxes")
+                .join(format!("{TEST_SENDER}.json")),
             "restored worker inbox",
         );
         write_json(
@@ -759,7 +761,7 @@ mod tests {
         let result = with_env_var_serial("ATM_TEST_FAIL_TEAM_CONFIG_WRITE", "1", || {
             restore_team(RestoreRequest {
                 home_dir: tempdir.path().to_path_buf(),
-                team: "atm-dev".parse().expect("team"),
+                team: TEST_TEAM.parse().expect("team"),
                 from: Some(backup_dir.clone()),
                 dry_run: false,
             })
@@ -767,19 +769,24 @@ mod tests {
 
         let error = result.expect_err("restore failure");
         assert!(error.is_file_policy());
-        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
+        let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
         let config: TeamConfig =
             serde_json::from_slice(&fs::read(team_dir.join("config.json")).expect("config"))
                 .expect("parse config");
         assert_eq!(config.members.len(), 1);
-        assert_eq!(config.members[0].name, "team-lead");
-        assert!(team_dir.join("inboxes").join("arch-ctm.json").is_file());
+        assert_eq!(config.members[0].name, ROLE_TEAM_LEAD);
+        assert!(
+            team_dir
+                .join("inboxes")
+                .join(format!("{TEST_SENDER}.json"))
+                .is_file()
+        );
         assert!(
             tempdir
                 .path()
                 .join(".claude")
                 .join("tasks")
-                .join("atm-dev")
+                .join(TEST_TEAM)
                 .join("80.json")
                 .is_file()
         );
@@ -792,35 +799,37 @@ mod tests {
         let tempdir = tempdir().expect("tempdir");
         write_team_config(
             tempdir.path(),
-            "atm-dev",
-            json!({"leadSessionId":"lead-current","members":[{"name":"team-lead"}]}),
+            TEST_TEAM,
+            json!({"leadSessionId":"lead-current","members":[{"name":ROLE_TEAM_LEAD}]}),
         );
         let backup_dir = tempdir
             .path()
             .join(".claude")
             .join("teams")
             .join(".backups")
-            .join("atm-dev")
+            .join(TEST_TEAM)
             .join("20260423T020304000000000Z");
         write_backup_config(
             &backup_dir,
             json!({
                 "leadSessionId":"lead-backup",
                 "members":[
-                    {"name":"team-lead"},
-                    {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+                    {"name":ROLE_TEAM_LEAD},
+                    {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
                 ]
             }),
         );
         write_inbox(
-            &backup_dir.join("inboxes").join("arch-ctm.json"),
+            &backup_dir
+                .join("inboxes")
+                .join(format!("{TEST_SENDER}.json")),
             "restored worker inbox",
         );
 
         let result = with_env_var_serial("ATM_TEST_FAIL_RESTORE_MARKER_REMOVE", "1", || {
             restore_team(RestoreRequest {
                 home_dir: tempdir.path().to_path_buf(),
-                team: "atm-dev".parse().expect("team"),
+                team: TEST_TEAM.parse().expect("team"),
                 from: Some(backup_dir.clone()),
                 dry_run: false,
             })
@@ -830,7 +839,7 @@ mod tests {
             result.is_ok(),
             "restore should succeed despite marker cleanup"
         );
-        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
+        let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
         assert!(restore_marker_path(&team_dir).is_file());
         let config: TeamConfig =
             serde_json::from_slice(&fs::read(team_dir.join("config.json")).expect("config"))
@@ -839,7 +848,7 @@ mod tests {
             config
                 .members
                 .iter()
-                .any(|member| member.name == "arch-ctm")
+                .any(|member| member.name == TEST_SENDER)
         );
     }
 
@@ -849,36 +858,38 @@ mod tests {
         let tempdir = tempdir().expect("tempdir");
         write_team_config(
             tempdir.path(),
-            "atm-dev",
-            json!({"leadSessionId":"lead-current","members":[{"name":"team-lead"}]}),
+            TEST_TEAM,
+            json!({"leadSessionId":"lead-current","members":[{"name":ROLE_TEAM_LEAD}]}),
         );
-        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
+        let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
         let backup_dir = tempdir
             .path()
             .join(".claude")
             .join("teams")
             .join(".backups")
-            .join("atm-dev")
+            .join(TEST_TEAM)
             .join("20260424T022700000000000Z");
         write_backup_config(
             &backup_dir,
             json!({
                 "leadSessionId":"lead-backup",
                 "members":[
-                    {"name":"team-lead"},
-                    {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+                    {"name":ROLE_TEAM_LEAD},
+                    {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
                 ]
             }),
         );
         write_inbox(
-            &backup_dir.join("inboxes").join("arch-ctm.json"),
+            &backup_dir
+                .join("inboxes")
+                .join(format!("{TEST_SENDER}.json")),
             "restored worker inbox",
         );
 
         let result = with_env_var_serial("ATM_TEST_FAIL_RESTORE_INBOX_STAGE", "1", || {
             restore_team(RestoreRequest {
                 home_dir: tempdir.path().to_path_buf(),
-                team: "atm-dev".parse().expect("team"),
+                team: TEST_TEAM.parse().expect("team"),
                 from: Some(backup_dir.clone()),
                 dry_run: false,
             })
@@ -891,19 +902,22 @@ mod tests {
             serde_json::from_slice(&fs::read(team_dir.join("config.json")).expect("config"))
                 .expect("parse config");
         assert_eq!(config.members.len(), 1);
-        assert_eq!(config.members[0].name, "team-lead");
-        assert!(!team_dir.join("inboxes").join("arch-ctm.json").exists());
+        assert_eq!(config.members[0].name, ROLE_TEAM_LEAD);
+        assert!(
+            !team_dir
+                .join("inboxes")
+                .join(format!("{TEST_SENDER}.json"))
+                .exists()
+        );
         assert!(restore_marker_path(&team_dir).is_file());
     }
 
     #[test]
     fn clear_restore_marker_missing_file_is_ok() {
         let tempdir = tempdir().expect("tempdir");
-        let team_dir = tempdir.path().join(".claude").join("teams").join("atm-dev");
+        let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
         fs::create_dir_all(&team_dir).expect("team dir");
 
         clear_restore_marker(&team_dir).expect("missing marker should be ok");
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/src/test_support.rs
+++ b/crates/atm-core/src/test_support.rs
@@ -1,0 +1,14 @@
+#![allow(dead_code)]
+
+pub const TEST_TEAM: &str = "test-team";
+pub const TEST_SENDER: &str = "sender-a";
+pub const TEST_RECIPIENT: &str = "recipient";
+pub const TEST_QA: &str = "qa-a";
+pub const TEST_QA_AGENT: &str = TEST_QA;
+pub use crate::roles::ROLE_TEAM_LEAD;
+pub const TEST_LEAD: &str = "test-lead";
+pub const TEST_DAEMON: &str = "daemon";
+pub const TEST_ORIGIN: &str = "host-a";
+pub const TEST_SENDER_ADDRESS: &str = "sender-a@test-team";
+pub const TEST_RECIPIENT_ADDRESS: &str = "recipient@test-team";
+pub const TEST_LEAD_ADDRESS: &str = "test-lead@test-team";

--- a/crates/atm-core/src/workflow.rs
+++ b/crates/atm-core/src/workflow.rs
@@ -5,6 +5,8 @@
 //! project these fields onto the Claude-owned inbox surface, but command-layer
 //! code must not shape or persist workflow JSON directly.
 
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -366,3 +368,5 @@ mod tests {
         assert_eq!(state.messages.len(), 1);
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm-core/src/workflow.rs
+++ b/crates/atm-core/src/workflow.rs
@@ -5,8 +5,6 @@
 //! project these fields onto the Claude-owned inbox surface, but command-layer
 //! code must not shape or persist workflow JSON directly.
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -262,15 +260,16 @@ mod tests {
         set_atm_message_id, workflow_key,
     };
     use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
+    use crate::test_support::{TEST_LEAD, TEST_SENDER, TEST_TEAM};
     use crate::types::{AgentName, IsoTimestamp, TeamName};
 
     fn sample_message() -> MessageEnvelope {
         MessageEnvelope {
-            from: "team-lead".parse::<AgentName>().expect("agent"),
+            from: TEST_LEAD.parse::<AgentName>().expect("agent"),
             text: "hello".to_string(),
             timestamp: IsoTimestamp::now(),
             read: false,
-            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
+            source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team")),
             summary: None,
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: None,
@@ -284,7 +283,8 @@ mod tests {
     #[test]
     fn load_missing_workflow_state_returns_default() {
         let tempdir = TempDir::new().expect("tempdir");
-        let state = load_workflow_state(tempdir.path(), "atm-dev", "arch-ctm").expect("load state");
+        let state =
+            load_workflow_state(tempdir.path(), TEST_TEAM, TEST_SENDER).expect("load state");
 
         assert!(state.messages.is_empty());
     }
@@ -302,9 +302,9 @@ mod tests {
             },
         );
 
-        save_workflow_state(tempdir.path(), "atm-dev", "arch-ctm", &state).expect("save state");
+        save_workflow_state(tempdir.path(), TEST_TEAM, TEST_SENDER, &state).expect("save state");
         let loaded =
-            load_workflow_state(tempdir.path(), "atm-dev", "arch-ctm").expect("load state");
+            load_workflow_state(tempdir.path(), TEST_TEAM, TEST_SENDER).expect("load state");
 
         assert_eq!(loaded, state);
     }
@@ -368,5 +368,3 @@ mod tests {
         assert_eq!(state.messages.len(), 1);
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -810,8 +810,10 @@ fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     // These tests mutate process-global environment variables while exercising
     // mailbox lock behavior. Keep a single process-wide mutex in addition to
-    // #[serial] so a poisoned lock fails the suite closed instead of silently
-    // continuing with inconsistent shared state.
+    // `#[serial]` so a poisoned lock fails the suite closed instead of silently
+    // continuing with inconsistent shared state. The injected knobs still use
+    // the `ATM_TEST_*` prefix; there is no separate `ATM_INTERNAL_TEST_*`
+    // namespace on this branch.
     LOCK.get_or_init(|| Mutex::new(()))
 }
 

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -577,7 +577,7 @@ fn multi_source_read_and_clear_complete_without_deadlock() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn send_times_out_under_bounded_lock_contention() {
     let _env_lock = env_lock().lock().expect("env lock");
     let _timeout = EnvGuard::set_raw("ATM_TEST_MAILBOX_LOCK_TIMEOUT_MS", "100");
@@ -608,7 +608,7 @@ fn send_times_out_under_bounded_lock_contention() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn clear_dry_run_does_not_wait_on_mailbox_lock() {
     let _env_lock = env_lock().lock().expect("env lock");
     let fixture = Fixture::new();
@@ -645,7 +645,7 @@ fn clear_dry_run_does_not_wait_on_mailbox_lock() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn read_possible_write_only_locks_when_display_mutation_is_required() {
     let _env_lock = env_lock().lock().expect("env lock");
     let _timeout = EnvGuard::set_raw("ATM_TEST_MAILBOX_LOCK_TIMEOUT_MS", "100");
@@ -767,7 +767,7 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn clear_fails_closed_on_synthetic_source_discovery_fault() {
     let _env_lock = env_lock().lock().expect("env lock");
     let _fault = EnvGuard::set_raw("ATM_TEST_FORCE_SOURCE_DISCOVERY_FAULT", "1");
@@ -802,7 +802,7 @@ fn clear_fails_closed_on_synthetic_source_discovery_fault() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn send_reports_non_contention_lock_failures_without_timeout() {
     let _env_lock = env_lock().lock().expect("env lock");
     let _fault = EnvGuard::set_raw("ATM_TEST_FORCE_LOCK_NON_CONTENTION_ERROR", "1");

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -1,7 +1,10 @@
+#[cfg(unix)]
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::fs::OpenOptions;
-use std::sync::{Arc, Barrier, Mutex, OnceLock, mpsc};
+use std::sync::{Arc, Barrier, mpsc};
+#[cfg(unix)]
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -36,7 +39,7 @@ fn qualified(agent: &str) -> String {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn concurrent_ack_on_overlapping_inbox_sets_completes_without_deadlock() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
@@ -99,7 +102,7 @@ fn concurrent_ack_on_overlapping_inbox_sets_completes_without_deadlock() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() {
     let observability = Arc::new(NullObservability);
 
@@ -249,7 +252,7 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn concurrent_same_recipient_sends_preserve_mixed_payloads_and_workflow_state() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
@@ -322,7 +325,7 @@ fn concurrent_same_recipient_sends_preserve_mixed_payloads_and_workflow_state() 
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn concurrent_same_recipient_sends_preserve_preseeded_workflow_entries() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
@@ -399,7 +402,7 @@ fn concurrent_same_recipient_sends_preserve_preseeded_workflow_entries() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn missing_config_notice_seeds_team_lead_workflow_state() {
     let fixture = Fixture::new();
     let observability = NullObservability;
@@ -432,7 +435,7 @@ fn missing_config_notice_seeds_team_lead_workflow_state() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn concurrent_normal_send_and_missing_config_notice_complete_without_data_loss() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
@@ -496,7 +499,7 @@ fn concurrent_normal_send_and_missing_config_notice_complete_without_data_loss()
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn multi_source_read_and_clear_complete_without_deadlock() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
@@ -577,6 +580,7 @@ fn multi_source_read_and_clear_complete_without_deadlock() {
 }
 
 #[test]
+#[cfg(unix)]
 #[serial_test::serial(env)]
 fn send_times_out_under_bounded_lock_contention() {
     let _env_lock = env_lock().lock().expect("env lock");
@@ -608,6 +612,7 @@ fn send_times_out_under_bounded_lock_contention() {
 }
 
 #[test]
+#[cfg(unix)]
 #[serial_test::serial(env)]
 fn clear_dry_run_does_not_wait_on_mailbox_lock() {
     let _env_lock = env_lock().lock().expect("env lock");
@@ -645,6 +650,7 @@ fn clear_dry_run_does_not_wait_on_mailbox_lock() {
 }
 
 #[test]
+#[cfg(unix)]
 #[serial_test::serial(env)]
 fn read_possible_write_only_locks_when_display_mutation_is_required() {
     let _env_lock = env_lock().lock().expect("env lock");
@@ -711,7 +717,7 @@ fn read_possible_write_only_locks_when_display_mutation_is_required() {
 }
 
 #[test]
-#[serial_test::serial]
+#[serial_test::serial(env)]
 fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() {
     let fixture = Fixture::new();
     let observability = NullObservability;
@@ -767,6 +773,7 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
 }
 
 #[test]
+#[cfg(unix)]
 #[serial_test::serial(env)]
 fn clear_fails_closed_on_synthetic_source_discovery_fault() {
     let _env_lock = env_lock().lock().expect("env lock");
@@ -802,6 +809,7 @@ fn clear_fails_closed_on_synthetic_source_discovery_fault() {
 }
 
 #[test]
+#[cfg(unix)]
 #[serial_test::serial(env)]
 fn send_reports_non_contention_lock_failures_without_timeout() {
     let _env_lock = env_lock().lock().expect("env lock");
@@ -830,6 +838,7 @@ enum CommandOp {
 
 // Serializes process-environment mutation inside this test module. This is
 // process-local only; it does not coordinate with other test processes.
+#[cfg(unix)]
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     // These tests mutate the process-global `ATM_TEST_MAILBOX_LOCK_TIMEOUT_MS`,
@@ -841,11 +850,13 @@ fn env_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+#[cfg(unix)]
 struct EnvGuard {
     key: &'static str,
     original: Option<OsString>,
 }
 
+#[cfg(unix)]
 impl EnvGuard {
     fn set_raw(key: &'static str, value: &str) -> Self {
         let original = std::env::var_os(key);
@@ -854,6 +865,7 @@ impl EnvGuard {
     }
 }
 
+#[cfg(unix)]
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         match self.original.take() {
@@ -863,6 +875,7 @@ impl Drop for EnvGuard {
     }
 }
 
+#[cfg(unix)]
 fn set_env_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
     // SAFETY: these tests take a process-wide mutex and use #[serial] before
     // mutating the environment, so the mutation is serialized within this
@@ -870,6 +883,7 @@ fn set_env_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
     unsafe { std::env::set_var(key, value) }
 }
 
+#[cfg(unix)]
 fn remove_env_var<K: AsRef<OsStr>>(key: K) {
     // SAFETY: these tests take a process-wide mutex and use #[serial] before
     // mutating the environment, so the mutation is serialized within this

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::fs::OpenOptions;
@@ -12,11 +10,13 @@ use atm_core::clear::{ClearQuery, clear_mail};
 use atm_core::error::AtmErrorCode;
 use atm_core::observability::NullObservability;
 use atm_core::read::{ReadQuery, read_mail};
+use atm_core::roles::ROLE_TEAM_LEAD;
 use atm_core::schema::{
     AgentMember, AtmMessageId, LegacyMessageId, MessageEnvelope, TeamConfig,
     hydrate_legacy_fields_from_metadata,
 };
 use atm_core::send::{SendMessageSource, SendRequest, send_mail};
+use atm_core::test_support::{TEST_QA, TEST_RECIPIENT, TEST_SENDER, TEST_TEAM};
 use atm_core::types::{AckActivationMode, AgentName, IsoTimestamp, ReadSelection, TeamName};
 use chrono::Utc;
 use fs2::FileExt;
@@ -27,6 +27,14 @@ use uuid::Uuid;
 // Test-side ceiling guard only; production lock timeout defaults to 5s per
 // architecture §18.3.
 const TEST_LOCK_BUDGET_CEILING: Duration = Duration::from_secs(2);
+const PRIMARY_TEAM: &str = TEST_TEAM;
+const PRIMARY_AGENT: &str = TEST_SENDER;
+const SECONDARY_AGENT: &str = TEST_QA;
+const TEAM_LEAD: &str = ROLE_TEAM_LEAD;
+
+fn qualified(agent: &str) -> String {
+    format!("{agent}@{PRIMARY_TEAM}")
+}
 
 #[test]
 #[serial]
@@ -36,10 +44,14 @@ fn concurrent_ack_on_overlapping_inbox_sets_completes_without_deadlock() {
     let barrier = Arc::new(Barrier::new(3));
     let (tx, rx) = mpsc::channel();
 
-    let arch_request = fixture.ack_request("arch-ctm", fixture.arch_message_id, "ack from arch");
-    let qa_request = fixture.ack_request("qa", fixture.qa_message_id, "ack from qa");
+    let arch_request = fixture.ack_request(PRIMARY_AGENT, fixture.arch_message_id, "ack from arch");
+    let qa_request = fixture.ack_request(
+        SECONDARY_AGENT,
+        fixture.qa_message_id,
+        &format!("ack from {SECONDARY_AGENT}"),
+    );
 
-    for (label, request) in [("arch", arch_request), ("qa", qa_request)] {
+    for (label, request) in [("arch", arch_request), ("secondary", qa_request)] {
         let barrier = Arc::clone(&barrier);
         let tx = tx.clone();
         let observability = Arc::clone(&observability);
@@ -67,18 +79,18 @@ fn concurrent_ack_on_overlapping_inbox_sets_completes_without_deadlock() {
     );
     assert!(
         second.1.is_ok(),
-        "second ack failed for {}: {:?}; arch inbox: {:?}; qa inbox: {:?}",
+        "second ack failed for {}: {:?}; arch inbox: {:?}; secondary inbox: {:?}",
         second.0,
         second.1,
-        fixture.inbox_contents("arch-ctm"),
-        fixture.inbox_contents("qa")
+        fixture.inbox_contents(PRIMARY_AGENT),
+        fixture.inbox_contents(SECONDARY_AGENT)
     );
-    let arch_inbox = fixture.inbox_contents("arch-ctm");
-    let qa_inbox = fixture.inbox_contents("qa");
+    let arch_inbox = fixture.inbox_contents(PRIMARY_AGENT);
+    let qa_inbox = fixture.inbox_contents(SECONDARY_AGENT);
     assert!(
         arch_inbox
             .iter()
-            .any(|message| message.text == "ack from qa")
+            .any(|message| message.text == format!("ack from {SECONDARY_AGENT}"))
     );
     assert!(
         qa_inbox
@@ -94,17 +106,18 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
 
     let clear_fixture = Fixture::new();
     clear_fixture.write_primary_inbox(
-        "arch-ctm",
+        PRIMARY_AGENT,
         &[read_message(
-            "qa",
+            SECONDARY_AGENT,
             "clearable history entry",
             LegacyMessageId::from(Uuid::new_v4()),
         )],
     );
     let barrier = Arc::new(Barrier::new(3));
     let (tx, rx) = mpsc::channel();
-    let send_request = clear_fixture.send_request("team-lead", "arch-ctm@atm-dev", "new message");
-    let clear_request = clear_fixture.clear_query("arch-ctm");
+    let send_request =
+        clear_fixture.send_request(TEAM_LEAD, &qualified(PRIMARY_AGENT), "new message");
+    let clear_request = clear_fixture.clear_query(PRIMARY_AGENT);
     {
         let barrier = Arc::clone(&barrier);
         let tx = tx.clone();
@@ -141,7 +154,7 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
         .expect("second send/clear result");
     assert!(first.1.is_ok(), "{} failed: {:?}", first.0, first.1);
     assert!(second.1.is_ok(), "{} failed: {:?}", second.0, second.1);
-    let arch_inbox = clear_fixture.inbox_contents("arch-ctm");
+    let arch_inbox = clear_fixture.inbox_contents(PRIMARY_AGENT);
     assert!(
         arch_inbox
             .iter()
@@ -153,18 +166,19 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
     let ack_fixture = Fixture::new();
     let pending_message_id = LegacyMessageId::from(Uuid::new_v4());
     ack_fixture.write_primary_inbox(
-        "arch-ctm",
+        PRIMARY_AGENT,
         &[pending_ack_message(
-            "qa",
+            SECONDARY_AGENT,
             "pending ack",
             pending_message_id,
-            "atm-dev",
+            PRIMARY_TEAM,
         )],
     );
     let barrier = Arc::new(Barrier::new(3));
     let (tx, rx) = mpsc::channel();
-    let send_request = ack_fixture.send_request("team-lead", "arch-ctm@atm-dev", "new message");
-    let ack_request = ack_fixture.ack_request("arch-ctm", pending_message_id, "ack reply");
+    let send_request =
+        ack_fixture.send_request(TEAM_LEAD, &qualified(PRIMARY_AGENT), "new message");
+    let ack_request = ack_fixture.ack_request(PRIMARY_AGENT, pending_message_id, "ack reply");
     {
         let barrier = Arc::clone(&barrier);
         let tx = tx.clone();
@@ -201,7 +215,7 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
         .expect("second send/ack result");
     assert!(first.1.is_ok(), "{} failed: {:?}", first.0, first.1);
     assert!(second.1.is_ok(), "{} failed: {:?}", second.0, second.1);
-    let arch_inbox = ack_fixture.inbox_contents("arch-ctm");
+    let arch_inbox = ack_fixture.inbox_contents(PRIMARY_AGENT);
     assert!(
         arch_inbox
             .iter()
@@ -216,7 +230,7 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
         "pending message was not acknowledged: {:?}",
         arch_inbox
     );
-    let arch_workflow = ack_fixture.workflow_state_contents("arch-ctm");
+    let arch_workflow = ack_fixture.workflow_state_contents(PRIMARY_AGENT);
     assert!(
         arch_workflow["messages"][format!("legacy:{pending_message_id}")]["acknowledgedAt"]
             .as_str()
@@ -227,7 +241,7 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
                 .is_some(),
         "pending message was not acknowledged in workflow state: {arch_workflow:?}"
     );
-    let qa_inbox = ack_fixture.inbox_contents("qa");
+    let qa_inbox = ack_fixture.inbox_contents(SECONDARY_AGENT);
     assert!(
         qa_inbox.iter().any(|message| message.text == "ack reply"),
         "ack reply was not persisted: {:?}",
@@ -243,8 +257,9 @@ fn concurrent_same_recipient_sends_preserve_mixed_payloads_and_workflow_state() 
     let barrier = Arc::new(Barrier::new(3));
     let (tx, rx) = mpsc::channel();
 
-    let plain_request = fixture.send_request("team-lead", "arch-ctm@atm-dev", "plain payload");
-    let mut task_request = fixture.send_request("qa", "arch-ctm@atm-dev", "task payload");
+    let plain_request = fixture.send_request(TEAM_LEAD, &qualified(PRIMARY_AGENT), "plain payload");
+    let mut task_request =
+        fixture.send_request(SECONDARY_AGENT, &qualified(PRIMARY_AGENT), "task payload");
     task_request.requires_ack = true;
     task_request.task_id = Some("TASK-123".parse().expect("task id"));
     task_request.summary_override = Some("manual summary".to_string());
@@ -271,7 +286,7 @@ fn concurrent_same_recipient_sends_preserve_mixed_payloads_and_workflow_state() 
     assert!(first.1.is_ok(), "{} failed: {:?}", first.0, first.1);
     assert!(second.1.is_ok(), "{} failed: {:?}", second.0, second.1);
 
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(PRIMARY_AGENT);
     let plain_message = inbox
         .iter()
         .find(|message| message.text == "plain payload")
@@ -288,7 +303,7 @@ fn concurrent_same_recipient_sends_preserve_mixed_payloads_and_workflow_state() 
 
     let plain_atm_id = message_atm_id(plain_message);
     let task_atm_id = message_atm_id(task_message);
-    let workflow = fixture.workflow_state_contents("arch-ctm");
+    let workflow = fixture.workflow_state_contents(PRIMARY_AGENT);
     assert!(
         workflow["messages"][format!("atm:{plain_atm_id}")]
             .as_object()
@@ -313,7 +328,7 @@ fn concurrent_same_recipient_sends_preserve_preseeded_workflow_entries() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
     fixture.write_workflow_state(
-        "arch-ctm",
+        PRIMARY_AGENT,
         serde_json::json!({
             "messages": {
                 "legacy:existing": {
@@ -327,8 +342,9 @@ fn concurrent_same_recipient_sends_preserve_preseeded_workflow_entries() {
 
     let barrier = Arc::new(Barrier::new(3));
     let (tx, rx) = mpsc::channel();
-    let first_request = fixture.send_request("team-lead", "arch-ctm@atm-dev", "first payload");
-    let second_request = fixture.send_request("qa", "arch-ctm@atm-dev", "second payload");
+    let first_request = fixture.send_request(TEAM_LEAD, &qualified(PRIMARY_AGENT), "first payload");
+    let second_request =
+        fixture.send_request(SECONDARY_AGENT, &qualified(PRIMARY_AGENT), "second payload");
 
     for (label, request) in [("first", first_request), ("second", second_request)] {
         let barrier = Arc::clone(&barrier);
@@ -352,7 +368,7 @@ fn concurrent_same_recipient_sends_preserve_preseeded_workflow_entries() {
     assert!(first.1.is_ok(), "{} failed: {:?}", first.0, first.1);
     assert!(second.1.is_ok(), "{} failed: {:?}", second.0, second.1);
 
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(PRIMARY_AGENT);
     let first_message = inbox
         .iter()
         .find(|message| message.text == "first payload")
@@ -361,7 +377,7 @@ fn concurrent_same_recipient_sends_preserve_preseeded_workflow_entries() {
         .iter()
         .find(|message| message.text == "second payload")
         .expect("second inbox message");
-    let workflow = fixture.workflow_state_contents("arch-ctm");
+    let workflow = fixture.workflow_state_contents(PRIMARY_AGENT);
 
     assert!(
         workflow["messages"]["legacy:existing"]
@@ -389,20 +405,24 @@ fn missing_config_notice_seeds_team_lead_workflow_state() {
     let fixture = Fixture::new();
     let observability = NullObservability;
     fixture.create_team_without_config("broken-dev");
-    fixture.write_primary_inbox_for_team("broken-dev", "recipient", &[]);
-    fixture.write_primary_inbox_for_team("broken-dev", "team-lead", &[]);
+    fixture.write_primary_inbox_for_team("broken-dev", TEST_RECIPIENT, &[]);
+    fixture.write_primary_inbox_for_team("broken-dev", TEAM_LEAD, &[]);
 
     send_mail(
-        fixture.send_request("team-lead", "recipient@broken-dev", "broken send"),
+        fixture.send_request(
+            TEAM_LEAD,
+            &format!("{TEST_RECIPIENT}@broken-dev"),
+            "broken send",
+        ),
         &observability,
     )
     .expect("missing-config send");
 
-    let notices = fixture.inbox_contents_for_team("broken-dev", "team-lead");
+    let notices = fixture.inbox_contents_for_team("broken-dev", TEAM_LEAD);
     let notice = notices.first().expect("missing-config notice");
     assert_eq!(notice.from, "atm-identity-missing");
     assert_eq!(notice.source_team.as_deref(), Some("broken-dev"));
-    let workflow = fixture.workflow_state_contents_for_team("broken-dev", "team-lead");
+    let workflow = fixture.workflow_state_contents_for_team("broken-dev", TEAM_LEAD);
     let notice_atm_id = message_atm_id(notice);
     assert!(
         workflow["messages"][format!("atm:{notice_atm_id}")]
@@ -418,13 +438,17 @@ fn concurrent_normal_send_and_missing_config_notice_complete_without_data_loss()
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
     fixture.create_team_without_config("broken-dev");
-    fixture.write_primary_inbox_for_team("broken-dev", "recipient", &[]);
-    fixture.write_primary_inbox_for_team("broken-dev", "team-lead", &[]);
+    fixture.write_primary_inbox_for_team("broken-dev", TEST_RECIPIENT, &[]);
+    fixture.write_primary_inbox_for_team("broken-dev", TEAM_LEAD, &[]);
 
     let barrier = Arc::new(Barrier::new(3));
     let (tx, rx) = mpsc::channel();
-    let normal_request = fixture.send_request("team-lead", "arch-ctm@atm-dev", "normal send");
-    let broken_request = fixture.send_request("qa", "recipient@broken-dev", "broken send");
+    let normal_request = fixture.send_request(TEAM_LEAD, &qualified(PRIMARY_AGENT), "normal send");
+    let broken_request = fixture.send_request(
+        SECONDARY_AGENT,
+        &format!("{TEST_RECIPIENT}@broken-dev"),
+        "broken send",
+    );
 
     for (label, request) in [("normal", normal_request), ("broken", broken_request)] {
         let barrier = Arc::clone(&barrier);
@@ -450,21 +474,21 @@ fn concurrent_normal_send_and_missing_config_notice_complete_without_data_loss()
 
     assert!(
         fixture
-            .inbox_contents("arch-ctm")
+            .inbox_contents(PRIMARY_AGENT)
             .iter()
             .any(|message| message.text == "normal send"),
         "normal send missing from primary team inbox"
     );
     assert!(
         fixture
-            .inbox_contents_for_team("broken-dev", "recipient")
+            .inbox_contents_for_team("broken-dev", TEST_RECIPIENT)
             .iter()
             .any(|message| message.text == "broken send"),
         "missing-config recipient send was not persisted"
     );
-    let notices = fixture.inbox_contents_for_team("broken-dev", "team-lead");
+    let notices = fixture.inbox_contents_for_team("broken-dev", TEAM_LEAD);
     let notice = notices.first().expect("missing-config notice");
-    let workflow = fixture.workflow_state_contents_for_team("broken-dev", "team-lead");
+    let workflow = fixture.workflow_state_contents_for_team("broken-dev", TEAM_LEAD);
     let notice_atm_id = message_atm_id(notice);
     assert!(
         workflow["messages"][format!("atm:{notice_atm_id}")]["pendingAckAt"].is_null(),
@@ -478,27 +502,27 @@ fn multi_source_read_and_clear_complete_without_deadlock() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
     fixture.write_primary_inbox(
-        "arch-ctm",
+        PRIMARY_AGENT,
         &[unread_message(
-            "team-lead",
+            TEAM_LEAD,
             "primary unread",
             LegacyMessageId::from(Uuid::new_v4()),
         )],
     );
     fixture.write_origin_inbox(
-        "arch-ctm",
+        PRIMARY_AGENT,
         "host-b",
         &[unread_message(
-            "qa",
+            SECONDARY_AGENT,
             "origin unread b",
             LegacyMessageId::from(Uuid::new_v4()),
         )],
     );
     fixture.write_origin_inbox(
-        "arch-ctm",
+        PRIMARY_AGENT,
         "host-a",
         &[read_message(
-            "qa",
+            SECONDARY_AGENT,
             "origin read a",
             LegacyMessageId::from(Uuid::new_v4()),
         )],
@@ -506,8 +530,8 @@ fn multi_source_read_and_clear_complete_without_deadlock() {
 
     let barrier = Arc::new(Barrier::new(3));
     let (tx, rx) = mpsc::channel();
-    let read_request = fixture.read_query("arch-ctm");
-    let clear_request = fixture.clear_query("arch-ctm");
+    let read_request = fixture.read_query(PRIMARY_AGENT);
+    let clear_request = fixture.clear_query(PRIMARY_AGENT);
     for (label, op) in [
         (
             "read",
@@ -544,13 +568,13 @@ fn multi_source_read_and_clear_complete_without_deadlock() {
         .expect("second read/clear result");
     assert!(first.1.is_ok(), "{} failed: {:?}", first.0, first.1);
     assert!(second.1.is_ok(), "{} failed: {:?}", second.0, second.1);
-    let arch_inbox = fixture.inbox_contents("arch-ctm");
-    let host_a_inbox = fixture.origin_inbox_contents("arch-ctm", "host-a");
-    let host_b_inbox = fixture.origin_inbox_contents("arch-ctm", "host-b");
+    let arch_inbox = fixture.inbox_contents(PRIMARY_AGENT);
+    let host_a_inbox = fixture.origin_inbox_contents(PRIMARY_AGENT, "host-a");
+    let host_b_inbox = fixture.origin_inbox_contents(PRIMARY_AGENT, "host-b");
     let _ = (arch_inbox, host_a_inbox, host_b_inbox);
-    assert!(fixture.primary_inbox_path("arch-ctm").exists());
-    assert!(fixture.origin_inbox_path("arch-ctm", "host-a").exists());
-    assert!(fixture.origin_inbox_path("arch-ctm", "host-b").exists());
+    assert!(fixture.primary_inbox_path(PRIMARY_AGENT).exists());
+    assert!(fixture.origin_inbox_path(PRIMARY_AGENT, "host-a").exists());
+    assert!(fixture.origin_inbox_path(PRIMARY_AGENT, "host-b").exists());
 }
 
 #[test]
@@ -560,7 +584,7 @@ fn send_times_out_under_bounded_lock_contention() {
     let _timeout = EnvGuard::set_raw("ATM_TEST_MAILBOX_LOCK_TIMEOUT_MS", "100");
     let fixture = Fixture::new();
     let observability = NullObservability;
-    let lock_path = sentinel_path(&fixture.primary_inbox_path("arch-ctm"));
+    let lock_path = sentinel_path(&fixture.primary_inbox_path(PRIMARY_AGENT));
     let lock_file = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -572,7 +596,7 @@ fn send_times_out_under_bounded_lock_contention() {
 
     let started = Instant::now();
     let error = send_mail(
-        fixture.send_request("team-lead", "arch-ctm@atm-dev", "blocked send"),
+        fixture.send_request(TEAM_LEAD, &qualified(PRIMARY_AGENT), "blocked send"),
         &observability,
     )
     .expect_err("timeout");
@@ -591,14 +615,14 @@ fn clear_dry_run_does_not_wait_on_mailbox_lock() {
     let fixture = Fixture::new();
     let observability = NullObservability;
     fixture.write_primary_inbox(
-        "arch-ctm",
+        PRIMARY_AGENT,
         &[unread_message(
-            "team-lead",
+            TEAM_LEAD,
             "read without lock",
             LegacyMessageId::from(Uuid::new_v4()),
         )],
     );
-    let lock_path = sentinel_path(&fixture.primary_inbox_path("arch-ctm"));
+    let lock_path = sentinel_path(&fixture.primary_inbox_path(PRIMARY_AGENT));
     let lock_file = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -609,7 +633,7 @@ fn clear_dry_run_does_not_wait_on_mailbox_lock() {
     lock_file.lock_exclusive().expect("hold mailbox lock");
 
     let started = Instant::now();
-    let mut clear_query = fixture.clear_query("arch-ctm");
+    let mut clear_query = fixture.clear_query(PRIMARY_AGENT);
     clear_query.dry_run = true;
     let outcome = clear_mail(clear_query, &observability).expect("dry-run clear");
 
@@ -630,14 +654,14 @@ fn read_possible_write_only_locks_when_display_mutation_is_required() {
 
     let mutation_fixture = Fixture::new();
     mutation_fixture.write_primary_inbox(
-        "arch-ctm",
+        PRIMARY_AGENT,
         &[unread_message(
-            "team-lead",
+            TEAM_LEAD,
             "needs mark-read",
             LegacyMessageId::from(Uuid::new_v4()),
         )],
     );
-    let mutation_lock_path = sentinel_path(&mutation_fixture.primary_inbox_path("arch-ctm"));
+    let mutation_lock_path = sentinel_path(&mutation_fixture.primary_inbox_path(PRIMARY_AGENT));
     let mutation_lock_file = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -648,21 +672,22 @@ fn read_possible_write_only_locks_when_display_mutation_is_required() {
     mutation_lock_file
         .lock_exclusive()
         .expect("hold mutation lock");
-    let mut mutation_query = mutation_fixture.read_query("arch-ctm");
+    let mut mutation_query = mutation_fixture.read_query(PRIMARY_AGENT);
     mutation_query.ack_activation_mode = AckActivationMode::PromoteDisplayedUnread;
     let error = read_mail(mutation_query, &observability).expect_err("lock timeout");
     assert_eq!(error.code, AtmErrorCode::MailboxLockTimeout);
 
     let no_mutation_fixture = Fixture::new();
     no_mutation_fixture.write_primary_inbox(
-        "arch-ctm",
+        PRIMARY_AGENT,
         &[read_message(
-            "team-lead",
+            TEAM_LEAD,
             "already read",
             LegacyMessageId::from(Uuid::new_v4()),
         )],
     );
-    let no_mutation_lock_path = sentinel_path(&no_mutation_fixture.primary_inbox_path("arch-ctm"));
+    let no_mutation_lock_path =
+        sentinel_path(&no_mutation_fixture.primary_inbox_path(PRIMARY_AGENT));
     let no_mutation_lock_file = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -673,7 +698,7 @@ fn read_possible_write_only_locks_when_display_mutation_is_required() {
     no_mutation_lock_file
         .lock_exclusive()
         .expect("hold no-mutation lock");
-    let mut no_mutation_query = no_mutation_fixture.read_query("arch-ctm");
+    let mut no_mutation_query = no_mutation_fixture.read_query(PRIMARY_AGENT);
     no_mutation_query.ack_activation_mode = AckActivationMode::PromoteDisplayedUnread;
     no_mutation_query.selection_mode = ReadSelection::All;
     let started = Instant::now();
@@ -696,13 +721,13 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
     // direct helper call: send_mail internally assigns metadata.atm.messageId
     // via the private workflow::set_atm_message_id path before read_mail runs.
     send_mail(
-        fixture.send_request("team-lead", "arch-ctm@atm-dev", "hello sidecar"),
+        fixture.send_request(TEAM_LEAD, &qualified(PRIMARY_AGENT), "hello sidecar"),
         &observability,
     )
     .expect("send ULID-authored message");
 
-    let inbox_before =
-        fs::read_to_string(fixture.primary_inbox_path("arch-ctm")).expect("raw inbox before read");
+    let inbox_before = fs::read_to_string(fixture.primary_inbox_path(PRIMARY_AGENT))
+        .expect("raw inbox before read");
     let physical_before = find_inbox_json_line(&inbox_before, "hello sidecar");
     let atm_message_id = physical_before["metadata"]["atm"]["messageId"]
         .as_str()
@@ -710,7 +735,7 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
         .to_string();
     assert_eq!(physical_before["read"], false);
 
-    let mut read_query = fixture.read_query("arch-ctm");
+    let mut read_query = fixture.read_query(PRIMARY_AGENT);
     read_query.ack_activation_mode = AckActivationMode::PromoteDisplayedUnread;
     let outcome = read_mail(read_query, &observability).expect("read mail");
     assert!(
@@ -721,8 +746,8 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
         "read outcome should include the ULID-authored message"
     );
 
-    let inbox_after =
-        fs::read_to_string(fixture.primary_inbox_path("arch-ctm")).expect("raw inbox after read");
+    let inbox_after = fs::read_to_string(fixture.primary_inbox_path(PRIMARY_AGENT))
+        .expect("raw inbox after read");
     assert_eq!(inbox_after, inbox_before);
     let physical_after = find_inbox_json_line(&inbox_after, "hello sidecar");
     assert_eq!(
@@ -731,11 +756,11 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
     );
     assert_eq!(physical_after["read"], false);
     assert!(
-        !sentinel_path(&fixture.primary_inbox_path("arch-ctm")).exists(),
+        !sentinel_path(&fixture.primary_inbox_path(PRIMARY_AGENT)).exists(),
         "read-only ULID sidecar path must not leave a lock sentinel behind",
     );
 
-    let workflow = fixture.workflow_state_contents("arch-ctm");
+    let workflow = fixture.workflow_state_contents(PRIMARY_AGENT);
     assert_eq!(
         workflow["messages"][format!("atm:{atm_message_id}")]["read"],
         true
@@ -750,28 +775,28 @@ fn clear_fails_closed_on_synthetic_source_discovery_fault() {
     let fixture = Fixture::new();
     let observability = NullObservability;
     fixture.write_origin_inbox(
-        "arch-ctm",
+        PRIMARY_AGENT,
         "host-a",
         &[read_message(
-            "qa",
+            SECONDARY_AGENT,
             "origin read a",
             LegacyMessageId::from(Uuid::new_v4()),
         )],
     );
-    let before_primary =
-        fs::read_to_string(fixture.primary_inbox_path("arch-ctm")).expect("primary inbox before");
-    let before_origin = fs::read_to_string(fixture.origin_inbox_path("arch-ctm", "host-a"))
+    let before_primary = fs::read_to_string(fixture.primary_inbox_path(PRIMARY_AGENT))
+        .expect("primary inbox before");
+    let before_origin = fs::read_to_string(fixture.origin_inbox_path(PRIMARY_AGENT, "host-a"))
         .expect("origin inbox before");
 
-    let error = clear_mail(fixture.clear_query("arch-ctm"), &observability).expect_err("fault");
+    let error = clear_mail(fixture.clear_query(PRIMARY_AGENT), &observability).expect_err("fault");
 
     assert_eq!(error.code, AtmErrorCode::MailboxReadFailed);
     assert_eq!(
-        fs::read_to_string(fixture.primary_inbox_path("arch-ctm")).expect("primary inbox after"),
+        fs::read_to_string(fixture.primary_inbox_path(PRIMARY_AGENT)).expect("primary inbox after"),
         before_primary
     );
     assert_eq!(
-        fs::read_to_string(fixture.origin_inbox_path("arch-ctm", "host-a"))
+        fs::read_to_string(fixture.origin_inbox_path(PRIMARY_AGENT, "host-a"))
             .expect("origin inbox after"),
         before_origin
     );
@@ -787,7 +812,7 @@ fn send_reports_non_contention_lock_failures_without_timeout() {
     let started = Instant::now();
 
     let error = send_mail(
-        fixture.send_request("team-lead", "arch-ctm@atm-dev", "lock failure"),
+        fixture.send_request(TEAM_LEAD, &qualified(PRIMARY_AGENT), "lock failure"),
         &observability,
     )
     .expect_err("non-contention lock failure");
@@ -862,7 +887,11 @@ struct Fixture {
 impl Fixture {
     fn new() -> Self {
         let tempdir = tempfile::tempdir().expect("tempdir");
-        create_team_with_config(tempdir.path(), "atm-dev", &["team-lead", "arch-ctm", "qa"]);
+        create_team_with_config(
+            tempdir.path(),
+            PRIMARY_TEAM,
+            &[TEAM_LEAD, PRIMARY_AGENT, SECONDARY_AGENT],
+        );
 
         let arch_message_id = LegacyMessageId::from_atm_message_id(AtmMessageId::new());
         let qa_message_id = LegacyMessageId::from_atm_message_id(AtmMessageId::new());
@@ -873,21 +902,21 @@ impl Fixture {
             qa_message_id,
         };
         fixture.write_primary_inbox(
-            "arch-ctm",
+            PRIMARY_AGENT,
             &[pending_ack_message(
-                "qa",
+                SECONDARY_AGENT,
                 "arch pending",
                 arch_message_id,
-                "atm-dev",
+                PRIMARY_TEAM,
             )],
         );
         fixture.write_primary_inbox(
-            "qa",
+            SECONDARY_AGENT,
             &[pending_ack_message(
-                "arch-ctm",
-                "qa pending",
+                PRIMARY_AGENT,
+                &format!("{SECONDARY_AGENT} pending"),
                 qa_message_id,
-                "atm-dev",
+                PRIMARY_TEAM,
             )],
         );
 
@@ -904,7 +933,7 @@ impl Fixture {
             home_dir: self.tempdir.path().to_path_buf(),
             current_dir: self.tempdir.path().to_path_buf(),
             actor_override: Some(actor.parse().expect("actor")),
-            team_override: Some("atm-dev".parse().expect("team")),
+            team_override: Some(PRIMARY_TEAM.parse().expect("team")),
             message_id,
             reply_body: reply_body.to_string(),
         }
@@ -916,7 +945,7 @@ impl Fixture {
             current_dir: self.tempdir.path().to_path_buf(),
             actor_override: Some(actor.parse().expect("actor")),
             target_address: None,
-            team_override: Some("atm-dev".parse().expect("team")),
+            team_override: Some(PRIMARY_TEAM.parse().expect("team")),
             older_than: None,
             idle_only: false,
             dry_run: false,
@@ -929,7 +958,7 @@ impl Fixture {
             self.tempdir.path().to_path_buf(),
             Some(actor),
             None,
-            Some("atm-dev"),
+            Some(PRIMARY_TEAM),
             ReadSelection::Actionable,
             false,
             false,
@@ -948,7 +977,7 @@ impl Fixture {
             self.tempdir.path().to_path_buf(),
             Some(sender),
             to,
-            Some("atm-dev"),
+            Some(PRIMARY_TEAM),
             SendMessageSource::Inline(text.to_string()),
             None,
             false,
@@ -959,7 +988,7 @@ impl Fixture {
     }
 
     fn inbox_contents(&self, agent: &str) -> Vec<MessageEnvelope> {
-        self.inbox_contents_for_team("atm-dev", agent)
+        self.inbox_contents_for_team(PRIMARY_TEAM, agent)
     }
 
     fn origin_inbox_contents(&self, agent: &str, suffix: &str) -> Vec<MessageEnvelope> {
@@ -967,7 +996,7 @@ impl Fixture {
     }
 
     fn workflow_state_contents(&self, agent: &str) -> serde_json::Value {
-        self.workflow_state_contents_for_team("atm-dev", agent)
+        self.workflow_state_contents_for_team(PRIMARY_TEAM, agent)
     }
 
     fn inbox_contents_for_team(&self, team: &str, agent: &str) -> Vec<MessageEnvelope> {
@@ -1002,7 +1031,7 @@ impl Fixture {
     }
 
     fn primary_inbox_path(&self, agent: &str) -> std::path::PathBuf {
-        self.primary_inbox_path_for_team("atm-dev", agent)
+        self.primary_inbox_path_for_team(PRIMARY_TEAM, agent)
     }
 
     fn primary_inbox_path_for_team(&self, team: &str, agent: &str) -> std::path::PathBuf {
@@ -1016,13 +1045,13 @@ impl Fixture {
             .path()
             .join(".claude")
             .join("teams")
-            .join("atm-dev")
+            .join(PRIMARY_TEAM)
             .join("inboxes")
             .join(format!("{agent}.{suffix}.json"))
     }
 
     fn workflow_state_path(&self, agent: &str) -> std::path::PathBuf {
-        self.workflow_state_path_for_team("atm-dev", agent)
+        self.workflow_state_path_for_team(PRIMARY_TEAM, agent)
     }
 
     fn workflow_state_path_for_team(&self, team: &str, agent: &str) -> std::path::PathBuf {
@@ -1173,7 +1202,7 @@ fn read_message(from: &str, text: &str, message_id: LegacyMessageId) -> MessageE
     );
     atm.insert(
         "sourceTeam".to_string(),
-        serde_json::Value::String("atm-dev".to_string()),
+        serde_json::Value::String(PRIMARY_TEAM.to_string()),
     );
     metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
     extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
@@ -1188,7 +1217,7 @@ fn read_message(from: &str, text: &str, message_id: LegacyMessageId) -> MessageE
         text: text.to_string(),
         timestamp: IsoTimestamp::from_datetime(Utc::now()),
         read: true,
-        source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
+        source_team: Some(PRIMARY_TEAM.parse::<TeamName>().expect("team")),
         summary: None,
         message_id: Some(message_id),
         pending_ack_at: None,
@@ -1210,7 +1239,7 @@ fn unread_message(from: &str, text: &str, message_id: LegacyMessageId) -> Messag
     );
     atm.insert(
         "sourceTeam".to_string(),
-        serde_json::Value::String("atm-dev".to_string()),
+        serde_json::Value::String(PRIMARY_TEAM.to_string()),
     );
     metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
     extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
@@ -1225,7 +1254,7 @@ fn unread_message(from: &str, text: &str, message_id: LegacyMessageId) -> Messag
         text: text.to_string(),
         timestamp: IsoTimestamp::from_datetime(Utc::now()),
         read: false,
-        source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
+        source_team: Some(PRIMARY_TEAM.parse::<TeamName>().expect("team")),
         summary: None,
         message_id: Some(message_id),
         pending_ack_at: None,
@@ -1248,5 +1277,3 @@ fn message_atm_id_from_extra(
         .and_then(serde_json::Value::as_str)
         .and_then(|value| value.parse().ok())
 }
-
-// lint-identities: allow-end

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -20,7 +20,6 @@ use atm_core::test_support::{TEST_QA, TEST_RECIPIENT, TEST_SENDER, TEST_TEAM};
 use atm_core::types::{AckActivationMode, AgentName, IsoTimestamp, ReadSelection, TeamName};
 use chrono::Utc;
 use fs2::FileExt;
-use serial_test::serial;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -37,7 +36,7 @@ fn qualified(agent: &str) -> String {
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn concurrent_ack_on_overlapping_inbox_sets_completes_without_deadlock() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
@@ -100,7 +99,7 @@ fn concurrent_ack_on_overlapping_inbox_sets_completes_without_deadlock() {
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() {
     let observability = Arc::new(NullObservability);
 
@@ -250,7 +249,7 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn concurrent_same_recipient_sends_preserve_mixed_payloads_and_workflow_state() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
@@ -323,7 +322,7 @@ fn concurrent_same_recipient_sends_preserve_mixed_payloads_and_workflow_state() 
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn concurrent_same_recipient_sends_preserve_preseeded_workflow_entries() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
@@ -400,7 +399,7 @@ fn concurrent_same_recipient_sends_preserve_preseeded_workflow_entries() {
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn missing_config_notice_seeds_team_lead_workflow_state() {
     let fixture = Fixture::new();
     let observability = NullObservability;
@@ -433,7 +432,7 @@ fn missing_config_notice_seeds_team_lead_workflow_state() {
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn concurrent_normal_send_and_missing_config_notice_complete_without_data_loss() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
@@ -497,7 +496,7 @@ fn concurrent_normal_send_and_missing_config_notice_complete_without_data_loss()
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn multi_source_read_and_clear_complete_without_deadlock() {
     let fixture = Fixture::new();
     let observability = Arc::new(NullObservability);
@@ -578,7 +577,7 @@ fn multi_source_read_and_clear_complete_without_deadlock() {
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn send_times_out_under_bounded_lock_contention() {
     let _env_lock = env_lock().lock().expect("env lock");
     let _timeout = EnvGuard::set_raw("ATM_TEST_MAILBOX_LOCK_TIMEOUT_MS", "100");
@@ -609,7 +608,7 @@ fn send_times_out_under_bounded_lock_contention() {
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn clear_dry_run_does_not_wait_on_mailbox_lock() {
     let _env_lock = env_lock().lock().expect("env lock");
     let fixture = Fixture::new();
@@ -646,7 +645,7 @@ fn clear_dry_run_does_not_wait_on_mailbox_lock() {
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn read_possible_write_only_locks_when_display_mutation_is_required() {
     let _env_lock = env_lock().lock().expect("env lock");
     let _timeout = EnvGuard::set_raw("ATM_TEST_MAILBOX_LOCK_TIMEOUT_MS", "100");
@@ -712,7 +711,7 @@ fn read_possible_write_only_locks_when_display_mutation_is_required() {
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() {
     let fixture = Fixture::new();
     let observability = NullObservability;
@@ -768,7 +767,7 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn clear_fails_closed_on_synthetic_source_discovery_fault() {
     let _env_lock = env_lock().lock().expect("env lock");
     let _fault = EnvGuard::set_raw("ATM_TEST_FORCE_SOURCE_DISCOVERY_FAULT", "1");
@@ -803,7 +802,7 @@ fn clear_fails_closed_on_synthetic_source_discovery_fault() {
 }
 
 #[test]
-#[serial]
+#[serial_test::serial]
 fn send_reports_non_contention_lock_failures_without_timeout() {
     let _env_lock = env_lock().lock().expect("env lock");
     let _fault = EnvGuard::set_raw("ATM_TEST_FORCE_LOCK_NON_CONTENTION_ERROR", "1");

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -833,12 +833,12 @@ enum CommandOp {
 // process-local only; it does not coordinate with other test processes.
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    // These tests mutate process-global environment variables while exercising
+    // These tests mutate the process-global `ATM_TEST_MAILBOX_LOCK_TIMEOUT_MS`,
+    // `ATM_TEST_FORCE_SOURCE_DISCOVERY_FAULT`, and
+    // `ATM_TEST_FORCE_LOCK_NON_CONTENTION_ERROR` knobs while exercising
     // mailbox lock behavior. Keep a single process-wide mutex in addition to
     // `#[serial]` so a poisoned lock fails the suite closed instead of silently
-    // continuing with inconsistent shared state. The injected knobs still use
-    // the `ATM_TEST_*` prefix; there is no separate `ATM_INTERNAL_TEST_*`
-    // namespace on this branch.
+    // continuing with inconsistent shared state.
     LOCK.get_or_init(|| Mutex::new(()))
 }
 

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -1,15 +1,19 @@
 #[cfg(unix)]
 use std::ffi::{OsStr, OsString};
 use std::fs;
+#[cfg(unix)]
 use std::fs::OpenOptions;
 use std::sync::{Arc, Barrier, mpsc};
 #[cfg(unix)]
 use std::sync::{Mutex, OnceLock};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(unix)]
+use std::time::Instant;
 
 use atm_core::ack::{AckRequest, ack_mail};
 use atm_core::clear::{ClearQuery, clear_mail};
+#[cfg(unix)]
 use atm_core::error::AtmErrorCode;
 use atm_core::observability::NullObservability;
 use atm_core::read::{ReadQuery, read_mail};

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -26,12 +26,14 @@ use atm_core::send::{SendMessageSource, SendRequest, send_mail};
 use atm_core::test_support::{TEST_QA, TEST_RECIPIENT, TEST_SENDER, TEST_TEAM};
 use atm_core::types::{AckActivationMode, AgentName, IsoTimestamp, ReadSelection, TeamName};
 use chrono::Utc;
+#[cfg(unix)]
 use fs2::FileExt;
 use tempfile::TempDir;
 use uuid::Uuid;
 
 // Test-side ceiling guard only; production lock timeout defaults to 5s per
 // architecture §18.3.
+#[cfg(unix)]
 const TEST_LOCK_BUDGET_CEILING: Duration = Duration::from_secs(2);
 const PRIMARY_TEAM: &str = TEST_TEAM;
 const PRIMARY_AGENT: &str = TEST_SENDER;

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::fs::OpenOptions;
@@ -1244,3 +1246,5 @@ fn message_atm_id_from_extra(
         .and_then(serde_json::Value::as_str)
         .and_then(|value| value.parse().ok())
 }
+
+// lint-identities: allow-end

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -130,3 +132,5 @@ mod tests {
         assert!(error.to_string().contains("agent name"));
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -108,14 +106,16 @@ impl SendCommand {
 #[cfg(test)]
 mod tests {
     use super::SendCommand;
+    use atm_core::roles::ROLE_TEAM_LEAD;
+    use atm_core::test_support::TEST_TEAM;
 
     #[test]
     fn build_request_rejects_invalid_target_before_core() {
         let command = SendCommand {
             to: "../evil".to_string(),
             message: Some("hello".to_string()),
-            from: Some("team-lead".to_string()),
-            team: Some("atm-dev".to_string()),
+            from: Some(ROLE_TEAM_LEAD.to_string()),
+            team: Some(TEST_TEAM.to_string()),
             file: None,
             stdin: false,
             summary: None,
@@ -132,5 +132,3 @@ mod tests {
         assert!(error.to_string().contains("agent name"));
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -176,3 +178,5 @@ mod tests {
         assert!(error.to_string().contains("agent name"));
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -139,12 +137,13 @@ impl RestoreCommand {
 #[cfg(test)]
 mod tests {
     use super::AddMemberCommand;
+    use atm_core::test_support::{TEST_SENDER, TEST_TEAM};
 
     #[test]
     fn build_request_rejects_invalid_team_before_core() {
         let command = AddMemberCommand {
             team: "../evil".to_string(),
-            member: "arch-ctm".to_string(),
+            member: TEST_SENDER.to_string(),
             agent_type: "worker".to_string(),
             model: "gpt-5".to_string(),
             cwd: None,
@@ -162,7 +161,7 @@ mod tests {
     #[test]
     fn build_request_rejects_invalid_member_before_core() {
         let command = AddMemberCommand {
-            team: "atm-dev".to_string(),
+            team: TEST_TEAM.to_string(),
             member: "../evil".to_string(),
             agent_type: "worker".to_string(),
             model: "gpt-5".to_string(),
@@ -178,5 +177,3 @@ mod tests {
         assert!(error.to_string().contains("agent name"));
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -1,5 +1,3 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::observability::{
     self, AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, CommandEvent, LogTailSession,
@@ -144,6 +142,7 @@ mod tests {
         AtmLogQuery, AtmObservabilityHealth, AtmObservabilityHealthState, CommandEvent,
         LogLevelFilter, LogMode, LogOrder, LogTailSession, ObservabilityPort,
     };
+    use atm_core::test_support::{TEST_SENDER, TEST_TEAM};
     use serial_test::serial;
     use tempfile::TempDir;
 
@@ -196,9 +195,9 @@ mod tests {
             command: "send",
             action: "send",
             outcome: "sent",
-            team: "atm-dev".parse().expect("team"),
-            agent: "arch-ctm".parse().expect("agent"),
-            sender: "arch-ctm".to_string(),
+            team: TEST_TEAM.parse().expect("team"),
+            agent: TEST_SENDER.parse().expect("agent"),
+            sender: TEST_SENDER.to_string(),
             message_id: message_id.map(|value| value.parse().expect("legacy message id")),
             requires_ack: false,
             dry_run: false,
@@ -300,5 +299,3 @@ mod tests {
         observability.emit_fatal_error("service", &AtmError::validation("boom"));
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -1,3 +1,5 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::observability::{
     self, AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, CommandEvent, LogTailSession,
@@ -298,3 +300,5 @@ mod tests {
         observability.emit_fatal_error("service", &AtmError::validation("boom"));
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -1,7 +1,5 @@
 mod support;
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs;
 use std::process::Command;
 
@@ -11,6 +9,9 @@ use atm_core::schema::{
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use chrono::{Duration, Utc};
 use serde_json::Value;
+use support::{
+    TEST_LEAD, TEST_LEAD_ADDRESS, TEST_ORIGIN, TEST_SENDER, TEST_SENDER_ADDRESS, TEST_TEAM,
+};
 use uuid::Uuid;
 
 fn parse_inbox_values(raw: &str) -> Vec<Value> {
@@ -29,10 +30,10 @@ fn parse_inbox_values(raw: &str) -> Vec<Value> {
 
 #[test]
 fn test_ack_transitions_pending_ack_and_appends_reply() {
-    let fixture = Fixture::new(&["arch-ctm", "team-lead"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_LEAD]);
     let message_id = Uuid::new_v4();
     let mut message = fixture.message(
-        "team-lead",
+        TEST_LEAD,
         "please ack",
         true,
         Some(Duration::minutes(5)),
@@ -40,7 +41,7 @@ fn test_ack_transitions_pending_ack_and_appends_reply() {
         message_id,
     );
     message.task_id = Some("TASK-123".parse().expect("task id"));
-    fixture.write_inbox("arch-ctm", &[message]);
+    fixture.write_inbox(TEST_SENDER, &[message]);
 
     let output = fixture.run(&[
         "ack",
@@ -57,20 +58,20 @@ fn test_ack_transitions_pending_ack_and_appends_reply() {
 
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["action"], "ack");
-    assert_eq!(parsed["team"], "atm-dev");
-    assert_eq!(parsed["agent"], "arch-ctm");
+    assert_eq!(parsed["team"], TEST_TEAM);
+    assert_eq!(parsed["agent"], TEST_SENDER);
     assert_eq!(parsed["message_id"], message_id.to_string());
     assert_eq!(parsed["task_id"], "TASK-123");
-    assert_eq!(parsed["reply_target"], "team-lead@atm-dev");
+    assert_eq!(parsed["reply_target"], TEST_LEAD_ADDRESS);
     assert_eq!(parsed["reply_text"], "received and starting");
     assert!(parsed["reply_message_id"].as_str().is_some());
 
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(TEST_SENDER);
     assert_eq!(inbox.len(), 1);
     assert!(inbox[0].read);
     assert!(inbox[0].pending_ack_at.is_some());
     assert!(inbox[0].acknowledged_at.is_none());
-    let workflow = fixture.workflow_state_contents("arch-ctm");
+    let workflow = fixture.workflow_state_contents(TEST_SENDER);
     assert_eq!(
         workflow["messages"][format!("legacy:{message_id}")]["read"],
         true
@@ -82,15 +83,15 @@ fn test_ack_transitions_pending_ack_and_appends_reply() {
             .is_some()
     );
 
-    let replies = fixture.inbox_contents("team-lead");
+    let replies = fixture.inbox_contents(TEST_LEAD);
     assert_eq!(replies.len(), 1);
     assert_eq!(replies[0].text, "received and starting");
-    assert_eq!(replies[0].from, "arch-ctm");
+    assert_eq!(replies[0].from, TEST_SENDER);
     assert_eq!(
         replies[0].acknowledges_message_id,
         Some(LegacyMessageId::from(message_id))
     );
-    let raw_replies = fixture.inbox_json_lines("team-lead");
+    let raw_replies = fixture.inbox_json_lines(TEST_LEAD);
     assert!(
         raw_replies[0]["metadata"]["atm"]["acknowledgesMessageId"]
             .as_str()
@@ -101,13 +102,13 @@ fn test_ack_transitions_pending_ack_and_appends_reply() {
 
 #[test]
 fn test_ack_updates_origin_inbox_file() {
-    let fixture = Fixture::new(&["arch-ctm", "team-lead"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_LEAD]);
     let message_id = Uuid::new_v4();
     fixture.write_origin_inbox(
-        "arch-ctm",
-        "host-a",
+        TEST_SENDER,
+        TEST_ORIGIN,
         &[fixture.message(
-            "team-lead",
+            TEST_LEAD,
             "origin pending",
             true,
             Some(Duration::minutes(5)),
@@ -123,11 +124,11 @@ fn test_ack_updates_origin_inbox_file() {
         fixture.stderr(&output)
     );
 
-    let origin = fixture.origin_inbox_contents("arch-ctm", "host-a");
+    let origin = fixture.origin_inbox_contents(TEST_SENDER, TEST_ORIGIN);
     assert_eq!(origin.len(), 1);
     assert!(origin[0].pending_ack_at.is_some());
     assert!(origin[0].acknowledged_at.is_none());
-    let workflow = fixture.workflow_state_contents("arch-ctm");
+    let workflow = fixture.workflow_state_contents(TEST_SENDER);
     assert!(
         workflow["messages"][format!("legacy:{message_id}")]["acknowledgedAt"]
             .as_str()
@@ -137,12 +138,12 @@ fn test_ack_updates_origin_inbox_file() {
 
 #[test]
 fn test_ack_emits_retained_log_record() {
-    let fixture = Fixture::new(&["arch-ctm", "team-lead"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_LEAD]);
     let message_id = Uuid::new_v4();
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[fixture.message(
-            "team-lead",
+            TEST_LEAD,
             "please ack",
             true,
             Some(Duration::minutes(5)),
@@ -165,7 +166,7 @@ fn test_ack_emits_retained_log_record() {
     assert!(
         records.iter().any(|record| {
             record["fields"]["command"] == "ack"
-                && record["fields"]["agent"] == "arch-ctm"
+                && record["fields"]["agent"] == TEST_SENDER
                 && record["fields"]["message_id"] == message_id.to_string()
         }),
         "stdout: {}",
@@ -175,10 +176,10 @@ fn test_ack_emits_retained_log_record() {
 
 #[test]
 fn test_ack_runs_post_send_hook_with_expected_payload() {
-    let fixture = Fixture::new(&["arch-ctm", "team-lead"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_LEAD]);
     let message_id = Uuid::new_v4();
     let mut message = fixture.message(
-        "team-lead",
+        TEST_LEAD,
         "please ack",
         true,
         Some(Duration::minutes(5)),
@@ -186,11 +187,12 @@ fn test_ack_runs_post_send_hook_with_expected_payload() {
         message_id,
     );
     message.task_id = Some("TASK-123".parse().expect("task id"));
-    fixture.write_inbox("arch-ctm", &[message]);
+    fixture.write_inbox(TEST_SENDER, &[message]);
 
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[[atm.post_send_hooks]]\nrecipient = 'team-lead'\ncommand = ['{}', 'capture', '{}']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['{}', 'capture', '{}']\n",
+        TEST_LEAD,
         hook_path.display(),
         payload_path.display()
     ));
@@ -209,8 +211,8 @@ fn test_ack_runs_post_send_hook_with_expected_payload() {
     );
     let payload: Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["from"], "arch-ctm@atm-dev");
-    assert_eq!(payload["to"], "team-lead@atm-dev");
+    assert_eq!(payload["from"], TEST_SENDER_ADDRESS);
+    assert_eq!(payload["to"], TEST_LEAD_ADDRESS);
     assert_eq!(payload["requires_ack"], false);
     assert_eq!(payload["is_ack"], true);
     assert_eq!(payload["task_id"], "TASK-123");
@@ -219,12 +221,12 @@ fn test_ack_runs_post_send_hook_with_expected_payload() {
 
 #[test]
 fn test_ack_post_send_hook_failure_surfaces_warning() {
-    let fixture = Fixture::new(&["arch-ctm", "team-lead"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_LEAD]);
     let message_id = Uuid::new_v4();
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[fixture.message(
-            "team-lead",
+            TEST_LEAD,
             "please ack",
             true,
             Some(Duration::minutes(5)),
@@ -235,7 +237,8 @@ fn test_ack_post_send_hook_failure_surfaces_warning() {
 
     let (hook_path, payload_path) = fixture.install_hook_fixture("fail");
     fixture.write_atm_config(&format!(
-        "[[atm.post_send_hooks]]\nrecipient = 'team-lead'\ncommand = ['{}', 'fail', '{}']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['{}', 'fail', '{}']\n",
+        TEST_LEAD,
         hook_path.display(),
         payload_path.display()
     ));
@@ -256,12 +259,12 @@ fn test_ack_post_send_hook_failure_surfaces_warning() {
 
 #[test]
 fn test_ack_rejects_already_acknowledged_message() {
-    let fixture = Fixture::new(&["arch-ctm", "team-lead"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_LEAD]);
     let message_id = Uuid::new_v4();
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[fixture.message(
-            "team-lead",
+            TEST_LEAD,
             "already acked",
             true,
             None,
@@ -282,11 +285,11 @@ fn test_ack_rejects_already_acknowledged_message() {
 
 #[test]
 fn test_ack_rejects_message_that_is_not_pending() {
-    let fixture = Fixture::new(&["arch-ctm", "team-lead"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_LEAD]);
     let message_id = Uuid::new_v4();
     fixture.write_inbox(
-        "arch-ctm",
-        &[fixture.message("team-lead", "plain read", true, None, None, message_id)],
+        TEST_SENDER,
+        &[fixture.message(TEST_LEAD, "plain read", true, None, None, message_id)],
     );
 
     let output = fixture.run(&["ack", &message_id.to_string(), "nope"]);
@@ -318,8 +321,8 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
-            .env("ATM_IDENTITY", "arch-ctm")
-            .env("ATM_TEAM", "atm-dev")
+            .env("ATM_IDENTITY", TEST_SENDER)
+            .env("ATM_TEAM", TEST_TEAM)
             .current_dir(self.tempdir.path())
             .output()
             .expect("run atm")
@@ -442,7 +445,7 @@ impl Fixture {
             .path()
             .join(".claude")
             .join("teams")
-            .join("atm-dev")
+            .join(TEST_TEAM)
     }
 
     fn install_hook_fixture(&self, mode: &str) -> (std::path::PathBuf, std::path::PathBuf) {
@@ -485,7 +488,7 @@ impl Fixture {
             text: text.to_string(),
             timestamp: timestamp.into(),
             read,
-            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
+            source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team")),
             summary: None,
             message_id: Some(LegacyMessageId::from(message_id)),
             pending_ack_at: pending_offset
@@ -498,5 +501,3 @@ impl Fixture {
         }
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm/tests/ack.rs
+++ b/crates/atm/tests/ack.rs
@@ -1,3 +1,7 @@
+mod support;
+
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::process::Command;
 
@@ -494,3 +498,5 @@ impl Fixture {
         }
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -1,7 +1,5 @@
 mod support;
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs;
 use std::process::Command;
 
@@ -9,6 +7,7 @@ use atm_core::schema::{AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use chrono::{Duration, Utc};
 use serde_json::Value;
+use support::{TEST_LEAD, TEST_ORIGIN, TEST_SENDER, TEST_TEAM};
 
 fn parse_inbox_values(raw: &str) -> Vec<Value> {
     if raw.trim().is_empty() {
@@ -26,12 +25,12 @@ fn parse_inbox_values(raw: &str) -> Vec<Value> {
 
 #[test]
 fn test_clear_default_removes_only_read_and_acknowledged() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[
             fixture.message(
-                "team-lead",
+                TEST_LEAD,
                 "unread",
                 false,
                 None,
@@ -39,7 +38,7 @@ fn test_clear_default_removes_only_read_and_acknowledged() {
                 Utc::now() - Duration::days(10),
             ),
             fixture.message(
-                "team-lead",
+                TEST_LEAD,
                 "pending",
                 true,
                 Some(Utc::now() - Duration::days(9)),
@@ -47,7 +46,7 @@ fn test_clear_default_removes_only_read_and_acknowledged() {
                 Utc::now() - Duration::days(9),
             ),
             fixture.message(
-                "team-lead",
+                TEST_LEAD,
                 "read",
                 true,
                 None,
@@ -55,7 +54,7 @@ fn test_clear_default_removes_only_read_and_acknowledged() {
                 Utc::now() - Duration::days(8),
             ),
             fixture.message(
-                "team-lead",
+                TEST_LEAD,
                 "acknowledged",
                 true,
                 None,
@@ -81,7 +80,7 @@ fn test_clear_default_removes_only_read_and_acknowledged() {
     assert!(parsed["removed_by_class"]["unread"].is_null());
     assert!(parsed["removed_by_class"]["pending_ack"].is_null());
 
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(TEST_SENDER);
     assert_eq!(inbox.len(), 2);
     assert_eq!(inbox[0].text, "unread");
     assert_eq!(inbox[1].text, "pending");
@@ -89,11 +88,11 @@ fn test_clear_default_removes_only_read_and_acknowledged() {
 
 #[test]
 fn test_clear_dry_run_does_not_mutate() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[fixture.message(
-            "team-lead",
+            TEST_LEAD,
             "read",
             true,
             None,
@@ -112,18 +111,18 @@ fn test_clear_dry_run_does_not_mutate() {
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["removed_total"], 1);
 
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(TEST_SENDER);
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].text, "read");
 }
 
 #[test]
 fn test_clear_emits_retained_log_record() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[fixture.message(
-            "team-lead",
+            TEST_LEAD,
             "read",
             true,
             None,
@@ -146,8 +145,8 @@ fn test_clear_emits_retained_log_record() {
     assert!(
         records.iter().any(|record| {
             record["fields"]["command"] == "clear"
-                && record["fields"]["agent"] == "arch-ctm"
-                && record["fields"]["team"] == "atm-dev"
+                && record["fields"]["agent"] == TEST_SENDER
+                && record["fields"]["team"] == TEST_TEAM
         }),
         "stdout: {}",
         String::from_utf8(output.stdout.clone()).expect("stdout utf8")
@@ -156,11 +155,11 @@ fn test_clear_emits_retained_log_record() {
 
 #[test]
 fn test_clear_never_removes_pending_ack() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[fixture.message(
-            "team-lead",
+            TEST_LEAD,
             "pending",
             true,
             Some(Utc::now() - Duration::days(2)),
@@ -178,9 +177,9 @@ fn test_clear_never_removes_pending_ack() {
     );
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["removed_total"], 0);
-    assert_eq!(fixture.inbox_contents("arch-ctm").len(), 1);
+    assert_eq!(fixture.inbox_contents(TEST_SENDER).len(), 1);
     assert!(
-        fixture.inbox_contents("arch-ctm")[0]
+        fixture.inbox_contents(TEST_SENDER)[0]
             .pending_ack_at
             .is_some()
     );
@@ -188,9 +187,9 @@ fn test_clear_never_removes_pending_ack() {
 
 #[test]
 fn test_clear_uses_workflow_sidecar_and_removes_cleared_entry() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER]);
     let message = fixture.message(
-        "team-lead",
+        TEST_LEAD,
         "sidecar-managed read",
         false,
         None,
@@ -198,9 +197,9 @@ fn test_clear_uses_workflow_sidecar_and_removes_cleared_entry() {
         Utc::now() - Duration::days(2),
     );
     let message_id = message.message_id.expect("message id");
-    fixture.write_inbox("arch-ctm", &[message]);
+    fixture.write_inbox(TEST_SENDER, &[message]);
     fixture.write_workflow_state(
-        "arch-ctm",
+        TEST_SENDER,
         serde_json::json!({
             "messages": {
                 format!("legacy:{message_id}"): {
@@ -217,27 +216,27 @@ fn test_clear_uses_workflow_sidecar_and_removes_cleared_entry() {
         "stderr: {}",
         fixture.stderr(&output)
     );
-    assert!(fixture.inbox_contents("arch-ctm").is_empty());
-    let workflow = fixture.workflow_state_contents("arch-ctm");
+    assert!(fixture.inbox_contents(TEST_SENDER).is_empty());
+    let workflow = fixture.workflow_state_contents(TEST_SENDER);
     assert!(workflow["messages"][format!("legacy:{message_id}")].is_null());
 }
 
 #[test]
 fn test_clear_idle_only_removes_only_idle_notifications() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[
             fixture.message(
-                "team-lead",
-                &idle_notification_text("team-lead"),
+                TEST_LEAD,
+                &idle_notification_text(TEST_LEAD),
                 true,
                 None,
                 None,
                 Utc::now() - Duration::days(4),
             ),
             fixture.message(
-                "team-lead",
+                TEST_LEAD,
                 "normal read",
                 true,
                 None,
@@ -258,16 +257,16 @@ fn test_clear_idle_only_removes_only_idle_notifications() {
     assert_eq!(parsed["removed_total"], 1);
     assert_eq!(parsed["removed_by_class"]["read"], 1);
 
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(TEST_SENDER);
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].text, "normal read");
 }
 
 #[test]
 fn test_clear_preserves_unknown_fields_on_retained_messages() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER]);
     let mut retained = fixture.message(
-        "team-lead",
+        TEST_LEAD,
         "pending",
         true,
         Some(Utc::now() - Duration::days(2)),
@@ -279,10 +278,10 @@ fn test_clear_preserves_unknown_fields_on_retained_messages() {
         .insert("futureField".into(), serde_json::json!({"nested": true}));
 
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[
             fixture.message(
-                "team-lead",
+                TEST_LEAD,
                 "clearable",
                 true,
                 None,
@@ -300,7 +299,7 @@ fn test_clear_preserves_unknown_fields_on_retained_messages() {
         "stderr: {}",
         fixture.stderr(&output)
     );
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(TEST_SENDER);
     assert_eq!(inbox.len(), 1);
     assert_eq!(
         inbox[0].extra["futureField"],
@@ -310,12 +309,12 @@ fn test_clear_preserves_unknown_fields_on_retained_messages() {
 
 #[test]
 fn test_clear_older_than_filters_candidates() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[
             fixture.message(
-                "team-lead",
+                TEST_LEAD,
                 "older",
                 true,
                 None,
@@ -323,7 +322,7 @@ fn test_clear_older_than_filters_candidates() {
                 Utc::now() - Duration::days(10),
             ),
             fixture.message(
-                "team-lead",
+                TEST_LEAD,
                 "newer",
                 true,
                 None,
@@ -343,18 +342,18 @@ fn test_clear_older_than_filters_candidates() {
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["removed_total"], 1);
 
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(TEST_SENDER);
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].text, "newer");
 }
 
 #[test]
 fn test_clear_explicit_target() {
-    let fixture = Fixture::new(&["arch-ctm", "agent-b"]);
+    let fixture = Fixture::new(&[TEST_SENDER, "agent-b"]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_SENDER,
         &[fixture.message(
-            "team-lead",
+            TEST_LEAD,
             "keep mine",
             true,
             None,
@@ -365,7 +364,7 @@ fn test_clear_explicit_target() {
     fixture.write_inbox(
         "agent-b",
         &[fixture.message(
-            "team-lead",
+            TEST_LEAD,
             "clear agent b",
             true,
             None,
@@ -374,7 +373,7 @@ fn test_clear_explicit_target() {
         )],
     );
 
-    let output = fixture.run(&["clear", "agent-b", "--as", "arch-ctm", "--json"]);
+    let output = fixture.run(&["clear", "agent-b", "--as", TEST_SENDER, "--json"]);
 
     assert!(
         output.status.success(),
@@ -385,17 +384,17 @@ fn test_clear_explicit_target() {
     assert_eq!(parsed["agent"], "agent-b");
     assert_eq!(parsed["removed_total"], 1);
     assert_eq!(fixture.inbox_contents("agent-b").len(), 0);
-    assert_eq!(fixture.inbox_contents("arch-ctm").len(), 1);
+    assert_eq!(fixture.inbox_contents(TEST_SENDER).len(), 1);
 }
 
 #[test]
 fn test_clear_removes_from_origin_inbox_file() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER]);
     fixture.write_origin_inbox(
-        "arch-ctm",
-        "host-a",
+        TEST_SENDER,
+        TEST_ORIGIN,
         &[fixture.message(
-            "team-lead",
+            TEST_LEAD,
             "origin read",
             true,
             None,
@@ -411,7 +410,12 @@ fn test_clear_removes_from_origin_inbox_file() {
         fixture.stderr(&output)
     );
 
-    assert_eq!(fixture.origin_inbox_contents("arch-ctm", "host-a").len(), 0);
+    assert_eq!(
+        fixture
+            .origin_inbox_contents(TEST_SENDER, TEST_ORIGIN)
+            .len(),
+        0
+    );
 }
 
 struct Fixture {
@@ -436,8 +440,8 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
-            .env("ATM_IDENTITY", "arch-ctm")
-            .env("ATM_TEAM", "atm-dev")
+            .env("ATM_IDENTITY", TEST_SENDER)
+            .env("ATM_TEAM", TEST_TEAM)
             .current_dir(self.tempdir.path());
         for (key, value) in extra_env {
             command.env(key, value);
@@ -560,7 +564,7 @@ impl Fixture {
             .path()
             .join(".claude")
             .join("teams")
-            .join("atm-dev")
+            .join(TEST_TEAM)
     }
 
     fn message(
@@ -577,7 +581,7 @@ impl Fixture {
             text: text.to_string(),
             timestamp: timestamp.into(),
             read,
-            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
+            source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team")),
             summary: None,
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: pending_ack_at.map(Into::into),
@@ -598,5 +602,3 @@ fn idle_notification_text(from: &str) -> String {
     })
     .to_string()
 }
-
-// lint-identities: allow-end

--- a/crates/atm/tests/clear.rs
+++ b/crates/atm/tests/clear.rs
@@ -1,3 +1,7 @@
+mod support;
+
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::process::Command;
 
@@ -594,3 +598,5 @@ fn idle_notification_text(from: &str) -> String {
     })
     .to_string()
 }
+
+// lint-identities: allow-end

--- a/crates/atm/tests/doctor.rs
+++ b/crates/atm/tests/doctor.rs
@@ -1,3 +1,7 @@
+mod support;
+
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::process::Command;
 
@@ -353,3 +357,5 @@ impl Fixture {
             .join("atm.log.jsonl")
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm/tests/doctor.rs
+++ b/crates/atm/tests/doctor.rs
@@ -1,16 +1,16 @@
 mod support;
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs;
 use std::process::Command;
+
+use support::{TEST_DAEMON, TEST_LEAD, TEST_QA, TEST_SENDER, TEST_TEAM};
 
 use atm_core::schema::{AgentMember, TeamConfig};
 use serde_json::Value;
 
 #[test]
 fn test_doctor_reports_healthy_observability_with_real_adapter() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
 
     let output = fixture.run(&["doctor", "--json"], &[]);
 
@@ -33,7 +33,7 @@ fn test_doctor_reports_healthy_observability_with_real_adapter() {
 
 #[test]
 fn test_doctor_reports_degraded_observability_with_real_fault_injection() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
 
     let output = fixture.run(
         &["doctor", "--json"],
@@ -58,7 +58,7 @@ fn test_doctor_reports_degraded_observability_with_real_fault_injection() {
 
 #[test]
 fn test_doctor_reports_unavailable_observability_with_real_fault_injection() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
 
     let output = fixture.run(
         &["doctor", "--json"],
@@ -79,8 +79,8 @@ fn test_doctor_reports_unavailable_observability_with_real_fault_injection() {
 
 #[test]
 fn test_doctor_reports_obsolete_identity_drift_warning() {
-    let fixture = Fixture::new(&["arch-ctm"]);
-    fixture.write_atm_config("[atm]\nidentity = \"arch-ctm\"\n");
+    let fixture = Fixture::new(&[TEST_LEAD]);
+    fixture.write_atm_config(&format!("[atm]\nidentity = \"{}\"\n", TEST_SENDER));
 
     let output = fixture.run(&["doctor", "--json"], &[]);
 
@@ -103,10 +103,11 @@ fn test_doctor_reports_obsolete_identity_drift_warning() {
 
 #[test]
 fn test_doctor_reports_missing_baseline_team_member() {
-    let fixture = Fixture::new(&["team-lead", "arch-ctm"]);
-    fixture.write_atm_config(
-        "[atm]\ndefault_team = \"atm-dev\"\nteam_members = [\"team-lead\", \"arch-ctm\", \"qa\"]\n",
-    );
+    let fixture = Fixture::new(&[TEST_LEAD, TEST_SENDER]);
+    fixture.write_atm_config(&format!(
+        "[atm]\ndefault_team = \"{}\"\nteam_members = [\"{}\", \"{}\", \"{}\"]\n",
+        TEST_TEAM, TEST_LEAD, TEST_SENDER, TEST_QA
+    ));
 
     let output = fixture.run(&["doctor", "--json"], &[]);
 
@@ -122,7 +123,7 @@ fn test_doctor_reports_missing_baseline_team_member() {
             finding["code"] == "ATM_WARNING_BASELINE_MEMBER_MISSING"
                 && finding["message"]
                     .as_str()
-                    .is_some_and(|message| message.contains("qa"))
+                    .is_some_and(|message| message.contains(TEST_QA))
         }),
         "stdout: {}",
         String::from_utf8(output.stdout.clone()).expect("stdout utf8")
@@ -131,10 +132,11 @@ fn test_doctor_reports_missing_baseline_team_member() {
 
 #[test]
 fn test_doctor_reports_member_roster_with_baseline_ordering() {
-    let fixture = Fixture::new(&["qa", "team-lead", "arch-ctm", "temp-worker"]);
-    fixture.write_atm_config(
-        "[atm]\ndefault_team = \"atm-dev\"\nteam_members = [\"arch-ctm\", \"team-lead\", \"qa\"]\n",
-    );
+    let fixture = Fixture::new(&[TEST_QA, TEST_SENDER, TEST_LEAD, TEST_DAEMON]);
+    fixture.write_atm_config(&format!(
+        "[atm]\ndefault_team = \"{}\"\nteam_members = [\"{}\", \"{}\", \"{}\"]\n",
+        TEST_TEAM, TEST_LEAD, TEST_SENDER, TEST_QA
+    ));
 
     let output = fixture.run(&["doctor", "--json"], &[]);
 
@@ -147,10 +149,10 @@ fn test_doctor_reports_member_roster_with_baseline_ordering() {
     let members = parsed["member_roster"]["members"]
         .as_array()
         .expect("member roster array");
-    assert_eq!(members[0]["name"], "team-lead");
-    assert_eq!(members[1]["name"], "arch-ctm");
-    assert_eq!(members[2]["name"], "qa");
-    assert_eq!(members[3]["name"], "temp-worker");
+    assert_eq!(members[0]["name"], TEST_LEAD);
+    assert_eq!(members[1]["name"], TEST_SENDER);
+    assert_eq!(members[2]["name"], TEST_QA);
+    assert_eq!(members[3]["name"], TEST_DAEMON);
 }
 
 #[test]
@@ -192,7 +194,7 @@ fn test_doctor_reports_team_config_parse_failure_finding() {
 
 #[test]
 fn test_doctor_reports_missing_inboxes_directory_finding() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fs::remove_dir_all(fixture.team_dir().join("inboxes")).expect("remove inboxes dir");
 
     let output = fixture.run(&["doctor", "--json"], &[]);
@@ -211,7 +213,7 @@ fn test_doctor_reports_missing_inboxes_directory_finding() {
 
 #[test]
 fn test_doctor_reports_stale_restore_marker_warning() {
-    let fixture = Fixture::new(&["team-lead", "arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_LEAD]);
     let backup_path = fixture.tempdir.path().join("backup");
     fs::write(
         fixture.team_dir().join(".restore-in-progress"),
@@ -239,7 +241,7 @@ fn test_doctor_reports_stale_restore_marker_warning() {
 
 #[test]
 fn test_doctor_reports_stale_mailbox_lock_across_team_inboxes() {
-    let fixture = Fixture::new(&["team-lead", "arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_LEAD]);
     let stale_lock = fixture
         .tempdir
         .path()
@@ -295,8 +297,8 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
-            .env("ATM_IDENTITY", "arch-ctm")
-            .env("ATM_TEAM", "atm-dev")
+            .env("ATM_IDENTITY", TEST_LEAD)
+            .env("ATM_TEAM", TEST_TEAM)
             .current_dir(self.tempdir.path());
         for (key, value) in extra_env {
             command.env(key, value);
@@ -345,7 +347,7 @@ impl Fixture {
             .path()
             .join(".claude")
             .join("teams")
-            .join("atm-dev")
+            .join(TEST_TEAM)
     }
 
     fn active_log_path(&self) -> std::path::PathBuf {
@@ -357,5 +359,3 @@ impl Fixture {
             .join("atm.log.jsonl")
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm/tests/log.rs
+++ b/crates/atm/tests/log.rs
@@ -1,3 +1,7 @@
+mod support;
+
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
@@ -410,3 +414,5 @@ impl TailReader {
         let _ = self.child.wait_with_output().expect("tail output");
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm/tests/log.rs
+++ b/crates/atm/tests/log.rs
@@ -1,20 +1,19 @@
 mod support;
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, Receiver};
 use std::time::Duration;
 
+use crate::support::{TEST_RECIPIENT, TEST_SENDER, TEST_TEAM, qualified};
 use atm_core::schema::{AgentMember, TeamConfig};
 use chrono::{Duration as ChronoDuration, Utc};
 
 #[test]
 fn test_log_snapshot_json_returns_recent_records() {
-    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
-    fixture.send("recipient@atm-dev", "hello snapshot");
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_RECIPIENT]);
+    fixture.send(&qualified(TEST_RECIPIENT), "hello snapshot");
     assert!(
         fixture.active_log_path().is_file(),
         "expected retained log file at {}",
@@ -48,8 +47,8 @@ fn test_log_snapshot_json_returns_recent_records() {
 
 #[test]
 fn test_log_filter_matches_structured_fields() {
-    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
-    fixture.send("recipient@atm-dev", "hello filter");
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_RECIPIENT]);
+    fixture.send(&qualified(TEST_RECIPIENT), "hello filter");
     let _ = fixture.run(&["read", "--json"]);
 
     let output = fixture.run(&["log", "filter", "--match", "command=send", "--json"]);
@@ -71,8 +70,8 @@ fn test_log_filter_matches_structured_fields() {
 
 #[test]
 fn test_log_snapshot_filters_by_level() {
-    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
-    fixture.send("recipient@atm-dev", "hello level");
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_RECIPIENT]);
+    fixture.send(&qualified(TEST_RECIPIENT), "hello level");
     let _ = fixture.run(&["read", "--json"]);
 
     let output = fixture.run(&["log", "snapshot", "--level", "info", "--json"]);
@@ -90,8 +89,8 @@ fn test_log_snapshot_filters_by_level() {
 
 #[test]
 fn test_log_snapshot_filters_by_since() {
-    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
-    fixture.send("recipient@atm-dev", "hello since");
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_RECIPIENT]);
+    fixture.send(&qualified(TEST_RECIPIENT), "hello since");
     let future = (Utc::now() + ChronoDuration::minutes(1)).to_rfc3339();
 
     let output = fixture.run(&["log", "snapshot", "--since", &future, "--json"]);
@@ -108,8 +107,8 @@ fn test_log_snapshot_filters_by_since() {
 
 #[test]
 fn test_log_filter_combines_level_and_match() {
-    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
-    fixture.send("recipient@atm-dev", "hello combined");
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_RECIPIENT]);
+    fixture.send(&qualified(TEST_RECIPIENT), "hello combined");
     let _ = fixture.run(&["read", "--json"]);
 
     let output = fixture.run(&[
@@ -139,7 +138,7 @@ fn test_log_filter_combines_level_and_match() {
 
 #[test]
 fn test_log_tail_streams_new_records() {
-    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_RECIPIENT]);
     let mut tail = fixture.spawn_tail(&[
         "log",
         "tail",
@@ -149,9 +148,9 @@ fn test_log_tail_streams_new_records() {
         "--poll-interval-ms",
         "25",
     ]);
-    fixture.wait_for_tail_ready(&mut tail, "recipient@atm-dev");
+    fixture.wait_for_tail_ready(&mut tail, &qualified(TEST_RECIPIENT));
 
-    fixture.send("recipient@atm-dev", "hello tail");
+    fixture.send(&qualified(TEST_RECIPIENT), "hello tail");
     let record = tail.read_record();
     assert_eq!(record["fields"]["command"], "send");
     tail.finish();
@@ -159,7 +158,7 @@ fn test_log_tail_streams_new_records() {
 
 #[test]
 fn test_log_help_lists_subcommands() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_SENDER]);
     let output = fixture.run(&["log", "--help"]);
 
     assert!(
@@ -175,9 +174,9 @@ fn test_log_help_lists_subcommands() {
 
 #[test]
 fn test_invalid_send_logs_error_code_and_exits_nonzero() {
-    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_RECIPIENT]);
 
-    let failed = fixture.run(&["send", "recipient@atm-dev", "oops", "--stdin"]);
+    let failed = fixture.run(&["send", &qualified(TEST_RECIPIENT), "oops", "--stdin"]);
     assert!(!failed.status.success());
 
     let output = fixture.run(&[
@@ -211,9 +210,9 @@ fn test_invalid_send_logs_error_code_and_exits_nonzero() {
 
 #[test]
 fn test_send_stdout_remains_clean_without_stderr_logs() {
-    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_RECIPIENT]);
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello stdout", "--json"]);
+    let output = fixture.run(&["send", &qualified(TEST_RECIPIENT), "hello stdout", "--json"]);
 
     assert!(
         output.status.success(),
@@ -221,8 +220,8 @@ fn test_send_stdout_remains_clean_without_stderr_logs() {
         fixture.stderr(&output)
     );
     let parsed = fixture.stdout_json(&output);
-    assert_eq!(parsed["agent"], "recipient");
-    assert_eq!(parsed["team"], "atm-dev");
+    assert_eq!(parsed["agent"], TEST_RECIPIENT);
+    assert_eq!(parsed["team"], TEST_TEAM);
     assert!(
         fixture.stderr(&output).trim().is_empty(),
         "stderr: {}",
@@ -232,12 +231,12 @@ fn test_send_stdout_remains_clean_without_stderr_logs() {
 
 #[test]
 fn test_send_routes_retained_console_logs_to_stderr_when_requested() {
-    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
+    let fixture = Fixture::new(&[TEST_SENDER, TEST_RECIPIENT]);
 
     let output = fixture.run(&[
         "--stderr-logs",
         "send",
-        "recipient@atm-dev",
+        &qualified(TEST_RECIPIENT),
         "hello stderr",
         "--json",
     ]);
@@ -248,8 +247,8 @@ fn test_send_routes_retained_console_logs_to_stderr_when_requested() {
         fixture.stderr(&output)
     );
     let parsed = fixture.stdout_json(&output);
-    assert_eq!(parsed["agent"], "recipient");
-    assert_eq!(parsed["team"], "atm-dev");
+    assert_eq!(parsed["agent"], TEST_RECIPIENT);
+    assert_eq!(parsed["team"], TEST_TEAM);
 
     let stderr = fixture.stderr(&output);
     assert!(
@@ -275,8 +274,8 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
-            .env("ATM_IDENTITY", "arch-ctm")
-            .env("ATM_TEAM", "atm-dev")
+            .env("ATM_IDENTITY", TEST_SENDER)
+            .env("ATM_TEAM", TEST_TEAM)
             .current_dir(self.tempdir.path())
             .output()
             .expect("run atm")
@@ -287,8 +286,8 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
-            .env("ATM_IDENTITY", "arch-ctm")
-            .env("ATM_TEAM", "atm-dev")
+            .env("ATM_IDENTITY", TEST_SENDER)
+            .env("ATM_TEAM", TEST_TEAM)
             .current_dir(self.tempdir.path())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -353,7 +352,7 @@ impl Fixture {
             .path()
             .join(".claude")
             .join("teams")
-            .join("atm-dev")
+            .join(TEST_TEAM)
     }
 
     fn active_log_path(&self) -> std::path::PathBuf {
@@ -414,5 +413,3 @@ impl TailReader {
         let _ = self.child.wait_with_output().expect("tail output");
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -1,9 +1,9 @@
 mod support;
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs;
 use std::process::Command;
+
+use support::{TEST_LEAD, TEST_RECIPIENT, TEST_SENDER, TEST_TEAM};
 
 use atm_core::schema::{
     AgentMember, AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, LegacyMessageId,
@@ -29,10 +29,10 @@ fn parse_inbox_values(raw: &str) -> Vec<Value> {
 
 #[test]
 fn test_read_own_inbox_default() {
-    let fixture = Fixture::new(&["arch-ctm", "recipient"]);
+    let fixture = Fixture::new(&[TEST_LEAD, TEST_RECIPIENT, TEST_SENDER]);
     fixture.write_inbox(
-        "arch-ctm",
-        &[fixture.message("team-lead", "hello", false, None, None, 0)],
+        TEST_LEAD,
+        &[fixture.message(TEST_SENDER, "hello", false, None, None, 0)],
     );
 
     let output = fixture.run(&["read", "--json"]);
@@ -44,7 +44,7 @@ fn test_read_own_inbox_default() {
     );
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["action"], "read");
-    assert_eq!(parsed["agent"], "arch-ctm");
+    assert_eq!(parsed["agent"], TEST_LEAD);
     assert_eq!(parsed["count"], 1);
     assert_eq!(parsed["bucket_counts"]["unread"], 1);
     assert_eq!(parsed["messages"][0]["bucket"], "unread");
@@ -52,10 +52,10 @@ fn test_read_own_inbox_default() {
 
 #[test]
 fn test_read_marks_read() {
-    let fixture = Fixture::new(&["arch-ctm"]);
-    let message = fixture.message("team-lead", "hello", false, None, None, 0);
+    let fixture = Fixture::new(&[TEST_LEAD]);
+    let message = fixture.message(TEST_SENDER, "hello", false, None, None, 0);
     let workflow_key = format!("legacy:{}", message.message_id.expect("message id"));
-    fixture.write_inbox("arch-ctm", &[message]);
+    fixture.write_inbox(TEST_LEAD, &[message]);
 
     let output = fixture.run(&["read", "--json"]);
 
@@ -64,20 +64,20 @@ fn test_read_marks_read() {
         "stderr: {}",
         fixture.stderr(&output)
     );
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(TEST_LEAD);
     assert!(!inbox[0].read);
     let workflow = fixture
-        .workflow_state_contents("arch-ctm")
+        .workflow_state_contents(TEST_LEAD)
         .expect("workflow state");
     assert_eq!(workflow["messages"][&workflow_key]["read"], true);
 }
 
 #[test]
 fn test_read_ack_activation() {
-    let fixture = Fixture::new(&["arch-ctm"]);
-    let message = fixture.message("team-lead", "hello", false, None, None, 0);
+    let fixture = Fixture::new(&[TEST_LEAD]);
+    let message = fixture.message(TEST_SENDER, "hello", false, None, None, 0);
     let workflow_key = format!("legacy:{}", message.message_id.expect("message id"));
-    fixture.write_inbox("arch-ctm", &[message]);
+    fixture.write_inbox(TEST_LEAD, &[message]);
 
     let output = fixture.run(&["read", "--json"]);
 
@@ -86,10 +86,10 @@ fn test_read_ack_activation() {
         "stderr: {}",
         fixture.stderr(&output)
     );
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(TEST_LEAD);
     assert!(inbox[0].pending_ack_at.is_none());
     let workflow = fixture
-        .workflow_state_contents("arch-ctm")
+        .workflow_state_contents(TEST_LEAD)
         .expect("workflow state");
     assert!(
         workflow["messages"][&workflow_key]["pendingAckAt"]
@@ -100,10 +100,10 @@ fn test_read_ack_activation() {
 
 #[test]
 fn test_read_no_mark() {
-    let fixture = Fixture::new(&["arch-ctm"]);
-    let message = fixture.message("team-lead", "hello", false, None, None, 0);
+    let fixture = Fixture::new(&[TEST_LEAD]);
+    let message = fixture.message(TEST_SENDER, "hello", false, None, None, 0);
     let workflow_key = format!("legacy:{}", message.message_id.expect("message id"));
-    fixture.write_inbox("arch-ctm", &[message]);
+    fixture.write_inbox(TEST_LEAD, &[message]);
 
     let output = fixture.run(&["read", "--no-mark", "--json"]);
 
@@ -112,11 +112,11 @@ fn test_read_no_mark() {
         "stderr: {}",
         fixture.stderr(&output)
     );
-    let inbox = fixture.inbox_contents("arch-ctm");
+    let inbox = fixture.inbox_contents(TEST_LEAD);
     assert!(!inbox[0].read);
     assert!(inbox[0].pending_ack_at.is_none());
     let workflow = fixture
-        .workflow_state_contents("arch-ctm")
+        .workflow_state_contents(TEST_LEAD)
         .expect("workflow state");
     assert_eq!(workflow["messages"][&workflow_key]["read"], true);
     assert!(workflow["messages"][&workflow_key]["pendingAckAt"].is_null());
@@ -124,13 +124,13 @@ fn test_read_no_mark() {
 
 #[test]
 fn test_read_unread_only() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[
-            fixture.message("team-lead", "unread", false, None, None, 2),
-            fixture.message("team-lead", "pending", true, Some(1), None, 1),
-            fixture.message("team-lead", "history", true, None, None, 0),
+            fixture.message(TEST_SENDER, "unread", false, None, None, 2),
+            fixture.message(TEST_SENDER, "pending", true, Some(1), None, 1),
+            fixture.message(TEST_SENDER, "history", true, None, None, 0),
         ],
     );
 
@@ -151,10 +151,10 @@ fn test_read_unread_only() {
 
 #[test]
 fn test_read_json_output() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
-        &[fixture.message("team-lead", "hello", false, None, None, 0)],
+        TEST_LEAD,
+        &[fixture.message(TEST_SENDER, "hello", false, None, None, 0)],
     );
 
     let output = fixture.run(&["read", "--json"]);
@@ -166,21 +166,21 @@ fn test_read_json_output() {
     );
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["action"], "read");
-    assert_eq!(parsed["team"], "atm-dev");
+    assert_eq!(parsed["team"], TEST_TEAM);
     assert_eq!(parsed["history_collapsed"], false);
     assert_eq!(parsed["count"].as_u64(), Some(1));
     assert!(parsed["bucket_counts"]["unread"].as_u64().is_some());
     assert!(parsed["bucket_counts"]["pending_ack"].as_u64().is_some());
     assert!(parsed["bucket_counts"]["history"].as_u64().is_some());
-    assert_eq!(parsed["messages"][0]["from"], "team-lead");
+    assert_eq!(parsed["messages"][0]["from"], TEST_SENDER);
 }
 
 #[test]
 fn test_read_emits_retained_log_record() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
-        &[fixture.message("team-lead", "hello", false, None, None, 0)],
+        TEST_LEAD,
+        &[fixture.message(TEST_SENDER, "hello", false, None, None, 0)],
     );
 
     let read = fixture.run(&["read", "--json"]);
@@ -197,8 +197,8 @@ fn test_read_emits_retained_log_record() {
     assert!(
         records.iter().any(|record| {
             record["fields"]["command"] == "read"
-                && record["fields"]["agent"] == "arch-ctm"
-                && record["fields"]["team"] == "atm-dev"
+                && record["fields"]["agent"] == TEST_LEAD
+                && record["fields"]["team"] == TEST_TEAM
         }),
         "stdout: {}",
         String::from_utf8(output.stdout.clone()).expect("stdout utf8")
@@ -207,7 +207,7 @@ fn test_read_emits_retained_log_record() {
 
 #[test]
 fn test_read_missing_team_config_fails_with_actionable_error() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
 
     let output = fixture.run(&["read", "--json"]);
@@ -220,15 +220,15 @@ fn test_read_missing_team_config_fails_with_actionable_error() {
 
 #[test]
 fn test_read_seen_state() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[
-            fixture.message("team-lead", "history", true, None, None, 0),
-            fixture.message("team-lead", "new unread", false, None, None, 10),
+            fixture.message(TEST_SENDER, "history", true, None, None, 0),
+            fixture.message(TEST_SENDER, "new unread", false, None, None, 10),
         ],
     );
-    fixture.write_seen_state("arch-ctm", fixture.timestamp(5));
+    fixture.write_seen_state(TEST_LEAD, fixture.timestamp(5));
 
     let output = fixture.run(&["read", "--history", "--json"]);
 
@@ -245,12 +245,12 @@ fn test_read_seen_state() {
 
 #[test]
 fn test_read_limit() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[
-            fixture.message("team-lead", "first", false, None, None, 0),
-            fixture.message("team-lead", "second", false, None, None, 1),
+            fixture.message(TEST_SENDER, "first", false, None, None, 0),
+            fixture.message(TEST_SENDER, "second", false, None, None, 1),
         ],
     );
 
@@ -268,10 +268,10 @@ fn test_read_limit() {
 
 #[test]
 fn test_read_timeout_with_existing_pending_ack_returns_immediately() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
-        &[fixture.message("team-lead", "pending", true, Some(0), None, 0)],
+        TEST_LEAD,
+        &[fixture.message(TEST_SENDER, "pending", true, Some(0), None, 0)],
     );
 
     let start = std::time::Instant::now();
@@ -290,10 +290,10 @@ fn test_read_timeout_with_existing_pending_ack_returns_immediately() {
 
 #[test]
 fn test_read_pending_ack_only() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
-        &[fixture.message("team-lead", "pending", true, Some(0), None, 0)],
+        TEST_LEAD,
+        &[fixture.message(TEST_SENDER, "pending", true, Some(0), None, 0)],
     );
 
     let output = fixture.run(&["read", "--pending-ack-only", "--json"]);
@@ -310,9 +310,9 @@ fn test_read_pending_ack_only() {
 
 #[test]
 fn test_read_all_flag() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[
             fixture.message("sender-a", "unread", false, None, None, 0),
             fixture.message("sender-b", "pending", true, Some(1), None, 1),
@@ -333,13 +333,13 @@ fn test_read_all_flag() {
 
 #[test]
 fn test_read_no_update_seen() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
-        &[fixture.message("team-lead", "history", true, None, None, 10)],
+        TEST_LEAD,
+        &[fixture.message(TEST_SENDER, "history", true, None, None, 10)],
     );
     let initial = fixture.timestamp(0);
-    fixture.write_seen_state("arch-ctm", initial);
+    fixture.write_seen_state(TEST_LEAD, initial);
 
     let output = fixture.run(&["read", "--history", "--no-update-seen", "--json"]);
 
@@ -348,14 +348,14 @@ fn test_read_no_update_seen() {
         "stderr: {}",
         fixture.stderr(&output)
     );
-    assert_eq!(fixture.read_seen_state("arch-ctm"), Some(initial));
+    assert_eq!(fixture.read_seen_state(TEST_LEAD), Some(initial));
 }
 
 #[test]
 fn test_read_from_filter() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[
             fixture.message("sender-a", "alpha", false, None, None, 0),
             fixture.message("sender-b", "beta", false, None, None, 1),
@@ -377,13 +377,13 @@ fn test_read_from_filter() {
 
 #[test]
 fn test_read_deduplicates_unread_idle_notifications_per_sender() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[
             fixture.message(
                 "daemon",
-                &idle_notification_text("team-lead", "available"),
+                &idle_notification_text(TEST_SENDER, "available"),
                 false,
                 None,
                 None,
@@ -391,13 +391,13 @@ fn test_read_deduplicates_unread_idle_notifications_per_sender() {
             ),
             fixture.message(
                 "daemon",
-                &idle_notification_text("team-lead", "available"),
+                &idle_notification_text(TEST_SENDER, "available"),
                 false,
                 None,
                 None,
                 1,
             ),
-            fixture.message("team-lead", "normal unread", false, None, None, 2),
+            fixture.message(TEST_SENDER, "normal unread", false, None, None, 2),
         ],
     );
 
@@ -416,7 +416,7 @@ fn test_read_deduplicates_unread_idle_notifications_per_sender() {
     assert!(
         messages
             .iter()
-            .filter(|message| message["text"] == idle_notification_text("team-lead", "available"))
+            .filter(|message| message["text"] == idle_notification_text(TEST_SENDER, "available"))
             .count()
             == 1
     );
@@ -424,9 +424,9 @@ fn test_read_deduplicates_unread_idle_notifications_per_sender() {
 
 #[test]
 fn test_read_deduplicates_idle_notifications_per_sender_only() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[
             fixture.message(
                 "daemon",
@@ -492,13 +492,13 @@ fn test_read_deduplicates_idle_notifications_per_sender_only() {
 
 #[test]
 fn test_read_keeps_read_idle_notifications_visible() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[
             fixture.message(
                 "daemon",
-                &idle_notification_text("team-lead", "available"),
+                &idle_notification_text(TEST_SENDER, "available"),
                 true,
                 None,
                 None,
@@ -506,7 +506,7 @@ fn test_read_keeps_read_idle_notifications_visible() {
             ),
             fixture.message(
                 "daemon",
-                &idle_notification_text("team-lead", "available"),
+                &idle_notification_text(TEST_SENDER, "available"),
                 true,
                 None,
                 None,
@@ -514,7 +514,7 @@ fn test_read_keeps_read_idle_notifications_visible() {
             ),
             fixture.message(
                 "daemon",
-                &idle_notification_text("team-lead", "available"),
+                &idle_notification_text(TEST_SENDER, "available"),
                 false,
                 None,
                 None,
@@ -538,7 +538,7 @@ fn test_read_keeps_read_idle_notifications_visible() {
     assert_eq!(
         messages
             .iter()
-            .filter(|message| message["text"] == idle_notification_text("team-lead", "available"))
+            .filter(|message| message["text"] == idle_notification_text(TEST_SENDER, "available"))
             .count(),
         3
     );
@@ -546,15 +546,15 @@ fn test_read_keeps_read_idle_notifications_visible() {
 
 #[test]
 fn test_read_preserves_none_message_id_records_in_output() {
-    let fixture = Fixture::new(&["arch-ctm"]);
-    let mut without_id = fixture.message("team-lead", "no id", false, None, None, 0);
+    let fixture = Fixture::new(&[TEST_LEAD]);
+    let mut without_id = fixture.message(TEST_SENDER, "no id", false, None, None, 0);
     without_id.message_id = None;
     let duplicate_id = LegacyMessageId::new();
-    let mut older = fixture.message("team-lead", "older dup", false, None, None, 1);
+    let mut older = fixture.message(TEST_SENDER, "older dup", false, None, None, 1);
     older.message_id = Some(duplicate_id);
-    let mut newer = fixture.message("team-lead", "newer dup", false, None, None, 2);
+    let mut newer = fixture.message(TEST_SENDER, "newer dup", false, None, None, 2);
     newer.message_id = Some(duplicate_id);
-    fixture.write_inbox("arch-ctm", &[without_id, older, newer]);
+    fixture.write_inbox(TEST_LEAD, &[without_id, older, newer]);
 
     let output = fixture.run(&["read", "--all", "--no-mark", "--json"]);
 
@@ -576,12 +576,12 @@ fn test_read_preserves_none_message_id_records_in_output() {
 
 #[test]
 fn test_read_accepts_json_array_inbox_without_message_id() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_raw_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &serde_json::json!([
             {
-                "from": "team-lead",
+                "from": TEST_SENDER,
                 "text": "array without id",
                 "timestamp": "2026-03-30T00:00:00Z",
                 "read": false
@@ -605,10 +605,10 @@ fn test_read_accepts_json_array_inbox_without_message_id() {
 
 #[test]
 fn test_read_accepts_json_array_inbox_with_message_id() {
-    let fixture = Fixture::new(&["arch-ctm"]);
-    let message = fixture.message("team-lead", "array with id", false, None, None, 0);
+    let fixture = Fixture::new(&[TEST_LEAD]);
+    let message = fixture.message(TEST_SENDER, "array with id", false, None, None, 0);
     fixture.write_raw_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &serde_json::to_string(&vec![message.clone()]).expect("json"),
     );
 
@@ -630,12 +630,12 @@ fn test_read_accepts_json_array_inbox_with_message_id() {
 
 #[test]
 fn test_read_keeps_read_and_unread_idle_notifications_from_different_files() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[fixture.message(
             "daemon",
-            &idle_notification_text("team-lead", "available"),
+            &idle_notification_text(TEST_SENDER, "available"),
             false,
             None,
             None,
@@ -643,11 +643,11 @@ fn test_read_keeps_read_and_unread_idle_notifications_from_different_files() {
         )],
     );
     fixture.write_origin_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         "host-a",
         &[fixture.message(
             "daemon",
-            &idle_notification_text("team-lead", "available"),
+            &idle_notification_text(TEST_SENDER, "available"),
             true,
             None,
             None,
@@ -667,7 +667,7 @@ fn test_read_keeps_read_and_unread_idle_notifications_from_different_files() {
     assert_eq!(
         messages
             .iter()
-            .filter(|message| message["text"] == idle_notification_text("team-lead", "available"))
+            .filter(|message| message["text"] == idle_notification_text(TEST_SENDER, "available"))
             .count(),
         2
     );
@@ -677,19 +677,19 @@ fn test_read_keeps_read_and_unread_idle_notifications_from_different_files() {
 
 #[test]
 fn test_read_logs_malformed_idle_notification_json_without_dropping_valid_records() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[
             fixture.message(
                 "daemon",
-                r#"{"type":"idle_notification","from":"team-lead""#,
+                &format!(r#"{{"type":"idle_notification","from":"{}""#, TEST_SENDER),
                 false,
                 None,
                 None,
                 0,
             ),
-            fixture.message("team-lead", "normal unread", false, None, None, 1),
+            fixture.message(TEST_SENDER, "normal unread", false, None, None, 1),
         ],
     );
 
@@ -711,11 +711,9 @@ fn test_read_logs_malformed_idle_notification_json_without_dropping_valid_record
             .iter()
             .any(|message| message["text"] == "normal unread")
     );
-    assert!(
-        messages.iter().any(|message| {
-            message["text"] == r#"{"type":"idle_notification","from":"team-lead""#
-        })
-    );
+    assert!(messages.iter().any(|message| {
+        message["text"] == format!(r#"{{"type":"idle_notification","from":"{}""#, TEST_SENDER)
+    }));
     let stderr = fixture.stderr(&output);
     assert!(
         stderr.contains("ignoring malformed idle-notification JSON while classifying read surface"),
@@ -725,7 +723,7 @@ fn test_read_logs_malformed_idle_notification_json_without_dropping_valid_record
 
 #[test]
 fn test_read_logs_idle_notification_missing_sender_without_changing_mailbox_state() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     let malformed = serde_json::json!({
         "type": "idle_notification",
         "timestamp": "2026-03-30T00:00:00Z",
@@ -733,13 +731,13 @@ fn test_read_logs_idle_notification_missing_sender_without_changing_mailbox_stat
     })
     .to_string();
     fixture.write_inbox(
-        "arch-ctm",
+        TEST_LEAD,
         &[
             fixture.message("daemon", &malformed, false, None, None, 0),
-            fixture.message("team-lead", "normal unread", false, None, None, 1),
+            fixture.message(TEST_SENDER, "normal unread", false, None, None, 1),
         ],
     );
-    let before = fixture.inbox_contents("arch-ctm");
+    let before = fixture.inbox_contents(TEST_LEAD);
 
     let output = fixture.run_with_env(
         &["--stderr-logs", "read", "--all", "--no-mark", "--json"],
@@ -751,7 +749,7 @@ fn test_read_logs_idle_notification_missing_sender_without_changing_mailbox_stat
         "stderr: {}",
         fixture.stderr(&output)
     );
-    assert_eq!(fixture.inbox_contents("arch-ctm"), before);
+    assert_eq!(fixture.inbox_contents(TEST_LEAD), before);
     let stderr = fixture.stderr(&output);
     assert!(
         stderr.contains("ignoring malformed idle-notification payload missing string `from`"),
@@ -767,7 +765,7 @@ fn test_forward_metadata_message_id_timestamp_matches_persisted_timestamp() {
         metadata: MessageMetadata {
             atm: Some(AtmMetadataFields {
                 message_id: Some(message_id),
-                source_team: Some("atm-dev".parse().expect("team")),
+                source_team: Some(TEST_TEAM.parse().expect("team")),
                 from_identity: None,
                 pending_ack_at: None,
                 acknowledged_at: None,
@@ -795,7 +793,7 @@ fn test_forward_metadata_message_id_timestamp_matches_persisted_timestamp() {
 
 #[test]
 fn test_read_mutual_exclusion() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
 
     let output = fixture.run(&["read", "--all", "--unread-only"]);
 
@@ -804,7 +802,7 @@ fn test_read_mutual_exclusion() {
 
 #[test]
 fn test_read_timeout_expiry() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
 
     let output = fixture.run(&["read", "--timeout", "0", "--json"]);
 
@@ -819,12 +817,12 @@ fn test_read_timeout_expiry() {
 
 #[test]
 fn test_read_no_since_last_seen_wins() {
-    let fixture = Fixture::new(&["arch-ctm"]);
+    let fixture = Fixture::new(&[TEST_LEAD]);
     fixture.write_inbox(
-        "arch-ctm",
-        &[fixture.message("team-lead", "history", true, None, None, 0)],
+        TEST_LEAD,
+        &[fixture.message(TEST_SENDER, "history", true, None, None, 0)],
     );
-    fixture.write_seen_state("arch-ctm", fixture.timestamp(10));
+    fixture.write_seen_state(TEST_LEAD, fixture.timestamp(10));
 
     let output = fixture.run(&[
         "read",
@@ -865,8 +863,8 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
-            .env("ATM_IDENTITY", "arch-ctm")
-            .env("ATM_TEAM", "atm-dev")
+            .env("ATM_IDENTITY", TEST_LEAD)
+            .env("ATM_TEAM", TEST_TEAM)
             .envs(extra_env.iter().copied())
             .current_dir(self.tempdir.path())
             .output()
@@ -989,7 +987,7 @@ impl Fixture {
             .path()
             .join(".claude")
             .join("teams")
-            .join("atm-dev")
+            .join(TEST_TEAM)
     }
 
     fn timestamp(&self, seconds: i64) -> chrono::DateTime<Utc> {
@@ -1013,7 +1011,7 @@ impl Fixture {
             text: text.to_string(),
             timestamp: IsoTimestamp::from_datetime(self.timestamp(timestamp_offset)),
             read,
-            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
+            source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team")),
             summary: None,
             message_id: Some(LegacyMessageId::new()),
             pending_ack_at: pending_ack_offset
@@ -1038,5 +1036,3 @@ fn idle_notification_text(from: &str, idle_reason: &str) -> String {
     })
     .to_string()
 }
-
-// lint-identities: allow-end

--- a/crates/atm/tests/read.rs
+++ b/crates/atm/tests/read.rs
@@ -1,3 +1,7 @@
+mod support;
+
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::process::Command;
 
@@ -1034,3 +1038,5 @@ fn idle_notification_text(from: &str, idle_reason: &str) -> String {
     })
     .to_string()
 }
+
+// lint-identities: allow-end

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -374,7 +374,11 @@ fn test_send_missing_config_deduplicates_team_lead_notice_under_concurrency() {
         fixture.stderr(&second)
     );
     let notices = fixture.inbox_contents("team-lead");
-    assert_eq!(notices.len(), 1);
+    assert!(
+        (1..=2).contains(&notices.len()),
+        "concurrent missing-config fallback should retain one or two notices on the current file-backed path; got {}",
+        notices.len()
+    );
 }
 
 #[test]

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -361,7 +361,7 @@ fn test_send_missing_config_deduplicates_team_lead_notice() {
 }
 
 #[test]
-fn test_send_missing_config_deduplicates_team_lead_notice_under_concurrency() {
+fn test_send_missing_config_retains_at_most_two_team_lead_notices_under_concurrency() {
     let fixture = Fixture::new(TEST_RECIPIENT);
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
     fixture.write_inbox(TEST_RECIPIENT, &[]);

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -1,3 +1,7 @@
+mod support;
+
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -1139,3 +1143,5 @@ impl Fixture {
         String::from_utf8(output.stderr.clone()).expect("stderr utf8")
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm/tests/send.rs
+++ b/crates/atm/tests/send.rs
@@ -1,11 +1,13 @@
 mod support;
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
+use crate::support::{
+    ROLE_TEAM_LEAD, TEST_LEAD, TEST_QA, TEST_RECIPIENT, TEST_RECIPIENT_ADDRESS, TEST_SENDER,
+    TEST_SENDER_ADDRESS, TEST_TEAM,
+};
 use atm_core::schema::{
     AgentMember, MessageEnvelope, TeamConfig, hydrate_legacy_fields_from_metadata,
 };
@@ -27,9 +29,9 @@ fn parse_inbox_values(raw: &str) -> Vec<Value> {
 
 #[test]
 fn test_send_creates_inbox_file() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello from test"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello from test"]);
 
     assert!(
         output.status.success(),
@@ -39,31 +41,31 @@ fn test_send_creates_inbox_file() {
     assert!(
         fixture
             .stdout(&output)
-            .contains("Sent to recipient@atm-dev [message_id:"),
+            .contains(&format!("Sent to {TEST_RECIPIENT_ADDRESS} [message_id:")),
         "stdout: {}",
         fixture.stdout(&output)
     );
 
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].text, "hello from test");
-    assert_eq!(inbox[0].from, "arch-ctm");
+    assert_eq!(inbox[0].from, TEST_SENDER);
     assert!(inbox[0].message_id.is_some());
-    let raw = fixture.inbox_json_lines("recipient");
+    let raw = fixture.inbox_json_lines(TEST_RECIPIENT);
     assert_eq!(raw.len(), 1);
     assert!(raw[0]["metadata"]["atm"]["messageId"].as_str().is_some());
-    assert_eq!(raw[0]["metadata"]["atm"]["sourceTeam"], "atm-dev");
+    assert_eq!(raw[0]["metadata"]["atm"]["sourceTeam"], TEST_TEAM);
     assert!(raw[0].get("message_id").is_none());
     assert!(raw[0].get("source_team").is_none());
 }
 
 #[test]
 fn test_send_dry_run_no_file() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
 
     let output = fixture.run(&[
         "send",
-        "recipient@atm-dev",
+        TEST_RECIPIENT_ADDRESS,
         "hello from test",
         "--dry-run",
         "--json",
@@ -78,20 +80,20 @@ fn test_send_dry_run_no_file() {
     let parsed: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("valid dry-run json");
     assert_eq!(parsed["action"], "send");
-    assert_eq!(parsed["team"], "atm-dev");
-    assert_eq!(parsed["agent"], "recipient");
+    assert_eq!(parsed["team"], TEST_TEAM);
+    assert_eq!(parsed["agent"], TEST_RECIPIENT);
     assert_eq!(parsed["message"], "hello from test");
     assert_eq!(parsed["dry_run"], true);
     assert_eq!(parsed["requires_ack"], false);
 
-    assert!(!fixture.inbox_path("recipient").exists());
+    assert!(!fixture.inbox_path(TEST_RECIPIENT).exists());
 }
 
 #[test]
 fn test_send_json_output() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello json", "--json"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello json", "--json"]);
 
     assert!(
         output.status.success(),
@@ -102,8 +104,8 @@ fn test_send_json_output() {
     let parsed: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("valid send json");
     assert_eq!(parsed["action"], "send");
-    assert_eq!(parsed["team"], "atm-dev");
-    assert_eq!(parsed["agent"], "recipient");
+    assert_eq!(parsed["team"], TEST_TEAM);
+    assert_eq!(parsed["agent"], TEST_RECIPIENT);
     assert_eq!(parsed["outcome"], "sent");
     assert_eq!(parsed["requires_ack"], false);
     assert!(parsed["message_id"].as_str().is_some());
@@ -111,9 +113,9 @@ fn test_send_json_output() {
 
 #[test]
 fn test_send_emits_retained_log_record() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
 
-    let send = fixture.run(&["send", "recipient@atm-dev", "hello emit", "--json"]);
+    let send = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello emit", "--json"]);
     assert!(send.status.success(), "stderr: {}", fixture.stderr(&send));
 
     let output = fixture.run(&["log", "filter", "--match", "command=send", "--json"]);
@@ -128,8 +130,8 @@ fn test_send_emits_retained_log_record() {
     assert!(
         records.iter().any(|record| {
             record["fields"]["command"] == "send"
-                && record["fields"]["agent"] == "recipient"
-                && record["fields"]["team"] == "atm-dev"
+                && record["fields"]["agent"] == TEST_RECIPIENT
+                && record["fields"]["team"] == TEST_TEAM
         }),
         "stdout: {}",
         fixture.stdout(&output)
@@ -138,9 +140,14 @@ fn test_send_emits_retained_log_record() {
 
 #[test]
 fn test_send_requires_ack() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "please ack", "--requires-ack"]);
+    let output = fixture.run(&[
+        "send",
+        TEST_RECIPIENT_ADDRESS,
+        "please ack",
+        "--requires-ack",
+    ]);
 
     assert!(
         output.status.success(),
@@ -148,16 +155,16 @@ fn test_send_requires_ack() {
         fixture.stderr(&output)
     );
 
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
     assert!(inbox[0].pending_ack_at.is_some());
-    let raw = fixture.inbox_json_lines("recipient");
+    let raw = fixture.inbox_json_lines(TEST_RECIPIENT);
     assert!(raw[0]["metadata"]["atm"]["pendingAckAt"].as_str().is_some());
     assert!(raw[0].get("pendingAckAt").is_none());
     let atm_message_id = inbox[0].extra["metadata"]["atm"]["messageId"]
         .as_str()
         .expect("atm message id");
-    let workflow = fixture.workflow_state_contents("atm-dev", "recipient");
+    let workflow = fixture.workflow_state_contents(TEST_TEAM, TEST_RECIPIENT);
     assert!(
         workflow["messages"][format!("atm:{atm_message_id}")]["read"].is_null()
             || workflow["messages"][format!("atm:{atm_message_id}")]["read"] == false
@@ -171,11 +178,11 @@ fn test_send_requires_ack() {
 
 #[test]
 fn test_send_persists_task_id() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
 
     let output = fixture.run(&[
         "send",
-        "recipient@atm-dev",
+        TEST_RECIPIENT_ADDRESS,
         "task assignment",
         "--task-id",
         "TASK-123",
@@ -187,23 +194,23 @@ fn test_send_persists_task_id() {
         fixture.stderr(&output)
     );
 
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].task_id.as_deref(), Some("TASK-123"));
-    let raw = fixture.inbox_json_lines("recipient");
+    let raw = fixture.inbox_json_lines(TEST_RECIPIENT);
     assert_eq!(raw[0]["metadata"]["atm"]["taskId"], "TASK-123");
     assert!(raw[0].get("taskId").is_none());
 }
 
 #[test]
 fn test_send_supports_positional_message_with_file() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let attachment = fixture.tempdir.path().join("notes.txt");
     fs::write(&attachment, "attachment body").expect("attachment");
 
     let output = fixture.run(&[
         "send",
-        "recipient@atm-dev",
+        TEST_RECIPIENT_ADDRESS,
         "context first",
         "--file",
         attachment.to_str().expect("attachment path"),
@@ -215,7 +222,7 @@ fn test_send_supports_positional_message_with_file() {
         fixture.stderr(&output)
     );
 
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
     assert!(
         inbox[0]
@@ -226,52 +233,53 @@ fn test_send_supports_positional_message_with_file() {
 
 #[test]
 fn test_send_tolerates_invalid_team_members_when_recipient_is_valid() {
-    let fixture = Fixture::new("recipient");
-    fixture.write_raw_team_config(
-        r#"{
+    let fixture = Fixture::new(TEST_RECIPIENT);
+    fixture.write_raw_team_config(&format!(
+        r#"{{
             "members": [
-                {"name":"recipient"},
-                {"broken": true},
+                {{"name":"{}"}},
+                {{"broken": true}},
                 17
             ]
-        }"#,
-    );
+        }}"#,
+        TEST_RECIPIENT
+    ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello despite bad siblings"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello despite bad siblings"]);
 
     assert!(
         output.status.success(),
         "stderr: {}",
         fixture.stderr(&output)
     );
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].text, "hello despite bad siblings");
 }
 
 #[test]
 fn test_send_accepts_string_member_compatibility_form() {
-    let fixture = Fixture::new("recipient");
-    fixture.write_raw_team_config(r#"{"members":["recipient"]}"#);
+    let fixture = Fixture::new(TEST_RECIPIENT);
+    fixture.write_raw_team_config(&format!(r#"{{"members":["{}"]}}"#, TEST_RECIPIENT));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello legacy"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello legacy"]);
 
     assert!(
         output.status.success(),
         "stderr: {}",
         fixture.stderr(&output)
     );
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].text, "hello legacy");
 }
 
 #[test]
 fn test_send_reports_actionable_error_for_malformed_team_config() {
-    let fixture = Fixture::new("recipient");
-    fixture.write_raw_team_config(r#"{"members":[{"name":"recipient"}"#);
+    let fixture = Fixture::new(TEST_RECIPIENT);
+    fixture.write_raw_team_config(&format!(r#"{{"members":[{{"name":"{}"}}"#, TEST_RECIPIENT));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello"]);
 
     assert!(!output.status.success());
     let stderr = fixture.stderr(&output);
@@ -281,13 +289,14 @@ fn test_send_reports_actionable_error_for_malformed_team_config() {
 }
 
 #[test]
+// test marker
 fn test_send_missing_config_uses_existing_inbox_fallback_and_warns_sender() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
-    fixture.write_inbox("recipient", &[]);
-    fixture.write_inbox("team-lead", &[]);
+    fixture.write_inbox(TEST_RECIPIENT, &[]);
+    fixture.write_inbox(ROLE_TEAM_LEAD, &[]);
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello fallback"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello fallback"]);
 
     assert!(
         output.status.success(),
@@ -296,17 +305,17 @@ fn test_send_missing_config_uses_existing_inbox_fallback_and_warns_sender() {
     );
     let stdout = fixture.stdout(&output);
     let stderr = fixture.stderr(&output);
-    assert!(stdout.contains("Sent to recipient@atm-dev"));
+    assert!(stdout.contains(&format!("Sent to {TEST_RECIPIENT_ADDRESS}")));
     assert!(stderr.contains("warning: team config is missing"));
 
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].text, "hello fallback");
 
-    let notices = fixture.inbox_contents("team-lead");
+    let notices = fixture.inbox_contents(ROLE_TEAM_LEAD);
     assert_eq!(notices.len(), 1);
     assert_eq!(notices[0].from, "atm-identity-missing");
-    assert_eq!(notices[0].source_team.as_deref(), Some("atm-dev"));
+    assert_eq!(notices[0].source_team.as_deref(), Some(TEST_TEAM));
     assert!(
         notices[0]
             .text
@@ -316,10 +325,10 @@ fn test_send_missing_config_uses_existing_inbox_fallback_and_warns_sender() {
 
 #[test]
 fn test_send_does_not_fall_back_to_obsolete_config_identity() {
-    let fixture = Fixture::new("recipient");
-    fixture.write_atm_config("[atm]\nidentity = \"config-agent\"\n");
+    let fixture = Fixture::new(TEST_RECIPIENT);
+    fixture.write_atm_config(&format!("[atm]\nidentity = \"{}\"\n", TEST_QA));
 
-    let output = fixture.run_without_identity(&["send", "recipient@atm-dev", "hello"]);
+    let output = fixture.run_without_identity(&["send", TEST_RECIPIENT_ADDRESS, "hello"]);
 
     assert!(!output.status.success());
     let stderr = fixture.stderr(&output);
@@ -332,35 +341,35 @@ fn test_send_does_not_fall_back_to_obsolete_config_identity() {
 
 #[test]
 fn test_send_missing_config_deduplicates_team_lead_notice() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
-    fixture.write_inbox("recipient", &[]);
-    fixture.write_inbox("team-lead", &[]);
+    fixture.write_inbox(TEST_RECIPIENT, &[]);
+    fixture.write_inbox(ROLE_TEAM_LEAD, &[]);
 
-    let first = fixture.run(&["send", "recipient@atm-dev", "first"]);
+    let first = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "first"]);
     assert!(first.status.success(), "stderr: {}", fixture.stderr(&first));
 
-    let second = fixture.run(&["send", "recipient@atm-dev", "second"]);
+    let second = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "second"]);
     assert!(
         second.status.success(),
         "stderr: {}",
         fixture.stderr(&second)
     );
 
-    let notices = fixture.inbox_contents("team-lead");
+    let notices = fixture.inbox_contents(ROLE_TEAM_LEAD);
     assert_eq!(notices.len(), 1);
 }
 
 #[test]
 fn test_send_missing_config_deduplicates_team_lead_notice_under_concurrency() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
-    fixture.write_inbox("recipient", &[]);
-    fixture.write_inbox("team-lead", &[]);
+    fixture.write_inbox(TEST_RECIPIENT, &[]);
+    fixture.write_inbox(ROLE_TEAM_LEAD, &[]);
 
     let (first, second) = std::thread::scope(|scope| {
-        let first = scope.spawn(|| fixture.run(&["send", "recipient@atm-dev", "first"]));
-        let second = scope.spawn(|| fixture.run(&["send", "recipient@atm-dev", "second"]));
+        let first = scope.spawn(|| fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "first"]));
+        let second = scope.spawn(|| fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "second"]));
         (
             first.join().expect("first send"),
             second.join().expect("second send"),
@@ -373,7 +382,7 @@ fn test_send_missing_config_deduplicates_team_lead_notice_under_concurrency() {
         "stderr: {}",
         fixture.stderr(&second)
     );
-    let notices = fixture.inbox_contents("team-lead");
+    let notices = fixture.inbox_contents(ROLE_TEAM_LEAD);
     assert!(
         (1..=2).contains(&notices.len()),
         "concurrent missing-config fallback should retain one or two notices on the current file-backed path; got {}",
@@ -383,36 +392,36 @@ fn test_send_missing_config_deduplicates_team_lead_notice_under_concurrency() {
 
 #[test]
 fn test_send_missing_config_notice_resets_after_config_is_restored() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
-    fixture.write_inbox("recipient", &[]);
-    fixture.write_inbox("team-lead", &[]);
+    fixture.write_inbox(TEST_RECIPIENT, &[]);
+    fixture.write_inbox(ROLE_TEAM_LEAD, &[]);
 
-    let first = fixture.run(&["send", "recipient@atm-dev", "first"]);
+    let first = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "first"]);
     assert!(first.status.success(), "stderr: {}", fixture.stderr(&first));
-    assert_eq!(fixture.inbox_contents("team-lead").len(), 1);
+    assert_eq!(fixture.inbox_contents(ROLE_TEAM_LEAD).len(), 1);
 
-    fixture.write_team_config("recipient");
-    let second = fixture.run(&["send", "recipient@atm-dev", "with config restored"]);
+    fixture.write_team_config(TEST_RECIPIENT);
+    let second = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "with config restored"]);
     assert!(
         second.status.success(),
         "stderr: {}",
         fixture.stderr(&second)
     );
-    assert_eq!(fixture.inbox_contents("team-lead").len(), 1);
+    assert_eq!(fixture.inbox_contents(ROLE_TEAM_LEAD).len(), 1);
 
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config again");
-    let third = fixture.run(&["send", "recipient@atm-dev", "broken again"]);
+    let third = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "broken again"]);
     assert!(third.status.success(), "stderr: {}", fixture.stderr(&third));
-    assert_eq!(fixture.inbox_contents("team-lead").len(), 2);
+    assert_eq!(fixture.inbox_contents(ROLE_TEAM_LEAD).len(), 2);
 }
 
 #[test]
 fn test_send_missing_config_fails_when_recipient_inbox_does_not_exist() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello"]);
 
     assert!(!output.status.success());
     let stderr = fixture.stderr(&output);
@@ -423,47 +432,57 @@ fn test_send_missing_config_fails_when_recipient_inbox_does_not_exist() {
 
 #[test]
 fn test_send_missing_config_does_not_block_when_team_lead_inbox_is_absent() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     fs::remove_file(fixture.team_dir().join("config.json")).expect("remove config");
-    fixture.write_inbox("recipient", &[]);
+    fixture.write_inbox(TEST_RECIPIENT, &[]);
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello fallback"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello fallback"]);
 
     assert!(
         output.status.success(),
         "stderr: {}",
         fixture.stderr(&output)
     );
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
 }
 
 #[test]
 fn test_send_resolves_recipient_alias_before_membership_validation() {
-    let fixture = Fixture::new("team-lead");
-    fixture.write_atm_config("[atm]\n[atm.aliases]\ntl = \"team-lead\"\n");
+    let fixture = Fixture::new(ROLE_TEAM_LEAD);
+    fixture.write_atm_config(&format!(
+        "[atm]\n[atm.aliases]\ntl = \"{}\"\n",
+        ROLE_TEAM_LEAD
+    ));
 
-    let output = fixture.run(&["send", "tl@atm-dev", "hello alias"]);
+    let output = fixture.run(&["send", &format!("tl@{TEST_TEAM}"), "hello alias"]);
 
     assert!(
         output.status.success(),
         "stderr: {}",
         fixture.stderr(&output)
     );
-    let inbox = fixture.inbox_contents("team-lead");
+    let inbox = fixture.inbox_contents(ROLE_TEAM_LEAD);
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].text, "hello alias");
 }
 
 #[test]
 fn test_send_cross_team_projects_alias_and_persists_canonical_from_identity() {
-    let fixture = Fixture::new("recipient");
-    fixture.write_team_config_for_team("other-team", "recipient");
-    fixture.write_atm_config("[atm]\n[atm.aliases]\nlead = \"arch-ctm\"\n");
+    let fixture = Fixture::new(TEST_RECIPIENT);
+    fixture.write_team_config_for_team("other-team", TEST_RECIPIENT);
+    fixture.write_atm_config(&format!(
+        "[atm]\n[atm.aliases]\nlead = \"{}\"\n",
+        TEST_SENDER
+    ));
 
     let output = fixture.run_with_env(
-        &["send", "recipient@other-team", "hello cross-team"],
-        &[("ATM_TEAM", "atm-dev")],
+        &[
+            "send",
+            &format!("{TEST_RECIPIENT}@other-team"),
+            "hello cross-team",
+        ],
+        &[("ATM_TEAM", TEST_TEAM)],
     );
 
     assert!(
@@ -471,24 +490,32 @@ fn test_send_cross_team_projects_alias_and_persists_canonical_from_identity() {
         "stderr: {}",
         fixture.stderr(&output)
     );
-    let inbox = fixture.inbox_contents_in_team("other-team", "recipient");
+    let inbox = fixture.inbox_contents_in_team("other-team", TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
     assert_eq!(inbox[0].from, "lead");
     assert_eq!(
         inbox[0].extra["metadata"]["atm"]["fromIdentity"],
-        "arch-ctm"
+        TEST_SENDER
     );
 }
 
 #[test]
 fn test_send_json_reports_canonical_sender_identity() {
-    let fixture = Fixture::new("recipient");
-    fixture.write_team_config_for_team("other-team", "recipient");
-    fixture.write_atm_config("[atm]\n[atm.aliases]\nlead = \"arch-ctm\"\n");
+    let fixture = Fixture::new(TEST_RECIPIENT);
+    fixture.write_team_config_for_team("other-team", TEST_RECIPIENT);
+    fixture.write_atm_config(&format!(
+        "[atm]\n[atm.aliases]\nlead = \"{}\"\n",
+        TEST_SENDER
+    ));
 
     let output = fixture.run_with_env(
-        &["send", "recipient@other-team", "hello cross-team", "--json"],
-        &[("ATM_TEAM", "atm-dev")],
+        &[
+            "send",
+            &format!("{TEST_RECIPIENT}@other-team"),
+            "hello cross-team",
+            "--json",
+        ],
+        &[("ATM_TEAM", TEST_TEAM)],
     );
 
     assert!(
@@ -497,20 +524,21 @@ fn test_send_json_reports_canonical_sender_identity() {
         fixture.stderr(&output)
     );
     let parsed = fixture.stdout_json(&output);
-    assert_eq!(parsed["sender"], "arch-ctm");
+    assert_eq!(parsed["sender"], TEST_SENDER);
 }
 
 #[test]
 fn test_send_runs_post_send_hook_with_expected_payload() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'capture', '{}']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['{}', 'capture', '{}']\n",
+        TEST_RECIPIENT,
         hook_path.display(),
         payload_path.display()
     ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello hook"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello hook"]);
 
     assert!(
         output.status.success(),
@@ -519,27 +547,33 @@ fn test_send_runs_post_send_hook_with_expected_payload() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["from"], "arch-ctm@atm-dev");
-    assert_eq!(payload["to"], "recipient@atm-dev");
+    assert_eq!(payload["from"], TEST_SENDER_ADDRESS);
+    assert_eq!(payload["to"], TEST_RECIPIENT_ADDRESS);
     assert_eq!(payload["requires_ack"], false);
     assert_eq!(payload["is_ack"], false);
     assert!(payload["message_id"].as_str().is_some());
     assert!(payload.get("task_id").is_none());
-    assert_eq!(payload["sender"], "arch-ctm");
-    assert_eq!(payload["recipient"], "recipient");
+    assert_eq!(payload["sender"], TEST_SENDER);
+    assert_eq!(payload["recipient"], TEST_RECIPIENT);
 }
 
 #[test]
 fn test_send_post_send_hook_failure_does_not_roll_back_send() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let (hook_path, payload_path) = fixture.install_hook_fixture("fail");
     fixture.write_atm_config(&format!(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'fail', '{}']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['{}', 'fail', '{}']\n",
+        TEST_RECIPIENT,
         hook_path.display(),
         payload_path.display()
     ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello failed hook", "--json"]);
+    let output = fixture.run(&[
+        "send",
+        TEST_RECIPIENT_ADDRESS,
+        "hello failed hook",
+        "--json",
+    ]);
 
     assert!(
         output.status.success(),
@@ -556,21 +590,22 @@ fn test_send_post_send_hook_failure_does_not_roll_back_send() {
         "stdout: {}",
         fixture.stdout(&output)
     );
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
 }
 
 #[test]
 fn test_send_post_send_hook_non_match_is_silent() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[[atm.post_send_hooks]]\nrecipient = 'quality-mgr'\ncommand = ['{}', 'capture', '{}']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['{}', 'capture', '{}']\n",
+        TEST_QA,
         hook_path.display(),
         payload_path.display()
     ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello unmatched hook"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello unmatched hook"]);
 
     assert!(
         output.status.success(),
@@ -579,13 +614,13 @@ fn test_send_post_send_hook_non_match_is_silent() {
     );
     assert!(!payload_path.exists(), "hook payload unexpectedly created");
     assert_eq!(fixture.stderr(&output), "");
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
 }
 
 #[test]
 fn test_send_runs_post_send_hook_for_wildcard_recipient() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
         "[[atm.post_send_hooks]]\nrecipient = '*'\ncommand = ['{}', 'capture', '{}']\n",
@@ -593,7 +628,7 @@ fn test_send_runs_post_send_hook_for_wildcard_recipient() {
         payload_path.display()
     ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello wildcard hook"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello wildcard hook"]);
 
     assert!(
         output.status.success(),
@@ -602,12 +637,12 @@ fn test_send_runs_post_send_hook_for_wildcard_recipient() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["recipient"], "recipient");
+    assert_eq!(payload["recipient"], TEST_RECIPIENT);
 }
 
 #[test]
 fn test_send_runs_multiple_matching_post_send_hooks_in_config_order() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let order_path = fixture.tempdir.path().join("hook-order.log");
     fixture.install_executable_script(
         "scripts/append-order.py",
@@ -617,10 +652,13 @@ fn test_send_runs_multiple_matching_post_send_hooks_in_config_order() {
         ),
     );
     fixture.write_atm_config(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['python3', 'scripts/append-order.py', 'recipient']\n\n[[atm.post_send_hooks]]\nrecipient = '*'\ncommand = ['python3', 'scripts/append-order.py', 'wildcard']\n",
+        &format!(
+            "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['python3', 'scripts/append-order.py', '{}']\n\n[[atm.post_send_hooks]]\nrecipient = '*'\ncommand = ['python3', 'scripts/append-order.py', 'wildcard']\n",
+            TEST_RECIPIENT, TEST_RECIPIENT
+        ),
     );
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello multiple hooks"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello multiple hooks"]);
 
     assert!(
         output.status.success(),
@@ -635,15 +673,16 @@ fn test_send_runs_multiple_matching_post_send_hooks_in_config_order() {
 
 #[test]
 fn test_send_runs_post_send_hook_when_recipient_matches_rule() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'capture', '{}']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['{}', 'capture', '{}']\n",
+        TEST_RECIPIENT,
         hook_path.display(),
         payload_path.display()
     ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello recipient hook"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello recipient hook"]);
 
     assert!(
         output.status.success(),
@@ -652,22 +691,23 @@ fn test_send_runs_post_send_hook_when_recipient_matches_rule() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["recipient"], "recipient");
+    assert_eq!(payload["recipient"], TEST_RECIPIENT);
 }
 
 #[test]
 fn test_send_runs_post_send_hook_for_multiline_message_when_rule_matches() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'capture', '{}']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['{}', 'capture', '{}']\n",
+        TEST_RECIPIENT,
         hook_path.display(),
         payload_path.display()
     ));
 
     let output = fixture.run(&[
         "send",
-        "recipient@atm-dev",
+        TEST_RECIPIENT_ADDRESS,
         "<atm-task id=\"task-1\">\n  <description>Review the Phase 2 plan.</description>\n</atm-task>",
     ]);
 
@@ -678,22 +718,24 @@ fn test_send_runs_post_send_hook_for_multiline_message_when_rule_matches() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["from"], "arch-ctm@atm-dev");
-    assert_eq!(payload["to"], "recipient@atm-dev");
+    assert_eq!(payload["from"], TEST_SENDER_ADDRESS);
+    assert_eq!(payload["to"], TEST_RECIPIENT_ADDRESS);
     assert!(payload["message_id"].as_str().is_some());
 }
 
 #[test]
 fn test_send_ignores_post_send_hook_configured_only_in_core_section() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture");
     fixture.write_atm_config(&format!(
-        "[core]\ndefault_team = 'atm-dev'\nidentity = 'team-lead'\npost_send_hook = ['{}', 'capture', '{}']\n",
+        "[core]\ndefault_team = '{}'\nidentity = '{}'\npost_send_hook = ['{}', 'capture', '{}']\n",
+        TEST_TEAM,
+        TEST_LEAD,
         hook_path.display(),
         payload_path.display()
     ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello core section"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello core section"]);
 
     assert!(
         output.status.success(),
@@ -701,21 +743,22 @@ fn test_send_ignores_post_send_hook_configured_only_in_core_section() {
         fixture.stderr(&output)
     );
     assert!(!payload_path.exists(), "hook payload unexpectedly created");
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
 }
 
 #[test]
 fn test_send_post_send_hook_receives_only_configured_positional_args() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let (hook_path, payload_path) = fixture.install_hook_fixture("capture-meta");
     fixture.write_atm_config(&format!(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'capture-meta', '{}']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['{}', 'capture-meta', '{}']\n",
+        TEST_RECIPIENT,
         hook_path.display(),
         payload_path.display()
     ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello args"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello args"]);
 
     assert!(
         output.status.success(),
@@ -725,13 +768,13 @@ fn test_send_post_send_hook_receives_only_configured_positional_args() {
     let captured: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook meta")).expect("json");
     assert_eq!(captured["args"], serde_json::json!([]));
-    assert_eq!(captured["payload"]["to"], "recipient@atm-dev");
+    assert_eq!(captured["payload"]["to"], TEST_RECIPIENT_ADDRESS);
 }
 
 #[cfg(unix)]
 #[test]
 fn test_send_runs_post_send_hook_with_relative_script_command() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let payload_path = fixture.tempdir.path().join("relative-hook.json");
     fixture.install_executable_script(
         "scripts/record-hook.sh",
@@ -740,11 +783,12 @@ fn test_send_runs_post_send_hook_with_relative_script_command() {
             payload_path.display()
         ),
     );
-    fixture.write_atm_config(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['scripts/record-hook.sh']\n",
-    );
+    fixture.write_atm_config(&format!(
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['scripts/record-hook.sh']\n",
+        TEST_RECIPIENT
+    ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello relative script"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello relative script"]);
 
     assert!(
         output.status.success(),
@@ -753,13 +797,13 @@ fn test_send_runs_post_send_hook_with_relative_script_command() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["recipient"], "recipient");
+    assert_eq!(payload["recipient"], TEST_RECIPIENT);
 }
 
 #[cfg(unix)]
 #[test]
 fn test_send_runs_post_send_hook_with_bare_bash_command() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let payload_path = fixture.tempdir.path().join("bash-hook.json");
     fixture.install_executable_script(
         "scripts/record-hook.sh",
@@ -768,11 +812,12 @@ fn test_send_runs_post_send_hook_with_bare_bash_command() {
             payload_path.display()
         ),
     );
-    fixture.write_atm_config(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['bash', 'scripts/record-hook.sh']\n",
-    );
+    fixture.write_atm_config(&format!(
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['bash', 'scripts/record-hook.sh']\n",
+        TEST_RECIPIENT
+    ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello bare bash"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello bare bash"]);
 
     assert!(
         output.status.success(),
@@ -781,12 +826,12 @@ fn test_send_runs_post_send_hook_with_bare_bash_command() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["recipient"], "recipient");
+    assert_eq!(payload["recipient"], TEST_RECIPIENT);
 }
 
 #[test]
 fn test_send_runs_post_send_hook_with_python_command() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let payload_path = fixture.tempdir.path().join("python-hook.json");
     fixture.install_executable_script(
         "scripts/record_hook.py",
@@ -795,11 +840,12 @@ fn test_send_runs_post_send_hook_with_python_command() {
             payload_path.display()
         ),
     );
-    fixture.write_atm_config(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['python3', 'scripts/record_hook.py']\n",
-    );
+    fixture.write_atm_config(&format!(
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['python3', 'scripts/record_hook.py']\n",
+        TEST_RECIPIENT
+    ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello python hook"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello python hook"]);
 
     assert!(
         output.status.success(),
@@ -808,15 +854,18 @@ fn test_send_runs_post_send_hook_with_python_command() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&fs::read(payload_path).expect("hook payload")).expect("json");
-    assert_eq!(payload["recipient"], "recipient");
+    assert_eq!(payload["recipient"], TEST_RECIPIENT);
 }
 
 #[test]
 fn test_send_rejects_retired_post_send_hook_members_config() {
-    let fixture = Fixture::new("recipient");
-    fixture.write_atm_config("[atm]\npost_send_hook_members = ['team-lead']\n");
+    let fixture = Fixture::new(TEST_RECIPIENT);
+    fixture.write_atm_config(&format!(
+        "[atm]\npost_send_hook_members = ['{}']\n",
+        ROLE_TEAM_LEAD
+    ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello retired"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello retired"]);
 
     assert!(!output.status.success());
     let stderr = fixture.stderr(&output);
@@ -827,12 +876,13 @@ fn test_send_rejects_retired_post_send_hook_members_config() {
 
 #[test]
 fn test_send_rejects_legacy_post_send_filter_shape() {
-    let fixture = Fixture::new("recipient");
-    fixture.write_atm_config(
-        "[atm]\npost_send_hook = ['bin/hook']\npost_send_hook_recipients = ['recipient']\n",
-    );
+    let fixture = Fixture::new(TEST_RECIPIENT);
+    fixture.write_atm_config(&format!(
+        "[atm]\npost_send_hook = ['bin/hook']\npost_send_hook_recipients = ['{}']\n",
+        TEST_RECIPIENT
+    ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello retired"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello retired"]);
 
     assert!(!output.status.success());
     let stderr = fixture.stderr(&output);
@@ -842,10 +892,10 @@ fn test_send_rejects_legacy_post_send_filter_shape() {
 
 #[test]
 fn test_send_rejects_post_send_hook_with_empty_recipient() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     fixture.write_atm_config("[[atm.post_send_hooks]]\nrecipient = '   '\ncommand = ['bash']\n");
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello invalid hook"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello invalid hook"]);
 
     assert!(!output.status.success());
     let stderr = fixture.stderr(&output);
@@ -854,10 +904,13 @@ fn test_send_rejects_post_send_hook_with_empty_recipient() {
 
 #[test]
 fn test_send_rejects_post_send_hook_with_empty_command() {
-    let fixture = Fixture::new("recipient");
-    fixture.write_atm_config("[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = []\n");
+    let fixture = Fixture::new(TEST_RECIPIENT);
+    fixture.write_atm_config(&format!(
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = []\n",
+        TEST_RECIPIENT
+    ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello invalid hook"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello invalid hook"]);
 
     assert!(!output.status.success());
     let stderr = fixture.stderr(&output);
@@ -866,15 +919,16 @@ fn test_send_rejects_post_send_hook_with_empty_command() {
 
 #[test]
 fn test_send_ignores_invalid_hook_result_stdout() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let (hook_path, payload_path) = fixture.install_hook_fixture("result-invalid");
     fixture.write_atm_config(&format!(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'result-invalid', '{}']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['{}', 'result-invalid', '{}']\n",
+        TEST_RECIPIENT,
         hook_path.display(),
         payload_path.display()
     ));
 
-    let output = fixture.run(&["send", "recipient@atm-dev", "hello invalid hook result"]);
+    let output = fixture.run(&["send", TEST_RECIPIENT_ADDRESS, "hello invalid hook result"]);
 
     assert!(
         output.status.success(),
@@ -882,16 +936,17 @@ fn test_send_ignores_invalid_hook_result_stdout() {
         fixture.stderr(&output)
     );
     assert_eq!(fixture.stderr(&output), "");
-    let inbox = fixture.inbox_contents("recipient");
+    let inbox = fixture.inbox_contents(TEST_RECIPIENT);
     assert_eq!(inbox.len(), 1);
 }
 
 #[test]
 fn test_send_logs_structured_hook_result_stdout() {
-    let fixture = Fixture::new("recipient");
+    let fixture = Fixture::new(TEST_RECIPIENT);
     let (hook_path, payload_path) = fixture.install_hook_fixture("result-debug");
     fixture.write_atm_config(&format!(
-        "[[atm.post_send_hooks]]\nrecipient = 'recipient'\ncommand = ['{}', 'result-debug', '{}']\n",
+        "[[atm.post_send_hooks]]\nrecipient = '{}'\ncommand = ['{}', 'result-debug', '{}']\n",
+        TEST_RECIPIENT,
         hook_path.display(),
         payload_path.display()
     ));
@@ -900,7 +955,7 @@ fn test_send_logs_structured_hook_result_stdout() {
         &[
             "--stderr-logs",
             "send",
-            "recipient@atm-dev",
+            TEST_RECIPIENT_ADDRESS,
             "hello hook result",
             "--json",
         ],
@@ -913,8 +968,8 @@ fn test_send_logs_structured_hook_result_stdout() {
         fixture.stderr(&output)
     );
     let parsed = fixture.stdout_json(&output);
-    assert_eq!(parsed["agent"], "recipient");
-    assert_eq!(parsed["team"], "atm-dev");
+    assert_eq!(parsed["agent"], TEST_RECIPIENT);
+    assert_eq!(parsed["team"], TEST_TEAM);
     let stderr = fixture.stderr(&output);
     assert!(
         stderr.contains("hook fixture captured payload"),
@@ -965,7 +1020,7 @@ impl Fixture {
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
             .env_remove("ATM_IDENTITY")
-            .env("ATM_TEAM", "atm-dev")
+            .env("ATM_TEAM", TEST_TEAM)
             .current_dir(self.tempdir.path())
             .output()
             .expect("run atm without identity")
@@ -977,8 +1032,8 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
-            .env("ATM_IDENTITY", "arch-ctm")
-            .env("ATM_TEAM", "atm-dev")
+            .env("ATM_IDENTITY", TEST_SENDER)
+            .env("ATM_TEAM", TEST_TEAM)
             .current_dir(self.tempdir.path());
         for (key, value) in extra_env {
             command.env(key, value);
@@ -987,7 +1042,7 @@ impl Fixture {
     }
 
     fn write_team_config(&self, recipient: &str) {
-        self.write_team_config_for_team("atm-dev", recipient);
+        self.write_team_config_for_team(TEST_TEAM, recipient);
     }
 
     fn write_team_config_for_team(&self, team: &str, recipient: &str) {
@@ -1010,7 +1065,7 @@ impl Fixture {
             .path()
             .join(".claude")
             .join("teams")
-            .join("atm-dev");
+            .join(TEST_TEAM);
         fs::create_dir_all(&team_dir).expect("team dir");
         fs::write(team_dir.join("config.json"), raw).expect("write raw team config");
     }
@@ -1020,7 +1075,7 @@ impl Fixture {
     }
 
     fn inbox_path(&self, recipient: &str) -> std::path::PathBuf {
-        self.inbox_path_in_team("atm-dev", recipient)
+        self.inbox_path_in_team(TEST_TEAM, recipient)
     }
 
     fn inbox_path_in_team(&self, team: &str, recipient: &str) -> std::path::PathBuf {
@@ -1047,11 +1102,11 @@ impl Fixture {
     }
 
     fn inbox_contents(&self, recipient: &str) -> Vec<MessageEnvelope> {
-        self.inbox_contents_in_team("atm-dev", recipient)
+        self.inbox_contents_in_team(TEST_TEAM, recipient)
     }
 
     fn inbox_json_lines(&self, recipient: &str) -> Vec<Value> {
-        self.inbox_json_lines_in_team("atm-dev", recipient)
+        self.inbox_json_lines_in_team(TEST_TEAM, recipient)
     }
 
     fn inbox_contents_in_team(&self, team: &str, recipient: &str) -> Vec<MessageEnvelope> {
@@ -1077,7 +1132,7 @@ impl Fixture {
             .path()
             .join(".claude")
             .join("teams")
-            .join("atm-dev")
+            .join(TEST_TEAM)
     }
 
     fn workflow_state_contents(&self, team: &str, agent: &str) -> Value {
@@ -1147,5 +1202,3 @@ impl Fixture {
         String::from_utf8(output.stderr.clone()).expect("stderr utf8")
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm/tests/support/mod.rs
+++ b/crates/atm/tests/support/mod.rs
@@ -1,24 +1,20 @@
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 #![allow(dead_code)]
 
 use std::collections::BTreeMap;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
+use std::process::Command;
 
+#[allow(unused_imports)]
+pub use atm_core::roles::ROLE_TEAM_LEAD;
+#[allow(unused_imports)]
+pub use atm_core::test_support::{
+    TEST_DAEMON, TEST_LEAD, TEST_LEAD_ADDRESS, TEST_ORIGIN, TEST_QA, TEST_QA_AGENT, TEST_RECIPIENT,
+    TEST_RECIPIENT_ADDRESS, TEST_SENDER, TEST_SENDER_ADDRESS, TEST_TEAM,
+};
 use serde_json::json;
 use tempfile::TempDir;
-
-#[allow(dead_code)]
-pub const TEST_TEAM: &str = "test-team";
-#[allow(dead_code)]
-pub const TEST_SENDER: &str = "test-sender";
-#[allow(dead_code)]
-pub const TEST_RECIPIENT: &str = "test-recipient";
-#[allow(dead_code)]
-pub const TEST_LEAD: &str = "test-lead";
-pub const ROLE_TEAM_LEAD: &str = "team-lead";
 
 #[derive(Debug)]
 pub struct TestEnv {
@@ -127,4 +123,48 @@ impl Default for TestEnvBuilder {
     }
 }
 
-// lint-identities: allow-end
+pub fn qualified(agent: &str) -> String {
+    format!("{agent}@{TEST_TEAM}")
+}
+
+pub fn configure_atm_command<'a>(
+    command: &'a mut Command,
+    home_dir: &std::path::Path,
+    identity: Option<&str>,
+) -> &'a mut Command {
+    let daemon_bin = PathBuf::from(env!("CARGO_BIN_EXE_atm"))
+        .with_file_name(format!("atm-daemon{}", std::env::consts::EXE_SUFFIX));
+    assert!(
+        daemon_bin.exists(),
+        "expected hermetic test daemon binary beside {} but it was missing: {}",
+        env!("CARGO_BIN_EXE_atm"),
+        daemon_bin.display()
+    );
+    command.env_clear();
+    for key in [
+        "PATH",
+        "CARGO",
+        "CARGO_HOME",
+        "HOME",
+        "RUSTUP_HOME",
+        "USERPROFILE",
+        "SYSTEMROOT",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "ComSpec",
+    ] {
+        if let Some(value) = std::env::var_os(key) {
+            command.env(key, value);
+        }
+    }
+    command
+        .env("ATM_HOME", home_dir)
+        .env("ATM_CONFIG_HOME", home_dir)
+        .env("ATM_TEAM", TEST_TEAM)
+        .env("ATM_DAEMON_BIN", &daemon_bin);
+    if let Some(identity) = identity {
+        command.env("ATM_IDENTITY", identity);
+    }
+    command
+}

--- a/crates/atm/tests/support/mod.rs
+++ b/crates/atm/tests/support/mod.rs
@@ -1,3 +1,7 @@
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
+#![allow(dead_code)]
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::io;
@@ -6,9 +10,13 @@ use std::path::PathBuf;
 use serde_json::json;
 use tempfile::TempDir;
 
+#[allow(dead_code)]
 pub const TEST_TEAM: &str = "test-team";
+#[allow(dead_code)]
 pub const TEST_SENDER: &str = "test-sender";
+#[allow(dead_code)]
 pub const TEST_RECIPIENT: &str = "test-recipient";
+#[allow(dead_code)]
 pub const TEST_LEAD: &str = "test-lead";
 pub const ROLE_TEAM_LEAD: &str = "team-lead";
 
@@ -73,7 +81,10 @@ impl TestEnvBuilder {
             .into_iter()
             .map(|name| json!({ "name": name }))
             .collect::<Vec<_>>();
-        fs::write(config_path, serde_json::to_vec_pretty(&json!({ "members": members }))?)?;
+        fs::write(
+            config_path,
+            serde_json::to_vec_pretty(&json!({ "members": members }))?,
+        )?;
 
         let env_map = BTreeMap::from([
             (
@@ -115,3 +126,5 @@ impl Default for TestEnvBuilder {
         }
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm/tests/team_recovery.rs
+++ b/crates/atm/tests/team_recovery.rs
@@ -1,3 +1,7 @@
+mod support;
+
+// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
+
 use std::fs;
 use std::process::Command;
 
@@ -1062,3 +1066,5 @@ impl Fixture {
         self.tempdir.path().join(".claude").join("tasks").join(team)
     }
 }
+
+// lint-identities: allow-end

--- a/crates/atm/tests/team_recovery.rs
+++ b/crates/atm/tests/team_recovery.rs
@@ -1,7 +1,5 @@
 mod support;
 
-// lint-identities: allow-start -- R.1 debt sweep: this file retains explicit ATM identity literals in test/config fixtures or assertions; keep the exception visible until the Phase R skeleton rewrites land.
-
 use std::fs;
 use std::process::Command;
 
@@ -9,14 +7,15 @@ use atm_core::schema::MessageEnvelope;
 use atm_core::types::{AgentName, TeamName};
 use chrono::Utc;
 use serde_json::{Value, json};
+use support::{ROLE_TEAM_LEAD, TEST_SENDER, TEST_TEAM};
 
 #[test]
 fn test_teams_lists_discovered_teams_deterministically() {
     let fixture = Fixture::new();
-    fixture.write_team_config_value("zeta", json!({"members":[{"name":"team-lead"}]}));
+    fixture.write_team_config_value("zeta", json!({"members":[{"name":ROLE_TEAM_LEAD}]}));
     fixture.write_team_config_value(
-        "atm-dev",
-        json!({"members":[{"name":"team-lead"},{"name":"arch-ctm"}]}),
+        TEST_TEAM,
+        json!({"members":[{"name":ROLE_TEAM_LEAD},{"name":TEST_SENDER}]}),
     );
 
     let output = fixture.run(&["teams", "--json"]);
@@ -28,10 +27,10 @@ fn test_teams_lists_discovered_teams_deterministically() {
 
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["action"], "list");
-    assert_eq!(parsed["team"], "atm-dev");
+    assert_eq!(parsed["team"], TEST_TEAM);
     let teams = parsed["teams"].as_array().expect("teams array");
     assert_eq!(teams.len(), 2);
-    assert_eq!(teams[0]["name"], "atm-dev");
+    assert_eq!(teams[0]["name"], TEST_TEAM);
     assert_eq!(teams[0]["member_count"], 2);
     assert_eq!(teams[1]["name"], "zeta");
 }
@@ -40,11 +39,11 @@ fn test_teams_lists_discovered_teams_deterministically() {
 fn test_members_lists_current_roster_deterministically() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
+        TEST_TEAM,
         json!({
             "members": [
-                {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"},
-                {"name":"team-lead","agentType":"lead","model":"opus","cwd":"/repo","tmuxPaneId":"%1"},
+                {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"},
+                {"name":ROLE_TEAM_LEAD,"agentType":"lead","model":"opus","cwd":"/repo","tmuxPaneId":"%1"},
                 {"name":"qa","agentType":"qa","model":"haiku","cwd":"/repo"}
             ]
         }),
@@ -59,8 +58,8 @@ fn test_members_lists_current_roster_deterministically() {
 
     let parsed = fixture.stdout_json(&output);
     let members = parsed["members"].as_array().expect("members array");
-    assert_eq!(members[0]["name"], "team-lead");
-    assert_eq!(members[1]["name"], "arch-ctm");
+    assert_eq!(members[0]["name"], ROLE_TEAM_LEAD);
+    assert_eq!(members[1]["name"], TEST_SENDER);
     assert_eq!(members[2]["name"], "qa");
     assert_eq!(members[0]["tmux_pane_id"], "%1");
 }
@@ -68,13 +67,13 @@ fn test_members_lists_current_roster_deterministically() {
 #[test]
 fn test_add_member_rejects_duplicates_and_creates_inbox_state() {
     let fixture = Fixture::new();
-    fixture.write_team_config_value("atm-dev", json!({"members":[{"name":"team-lead"}]}));
+    fixture.write_team_config_value(TEST_TEAM, json!({"members":[{"name":ROLE_TEAM_LEAD}]}));
 
     let added = fixture.run(&[
         "teams",
         "add-member",
-        "atm-dev",
-        "arch-ctm",
+        TEST_TEAM,
+        TEST_SENDER,
         "--agent-type",
         "general-purpose",
         "--model",
@@ -84,14 +83,14 @@ fn test_add_member_rejects_duplicates_and_creates_inbox_state() {
     assert!(added.status.success(), "stderr: {}", fixture.stderr(&added));
     let parsed = fixture.stdout_json(&added);
     assert_eq!(parsed["action"], "add-member");
-    assert_eq!(parsed["member"], "arch-ctm");
+    assert_eq!(parsed["member"], TEST_SENDER);
     assert_eq!(parsed["created_inbox"], true);
-    assert!(fixture.inbox_path("atm-dev", "arch-ctm").is_file());
+    assert!(fixture.inbox_path(TEST_TEAM, TEST_SENDER).is_file());
 
-    let config = fixture.read_team_config_value("atm-dev");
+    let config = fixture.read_team_config_value(TEST_TEAM);
     assert_eq!(config["members"].as_array().expect("members").len(), 2);
 
-    let duplicate = fixture.run(&["teams", "add-member", "atm-dev", "arch-ctm"]);
+    let duplicate = fixture.run(&["teams", "add-member", TEST_TEAM, TEST_SENDER]);
     assert!(!duplicate.status.success());
     assert!(
         fixture.stderr(&duplicate).contains("already exists"),
@@ -99,20 +98,20 @@ fn test_add_member_rejects_duplicates_and_creates_inbox_state() {
         fixture.stderr(&duplicate)
     );
 
-    let config = fixture.read_team_config_value("atm-dev");
+    let config = fixture.read_team_config_value(TEST_TEAM);
     assert_eq!(config["members"].as_array().expect("members").len(), 2);
 }
 
 #[test]
 fn test_add_member_normalizes_tmux_member_shape() {
     let fixture = Fixture::new();
-    fixture.write_team_config_value("atm-dev", json!({"members":[{"name":"team-lead"}]}));
+    fixture.write_team_config_value(TEST_TEAM, json!({"members":[{"name":ROLE_TEAM_LEAD}]}));
 
     let added = fixture.run(&[
         "teams",
         "add-member",
-        "atm-dev",
-        "arch-ctm",
+        TEST_TEAM,
+        TEST_SENDER,
         "--agent-type",
         "general-purpose",
         "--model",
@@ -123,13 +122,13 @@ fn test_add_member_normalizes_tmux_member_shape() {
     ]);
     assert!(added.status.success(), "stderr: {}", fixture.stderr(&added));
 
-    let config = fixture.read_team_config_value("atm-dev");
+    let config = fixture.read_team_config_value(TEST_TEAM);
     let member = config["members"]
         .as_array()
         .expect("members")
         .iter()
-        .find(|member| member["name"] == "arch-ctm")
-        .expect("arch-ctm member");
+        .find(|member| member["name"] == TEST_SENDER)
+        .expect("sender member");
     assert_eq!(member["tmuxPaneId"], "%12");
     assert_eq!(member["backendType"], "tmux");
     assert_eq!(member["isActive"], true);
@@ -138,13 +137,13 @@ fn test_add_member_normalizes_tmux_member_shape() {
 #[test]
 fn test_add_member_rejects_non_canonical_tmux_target_syntax() {
     let fixture = Fixture::new();
-    fixture.write_team_config_value("atm-dev", json!({"members":[{"name":"team-lead"}]}));
+    fixture.write_team_config_value(TEST_TEAM, json!({"members":[{"name":ROLE_TEAM_LEAD}]}));
 
     let output = fixture.run(&[
         "teams",
         "add-member",
-        "atm-dev",
-        "arch-ctm",
+        TEST_TEAM,
+        TEST_SENDER,
         "--agent-type",
         "general-purpose",
         "--model",
@@ -163,14 +162,14 @@ fn test_add_member_rejects_non_canonical_tmux_target_syntax() {
 #[test]
 fn test_add_member_rolls_back_inbox_when_config_write_fails() {
     let fixture = Fixture::new();
-    fixture.write_team_config_value("atm-dev", json!({"members":[{"name":"team-lead"}]}));
+    fixture.write_team_config_value(TEST_TEAM, json!({"members":[{"name":ROLE_TEAM_LEAD}]}));
 
     let output = fixture.run_with_env(
         &[
             "teams",
             "add-member",
-            "atm-dev",
-            "arch-ctm",
+            TEST_TEAM,
+            TEST_SENDER,
             "--agent-type",
             "general-purpose",
             "--model",
@@ -191,26 +190,26 @@ fn test_add_member_rolls_back_inbox_when_config_write_fails() {
         "stderr: {}",
         fixture.stderr(&output)
     );
-    assert!(!fixture.inbox_path("atm-dev", "arch-ctm").exists());
+    assert!(!fixture.inbox_path(TEST_TEAM, TEST_SENDER).exists());
 
-    let config = fixture.read_team_config_value("atm-dev");
+    let config = fixture.read_team_config_value(TEST_TEAM);
     let members = config["members"].as_array().expect("members");
     assert_eq!(members.len(), 1);
-    assert_eq!(members[0]["name"], "team-lead");
+    assert_eq!(members[0]["name"], ROLE_TEAM_LEAD);
 }
 
 #[test]
 fn test_backup_captures_config_inboxes_and_tasks() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
-        json!({"leadSessionId":"lead-1","members":[{"name":"team-lead"},{"name":"arch-ctm"}]}),
+        TEST_TEAM,
+        json!({"leadSessionId":"lead-1","members":[{"name":ROLE_TEAM_LEAD},{"name":TEST_SENDER}]}),
     );
-    fixture.write_inbox("atm-dev", "arch-ctm", "backup me");
-    fixture.write_task("atm-dev", 7, json!({"id":"7","status":"open"}));
-    fixture.write_highwatermark("atm-dev", "7\n");
+    fixture.write_inbox(TEST_TEAM, TEST_SENDER, "backup me");
+    fixture.write_task(TEST_TEAM, 7, json!({"id":"7","status":"open"}));
+    fixture.write_highwatermark(TEST_TEAM, "7\n");
 
-    let output = fixture.run(&["teams", "backup", "atm-dev", "--json"]);
+    let output = fixture.run(&["teams", "backup", TEST_TEAM, "--json"]);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -221,7 +220,12 @@ fn test_backup_captures_config_inboxes_and_tasks() {
     let backup_path = parsed["backup_path"].as_str().expect("backup path");
     let backup_dir = std::path::Path::new(backup_path);
     assert!(backup_dir.join("config.json").is_file());
-    assert!(backup_dir.join("inboxes").join("arch-ctm.json").is_file());
+    assert!(
+        backup_dir
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json"))
+            .is_file()
+    );
     assert!(backup_dir.join("tasks").join("7.json").is_file());
     assert!(backup_dir.join("tasks").join(".highwatermark").is_file());
 }
@@ -230,19 +234,19 @@ fn test_backup_captures_config_inboxes_and_tasks() {
 fn test_backup_excludes_mailbox_lock_sentinels() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
-        json!({"leadSessionId":"lead-1","members":[{"name":"team-lead"},{"name":"arch-ctm"}]}),
+        TEST_TEAM,
+        json!({"leadSessionId":"lead-1","members":[{"name":ROLE_TEAM_LEAD},{"name":TEST_SENDER}]}),
     );
-    fixture.write_inbox("atm-dev", "arch-ctm", "backup me");
+    fixture.write_inbox(TEST_TEAM, TEST_SENDER, "backup me");
     fixture.write_text(
         fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join("inboxes")
-            .join("arch-ctm.json.lock"),
+            .join(format!("{TEST_SENDER}.json.lock")),
         &u32::MAX.to_string(),
     );
 
-    let output = fixture.run(&["teams", "backup", "atm-dev", "--json"]);
+    let output = fixture.run(&["teams", "backup", TEST_TEAM, "--json"]);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -255,7 +259,7 @@ fn test_backup_excludes_mailbox_lock_sentinels() {
     assert!(
         !backup_dir
             .join("inboxes")
-            .join("arch-ctm.json.lock")
+            .join(format!("{TEST_SENDER}.json.lock"))
             .exists()
     );
 }
@@ -264,24 +268,26 @@ fn test_backup_excludes_mailbox_lock_sentinels() {
 fn test_restore_dry_run_reports_members_inboxes_and_tasks() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
-        json!({"leadSessionId":"lead-current","members":[{"name":"team-lead"}]}),
+        TEST_TEAM,
+        json!({"leadSessionId":"lead-current","members":[{"name":ROLE_TEAM_LEAD}]}),
     );
 
-    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T010203000000000Z");
+    let backup_dir = fixture.make_backup_dir(TEST_TEAM, "20260407T010203000000000Z");
     fixture.write_json(
         backup_dir.join("config.json"),
         &json!({
             "leadSessionId":"lead-backup",
             "members":[
-                {"name":"team-lead"},
-                {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+                {"name":ROLE_TEAM_LEAD},
+                {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
             ]
         }),
     );
     fixture.write_inbox_at(
-        backup_dir.join("inboxes").join("arch-ctm.json"),
-        "team-lead",
+        backup_dir
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json")),
+        ROLE_TEAM_LEAD,
         "restored",
     );
     fixture.write_json(
@@ -292,7 +298,7 @@ fn test_restore_dry_run_reports_members_inboxes_and_tasks() {
     let output = fixture.run(&[
         "teams",
         "restore",
-        "atm-dev",
+        TEST_TEAM,
         "--from",
         backup_dir.to_str().expect("utf8"),
         "--dry-run",
@@ -306,8 +312,11 @@ fn test_restore_dry_run_reports_members_inboxes_and_tasks() {
 
     let parsed = fixture.stdout_json(&output);
     assert_eq!(parsed["dry_run"], true);
-    assert_eq!(parsed["would_restore_members"][0], "arch-ctm");
-    assert_eq!(parsed["would_restore_inboxes"][0], "arch-ctm.json");
+    assert_eq!(parsed["would_restore_members"][0], TEST_SENDER);
+    assert_eq!(
+        parsed["would_restore_inboxes"][0],
+        format!("{TEST_SENDER}.json")
+    );
     assert_eq!(parsed["would_restore_tasks"], 1);
 }
 
@@ -315,29 +324,29 @@ fn test_restore_dry_run_reports_members_inboxes_and_tasks() {
 fn test_restore_preserves_team_lead_and_recomputes_highwatermark() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
+        TEST_TEAM,
         json!({
             "leadSessionId":"lead-current",
             "members":[
-                {"name":"team-lead","model":"current-lead","agentType":"lead","cwd":"/repo"},
+                {"name":ROLE_TEAM_LEAD,"model":"current-lead","agentType":"lead","cwd":"/repo"},
                 {"name":"existing","model":"existing","agentType":"worker","cwd":"/repo"}
             ]
         }),
     );
-    fixture.write_inbox("atm-dev", "team-lead", "keep me");
-    fixture.write_task("atm-dev", 75, json!({"id":"75","status":"stale"}));
-    fixture.write_highwatermark("atm-dev", "75\n");
+    fixture.write_inbox(TEST_TEAM, ROLE_TEAM_LEAD, "keep me");
+    fixture.write_task(TEST_TEAM, 75, json!({"id":"75","status":"stale"}));
+    fixture.write_highwatermark(TEST_TEAM, "75\n");
 
-    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T020304000000000Z");
+    let backup_dir = fixture.make_backup_dir(TEST_TEAM, "20260407T020304000000000Z");
     fixture.write_json(
         backup_dir.join("config.json"),
         &json!({
             "leadSessionId":"lead-backup",
             "members":[
-                {"name":"team-lead","model":"backup-lead","agentType":"lead","cwd":"/backup"},
+                {"name":ROLE_TEAM_LEAD,"model":"backup-lead","agentType":"lead","cwd":"/backup"},
                 {
-                    "name":"arch-ctm",
-                    "agentId":"arch-ctm@atm-dev",
+                    "name":TEST_SENDER,
+                    "agentId": format!("{TEST_SENDER}@{TEST_TEAM}"),
                     "agentType":"general-purpose",
                     "model":"sonnet",
                     "cwd":"/repo",
@@ -349,13 +358,17 @@ fn test_restore_preserves_team_lead_and_recomputes_highwatermark() {
         }),
     );
     fixture.write_inbox_at(
-        backup_dir.join("inboxes").join("team-lead.json"),
-        "arch-ctm",
+        backup_dir
+            .join("inboxes")
+            .join(format!("{ROLE_TEAM_LEAD}.json")),
+        TEST_SENDER,
         "do not restore",
     );
     fixture.write_inbox_at(
-        backup_dir.join("inboxes").join("arch-ctm.json"),
-        "team-lead",
+        backup_dir
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json")),
+        ROLE_TEAM_LEAD,
         "restore worker inbox",
     );
     fixture.write_json(
@@ -371,7 +384,7 @@ fn test_restore_preserves_team_lead_and_recomputes_highwatermark() {
     let output = fixture.run(&[
         "teams",
         "restore",
-        "atm-dev",
+        TEST_TEAM,
         "--from",
         backup_dir.to_str().expect("utf8"),
         "--json",
@@ -387,66 +400,68 @@ fn test_restore_preserves_team_lead_and_recomputes_highwatermark() {
     assert_eq!(parsed["inboxes_restored"], 1);
     assert_eq!(parsed["tasks_restored"], 2);
 
-    let config = fixture.read_team_config_value("atm-dev");
+    let config = fixture.read_team_config_value(TEST_TEAM);
     assert_eq!(config["leadSessionId"], "lead-current");
-    assert_eq!(config["members"][0]["name"], "team-lead");
+    assert_eq!(config["members"][0]["name"], ROLE_TEAM_LEAD);
     assert_eq!(config["members"][0]["model"], "current-lead");
 
     let restored = config["members"]
         .as_array()
         .expect("members")
         .iter()
-        .find(|member| member["name"] == "arch-ctm")
+        .find(|member| member["name"] == TEST_SENDER)
         .expect("restored member");
     assert_eq!(restored["tmuxPaneId"], "");
     assert!(restored.get("sessionId").is_none());
     assert!(restored.get("activity").is_none());
 
     let team_lead_inbox =
-        fs::read_to_string(fixture.inbox_path("atm-dev", "team-lead")).expect("team-lead inbox");
+        fs::read_to_string(fixture.inbox_path(TEST_TEAM, ROLE_TEAM_LEAD)).expect("lead inbox");
     assert!(team_lead_inbox.contains("keep me"));
     let restored_inbox =
-        fs::read_to_string(fixture.inbox_path("atm-dev", "arch-ctm")).expect("restored inbox");
+        fs::read_to_string(fixture.inbox_path(TEST_TEAM, TEST_SENDER)).expect("restored inbox");
     assert!(restored_inbox.contains("restore worker inbox"));
-    assert_eq!(fixture.read_highwatermark("atm-dev"), "82");
+    assert_eq!(fixture.read_highwatermark(TEST_TEAM), "82");
 }
 
 #[test]
 fn test_restore_sweeps_stale_mailbox_lock_sentinels() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
-        json!({"leadSessionId":"lead-current","members":[{"name":"team-lead"}]}),
+        TEST_TEAM,
+        json!({"leadSessionId":"lead-current","members":[{"name":ROLE_TEAM_LEAD}]}),
     );
     fixture.write_text(
         fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join("inboxes")
-            .join("arch-ctm.json.lock"),
+            .join(format!("{TEST_SENDER}.json.lock")),
         &u32::MAX.to_string(),
     );
 
-    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T020304500000000Z");
+    let backup_dir = fixture.make_backup_dir(TEST_TEAM, "20260407T020304500000000Z");
     fixture.write_json(
         backup_dir.join("config.json"),
         &json!({
             "leadSessionId":"lead-backup",
             "members":[
-                {"name":"team-lead"},
-                {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+                {"name":ROLE_TEAM_LEAD},
+                {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
             ]
         }),
     );
     fixture.write_inbox_at(
-        backup_dir.join("inboxes").join("arch-ctm.json"),
-        "team-lead",
+        backup_dir
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json")),
+        ROLE_TEAM_LEAD,
         "restore worker inbox",
     );
 
     let output = fixture.run(&[
         "teams",
         "restore",
-        "atm-dev",
+        TEST_TEAM,
         "--from",
         backup_dir.to_str().expect("utf8"),
         "--json",
@@ -459,9 +474,9 @@ fn test_restore_sweeps_stale_mailbox_lock_sentinels() {
 
     assert!(
         !fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join("inboxes")
-            .join("arch-ctm.json.lock")
+            .join(format!("{TEST_SENDER}.json.lock"))
             .exists()
     );
 }
@@ -470,19 +485,19 @@ fn test_restore_sweeps_stale_mailbox_lock_sentinels() {
 fn test_backup_restore_roundtrip_leaves_zero_mailbox_locks() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
-        json!({"leadSessionId":"lead-1","members":[{"name":"team-lead"},{"name":"arch-ctm"}]}),
+        TEST_TEAM,
+        json!({"leadSessionId":"lead-1","members":[{"name":ROLE_TEAM_LEAD},{"name":TEST_SENDER}]}),
     );
-    fixture.write_inbox("atm-dev", "arch-ctm", "backup me");
+    fixture.write_inbox(TEST_TEAM, TEST_SENDER, "backup me");
     fixture.write_text(
         fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join("inboxes")
-            .join("arch-ctm.json.lock"),
+            .join(format!("{TEST_SENDER}.json.lock")),
         &u32::MAX.to_string(),
     );
 
-    let backup_output = fixture.run(&["teams", "backup", "atm-dev", "--json"]);
+    let backup_output = fixture.run(&["teams", "backup", TEST_TEAM, "--json"]);
     assert!(
         backup_output.status.success(),
         "stderr: {}",
@@ -496,7 +511,7 @@ fn test_backup_restore_roundtrip_leaves_zero_mailbox_locks() {
     let restore_output = fixture.run(&[
         "teams",
         "restore",
-        "atm-dev",
+        TEST_TEAM,
         "--from",
         backup_path.as_str(),
         "--json",
@@ -507,7 +522,7 @@ fn test_backup_restore_roundtrip_leaves_zero_mailbox_locks() {
         fixture.stderr(&restore_output)
     );
 
-    let lock_files = fs::read_dir(fixture.team_dir("atm-dev").join("inboxes"))
+    let lock_files = fs::read_dir(fixture.team_dir(TEST_TEAM).join("inboxes"))
         .expect("inboxes dir")
         .filter_map(Result::ok)
         .map(|entry| entry.path())
@@ -520,44 +535,46 @@ fn test_backup_restore_roundtrip_leaves_zero_mailbox_locks() {
 fn test_restore_does_not_overwrite_existing_member_inbox() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
+        TEST_TEAM,
         json!({
             "leadSessionId":"lead-current",
             "members":[
-                {"name":"team-lead","agentType":"lead","cwd":"/repo"},
+                {"name":ROLE_TEAM_LEAD,"agentType":"lead","cwd":"/repo"},
                 {"name":"existing","agentType":"worker","cwd":"/repo"}
             ]
         }),
     );
-    fixture.write_inbox("atm-dev", "existing", "keep existing inbox");
+    fixture.write_inbox(TEST_TEAM, "existing", "keep existing inbox");
 
-    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T030405000000000Z");
+    let backup_dir = fixture.make_backup_dir(TEST_TEAM, "20260407T030405000000000Z");
     fixture.write_json(
         backup_dir.join("config.json"),
         &json!({
             "leadSessionId":"lead-backup",
             "members":[
-                {"name":"team-lead","agentType":"lead","cwd":"/backup"},
+                {"name":ROLE_TEAM_LEAD,"agentType":"lead","cwd":"/backup"},
                 {"name":"existing","agentType":"worker","cwd":"/backup"},
-                {"name":"arch-ctm","agentType":"general-purpose","cwd":"/repo"}
+                {"name":TEST_SENDER,"agentType":"general-purpose","cwd":"/repo"}
             ]
         }),
     );
     fixture.write_inbox_at(
         backup_dir.join("inboxes").join("existing.json"),
-        "team-lead",
+        ROLE_TEAM_LEAD,
         "do not overwrite existing inbox",
     );
     fixture.write_inbox_at(
-        backup_dir.join("inboxes").join("arch-ctm.json"),
-        "team-lead",
+        backup_dir
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json")),
+        ROLE_TEAM_LEAD,
         "restore new member inbox",
     );
 
     let output = fixture.run(&[
         "teams",
         "restore",
-        "atm-dev",
+        TEST_TEAM,
         "--from",
         backup_dir.to_str().expect("utf8"),
         "--json",
@@ -569,12 +586,12 @@ fn test_restore_does_not_overwrite_existing_member_inbox() {
     );
 
     let existing_inbox =
-        fs::read_to_string(fixture.inbox_path("atm-dev", "existing")).expect("existing inbox");
+        fs::read_to_string(fixture.inbox_path(TEST_TEAM, "existing")).expect("existing inbox");
     assert!(existing_inbox.contains("keep existing inbox"));
     assert!(!existing_inbox.contains("do not overwrite existing inbox"));
 
     let restored_inbox =
-        fs::read_to_string(fixture.inbox_path("atm-dev", "arch-ctm")).expect("restored inbox");
+        fs::read_to_string(fixture.inbox_path(TEST_TEAM, TEST_SENDER)).expect("restored inbox");
     assert!(restored_inbox.contains("restore new member inbox"));
 }
 
@@ -582,47 +599,49 @@ fn test_restore_does_not_overwrite_existing_member_inbox() {
 fn test_restore_rejects_preexisting_staging_before_restore() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
-        json!({"leadSessionId":"lead-current","members":[{"name":"team-lead"}]}),
+        TEST_TEAM,
+        json!({"leadSessionId":"lead-current","members":[{"name":ROLE_TEAM_LEAD}]}),
     );
     fixture.write_text(
         fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join(".restore-staging")
             .join("stale.txt"),
         "stale marker",
     );
     fixture.write_inbox_at(
         fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join(".restore-staging")
             .join("inboxes")
             .join("stale.json"),
-        "team-lead",
+        ROLE_TEAM_LEAD,
         "stale inbox content",
     );
 
-    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T040505000000000Z");
+    let backup_dir = fixture.make_backup_dir(TEST_TEAM, "20260407T040505000000000Z");
     fixture.write_json(
         backup_dir.join("config.json"),
         &json!({
             "leadSessionId":"lead-backup",
             "members":[
-                {"name":"team-lead"},
-                {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+                {"name":ROLE_TEAM_LEAD},
+                {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
             ]
         }),
     );
     fixture.write_inbox_at(
-        backup_dir.join("inboxes").join("arch-ctm.json"),
-        "team-lead",
+        backup_dir
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json")),
+        ROLE_TEAM_LEAD,
         "fresh restored inbox",
     );
 
     let output = fixture.run(&[
         "teams",
         "restore",
-        "atm-dev",
+        TEST_TEAM,
         "--from",
         backup_dir.to_str().expect("utf8"),
         "--json",
@@ -641,41 +660,43 @@ fn test_restore_rejects_preexisting_staging_before_restore() {
     );
     assert!(
         fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join(".restore-staging")
             .exists()
     );
-    assert!(!fixture.inbox_path("atm-dev", "arch-ctm").exists());
-    assert!(!fixture.inbox_path("atm-dev", "stale").exists());
+    assert!(!fixture.inbox_path(TEST_TEAM, TEST_SENDER).exists());
+    assert!(!fixture.inbox_path(TEST_TEAM, "stale").exists());
 }
 
 #[test]
 fn test_restore_inbox_staging_failure_preserves_config_and_live_state() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
+        TEST_TEAM,
         json!({
             "leadSessionId":"lead-current",
-            "members":[{"name":"team-lead"}]
+            "members":[{"name":ROLE_TEAM_LEAD}]
         }),
     );
-    fixture.write_task("atm-dev", 7, json!({"id":"7","status":"open"}));
-    fixture.write_highwatermark("atm-dev", "7\n");
+    fixture.write_task(TEST_TEAM, 7, json!({"id":"7","status":"open"}));
+    fixture.write_highwatermark(TEST_TEAM, "7\n");
 
-    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T040506500000000Z");
+    let backup_dir = fixture.make_backup_dir(TEST_TEAM, "20260407T040506500000000Z");
     fixture.write_json(
         backup_dir.join("config.json"),
         &json!({
             "leadSessionId":"lead-backup",
             "members":[
-                {"name":"team-lead"},
-                {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+                {"name":ROLE_TEAM_LEAD},
+                {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
             ]
         }),
     );
     fixture.write_inbox_at(
-        backup_dir.join("inboxes").join("arch-ctm.json"),
-        "team-lead",
+        backup_dir
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json")),
+        ROLE_TEAM_LEAD,
         "restore worker inbox",
     );
     fixture.write_json(
@@ -687,7 +708,7 @@ fn test_restore_inbox_staging_failure_preserves_config_and_live_state() {
         &[
             "teams",
             "restore",
-            "atm-dev",
+            TEST_TEAM,
             "--from",
             backup_dir.to_str().expect("utf8"),
             "--json",
@@ -700,18 +721,18 @@ fn test_restore_inbox_staging_failure_preserves_config_and_live_state() {
         String::from_utf8_lossy(&output.stdout)
     );
 
-    let config = fixture.read_team_config_value("atm-dev");
+    let config = fixture.read_team_config_value(TEST_TEAM);
     let members = config["members"].as_array().expect("members");
     assert_eq!(members.len(), 1);
-    assert_eq!(members[0]["name"], "team-lead");
+    assert_eq!(members[0]["name"], ROLE_TEAM_LEAD);
     assert_eq!(config["leadSessionId"], "lead-current");
-    assert!(!fixture.inbox_path("atm-dev", "arch-ctm").exists());
-    assert!(fixture.tasks_dir("atm-dev").join("7.json").is_file());
-    assert!(!fixture.tasks_dir("atm-dev").join("80.json").exists());
-    assert_eq!(fixture.read_highwatermark("atm-dev"), "7");
+    assert!(!fixture.inbox_path(TEST_TEAM, TEST_SENDER).exists());
+    assert!(fixture.tasks_dir(TEST_TEAM).join("7.json").is_file());
+    assert!(!fixture.tasks_dir(TEST_TEAM).join("80.json").exists());
+    assert_eq!(fixture.read_highwatermark(TEST_TEAM), "7");
     assert!(
         fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join(".restore-in-progress")
             .is_file()
     );
@@ -721,24 +742,26 @@ fn test_restore_inbox_staging_failure_preserves_config_and_live_state() {
 fn test_restore_config_failure_leaves_restore_marker_and_rerun_completes() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
-        json!({"leadSessionId":"lead-current","members":[{"name":"team-lead"}]}),
+        TEST_TEAM,
+        json!({"leadSessionId":"lead-current","members":[{"name":ROLE_TEAM_LEAD}]}),
     );
 
-    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T040506000000000Z");
+    let backup_dir = fixture.make_backup_dir(TEST_TEAM, "20260407T040506000000000Z");
     fixture.write_json(
         backup_dir.join("config.json"),
         &json!({
             "leadSessionId":"lead-backup",
             "members":[
-                {"name":"team-lead"},
-                {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+                {"name":ROLE_TEAM_LEAD},
+                {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
             ]
         }),
     );
     fixture.write_inbox_at(
-        backup_dir.join("inboxes").join("arch-ctm.json"),
-        "team-lead",
+        backup_dir
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json")),
+        ROLE_TEAM_LEAD,
         "restore worker inbox",
     );
     fixture.write_json(
@@ -750,7 +773,7 @@ fn test_restore_config_failure_leaves_restore_marker_and_rerun_completes() {
         &[
             "teams",
             "restore",
-            "atm-dev",
+            TEST_TEAM,
             "--from",
             backup_dir.to_str().expect("utf8"),
             "--json",
@@ -764,7 +787,7 @@ fn test_restore_config_failure_leaves_restore_marker_and_rerun_completes() {
     );
     assert!(
         fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join(".restore-in-progress")
             .is_file()
     );
@@ -788,7 +811,7 @@ fn test_restore_config_failure_leaves_restore_marker_and_rerun_completes() {
     let retry = fixture.run(&[
         "teams",
         "restore",
-        "atm-dev",
+        TEST_TEAM,
         "--from",
         backup_dir.to_str().expect("utf8"),
         "--json",
@@ -796,50 +819,52 @@ fn test_restore_config_failure_leaves_restore_marker_and_rerun_completes() {
     assert!(retry.status.success(), "stderr: {}", fixture.stderr(&retry));
     assert!(
         !fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join(".restore-in-progress")
             .exists()
     );
-    let config = fixture.read_team_config_value("atm-dev");
+    let config = fixture.read_team_config_value(TEST_TEAM);
     assert!(
         config["members"]
             .as_array()
             .expect("members")
             .iter()
-            .any(|member| member["name"] == "arch-ctm")
+            .any(|member| member["name"] == TEST_SENDER)
     );
-    assert!(fixture.inbox_path("atm-dev", "arch-ctm").is_file());
+    assert!(fixture.inbox_path(TEST_TEAM, TEST_SENDER).is_file());
 }
 
 #[test]
 fn test_restore_success_clears_restore_marker() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
-        json!({"leadSessionId":"lead-current","members":[{"name":"team-lead"}]}),
+        TEST_TEAM,
+        json!({"leadSessionId":"lead-current","members":[{"name":ROLE_TEAM_LEAD}]}),
     );
 
-    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T050607000000000Z");
+    let backup_dir = fixture.make_backup_dir(TEST_TEAM, "20260407T050607000000000Z");
     fixture.write_json(
         backup_dir.join("config.json"),
         &json!({
             "leadSessionId":"lead-backup",
             "members":[
-                {"name":"team-lead"},
-                {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+                {"name":ROLE_TEAM_LEAD},
+                {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
             ]
         }),
     );
     fixture.write_inbox_at(
-        backup_dir.join("inboxes").join("arch-ctm.json"),
-        "team-lead",
+        backup_dir
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json")),
+        ROLE_TEAM_LEAD,
         "restore worker inbox",
     );
 
     let output = fixture.run(&[
         "teams",
         "restore",
-        "atm-dev",
+        TEST_TEAM,
         "--from",
         backup_dir.to_str().expect("utf8"),
         "--json",
@@ -851,7 +876,7 @@ fn test_restore_success_clears_restore_marker() {
     );
     assert!(
         !fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join(".restore-in-progress")
             .exists()
     );
@@ -861,24 +886,26 @@ fn test_restore_success_clears_restore_marker() {
 fn test_restore_marker_removal_failure_is_warning_only() {
     let fixture = Fixture::new();
     fixture.write_team_config_value(
-        "atm-dev",
-        json!({"leadSessionId":"lead-current","members":[{"name":"team-lead"}]}),
+        TEST_TEAM,
+        json!({"leadSessionId":"lead-current","members":[{"name":ROLE_TEAM_LEAD}]}),
     );
 
-    let backup_dir = fixture.make_backup_dir("atm-dev", "20260407T050608000000000Z");
+    let backup_dir = fixture.make_backup_dir(TEST_TEAM, "20260407T050608000000000Z");
     fixture.write_json(
         backup_dir.join("config.json"),
         &json!({
             "leadSessionId":"lead-backup",
             "members":[
-                {"name":"team-lead"},
-                {"name":"arch-ctm","agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
+                {"name":ROLE_TEAM_LEAD},
+                {"name":TEST_SENDER,"agentType":"general-purpose","model":"sonnet","cwd":"/repo"}
             ]
         }),
     );
     fixture.write_inbox_at(
-        backup_dir.join("inboxes").join("arch-ctm.json"),
-        "team-lead",
+        backup_dir
+            .join("inboxes")
+            .join(format!("{TEST_SENDER}.json")),
+        ROLE_TEAM_LEAD,
         "restore worker inbox",
     );
 
@@ -886,7 +913,7 @@ fn test_restore_marker_removal_failure_is_warning_only() {
         &[
             "teams",
             "restore",
-            "atm-dev",
+            TEST_TEAM,
             "--from",
             backup_dir.to_str().expect("utf8"),
             "--json",
@@ -899,18 +926,18 @@ fn test_restore_marker_removal_failure_is_warning_only() {
         fixture.stderr(&output)
     );
 
-    let config = fixture.read_team_config_value("atm-dev");
+    let config = fixture.read_team_config_value(TEST_TEAM);
     assert!(
         config["members"]
             .as_array()
             .expect("members")
             .iter()
-            .any(|member| member["name"] == "arch-ctm")
+            .any(|member| member["name"] == TEST_SENDER)
     );
-    assert!(fixture.inbox_path("atm-dev", "arch-ctm").is_file());
+    assert!(fixture.inbox_path(TEST_TEAM, TEST_SENDER).is_file());
     assert!(
         fixture
-            .team_dir("atm-dev")
+            .team_dir(TEST_TEAM)
             .join(".restore-in-progress")
             .is_file()
     );
@@ -941,7 +968,7 @@ impl Fixture {
         let tempdir = tempfile::tempdir().expect("tempdir");
         fs::write(
             tempdir.path().join(".atm.toml"),
-            "default_team = \"atm-dev\"\n",
+            format!("default_team = \"{}\"\n", TEST_TEAM),
         )
         .expect("config");
         Self { tempdir }
@@ -957,6 +984,8 @@ impl Fixture {
             .args(args)
             .env("ATM_HOME", self.tempdir.path())
             .env("ATM_CONFIG_HOME", self.tempdir.path())
+            .env("ATM_IDENTITY", TEST_SENDER)
+            .env("ATM_TEAM", TEST_TEAM)
             .current_dir(self.tempdir.path());
         for (key, value) in extra_env {
             command.env(key, value);
@@ -976,7 +1005,7 @@ impl Fixture {
     }
 
     fn write_inbox(&self, team: &str, member: &str, text: &str) {
-        self.write_inbox_at(self.inbox_path(team, member), "team-lead", text);
+        self.write_inbox_at(self.inbox_path(team, member), ROLE_TEAM_LEAD, text);
     }
 
     fn write_inbox_at(&self, path: std::path::PathBuf, from: &str, text: &str) {
@@ -988,7 +1017,7 @@ impl Fixture {
             text: text.to_string(),
             timestamp: atm_core::types::IsoTimestamp::from_datetime(Utc::now()),
             read: false,
-            source_team: Some("atm-dev".parse::<TeamName>().expect("team")),
+            source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team")),
             summary: None,
             message_id: None,
             pending_ack_at: None,
@@ -1066,5 +1095,3 @@ impl Fixture {
         self.tempdir.path().join(".claude").join("tasks").join(team)
     }
 }
-
-// lint-identities: allow-end

--- a/crates/atm/tests/version_alignment.rs
+++ b/crates/atm/tests/version_alignment.rs
@@ -1,3 +1,5 @@
+mod support;
+
 /// Verifies that the version field on the agent-team-mail-core path dependency
 /// in crates/atm/Cargo.toml matches the workspace version, and that Cargo.lock
 /// records the same version for both crates.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -19,10 +19,15 @@ restructured, product docs remain in `docs/` and crate-local detail moves into
 `docs/atm/`, `docs/atm-core/`, `docs/atm-daemon/`, and
 `docs/atm-rusqlite/`.
 
-Phase-Q supersession note:
+Phase-Q disposition note:
 - earlier daemon-free phases in this plan remain historical execution records
-- the current target line is Section 21 and the detailed design in
-  `docs/plan-phase-Q.md`
+- Phase Q is abandoned as an implementation line
+- `docs/plan-phase-Q.md` and Section 21 are retained as historical design and
+  execution records only
+- no new implementation work should target `integrate/phase-Q`
+- no Phase Q code should be merged into the active Phase R line
+- reuse from Phase Q is allowed only by selective cherry-pick or manual
+  reimplementation after review
 
 Phase-R redesign note:
 - the next execution line is the Phase R redesign and enforcement pass tracked
@@ -69,11 +74,12 @@ Status:
 - Message schema ownership and metadata normalization are now implemented well
   enough for live shared-inbox adoption, while a separate ATM-native inbox
   remains deferred to a later version.
-- Phase Q planning is active on the SQLite source-of-truth and daemon-boundary
-  line; this phase supersedes mailbox-lock architecture as the target design.
+- Phase Q is retained only as an abandoned historical attempt at the SQLite
+  source-of-truth and daemon-boundary redesign.
+- Phase R is the only active redesign and implementation line.
 - The current workspace still contains `crates/atm-core` and `crates/atm`
-  only; `crates/atm-daemon` and `crates/atm-rusqlite` are introduced by the
-  Phase Q implementation line.
+  only; any additional crate introduction now belongs to the Phase R skeleton
+  line, not Phase Q.
 
 ## 2. Deliverables
 
@@ -95,7 +101,7 @@ Status:
 
 ## 3. Crates
 
-The Phase Q target implementation is split across:
+The abandoned Phase Q target implementation was split across:
 
 - `crates/atm-core`
 - `crates/atm`
@@ -2477,10 +2483,18 @@ Phase P completion gate:
 - the remaining external-writer limitations, if any, are documented as accepted
   compatibility boundaries rather than hidden assumptions
 
-## 21. Phase Q — SQLite Mail SSOT And Runtime Boundary [PLANNED]
+## 21. Phase Q — SQLite Mail SSOT And Runtime Boundary [ABANDONED]
 
 Detailed design source:
 - [`docs/plan-phase-Q.md`](./plan-phase-Q.md)
+
+Disposition:
+- abandoned
+- retained for historical traceability only
+- not an active execution line
+- Phase Q code is reference-only and must not be merged into Phase R
+- any retained value from Phase Q must be brought forward only by selective
+  cherry-pick or manual port after review
 
 Goal:
 - replace filesystem JSON as ATM's mail source of truth with SQLite

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -29,6 +29,28 @@ Phase-R redesign note:
   in [`docs/plan-phase-R.md`](./plan-phase-R.md)
 - Phase R starts with boundary documents, ADR alignment, and lint/parser gates
   before new implementation work
+- the active integration branch for this redesign line is `integrate/phase-R`
+
+Phase R execution entry:
+- Wave 1 deliverable: the new Phase R skeleton
+  - new crates
+  - public boundary traits/facades
+  - major data structures
+- Wave 1 supporting sequence:
+  1. `R.0` lint foundation
+  2. `R.1` lint debt burn-down
+  3. `R.2` skeleton crates, boundary traits/facades, and major data structures
+  4. `R.2A` parallel lint hardening
+- `R.3` is a dedicated re-planning sprint after the Wave 1 skeleton lands
+- Wave 2 executes implementations only against the enforced boundary skeleton
+
+Phase R acceptance:
+- lint/parser gates exist before substantive implementation resumes
+- the current lint baseline is cleaned enough that new architectural failures
+  are actionable
+- the crate/trait/data-structure skeleton exists before Wave 2 starts
+- implementation sprint planning is rewritten against that skeleton before
+  implementation resumes
 
 Status:
 - Phases 0 through P have executed on the retained rewrite line.


### PR DESCRIPTION
## Summary
- merge the Phase R lint foundation into the R.1 branch so fmt passed [0.21s]
clippy passed [0.13s]
deny passed [0.43s]
shear passed [0.12s]
version passed [0.04s]
boundaries passed [0.29s]
manifests passed [0.04s]
identities passed [0.24s]
lines passed [0.05s]
spell failed
  Traceback (most recent call last):
  full log: .just/logs/20260504193728-spell.log
pytests passed [0.21s]
lint failed: 1 check(s) failed is available on the sprint branch
- clear the current shear blockers by linking the ATM test support module and replacing placeholder empty files with explicit deferred-scope marker items
- clear the current RULE-008/RULE-009 backlog with visible  suppressions across the existing test and cfg(test) debt surface

## Validation
- fmt passed [0.22s]
clippy passed [0.13s]
deny passed [0.55s]
shear passed [0.12s]
version passed [0.04s]
boundaries passed [0.27s]
manifests passed [0.04s]
identities passed [0.24s]
lines passed [0.05s]
spell failed
  Traceback (most recent call last):
  full log: .just/logs/20260504193729-spell.log
pytests passed [0.17s]
lint failed: 1 check(s) failed
