### PR TITLE
feat(R.4): transport and dispatcher method surfaces

### DIFF
--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -318,7 +318,7 @@ pub fn ack_mail(
         outcome: "ok",
         team,
         agent: actor.clone(),
-        sender: actor.to_string(),
+        sender: actor.clone(),
         message_id: Some(request.message_id),
         requires_ack: false,
         dry_run: false,

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -1,6 +1,7 @@
 //! Phase R boundary skeleton contracts.
 
 use crate::error::AtmError;
+use crate::protocol::{FramePayload, RequestEnvelope, ResponseEnvelope};
 
 /// Workspace-convention seal only; not compiler-enforced outside this crate.
 ///
@@ -12,64 +13,79 @@ pub mod sealed {
 }
 
 /// Stub ATM request envelope for the Phase R protocol skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct AtmRequestEnvelope;
+///
+/// Prefer `RequestEnvelope` from `atm_core::protocol` as the canonical type.
+pub type AtmRequestEnvelope = RequestEnvelope;
 
 /// Stub ATM response envelope for the Phase R protocol skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct AtmResponseEnvelope;
+///
+/// Prefer `ResponseEnvelope` from `atm_core::protocol` as the canonical type.
+pub type AtmResponseEnvelope = ResponseEnvelope;
 
 /// Stub ATM frame payload for the Phase R protocol skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct AtmFramePayload;
+///
+/// Prefer `FramePayload` from `atm_core::protocol` as the canonical type.
+pub type AtmFramePayload = FramePayload;
 
 /// Stub outbound client-transport request for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ClientTransportRequest;
+///
+/// Compatibility alias to the canonical protocol request type.
+pub type ClientTransportRequest = RequestEnvelope;
 
 /// Stub outbound client-transport response for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ClientTransportResponse;
+///
+/// Compatibility alias to the canonical protocol response type.
+pub type ClientTransportResponse = ResponseEnvelope;
 
 /// Stub inbound server-transport request for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ServerTransportRequest;
+///
+/// Compatibility alias to the canonical protocol frame type.
+pub type ServerTransportRequest = FramePayload;
 
 /// Stub inbound server-transport response for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ServerTransportResponse;
+///
+/// Compatibility alias to the canonical protocol frame type.
+pub type ServerTransportResponse = FramePayload;
 
 /// Stub dispatcher request envelope for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct DispatchRequestEnvelope;
+///
+/// Compatibility alias to the canonical protocol request type.
+pub type DispatchRequestEnvelope = RequestEnvelope;
 
 /// Stub dispatcher response envelope for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct DispatchResponseEnvelope;
+///
+/// Compatibility alias to the canonical protocol response type.
+pub type DispatchResponseEnvelope = ResponseEnvelope;
 
 /// Stub outbound notification event for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct NotificationEvent;
+///
+/// Canonical payload is `protocol::NotificationEvent`.
+pub type NotificationEvent = crate::protocol::NotificationEvent;
 
 /// Stub inbound runtime-status snapshot for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct RuntimeStatusSnapshot;
+///
+/// Canonical payload is `protocol::RuntimeStatusSnapshot`.
+pub type RuntimeStatusSnapshot = crate::protocol::RuntimeStatusSnapshot;
 
 /// Stub watch-subscription request for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct WatchSubscriptionRequest;
+///
+/// Canonical payload is `protocol::WatchSubscriptionRequest`.
+pub type WatchSubscriptionRequest = crate::protocol::WatchSubscriptionRequest;
 
 /// Stub watch event batch for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct WatchEventBatch;
+///
+/// Canonical payload is `protocol::WatchEventBatch`.
+pub type WatchEventBatch = crate::protocol::WatchEventBatch;
 
 /// Stub reconcile request for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ReconcileRequest;
+///
+/// Canonical payload is `protocol::ReconcileRequest`.
+pub type ReconcileRequest = crate::protocol::ReconcileRequest;
 
 /// Stub reconcile result for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ReconcileResult;
+///
+/// Canonical payload is `protocol::ReconcileResult`.
+pub type ReconcileResult = crate::protocol::ReconcileResult;
 
 /// Stub mail-store request for the Phase R skeleton.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -305,28 +321,92 @@ pub type InboxExportRequest = InboxExportRecordRequest;
 pub type InboxExportResponse = InboxExportRecordResponse;
 
 /// BOUNDARY-AtmProtocol — see docs/atm-core/boundaries.md.
-pub trait AtmProtocol: sealed::Sealed {}
+pub trait AtmProtocol: sealed::Sealed {
+    /// # Errors
+    ///
+    /// Returns `AtmError` when a protocol request envelope cannot be converted
+    /// into a frame payload.
+    fn request_to_frame(&self, request: RequestEnvelope) -> Result<FramePayload, AtmError>;
+
+    /// # Errors
+    ///
+    /// Returns `AtmError` when a frame payload cannot be decoded into a
+    /// protocol request envelope.
+    fn request_from_frame(&self, frame: FramePayload) -> Result<RequestEnvelope, AtmError>;
+
+    /// # Errors
+    ///
+    /// Returns `AtmError` when a protocol response envelope cannot be
+    /// converted into a frame payload.
+    fn response_to_frame(&self, response: ResponseEnvelope) -> Result<FramePayload, AtmError>;
+
+    /// # Errors
+    ///
+    /// Returns `AtmError` when a frame payload cannot be decoded into a
+    /// protocol response envelope.
+    fn response_from_frame(&self, frame: FramePayload) -> Result<ResponseEnvelope, AtmError>;
+}
 
 /// BOUNDARY-ClientTransport — see docs/atm-core/boundaries.md.
-pub trait ClientTransport: sealed::Sealed {}
+pub trait ClientTransport: sealed::Sealed {
+    /// # Errors
+    ///
+    /// Returns `AtmError` when the framed request cannot be delivered or when
+    /// the peer returns an unrecoverable protocol response.
+    fn send(&self, request: RequestEnvelope) -> Result<ResponseEnvelope, AtmError>;
+}
 
 /// BOUNDARY-ServerTransport — see docs/atm-core/boundaries.md.
-pub trait ServerTransport: sealed::Sealed {}
+pub trait ServerTransport: sealed::Sealed {
+    /// # Errors
+    ///
+    /// Returns `AtmError` when framing, transport serving, or dispatch handoff
+    /// cannot proceed reliably.
+    fn serve(&self, dispatcher: &dyn RequestDispatcher) -> Result<(), AtmError>;
+}
 
 /// BOUNDARY-RequestDispatcher — see docs/atm-core/boundaries.md.
-pub trait RequestDispatcher: sealed::Sealed {}
+pub trait RequestDispatcher: sealed::Sealed {
+    /// # Errors
+    ///
+    /// Returns `AtmError` when protocol request routing or handler dispatch
+    /// cannot produce a valid response.
+    fn dispatch(&self, request: RequestEnvelope) -> Result<ResponseEnvelope, AtmError>;
+}
 
 /// BOUNDARY-NotificationSink — see docs/atm-core/boundaries.md.
-pub trait NotificationSink: sealed::Sealed {}
+pub trait NotificationSink: sealed::Sealed {
+    /// # Errors
+    ///
+    /// Returns `AtmError` when notification delivery cannot be executed.
+    fn deliver(&self, event: NotificationEvent) -> Result<(), AtmError>;
+}
 
 /// BOUNDARY-StatusSource — see docs/atm-core/boundaries.md.
-pub trait StatusSource: sealed::Sealed {}
+pub trait StatusSource: sealed::Sealed {
+    /// # Errors
+    ///
+    /// Returns `AtmError` when a runtime status snapshot cannot be collected.
+    fn snapshot(&self) -> Result<RuntimeStatusSnapshot, AtmError>;
+}
 
 /// BOUNDARY-WatchEventSource — see docs/atm-core/boundaries.md.
-pub trait WatchEventSource: sealed::Sealed {}
+pub trait WatchEventSource: sealed::Sealed {
+    /// # Errors
+    ///
+    /// Returns `AtmError` when watch subscriptions cannot be created or events
+    /// cannot be delivered as a batch.
+    fn poll(&self, request: WatchSubscriptionRequest) -> Result<WatchEventBatch, AtmError>;
+}
 
 /// BOUNDARY-ReconcileCoordinator — see docs/atm-core/boundaries.md.
-pub trait ReconcileCoordinator: sealed::Sealed {}
+pub trait ReconcileCoordinator: sealed::Sealed {
+    /// # Errors
+    ///
+    /// Returns `AtmError` when reconcile policy cannot be executed for the
+    /// request input.
+    fn reconcile(&self, request: ReconcileRequest) -> Result<ReconcileResult, AtmError>;
+}
 
 /// BOUNDARY-MailStore — see docs/atm-core/boundaries.md.
 pub trait MailStore: sealed::Sealed {

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -2,6 +2,10 @@
 
 use crate::error::AtmError;
 use crate::protocol::{FramePayload, RequestEnvelope, ResponseEnvelope};
+pub use crate::protocol::{
+    NotificationEvent, ReconcileRequest, ReconcileResult, RuntimeStatusSnapshot, WatchEventBatch,
+    WatchSubscriptionRequest,
+};
 
 /// Workspace-convention seal only; not compiler-enforced outside this crate.
 ///
@@ -47,30 +51,6 @@ pub struct DispatchRequestEnvelope;
 /// Stub dispatcher response envelope for the Phase R skeleton.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DispatchResponseEnvelope;
-
-/// Stub outbound notification event for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct NotificationEvent;
-
-/// Stub inbound runtime-status snapshot for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct RuntimeStatusSnapshot;
-
-/// Stub watch-subscription request for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct WatchSubscriptionRequest;
-
-/// Stub watch event batch for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct WatchEventBatch;
-
-/// Stub reconcile request for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ReconcileRequest;
-
-/// Stub reconcile result for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ReconcileResult;
 
 /// Stub mail-store request for the Phase R skeleton.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -144,10 +124,13 @@ pub struct MailStoreHealthSnapshotRequest;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MailStoreHealthSnapshotResponse;
 
-/// Bootstrap-variant compatibility alias for the initial Phase R mail-store stub.
-pub type MailStoreRequest = MailStoreBootstrapRequest;
-/// Bootstrap-variant compatibility alias for the initial Phase R mail-store stub.
-pub type MailStoreResponse = MailStoreBootstrapResponse;
+/// Canonical Phase R mail-store request entrypoint payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MailStoreRequest;
+
+/// Canonical Phase R mail-store response entrypoint payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MailStoreResponse;
 
 /// Stub task-store request for the Phase R skeleton.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -205,10 +188,13 @@ pub struct TaskStoreQueryTaskMetadataRequest;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TaskStoreQueryTaskMetadataResponse;
 
-/// Bootstrap-variant compatibility alias for the initial Phase R task-store stub.
-pub type TaskStoreRequest = TaskStoreCreateTaskRequest;
-/// Bootstrap-variant compatibility alias for the initial Phase R task-store stub.
-pub type TaskStoreResponse = TaskStoreCreateTaskResponse;
+/// Canonical Phase R task-store request entrypoint payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TaskStoreRequest;
+
+/// Canonical Phase R task-store response entrypoint payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TaskStoreResponse;
 
 /// Stub roster-store request for the Phase R skeleton.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -242,10 +228,13 @@ pub struct RosterStoreHealthSnapshotRequest;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RosterStoreHealthSnapshotResponse;
 
-/// Bootstrap-variant compatibility alias for the initial Phase R roster-store stub.
-pub type RosterStoreRequest = RosterStoreReplaceRosterRequest;
-/// Bootstrap-variant compatibility alias for the initial Phase R roster-store stub.
-pub type RosterStoreResponse = RosterStoreReplaceRosterResponse;
+/// Canonical Phase R roster-store request entrypoint payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RosterStoreRequest;
+
+/// Canonical Phase R roster-store response entrypoint payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RosterStoreResponse;
 
 /// Stub config-ingress request for the Phase R skeleton.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -279,10 +268,13 @@ pub struct InboxIngressDiagnosticsRequest;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct InboxIngressDiagnosticsResponse;
 
-/// Import-variant compatibility alias for the initial Phase R inbox-ingress stub.
-pub type InboxIngressRequest = InboxIngressImportRequest;
-/// Import-variant compatibility alias for the initial Phase R inbox-ingress stub.
-pub type InboxIngressResponse = InboxIngressImportResponse;
+/// Canonical Phase R inbox-ingress request entrypoint payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InboxIngressRequest;
+
+/// Canonical Phase R inbox-ingress response entrypoint payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InboxIngressResponse;
 
 /// Stub inbox-export request for the Phase R skeleton.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -300,10 +292,13 @@ pub struct InboxExportReexportMessageRequest;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct InboxExportReexportMessageResponse;
 
-/// Record-export compatibility alias for the initial Phase R inbox-export stub.
-pub type InboxExportRequest = InboxExportRecordRequest;
-/// Record-export compatibility alias for the initial Phase R inbox-export stub.
-pub type InboxExportResponse = InboxExportRecordResponse;
+/// Canonical Phase R inbox-export request entrypoint payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InboxExportRequest;
+
+/// Canonical Phase R inbox-export response entrypoint payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InboxExportResponse;
 
 /// BOUNDARY-AtmProtocol — see docs/atm-core/boundaries.md.
 pub trait AtmProtocol: sealed::Sealed {

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -13,79 +13,64 @@ pub mod sealed {
 }
 
 /// Stub ATM request envelope for the Phase R protocol skeleton.
-///
-/// Prefer `RequestEnvelope` from `atm_core::protocol` as the canonical type.
-pub type AtmRequestEnvelope = RequestEnvelope;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AtmRequestEnvelope;
 
 /// Stub ATM response envelope for the Phase R protocol skeleton.
-///
-/// Prefer `ResponseEnvelope` from `atm_core::protocol` as the canonical type.
-pub type AtmResponseEnvelope = ResponseEnvelope;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AtmResponseEnvelope;
 
 /// Stub ATM frame payload for the Phase R protocol skeleton.
-///
-/// Prefer `FramePayload` from `atm_core::protocol` as the canonical type.
-pub type AtmFramePayload = FramePayload;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AtmFramePayload;
 
 /// Stub outbound client-transport request for the Phase R skeleton.
-///
-/// Compatibility alias to the canonical protocol request type.
-pub type ClientTransportRequest = RequestEnvelope;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ClientTransportRequest;
 
 /// Stub outbound client-transport response for the Phase R skeleton.
-///
-/// Compatibility alias to the canonical protocol response type.
-pub type ClientTransportResponse = ResponseEnvelope;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ClientTransportResponse;
 
 /// Stub inbound server-transport request for the Phase R skeleton.
-///
-/// Compatibility alias to the canonical protocol frame type.
-pub type ServerTransportRequest = FramePayload;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ServerTransportRequest;
 
 /// Stub inbound server-transport response for the Phase R skeleton.
-///
-/// Compatibility alias to the canonical protocol frame type.
-pub type ServerTransportResponse = FramePayload;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ServerTransportResponse;
 
 /// Stub dispatcher request envelope for the Phase R skeleton.
-///
-/// Compatibility alias to the canonical protocol request type.
-pub type DispatchRequestEnvelope = RequestEnvelope;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DispatchRequestEnvelope;
 
 /// Stub dispatcher response envelope for the Phase R skeleton.
-///
-/// Compatibility alias to the canonical protocol response type.
-pub type DispatchResponseEnvelope = ResponseEnvelope;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DispatchResponseEnvelope;
 
 /// Stub outbound notification event for the Phase R skeleton.
-///
-/// Canonical payload is `protocol::NotificationEvent`.
-pub type NotificationEvent = crate::protocol::NotificationEvent;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NotificationEvent;
 
 /// Stub inbound runtime-status snapshot for the Phase R skeleton.
-///
-/// Canonical payload is `protocol::RuntimeStatusSnapshot`.
-pub type RuntimeStatusSnapshot = crate::protocol::RuntimeStatusSnapshot;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeStatusSnapshot;
 
 /// Stub watch-subscription request for the Phase R skeleton.
-///
-/// Canonical payload is `protocol::WatchSubscriptionRequest`.
-pub type WatchSubscriptionRequest = crate::protocol::WatchSubscriptionRequest;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchSubscriptionRequest;
 
 /// Stub watch event batch for the Phase R skeleton.
-///
-/// Canonical payload is `protocol::WatchEventBatch`.
-pub type WatchEventBatch = crate::protocol::WatchEventBatch;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchEventBatch;
 
 /// Stub reconcile request for the Phase R skeleton.
-///
-/// Canonical payload is `protocol::ReconcileRequest`.
-pub type ReconcileRequest = crate::protocol::ReconcileRequest;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileRequest;
 
 /// Stub reconcile result for the Phase R skeleton.
-///
-/// Canonical payload is `protocol::ReconcileResult`.
-pub type ReconcileResult = crate::protocol::ReconcileResult;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileResult;
 
 /// Stub mail-store request for the Phase R skeleton.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -16,42 +16,6 @@ pub mod sealed {
     pub trait Sealed {}
 }
 
-/// Stub ATM request envelope for the Phase R protocol skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct AtmRequestEnvelope;
-
-/// Stub ATM response envelope for the Phase R protocol skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct AtmResponseEnvelope;
-
-/// Stub ATM frame payload for the Phase R protocol skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct AtmFramePayload;
-
-/// Stub outbound client-transport request for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ClientTransportRequest;
-
-/// Stub outbound client-transport response for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ClientTransportResponse;
-
-/// Stub inbound server-transport request for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ServerTransportRequest;
-
-/// Stub inbound server-transport response for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ServerTransportResponse;
-
-/// Stub dispatcher request envelope for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct DispatchRequestEnvelope;
-
-/// Stub dispatcher response envelope for the Phase R skeleton.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct DispatchResponseEnvelope;
-
 /// Stub mail-store request for the Phase R skeleton.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MailStoreBootstrapRequest;

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -175,7 +175,7 @@ pub fn clear_mail(
         outcome: if query.dry_run { "dry_run" } else { "ok" },
         team: outcome.team.clone(),
         agent: outcome.agent.clone(),
-        sender: actor.to_string(),
+        sender: actor.clone(),
         message_id: None,
         requires_ack: false,
         dry_run: query.dry_run,

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -155,6 +155,12 @@ impl AtmError {
         .with_recovery("Set ATM_HOME or ensure the OS home directory can be resolved.")
     }
 
+    pub fn config(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorKind::Config, message).with_recovery(
+            "Check the active ATM configuration, runtime wiring, and local path settings before retrying.",
+        )
+    }
+
     pub fn address_parse(message: impl Into<String>) -> Self {
         Self::new(
             AtmErrorKind::Address,
@@ -412,6 +418,14 @@ mod tests {
         assert!(rendered.contains("boom"));
         assert!(!rendered.contains("Backtrace:"));
         assert!(error.backtrace().is_some());
+    }
+
+    #[test]
+    fn config_helper_uses_config_kind() {
+        let error = AtmError::config("config failed");
+
+        assert!(error.is_config());
+        assert_eq!(error.code, AtmErrorCode::ConfigParseFailed);
     }
 
     #[test]

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -30,6 +30,8 @@ pub mod observability;
 pub(crate) mod persistence;
 /// Internal process-liveness helpers shared across lock implementations.
 pub(crate) mod process;
+/// Shared protocol DTOs used by boundary transport and adapter contracts.
+pub mod protocol;
 /// Mailbox read/query workflows and output models.
 pub mod read;
 /// Reserved production role constants shared across runtime and tests.
@@ -64,3 +66,4 @@ pub use boundary::{
     ServerTransportResponse, StatusSource, TaskStore, TaskStoreRequest, TaskStoreResponse,
     WatchEventBatch, WatchEventSource, WatchSubscriptionRequest,
 };
+pub use protocol::{FramePayload, RequestEnvelope, ResponseEnvelope};

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -53,17 +53,15 @@ pub mod types;
 pub(crate) mod workflow;
 
 pub use boundary::{
-    AtmFramePayload, AtmProtocol, AtmRequestEnvelope, AtmResponseEnvelope, ClientTransport,
-    ClientTransportRequest, ClientTransportResponse, ConfigIngress, ConfigLoadRequest,
-    ConfigLoadResponse, DispatchRequestEnvelope, DispatchResponseEnvelope, InboxExport,
-    InboxExportReexportMessageRequest, InboxExportReexportMessageResponse, InboxExportRequest,
-    InboxExportResponse, InboxIngress, InboxIngressDiagnosticsRequest,
+    AtmProtocol, ClientTransport, ConfigIngress, ConfigLoadRequest, ConfigLoadResponse,
+    InboxExport, InboxExportReexportMessageRequest, InboxExportReexportMessageResponse,
+    InboxExportRequest, InboxExportResponse, InboxIngress, InboxIngressDiagnosticsRequest,
     InboxIngressDiagnosticsResponse, InboxIngressIdentityFingerprintRequest,
     InboxIngressIdentityFingerprintResponse, InboxIngressRequest, InboxIngressResponse, MailStore,
     MailStoreRequest, MailStoreResponse, NotificationEvent, NotificationSink, ReconcileCoordinator,
     ReconcileRequest, ReconcileResult, RequestDispatcher, RosterStore, RosterStoreRequest,
-    RosterStoreResponse, RuntimeStatusSnapshot, ServerTransport, ServerTransportRequest,
-    ServerTransportResponse, StatusSource, TaskStore, TaskStoreRequest, TaskStoreResponse,
-    WatchEventBatch, WatchEventSource, WatchSubscriptionRequest,
+    RosterStoreResponse, RuntimeStatusSnapshot, ServerTransport, StatusSource, TaskStore,
+    TaskStoreRequest, TaskStoreResponse, WatchEventBatch, WatchEventSource,
+    WatchSubscriptionRequest,
 };
 pub use protocol::{FramePayload, RequestEnvelope, ResponseEnvelope};

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -19,7 +19,7 @@ pub struct CommandEvent {
     pub outcome: &'static str,
     pub team: TeamName,
     pub agent: AgentName,
-    pub sender: String,
+    pub sender: AgentName,
     pub message_id: Option<LegacyMessageId>,
     pub requires_ack: bool,
     pub dry_run: bool,

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -1,0 +1,37 @@
+//! Shared protocol DTO stubs for the core transport boundary family.
+
+/// Shared protocol request envelope.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RequestEnvelope;
+
+/// Shared protocol response envelope.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResponseEnvelope;
+
+/// Raw protocol frame payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FramePayload;
+
+/// Shared notification event payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NotificationEvent;
+
+/// Runtime status snapshot transport payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeStatusSnapshot;
+
+/// Watch subscription request payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchSubscriptionRequest;
+
+/// Watch event batch transport payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchEventBatch;
+
+/// Reconcile request transport payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileRequest;
+
+/// Reconcile outcome transport payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileResult;

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -315,7 +315,7 @@ pub fn read_mail(
         outcome: if timed_out { "timeout" } else { "ok" },
         team: outcome.team.clone(),
         agent: outcome.agent.clone(),
-        sender: actor.to_string(),
+        sender: actor.clone(),
         message_id: None,
         requires_ack: false,
         dry_run: false,

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -277,7 +277,7 @@ pub fn send_mail(
         outcome: outcome.outcome,
         team: outcome.team.clone(),
         agent: outcome.agent.clone(),
-        sender: canonical_sender.to_string(),
+        sender: canonical_sender.clone(),
         message_id: Some(outcome.message_id),
         requires_ack: outcome.requires_ack,
         dry_run: outcome.dry_run,

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -3,7 +3,10 @@ use crate::{
     DaemonReconcileCoordinator, DaemonStatusSource, FileWatchEventSource,
     LocalSocketServerTransport,
 };
-use atm_core::error::AtmError;
+use atm_core::{
+    boundary::{RequestDispatcher, ServerTransport},
+    error::AtmError,
+};
 use std::error::Error as StdError;
 use std::fmt;
 
@@ -91,6 +94,10 @@ impl RuntimeComposition {
             "Finish RuntimeComposition startup wiring before invoking the daemon entrypoint.",
         )
         .with_source(RuntimeStartStubError::RuntimeStartNotWired))
+    }
+
+    pub(crate) fn serve(&self, dispatcher: &dyn RequestDispatcher) -> Result<(), AtmError> {
+        self.server_transport.serve(dispatcher)
     }
 }
 

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -1,9 +1,15 @@
 use crate::{
     DaemonConfigIngress, DaemonInboxExport, DaemonInboxIngress, DaemonNotificationSink,
     DaemonReconcileCoordinator, DaemonRequestDispatcher, DaemonStatusSource, FileWatchEventSource,
-    LocalSocketServerTransport,
+    LocalSocketServerTransport, PeerClientTransport,
 };
-use atm_core::{boundary::ServerTransport, error::AtmError};
+use atm_core::{
+    boundary::{
+        ClientTransport, ConfigIngress, InboxExport, InboxIngress, NotificationSink,
+        ReconcileCoordinator, RequestDispatcher, ServerTransport, StatusSource, WatchEventSource,
+    },
+    error::AtmError,
+};
 use std::error::Error as StdError;
 use std::fmt;
 
@@ -36,6 +42,7 @@ pub(crate) struct RuntimeComposition {
     config_ingress: DaemonConfigIngress,
     inbox_ingress: DaemonInboxIngress,
     inbox_export: DaemonInboxExport,
+    peer_client_transport: PeerClientTransport,
 }
 
 impl RuntimeComposition {
@@ -50,43 +57,48 @@ impl RuntimeComposition {
             config_ingress: DaemonConfigIngress::new(),
             inbox_ingress: DaemonInboxIngress::new(),
             inbox_export: DaemonInboxExport::new(),
+            peer_client_transport: PeerClientTransport::new(),
         }
     }
 
-    pub(crate) fn server_transport(&self) -> &LocalSocketServerTransport {
+    pub(crate) fn server_transport(&self) -> &dyn ServerTransport {
         &self.server_transport
     }
 
-    pub(crate) fn notification_sink(&self) -> &DaemonNotificationSink {
+    pub(crate) fn notification_sink(&self) -> &dyn NotificationSink {
         &self.notification_sink
     }
 
-    pub(crate) fn request_dispatcher(&self) -> &DaemonRequestDispatcher {
+    pub(crate) fn request_dispatcher(&self) -> &dyn RequestDispatcher {
         &self.request_dispatcher
     }
 
-    pub(crate) fn status_source(&self) -> &DaemonStatusSource {
+    pub(crate) fn status_source(&self) -> &dyn StatusSource {
         &self.status_source
     }
 
-    pub(crate) fn watch_event_source(&self) -> &FileWatchEventSource {
+    pub(crate) fn watch_event_source(&self) -> &dyn WatchEventSource {
         &self.watch_event_source
     }
 
-    pub(crate) fn reconcile_coordinator(&self) -> &DaemonReconcileCoordinator {
+    pub(crate) fn reconcile_coordinator(&self) -> &dyn ReconcileCoordinator {
         &self.reconcile_coordinator
     }
 
-    pub(crate) fn config_ingress(&self) -> &DaemonConfigIngress {
+    pub(crate) fn config_ingress(&self) -> &dyn ConfigIngress {
         &self.config_ingress
     }
 
-    pub(crate) fn inbox_ingress(&self) -> &DaemonInboxIngress {
+    pub(crate) fn inbox_ingress(&self) -> &dyn InboxIngress {
         &self.inbox_ingress
     }
 
-    pub(crate) fn inbox_export(&self) -> &DaemonInboxExport {
+    pub(crate) fn inbox_export(&self) -> &dyn InboxExport {
         &self.inbox_export
+    }
+
+    pub(crate) fn peer_client_transport(&self) -> &dyn ClientTransport {
+        &self.peer_client_transport
     }
 
     pub(crate) fn start(&self) -> Result<(), AtmError> {
@@ -100,7 +112,7 @@ impl RuntimeComposition {
     }
 
     pub(crate) fn serve(&self) -> Result<(), AtmError> {
-        self.server_transport.serve(&self.request_dispatcher)
+        self.server_transport().serve(self.request_dispatcher())
     }
 }
 

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -102,9 +102,7 @@ impl RuntimeComposition {
     }
 
     pub(crate) fn start(&self) -> Result<(), AtmError> {
-        Err(AtmError::observability_bootstrap(
-            "daemon runtime start scaffold is not implemented yet",
-        )
+        Err(AtmError::config("daemon runtime start scaffold is not implemented yet")
         .with_recovery(
             "Finish RuntimeComposition startup wiring before invoking the daemon entrypoint.",
         )

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -1,12 +1,9 @@
 use crate::{
     DaemonConfigIngress, DaemonInboxExport, DaemonInboxIngress, DaemonNotificationSink,
-    DaemonReconcileCoordinator, DaemonStatusSource, FileWatchEventSource,
+    DaemonReconcileCoordinator, DaemonRequestDispatcher, DaemonStatusSource, FileWatchEventSource,
     LocalSocketServerTransport,
 };
-use atm_core::{
-    boundary::{RequestDispatcher, ServerTransport},
-    error::AtmError,
-};
+use atm_core::{boundary::ServerTransport, error::AtmError};
 use std::error::Error as StdError;
 use std::fmt;
 
@@ -31,6 +28,7 @@ impl StdError for RuntimeStartStubError {}
 #[derive(Debug, Default)]
 pub(crate) struct RuntimeComposition {
     server_transport: LocalSocketServerTransport,
+    request_dispatcher: DaemonRequestDispatcher,
     notification_sink: DaemonNotificationSink,
     status_source: DaemonStatusSource,
     watch_event_source: FileWatchEventSource,
@@ -44,6 +42,7 @@ impl RuntimeComposition {
     pub(crate) fn new() -> Self {
         Self {
             server_transport: LocalSocketServerTransport::new(),
+            request_dispatcher: DaemonRequestDispatcher::new(),
             notification_sink: DaemonNotificationSink::new(),
             status_source: DaemonStatusSource::new(),
             watch_event_source: FileWatchEventSource::new(),
@@ -60,6 +59,10 @@ impl RuntimeComposition {
 
     pub(crate) fn notification_sink(&self) -> &DaemonNotificationSink {
         &self.notification_sink
+    }
+
+    pub(crate) fn request_dispatcher(&self) -> &DaemonRequestDispatcher {
+        &self.request_dispatcher
     }
 
     pub(crate) fn status_source(&self) -> &DaemonStatusSource {
@@ -96,8 +99,8 @@ impl RuntimeComposition {
         .with_source(RuntimeStartStubError::RuntimeStartNotWired))
     }
 
-    pub(crate) fn serve(&self, dispatcher: &dyn RequestDispatcher) -> Result<(), AtmError> {
-        self.server_transport.serve(dispatcher)
+    pub(crate) fn serve(&self) -> Result<(), AtmError> {
+        self.server_transport.serve(&self.request_dispatcher)
     }
 }
 

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -15,13 +15,22 @@ use atm_core::{
         InboxExportReexportMessageResponse, InboxIngress, InboxIngressDiagnosticsRequest,
         InboxIngressDiagnosticsResponse, InboxIngressIdentityFingerprintRequest,
         InboxIngressIdentityFingerprintResponse, InboxIngressImportRequest,
-        InboxIngressImportResponse,
+        InboxIngressImportResponse, RequestDispatcher,
     },
     error::AtmError,
+    protocol::{
+        NotificationEvent, ReconcileRequest, ReconcileResult, RuntimeStatusSnapshot,
+        WatchEventBatch, WatchSubscriptionRequest,
+    },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DaemonBoundaryStubError {
+    ServerTransport,
+    NotificationSink,
+    StatusSource,
+    WatchEventSource,
+    ReconcileCoordinator,
     ConfigIngress,
     InboxIngress,
     InboxExport,
@@ -30,6 +39,11 @@ enum DaemonBoundaryStubError {
 impl fmt::Display for DaemonBoundaryStubError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let message = match self {
+            Self::ServerTransport => "daemon server transport scaffold is not wired",
+            Self::NotificationSink => "daemon notification sink scaffold is not wired",
+            Self::StatusSource => "daemon status source scaffold is not wired",
+            Self::WatchEventSource => "daemon watch event source scaffold is not wired",
+            Self::ReconcileCoordinator => "daemon reconcile coordinator scaffold is not wired",
             Self::ConfigIngress => "daemon config ingress scaffold is not wired",
             Self::InboxIngress => "daemon inbox ingress scaffold is not wired",
             Self::InboxExport => "daemon inbox export scaffold is not wired",
@@ -59,7 +73,14 @@ impl LocalSocketServerTransport {
 
 impl boundary::sealed::Sealed for LocalSocketServerTransport {}
 
-impl boundary::ServerTransport for LocalSocketServerTransport {}
+impl boundary::ServerTransport for LocalSocketServerTransport {
+    fn serve(&self, _dispatcher: &dyn RequestDispatcher) -> Result<(), AtmError> {
+        Err(daemon_boundary_stub_error(
+            "daemon server transport stub is not implemented yet",
+            DaemonBoundaryStubError::ServerTransport,
+        ))
+    }
+}
 
 /// Placeholder runtime sink for daemon-emitted notifications.
 #[derive(Debug, Default)]
@@ -73,7 +94,14 @@ impl DaemonNotificationSink {
 
 impl boundary::sealed::Sealed for DaemonNotificationSink {}
 
-impl boundary::NotificationSink for DaemonNotificationSink {}
+impl boundary::NotificationSink for DaemonNotificationSink {
+    fn deliver(&self, _event: NotificationEvent) -> Result<(), AtmError> {
+        Err(daemon_boundary_stub_error(
+            "daemon notification sink stub is not implemented yet",
+            DaemonBoundaryStubError::NotificationSink,
+        ))
+    }
+}
 
 /// Placeholder runtime source for daemon status snapshots.
 #[derive(Debug, Default)]
@@ -87,7 +115,14 @@ impl DaemonStatusSource {
 
 impl boundary::sealed::Sealed for DaemonStatusSource {}
 
-impl boundary::StatusSource for DaemonStatusSource {}
+impl boundary::StatusSource for DaemonStatusSource {
+    fn snapshot(&self) -> Result<RuntimeStatusSnapshot, AtmError> {
+        Err(daemon_boundary_stub_error(
+            "daemon status source stub is not implemented yet",
+            DaemonBoundaryStubError::StatusSource,
+        ))
+    }
+}
 
 /// Placeholder runtime source for daemon watch events.
 #[derive(Debug, Default)]
@@ -101,7 +136,14 @@ impl FileWatchEventSource {
 
 impl boundary::sealed::Sealed for FileWatchEventSource {}
 
-impl boundary::WatchEventSource for FileWatchEventSource {}
+impl boundary::WatchEventSource for FileWatchEventSource {
+    fn poll(&self, _request: WatchSubscriptionRequest) -> Result<WatchEventBatch, AtmError> {
+        Err(daemon_boundary_stub_error(
+            "daemon watch event source stub is not implemented yet",
+            DaemonBoundaryStubError::WatchEventSource,
+        ))
+    }
+}
 
 /// Placeholder runtime coordinator for daemon reconcile work.
 #[derive(Debug, Default)]
@@ -115,7 +157,14 @@ impl DaemonReconcileCoordinator {
 
 impl boundary::sealed::Sealed for DaemonReconcileCoordinator {}
 
-impl boundary::ReconcileCoordinator for DaemonReconcileCoordinator {}
+impl boundary::ReconcileCoordinator for DaemonReconcileCoordinator {
+    fn reconcile(&self, _request: ReconcileRequest) -> Result<ReconcileResult, AtmError> {
+        Err(daemon_boundary_stub_error(
+            "daemon reconcile coordinator stub is not implemented yet",
+            DaemonBoundaryStubError::ReconcileCoordinator,
+        ))
+    }
+}
 
 /// Placeholder runtime config ingress for daemon-owned config loading.
 #[derive(Debug, Default)]

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -33,12 +33,14 @@ enum DaemonBoundaryStubError {
     ConfigIngress,
     InboxIngress,
     InboxExport,
+    PeerClientTransport,
 }
 
 impl fmt::Display for DaemonBoundaryStubError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let message = match self {
             Self::ServerTransport => "daemon server transport scaffold is not wired",
+            Self::PeerClientTransport => "daemon peer client transport scaffold is not wired",
             Self::RequestDispatcher => "daemon request dispatcher scaffold is not wired",
             Self::NotificationSink => "daemon notification sink scaffold is not wired",
             Self::StatusSource => "daemon status source scaffold is not wired",
@@ -84,10 +86,10 @@ impl boundary::ServerTransport for LocalSocketServerTransport {
 
 /// Placeholder runtime dispatcher for daemon-owned protocol routing.
 #[derive(Debug, Default)]
-pub(crate) struct DaemonRequestDispatcher;
+struct DaemonRequestDispatcher;
 
 impl DaemonRequestDispatcher {
-    pub(crate) const fn new() -> Self {
+    const fn new() -> Self {
         Self
     }
 }
@@ -120,6 +122,27 @@ impl boundary::NotificationSink for DaemonNotificationSink {
         Err(daemon_boundary_stub_error(
             "daemon notification sink stub is not implemented yet",
             DaemonBoundaryStubError::NotificationSink,
+        ))
+    }
+}
+
+/// Placeholder runtime client transport for peer-to-peer daemon delivery.
+#[derive(Debug, Default)]
+struct PeerClientTransport;
+
+impl PeerClientTransport {
+    const fn new() -> Self {
+        Self
+    }
+}
+
+impl boundary::sealed::Sealed for PeerClientTransport {}
+
+impl boundary::ClientTransport for PeerClientTransport {
+    fn send(&self, _request: RequestEnvelope) -> Result<ResponseEnvelope, AtmError> {
+        Err(daemon_boundary_stub_error(
+            "daemon peer client transport stub is not implemented yet",
+            DaemonBoundaryStubError::PeerClientTransport,
         ))
     }
 }

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -9,24 +9,23 @@ use std::error::Error as StdError;
 use std::fmt;
 
 use atm_core::{
+    RequestEnvelope, ResponseEnvelope,
     boundary::{
         self, ConfigIngress, ConfigLoadRequest, ConfigLoadResponse, InboxExport,
         InboxExportRecordRequest, InboxExportRecordResponse, InboxExportReexportMessageRequest,
         InboxExportReexportMessageResponse, InboxIngress, InboxIngressDiagnosticsRequest,
         InboxIngressDiagnosticsResponse, InboxIngressIdentityFingerprintRequest,
         InboxIngressIdentityFingerprintResponse, InboxIngressImportRequest,
-        InboxIngressImportResponse, RequestDispatcher,
+        InboxIngressImportResponse, NotificationEvent, ReconcileRequest, ReconcileResult,
+        RequestDispatcher, RuntimeStatusSnapshot, WatchEventBatch, WatchSubscriptionRequest,
     },
     error::AtmError,
-    protocol::{
-        NotificationEvent, ReconcileRequest, ReconcileResult, RuntimeStatusSnapshot,
-        WatchEventBatch, WatchSubscriptionRequest,
-    },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DaemonBoundaryStubError {
     ServerTransport,
+    RequestDispatcher,
     NotificationSink,
     StatusSource,
     WatchEventSource,
@@ -40,6 +39,7 @@ impl fmt::Display for DaemonBoundaryStubError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let message = match self {
             Self::ServerTransport => "daemon server transport scaffold is not wired",
+            Self::RequestDispatcher => "daemon request dispatcher scaffold is not wired",
             Self::NotificationSink => "daemon notification sink scaffold is not wired",
             Self::StatusSource => "daemon status source scaffold is not wired",
             Self::WatchEventSource => "daemon watch event source scaffold is not wired",
@@ -78,6 +78,27 @@ impl boundary::ServerTransport for LocalSocketServerTransport {
         Err(daemon_boundary_stub_error(
             "daemon server transport stub is not implemented yet",
             DaemonBoundaryStubError::ServerTransport,
+        ))
+    }
+}
+
+/// Placeholder runtime dispatcher for daemon-owned protocol routing.
+#[derive(Debug, Default)]
+pub(crate) struct DaemonRequestDispatcher;
+
+impl DaemonRequestDispatcher {
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+}
+
+impl boundary::sealed::Sealed for DaemonRequestDispatcher {}
+
+impl boundary::RequestDispatcher for DaemonRequestDispatcher {
+    fn dispatch(&self, _request: RequestEnvelope) -> Result<ResponseEnvelope, AtmError> {
+        Err(daemon_boundary_stub_error(
+            "daemon request dispatcher stub is not implemented yet",
+            DaemonBoundaryStubError::RequestDispatcher,
         ))
     }
 }

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -58,7 +58,7 @@ impl fmt::Display for DaemonBoundaryStubError {
 impl StdError for DaemonBoundaryStubError {}
 
 fn daemon_boundary_stub_error(message: &'static str, source: DaemonBoundaryStubError) -> AtmError {
-    AtmError::validation(message)
+    AtmError::config(message)
         .with_recovery("Complete the Phase R daemon boundary wiring before invoking this path.")
         .with_source(source)
 }

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -3,6 +3,7 @@
 use atm_core::boundary::ClientTransport;
 use atm_core::error::AtmError;
 use atm_core::observability::{NullObservability, ObservabilityPort};
+use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
 use std::error::Error as StdError;
 use std::fmt;
 
@@ -60,6 +61,13 @@ impl CliComposition {
 
     pub(crate) fn transport(&self) -> &dyn ClientTransport {
         self.transport.as_ref()
+    }
+
+    pub(crate) fn send_request(
+        &self,
+        request: RequestEnvelope,
+    ) -> Result<ResponseEnvelope, AtmError> {
+        self.transport.send(request)
     }
 
     pub(crate) fn observability_port(&self) -> &(dyn ObservabilityPort + Send + Sync) {

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -49,6 +49,17 @@ pub(crate) struct CliComposition {
     receive_command: ReceiveCommandEntryPoint,
 }
 
+impl fmt::Debug for CliComposition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CliComposition")
+            .field("transport", &"dyn ClientTransport")
+            .field("observability_port", &"dyn ObservabilityPort")
+            .field("send_command", &self.send_command)
+            .field("receive_command", &self.receive_command)
+            .finish()
+    }
+}
+
 impl CliComposition {
     pub(crate) fn from_transport(transport: Box<dyn ClientTransport>) -> Self {
         Self {
@@ -83,10 +94,12 @@ impl CliComposition {
     }
 
     pub(crate) fn bootstrap() -> Result<Self, AtmError> {
-        Err(AtmError::observability_bootstrap(
-            "CLI composition bootstrap scaffold is not implemented yet",
+        Err(
+            AtmError::config("CLI composition bootstrap scaffold is not implemented yet")
+                .with_recovery(
+                    "Wire the CLI transport and command entry points before using bootstrap().",
+                )
+                .with_source(CliBootstrapStubError::BootstrapNotWired),
         )
-        .with_recovery("Wire the CLI transport and command entry points before using bootstrap().")
-        .with_source(CliBootstrapStubError::BootstrapNotWired))
     }
 }

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -401,7 +401,7 @@ fn map_command_event(
     );
     fields.insert(
         "sender".to_string(),
-        serde_json::Value::String(event.sender.clone()),
+        serde_json::Value::String(event.sender.to_string()),
     );
     fields.insert(
         "requires_ack".to_string(),

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -71,14 +71,14 @@ fn run() -> anyhow::Result<()> {
             }
             let validation_error = atm_core::error::AtmError::validation(error.to_string());
             observability::CliObservability::fallback()
-                .emit_fatal_error("parse", &validation_error);
+                .report_fatal_error("parse", &validation_error);
             return Err(error.into());
         }
     };
 
     if let Err(error) = init_tracing(cli.stderr_logs()) {
         let fallback = observability::CliObservability::fallback();
-        fallback.emit_fatal_error("bootstrap", &error);
+        fallback.report_fatal_error("bootstrap", &error);
         return Err(error.into());
     }
 
@@ -86,7 +86,7 @@ fn run() -> anyhow::Result<()> {
         Ok(observability) => observability,
         Err(error) => {
             let fallback = observability::CliObservability::fallback();
-            fallback.emit_fatal_error("bootstrap", &error);
+            fallback.report_fatal_error("bootstrap", &error);
             return Err(error.into());
         }
     };
@@ -94,7 +94,7 @@ fn run() -> anyhow::Result<()> {
     match cli.run(&observability) {
         Ok(()) => Ok(()),
         Err(error) => {
-            observability.emit_fatal_error("service", error.as_ref());
+            observability.report_fatal_error("service", error.as_ref());
             Err(error)
         }
     }

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -635,8 +635,8 @@ fn render_diagnostic_summary(summary: sc_observability_types::DiagnosticSummary)
     }
 }
 
-#[cfg(test)]
-pub(crate) fn new_adapter_port_for_tests(
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn new_adapter_port(
     home_dir: &std::path::Path,
     stderr_logs: bool,
 ) -> Result<Box<dyn ObservabilityPort + Send + Sync>, AtmError> {

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -49,7 +49,11 @@ impl CliObservability {
         }
     }
 
-    pub fn emit_fatal_error(&self, stage: &'static str, error: &(dyn std::error::Error + 'static)) {
+    pub fn report_fatal_error(
+        &self,
+        stage: &'static str,
+        error: &(dyn std::error::Error + 'static),
+    ) {
         let (code, message) = if let Some(atm_error) = error.downcast_ref::<AtmError>() {
             (atm_error.code, atm_error.to_string())
         } else {
@@ -296,6 +300,6 @@ mod tests {
     #[test]
     fn emit_fatal_error_executes_secondary_failure_path_without_panicking() {
         let observability = CliObservability::from_test_port(FailingEmitObservability);
-        observability.emit_fatal_error("service", &AtmError::validation("boom"));
+        observability.report_fatal_error("service", &AtmError::validation("boom"));
     }
 }

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -93,12 +93,12 @@ impl CliObservability {
         }
     }
 
-    #[cfg(test)]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn new(
         home_dir: &std::path::Path,
         options: CliObservabilityOptions,
     ) -> Result<Self, AtmError> {
-        Ok(Self::from_boxed_port(crate::new_adapter_port_for_tests(
+        Ok(Self::from_boxed_port(crate::new_adapter_port(
             home_dir,
             options.stderr_logs,
         )?))

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -72,7 +72,9 @@ impl CliObservability {
             agent: identity
                 .parse()
                 .unwrap_or_else(|_| "unknown".parse().expect("agent")),
-            sender: identity,
+            sender: identity
+                .parse()
+                .unwrap_or_else(|_| "unknown".parse().expect("agent")),
             message_id: None,
             requires_ack: false,
             dry_run: false,
@@ -201,7 +203,7 @@ mod tests {
             outcome: "sent",
             team: TEST_TEAM.parse().expect("team"),
             agent: TEST_SENDER.parse().expect("agent"),
-            sender: TEST_SENDER.to_string(),
+            sender: TEST_SENDER.parse().expect("sender"),
             message_id: message_id.map(|value| value.parse().expect("legacy message id")),
             requires_ack: false,
             dry_run: false,

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -11,6 +11,9 @@ Contract-owner records intentionally use:
 That means `atm-core` owns the public contract and semantics, but not a default
 concrete adapter in this crate.
 
+Test doubles planned; not yet landed. Until they exist, `allowed_test_double_paths`
+remains empty for the `atm-core` contract-owner records below.
+
 ## AtmProtocol
 
 ```yaml
@@ -59,9 +62,9 @@ references:
 
 contracts:
   request_types:
-    - AtmRequestEnvelope
+    - RequestEnvelope
   response_types:
-    - AtmResponseEnvelope
+    - ResponseEnvelope
   error_types:
     - AtmError
 
@@ -78,7 +81,7 @@ enforcement:
 status:
   state: stub_landed
   notes:
-    - trait plus request/response/frame stubs landed in atm_core::boundary
+    - trait plus protocol request/response/frame DTOs landed in atm_core::protocol
     - ack is represented inside send-shape request data, not as a top-level protocol family
 ```
 
@@ -135,15 +138,14 @@ references:
 
 contracts:
   request_types:
-    - AtmRequestEnvelope
+    - RequestEnvelope
   response_types:
-    - AtmResponseEnvelope
+    - ResponseEnvelope
   error_types:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::InProcessClientTransport
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - atm_daemon::client
 
@@ -217,8 +219,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubWatchEventSource
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - notify::recommended_watcher
 
@@ -292,8 +293,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubReconcileCoordinator
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - mailbox::store::observe_source_files
 
@@ -360,15 +360,14 @@ references:
 
 contracts:
   request_types:
-    - AtmRequestEnvelope
+    - RequestEnvelope
   response_types:
-    - AtmResponseEnvelope
+    - ResponseEnvelope
   error_types:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::InProcessServerTransport
+  allowed_test_double_paths: []
   forbidden_test_bypasses: []
 
 enforcement:
@@ -440,8 +439,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubRequestDispatcher
+  allowed_test_double_paths: []
   forbidden_test_bypasses: []
 
 enforcement:
@@ -513,8 +511,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::InMemoryMailStore
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - rusqlite::Connection
 
@@ -587,8 +584,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::InMemoryTaskStore
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - rusqlite::Connection
 
@@ -661,8 +657,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::InMemoryRosterStore
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - rusqlite::Connection
 
@@ -736,8 +731,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubConfigIngress
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - std::fs::read_to_string
 
@@ -810,8 +804,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubInboxIngress
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - mailbox::store::observe_source_files
 
@@ -884,8 +877,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubInboxExport
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - mailbox::store::with_locked_source_files
 
@@ -957,8 +949,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubNotificationSink
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - std::process::Command
 
@@ -1028,8 +1019,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubStatusSource
+  allowed_test_double_paths: []
   forbidden_test_bypasses: []
 
 enforcement:

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -159,10 +159,10 @@ enforcement:
     - no_cli_to_daemon_edge
 
 status:
-  state: planned
+  state: stub_landed
   notes:
     - remote daemon-to-daemon delivery uses the same shared client transport family
-    - runtime composition will land through atm_daemon::composition when this adapter is introduced
+    - stub implementation currently lives at crate root and is assembled through atm_daemon::composition
 ```
 
 Purpose:
@@ -396,7 +396,7 @@ enforcement:
     - no_socket_specific_business_logic
 
 status:
-  state: planned
+  state: stub_landed
   notes:
     - dispatcher remains thin and runtime-owned
     - runtime composition will land through atm_daemon::composition when this adapter is introduced

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -6,6 +6,9 @@ Current design assumption:
 - `atm-daemon` is the production runtime composition root
 - `allowed_dependents: []` means no external crate should depend on these
   daemon-private concrete adapters
+- Test doubles planned; not yet landed. Until they exist,
+  `allowed_test_double_paths` remains empty for the daemon-owned adapter
+  records below.
 
 ## SocketServerTransportAdapter
 
@@ -63,8 +66,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::InProcessServerTransport
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - tokio::net::UnixListener
 
@@ -145,8 +147,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::InProcessClientTransport
+  allowed_test_double_paths: []
   forbidden_test_bypasses: []
 
 enforcement:
@@ -224,8 +225,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubWatchEventSource
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - notify::recommended_watcher
 
@@ -304,8 +304,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubReconcileCoordinator
+  allowed_test_double_paths: []
   forbidden_test_bypasses: []
 
 enforcement:
@@ -382,8 +381,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubRequestDispatcher
+  allowed_test_double_paths: []
   forbidden_test_bypasses: []
 
 enforcement:
@@ -462,8 +460,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubConfigIngress
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - std::fs::read_to_string
 
@@ -543,8 +540,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubInboxIngress
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - mailbox::store::observe_source_files
 
@@ -624,8 +620,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubInboxExport
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - mailbox::store::with_locked_source_files
 
@@ -704,8 +699,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubNotificationSink
+  allowed_test_double_paths: []
   forbidden_test_bypasses:
     - std::process::Command
 
@@ -782,8 +776,7 @@ contracts:
     - AtmError
 
 testing:
-  allowed_test_double_paths:
-    - atm_core::test_support::StubStatusSource
+  allowed_test_double_paths: []
   forbidden_test_bypasses: []
 
 enforcement:


### PR DESCRIPTION
## Summary

- `atm_core::protocol` module with named stub DTOs (RequestEnvelope, ResponseEnvelope, FramePayload)
- Callable method surfaces on all 8 boundary traits (AtmProtocol, ClientTransport, ServerTransport, RequestDispatcher, NotificationSink, StatusSource, WatchEventSource, ReconcileCoordinator)
- Named stub structs for all new DTOs (NotificationEvent, RuntimeStatusSnapshot, WatchSubscriptionRequest, WatchEventBatch, ReconcileRequest, ReconcileResult)
- Daemon and CLI composition stubs compile against callable transport/runtime seams
- ADR-001 lint_boundaries.py and #[doc(hidden)] action items verified

## Test plan
- [ ] QA: req-qa, arch-qa, rust-qa-agent, rust-best-practices-agent
- [ ] CI: all checks green
- [ ] lint_boundaries.py gate verified
- [ ] No direct atm→atm-daemon or atm→atm-rusqlite edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)