### PR TITLE
Plan S.5 no-flaky-test guardrails

### DIFF
--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -17,6 +17,11 @@ consolidation step.
 This agent is **pre-dispatch only**. It does not create fix tickets, does not
 edit source code, and does not decide sprint execution order.
 
+This agent also does **not** commit triage records to git directly. Parallel
+triage agents may write multiple `.ttl` files in the same batch, so the
+required git commit happens later in the team-lead aggregation step after the
+batch is complete.
+
 ## Inputs
 
 Input must be JSON, either as a raw JSON object or fenced JSON. Do not proceed
@@ -145,7 +150,11 @@ Mode rules:
 12. Validate the Turtle output:
    - use a temporary Oxigraph store and `oxigraph load` against the TTL file
    - fail if the Turtle cannot be parsed
-13. Return fenced JSON only.
+13. Return enough information for the team-lead batch commit step:
+   - exact Turtle path written
+   - whether the file was created or updated
+   - whether dispatch should block until the batch triage commit is recorded
+14. Return fenced JSON only.
 
 ## Canonical Graph Model
 

--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -60,7 +60,9 @@ with free-form input.
       "order_index": 17
     }
   ],
-  "triage_root": "/abs/main-repo/.triage",
+  "integration_branch": "integrate/phase-R",
+  "integration_worktree_path": "/abs/worktree-phase-r",
+  "triage_root": "/abs/worktree-phase-r/.triage",
   "references": [
     "PR #194",
     "QA report comment url"
@@ -73,7 +75,8 @@ Input rules:
 - `triage_mode` is required. Allowed values: `initial_pass`, `followup_pass`.
 - `phase_id` is required.
 - `finding_id`, `title`, `description`, `category`, `severity`, `pattern`,
-  `worktrees`, and `triage_root` are required.
+  `worktrees`, `integration_branch`, `integration_worktree_path`, and
+  `triage_root` are required.
 - `worktrees` must already be listed in the desired promotion order. Do not
   invent or infer branch priority from branch names.
 - `repeatable` is required.
@@ -81,6 +84,10 @@ Input rules:
   Default to `file_only` when omitted.
 - `file_filter` is optional.
 - `triage_root` must be an absolute path.
+- `integration_worktree_path` must be an absolute path.
+- `triage_root` must live under `integration_worktree_path`.
+- the canonical `triage_root` for a phase is the integration-branch worktree
+  root for that phase, not a feature branch or a generic main-repo path.
 
 Mode rules:
 - `initial_pass`:
@@ -267,7 +274,8 @@ Return fenced JSON only.
     "highest_fixed_branch": "R.16",
     "promote_to_branch": "R.17",
     "dispatch_ready": true,
-    "ttl_path": "/abs/.triage/phase-R/findings/FTQ-001.ttl",
+    "dispatch_blocked_pending_triage_commit": true,
+    "ttl_path": "/abs/worktree-phase-r/.triage/phase-R/findings/FTQ-001.ttl",
     "occurrences": [
       {
         "branch": "R.17",
@@ -311,6 +319,9 @@ Output rules:
   remain.
 - `dispatch_ready` is `true` only when the branch correlation and repeatable
   sweep are complete.
+- `dispatch_blocked_pending_triage_commit` must be `true` until the team-lead
+  batch commit records the `.ttl` artifacts on the integration-branch
+  worktree.
 - Do not emit fix-ticket text. This agent reports triage facts only.
 - `fixed` / `closed` first belongs to the occurrence and branch-state level.
   The finding-level `status` is an aggregate derived from those lower-level

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -119,6 +119,31 @@ Separate them into:
 - regressed findings
 - non-dispatchable findings
 
+### 3.1 Commit triage artifacts before dispatch
+
+After all `qa-triage` agents in the batch have finished and after aggregation
+confirms the `.ttl` set is complete, stage and commit the triage artifacts to
+git before sending any dev assignment to `arch-ctm`.
+
+Required commit scope:
+- the phase findings under `<triage_root>/<phase_id>/findings/`
+- any phase-local triage metadata needed for later follow-up, such as
+  worktree inventories under `<triage_root>/<phase_id>/`
+
+Required timing:
+- after triage batch aggregation
+- before branch-scoped fix dispatch
+- on the integration branch or other branch designated as the triage source of
+  truth for the phase
+
+Reason:
+- parallel `qa-triage` agents write into one shared triage root
+- committing inside each agent would create batch races and partial evidence
+- leaving `.ttl` records untracked until phase end risks silent loss of the
+  canonical QA evidence
+
+Do not dispatch dev work from uncommitted `.ttl` state.
+
 The per-finding `.ttl` record is canonical. Aggregation is derived.
 
 ### 4. Dispatch branch-scoped fix work to `arch-ctm`

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -39,6 +39,8 @@ Do not send raw QA findings directly to `arch-ctm`.
 
 For each triage batch, assemble:
 - `phase_id`
+- `integration_branch`
+- `integration_worktree_path`
 - `triage_root`
 - ordered `worktrees` with branch, absolute path, head SHA, and order index
 - finding records with:
@@ -55,6 +57,11 @@ For each triage batch, assemble:
 
 Canonical triage artifacts live at:
 - `<triage_root>/<phase_id>/findings/<finding_id>.ttl`
+
+Required path rule:
+- `triage_root` must live under `integration_worktree_path`
+- `integration_worktree_path` must be the integration-branch worktree for the
+  active phase
 
 ## Triage Modes
 
@@ -133,7 +140,7 @@ Required commit scope:
 Required timing:
 - after triage batch aggregation
 - before branch-scoped fix dispatch
-- on the integration branch or other branch designated as the triage source of
+- on the integration-branch worktree that is the canonical triage source of
   truth for the phase
 
 `triage_root` must point to the integration-branch worktree for the active

--- a/boundaries/atm-core/config-ingress.toml
+++ b/boundaries/atm-core/config-ingress.toml
@@ -42,4 +42,4 @@ review_gates = ["no_direct_config_parser_calls"]
 
 [status]
 state = "stub_landed"
-notes = ["typed workspace and team config request/response contracts landed in atm_core::boundary", "retained command/service cutover to this boundary is formally deferred to R.7 in docs/plan-phase-R.md"]
+notes = ["typed workspace and team config request/response contracts landed in atm_core::boundary", "retained command/service cutover to this boundary is formally deferred to R.7 in docs/plan-phase-R.md", "parsing and validation of [atm].claude_jsonl_body_export_max_bytes remains owned here for the ADR-010 compatibility-envelope contract"]

--- a/boundaries/atm-core/inbox-export.toml
+++ b/boundaries/atm-core/inbox-export.toml
@@ -31,6 +31,7 @@ forbidden = []
 request_types = ["export write requests"]
 response_types = ["typed export result models"]
 error_types = ["AtmError"]
+notes = ["ATM-authored compatibility projection may replace oversized JSONL bodies with the exact retrieval stub `atm read --message-id <id>` while preserving summary text and metadata", "Claude-native inbound messages must not be rewritten into ATM retrieval stubs"]
 
 [testing]
 allowed_test_double_paths = []
@@ -42,4 +43,4 @@ review_gates = ["no_direct_mailbox_helper_calls"]
 
 [status]
 state = "stub_landed"
-notes = ["typed record/export request and response contracts landed in atm_core::boundary", "send and receive state transitions should reach compatibility files through this boundary only"]
+notes = ["typed record/export request and response contracts landed in atm_core::boundary", "send and receive state transitions should reach compatibility files through this boundary only", "the ADR-010 compatibility envelope keeps full ATM-authored bodies durable in SQLite while this boundary owns the bounded Claude JSONL projection"]

--- a/boundaries/atm-daemon/daemon-inbox-export.toml
+++ b/boundaries/atm-daemon/daemon-inbox-export.toml
@@ -32,6 +32,7 @@ forbidden = ["DaemonInboxExport"]
 request_types = ["export write requests"]
 response_types = ["typed export result models"]
 error_types = ["AtmError"]
+notes = ["ATM-authored compatibility projection updates for the same logical message must be treated as idempotent to avoid watcher/reconcile churn loops", "daemon-owned compatibility export must preserve the exact retrieval stub text chosen by the atm-core inbox-export contract"]
 
 [testing]
 allowed_test_double_paths = []
@@ -43,4 +44,4 @@ review_gates = ["no_public_impl", "no_public_constructor", "no_direct_mailbox_he
 
 [status]
 state = "active"
-notes = ["atm_core owns the contract; daemon runtime now supplies the crate-root adapter implementation", "send and receive compatibility writes must stay behind this adapter rather than reaching mailbox helpers directly"]
+notes = ["atm_core owns the contract; daemon runtime now supplies the crate-root adapter implementation", "send and receive compatibility writes must stay behind this adapter rather than reaching mailbox helpers directly", "watcher/reconcile handling for ATM-authored compatibility projection updates must remain idempotent under this adapter boundary"]

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -100,9 +100,9 @@ pub struct SendOutcome {
     pub summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-    // This Vec<String> warning surface is a retained simplification.
-    // A future WarningEntry refactor should separate recovery guidance from the
-    // rendered warning text once the send/result contract is widened.
+    // TODO(v1.1.0): Replace this Vec<String> with a structured WarningEntry type
+    // so degraded-mode warnings can carry recovery guidance separately from the
+    // rendered message text.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "is_false")]

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -100,9 +100,9 @@ pub struct SendOutcome {
     pub summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-    // TODO(v1.1.0): Replace this Vec<String> with a structured WarningEntry type
-    // so degraded-mode warnings can carry recovery guidance separately from the
-    // rendered message text.
+    // This Vec<String> warning surface is a retained simplification.
+    // A future WarningEntry refactor should separate recovery guidance from the
+    // rendered warning text once the send/result contract is widened.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "is_false")]

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -161,7 +161,9 @@ impl RetainedServiceRuntime for LocalServiceRuntime {
     }
 
     fn default_lock_timeout(&self) -> Duration {
-        // TODO(phase-R): move this retained mailbox-lock default behind a boundary-owned timeout policy.
+        // This retained mailbox-lock timeout still comes from a module-level
+        // default. A future boundary-owned timeout policy should move that
+        // configuration behind the service boundary instead of this helper.
         crate::mailbox::lock::default_lock_timeout()
     }
 

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -161,9 +161,7 @@ impl RetainedServiceRuntime for LocalServiceRuntime {
     }
 
     fn default_lock_timeout(&self) -> Duration {
-        // This retained mailbox-lock timeout still comes from a module-level
-        // default. A future boundary-owned timeout policy should move that
-        // configuration behind the service boundary instead of this helper.
+        // TODO(phase-R): move this retained mailbox-lock default behind a boundary-owned timeout policy.
         crate::mailbox::lock::default_lock_timeout()
     }
 

--- a/docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md
+++ b/docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md
@@ -1,0 +1,135 @@
+# ADR-008 — No-Flaky-Test Policy And Mechanical Enforcement
+
+| Field | Value |
+|---|---|
+| ID | ADR-008 |
+| Status | **Accepted** |
+| Date | 2026-05-09 |
+| Deciders | Rand Lee |
+| Relates to | REQ-P-TEST-001, REQ-P-LINT-POSTMORTEM-001, REQ-CORE-TEST-RUNTIME-001, REQ-DAEMON-TEST-004 |
+| Supersedes | — |
+
+---
+
+## Context
+
+Phase S hardens same-host daemon parity across macOS, Linux, and Windows.
+During implementation and QA, several failures were not ordinary logic bugs:
+
+- Windows runs that could block long enough to consume CI time without naming
+  the active test
+- test logic that still depended on timing or process-scheduling luck
+- runtime/test helper patterns that could strand threads, hooks, or global
+  state after panic or timeout paths
+
+The existing docs already reject fixed sleeps and timing-only stabilization, but
+that rule is not strong enough by itself. A test can still be flaky or hang
+indefinitely without using `thread::sleep(...)`.
+
+ATM therefore needs one explicit policy:
+
+- a test that might hang is not acceptable
+- a test that depends on timing luck is not acceptable
+- any prohibited pattern that can be detected mechanically must become a lint
+  or CI gate instead of recurring QA rediscovery
+
+## Decision Drivers
+
+- Phase S parity work is cross-platform and CI-heavy; hanging tests waste
+  review time and block multiple branches at once
+- same-host daemon migration adds threads, channels, deadlines, shutdown, and
+  lifecycle-control behavior that is especially vulnerable to hidden flake
+- ATM already uses repository-local lint gates; the policy should be enforced
+  there when feasible
+- not every risky pattern is cheap to detect mechanically, so the enforcement
+  plan must distinguish immediate rules from deferred analyzer work
+
+## Decision
+
+ATM adopts a repository-wide no-flaky-test policy for retained test surfaces,
+with special emphasis on Phase S same-host daemon and runtime coverage.
+
+### Required Policy
+
+Tests must be:
+
+- deterministic
+- bounded
+- explicit about readiness and shutdown predicates
+- panic-safe in their cleanup of shared/global test state
+
+Tests must not:
+
+- depend on timing luck
+- contain a path that can block indefinitely
+- rely on missed-wakeup-sensitive synchronization without a bounded fallback
+- leave cross-thread helpers running after the test has already concluded
+
+### Required Synchronization Shape
+
+Approved shapes include:
+
+- channel handshakes with bounded timeout
+- `Barrier`, `Condvar`, or latch/predicate synchronization with bounded wait
+- readiness probes tied to explicit observable state on documented deadlines
+- bounded shutdown/finalizer drain with observable completion
+
+Forbidden shapes include:
+
+- fixed sleeps as the primary correctness mechanism
+- unbounded `recv()`, `wait()`, or similar waits in flaky-risk test paths
+- bare `join()` when the test has no prior bounded proof that the worker has
+  already completed
+- retry-until-success loops with no explicit state predicate or deadline
+- global test hooks or registries without panic-safe cleanup
+
+### Mechanical Enforcement Rule
+
+If a prohibited pattern is cheap and deterministic to detect, it must be
+enforced in `just lint` or an equivalent CI gate. Review-only enforcement is
+not sufficient for mechanically detectable cases.
+
+## Enforcement Partition
+
+### Feasible Now In Phase S
+
+- fixed-sleep test hygiene checks, with the current repository-local rule
+  treated as the proving implementation before `sc-lint` extraction
+- repository-local daemon-spawn and warmup helper checks
+- reusable production runtime liveness checks for:
+  - bare `Condvar::wait(...)`
+  - discarded `wait_timeout*` results
+- repository-local targeted checks for unbounded test waits in the narrow
+  same-host daemon/runtime suites when the syntax is cheap to detect
+
+### Deferred Beyond Immediate Phase S
+
+- proving every polling loop checks terminate state at the correct point
+- proving every global test hook has panic-safe cleanup automatically
+- proving every `join()` is safe without path-sensitive control-flow analysis
+- proving every bounded wait inspects timeout state correctly inside test code
+
+Deferred work is still required; it is not optional. It simply needs either
+Rust-aware analyzer support or a narrower rule design before it can become a
+default lint.
+
+## Consequences
+
+### Positive
+
+- Phase S and follow-on daemon work get one explicit anti-flake contract
+- reviewers can reject hang-prone tests by policy rather than by preference
+- repository lints can grow from a clear source-of-truth document
+
+### Negative
+
+- some existing test/helper idioms will need redesign rather than stabilization
+- a few desired lint families must remain planned work until their false-
+  positive shape is understood
+
+## Follow-Up Work
+
+- add S.5 planning for phase-wide policy hardening and lint-family expansion
+- tighten top-level and Phase S sprint language so “no fixed sleeps” becomes
+  the broader “no flaky or unbounded waits” contract
+- add a feasible-now vs deferred lint inventory to the Phase S planning docs

--- a/docs/adr/ADR-009-bounded-queue-query-surface.md
+++ b/docs/adr/ADR-009-bounded-queue-query-surface.md
@@ -1,0 +1,163 @@
+# ADR-009 — Bounded Queue Query Surface
+
+| Field | Value |
+|---|---|
+| ID | ADR-009 |
+| Status | **Accepted** |
+| Date | 2026-05-09 |
+| Deciders | Rand Lee |
+| Relates to | REQ-P-LIST-001, REQ-P-READ-001, REQ-CORE-LIST-001, REQ-CORE-WORKFLOW-001 |
+| Supersedes | — |
+
+---
+
+## Context
+
+ATM mail history is moving onto SQLite-backed durable storage. That means
+mailboxes will grow without a practical fixed upper bound. The current `atm read`
+shape mixes two different jobs:
+
+- finding candidate messages
+- opening full message detail
+
+That coupling causes two product problems:
+
+- queue inspection can flood operator context with long message bodies
+- default reads still depend on full-surface materialization instead of a
+  bounded query-first path
+
+Phase S also exposed two concrete reliability failures in the current full-read
+path:
+
+- GitHub issue `#213`: full-read reliability failure (`failed to write daemon
+  response frame` / JSON EOF)
+- GitHub issue `#214`: default read path still materializes full history rather
+  than a bounded unread/head query
+
+ATM therefore needs a cleaner command split before the SQLite-backed mailbox
+surface becomes the only normal source of truth.
+
+## Decision Drivers
+
+- queue inspection must not require rendering full message bodies
+- default operational reads must remain bounded even when mailbox history is
+  large
+- `atm read` should become deterministic and single-message oriented
+- shared search semantics should not diverge between metadata listing and full
+  message retrieval
+- malformed compatibility ingress records are tolerable at the Claude JSONL
+  boundary, but malformed durable SQLite rows are not
+
+## Decision
+
+ATM splits queue inspection into two top-level commands:
+
+- `atm list` finds messages
+- `atm read` opens one message
+
+### `atm list`
+
+`atm list` is the bounded queue/index surface.
+
+It returns compact metadata rows rather than full message bodies. The canonical
+row fields are:
+
+- `message_id`
+- `summary`
+- `from`
+- `timestamp`
+- `read`
+- `pending_ack`
+- `task_id` when present
+
+Default `atm list` behavior is a bounded actionable queue view. Full-history
+listing is an explicit opt-in path rather than the implicit default.
+
+### `atm read`
+
+`atm read` is the single-message detail surface.
+
+It returns exactly one full message. Message selection rules are:
+
+- `--message-id <id>` selects that exact message when present
+- shared match filters such as `--task`, `--from`, `--since`, `--contains`,
+  `--unread`, and `--pending-ack` select a candidate set
+- when multiple matches remain, `atm read` returns the most recent match
+- the response must also expose:
+  - `selected_message_id`
+  - `match_count`
+  - `additional_match_count`
+
+Bare `atm read` with no explicit selector returns the most recent unread
+actionable message, prioritizing pending-ack messages ahead of non-ack unread
+messages.
+
+### Shared Filter Contract
+
+`atm list` and `atm read` share the same semantic search filters for matching
+messages. The accepted S.5 baseline is:
+
+- optional target inbox (`agent` or `agent@team`)
+- `--team`
+- `--from`
+- `--since`
+- `--task`
+- `--contains`
+- `--unread`
+- `--pending-ack`
+- `--all`
+
+List-specific pagination and presentation controls such as `--limit` may remain
+list-only, but the message-selection semantics themselves must stay aligned.
+
+`--contains` searches both summary text and full message body text.
+
+### Bounded Query Rule
+
+Default queue inspection must be bounded by query shape, not merely by final
+render truncation.
+
+That means:
+
+- default `atm list` must not materialize full mailbox history just to throw
+  most of it away
+- default `atm read` must not behave like "list many, then print the first"
+- summary/count queries must be able to execute without loading every message
+  body into the operator-facing response path
+
+### Durable Data Integrity Rule
+
+Malformed shared-inbox JSON records remain a compatibility-ingress problem and
+may degrade per record.
+
+Malformed durable SQLite rows are different:
+
+- ATM-owned SQLite message rows must contain valid serialized message state
+- malformed durable rows are corruption/store-failure conditions, not a normal
+  skip-and-continue read mode
+
+## Consequences
+
+### Positive
+
+- queue inspection no longer floods context with message bodies
+- `atm read` becomes deterministic and easier to script
+- default operational queries remain bounded as mailbox history grows
+- list/read command semantics become easier to explain and test
+
+### Negative
+
+- the existing `atm read` multi-message surface must be retired or migrated
+- current `ReadQuery` / `ReadOutcome` shapes become transitional rather than
+  the long-term command model
+- implementation must separate metadata search from detail fetch rather than
+  relying on one broad mailbox materialization path
+
+## Follow-Up Work
+
+- add S.5 planning for the new `atm list` command and single-message `atm read`
+  semantics
+- update product and crate-local CLI documentation so `atm list` owns queue
+  search and `atm read` owns detail fetch
+- redesign the mailbox query service so default list/read flows are bounded by
+  query behavior instead of full-surface materialization

--- a/docs/adr/ADR-009-bounded-queue-query-surface.md
+++ b/docs/adr/ADR-009-bounded-queue-query-surface.md
@@ -6,7 +6,7 @@
 | Status | **Accepted** |
 | Date | 2026-05-09 |
 | Deciders | Rand Lee |
-| Relates to | REQ-P-LIST-001, REQ-P-READ-001, REQ-CORE-LIST-001, REQ-CORE-WORKFLOW-001 |
+| Relates to | REQ-P-LIST-001, REQ-P-READ-001, REQ-CORE-LIST-001, REQ-CORE-WORKFLOW-001, ADR-010 |
 | Supersedes | — |
 
 ---
@@ -70,6 +70,9 @@ row fields are:
 - `pending_ack`
 - `task_id` when present
 
+In JSON output, `task_id` is always present and is `null` when the logical
+message is not task-linked.
+
 Default `atm list` behavior is a bounded actionable queue view. Full-history
 listing is an explicit opt-in path rather than the implicit default.
 
@@ -82,11 +85,20 @@ It returns exactly one full message. Message selection rules are:
 - `--message-id <id>` selects that exact message when present
 - shared match filters such as `--task`, `--from`, `--since`, `--contains`,
   `--unread`, and `--pending-ack` select a candidate set
+- successor/update chains are one logical message; selection operates on the
+  current terminal node for each chain rather than on superseded predecessors
+- `--task <task-id>` first finds task-linked messages, then collapses each
+  successor chain to its terminal node before choosing the most recent logical
+  current message
 - when multiple matches remain, `atm read` returns the most recent match
 - the response must also expose:
   - `selected_message_id`
   - `match_count`
   - `additional_match_count`
+
+`match_count` is the total number of logical current-message matches after all
+filters and successor-chain collapse are applied. `additional_match_count` is
+`match_count - 1` for a successful read.
 
 Bare `atm read` with no explicit selector returns the most recent unread
 actionable message, prioritizing pending-ack messages ahead of non-ack unread
@@ -112,6 +124,22 @@ list-only, but the message-selection semantics themselves must stay aligned.
 
 `--contains` searches both summary text and full message body text.
 
+### Legacy Flag Migration
+
+The old multi-message `atm read` surface exposed flags whose names no longer
+fit the split command model. Phase S.5 adopts this migration:
+
+- `--unread-only` is a deprecated alias for `--unread`
+- `--pending-ack-only` is a deprecated alias for `--pending-ack`
+- `--history` is a deprecated alias for `--all`
+- `--since-last-seen` remains accepted as an explicit restatement of the
+  default seen-state behavior
+- `--no-since-last-seen` remains the opt-out for the default seen-state filter
+
+Deprecation warnings must direct operators toward the new flag names. The
+long-term surface keeps one naming system rather than carrying the legacy names
+indefinitely.
+
 ### Bounded Query Rule
 
 Default queue inspection must be bounded by query shape, not merely by final
@@ -124,6 +152,9 @@ That means:
 - default `atm read` must not behave like "list many, then print the first"
 - summary/count queries must be able to execute without loading every message
   body into the operator-facing response path
+- metadata search and full-message fetch must remain separate service paths
+  rather than one broad mailbox materialization step followed by local
+  filtering
 
 ### Durable Data Integrity Rule
 

--- a/docs/adr/ADR-010-claude-jsonl-compatibility-envelope.md
+++ b/docs/adr/ADR-010-claude-jsonl-compatibility-envelope.md
@@ -1,0 +1,113 @@
+# ADR-010 — Claude JSONL Compatibility Envelope
+
+| Field | Value |
+|---|---|
+| ID | ADR-010 |
+| Status | **Accepted** |
+| Date | 2026-05-09 |
+| Deciders | Rand Lee |
+| Relates to | REQ-CORE-COMPAT-001, REQ-CORE-MAILBOX-001, REQ-P-RELIABILITY-001, ADR-009 |
+| Supersedes | — |
+
+---
+
+## Context
+
+SQLite-backed durable storage removes the old practical mailbox-size ceiling,
+but Claude Code JSONL inboxes remain a tighter operational interface than the
+durable store:
+
+- JSONL is a compatibility ingress/egress surface, not ATM's durable source of
+  truth
+- Claude-facing tooling is more sensitive to message size than SQLite-backed
+  storage
+- large ATM-authored message bodies can flood operator context or exceed
+  practical Claude tooling envelopes even when they are valid durable ATM mail
+
+Phase S.5 therefore needs an explicit compatibility-envelope rule for ATM
+authored JSONL export.
+
+## Decision Drivers
+
+- ATM must keep durable full-message fidelity in SQLite
+- routine Claude inbox projection must stay small enough for operational use
+- oversized ATM-authored messages must remain retrievable without copying the
+  full body into Claude JSONL
+- compatibility projection updates must not create self-induced watcher churn
+- malformed JSONL must remain an ingress issue, not an ATM-authored durable
+  store behavior
+
+## Decision
+
+ATM keeps the full ATM-authored message body in SQLite and exports a bounded
+compatibility projection to Claude JSONL.
+
+### Export Limit
+
+The default ATM-authored JSONL body export limit is `128 KiB`.
+
+ATM must expose a configuration setting:
+
+- `[atm].claude_jsonl_body_export_max_bytes`
+
+Allowed values:
+
+- `0`: never export ATM-authored full bodies to Claude JSONL
+- positive integer: export the full ATM-authored body only when it is less than
+  or equal to that limit
+
+### Oversized ATM-Authored Message Projection
+
+When an ATM-authored message body exceeds the configured JSONL export limit:
+
+- the full body remains in SQLite
+- the Claude JSONL `text` field is replaced with exactly:
+  - `atm read --message-id <id>`
+- the message summary remains populated
+- ATM machine metadata remains under `metadata.atm`
+
+This projection rule applies only to ATM-authored exports. ATM must not rewrite
+Claude-native inbound messages into stub form.
+
+### Watcher / Reconcile Rule
+
+JSONL remains a compatibility projection. Watcher/reconcile logic must treat a
+re-observed ATM-authored projection for the same logical message as idempotent
+state, not as new logical mail.
+
+Projection updates that only restate the same ATM-owned logical message,
+including the same retrieval stub for the same `message_id`, must not trigger
+new-mail churn loops.
+
+### Integrity Rule
+
+ATM-authored JSONL exports must always remain valid JSONL records. Malformed
+JSONL is tolerated only as an external ingress compatibility problem. Malformed
+durable SQLite message rows remain corruption or store-failure conditions.
+
+## Consequences
+
+### Positive
+
+- large ATM-authored messages stay durable without flooding Claude inbox
+  context
+- operators have one stable retrieval command for oversized ATM-authored
+  messages
+- queue inspection and Claude-facing inbox projection stay bounded
+- watcher/reconcile behavior can be tested against one explicit no-churn rule
+
+### Negative
+
+- operators may need to use ATM to fetch full bodies that are no longer
+  mirrored into Claude JSONL
+- export behavior now depends on one explicit configuration setting
+- send/export code must distinguish ATM-authored messages from Claude-native
+  compatibility messages
+
+## Follow-Up Work
+
+- document the compatibility-envelope rule in product, architecture, and
+  crate-local docs
+- implement the JSONL export limit config and retrieval-stub projection
+- keep watcher/reconcile logic projection-aware so ATM-authored exports do not
+  re-enter as new logical messages

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -12,6 +12,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-006 — Bounded SIGHUP Reload Delivery In R.18](./ADR-006-sighup-reload-deferral.md)
 - [ADR-007 — Supported Platform Feature Parity](./ADR-007-supported-platform-parity.md)
 - [ADR-008 — No-Flaky-Test Policy And Mechanical Enforcement](./ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md)
+- [ADR-009 — Bounded Queue Query Surface](./ADR-009-bounded-queue-query-surface.md)
 
 ## Embedded Crate-Local ADR Records
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -13,6 +13,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-007 — Supported Platform Feature Parity](./ADR-007-supported-platform-parity.md)
 - [ADR-008 — No-Flaky-Test Policy And Mechanical Enforcement](./ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md)
 - [ADR-009 — Bounded Queue Query Surface](./ADR-009-bounded-queue-query-surface.md)
+- [ADR-010 — Claude JSONL Compatibility Envelope](./ADR-010-claude-jsonl-compatibility-envelope.md)
 
 ## Embedded Crate-Local ADR Records
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -11,6 +11,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-005 — Host-Scoped SQLite State Root](./ADR-005-host-scoped-sqlite-state-root.md)
 - [ADR-006 — Bounded SIGHUP Reload Delivery In R.18](./ADR-006-sighup-reload-deferral.md)
 - [ADR-007 — Supported Platform Feature Parity](./ADR-007-supported-platform-parity.md)
+- [ADR-008 — No-Flaky-Test Policy And Mechanical Enforcement](./ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md)
 
 ## Embedded Crate-Local ADR Records
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -966,6 +966,13 @@ Queue-inspection architectural rules:
   pending-ack messages prioritized ahead of non-ack unread messages
 - selector-driven `atm read` must return the most recent match and report
   additional matches in metadata rather than returning multiple full bodies
+- selector-driven `atm list` and `atm read` operate on logical current
+  messages; successor/update chains are collapsed to their terminal node before
+  result selection or row shaping
+- `--task <task-id>` selection happens after that terminal-node collapse so one
+  logical task thread does not surface as several superseded matches
+- `--contains` applies to both summary text and full durable message body text
+- summary/count queries must remain separable from full-body detail fetch
 
 Deduplication rule:
 - collapse multiple entries with the same non-null `message_id` to the most
@@ -2283,6 +2290,11 @@ Claude-owned inbox JSONL files remain required for:
 Architectural rule:
 - JSONL is ingress/egress compatibility only
 - JSONL is not ATM's authoritative durable mail state
+- ATM-authored JSONL exports are a bounded compatibility projection over the
+  durable SQLite message body
+- the default ATM-authored JSONL body export cap is `128 KiB`
+- config `[atm].claude_jsonl_body_export_max_bytes` may lower that cap,
+  including `0` for stub-only ATM-authored export
 
 `config.json` remains a team-ingress surface, but roster truth moves to
 SQLite.
@@ -2296,6 +2308,8 @@ There are three distinct paths:
    - ATM imports through one owned inbox-ingress boundary
    - imported records become durable in SQLite
    - replay is idempotent and parseable rows are not silently dropped
+   - ATM-authored oversized-body exports replace JSONL `text` with exactly
+     `atm read --message-id <id>` while keeping the full body durable in SQLite
 
 2. Native agent path
    - native agent/plugin traffic does not use JSONL
@@ -2307,6 +2321,13 @@ There are three distinct paths:
    - routing expands from `agent@team` to `agent@team.host`
    - sender-side daemons do not write remote host JSONL directly
    - successful remote delivery requires remote daemon acceptance
+
+Projection-awareness rule:
+- watcher/reconcile logic must treat re-observed ATM-authored compatibility
+  projections for the same logical message as idempotent state rather than new
+  mail
+- re-observing the same ATM retrieval stub for the same `message_id` must not
+  trigger a new logical message import or notification loop
 
 ### 21.4 One Interface, Two Transport Implementations
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ The CLI stays thin. Product logic moves into `atm-core`.
 
 The retained command surface is:
 - `send`
+- `list`
 - `read`
 - `ack`
 - `clear`
@@ -73,6 +74,9 @@ Phase-S portability note:
   CLI surface:
   - daemon packets: `send`, `ack`, `read`, `clear`, `doctor`, heartbeat
   - non-packet retained surfaces: `log`, `teams`, `members`
+- S.5 planning adds `atm list` as a distinct CLI query surface; implementation
+  must refine the queue-query packet mapping instead of preserving the old
+  multi-message `read` response shape as the final contract
 - Phase S planning is tracked in [`docs/plan-phase-S.md`](./plan-phase-S.md)
 
 ## 2. Crate Boundaries
@@ -893,51 +897,77 @@ Missing-team-config fallback is limited to `send`:
 - repair notices must be deduplicated by unresolved condition so repeated sends
   do not flood inboxes
 
-### 6.2 Read Service
+### 6.2 Queue Inspection Services
 
-Public entrypoint:
+Phase S.5 splits queue inspection into two command surfaces:
 
-`read::read_mail(query: ReadQuery, observability: &dyn ObservabilityPort) -> Result<ReadOutcome, AtmError>`
+- `atm list` finds messages through a bounded metadata query
+- `atm read` opens one full message
 
-`ReadQuery` contains:
+Target service shape:
+
+- `list::list_mail(query: ListQuery, observability: &dyn ObservabilityPort)
+  -> Result<ListOutcome, AtmError>`
+- `read::read_mail(query: ReadQuery, observability: &dyn ObservabilityPort)
+  -> Result<ReadOutcome, AtmError>`
+
+Shared query model:
 - home directory
 - current directory
 - actor override
 - optional target address
 - team override
-- selection_mode
-- seen_state_filter
-- seen_state_update
-- ack_activation_mode
-- limit
-- sender_filter
-- timestamp_filter
+- sender filter
+- timestamp filter
+- task filter
+- contains filter
+- queue-state filters (`unread`, `pending_ack`, `all`)
+
+`ListQuery` adds:
+- optional limit
+
+`ReadQuery` adds:
+- optional exact `message_id`
 - optional timeout
+- read-mutation controls such as seen-state update and ack activation
 
-`seen_state_filter` is false when `--no-since-last-seen` is set. `--all` bypasses this filter regardless of the stored value.
+`ListOutcome` contains:
+- action
+- resolved team
+- resolved agent
+- messages
+- count
+- bucket_counts
 
-`seen_state_update` is false when `--no-update-seen` is set.
-
-Timeout rule:
-- if the requested selection is already non-empty after filtering and selection-mode application, return immediately
-- otherwise wait for a newly eligible message until the timeout expires
+Each list row contains:
+- `message_id`
+- `summary`
+- `from`
+- `timestamp`
+- `read`
+- `pending_ack`
+- `task_id`
 
 `ReadOutcome` contains:
 - action
 - resolved team
 - resolved agent
-- selection_mode
-- history_collapsed
-- mutation_applied
-- messages
+- selected message
+- `selected_message_id`
+- `match_count`
+- `additional_match_count`
+- `mutation_applied`
 - bucket_counts
 
-`ReadOutcome.bucket_counts` exposes:
-- unread
-- pending_ack
-- history
+Queue-inspection architectural rules:
+- default `atm list` must stay bounded by query behavior rather than
+  materializing full mailbox history and truncating it at render time
+- bare `atm read` must return one most-recent unread actionable message, with
+  pending-ack messages prioritized ahead of non-ack unread messages
+- selector-driven `atm read` must return the most recent match and report
+  additional matches in metadata rather than returning multiple full bodies
 
-Read deduplication rule:
+Deduplication rule:
 - collapse multiple entries with the same non-null `message_id` to the most
   recent entry before bucket selection and output rendering
 - when timestamps tie, keep the later encountered inbox record
@@ -950,18 +980,13 @@ Read/enrichment rule:
   `from`, which also requires canonical sender identity in
   `metadata.atm.fromIdentity`
 
-The read service derives `MessageClass` from `(ReadState, AckState)` and applies display-bucket selection to the derived class, not to raw persisted fields.
+The queue-query services derive `MessageClass` from `(ReadState, AckState)` and
+apply display-bucket selection to the derived class, not to raw persisted
+fields.
 
-For merged inbox surfaces, any displayed-message mutation must be written back to the physical inbox file that contributed the displayed record. The merged view is a read projection, not a synthetic write target.
-
-The CLI JSON output mirrors the current contract:
-- `action`
-- `team`
-- `agent`
-- `messages`
-- `count`
-- `bucket_counts`
-- `history_collapsed`
+For merged inbox surfaces, any displayed-message mutation must be written back
+to the physical inbox file that contributed the displayed record. The merged
+view is a read projection, not a synthetic write target.
 
 ### 6.3 Ack Service
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,9 +74,10 @@ Phase-S portability note:
   CLI surface:
   - daemon packets: `send`, `ack`, `read`, `clear`, `doctor`, heartbeat
   - non-packet retained surfaces: `log`, `teams`, `members`
-- S.5 planning adds `atm list` as a distinct CLI query surface; implementation
-  must refine the queue-query packet mapping instead of preserving the old
-  multi-message `read` response shape as the final contract
+- S.5 planning adds `atm list` as a distinct CLI query surface; S.7 owns the
+  implementation line that refines the queue-query packet mapping instead of
+  preserving the old multi-message `read` response shape as the final
+  contract
 - Phase S planning is tracked in [`docs/plan-phase-S.md`](./plan-phase-S.md)
 
 ## 2. Crate Boundaries

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,9 +127,12 @@ Lint and tooling boundary rules:
   - reusable/static rules:
     - Unix platform-gating checks
     - bare production `Condvar::wait(...)` checks
+    - fixed-sleep test-hygiene checks after the current repository-local rule
+      shape is proven and extracted to `sc-lint`
   - ATM-local rules:
     - duplicate semantic string-literal checks in non-test Rust code
-    - fixed-sleep test-hygiene checks
+    - targeted same-host daemon test unbounded-wait checks until or unless the
+      rule family proves reusable enough for `sc-lint`
     - triage Turtle consistency checks
 
 Crate-local boundary detail is owned by:
@@ -163,11 +166,16 @@ Current Phase R lint partition direction:
   rules
 - extend the existing `sc-boundary` analyzer for reusable production-liveness
   rules that need Rust-aware analysis
+- treat fixed-sleep test hygiene as a reusable lint family whose current
+  repository-local rule is the proving implementation before `sc-lint`
+  extraction
 - keep ATM duplicate semantic literal policy in the existing repository-local
   identity lint
-- add any fixed-sleep and triage-record validation as repository-local lint/CI
-  steps first, then reevaluate extraction only after the false-positive and
+- keep targeted same-host daemon unbounded-wait checks as repository-local
+  lint/CI first, then reevaluate extraction only after the false-positive and
   allow-list shape is proven on `atm-core`
+- keep triage-record validation as repository-local lint/CI unless its rule
+  semantics become clearly reusable
 
 Active postmortem rule families:
 - reusable analyzer rules:
@@ -182,7 +190,7 @@ Active postmortem rule families:
   - `SCB-RUNTIME-002` discarded `wait_timeout*` results in production code
 - ATM-local repository rules:
   - duplicate semantic role-name literals in non-test Rust code
-  - fixed-sleep test-hygiene checks
+  - targeted same-host daemon test unbounded-wait checks
   - triage Turtle aggregate/branch consistency checks
 
 ### 2.3 Release Publication Boundary

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -208,6 +208,8 @@ Phase R redesign notes:
   cross-host daemon transport
 - `atm-core` owns the queue-query semantics shared by `atm list` and
   single-message `atm read`
+- selector-driven queue inspection operates on logical terminal-node messages,
+  not raw superseded predecessors
 - the canonical ICD owns the exact frame constants, packet-kind assignments,
   and payload DTO mapping that `atm-core` must encode and decode
 - `atm-core` owns the current daemon packet family for:
@@ -435,6 +437,8 @@ Architectural rules:
   - team roster
 - daemon memory is the live source of truth for agent status
 - Claude inbox JSONL is ingress/egress compatibility only
+- ATM-authored JSONL export is a bounded compatibility projection over the full
+  durable message body
 
 Migration implication:
 - current mailbox/workflow-sidecar logic is transitional and must converge onto

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -206,6 +206,8 @@ Phase R redesign notes:
   store, ingress/export, watch/reconcile, and notification/status surfaces
 - `atm-core` owns the ATM frame schema used by both same-host local IPC and
   cross-host daemon transport
+- `atm-core` owns the queue-query semantics shared by `atm list` and
+  single-message `atm read`
 - the canonical ICD owns the exact frame constants, packet-kind assignments,
   and payload DTO mapping that `atm-core` must encode and decode
 - `atm-core` owns the current daemon packet family for:
@@ -219,6 +221,8 @@ Phase R redesign notes:
 - `ack` remains a workflow/state concern, but thin-client protocol shape
   should carry it inside send-shaped requests rather than a separate top-level
   method family
+- queue inspection must not remain one "read many full messages" surface once
+  SQLite-backed mailbox history becomes the ordinary durable source of truth
 
 Required frame direction:
 - transport framing must not depend on EOF or socket half-close semantics

--- a/docs/atm-core/modules/config.md
+++ b/docs/atm-core/modules/config.md
@@ -8,6 +8,8 @@ Also owns persisted config/team loading policy:
 - classification of missing-document, record-level, and document-level failures
 - recovery guidance and parser-context preservation for config errors
 - refusal to guess identity or routing data during recovery
+- parsing and validation of `[atm].claude_jsonl_body_export_max_bytes` for the
+  ATM-authored Claude JSONL compatibility-envelope rule
 
 References:
 

--- a/docs/atm-core/modules/list.md
+++ b/docs/atm-core/modules/list.md
@@ -1,0 +1,14 @@
+# `atm-core::list`
+
+Owns bounded metadata query behavior for queue inspection, including shared
+filter semantics with `atm read`, deduplication by `message_id`, and compact
+row shaping for the CLI layer to render.
+
+References:
+
+- Product requirements: `docs/requirements.md` §7
+- `REQ-P-LIST-001`
+- `REQ-CORE-LIST-001`
+- `REQ-CORE-WORKFLOW-001`
+- Cross-cutting behavior: `docs/read-behavior.md`
+- CLI surface: `docs/atm/commands/list.md`

--- a/docs/atm-core/modules/list.md
+++ b/docs/atm-core/modules/list.md
@@ -1,8 +1,9 @@
 # `atm-core::list`
 
 Owns bounded metadata query behavior for queue inspection, including shared
-filter semantics with `atm read`, deduplication by `message_id`, and compact
-row shaping for the CLI layer to render.
+filter semantics with `atm read`, successor-chain terminal-node collapse,
+deduplication by `message_id`, compact row shaping, and metadata/count query
+paths that do not require full-body response materialization.
 
 References:
 

--- a/docs/atm-core/modules/read.md
+++ b/docs/atm-core/modules/read.md
@@ -1,12 +1,14 @@
 # `atm-core::read`
 
-Owns read selection, bucket classification, seen-state updates, timeout
-behavior, and readable result shaping for the CLI layer to render.
+Owns single-message selection, bucket classification, seen-state updates,
+timeout behavior, and detailed message-result shaping for the CLI layer to
+render.
 
 References:
 
 - Product requirements: `docs/requirements.md` §7 and §14
 - `REQ-P-READ-001`
+- `REQ-CORE-LIST-001`
 - `REQ-P-WORKFLOW-001`
 - `REQ-CORE-WORKFLOW-001`
 - Cross-cutting behavior: `docs/read-behavior.md`

--- a/docs/atm-core/modules/read.md
+++ b/docs/atm-core/modules/read.md
@@ -1,6 +1,7 @@
 # `atm-core::read`
 
-Owns single-message selection, bucket classification, seen-state updates,
+Owns single-message selection, successor-chain terminal-node collapse for
+logical current-message matching, bucket classification, seen-state updates,
 timeout behavior, and detailed message-result shaping for the CLI layer to
 render.
 

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -525,7 +525,7 @@ Required doctor rules:
   end of the run; any lock path present in both snapshots is stale and must be
   reported with `ATM_WARNING_STALE_MAILBOX_LOCK` plus `rm -f <path>` recovery guidance
 
-## 9. Retained Team Recovery Surface
+## 10. Retained Team Recovery Surface
 
 Requirement ID:
 - `REQ-CORE-TEAM-001`

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -21,7 +21,7 @@ The crate-local machine-readable boundary inventory lives in:
 - inbox ingress/export contracts
 - config ingress contracts
 - workflow and typestate rules
-- send/read/ack/clear service behavior
+- list/send/read/ack/clear service behavior
 - log query/follow service behavior over the observability boundary
 - doctor service behavior
 - structured core errors
@@ -45,6 +45,7 @@ Initial allocation:
 - `REQ-CORE-CONFIG-*`
 - `REQ-CORE-MAILBOX-*`
 - `REQ-CORE-WORKFLOW-*`
+- `REQ-CORE-LIST-*`
 - `REQ-CORE-SEND-*`
 - `REQ-CORE-READ-*`
 - `REQ-CORE-ACK-*`
@@ -72,7 +73,7 @@ Initial crate requirement IDs:
 - `REQ-CORE-CONFIG-002` `atm-core` owns shared address parsing, alias rewrite,
   and team/member validation policy. Satisfies the address resolution and
   target-validation aspects of:
-  `REQ-P-ADDRESS-001`, `REQ-P-SEND-001`, `REQ-P-READ-001`,
+  `REQ-P-ADDRESS-001`, `REQ-P-SEND-001`, `REQ-P-LIST-001`, `REQ-P-READ-001`,
   `REQ-P-CLEAR-001`.
 - `REQ-CORE-CONFIG-003` `atm-core` owns persisted config/team schema recovery
   and diagnostic policy. Satisfies the compatibility-recovery and
@@ -92,14 +93,18 @@ Initial crate requirement IDs:
 - `REQ-CORE-MAILBOX-001` `atm-core` owns transitional mailbox compatibility
   behavior and the file-backed import/export boundary during the migration
   line. Satisfies the persisted mailbox compatibility aspects of:
-  `REQ-P-CONTRACT-001`, `REQ-P-SEND-001`, `REQ-P-READ-001`,
+  `REQ-P-CONTRACT-001`, `REQ-P-SEND-001`, `REQ-P-LIST-001`, `REQ-P-READ-001`,
   `REQ-P-ACK-001`, `REQ-P-CLEAR-001`, `REQ-P-RELIABILITY-001`,
   `REQ-P-IDLE-001`.
 - `REQ-CORE-WORKFLOW-001` `atm-core` owns the two-axis workflow model and legal
   transitions. Satisfies the state-classification and legal-transition aspects
   of:
-  `REQ-P-READ-001`, `REQ-P-ACK-001`, `REQ-P-CLEAR-001`,
+  `REQ-P-LIST-001`, `REQ-P-READ-001`, `REQ-P-ACK-001`, `REQ-P-CLEAR-001`,
   `REQ-P-WORKFLOW-001`.
+- `REQ-CORE-LIST-001` `atm-core` owns the metadata-first queue query contract
+  shared by `atm list` and selector-driven `atm read`, including bounded
+  query behavior, shared match filters, and list-row shaping. Satisfies:
+  `REQ-P-LIST-001`, `REQ-P-READ-001`, `REQ-P-RELIABILITY-001`.
 - `REQ-CORE-SEND-003` `atm-core` owns send-path message construction,
   classification, and compatibility-export behavior above the owned
   ingress/export boundaries. Satisfies the send-path service aspects of:
@@ -202,6 +207,7 @@ Initial crate requirement IDs:
 
 Per-module documentation lives under:
 
+- [`modules/list.md`](./modules/list.md)
 - [`modules/send.md`](./modules/send.md)
 - [`modules/read.md`](./modules/read.md)
 - [`modules/ack.md`](./modules/ack.md)

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -70,6 +70,8 @@ Initial crate requirement IDs:
   resolution policy across the CLI and daemon-backed runtime. Satisfies the
   path/config/identity aspects of:
   `REQ-P-CONTRACT-001`, `REQ-P-IDENTITY-001`, `REQ-P-DOCTOR-001`.
+  It also owns parsing and validation of `[atm].claude_jsonl_body_export_max_bytes`
+  for the ATM-authored JSONL compatibility envelope.
 - `REQ-CORE-CONFIG-002` `atm-core` owns shared address parsing, alias rewrite,
   and team/member validation policy. Satisfies the address resolution and
   target-validation aspects of:
@@ -103,7 +105,8 @@ Initial crate requirement IDs:
   `REQ-P-WORKFLOW-001`.
 - `REQ-CORE-LIST-001` `atm-core` owns the metadata-first queue query contract
   shared by `atm list` and selector-driven `atm read`, including bounded
-  query behavior, shared match filters, and list-row shaping. Satisfies:
+  query behavior, shared match filters, successor-chain terminal-node
+  selection, and list-row shaping. Satisfies:
   `REQ-P-LIST-001`, `REQ-P-READ-001`, `REQ-P-RELIABILITY-001`.
 - `REQ-CORE-SEND-003` `atm-core` owns send-path message construction,
   classification, and compatibility-export behavior above the owned

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -56,6 +56,7 @@ Initial allocation:
 - `REQ-CORE-TEAM-*`
 - `REQ-CORE-RUNTIME-*`
 - `REQ-CORE-STORE-*`
+- `REQ-CORE-COMPAT-*`
 - `REQ-CORE-INGEST-*`
 - `REQ-CORE-BOUNDARY-*`
 - `REQ-CORE-TRANSPORT-*`
@@ -98,6 +99,12 @@ Initial crate requirement IDs:
   `REQ-P-CONTRACT-001`, `REQ-P-SEND-001`, `REQ-P-LIST-001`, `REQ-P-READ-001`,
   `REQ-P-ACK-001`, `REQ-P-CLEAR-001`, `REQ-P-RELIABILITY-001`,
   `REQ-P-IDLE-001`.
+- `REQ-CORE-COMPAT-001` `atm-core` owns the Claude JSONL compatibility
+  projection contract for ATM-authored exports and inbound compatibility
+  ingestion, including the bounded export cap, retrieval-stub rule, and
+  idempotent watcher/reconcile projection handling for the same logical
+  message. Satisfies:
+  `REQ-P-CONTRACT-001`, `REQ-P-RELIABILITY-001`.
 - `REQ-CORE-WORKFLOW-001` `atm-core` owns the two-axis workflow model and legal
   transitions. Satisfies the state-classification and legal-transition aspects
   of:

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -141,7 +141,8 @@ Current retained ATM surfaces outside the daemon request/response packet family:
 - bounded transient retry uses exponential backoff with jitter, an initial
   delay of 250ms, a per-attempt maximum of 5s, jitter of +/-20%, and a hard
   total retry ceiling within the documented timeout budget; it must not
-  collapse into fixed sleeps or unbounded churn
+  collapse into fixed sleeps, unbounded churn, or tests that can wait
+  indefinitely for eventual success
 - retryable peer failures are limited to transient pre-acceptance socket
   failures:
   - timeout

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -13,8 +13,8 @@ The canonical daemon wire contract lives in:
 The crate-local machine-readable boundary inventory lives in:
 - [`./boundaries.md`](./boundaries.md)
 
-This crate is introduced by the Phase Q implementation line and is not part of
-the current pre-Phase-Q workspace yet.
+This crate was introduced on the Phase Q implementation line and remains part
+of the current workspace.
 
 ## 1.1 ADRs
 
@@ -188,6 +188,9 @@ Current retained ATM surfaces outside the daemon request/response packet family:
 - watcher/reconcile adapters remain crate-private and dispatch through owned
   ingress/service handlers rather than touching store/transport/notifier
   internals directly
+- watcher/reconcile observation of ATM-authored compatibility projection
+  updates must be idempotent for the same logical message; re-observing the
+  same retrieval-stub projection must not create a new-mail churn loop
 - the watcher/reconcile boundary minimum method set is defined in product
   [architecture.md §21.6.1](../architecture.md)
 

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -9,8 +9,8 @@ Product behavior remains defined in [`../requirements.md`](../requirements.md).
 `atm-daemon` must satisfy those product requirements without re-owning
 `atm-core` business logic.
 
-This crate is introduced by the Phase Q implementation line. It is not present
-in the pre-Phase-Q workspace yet.
+This crate was introduced on the Phase Q implementation line and remains part
+of the current workspace.
 
 The crate-local machine-readable boundary inventory lives in:
 - [`./boundaries.md`](./boundaries.md)
@@ -30,6 +30,8 @@ The canonical daemon transport wire contract lives in:
 - live agent status cache
 - runtime watch/reconcile loop if enabled
 - daemon-side `sc-observability` emission
+- daemon-side compatibility projection behavior that must keep ATM-authored
+  JSONL re-export idempotent under watcher/reconcile observation
 
 `atm-daemon` does not own:
 
@@ -200,6 +202,10 @@ Initial crate requirement IDs:
   readiness, shutdown, retry, and helper-thread drain behavior must be proven
   through explicit synchronization or bounded runtime contracts. Satisfies:
   `REQ-P-TEST-001`, `REQ-P-PLATFORM-002`.
+- `REQ-DAEMON-RUNTIME-008` watcher/reconcile handling of ATM-authored
+  compatibility projection updates must remain idempotent for the same
+  logical message and must not create self-induced churn loops. Satisfies:
+  `REQ-CORE-COMPAT-001`, `REQ-P-RELIABILITY-001`.
 
 ## 4. Required References
 

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -192,10 +192,10 @@ Initial crate requirement IDs:
   platform-specific test code limited to the owned portability adapters.
   Satisfies:
   `REQ-P-PLATFORM-002`, `REQ-CORE-TEST-RUNTIME-001`.
-- `REQ-DAEMON-TEST-004` `atm-daemon` must not use fixed sleeps or timing-only
-  stabilization in same-host functional tests; readiness, shutdown, and retry
-  behavior must be proven through explicit synchronization or bounded runtime
-  contracts. Satisfies:
+- `REQ-DAEMON-TEST-004` `atm-daemon` must not use fixed sleeps, timing-only
+  stabilization, or unbounded wait paths in same-host functional tests;
+  readiness, shutdown, retry, and helper-thread drain behavior must be proven
+  through explicit synchronization or bounded runtime contracts. Satisfies:
   `REQ-P-TEST-001`, `REQ-P-PLATFORM-002`.
 
 ## 4. Required References
@@ -357,9 +357,9 @@ Required runtime rules:
 - same-host functional tests must use shared infrastructure on Unix and Windows
   so one handler/dispatcher contract is proven through both platform
   implementations
-- fixed sleeps, warmup polling, and timing-only daemon stabilization are
-  prohibited in same-host functional tests; tests must use explicit
-  synchronization or bounded runtime contracts
+- fixed sleeps, warmup polling, timing-only daemon stabilization, and
+  unbounded wait paths are prohibited in same-host functional tests; tests
+  must use explicit synchronization or bounded runtime contracts
 - transport/store/health operations must obey one documented timeout budget
   - authoritative timeout budget references:
     [`../architecture.md §21.6.4`](../architecture.md) and

--- a/docs/atm-rusqlite/architecture.md
+++ b/docs/atm-rusqlite/architecture.md
@@ -59,6 +59,8 @@ Follow-up work:
 - `atm-rusqlite` implements store contracts; it does not define them.
 - `atm-rusqlite` must not own workflow, routing, daemon, watcher, transport,
   or notifier business logic.
+- bounded queue-query support for Phase S may add concrete SQL projections or
+  indexes, but logical message selection rules remain in `atm-core`
 - all direct SQLite access stays inside this crate.
 - concrete `rusqlite` types, row mappers, connection wiring, and migration
   helpers remain private implementation details.

--- a/docs/atm-rusqlite/requirements.md
+++ b/docs/atm-rusqlite/requirements.md
@@ -68,6 +68,7 @@ The `atm-rusqlite` crate docs must remain aligned with:
 - [`../project-plan.md`](../project-plan.md)
 - [`../plan-phase-Q.md`](../plan-phase-Q.md)
 - [`../plan-phase-R.md`](../plan-phase-R.md)
+- [`../plan-phase-S.md`](../plan-phase-S.md)
 - [`../atm-core/requirements.md`](../atm-core/requirements.md)
 - [`../atm-core/architecture.md`](../atm-core/architecture.md)
 - [`../atm-error-codes.md`](../atm-error-codes.md)
@@ -116,6 +117,9 @@ Required rules:
   ATM errors rather than validation
 - conformance tests should validate behavior through the `atm-core` store
   traits rather than by depending on internal SQLite details
+- follow-on Phase S queue work may add bounded metadata-query helpers and
+  supporting indexes for `atm list` / selector-driven `atm read`, but
+  selector semantics remain owned by `atm-core`
 - most SQLite tests should use dedicated in-memory fixtures with explicit
   setup/cleanup
 - only a small deliberate suite may use on-disk temporary databases for

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -43,7 +43,9 @@ Phase R redesign notes:
   request/response packet surface in the current Phase S line
 - S.5 planning adds `atm list` as a distinct CLI verb; implementation must
   keep its search semantics aligned with `atm read` while avoiding
-  multi-message body rendering
+  multi-message body rendering and must preserve the exact
+  `atm read --message-id <id>` retrieval path used by ATM-authored JSONL body
+  stubs
 
 ## 1.1 ADRs
 

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -41,11 +41,10 @@ Phase R redesign notes:
 - the current daemon packet family serves `send`, `ack`, `read`, `clear`, and
   `doctor`; retained `log`, `teams`, and `members` stay outside the daemon
   request/response packet surface in the current Phase S line
-- S.5 planning adds `atm list` as a distinct CLI verb; implementation must
-  keep its search semantics aligned with `atm read` while avoiding
-  multi-message body rendering and must preserve the exact
-  `atm read --message-id <id>` retrieval path used by ATM-authored JSONL body
-  stubs
+- S.5 planning adds `atm list` as a distinct CLI verb; S.7 owns the aligned
+  list/read implementation while S.8 owns the JSONL retrieval-stub
+  compatibility path that preserves the exact
+  `atm read --message-id <id>` retrieval command
 
 ## 1.1 ADRs
 

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -25,6 +25,8 @@ The `atm` crate is responsible for:
 - constructing the production daemon client / runtime request adapter
 - maintaining the retained CLI subcommand surface, including `teams` and
   `members`
+- maintaining the queue-inspection command split where `atm list` is the
+  metadata-search surface and `atm read` is the single-message detail surface
 
 The `atm` crate must remain thin.
 
@@ -39,6 +41,9 @@ Phase R redesign notes:
 - the current daemon packet family serves `send`, `ack`, `read`, `clear`, and
   `doctor`; retained `log`, `teams`, and `members` stay outside the daemon
   request/response packet surface in the current Phase S line
+- S.5 planning adds `atm list` as a distinct CLI verb; implementation must
+  keep its search semantics aligned with `atm read` while avoiding
+  multi-message body rendering
 
 ## 1.1 ADRs
 

--- a/docs/atm/commands/list.md
+++ b/docs/atm/commands/list.md
@@ -4,6 +4,7 @@ CLI ownership for `atm list`:
 
 - bounded metadata-search flag parsing
 - shared queue-filter parsing aligned with `atm read`
+- match-filter parsing for task/thread lookups without full-body rendering
 - conversion into `atm-core` list/query requests
 - human-readable metadata row rendering
 - JSON metadata output

--- a/docs/atm/commands/list.md
+++ b/docs/atm/commands/list.md
@@ -1,0 +1,20 @@
+# `atm list`
+
+CLI ownership for `atm list`:
+
+- bounded metadata-search flag parsing
+- shared queue-filter parsing aligned with `atm read`
+- conversion into `atm-core` list/query requests
+- human-readable metadata row rendering
+- JSON metadata output
+
+Workflow/state behavior remains owned by `atm-core`.
+
+References:
+
+- Product requirements: `docs/requirements.md` §7 and `read-behavior.md`
+- `REQ-P-LIST-001`
+- `REQ-ATM-CMD-001`
+- `REQ-ATM-OUT-001`
+- Product architecture: `docs/architecture.md`
+- Core module: `docs/atm-core/modules/list.md`

--- a/docs/atm/commands/read.md
+++ b/docs/atm/commands/read.md
@@ -4,10 +4,12 @@ CLI ownership for `atm read`:
 
 - single-message selection flag parsing
 - shared queue-filter parsing aligned with `atm list`
+- deprecated legacy read-flag alias handling and warning presentation
 - timeout flag parsing
 - conversion into `atm-core` read requests
 - human-readable full-message rendering
 - JSON output for one selected message plus match metadata
+- exact-message retrieval help text for ATM-authored JSONL retrieval stubs
 
 Workflow/state behavior remains owned by `atm-core`.
 

--- a/docs/atm/commands/read.md
+++ b/docs/atm/commands/read.md
@@ -2,11 +2,12 @@
 
 CLI ownership for `atm read`:
 
-- selection flag parsing
+- single-message selection flag parsing
+- shared queue-filter parsing aligned with `atm list`
 - timeout flag parsing
 - conversion into `atm-core` read requests
-- human-readable queue rendering
-- JSON output
+- human-readable full-message rendering
+- JSON output for one selected message plus match metadata
 
 Workflow/state behavior remains owned by `atm-core`.
 

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -162,6 +162,9 @@ Required Phase R rules:
 - `atm` must not contain business logic that duplicates `atm-core`
 - `atm` test coverage must be able to use in-process harnesses rather than
   depending on daemon process spawning
+- `atm` owns legacy queue-flag deprecation warnings and the exact
+  `atm read --message-id <id>` retrieval guidance shown for ATM-authored JSONL
+  body stubs
 - daemon auto-start is a supervised runtime entry concern, not a side effect of
   transport object construction
 - the CLI-side auto-start path must acquire the documented pre-spawn launch

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -55,13 +55,13 @@ Initial crate requirement IDs:
 - `REQ-ATM-CMD-001` `atm` owns clap parsing, flag validation, and command
   dispatch for the retained command surface. Satisfies the CLI
   entry/parse/dispatch aspects of:
-  `REQ-P-SEND-001`, `REQ-P-READ-001`, `REQ-P-ACK-001`, `REQ-P-CLEAR-001`,
-  `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`, `REQ-P-TEAMS-001`,
+  `REQ-P-SEND-001`, `REQ-P-LIST-001`, `REQ-P-READ-001`, `REQ-P-ACK-001`,
+  `REQ-P-CLEAR-001`, `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`, `REQ-P-TEAMS-001`,
   `REQ-P-MEMBERS-001`.
 - `REQ-ATM-OUT-001` `atm` owns human-readable and JSON rendering for retained
   commands. Satisfies the output-shaping and rendering aspects of:
-  `REQ-P-SEND-001`, `REQ-P-READ-001`, `REQ-P-ACK-001`, `REQ-P-CLEAR-001`,
-  `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`, `REQ-P-TEAMS-001`,
+  `REQ-P-SEND-001`, `REQ-P-LIST-001`, `REQ-P-READ-001`, `REQ-P-ACK-001`,
+  `REQ-P-CLEAR-001`, `REQ-P-LOG-001`, `REQ-P-DOCTOR-001`, `REQ-P-TEAMS-001`,
   `REQ-P-MEMBERS-001`.
 - `REQ-ATM-OBS-001` `atm` owns concrete observability bootstrap and injection
   into `atm-core`. Satisfies the CLI bootstrap/injection aspects of:
@@ -110,6 +110,7 @@ Initial crate requirement IDs:
 Per-command documentation lives under:
 
 - [`commands/send.md`](./commands/send.md)
+- [`commands/list.md`](./commands/list.md)
 - [`commands/read.md`](./commands/read.md)
 - [`commands/ack.md`](./commands/ack.md)
 - [`commands/clear.md`](./commands/clear.md)

--- a/docs/claude-code-message-schema.md
+++ b/docs/claude-code-message-schema.md
@@ -86,6 +86,11 @@ This file does not define ATM-added persisted envelope fields such as:
 message field. ATM may interpret `taskId` when present, but that ownership is
 documented in [`atm-message-schema.md`](./atm-message-schema.md), not here.
 
+This file also does not define ATM-authored JSONL export size policy, retrieval
+stub behavior, or durable-store limits. Those ATM-owned compatibility-envelope
+rules are documented in
+[`ADR-010`](./adr/ADR-010-claude-jsonl-compatibility-envelope.md).
+
 Historical provenance note:
 
 - `quality-mgr` analysis over 7,297 persisted messages across 24 teams found

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -19,6 +19,28 @@ Review rule:
   operating system through the documented portability boundaries, the docs and
   architecture must be updated before implementation continues
 
+## No-Flaky-Test Policy
+
+Cross-platform daemon and runtime tests must not rely on timing luck and must
+not contain a path that can block indefinitely.
+
+Required shapes:
+- bounded channel handshakes
+- `Barrier`, `Condvar`, or predicate synchronization with a bounded wait
+- bounded readiness and shutdown probes tied to observable state
+- panic-safe cleanup for shared/global test hooks
+
+Forbidden shapes:
+- fixed sleeps as the primary correctness mechanism
+- retry-until-success loops with no predicate or deadline
+- unbounded `recv()`, `wait()`, or equivalent blocking calls in risky
+  same-host daemon/runtime tests
+- bare `join()` when the test has no bounded proof of completion first
+
+Mechanical-enforcement rule:
+- if a prohibited pattern is cheap and deterministic to detect, it belongs in
+  `just lint` rather than review-only guidance
+
 ## Home Directory Resolution
 
 **Problem**: `dirs::home_dir()` on Windows uses the Windows API (`SHGetKnownFolderPath`), which ignores both `HOME` and `USERPROFILE` environment variables. Tests that only redirect `HOME` do not relocate the canonical `~/.claude` config root on Windows.
@@ -61,6 +83,23 @@ Before declaring dev work complete, grep all integration test files:
 grep -rn 'ATM_CONFIG_HOME' crates/atm/tests/ || echo "FAIL: Missing ATM_CONFIG_HOME in test helpers"
 grep -rn 'env(\"HOME\"' crates/atm/tests/
 ```
+
+### Planned Phase S.5 Guardrails
+
+Immediate/default-lint families:
+- fixed-sleep test hygiene, with the current repository-local rule treated as
+  the proving implementation for later `sc-lint` extraction
+- daemon-spawn and warmup-helper rejection
+- production bare `Condvar::wait(...)`
+- production discarded `wait_timeout*` results
+- targeted same-host daemon test checks for cheap unbounded-wait syntax once
+  the repository-local rule is landed
+
+Deferred analyzer families:
+- path-sensitive `JoinHandle::join()` safety
+- polling-loop terminate-state placement
+- panic-safe cleanup proof for shared/global hook registries
+- bounded-wait result handling in test code
 
 ## Clippy Compliance
 

--- a/docs/phase-S/issues.md
+++ b/docs/phase-S/issues.md
@@ -57,3 +57,15 @@ Planning baseline:
     cross-platform-compatible lock-file shape; they left room for Unix-shaped
     deletion signaling instead of one stable `launch.lock` / `owner.lock`
     model with held-lock owner metadata.
+
+14. The original Phase S anti-flake wording was too narrow: it prohibited
+    fixed sleeps, but it did not define the broader no-flaky-test and
+    no-unbounded-wait policy needed for cross-platform daemon work.
+
+15. Phase S did not explicitly classify which anti-flake guardrails are
+    feasible in the default `just lint` path versus which require deferred
+    Rust-aware analyzer work.
+
+16. Phase S did not explicitly require panic-safe cleanup of shared/global test
+    hooks or ban unbounded wait shapes such as bare `recv()` / `wait()` /
+    `join()` in the risky same-host daemon test surfaces.

--- a/docs/phase-S/issues.md
+++ b/docs/phase-S/issues.md
@@ -7,7 +7,7 @@ Planning baseline:
 - follow-on CI-only compatibility fixes do not change the architectural issue
   set tracked here
 
-## Open Issues
+## Closed Historical Planning Issues
 
 1. Product requirement miss: full daemon functionality is expected on Windows,
    but the integrated daemon host shell only supports Unix-hosted same-host
@@ -69,3 +69,56 @@ Planning baseline:
 16. Phase S did not explicitly require panic-safe cleanup of shared/global test
     hooks or ban unbounded wait shapes such as bare `recv()` / `wait()` /
     `join()` in the risky same-host daemon test surfaces.
+
+Disposition:
+- these planning issues are closed by the merged S.0-S.5 documentation and
+  implementation line
+- they remain listed here as the historical problem inventory that justified
+  the Phase S sprint sequence
+
+## Open Remaining Implementation / Process Issues
+
+17. Phase S still carries four concrete post-S.4 daemon/runtime remediation
+    items that must remain in the active sprint line until closed:
+    - `RSH-001`
+    - `RSH-014`
+    - `WIN-001`
+    - `ATM-QA-S4-001`
+
+18. The mailbox-query redesign exposed by GitHub issues `#213` and `#214`
+    remains unimplemented after S.4. `atm list`, single-message `atm read`,
+    shared selector semantics, and bounded durable query behavior must stay
+    assigned to follow-on Phase S execution work.
+
+19. ATM-authored Claude JSONL compatibility projection still lacks the
+    implemented export-cap, retrieval-stub, and watcher no-churn behavior
+    accepted in ADR-010.
+
+20. The triage process hardening line is incomplete until `qa-triage`,
+    `triaging-findings`, and the phase integration-worktree ownership rule all
+    agree on the canonical `triage_root`.
+
+## Assigned Follow-On Sprint Ownership
+
+- `S.6`
+  - `RSH-001`
+  - `RSH-014`
+  - `WIN-001`
+  - `ATM-QA-S4-001`
+- `S.7`
+  - `atm list`
+  - single-message `atm read`
+  - shared list/read filter surface
+  - legacy `atm read` flag migration
+  - bounded durable query behavior
+- `S.8`
+  - `[atm].claude_jsonl_body_export_max_bytes`
+  - oversized ATM-authored retrieval-stub export
+  - watcher/reconcile no-churn handling for ATM-authored projections
+
+## Deferred Follow-Up
+
+- `FTQ-001`
+  - remains deferred to later lint/analyzer work
+  - it is not treated as an S.6-S.8 code-implementation item in the current
+    Phase S line

--- a/docs/phase-S/sprint-S0.md
+++ b/docs/phase-S/sprint-S0.md
@@ -43,6 +43,7 @@ implementation sprints will follow.
 - `docs/adr/ADR-003-test-fidelity-and-daemon-isolation.md`
 - `docs/adr/ADR-005-host-scoped-sqlite-state-root.md`
 - `docs/adr/ADR-007-supported-platform-parity.md`
+- `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
 
 ## Governing ICD Sections
 
@@ -184,7 +185,7 @@ daemon docs, and Phase S sequence are all updated together.
   permanent `launch.lock` / `owner.lock` paths plus held-lock owner metadata
 - the Phase S sprint sequence is concrete enough to execute without reopening
   the architectural direction
-- the S.1-S.4 sprint documents exist and each names the exact code targets,
+- the S.1-S.5 sprint documents exist and each names the exact code targets,
   governing references, and acceptance criteria required for implementation
   review
 - Phase S docs explicitly require feature parity on all supported operating
@@ -198,18 +199,23 @@ daemon docs, and Phase S sequence are all updated together.
 - Phase S docs define the temporary Windows CI lint narrowing and the S.4
   requirement to remove it
 
-## Anti-Flake Synchronization Contract
+## No-Flaky-Test And Bounded-Wait Contract
 
 Phase S same-host daemon tests must use positive synchronization primitives:
 - channel-based ready handshakes
 - `Barrier`, `Condvar`, or latch/predicate synchronization
 - documented listener-ready or worker-ready probes with bounded deadlines
+- panic-safe cleanup of shared/global test hooks
+- bounded drain/join of helper threads and finalizer threads
 
 They must not use:
 - fixed sleeps
 - warm-up delays
 - retry loops with no observable readiness predicate
 - OS-specific timing fudge added only to appease Windows CI
+- unbounded `recv()`, `wait()`, or equivalent blocking operations in risky
+  same-host daemon test paths
+- bare `join()` when no prior bounded handshake proves completion
 
 ## Required Validation
 
@@ -224,6 +230,7 @@ They must not use:
 - `docs/phase-S/sprint-S2.md`
 - `docs/phase-S/sprint-S3.md`
 - `docs/phase-S/sprint-S4.md`
+- `docs/phase-S/sprint-S5.md`
 - `docs/phase-S/issues.md`
 - `docs/project-plan.md`
 - `docs/requirements.md`
@@ -242,6 +249,7 @@ They must not use:
 - `docs/testing-guidelines.md`
 - `docs/cross-platform-guidelines.md`
 - `docs/adr/ADR-007-supported-platform-parity.md`
+- `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
 
 ## Risks And Watchouts
 

--- a/docs/phase-S/sprint-S1.md
+++ b/docs/phase-S/sprint-S1.md
@@ -18,6 +18,7 @@ depends directly on Unix APIs.
 
 - `REQ-P-PLATFORM-001`
 - `REQ-P-PLATFORM-002`
+- `REQ-P-TEST-001`
 - `REQ-DAEMON-PLATFORM-001`
 - `REQ-DAEMON-PLATFORM-002`
 - `REQ-DAEMON-TRANSPORT-008`
@@ -29,6 +30,7 @@ depends directly on Unix APIs.
 - `docs/adr/ADR-002-host-wide-daemon-singleton.md`
 - `docs/adr/ADR-003-test-fidelity-and-daemon-isolation.md`
 - `docs/adr/ADR-007-supported-platform-parity.md`
+- `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
 
 ## Governing ICD Sections
 
@@ -116,6 +118,9 @@ depends directly on Unix APIs.
   types outside the three documented daemon-owned portability facades
 - any remaining unsupported-path stub is temporary, explicitly documented, and
   limited to the still-unimplemented adapter
+- any new same-host daemon tests added by S.1 are bounded, explicit about
+  readiness predicates, and do not introduce unbounded wait or panic-stranded
+  shared-hook behavior
 
 ## Required Validation
 

--- a/docs/phase-S/sprint-S2.md
+++ b/docs/phase-S/sprint-S2.md
@@ -17,6 +17,7 @@ boundary while preserving one shared protocol, dispatcher, and test harness.
 
 - `REQ-P-PLATFORM-001`
 - `REQ-P-PLATFORM-002`
+- `REQ-P-TEST-001`
 - `REQ-DAEMON-TRANSPORT-001`
 - `REQ-DAEMON-TRANSPORT-008`
 - `REQ-DAEMON-PLATFORM-001`
@@ -28,6 +29,7 @@ boundary while preserving one shared protocol, dispatcher, and test harness.
 
 - `docs/adr/ADR-003-test-fidelity-and-daemon-isolation.md`
 - `docs/adr/ADR-007-supported-platform-parity.md`
+- `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
 
 ## Governing ICD Sections
 
@@ -93,10 +95,10 @@ boundary while preserving one shared protocol, dispatcher, and test harness.
   Windows
 - same-host functional tests prove the real transport on Windows through the
   shared harness
-- no fixed sleeps are used to stabilize the transport tests; readiness and
-  shutdown are proven through explicit synchronization such as channel
-  handshakes, `Barrier`, or `Condvar` predicates, following the contract in
-  `docs/testing-guidelines.md §5`
+- no fixed sleeps or unbounded waits are used to stabilize the transport
+  tests; readiness and shutdown are proven through explicit synchronization
+  such as channel handshakes, `Barrier`, or `Condvar` predicates, following
+  the contract in `docs/testing-guidelines.md §5`
 
 ## Required Validation
 

--- a/docs/phase-S/sprint-S3.md
+++ b/docs/phase-S/sprint-S3.md
@@ -20,6 +20,7 @@ shutdown semantics on every supported operating system.
 - `REQ-P-PLATFORM-002`
 - `REQ-P-RUNTIME-002`
 - `REQ-P-RUNTIME-003`
+- `REQ-P-TEST-001`
 - `REQ-DAEMON-RUNTIME-001`
 - `REQ-DAEMON-RUNTIME-003`
 - `REQ-DAEMON-RUNTIME-005`
@@ -35,6 +36,7 @@ shutdown semantics on every supported operating system.
 
 - `docs/adr/ADR-002-host-wide-daemon-singleton.md`
 - `docs/adr/ADR-007-supported-platform-parity.md`
+- `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
 
 ## Governing ICD Sections
 
@@ -110,6 +112,9 @@ shutdown semantics on every supported operating system.
 - Windows and Unix lifecycle-control / host-ownership tests prove the same
   externally visible contract, with platform-specific assertions limited to the
   adapter internals
+- shutdown, stale-owner recovery, and lifecycle-control tests use bounded
+  synchronization and panic-safe cleanup rather than unbounded waits or
+  timing-luck stabilization
 
 ## Required Validation
 

--- a/docs/phase-S/sprint-S4.md
+++ b/docs/phase-S/sprint-S4.md
@@ -18,6 +18,7 @@ Unix-only behavior.
 
 - `REQ-P-PLATFORM-001`
 - `REQ-P-PLATFORM-002`
+- `REQ-P-TEST-001`
 - `REQ-DAEMON-RUNTIME-001`
 - `REQ-DAEMON-RUNTIME-002`
 - `REQ-DAEMON-RUNTIME-003`
@@ -30,6 +31,7 @@ Unix-only behavior.
 
 - `docs/adr/ADR-003-test-fidelity-and-daemon-isolation.md`
 - `docs/adr/ADR-007-supported-platform-parity.md`
+- `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
 
 ## Governing ICD Sections
 
@@ -71,7 +73,7 @@ Unix-only behavior.
 - no remaining production path depends on Unix-only host APIs outside the
   owned portability adapters
 - the test suite forbids flaky timing-based stabilization for same-host daemon
-  coverage
+  coverage and forbids unbounded waits in same-host daemon coverage
 - the shutdown drain, WAL checkpoint, and singleton release sequence remains
   ordered and bounded after S.4 hardening
 - Windows CI and local `just lint` both run full workspace clippy without the

--- a/docs/phase-S/sprint-S5.md
+++ b/docs/phase-S/sprint-S5.md
@@ -74,6 +74,17 @@ hang-prone regression patterns from re-entering the same-host daemon line.
 5. Record any ADR needed for the repository-wide no-flaky-test decision and
    enforcement partition.
 
+6. Harden the Phase S triage process so canonical `.triage/<phase>/findings/*.ttl`
+   records are committed to git at the correct workflow point.
+6.1 Set the commit point at the team-lead triage batch stage:
+   - after all parallel `qa-triage` agents finish writing `.ttl` files
+   - after aggregation confirms the batch is complete
+   - before any branch-scoped fix dispatch to `arch-ctm`
+6.2 Update the relevant triage prompt/skill so the process explicitly forbids
+    leaving phase findings untracked in the working tree until phase end.
+6.3 Keep this track separate from the mailbox-read planning follow-up; the
+    triage git-commit gap is an independent process-hardening item.
+
 ## Required Document Updates
 
 - `docs/plan-phase-S.md`
@@ -90,6 +101,8 @@ hang-prone regression patterns from re-entering the same-host daemon line.
 - `docs/project-plan.md`
 - `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
 - `docs/adr/INDEX.md`
+- `.claude/agents/qa-triage.md`
+- `.claude/skills/triaging-findings/SKILL.md`
 
 ## Acceptance Criteria
 
@@ -103,6 +116,10 @@ hang-prone regression patterns from re-entering the same-host daemon line.
   which new anti-flake families belong there
 - the mechanical guardrail plan names the intended implementation home for
   each rule family (`sc-lint-*` vs `.just/` / `scripts/`)
+- the triage workflow names an explicit git-commit step for phase `.ttl`
+  records before dev dispatch begins
+- the chosen triage commit point prevents a repeat of the Phase S gap where
+  findings remained untracked until manual intervention
 
 ## Required Validation
 

--- a/docs/phase-S/sprint-S5.md
+++ b/docs/phase-S/sprint-S5.md
@@ -22,7 +22,11 @@ Close the remaining Phase S process and product-surface gaps by:
 
 - `REQ-P-TEST-001`
 - `REQ-P-LINT-POSTMORTEM-001`
+- `REQ-P-LIST-001`
+- `REQ-P-READ-001`
 - `REQ-CORE-TEST-RUNTIME-001`
+- `REQ-CORE-LIST-001`
+- `REQ-CORE-COMPAT-001`
 - `REQ-DAEMON-TEST-004`
 - `REQ-DAEMON-PLATFORM-002`
 
@@ -32,6 +36,7 @@ Close the remaining Phase S process and product-surface gaps by:
 - `docs/adr/ADR-007-supported-platform-parity.md`
 - `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
 - `docs/adr/ADR-009-bounded-queue-query-surface.md`
+- `docs/adr/ADR-010-claude-jsonl-compatibility-envelope.md`
 
 ## Hard Dependencies
 
@@ -121,11 +126,21 @@ Close the remaining Phase S process and product-surface gaps by:
    - `--unread`
    - `--pending-ack`
    - `--all`
+7.4.1 Define the legacy `atm read` flag migration:
+   - `--unread-only` -> deprecated alias for `--unread`
+   - `--pending-ack-only` -> deprecated alias for `--pending-ack`
+   - `--history` -> deprecated alias for `--all`
+   - `--since-last-seen` remains an explicit restatement of the default
+     watermark behavior
 7.5 Define `atm read` selection behavior:
    - bare `atm read` returns the most recent unread actionable message
    - pending-ack messages are prioritized ahead of non-ack unread messages
    - selector-driven reads return the most recent match when multiple messages
      match
+   - successor/update chains are one logical message and selection operates on
+     their terminal node
+   - `--task <task-id>` chooses the most recent terminal-node logical message
+     among task-linked matches
    - the read result must expose `match_count` and
      `additional_match_count`
 7.6 Record the bounded-query rule:
@@ -133,6 +148,18 @@ Close the remaining Phase S process and product-surface gaps by:
      render truncation
    - durable SQLite rows must not tolerate malformed JSON as a normal degraded
      read mode
+7.7 Define the Claude Code compatibility-envelope rule:
+   - ATM-authored JSONL body export defaults to a `128 KiB` cap
+   - config `[atm].claude_jsonl_body_export_max_bytes` may lower that cap,
+     including `0` for stub-only ATM-authored export
+   - if ATM skips the full body, the JSONL `text` field becomes exactly
+     `atm read --message-id <id>`
+   - summary text remains populated when ATM exports that retrieval stub
+   - full ATM-authored bodies remain durable in SQLite
+   - Claude-native inbound messages are never rewritten into ATM retrieval
+     stubs
+   - watcher/reconcile logic must treat ATM-authored compatibility projection
+     updates as idempotent and must not create self-induced churn loops
 
 ## Required Document Updates
 
@@ -150,10 +177,17 @@ Close the remaining Phase S process and product-surface gaps by:
 - `docs/project-plan.md`
 - `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
 - `docs/adr/ADR-009-bounded-queue-query-surface.md`
+- `docs/adr/ADR-010-claude-jsonl-compatibility-envelope.md`
 - `docs/adr/INDEX.md`
 - `docs/read-behavior.md`
+- `docs/claude-code-message-schema.md`
+- `docs/atm/requirements.md`
+- `docs/atm/architecture.md`
 - `docs/atm/commands/list.md`
 - `docs/atm/commands/read.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/modules/config.md`
 - `docs/atm-core/modules/list.md`
 - `docs/atm-core/modules/read.md`
 - `.claude/agents/qa-triage.md`
@@ -184,6 +218,14 @@ Close the remaining Phase S process and product-surface gaps by:
   SQLite-backed mailbox history grows without a fixed upper bound
 - the docs define how `atm read` reports multiple matches without returning
   multiple full message bodies
+- the docs define how successor/task-linked logical messages collapse before
+  `atm read` chooses one current match
+- the docs define the legacy `atm read` flag migration instead of leaving the
+  deprecation surface implicit
+- the docs define the ATM-authored Claude JSONL export cap, retrieval-stub
+  behavior, and watcher no-churn rule
+- the docs state that stubbed ATM-authored JSONL exports retain summary text
+  and never rewrite Claude-native inbound messages
 
 ## Required Validation
 

--- a/docs/phase-S/sprint-S5.md
+++ b/docs/phase-S/sprint-S5.md
@@ -1,0 +1,109 @@
+# Phase S.5 — No-Flaky-Test Policy And Mechanical Guardrails
+
+```yaml
+plan_type: sprint_plan
+phase: S
+sprint: "S.5"
+status: planned
+estimated_scope: M
+```
+
+## Goal
+
+Close the remaining Phase S process gap by making the no-flaky-test contract
+phase-wide and by defining the mechanical lint families that must prevent
+hang-prone regression patterns from re-entering the same-host daemon line.
+
+## Governing Requirements
+
+- `REQ-P-TEST-001`
+- `REQ-P-LINT-POSTMORTEM-001`
+- `REQ-CORE-TEST-RUNTIME-001`
+- `REQ-DAEMON-TEST-004`
+- `REQ-DAEMON-PLATFORM-002`
+
+## Governing ADRs
+
+- `docs/adr/ADR-003-test-fidelity-and-daemon-isolation.md`
+- `docs/adr/ADR-007-supported-platform-parity.md`
+- `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
+
+## Hard Dependencies
+
+- `integrate/phase-S` contains the merged S.1 through S.4 implementation line
+- the existing fixed-sleep, singleton, portability, and runtime-waits lint
+  gates remain green before S.5 follow-on planning starts
+
+## Required Work
+
+1. Tighten the Phase S wording from "no fixed sleeps" to the stronger
+   no-flaky-test and no-unbounded-wait policy.
+1.1 Update the active Phase S plan and sprint docs so same-host daemon tests
+    explicitly forbid:
+   - unbounded waits
+   - missed-wakeup-sensitive waits with no bounded fallback
+   - panic-unsafe global/shared test hooks
+   - retry-until-success loops with no state predicate
+1.2 Carry the same contract into:
+   - `docs/testing-guidelines.md`
+   - `docs/cross-platform-guidelines.md`
+   - top-level requirements and architecture docs
+
+2. Define the mechanical anti-flake guardrail inventory.
+2.1 Record which rules are feasible now in the default `just lint` path:
+   - fixed-sleep test hygiene, with the current repository-local rule treated
+     as the proving implementation for later `sc-lint` extraction
+   - daemon-spawn helper rejection
+   - production bare `Condvar::wait(...)`
+   - production discarded `wait_timeout*` results
+   - targeted same-host daemon test checks for cheap unbounded-wait syntax
+2.2 Record which rules require deferred analyzer or rule-design work:
+   - path-sensitive `JoinHandle::join()` safety
+   - polling-loop terminate-state placement
+   - panic-safe cleanup proof for global test hooks
+   - bounded-wait result handling in test code
+
+3. Name the intended lint ownership for each family.
+3.1 Reusable Rust-aware analyzer rules remain `sc-lint-*` candidates.
+3.2 ATM-specific repository policy checks remain `.just/` or `scripts/` lints
+    until their rule shape is proven reusable.
+
+4. Update the Phase S issue inventory so the remaining policy and guardrail
+   gaps are explicit rather than implied by QA findings.
+
+5. Record any ADR needed for the repository-wide no-flaky-test decision and
+   enforcement partition.
+
+## Required Document Updates
+
+- `docs/plan-phase-S.md`
+- `docs/phase-S/issues.md`
+- `docs/phase-S/sprint-S0.md`
+- `docs/phase-S/sprint-S1.md`
+- `docs/phase-S/sprint-S2.md`
+- `docs/phase-S/sprint-S3.md`
+- `docs/phase-S/sprint-S4.md`
+- `docs/testing-guidelines.md`
+- `docs/cross-platform-guidelines.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/project-plan.md`
+- `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
+- `docs/adr/INDEX.md`
+
+## Acceptance Criteria
+
+- Phase S has one explicit phase-wide no-flaky-test contract rather than a
+  narrow fixed-sleep-only rule
+- the active docs state that a test which might hang is invalid even if it
+  does not use `thread::sleep(...)`
+- the active docs distinguish feasible-now lint families from deferred
+  analyzer work
+- the default development gate remains `just lint`, and the S.5 docs name
+  which new anti-flake families belong there
+- the mechanical guardrail plan names the intended implementation home for
+  each rule family (`sc-lint-*` vs `.just/` / `scripts/`)
+
+## Required Validation
+
+- `just lint`

--- a/docs/phase-S/sprint-S5.md
+++ b/docs/phase-S/sprint-S5.md
@@ -17,6 +17,8 @@ Close the remaining Phase S process and product-surface gaps by:
   regression patterns from re-entering the same-host daemon line
 - documenting the bounded mailbox-query split where `atm list` owns metadata
   search and `atm read` owns single-message detail fetch
+- assigning every remaining post-S.4 implementation item to an execution-ready
+  follow-on sprint
 
 ## Governing Requirements
 
@@ -161,6 +163,31 @@ Close the remaining Phase S process and product-surface gaps by:
    - watcher/reconcile logic must treat ATM-authored compatibility projection
      updates as idempotent and must not create self-induced churn loops
 
+8. Create the follow-on execution sprint line for all remaining Phase S work.
+8.1 `S.6` must own the daemon/runtime post-mortem remediation items:
+   - `RSH-001` `crates/atm-daemon/src/composition.rs::shutdown_background_lanes`
+   - `RSH-014` `crates/atm-daemon/src/lifecycle_control.rs` Unix EOF wake
+     propagation gap
+   - `WIN-001` Windows graceful shutdown regression in the daemon shutdown
+     signal path and its test coverage
+   - `ATM-QA-S4-001`
+     `crates/atm-daemon/src/local_ipc_transport.rs::prepare_local_ipc_endpoint`
+8.2 `S.7` must own the bounded queue-query implementation:
+   - add `atm list`
+   - convert `atm read` to single-message logical-current selection
+   - implement shared list/read filters and legacy read-flag migration
+   - implement bounded metadata-query paths instead of full-surface read
+     materialization
+8.3 `S.8` must own the ATM-authored Claude JSONL compatibility-envelope
+    implementation:
+   - `[atm].claude_jsonl_body_export_max_bytes`
+   - oversized ATM-authored body stub export
+   - watcher/reconcile no-churn handling for ATM-authored compatibility
+     projections
+8.4 `FTQ-001` remains explicitly deferred from the execution line here. Keep it
+    recorded as a lint/analyzer follow-up item rather than an S.6-S.8 code
+    implementation item unless a later audit reclassifies it.
+
 ## Required Document Updates
 
 - `docs/plan-phase-S.md`
@@ -170,6 +197,9 @@ Close the remaining Phase S process and product-surface gaps by:
 - `docs/phase-S/sprint-S2.md`
 - `docs/phase-S/sprint-S3.md`
 - `docs/phase-S/sprint-S4.md`
+- `docs/phase-S/sprint-S6.md`
+- `docs/phase-S/sprint-S7.md`
+- `docs/phase-S/sprint-S8.md`
 - `docs/testing-guidelines.md`
 - `docs/cross-platform-guidelines.md`
 - `docs/requirements.md`
@@ -190,8 +220,15 @@ Close the remaining Phase S process and product-surface gaps by:
 - `docs/atm-core/modules/config.md`
 - `docs/atm-core/modules/list.md`
 - `docs/atm-core/modules/read.md`
+- `docs/atm-rusqlite/requirements.md`
+- `docs/atm-rusqlite/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
 - `.claude/agents/qa-triage.md`
 - `.claude/skills/triaging-findings/SKILL.md`
+- `boundaries/atm-core/config-ingress.toml`
+- `boundaries/atm-core/inbox-export.toml`
+- `boundaries/atm-daemon/daemon-inbox-export.toml`
 
 ## Acceptance Criteria
 
@@ -226,6 +263,12 @@ Close the remaining Phase S process and product-surface gaps by:
   behavior, and watcher no-churn rule
 - the docs state that stubbed ATM-authored JSONL exports retain summary text
   and never rewrite Claude-native inbound messages
+- S.6, S.7, and S.8 sprint docs exist and assign every remaining post-S.4
+  implementation item to an execution-ready sprint
+- `RSH-001`, `RSH-014`, `WIN-001`, and `ATM-QA-S4-001` have explicit sprint
+  ownership with concrete code targets
+- `FTQ-001` is explicitly recorded as a deferred lint/analyzer item rather
+  than being left ambiguous between planning and implementation
 
 ## Required Validation
 

--- a/docs/phase-S/sprint-S5.md
+++ b/docs/phase-S/sprint-S5.md
@@ -1,4 +1,4 @@
-# Phase S.5 — No-Flaky-Test Policy And Mechanical Guardrails
+# Phase S.5 — Guardrails And Bounded Queue Queries
 
 ```yaml
 plan_type: sprint_plan
@@ -10,9 +10,13 @@ estimated_scope: M
 
 ## Goal
 
-Close the remaining Phase S process gap by making the no-flaky-test contract
-phase-wide and by defining the mechanical lint families that must prevent
-hang-prone regression patterns from re-entering the same-host daemon line.
+Close the remaining Phase S process and product-surface gaps by:
+
+- making the no-flaky-test contract phase-wide
+- defining the mechanical lint families that must prevent hang-prone
+  regression patterns from re-entering the same-host daemon line
+- documenting the bounded mailbox-query split where `atm list` owns metadata
+  search and `atm read` owns single-message detail fetch
 
 ## Governing Requirements
 
@@ -27,6 +31,7 @@ hang-prone regression patterns from re-entering the same-host daemon line.
 - `docs/adr/ADR-003-test-fidelity-and-daemon-isolation.md`
 - `docs/adr/ADR-007-supported-platform-parity.md`
 - `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
+- `docs/adr/ADR-009-bounded-queue-query-surface.md`
 
 ## Hard Dependencies
 
@@ -91,6 +96,44 @@ hang-prone regression patterns from re-entering the same-host daemon line.
 6.4 Land any `qa-triage` prompt edits from a develop-based worktree if that
     prompt is shared outside the active Phase S planning branch.
 
+7. Add the mailbox-query reliability and CLI-surface track.
+7.1 Record that GitHub issues `#213` and `#214` are not isolated read-path
+    bugs; they expose a broader queue-inspection design problem where default
+    reads still materialize too much mailbox history.
+7.2 Document the accepted command split:
+   - `atm list` is the bounded metadata-search surface
+   - `atm read` returns one selected full message
+7.3 Define the accepted list-row field contract:
+   - `message_id`
+   - `summary`
+   - `from`
+   - `timestamp`
+   - `read`
+   - `pending_ack`
+   - `task_id` when present
+7.4 Define the shared list/read filter contract:
+   - optional target inbox
+   - `--team`
+   - `--from`
+   - `--since`
+   - `--task`
+   - `--contains`
+   - `--unread`
+   - `--pending-ack`
+   - `--all`
+7.5 Define `atm read` selection behavior:
+   - bare `atm read` returns the most recent unread actionable message
+   - pending-ack messages are prioritized ahead of non-ack unread messages
+   - selector-driven reads return the most recent match when multiple messages
+     match
+   - the read result must expose `match_count` and
+     `additional_match_count`
+7.6 Record the bounded-query rule:
+   - default queue inspection must be bounded by query behavior, not merely by
+     render truncation
+   - durable SQLite rows must not tolerate malformed JSON as a normal degraded
+     read mode
+
 ## Required Document Updates
 
 - `docs/plan-phase-S.md`
@@ -106,7 +149,13 @@ hang-prone regression patterns from re-entering the same-host daemon line.
 - `docs/architecture.md`
 - `docs/project-plan.md`
 - `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
+- `docs/adr/ADR-009-bounded-queue-query-surface.md`
 - `docs/adr/INDEX.md`
+- `docs/read-behavior.md`
+- `docs/atm/commands/list.md`
+- `docs/atm/commands/read.md`
+- `docs/atm-core/modules/list.md`
+- `docs/atm-core/modules/read.md`
 - `.claude/agents/qa-triage.md`
 - `.claude/skills/triaging-findings/SKILL.md`
 
@@ -128,6 +177,13 @@ hang-prone regression patterns from re-entering the same-host daemon line.
   lives on that phase's integration-branch worktree
 - the chosen triage commit point prevents a repeat of the Phase S gap where
   findings remained untracked until manual intervention
+- the active product and crate-local docs describe one clean queue-inspection
+  split where `atm list` is the search/index surface and `atm read` is the
+  single-message detail surface
+- the docs state that default queue inspection must stay bounded even as
+  SQLite-backed mailbox history grows without a fixed upper bound
+- the docs define how `atm read` reports multiple matches without returning
+  multiple full message bodies
 
 ## Required Validation
 

--- a/docs/phase-S/sprint-S5.md
+++ b/docs/phase-S/sprint-S5.md
@@ -80,10 +80,16 @@ hang-prone regression patterns from re-entering the same-host daemon line.
    - after all parallel `qa-triage` agents finish writing `.ttl` files
    - after aggregation confirms the batch is complete
    - before any branch-scoped fix dispatch to `arch-ctm`
+   - on the phase integration-branch worktree, which is the canonical triage
+     source of truth for that phase
 6.2 Update the relevant triage prompt/skill so the process explicitly forbids
-    leaving phase findings untracked in the working tree until phase end.
+    leaving phase findings untracked in the working tree until phase end and
+    explicitly requires `triage_root` to live under the integration-branch
+    worktree rather than an arbitrary feature branch.
 6.3 Keep this track separate from the mailbox-read planning follow-up; the
     triage git-commit gap is an independent process-hardening item.
+6.4 Land any `qa-triage` prompt edits from a develop-based worktree if that
+    prompt is shared outside the active Phase S planning branch.
 
 ## Required Document Updates
 
@@ -118,6 +124,8 @@ hang-prone regression patterns from re-entering the same-host daemon line.
   each rule family (`sc-lint-*` vs `.just/` / `scripts/`)
 - the triage workflow names an explicit git-commit step for phase `.ttl`
   records before dev dispatch begins
+- the active planning docs state that the canonical `triage_root` for a phase
+  lives on that phase's integration-branch worktree
 - the chosen triage commit point prevents a repeat of the Phase S gap where
   findings remained untracked until manual intervention
 

--- a/docs/phase-S/sprint-S6.md
+++ b/docs/phase-S/sprint-S6.md
@@ -1,0 +1,95 @@
+# Phase S.6 — Daemon Post-Mortem Runtime Remediation
+
+```yaml
+plan_type: sprint_plan
+phase: S
+sprint: "S.6"
+status: planned
+estimated_scope: M
+```
+
+## Goal
+
+Close the remaining daemon/runtime post-mortem fixes left open after S.4 so
+the cross-platform host line is no longer carrying known shutdown, wakeup, or
+endpoint-preparation defects.
+
+## Governing Requirements
+
+- `REQ-P-PLATFORM-002`
+- `REQ-P-TEST-001`
+- `REQ-DAEMON-RUNTIME-003`
+- `REQ-DAEMON-TRANSPORT-004`
+- `REQ-DAEMON-SIGNAL-001`
+- `REQ-DAEMON-TEST-004`
+
+## Governing ADRs
+
+- `docs/adr/ADR-003-test-fidelity-and-daemon-isolation.md`
+- `docs/adr/ADR-007-supported-platform-parity.md`
+- `docs/adr/ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md`
+
+## Hard Dependencies
+
+- S.4 cross-platform parity and closeout work is merged
+- S.5 planning hardening is merged
+- no new Phase S daemon remediation item may bypass this sprint once it is
+  accepted as a live post-mortem fix
+
+## Required Work
+
+1. Close `RSH-001` in `crates/atm-daemon/src/composition.rs`.
+1.1 Fix `shutdown_background_lanes` so partial shutdown cannot strand
+    background lanes after an earlier lane fails.
+1.2 Audit all call sites in:
+   - `RuntimeComposition::begin_shutdown`
+   - `RuntimeComposition::finalize_shutdown`
+   - `RuntimeComposition::start`
+
+2. Close `RSH-014` in `crates/atm-daemon/src/lifecycle_control.rs`.
+2.1 Fix the Unix EOF wake path so lifecycle-control shutdown propagation does
+    not silently miss the notify step.
+2.2 Prove the wake path through bounded Unix-focused coverage.
+
+3. Close `WIN-001` in the Windows daemon graceful-shutdown path.
+3.1 Restore the missing Windows graceful-shutdown behavior in the daemon
+    shutdown-signal / lifecycle-control line.
+3.2 Tighten the daemon shutdown-signal tests in `crates/atm-daemon/src/tests.rs`
+    and any Windows lifecycle-control tests so the regression is covered.
+
+4. Close `ATM-QA-S4-001` in
+   `crates/atm-daemon/src/local_ipc_transport.rs::prepare_local_ipc_endpoint`.
+4.1 Replace the silent non-Unix `Ok(())` path with explicit documented
+    behavior that matches the named-pipe endpoint-preparation contract.
+4.2 Keep the adapter behavior platform-neutral above the owned local-IPC
+    implementation layer.
+
+5. Re-run the daemon post-mortem audit after the fixes land.
+5.1 Update any affected product or crate-local docs if the runtime behavior
+    contract changes while fixing these defects.
+5.2 Keep `FTQ-001` out of scope here; it remains a lint/analyzer deferral.
+
+## Required Code Targets
+
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/tests.rs`
+
+## Acceptance Criteria
+
+- `RSH-001`, `RSH-014`, `WIN-001`, and `ATM-QA-S4-001` are closed on the
+  active branch
+- shutdown sequencing remains ordered and bounded after partial-lane failure
+- the Unix lifecycle-control EOF path always performs the documented wake
+  notification
+- the Windows graceful-shutdown path is covered again and no longer regresses
+- local-IPC endpoint preparation no longer hides non-Unix behavior behind a
+  silent success path
+
+## Required Validation
+
+- `just lint`
+- `cargo test -p atm-daemon`
+- `cargo xwin check --workspace --target x86_64-pc-windows-msvc`
+- `cargo xwin clippy --workspace --all-targets --target x86_64-pc-windows-msvc -- -D warnings`

--- a/docs/phase-S/sprint-S7.md
+++ b/docs/phase-S/sprint-S7.md
@@ -1,0 +1,123 @@
+# Phase S.7 — Bounded Queue Query Implementation
+
+```yaml
+plan_type: sprint_plan
+phase: S
+sprint: "S.7"
+status: planned
+estimated_scope: L
+```
+
+## Goal
+
+Implement the queue-query split defined in ADR-009 so `atm list` becomes the
+bounded metadata-search surface and `atm read` becomes the single-message
+detail surface.
+
+## Governing Requirements
+
+- `REQ-P-LIST-001`
+- `REQ-P-READ-001`
+- `REQ-CORE-LIST-001`
+- `REQ-CORE-WORKFLOW-001`
+- `REQ-ATM-CMD-001`
+- `REQ-ATM-OUT-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-009-bounded-queue-query-surface.md`
+
+## Hard Dependencies
+
+- S.5 planning hardening is merged
+- the durable mailbox source of truth remains SQLite-backed
+- successor/update chain semantics remain the current source of truth for
+  logical message selection
+
+## Required Work
+
+1. Add the `atm list` CLI surface.
+1.1 Create `crates/atm/src/commands/list.rs`.
+1.2 Wire the command into:
+   - `crates/atm/src/commands/mod.rs`
+   - `crates/atm/src/main.rs`
+   - `crates/atm/src/output.rs`
+
+2. Convert `atm read` to single-message logical-current selection.
+2.1 Update `crates/atm/src/commands/read.rs` so selector-driven reads return
+    one most-recent logical current message.
+2.2 Emit `selected_message_id`, `match_count`, and
+    `additional_match_count` in JSON output and human-readable follow-up text.
+
+3. Implement the shared list/read filter contract.
+3.1 Keep `atm list` and `atm read` aligned on:
+   - `--team`
+   - `--from`
+   - `--since`
+   - `--task`
+   - `--contains`
+   - `--unread`
+   - `--pending-ack`
+   - `--all`
+3.2 Implement the legacy `atm read` alias migration:
+   - `--unread-only`
+   - `--pending-ack-only`
+   - `--history`
+   - `--since-last-seen`
+
+4. Split metadata query from full-message fetch in `atm-core`.
+4.1 Implement the bounded list/query service path in a dedicated core module.
+4.2 Keep successor/update-chain terminal-node collapse shared between list and
+    selector-driven read paths.
+4.3 Ensure bare `atm read` still prioritizes pending-ack messages ahead of
+    non-ack unread messages.
+
+5. Implement the bounded durable query path.
+5.1 Extend the concrete SQLite path in `crates/atm-rusqlite/src/shared_db.rs`
+    so list/count queries are bounded and do not materialize full mailbox
+    history for operator-facing responses.
+5.2 Keep selection semantics owned by `atm-core`, not by `atm-rusqlite`.
+
+## Required Code Targets
+
+- `crates/atm/src/commands/list.rs`
+- `crates/atm/src/commands/read.rs`
+- `crates/atm/src/commands/mod.rs`
+- `crates/atm/src/main.rs`
+- `crates/atm/src/output.rs`
+- `crates/atm-core/src/read/mod.rs`
+- `crates/atm-core/src/read/filters.rs`
+- `crates/atm-core/src/read/wait.rs`
+- `crates/atm-core/src/workflow.rs`
+- `crates/atm-rusqlite/src/shared_db.rs`
+
+## Required Document Updates
+
+- `docs/atm/commands/list.md`
+- `docs/atm/commands/read.md`
+- `docs/atm/requirements.md`
+- `docs/atm/architecture.md`
+- `docs/atm-core/modules/list.md`
+- `docs/atm-core/modules/read.md`
+- `docs/atm-rusqlite/requirements.md`
+- `docs/atm-rusqlite/architecture.md`
+
+## Acceptance Criteria
+
+- `atm list` exists as a top-level CLI verb
+- default queue inspection is bounded by query behavior rather than render
+  truncation
+- `atm read` returns exactly one logical current message
+- selector-driven reads report extra matches in metadata instead of returning
+  multiple full bodies
+- successor/task-thread selection operates on terminal-node logical current
+  messages rather than superseded predecessors
+- the legacy read aliases remain supported only as deprecated compatibility
+  spellings
+
+## Required Validation
+
+- `just lint`
+- targeted CLI tests for `atm list` and `atm read`
+- queue selection tests in `atm-core`
+- SQLite-backed bounded-query tests in `atm-rusqlite`

--- a/docs/phase-S/sprint-S7.md
+++ b/docs/phase-S/sprint-S7.md
@@ -78,6 +78,14 @@ detail surface.
     history for operator-facing responses.
 5.2 Keep selection semantics owned by `atm-core`, not by `atm-rusqlite`.
 
+6. Close the retained `atm-core` follow-up items surfaced by TODO triage.
+6.1 Replace `SendOutcome::warnings` in
+    `crates/atm-core/src/send/mod.rs` with a structured `WarningEntry` type
+    so warning text and recovery guidance are modeled separately.
+6.2 Move `crates/atm-core/src/service_runtime.rs::default_lock_timeout`
+    behind a boundary-owned timeout policy instead of the current module-level
+    default helper.
+
 ## Required Code Targets
 
 - `crates/atm/src/commands/list.rs`

--- a/docs/phase-S/sprint-S8.md
+++ b/docs/phase-S/sprint-S8.md
@@ -1,0 +1,96 @@
+# Phase S.8 — Claude JSONL Compatibility Envelope
+
+```yaml
+plan_type: sprint_plan
+phase: S
+sprint: "S.8"
+status: planned
+estimated_scope: M
+```
+
+## Goal
+
+Implement the ATM-authored Claude JSONL compatibility-envelope rules from
+ADR-010 so oversized ATM-authored bodies stay durable in SQLite without
+flooding Claude-facing inbox surfaces or causing watcher churn.
+
+## Governing Requirements
+
+- `REQ-CORE-COMPAT-001`
+- `REQ-CORE-MAILBOX-001`
+- `REQ-P-RELIABILITY-001`
+- `REQ-CORE-CONFIG-001`
+- `REQ-CORE-CONFIG-002`
+
+## Governing ADRs
+
+- `docs/adr/ADR-009-bounded-queue-query-surface.md`
+- `docs/adr/ADR-010-claude-jsonl-compatibility-envelope.md`
+
+## Hard Dependencies
+
+- S.7 bounded queue-query implementation is merged
+- the durable message source of truth remains SQLite
+- watcher/reconcile import/export stays behind the documented daemon and
+  inbox-export boundaries
+
+## Required Work
+
+1. Implement ATM-authored JSONL body export limits.
+1.1 Add config parsing and validation for
+    `[atm].claude_jsonl_body_export_max_bytes`.
+1.2 Default the export cap to `128 KiB`.
+1.3 Support `0` as stub-only ATM-authored export.
+
+2. Implement oversized ATM-authored compatibility projection.
+2.1 When an ATM-authored body exceeds the configured export limit, replace the
+    JSONL `text` field with exactly:
+   - `atm read --message-id <id>`
+2.2 Preserve summary text and ATM metadata while keeping the full body durable
+    in SQLite.
+2.3 Never rewrite Claude-native inbound messages into retrieval stubs.
+
+3. Make watcher/reconcile projection-aware.
+3.1 Treat ATM-authored compatibility projection updates as idempotent for the
+    same logical message.
+3.2 Prevent self-induced churn loops when the same retrieval stub for the same
+    `message_id` is re-observed.
+
+4. Align the export and reconcile paths across core and daemon adapters.
+4.1 Keep config ownership in `atm-core`.
+4.2 Keep compatibility projection wiring behind the inbox-export boundaries.
+4.3 Keep daemon watcher/reconcile behavior aligned with the no-churn rule.
+
+## Required Code Targets
+
+- `crates/atm-core/src/config/mod.rs`
+- `crates/atm-core/src/config/types.rs`
+- `crates/atm-core/src/schema/inbox_message.rs`
+- `crates/atm-core/src/boundary_support.rs`
+- `crates/atm-daemon/src/boundary_adapters.rs`
+- `crates/atm-daemon/src/watch_runtime.rs`
+- `crates/atm-daemon/src/reconcile_runtime.rs`
+
+## Required Document Updates
+
+- `docs/claude-code-message-schema.md`
+- `docs/atm-core/modules/config.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+
+## Acceptance Criteria
+
+- ATM-authored JSONL export defaults to a `128 KiB` body cap
+- the export cap is configurable downward to `0`
+- oversized ATM-authored messages export the exact retrieval stub
+  `atm read --message-id <id>`
+- summary text remains present when the retrieval stub is exported
+- full ATM-authored bodies remain durable in SQLite
+- watcher/reconcile logic treats ATM-authored compatibility projection updates
+  as idempotent and does not generate self-induced churn loops
+
+## Required Validation
+
+- `just lint`
+- compatibility-export tests in `atm-core`
+- watcher/reconcile no-churn tests in `atm-daemon`

--- a/docs/phase-S/sprint-S8.md
+++ b/docs/phase-S/sprint-S8.md
@@ -20,7 +20,6 @@ flooding Claude-facing inbox surfaces or causing watcher churn.
 - `REQ-CORE-MAILBOX-001`
 - `REQ-P-RELIABILITY-001`
 - `REQ-CORE-CONFIG-001`
-- `REQ-CORE-CONFIG-002`
 
 ## Governing ADRs
 

--- a/docs/plan-phase-S.md
+++ b/docs/plan-phase-S.md
@@ -181,20 +181,28 @@ Acceptance:
   daemon host design instead of a Unix-only host shell plus Windows compile
   stubs
 
-## 4.1 Anti-Flake Synchronization Contract
+## 4.1 No-Flaky-Test And Bounded-Wait Contract
 
-The same-host daemon plan must forbid timing-only stabilization and must name
-the positive replacements that implementation sprints use instead:
+The same-host daemon plan must forbid timing-only stabilization and any test
+shape that can block indefinitely, and must name the positive replacements
+that implementation sprints use instead:
 - explicit ready handshakes over channels
 - `Barrier`, `Condvar`, or latch-style predicate synchronization
 - listener-ready or worker-ready state probes on documented bounded deadlines
 - bounded retry only when tied to an explicit observable state transition
+- panic-safe cleanup of shared/global test hooks
+- bounded finalizer and helper-thread drain paths
 
 The following are not acceptable for same-host daemon parity coverage:
 - fixed sleeps
 - warm-up delays
 - retry loops with no explicit state predicate
 - platform-specific timing fudge intended only to “make Windows pass”
+- unbounded `recv()`, `wait()`, or equivalent blocking operations in flaky-risk
+  test paths
+- bare `join()` when the test has no prior bounded proof that the worker
+  already completed
+- shared/global test hooks that can remain installed after panic or timeout
 
 ## 5. Planned Sprint Sequence
 
@@ -397,6 +405,30 @@ Required closeout work:
   - Unix-only same-host functionality in production paths
 - reconcile docs, ADRs, and machine-readable boundaries so the production
   design names every allowed OS-specific implementation difference
+
+### S.5 No-Flaky-Test Policy And Mechanical Guardrails
+
+Goal:
+- tighten Phase S and top-level ATM language so the anti-flake contract is
+  phase-wide rather than fixed-sleep-only
+- define which anti-flake guardrails are feasible now in `just lint` versus
+  deferred analyzer work
+
+Required outcomes:
+- top-level requirements, architecture, and test guidelines explicitly state
+  that a test which might hang is invalid
+- Phase S sprint docs state that same-host daemon coverage must avoid both
+  timing-only stabilization and unbounded wait paths
+- the repo has one review-visible inventory of feasible-now versus deferred
+  mechanical anti-flake lint families
+
+Required closeout work:
+- add the S.5 sprint plan under `docs/phase-S/sprint-S5.md`
+- add an ADR for the repository-wide no-flaky-test policy and enforcement
+  partition if the existing ADRs are not sufficient
+- update Phase S issue inventory with the remaining policy and lint gaps
+- reconcile testing and cross-platform guidelines with the stronger no-hang
+  contract
 
 ## 6. Temporary Windows CI Guardrail
 

--- a/docs/plan-phase-S.md
+++ b/docs/plan-phase-S.md
@@ -406,13 +406,16 @@ Required closeout work:
 - reconcile docs, ADRs, and machine-readable boundaries so the production
   design names every allowed OS-specific implementation difference
 
-### S.5 No-Flaky-Test Policy And Mechanical Guardrails
+### S.5 Guardrails And Bounded Queue Queries
 
 Goal:
 - tighten Phase S and top-level ATM language so the anti-flake contract is
   phase-wide rather than fixed-sleep-only
 - define which anti-flake guardrails are feasible now in `just lint` versus
   deferred analyzer work
+- document the mailbox-query redesign where `atm list` becomes the bounded
+  metadata-search surface and `atm read` becomes the single-message detail
+  surface
 
 Required outcomes:
 - top-level requirements, architecture, and test guidelines explicitly state
@@ -421,14 +424,22 @@ Required outcomes:
   timing-only stabilization and unbounded wait paths
 - the repo has one review-visible inventory of feasible-now versus deferred
   mechanical anti-flake lint families
+- the active docs state that default queue inspection must remain bounded even
+  as SQLite-backed mailbox history grows without a practical fixed upper bound
+- the active docs define the accepted `atm list` / `atm read` split and the
+  shared filter contract between them
 
 Required closeout work:
 - add the S.5 sprint plan under `docs/phase-S/sprint-S5.md`
 - add an ADR for the repository-wide no-flaky-test policy and enforcement
   partition if the existing ADRs are not sufficient
+- add an ADR for the bounded queue-query surface (`atm list` / single-message
+  `atm read`)
 - update Phase S issue inventory with the remaining policy and lint gaps
 - reconcile testing and cross-platform guidelines with the stronger no-hang
   contract
+- reconcile the product and crate-local CLI docs with the new queue-inspection
+  command split
 
 ## 6. Temporary Windows CI Guardrail
 

--- a/docs/plan-phase-S.md
+++ b/docs/plan-phase-S.md
@@ -428,6 +428,9 @@ Required outcomes:
   as SQLite-backed mailbox history grows without a practical fixed upper bound
 - the active docs define the accepted `atm list` / `atm read` split and the
   shared filter contract between them
+- the active docs define the legacy `atm read` flag migration, logical
+  task/thread selection rule, and the ATM-authored Claude JSONL compatibility
+  envelope
 
 Required closeout work:
 - add the S.5 sprint plan under `docs/phase-S/sprint-S5.md`
@@ -435,6 +438,8 @@ Required closeout work:
   partition if the existing ADRs are not sufficient
 - add an ADR for the bounded queue-query surface (`atm list` / single-message
   `atm read`)
+- add an ADR for the ATM-authored Claude JSONL compatibility envelope and
+  oversized-body projection rule
 - update Phase S issue inventory with the remaining policy and lint gaps
 - reconcile testing and cross-platform guidelines with the stronger no-hang
   contract

--- a/docs/plan-phase-S.md
+++ b/docs/plan-phase-S.md
@@ -458,6 +458,67 @@ Required closeout work:
   contract
 - reconcile the product and crate-local CLI docs with the new queue-inspection
   command split
+- create the follow-on implementation sprint docs required to finish the phase
+
+### S.6 Daemon Post-Mortem Runtime Remediation
+
+Goal:
+- close the remaining daemon/runtime remediation items left open after the
+  S.4 parity line
+
+Required outcomes:
+- `RSH-001`, `RSH-014`, `WIN-001`, and `ATM-QA-S4-001` are assigned to one
+  explicit execution sprint with concrete code targets
+- shutdown ordering, lifecycle wake propagation, Windows graceful shutdown,
+  and local-IPC endpoint-preparation behavior are all covered by one bounded
+  remediation line
+
+Required closeout work:
+- fix `crates/atm-daemon/src/composition.rs::shutdown_background_lanes`
+- fix the Unix lifecycle-control EOF wake propagation gap
+- restore the Windows graceful-shutdown path and its coverage
+- remove the silent non-Unix success path from
+  `prepare_local_ipc_endpoint`
+
+### S.7 Bounded Queue Query Implementation
+
+Goal:
+- implement the queue-query split defined by ADR-009
+
+Required outcomes:
+- `atm list` exists as a bounded metadata-query CLI surface
+- `atm read` is a single-message logical-current selection path
+- shared list/read filters stay aligned
+- the durable query path is bounded by query behavior rather than full
+  history materialization
+
+Required closeout work:
+- add `crates/atm/src/commands/list.rs`
+- update `crates/atm/src/commands/read.rs` and output handling for
+  single-message selection and match metadata
+- add the bounded metadata-query service path in `atm-core`
+- add the SQLite-backed bounded query implementation support in
+  `atm-rusqlite`
+
+### S.8 Claude JSONL Compatibility Envelope
+
+Goal:
+- implement the ADR-010 compatibility-envelope contract for ATM-authored
+  Claude JSONL export and watcher/reconcile no-churn behavior
+
+Required outcomes:
+- `[atm].claude_jsonl_body_export_max_bytes` is implemented
+- oversized ATM-authored messages export retrieval stubs instead of full
+  bodies
+- watcher/reconcile logic treats ATM-authored projection updates as
+  idempotent
+
+Required closeout work:
+- add the config-backed ATM-authored export cap
+- export `atm read --message-id <id>` stubs for oversized ATM-authored bodies
+- preserve summary text while keeping full ATM-authored bodies durable in
+  SQLite
+- prevent self-induced churn loops in watcher/reconcile paths
 
 ## 6. Removed Windows CI Guardrail
 
@@ -514,3 +575,5 @@ Explicit deferral:
   they need separate review and enforcement surfaces
 - do not treat the temporary Windows clippy scope narrowing as a durable fix;
   S.4 must remove it
+- do not let S.5 end the documented sprint line while remaining post-mortem or
+  queue-query implementation work is still unassigned

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -56,6 +56,10 @@ Phase-S planning note:
   documents the bounded queue-query split between `atm list` and
   single-message `atm read`, including the ATM-authored Claude JSONL
   compatibility envelope for oversized message bodies
+- the remaining Phase S implementation work continues in:
+  - `S.6` daemon post-mortem runtime remediation
+  - `S.7` bounded queue-query implementation
+  - `S.8` Claude JSONL compatibility-envelope implementation
 
 Phase R execution entry:
 - Wave 1 deliverable: the new Phase R skeleton

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -54,7 +54,8 @@ Phase-S planning note:
 - S.5 is the follow-on planning slice that tightens the no-flaky-test policy,
   defines which anti-flake guardrails belong in the default lint path, and
   documents the bounded queue-query split between `atm list` and
-  single-message `atm read`
+  single-message `atm read`, including the ATM-authored Claude JSONL
+  compatibility envelope for oversized message bodies
 
 Phase R execution entry:
 - Wave 1 deliverable: the new Phase R skeleton
@@ -2538,6 +2539,8 @@ Core design decisions:
 - `atm doctor` remains a CLI command but must query daemon/runtime state in the
   Phase Q target architecture
 - Claude inbox JSONL remains compatibility ingress/egress only
+- ATM-authored JSONL export is a bounded compatibility projection over the full
+  durable SQLite message body
 - native agent/plugin traffic does not use JSONL
 - one daemon API, two production transport implementations:
   - cross-platform local IPC for same-host

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -51,8 +51,10 @@ Phase-S planning note:
   or from the governing requirements, architecture, ADR, and ICD documents it
   names; the project plan does not override those lower-level sources of truth
 - the planning baseline is `integrate/phase-R` at `6a072c1`
-- S.5 is the follow-on planning slice that tightens the no-flaky-test policy
-  and defines which anti-flake guardrails belong in the default lint path
+- S.5 is the follow-on planning slice that tightens the no-flaky-test policy,
+  defines which anti-flake guardrails belong in the default lint path, and
+  documents the bounded queue-query split between `atm list` and
+  single-message `atm read`
 
 Phase R execution entry:
 - Wave 1 deliverable: the new Phase R skeleton

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -51,6 +51,8 @@ Phase-S planning note:
   or from the governing requirements, architecture, ADR, and ICD documents it
   names; the project plan does not override those lower-level sources of truth
 - the planning baseline is `integrate/phase-R` at `6a072c1`
+- S.5 is the follow-on planning slice that tightens the no-flaky-test policy
+  and defines which anti-flake guardrails belong in the default lint path
 
 Phase R execution entry:
 - Wave 1 deliverable: the new Phase R skeleton

--- a/docs/read-behavior.md
+++ b/docs/read-behavior.md
@@ -1,69 +1,102 @@
-# ATM Read Behavior Review
+# ATM Queue List / Read Behavior Review
 
 **Lifecycle**: Permanent cross-cutting document
 
-This document remains part of the durable documentation set because read
+This document remains part of the durable documentation set because queue
 selection, bucket behavior, seen-state rules, and wait semantics are
 cross-cutting product behavior rather than crate-local implementation detail.
 
-This document defines the canonical read behavior for the rewrite and records which parts of current ATM behavior are preserved.
+This document defines the canonical queue-inspection behavior for the rewrite
+and records which parts of current ATM behavior are preserved.
 
 ## 1. Why This Document Exists
 
-The current read path mixes several concerns:
-- mail visibility
+The current `atm read` path mixes several concerns:
+- queue discovery
+- full message retrieval
 - workflow axes
 - display buckets
 - watermark tracking
 - wait-mode behavior
 
-That makes the command hard to reason about and easy to regress.
+That makes the command hard to reason about, easy to regress, and too eager to
+materialize long message bodies during ordinary queue inspection.
 
-The rewrite keeps the useful read behavior but makes the model explicit:
-- canonical message axes
-- display bucket mapping
-- selection policy
-- legal state transitions
+The rewrite keeps the useful queue behavior but makes the model explicit:
+- `atm list` owns metadata search
+- `atm read` owns one-message detail fetch
+- canonical message axes remain shared
+- display bucket mapping remains shared
+- selection policy and legal state transitions remain explicit in code
 
 ## 2. Best Current ATM Behavior To Preserve
 
-The current command already has useful queue behavior that should survive the rewrite:
+The current queue behavior already has useful properties that should survive
+the rewrite:
 - default view shows actionable work only
 - pending-ack messages stay visible until they are acknowledged
 - task-linked ack-required messages arrive already actionable
 - duplicate deliveries should collapse by `message_id` instead of showing the
   same message repeatedly
-- history can be expanded without hiding actionable work
+- history can still be expanded explicitly without hiding actionable work
 - `--all` shows everything
-- older unread messages remain visible even when the seen-state watermark is newer
-- last-seen updates from the latest displayed message, not the latest message in the inbox
+- older unread messages remain visible even when the seen-state watermark is
+  newer
+- last-seen updates from the latest displayed message, not the latest message
+  in the inbox
 
-The rewrite should preserve those behaviors while removing daemon coupling and making the workflow explicit in code.
+The rewrite should preserve those behaviors while removing the current
+multi-message `atm read` coupling and making the workflow explicit in code.
 
-## 3. Current Read Contract
+## 3. Queue Inspection Contract
 
-### 3.1 Display Buckets
+### 3.1 Command Split
 
-The current command exposes three display buckets:
+Queue inspection is split into two commands:
+
+- `atm list` returns compact metadata rows only
+- `atm read` returns one full message only
+
+`atm list` is the normal operator-facing queue search surface.
+
+`atm read` is the detail surface:
+- bare `atm read` returns the most recent unread actionable message
+- pending-ack messages are prioritized ahead of non-ack unread messages
+- selector-driven reads return the most recent match
+- additional matches are reported in metadata, not as more full message bodies
+
+### 3.2 Shared Filters
+
+`atm list` and `atm read` share one semantic filter model:
+- target inbox
+- `--team`
+- `--from`
+- `--since`
+- `--task`
+- `--contains`
+- `--unread`
+- `--pending-ack`
+- `--all`
+
+`atm list` may add pagination controls such as `--limit`.
+
+`--contains` must search full message body text as well as summary text.
+
+### 3.3 Display Buckets
+
+The shared queue model exposes three display buckets:
 - unread
 - pending ack
 - history
 
 Current default output:
-- show unread bucket
-- show pending-ack bucket
-- collapse history to a count line
+- `atm list` shows bounded actionable results by default
+- `atm read` renders one selected actionable message by default
+- history remains opt-in rather than implicit
 
-Current flag behavior:
-- default => actionable queue only
-- `--unread-only` => unread bucket only
-- `--pending-ack-only` => pending-ack bucket only
-- `--history` => actionable queue plus history bucket
-- `--all` => everything
+### 3.4 Watermark Behavior
 
-### 3.2 Watermark Behavior
-
-Current tests establish these rules:
+Retained tests and requirements establish these rules:
 - seen-state filtering is on by default
 - unread messages remain visible even when older than the watermark
 - pending-ack messages remain visible even when older than the watermark
@@ -71,12 +104,16 @@ Current tests establish these rules:
 - `--all` bypasses the seen-state filter
 - first run still shows only pending-action messages by default
 
-### 3.3 Current Mutation Behavior
+### 3.5 Mutation Behavior
 
-Current behavior when reading a message should become:
-- displayed messages are always written back with `read = true`
-- displayed unread messages in your own inbox also receive `pendingAckAt` when marking is enabled and the message did not already require acknowledgement
-- displayed unread messages that already require acknowledgement remain pending-ack after display
+Mutation belongs to `atm read`, not to `atm list`.
+
+Required `atm read` behavior:
+- the selected displayed message is always written back with `read = true`
+- selected unread messages in your own inbox also receive `pendingAckAt` when
+  marking is enabled and the message did not already require acknowledgement
+- selected unread messages that already require acknowledgement remain
+  pending-ack after display
 
 Current ack behavior:
 - an acknowledged message receives `acknowledgedAt`
@@ -87,7 +124,8 @@ Current clear behavior that must survive:
 - clear removes acknowledged messages
 - pending-ack messages are not clearable by default
 
-This behavior is messy in the current code because the state machine is implicit. The rewrite keeps the behavior but makes the state model explicit.
+This behavior is messy in the current code because the state machine is
+implicit. The rewrite keeps the behavior but makes the state model explicit.
 
 ## 4. Canonical Two-Axis Model
 
@@ -290,56 +328,97 @@ Classification boundary:
 Rendering boundary:
 - stateful core model -> CLI display buckets and rows
 
-## 10. Recommended Read Algorithm
+## 10. Recommended Queue Query Algorithm
+
+Shared query phases:
 
 1. Resolve actor identity and target inbox.
 2. Build the hostname registry for configured origin inboxes.
 3. Load the merged inbox surface.
-4. Convert wire records into canonical axis-typed messages and derive the display class.
-5. Apply sender and timestamp filters (`--from`, `--since`).
+4. Convert wire records into canonical axis-typed messages and derive the
+   display class.
+5. Apply sender, timestamp, task, and body-text filters.
 6. Apply seen-state filtering unless selection is `All`.
-7. Map derived message classes to display buckets and apply selection mode.
-8. If `--timeout` is set and the current selection is empty, wait for a newly eligible message.
+7. Map derived message classes to display buckets and apply queue selection.
+8. Deduplicate by `message_id`.
+
+`atm list` then:
+
 9. Sort newest-first and apply limit.
-10. Apply legal read-axis and ack-axis transitions for displayed messages if allowed.
-11. Persist state changes atomically.
-12. Update seen-state from the displayed set when enabled.
-13. Return `ReadOutcome`.
+10. Shape compact metadata rows only.
+11. Return `ListOutcome`.
+
+`atm read` then:
+
+9. Choose the most recent selected message.
+10. If `--timeout` is set and no selected message exists, wait for a newly
+    eligible message.
+11. Re-run selection and choose one selected message.
+12. Apply legal read-axis and ack-axis transitions for that one message if
+    allowed.
+13. Persist state changes atomically.
+14. Update seen-state from the selected message when enabled.
+15. Return `ReadOutcome` with match metadata.
 
 This order matters.
 
 In particular:
 - selection must happen before mutation
-- mutation must happen before final output is returned
-- seen-state updates must use the displayed set, not the full inbox
-- when the merged inbox surface includes origin inbox files, each displayed-message mutation must be written back to the physical source file for that record
+- `atm list` must not materialize or render multiple full message bodies
+- `atm read` must choose one message before mutation
+- mutation must happen before final `atm read` output is returned
+- seen-state updates must use the selected/displayed message, not the full
+  inbox
+- when the merged inbox surface includes origin inbox files, each
+  selected-message mutation must be written back to the physical source file
+  for that record
 
 ## 11. Output Contract
 
-Human output:
-- queue heading
-- bucket counts line
-- unread bucket
-- pending-ack bucket
-- optional history bucket
-- hidden-history line when history is collapsed
+`atm list` human output:
+- compact metadata rows only
+- no message body rendering
 
-JSON output:
+`atm list` JSON output:
+- `action = "list"`
+- `team`
+- `agent`
+- `messages`
+- `count`
+- `bucket_counts`
+
+Each list row:
+- `message_id`
+- `summary`
+- `from`
+- `timestamp`
+- `read`
+- `pending_ack`
+- `task_id`
+
+`atm read` human output:
+- one full message body
+- optional note when additional matches exist
+
+`atm read` JSON output:
 - `action = "read"`
 - `team`
 - `agent`
-- `messages` (selected messages only)
-- `count`
+- `message`
+- `selected_message_id`
+- `match_count`
+- `additional_match_count`
 - `bucket_counts`
 - `history_collapsed`
 
 Cross-document invariants:
-- displayed messages always persist `read = true`
+- displayed/read messages always persist `read = true`
 - task-linked messages are ack-required from send time
 - pending-ack messages remain actionable until acknowledged
 - `atm clear` never removes unread messages
 - `atm clear` never removes pending-ack messages
-- `--timeout` returns immediately when the requested selection is already non-empty
+- `--timeout` returns immediately when the requested selection is already
+  non-empty
 
 `bucket_counts` fields:
 - `unread`
@@ -348,11 +427,14 @@ Cross-document invariants:
 
 ## 12. Review Standard
 
-An implementation of `atm read` is acceptable only if:
+An implementation of the queue-inspection surface is acceptable only if:
 - it uses the canonical two-axis workflow model
 - it keeps display buckets separate from the canonical axes
 - it preserves default actionable-queue behavior
 - it preserves the current pending-ack lifecycle
 - it preserves task-linked pending-ack visibility until acknowledgement
-- no daemon-only logic survives in core read behavior
-- read-axis and ack-axis transitions are enforced by API shape, not only by tests
+- `atm list` stays metadata-only and bounded by query behavior
+- `atm read` returns one message and reports additional matches in metadata
+- no daemon-only logic survives in core queue behavior
+- read-axis and ack-axis transitions are enforced by API shape, not only by
+  tests

--- a/docs/read-behavior.md
+++ b/docs/read-behavior.md
@@ -82,7 +82,28 @@ Queue inspection is split into two commands:
 
 `--contains` must search full message body text as well as summary text.
 
-### 3.3 Display Buckets
+Legacy `atm read` flag migration:
+- `--unread-only` -> deprecated alias for `--unread`
+- `--pending-ack-only` -> deprecated alias for `--pending-ack`
+- `--history` -> deprecated alias for `--all`
+- `--since-last-seen` remains an explicit spelling of the default watermark
+  behavior
+
+### 3.3 Logical Current Message Selection
+
+Selector-driven queue inspection operates on logical current messages rather
+than raw predecessor rows.
+
+Rules:
+- successor/update chains are one logical message for UX
+- a logical message is represented by the terminal node in its successor chain
+- `atm list` rows represent those terminal-node logical messages
+- `atm read --task <task-id>` finds task-linked messages, collapses each chain
+  to its terminal node, and returns the most recent terminal-node logical
+  match
+- superseded predecessors must not appear as separate current matches
+
+### 3.4 Display Buckets
 
 The shared queue model exposes three display buckets:
 - unread
@@ -94,7 +115,7 @@ Current default output:
 - `atm read` renders one selected actionable message by default
 - history remains opt-in rather than implicit
 
-### 3.4 Watermark Behavior
+### 3.5 Watermark Behavior
 
 Retained tests and requirements establish these rules:
 - seen-state filtering is on by default
@@ -104,7 +125,7 @@ Retained tests and requirements establish these rules:
 - `--all` bypasses the seen-state filter
 - first run still shows only pending-action messages by default
 
-### 3.5 Mutation Behavior
+### 3.6 Mutation Behavior
 
 Mutation belongs to `atm read`, not to `atm list`.
 
@@ -394,7 +415,7 @@ Each list row:
 - `timestamp`
 - `read`
 - `pending_ack`
-- `task_id`
+- `task_id` (`null` in JSON output when the logical message is not task-linked)
 
 `atm read` human output:
 - one full message body
@@ -409,7 +430,10 @@ Each list row:
 - `match_count`
 - `additional_match_count`
 - `bucket_counts`
-- `history_collapsed`
+
+`match_count` is the total number of logical current-message matches after all
+filters and successor-chain collapse are applied. `additional_match_count` is
+`match_count - 1` for a successful read.
 
 Cross-document invariants:
 - displayed/read messages always persist `read = true`
@@ -425,7 +449,25 @@ Cross-document invariants:
 - `pending_ack`
 - `history`
 
-## 12. Review Standard
+## 12. Claude JSONL Compatibility Projection
+
+Claude inbox JSONL remains a compatibility surface, not the durable source of
+truth.
+
+Rules:
+- ATM keeps the full ATM-authored body in SQLite
+- the default ATM-authored JSONL body export cap is `128 KiB`
+- config `[atm].claude_jsonl_body_export_max_bytes` may lower that cap, including
+  `0`
+- when ATM skips a full ATM-authored body during JSONL export, the JSONL
+  `text` field becomes exactly:
+  - `atm read --message-id <id>`
+- summary remains populated
+- Claude-native inbound messages are not rewritten into ATM retrieval stubs
+- watcher/reconcile logic must treat re-observed ATM-authored compatibility
+  projections as idempotent and must not create self-induced churn loops
+
+## 13. Review Standard
 
 An implementation of the queue-inspection surface is acceptable only if:
 - it uses the canonical two-axis workflow model

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -4,9 +4,9 @@
 
 Product requirement ID:
 - `REQ-P-PRODUCT-001` The retained ATM product surface consists of
-  `send`, `read`, `ack`, `clear`, `log`, `doctor`, `teams`, and `members`,
-  backed by a singleton daemon runtime and SQLite source-of-truth for mail and
-  roster state in the current daemon architecture.
+  `send`, `list`, `read`, `ack`, `clear`, `log`, `doctor`, `teams`, and
+  `members`, backed by a singleton daemon runtime and SQLite source-of-truth
+  for mail and roster state in the current daemon architecture.
 
 Satisfied by:
 - intentionally undecomposed product requirement; this governs overall retained
@@ -22,6 +22,7 @@ surface.
 
 The retained product surface is:
 - `atm send`
+- `atm list`
 - `atm read`
 - `atm ack`
 - `atm clear`
@@ -106,6 +107,9 @@ Phase-S portability note:
   - `clear`
   - `doctor`
   - daemon heartbeat/runtime liveness exchange
+- S.5 planning adds `atm list` as a distinct CLI surface; implementation must
+  refine the current queue-query packet mapping rather than assuming the old
+  multi-message `read` response shape is still the final product contract
 - retained `log`, `teams`, and `members` remain outside the daemon
   request/response packet family in the current Phase S line
 - Phase S planning is tracked in [`plan-phase-S.md`](./plan-phase-S.md)
@@ -936,65 +940,124 @@ Dry-run JSON output must include:
 - `requires_ack`
 - `task_id`
 
-## 7. `atm read`
+## 7. Queue Inspection Surfaces (`atm list` and `atm read`)
 
-Product requirement ID:
-- `REQ-P-READ-001` `atm read` must satisfy the documented read/selection/wait
-  contract.
+Product requirement IDs:
+- `REQ-P-LIST-001` `atm list` must satisfy the bounded queue/search contract.
+- `REQ-P-READ-001` `atm read` must satisfy the documented single-message
+  selection, mutation, and wait contract.
 
 Satisfied by:
 - `REQ-ATM-CMD-001` for CLI entry, parsing, and dispatch aspects
 - `REQ-ATM-OUT-001` for human-readable and JSON output aspects
 - `REQ-CORE-CONFIG-002` for target-validation aspects
+- `REQ-CORE-LIST-001` for bounded metadata search, row shaping, and shared
+  filter semantics
 - `REQ-CORE-MAILBOX-001` for merged inbox load/persist aspects
 - `REQ-CORE-WORKFLOW-001` for classification, queue selection, and legal
   transition aspects
 
-### 7.1 Purpose
+### 7.1 Shared Purpose
 
-Read messages from one inbox.
+Queue inspection is split into two commands:
 
-### 7.2 Supported Flags
+- `atm list` finds messages without returning full message bodies
+- `atm read` opens one full message
 
+The split exists so ATM can keep default queue inspection bounded even when
+SQLite-backed mailbox history grows without a practical fixed upper bound.
+
+### 7.2 Shared Selection And Filter Contract
+
+Shared queue filters:
 - optional target: `agent` or `agent@team`
 - `--team <name>`
+- `--from <name>`
+- `--since <iso8601>`
+- `--task <task-id>`
+- `--contains <text>`
+- `--unread`
+- `--pending-ack`
 - `--all`
-- `--unread-only`
-- `--pending-ack-only`
-- `--history`
+- `--json`
+- `--as <name>`
+
+Shared rules:
+- both commands must default to the caller's own inbox when no target agent is
+  provided
+- both commands must resolve identity and target address using the defined
+  precedence
+- both commands must verify target team exists
+- both commands must verify explicit target agent exists in team config
+- both commands must support the same semantic message filters even when their
+  output shapes differ
+- `--contains` must search both summary text and full message body text
+- both commands must preserve origin-inbox visibility when bridge remotes are
+  configured
+
+### 7.3 `atm list`
+
+Additional supported flags:
+- `--limit <n>`
+
+Required behavior:
+- load the mailbox/query surface through a bounded metadata-first query path
+- return compact rows only, not full message bodies
+- support the canonical row fields:
+  - `message_id`
+  - `summary`
+  - `from`
+  - `timestamp`
+  - `read`
+  - `pending_ack`
+  - `task_id` when present
+- sort newest-first before limiting
+- perform no read-state or ack-state mutation
+- keep default output bounded to actionable/head results rather than
+  materializing full history by default
+
+### 7.4 `atm read`
+
+Additional supported flags:
+- `--message-id <id>`
+- `--timeout <seconds>`
 - `--since-last-seen`
 - `--no-since-last-seen`
 - `--no-mark`
 - `--no-update-seen`
-- `--limit <n>`
-- `--since <iso8601>`
-- `--from <name>`
-- `--json`
-- `--timeout <seconds>`
-- `--as <name>`
 
-### 7.3 Required Behavior
-
-- default to the caller’s own inbox when no target agent is provided
-- resolve identity and target address using the defined precedence
-- verify target team exists
-- verify explicit target agent exists in team config
-- load messages from the merged inbox surface
-- deduplicate entries by `message_id` before bucket selection and output rendering
-- classify each message into the read axis, the ack axis, and a derived message class
-- map the derived message class into display buckets
-- support filtering by sender and timestamp
-- support selection by queue mode
-- preserve origin-inbox visibility when bridge remotes are configured
-- sort newest-first before limiting
-- write displayed messages back through the read-axis mutation rules
-- persist read-triggered state changes back to the physical inbox file that owns each displayed message when origin inbox files are present in the merged surface
+Required behavior:
+- return exactly one full message
+- when `--message-id <id>` is present, resolve that exact message when present
+- when selectors such as `--task`, `--from`, `--since`, `--contains`,
+  `--unread`, or `--pending-ack` match multiple messages, return the most
+  recent match
+- when multiple matches exist, include:
+  - `selected_message_id`
+  - `match_count`
+  - `additional_match_count`
+- when no selector is provided, return the most recent unread actionable
+  message
+- when no selector is provided, prioritize pending-ack messages ahead of
+  unread messages that do not require acknowledgement
 - support optional wait mode with timeout
-- support optional seen-state filtering and updates
+- write the selected message back through the read-axis mutation rules
+- persist read-triggered state changes back to the physical inbox file that
+  owns the selected displayed message when origin inbox files are present in
+  the merged surface
 
-When multiple inbox entries share the same non-null `message_id`, `atm read`
-must display only the most recent entry. Earlier duplicates are silently
-suppressed.
+### 7.5 Shared Message Classification And Deduplication
+
+- load messages from the merged inbox surface
+- deduplicate entries by `message_id` before bucket selection and output
+  rendering
+- classify each message into the read axis, the ack axis, and a derived
+  message class
+- map the derived message class into display buckets
+
+When multiple inbox entries share the same non-null `message_id`, queue
+inspection must display only the most recent entry. Earlier duplicates are
+silently suppressed.
 
 Deduplication order:
 - compare entries by `message_id`
@@ -1002,11 +1065,9 @@ Deduplication order:
 - when timestamps are equal, keep the later record encountered in inbox order
 - do not emit suppressed duplicates in either human or JSON output
 
-`--timeout` preserves the current queue-first behavior: if the requested read selection already contains unread or pending-ack messages at command start, the command returns immediately with those messages. It blocks only when the requested selection is empty at command start.
+### 7.6 Display Buckets
 
-### 7.4 Display Buckets
-
-The CLI exposes three display buckets:
+The shared queue model exposes three display buckets:
 - `unread`
 - `pending_ack`
 - `history`
@@ -1017,32 +1078,23 @@ Bucket mapping from the derived message class:
 - `Read` -> `history`
 - `Acknowledged` -> `history`
 
-The display buckets are a presentation contract. They are not the canonical two-axis model.
+The display buckets are a presentation contract. They are not the canonical
+two-axis model.
 
-### 7.5 Selection Modes
+### 7.7 Default Selection And Historical Expansion
 
-Default selection is the actionable queue:
-- unread
-- pending-ack
+Default queue inspection behavior:
+- `atm list` returns a bounded actionable/head view
+- bare `atm read` returns one selected actionable message
+- `--all` is the explicit full-surface override and may be slower
 
-Explicit selection modes:
-- default => actionable queue only
-- `--unread-only` => unread bucket only
-- `--pending-ack-only` => pending-ack bucket only
-- `--history` => actionable queue plus history bucket
-- `--all` => all buckets and bypass seen-state filtering
-
-Mutual exclusion:
-- `--all`
-- `--unread-only`
-- `--pending-ack-only`
-- `--history`
-
-### 7.6 Seen-State Rules
+### 7.8 Seen-State Rules
 
 Seen-state is enabled by default unless `--no-since-last-seen` is set.
 
-`--since-last-seen` explicitly enables the default watermark filter. When set explicitly, it behaves the same as the default. If both `--since-last-seen` and `--no-since-last-seen` appear, `--no-since-last-seen` wins.
+`--since-last-seen` explicitly enables the default watermark filter. When set
+explicitly, it behaves the same as the default. If both `--since-last-seen`
+and `--no-since-last-seen` appear, `--no-since-last-seen` wins.
 
 When seen-state is enabled and a watermark exists:
 - unread messages remain eligible even when older than the watermark
@@ -1050,8 +1102,8 @@ When seen-state is enabled and a watermark exists:
 - history messages are filtered by the watermark
 
 On a true first run with no stored watermark:
-- the default read view still shows only actionable messages
-- historical messages remain hidden unless `--history` or `--all` is used
+- the default queue view still shows only actionable messages
+- historical messages remain hidden unless `--all` is used
 
 `--all` bypasses seen-state filtering entirely.
 
@@ -1059,31 +1111,45 @@ If seen-state updates are enabled:
 - update the watermark using the latest displayed message timestamp
 - do not use non-displayed messages when computing the watermark
 
-`--no-update-seen`: when this flag is set, messages are read and displayed normally but the seen-state watermark is not updated after the operation. The watermark is left unchanged regardless of which messages were displayed.
+`--no-update-seen`: when this flag is set, messages are read and displayed
+normally but the seen-state watermark is not updated after the operation. The
+watermark is left unchanged regardless of which messages were displayed.
 
-`--since <iso8601>`: filters to messages whose `timestamp` field is greater than or equal to the given ISO 8601 datetime. It filters by message timestamp, not by the seen-state watermark. It may be combined with seen-state filtering; both constraints apply independently.
+`--since <iso8601>` filters to messages whose `timestamp` field is greater
+than or equal to the given ISO 8601 datetime. It filters by message timestamp,
+not by the seen-state watermark. It may be combined with seen-state filtering;
+both constraints apply independently.
 
-`--from <name>` in read context is a sender filter: it restricts displayed messages to those sent by the named agent. It does not override the caller's identity.
+`--from <name>` is a sender filter: it restricts matched messages to those
+sent by the named agent. It does not override the caller's identity.
 
-### 7.7 Wait Mode Rules
+### 7.9 Wait Mode Rules
 
-When `--timeout <seconds>` is set:
-- establish the read selection baseline after actor resolution, inbox loading, workflow classification, and filter application
-- if the requested selection already contains eligible messages at wait start, return immediately without blocking
-- otherwise block until a newly arrived message becomes eligible for the requested read selection, or until the timeout expires
-- re-run the normal read selection over the updated merged inbox surface once a new eligible message arrives
-- preserve the same sender, timestamp, seen-state, and selection filters during the wait
+When `--timeout <seconds>` is set on `atm read`:
+- establish the read selection baseline after actor resolution, inbox loading,
+  workflow classification, and filter application
+- if the requested selection already contains an eligible message at wait
+  start, return immediately without blocking
+- otherwise block until a newly arrived message becomes eligible for the
+  requested read selection, or until the timeout expires
+- re-run the normal selection over the updated merged inbox surface once a new
+  eligible message arrives
+- preserve the same sender, timestamp, seen-state, and selection filters
+  during the wait
 
 Timeout success condition:
-- either the initial selection is already non-empty, or at least one message that was not eligible at wait start becomes eligible before the timeout expires
+- either the initial selection is already non-empty, or at least one message
+  that was not eligible at wait start becomes eligible before the timeout
+  expires
 
 Timeout failure condition:
-- the initial selection is empty and no newly eligible message arrives before the timeout expires
+- the initial selection is empty and no newly eligible message arrives before
+  the timeout expires
 
-### 7.8 Mutation Rules
+### 7.10 Mutation Rules
 
 Base display mutation:
-- any displayed message is written back with `read = true`
+- any selected message is written back with `read = true`
 
 Ack-axis activation on display happens only when:
 - the caller is reading their own inbox
@@ -1106,43 +1172,42 @@ No additional ack-axis mutation happens when:
 - the message is already `Acknowledged`
 - the message is already `Read`
 
-### 7.9 Processing Order
+### 7.11 Output Contract
 
-1. resolve actor and target inbox
-2. build the hostname registry for configured origin inboxes
-3. load messages from the merged inbox surface
-4. classify canonical state
-5. apply sender and timestamp filters (`--from`, `--since`)
-6. apply seen-state filter when enabled and selection is not `--all`
-7. map canonical state to display buckets and apply selection mode
-8. if `--timeout` is set and the current selection is empty, block until a newly eligible message arrives or the timeout expires
-9. sort newest-first and apply limit
-10. apply read-axis and ack-axis transitions to displayed messages
-11. persist read-triggered state changes atomically
-12. update seen-state when enabled
-13. render output
+`atm list` human-readable output must remain metadata-only.
 
-### 7.10 Output Contract
-
-Human output must preserve the current queue-oriented shape:
-- queue heading
-- bucket counts line
-- bucketed message output
-- hidden-history summary when history is collapsed
-
-JSON output must include:
-- `action = "read"`
+`atm list` JSON output must include:
+- `action = "list"`
 - `team`
 - `agent`
 - `messages`
 - `count`
 - `bucket_counts`
-- `history_collapsed`
 
-`bucket_counts` fields:
-- `unread`
+Every list row must include:
+- `message_id`
+- `summary`
+- `from`
+- `timestamp`
+- `read`
 - `pending_ack`
-- `history`
+- `task_id`
+
+`atm read` JSON output must include:
+- `action = "read"`
+- `team`
+- `agent`
+- `message`
+- `selected_message_id`
+- `match_count`
+- `additional_match_count`
+- `bucket_counts`
+- `history_collapsed` when applicable
+
+Human-readable `atm read` output must render one message body only. When
+additional matches exist, it must state that more matches were found and direct
+the operator to `atm list` for metadata inspection instead of emitting
+additional full bodies.
 
 ## 8. `atm ack`
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -514,6 +514,7 @@ Required config fields:
 Supported optional config fields:
 - `[atm].team_members`
 - `[atm].aliases`
+- `[atm].claude_jsonl_body_export_max_bytes`
 - `[[atm.post_send_hooks]]`
 
 Runtime identity rules:
@@ -530,6 +531,9 @@ Runtime identity rules:
   should always be present in `config.json`
 - `.atm.toml` may define `[atm].aliases` for ATM-owned shorthand addressing of
   canonical member identities
+- `.atm.toml` may define `[atm].claude_jsonl_body_export_max_bytes` as the
+  ATM-authored Claude JSONL body export cap; `0` means stub-only ATM-authored
+  export
 - `.atm.toml` may define one or more `[[atm.post_send_hooks]]` rules for
   best-effort recipient-scoped post-send automation
 - retired `[atm].post_send_hook`, `[atm].post_send_hook_senders`,
@@ -979,6 +983,8 @@ Shared queue filters:
 - `--unread`
 - `--pending-ack`
 - `--all`
+
+Shared command options:
 - `--json`
 - `--as <name>`
 
@@ -987,6 +993,8 @@ Shared rules:
   provided
 - both commands must resolve identity and target address using the defined
   precedence
+- `--as <name>` changes caller identity resolution, not message matching
+- `--json` changes output format only and is not a message-selection filter
 - both commands must verify target team exists
 - both commands must verify explicit target agent exists in team config
 - both commands must support the same semantic message filters even when their
@@ -995,6 +1003,14 @@ Shared rules:
 - both commands must preserve origin-inbox visibility when bridge remotes are
   configured
 
+Legacy `atm read` flag migration:
+- `--unread-only` is a deprecated alias for `--unread`
+- `--pending-ack-only` is a deprecated alias for `--pending-ack`
+- `--history` is a deprecated alias for `--all`
+- `--since-last-seen` remains accepted as an explicit restatement of the
+  default seen-state filter
+- deprecation warnings must direct operators to the new flag names
+
 ### 7.3 `atm list`
 
 Additional supported flags:
@@ -1002,6 +1018,7 @@ Additional supported flags:
 
 Required behavior:
 - load the mailbox/query surface through a bounded metadata-first query path
+- query logical current messages rather than superseded predecessors
 - return compact rows only, not full message bodies
 - support the canonical row fields:
   - `message_id`
@@ -1010,8 +1027,11 @@ Required behavior:
   - `timestamp`
   - `read`
   - `pending_ack`
-  - `task_id` when present
+  - `task_id`, with `null` in JSON output when the logical message is not
+    task-linked
 - sort newest-first before limiting
+- compute bucket/count summaries through bounded summary queries rather than by
+  materializing every full message body for operator-facing response shaping
 - perform no read-state or ack-state mutation
 - keep default output bounded to actionable/head results rather than
   materializing full history by default
@@ -1029,6 +1049,12 @@ Additional supported flags:
 Required behavior:
 - return exactly one full message
 - when `--message-id <id>` is present, resolve that exact message when present
+- collapse successor/update chains to their terminal node before selector-based
+  matching so superseded predecessors do not appear as separate current
+  messages
+- when `--task <task-id>` is present, find task-linked messages, collapse each
+  successor chain to its terminal node, then select the most recent logical
+  current message
 - when selectors such as `--task`, `--from`, `--since`, `--contains`,
   `--unread`, or `--pending-ack` match multiple messages, return the most
   recent match
@@ -1036,6 +1062,9 @@ Required behavior:
   - `selected_message_id`
   - `match_count`
   - `additional_match_count`
+- `match_count` is the total number of logical current-message matches after
+  all filters and successor-chain collapse are applied
+- `additional_match_count` is `match_count - 1` for a successful read
 - when no selector is provided, return the most recent unread actionable
   message
 - when no selector is provided, prioritize pending-ack messages ahead of
@@ -1191,7 +1220,7 @@ Every list row must include:
 - `timestamp`
 - `read`
 - `pending_ack`
-- `task_id`
+- `task_id` (`null` when the logical message is not task-linked)
 
 `atm read` JSON output must include:
 - `action = "read"`
@@ -1202,7 +1231,6 @@ Every list row must include:
 - `match_count`
 - `additional_match_count`
 - `bucket_counts`
-- `history_collapsed` when applicable
 
 Human-readable `atm read` output must render one message body only. When
 additional matches exist, it must state that more matches were found and direct
@@ -3045,9 +3073,24 @@ mail correctness.
   - once team roster and pane mapping truth move to SQLite, ATM-owned
     post-send-hook payloads must carry the authoritative `recipient_pane_id`
     from roster truth when known
-  - post-send hooks must be able to rely on that payload field instead of
-    rediscovering pane mappings from local files once the Phase Q migration is
-    complete
+- post-send hooks must be able to rely on that payload field instead of
+  rediscovering pane mappings from local files once the Phase Q migration is
+  complete
+  - ATM-authored JSONL exports must remain valid JSONL records with ATM machine
+    fields under `metadata.atm`
+  - the default ATM-authored JSONL body export cap is `128 KiB`
+  - ATM must expose config `[atm].claude_jsonl_body_export_max_bytes`; `0`
+    means stub-only ATM-authored export
+  - when an ATM-authored body exceeds the configured export cap, the exported
+    JSONL `text` field must be exactly `atm read --message-id <id>`
+  - summary text must remain populated when ATM exports that retrieval stub
+  - the full ATM-authored body must remain durable in SQLite even when JSONL
+    export is stubbed
+  - Claude-native inbound messages must not be rewritten into ATM retrieval
+    stubs
+  - watcher/reconcile logic must treat re-observed ATM-authored compatibility
+    projections for the same logical message as idempotent state, not as new
+    logical mail
 
 - `REQ-CORE-COMPAT-002` Native agent/plugin traffic must not use JSONL.
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1979,8 +1979,16 @@ Required testing architecture:
   - retry sleeps
   - environment mutation races
   - auto-start side effects
+  - unbounded waits
+  - panic-unsafe shared/global test hooks
 - these patterns are treated as sources of flake and false confidence rather
   than as acceptable test infrastructure
+- a test that might hang is invalid even if it does not use
+  `thread::sleep(...)`
+- tests must use bounded waits tied to observable predicates or handshakes
+- bare `join()`, `recv()`, `wait()`, or equivalent waits are prohibited in
+  risky runtime/daemon test paths unless completion has already been proven by
+  a bounded synchronization step
 - test code must not use or reintroduce the current daemon-spawn pattern by
   name:
   - `spawn_test_daemon`
@@ -3111,6 +3119,9 @@ mail correctness.
   - fixed `thread::sleep(...)` in ordinary Rust test code must fail a
     test-hygiene gate unless the file or callsite is explicitly part of the
     narrow daemon-runtime suite
+  - mechanically-detectable unbounded wait patterns in the narrow same-host
+    daemon/runtime suites must move into repository lint or analyzer gates once
+    the rule shape is proven deterministic enough for default local use
   - `PORT-004` must reject production `std::os::unix` imports that are not
     protected by an approved Unix-only boundary
   - `PORT-005` must reject

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -107,9 +107,10 @@ Phase-S portability note:
   - `clear`
   - `doctor`
   - daemon heartbeat/runtime liveness exchange
-- S.5 planning adds `atm list` as a distinct CLI surface; implementation must
-  refine the current queue-query packet mapping rather than assuming the old
-  multi-message `read` response shape is still the final product contract
+- S.5 planning adds `atm list` as a distinct CLI surface; S.7 owns the
+  implementation line that refines the current queue-query packet mapping
+  instead of assuming the old multi-message `read` response shape is still the
+  final product contract
 - retained `log`, `teams`, and `members` remain outside the daemon
   request/response packet family in the current Phase S line
 - Phase S planning is tracked in [`plan-phase-S.md`](./plan-phase-S.md)

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -28,6 +28,8 @@ Most tests must not depend on:
 - retry sleeps
 - environment mutation races
 - auto-start side effects
+- unbounded waits
+- panic-unsafe shared/global test hooks
 
 These patterns are treated as sources of flake and false confidence rather
 than as acceptable test infrastructure.
@@ -49,6 +51,10 @@ singleton lint gate:
   to justify fixed warmup sleeps in ordinary tests
 - ad hoc daemon auto-start retries used as test stabilization
 - fixed sleeps that attempt to wait for daemon socket publication
+- unbounded `recv()`, `wait()`, or equivalent blocking operations used as the
+  correctness mechanism in risky daemon/runtime tests
+- bare `join()` when the test has no prior bounded proof that the worker is
+  already complete
 - parent-process environment mutation when command-local `Command::env(...)`
   or explicit in-process injection can be used instead
 
@@ -137,12 +143,15 @@ Phase S adds one mandatory coverage layer for daemon hosting:
 - When environment variables are necessary, prefer `Command::env(...)` over
   mutating the parent process.
 - Retry loops and sleeps are not correctness mechanisms.
+- Tests must not contain a path that can block indefinitely.
 - Bounded retry/sleep may appear only inside the dedicated daemon-runtime suite
   when required to observe a documented runtime invariant, and the reason must
   be explicit in the test.
 - Fixed sleeps are prohibited in cross-platform same-host functional tests even
   inside daemon-host coverage; readiness and shutdown must use explicit
   synchronization, bounded protocol deadlines, or observable runtime state
+- Shared/global test hooks must use panic-safe cleanup so failure paths cannot
+  strand state into later tests
 
 ## 6. Lint And CI Enforcement
 
@@ -160,6 +169,9 @@ Required behavior:
 - fail on new ad hoc daemon launch helpers
 - fail on timing-based daemon stabilization patterns that bypass the approved
   test tiers
+- fail on newly-added cheap-to-detect unbounded wait patterns in the narrow
+  same-host daemon/runtime suites once the rule family is promoted from S.5
+  planning into the default lint path
 - document an explicit allow-list for Tier 3 daemon-runtime suite patterns so
   the narrow exceptions remain auditable
 - treat an empty allow-list as explicit "no approved exceptions"


### PR DESCRIPTION
## Summary
- add S.5 planning for phase-wide no-flaky-test hardening
- add ADR-008 for the no-flaky-test policy and mechanical enforcement split
- tighten Phase S, top-level requirements, and test/cross-platform guidelines around bounded waits and anti-flake guardrails

## Validation
- just lint
