### PR TITLE
docs(R.3.2): behavior sprint planning — R.4-R.8 concrete checklists

### DIFF
--- a/docs/adr/ADR-001-sealed-trait-pattern.md
+++ b/docs/adr/ADR-001-sealed-trait-pattern.md
@@ -217,10 +217,10 @@ Option 3:
 
 | Action | Owner | Gate |
 |---|---|---|
-| Add `#[doc(hidden)]` to `pub mod sealed` in `atm-core` | arch-ctm | Phase R |
+| Add `#[doc(hidden)]` to `pub mod sealed` in `atm-core` | arch-ctm | R.4 |
 | Add sealed module doc comment (workspace-convention language) | arch-ctm | Done (49861c4) |
 | Verify boundary records reference permitted impl sites | arch-ctm | Phase R |
-| Add ADR reference to `AGENTS.md` — agents must not modify `pub mod sealed` without ADR review | team-lead | Phase R |
+| Add ADR reference to `AGENTS.md` — agents must not modify `pub mod sealed` without ADR review | team-lead | Done (cd70665) |
 | Close ARCH-001 | team-lead | Done |
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,9 @@ Phase-R redesign note:
   then rebuilds the implementation under lint/visibility guardrails
 - Phase R treats thin-client extension pressure, including `atm-graft`, as a
   first-class architectural input
+- for the boundary / adapter model, Phase R supersedes any earlier
+  pre-Phase-R architecture statements in this document that conflict with the
+  crate-local boundary inventories, ADRs, or `docs/plan-phase-R.md`
 
 ## 2. Crate Boundaries
 

--- a/docs/plan-phase-R.md
+++ b/docs/plan-phase-R.md
@@ -584,9 +584,10 @@ Review targets:
      - thin clients do not require daemon-internal or sqlite-facing knowledge
      - REQ-P-RUNTIME-001 preserved at `R.8` close:
        - daemon auto-start when absent remains supported
-       - auto-start failure emits a typed actionable error rather than silent
-         fallback
-       - no in-process fallback is permitted
+       - auto-start failure emits a typed actionable error and recovery
+         guidance
+       - no production path may silently fall back to direct SQLite or
+         inbox-file access
      - daemon lifecycle (`start` / `stop` / `health`) and all currently
        supported `atm` CLI commands remain functional at `R.8` close
      - `lint_manifests.py` confirms the following ADR-001 dependency edges

--- a/docs/plan-phase-R.md
+++ b/docs/plan-phase-R.md
@@ -365,10 +365,16 @@ Concrete checklist:
 Acceptance:
 - the architecture can compile in skeleton form before feature behavior lands
 
-### R.3.2 Behavior Sprints
+### R.3.2 Behavior Sprint Review
 
 Status:
-- pending
+- in progress
+
+Purpose:
+- review, drill, and finalize the proposed `R.4` through `R.8` sprint scopes
+- identify open scope decisions before Wave 2 implementation begins
+- convert the current wave outline into reviewable sprint checklists, not to
+  declare those sprints implicitly approved
 
 Required order:
 1. protocol and transport
@@ -377,39 +383,158 @@ Required order:
 4. service orchestration
 5. thin client surfaces
 
-Ordered sprint breakdown:
+Review targets:
 1. `R.4 Protocol + Transport`
-   - harden `AtmProtocol` request/response/frame types
-   - land callable `ClientTransport` and `ServerTransport` trait surfaces
-   - land `RequestDispatcher` request-routing contract
-   - review whether daemon-side `PeerClientTransport` and
-     `DaemonRequestDispatcher` stay in scope for this wave before landing their
-     concrete adapters
-   - connect CLI composition root and daemon composition root to these
-     contracts without introducing retained direct call paths
+   - Scope review required first:
+     - `ServerTransport`, `NotificationSink`, `StatusSource`,
+       `WatchEventSource`, and `ReconcileCoordinator` currently have zero
+       methods; define their minimal callable method surfaces before behavior
+       work starts
+     - confirm whether `PeerClientTransport` and daemon-side
+       `RequestDispatcher` concrete adapters stay in this wave or remain
+       deferred
+   - `crates/atm-core/src/boundary/mod.rs`
+     - replace placeholder `AtmRequestEnvelope`, `AtmResponseEnvelope`, and
+       `AtmFramePayload` with named protocol request / response / frame types
+       for thin `send` / `receive`
+     - add callable methods to:
+       - `AtmProtocol`
+       - `ClientTransport`
+       - `ServerTransport`
+       - `RequestDispatcher`
+       - `NotificationSink`
+       - `StatusSource`
+       - `WatchEventSource`
+       - `ReconcileCoordinator`
+   - `crates/atm-daemon/src/lib.rs`
+     - implement stub method signatures for runtime-owned adapters:
+       - `LocalSocketServerTransport`
+       - `DaemonNotificationSink`
+       - `DaemonStatusSource`
+       - `FileWatchEventSource`
+       - `DaemonReconcileCoordinator`
+     - add daemon-side `PeerClientTransport` and `DaemonRequestDispatcher`
+       adapters if R.4 scope keeps them in wave 2
+   - `crates/atm-daemon/src/composition.rs`
+     - wire runtime composition to the new transport/dispatcher method surfaces
+       without introducing direct CLI or sqlite dependencies
+   - `crates/atm/src/composition.rs`
+     - wire `CliComposition` against the `ClientTransport` method surface only
+   - Acceptance:
+     - protocol request / response / frame DTOs are named and exported from
+       `atm-core`
+     - zero-method runtime traits resolved by explicit method surfaces
+     - CLI and daemon compositions compile against callable transport traits
+     - no direct `atm -> atm-daemon` or `atm -> atm-rusqlite` edge appears
 2. `R.5 Store Boundaries`
-   - implement `MailStore`, `TaskStore`, and `RosterStore` trait contracts in
-     `atm-core`
-   - land private SQLite adapter shells in `atm-rusqlite`
-   - move current retained direct SQLite ownership behind those contracts
+   - `crates/atm-core/src/boundary/mod.rs`
+     - finalize request / response DTOs for:
+       - `MailStore`
+       - `TaskStore`
+       - `RosterStore`
+     - ensure method families match actual retained behaviors:
+       - message persistence / visibility / replay state
+       - task creation / update / ack transition / message links
+       - roster replace / load / membership query / health
+   - `crates/atm-rusqlite/src/lib.rs`
+     - replace typed stub failures with real trait implementations for:
+       - `SqliteMailStore`
+       - `SqliteTaskStore`
+       - `SqliteRosterStore`
+     - keep constructors private and assembly boundary-facing only
+   - Retained behavior cutover:
+     - identify and replace direct store ownership in existing retained flows
+       under:
+       - `crates/atm-core/src/read/`
+       - `crates/atm-core/src/clear/`
+       - `crates/atm-core/src/send/`
+       - `crates/atm-core/src/ack/`
+       - `crates/atm-core/src/team_admin/`
+   - Tests:
+     - add store-contract coverage in `crates/atm-core/tests/`
+     - keep adapter-specific behavior tests in `crates/atm-rusqlite`
+   - Acceptance:
+     - SQLite-backed behavior lives behind `MailStore` / `TaskStore` /
+       `RosterStore`
+     - retained core flows no longer own sqlite-facing logic directly
+     - replacing the sqlite adapter does not require caller changes outside
+       composition or adapter crates
 3. `R.6 Config / Inbox / Notification / Watch`
-   - land `ConfigIngress`, `InboxIngress`, and `InboxExport`
-   - land `NotificationSink`, `StatusSource`, `WatchEventSource`, and
-     `ReconcileCoordinator`
-   - decide and implement the retained compatibility-policy locations inside
-     those adapters
+   - `crates/atm-core/src/boundary/mod.rs`
+     - finalize method surfaces and DTOs for:
+       - `ConfigIngress`
+       - `InboxIngress`
+       - `InboxExport`
+       - `NotificationSink`
+       - `StatusSource`
+       - `WatchEventSource`
+       - `ReconcileCoordinator`
+   - `crates/atm-daemon/src/lib.rs`
+     - implement real daemon-owned adapters for:
+       - config loading
+       - inbox import/export
+       - notification delivery
+       - status reporting
+       - watch capture
+       - reconcile coordination
+   - Policy placement review:
+     - document and implement where compatibility / recovery policy is allowed
+       to live inside ingress/export adapters versus service orchestration
+   - Retained behavior cutover:
+     - remove direct config parsing, inbox compatibility handling, and watch
+       ownership from retained command/service code
+   - Acceptance:
+     - config/inbox/notification/watch behavior is owned by explicit adapters
+     - retained service code consumes those behaviors only through boundary
+       traits
+     - compatibility policy location is documented and matches implementation
 4. `R.7 Service Orchestration`
-   - route retained core command flows through the boundary-owned contracts
-   - eliminate direct retained call paths that bypass stores, config, inbox, or
-     runtime adapters
-   - make daemon runtime and CLI composition roots the only legal wiring points
+   - Files in scope:
+     - `crates/atm-core/src/send/`
+     - `crates/atm-core/src/read/`
+     - `crates/atm-core/src/clear/`
+     - `crates/atm-core/src/ack/`
+     - `crates/atm-core/src/doctor/`
+     - retained shared helpers those flows still call directly
+   - Required routing changes:
+     - all retained command/service flows call boundary traits or service-owned
+       orchestration seams only
+     - remove parallel helper paths that bypass:
+       - store boundaries
+       - config ingress
+       - inbox ingress/export
+       - notification / status / watch adapters
+   - Composition constraints:
+     - daemon composition and CLI composition remain the only legal wiring roots
+     - no direct adapter construction from retained command modules
+   - Acceptance:
+     - direct retained bypasses are removed from service code
+     - orchestration layer is explicit and thin
+     - boundary lint remains green after routing changes
 5. `R.8 Thin Client Surfaces`
-   - reshape CLI/graft-facing surfaces around thin `send` / `receive`
-   - keep `ack` folded into send-shaped requests
-   - finalize the public client surface once the service graph is stable
+   - `crates/atm/src/`
+     - finalize CLI composition around:
+       - `ClientTransport`
+       - observability port
+       - thin `send` entry point
+       - thin `receive` entry point
+     - remove or isolate any retained command construction path that bypasses
+       the composition module
+   - Shared protocol surface:
+     - keep `ack` folded into send-shaped requests rather than a separate
+       top-level thin-client method family
+   - Extension readiness:
+     - ensure `atm-graft`-style thin client callers can stop at
+       `AtmProtocol` + `ClientTransport` without daemon or sqlite references
+   - Acceptance:
+     - CLI public surface is thin and transport-driven
+     - `ack` remains modeled inside `send`
+     - thin clients do not require daemon-internal or sqlite-facing knowledge
 
 Acceptance:
 - no feature sprint begins before the relevant boundary and lint guardrails are in place
+- `R.4` through `R.8` are reviewable as concrete sprint proposals with explicit
+  files, traits, and acceptance criteria
 
 ## 6. Working Rule
 

--- a/docs/plan-phase-R.md
+++ b/docs/plan-phase-R.md
@@ -415,6 +415,9 @@ Review targets:
        - `DaemonReconcileCoordinator`
      - add daemon-side `PeerClientTransport` and `DaemonRequestDispatcher`
        adapters if R.4 scope keeps them in wave 2
+     - when any new concrete runtime impl structs land, update the matching
+       boundary records with explicit `implementation.visibility` and
+       `implementation.constructor` expectations in the same sprint
    - `crates/atm-daemon/src/composition.rs`
      - wire runtime composition to the new transport/dispatcher method surfaces
        without introducing direct CLI or sqlite dependencies
@@ -426,6 +429,8 @@ Review targets:
      - zero-method runtime traits resolved by explicit method surfaces
      - CLI and daemon compositions compile against callable transport traits
      - no direct `atm -> atm-daemon` or `atm -> atm-rusqlite` edge appears
+     - QA verifies any new runtime impl structs are covered by active privacy /
+       constructor lint checks
 2. `R.5 Store Boundaries`
    - `crates/atm-core/src/boundary/mod.rs`
      - finalize request / response DTOs for:
@@ -442,6 +447,8 @@ Review targets:
        - `SqliteTaskStore`
        - `SqliteRosterStore`
      - keep constructors private and assembly boundary-facing only
+     - keep boundary records and lint privacy rules in lockstep with every new
+       concrete store implementation struct
    - Retained behavior cutover:
      - identify and replace direct store ownership in existing retained flows
        under:
@@ -459,6 +466,7 @@ Review targets:
      - retained core flows no longer own sqlite-facing logic directly
      - replacing the sqlite adapter does not require caller changes outside
        composition or adapter crates
+     - QA verifies store impl structs remain private and lint-enforced as such
 3. `R.6 Config / Inbox / Notification / Watch`
    - `crates/atm-core/src/boundary/mod.rs`
      - finalize method surfaces and DTOs for:
@@ -477,6 +485,8 @@ Review targets:
        - status reporting
        - watch capture
        - reconcile coordination
+     - keep boundary records and lint privacy expectations updated for every
+       newly landed daemon-owned implementation struct
    - Policy placement review:
      - document and implement where compatibility / recovery policy is allowed
        to live inside ingress/export adapters versus service orchestration
@@ -488,6 +498,8 @@ Review targets:
      - retained service code consumes those behaviors only through boundary
        traits
      - compatibility policy location is documented and matches implementation
+     - QA verifies newly introduced adapter impl structs are covered by privacy
+       and constructor lint rules
 4. `R.7 Service Orchestration`
    - Files in scope:
      - `crates/atm-core/src/send/`
@@ -511,6 +523,8 @@ Review targets:
      - direct retained bypasses are removed from service code
      - orchestration layer is explicit and thin
      - boundary lint remains green after routing changes
+     - QA verifies no orchestration change required widening adapter visibility
+       or bypassing boundary privacy rules
 5. `R.8 Thin Client Surfaces`
    - `crates/atm/src/`
      - finalize CLI composition around:
@@ -530,11 +544,23 @@ Review targets:
      - CLI public surface is thin and transport-driven
      - `ack` remains modeled inside `send`
      - thin clients do not require daemon-internal or sqlite-facing knowledge
+     - QA verifies no thin-client change introduces direct references to daemon
+       or adapter implementation structs
 
 Acceptance:
 - no feature sprint begins before the relevant boundary and lint guardrails are in place
 - `R.4` through `R.8` are reviewable as concrete sprint proposals with explicit
   files, traits, and acceptance criteria
+
+Cross-sprint hardening rule:
+- whenever a sprint introduces a new concrete implementation struct for a
+  boundary, that same sprint must also:
+  - add or update the `boundaries.md` record for that implementation
+  - set explicit `implementation.visibility` and
+    `implementation.constructor` requirements
+  - ensure boundary lint actively enforces those privacy expectations
+  - include QA verification that the privacy / constructor / re-export rules
+    are present and passing in `just lint`
 
 ## 6. Working Rule
 

--- a/docs/plan-phase-R.md
+++ b/docs/plan-phase-R.md
@@ -206,9 +206,9 @@ Initial lint passes:
 - owner-crate test-bypass checks
 
 Deferred until after design freeze:
-- composition-root enforcement
-- cargo-modules cycle gating beyond false-positive review
-- unsafe view hardening beyond cargo-geiger package-resolution failures
+- composition-root enforcement (carry into `R.4`)
+- cargo-modules cycle gating beyond false-positive review (carry into `R.4`)
+- unsafe view hardening beyond cargo-geiger package-resolution failures (carry into `R.6`)
 
 Acceptance:
 - `just lint` can fail on the first hard architectural violations
@@ -443,12 +443,17 @@ Review targets:
      - verify the remaining open ADR-001 action item is closed by confirming
        `lint_boundaries.py` and the boundary records reflect all current
        permitted impl sites
+     - verify the `#[doc(hidden)]` ADR-001 action item is closed in the landed
+       `atm-core` boundary module implementation
      - any new concrete implementation struct introduced in this sprint must:
        (a) add boundary-record visibility/constructor rules; (b) have boundary
        lint enforce them; (c) pass QA verification of those checks
      - QA verifies any new runtime impl structs are covered by active privacy /
        constructor lint checks
 2. `R.5 Store Boundaries`
+   - Start gate:
+     - `R.5` may not begin until `R.4` acceptance criteria are signed off by
+       team-lead
    - `crates/atm-core/src/boundary/mod.rs`
      - finalize request / response DTOs for:
        - `MailStore`
@@ -579,6 +584,8 @@ Review targets:
      - thin clients do not require daemon-internal or sqlite-facing knowledge
      - daemon lifecycle (`start` / `stop` / `health`) and all currently
        supported `atm` CLI commands remain functional at `R.8` close
+     - auto-start when the daemon is absent remains supported, with no silent
+       fallback to in-process execution
      - `lint_manifests.py` confirms the following ADR-001 dependency edges
        remain FORBIDDEN:
        - `atm -> atm-daemon`
@@ -606,6 +613,9 @@ Cross-sprint hardening rule:
   - ensure boundary lint actively enforces those privacy expectations
   - include QA verification that the privacy / constructor / re-export rules
     are present and passing in `just lint`
+- ADR-001 AGENTS.md guard note:
+  - complete at `cd70665`; no further sprint ownership needed unless the
+    prompt location changes again
 
 ## 6. Working Rule
 

--- a/docs/plan-phase-R.md
+++ b/docs/plan-phase-R.md
@@ -390,13 +390,19 @@ Review targets:
        `WatchEventSource`, and `ReconcileCoordinator` currently have zero
        methods; define their minimal callable method surfaces before behavior
        work starts
-     - confirm whether `PeerClientTransport` and daemon-side
-       `RequestDispatcher` concrete adapters stay in this wave or remain
-       deferred
+     - no `R.4` implementation may start until that scope review is documented
+       and approved by team-lead
+     - `PeerClientTransport` and `DaemonRequestDispatcher`: define trait
+       surfaces in `R.4`; concrete daemon adapter implementations are deferred
+       to a later sprint
    - `crates/atm-core/src/boundary/mod.rs`
      - replace placeholder `AtmRequestEnvelope`, `AtmResponseEnvelope`, and
-       `AtmFramePayload` with named protocol request / response / frame types
-       for thin `send` / `receive`
+       `AtmFramePayload` with:
+       - `RequestEnvelope`
+       - `ResponseEnvelope`
+       - `FramePayload`
+       in an explicit `atm_core::protocol` module or equivalent architecturally
+       correct home
      - add callable methods to:
        - `AtmProtocol`
        - `ClientTransport`
@@ -413,8 +419,6 @@ Review targets:
        - `DaemonStatusSource`
        - `FileWatchEventSource`
        - `DaemonReconcileCoordinator`
-     - add daemon-side `PeerClientTransport` and `DaemonRequestDispatcher`
-       adapters if R.4 scope keeps them in wave 2
      - when any new concrete runtime impl structs land, update the matching
        boundary records with explicit `implementation.visibility` and
        `implementation.constructor` expectations in the same sprint
@@ -424,11 +428,16 @@ Review targets:
    - `crates/atm/src/composition.rs`
      - wire `CliComposition` against the `ClientTransport` method surface only
    - Acceptance:
-     - protocol request / response / frame DTOs are named and exported from
-       `atm-core`
+     - `RequestEnvelope`, `ResponseEnvelope`, and `FramePayload` are named
+       protocol DTO targets and exported from the agreed protocol home
      - zero-method runtime traits resolved by explicit method surfaces
      - CLI and daemon compositions compile against callable transport traits
      - no direct `atm -> atm-daemon` or `atm -> atm-rusqlite` edge appears
+     - verify `lint_boundaries.py` rejects any impl of boundary traits outside
+       permitted impl sites documented in `docs/*/boundaries.md`
+     - any new concrete implementation struct introduced in this sprint must:
+       (a) add boundary-record visibility/constructor rules; (b) have boundary
+       lint enforce them; (c) pass QA verification of those checks
      - QA verifies any new runtime impl structs are covered by active privacy /
        constructor lint checks
 2. `R.5 Store Boundaries`
@@ -466,6 +475,9 @@ Review targets:
      - retained core flows no longer own sqlite-facing logic directly
      - replacing the sqlite adapter does not require caller changes outside
        composition or adapter crates
+     - any new concrete implementation struct introduced in this sprint must:
+       (a) add boundary-record visibility/constructor rules; (b) have boundary
+       lint enforce them; (c) pass QA verification of those checks
      - QA verifies store impl structs remain private and lint-enforced as such
 3. `R.6 Config / Inbox / Notification / Watch`
    - `crates/atm-core/src/boundary/mod.rs`
@@ -498,6 +510,9 @@ Review targets:
      - retained service code consumes those behaviors only through boundary
        traits
      - compatibility policy location is documented and matches implementation
+     - any new concrete implementation struct introduced in this sprint must:
+       (a) add boundary-record visibility/constructor rules; (b) have boundary
+       lint enforce them; (c) pass QA verification of those checks
      - QA verifies newly introduced adapter impl structs are covered by privacy
        and constructor lint rules
 4. `R.7 Service Orchestration`
@@ -523,6 +538,9 @@ Review targets:
      - direct retained bypasses are removed from service code
      - orchestration layer is explicit and thin
      - boundary lint remains green after routing changes
+     - any new concrete implementation struct introduced in this sprint must:
+       (a) add boundary-record visibility/constructor rules; (b) have boundary
+       lint enforce them; (c) pass QA verification of those checks
      - QA verifies no orchestration change required widening adapter visibility
        or bypassing boundary privacy rules
 5. `R.8 Thin Client Surfaces`
@@ -544,6 +562,11 @@ Review targets:
      - CLI public surface is thin and transport-driven
      - `ack` remains modeled inside `send`
      - thin clients do not require daemon-internal or sqlite-facing knowledge
+     - `lint_manifests.py` confirms `atm -> atm-daemon` and
+       `atm -> atm-rusqlite` dependency edges remain FORBIDDEN (ADR-001)
+     - any new concrete implementation struct introduced in this sprint must:
+       (a) add boundary-record visibility/constructor rules; (b) have boundary
+       lint enforce them; (c) pass QA verification of those checks
      - QA verifies no thin-client change introduces direct references to daemon
        or adapter implementation structs
 

--- a/docs/plan-phase-R.md
+++ b/docs/plan-phase-R.md
@@ -425,6 +425,11 @@ Review targets:
    - `crates/atm-daemon/src/composition.rs`
      - wire runtime composition to the new transport/dispatcher method surfaces
        without introducing direct CLI or sqlite dependencies
+     - carry forward the remaining `R.3.1` runtime-composition residuals:
+       - define the trait-only composition path that preserves no direct
+         `atm-daemon -> atm-rusqlite` dependency
+       - map any remaining daemon/runtime module-split work needed by transport
+         and dispatcher ownership
    - `crates/atm/src/composition.rs`
      - wire `CliComposition` against the `ClientTransport` method surface only
    - Acceptance:
@@ -435,6 +440,9 @@ Review targets:
      - no direct `atm -> atm-daemon` or `atm -> atm-rusqlite` edge appears
      - verify `lint_boundaries.py` rejects any impl of boundary traits outside
        permitted impl sites documented in `docs/*/boundaries.md`
+     - verify the remaining open ADR-001 action item is closed by confirming
+       `lint_boundaries.py` and the boundary records reflect all current
+       permitted impl sites
      - any new concrete implementation struct introduced in this sprint must:
        (a) add boundary-record visibility/constructor rules; (b) have boundary
        lint enforce them; (c) pass QA verification of those checks
@@ -458,6 +466,11 @@ Review targets:
      - keep constructors private and assembly boundary-facing only
      - keep boundary records and lint privacy rules in lockstep with every new
        concrete store implementation struct
+     - carry forward the remaining `R.3.1` sqlite residuals:
+       - complete the adapter/module split beyond the current crate-root
+         skeleton file
+       - keep the runtime-to-sqlite path trait-only rather than a direct daemon
+         dependency
    - Retained behavior cutover:
      - identify and replace direct store ownership in existing retained flows
        under:
@@ -505,6 +518,8 @@ Review targets:
    - Retained behavior cutover:
      - remove direct config parsing, inbox compatibility handling, and watch
        ownership from retained command/service code
+     - carry forward the remaining `R.3.1` service-shell residuals for these
+       domains before R.7 final orchestration cutover
    - Acceptance:
      - config/inbox/notification/watch behavior is owned by explicit adapters
      - retained service code consumes those behaviors only through boundary
@@ -562,8 +577,15 @@ Review targets:
      - CLI public surface is thin and transport-driven
      - `ack` remains modeled inside `send`
      - thin clients do not require daemon-internal or sqlite-facing knowledge
-     - `lint_manifests.py` confirms `atm -> atm-daemon` and
-       `atm -> atm-rusqlite` dependency edges remain FORBIDDEN (ADR-001)
+     - daemon lifecycle (`start` / `stop` / `health`) and all currently
+       supported `atm` CLI commands remain functional at `R.8` close
+     - `lint_manifests.py` confirms the following ADR-001 dependency edges
+       remain FORBIDDEN:
+       - `atm -> atm-daemon`
+       - `atm -> atm-rusqlite`
+       - `atm-core -> atm-daemon`
+       - `atm-core -> atm-rusqlite`
+       - `atm-daemon -> atm-rusqlite` (trait-only/reference-only)
      - any new concrete implementation struct introduced in this sprint must:
        (a) add boundary-record visibility/constructor rules; (b) have boundary
        lint enforce them; (c) pass QA verification of those checks

--- a/docs/plan-phase-R.md
+++ b/docs/plan-phase-R.md
@@ -582,10 +582,13 @@ Review targets:
      - CLI public surface is thin and transport-driven
      - `ack` remains modeled inside `send`
      - thin clients do not require daemon-internal or sqlite-facing knowledge
+     - REQ-P-RUNTIME-001 preserved at `R.8` close:
+       - daemon auto-start when absent remains supported
+       - auto-start failure emits a typed actionable error rather than silent
+         fallback
+       - no in-process fallback is permitted
      - daemon lifecycle (`start` / `stop` / `health`) and all currently
        supported `atm` CLI commands remain functional at `R.8` close
-     - auto-start when the daemon is absent remains supported, with no silent
-       fallback to in-process execution
      - `lint_manifests.py` confirms the following ADR-001 dependency edges
        remain FORBIDDEN:
        - `atm -> atm-daemon`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -46,20 +46,22 @@ Phase R execution entry:
   2. `R.1` lint debt burn-down
   3. `R.2` skeleton crates, boundary traits/facades, and major data structures
   4. `R.2A` parallel lint hardening
-- `R.3` is a dedicated re-planning sprint after the Wave 1 skeleton lands
+- `R.3` is a dedicated review/re-planning stage after the Wave 1 skeleton lands
 - Wave 2 executes implementations only against the enforced boundary skeleton
 
 Current Phase R status:
 - `R.0` lint foundation is complete enough to enforce the boundary documents
 - `R.1` lint debt burn-down is complete on the active redesign line
-- `R.2` landed the first `atm-core` boundary skeleton in
-  `crates/atm-core/src/boundary/mod.rs`
+- `R.2` / `R.3.1` landed the Phase R skeleton context now carried by:
+  - `crates/atm-core/src/boundary/mod.rs`
+  - `crates/atm-daemon`
+  - `crates/atm-rusqlite`
+  - `crates/atm/src/composition.rs`
 - `R.2A` tooling hardening remains in progress for view/module/unsafe follow-up
-- `R.3` is the active sprint and must convert the current merged baseline into
-  a concrete Wave 2 execution plan
-- the current merged baseline does not yet include `crates/atm-daemon` or
-  `crates/atm-rusqlite`; those crate introductions remain part of the next
-  skeleton work
+- `R.3.1` skeleton-first work is complete on the active planning line pending
+  merge through the normal integration path
+- `R.3.2` is the active sprint and is reviewing / drilling the proposed
+  `R.4` through `R.8` Wave 2 sprints into concrete, reviewable assignments
 
 Phase R acceptance:
 - lint/parser gates exist before substantive implementation resumes


### PR DESCRIPTION
## Summary

- Drills R.4–R.8 into concrete sprint checklists with trait/file/crate targets and acceptance criteria
- Merge-forward from feature/pR-s4-replan (R.3.1 skeleton baseline)
- Hardens behavior sprint review gate: any sprint introducing a concrete impl struct must add boundary-record visibility/constructor rules + boundary lint enforcement + QA verification
- ATM-QA-001 carry-forward (zero-method runtime traits) explicitly noted in R.4 scope

## Test plan

- [ ] docs/plan-phase-R.md R.4–R.8 each have concrete checklists
- [ ] just lint passes (verified by arch-ctm on 167063b)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)