### PR TITLE
S.10: daemon retained logger bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,8 @@ dependencies = [
  "chrono",
  "fs2",
  "interprocess",
+ "sc-observability",
+ "sc-observability-types",
  "serde_json",
  "serial_test",
  "signal-hook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,6 @@ dependencies = [
  "signal-hook",
  "tempfile",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -19,7 +19,6 @@ sc-observability = "1.0.0"
 sc-observability-types = "1.0.0"
 serde_json.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -18,6 +18,8 @@ atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }
 chrono = { version = "0.4", features = ["serde"] }
 fs2 = "0.4"
 interprocess = "2.4.2"
+sc-observability = "1.0.0"
+sc-observability-types = "1.0.0"
 serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
@@ -30,5 +32,6 @@ signal-hook = "0.3"
 
 [dev-dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2", features = ["test-utils"] }
+sc-observability = { version = "1.0.0", features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -9,9 +9,6 @@ description = "ATM daemon runtime crate scaffold."
 repository.workspace = true
 homepage.workspace = true
 
-[lib]
-name = "atm_daemon"
-
 [dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2" }
 atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -5,7 +5,8 @@ use crate::boundary_adapters::{
 use crate::runtime_health::DaemonRequestDispatcher;
 use crate::runtime_health::{DaemonStatusSource, RuntimeStatusCache};
 use crate::{
-    LocalIpcServerTransportAdapter, PeerTransportRuntime, sqlite_remote_replay_store_from_path,
+    DaemonObservability, LocalIpcServerTransportAdapter, PeerTransportRuntime,
+    sqlite_remote_replay_store_from_path,
 };
 use atm_core::boundary::RequestDispatcher;
 use atm_core::error::AtmError;
@@ -129,12 +130,14 @@ impl RuntimeComposition {
         Self::new_with_replay_store_path(
             home_dir.clone(),
             atm_core::home::host_mail_db_path_from_home(&home_dir),
+            DaemonObservability::new_for_test(atm_core::home::host_log_dir_from_home(&home_dir))?,
         )
     }
 
     fn new_with_replay_store_path(
         home_dir: PathBuf,
         replay_store_path: PathBuf,
+        observability: DaemonObservability,
     ) -> Result<Self, AtmError> {
         let status_cache = RuntimeStatusCache::new();
         let notification_sink = DaemonNotificationSink::new();
@@ -156,6 +159,7 @@ impl RuntimeComposition {
             request_dispatcher: Arc::new(DaemonRequestDispatcher::new(
                 home_dir,
                 status_cache.clone(),
+                observability,
             )),
             _notification_sink: notification_sink.clone(),
             _status_source: DaemonStatusSource::new(status_cache),
@@ -177,6 +181,11 @@ impl RuntimeComposition {
     }
 
     fn begin_shutdown(&self) -> Result<(), AtmError> {
+        self.request_dispatcher.emit_runtime_event(
+            "shutdown_requested",
+            "ok",
+            "daemon shutdown requested",
+        );
         self.lifecycle.transition(RuntimeLifecycleState::Draining)?;
         // Attempt every lane shutdown even if one lane fails so the runtime
         // still reaches checkpoint/flush finalization with the fullest cleanup
@@ -190,12 +199,22 @@ impl RuntimeComposition {
     }
 
     pub(crate) fn start(&self) -> Result<(), AtmError> {
+        self.request_dispatcher.emit_runtime_event(
+            "start_requested",
+            "ok",
+            "daemon start requested",
+        );
         self.lifecycle.transition(RuntimeLifecycleState::Starting)?;
         // Startup replay must finish before the daemon binds its socket so
         // crash-recovered work cannot race newly accepted requests.
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
+                self.request_dispatcher.emit_runtime_event(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
@@ -212,6 +231,11 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
+            self.request_dispatcher.emit_runtime_event(
+                "startup_failed",
+                "failed",
+                "daemon startup failed",
+            );
             self.lifecycle.force_stopped()?;
             return Err(error);
         }
@@ -224,11 +248,21 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during runtime preparation rollback"
                     );
                 }
+                self.request_dispatcher.emit_runtime_event(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
         };
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
+        self.request_dispatcher.emit_runtime_event(
+            "startup_completed",
+            "ok",
+            "daemon startup completed",
+        );
         let request_dispatcher = Arc::clone(&self.request_dispatcher);
         let result = runtime.serve_with_runtime_hooks(
             self.request_dispatcher(),
@@ -247,10 +281,20 @@ impl RuntimeComposition {
         &self,
         socket_path: PathBuf,
     ) -> Result<(), AtmError> {
+        self.request_dispatcher.emit_runtime_event(
+            "start_requested",
+            "ok",
+            "daemon start requested",
+        );
         self.lifecycle.transition(RuntimeLifecycleState::Starting)?;
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
+                self.request_dispatcher.emit_runtime_event(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
@@ -267,6 +311,11 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
+            self.request_dispatcher.emit_runtime_event(
+                "startup_failed",
+                "failed",
+                "daemon startup failed",
+            );
             self.lifecycle.force_stopped()?;
             return Err(error);
         }
@@ -282,11 +331,21 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during test runtime preparation rollback"
                     );
                 }
+                self.request_dispatcher.emit_runtime_event(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
         };
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
+        self.request_dispatcher.emit_runtime_event(
+            "startup_completed",
+            "ok",
+            "daemon startup completed",
+        );
         let request_dispatcher = Arc::clone(&self.request_dispatcher);
         let result = runtime.serve_with_runtime_hooks(
             self.request_dispatcher(),
@@ -323,6 +382,18 @@ impl RuntimeComposition {
                 Err(error) => Err(error),
                 Ok(()) => Err(force_error),
             };
+        }
+        match result.as_ref() {
+            Ok(()) => self.request_dispatcher.emit_runtime_event(
+                "shutdown_completed",
+                "ok",
+                "daemon shutdown completed",
+            ),
+            Err(_) => self.request_dispatcher.emit_runtime_event(
+                "shutdown_failed",
+                "failed",
+                "daemon shutdown failed",
+            ),
         }
         result
     }
@@ -496,10 +567,16 @@ fn validate_runtime_home_dir(home_dir: &std::path::Path) -> Result<(), AtmError>
     Ok(())
 }
 
-pub(crate) fn compose_runtime() -> Result<RuntimeComposition, AtmError> {
+pub(crate) fn compose_runtime(
+    observability: DaemonObservability,
+) -> Result<RuntimeComposition, AtmError> {
     let home_dir = atm_core::home::atm_home()?;
     validate_runtime_home_dir(&home_dir)?;
-    RuntimeComposition::new_with_replay_store_path(home_dir, atm_core::home::host_mail_db_path()?)
+    RuntimeComposition::new_with_replay_store_path(
+        home_dir,
+        atm_core::home::host_mail_db_path()?,
+        observability,
+    )
 }
 
 #[cfg(all(test, unix))]
@@ -611,6 +688,11 @@ mod tests {
 
         assert!(error.is_daemon_unavailable());
         assert_eq!(runtime.lifecycle_state(), RuntimeLifecycleState::Stopped);
+        let retained_log_path =
+            atm_core::home::host_log_dir_from_home(tempdir.path()).join("atm.log.jsonl");
+        let retained_log = std::fs::read_to_string(retained_log_path).expect("retained log");
+        assert!(retained_log.contains("daemon start requested"));
+        assert!(retained_log.contains("daemon startup failed"));
     }
 
     #[test]

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -2,11 +2,11 @@ use crate::boundary_adapters::{
     DaemonConfigIngress, DaemonInboxExport, DaemonInboxIngress, DaemonNotificationSink,
     DaemonReconcileCoordinator, FileWatchEventSource,
 };
+use crate::daemon_runtime_observability::DaemonRuntimeObservability;
 use crate::runtime_health::DaemonRequestDispatcher;
 use crate::runtime_health::{DaemonStatusSource, RuntimeStatusCache};
 use crate::{
-    DaemonObservability, LocalIpcServerTransportAdapter, PeerTransportRuntime,
-    sqlite_remote_replay_store_from_path,
+    LocalIpcServerTransportAdapter, PeerTransportRuntime, sqlite_remote_replay_store_from_path,
 };
 use atm_core::boundary::RequestDispatcher;
 use atm_core::error::AtmError;
@@ -130,14 +130,16 @@ impl RuntimeComposition {
         Self::new_with_replay_store_path(
             home_dir.clone(),
             atm_core::home::host_mail_db_path_from_home(&home_dir),
-            DaemonObservability::new_for_test(atm_core::home::host_log_dir_from_home(&home_dir))?,
+            Arc::new(crate::test_observability::TestDaemonObservability::new(
+                atm_core::home::host_log_dir_from_home(&home_dir),
+            )?),
         )
     }
 
     fn new_with_replay_store_path(
         home_dir: PathBuf,
         replay_store_path: PathBuf,
-        observability: DaemonObservability,
+        observability: Arc<dyn DaemonRuntimeObservability>,
     ) -> Result<Self, AtmError> {
         let status_cache = RuntimeStatusCache::new();
         let notification_sink = DaemonNotificationSink::new();
@@ -568,7 +570,7 @@ fn validate_runtime_home_dir(home_dir: &std::path::Path) -> Result<(), AtmError>
 }
 
 pub(crate) fn compose_runtime(
-    observability: DaemonObservability,
+    observability: Arc<dyn DaemonRuntimeObservability>,
 ) -> Result<RuntimeComposition, AtmError> {
     let home_dir = atm_core::home::atm_home()?;
     validate_runtime_home_dir(&home_dir)?;

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -1,0 +1,605 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::{fs, fs::OpenOptions};
+
+use atm_core::boundary;
+use atm_core::error::AtmError;
+use atm_core::error_codes::AtmErrorCode;
+use atm_core::home;
+use atm_core::observability::{
+    AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState, CommandEvent,
+    LogTailSession, ObservabilityPort, RetainedSinkFaultMode,
+};
+use sc_observability::{
+    JsonlFileSink, LogSink, Logger, LoggerConfig, RetentionPolicy, RotationPolicy, SinkRegistration,
+};
+use sc_observability_types::{
+    ActionName, CorrelationId, DiagnosticInfo, Level, LevelFilter as SharedLevelFilter, LogEvent,
+    LogSinkError, OutcomeLabel, ProcessIdentity, SchemaVersion, ServiceName, TargetCategory,
+    Timestamp,
+};
+use serde_json::Map;
+
+const ATM_SERVICE_NAME: &str = "atm";
+const ATM_DAEMON_TARGET: &str = "atm.daemon";
+const ATM_LOG_LEVEL_ENV: &str = "ATM_LOG";
+#[cfg(test)]
+const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAINED_SINK_FAULT";
+
+pub struct DaemonObservability {
+    logger: Arc<Logger>,
+    active_log_path: PathBuf,
+    service_name: ServiceName,
+    target_category: TargetCategory,
+}
+
+impl std::fmt::Debug for DaemonObservability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DaemonObservability")
+            .field("active_log_path", &self.active_log_path)
+            .field("service_name", &self.service_name)
+            .field("target_category", &self.target_category)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Clone for DaemonObservability {
+    fn clone(&self) -> Self {
+        Self {
+            logger: Arc::clone(&self.logger),
+            active_log_path: self.active_log_path.clone(),
+            service_name: self.service_name.clone(),
+            target_category: self.target_category.clone(),
+        }
+    }
+}
+
+impl DaemonObservability {
+    pub(crate) fn bootstrap() -> Result<Self, AtmError> {
+        Self::bootstrap_at_log_dir(home::host_log_dir()?)
+    }
+
+    fn bootstrap_at_log_dir(log_dir: PathBuf) -> Result<Self, AtmError> {
+        let service_name = ServiceName::new(ATM_SERVICE_NAME).map_err(|source| {
+            AtmError::observability_bootstrap("failed to validate ATM daemon service name")
+                .with_source(source)
+        })?;
+        let target_category = TargetCategory::new(ATM_DAEMON_TARGET).map_err(|source| {
+            AtmError::observability_bootstrap("failed to validate ATM daemon observability target")
+                .with_source(source)
+        })?;
+        let retained_sink_fault = retained_sink_fault_mode()?;
+        let (logger, active_log_path) = build_logger(&log_dir, retained_sink_fault, &service_name)?;
+        Ok(Self {
+            logger: Arc::new(logger),
+            active_log_path,
+            service_name,
+            target_category,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(log_dir: PathBuf) -> Result<Self, AtmError> {
+        Self::bootstrap_at_log_dir(log_dir)
+    }
+
+    pub(crate) fn emit_runtime_event(
+        &self,
+        action: &'static str,
+        outcome: &'static str,
+        message: &'static str,
+    ) -> Result<(), AtmError> {
+        let event = map_runtime_event(
+            &self.service_name,
+            &self.target_category,
+            action,
+            outcome,
+            message,
+        )?;
+        self.logger.emit(event).map_err(|source| {
+            let code = source.diagnostic().code.as_str().to_string();
+            AtmError::observability_emit(format!(
+                "shared daemon observability emit failed ({code})"
+            ))
+            .with_source(source)
+        })
+    }
+
+    pub(crate) fn best_effort_flush_blocking(&self) -> Result<(), AtmError> {
+        self.logger.flush().map_err(|source| {
+            AtmError::observability_health(
+                "failed to flush retained observability sink during daemon shutdown",
+            )
+            .with_source(source)
+        })?;
+        if !self.active_log_path.exists() {
+            return Ok(());
+        }
+        let file = OpenOptions::new()
+            .append(true)
+            .open(&self.active_log_path)
+            .map_err(|source| {
+                AtmError::observability_health(format!(
+                    "failed to open retained observability sink at {} for best-effort flush",
+                    self.active_log_path.display()
+                ))
+                .with_source(source)
+            })?;
+        file.sync_all().map_err(|source| {
+            AtmError::observability_health(format!(
+                "failed to sync retained observability sink at {}",
+                self.active_log_path.display()
+            ))
+            .with_source(source)
+        })
+    }
+}
+
+impl boundary::sealed::Sealed for DaemonObservability {}
+
+impl ObservabilityPort for DaemonObservability {
+    fn emit(&self, event: CommandEvent) -> Result<(), AtmError> {
+        let event = map_command_event(&self.service_name, &self.target_category, event)?;
+        self.logger.emit(event).map_err(|source| {
+            let code = source.diagnostic().code.as_str().to_string();
+            AtmError::observability_emit(format!(
+                "shared daemon observability emit failed ({code})"
+            ))
+            .with_source(source)
+        })
+    }
+
+    fn query(&self, _req: AtmLogQuery) -> Result<AtmLogSnapshot, AtmError> {
+        Err(
+            AtmError::observability_query(
+                "daemon retained-log query is unavailable from the exact-path daemon logger adapter",
+            )
+            .with_recovery(
+                "Use the CLI-owned retained log query surface for historical log reads until daemon query support is explicitly extracted.",
+            ),
+        )
+    }
+
+    fn follow(&self, _req: AtmLogQuery) -> Result<LogTailSession, AtmError> {
+        Err(
+            AtmError::observability_follow(
+                "daemon retained-log follow is unavailable from the exact-path daemon logger adapter",
+            )
+            .with_recovery(
+                "Use the CLI-owned retained log follow surface until daemon follow support is explicitly extracted.",
+            ),
+        )
+    }
+
+    fn health(&self) -> Result<AtmObservabilityHealth, AtmError> {
+        let report = self.logger.health();
+        Ok(AtmObservabilityHealth {
+            active_log_path: Some(self.active_log_path.clone()),
+            logging_state: map_logging_state(report.state),
+            query_state: None,
+            detail: report.last_error.map(render_diagnostic_summary),
+        })
+    }
+}
+
+fn build_logger(
+    log_dir: &Path,
+    retained_sink_fault: Option<RetainedSinkFaultMode>,
+    service_name: &ServiceName,
+) -> Result<(Logger, PathBuf), AtmError> {
+    let active_log_path = log_dir.join("atm.log.jsonl");
+    ensure_retained_log_ready(log_dir, &active_log_path)?;
+    let mut config = LoggerConfig::default_for(service_name.clone(), PathBuf::new());
+    config.level = logger_level_override()?.unwrap_or(SharedLevelFilter::Info);
+    config.enable_console_sink = false;
+    config.enable_file_sink = false;
+    let mut builder = Logger::builder(config).map_err(|source| {
+        AtmError::observability_bootstrap("failed to initialize shared daemon observability logger")
+            .with_source(source)
+    })?;
+    let sink = Arc::new(JsonlFileSink::new(
+        active_log_path.clone(),
+        RotationPolicy::default(),
+        RetentionPolicy::default(),
+    ));
+    let sink: Arc<dyn LogSink> = match retained_sink_fault {
+        Some(mode) => Arc::new(RetainedSinkHealthOverride::new(sink, mode)),
+        None => sink,
+    };
+    builder.register_sink(SinkRegistration::new(sink));
+    Ok((builder.build(), active_log_path))
+}
+
+fn ensure_retained_log_ready(log_dir: &Path, active_log_path: &Path) -> Result<(), AtmError> {
+    fs::create_dir_all(log_dir).map_err(|source| {
+        AtmError::observability_bootstrap(format!(
+            "failed to create retained log directory {}",
+            log_dir.display()
+        ))
+        .with_source(source)
+    })?;
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(active_log_path)
+        .map(|_| ())
+        .map_err(|source| {
+            AtmError::observability_bootstrap(format!(
+                "failed to open retained log file {} during startup",
+                active_log_path.display()
+            ))
+            .with_source(source)
+        })
+}
+
+fn logger_level_override() -> Result<Option<SharedLevelFilter>, AtmError> {
+    let Some(value) = std::env::var(ATM_LOG_LEVEL_ENV)
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+
+    match value.as_str() {
+        "trace" => Ok(Some(SharedLevelFilter::Trace)),
+        "debug" => Ok(Some(SharedLevelFilter::Debug)),
+        "info" => Ok(Some(SharedLevelFilter::Info)),
+        "warn" => Ok(Some(SharedLevelFilter::Warn)),
+        "error" => Ok(Some(SharedLevelFilter::Error)),
+        "off" => Ok(Some(SharedLevelFilter::Off)),
+        _ => Err(AtmError::observability_bootstrap(format!(
+            "invalid {ATM_LOG_LEVEL_ENV} value `{value}`; use `trace`, `debug`, `info`, `warn`, `error`, or `off`"
+        ))),
+    }
+}
+
+pub fn tracing_level_override() -> Result<tracing::Level, AtmError> {
+    Ok(
+        match logger_level_override()?.unwrap_or(SharedLevelFilter::Info) {
+            SharedLevelFilter::Trace => tracing::Level::TRACE,
+            SharedLevelFilter::Debug => tracing::Level::DEBUG,
+            SharedLevelFilter::Info => tracing::Level::INFO,
+            SharedLevelFilter::Warn => tracing::Level::WARN,
+            SharedLevelFilter::Error | SharedLevelFilter::Off => tracing::Level::ERROR,
+        },
+    )
+}
+
+fn retained_sink_fault_mode() -> Result<Option<RetainedSinkFaultMode>, AtmError> {
+    #[cfg(not(test))]
+    {
+        Ok(None)
+    }
+    #[cfg(test)]
+    {
+        let Some(value) = std::env::var(ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV)
+            .ok()
+            .map(|value| value.trim().to_ascii_lowercase())
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(None);
+        };
+
+        match value.as_str() {
+            "degraded" => Ok(Some(RetainedSinkFaultMode::Degraded)),
+            "unavailable" => Ok(Some(RetainedSinkFaultMode::Unavailable)),
+            _ => Err(AtmError::observability_bootstrap(format!(
+                "invalid {ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV} value `{value}`; use `degraded` or `unavailable`"
+            ))),
+        }
+    }
+}
+
+fn map_command_event(
+    service_name: &ServiceName,
+    target_category: &TargetCategory,
+    event: CommandEvent,
+) -> Result<LogEvent, AtmError> {
+    let schema_version =
+        SchemaVersion::new(sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION)
+            .map_err(|source| {
+                AtmError::observability_emit(
+                    "failed to validate ATM daemon observability schema version",
+                )
+                .with_source(source)
+            })?;
+    let action = ActionName::new(event.action).map_err(|source| {
+        AtmError::observability_emit("failed to validate ATM daemon observability action")
+            .with_source(source)
+    })?;
+    let request_id = event
+        .message_id
+        .map(|value| CorrelationId::new(value.to_string()))
+        .transpose()
+        .map_err(|source| {
+            AtmError::observability_emit("failed to validate ATM daemon request id")
+                .with_source(source)
+        })?;
+    let correlation_id = event
+        .task_id
+        .as_deref()
+        .map(CorrelationId::new)
+        .transpose()
+        .map_err(|source| {
+            AtmError::observability_emit("failed to validate ATM daemon correlation id")
+                .with_source(source)
+        })?;
+    let outcome = OutcomeLabel::new(event.outcome).map_err(|source| {
+        AtmError::observability_emit("failed to validate ATM daemon outcome label")
+            .with_source(source)
+    })?;
+
+    let mut fields = Map::new();
+    fields.insert(
+        "command".to_string(),
+        serde_json::Value::String(event.command.to_string()),
+    );
+    fields.insert(
+        "team".to_string(),
+        serde_json::Value::String(event.team.to_string()),
+    );
+    fields.insert(
+        "agent".to_string(),
+        serde_json::Value::String(event.agent.to_string()),
+    );
+    fields.insert(
+        "sender".to_string(),
+        serde_json::Value::String(event.sender.to_string()),
+    );
+    fields.insert(
+        "requires_ack".to_string(),
+        serde_json::Value::Bool(event.requires_ack),
+    );
+    fields.insert(
+        "dry_run".to_string(),
+        serde_json::Value::Bool(event.dry_run),
+    );
+    if let Some(message_id) = event.message_id {
+        fields.insert(
+            "message_id".to_string(),
+            serde_json::Value::String(message_id.to_string()),
+        );
+    }
+    if let Some(task_id) = &event.task_id {
+        fields.insert(
+            "task_id".to_string(),
+            serde_json::Value::String(task_id.to_string()),
+        );
+    }
+    if let Some(error_code) = event.error_code {
+        fields.insert(
+            "error_code".to_string(),
+            serde_json::Value::String(error_code.to_string()),
+        );
+    }
+    if let Some(error_message) = &event.error_message {
+        fields.insert(
+            "error_message".to_string(),
+            serde_json::Value::String(error_message.clone()),
+        );
+    }
+
+    Ok(LogEvent {
+        version: schema_version,
+        timestamp: Timestamp::now_utc(),
+        level: level_for_outcome(event.outcome),
+        service: service_name.clone(),
+        target: target_category.clone(),
+        action,
+        message: Some(format!(
+            "ATM daemon handled {} with outcome {}",
+            event.command, event.outcome
+        )),
+        identity: ProcessIdentity::default(),
+        trace: None,
+        request_id,
+        correlation_id,
+        outcome: Some(outcome),
+        diagnostic: None,
+        state_transition: None,
+        fields,
+    })
+}
+
+fn map_runtime_event(
+    service_name: &ServiceName,
+    target_category: &TargetCategory,
+    action: &'static str,
+    outcome: &'static str,
+    message: &'static str,
+) -> Result<LogEvent, AtmError> {
+    let schema_version =
+        SchemaVersion::new(sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION)
+            .map_err(|source| {
+                AtmError::observability_emit(
+                    "failed to validate ATM daemon lifecycle schema version",
+                )
+                .with_source(source)
+            })?;
+    let action = ActionName::new(action).map_err(|source| {
+        AtmError::observability_emit("failed to validate ATM daemon lifecycle action")
+            .with_source(source)
+    })?;
+    let outcome = OutcomeLabel::new(outcome).map_err(|source| {
+        AtmError::observability_emit("failed to validate ATM daemon lifecycle outcome")
+            .with_source(source)
+    })?;
+    let fields = Map::from_iter([(
+        "component".to_string(),
+        serde_json::Value::String("daemon_runtime".to_string()),
+    )]);
+
+    Ok(LogEvent {
+        version: schema_version,
+        timestamp: Timestamp::now_utc(),
+        level: level_for_outcome(outcome.as_str()),
+        service: service_name.clone(),
+        target: target_category.clone(),
+        action,
+        message: Some(message.to_string()),
+        identity: ProcessIdentity::default(),
+        trace: None,
+        request_id: None,
+        correlation_id: None,
+        outcome: Some(outcome),
+        diagnostic: None,
+        state_transition: None,
+        fields,
+    })
+}
+
+fn map_logging_state(
+    state: sc_observability_types::LoggingHealthState,
+) -> AtmObservabilityHealthState {
+    match state {
+        sc_observability_types::LoggingHealthState::Healthy => AtmObservabilityHealthState::Healthy,
+        sc_observability_types::LoggingHealthState::DegradedDropping => {
+            AtmObservabilityHealthState::Degraded
+        }
+        sc_observability_types::LoggingHealthState::Unavailable => {
+            AtmObservabilityHealthState::Unavailable
+        }
+    }
+}
+
+fn render_diagnostic_summary(summary: sc_observability_types::DiagnosticSummary) -> String {
+    match summary.code {
+        Some(code) => format!("{}: {}", code.as_str(), summary.message),
+        None => summary.message,
+    }
+}
+
+fn level_for_outcome(outcome: &str) -> Level {
+    match outcome {
+        "ok" | "sent" | "dry_run" => Level::Info,
+        "timeout" => Level::Warn,
+        "error" | "failed" => Level::Error,
+        other => {
+            tracing::warn!(
+                code = %AtmErrorCode::ObservabilityEmitFailed,
+                outcome = other,
+                "unknown ATM daemon outcome for observability level"
+            );
+            Level::Warn
+        }
+    }
+}
+
+struct RetainedSinkHealthOverride {
+    inner: Arc<dyn LogSink>,
+    mode: RetainedSinkFaultMode,
+}
+
+impl RetainedSinkHealthOverride {
+    fn new(inner: Arc<dyn LogSink>, mode: RetainedSinkFaultMode) -> Self {
+        Self { inner, mode }
+    }
+}
+
+impl LogSink for RetainedSinkHealthOverride {
+    fn write(&self, _event: &LogEvent) -> Result<(), LogSinkError> {
+        match self.mode {
+            RetainedSinkFaultMode::Degraded => Err(LogSinkError(Box::new(
+                sc_observability_types::ErrorContext::new(
+                    sc_observability_types::ErrorCode::new_static("SC_TEST_DAEMON_SINK_DEGRADED"),
+                    "daemon retained sink degraded by test fault injection",
+                    sc_observability_types::Remediation::not_recoverable(
+                        "clear the daemon retained sink fault injection mode before retrying",
+                    ),
+                ),
+            ))),
+            RetainedSinkFaultMode::Unavailable => Err(LogSinkError(Box::new(
+                sc_observability_types::ErrorContext::new(
+                    sc_observability_types::ErrorCode::new_static(
+                        "SC_TEST_DAEMON_SINK_UNAVAILABLE",
+                    ),
+                    "daemon retained sink unavailable by test fault injection",
+                    sc_observability_types::Remediation::not_recoverable(
+                        "clear the daemon retained sink fault injection mode before retrying",
+                    ),
+                ),
+            ))),
+        }
+    }
+
+    fn flush(&self) -> Result<(), LogSinkError> {
+        self.inner.flush()
+    }
+
+    fn health(&self) -> sc_observability_types::SinkHealth {
+        let mut health = self.inner.health();
+        health.state = match self.mode {
+            RetainedSinkFaultMode::Degraded => {
+                sc_observability_types::SinkHealthState::DegradedDropping
+            }
+            RetainedSinkFaultMode::Unavailable => {
+                sc_observability_types::SinkHealthState::Unavailable
+            }
+        };
+        health
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use atm_core::observability::{AtmObservabilityHealthState, ObservabilityPort};
+    use atm_core::test_support::EnvGuard;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    use super::DaemonObservability;
+
+    #[test]
+    #[serial]
+    fn bootstrap_writes_lifecycle_events_to_host_scoped_retained_log() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let _env = EnvGuard::set_many([
+            ("ATM_LOG", Some("info")),
+            ("ATM_LOG_DIR", None),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
+            ("USERPROFILE", None),
+            ("ATM_OBSERVABILITY_RETAINED_SINK_FAULT", None),
+        ]);
+
+        let observability = DaemonObservability::bootstrap().expect("bootstrap");
+        observability
+            .emit_runtime_event("start_requested", "ok", "daemon start requested")
+            .expect("emit start");
+        observability
+            .emit_runtime_event("shutdown_completed", "ok", "daemon shutdown completed")
+            .expect("emit shutdown");
+        observability
+            .best_effort_flush_blocking()
+            .expect("best effort flush");
+
+        let active_log_path = tempdir
+            .path()
+            .join(".atm")
+            .join("logs")
+            .join("atm.log.jsonl");
+        let output = std::fs::read_to_string(&active_log_path).expect("retained log");
+        assert!(output.contains("daemon start requested"));
+        assert!(output.contains("daemon shutdown completed"));
+
+        let health = observability.health().expect("health");
+        assert_eq!(health.active_log_path, Some(active_log_path));
+        assert_eq!(health.logging_state, AtmObservabilityHealthState::Healthy);
+    }
+
+    #[test]
+    #[serial]
+    fn bootstrap_fails_closed_when_atm_log_dir_is_invalid() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let _env = EnvGuard::set_many([
+            ("ATM_LOG_DIR", Some("relative/logs")),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
+            ("USERPROFILE", None),
+            ("ATM_OBSERVABILITY_RETAINED_SINK_FAULT", None),
+        ]);
+
+        let error = DaemonObservability::bootstrap().expect_err("invalid ATM_LOG_DIR");
+        assert!(error.is_config());
+        assert!(error.message.contains("absolute path"));
+    }
+}

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -491,6 +491,8 @@ fn level_for_outcome(outcome: &str) -> Level {
         "timeout" => Level::Warn,
         "error" | "failed" => Level::Error,
         other => {
+            // No global tracing subscriber is installed in production; daemon lifecycle records
+            // route through emit_runtime_event(), so this unknown-outcome warning is intentionally silent.
             tracing::warn!(
                 code = %AtmErrorCode::ObservabilityEmitFailed,
                 outcome = other,

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -1,8 +1,8 @@
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fs, fs::OpenOptions};
 
-use atm_core::boundary;
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::home;
@@ -13,16 +13,20 @@ use atm_core::observability::{
 use sc_observability::{
     JsonlFileSink, LogSink, Logger, LoggerConfig, RetentionPolicy, RotationPolicy, SinkRegistration,
 };
+#[cfg(test)]
+use sc_observability_types::LogSinkError;
 use sc_observability_types::{
     ActionName, CorrelationId, DiagnosticInfo, Level, LevelFilter as SharedLevelFilter, LogEvent,
-    LogSinkError, OutcomeLabel, ProcessIdentity, SchemaVersion, ServiceName, TargetCategory,
-    Timestamp,
+    OutcomeLabel, ProcessIdentity, SchemaVersion, ServiceName, TargetCategory, Timestamp,
 };
 use serde_json::Map;
 
 const ATM_SERVICE_NAME: &str = "atm";
 const ATM_DAEMON_TARGET: &str = "atm.daemon";
 const ATM_LOG_LEVEL_ENV: &str = "ATM_LOG";
+const RETAINED_LOG_ROTATION_MAX_BYTES: u64 = 10 * 1024 * 1024;
+const RETAINED_LOG_ROTATION_MAX_FILES: u32 = 5;
+const RETAINED_LOG_RETENTION_MAX_AGE_DAYS: u32 = 7;
 #[cfg(test)]
 const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAINED_SINK_FAULT";
 
@@ -78,11 +82,6 @@ impl DaemonObservability {
         })
     }
 
-    #[cfg(test)]
-    pub(crate) fn new_for_test(log_dir: PathBuf) -> Result<Self, AtmError> {
-        Self::bootstrap_at_log_dir(log_dir)
-    }
-
     pub(crate) fn emit_runtime_event(
         &self,
         action: &'static str,
@@ -112,19 +111,17 @@ impl DaemonObservability {
             )
             .with_source(source)
         })?;
-        if !self.active_log_path.exists() {
-            return Ok(());
-        }
-        let file = OpenOptions::new()
-            .append(true)
-            .open(&self.active_log_path)
-            .map_err(|source| {
-                AtmError::observability_health(format!(
+        let file = match OpenOptions::new().append(true).open(&self.active_log_path) {
+            Ok(file) => file,
+            Err(source) if source.kind() == ErrorKind::NotFound => return Ok(()),
+            Err(source) => {
+                return Err(AtmError::observability_health(format!(
                     "failed to open retained observability sink at {} for best-effort flush",
                     self.active_log_path.display()
                 ))
-                .with_source(source)
-            })?;
+                .with_source(source));
+            }
+        };
         file.sync_all().map_err(|source| {
             AtmError::observability_health(format!(
                 "failed to sync retained observability sink at {}",
@@ -135,7 +132,7 @@ impl DaemonObservability {
     }
 }
 
-impl boundary::sealed::Sealed for DaemonObservability {}
+impl atm_core::boundary::sealed::Sealed for DaemonObservability {}
 
 impl ObservabilityPort for DaemonObservability {
     fn emit(&self, event: CommandEvent) -> Result<(), AtmError> {
@@ -182,6 +179,21 @@ impl ObservabilityPort for DaemonObservability {
     }
 }
 
+impl atm_daemon::DaemonRuntimeObservability for DaemonObservability {
+    fn emit_runtime_event(
+        &self,
+        action: &'static str,
+        outcome: &'static str,
+        message: &'static str,
+    ) -> Result<(), AtmError> {
+        Self::emit_runtime_event(self, action, outcome, message)
+    }
+
+    fn best_effort_flush_blocking(&self) -> Result<(), AtmError> {
+        Self::best_effort_flush_blocking(self)
+    }
+}
+
 fn build_logger(
     log_dir: &Path,
     retained_sink_fault: Option<RetainedSinkFaultMode>,
@@ -197,14 +209,29 @@ fn build_logger(
         AtmError::observability_bootstrap("failed to initialize shared daemon observability logger")
             .with_source(source)
     })?;
+    // sc-observability 1.0.0 JsonlFileSink performs synchronous local-file writes.
+    // atm-daemon satisfies ADR-011's non-blocking-executor rule by never calling
+    // this sink from an async executor thread; retained writes stay on ordinary
+    // daemon OS threads, and shutdown flush runs on a dedicated finalizer thread.
     let sink = Arc::new(JsonlFileSink::new(
         active_log_path.clone(),
-        RotationPolicy::default(),
-        RetentionPolicy::default(),
+        RotationPolicy {
+            max_bytes: RETAINED_LOG_ROTATION_MAX_BYTES,
+            max_files: RETAINED_LOG_ROTATION_MAX_FILES,
+        },
+        RetentionPolicy {
+            max_age_days: RETAINED_LOG_RETENTION_MAX_AGE_DAYS,
+        },
     ));
+    #[cfg(test)]
     let sink: Arc<dyn LogSink> = match retained_sink_fault {
         Some(mode) => Arc::new(RetainedSinkHealthOverride::new(sink, mode)),
         None => sink,
+    };
+    #[cfg(not(test))]
+    let sink: Arc<dyn LogSink> = {
+        let _ = retained_sink_fault;
+        sink
     };
     builder.register_sink(SinkRegistration::new(sink));
     Ok((builder.build(), active_log_path))
@@ -252,18 +279,6 @@ fn logger_level_override() -> Result<Option<SharedLevelFilter>, AtmError> {
             "invalid {ATM_LOG_LEVEL_ENV} value `{value}`; use `trace`, `debug`, `info`, `warn`, `error`, or `off`"
         ))),
     }
-}
-
-pub fn tracing_level_override() -> Result<tracing::Level, AtmError> {
-    Ok(
-        match logger_level_override()?.unwrap_or(SharedLevelFilter::Info) {
-            SharedLevelFilter::Trace => tracing::Level::TRACE,
-            SharedLevelFilter::Debug => tracing::Level::DEBUG,
-            SharedLevelFilter::Info => tracing::Level::INFO,
-            SharedLevelFilter::Warn => tracing::Level::WARN,
-            SharedLevelFilter::Error | SharedLevelFilter::Off => tracing::Level::ERROR,
-        },
-    )
 }
 
 fn retained_sink_fault_mode() -> Result<Option<RetainedSinkFaultMode>, AtmError> {
@@ -486,17 +501,20 @@ fn level_for_outcome(outcome: &str) -> Level {
     }
 }
 
+#[cfg(test)]
 struct RetainedSinkHealthOverride {
     inner: Arc<dyn LogSink>,
     mode: RetainedSinkFaultMode,
 }
 
+#[cfg(test)]
 impl RetainedSinkHealthOverride {
     fn new(inner: Arc<dyn LogSink>, mode: RetainedSinkFaultMode) -> Self {
         Self { inner, mode }
     }
 }
 
+#[cfg(test)]
 impl LogSink for RetainedSinkHealthOverride {
     fn write(&self, _event: &LogEvent) -> Result<(), LogSinkError> {
         match self.mode {
@@ -601,5 +619,61 @@ mod tests {
         let error = DaemonObservability::bootstrap().expect_err("invalid ATM_LOG_DIR");
         assert!(error.is_config());
         assert!(error.message.contains("absolute path"));
+    }
+
+    #[test]
+    #[serial]
+    fn bootstrap_fails_closed_when_retained_log_dir_cannot_be_created() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let blocked_parent = tempdir.path().join("blocked-parent");
+        std::fs::write(&blocked_parent, "not a directory").expect("blocked parent");
+        let blocked_log_dir = blocked_parent.join("logs");
+        let _env = EnvGuard::set_many([
+            (
+                "ATM_LOG_DIR",
+                Some(blocked_log_dir.to_str().expect("utf8 blocked log dir")),
+            ),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
+            ("USERPROFILE", None),
+            ("ATM_OBSERVABILITY_RETAINED_SINK_FAULT", None),
+        ]);
+
+        let error =
+            DaemonObservability::bootstrap().expect_err("retained log dir create should fail");
+        assert!(error.is_observability_bootstrap());
+        assert!(
+            error
+                .message
+                .contains(&blocked_log_dir.display().to_string())
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn bootstrap_fails_closed_when_retained_log_file_is_not_appendable() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let blocked_log_dir = tempdir.path().join("logs");
+        std::fs::create_dir_all(&blocked_log_dir).expect("blocked log dir");
+        std::fs::create_dir(blocked_log_dir.join("atm.log.jsonl"))
+            .expect("non-appendable log path");
+        let _env = EnvGuard::set_many([
+            (
+                "ATM_LOG_DIR",
+                Some(blocked_log_dir.to_str().expect("utf8 blocked log dir")),
+            ),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 path"))),
+            ("USERPROFILE", None),
+            ("ATM_OBSERVABILITY_RETAINED_SINK_FAULT", None),
+        ]);
+
+        let error =
+            DaemonObservability::bootstrap().expect_err("retained log file open should fail");
+        assert!(error.is_observability_bootstrap());
+        assert!(error.message.contains("atm.log.jsonl"));
+        assert!(
+            error
+                .message
+                .contains(&blocked_log_dir.join("atm.log.jsonl").display().to_string())
+        );
     }
 }

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -1,0 +1,17 @@
+use atm_core::error::AtmError;
+use atm_core::observability::ObservabilityPort;
+
+/// Daemon-runtime observability operations that stay daemon-specific above the
+/// shared ATM observability boundary.
+pub trait DaemonRuntimeObservability: ObservabilityPort + Send + Sync {
+    /// Emit one daemon lifecycle/runtime event into the retained sink.
+    fn emit_runtime_event(
+        &self,
+        action: &'static str,
+        outcome: &'static str,
+        message: &'static str,
+    ) -> Result<(), AtmError>;
+
+    /// Attempt one best-effort synchronous flush during daemon shutdown.
+    fn best_effort_flush_blocking(&self) -> Result<(), AtmError>;
+}

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod boundary_adapters;
 pub(crate) mod composition;
+mod daemon_observability;
 mod direct_boundaries;
 // ADR-002 intentionally splits launch.lock admission from owner.lock serving
 // ownership so only one launcher can fork while only one daemon can publish the
@@ -22,6 +23,8 @@ use std::time::Duration;
 
 use atm_core::error::AtmError;
 use atm_rusqlite::SqliteBoundaryAssembly;
+pub(crate) use daemon_observability::DaemonObservability;
+pub use daemon_observability::tracing_level_override;
 
 pub(crate) use atm_rusqlite::RemoteReplayStateRecord;
 pub(crate) use local_ipc_transport::LocalIpcServerTransportAdapter;
@@ -79,7 +82,16 @@ pub(crate) fn sqlite_remote_replay_store_from_path(
 ///
 /// Returns [`AtmError`] when the daemon transport cannot start or serve.
 pub fn run_daemon() -> Result<(), AtmError> {
-    composition::compose_runtime()?.start()
+    let observability = bootstrap_observability()?;
+    run_daemon_with_observability(observability)
+}
+
+pub fn bootstrap_observability() -> Result<DaemonObservability, AtmError> {
+    DaemonObservability::bootstrap()
+}
+
+pub fn run_daemon_with_observability(observability: DaemonObservability) -> Result<(), AtmError> {
+    composition::compose_runtime(observability)?.start()
 }
 
 #[cfg(test)]

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -3,7 +3,7 @@
 
 mod boundary_adapters;
 pub(crate) mod composition;
-mod daemon_observability;
+mod daemon_runtime_observability;
 mod direct_boundaries;
 // ADR-002 intentionally splits launch.lock admission from owner.lock serving
 // ownership so only one launcher can fork while only one daemon can publish the
@@ -15,6 +15,8 @@ mod notification_runtime;
 mod peer_transport;
 mod reconcile_runtime;
 mod runtime_health;
+#[cfg(test)]
+mod test_observability;
 mod watch_runtime;
 
 use std::path::PathBuf;
@@ -23,8 +25,7 @@ use std::time::Duration;
 
 use atm_core::error::AtmError;
 use atm_rusqlite::SqliteBoundaryAssembly;
-pub(crate) use daemon_observability::DaemonObservability;
-pub use daemon_observability::tracing_level_override;
+pub use daemon_runtime_observability::DaemonRuntimeObservability;
 
 pub(crate) use atm_rusqlite::RemoteReplayStateRecord;
 pub(crate) use local_ipc_transport::LocalIpcServerTransportAdapter;
@@ -81,16 +82,9 @@ pub(crate) fn sqlite_remote_replay_store_from_path(
 /// # Errors
 ///
 /// Returns [`AtmError`] when the daemon transport cannot start or serve.
-pub fn run_daemon() -> Result<(), AtmError> {
-    let observability = bootstrap_observability()?;
-    run_daemon_with_observability(observability)
-}
-
-pub fn bootstrap_observability() -> Result<DaemonObservability, AtmError> {
-    DaemonObservability::bootstrap()
-}
-
-pub fn run_daemon_with_observability(observability: DaemonObservability) -> Result<(), AtmError> {
+pub fn run_daemon_with_observability(
+    observability: Arc<dyn DaemonRuntimeObservability>,
+) -> Result<(), AtmError> {
     composition::compose_runtime(observability)?.start()
 }
 

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -12,30 +12,17 @@ fn main() {
 }
 
 fn run() -> Result<(), AtmError> {
-    init_tracing();
-    atm_daemon::run_daemon()
+    let observability = atm_daemon::bootstrap_observability()?;
+    init_tracing()?;
+    atm_daemon::run_daemon_with_observability(observability)
 }
 
-fn init_tracing() {
-    let level = match std::env::var("ATM_LOG")
-        .ok()
-        .map(|value| value.trim().to_ascii_lowercase())
-        .filter(|value| !value.is_empty())
-    {
-        Some(value) => match value.as_str() {
-            "trace" => tracing::Level::TRACE,
-            "debug" => tracing::Level::DEBUG,
-            "warn" => tracing::Level::WARN,
-            "error" => tracing::Level::ERROR,
-            _ => tracing::Level::INFO,
-        },
-        None => tracing::Level::WARN,
-    };
-
+fn init_tracing() -> Result<(), AtmError> {
     let _ = tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_ansi(false)
-        .with_max_level(level)
+        .with_max_level(atm_daemon::tracing_level_override()?)
         .without_time()
         .try_init();
+    Ok(())
 }

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -1,4 +1,11 @@
+use std::sync::Arc;
+
 use atm_core::error::AtmError;
+
+#[path = "daemon_observability.rs"]
+mod daemon_observability;
+
+use daemon_observability::DaemonObservability;
 
 fn main() {
     let exit_code = match run() {
@@ -12,17 +19,7 @@ fn main() {
 }
 
 fn run() -> Result<(), AtmError> {
-    let observability = atm_daemon::bootstrap_observability()?;
-    init_tracing()?;
+    let observability: Arc<dyn atm_daemon::DaemonRuntimeObservability> =
+        Arc::new(DaemonObservability::bootstrap()?);
     atm_daemon::run_daemon_with_observability(observability)
-}
-
-fn init_tracing() -> Result<(), AtmError> {
-    let _ = tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_ansi(false)
-        .with_max_level(atm_daemon::tracing_level_override()?)
-        .without_time()
-        .try_init();
-    Ok(())
 }

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -27,7 +27,7 @@ use atm_core::{
 };
 use atm_rusqlite::{SqliteBoundaryAssembly, assemble_default_boundary};
 
-use crate::DaemonObservability;
+use crate::daemon_runtime_observability::DaemonRuntimeObservability;
 
 const MAX_STATUS_CACHE_ENTRIES: usize = 4096;
 const MAX_RELOAD_TEAMS: usize = 256;
@@ -37,6 +37,9 @@ const SHUTDOWN_WAL_CHECKPOINT_DEADLINE: Duration = Duration::from_secs(2);
 const SHUTDOWN_OBSERVABILITY_FLUSH_DEADLINE: Duration = Duration::from_secs(2);
 
 #[cfg(test)]
+// The shutdown-step helper is static, so timed-out join handles need one
+// process-wide test registry that drain_shutdown_finalizer_threads_for_test()
+// can clean up after each bounded-timeout scenario.
 static SHUTDOWN_FINALIZER_THREADS: std::sync::Mutex<Vec<std::thread::JoinHandle<()>>> =
     std::sync::Mutex::new(Vec::new());
 
@@ -317,12 +320,23 @@ fn finish_runtime_snapshot(
     }
 }
 
-#[derive(Debug)]
 pub(crate) struct DaemonRequestDispatcher {
+    // Invariant: this is the validated ATM_HOME root for the running daemon,
+    // not an arbitrary workspace path.
     home_dir: PathBuf,
-    observability: DaemonObservability,
+    observability: Arc<dyn DaemonRuntimeObservability>,
     status_cache: RuntimeStatusCache,
     sqlite_boundary: Option<SqliteBoundaryAssembly>,
+}
+
+impl std::fmt::Debug for DaemonRequestDispatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DaemonRequestDispatcher")
+            .field("home_dir", &self.home_dir)
+            .field("status_cache", &self.status_cache)
+            .field("sqlite_boundary_present", &self.sqlite_boundary.is_some())
+            .finish()
+    }
 }
 
 impl DaemonRequestDispatcher {
@@ -378,6 +392,8 @@ impl DaemonRequestDispatcher {
                 }
                 #[cfg(not(test))]
                 {
+                    // Intentionally detach the timed-out worker so shutdown
+                    // remains bounded even if the finalizer exits later.
                     drop(shutdown_handle);
                 }
                 tracing::warn!(
@@ -399,7 +415,7 @@ impl DaemonRequestDispatcher {
     pub(crate) fn new(
         home_dir: PathBuf,
         status_cache: RuntimeStatusCache,
-        observability: DaemonObservability,
+        observability: Arc<dyn DaemonRuntimeObservability>,
     ) -> Self {
         let sqlite_boundary = match assemble_default_boundary() {
             Ok(boundary) => {
@@ -448,12 +464,12 @@ impl boundary::RequestDispatcher for DaemonRequestDispatcher {
         match request {
             RequestEnvelope::Send(SendRequestEnvelope::Compose(request)) => {
                 Ok(ResponseEnvelope::Send(SendResponseEnvelope::Sent(
-                    send_mail(request, &self.observability)?,
+                    send_mail(request, self.observability.as_ref())?,
                 )))
             }
             RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(request)) => {
                 Ok(ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(
-                    ack_mail(request, &self.observability)?,
+                    ack_mail(request, self.observability.as_ref())?,
                 )))
             }
             RequestEnvelope::Heartbeat(request) => {
@@ -461,15 +477,15 @@ impl boundary::RequestDispatcher for DaemonRequestDispatcher {
             }
             RequestEnvelope::List(query) => Ok(ResponseEnvelope::List(list_mail(
                 query,
-                &self.observability,
+                self.observability.as_ref(),
             )?)),
             RequestEnvelope::Receive(query) => Ok(ResponseEnvelope::Receive(read_mail(
                 query,
-                &self.observability,
+                self.observability.as_ref(),
             )?)),
             RequestEnvelope::Clear(query) => Ok(ResponseEnvelope::Clear(clear_mail(
                 query,
-                &self.observability,
+                self.observability.as_ref(),
             )?)),
             RequestEnvelope::Doctor(query) => {
                 Ok(ResponseEnvelope::Doctor(self.project_doctor_report(query)?))
@@ -578,7 +594,12 @@ impl DaemonRequestDispatcher {
     }
 
     fn project_doctor_report(&self, query: DoctorQuery) -> Result<DoctorReport, AtmError> {
-        let mut report = doctor::run_doctor(query, &self.observability)?;
+        let mut report = doctor::run_doctor(query, self.observability.as_ref())?;
+        let daemon_observability_finding = match self.observability.health() {
+            Ok(health) => daemon_observability_finding(&health),
+            Err(error) => doctor::health::observability_finding_from_error(&error),
+        };
+        report.findings.push(daemon_observability_finding);
         let runtime_status = match &report.member_roster {
             Some(roster) => self.status_cache.snapshot_for_members(
                 roster
@@ -764,6 +785,53 @@ fn runtime_status_finding(snapshot: &RuntimeStatusSnapshot) -> DoctorFinding {
             remediation: snapshot.detail.clone().or(Some(
                 "Restore daemon runtime availability and rerun `atm doctor`.".to_string(),
             )),
+        },
+    }
+}
+
+fn daemon_observability_finding(
+    health: &atm_core::observability::AtmObservabilityHealth,
+) -> DoctorFinding {
+    let path = health
+        .active_log_path
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "<unavailable>".to_string());
+    let detail = health
+        .detail
+        .as_ref()
+        .map(|detail| format!(" Detail: {detail}"))
+        .unwrap_or_default();
+    match health.logging_state {
+        atm_core::observability::AtmObservabilityHealthState::Healthy => DoctorFinding {
+            severity: DoctorSeverity::Info,
+            code: atm_core::error_codes::AtmErrorCode::ObservabilityHealthOk,
+            message: format!(
+                "daemon retained observability sink is healthy at {path}; daemon query/follow remain deferred to the CLI-owned log surface.{detail}"
+            ),
+            remediation: None,
+        },
+        atm_core::observability::AtmObservabilityHealthState::Degraded => DoctorFinding {
+            severity: DoctorSeverity::Warning,
+            code: atm_core::error_codes::AtmErrorCode::WarningObservabilityHealthDegraded,
+            message: format!(
+                "daemon retained observability sink is degraded at {path}; daemon query/follow remain deferred to the CLI-owned log surface.{detail}"
+            ),
+            remediation: Some(
+                "Inspect the daemon retained log path and sink errors, then re-run `atm doctor`."
+                    .to_string(),
+            ),
+        },
+        atm_core::observability::AtmObservabilityHealthState::Unavailable => DoctorFinding {
+            severity: DoctorSeverity::Error,
+            code: atm_core::error_codes::AtmErrorCode::ObservabilityHealthFailed,
+            message: format!(
+                "daemon retained observability sink is unavailable at {path}; daemon query/follow remain deferred to the CLI-owned log surface.{detail}"
+            ),
+            remediation: Some(
+                "Restore the daemon retained-log path and confirm it is writable before re-running `atm doctor`."
+                    .to_string(),
+            ),
         },
     }
 }

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -413,6 +413,7 @@ impl DaemonRequestDispatcher {
     }
 
     pub(crate) fn new(
+        // Must be the validated ATM home dir for this daemon runtime.
         home_dir: PathBuf,
         status_cache: RuntimeStatusCache,
         observability: Arc<dyn DaemonRuntimeObservability>,

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
@@ -14,12 +13,7 @@ use atm_core::{
         self, DoctorFinding, DoctorQuery, DoctorReport, DoctorSeverity, DoctorStatus, DoctorSummary,
     },
     error::AtmError,
-    home,
     list::list_mail,
-    observability::{
-        AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState,
-        CommandEvent, LogTailSession, ObservabilityPort, RetainedSinkFaultMode,
-    },
     process::process_is_alive,
     protocol::{
         HeartbeatActivity, RuntimeLivenessState, RuntimeMemberState, RuntimeReadinessState,
@@ -33,6 +27,8 @@ use atm_core::{
 };
 use atm_rusqlite::{SqliteBoundaryAssembly, assemble_default_boundary};
 
+use crate::DaemonObservability;
+
 const MAX_STATUS_CACHE_ENTRIES: usize = 4096;
 const MAX_RELOAD_TEAMS: usize = 256;
 const SHUTDOWN_WAL_CHECKPOINT_DEADLINE: Duration = Duration::from_secs(2);
@@ -43,104 +39,6 @@ const SHUTDOWN_OBSERVABILITY_FLUSH_DEADLINE: Duration = Duration::from_secs(2);
 #[cfg(test)]
 static SHUTDOWN_FINALIZER_THREADS: std::sync::Mutex<Vec<std::thread::JoinHandle<()>>> =
     std::sync::Mutex::new(Vec::new());
-
-#[derive(Debug, Clone)]
-struct DaemonObservability {
-    retained_sink_fault: Option<RetainedSinkFaultMode>,
-}
-
-impl DaemonObservability {
-    fn new() -> Result<Self, AtmError> {
-        let retained_sink_fault = match std::env::var("ATM_OBSERVABILITY_RETAINED_SINK_FAULT")
-            .ok()
-            .map(|value| value.trim().to_ascii_lowercase())
-            .filter(|value| !value.is_empty())
-        {
-            None => None,
-            Some(value) => match value.as_str() {
-                "degraded" => Some(RetainedSinkFaultMode::Degraded),
-                "unavailable" => Some(RetainedSinkFaultMode::Unavailable),
-                _ => {
-                    return Err(AtmError::observability_bootstrap(format!(
-                        "invalid ATM_OBSERVABILITY_RETAINED_SINK_FAULT value `{value}`; use `degraded` or `unavailable`"
-                    )));
-                }
-            },
-        };
-        Ok(Self::new_with_sink_fault(retained_sink_fault))
-    }
-
-    fn new_with_sink_fault(retained_sink_fault: Option<RetainedSinkFaultMode>) -> Self {
-        Self {
-            retained_sink_fault,
-        }
-    }
-
-    fn active_log_path(&self) -> Result<PathBuf, AtmError> {
-        Ok(home::host_log_dir()?.join("atm.log.jsonl"))
-    }
-
-    fn best_effort_flush_blocking(&self) -> Result<(), AtmError> {
-        let active_log_path = self.active_log_path()?;
-        if !active_log_path.exists() {
-            return Ok(());
-        }
-        let file = OpenOptions::new()
-            .append(true)
-            .open(&active_log_path)
-            .map_err(|source| {
-                AtmError::observability_health(format!(
-                    "failed to open retained observability sink at {} for best-effort flush",
-                    active_log_path.display()
-                ))
-                .with_source(source)
-            })?;
-        file.sync_all().map_err(|source| {
-            AtmError::observability_health(format!(
-                "failed to sync retained observability sink at {}",
-                active_log_path.display()
-            ))
-            .with_source(source)
-        })
-    }
-}
-
-impl boundary::sealed::Sealed for DaemonObservability {}
-
-impl ObservabilityPort for DaemonObservability {
-    fn emit(&self, _event: CommandEvent) -> Result<(), AtmError> {
-        // R.15 keeps retained-log emission owned by the shared observability
-        // stack, so the daemon-side health adapter is intentionally a no-op.
-        Ok(())
-    }
-
-    fn query(&self, _req: AtmLogQuery) -> Result<AtmLogSnapshot, AtmError> {
-        // Runtime health only needs the shared observability surface to be
-        // queryable; command-log projection still lives in atm-core.
-        Ok(AtmLogSnapshot::default())
-    }
-
-    fn follow(&self, _req: AtmLogQuery) -> Result<LogTailSession, AtmError> {
-        // Doctor health does not tail logs directly in R.15, so the daemon
-        // adapter exposes an empty tail session instead of a second log owner.
-        Ok(LogTailSession::empty())
-    }
-
-    fn health(&self) -> Result<AtmObservabilityHealth, AtmError> {
-        let active_log_path = self.active_log_path()?;
-        let logging_state = match self.retained_sink_fault {
-            None => AtmObservabilityHealthState::Healthy,
-            Some(RetainedSinkFaultMode::Degraded) => AtmObservabilityHealthState::Degraded,
-            Some(RetainedSinkFaultMode::Unavailable) => AtmObservabilityHealthState::Unavailable,
-        };
-        Ok(AtmObservabilityHealth {
-            active_log_path: Some(active_log_path),
-            logging_state,
-            query_state: Some(AtmObservabilityHealthState::Healthy),
-            detail: None,
-        })
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct RuntimeMemberKey {
@@ -498,7 +396,11 @@ impl DaemonRequestDispatcher {
         }
     }
 
-    pub(crate) fn new(home_dir: PathBuf, status_cache: RuntimeStatusCache) -> Self {
+    pub(crate) fn new(
+        home_dir: PathBuf,
+        status_cache: RuntimeStatusCache,
+        observability: DaemonObservability,
+    ) -> Self {
         let sqlite_boundary = match assemble_default_boundary() {
             Ok(boundary) => {
                 if let Err(error) =
@@ -516,20 +418,25 @@ impl DaemonRequestDispatcher {
                 None
             }
         };
-        let observability = match DaemonObservability::new() {
-            Ok(observability) => observability,
-            Err(error) => {
-                // Daemon health treats invalid retained-sink fault injection as a local
-                // non-fatal test knob and falls back to Healthy after warning, unlike CLI bootstrap.
-                tracing::warn!(%error, "failed to initialize daemon observability state");
-                DaemonObservability::new_with_sink_fault(None)
-            }
-        };
         Self {
             home_dir: home_dir.clone(),
             observability,
             status_cache,
             sqlite_boundary,
+        }
+    }
+
+    pub(crate) fn emit_runtime_event(
+        &self,
+        action: &'static str,
+        outcome: &'static str,
+        message: &'static str,
+    ) {
+        if let Err(error) = self
+            .observability
+            .emit_runtime_event(action, outcome, message)
+        {
+            tracing::warn!(%error, action, outcome, "daemon runtime lifecycle emission failed");
         }
     }
 }

--- a/crates/atm-daemon/src/runtime_health_test_support.rs
+++ b/crates/atm-daemon/src/runtime_health_test_support.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::sync::Arc;
 
 impl RuntimeStatusCache {
     pub(crate) fn member_state_for_test(
@@ -92,9 +93,12 @@ impl DaemonRequestDispatcher {
                 None
             }
         };
-        let observability =
-            DaemonObservability::new_for_test(atm_core::home::host_log_dir_from_home(&home_dir))
-                .expect("daemon test observability");
+        let observability = Arc::new(
+            crate::test_observability::TestDaemonObservability::new(
+                atm_core::home::host_log_dir_from_home(&home_dir),
+            )
+            .expect("daemon test observability"),
+        );
         Self {
             home_dir: home_dir.clone(),
             observability,

--- a/crates/atm-daemon/src/runtime_health_test_support.rs
+++ b/crates/atm-daemon/src/runtime_health_test_support.rs
@@ -92,9 +92,12 @@ impl DaemonRequestDispatcher {
                 None
             }
         };
+        let observability =
+            DaemonObservability::new_for_test(atm_core::home::host_log_dir_from_home(&home_dir))
+                .expect("daemon test observability");
         Self {
             home_dir: home_dir.clone(),
-            observability: DaemonObservability::new_with_sink_fault(None),
+            observability,
             status_cache,
             sqlite_boundary,
         }

--- a/crates/atm-daemon/src/test_observability.rs
+++ b/crates/atm-daemon/src/test_observability.rs
@@ -1,0 +1,154 @@
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use atm_core::boundary;
+use atm_core::error::AtmError;
+use atm_core::observability::{
+    AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState, CommandEvent,
+    LogTailSession, ObservabilityPort,
+};
+
+use crate::DaemonRuntimeObservability;
+
+#[derive(Debug)]
+pub(crate) struct TestDaemonObservability {
+    active_log_path: PathBuf,
+    detail: Mutex<Option<String>>,
+}
+
+impl TestDaemonObservability {
+    pub(crate) fn new(log_dir: PathBuf) -> Result<Self, AtmError> {
+        fs::create_dir_all(&log_dir).map_err(|source| {
+            AtmError::observability_bootstrap(format!(
+                "failed to create retained log directory {}",
+                log_dir.display()
+            ))
+            .with_source(source)
+        })?;
+        let active_log_path = log_dir.join("atm.log.jsonl");
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&active_log_path)
+            .map_err(|source| {
+                AtmError::observability_bootstrap(format!(
+                    "failed to open retained log file {} during startup",
+                    active_log_path.display()
+                ))
+                .with_source(source)
+            })?;
+        Ok(Self {
+            active_log_path,
+            detail: Mutex::new(None),
+        })
+    }
+
+    fn append_message(&self, message: String) -> Result<(), AtmError> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.active_log_path)
+            .map_err(|source| {
+                AtmError::observability_emit(format!(
+                    "failed to open retained test log file {}",
+                    self.active_log_path.display()
+                ))
+                .with_source(source)
+            })?;
+        writeln!(file, "{message}").map_err(|source| {
+            AtmError::observability_emit(format!(
+                "failed to append retained test log file {}",
+                self.active_log_path.display()
+            ))
+            .with_source(source)
+        })
+    }
+}
+
+impl boundary::sealed::Sealed for TestDaemonObservability {}
+
+impl ObservabilityPort for TestDaemonObservability {
+    fn emit(&self, event: CommandEvent) -> Result<(), AtmError> {
+        self.append_message(format!(
+            "{{\"command\":\"{}\",\"action\":\"{}\",\"outcome\":\"{}\"}}",
+            event.command, event.action, event.outcome
+        ))
+    }
+
+    fn query(&self, _req: AtmLogQuery) -> Result<AtmLogSnapshot, AtmError> {
+        Err(
+            AtmError::observability_query(
+                "daemon retained-log query is unavailable from the test daemon logger adapter",
+            )
+            .with_recovery(
+                "Use the CLI-owned retained log query surface for historical log reads until daemon query support is explicitly extracted.",
+            ),
+        )
+    }
+
+    fn follow(&self, _req: AtmLogQuery) -> Result<LogTailSession, AtmError> {
+        Err(
+            AtmError::observability_follow(
+                "daemon retained-log follow is unavailable from the test daemon logger adapter",
+            )
+            .with_recovery(
+                "Use the CLI-owned retained log follow surface until daemon follow support is explicitly extracted.",
+            ),
+        )
+    }
+
+    fn health(&self) -> Result<AtmObservabilityHealth, AtmError> {
+        let detail = self
+            .detail
+            .lock()
+            .expect("test observability detail")
+            .clone();
+        match OpenOptions::new().append(true).open(&self.active_log_path) {
+            Ok(_) => Ok(AtmObservabilityHealth {
+                active_log_path: Some(self.active_log_path.clone()),
+                logging_state: AtmObservabilityHealthState::Healthy,
+                query_state: None,
+                detail,
+            }),
+            Err(source) => Ok(AtmObservabilityHealth {
+                active_log_path: Some(self.active_log_path.clone()),
+                logging_state: AtmObservabilityHealthState::Unavailable,
+                query_state: None,
+                detail: Some(format!("{source}")),
+            }),
+        }
+    }
+}
+
+impl DaemonRuntimeObservability for TestDaemonObservability {
+    fn emit_runtime_event(
+        &self,
+        action: &'static str,
+        outcome: &'static str,
+        message: &'static str,
+    ) -> Result<(), AtmError> {
+        self.append_message(format!(
+            "{{\"action\":\"{action}\",\"outcome\":\"{outcome}\",\"message\":\"{message}\"}}"
+        ))
+    }
+
+    fn best_effort_flush_blocking(&self) -> Result<(), AtmError> {
+        match OpenOptions::new().append(true).open(&self.active_log_path) {
+            Ok(file) => file.sync_all().map_err(|source| {
+                AtmError::observability_health(format!(
+                    "failed to sync retained test log file at {}",
+                    self.active_log_path.display()
+                ))
+                .with_source(source)
+            }),
+            Err(source) if source.kind() == ErrorKind::NotFound => Ok(()),
+            Err(source) => Err(AtmError::observability_health(format!(
+                "failed to open retained test log file at {} for best-effort flush",
+                self.active_log_path.display()
+            ))
+            .with_source(source)),
+        }
+    }
+}

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -18,6 +18,7 @@ use atm_core::protocol::{
     RuntimeReadinessState, TeamMemberHeartbeatRequest,
 };
 use atm_core::schema::{AgentMember, TeamConfig};
+use atm_core::test_support::EnvGuard;
 use atm_core::test_support::ROLE_TEAM_LEAD;
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_rusqlite::assemble_boundary;
@@ -218,6 +219,89 @@ fn local_ipc_runtime_round_trips_doctor_requests_on_shared_transport() {
         .expect("recv serve result")
         .expect("serve runtime result");
     join.join().expect("join serve thread");
+}
+
+#[test]
+#[serial]
+fn compose_runtime_start_writes_retained_log_and_reports_healthy_observability() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let atm_home = tempdir.path().join("atm-home");
+    std::fs::create_dir_all(&atm_home).expect("atm home dir");
+    let _env = EnvGuard::set_many([
+        ("ATM_HOME", Some(atm_home.to_str().expect("utf8 atm home"))),
+        ("ATM_LOG_DIR", None),
+        ("HOME", Some(tempdir.path().to_str().expect("utf8 home"))),
+        ("USERPROFILE", None),
+    ]);
+    let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
+    let _reset = LifecycleFlagResetGuard::install(lifecycle.clone());
+    let observability = std::sync::Arc::new(
+        crate::test_observability::TestDaemonObservability::new(
+            atm_core::home::host_log_dir_from_home(&atm_home),
+        )
+        .expect("test observability"),
+    );
+    let runtime = crate::composition::compose_runtime(observability).expect("compose runtime");
+    let socket_path = atm_core::protocol::daemon_socket_path().expect("daemon socket path");
+    let (result_tx, result_rx) = mpsc::channel();
+
+    let join = std::thread::spawn(move || {
+        let result = runtime.start();
+        result_tx.send(result).expect("send runtime result");
+    });
+
+    let mut stream = connect_daemon_local_ipc_until_ready(&socket_path);
+    stream
+        .set_send_timeout(Some(Duration::from_secs(5)))
+        .expect("set send timeout");
+    stream
+        .set_recv_timeout(Some(Duration::from_secs(5)))
+        .expect("set recv timeout");
+    let request = RequestEnvelope::Doctor(DoctorQuery {
+        home_dir: atm_home.clone(),
+        current_dir: atm_home.clone(),
+        team_override: None,
+    });
+    let request_id = atm_core::protocol::next_request_id();
+    let frame = atm_core::protocol::request_to_frame_payload(request_id, request).expect("frame");
+    atm_core::protocol::write_frame(&mut stream, &frame, "write doctor frame").expect("write");
+    stream.flush().expect("flush");
+    let response_frame =
+        atm_core::protocol::read_frame(&mut stream, "read doctor frame", "doctor frame too large")
+            .expect("read frame")
+            .expect("response frame");
+    let (response_id, response) =
+        atm_core::protocol::response_from_frame_payload(response_frame).expect("decode response");
+    assert_eq!(response_id, request_id);
+    match response {
+        ResponseEnvelope::Doctor(report) => {
+            assert_eq!(
+                report.observability.logging_state,
+                AtmObservabilityHealthState::Healthy
+            );
+        }
+        other => panic!("expected doctor response, got {other:?}"),
+    }
+
+    let retained_log_path = atm_core::home::host_log_dir_from_home(&atm_home).join("atm.log.jsonl");
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        match std::fs::read_to_string(&retained_log_path) {
+            Ok(contents) if contents.contains("daemon start requested") => break,
+            Ok(_) | Err(_) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(5))
+            }
+            Err(error) => panic!("read retained log: {error}"),
+            Ok(contents) => panic!("retained log missing startup event: {contents}"),
+        }
+    }
+
+    lifecycle.set_terminate_for_test(true);
+    result_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("recv runtime result")
+        .expect("runtime result");
+    join.join().expect("join runtime thread");
 }
 
 #[cfg(windows)]

--- a/docs/adr/ADR-011-host-scoped-retained-log-root.md
+++ b/docs/adr/ADR-011-host-scoped-retained-log-root.md
@@ -86,23 +86,23 @@ Shutdown behavior:
 
 ## Rotation Policy
 
-V1 does not define built-in retained-log rotation.
+ATM retained logs use explicit built-in rotation:
 
-Operator guidance:
-
-- retained logs may grow without automatic rollover
-- use a filesystem with quota or external log management if growth matters
-
-Future work:
-
-- a later sprint may add bounded size/rotation if operator evidence justifies
-  it
+- active file rotation at `10 MiB`
+- retain the newest `5` rotated files beside the active log
+- prune rotated files older than `7` days
 
 ## Implementation Constraints
 
 - retained-log writes must not block async executor threads
 - the implementation must use a dedicated sync writer thread or an explicit
   blocking task boundary
+- `atm-daemon` satisfies that rule by keeping `JsonlFileSink` synchronous file
+  I/O on ordinary daemon OS threads rather than on an async executor thread;
+  the bounded shutdown flush runs on its own finalizer thread
+- explicit daemon retained-log sink policy is `10 MiB` active-file rotation,
+  `5` rotated files, and `7`-day rotated-file pruning so host-scoped retained
+  diagnostics stay bounded by default
 - watcher/reconcile paths must exclude `~/.atm/logs/` so retained-log appends
   cannot create false mailbox/reconcile churn
 

--- a/docs/atm-daemon/logging.md
+++ b/docs/atm-daemon/logging.md
@@ -94,18 +94,32 @@ Cross-reference:
 
 ## Rotation / Size Cap
 
-V1 defines no built-in retained-log rotation.
+The daemon retained log uses explicit built-in rotation:
 
-Current operator contract:
+- active file rotation at `10 MiB`
+- retain the newest `5` rotated files beside the active log
+- prune rotated files older than `7` days
 
-- ATM will continue appending to the retained log file
-- operators are responsible for external rotation or quota management
-- a filesystem with quota or external log management is recommended
+Operator contract:
 
-Future work:
+- ATM keeps a bounded recent daemon history under the host-scoped log root
+- operators may still layer external rotation or quota management if they need
+  stricter retention
 
-- a later sprint may introduce bounded rotation if operator evidence justifies
-  it
+## Non-Blocking Write Constraint
+
+ADR-011 forbids retained-log writes from blocking async executor threads.
+
+`atm-daemon` satisfies that requirement by architecture rather than by an
+internal sink worker thread:
+
+- the daemon does not route retained-log writes through an async executor
+- `sc-observability 1.0.0` `JsonlFileSink` performs synchronous local-file
+  writes on the daemon's ordinary OS threads
+- shutdown flush runs on a dedicated bounded finalizer thread
+
+That keeps retained logging out of async-executor hot paths while preserving
+the fail-closed bootstrap and fail-open mid-run behavior required by ADR-011.
 
 ## Watcher / Reconcile Exclusion
 

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -176,6 +176,9 @@ Initial crate requirement IDs:
   daemon/runtime/transport `warn!` / `error!` event at the default retained
   logger level and host-scoped retained path. Satisfies:
   `REQ-P-OBS-002`, `REQ-P-OBS-003`, `REQ-CORE-OBS-002`.
+  In S.10, daemon-side historical log `query()` / `follow()` remain deferred;
+  operators use the CLI-owned retained-log surface until a later sprint
+  extracts daemon-side query/follow support explicitly.
   If S.9 introduces any public retained-logging trait or sink boundary, that
   trait must be sealed by default per the product architecture trait-extension
   policy.

--- a/docs/phase-S/sprint-S10.md
+++ b/docs/phase-S/sprint-S10.md
@@ -41,6 +41,8 @@ Add a test proving that `atm-daemon` startup/shutdown lifecycle events land in t
 - `atm-daemon` writes lifecycle events to `~/.atm/logs/atm.log.jsonl` by default
 - `atm doctor` health reflects real retained-sink state, not the fault-injection stub
 - Daemon startup fails-closed when `host_log_dir()` returns Err
+- daemon-side retained log query/follow remain explicitly deferred to the
+  CLI-owned log surface for S.10
 - `just lint` PASS
 - `cargo test -p atm-daemon` PASS
 - `cargo test -p atm` PASS
@@ -51,5 +53,5 @@ Add a test proving that `atm-daemon` startup/shutdown lifecycle events land in t
 - `docs/adr/ADR-011-host-scoped-retained-log-root.md` — host-scoped log root contract
 - `docs/atm-daemon/requirements.md:171-178` — daemon observability requirements
 - Arch-ctm prod review TASK-1214-PROD-REVIEW finding #1 (P1)
-- `crates/atm-daemon/src/runtime_health.rs:79-141` — synthetic adapter to replace
+- `crates/atm-daemon/src/runtime_health.rs` — daemon doctor/runtime-health projection
 - `crates/atm/src/main.rs` — reference implementation of sc-observability bootstrap

--- a/docs/phase-S/sprint-S10.md
+++ b/docs/phase-S/sprint-S10.md
@@ -51,7 +51,7 @@ Add a test proving that `atm-daemon` startup/shutdown lifecycle events land in t
 ## References
 
 - `docs/adr/ADR-011-host-scoped-retained-log-root.md` — host-scoped log root contract
-- `docs/atm-daemon/requirements.md:171-178` — daemon observability requirements
+- `docs/atm-daemon/requirements.md:171-184` — daemon observability requirements
 - Arch-ctm prod review TASK-1214-PROD-REVIEW finding #1 (P1)
 - `crates/atm-daemon/src/runtime_health.rs` — daemon doctor/runtime-health projection
 - `crates/atm/src/main.rs` — reference implementation of sc-observability bootstrap

--- a/docs/phase-S/sprint-S10.md
+++ b/docs/phase-S/sprint-S10.md
@@ -1,0 +1,55 @@
+# Sprint S.10 — Daemon Retained Logger Bootstrap
+
+**Branch**: feature/pS-s10-daemon-retained-logger  
+**Base**: integrate/phase-S @ 3151d4b  
+**PR target**: integrate/phase-S  
+**Status**: Implementation
+
+## Goal
+
+Wire the shared sc-observability retained logger into `atm-daemon`. S.9 landed path resolution and validation (`host_log_dir`, ADR-011) but the daemon entrypoint never bootstraps the live adapter. Daemon lifecycle events do not reach `~/.atm/logs/atm.log.jsonl`, and `atm doctor` reports Healthy observability from a no-op stub.
+
+## Required Work
+
+### 1. Bootstrap retained logger in daemon entrypoint
+
+`crates/atm-daemon/src/main.rs` — replace the stderr-only `tracing_subscriber` setup with the shared sc-observability adapter used by the `atm` CLI:
+
+- Call `new_adapter_port(home_dir, stderr_logs)` (or equivalent daemon variant) at daemon startup
+- Route daemon lifecycle, request, and runtime events through the live retained-file sink
+- Default log file: `~/.atm/logs/atm.log.jsonl` (via `host_log_dir()`)
+- Respect `ATM_LOG` env var for level filtering (same as CLI)
+- Fail-closed: if the retained logger cannot be initialized, abort daemon startup with a clear error
+
+### 2. Wire doctor health to live sink health
+
+`crates/atm-daemon/src/runtime_health.rs` — replace the synthetic `DaemonObservabilityPort` stub:
+
+- `emit()` must route to the live retained logger
+- `health()` must reflect real sink health (file writable, no I/O errors) rather than the `ATM_OBSERVABILITY_RETAINED_SINK_FAULT` test knob
+- The test knob (`ATM_OBSERVABILITY_RETAINED_SINK_FAULT`) may remain for test-only fault injection but must not be the primary health source in production builds
+
+### 3. Integration test
+
+Add a test proving that `atm-daemon` startup/shutdown lifecycle events land in the retained log file:
+- Spin up daemon with a temp `home_dir`
+- Verify `~/.atm/logs/atm.log.jsonl` exists and contains at least one event after startup
+- Verify `atm doctor` reports healthy observability when the file is writable
+
+## Acceptance Criteria
+
+- `atm-daemon` writes lifecycle events to `~/.atm/logs/atm.log.jsonl` by default
+- `atm doctor` health reflects real retained-sink state, not the fault-injection stub
+- Daemon startup fails-closed when `host_log_dir()` returns Err
+- `just lint` PASS
+- `cargo test -p atm-daemon` PASS
+- `cargo test -p atm` PASS
+- `cargo xwin check --workspace --target x86_64-pc-windows-msvc` PASS
+
+## References
+
+- `docs/adr/ADR-011-host-scoped-retained-log-root.md` — host-scoped log root contract
+- `docs/atm-daemon/requirements.md:171-178` — daemon observability requirements
+- Arch-ctm prod review TASK-1214-PROD-REVIEW finding #1 (P1)
+- `crates/atm-daemon/src/runtime_health.rs:79-141` — synthetic adapter to replace
+- `crates/atm/src/main.rs` — reference implementation of sc-observability bootstrap

--- a/docs/plan-phase-S.md
+++ b/docs/plan-phase-S.md
@@ -543,6 +543,28 @@ Required closeout work:
 - prove no reconcile event fires when a retained-log append writes to
   `~/.atm/logs/atm.log.jsonl`
 
+### S.10 Daemon Retained Logger Bootstrap
+
+Goal:
+- make `atm-daemon` boot the live retained logger rather than reporting
+  synthetic observability health from a stub
+
+Required outcomes:
+- daemon startup/shutdown lifecycle events land in `~/.atm/logs/atm.log.jsonl`
+- `atm doctor` reflects live daemon retained-sink health
+- daemon retained-log bootstrap fails closed when the host-scoped log path
+  cannot be created or opened
+- daemon retained logs rotate explicitly at bounded size/retention settings
+
+Required closeout work:
+- keep `sc-observability` imports out of the `atm-daemon` library target and
+  construct the concrete adapter only in the binary entrypoint
+- replace the legacy stderr-only bootstrap path with the live retained logger
+- add a daemon-runtime integration test that boots the composed runtime and
+  verifies retained-log output plus healthy doctor observability
+- document that daemon-side query/follow remain deferred to the CLI-owned
+  retained-log surface
+
 ## 6. Removed Windows CI Guardrail
 
 The temporary Windows clippy narrowing used during S.0-S.3 is retired.


### PR DESCRIPTION
## S.10 — Daemon Retained Logger Bootstrap

Wires sc-observability retained logger into atm-daemon. Daemon lifecycle events now reach `~/.atm/logs/atm.log.jsonl`. Doctor health reflects real sink state.

**FIX-R1 @ 953dee2**: S10-QA1-001 (RULE-001 — removed [lib], adapter in binary target only), QA1-003/006/015/016 (init_tracing removed), QA1-004 (integration test), QA1-005 (doctor health plumbing), QA1-012 (explicit rotation/retention), removed unused tracing-subscriber dep, all minor findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)