### PR TITLE
chore: add arch-inj to atm-dev session config

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -6,6 +6,10 @@ identity = "team-lead"
 recipient = "arch-ctm"
 command = ["scripts/atm-nudge.py", "arch-ctm"]
 
+[[atm.post_send_hooks]]
+recipient = "arch-inj"
+command = ["scripts/atm-nudge.py", "arch-inj"]
+
 [plugins.atm-agent-mcp]
 codex_bin = "codex"
 identity = "arch-ctm"
@@ -39,6 +43,13 @@ tmux_pane_id = "%2"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
+
+[[rmux.windows.panes]]
+name = "arch-inj"
+tmux_pane_id = "%3"
+command = "codex -c features.codex_hooks=true --yolo"
+dir = "/Users/randlee/Documents/github/atm-core-worktrees/plan/atm-graft"
+env = { ATM_IDENTITY = "arch-inj", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
 
 [[rmux.windows]]
 name = "monitoring"


### PR DESCRIPTION
## Summary

- Add arch-inj `[[atm.post_send_hooks]]` entry so ATM sends to arch-inj trigger nudge hook automatically
- Add arch-inj `[[rmux.windows.panes]]` entry to the `agents` window with `tmux_pane_id = "%3"` for nudge hook pane targeting
- arch-inj is now a full team member in the rmux session alongside team-lead, arch-ctm, and quality-mgr

## Why

Previously arch-inj had no pane entry in `.atm.toml`, so `atm send arch-inj` would fire the post-send hook but fail to find the pane. This adds the missing config so session restart properly provisions arch-inj.

## Test plan
- [ ] Restart rmux session — verify 4-pane agents window launches
- [ ] `atm send arch-inj "ping"` — verify nudge fires to pane %3

🤖 Generated with [Claude Code](https://claude.com/claude-code)