### PR TITLE
feat(R.2): atm-core boundary module — 8 sealed trait stubs

### DIFF
--- a/.just/lint_boundaries.py
+++ b/.just/lint_boundaries.py
@@ -46,7 +46,7 @@ REQUIRED_BOUNDARY_FIELDS = (
 VISIBILITY_VALUES = {"private", "pub(crate)", "public", "trait_only"}
 CONSTRUCTOR_VALUES = {"private", "pub(crate)", "public", "none"}
 REFERENCE_SCOPE_VALUES = {"global", "outside_owner_crate"}
-STATE_VALUES = {"planned", "active", "retired"}
+STATE_VALUES = {"planned", "active", "deferred", "retired"}
 PACKAGE_NAME_RE = re.compile(r"^[a-z0-9]+(?:[.-][a-z0-9]+)*$")
 CRATE_PATH_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 RUST_PATH_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$")
@@ -1038,6 +1038,7 @@ def boundary_doc_section_lines(repo_root: Path, records: list[BoundaryRecord]) -
             "records": 0,
             "active": 0,
             "planned": 0,
+            "deferred": 0,
             "retired": 0,
         }
 
@@ -1048,7 +1049,7 @@ def boundary_doc_section_lines(repo_root: Path, records: list[BoundaryRecord]) -
             doc_key = record.source_path.as_posix()
         counts = record_counts_by_doc.setdefault(
             doc_key,
-            {"records": 0, "active": 0, "planned": 0, "retired": 0},
+            {"records": 0, "active": 0, "planned": 0, "deferred": 0, "retired": 0},
         )
         counts["records"] += 1
         if record.status_state in counts:
@@ -1063,6 +1064,7 @@ def boundary_doc_section_lines(repo_root: Path, records: list[BoundaryRecord]) -
                 "records": str(counts["records"]),
                 "active": str(counts["active"]),
                 "planned": str(counts["planned"]),
+                "deferred": str(counts["deferred"]),
                 "retired": str(counts["retired"]),
             }
         )
@@ -1076,6 +1078,7 @@ def boundary_doc_section_lines(repo_root: Path, records: list[BoundaryRecord]) -
                 ("records", "records"),
                 ("active", "active"),
                 ("planned", "planned"),
+                ("deferred", "deferred"),
                 ("retired", "retired"),
             ],
         )

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -1,0 +1,89 @@
+//! Phase R boundary skeleton contracts.
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Stub ATM request envelope for the Phase R protocol skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AtmRequestEnvelope;
+
+/// Stub ATM response envelope for the Phase R protocol skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AtmResponseEnvelope;
+
+/// Stub ATM frame payload for the Phase R protocol skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AtmFramePayload;
+
+/// Stub outbound client-transport request for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ClientTransportRequest;
+
+/// Stub outbound client-transport response for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ClientTransportResponse;
+
+/// Stub inbound server-transport request for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ServerTransportRequest;
+
+/// Stub inbound server-transport response for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ServerTransportResponse;
+
+/// Stub dispatcher request envelope for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DispatchRequestEnvelope;
+
+/// Stub dispatcher response envelope for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DispatchResponseEnvelope;
+
+/// Stub outbound notification event for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NotificationEvent;
+
+/// Stub inbound runtime-status snapshot for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeStatusSnapshot;
+
+/// Stub watch-subscription request for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchSubscriptionRequest;
+
+/// Stub watch event batch for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchEventBatch;
+
+/// Stub reconcile request for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileRequest;
+
+/// Stub reconcile result for the Phase R skeleton.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileResult;
+
+/// BOUNDARY-AtmProtocol — see docs/atm-core/boundaries.md.
+pub trait AtmProtocol: sealed::Sealed {}
+
+/// BOUNDARY-ClientTransport — see docs/atm-core/boundaries.md.
+pub trait ClientTransport: sealed::Sealed {}
+
+/// BOUNDARY-ServerTransport — see docs/atm-core/boundaries.md.
+pub trait ServerTransport: sealed::Sealed {}
+
+/// BOUNDARY-RequestDispatcher — see docs/atm-core/boundaries.md.
+pub trait RequestDispatcher: sealed::Sealed {}
+
+/// BOUNDARY-NotificationSink — see docs/atm-core/boundaries.md.
+pub trait NotificationSink: sealed::Sealed {}
+
+/// BOUNDARY-StatusSource — see docs/atm-core/boundaries.md.
+pub trait StatusSource: sealed::Sealed {}
+
+/// BOUNDARY-WatchEventSource — see docs/atm-core/boundaries.md.
+pub trait WatchEventSource: sealed::Sealed {}
+
+/// BOUNDARY-ReconcileCoordinator — see docs/atm-core/boundaries.md.
+pub trait ReconcileCoordinator: sealed::Sealed {}

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -2,6 +2,8 @@
 pub mod ack;
 /// Public agent-address parsing and normalization helpers.
 pub mod address;
+/// Phase R boundary traits and placeholder contract types.
+pub mod boundary;
 /// Mailbox cleanup workflows for read and acknowledged messages.
 pub mod clear;
 /// Internal configuration discovery and resolution helpers.
@@ -47,3 +49,8 @@ pub(crate) mod text;
 pub mod types;
 /// Internal ATM-owned workflow-state helpers shared across mailbox services.
 pub(crate) mod workflow;
+
+pub use boundary::{
+    AtmProtocol, ClientTransport, NotificationSink, ReconcileCoordinator, RequestDispatcher,
+    ServerTransport, StatusSource, WatchEventSource,
+};

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -51,6 +51,10 @@ pub mod types;
 pub(crate) mod workflow;
 
 pub use boundary::{
-    AtmProtocol, ClientTransport, NotificationSink, ReconcileCoordinator, RequestDispatcher,
-    ServerTransport, StatusSource, WatchEventSource,
+    AtmFramePayload, AtmProtocol, AtmRequestEnvelope, AtmResponseEnvelope, ClientTransport,
+    ClientTransportRequest, ClientTransportResponse, DispatchRequestEnvelope,
+    DispatchResponseEnvelope, NotificationEvent, NotificationSink, ReconcileCoordinator,
+    ReconcileRequest, ReconcileResult, RequestDispatcher, RuntimeStatusSnapshot, ServerTransport,
+    ServerTransportRequest, ServerTransportResponse, StatusSource, WatchEventBatch,
+    WatchEventSource, WatchSubscriptionRequest,
 };

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -20,8 +20,8 @@ owner_crate_path: atm_core
 name: AtmProtocol
 
 public:
-  trait: null
-  facade: AtmProtocol
+  trait: AtmProtocol
+  facade: null
 
 implementation:
   type: null
@@ -59,11 +59,9 @@ references:
 
 contracts:
   request_types:
-    - SendRequest
-    - ReceiveRequest
+    - AtmRequestEnvelope
   response_types:
-    - SendResponse
-    - ReceiveResponse
+    - AtmResponseEnvelope
   error_types:
     - AtmError
 
@@ -136,9 +134,9 @@ references:
 
 contracts:
   request_types:
-    - AtmProtocol requests
+    - AtmRequestEnvelope
   response_types:
-    - AtmProtocol responses
+    - AtmResponseEnvelope
   error_types:
     - AtmError
 
@@ -358,9 +356,9 @@ references:
 
 contracts:
   request_types:
-    - AtmProtocol requests
+    - AtmRequestEnvelope
   response_types:
-    - AtmProtocol responses
+    - AtmResponseEnvelope
   error_types:
     - AtmError
 
@@ -523,8 +521,9 @@ enforcement:
     - no_concrete_store_leakage
 
 status:
-  state: planned
+  state: deferred
   notes:
+    - Wave 2 (R.4) — implementation sprint not yet scheduled
     - mail state remains distinct from task and roster state
 ```
 
@@ -597,8 +596,9 @@ enforcement:
     - no_concrete_store_leakage
 
 status:
-  state: planned
+  state: deferred
   notes:
+    - Wave 2 (R.4) — implementation sprint not yet scheduled
     - ack-specific state changes belong here even when ack is modeled through send
 ```
 
@@ -671,8 +671,9 @@ enforcement:
     - no_concrete_store_leakage
 
 status:
-  state: planned
+  state: deferred
   notes:
+    - Wave 2 (R.4) — implementation sprint not yet scheduled
     - live status belongs elsewhere; this boundary owns durable roster truth only
 ```
 
@@ -746,8 +747,9 @@ enforcement:
     - no_direct_config_parser_calls
 
 status:
-  state: planned
+  state: deferred
   notes:
+    - Wave 2 (R.4) — implementation sprint not yet scheduled
     - this boundary replaces direct command/service calls into a concrete parser module
 ```
 
@@ -819,8 +821,9 @@ enforcement:
     - no_direct_mailbox_helper_calls
 
 status:
-  state: planned
+  state: deferred
   notes:
+    - Wave 2 (R.4) — implementation sprint not yet scheduled
     - watcher-driven reconcile should call this boundary rather than store helpers directly
 ```
 
@@ -893,8 +896,9 @@ enforcement:
     - no_direct_mailbox_helper_calls
 
 status:
-  state: planned
+  state: deferred
   notes:
+    - Wave 2 (R.4) — implementation sprint not yet scheduled
     - send and receive state transitions should reach compatibility files through this boundary only
 ```
 

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -468,6 +468,7 @@ name: MailStore
 public:
   trait: MailStore
   facade: null
+  notes: planned trait name — not yet landed (Wave 2, R.4)
 
 implementation:
   type: null
@@ -544,6 +545,7 @@ name: TaskStore
 public:
   trait: TaskStore
   facade: null
+  notes: planned trait name — not yet landed (Wave 2, R.4)
 
 implementation:
   type: null
@@ -619,6 +621,7 @@ name: RosterStore
 public:
   trait: RosterStore
   facade: null
+  notes: planned trait name — not yet landed (Wave 2, R.4)
 
 implementation:
   type: null
@@ -694,6 +697,7 @@ name: ConfigIngress
 public:
   trait: ConfigIngress
   facade: null
+  notes: planned trait name — not yet landed (Wave 2, R.4)
 
 implementation:
   type: null
@@ -770,6 +774,7 @@ name: InboxIngress
 public:
   trait: InboxIngress
   facade: null
+  notes: planned trait name — not yet landed (Wave 2, R.4)
 
 implementation:
   type: null
@@ -844,6 +849,7 @@ name: InboxExport
 public:
   trait: InboxExport
   facade: null
+  notes: planned trait name — not yet landed (Wave 2, R.4)
 
 implementation:
   type: null

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2553,6 +2553,7 @@ Scope:
 
 Implementation focus:
 - one shared inbox write boundary
+
 - one shared inbox hydration boundary
 - one owned message-id compatibility bridge
 - explicit roster/member construction instead of hidden defaults
@@ -2740,3 +2741,23 @@ QA invariants for every Phase Q pass:
 - SQLite remains the source of truth for mail and roster
 - live status remains daemon-memory truth
 - Claude compatibility remains Claude-native top-level plus `metadata.atm`
+
+## 22. Phase R — Boundary Establishment And Enforcement
+
+Detailed execution source:
+- [`docs/plan-phase-R.md`](./plan-phase-R.md)
+
+Summary:
+- Phase R is the active redesign line that replaces the abandoned Phase Q
+  implementation path.
+- Wave 1 establishes enforceable crate boundaries before substantive feature
+  work resumes:
+  - lint/parser foundation and debt burn-down
+  - the new crate skeleton
+  - public boundary traits/facades
+  - major shared data structures
+- Wave 2 implements behavior only against those enforced boundaries.
+
+Cross-reference:
+- The authoritative sprint-by-sprint Phase R plan lives in
+  [`docs/plan-phase-R.md`](./plan-phase-R.md).


### PR DESCRIPTION
## Summary

- New `atm_core::boundary` module with 8 sealed public trait definitions: `AtmProtocol`, `ClientTransport`, `ServerTransport`, `RequestDispatcher`, `NotificationSink`, `StatusSource`, `WatchEventSource`, `ReconcileCoordinator`
- Minimal placeholder data types for trait signatures to compile
- Re-exported from `lib.rs`; no concrete implementations in `atm-core`
- Merged R.1 (feature/pR-s1-lint-debt at 35d6d51) forward as baseline

## Phase R Wave 1 — Skeleton

This sprint establishes the compile-time boundary contract in `atm-core`. Traits are sealed by default (no external implementations without explicit review). All boundary records reference their `boundaries.md` `boundary_id`.

## Test plan
- [ ] `cargo build --workspace` passes
- [ ] `just lint` passes all platforms
- [ ] All 8 boundary traits exist as sealed empty stubs in `atm-core::boundary`
- [ ] No concrete implementations shipped in `atm-core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)