### PR TITLE
S.9: host-scoped logging defaults (~/.atm/logs/, ATM_LOG_DIR, ADR-011)

### DIFF
--- a/crates/atm-core/src/boundary_support.rs
+++ b/crates/atm-core/src/boundary_support.rs
@@ -44,7 +44,7 @@ pub fn load_workspace_config(request: ConfigLoadRequest) -> Result<ConfigLoadRes
 pub fn load_team_config(
     request: ConfigTeamLoadRequest,
 ) -> Result<ConfigTeamLoadResponse, AtmError> {
-    let team_dir = home::team_dir_from_home(&request.home_dir, request.team.as_str())?;
+    let team_dir = home::team_dir_from_home(&request.home_dir, &request.team)?;
     let team_config = config::load_team_config(&team_dir)?;
     Ok(ConfigTeamLoadResponse {
         team_dir,

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -78,6 +78,24 @@ pub fn host_mail_db_path_from_home(home_dir: &Path) -> PathBuf {
     host_db_dir_from_home(home_dir).join("mail.db")
 }
 
+/// Resolve the host-scoped ATM retained log directory independent of `ATM_HOME`.
+///
+/// # Errors
+///
+/// Returns [`AtmError`] when the OS user-home directory cannot be resolved.
+pub fn host_log_dir() -> Result<PathBuf, AtmError> {
+    if let Some(path) = env::var_os("ATM_LOG_DIR").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(path));
+    }
+
+    Ok(host_log_dir_from_home(&resolve_user_home()?))
+}
+
+/// Resolve the host-scoped ATM retained log directory from an explicit user-home root.
+pub fn host_log_dir_from_home(home_dir: &Path) -> PathBuf {
+    home_dir.join(".atm").join("logs")
+}
+
 /// Resolve the team directory for `team` under the current ATM home.
 ///
 /// # Errors
@@ -166,12 +184,12 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        atm_home, host_db_dir_from_home, host_mail_db_path_from_home, host_runtime_dir_from_home,
-        host_runtime_lock_path_from_home, inbox_path, inbox_path_from_home, team_dir,
-        team_dir_from_home, workflow_state_path_from_home,
+        atm_home, host_db_dir_from_home, host_log_dir_from_home, host_mail_db_path_from_home,
+        host_runtime_dir_from_home, host_runtime_lock_path_from_home, inbox_path,
+        inbox_path_from_home, team_dir, team_dir_from_home, workflow_state_path_from_home,
     };
     #[cfg(unix)]
-    use super::{host_db_dir, host_mail_db_path, host_runtime_dir};
+    use super::{host_db_dir, host_log_dir, host_mail_db_path, host_runtime_dir};
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
 
     // Serializes process-environment mutation inside this test module. This is
@@ -361,6 +379,43 @@ mod tests {
             host_mail_db_path_from_home(tempdir.path()),
             tempdir.path().join(".atm").join("db").join("mail.db")
         );
+    }
+
+    #[test]
+    fn host_log_dir_from_home_uses_fixed_atm_logs_subtree() {
+        let tempdir = TempDir::new().expect("tempdir");
+        assert_eq!(
+            host_log_dir_from_home(tempdir.path()),
+            tempdir.path().join(".atm").join("logs")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn host_log_dir_prefers_atm_log_dir_override() {
+        let _guard = env_lock().lock().expect("env lock");
+        let tempdir = TempDir::new().expect("tempdir");
+        let _atm_log_dir =
+            EnvGuard::set_raw("ATM_LOG_DIR", tempdir.path().to_str().expect("utf8 path"));
+
+        let resolved = host_log_dir().expect("host log dir");
+        assert_eq!(resolved, tempdir.path());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn host_log_dir_uses_os_home_not_atm_home() {
+        let _guard = env_lock().lock().expect("env lock");
+        let atm_home_dir = TempDir::new().expect("atm home");
+        let os_home_dir = TempDir::new().expect("os home");
+        let _atm_home = EnvGuard::set("ATM_HOME", atm_home_dir.path());
+        let _atm_log_dir = EnvGuard::remove("ATM_LOG_DIR");
+        let _home = EnvGuard::set_raw("HOME", os_home_dir.path().to_str().expect("utf8 path"));
+
+        let resolved = host_log_dir().expect("host log dir");
+        assert_eq!(resolved, os_home_dir.path().join(".atm").join("logs"));
     }
 
     #[test]

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -282,6 +282,7 @@ mod tests {
             }
         }
 
+        #[cfg(unix)]
         fn set_many<const N: usize>(changes: [(&'static str, Option<&str>); N]) -> LocalEnvSet {
             let guard = env_lock().lock().expect("env lock");
             let restorations = changes
@@ -308,6 +309,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     struct LocalEnvSet {
         restorations: Vec<(&'static str, Option<OsString>)>,
         _guard: MutexGuard<'static, ()>,
@@ -328,6 +330,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     impl Drop for LocalEnvSet {
         fn drop(&mut self) {
             for (key, original) in self.restorations.iter_mut().rev() {
@@ -592,9 +595,10 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn host_log_dir_rejects_non_absolute_override() {
+        let tempdir = TempDir::new().expect("tempdir");
         let _env = LocalEnvGuard::set_many([
             ("ATM_LOG_DIR", Some("relative/logs")),
-            ("HOME", Some("/tmp")),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
         ]);
 
         let error = host_log_dir().expect_err("non-absolute ATM_LOG_DIR should fail");
@@ -602,6 +606,8 @@ mod tests {
         assert!(error.message.contains("absolute path"));
     }
 
+    /// Windows ATM_LOG_DIR path-shape validation is covered by cross-compile CI
+    /// (`cargo xwin check`) rather than native test execution.
     #[cfg(unix)]
     #[test]
     #[serial_test::serial]

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -625,8 +625,7 @@ mod tests {
         use std::os::unix::ffi::OsStringExt;
 
         let home_dir = TempDir::new().expect("home");
-        let _home =
-            LocalEnvGuard::set_raw("HOME", home_dir.path().to_str().expect("utf8 path"));
+        let _home = LocalEnvGuard::set_raw("HOME", home_dir.path().to_str().expect("utf8 path"));
         let _atm_log_dir = Utf8EnvGuard {
             key: "ATM_LOG_DIR",
             original: std::env::var_os("ATM_LOG_DIR"),

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -5,6 +5,8 @@ use crate::address::validate_path_segment;
 use crate::error::AtmError;
 use crate::types::{AgentName, TeamName};
 
+const MAX_HOST_LOG_DIR_UTF8_BYTES: usize = 4096;
+
 /// Resolve the ATM home directory for the current process.
 ///
 /// # Errors
@@ -92,6 +94,16 @@ pub fn host_log_dir() -> Result<PathBuf, AtmError> {
                 "Set ATM_LOG_DIR to an absolute UTF-8 local filesystem path outside ~/.claude/ and ~/.atm/daemon/ before retrying.",
             )
         })?;
+        if raw_path.len() > MAX_HOST_LOG_DIR_UTF8_BYTES {
+            return Err(
+                AtmError::config(format!(
+                    "ATM_LOG_DIR must not exceed {MAX_HOST_LOG_DIR_UTF8_BYTES} UTF-8 bytes"
+                ))
+                .with_recovery(
+                    "Shorten ATM_LOG_DIR to a local filesystem path no longer than 4096 UTF-8 bytes before retrying.",
+                ),
+            );
+        }
         let path = PathBuf::from(raw_path);
         if !path.is_absolute() {
             return Err(
@@ -223,6 +235,8 @@ pub fn resolve_user_home() -> Result<PathBuf, AtmError> {
         .ok_or_else(AtmError::home_directory_unavailable)
 }
 
+/// Unix-only ATM_LOG_DIR validation tests cover non-UTF-8 and path-shape cases.
+/// Windows keeps these invariants compile-checked here and exercises them in cross-target validation.
 #[cfg(test)]
 mod tests {
     #[cfg(unix)]
@@ -232,9 +246,10 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        atm_home, host_db_dir_from_home, host_log_dir_from_home, host_mail_db_path_from_home,
-        host_runtime_dir_from_home, host_runtime_lock_path_from_home, inbox_path,
-        inbox_path_from_home, team_dir, team_dir_from_home, workflow_state_path_from_home,
+        MAX_HOST_LOG_DIR_UTF8_BYTES, atm_home, host_db_dir_from_home, host_log_dir_from_home,
+        host_mail_db_path_from_home, host_runtime_dir_from_home, host_runtime_lock_path_from_home,
+        inbox_path, inbox_path_from_home, team_dir, team_dir_from_home,
+        workflow_state_path_from_home,
     };
     #[cfg(any(unix, windows))]
     use super::{host_db_dir, host_log_dir, host_mail_db_path, host_runtime_dir};
@@ -636,6 +651,22 @@ mod tests {
         let error = host_log_dir().expect_err("non-utf8 override should fail");
         assert!(error.is_config());
         assert!(error.message.contains("UTF-8"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn host_log_dir_rejects_overlong_override() {
+        let home_dir = TempDir::new().expect("home");
+        let too_long = format!("/{}", "a".repeat(MAX_HOST_LOG_DIR_UTF8_BYTES));
+        let _env = LocalEnvGuard::set_many([
+            ("ATM_LOG_DIR", Some(too_long.as_str())),
+            ("HOME", Some(home_dir.path().to_str().expect("utf8 path"))),
+        ]);
+
+        let error = host_log_dir().expect_err("overlong ATM_LOG_DIR should fail");
+        assert!(error.is_config());
+        assert!(error.message.contains("4096"));
     }
 
     #[cfg(unix)]

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::address::validate_path_segment;
 use crate::error::AtmError;
+use crate::types::{AgentName, TeamName};
 
 /// Resolve the ATM home directory for the current process.
 ///
@@ -84,11 +85,53 @@ pub fn host_mail_db_path_from_home(home_dir: &Path) -> PathBuf {
 ///
 /// Returns [`AtmError`] when the OS user-home directory cannot be resolved.
 pub fn host_log_dir() -> Result<PathBuf, AtmError> {
-    if let Some(path) = env::var_os("ATM_LOG_DIR").filter(|value| !value.is_empty()) {
-        return Ok(PathBuf::from(path));
+    let user_home = resolve_user_home()?;
+    if let Some(raw_path) = env::var_os("ATM_LOG_DIR").filter(|value| !value.is_empty()) {
+        let raw_path = raw_path.to_str().ok_or_else(|| {
+            AtmError::config("ATM_LOG_DIR must be valid UTF-8").with_recovery(
+                "Set ATM_LOG_DIR to an absolute UTF-8 local filesystem path outside ~/.claude/ and ~/.atm/daemon/ before retrying.",
+            )
+        })?;
+        let path = PathBuf::from(raw_path);
+        if !path.is_absolute() {
+            return Err(
+                AtmError::config(format!(
+                    "ATM_LOG_DIR must be an absolute path: {}",
+                    path.display()
+                ))
+                .with_recovery(
+                    "Set ATM_LOG_DIR to an absolute local filesystem path outside ~/.claude/ and ~/.atm/daemon/ before retrying.",
+                ),
+            );
+        }
+        let daemon_dir = host_runtime_dir_from_home(&user_home);
+        if path.starts_with(&daemon_dir) || daemon_dir.starts_with(&path) {
+            return Err(
+                AtmError::config(format!(
+                    "ATM_LOG_DIR must not overlap the host-scoped daemon runtime directory {}",
+                    daemon_dir.display()
+                ))
+                .with_recovery(
+                    "Point ATM_LOG_DIR at a separate absolute log directory outside ~/.atm/daemon/ before retrying.",
+                ),
+            );
+        }
+        let claude_dir = user_home.join(".claude");
+        if path.starts_with(&claude_dir) {
+            return Err(
+                AtmError::config(format!(
+                    "ATM_LOG_DIR must not resolve under the Claude home directory {}",
+                    claude_dir.display()
+                ))
+                .with_recovery(
+                    "Point ATM_LOG_DIR at an ATM-owned absolute log directory outside ~/.claude/ before retrying.",
+                ),
+            );
+        }
+        return Ok(path);
     }
 
-    Ok(host_log_dir_from_home(&resolve_user_home()?))
+    Ok(host_log_dir_from_home(&user_home))
 }
 
 /// Resolve the host-scoped ATM retained log directory from an explicit user-home root.
@@ -102,7 +145,7 @@ pub fn host_log_dir_from_home(home_dir: &Path) -> PathBuf {
 ///
 /// Propagates [`atm_home`] failures when the ATM home directory cannot be
 /// resolved.
-pub fn team_dir(team: &str) -> Result<PathBuf, AtmError> {
+pub fn team_dir(team: &TeamName) -> Result<PathBuf, AtmError> {
     team_dir_from_home(&atm_home()?, team)
 }
 
@@ -112,7 +155,7 @@ pub fn team_dir(team: &str) -> Result<PathBuf, AtmError> {
 ///
 /// Propagates [`atm_home`] failures when the ATM home directory cannot be
 /// resolved.
-pub fn inbox_path(team: &str, agent: &str) -> Result<PathBuf, AtmError> {
+pub fn inbox_path(team: &TeamName, agent: &AgentName) -> Result<PathBuf, AtmError> {
     inbox_path_from_home(&atm_home()?, team, agent)
 }
 
@@ -124,9 +167,9 @@ pub fn inbox_path(team: &str, agent: &str) -> Result<PathBuf, AtmError> {
 /// [`crate::error_codes::AtmErrorCode::AddressParseFailed`] when `team`
 /// contains path traversal, path separators, or other invalid path-segment
 /// characters.
-pub fn team_dir_from_home(home_dir: &Path, team: &str) -> Result<PathBuf, AtmError> {
-    validate_path_segment(team, "team")?;
-    Ok(home_dir.join(".claude").join("teams").join(team))
+pub fn team_dir_from_home(home_dir: &Path, team: &TeamName) -> Result<PathBuf, AtmError> {
+    validate_path_segment(team.as_str(), "team")?;
+    Ok(home_dir.join(".claude").join("teams").join(team.as_str()))
 }
 
 /// Resolve the primary inbox path for `agent` in `team` under an explicit ATM home root.
@@ -137,8 +180,12 @@ pub fn team_dir_from_home(home_dir: &Path, team: &str) -> Result<PathBuf, AtmErr
 /// [`crate::error_codes::AtmErrorCode::AddressParseFailed`] when `team` or
 /// `agent` contains path traversal, path separators, or other invalid
 /// path-segment characters.
-pub fn inbox_path_from_home(home_dir: &Path, team: &str, agent: &str) -> Result<PathBuf, AtmError> {
-    validate_path_segment(agent, "agent")?;
+pub fn inbox_path_from_home(
+    home_dir: &Path,
+    team: &TeamName,
+    agent: &AgentName,
+) -> Result<PathBuf, AtmError> {
+    validate_path_segment(agent.as_str(), "agent")?;
     Ok(team_dir_from_home(home_dir, team)?
         .join("inboxes")
         .join(format!("{agent}.json")))
@@ -154,17 +201,17 @@ pub fn inbox_path_from_home(home_dir: &Path, team: &str, agent: &str) -> Result<
 /// path-segment characters.
 pub fn workflow_state_path_from_home(
     home_dir: &Path,
-    team: &str,
-    agent: &str,
+    team: &TeamName,
+    agent: &AgentName,
 ) -> Result<PathBuf, AtmError> {
-    validate_path_segment(agent, "agent")?;
+    validate_path_segment(agent.as_str(), "agent")?;
     Ok(team_dir_from_home(home_dir, team)?
         .join(".atm-state")
         .join("workflow")
         .join(format!("{agent}.json")))
 }
 
-fn resolve_user_home() -> Result<PathBuf, AtmError> {
+pub fn resolve_user_home() -> Result<PathBuf, AtmError> {
     env::var_os("HOME")
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
@@ -178,8 +225,9 @@ fn resolve_user_home() -> Result<PathBuf, AtmError> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use std::ffi::OsString;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     use tempfile::TempDir;
 
@@ -188,71 +236,105 @@ mod tests {
         host_runtime_dir_from_home, host_runtime_lock_path_from_home, inbox_path,
         inbox_path_from_home, team_dir, team_dir_from_home, workflow_state_path_from_home,
     };
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     use super::{host_db_dir, host_log_dir, host_mail_db_path, host_runtime_dir};
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
+    use crate::types::{AgentName, TeamName};
 
-    // Serializes process-environment mutation inside this test module. This is
-    // process-local only; it does not coordinate with other test processes.
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
-    struct EnvGuard {
+    struct LocalEnvGuard {
         key: &'static str,
         original: Option<OsString>,
+        _guard: MutexGuard<'static, ()>,
     }
 
-    impl EnvGuard {
-        fn set(key: &'static str, value: &std::path::Path) -> Self {
-            let original = std::env::var_os(key);
-            set_env_var(key, value);
-            Self { key, original }
-        }
-
-        #[cfg(unix)]
+    impl LocalEnvGuard {
         fn set_raw(key: &'static str, value: &str) -> Self {
+            let guard = env_lock().lock().expect("env lock");
             let original = std::env::var_os(key);
-            set_env_var(key, value);
-            Self { key, original }
+            // SAFETY: this helper serializes all environment mutation with the
+            // local process-wide mutex it holds for the full guard lifetime.
+            unsafe { std::env::set_var(key, value) };
+            Self {
+                key,
+                original,
+                _guard: guard,
+            }
         }
 
-        #[cfg(unix)]
-        fn remove(key: &'static str) -> Self {
-            let original = std::env::var_os(key);
-            remove_env_var(key);
-            Self { key, original }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.original.take() {
-                Some(value) => set_env_var(self.key, value),
-                None => remove_env_var(self.key),
+        fn set_many<const N: usize>(changes: [(&'static str, Option<&str>); N]) -> LocalEnvSet {
+            let guard = env_lock().lock().expect("env lock");
+            let restorations = changes
+                .into_iter()
+                .map(|(key, value)| {
+                    let original = std::env::var_os(key);
+                    match value {
+                        Some(value) => {
+                            // SAFETY: serialized by the local env mutex above.
+                            unsafe { std::env::set_var(key, value) };
+                        }
+                        None => {
+                            // SAFETY: serialized by the local env mutex above.
+                            unsafe { std::env::remove_var(key) };
+                        }
+                    }
+                    (key, original)
+                })
+                .collect();
+            LocalEnvSet {
+                restorations,
+                _guard: guard,
             }
         }
     }
 
-    fn set_env_var<K: AsRef<std::ffi::OsStr>, V: AsRef<std::ffi::OsStr>>(key: K, value: V) {
-        // SAFETY: these tests take a process-wide mutex before mutating the
-        // environment, so the mutation is serialized within this process.
-        unsafe { std::env::set_var(key, value) }
+    struct LocalEnvSet {
+        restorations: Vec<(&'static str, Option<OsString>)>,
+        _guard: MutexGuard<'static, ()>,
     }
 
-    fn remove_env_var<K: AsRef<std::ffi::OsStr>>(key: K) {
-        // SAFETY: these tests take a process-wide mutex before mutating the
-        // environment, so the mutation is serialized within this process.
-        unsafe { std::env::remove_var(key) }
+    impl Drop for LocalEnvGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                Some(value) => {
+                    // SAFETY: the guard still holds the local env mutex.
+                    unsafe { std::env::set_var(self.key, value) }
+                }
+                None => {
+                    // SAFETY: the guard still holds the local env mutex.
+                    unsafe { std::env::remove_var(self.key) }
+                }
+            }
+        }
+    }
+
+    impl Drop for LocalEnvSet {
+        fn drop(&mut self) {
+            for (key, original) in self.restorations.iter_mut().rev() {
+                match original.take() {
+                    Some(value) => {
+                        // SAFETY: the guard still holds the local env mutex.
+                        unsafe { std::env::set_var(key, value) }
+                    }
+                    None => {
+                        // SAFETY: the guard still holds the local env mutex.
+                        unsafe { std::env::remove_var(key) }
+                    }
+                }
+            }
+        }
     }
 
     #[test]
     #[serial_test::serial]
     fn atm_home_prefers_atm_home_env() {
-        let _guard = env_lock().lock().expect("env lock");
         let tempdir = TempDir::new().expect("tempdir");
-        let _atm_home = EnvGuard::set("ATM_HOME", tempdir.path());
+        let _atm_home =
+            LocalEnvGuard::set_raw("ATM_HOME", tempdir.path().to_str().expect("utf8 path"));
 
         let resolved = atm_home().expect("atm home");
         assert_eq!(resolved, tempdir.path());
@@ -262,10 +344,11 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn atm_home_falls_back_to_home_dir() {
-        let _guard = env_lock().lock().expect("env lock");
         let tempdir = TempDir::new().expect("tempdir");
-        let _atm_home = EnvGuard::remove("ATM_HOME");
-        let _home = EnvGuard::set_raw("HOME", tempdir.path().to_str().expect("utf8 path"));
+        let _env = LocalEnvGuard::set_many([
+            ("ATM_HOME", None),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
+        ]);
 
         let resolved = atm_home().expect("atm home");
         assert_eq!(resolved, tempdir.path());
@@ -274,16 +357,18 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn team_and_inbox_paths_use_claude_team_layout() {
-        let _guard = env_lock().lock().expect("env lock");
         let tempdir = TempDir::new().expect("tempdir");
-        let _atm_home = EnvGuard::set("ATM_HOME", tempdir.path());
+        let _atm_home =
+            LocalEnvGuard::set_raw("ATM_HOME", tempdir.path().to_str().expect("utf8 path"));
+        let team: TeamName = TEST_TEAM.parse().expect("team");
+        let agent: AgentName = TEST_SENDER.parse().expect("agent");
 
         assert_eq!(
-            team_dir(TEST_TEAM).expect("team dir"),
+            team_dir(&team).expect("team dir"),
             tempdir.path().join(".claude").join("teams").join(TEST_TEAM)
         );
         assert_eq!(
-            inbox_path(TEST_TEAM, TEST_SENDER).expect("inbox path"),
+            inbox_path(&team, &agent).expect("inbox path"),
             tempdir
                 .path()
                 .join(".claude")
@@ -313,11 +398,15 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn host_runtime_dir_uses_os_home_not_atm_home() {
-        let _guard = env_lock().lock().expect("env lock");
         let tempdir = TempDir::new().expect("tempdir");
         let atm_home_dir = TempDir::new().expect("atm home tempdir");
-        let _atm_home = EnvGuard::set("ATM_HOME", atm_home_dir.path());
-        let _home = EnvGuard::set_raw("HOME", tempdir.path().to_str().expect("utf8 path"));
+        let _env = LocalEnvGuard::set_many([
+            (
+                "ATM_HOME",
+                Some(atm_home_dir.path().to_str().expect("utf8 path")),
+            ),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
+        ]);
 
         let resolved = host_runtime_dir().expect("host runtime dir");
         assert_eq!(resolved, tempdir.path().join(".atm").join("daemon"));
@@ -336,11 +425,18 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn host_db_dir_uses_os_home_not_atm_home() {
-        let _guard = env_lock().lock().expect("env lock");
         let atm_home_dir = TempDir::new().expect("atm home");
         let os_home_dir = TempDir::new().expect("os home");
-        let _atm_home = EnvGuard::set("ATM_HOME", atm_home_dir.path());
-        let _home = EnvGuard::set_raw("HOME", os_home_dir.path().to_str().expect("utf8 path"));
+        let _env = LocalEnvGuard::set_many([
+            (
+                "ATM_HOME",
+                Some(atm_home_dir.path().to_str().expect("utf8 path")),
+            ),
+            (
+                "HOME",
+                Some(os_home_dir.path().to_str().expect("utf8 path")),
+            ),
+        ]);
 
         let resolved = host_db_dir().expect("host db dir");
         assert_eq!(resolved, os_home_dir.path().join(".atm").join("db"));
@@ -359,11 +455,18 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn host_mail_db_path_uses_os_home_not_atm_home() {
-        let _guard = env_lock().lock().expect("env lock");
         let atm_home_dir = TempDir::new().expect("atm home");
         let os_home_dir = TempDir::new().expect("os home");
-        let _atm_home = EnvGuard::set("ATM_HOME", atm_home_dir.path());
-        let _home = EnvGuard::set_raw("HOME", os_home_dir.path().to_str().expect("utf8 path"));
+        let _env = LocalEnvGuard::set_many([
+            (
+                "ATM_HOME",
+                Some(atm_home_dir.path().to_str().expect("utf8 path")),
+            ),
+            (
+                "HOME",
+                Some(os_home_dir.path().to_str().expect("utf8 path")),
+            ),
+        ]);
 
         let resolved = host_mail_db_path().expect("host mail db path");
         assert_eq!(
@@ -394,10 +497,9 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn host_log_dir_prefers_atm_log_dir_override() {
-        let _guard = env_lock().lock().expect("env lock");
         let tempdir = TempDir::new().expect("tempdir");
         let _atm_log_dir =
-            EnvGuard::set_raw("ATM_LOG_DIR", tempdir.path().to_str().expect("utf8 path"));
+            LocalEnvGuard::set_raw("ATM_LOG_DIR", tempdir.path().to_str().expect("utf8 path"));
 
         let resolved = host_log_dir().expect("host log dir");
         assert_eq!(resolved, tempdir.path());
@@ -407,12 +509,19 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn host_log_dir_uses_os_home_not_atm_home() {
-        let _guard = env_lock().lock().expect("env lock");
         let atm_home_dir = TempDir::new().expect("atm home");
         let os_home_dir = TempDir::new().expect("os home");
-        let _atm_home = EnvGuard::set("ATM_HOME", atm_home_dir.path());
-        let _atm_log_dir = EnvGuard::remove("ATM_LOG_DIR");
-        let _home = EnvGuard::set_raw("HOME", os_home_dir.path().to_str().expect("utf8 path"));
+        let _env = LocalEnvGuard::set_many([
+            (
+                "ATM_HOME",
+                Some(atm_home_dir.path().to_str().expect("utf8 path")),
+            ),
+            ("ATM_LOG_DIR", None),
+            (
+                "HOME",
+                Some(os_home_dir.path().to_str().expect("utf8 path")),
+            ),
+        ]);
 
         let resolved = host_log_dir().expect("host log dir");
         assert_eq!(resolved, os_home_dir.path().join(".atm").join("logs"));
@@ -421,7 +530,10 @@ mod tests {
     #[test]
     fn team_dir_from_home_rejects_path_traversal_segments() {
         let tempdir = TempDir::new().expect("tempdir");
-        let error = team_dir_from_home(tempdir.path(), "../evil").expect_err("invalid team");
+        let error = "../evil"
+            .parse::<TeamName>()
+            .and_then(|team| team_dir_from_home(tempdir.path(), &team))
+            .expect_err("invalid team");
 
         assert!(error.is_address());
         assert!(error.message.contains("team name"));
@@ -430,8 +542,11 @@ mod tests {
     #[test]
     fn inbox_path_from_home_rejects_path_traversal_segments() {
         let tempdir = TempDir::new().expect("tempdir");
-        let error =
-            inbox_path_from_home(tempdir.path(), TEST_TEAM, "../evil").expect_err("invalid agent");
+        let team: TeamName = TEST_TEAM.parse().expect("team");
+        let error = "../evil"
+            .parse::<AgentName>()
+            .and_then(|agent| inbox_path_from_home(tempdir.path(), &team, &agent))
+            .expect_err("invalid agent");
 
         assert!(error.is_address());
         assert!(error.message.contains("agent name"));
@@ -440,9 +555,11 @@ mod tests {
     #[test]
     fn workflow_state_path_uses_atm_state_layout() {
         let tempdir = TempDir::new().expect("tempdir");
+        let team: TeamName = TEST_TEAM.parse().expect("team");
+        let agent: AgentName = TEST_SENDER.parse().expect("agent");
 
         assert_eq!(
-            workflow_state_path_from_home(tempdir.path(), TEST_TEAM, TEST_SENDER)
+            workflow_state_path_from_home(tempdir.path(), &team, &agent)
                 .expect("workflow state path"),
             tempdir
                 .path()
@@ -453,5 +570,94 @@ mod tests {
                 .join("workflow")
                 .join(format!("{TEST_SENDER}.json"))
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn host_log_dir_rejects_non_absolute_override() {
+        let _env = LocalEnvGuard::set_many([
+            ("ATM_LOG_DIR", Some("relative/logs")),
+            ("HOME", Some("/tmp")),
+        ]);
+
+        let error = host_log_dir().expect_err("non-absolute ATM_LOG_DIR should fail");
+        assert!(error.is_config());
+        assert!(error.message.contains("absolute path"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn host_log_dir_rejects_claude_subtree_override() {
+        let home_dir = TempDir::new().expect("home");
+        let forbidden = home_dir.path().join(".claude").join("logs");
+        let _env = LocalEnvGuard::set_many([
+            ("ATM_LOG_DIR", Some(forbidden.to_str().expect("utf8 path"))),
+            ("HOME", Some(home_dir.path().to_str().expect("utf8 path"))),
+        ]);
+
+        let error = host_log_dir().expect_err("claude subtree should fail");
+        assert!(error.is_config());
+        assert!(error.message.contains(".claude"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn host_log_dir_rejects_daemon_overlap_override() {
+        let home_dir = TempDir::new().expect("home");
+        let forbidden = home_dir.path().join(".atm").join("daemon").join("logs");
+        let _env = LocalEnvGuard::set_many([
+            ("ATM_LOG_DIR", Some(forbidden.to_str().expect("utf8 path"))),
+            ("HOME", Some(home_dir.path().to_str().expect("utf8 path"))),
+        ]);
+
+        let error = host_log_dir().expect_err("daemon overlap should fail");
+        assert!(error.is_config());
+        assert!(error.message.contains(".atm/daemon"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn host_log_dir_rejects_non_utf8_override() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let home_dir = TempDir::new().expect("home");
+        let _home =
+            LocalEnvGuard::set_raw("HOME", home_dir.path().to_str().expect("utf8 path"));
+        let _atm_log_dir = Utf8EnvGuard {
+            key: "ATM_LOG_DIR",
+            original: std::env::var_os("ATM_LOG_DIR"),
+        };
+        // SAFETY: the test helper serializes environment mutation in-process.
+        unsafe { std::env::set_var("ATM_LOG_DIR", OsString::from_vec(vec![0x66, 0x6f, 0x80])) };
+
+        let error = host_log_dir().expect_err("non-utf8 override should fail");
+        assert!(error.is_config());
+        assert!(error.message.contains("UTF-8"));
+    }
+
+    #[cfg(unix)]
+    struct Utf8EnvGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    #[cfg(unix)]
+    impl Drop for Utf8EnvGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                Some(value) => {
+                    // SAFETY: the shared test env guard serializes process environment mutation.
+                    unsafe { std::env::set_var(self.key, value) }
+                }
+                None => {
+                    // SAFETY: the shared test env guard serializes process environment mutation.
+                    unsafe { std::env::remove_var(self.key) }
+                }
+            }
+        }
     }
 }

--- a/crates/atm-core/src/home.rs
+++ b/crates/atm-core/src/home.rs
@@ -236,22 +236,23 @@ pub fn resolve_user_home() -> Result<PathBuf, AtmError> {
 }
 
 /// Unix-only ATM_LOG_DIR validation tests cover non-UTF-8 and path-shape cases.
-/// Windows keeps these invariants compile-checked here and exercises them in cross-target validation.
+/// Windows keeps these invariants compile-checked here, and cross-target CI verifies the
+/// shared `host_log_dir()` contract even though the path-shape override cases below stay Unix-only.
 #[cfg(test)]
 mod tests {
-    #[cfg(unix)]
     use std::ffi::OsString;
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
     use tempfile::TempDir;
 
+    #[cfg(unix)]
+    use super::MAX_HOST_LOG_DIR_UTF8_BYTES;
     use super::{
-        MAX_HOST_LOG_DIR_UTF8_BYTES, atm_home, host_db_dir_from_home, host_log_dir_from_home,
-        host_mail_db_path_from_home, host_runtime_dir_from_home, host_runtime_lock_path_from_home,
-        inbox_path, inbox_path_from_home, team_dir, team_dir_from_home,
-        workflow_state_path_from_home,
+        atm_home, host_db_dir_from_home, host_log_dir_from_home, host_mail_db_path_from_home,
+        host_runtime_dir_from_home, host_runtime_lock_path_from_home, inbox_path,
+        inbox_path_from_home, team_dir, team_dir_from_home, workflow_state_path_from_home,
     };
-    #[cfg(any(unix, windows))]
+    #[cfg(unix)]
     use super::{host_db_dir, host_log_dir, host_mail_db_path, host_runtime_dir};
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::{AgentName, TeamName};

--- a/crates/atm-core/src/mailbox/source.rs
+++ b/crates/atm-core/src/mailbox/source.rs
@@ -139,7 +139,7 @@ pub(crate) fn discover_source_paths(
     team: &TeamName,
     agent: &AgentName,
 ) -> Result<Vec<PathBuf>, AtmError> {
-    let inbox_path = home::inbox_path_from_home(home_dir, team.as_str(), agent.as_str())?;
+    let inbox_path = home::inbox_path_from_home(home_dir, team, agent)?;
     let inboxes_dir = inbox_path
         .parent()
         .ok_or_else(|| AtmError::mailbox_read("inbox path has no parent directory"))?;

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -392,6 +392,12 @@ pub enum AtmObservabilityHealthState {
     Unavailable,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetainedSinkFaultMode {
+    Degraded,
+    Unavailable,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AtmObservabilityHealth {
     pub active_log_path: Option<PathBuf>,

--- a/crates/atm-core/src/workflow.rs
+++ b/crates/atm-core/src/workflow.rs
@@ -18,7 +18,7 @@ use crate::home;
 use crate::mailbox::lock;
 use crate::persistence;
 use crate::schema::{AtmMessageId, MessageEnvelope};
-use crate::types::IsoTimestamp;
+use crate::types::{AgentName, IsoTimestamp, TeamName};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub(crate) struct WorkflowStateFile {
@@ -47,7 +47,9 @@ pub(crate) fn load_workflow_state(
     team: &str,
     agent: &str,
 ) -> Result<WorkflowStateFile, AtmError> {
-    let path = home::workflow_state_path_from_home(home_dir, team, agent)?;
+    let team: TeamName = team.parse()?;
+    let agent: AgentName = agent.parse()?;
+    let path = home::workflow_state_path_from_home(home_dir, &team, &agent)?;
     if !path.exists() {
         return Ok(WorkflowStateFile::default());
     }
@@ -81,7 +83,9 @@ pub(crate) fn save_workflow_state(
     agent: &str,
     state: &WorkflowStateFile,
 ) -> Result<(), AtmError> {
-    let path = home::workflow_state_path_from_home(home_dir, team, agent)?;
+    let team: TeamName = team.parse()?;
+    let agent: AgentName = agent.parse()?;
+    let path = home::workflow_state_path_from_home(home_dir, &team, &agent)?;
     let encoded = serde_json::to_string_pretty(state).map_err(|error| {
         AtmError::new(
             AtmErrorKind::Serialization,
@@ -113,7 +117,9 @@ where
     I: IntoIterator<Item = PathBuf>,
     F: FnOnce(&mut WorkflowStateFile) -> Result<(T, bool), AtmError>,
 {
-    let workflow_path = home::workflow_state_path_from_home(home_dir, team, agent)?;
+    let team_name: TeamName = team.parse()?;
+    let agent_name: AgentName = agent.parse()?;
+    let workflow_path = home::workflow_state_path_from_home(home_dir, &team_name, &agent_name)?;
     let mut write_paths = vec![workflow_path];
     write_paths.extend(extra_write_paths);
     let _locks = lock::acquire_many_sorted(write_paths, timeout)?;

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -519,6 +519,8 @@ impl DaemonRequestDispatcher {
         let observability = match DaemonObservability::new() {
             Ok(observability) => observability,
             Err(error) => {
+                // Daemon health treats invalid retained-sink fault injection as a local
+                // non-fatal test knob and falls back to Healthy after warning, unlike CLI bootstrap.
                 tracing::warn!(%error, "failed to initialize daemon observability state");
                 DaemonObservability::new_with_sink_fault(None)
             }

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -18,7 +18,7 @@ use atm_core::{
     list::list_mail,
     observability::{
         AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState,
-        CommandEvent, LogTailSession, ObservabilityPort,
+        CommandEvent, LogTailSession, ObservabilityPort, RetainedSinkFaultMode,
     },
     process::process_is_alive,
     protocol::{
@@ -46,44 +46,42 @@ static SHUTDOWN_FINALIZER_THREADS: std::sync::Mutex<Vec<std::thread::JoinHandle<
 
 #[derive(Debug, Clone)]
 struct DaemonObservability {
-    home_dir: PathBuf,
-    retained_sink_fault: RetainedSinkFault,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RetainedSinkFault {
-    Healthy,
-    Degraded,
-    Unavailable,
+    retained_sink_fault: Option<RetainedSinkFaultMode>,
 }
 
 impl DaemonObservability {
-    fn new(home_dir: PathBuf) -> Self {
+    fn new() -> Result<Self, AtmError> {
         let retained_sink_fault = match std::env::var("ATM_OBSERVABILITY_RETAINED_SINK_FAULT")
             .ok()
             .map(|value| value.trim().to_ascii_lowercase())
-            .as_deref()
+            .filter(|value| !value.is_empty())
         {
-            Some("degraded") => RetainedSinkFault::Degraded,
-            Some("unavailable") => RetainedSinkFault::Unavailable,
-            _ => RetainedSinkFault::Healthy,
+            None => None,
+            Some(value) => match value.as_str() {
+                "degraded" => Some(RetainedSinkFaultMode::Degraded),
+                "unavailable" => Some(RetainedSinkFaultMode::Unavailable),
+                _ => {
+                    return Err(AtmError::observability_bootstrap(format!(
+                        "invalid ATM_OBSERVABILITY_RETAINED_SINK_FAULT value `{value}`; use `degraded` or `unavailable`"
+                    )));
+                }
+            },
         };
-        Self::new_with_sink_fault(home_dir, retained_sink_fault)
+        Ok(Self::new_with_sink_fault(retained_sink_fault))
     }
 
-    fn new_with_sink_fault(home_dir: PathBuf, retained_sink_fault: RetainedSinkFault) -> Self {
+    fn new_with_sink_fault(retained_sink_fault: Option<RetainedSinkFaultMode>) -> Self {
         Self {
-            home_dir,
             retained_sink_fault,
         }
     }
 
-    fn active_log_path(&self) -> PathBuf {
-        home::host_log_dir_from_home(&self.home_dir).join("atm.log.jsonl")
+    fn active_log_path(&self) -> Result<PathBuf, AtmError> {
+        Ok(home::host_log_dir()?.join("atm.log.jsonl"))
     }
 
-    fn best_effort_flush(&self) -> Result<(), AtmError> {
-        let active_log_path = self.active_log_path();
+    fn best_effort_flush_blocking(&self) -> Result<(), AtmError> {
+        let active_log_path = self.active_log_path()?;
         if !active_log_path.exists() {
             return Ok(());
         }
@@ -129,11 +127,11 @@ impl ObservabilityPort for DaemonObservability {
     }
 
     fn health(&self) -> Result<AtmObservabilityHealth, AtmError> {
-        let active_log_path = self.active_log_path();
+        let active_log_path = self.active_log_path()?;
         let logging_state = match self.retained_sink_fault {
-            RetainedSinkFault::Healthy => AtmObservabilityHealthState::Healthy,
-            RetainedSinkFault::Degraded => AtmObservabilityHealthState::Degraded,
-            RetainedSinkFault::Unavailable => AtmObservabilityHealthState::Unavailable,
+            None => AtmObservabilityHealthState::Healthy,
+            Some(RetainedSinkFaultMode::Degraded) => AtmObservabilityHealthState::Degraded,
+            Some(RetainedSinkFaultMode::Unavailable) => AtmObservabilityHealthState::Unavailable,
         };
         Ok(AtmObservabilityHealth {
             active_log_path: Some(active_log_path),
@@ -482,7 +480,7 @@ impl DaemonRequestDispatcher {
                 }
                 #[cfg(not(test))]
                 {
-                    let _ = shutdown_handle.join();
+                    drop(shutdown_handle);
                 }
                 tracing::warn!(
                     step = label,
@@ -518,9 +516,16 @@ impl DaemonRequestDispatcher {
                 None
             }
         };
+        let observability = match DaemonObservability::new() {
+            Ok(observability) => observability,
+            Err(error) => {
+                tracing::warn!(%error, "failed to initialize daemon observability state");
+                DaemonObservability::new_with_sink_fault(None)
+            }
+        };
         Self {
             home_dir: home_dir.clone(),
-            observability: DaemonObservability::new(home_dir),
+            observability,
             status_cache,
             sqlite_boundary,
         }
@@ -603,7 +608,9 @@ impl DaemonRequestDispatcher {
         Self::run_bounded_shutdown_step(
             "observability_flush",
             SHUTDOWN_OBSERVABILITY_FLUSH_DEADLINE,
-            move || observability.best_effort_flush(),
+            // The finalizer step already runs on a dedicated shutdown thread,
+            // so the retained-log flush remains in a sync context.
+            move || observability.best_effort_flush_blocking(),
         );
     }
 
@@ -868,6 +875,41 @@ impl boundary::sealed::Sealed for DaemonStatusSource {}
 impl boundary::StatusSource for DaemonStatusSource {
     fn snapshot(&self) -> Result<RuntimeStatusSnapshot, AtmError> {
         self.status_cache.snapshot()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DaemonRequestDispatcher;
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn bounded_shutdown_step_returns_after_deadline() {
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let blocker = Arc::clone(&release);
+        let started = Instant::now();
+        DaemonRequestDispatcher::run_bounded_shutdown_step(
+            "blocking_test_step",
+            Duration::from_millis(10),
+            move || {
+                let (released, wake) = &*blocker;
+                let mut released = released.lock().expect("released");
+                while !*released {
+                    released = wake.wait(released).expect("released wait");
+                }
+                Ok(())
+            },
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "bounded shutdown step should return promptly after its deadline"
+        );
+
+        let (released, wake) = &*release;
+        *released.lock().expect("released") = true;
+        wake.notify_all();
+        DaemonRequestDispatcher::drain_shutdown_finalizer_threads_for_test();
     }
 }
 

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -14,6 +14,7 @@ use atm_core::{
         self, DoctorFinding, DoctorQuery, DoctorReport, DoctorSeverity, DoctorStatus, DoctorSummary,
     },
     error::AtmError,
+    home,
     list::list_mail,
     observability::{
         AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState,
@@ -77,16 +78,12 @@ impl DaemonObservability {
         }
     }
 
+    fn active_log_path(&self) -> PathBuf {
+        home::host_log_dir_from_home(&self.home_dir).join("atm.log.jsonl")
+    }
+
     fn best_effort_flush(&self) -> Result<(), AtmError> {
-        #[cfg(unix)]
-        let active_log_path = self
-            .home_dir
-            .join(".local")
-            .join("share")
-            .join("logs")
-            .join("atm.log.jsonl");
-        #[cfg(not(unix))]
-        let active_log_path = self.home_dir.join("logs").join("atm.log.jsonl");
+        let active_log_path = self.active_log_path();
         if !active_log_path.exists() {
             return Ok(());
         }
@@ -132,15 +129,7 @@ impl ObservabilityPort for DaemonObservability {
     }
 
     fn health(&self) -> Result<AtmObservabilityHealth, AtmError> {
-        #[cfg(unix)]
-        let active_log_path = self
-            .home_dir
-            .join(".local")
-            .join("share")
-            .join("logs")
-            .join("atm.log.jsonl");
-        #[cfg(not(unix))]
-        let active_log_path = self.home_dir.join("logs").join("atm.log.jsonl");
+        let active_log_path = self.active_log_path();
         let logging_state = match self.retained_sink_fault {
             RetainedSinkFault::Healthy => AtmObservabilityHealthState::Healthy,
             RetainedSinkFault::Degraded => AtmObservabilityHealthState::Degraded,
@@ -434,6 +423,7 @@ fn finish_runtime_snapshot(
 
 #[derive(Debug)]
 pub(crate) struct DaemonRequestDispatcher {
+    home_dir: PathBuf,
     observability: DaemonObservability,
     status_cache: RuntimeStatusCache,
     sqlite_boundary: Option<SqliteBoundaryAssembly>,
@@ -529,6 +519,7 @@ impl DaemonRequestDispatcher {
             }
         };
         Self {
+            home_dir: home_dir.clone(),
             observability: DaemonObservability::new(home_dir),
             status_cache,
             sqlite_boundary,
@@ -589,11 +580,8 @@ impl DaemonRequestDispatcher {
                 )
             })?;
         let current_state = self.status_cache.clone_state()?;
-        let next_state = build_runtime_status_cache_state(
-            Some(&current_state),
-            &self.observability.home_dir,
-            roster_store,
-        )?;
+        let next_state =
+            build_runtime_status_cache_state(Some(&current_state), &self.home_dir, roster_store)?;
         let reloaded_members = next_state.members.len();
         self.status_cache.replace_state(next_state)?;
         tracing::info!(

--- a/crates/atm-daemon/src/runtime_health_test_support.rs
+++ b/crates/atm-daemon/src/runtime_health_test_support.rs
@@ -93,6 +93,7 @@ impl DaemonRequestDispatcher {
             }
         };
         Self {
+            home_dir: home_dir.clone(),
             observability: DaemonObservability::new_with_sink_fault(
                 home_dir,
                 RetainedSinkFault::Healthy,

--- a/crates/atm-daemon/src/runtime_health_test_support.rs
+++ b/crates/atm-daemon/src/runtime_health_test_support.rs
@@ -94,10 +94,7 @@ impl DaemonRequestDispatcher {
         };
         Self {
             home_dir: home_dir.clone(),
-            observability: DaemonObservability::new_with_sink_fault(
-                home_dir,
-                RetainedSinkFault::Healthy,
-            ),
+            observability: DaemonObservability::new_with_sink_fault(None),
             status_cache,
             sqlite_boundary,
         }

--- a/crates/atm-daemon/src/watch_runtime.rs
+++ b/crates/atm-daemon/src/watch_runtime.rs
@@ -4,13 +4,17 @@ use atm_core::protocol::ProtocolErrorEnvelope;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 const DEFAULT_WATCH_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_WATCH_SUBSCRIPTIONS: usize = 256;
 const WATCH_POLL_HEALTH_TIMEOUT_MULTIPLIER: u32 = 5;
+#[cfg(not(test))]
+const WATCH_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(2);
+#[cfg(test)]
+const WATCH_SHUTDOWN_DEADLINE: Duration = Duration::from_millis(100);
 
 #[derive(Clone)]
 pub(crate) struct WatchRuntime {
@@ -215,9 +219,34 @@ impl WatchRuntime {
             .map_err(|_| AtmError::daemon_unavailable("watch runtime worker lock poisoned"))?
             .take()
         {
-            handle.join().map_err(|_| {
-                AtmError::daemon_unavailable("watch runtime worker panicked during shutdown")
-            })?;
+            let (result_tx, result_rx) = mpsc::sync_channel(1);
+            let join_helper = thread::spawn(move || {
+                let _ = result_tx.send(handle.join());
+            });
+            match result_rx.recv_timeout(WATCH_SHUTDOWN_DEADLINE) {
+                Ok(Ok(())) => {
+                    let _ = join_helper.join();
+                }
+                Ok(Err(_)) => {
+                    let _ = join_helper.join();
+                    return Err(AtmError::daemon_unavailable(
+                        "watch runtime worker panicked during shutdown",
+                    ));
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    drop(join_helper);
+                    tracing::warn!(
+                        timeout_ms = WATCH_SHUTDOWN_DEADLINE.as_millis(),
+                        "watch runtime worker exceeded shutdown deadline; detaching join helper"
+                    );
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    let _ = join_helper.join();
+                    tracing::warn!(
+                        "watch runtime worker join helper exited before reporting shutdown status"
+                    );
+                }
+            }
         }
         Ok(())
     }
@@ -399,7 +428,7 @@ fn watch_worker_loop(inner: Arc<WatchRuntimeInner>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{MAX_WATCH_SUBSCRIPTIONS, WatchRuntime};
+    use super::{MAX_WATCH_SUBSCRIPTIONS, WATCH_SHUTDOWN_DEADLINE, WatchRuntime};
     use atm_core::boundary::WatchEventBatch;
     use atm_core::boundary::WatchSubscriptionRequest;
     use atm_core::error::AtmError;
@@ -517,6 +546,55 @@ mod tests {
         let error = runtime.poll(request()).expect_err("degraded");
         assert!(error.message.contains("watch poll failed"));
         runtime.shutdown().expect("shutdown");
+    }
+
+    #[test]
+    fn watch_runtime_shutdown_returns_within_bounded_deadline() {
+        let (started_tx, started_rx) = mpsc::channel();
+        let release: Arc<(Mutex<bool>, Condvar)> = Arc::new((Mutex::new(false), Condvar::new()));
+        let runtime = WatchRuntime::new_for_test(
+            Arc::new({
+                let release = Arc::clone(&release);
+                move |_| {
+                    let (released, wake) = &*release;
+                    let mut released = released.lock().expect("released");
+                    started_tx.send(()).expect("started");
+                    while !*released {
+                        let wait = wake
+                            .wait_timeout(released, Duration::from_secs(1))
+                            .expect("released wait");
+                        released = wait.0;
+                        assert!(!wait.1.timed_out(), "watch test release timed out");
+                    }
+                    Ok(WatchEventBatch { paths: Vec::new() })
+                }
+            }),
+            Duration::from_millis(10),
+        );
+        runtime.start().expect("start");
+
+        let runtime_for_thread = runtime.clone();
+        let poll_join = std::thread::spawn(move || runtime_for_thread.poll(request()));
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("worker started");
+
+        let shutdown_started = std::time::Instant::now();
+        runtime.shutdown().expect("shutdown");
+        assert!(
+            shutdown_started.elapsed() < WATCH_SHUTDOWN_DEADLINE + Duration::from_secs(1),
+            "watch runtime shutdown exceeded bounded deadline"
+        );
+
+        let (released, wake) = &*release;
+        *released.lock().expect("released") = true;
+        wake.notify_all();
+
+        let error = poll_join
+            .join()
+            .expect("poll join")
+            .expect_err("shutdown should interrupt the blocked poll");
+        assert!(error.message.contains("shut down before delivering"));
     }
 
     #[test]

--- a/crates/atm-daemon/src/watch_runtime.rs
+++ b/crates/atm-daemon/src/watch_runtime.rs
@@ -102,8 +102,8 @@ impl WatchRuntime {
             Arc::new(|request| {
                 let inbox_path = atm_core::home::inbox_path_from_home(
                     &request.home_dir,
-                    request.team.as_str(),
-                    request.agent.as_str(),
+                    &request.team,
+                    &request.agent,
                 )?;
                 let mut paths = Vec::new();
                 if inbox_path.exists() {
@@ -403,9 +403,11 @@ mod tests {
     use atm_core::boundary::WatchEventBatch;
     use atm_core::boundary::WatchSubscriptionRequest;
     use atm_core::error::AtmError;
+    use std::fs;
     use std::path::PathBuf;
     use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::time::Duration;
+    use tempfile::TempDir;
 
     fn request() -> WatchSubscriptionRequest {
         request_for("test-agent")
@@ -417,6 +419,47 @@ mod tests {
             team: "test-team".parse().expect("team"),
             agent: agent.parse().expect("agent"),
         }
+    }
+
+    #[test]
+    fn watch_runtime_ignores_host_scoped_log_directory() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let inboxes_dir = tempdir
+            .path()
+            .join(".claude")
+            .join("teams")
+            .join("test-team")
+            .join("inboxes");
+        fs::create_dir_all(&inboxes_dir).expect("create inboxes");
+        let primary = inboxes_dir.join("test-agent.json");
+        let origin = inboxes_dir.join("test-agent.host-a.json");
+        fs::write(&primary, "[]").expect("write primary inbox");
+        fs::write(&origin, "[]").expect("write origin inbox");
+
+        let logs_dir = tempdir.path().join(".atm").join("logs");
+        fs::create_dir_all(&logs_dir).expect("create logs dir");
+        fs::write(
+            logs_dir.join("atm.log.jsonl"),
+            "{\"message\":\"retained\"}\n",
+        )
+        .expect("write retained log");
+
+        let runtime = WatchRuntime::new();
+        runtime.start().expect("start");
+        let batch = runtime
+            .poll(WatchSubscriptionRequest {
+                home_dir: tempdir.path().to_path_buf(),
+                team: "test-team".parse().expect("team"),
+                agent: "test-agent".parse().expect("agent"),
+            })
+            .expect("poll");
+        runtime.shutdown().expect("shutdown");
+
+        assert_eq!(batch.paths, vec![origin, primary]);
+        assert!(
+            batch.paths.iter().all(|path| !path.starts_with(&logs_dir)),
+            "watch runtime must not subscribe to the host-scoped retained log directory"
+        );
     }
 
     #[test]

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -35,6 +35,7 @@ const ATM_SERVICE_NAME: &str = "atm";
 const ATM_COMMAND_TARGET: &str = "atm.command";
 const ATM_LOG_LEVEL_ENV: &str = "ATM_LOG";
 const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAINED_SINK_FAULT";
+const MAX_RETAINED_QUERY_RECORD_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ConsoleLogRoute {
@@ -518,24 +519,43 @@ fn map_field_match(
 }
 
 fn map_snapshot(snapshot: sc_observability_types::LogSnapshot) -> Result<AtmLogSnapshot, AtmError> {
-    let records = snapshot
-        .events
-        .into_iter()
-        .map(map_record)
-        .collect::<Result<Vec<_>, _>>()?;
+    let records = snapshot.events.into_iter().try_fold(
+        Vec::new(),
+        |mut records, event| -> Result<Vec<AtmLogRecord>, AtmError> {
+            if let Some(record) = map_record(event)? {
+                records.push(record);
+            }
+            Ok(records)
+        },
+    )?;
     Ok(AtmLogSnapshot {
         records,
         truncated: snapshot.truncated,
     })
 }
 
-fn map_record(event: LogEvent) -> Result<AtmLogRecord, AtmError> {
+fn map_record(event: LogEvent) -> Result<Option<AtmLogRecord>, AtmError> {
+    let encoded = serde_json::to_vec(&event).map_err(|source| {
+        AtmError::observability_query("failed to encode shared retained log event")
+            .with_source(source)
+    })?;
+    if encoded.len() > MAX_RETAINED_QUERY_RECORD_BYTES {
+        tracing::warn!(
+            bytes = encoded.len(),
+            max_bytes = MAX_RETAINED_QUERY_RECORD_BYTES,
+            service = %event.service,
+            target = %event.target,
+            action = %event.action,
+            "dropping oversized retained log record during ATM projection"
+        );
+        return Ok(None);
+    }
     let fields = serde_json::from_value::<LogFieldMap>(serde_json::Value::Object(event.fields))
         .map_err(|source| {
             AtmError::observability_query("failed to project shared log fields into ATM types")
                 .with_source(source)
         })?;
-    Ok(AtmLogRecord {
+    Ok(Some(AtmLogRecord {
         timestamp: map_timestamp_back(event.timestamp)?,
         severity: map_level_back(event.level),
         service: event.service.to_string(),
@@ -543,7 +563,7 @@ fn map_record(event: LogEvent) -> Result<AtmLogRecord, AtmError> {
         action: Some(event.action.to_string()),
         message: event.message,
         fields,
-    })
+    }))
 }
 
 fn map_timestamp(timestamp: atm_core::types::IsoTimestamp) -> Result<Timestamp, AtmError> {

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -114,10 +114,10 @@ fn init_observability(stderr_logs: bool) -> Result<observability::CliObservabili
         AtmError::observability_bootstrap("failed to validate ATM observability target")
             .with_source(source)
     })?;
-    let logger = build_logger(&home_dir, console_log_route, &service_name)?;
+    let (logger, active_log_path) = build_logger(&home_dir, console_log_route, &service_name)?;
 
     Ok(observability::CliObservability::from_boxed_port(Box::new(
-        ScObservabilityAdapter::new(logger, service_name, target_category),
+        ScObservabilityAdapter::new(logger, active_log_path, service_name, target_category),
     )))
 }
 
@@ -125,11 +125,15 @@ pub(crate) fn build_logger(
     home_dir: &Path,
     console_log_route: ConsoleLogRoute,
     service_name: &ServiceName,
-) -> Result<Logger, AtmError> {
-    let mut config = LoggerConfig::default_for(service_name.clone(), log_root(home_dir));
+) -> Result<(Logger, PathBuf), AtmError> {
+    let log_dir = retained_log_dir(home_dir)?;
+    let active_log_path = log_dir.join("atm.log.jsonl");
+    let mut config = LoggerConfig::default_for(service_name.clone(), log_dir);
     if let Some(level) = logger_level_override()? {
         config.level = level;
     }
+    // Keep the default Info threshold so retained logging captures the S.9
+    // daemon lifecycle baseline unless ATM_LOG explicitly overrides it.
     // ATM CLI owns stdout/stderr UX by default; only opt into a shared
     // console sink when the CLI routing rule explicitly selects one.
     config.enable_console_sink = false;
@@ -141,19 +145,21 @@ pub(crate) fn build_logger(
         builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
     }
     if let Some(mode) = retained_sink_fault_mode()? {
-        register_retained_sink_fault(&mut builder, home_dir, mode);
+        register_retained_sink_fault(&mut builder, home_dir, mode)?;
     }
-    Ok(builder.build())
+    Ok((builder.build(), active_log_path))
 }
 
-fn log_root(home_dir: &Path) -> PathBuf {
-    home_dir.join(".local").join("share")
+fn retained_log_dir(home_dir: &Path) -> Result<PathBuf, AtmError> {
+    if let Some(path) = std::env::var_os("ATM_LOG_DIR").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(path));
+    }
+
+    Ok(home::host_log_dir_from_home(home_dir))
 }
 
-fn fault_injection_log_path(home_dir: &Path) -> PathBuf {
-    log_root(home_dir)
-        .join("logs")
-        .join("atm-fault-injection.log.jsonl")
+fn fault_injection_log_path(home_dir: &Path) -> Result<PathBuf, AtmError> {
+    Ok(retained_log_dir(home_dir)?.join("atm-fault-injection.log.jsonl"))
 }
 
 fn init_tracing(stderr_logs: bool) -> Result<(), AtmError> {
@@ -231,15 +237,16 @@ fn register_retained_sink_fault(
     builder: &mut LoggerBuilder,
     home_dir: &Path,
     mode: RetainedSinkFaultMode,
-) {
+) -> Result<(), AtmError> {
     let sink = Arc::new(JsonlFileSink::new(
-        fault_injection_log_path(home_dir),
+        fault_injection_log_path(home_dir)?,
         RotationPolicy::default(),
         RetentionPolicy::default(),
     ));
     builder.register_sink(SinkRegistration::new(Arc::new(
         RetainedSinkHealthOverride::new(sink, mode),
     )));
+    Ok(())
 }
 
 struct RetainedSinkHealthOverride {
@@ -281,14 +288,21 @@ impl LogSink for RetainedSinkHealthOverride {
 
 struct ScObservabilityAdapter {
     logger: Logger,
+    active_log_path: PathBuf,
     service_name: ServiceName,
     target_category: TargetCategory,
 }
 
 impl ScObservabilityAdapter {
-    fn new(logger: Logger, service_name: ServiceName, target_category: TargetCategory) -> Self {
+    fn new(
+        logger: Logger,
+        active_log_path: PathBuf,
+        service_name: ServiceName,
+        target_category: TargetCategory,
+    ) -> Self {
         Self {
             logger,
+            active_log_path,
             service_name,
             target_category,
         }
@@ -338,7 +352,7 @@ impl ObservabilityPort for ScObservabilityAdapter {
             .as_ref()
             .and_then(|query| query.last_error.clone().map(render_diagnostic_summary));
         Ok(AtmObservabilityHealth {
-            active_log_path: Some(report.active_log_path),
+            active_log_path: Some(self.active_log_path.clone()),
             logging_state: map_logging_state(report.state),
             query_state,
             detail: report
@@ -652,9 +666,10 @@ pub(crate) fn new_adapter_port(
     } else {
         ConsoleLogRoute::Disabled
     };
-    let logger = build_logger(home_dir, console_log_route, &service_name)?;
+    let (logger, active_log_path) = build_logger(home_dir, console_log_route, &service_name)?;
     Ok(Box::new(ScObservabilityAdapter::new(
         logger,
+        active_log_path,
         service_name,
         target_category,
     )))

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -719,10 +719,12 @@ mod adapter_tests {
     use atm_core::test_support::EnvGuard;
     use sc_observability_types::LevelFilter as SharedLevelFilter;
     use serial_test::serial;
+    use tempfile::TempDir;
     use tracing_subscriber::filter::LevelFilter as TracingLevelFilter;
 
     use super::{
-        ATM_LOG_LEVEL_ENV, level_for_outcome, logger_level_override, tracing_level_filter,
+        ATM_LOG_LEVEL_ENV, init_observability, level_for_outcome, logger_level_override,
+        tracing_level_filter,
     };
 
     fn with_env_var<R>(key: &'static str, value: Option<&str>, f: impl FnOnce() -> R) -> R {
@@ -793,5 +795,20 @@ mod adapter_tests {
             tracing_level_filter(SharedLevelFilter::Off),
             TracingLevelFilter::OFF
         );
+    }
+
+    #[test]
+    #[serial]
+    fn init_observability_fails_closed_when_atm_log_dir_is_invalid() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let _env = EnvGuard::set_many([
+            ("ATM_LOG", Some("info")),
+            ("ATM_LOG_DIR", Some("relative/logs")),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
+        ]);
+
+        let error = init_observability(false).expect_err("invalid ATM_LOG_DIR should fail closed");
+        assert!(error.is_config());
+        assert!(error.message.contains("absolute path"));
     }
 }

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -673,14 +673,7 @@ pub(crate) fn new_adapter_port(
     } else {
         ConsoleLogRoute::Disabled
     };
-    let test_log_dir = if std::env::var_os("ATM_LOG_DIR")
-        .filter(|value| !value.is_empty())
-        .is_some()
-    {
-        home::host_log_dir()?
-    } else {
-        home::host_log_dir_from_home(home_dir)
-    };
+    let test_log_dir = resolve_adapter_log_dir(home_dir)?;
     let (logger, active_log_path) = build_logger(&test_log_dir, console_log_route, &service_name)?;
     Ok(Box::new(ScObservabilityAdapter::new(
         logger,
@@ -688,6 +681,17 @@ pub(crate) fn new_adapter_port(
         service_name,
         target_category,
     )))
+}
+
+fn resolve_adapter_log_dir(_home_dir: &Path) -> Result<PathBuf, AtmError> {
+    match home::host_log_dir() {
+        Ok(log_dir) => Ok(log_dir),
+        #[cfg(test)]
+        Err(error) if error.code == AtmErrorCode::ConfigHomeUnavailable => {
+            Ok(home::host_log_dir_from_home(_home_dir))
+        }
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(test)]

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -5,6 +5,7 @@ mod output;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{fs, fs::OpenOptions};
 
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
@@ -12,7 +13,7 @@ use atm_core::home;
 use atm_core::observability::{
     AtmLogQuery, AtmLogRecord, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState,
     CommandEvent, LogFieldMap, LogFieldMatch, LogLevelFilter, LogOrder, LogTailSession,
-    ObservabilityPort,
+    ObservabilityPort, RetainedSinkFaultMode,
 };
 use chrono::{DateTime, Utc};
 use clap::Parser;
@@ -39,12 +40,6 @@ const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAI
 pub(crate) enum ConsoleLogRoute {
     Disabled,
     Stderr,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RetainedSinkFaultMode {
-    Degraded,
-    Unavailable,
 }
 
 fn main() {
@@ -101,7 +96,7 @@ fn run() -> anyhow::Result<()> {
 }
 
 fn init_observability(stderr_logs: bool) -> Result<observability::CliObservability, AtmError> {
-    let home_dir = home::atm_home()?;
+    let log_dir = home::host_log_dir()?;
     let console_log_route = if stderr_logs {
         ConsoleLogRoute::Stderr
     } else {
@@ -114,7 +109,7 @@ fn init_observability(stderr_logs: bool) -> Result<observability::CliObservabili
         AtmError::observability_bootstrap("failed to validate ATM observability target")
             .with_source(source)
     })?;
-    let (logger, active_log_path) = build_logger(&home_dir, console_log_route, &service_name)?;
+    let (logger, active_log_path) = build_logger(&log_dir, console_log_route, &service_name)?;
 
     Ok(observability::CliObservability::from_boxed_port(Box::new(
         ScObservabilityAdapter::new(logger, active_log_path, service_name, target_category),
@@ -122,18 +117,16 @@ fn init_observability(stderr_logs: bool) -> Result<observability::CliObservabili
 }
 
 pub(crate) fn build_logger(
-    home_dir: &Path,
+    log_dir: &Path,
     console_log_route: ConsoleLogRoute,
     service_name: &ServiceName,
 ) -> Result<(Logger, PathBuf), AtmError> {
-    let log_dir = retained_log_dir(home_dir)?;
     let active_log_path = log_dir.join("atm.log.jsonl");
-    let mut config = LoggerConfig::default_for(service_name.clone(), log_dir);
-    if let Some(level) = logger_level_override()? {
-        config.level = level;
-    }
-    // Keep the default Info threshold so retained logging captures the S.9
-    // daemon lifecycle baseline unless ATM_LOG explicitly overrides it.
+    ensure_retained_log_ready(log_dir, &active_log_path)?;
+    let mut config = LoggerConfig::default_for(service_name.clone(), log_dir.to_path_buf());
+    config.level = logger_level_override()?.unwrap_or(SharedLevelFilter::Info);
+    // Make the retained file threshold explicit so lifecycle info! events stay
+    // in the default retained log unless ATM_LOG overrides the level.
     // ATM CLI owns stdout/stderr UX by default; only opt into a shared
     // console sink when the CLI routing rule explicitly selects one.
     config.enable_console_sink = false;
@@ -145,21 +138,35 @@ pub(crate) fn build_logger(
         builder.register_sink(SinkRegistration::new(Arc::new(ConsoleSink::stderr())));
     }
     if let Some(mode) = retained_sink_fault_mode()? {
-        register_retained_sink_fault(&mut builder, home_dir, mode)?;
+        register_retained_sink_fault(&mut builder, log_dir, mode)?;
     }
     Ok((builder.build(), active_log_path))
 }
 
-fn retained_log_dir(home_dir: &Path) -> Result<PathBuf, AtmError> {
-    if let Some(path) = std::env::var_os("ATM_LOG_DIR").filter(|value| !value.is_empty()) {
-        return Ok(PathBuf::from(path));
-    }
-
-    Ok(home::host_log_dir_from_home(home_dir))
+fn ensure_retained_log_ready(log_dir: &Path, active_log_path: &Path) -> Result<(), AtmError> {
+    fs::create_dir_all(log_dir).map_err(|source| {
+        AtmError::observability_bootstrap(format!(
+            "failed to create retained log directory {}",
+            log_dir.display()
+        ))
+        .with_source(source)
+    })?;
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(active_log_path)
+        .map(|_| ())
+        .map_err(|source| {
+            AtmError::observability_bootstrap(format!(
+                "failed to open retained log file {} during startup",
+                active_log_path.display()
+            ))
+            .with_source(source)
+        })
 }
 
-fn fault_injection_log_path(home_dir: &Path) -> Result<PathBuf, AtmError> {
-    Ok(retained_log_dir(home_dir)?.join("atm-fault-injection.log.jsonl"))
+fn fault_injection_log_path(log_dir: &Path) -> PathBuf {
+    log_dir.join("atm-fault-injection.log.jsonl")
 }
 
 fn init_tracing(stderr_logs: bool) -> Result<(), AtmError> {
@@ -235,11 +242,11 @@ fn retained_sink_fault_mode() -> Result<Option<RetainedSinkFaultMode>, AtmError>
 
 fn register_retained_sink_fault(
     builder: &mut LoggerBuilder,
-    home_dir: &Path,
+    log_dir: &Path,
     mode: RetainedSinkFaultMode,
 ) -> Result<(), AtmError> {
     let sink = Arc::new(JsonlFileSink::new(
-        fault_injection_log_path(home_dir)?,
+        fault_injection_log_path(log_dir),
         RotationPolicy::default(),
         RetentionPolicy::default(),
     ));
@@ -666,7 +673,15 @@ pub(crate) fn new_adapter_port(
     } else {
         ConsoleLogRoute::Disabled
     };
-    let (logger, active_log_path) = build_logger(home_dir, console_log_route, &service_name)?;
+    let test_log_dir = if std::env::var_os("ATM_LOG_DIR")
+        .filter(|value| !value.is_empty())
+        .is_some()
+    {
+        home::host_log_dir()?
+    } else {
+        home::host_log_dir_from_home(home_dir)
+    };
+    let (logger, active_log_path) = build_logger(&test_log_dir, console_log_route, &service_name)?;
     Ok(Box::new(ScObservabilityAdapter::new(
         logger,
         active_log_path,

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -216,9 +216,39 @@ mod tests {
 
     #[test]
     #[serial]
+    fn concrete_adapter_uses_host_scoped_default_log_path() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let _env = EnvGuard::set_many([("ATM_LOG", Some("info")), ("ATM_LOG_DIR", None)]);
+        let observability =
+            CliObservability::new(tempdir.path(), CliObservabilityOptions::default())
+                .expect("concrete adapter");
+
+        observability
+            .emit(event(Some("550e8400-e29b-41d4-a716-446655440000")))
+            .expect("emit backlog");
+
+        let health = observability.health().expect("health");
+        assert_eq!(
+            health.active_log_path,
+            Some(
+                tempdir
+                    .path()
+                    .join(".atm")
+                    .join("logs")
+                    .join("atm.log.jsonl")
+            )
+        );
+    }
+
+    #[test]
+    #[serial]
     fn concrete_adapter_emits_queries_follows_and_reports_health() {
         let tempdir = TempDir::new().expect("tempdir");
-        let _atm_log = EnvGuard::set_raw("ATM_LOG", "info");
+        let log_dir = tempdir.path().join(".atm").join("logs");
+        let _env = EnvGuard::set_many([
+            ("ATM_LOG", Some("info")),
+            ("ATM_LOG_DIR", Some(log_dir.to_str().expect("utf8 path"))),
+        ]);
         let observability =
             CliObservability::new(tempdir.path(), CliObservabilityOptions::default())
                 .expect("concrete adapter");
@@ -247,17 +277,7 @@ mod tests {
             health.query_state,
             Some(AtmObservabilityHealthState::Healthy)
         );
-        assert_eq!(
-            health.active_log_path,
-            Some(
-                tempdir
-                    .path()
-                    .join(".local")
-                    .join("share")
-                    .join("logs")
-                    .join("atm.log.jsonl")
-            )
-        );
+        assert_eq!(health.active_log_path, Some(log_dir.join("atm.log.jsonl")));
         assert!(health.detail.is_none());
 
         let mut follow = observability

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -218,7 +218,11 @@ mod tests {
     #[serial]
     fn concrete_adapter_uses_host_scoped_default_log_path() {
         let tempdir = TempDir::new().expect("tempdir");
-        let _env = EnvGuard::set_many([("ATM_LOG", Some("info")), ("ATM_LOG_DIR", None)]);
+        let _env = EnvGuard::set_many([
+            ("ATM_LOG", Some("info")),
+            ("ATM_LOG_DIR", None),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
+        ]);
         let observability =
             CliObservability::new(tempdir.path(), CliObservabilityOptions::default())
                 .expect("concrete adapter");
@@ -248,6 +252,7 @@ mod tests {
         let _env = EnvGuard::set_many([
             ("ATM_LOG", Some("info")),
             ("ATM_LOG_DIR", Some(log_dir.to_str().expect("utf8 path"))),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
         ]);
         let observability =
             CliObservability::new(tempdir.path(), CliObservabilityOptions::default())

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -309,6 +309,22 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn concrete_adapter_fails_closed_when_atm_log_dir_is_invalid() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let _env = EnvGuard::set_many([
+            ("ATM_LOG", Some("info")),
+            ("ATM_LOG_DIR", Some("relative/logs")),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
+        ]);
+
+        let error = CliObservability::new(tempdir.path(), CliObservabilityOptions::default())
+            .expect_err("invalid ATM_LOG_DIR should fail closed");
+        assert!(error.is_config());
+        assert!(error.message.contains("absolute path"));
+    }
+
+    #[test]
     fn cli_observability_is_debuggable() {
         let observability =
             CliObservability::from_test_port(atm_core::observability::NullObservability);

--- a/docs/adr/ADR-011-host-scoped-retained-log-root.md
+++ b/docs/adr/ADR-011-host-scoped-retained-log-root.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | ID | ADR-011 |
 | Status | Accepted |
-| Date | 2026-05-10 |
+| Date | 2026-05-09 |
 | Deciders | arch-ctm, team-lead |
 | Relates-to | ADR-010 |
 | Supersedes | — |

--- a/docs/adr/ADR-011-host-scoped-retained-log-root.md
+++ b/docs/adr/ADR-011-host-scoped-retained-log-root.md
@@ -1,0 +1,75 @@
+# ADR-011 — Host-Scoped Retained Log Root
+
+## Status
+
+Accepted
+
+## Context
+
+Phase S.8 left ATM retained logging in an operationally weak state:
+
+- runtime/state files are host-scoped under `~/.atm/...`
+- retained log files still default to `.local/share/logs/...`
+- daemon lifetime visibility depends too much on implicit logger defaults
+
+That split makes routine support work harder than it needs to be. Operators
+should have one ATM-owned host-scoped place to look for retained diagnostics,
+and the default retained event set must be non-silent for daemon startup,
+shutdown, degradation, and subsystem warnings/errors.
+
+## Decision
+
+ATM retained logs are host-scoped and default to:
+
+- `~/.atm/logs/atm.log.jsonl`
+
+Auxiliary ATM-owned retained logs also live under the same host-scoped log
+directory unless a later ADR makes a narrower exception.
+
+The retained log directory is resolved independently of `ATM_HOME`:
+
+- default root: OS user home + `~/.atm/logs/`
+- override: `ATM_LOG_DIR`
+
+`ATM_LOG_DIR` is the exact retained log directory, not a parent root that
+requires another implicit `logs/` segment.
+
+Default retained logging must preserve at least this baseline:
+
+- daemon start requested
+- daemon startup completed / serving ready
+- daemon shutdown requested
+- daemon shutdown completed
+- daemon degraded / abnormal-exit signals
+- every `warn!` and `error!` event emitted by ATM subsystems
+
+The default retained logger level must therefore be high enough to include the
+daemon lifecycle `info!` events in addition to warning/error events. The
+console sink remains off by default for ordinary CLI command execution.
+
+## Consequences
+
+- `atm-core` must own a host-scoped log-directory helper distinct from
+  `atm_home()`
+- `atm` observability bootstrap must route retained logs through the
+  host-scoped ATM log directory rather than `.local/share/logs`
+- `atm-daemon` health/reporting must surface the same retained log path
+- daemon and CLI logging docs must describe one consistent default path and
+  default retained event baseline
+
+## Alternatives Considered
+
+### Keep `.local/share/logs`
+
+Rejected because it separates retained logs from the rest of ATM host-scoped
+runtime state and weakens operator discoverability.
+
+### Make `ATM_HOME` Own Retained Logs
+
+Rejected because retained diagnostics are host-scoped operational state, not
+team/workspace-local Claude layout state.
+
+### Keep Default Logging Quiet And Require `ATM_LOG`
+
+Rejected because daemon lifetime and degradation events must be available by
+default when operators are debugging startup/shutdown/runtime faults.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -15,6 +15,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-008 — No-Flaky-Test Policy And Mechanical Enforcement](./ADR-008-no-flaky-test-policy-and-mechanical-enforcement.md)
 - [ADR-009 — Bounded Queue Query Surface](./ADR-009-bounded-queue-query-surface.md)
 - [ADR-010 — Claude JSONL Compatibility Envelope](./ADR-010-claude-jsonl-compatibility-envelope.md)
+- [ADR-011 — Host-Scoped Retained Log Root](./ADR-011-host-scoped-retained-log-root.md)
 
 ## Embedded Crate-Local ADR Records
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1464,10 +1464,17 @@ Implementation rules:
   boundary
 - `atm` initializes the shared logger exactly once per process
 - the shared file sink is the authoritative retained log store for `atm log`
+- the default ATM-owned retained log file is `~/.atm/logs/atm.log.jsonl`
+- `ATM_LOG_DIR` overrides the exact retained log directory
+- retained log path ownership is host-scoped and independent of `ATM_HOME`
 - the shared console sink remains opt-in so it does not contaminate normal
   command output
 - the initial-release dependency is the published crates.io version
   `sc-observability = "1.0.0"`
+- the default retained logger baseline must include:
+  - daemon lifecycle `info!` events
+  - every subsystem `warn!` event
+  - every subsystem `error!` event
 
 ### 14.3 Failure Diagnostic Rules
 

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -177,6 +177,14 @@ Current retained ATM surfaces outside the daemon request/response packet family:
   debug-only runtime path replaces it in production.
 - plugin-local observability does not replace daemon-owned runtime/transport
   sinks; daemon-owned events stay daemon-owned.
+- daemon retained-log reporting must use the host-scoped ATM log contract:
+  `~/.atm/logs/atm.log.jsonl` by default and `ATM_LOG_DIR` when overridden.
+- daemon health/reporting must not point retained-log status at `.local/share`,
+  `~/logs`, `~/.claude/logs`, or other non-ATM-owned defaults.
+- the default retained daemon logging baseline must keep:
+  - daemon lifecycle `info!` events
+  - every daemon/runtime/transport `warn!` event
+  - every daemon/runtime/transport `error!` event
 - runtime subsystems stay fully isolated:
   - SQL/store calls belong only to the store boundary
   - file-watch/reconcile logic belongs only to the watcher/reconcile boundary

--- a/docs/atm-daemon/logging.md
+++ b/docs/atm-daemon/logging.md
@@ -1,0 +1,53 @@
+# ATM Daemon Logging Contract
+
+This document is the Phase S.9 logging contract for ATM-owned retained logs.
+It is a planning/specification document until the S.9 implementation lands.
+
+## Default Retained Log Path
+
+ATM-owned retained logs default to:
+
+- `~/.atm/logs/atm.log.jsonl`
+
+The retained log directory is host-scoped and independent of `ATM_HOME`.
+
+## Override
+
+`ATM_LOG_DIR` overrides the exact retained log directory.
+
+Examples:
+
+- default:
+  - `~/.atm/logs/atm.log.jsonl`
+- override:
+  - `ATM_LOG_DIR=/tmp/atm-logs`
+  - retained log path: `/tmp/atm-logs/atm.log.jsonl`
+
+## Default Retained Event Set
+
+Without extra operator tuning, retained logging must include at least:
+
+- daemon start requested
+- daemon startup completed / ready
+- daemon shutdown requested
+- daemon shutdown completed
+- daemon degraded / abnormal-exit signals
+- every `warn!` event emitted by ATM subsystems
+- every `error!` event emitted by ATM subsystems
+
+This contract is intentionally minimal. It is not a requirement to retain every
+possible `info!` event across the whole system, but the daemon lifecycle
+milestones above must remain visible by default.
+
+## Console Sink
+
+The shared console sink remains off by default for ordinary ATM CLI command
+execution so retained logs do not pollute normal stdout/stderr command output.
+
+## Forbidden Default Paths
+
+ATM-owned retained logs must not default to:
+
+- `~/logs/`
+- `~/.claude/logs/`
+- `.local/share/logs/`

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -171,6 +171,11 @@ Initial crate requirement IDs:
 - `REQ-DAEMON-OBS-001` `atm-daemon` owns daemon/runtime/transport structured
   event emission through `sc-observability`. Satisfies:
   `REQ-CORE-OBS-002`.
+- `REQ-DAEMON-OBS-002` `atm-daemon` owns the daemon-side retained logging
+  baseline and must preserve daemon lifecycle `info!` events plus every
+  daemon/runtime/transport `warn!` / `error!` event at the default retained
+  logger level and host-scoped retained path. Satisfies:
+  `REQ-P-OBS-002`, `REQ-P-OBS-003`, `REQ-CORE-OBS-002`.
 - `REQ-DAEMON-HEALTH-001` `atm-daemon` owns the daemon health interface
   consumed by `atm doctor`. Satisfies:
   `REQ-CORE-DOCTOR-002`.
@@ -223,6 +228,7 @@ The `atm-daemon` crate docs must remain aligned with:
 - [`../atm-core/architecture.md`](../atm-core/architecture.md)
 - [`./boundaries.md`](./boundaries.md)
 - [`./protocol-icd.md`](./protocol-icd.md)
+- [`./logging.md`](./logging.md)
 
 ## 5. Phase R Runtime Requirements
 

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -108,11 +108,17 @@ Follow-up work:
   `atm-core`.
 - `atm` owns the concrete published-crate bootstrap against
   `sc-observability = "1.0.0"`.
+- `atm` owns retained-log bootstrap against the host-scoped ATM log directory
+  contract (`~/.atm/logs/` by default, `ATM_LOG_DIR` when overridden) rather
+  than `.local/share/logs` or any `ATM_HOME`-derived path.
 - `atm` owns the structured construction contract for the concrete adapter:
   `CliObservability::new(home_dir, CliObservabilityOptions)`.
 - `atm` may retain `init(...)` only as a delegating helper.
 - `atm` owns CLI-layer observability for command entry, daemon connectivity,
   and render/exit outcomes.
+- `atm` owns the default retained logger baseline needed to keep daemon
+  lifecycle `info!` events and all `warn!` / `error!` events visible when
+  `ATM_LOG` is unset.
 - `atm` owns the retained local recovery CLI shape for `teams` and `members`,
   but not the underlying team/backup/restore business rules
 - `atm` must not access SQLite or inbox JSONL directly

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -89,6 +89,9 @@ Initial crate requirement IDs:
 
 - initializing the concrete shared logger once per CLI process
 - mapping ATM env/config decisions into shared logger configuration
+- resolving the retained log directory through the host-scoped ATM log-path
+  contract rather than through `ATM_HOME`
+- honoring `ATM_LOG_DIR` as the exact retained log-directory override
 - consuming the published `sc-observability = "1.0.0"` crate baseline rather
   than a local pre-publish checkout
 - exposing one structured construction contract for the concrete adapter:
@@ -98,6 +101,9 @@ Initial crate requirement IDs:
   implementation surfaces a concrete defect
 - logging CLI bootstrap, parse, and terminal command failures with stable
   ATM-owned error codes before exit
+- keeping the default retained logger baseline high enough to preserve daemon
+  lifecycle `info!` events plus all `warn!` / `error!` events when `ATM_LOG`
+  is unset
 - using the single ATM-owned code registry defined by
   [`../atm-error-codes.md`](../atm-error-codes.md) rather than local ad hoc
   code strings

--- a/docs/phase-S/issues.md
+++ b/docs/phase-S/issues.md
@@ -98,6 +98,12 @@ Disposition:
     `triaging-findings`, and the phase integration-worktree ownership rule all
     agree on the canonical `triage_root`.
 
+21. Retained ATM logging still uses an operationally weak default contract:
+    the current log-root behavior is split from the `~/.atm/` host state tree,
+    the `ATM_LOG_DIR` redirect is not yet part of the owned contract, and the
+    minimum daemon-lifecycle / warning / error event baseline is not yet
+    explicitly planned and reviewed.
+
 ## Assigned Follow-On Sprint Ownership
 
 - `S.6`
@@ -115,6 +121,10 @@ Disposition:
   - `[atm].claude_jsonl_body_export_max_bytes`
   - oversized ATM-authored retrieval-stub export
   - watcher/reconcile no-churn handling for ATM-authored projections
+- `S.9`
+  - host-scoped retained log directory contract
+  - `ATM_LOG_DIR` redirect behavior
+  - minimum default retained daemon-lifecycle / warning / error event set
 
 ## Deferred Follow-Up
 

--- a/docs/phase-S/sprint-S9.md
+++ b/docs/phase-S/sprint-S9.md
@@ -147,6 +147,9 @@ Implementation-sprint acceptance:
 - retained logging is host-scoped and independent of `ATM_HOME`
 - default retained logging includes daemon lifecycle `info!` events plus all
   `warn!` / `error!` events across ATM subsystems
+- console sink remains disabled by default; no retained-log output appears on
+  stdout/stderr during normal `atm send` / `atm read` runs unless an explicit
+  logging opt-in such as `ATM_LOG` is set
 - sink initialization fails closed at startup with typed path/context errors
 - mid-run retained-log write failures degrade to stderr-once plus continued
   operation rather than daemon termination

--- a/docs/phase-S/sprint-S9.md
+++ b/docs/phase-S/sprint-S9.md
@@ -1,0 +1,111 @@
+# Phase S.9 — Host-Scoped Logging Defaults
+
+```yaml
+plan_type: sprint_plan
+phase: S
+sprint: "S.9"
+status: planned
+estimated_scope: S
+```
+
+## Goal
+
+Finish Phase S retained logging by moving ATM-owned retained logs to the
+host-scoped ATM state root and defining the minimum default retained event set
+that must be present without extra operator tuning.
+
+## Governing Requirements
+
+- `REQ-P-OBS-001`
+- `REQ-P-OBS-002`
+- `REQ-P-OBS-003`
+- `REQ-ATM-OBS-001`
+- `REQ-DAEMON-OBS-001`
+- `REQ-DAEMON-OBS-002`
+
+## Governing ADRs
+
+- `docs/adr/ADR-011-host-scoped-retained-log-root.md`
+
+## Hard Dependencies
+
+- S.8 is merged
+- the shared `sc-observability` integration remains the retained log/query
+  substrate
+- host-scoped runtime/state ownership remains rooted under `~/.atm/`
+
+## Required Work
+
+1. Add one host-scoped ATM log-directory contract.
+1.1 Add `host_log_dir_from_home(home_dir: &Path) -> PathBuf` in
+    `atm-core/src/home.rs`.
+1.2 Add `host_log_dir() -> Result<PathBuf, AtmError>` that honors
+    `ATM_LOG_DIR` first, then falls back to the OS user home.
+1.3 Keep retained logs host-scoped and independent of `ATM_HOME`.
+
+2. Move retained ATM logs to the ATM host state root.
+2.1 Default retained log file:
+    - `~/.atm/logs/atm.log.jsonl`
+2.2 Auxiliary ATM-owned retained log files remain under `~/.atm/logs/`
+    unless a later ADR narrows them.
+2.3 No retained ATM log writes may default to:
+    - `~/logs/`
+    - `~/.claude/logs/`
+    - `.local/share/logs/`
+
+3. Define the default retained event baseline.
+3.1 Retain daemon lifecycle `info!` events by default:
+    - start requested
+    - startup completed / ready
+    - shutdown requested
+    - shutdown completed
+3.2 Retain every `warn!` and `error!` event across ATM subsystems by default.
+3.3 Keep the shared console sink disabled by default for ordinary CLI command
+    execution.
+
+4. Document the retained logging contract.
+4.1 Add `docs/atm-daemon/logging.md`.
+4.2 Document the default retained path and `ATM_LOG_DIR`.
+4.3 Document the minimum retained event set.
+4.4 Cross-link the daemon logging contract from top-level and crate-local docs.
+
+## Required Code Targets
+
+- `crates/atm-core/src/home.rs`
+- `crates/atm/src/main.rs`
+- `crates/atm/src/observability.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+
+## Required Document Updates
+
+- `docs/project-plan.md`
+- `docs/plan-phase-S.md`
+- `docs/phase-S/issues.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm/requirements.md`
+- `docs/atm/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+- `docs/atm-daemon/logging.md`
+- `docs/adr/ADR-011-host-scoped-retained-log-root.md`
+- `docs/adr/INDEX.md`
+
+## Acceptance Criteria
+
+- ATM retained logs default to `~/.atm/logs/atm.log.jsonl`
+- `ATM_LOG_DIR` redirects the exact retained log directory
+- retained logging is host-scoped and independent of `ATM_HOME`
+- default retained logging includes daemon lifecycle `info!` events plus all
+  `warn!` / `error!` events across ATM subsystems
+- the shared console sink remains off by default for ordinary CLI command
+  execution
+- no ATM-owned retained log defaults point at `~/logs/`, `~/.claude/logs/`,
+  or `.local/share/logs/`
+
+## Required Validation
+
+- `just lint`
+- `cargo test -p agent-team-mail-core`
+- `cargo test -p atm-daemon`
+- `cargo xwin check --workspace --target x86_64-pc-windows-msvc`

--- a/docs/plan-phase-S.md
+++ b/docs/plan-phase-S.md
@@ -518,6 +518,27 @@ Required closeout work:
 - export `atm read --message-id <id>` stubs for oversized ATM-authored bodies
 - preserve summary text while keeping full ATM-authored bodies durable in
   SQLite
+
+### S.9 Host-Scoped Logging Defaults
+
+Goal:
+- move retained ATM logs to the host-scoped ATM state root and define the
+  minimum default retained event set required for daemon operability
+
+Required outcomes:
+- ATM retained logs default to `~/.atm/logs/atm.log.jsonl`
+- `ATM_LOG_DIR` redirects the exact retained log directory
+- retained logs remain host-scoped and independent of `ATM_HOME`
+- default retained logging includes daemon lifecycle `info!` events plus all
+  `warn!` / `error!` events across ATM subsystems
+
+Required closeout work:
+- add `host_log_dir()` and `host_log_dir_from_home(...)` to `atm-core`
+- move CLI observability bootstrap and daemon health/reporting to the
+  host-scoped ATM log directory
+- add `docs/atm-daemon/logging.md`
+- reconcile product and crate-local observability docs with the new retained
+  path and event baseline
 - prevent self-induced churn loops in watcher/reconcile paths
 
 ## 6. Removed Windows CI Guardrail

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -60,6 +60,7 @@ Phase-S planning note:
   - `S.6` daemon post-mortem runtime remediation
   - `S.7` bounded queue-query implementation
   - `S.8` Claude JSONL compatibility-envelope implementation
+  - `S.9` host-scoped retained logging defaults
 
 Phase R execution entry:
 - Wave 1 deliverable: the new Phase R skeleton

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1866,12 +1866,19 @@ Required rules:
 Product requirement ID:
 - `REQ-P-OBS-001` ATM observability must satisfy the documented best-effort
   emit behavior and shared query/follow/health expectations.
+- `REQ-P-OBS-002` ATM retained logs must use one host-scoped ATM-owned default
+  directory and must not derive that retained location from `ATM_HOME`.
+- `REQ-P-OBS-003` ATM retained logging must be non-silent by default for the
+  daemon lifecycle baseline and for every warning/error emitted by ATM
+  subsystems.
 
 Satisfied by:
 - `REQ-ATM-OBS-001` for CLI bootstrap/injection aspects
 - `REQ-CORE-LOG-001` for ATM log query/follow service aspects
 - `REQ-CORE-DOCTOR-001` for observability health reporting aspects
 - `REQ-CORE-OBS-001` for ATM event and query-model boundary aspects
+- `REQ-DAEMON-OBS-001` and `REQ-DAEMON-OBS-002` for daemon/runtime retained
+  event-baseline aspects
 
 ATM must emit structured records through `sc-observability`.
 
@@ -1906,12 +1913,25 @@ Emission is best-effort:
 
 Sink policy:
 - the shared file sink is required for retained ATM observability
+- default ATM-owned retained logs live at `~/.atm/logs/atm.log.jsonl`
+- `ATM_LOG_DIR` overrides the exact retained log directory
+- retained log location is host-scoped and must not derive from `ATM_HOME`
+- ATM-owned retained logs must not default to:
+  - `~/logs/`
+  - `~/.claude/logs/`
+  - `.local/share/logs/`
 - the shared console sink is optional and must remain off by default for normal
   ATM CLI command execution so command output stays stable
 - console logging may be enabled later for explicit local debugging or
   integration testing
 
 Diagnostic logging rules:
+- retained logging must include the daemon lifecycle baseline by default:
+  - start requested
+  - startup completed / ready
+  - shutdown requested
+  - shutdown completed
+  - degraded / abnormal-exit signals
 - command failures must emit structured failure diagnostics before the CLI
   exits, even when the command fails before reaching a core service
 - degraded recovery paths that intentionally continue, such as malformed-record
@@ -1921,6 +1941,8 @@ Diagnostic logging rules:
   addition to human-readable text
 - command lifecycle failure events must include the stable error code when one
   is available
+- every `warn!` / `error!` event emitted by ATM subsystems must remain present
+  in retained logs by default
 
 `atm log` and `atm doctor` are not best-effort features in the same sense:
 - they are explicit observability consumers


### PR DESCRIPTION
## Summary

- Adds `host_log_dir_from_home` and `host_log_dir` to `atm-core/src/home.rs` — canonical path helpers for `~/.atm/logs/`, mirroring `host_runtime_dir` and `host_db_dir`
- Fixes `DaemonObservability` log path in `runtime_health.rs` (was `~/logs/`, now `~/.atm/logs/`)
- Fixes `log_root()` in `atm/src/main.rs` (was `~/.local/share`, now `~/.atm/logs/`)
- `ATM_LOG_DIR` env var redirects the log directory
- Adds ADR-011 (host-scoped retained log root) and `docs/atm-daemon/logging.md`

## Test plan

- [ ] `just lint` PASS
- [ ] `cargo test -p atm-core` PASS (host_log_dir_from_home / host_log_dir unit tests)
- [ ] `cargo test -p atm-daemon` PASS
- [ ] `cargo test -p atm` PASS (observability test updated to expect `.atm/logs/`)
- [ ] `cargo xwin check --workspace --target x86_64-pc-windows-msvc` PASS
- [ ] Default log path is `~/.atm/logs/atm.log.jsonl`
- [ ] `ATM_LOG_DIR` redirects log directory
- [ ] No writes to `~/logs/` or `~/.claude/logs/` or `~/.local/share/`

Sprint: phase-S/S.9
Plan QA: PASS (3 rounds, 4f84dc8)
Impl validation: PASS (d6f3b74)

🤖 Generated with [Claude Code](https://claude.com/claude-code)