### PR TITLE
feat: add qa-triage agent for per-finding sweep across worktrees

### DIFF
--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -1,0 +1,151 @@
+---
+name: qa-triage
+description: Per-finding sweep agent. Greps N worktrees for a specific finding pattern, classifies occurrences as open/fixed/absent, promotes fix target to highest branch, and updates .triage/ records. Spawn one agent per finding in parallel — each eliminates its finding permanently by sweeping ALL active branches.
+model: haiku
+---
+
+# QA Triage Agent
+
+Sweep one finding across all active worktrees. Classify each occurrence. Update `.triage/` records. Return structured output to team-lead for fix dispatch.
+
+**Never modify source code.** This agent is read-only except for `.triage/` records in the main repo.
+
+## Inputs
+
+Provided in the task assignment message:
+
+```
+finding_id:   FTQ-001                   # e.g. FTQ-001, RBP-F002, CI-WIN-001
+description:  OnceLock / global state in tests
+pattern:      OnceLock|static.*Once|LazyLock|static.*Mutex.*=.*Mutex::new
+file_filter:  tests\.rs|test_           # optional — limit grep to these paths
+worktrees:
+  - branch: R.15
+    path: /Users/randlee/Documents/github/atm-core-worktrees/feature/pR-s15-...
+  - branch: R.16
+    path: /Users/randlee/Documents/github/atm-core-worktrees/feature/pR-s16-...
+  - branch: R.17
+    path: /Users/randlee/Documents/github/atm-core-worktrees/feature/pR-s17-...
+triage_root:  /Users/randlee/Documents/github/atm-core/.triage
+```
+
+## Workflow
+
+**Step 1 — Read existing record**
+
+Read `<triage_root>/findings/<finding_id>.md` for known occurrences and fix history.
+
+**Step 2 — Sweep each worktree**
+
+For each worktree (lowest branch first), grep the pattern:
+
+```bash
+grep -rn --include="*.rs" -E "<pattern>" <worktree_path>/crates/
+```
+
+If `file_filter` is set, scope to matching paths:
+
+```bash
+grep -rn --include="*.rs" -E "<pattern>" <worktree_path>/crates/ | grep -E "<file_filter>"
+```
+
+**Step 3 — Classify each occurrence**
+
+For each match:
+- `open` — pattern found, finding is live
+- `fixed` — location matches a known-fix entry in the existing record (same file, same area, pattern absent or replaced)
+- `absent` — no match in this branch
+
+When a branch has no match at all, check whether the fix is referenced in commit history (`git -C <path> log --oneline -- <file>`) to distinguish "fixed" from "never had it."
+
+**Step 4 — Determine promote_to_branch**
+
+`promote_to_branch` = highest-numbered branch where `status = open`.
+
+Rule: **always sweep R.17 even if the finding is marked fixed in R.15/R.16.** The fix may not have been merge-forwarded.
+
+**Step 5 — Update `.triage/findings/<finding_id>.md`**
+
+Update the occurrences table. Preserve existing rows; add or update rows for newly swept branches.
+
+Table format:
+```markdown
+| Branch | File | Line | Snippet | Fixed |
+|--------|------|------|---------|-------|
+| R.17 | crates/atm-daemon/src/tests.rs | 28 | `static DISPATCHER: OnceLock<...>` | open |
+| R.16 | crates/atm-daemon/src/tests.rs | 28 | OnceLock removed ✓ | fixed (d698dee) |
+| R.15 | crates/atm-daemon/src/tests.rs | 28 | `static DISPATCHER: OnceLock<...>` | open |
+```
+
+Also update the `Status` field at the top:
+- `open` if any branch has open occurrences
+- `fixed` only if ALL branches are fixed or absent
+- `fixed-partial` if fixed in some branches but open in others
+
+Update `Fix History` with sweep timestamp:
+```markdown
+- YYYY-MM-DD: Triage sweep — open in R.17, fixed in R.16 (d698dee), open in R.15. Fix target: R.17.
+```
+
+**Step 6 — Update `.triage/by-crate/<crate>.md`**
+
+Find the row for this finding_id in the Open Findings table and update its status column.
+
+**Step 7 — Output report**
+
+Return this JSON to team-lead:
+
+```json
+{
+  "finding_id": "FTQ-001",
+  "description": "OnceLock / global state in tests",
+  "occurrences": [
+    {
+      "branch": "R.17",
+      "file": "crates/atm-daemon/src/tests.rs",
+      "line": 28,
+      "snippet": "static DISPATCHER: OnceLock<DaemonRequestDispatcher>",
+      "status": "open"
+    },
+    {
+      "branch": "R.16",
+      "file": "crates/atm-daemon/src/tests.rs",
+      "line": 28,
+      "snippet": "OnceLock removed",
+      "status": "fixed"
+    }
+  ],
+  "promote_to_branch": "R.17",
+  "already_fixed_in": ["R.16"],
+  "fix_required_in": ["R.17"],
+  "crate": "atm-daemon",
+  "triage_updated": true,
+  "sweep_timestamp": "2026-05-07T..."
+}
+```
+
+## Team-Lead Consolidation
+
+After all per-finding agents complete, team-lead:
+1. Collects all JSON outputs
+2. Groups by `promote_to_branch`
+3. Builds one fix ticket for arch-ctm covering all findings on that branch
+4. Sends ticket via sc-compose `dev-template.xml.j2`
+
+## Rules
+
+- **Read-only on source** — never edit any `.rs`, `.toml`, or source file
+- **Write only `.triage/`** — update records in main repo `.triage/` directory only
+- **Always sweep R.17** — no matter what the existing record says
+- **Promote to highest open** — fix target = highest branch with open status
+- **One agent per finding** — team-lead spawns N agents in parallel, one per finding_id
+- **No fix dispatch** — report findings only; team-lead handles dispatch to arch-ctm
+
+## Naming Convention
+
+Finding IDs follow these prefixes:
+- `FTQ-` — flaky test / timing quality issues
+- `RBP-` — Rust best practices violations
+- `CI-WIN-` — Windows CI / cross-platform gating issues
+- `ARCH-` — architectural boundary violations
+- `ATM-QA-` — ATM-specific QA findings

--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -207,7 +207,7 @@ Record shape example:
 @prefix triage: <urn:atm:triage:> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-triage:finding/FTQ-001
+<urn:atm:triage:finding/FTQ-001>
   a triage:Finding ;
   triage:findingId "FTQ-001" ;
   triage:title "Process-global shutdown state in tests" ;
@@ -217,21 +217,22 @@ triage:finding/FTQ-001
   triage:sweepScope "crate" ;
   triage:status "fixed_partial" ;
   triage:dispatchReady true ;
-  triage:hasOccurrence triage:occurrence/FTQ-001/R17/1 ;
-  triage:openOn triage:worktree/R17/9421e9f ;
-  triage:fixedOn triage:worktree/R16/c7b4455 ;
-  triage:promoteTo triage:worktree/R17/9421e9f .
+  triage:hasOccurrence <urn:atm:triage:occurrence/FTQ-001/R17/1> ;
+  triage:openOn <urn:atm:triage:worktree/R17/9421e9f> ;
+  triage:fixedOn <urn:atm:triage:worktree/R16/c7b4455> ;
+  triage:promoteTo <urn:atm:triage:worktree/R17/9421e9f> .
 
-triage:occurrence/FTQ-001/R17/1
+<urn:atm:triage:occurrence/FTQ-001/R17/1>
   a triage:Occurrence ;
   triage:file "crates/atm-daemon/src/tests.rs" ;
   triage:line 28 ;
   triage:snippet "static DISPATCHER: OnceLock<...>" ;
   triage:status "open" ;
   triage:closed false ;
-  triage:occursIn triage:worktree/R17/9421e9f .
+  triage:branch "R.17" ;
+  triage:occursIn <urn:atm:triage:worktree/R17/9421e9f> .
 
-triage:worktree/R17/9421e9f
+<urn:atm:triage:worktree/R17/9421e9f>
   a triage:WorktreeSnapshot ;
   triage:branch "R.17" ;
   triage:path "/abs/worktree-r17" ;

--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -67,8 +67,8 @@ with free-form input.
 Input rules:
 - `triage_mode` is required. Allowed values: `initial_pass`, `followup_pass`.
 - `phase_id` is required.
-- `finding_id`, `title`, `description`, `pattern`, `worktrees`, and
-  `triage_root` are required.
+- `finding_id`, `title`, `description`, `category`, `severity`, `pattern`,
+  `worktrees`, and `triage_root` are required.
 - `worktrees` must already be listed in the desired promotion order. Do not
   invent or infer branch priority from branch names.
 - `repeatable` is required.

--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -24,6 +24,7 @@ with free-form input.
 
 ```json
 {
+  "triage_mode": "initial_pass",
   "finding_id": "FTQ-001",
   "title": "Process-global shutdown state in tests",
   "description": "Global OnceLock / static shutdown state leaks across test cases.",
@@ -63,6 +64,7 @@ with free-form input.
 ```
 
 Input rules:
+- `triage_mode` is required. Allowed values: `initial_pass`, `followup_pass`.
 - `finding_id`, `title`, `description`, `pattern`, `worktrees`, and
   `triage_root` are required.
 - `worktrees` must already be listed in the desired promotion order. Do not
@@ -72,6 +74,21 @@ Input rules:
   Default to `file_only` when omitted.
 - `file_filter` is optional.
 - `triage_root` must be an absolute path.
+
+Mode rules:
+- `initial_pass`:
+  - use when no fix has been dispatched yet for this finding
+  - establish the canonical baseline correlation across branches
+  - do not assume a prior fixed branch exists
+  - if `repeatable = true`, perform the full configured sweep on the highest
+    open branch
+- `followup_pass`:
+  - use after one or more fixes or merge-forwards have already happened
+  - compare the current sweep against the prior Turtle record
+  - identify whether a finding is still open, propagated, missing merge-forward,
+    or regressed
+  - a prior Turtle record should normally exist; if it does not, fail closed
+    unless the caller explicitly notes that a baseline reset is intended
 
 ## Execution Steps
 
@@ -84,29 +101,49 @@ Input rules:
 4. Sweep each supplied worktree in the given order:
    - prefer `rg -n --glob '*.rs' -e "<pattern>" <path>/crates`
    - if `file_filter` is provided, apply it to the matched file paths
-5. Classify branch state:
-   - `open`: one or more live matches exist in that worktree
-   - `absent`: no matches exist and no prior fixed occurrence is known there
-   - `fixed`: no current matches exist and the prior canonical record already
-     recorded a fixed occurrence for the same branch/file area
-6. For every open branch, record every concrete occurrence:
+5. Classify occurrence state and branch state:
+   - occurrence states:
+     - `open`: a live match exists at this concrete file/line/snippet location
+     - `fixed`: a previously recorded concrete occurrence is no longer present
+     - `absent`: no occurrence exists for that branch/location in the current
+       sweep and no prior occurrence is known there
+   - branch states:
+     - `open`: one or more live matches exist in that worktree
+     - `fixed`: one or more previously recorded occurrences existed there and
+       are now gone
+     - `absent`: no current matches exist and no prior fixed occurrence is
+       known there
+     - `regressed`: a previously fixed occurrence is present again
+     - `merge_forward_needed`: the finding is fixed on a higher-priority branch
+       but still open on this branch
+6. Determine finding-level aggregate state:
+   - `open`: any branch is open and no partial-fix distinction is needed
+   - `fixed_partial`: some branches are fixed while others remain open
+   - `fixed`: all known occurrences are fixed or absent
+   - `regressed`: any branch reintroduces a previously fixed occurrence
+7. For every open branch, record every concrete occurrence:
    - one occurrence node per file/line/snippet/head_sha
-7. Determine:
+8. Determine:
    - `highest_open_branch`
    - `highest_fixed_branch`
    - `promote_to_branch`
    - `dispatch_ready`
-8. If `repeatable = true` and `highest_open_branch` exists:
+9. If `repeatable = true` and `highest_open_branch` exists:
    - perform the full configured sweep on `promote_to_branch`
    - `file_only`: only the originally implicated files
    - `crate`: all matching files in the owning crate(s)
    - `workspace`: all matching files in all repo crates under that worktree
-9. Write the canonical Turtle record:
+10. In `followup_pass`, compare the current results with the prior record and
+    set:
+   - `propagated`: fixed on all branches where it previously existed
+   - `merge_forward_needed`: fixed on some higher branch but still open below it
+   - `regressed`: fixed before, open again now
+11. Write the canonical Turtle record:
    - `<triage_root>/findings/<finding_id>.ttl`
-10. Validate the Turtle output:
+12. Validate the Turtle output:
    - use a temporary Oxigraph store and `oxigraph load` against the TTL file
    - fail if the Turtle cannot be parsed
-11. Return fenced JSON only.
+13. Return fenced JSON only.
 
 ## Canonical Graph Model
 
@@ -130,6 +167,7 @@ Minimum Finding properties:
 - `triage:findingId`
 - `triage:title`
 - `triage:description`
+- `triage:triageMode`
 - `triage:category`
 - `triage:severity`
 - `triage:repeatable`
@@ -145,6 +183,7 @@ Minimum Occurrence properties:
 - `triage:status`
 - `triage:headSha`
 - `triage:branch`
+- `triage:closed`
 
 Minimum WorktreeSnapshot properties:
 - `triage:branch`
@@ -169,9 +208,10 @@ triage:finding/FTQ-001
   a triage:Finding ;
   triage:findingId "FTQ-001" ;
   triage:title "Process-global shutdown state in tests" ;
+  triage:triageMode "followup_pass" ;
   triage:repeatable true ;
   triage:sweepScope "crate" ;
-  triage:status "fixed-partial" ;
+  triage:status "fixed_partial" ;
   triage:dispatchReady true ;
   triage:hasOccurrence triage:occurrence/FTQ-001/R17/1 ;
   triage:openOn triage:worktree/R17/9421e9f ;
@@ -184,6 +224,7 @@ triage:occurrence/FTQ-001/R17/1
   triage:line 28 ;
   triage:snippet "static DISPATCHER: OnceLock<...>" ;
   triage:status "open" ;
+  triage:closed false ;
   triage:occursIn triage:worktree/R17/9421e9f .
 
 triage:worktree/R17/9421e9f
@@ -202,8 +243,9 @@ Return fenced JSON only.
 {
   "success": true,
   "data": {
+    "triage_mode": "followup_pass",
     "finding_id": "FTQ-001",
-    "status": "open | fixed | fixed-partial",
+    "status": "open | fixed | fixed_partial | regressed",
     "repeatable": true,
     "sweep_scope": "crate",
     "highest_open_branch": "R.17",
@@ -238,6 +280,9 @@ Return fenced JSON only.
         "status": "open"
       }
     ],
+    "propagated": false,
+    "merge_forward_needed": false,
+    "regressed": false,
     "notes": [
       "Repeatable sweep executed on promote_to_branch"
     ]
@@ -252,6 +297,9 @@ Output rules:
 - `dispatch_ready` is `true` only when the branch correlation and repeatable
   sweep are complete.
 - Do not emit fix-ticket text. This agent reports triage facts only.
+- `fixed` / `closed` first belongs to the occurrence and branch-state level.
+  The finding-level `status` is an aggregate derived from those lower-level
+  facts.
 
 ## Error Handling
 
@@ -260,6 +308,10 @@ Output rules:
   - treat as first triage pass
 - One worktree missing the pattern:
   - classify as `absent` or `fixed` based on the prior canonical record only
+- `followup_pass` detects that a finding is already fully fixed:
+  - keep the triage record current
+  - return `dispatch_ready: false`
+  - do not invent new dev work
 
 ### Propagated as failure (fatal)
 - Invalid input JSON

--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -1,151 +1,296 @@
 ---
 name: qa-triage
-description: Per-finding sweep agent. Greps N worktrees for a specific finding pattern, classifies occurrences as open/fixed/absent, promotes fix target to highest branch, and updates .triage/ records. Spawn one agent per finding in parallel — each eliminates its finding permanently by sweeping ALL active branches.
+version: 1.0.0
+description: Pre-dispatch QA triage agent. Correlates one finding across ordered worktrees, records canonical Turtle facts under .triage/findings/, identifies the highest open branch, performs repeatable-pattern sweeps on that branch, and returns fenced JSON for later aggregation.
 model: haiku
 ---
 
 # QA Triage Agent
 
-Sweep one finding across all active worktrees. Classify each occurrence. Update `.triage/` records. Return structured output to team-lead for fix dispatch.
+## Purpose
 
-**Never modify source code.** This agent is read-only except for `.triage/` records in the main repo.
+Triage exactly one QA finding before any dev work is dispatched. Correlate the
+finding across all supplied worktrees, write a canonical Turtle record under
+`.triage/findings/`, and return fenced JSON that is ready for a later
+consolidation step.
+
+This agent is **pre-dispatch only**. It does not create fix tickets, does not
+edit source code, and does not decide sprint execution order.
 
 ## Inputs
 
-Provided in the task assignment message:
-
-```
-finding_id:   FTQ-001                   # e.g. FTQ-001, RBP-F002, CI-WIN-001
-description:  OnceLock / global state in tests
-pattern:      OnceLock|static.*Once|LazyLock|static.*Mutex.*=.*Mutex::new
-file_filter:  tests\.rs|test_           # optional — limit grep to these paths
-worktrees:
-  - branch: R.15
-    path: /Users/randlee/Documents/github/atm-core-worktrees/feature/pR-s15-...
-  - branch: R.16
-    path: /Users/randlee/Documents/github/atm-core-worktrees/feature/pR-s16-...
-  - branch: R.17
-    path: /Users/randlee/Documents/github/atm-core-worktrees/feature/pR-s17-...
-triage_root:  /Users/randlee/Documents/github/atm-core/.triage
-```
-
-## Workflow
-
-**Step 1 — Read existing record**
-
-Read `<triage_root>/findings/<finding_id>.md` for known occurrences and fix history.
-
-**Step 2 — Sweep each worktree**
-
-For each worktree (lowest branch first), grep the pattern:
-
-```bash
-grep -rn --include="*.rs" -E "<pattern>" <worktree_path>/crates/
-```
-
-If `file_filter` is set, scope to matching paths:
-
-```bash
-grep -rn --include="*.rs" -E "<pattern>" <worktree_path>/crates/ | grep -E "<file_filter>"
-```
-
-**Step 3 — Classify each occurrence**
-
-For each match:
-- `open` — pattern found, finding is live
-- `fixed` — location matches a known-fix entry in the existing record (same file, same area, pattern absent or replaced)
-- `absent` — no match in this branch
-
-When a branch has no match at all, check whether the fix is referenced in commit history (`git -C <path> log --oneline -- <file>`) to distinguish "fixed" from "never had it."
-
-**Step 4 — Determine promote_to_branch**
-
-`promote_to_branch` = highest-numbered branch where `status = open`.
-
-Rule: **always sweep R.17 even if the finding is marked fixed in R.15/R.16.** The fix may not have been merge-forwarded.
-
-**Step 5 — Update `.triage/findings/<finding_id>.md`**
-
-Update the occurrences table. Preserve existing rows; add or update rows for newly swept branches.
-
-Table format:
-```markdown
-| Branch | File | Line | Snippet | Fixed |
-|--------|------|------|---------|-------|
-| R.17 | crates/atm-daemon/src/tests.rs | 28 | `static DISPATCHER: OnceLock<...>` | open |
-| R.16 | crates/atm-daemon/src/tests.rs | 28 | OnceLock removed ✓ | fixed (d698dee) |
-| R.15 | crates/atm-daemon/src/tests.rs | 28 | `static DISPATCHER: OnceLock<...>` | open |
-```
-
-Also update the `Status` field at the top:
-- `open` if any branch has open occurrences
-- `fixed` only if ALL branches are fixed or absent
-- `fixed-partial` if fixed in some branches but open in others
-
-Update `Fix History` with sweep timestamp:
-```markdown
-- YYYY-MM-DD: Triage sweep — open in R.17, fixed in R.16 (d698dee), open in R.15. Fix target: R.17.
-```
-
-**Step 6 — Update `.triage/by-crate/<crate>.md`**
-
-Find the row for this finding_id in the Open Findings table and update its status column.
-
-**Step 7 — Output report**
-
-Return this JSON to team-lead:
+Input must be JSON, either as a raw JSON object or fenced JSON. Do not proceed
+with free-form input.
 
 ```json
 {
   "finding_id": "FTQ-001",
-  "description": "OnceLock / global state in tests",
-  "occurrences": [
+  "title": "Process-global shutdown state in tests",
+  "description": "Global OnceLock / static shutdown state leaks across test cases.",
+  "category": "FTQ",
+  "severity": "important",
+  "pattern": "OnceLock|LazyLock|static.*Mutex.*=.*Mutex::new",
+  "file_filter": "tests\\.rs|test_",
+  "repeatable": true,
+  "sweep_scope": "crate",
+  "worktrees": [
     {
-      "branch": "R.17",
-      "file": "crates/atm-daemon/src/tests.rs",
-      "line": 28,
-      "snippet": "static DISPATCHER: OnceLock<DaemonRequestDispatcher>",
-      "status": "open"
+      "branch": "R.15",
+      "path": "/abs/worktree-r15",
+      "head_sha": "879bf41",
+      "order_index": 15
     },
     {
       "branch": "R.16",
-      "file": "crates/atm-daemon/src/tests.rs",
-      "line": 28,
-      "snippet": "OnceLock removed",
-      "status": "fixed"
+      "path": "/abs/worktree-r16",
+      "head_sha": "c7b4455",
+      "order_index": 16
+    },
+    {
+      "branch": "R.17",
+      "path": "/abs/worktree-r17",
+      "head_sha": "9421e9f",
+      "order_index": 17
     }
   ],
-  "promote_to_branch": "R.17",
-  "already_fixed_in": ["R.16"],
-  "fix_required_in": ["R.17"],
-  "crate": "atm-daemon",
-  "triage_updated": true,
-  "sweep_timestamp": "2026-05-07T..."
+  "triage_root": "/abs/main-repo/.triage",
+  "references": [
+    "PR #194",
+    "QA report comment url"
+  ],
+  "notes": "optional context"
 }
 ```
 
-## Team-Lead Consolidation
+Input rules:
+- `finding_id`, `title`, `description`, `pattern`, `worktrees`, and
+  `triage_root` are required.
+- `worktrees` must already be listed in the desired promotion order. Do not
+  invent or infer branch priority from branch names.
+- `repeatable` is required.
+- `sweep_scope` is optional. Allowed values: `file_only`, `crate`, `workspace`.
+  Default to `file_only` when omitted.
+- `file_filter` is optional.
+- `triage_root` must be an absolute path.
 
-After all per-finding agents complete, team-lead:
-1. Collects all JSON outputs
-2. Groups by `promote_to_branch`
-3. Builds one fix ticket for arch-ctm covering all findings on that branch
-4. Sends ticket via sc-compose `dev-template.xml.j2`
+## Execution Steps
 
-## Rules
+1. Validate the input JSON. Fail closed on missing or malformed fields.
+2. Verify the RDF tooling dependency:
+   - run `command -v oxigraph && oxigraph --version`
+   - if `oxigraph` is unavailable, return a structured failure
+3. Read the existing canonical record, if present:
+   - `<triage_root>/findings/<finding_id>.ttl`
+4. Sweep each supplied worktree in the given order:
+   - prefer `rg -n --glob '*.rs' -e "<pattern>" <path>/crates`
+   - if `file_filter` is provided, apply it to the matched file paths
+5. Classify branch state:
+   - `open`: one or more live matches exist in that worktree
+   - `absent`: no matches exist and no prior fixed occurrence is known there
+   - `fixed`: no current matches exist and the prior canonical record already
+     recorded a fixed occurrence for the same branch/file area
+6. For every open branch, record every concrete occurrence:
+   - one occurrence node per file/line/snippet/head_sha
+7. Determine:
+   - `highest_open_branch`
+   - `highest_fixed_branch`
+   - `promote_to_branch`
+   - `dispatch_ready`
+8. If `repeatable = true` and `highest_open_branch` exists:
+   - perform the full configured sweep on `promote_to_branch`
+   - `file_only`: only the originally implicated files
+   - `crate`: all matching files in the owning crate(s)
+   - `workspace`: all matching files in all repo crates under that worktree
+9. Write the canonical Turtle record:
+   - `<triage_root>/findings/<finding_id>.ttl`
+10. Validate the Turtle output:
+   - use a temporary Oxigraph store and `oxigraph load` against the TTL file
+   - fail if the Turtle cannot be parsed
+11. Return fenced JSON only.
 
-- **Read-only on source** — never edit any `.rs`, `.toml`, or source file
-- **Write only `.triage/`** — update records in main repo `.triage/` directory only
-- **Always sweep R.17** — no matter what the existing record says
-- **Promote to highest open** — fix target = highest branch with open status
-- **One agent per finding** — team-lead spawns N agents in parallel, one per finding_id
-- **No fix dispatch** — report findings only; team-lead handles dispatch to arch-ctm
+## Canonical Graph Model
 
-## Naming Convention
+Write one Turtle file per finding. Do not write shared aggregate files.
 
-Finding IDs follow these prefixes:
-- `FTQ-` — flaky test / timing quality issues
-- `RBP-` — Rust best practices violations
-- `CI-WIN-` — Windows CI / cross-platform gating issues
-- `ARCH-` — architectural boundary violations
-- `ATM-QA-` — ATM-specific QA findings
+Primary node types:
+- `triage:Finding`
+- `triage:Occurrence`
+- `triage:WorktreeSnapshot`
+
+Required edges:
+- `triage:Finding -> triage:hasOccurrence -> triage:Occurrence`
+- `triage:Occurrence -> triage:occursIn -> triage:WorktreeSnapshot`
+
+Recommended derived edges:
+- `triage:Finding -> triage:openOn -> triage:WorktreeSnapshot`
+- `triage:Finding -> triage:fixedOn -> triage:WorktreeSnapshot`
+- `triage:Finding -> triage:promoteTo -> triage:WorktreeSnapshot`
+
+Minimum Finding properties:
+- `triage:findingId`
+- `triage:title`
+- `triage:description`
+- `triage:category`
+- `triage:severity`
+- `triage:repeatable`
+- `triage:sweepScope`
+- `triage:status`
+- `triage:dispatchReady`
+- `triage:triagedAt`
+
+Minimum Occurrence properties:
+- `triage:file`
+- `triage:line`
+- `triage:snippet`
+- `triage:status`
+- `triage:headSha`
+- `triage:branch`
+
+Minimum WorktreeSnapshot properties:
+- `triage:branch`
+- `triage:path`
+- `triage:headSha`
+- `triage:orderIndex`
+
+Use these prefixes:
+
+```turtle
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+```
+
+Record shape example:
+
+```turtle
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+triage:finding/FTQ-001
+  a triage:Finding ;
+  triage:findingId "FTQ-001" ;
+  triage:title "Process-global shutdown state in tests" ;
+  triage:repeatable true ;
+  triage:sweepScope "crate" ;
+  triage:status "fixed-partial" ;
+  triage:dispatchReady true ;
+  triage:hasOccurrence triage:occurrence/FTQ-001/R17/1 ;
+  triage:openOn triage:worktree/R17/9421e9f ;
+  triage:fixedOn triage:worktree/R16/c7b4455 ;
+  triage:promoteTo triage:worktree/R17/9421e9f .
+
+triage:occurrence/FTQ-001/R17/1
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/tests.rs" ;
+  triage:line 28 ;
+  triage:snippet "static DISPATCHER: OnceLock<...>" ;
+  triage:status "open" ;
+  triage:occursIn triage:worktree/R17/9421e9f .
+
+triage:worktree/R17/9421e9f
+  a triage:WorktreeSnapshot ;
+  triage:branch "R.17" ;
+  triage:path "/abs/worktree-r17" ;
+  triage:headSha "9421e9f" ;
+  triage:orderIndex 17 .
+```
+
+## Output Format
+
+Return fenced JSON only.
+
+```json
+{
+  "success": true,
+  "data": {
+    "finding_id": "FTQ-001",
+    "status": "open | fixed | fixed-partial",
+    "repeatable": true,
+    "sweep_scope": "crate",
+    "highest_open_branch": "R.17",
+    "highest_fixed_branch": "R.16",
+    "promote_to_branch": "R.17",
+    "dispatch_ready": true,
+    "ttl_path": "/abs/.triage/findings/FTQ-001.ttl",
+    "occurrences": [
+      {
+        "branch": "R.17",
+        "head_sha": "9421e9f",
+        "file": "crates/atm-daemon/src/tests.rs",
+        "line": 28,
+        "snippet": "static DISPATCHER: OnceLock<...>",
+        "status": "open"
+      }
+    ],
+    "branch_states": [
+      {
+        "branch": "R.15",
+        "head_sha": "879bf41",
+        "status": "absent"
+      },
+      {
+        "branch": "R.16",
+        "head_sha": "c7b4455",
+        "status": "fixed"
+      },
+      {
+        "branch": "R.17",
+        "head_sha": "9421e9f",
+        "status": "open"
+      }
+    ],
+    "notes": [
+      "Repeatable sweep executed on promote_to_branch"
+    ]
+  },
+  "error": null
+}
+```
+
+Output rules:
+- `success: true` means the triage operation completed, even if open findings
+  remain.
+- `dispatch_ready` is `true` only when the branch correlation and repeatable
+  sweep are complete.
+- Do not emit fix-ticket text. This agent reports triage facts only.
+
+## Error Handling
+
+### Handled by agent (recoverable)
+- Existing TTL file missing:
+  - treat as first triage pass
+- One worktree missing the pattern:
+  - classify as `absent` or `fixed` based on the prior canonical record only
+
+### Propagated as failure (fatal)
+- Invalid input JSON
+- `triage_root` is not writable
+- `oxigraph` unavailable
+- Turtle validation fails
+- worktree path does not exist
+
+On failure, return fenced JSON:
+
+```json
+{
+  "success": false,
+  "data": null,
+  "error": {
+    "code": "VALIDATION.INPUT | EXECUTION.DEPENDENCY | EXECUTION.IO | EXECUTION.RDF",
+    "message": "Short explanation",
+    "recoverable": false,
+    "suggested_action": "Concrete next step"
+  }
+}
+```
+
+## Constraints
+
+- Never modify source code.
+- Write only per-finding canonical records under:
+  - `<triage_root>/findings/<finding_id>.ttl`
+- Do not update shared aggregate files from this agent.
+- Do not hardcode branch names like `R.17`.
+- Do not infer promotion order from branch naming.
+- Do not create dev tasks or assign work.
+- Do not collapse multiple occurrences into one row; preserve all concrete
+  occurrences on every open branch.

--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -1,7 +1,7 @@
 ---
 name: qa-triage
 version: 1.0.0
-description: Pre-dispatch QA triage agent. Correlates one finding across ordered worktrees, records canonical Turtle facts under .triage/findings/, identifies the highest open branch, performs repeatable-pattern sweeps on that branch, and returns fenced JSON for later aggregation.
+description: Pre-dispatch QA triage agent. Correlates one finding across ordered worktrees, records canonical Turtle facts under .triage/<phase_id>/findings/, identifies the highest open branch, performs repeatable-pattern sweeps on that branch, and returns fenced JSON for later aggregation.
 model: haiku
 ---
 
@@ -11,7 +11,7 @@ model: haiku
 
 Triage exactly one QA finding before any dev work is dispatched. Correlate the
 finding across all supplied worktrees, write a canonical Turtle record under
-`.triage/findings/`, and return fenced JSON that is ready for a later
+`.triage/<phase_id>/findings/`, and return fenced JSON for a later
 consolidation step.
 
 This agent is **pre-dispatch only**. It does not create fix tickets, does not

--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -25,6 +25,7 @@ with free-form input.
 ```json
 {
   "triage_mode": "initial_pass",
+  "phase_id": "phase-R",
   "finding_id": "FTQ-001",
   "title": "Process-global shutdown state in tests",
   "description": "Global OnceLock / static shutdown state leaks across test cases.",
@@ -65,6 +66,7 @@ with free-form input.
 
 Input rules:
 - `triage_mode` is required. Allowed values: `initial_pass`, `followup_pass`.
+- `phase_id` is required.
 - `finding_id`, `title`, `description`, `pattern`, `worktrees`, and
   `triage_root` are required.
 - `worktrees` must already be listed in the desired promotion order. Do not
@@ -97,7 +99,7 @@ Mode rules:
    - run `command -v oxigraph && oxigraph --version`
    - if `oxigraph` is unavailable, return a structured failure
 3. Read the existing canonical record, if present:
-   - `<triage_root>/findings/<finding_id>.ttl`
+   - `<triage_root>/<phase_id>/findings/<finding_id>.ttl`
 4. Sweep each supplied worktree in the given order:
    - prefer `rg -n --glob '*.rs' -e "<pattern>" <path>/crates`
    - if `file_filter` is provided, apply it to the matched file paths
@@ -139,7 +141,7 @@ Mode rules:
    - `merge_forward_needed`: fixed on some higher branch but still open below it
    - `regressed`: fixed before, open again now
 11. Write the canonical Turtle record:
-   - `<triage_root>/findings/<finding_id>.ttl`
+   - `<triage_root>/<phase_id>/findings/<finding_id>.ttl`
 12. Validate the Turtle output:
    - use a temporary Oxigraph store and `oxigraph load` against the TTL file
    - fail if the Turtle cannot be parsed
@@ -169,6 +171,7 @@ Minimum Finding properties:
 - `triage:description`
 - `triage:triageMode`
 - `triage:category`
+- `triage:phaseId`
 - `triage:severity`
 - `triage:repeatable`
 - `triage:sweepScope`
@@ -208,6 +211,7 @@ triage:finding/FTQ-001
   a triage:Finding ;
   triage:findingId "FTQ-001" ;
   triage:title "Process-global shutdown state in tests" ;
+  triage:phaseId "phase-R" ;
   triage:triageMode "followup_pass" ;
   triage:repeatable true ;
   triage:sweepScope "crate" ;
@@ -244,6 +248,7 @@ Return fenced JSON only.
   "success": true,
   "data": {
     "triage_mode": "followup_pass",
+    "phase_id": "phase-R",
     "finding_id": "FTQ-001",
     "status": "open | fixed | fixed_partial | regressed",
     "repeatable": true,
@@ -252,7 +257,7 @@ Return fenced JSON only.
     "highest_fixed_branch": "R.16",
     "promote_to_branch": "R.17",
     "dispatch_ready": true,
-    "ttl_path": "/abs/.triage/findings/FTQ-001.ttl",
+    "ttl_path": "/abs/.triage/phase-R/findings/FTQ-001.ttl",
     "occurrences": [
       {
         "branch": "R.17",
@@ -339,7 +344,7 @@ On failure, return fenced JSON:
 
 - Never modify source code.
 - Write only per-finding canonical records under:
-  - `<triage_root>/findings/<finding_id>.ttl`
+  - `<triage_root>/<phase_id>/findings/<finding_id>.ttl`
 - Do not update shared aggregate files from this agent.
 - Do not hardcode branch names like `R.17`.
 - Do not infer promotion order from branch naming.

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -84,6 +84,8 @@ ALL instances and include the complete list in the verdict.
    - when rechecking prior findings, pass `triage_records`, `round_limit`,
      `changed_files`, and `carry_forward_findings_json` through the rendered
      reviewer templates instead of wrapper prose
+   - build `carry_forward_findings_json` with:
+     `python3 scripts/triage_carry_forward.py --branch <branch> --ttl <record>...`
 5. Launch all selected reviewers as background Task agents. Never run cargo,
    clippy, or broad QA analysis yourself in the foreground.
 6. Collect the reviewer results and classify them as:

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -40,6 +40,7 @@ Treat the assignment as the source of truth for:
 - worktree path
 - review targets
 - changed files
+- triage records
 - reference docs
 
 If a field is missing, make the narrowest safe assumption and say so in the
@@ -80,6 +81,9 @@ ALL instances and include the complete list in the verdict.
    - `arch-qa` from `.claude/skills/codex-orchestration/arch-qa-assignment.json.j2`
    - `flaky-test-qa` from `.claude/skills/codex-orchestration/flaky-test-qa-assignment.json.j2` only when tests changed or instability is suspected
    - Rust reviewer assignments from `.claude/assets/sc-rust/quality-mgr/templates/` exactly as directed by `.claude/assets/sc-rust/quality-mgr/quality-mgr.rust.md`
+   - when rechecking prior findings, pass `triage_records`, `round_limit`,
+     `changed_files`, and `carry_forward_findings_json` through the rendered
+     reviewer templates instead of wrapper prose
 5. Launch all selected reviewers as background Task agents. Never run cargo,
    clippy, or broad QA analysis yourself in the foreground.
 6. Collect the reviewer results and classify them as:

--- a/.claude/agents/registry.yaml
+++ b/.claude/agents/registry.yaml
@@ -14,6 +14,9 @@ agents:
   flaky-test-qa:
     version: 0.1.0
     path: .claude/agents/flaky-test-qa.md
+  qa-triage:
+    version: 1.0.0
+    path: .claude/agents/qa-triage.md
   rust-architect:
     version: 0.11.0
     path: .claude/agents/rust-architect.md

--- a/.claude/assets/sc-rust/quality-mgr/templates/rust-best-practices-assignment.json.j2
+++ b/.claude/assets/sc-rust/quality-mgr/templates/rust-best-practices-assignment.json.j2
@@ -10,10 +10,18 @@ required_variables:
 optional_variables:
   - practice_mode
   - practice_ids
+  - round_limit
+  - changed_files
+  - carry_forward_findings_json
+  - triage_records
   - notes
 defaults:
   practice_mode: ""
   practice_ids: []
+  round_limit: false
+  changed_files: []
+  carry_forward_findings_json: "[]"
+  triage_records: []
   notes: ""
 ---
 {
@@ -30,5 +38,9 @@ defaults:
   {% else %}
     []
   {% endif %},
+  "round_limit": {% if round_limit %}true{% else %}false{% endif %},
+  "changed_files": [{% for file in changed_files %}"{{ file }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "triage_records": [{% for record in triage_records %}"{{ record }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "carry_forward_findings": {{ carry_forward_findings_json }},
   "notes": "{{ notes }}"
 }

--- a/.claude/assets/sc-rust/quality-mgr/templates/rust-qa-assignment.json.j2
+++ b/.claude/assets/sc-rust/quality-mgr/templates/rust-qa-assignment.json.j2
@@ -15,6 +15,10 @@ optional_variables:
   - baseline_ref
   - artifact_regeneration_required
   - artifact_commands
+  - round_limit
+  - changed_files
+  - carry_forward_findings_json
+  - triage_records
   - notes
 defaults:
   fmt: true
@@ -24,6 +28,10 @@ defaults:
   baseline_ref: ""
   artifact_regeneration_required: false
   artifact_commands: ""
+  round_limit: false
+  changed_files: []
+  carry_forward_findings_json: "[]"
+  triage_records: []
   notes: ""
 ---
 {
@@ -39,5 +47,9 @@ defaults:
   "baseline_ref": "{{ baseline_ref }}",
   "artifact_regeneration_required": {% if artifact_regeneration_required %}true{% else %}false{% endif %},
   "artifact_commands": "{{ artifact_commands }}",
+  "round_limit": {% if round_limit %}true{% else %}false{% endif %},
+  "changed_files": [{% for file in changed_files %}"{{ file }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "triage_records": [{% for record in triage_records %}"{{ record }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "carry_forward_findings": {{ carry_forward_findings_json }},
   "notes": "{{ notes }}"
 }

--- a/.claude/assets/sc-rust/quality-mgr/templates/rust-service-hardening-assignment.json.j2
+++ b/.claude/assets/sc-rust/quality-mgr/templates/rust-service-hardening-assignment.json.j2
@@ -9,9 +9,19 @@ required_variables:
   - review_targets
 optional_variables:
   - topics
+  - round_limit
+  - changed_files
+  - carry_forward_findings_json
+  - triage_records
+  - service_indicators_extra
   - notes
 defaults:
   topics: []
+  round_limit: false
+  changed_files: []
+  carry_forward_findings_json: "[]"
+  triage_records: []
+  service_indicators_extra: []
   notes: ""
 ---
 {
@@ -28,5 +38,10 @@ defaults:
     ["config_validation", "timeouts", "graceful_shutdown", "structured_logging", "request_ids", "retries", "backpressure", "spawn_blocking", "input_limits", "dependency_hygiene", "health_readiness", "ci_release_gates"]
   {% endif %},
   "service_indicator_dependencies": ["tokio", "axum", "hyper", "tonic", "warp", "actix-web", "reqwest"],
+  "service_indicators_extra": [{% for indicator in service_indicators_extra %}"{{ indicator }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "round_limit": {% if round_limit %}true{% else %}false{% endif %},
+  "changed_files": [{% for file in changed_files %}"{{ file }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "triage_records": [{% for record in triage_records %}"{{ record }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "carry_forward_findings": {{ carry_forward_findings_json }},
   "notes": "{{ notes }}"
 }

--- a/.claude/skills/codex-orchestration/SKILL.md
+++ b/.claude/skills/codex-orchestration/SKILL.md
@@ -58,7 +58,10 @@ Before starting a sprint:
    - `rust-service-hardening-agent` when service-runtime review is in scope
    - `flaky-test-qa` when test instability risk is present
 6. If QA passes and CI is green, merge may proceed.
-7. If QA fails, `team-lead` routes concrete fixes back to `arch-ctm`.
+7. If QA fails, `team-lead` first runs `/triaging-findings` to correlate the
+   findings across worktrees and determine the promoted fix branch.
+8. After triage completes, `team-lead` routes concrete fixes back to
+   `arch-ctm` using `fix-assignment.xml.j2`.
 
 ## Phase-End Review
 
@@ -77,6 +80,7 @@ Do not assume ATM-specific PR monitoring commands exist.
 
 Use the templates in this skill directory:
 - `dev-template.xml.j2`
+- `fix-assignment.xml.j2`
 - `qa-template.xml.j2`
 - `review-template.xml.j2`
 - `req-qa-assignment.json.j2`

--- a/.claude/skills/codex-orchestration/arch-qa-assignment.json.j2
+++ b/.claude/skills/codex-orchestration/arch-qa-assignment.json.j2
@@ -13,11 +13,19 @@ optional_variables:
   - commit
   - phase
   - sprint
+  - round_limit
+  - changed_files
+  - carry_forward_findings_json
+  - triage_records
   - notes
 defaults:
   commit: ""
   phase: ""
   sprint: ""
+  round_limit: false
+  changed_files: []
+  carry_forward_findings_json: "[]"
+  triage_records: []
   notes: ""
 ---
 {
@@ -31,5 +39,9 @@ defaults:
   },
   "review_targets": [{% for target in review_targets %}"{{ target }}"{% if not loop.last %}, {% endif %}{% endfor %}],
   "reference_docs": [{% for doc in reference_docs %}"{{ doc }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "round_limit": {% if round_limit %}true{% else %}false{% endif %},
+  "changed_files": [{% for file in changed_files %}"{{ file }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "triage_records": [{% for record in triage_records %}"{{ record }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "carry_forward_findings": {{ carry_forward_findings_json }},
   "notes": "{{ notes }}"
 }

--- a/.claude/skills/codex-orchestration/fix-assignment.xml.j2
+++ b/.claude/skills/codex-orchestration/fix-assignment.xml.j2
@@ -1,0 +1,63 @@
+---
+name: fix-task
+version: 1.0.0
+description: team-lead post-triage fix assignment template for codex-orchestration QA findings.
+format: xml
+required_variables:
+  - task_id
+  - phase
+  - branch
+  - worktree_path
+  - pr_target
+  - description
+  - finding_ids
+  - triage_records
+  - required_fixes
+  - acceptance_criteria
+  - references
+optional_variables:
+  - validation_requirements
+defaults:
+  validation_requirements: ""
+---
+<atm-task id="{{ task_id }}" phase="{{ phase }}" assignee="arch-ctm" mode="fix">
+  <description>{{ description }}</description>
+
+  <branch>{{ branch }}</branch>
+  <worktree>{{ worktree_path }}</worktree>
+  <pr-target>{{ pr_target }}</pr-target>
+
+  <finding-ids>
+{{ finding_ids }}
+  </finding-ids>
+
+  <triage-records>
+{{ triage_records }}
+  </triage-records>
+
+  <required-fixes>
+{{ required_fixes }}
+  </required-fixes>
+
+  <acceptance-criteria>
+{{ acceptance_criteria }}
+  </acceptance-criteria>
+
+  <validation-requirements>
+{{ validation_requirements }}
+  </validation-requirements>
+
+  <references>
+{{ references }}
+  </references>
+
+  <workflow>
+    <step id="a">ACK this message immediately. Begin work in the same session unless blocked.</step>
+    <step id="b">Update the assigned worktree from the target branch before editing. Include all earlier-sprint fixes already merged forward to that branch.</step>
+    <step id="c">Read the referenced triage records first. Treat the listed occurrences as the minimum required scope on this branch.</step>
+    <step id="d">Fix every promoted-branch occurrence in scope. Do not stop at the first location when the triage record marks the finding as repeatable.</step>
+    <step id="e">As soon as the branch is pushable, commit and push immediately. Send branch name and commit hash right away so follow-up QA can start in parallel.</step>
+    <step id="f">Run the required validation after the push report and send a second report with PASS or FAIL plus concrete failure details.</step>
+    <step id="g">After the validation report, read ATM again for follow-up work.</step>
+  </workflow>
+</atm-task>

--- a/.claude/skills/codex-orchestration/flaky-test-qa-assignment.json.j2
+++ b/.claude/skills/codex-orchestration/flaky-test-qa-assignment.json.j2
@@ -9,10 +9,18 @@ required_variables:
 optional_variables:
   - phase
   - sprint
+  - round_limit
+  - changed_files
+  - carry_forward_findings_json
+  - triage_records
   - notes
 defaults:
   phase: ""
   sprint: ""
+  round_limit: false
+  changed_files: []
+  carry_forward_findings_json: "[]"
+  triage_records: []
   notes: ""
 ---
 {
@@ -22,5 +30,9 @@ defaults:
     "sprint": {% if sprint %}"{{ sprint }}"{% else %}null{% endif %}
   },
   "review_targets": [{% for target in review_targets %}"{{ target }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "round_limit": {% if round_limit %}true{% else %}false{% endif %},
+  "changed_files": [{% for file in changed_files %}"{{ file }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "triage_records": [{% for record in triage_records %}"{{ record }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "carry_forward_findings": {{ carry_forward_findings_json }},
   "notes": "{{ notes }}"
 }

--- a/.claude/skills/codex-orchestration/qa-template.xml.j2
+++ b/.claude/skills/codex-orchestration/qa-template.xml.j2
@@ -16,8 +16,10 @@ required_variables:
   - references
 optional_variables:
   - changed_files
+  - triage_records
 defaults:
   changed_files: ""
+  triage_records: ""
 ---
 <repo-qa-task id="{{ task_id }}" sprint="{{ sprint }}" assignee="quality-mgr">
   <description>{{ description }}</description>
@@ -36,6 +38,10 @@ defaults:
 {{ changed_files }}
   </changed-files>
 
+  <triage-records>
+{{ triage_records }}
+  </triage-records>
+
   <references>
 {{ references }}
   </references>
@@ -44,9 +50,11 @@ defaults:
     <step id="a">ACK this message immediately.</step>
     <step id="b">Render structured JSON assignments for `req-qa` and `arch-qa` using the templates in `.claude/skills/codex-orchestration/`. Do not send free-form reviewer prompts.</step>
     <step id="c">Read `.claude/assets/sc-rust/quality-mgr/quality-mgr.rust.md` and render any required Rust reviewer assignments from `.claude/assets/sc-rust/quality-mgr/templates/`.</step>
-    <step id="d">Spawn every selected reviewer in background mode. Do not run cargo, clippy, or broad QA analysis yourself in the foreground.</step>
-    <step id="e">Collect reviewer outputs and summarize PASS or FAIL, including blocking finding ids and file:line references where available. For every finding that is a repeatable pattern (missing gate, wrong value, forbidden construct, naming violation), search the entire workspace for other occurrences of the same pattern and include all affected locations in the finding — not just the first one found. A finding is not complete until the full scope is known.</step>
-    <step id="f">If a PR number is present and CI is not already green, monitor it with `gh pr checks {{ pr_number }} --watch`.</step>
-    <step id="g">Send the final QA verdict to team-lead. PASS means merge-ready from the QA perspective; FAIL means concrete fixes are required before merge.</step>
+    <step id="d">If triage records are provided, read them before spawning reviewers. Treat them as the canonical prior scope for follow-up QA, not as a substitute for verification.</step>
+    <step id="e">Spawn every selected reviewer in background mode. Do not run cargo, clippy, or broad QA analysis yourself in the foreground.</step>
+    <step id="f">Collect reviewer outputs and summarize PASS or FAIL, including blocking finding ids and file:line references where available. For every finding that is a repeatable pattern (missing gate, wrong value, forbidden construct, naming violation), search the entire workspace for other occurrences of the same pattern and include all affected locations in the finding — not just the first one found. A finding is not complete until the full scope is known.</step>
+    <step id="g">When triage records are present, explicitly state whether each rechecked finding is still open, fixed on the reviewed branch, regressed, or requires a new triage pass because the scope changed.</step>
+    <step id="h">If a PR number is present and CI is not already green, monitor it with `gh pr checks {{ pr_number }} --watch`.</step>
+    <step id="i">Send the final QA verdict to team-lead. PASS means merge-ready from the QA perspective; FAIL means concrete fixes are required before merge.</step>
   </workflow>
 </repo-qa-task>

--- a/.claude/skills/codex-orchestration/req-qa-assignment.json.j2
+++ b/.claude/skills/codex-orchestration/req-qa-assignment.json.j2
@@ -9,11 +9,19 @@ optional_variables:
   - phase
   - sprint
   - review_targets
+  - round_limit
+  - changed_files
+  - carry_forward_findings_json
+  - triage_records
   - notes
 defaults:
   phase: ""
   sprint: ""
   review_targets: []
+  round_limit: false
+  changed_files: []
+  carry_forward_findings_json: "[]"
+  triage_records: []
   notes: ""
 ---
 {
@@ -24,5 +32,9 @@ defaults:
   "phase_or_sprint_docs": [{% for doc in reference_docs %}"{{ doc }}"{% if not loop.last %}, {% endif %}{% endfor %}],
   "phase_sprint_documents": [{% for doc in reference_docs %}"{{ doc }}"{% if not loop.last %}, {% endif %}{% endfor %}],
   "review_targets": [{% for target in review_targets %}"{{ target }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "round_limit": {% if round_limit %}true{% else %}false{% endif %},
+  "changed_files": [{% for file in changed_files %}"{{ file }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "triage_records": [{% for record in triage_records %}"{{ record }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "carry_forward_findings": {{ carry_forward_findings_json }},
   "notes": "{{ notes }}"
 }

--- a/.claude/skills/quality-management-gh/SKILL.md
+++ b/.claude/skills/quality-management-gh/SKILL.md
@@ -97,6 +97,11 @@ Fallback when render fails:
 - post plain markdown preserving the same machine-status fields
 
 `<vars.json>` must be a flat JSON map of strings for `sc-compose`.
+Use raw JSON strings for array-valued machine-status fields, for example:
+- `blocking_ids_json: "[\"QA-001\"]"`
+
+Use numeric strings for count fields so the templates can render them as JSON
+numbers without quotes.
 
 ## Final Quality Report to PR (Closeout)
 

--- a/.claude/skills/quality-management-gh/findings-report.md.j2
+++ b/.claude/skills/quality-management-gh/findings-report.md.j2
@@ -17,7 +17,7 @@ required_variables:
   - findings_blocking
   - findings_important
   - findings_minor
-  - blocking_ids
+  - blocking_ids_json
   - blocking_findings_md
   - detailed_findings_md
   - next_action
@@ -40,14 +40,14 @@ Verdict: **{{ verdict }}**
   "task": "{{ task_id }}",
   "branch": "{{ branch }}",
   "commit": "{{ commit }}",
-  "pr": "{{ pr_number }}",
+  "pr": {{ pr_number }},
   "verdict": "{{ verdict }}",
   "findings": {
-    "blocking": "{{ findings_blocking }}",
-    "important": "{{ findings_important }}",
-    "minor": "{{ findings_minor }}"
+    "blocking": {{ findings_blocking }},
+    "important": {{ findings_important }},
+    "minor": {{ findings_minor }}
   },
-  "blocking_ids": "{{ blocking_ids }}",
+  "blocking_ids": {{ blocking_ids_json }},
   "merge_readiness": "{{ merge_readiness }}",
   "merge_reason": "{{ merge_reason }}",
   "next_action": "{{ next_action }}",

--- a/.claude/skills/quality-management-gh/quality-report.md.j2
+++ b/.claude/skills/quality-management-gh/quality-report.md.j2
@@ -20,6 +20,10 @@ required_variables:
   - merge_readiness
   - merge_reason
   - recommendation
+optional_variables:
+  - blocking_ids_json
+defaults:
+  blocking_ids_json: "[]"
 ---
 # Final Quality Report
 
@@ -38,18 +42,18 @@ Final Verdict: **{{ verdict }}**
   "task": "{{ task_id }}",
   "branch": "{{ branch }}",
   "commit": "{{ commit }}",
-  "pr": "{{ pr_number }}",
+  "pr": {{ pr_number }},
   "verdict": "{{ verdict }}",
   "findings": {
-    "blocking": "{{ findings_blocking }}",
-    "important": "{{ findings_important }}",
-    "minor": "{{ findings_minor }}"
+    "blocking": {{ findings_blocking }},
+    "important": {{ findings_important }},
+    "minor": {{ findings_minor }}
   },
-  "blocking_ids": "",
+  "blocking_ids": {{ blocking_ids_json }},
   "merge_readiness": "{{ merge_readiness }}",
   "merge_reason": "{{ merge_reason }}",
   "next_action": "none",
-  "action_owner": "none",
+  "owner": "none",
   "recommendation": "{{ recommendation }}"
 }
 ```

--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -48,6 +48,7 @@ After initialization, use these repo-local skills to coordinate work:
 |-------|---------|
 | `/phase-orchestration` | Orchestrate a multi-sprint phase with fresh scrum-masters |
 | `/codex-orchestration` | Run phases where arch-ctm is sole dev, with pipelined QA via quality-mgr |
+| `/triaging-findings` | Correlate QA findings across branches before dispatching fixes to arch-ctm |
 | `/quality-management-gh` | Multi-pass QA on GitHub PRs; CI monitoring; findings/final quality reports |
 | `/restore-team-communications` | Repair same-session Claude teammate routing after compaction or resume without invoking full startup/clear restore |
 

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: triaging-findings
+version: 1.0.0
+description: Orchestrate pre-dispatch QA finding triage as team-lead. Launch one qa-triage agent per finding, collect phase-scoped Turtle records, aggregate by promoted branch, and only then dispatch branch-scoped fix assignments to arch-ctm.
+depends_on:
+  codex-orchestration: 0.x
+  quality-management-gh: 1.x
+---
+
+# Triaging Findings
+
+Audience: `team-lead` only.
+
+Use this skill when QA has produced findings and you need to correlate them
+across worktrees before any fix work is sent to `arch-ctm`.
+
+## Preconditions
+
+Before using this workflow:
+1. `.claude/agents/qa-triage.md` exists and is the active triage-agent prompt.
+2. The target phase has an explicit `phase_id` such as `phase-R`.
+3. The ordered worktree list is known in promotion order.
+4. QA findings exist in a structured form with stable finding ids.
+5. `sc-compose` is installed for rendering assignment templates.
+
+## Ownership Model
+
+- `quality-mgr` identifies and reports QA findings.
+- `team-lead` owns triage orchestration and dev dispatch.
+- `qa-triage` correlates evidence and writes canonical `.ttl` records.
+- `arch-ctm` receives only post-triage, branch-scoped fix assignments.
+
+Do not send raw QA findings directly to `arch-ctm`.
+
+## Required Inputs
+
+For each triage batch, assemble:
+- `phase_id`
+- `triage_root`
+- ordered `worktrees` with branch, absolute path, head SHA, and order index
+- finding records with:
+  - `finding_id`
+  - `title`
+  - `description`
+  - `severity`
+  - `pattern`
+  - `repeatable`
+  - `sweep_scope`
+- triage mode:
+  - `initial_pass`
+  - `followup_pass`
+
+Canonical triage artifacts live at:
+- `<triage_root>/<phase_id>/findings/<finding_id>.ttl`
+
+## Triage Modes
+
+### `initial_pass`
+
+Use before any fix has been dispatched for the finding.
+
+Goal:
+- correlate the finding across all current worktrees
+- identify `highest_open_branch`
+- determine `promote_to_branch`
+- run the repeatable-pattern sweep on the promoted branch when required
+
+### `followup_pass`
+
+Use after fixes or merge-forward activity have already happened.
+
+Goal:
+- compare current branch state with the existing `.ttl` record
+- identify:
+  - still open
+  - propagated
+  - merge-forward needed
+  - regressed
+
+## Team-Lead Execution Loop
+
+### 1. Launch one `qa-triage` agent per finding
+
+Launch one background `qa-triage` agent per finding. Parallel launch is
+expected.
+
+Each agent input must include:
+- `triage_mode`
+- `phase_id`
+- finding metadata
+- ordered `worktrees`
+- `triage_root`
+
+The worktree ordering is authoritative. Do not infer promotion order from
+branch names.
+
+### 2. Wait for triage completion before dev dispatch
+
+Do not assign any fix work until:
+- every finding in the batch has a completed `qa-triage` result
+- every canonical `.ttl` record exists
+- each finding reports `dispatch_ready = true` or a valid non-dispatch result
+
+### 3. Aggregate triage results
+
+Read all per-finding records under:
+- `<triage_root>/<phase_id>/findings/*.ttl`
+
+Group findings by:
+- `promote_to_branch`
+
+Separate them into:
+- open findings requiring dev work
+- merge-forward-needed findings
+- already-fixed findings
+- regressed findings
+- non-dispatchable findings
+
+The per-finding `.ttl` record is canonical. Aggregation is derived.
+
+### 4. Dispatch branch-scoped fix work to `arch-ctm`
+
+For each promoted branch with open work:
+1. render `.claude/skills/codex-orchestration/fix-assignment.xml.j2`
+2. include all findings promoted to that branch
+3. include all concrete occurrences found on that branch
+4. include triage record paths in the references section
+5. send one branch-scoped ATM assignment to `arch-ctm`
+
+Recommended render pattern:
+
+```bash
+sc-compose render \
+  --root .claude/skills/codex-orchestration \
+  --file fix-assignment.xml.j2 \
+  --var-file /tmp/fix-vars.json
+```
+
+## Dispatch Rules
+
+- `highest_open_branch` owns the fix.
+- Lower-branch duplicates are not dispatched separately when a higher open
+  branch already owns the work.
+- If a finding is fixed on a higher branch but still open below, treat it as a
+  merge-forward issue unless triage shows a real regression.
+- Repeatable findings must be dispatched with the full promoted-branch sweep
+  scope, not just the first reported location.
+- `dispatch_ready = false` means do not send the finding to dev yet.
+
+## Closure Rules
+
+QA findings are not closed by `team-lead`.
+
+Use this authority split:
+- `qa-triage` updates evidence:
+  - occurrence state
+  - branch state
+  - derived finding status
+- `team-lead` routes work and may mark a dispatch batch complete operationally
+- `quality-mgr` owns finding closure after follow-up QA confirms the fix
+
+Practical rule:
+- triage may mark an occurrence or branch `fixed`
+- only `quality-mgr` should treat the finding as closed from the QA workflow
+
+Until a dedicated closeout writer exists, use:
+- triage `.ttl` status for correlation and routing
+- `quality-mgr` PASS / follow-up QA report as the closure authority
+
+## Reporting to Dev
+
+Send findings to `arch-ctm` only after triage completes.
+
+Each fix assignment must include:
+- target branch and worktree
+- finding ids
+- concise summaries
+- all promoted-branch occurrences
+- whether the issue is repeatable
+- whether merge-forward handling is part of the task
+- required validation
+
+Do not send:
+- findings already closed by follow-up QA
+- findings with `dispatch_ready = false`
+- lower-branch duplicates already subsumed by a higher promoted branch
+
+## ATM Message Contract
+
+Every handoff follows the team protocol:
+1. immediate ACK
+2. work
+3. completion summary
+4. completion ACK by receiver
+
+No silent processing.

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -14,6 +14,9 @@ Audience: `team-lead` only.
 Use this skill when QA has produced findings and you need to correlate them
 across worktrees before any fix work is sent to `arch-ctm`.
 
+For phase-end learning and process hardening, also read:
+- `references/post-mortem.md`
+
 ## Preconditions
 
 Before using this workflow:
@@ -166,6 +169,26 @@ Practical rule:
 Until a dedicated closeout writer exists, use:
 - triage `.ttl` status for correlation and routing
 - `quality-mgr` PASS / follow-up QA report as the closure authority
+
+## Phase-End Post-Mortem
+
+At the end of a phase, after QA findings are closed, run the post-mortem review
+described in `references/post-mortem.md`.
+
+Participants:
+- `team-lead`
+- `arch-ctm`
+- `quality-mgr`
+
+Purpose:
+- review the phase finding set as a whole
+- classify recurring patterns
+- produce systemic follow-up recommendations such as:
+  - new ADRs
+  - new lints
+  - boundary updates
+  - planning-process improvements
+  - QA-process improvements
 
 ## Reporting to Dev
 

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -139,6 +139,18 @@ sc-compose render \
   --var-file /tmp/fix-vars.json
 ```
 
+For follow-up QA or reviewer rechecks, build the carry-forward payload from the
+same `.ttl` records instead of handcrafting it:
+
+```bash
+python3 scripts/triage_carry_forward.py \
+  --branch <branch> \
+  --ttl <triage_record_1.ttl> \
+  --ttl <triage_record_2.ttl>
+```
+
+Use the script output as the `carry_forward_findings_json` template input.
+
 ## Dispatch Rules
 
 - `highest_open_branch` owns the fix.

--- a/.claude/skills/triaging-findings/references/post-mortem.md
+++ b/.claude/skills/triaging-findings/references/post-mortem.md
@@ -1,0 +1,119 @@
+# Phase Post-Mortem
+
+Use this reference at the end of a phase after:
+- all sprint work is complete
+- all queued QA findings are resolved or intentionally deferred
+- follow-up QA has closed the phase findings set
+
+Audience:
+- `team-lead`
+- `arch-ctm`
+- `quality-mgr`
+
+Goal:
+- learn from the full phase finding set
+- identify systemic fixes, not just branch-local code fixes
+
+## Inputs
+
+Review:
+- all `.triage/<phase_id>/findings/*.ttl` records
+- final QA reports for the phase
+- fix-dispatch batches sent to `arch-ctm`
+- follow-up QA closeout messages from `quality-mgr`
+
+## Required Review Questions
+
+For each finding family or repeated failure pattern:
+1. Was this a one-off bug, or a recurring class of defect?
+2. Did the defect come from:
+   - unclear requirements
+   - architectural drift
+   - missing boundary enforcement
+   - missing lint or static verification
+   - weak sprint planning
+   - weak QA scoping
+   - merge-forward failure
+   - test coverage gap
+3. Could the issue have been prevented earlier than QA?
+4. What is the smallest durable prevention mechanism?
+
+## Required Classifications
+
+Every reviewed finding family should end in one or more of these outcomes:
+- `new_adr`
+- `new_lint`
+- `boundary_update`
+- `requirements_update`
+- `architecture_update`
+- `project_plan_update`
+- `sprint_plan_update`
+- `qa_process_improvement`
+- `planning_process_improvement`
+- `test_hardening`
+- `merge_forward_process_improvement`
+- `no_systemic_followup`
+
+## Expected Recommendations
+
+### New ADR
+
+Choose this when QA repeatedly exposes an unresolved design rule or ownership
+boundary that should become explicit architecture policy.
+
+### New lint
+
+Choose this when the defect pattern is mechanically detectable and should be
+blocked before QA.
+
+Examples:
+- forbidden construct
+- missing gate
+- naming rule
+- boundary violation
+- unsafe platform-specific import
+
+### Planning process improvement
+
+Choose this when the bug existed because the sprint plan, phase plan, or task
+assignment omitted scope, sequencing, or acceptance criteria.
+
+### QA process improvement
+
+Choose this when QA or triage discovered the issue late because:
+- reviewer scope was too narrow
+- repeatable-pattern sweep was missing
+- carry-forward context was missing
+- round-limit rules were unclear
+
+## Output Shape
+
+Produce a concise post-mortem summary grouped by finding family:
+- finding family / ids
+- repeated pattern description
+- root cause classification
+- recommended systemic action
+- owner
+- target artifact
+
+Target artifacts should be concrete:
+- `docs/adr/...`
+- `.claude/skills/...`
+- `.claude/agents/...`
+- `boundaries/...`
+- lint script or template path
+- planning document path
+
+## Decision Rule
+
+Prefer the smallest upstream control that prevents recurrence.
+
+Order of preference:
+1. lint / static enforcement
+2. boundary enforcement
+3. ADR / architecture clarification
+4. planning or QA workflow improvement
+5. repeated manual reviewer vigilance
+
+If a repeatable pattern still relies mainly on manual QA attention, treat that
+as a process gap unless automation is genuinely not practical.

--- a/scripts/test_triage_carry_forward.py
+++ b/scripts/test_triage_carry_forward.py
@@ -1,0 +1,90 @@
+"""Unit tests for triage_carry_forward.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_SCRIPT = Path(__file__).parent / "triage_carry_forward.py"
+_SPEC = importlib.util.spec_from_file_location("triage_carry_forward", _SCRIPT)
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+
+
+def _write_record(path: Path) -> None:
+    path.write_text(
+        textwrap.dedent(
+            """
+            @prefix triage: <urn:atm:triage:> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+            <urn:atm:triage:finding/FTQ-001>
+              a triage:Finding ;
+              triage:findingId "FTQ-001" ;
+              triage:title "Process-global shutdown state in tests" ;
+              triage:severity "important" ;
+              triage:hasOccurrence <urn:atm:triage:occurrence/FTQ-001/R17/1> ;
+              triage:hasOccurrence <urn:atm:triage:occurrence/FTQ-001/R16/1> .
+
+            <urn:atm:triage:occurrence/FTQ-001/R17/1>
+              a triage:Occurrence ;
+              triage:file "crates/atm-daemon/src/tests.rs" ;
+              triage:line 28 ;
+              triage:status "open" ;
+              triage:branch "R.17" .
+
+            <urn:atm:triage:occurrence/FTQ-001/R16/1>
+              a triage:Occurrence ;
+              triage:file "crates/atm-daemon/src/tests.rs" ;
+              triage:line 28 ;
+              triage:status "fixed" ;
+              triage:branch "R.16" .
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestTriageCarryForward(unittest.TestCase):
+    def test_branch_filtered_payload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ttl = Path(tmp) / "FTQ-001.ttl"
+            _write_record(ttl)
+            stdout = io.StringIO()
+            with patch.object(_MOD, "require_oxigraph"), patch("sys.stdout", stdout):
+                rc = _MOD.main(
+                    [
+                        "--branch",
+                        "R.17",
+                        "--ttl",
+                        str(ttl),
+                    ]
+                )
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            [
+                {
+                    "id": "FTQ-001",
+                    "severity": "important",
+                    "file": "crates/atm-daemon/src/tests.rs",
+                    "line": 28,
+                    "summary": "Process-global shutdown state in tests",
+                }
+            ],
+        )
+
+    def test_missing_file_fails_closed(self):
+        with self.assertRaises(SystemExit) as exc:
+            _MOD.main(["--branch", "R.17", "--ttl", "/tmp/does-not-exist.ttl"])
+        self.assertIn("missing triage record", str(exc.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_triage_carry_forward.py
+++ b/scripts/test_triage_carry_forward.py
@@ -17,29 +17,36 @@ _MOD = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MOD)
 
 
-def _write_record(path: Path) -> None:
+def _write_record(
+    path: Path,
+    *,
+    finding_id: str = "FTQ-001",
+    include_category: bool = True,
+    include_severity: bool = True,
+) -> None:
+    category_line = '  triage:category "FTQ" ;\n' if include_category else ""
+    severity_line = '  triage:severity "important" ;\n' if include_severity else ""
     path.write_text(
         textwrap.dedent(
-            """
+            f"""
             @prefix triage: <urn:atm:triage:> .
             @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-            <urn:atm:triage:finding/FTQ-001>
+            <urn:atm:triage:finding/{finding_id}>
               a triage:Finding ;
-              triage:findingId "FTQ-001" ;
+              triage:findingId "{finding_id}" ;
               triage:title "Process-global shutdown state in tests" ;
-              triage:severity "important" ;
-              triage:hasOccurrence <urn:atm:triage:occurrence/FTQ-001/R17/1> ;
-              triage:hasOccurrence <urn:atm:triage:occurrence/FTQ-001/R16/1> .
+            {category_line}{severity_line}  triage:hasOccurrence <urn:atm:triage:occurrence/{finding_id}/R17/1> ;
+              triage:hasOccurrence <urn:atm:triage:occurrence/{finding_id}/R16/1> .
 
-            <urn:atm:triage:occurrence/FTQ-001/R17/1>
+            <urn:atm:triage:occurrence/{finding_id}/R17/1>
               a triage:Occurrence ;
               triage:file "crates/atm-daemon/src/tests.rs" ;
               triage:line 28 ;
               triage:status "open" ;
               triage:branch "R.17" .
 
-            <urn:atm:triage:occurrence/FTQ-001/R16/1>
+            <urn:atm:triage:occurrence/{finding_id}/R16/1>
               a triage:Occurrence ;
               triage:file "crates/atm-daemon/src/tests.rs" ;
               triage:line 28 ;
@@ -72,6 +79,7 @@ class TestTriageCarryForward(unittest.TestCase):
             [
                 {
                     "id": "FTQ-001",
+                    "category": "FTQ",
                     "severity": "important",
                     "file": "crates/atm-daemon/src/tests.rs",
                     "line": 28,
@@ -84,6 +92,51 @@ class TestTriageCarryForward(unittest.TestCase):
         with self.assertRaises(SystemExit) as exc:
             _MOD.main(["--branch", "R.17", "--ttl", "/tmp/does-not-exist.ttl"])
         self.assertIn("missing triage record", str(exc.exception))
+
+    def test_missing_category_or_severity_still_emits_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ttl_missing_category = Path(tmp) / "FTQ-001.ttl"
+            ttl_missing_severity = Path(tmp) / "FTQ-002.ttl"
+            _write_record(ttl_missing_category, include_category=False)
+            _write_record(
+                ttl_missing_severity,
+                finding_id="FTQ-002",
+                include_severity=False,
+            )
+            stdout = io.StringIO()
+            with patch.object(_MOD, "require_oxigraph"), patch("sys.stdout", stdout):
+                rc = _MOD.main(
+                    [
+                        "--branch",
+                        "R.17",
+                        "--ttl",
+                        str(ttl_missing_category),
+                        "--ttl",
+                        str(ttl_missing_severity),
+                    ]
+                )
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            [
+                {
+                    "id": "FTQ-001",
+                    "category": None,
+                    "severity": "important",
+                    "file": "crates/atm-daemon/src/tests.rs",
+                    "line": 28,
+                    "summary": "Process-global shutdown state in tests",
+                },
+                {
+                    "id": "FTQ-002",
+                    "category": "FTQ",
+                    "severity": None,
+                    "file": "crates/atm-daemon/src/tests.rs",
+                    "line": 28,
+                    "summary": "Process-global shutdown state in tests",
+                },
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/triage_carry_forward.py
+++ b/scripts/triage_carry_forward.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Build carry-forward finding payloads from triage Turtle records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+QUERY = """
+PREFIX triage: <urn:atm:triage:>
+
+SELECT ?finding_id ?severity ?summary ?file ?line
+WHERE {
+  ?finding a triage:Finding ;
+           triage:findingId ?finding_id ;
+           triage:severity ?severity ;
+           triage:title ?summary ;
+           triage:hasOccurrence ?occ .
+  ?occ a triage:Occurrence ;
+       triage:file ?file ;
+       triage:status ?occ_status ;
+       triage:branch ?branch .
+  OPTIONAL { ?occ triage:line ?line . }
+  FILTER(?branch = %BRANCH%)
+  FILTER(?occ_status = "open")
+}
+ORDER BY ?finding_id ?file ?line
+"""
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render the branch-specific carry_forward_findings_json payload from "
+            "one or more triage Turtle records."
+        )
+    )
+    parser.add_argument(
+        "--branch",
+        required=True,
+        help="Branch name to extract open occurrences for, e.g. R.17 or feature/pR-s17-watch-reconcile.",
+    )
+    parser.add_argument(
+        "--ttl",
+        dest="ttl_files",
+        action="append",
+        required=True,
+        help="Path to a triage Turtle record. Repeat for multiple findings.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print the JSON array instead of emitting a compact string.",
+    )
+    return parser.parse_args(argv)
+
+
+def require_oxigraph() -> None:
+    if shutil.which("oxigraph") is None:
+        raise SystemExit("oxigraph is required but was not found in PATH")
+
+
+def validate_files(paths: list[Path]) -> list[Path]:
+    validated: list[Path] = []
+    for path in paths:
+        if not path.is_file():
+            raise SystemExit(f"missing triage record: {path}")
+        validated.append(path.resolve())
+    return validated
+
+
+def load_records(store_dir: Path, ttl_files: list[Path]) -> None:
+    cmd = [
+        "oxigraph",
+        "load",
+        "--location",
+        str(store_dir),
+        "--file",
+        *[str(path) for path in ttl_files],
+    ]
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.stderr.strip() or "oxigraph load failed")
+
+
+def query_records(store_dir: Path, branch: str) -> list[dict[str, object]]:
+    cmd = [
+        "oxigraph",
+        "query",
+        "--location",
+        str(store_dir),
+        "--query",
+        QUERY.replace("%BRANCH%", json.dumps(branch)),
+        "--results-format",
+        "application/sparql-results+json",
+    ]
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.stderr.strip() or "oxigraph query failed")
+
+    data = json.loads(result.stdout)
+    rows: list[dict[str, object]] = []
+    for binding in data.get("results", {}).get("bindings", []):
+        line_term = binding.get("line")
+        rows.append(
+            {
+                "id": binding["finding_id"]["value"],
+                "severity": binding["severity"]["value"],
+                "file": binding["file"]["value"],
+                "line": int(line_term["value"]) if line_term else None,
+                "summary": binding["summary"]["value"],
+            }
+        )
+    return rows
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    require_oxigraph()
+    ttl_files = validate_files([Path(path) for path in args.ttl_files])
+
+    with tempfile.TemporaryDirectory(prefix="atm-triage-") as tmpdir:
+        store_dir = Path(tmpdir) / "store"
+        store_dir.mkdir(parents=True, exist_ok=True)
+        load_records(store_dir, ttl_files)
+        rows = query_records(store_dir, args.branch)
+
+    if args.pretty:
+        print(json.dumps(rows, indent=2))
+    else:
+        print(json.dumps(rows, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/triage_carry_forward.py
+++ b/scripts/triage_carry_forward.py
@@ -14,13 +14,14 @@ from pathlib import Path
 QUERY = """
 PREFIX triage: <urn:atm:triage:>
 
-SELECT ?finding_id ?severity ?summary ?file ?line
+SELECT ?finding_id ?category ?severity ?summary ?file ?line
 WHERE {
   ?finding a triage:Finding ;
            triage:findingId ?finding_id ;
-           triage:severity ?severity ;
            triage:title ?summary ;
            triage:hasOccurrence ?occ .
+  OPTIONAL { ?finding triage:category ?category . }
+  OPTIONAL { ?finding triage:severity ?severity . }
   ?occ a triage:Occurrence ;
        triage:file ?file ;
        triage:status ?occ_status ;
@@ -122,7 +123,8 @@ def query_records(store_dir: Path, branch: str) -> list[dict[str, object]]:
         rows.append(
             {
                 "id": binding["finding_id"]["value"],
-                "severity": binding["severity"]["value"],
+                "category": binding.get("category", {}).get("value"),
+                "severity": binding.get("severity", {}).get("value"),
                 "file": binding["file"]["value"],
                 "line": int(line_term["value"]) if line_term else None,
                 "summary": binding["summary"]["value"],


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/qa-triage.md` — rewritten triage agent with strict JSON input/output contract
- Adds `triaging-findings` skill for team-lead orchestration of per-finding sweeps
- Fix-assignment template, follow-up QA triage-record flow, reviewer carry-forward fields
- `service_indicators_extra` and phase post-mortem guidance
- GitHub QA report JSON contract tightened; sc-compose renders verified for dev/fix/QA/review/reviewer-assignment/quality-report templates
- Registry updated to `qa-triage 1.0.0`

## Design

- One agent instance per finding, run in parallel; read-only grep across all active worktrees
- Per-finding Turtle records under `.triage/findings/` with Oxigraph validation
- Explicit `highest-open` / `highest-fixed` / `promote` fields in fenced JSON output
- Repeatable-pattern sweep on promoted branch
- team-lead consolidates outputs → fix ticket to arch-ctm

## Review

Direct review by team-lead and quality-mgr only. Do not route through QA subagents.

## Test plan

- [ ] Merge to develop so agent and skill are available in main repo
- [ ] Dispatch for open findings (RULE-005, FTQ-001, FTQ-002) to verify sweep output

🤖 Generated with [Claude Code](https://claude.com/claude-code)