### PR TITLE
feat: add plan-hardening skill and template

### DIFF
--- a/.claude/skills/plan-hardening/SKILL.md
+++ b/.claude/skills/plan-hardening/SKILL.md
@@ -4,9 +4,9 @@ version: 1.0.0
 description: >
   Orchestrate a full documentation hardening pass for a multi-sprint development
   phase before implementation starts or resumes. Use when team-lead needs
-  arch-ctm to capture all known plan decisions, create any missing sprint docs,
-  and loop on audit/fix until the phase docs are complete, consistent, and
-  execution-ready.
+  arch-ctm to capture already-decided plan work, create any missing sprint
+  docs, and loop on audit/fix until the phase docs are complete, consistent,
+  and execution-ready.
 depends_on:
   codex-orchestration: 0.x
 ---
@@ -42,17 +42,19 @@ Do not use this skill for ordinary implementation or QA fix rounds. Use it only
 for the planning/documentation hardening step that `team-lead` delegates to
 `arch-ctm`.
 
-Use it only after the user discussion is complete enough that `team-lead`
-understands what the hardening task must accomplish and can delegate one stable
-task scope to `arch-ctm`.
+Use it only after the user discussion is complete enough that the plan
+decisions have already been communicated to `arch-ctm`. `team-lead` uses this
+skill to route work and provide a worktree, not to reinterpret or restate the
+plan.
 
 ## Prerequisites
 
 Before dispatching a hardening task:
 
 1. The target phase worktree exists and is on the correct branch.
-2. The user or team already knows the substantive plan decisions.
-3. `team-lead` can provide a concise `plan_context` summary in the assignment.
+2. `team-lead` created or obtained that worktree before assignment.
+3. The user or team already knows the substantive plan decisions, and those
+   decisions have already been communicated to `arch-ctm`.
 4. `sc-compose` is available for rendering the XML assignment template.
 
 If the plan is still being invented, finish the design discussion first. This
@@ -91,12 +93,22 @@ Prepare:
 - `worktree_path`
 - `branch`
 - `pr_target`
-- `plan_context`
+- `source_of_truth`
+- `questions_or_concerns`
 - `references`
 
-`plan_context` must summarize the known plan decisions that are already agreed
-but may not yet be fully documented. Keep it concise but concrete. The
-assignment tells `arch-ctm` not to rediscover the plan from scratch.
+`team-lead` is not the authority for re-summarizing the plan. The assignment
+must point at the already-approved source of truth that `arch-ctm` should use,
+for example:
+
+- the already-reviewed planning documents in the repo
+- a verbatim user-approved plan capsule previously authored by `arch-ctm`
+- explicit references to the prior planning discussion already completed with
+  `arch-ctm`
+
+`questions_or_concerns` is optional but recommended. Use it to append any
+specific team-lead concerns, ambiguities, or review points that `arch-ctm`
+should address immediately in the ACK before starting work.
 
 ### 2. Render the assignment template for `arch-ctm`
 
@@ -122,7 +134,8 @@ Suggested vars file shape:
   "worktree_path": "/abs/worktree",
   "branch": "feature/pS-plan-hardening",
   "pr_target": "integrate/phase-S",
-  "plan_context": "- Remaining work requires S.6-S.8 ...\n- atm list / atm read split is already decided ...",
+  "source_of_truth": "- User-approved planning discussion already completed with arch-ctm\n- docs/project-plan.md\n- docs/plan-phase-S.md\n- docs/requirements.md\n- docs/architecture.md",
+  "questions_or_concerns": "- Confirm whether missing follow-on sprints must be created on this branch if the current phase plan stops too early.",
   "references": "- docs/project-plan.md\n- docs/plan-phase-S.md\n- docs/requirements.md\n- docs/architecture.md"
 }
 ```
@@ -154,6 +167,10 @@ After the hardening push and validation report:
 The assignment template bakes in these hard requirements:
 
 - the plan is already known and must be captured before hardening begins
+- `team-lead` is responsible for worktree creation before assignment
+- `worktree_path` and `branch` are mandatory routing fields
+- `team-lead` provides routing metadata and any concerns, but does not rewrite
+  the source-of-truth plan content
 - all required document classes are audited
 - missing sprint docs are `GAP` findings
 - all unassigned remaining implementation work is `GAP`
@@ -164,7 +181,11 @@ The assignment template bakes in these hard requirements:
 
 ## Anti-Patterns
 
-- Do not send a hardening task without `plan_context`.
+- Do not send a hardening task before the worktree exists.
+- Do not send a hardening task with a rewritten freeform summary when
+  `arch-ctm` already has the user-approved plan in context or in source docs.
+- Do not omit `questions_or_concerns` if `team-lead` already knows there are
+  specific concerns that should be addressed immediately in the ACK.
 - Do not allow the agent to stop after "requirements and architecture are good"
   while remaining work still lacks sprint ownership.
 - Do not accept a phase plan that ends before the remaining work ends.

--- a/.claude/skills/plan-hardening/SKILL.md
+++ b/.claude/skills/plan-hardening/SKILL.md
@@ -2,11 +2,8 @@
 name: plan-hardening
 version: 1.0.0
 description: >
-  Orchestrate a full documentation hardening pass for a multi-sprint development
-  phase before implementation starts or resumes. Use when team-lead needs
-  arch-ctm to capture already-decided plan work, create any missing sprint
-  docs, and loop on audit/fix until the phase docs are complete, consistent,
-  and execution-ready.
+  Team-lead delegates plan hardening to arch-ctm after the user has already
+  discussed the plan details with arch-ctm.
 depends_on:
   codex-orchestration: 0.x
 ---
@@ -15,102 +12,61 @@ depends_on:
 
 Audience: `team-lead` only.
 
-Use this skill when a phase plan exists but the phase is not ready to execute
-because the documentation set may still be incomplete, inconsistent, or missing
-follow-on sprint decomposition.
+Use this only for phase-plan hardening before implementation starts or resumes.
 
-This skill is specifically for the "before implementation starts" or
-"before implementation resumes" hardening pass that turns a known plan into an
-execution-ready document set.
+If the user invokes this skill, that means that the plan details have already
+been discussed and are fresh in arch-ctm context. Do not request details from
+the user, the details will surface when the plan is delivered.
 
-## When To Use It
+`team-lead` is responsible for routing, worktree creation, and assignment
+metadata. `team-lead` is not the authority for rewriting the plan.
 
-Use `/plan-hardening` when one or more of these are true:
+## Preconditions
 
-- the phase has known product or architecture decisions that are not yet landed
-  in the required docs
-- requirements or ADRs mention remaining work that is not yet assigned to a
-  specific sprint
-- the phase currently stops at `S.N`, but everyone already knows more sprints
-  will be needed to finish the phase
-- protocol/schema/boundary docs changed, but the sprint sequence has not been
-  reconciled to those changes
-- the team wants a "zero findings" hardening loop before starting or resuming a
-  multi-sprint execution line
+- the target phase worktree already exists
+- `worktree_path` and `branch` are known
+- `sc-compose` is available
+- the plan has already been discussed with `arch-ctm`
 
-Do not use this skill for ordinary implementation or QA fix rounds. Use it only
-for the planning/documentation hardening step that `team-lead` delegates to
-`arch-ctm`.
+## Expected Result
 
-Use it only after the user discussion is complete enough that the plan
-decisions have already been communicated to `arch-ctm`. `team-lead` uses this
-skill to route work and provide a worktree, not to reinterpret or restate the
-plan.
+The task must end with:
+- complete/consistent planning docs
+- a hardened sprint doc for every sprint still required to finish the phase
+- no unassigned in-scope implementation work
+- branch pushed, validation reported, and plan review requested
 
-## Prerequisites
+Any remaining in-scope work without sprint ownership is a `GAP`. If more
+sprints are needed, hardening must create them.
 
-Before dispatching a hardening task:
+## Team-Lead Steps
 
-1. The target phase worktree exists and is on the correct branch.
-2. `team-lead` created or obtained that worktree before assignment.
-3. The user or team already knows the substantive plan decisions, and those
-   decisions have already been communicated to `arch-ctm`.
-4. `sc-compose` is available for rendering the XML assignment template.
+1. Prepare:
+   - `phase_id`
+   - `task_id`
+   - `description`
+   - `worktree_path`
+   - `branch`
+   - `pr_target`
+   - `source_of_truth`
+   - optional `questions_or_concerns`
+   - `references`
+2. Render `.claude/skills/plan-hardening/plan-hardening.xml.j2` with
+   `sc-compose`.
+3. Send the rendered ATM task to `arch-ctm`.
+4. Review the result:
+   - final finding count is `0`
+   - every remaining work item is assigned to a sprint
+   - missing sprint docs were created if needed
+   - branch was pushed and validation reported
 
-If the plan is still being invented, finish the design discussion first. This
-skill assumes the plan is already known and needs to be captured and hardened.
-
-## Required Outputs
-
-The hardening task must leave the phase with:
-
-- a top-level project plan that reflects the phase status
-- a phase plan document that covers the whole remaining phase
-- a hardened sprint doc for every sprint required to finish the phase
-- product requirements and architecture aligned with the phase
-- crate-local requirements/architecture docs for every affected crate
-- ADRs for every significant architectural decision plus an updated ADR index
-- protocol/schema/interface docs for every touched boundary
-- machine-readable boundary definitions for every boundary in scope
-- an issues inventory that matches the current state
-- testing and cross-platform guidance when the phase touches those concerns
-
-Critical rule:
-- any remaining in-scope implementation work not assigned to a specific sprint
-  doc is a `GAP` finding
-- if more sprints are needed beyond the currently documented set, new sprint
-  docs must be created during hardening
-
-## Team-Lead Workflow
-
-### 1. Assemble the plan context
-
-Prepare:
-
-- `phase_id`
-- `task_id`
-- `description`
-- `worktree_path`
-- `branch`
-- `pr_target`
-- `source_of_truth`
-- `questions_or_concerns`
-- `references`
-
-`team-lead` is not the authority for re-summarizing the plan. The assignment
-must point at the already-approved source of truth that `arch-ctm` should use,
-for example:
-
-- the already-reviewed planning documents in the repo
-- a verbatim user-approved plan capsule previously authored by `arch-ctm`
-- explicit references to the prior planning discussion already completed with
+`source_of_truth` should point at the already-approved planning sources:
+- reviewed planning docs in the repo
+- a verbatim user-approved plan capsule
+- explicit references to prior planning discussion already completed with
   `arch-ctm`
 
-`questions_or_concerns` is optional but recommended. Use it to append any
-specific team-lead concerns, ambiguities, or review points that `arch-ctm`
-should address immediately in the ACK before starting work.
-
-### 2. Render the assignment template for `arch-ctm`
+If `questions_or_concerns` is present, `arch-ctm` should answer it in the ACK.
 
 Render:
 - `.claude/skills/plan-hardening/plan-hardening.xml.j2`
@@ -140,54 +96,9 @@ Suggested vars file shape:
 }
 ```
 
-### 3. Send the rendered XML to `arch-ctm`
+## Guardrails
 
-The rendered template is an ATM task message whose assignee is `arch-ctm`.
-`team-lead` uses this skill to delegate the hardening work; `team-lead` does
-not perform the hardening loop directly.
-
-### 4. Review the hardening result
-
-Before accepting the result:
-
-- confirm the hardening report says `Final finding count: 0`
-- confirm every remaining in-scope work item is assigned to a sprint
-- confirm missing sprint docs were created if the phase needed more sprints
-- confirm the branch is pushed and validation is reported
-
-### 5. Route plan QA
-
-After the hardening push and validation report:
-
-- request a `quality-mgr` plan review if the phase is important enough to gate
-  before implementation
-
-## Template Contract
-
-The assignment template bakes in these hard requirements:
-
-- the plan is already known and must be captured before hardening begins
-- `team-lead` is responsible for worktree creation before assignment
-- `worktree_path` and `branch` are mandatory routing fields
-- `team-lead` provides routing metadata and any concerns, but does not rewrite
-  the source-of-truth plan content
-- all required document classes are audited
-- missing sprint docs are `GAP` findings
-- all unassigned remaining implementation work is `GAP`
-- sprint docs must be execution-ready, not just placeholders
-- audit/fix repeats until zero findings
-- the hardening work is delegated to `arch-ctm` through ATM, not executed
-  inline by `team-lead`
-
-## Anti-Patterns
-
-- Do not send a hardening task before the worktree exists.
-- Do not send a hardening task with a rewritten freeform summary when
-  `arch-ctm` already has the user-approved plan in context or in source docs.
-- Do not omit `questions_or_concerns` if `team-lead` already knows there are
-  specific concerns that should be addressed immediately in the ACK.
-- Do not allow the agent to stop after "requirements and architecture are good"
-  while remaining work still lacks sprint ownership.
-- Do not accept a phase plan that ends before the remaining work ends.
-- Do not treat ADR or architecture text as sufficient if no sprint owns the
-  implementation.
+- do not send the task before the worktree exists
+- do not rewrite the plan into a freeform summary
+- do not let the task stop while remaining work lacks sprint ownership
+- do not accept a phase plan that ends before the remaining work ends

--- a/.claude/skills/plan-hardening/SKILL.md
+++ b/.claude/skills/plan-hardening/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: plan-hardening
+version: 1.0.0
+description: >
+  Orchestrate a full documentation hardening pass for a multi-sprint development
+  phase before implementation starts or resumes. Use when team-lead needs
+  arch-ctm to capture all known plan decisions, create any missing sprint docs,
+  and loop on audit/fix until the phase docs are complete, consistent, and
+  execution-ready.
+depends_on:
+  codex-orchestration: 0.x
+---
+
+# Plan Hardening
+
+Audience: `team-lead` only.
+
+Use this skill when a phase plan exists but the phase is not ready to execute
+because the documentation set may still be incomplete, inconsistent, or missing
+follow-on sprint decomposition.
+
+This skill is specifically for the "before implementation starts" or
+"before implementation resumes" hardening pass that turns a known plan into an
+execution-ready document set.
+
+## When To Use It
+
+Use `/plan-hardening` when one or more of these are true:
+
+- the phase has known product or architecture decisions that are not yet landed
+  in the required docs
+- requirements or ADRs mention remaining work that is not yet assigned to a
+  specific sprint
+- the phase currently stops at `S.N`, but everyone already knows more sprints
+  will be needed to finish the phase
+- protocol/schema/boundary docs changed, but the sprint sequence has not been
+  reconciled to those changes
+- the team wants a "zero findings" hardening loop before starting or resuming a
+  multi-sprint execution line
+
+Do not use this skill for ordinary implementation or QA fix rounds. Use it only
+for the planning/documentation hardening step that `team-lead` delegates to
+`arch-ctm`.
+
+Use it only after the user discussion is complete enough that `team-lead`
+understands what the hardening task must accomplish and can delegate one stable
+task scope to `arch-ctm`.
+
+## Prerequisites
+
+Before dispatching a hardening task:
+
+1. The target phase worktree exists and is on the correct branch.
+2. The user or team already knows the substantive plan decisions.
+3. `team-lead` can provide a concise `plan_context` summary in the assignment.
+4. `sc-compose` is available for rendering the XML assignment template.
+
+If the plan is still being invented, finish the design discussion first. This
+skill assumes the plan is already known and needs to be captured and hardened.
+
+## Required Outputs
+
+The hardening task must leave the phase with:
+
+- a top-level project plan that reflects the phase status
+- a phase plan document that covers the whole remaining phase
+- a hardened sprint doc for every sprint required to finish the phase
+- product requirements and architecture aligned with the phase
+- crate-local requirements/architecture docs for every affected crate
+- ADRs for every significant architectural decision plus an updated ADR index
+- protocol/schema/interface docs for every touched boundary
+- machine-readable boundary definitions for every boundary in scope
+- an issues inventory that matches the current state
+- testing and cross-platform guidance when the phase touches those concerns
+
+Critical rule:
+- any remaining in-scope implementation work not assigned to a specific sprint
+  doc is a `GAP` finding
+- if more sprints are needed beyond the currently documented set, new sprint
+  docs must be created during hardening
+
+## Team-Lead Workflow
+
+### 1. Assemble the plan context
+
+Prepare:
+
+- `phase_id`
+- `task_id`
+- `description`
+- `worktree_path`
+- `branch`
+- `pr_target`
+- `plan_context`
+- `references`
+
+`plan_context` must summarize the known plan decisions that are already agreed
+but may not yet be fully documented. Keep it concise but concrete. The
+assignment tells `arch-ctm` not to rediscover the plan from scratch.
+
+### 2. Render the assignment template for `arch-ctm`
+
+Render:
+- `.claude/skills/plan-hardening/plan-hardening.xml.j2`
+
+Example:
+
+```bash
+sc-compose render \
+  --root .claude/skills/plan-hardening \
+  --file plan-hardening.xml.j2 \
+  --var-file /tmp/plan-hardening-vars.json
+```
+
+Suggested vars file shape:
+
+```json
+{
+  "task_id": "TASK-1234",
+  "phase": "phase-S",
+  "description": "Harden the second half of Phase S before implementation resumes.",
+  "worktree_path": "/abs/worktree",
+  "branch": "feature/pS-plan-hardening",
+  "pr_target": "integrate/phase-S",
+  "plan_context": "- Remaining work requires S.6-S.8 ...\n- atm list / atm read split is already decided ...",
+  "references": "- docs/project-plan.md\n- docs/plan-phase-S.md\n- docs/requirements.md\n- docs/architecture.md"
+}
+```
+
+### 3. Send the rendered XML to `arch-ctm`
+
+The rendered template is an ATM task message whose assignee is `arch-ctm`.
+`team-lead` uses this skill to delegate the hardening work; `team-lead` does
+not perform the hardening loop directly.
+
+### 4. Review the hardening result
+
+Before accepting the result:
+
+- confirm the hardening report says `Final finding count: 0`
+- confirm every remaining in-scope work item is assigned to a sprint
+- confirm missing sprint docs were created if the phase needed more sprints
+- confirm the branch is pushed and validation is reported
+
+### 5. Route plan QA
+
+After the hardening push and validation report:
+
+- request a `quality-mgr` plan review if the phase is important enough to gate
+  before implementation
+
+## Template Contract
+
+The assignment template bakes in these hard requirements:
+
+- the plan is already known and must be captured before hardening begins
+- all required document classes are audited
+- missing sprint docs are `GAP` findings
+- all unassigned remaining implementation work is `GAP`
+- sprint docs must be execution-ready, not just placeholders
+- audit/fix repeats until zero findings
+- the hardening work is delegated to `arch-ctm` through ATM, not executed
+  inline by `team-lead`
+
+## Anti-Patterns
+
+- Do not send a hardening task without `plan_context`.
+- Do not allow the agent to stop after "requirements and architecture are good"
+  while remaining work still lacks sprint ownership.
+- Do not accept a phase plan that ends before the remaining work ends.
+- Do not treat ADR or architecture text as sufficient if no sprint owns the
+  implementation.

--- a/.claude/skills/plan-hardening/SKILL.md
+++ b/.claude/skills/plan-hardening/SKILL.md
@@ -68,6 +68,10 @@ sprints are needed, hardening must create them.
 
 If `questions_or_concerns` is present, `arch-ctm` should answer it in the ACK.
 
+The ACK should also include a brief outline of the plan/work that `arch-ctm`
+understands to be in scope. `team-lead` should wait for that ACK and outline
+before raising scope concerns or discussing adjustments with the user.
+
 Render:
 - `.claude/skills/plan-hardening/plan-hardening.xml.j2`
 

--- a/.claude/skills/plan-hardening/plan-hardening.xml.j2
+++ b/.claude/skills/plan-hardening/plan-hardening.xml.j2
@@ -10,7 +10,7 @@ required_variables:
   - worktree_path
   - branch
   - pr_target
-  - plan_context
+  - source_of_truth
   - references
 ---
 <atm-task id="{{ task_id }}" sprint="{{ phase }}" assignee="arch-ctm" mode="plan-hardening">
@@ -20,9 +20,15 @@ required_variables:
   <branch>{{ branch }}</branch>
   <pr-target>{{ pr_target }}</pr-target>
 
-  <plan-context>
-{{ plan_context }}
-  </plan-context>
+  <source-of-truth>
+{{ source_of_truth }}
+  </source-of-truth>
+
+{% if questions_or_concerns is defined and questions_or_concerns | trim %}
+  <questions-or-concerns>
+{{ questions_or_concerns }}
+  </questions-or-concerns>
+{% endif %}
 
   <references>
 {{ references }}
@@ -36,6 +42,11 @@ required_variables:
     in context. Use the required-documents list as the target: every
     decision, definition, and constraint in context must land in the
     correct document before hardening begins.
+
+    The source-of-truth plan content comes from the user-approved material
+    already communicated to you plus the explicit source-of-truth references in
+    this task. `team-lead` is routing this task and may append questions or
+    concerns, but must not be treated as the authority for rewriting the plan.
 
     Any remaining in-scope implementation work not assigned to a specific
     sprint doc is a GAP finding. If the known remaining work extends beyond the
@@ -150,7 +161,7 @@ required_variables:
   </plan-hardening>
 
   <workflow>
-    <step id="a">ACK this message immediately. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
+    <step id="a">ACK this message immediately. If the task includes questions-or-concerns, address them explicitly in the ACK before starting work. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
     <step id="b">Immediately after ACK, begin executing the task in the same work session.</step>
     <step id="c">Before editing, update the worktree from the target branch and include prior fixes already merged to that target.</step>
     <step id="d">As soon as the hardening changes are complete and the branch is pushable, commit and push immediately. Send branch name and commit hash right away so plan review can begin in parallel.</step>

--- a/.claude/skills/plan-hardening/plan-hardening.xml.j2
+++ b/.claude/skills/plan-hardening/plan-hardening.xml.j2
@@ -161,7 +161,7 @@ required_variables:
   </plan-hardening>
 
   <workflow>
-    <step id="a">ACK this message immediately. If the task includes questions-or-concerns, address them explicitly in the ACK before starting work. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
+    <step id="a">ACK this message immediately. In the ACK, include a brief outline of the plan/work you understand to be in scope. If the task includes questions-or-concerns, address them explicitly in the same ACK before starting work. Team-lead should review that ACK and outline first, then discuss any scope concerns with the user after the ACK is received. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
     <step id="b">Immediately after ACK, begin executing the task in the same work session.</step>
     <step id="c">Before editing, update the worktree from the target branch and include prior fixes already merged to that target.</step>
     <step id="d">As soon as the hardening changes are complete and the branch is pushable, commit and push immediately. Send branch name and commit hash right away so plan review can begin in parallel.</step>

--- a/.claude/skills/plan-hardening/plan-hardening.xml.j2
+++ b/.claude/skills/plan-hardening/plan-hardening.xml.j2
@@ -167,6 +167,7 @@ required_variables:
     <step id="d">As soon as the hardening changes are complete and the branch is pushable, commit and push immediately. Send branch name and commit hash right away so plan review can begin in parallel.</step>
     <step id="e">After the push report, run the required validation. Do not wait for PR creation before starting validation.</step>
     <step id="f">When validation completes, send a second report with PASS or FAIL, concrete failure details if any, and whether follow-up fixes are required.</step>
-    <step id="g">After the validation report, read ATM again for follow-up work.</step>
+    <step id="g">After the hardening loop converges, ensure all document updates are staged, committed, and pushed. Send the git commit hash to team-lead and request a quality-mgr critical plan review.</step>
+    <step id="h">After the validation report, read ATM again for follow-up work.</step>
   </workflow>
 </atm-task>

--- a/.claude/skills/plan-hardening/plan-hardening.xml.j2
+++ b/.claude/skills/plan-hardening/plan-hardening.xml.j2
@@ -1,0 +1,161 @@
+---
+name: plan-hardening-task
+version: 1.0.0
+description: team-lead assignment template for full phase-plan hardening before implementation.
+format: xml
+required_variables:
+  - task_id
+  - phase
+  - description
+  - worktree_path
+  - branch
+  - pr_target
+  - plan_context
+  - references
+---
+<atm-task id="{{ task_id }}" sprint="{{ phase }}" assignee="arch-ctm" mode="plan-hardening">
+  <description>{{ description }}</description>
+
+  <worktree>{{ worktree_path }}</worktree>
+  <branch>{{ branch }}</branch>
+  <pr-target>{{ pr_target }}</pr-target>
+
+  <plan-context>
+{{ plan_context }}
+  </plan-context>
+
+  <references>
+{{ references }}
+  </references>
+
+  <plan-hardening>
+    You have the full plan in context. Your job is to ensure everything
+    you know is captured in the required documents, then harden those
+    documents until they are complete, consistent, and unambiguous.
+    Do not re-read documents to discover the plan — the plan is already
+    in context. Use the required-documents list as the target: every
+    decision, definition, and constraint in context must land in the
+    correct document before hardening begins.
+
+    Any remaining in-scope implementation work not assigned to a specific
+    sprint doc is a GAP finding. If the known remaining work extends beyond the
+    currently documented sprint set, create the additional sprint docs required
+    to finish the phase.
+
+    Sprint docs are not considered hardened unless they provide execution-ready
+    guidance:
+    - goal
+    - hard dependencies
+    - exact code or document targets when applicable
+    - required work
+    - acceptance criteria
+    - required validation
+
+    <audit-phase>
+      Verify that every document in the required-documents list exists,
+      is complete, and is consistent with all other documents and with
+      everything currently in context. Then create a structured task list
+      of all findings. Do not begin the fix phase until the task list
+      is complete.
+
+      <required-documents>
+        <doc id="project-plan">
+          Top-level project-plan covering the phase and all sprints in the phase.
+        </doc>
+        <doc id="phase-plan">
+          Phase plan covering the whole remaining phase, including every sprint
+          required to finish the phase.
+        </doc>
+        <doc id="sprint-plan">
+          A hardened sprint doc for every sprint in the phase. A sprint doc that
+          is referenced in the phase plan but does not exist is a GAP finding.
+        </doc>
+        <doc id="requirements">
+          Product requirements covering all features and behaviors in scope.
+        </doc>
+        <doc id="architecture">
+          Product architecture document.
+        </doc>
+        <doc id="crate-docs">
+          Requirements and architecture docs for every crate affected by this phase.
+        </doc>
+        <doc id="adrs">
+          An ADR for every significant architectural decision, plus an up-to-date ADR index.
+        </doc>
+        <doc id="protocol-schema-interface">
+          Protocol, schema, and interface docs for every boundary touched by this phase.
+        </doc>
+        <doc id="machine-readable-boundaries">
+          Machine-readable boundary definitions (e.g. interface contracts, schema files)
+          for every architectural boundary in scope.
+        </doc>
+        <doc id="issues-inventory">
+          Issues inventory reflecting the current state of known issues and their disposition.
+        </doc>
+        <doc id="testing-cross-platform">
+          Testing and cross-platform guidance. Required when the phase touches
+          platform-specific behavior or has cross-platform acceptance criteria.
+        </doc>
+        <doc id="process-qa-triage">
+          Process, QA, and triage docs or prompts when the phase changes ATM
+          workflow, triage flow, QA routing, or shared coordination prompts.
+        </doc>
+      </required-documents>
+
+      Each entry in the task list must include:
+        - Finding number
+        - Document name and section (or "missing" if the document does not exist)
+        - Finding type (from the list below)
+        - One-sentence description of the problem
+
+      <finding-types>
+        <type id="GAP">Required detail is absent entirely, or a required document does not exist.</type>
+        <type id="VAGUE">Language is ambiguous or leaves an implementation choice to the developer that the plan should resolve explicitly.</type>
+        <type id="CONTRA">Two or more documents contradict each other.</type>
+        <type id="MISSING-ADR">A significant architectural decision is made inline without a corresponding ADR.</type>
+        <type id="BOUNDARY">An architectural boundary, module ownership rule, or interface contract is undefined or incompletely specified.</type>
+        <type id="UNDEF">An important type, trait, struct, enum, or protocol is referenced but not explicitly defined in any document.</type>
+        <type id="CROSS-DOC">A definition or decision in one document is not reflected consistently in documents that depend on it.</type>
+        <type id="ORDERING">Task dependencies are missing or incorrectly ordered such that a dev agent could begin work out of sequence.</type>
+      </finding-types>
+    </audit-phase>
+
+    <fix-phase>
+      Work through every finding in the task list in order. For each finding:
+        1. State the finding number and type.
+        2. Describe the fix being applied.
+        3. Apply the fix. Fixes may require updating an existing document
+           or creating a new document (e.g. a missing sprint plan, ADR, or
+           architecture definition). Both are valid and expected fix actions.
+        4. Confirm the fix did not introduce a new finding.
+        5. Mark the finding as resolved in the task list.
+    </fix-phase>
+
+    <repeat>
+      After all findings are resolved, return to audit-phase and repeat.
+      Continue until audit-phase produces zero findings.
+    </repeat>
+
+    <exit-criterion>
+      Output this report when audit-phase produces zero findings:
+
+        HARDENING COMPLETE
+        Iterations:                           N
+        Total findings resolved:              N
+        Final finding count:                  0
+        Dev-agent decision points eliminated: N
+        Documents modified:                   [list]
+        Documents created:                    [list]
+    </exit-criterion>
+  </plan-hardening>
+
+  <workflow>
+    <step id="a">ACK this message immediately. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
+    <step id="b">Immediately after ACK, begin executing the task in the same work session.</step>
+    <step id="c">Before editing, update the worktree from the target branch and include prior fixes already merged to that target.</step>
+    <step id="d">As soon as the hardening changes are complete and the branch is pushable, commit and push immediately. Send branch name and commit hash right away so plan review can begin in parallel.</step>
+    <step id="e">After the push report, run the required validation. Do not wait for PR creation before starting validation.</step>
+    <step id="f">When validation completes, send a second report with PASS or FAIL, concrete failure details if any, and whether follow-up fixes are required.</step>
+    <step id="g">After the validation report, read ATM again for follow-up work.</step>
+  </workflow>
+</atm-task>

--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -48,6 +48,7 @@ After initialization, use these repo-local skills to coordinate work:
 |-------|---------|
 | `/phase-orchestration` | Orchestrate a multi-sprint phase with fresh scrum-masters |
 | `/codex-orchestration` | Run phases where arch-ctm is sole dev, with pipelined QA via quality-mgr |
+| `/plan-hardening` | Harden a phase plan and create any missing sprint docs before implementation starts or resumes |
 | `/triaging-findings` | Correlate QA findings across branches before dispatching fixes to arch-ctm |
 | `/quality-management-gh` | Multi-pass QA on GitHub PRs; CI monitoring; findings/final quality reports |
 | `/restore-team-communications` | Repair same-session Claude teammate routing after compaction or resume without invoking full startup/clear restore |


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/plan-hardening/SKILL.md` — team-lead orchestration guide for pre-implementation phase doc hardening passes (audit→fix loop until zero findings)
- Adds `.claude/skills/plan-hardening/plan-hardening.xml.j2` — sc-compose delegation template for dispatching hardening tasks to arch-ctm
- Updates `.claude/skills/team-lead/SKILL.md` to reference the new skill

## Test plan

- [ ] `just lint` PASS (confirmed at 1006813)
- [ ] SKILL.md renders correctly with sc-compose
- [ ] Template variables match SKILL.md documented vars file shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)