### PR TITLE
process: encode Phase R post-mortem RBP gate policy in orchestration skills

### DIFF
--- a/.claude/skills/codex-orchestration/SKILL.md
+++ b/.claude/skills/codex-orchestration/SKILL.md
@@ -48,19 +48,27 @@ Before starting a sprint:
 
 1. `team-lead` assigns development to `arch-ctm` using `dev-template.xml.j2`.
 2. `arch-ctm` ACKs, implements, commits, pushes, and reports branch plus SHA.
-3. `team-lead` opens or updates the PR.
-4. `team-lead` assigns QA to `quality-mgr` using `qa-template.xml.j2`.
-5. `quality-mgr` launches the reviewer set:
+3. Before QA-1, `arch-ctm` performs a self-directed Rust best-practices sweep on
+   the integration branch using the same `review_targets` planned for QA-1 and
+   fixes all RBP findings found there. This is a developer cleanup step, not a
+   QA surprise.
+4. `team-lead` opens or updates the PR.
+5. `team-lead` assigns QA to `quality-mgr` using `qa-template.xml.j2`.
+6. `quality-mgr` launches the reviewer set:
    - `req-qa`
    - `arch-qa`
    - `rust-qa-agent`
-   - `rust-best-practices-agent` when Rust design-pattern review is in scope
+   - `rust-best-practices-agent` in QA-1 only
    - `rust-service-hardening-agent` when service-runtime review is in scope
    - `flaky-test-qa` when test instability risk is present
-6. If QA passes and CI is green, merge may proceed.
-7. If QA fails, `team-lead` first runs `/triaging-findings` to correlate the
+7. QA-2 and later rounds must omit `rust-best-practices-agent`. Any unresolved
+   QA-1 RBP findings that are not fixed in the first fix round carry to the
+   next phase backlog automatically and are not re-raised in later QA rounds on
+   the same sprint branch.
+8. If QA passes and CI is green, merge may proceed.
+9. If QA fails, `team-lead` first runs `/triaging-findings` to correlate the
    findings across worktrees and determine the promoted fix branch.
-8. After triage completes, `team-lead` routes concrete fixes back to
+10. After triage completes, `team-lead` routes concrete fixes back to
    `arch-ctm` using `fix-assignment.xml.j2`.
 
 ## Phase-End Review

--- a/.claude/skills/codex-orchestration/qa-template.xml.j2
+++ b/.claude/skills/codex-orchestration/qa-template.xml.j2
@@ -49,7 +49,7 @@ defaults:
   <workflow>
     <step id="a">ACK this message immediately.</step>
     <step id="b">Render structured JSON assignments for `req-qa` and `arch-qa` using the templates in `.claude/skills/codex-orchestration/`. Do not send free-form reviewer prompts.</step>
-    <step id="c">Read `.claude/assets/sc-rust/quality-mgr/quality-mgr.rust.md` and render any required Rust reviewer assignments from `.claude/assets/sc-rust/quality-mgr/templates/`.</step>
+    <step id="c">Read `.claude/assets/sc-rust/quality-mgr/quality-mgr.rust.md` and render any required Rust reviewer assignments from `.claude/assets/sc-rust/quality-mgr/templates/`. Rust best-practices review is QA-1 only; omit it from QA-2 and later rounds on the same sprint branch.</step>
     <step id="d">If triage records are provided, read them before spawning reviewers. Treat them as the canonical prior scope for follow-up QA, not as a substitute for verification.</step>
     <step id="e">Spawn every selected reviewer in background mode. Do not run cargo, clippy, or broad QA analysis yourself in the foreground.</step>
     <step id="f">Collect reviewer outputs and summarize PASS or FAIL, including blocking finding ids and file:line references where available. For every finding that is a repeatable pattern (missing gate, wrong value, forbidden construct, naming violation), search the entire workspace for other occurrences of the same pattern and include all affected locations in the finding — not just the first one found. A finding is not complete until the full scope is known.</step>

--- a/.claude/skills/phase-orchestration/SKILL.md
+++ b/.claude/skills/phase-orchestration/SKILL.md
@@ -82,10 +82,17 @@ The sprint prompt should include:
 ### 3. Post-sprint: CI gate and merge
 
 After each scrum-master reports completion:
-1. verify QA passed
-2. wait for CI green
-3. merge PR to `integrate/phase-{N}` in dependency order
-4. update the integration branch
+1. before QA-1, require `arch-ctm` to run a self-directed Rust best-practices
+   sweep on the integration branch using the planned QA-1 review targets and
+   fix all findings found there
+2. verify QA passed
+   - QA-1 includes the Rust best-practices review
+   - QA-2 and later rounds must omit Rust best-practices review entirely
+   - unresolved QA-1 RBP findings not fixed in the first fix round carry to
+     the next phase backlog instead of being re-raised in later rounds
+3. wait for CI green
+4. merge PR to `integrate/phase-{N}` in dependency order
+5. update the integration branch
 
 ### 4. Post-sprint: arch-ctm design review
 

--- a/.claude/skills/quality-management-gh/SKILL.md
+++ b/.claude/skills/quality-management-gh/SKILL.md
@@ -58,7 +58,12 @@ Use fenced JSON for machine-readable status payloads:
 ## QA Lifecycle (Multi-Pass)
 
 1. Initial pass: usually `FAIL` with findings.
+   - If Rust best-practices review is in scope, run it in QA-1 only.
 2. Fix passes: `IN-FLIGHT` or `FAIL` while fixes are in progress.
+   - QA-2 and later rounds must not re-run Rust best-practices review on the
+     same sprint branch.
+   - Unresolved QA-1 RBP findings that are not fixed in the first fix round
+     carry to the next phase backlog instead of being re-raised in later rounds.
 3. Final pass: `PASS` with final quality report and merge recommendation.
 
 Do not treat QA as single-shot.


### PR DESCRIPTION
## Summary

- Pre-QA arch-ctm RBP self-sweep step added to codex-orchestration and phase-orchestration SKILL.md
- QA-1 includes `rust-best-practices-agent` (full sweep, merge-gate); QA-2+ explicitly excludes it
- Unresolved QA-1 RBP findings auto-carry to Phase S backlog after fix-round-1
- Same policy applied in quality-management-gh SKILL.md and qa-template.xml.j2

## Motivation

Phase R QA-2 raised 10 RBP findings on files that had passed clean (0B+0I+0m) in QA-1 — same code, different round, different output. Non-deterministic reviewer on unchanged files inflated finding count and forced 2 extra fix rounds. This policy stabilises the gate.

## Test plan

- [ ] cargo test --workspace PASS
- [ ] cargo clippy --workspace -- -D warnings PASS
- [ ] just lint EXEMPT (docs-only branch off develop; lint harness in integrate/phase-R, not yet on develop baseline)
- [ ] No Rust source changes — docs and templates only

🤖 Generated with [Claude Code](https://claude.com/claude-code)