### PR TITLE
docs: forbid boundary loosening in arch-qa and quality-mgr prompts

### DIFF
--- a/.claude/agents/arch-qa.md
+++ b/.claude/agents/arch-qa.md
@@ -167,6 +167,29 @@ Allowed narrow exceptions:
 Ambient reuse of a developer workstation ATM home, team, or identity is a
 blocking failure.
 
+### RULE-012: Boundary requirements must not be loosened
+Severity: CRITICAL
+
+Any change that weakens an established boundary constraint is a blocking
+violation regardless of functional justification. This includes:
+- Widening visibility of sealed types or modules (e.g., `mod sealed` ->
+  `pub mod sealed`) without a team-lead ruling and ADR
+- Adding new crates to permitted impl sites without updating boundary records
+  in `docs/*/boundaries.md` and team-lead approval
+- Removing or bypassing enforcement layers: lint rules, boundary records,
+  `lint_boundaries.py`, `lint_manifests.py`, or CI checks
+- Implementing `sealed::Sealed` or any boundary trait in a crate not listed as
+  a permitted impl site in the corresponding boundary record
+
+The correct path for any boundary relaxation is:
+1. team-lead ruling
+2. ADR or documented decision record
+3. boundary record update
+4. lint verification
+
+Do not accept `it compiles` or `tests pass` as justification for loosening a
+boundary. Reject and route to team-lead.
+
 ## Evaluation Process
 
 1. Read the input JSON.

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -134,3 +134,11 @@ After a FAIL verdict, include a short flat list of blocking findings with:
 - Keep all fix routing through team-lead.
 - Prefer structured reviewer outputs over narrative summaries.
 - Use `quality-management-gh` for PR reporting rather than ad hoc markdown.
+- Never accept boundary relaxation as a fix. If any change loosens an
+  established boundary requirement — widens visibility of sealed types or
+  modules, removes enforcement layers, expands permitted impl sites, or
+  bypasses `lint_boundaries.py` / `lint_manifests.py` checks — reject it as
+  BLOCKING and escalate to team-lead for a ruling. `It compiles` or `tests
+  pass` is not justification. The correct path is: team-lead ruling -> ADR ->
+  boundary record update -> lint verification. `arch-qa` RULE-012 governs
+  this; `quality-mgr` must not override or suppress it.


### PR DESCRIPTION
## Summary

- Adds RULE-012 (CRITICAL) to `arch-qa`: any change that weakens an established boundary constraint is a blocking violation — widening sealed visibility, expanding permitted impl sites, removing lint enforcement layers
- Adds matching constraint to `quality-mgr`: never accept boundary relaxation as a fix; escalate to team-lead for ruling; arch-qa RULE-012 cannot be suppressed

## Test plan

- [ ] arch-qa.md has RULE-012 with CRITICAL severity
- [ ] quality-mgr.md Constraints section has boundary-loosening prohibition
- [ ] just lint passes (verified by arch-ctm on e56159a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)