### PR TITLE
S.13: IPC/socket hardening — ShutdownBeacon, SocketEndpointGuard, typed exit codes

### DIFF
--- a/.triage/phase-S/findings/ATM-QA-006-exemption.ttl
+++ b/.triage/phase-S/findings/ATM-QA-006-exemption.ttl
@@ -1,0 +1,24 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ATM-QA-006-exemption>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-006-exemption" ;
+  triage:title "Windows 25ms lifecycle polling exception recorded as accepted plan exemption" ;
+  triage:description "The bounded 25ms Windows lifecycle wake polling loop remains an accepted temporary exception per docs/plan-phase-S.md §4.1. No code change is required on feature/pS-s15-rusqlite-hardening for this item." ;
+  triage:phaseId "phase-S" ;
+  triage:category "ATM-QA" ;
+  triage:severity "minor" ;
+  triage:status "accepted" ;
+  triage:triagedAt "2026-05-10T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-006-exemption/pS-s15/1> .
+
+<urn:atm:triage:occurrence/ATM-QA-006-exemption/pS-s15/1>
+  a triage:Occurrence ;
+  triage:file "docs/plan-phase-S.md" ;
+  triage:line 209 ;
+  triage:snippet "Windows lifecycle-control wake propagation uses a bounded `25ms` polling loop" ;
+  triage:status "accepted" ;
+  triage:closed true ;
+  triage:branch "feature/pS-s15-rusqlite-hardening" ;
+  triage:headSha "93c63a9" .

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,5 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 uuid = { version = "1", features = ["serde", "v4"] }
 cargo_metadata = "0.23"
+sc-observability = "1.0.0"
+sc-observability-types = "1.0.0"

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -1,7 +1,7 @@
 //! Phase R boundary skeleton contracts.
 
 use crate::error::AtmError;
-use crate::protocol::{FramePayload, RequestEnvelope, ResponseEnvelope};
+use crate::protocol::{FramePayload, RequestEnvelope, RequestId, ResponseEnvelope};
 pub use crate::protocol::{
     NotificationEvent, ReconcileRequest, ReconcileResult, RuntimeStatusSnapshot, WatchEventBatch,
     WatchSubscriptionRequest,
@@ -162,7 +162,7 @@ pub trait AtmProtocol: sealed::Sealed {
     /// into a frame payload.
     fn request_to_frame(
         &self,
-        request_id: u64,
+        request_id: RequestId,
         request: RequestEnvelope,
     ) -> Result<FramePayload, AtmError>;
 
@@ -170,7 +170,10 @@ pub trait AtmProtocol: sealed::Sealed {
     ///
     /// Returns `AtmError` when a frame payload cannot be decoded into a
     /// protocol request envelope.
-    fn request_from_frame(&self, frame: FramePayload) -> Result<(u64, RequestEnvelope), AtmError>;
+    fn request_from_frame(
+        &self,
+        frame: FramePayload,
+    ) -> Result<(RequestId, RequestEnvelope), AtmError>;
 
     /// # Errors
     ///
@@ -178,7 +181,7 @@ pub trait AtmProtocol: sealed::Sealed {
     /// converted into a frame payload.
     fn response_to_frame(
         &self,
-        request_id: u64,
+        request_id: RequestId,
         response: ResponseEnvelope,
     ) -> Result<FramePayload, AtmError>;
 
@@ -186,8 +189,10 @@ pub trait AtmProtocol: sealed::Sealed {
     ///
     /// Returns `AtmError` when a frame payload cannot be decoded into a
     /// protocol response envelope.
-    fn response_from_frame(&self, frame: FramePayload)
-    -> Result<(u64, ResponseEnvelope), AtmError>;
+    fn response_from_frame(
+        &self,
+        frame: FramePayload,
+    ) -> Result<(RequestId, ResponseEnvelope), AtmError>;
 }
 
 /// BOUNDARY-ClientTransport — see docs/atm-core/boundaries.md.

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -205,6 +205,17 @@ impl AtmError {
         )
     }
 
+    pub fn daemon_lifecycle_wedge(message: impl Into<String>) -> Self {
+        Self::new_with_code(
+            AtmErrorCode::DaemonLifecycleWedge,
+            AtmErrorKind::DaemonUnavailable,
+            message,
+        )
+        .with_recovery(
+            "Restart the daemon after the local IPC listener and lifecycle-control state fully stop, then inspect daemon logs for the wedged shutdown path.",
+        )
+    }
+
     pub fn daemon_launch_gate_rejected(message: impl Into<String>) -> Self {
         Self::new_with_code(
             AtmErrorCode::DaemonLaunchGateRejected,

--- a/crates/atm-core/src/error_codes.rs
+++ b/crates/atm-core/src/error_codes.rs
@@ -29,6 +29,8 @@ pub enum AtmErrorCode {
     IdentityConflict,
     /// The daemon transport could not be reached or started.
     DaemonUnavailable,
+    /// The daemon lifecycle-control or shutdown handshake wedged.
+    DaemonLifecycleWedge,
     /// The client-side daemon launch gate rejected a duplicate spawn.
     DaemonLaunchGateRejected,
     /// The daemon-side serving gate rejected duplicate ownership.
@@ -125,6 +127,7 @@ impl AtmErrorCode {
             Self::IdentityUnavailable => "ATM_IDENTITY_UNAVAILABLE",
             Self::IdentityConflict => "ATM_IDENTITY_CONFLICT",
             Self::DaemonUnavailable => "ATM_DAEMON_UNAVAILABLE",
+            Self::DaemonLifecycleWedge => "ATM_DAEMON_LIFECYCLE_WEDGE",
             Self::DaemonLaunchGateRejected => "ATM_DAEMON_LAUNCH_GATE_REJECTED",
             Self::DaemonServingStateRejected => "ATM_DAEMON_SERVING_STATE_REJECTED",
             Self::DaemonStaleOwnerRecoveryFailed => "ATM_DAEMON_STALE_OWNER_RECOVERY_FAILED",
@@ -184,6 +187,7 @@ impl FromStr for AtmErrorCode {
             "ATM_IDENTITY_UNAVAILABLE" => Ok(Self::IdentityUnavailable),
             "ATM_IDENTITY_CONFLICT" => Ok(Self::IdentityConflict),
             "ATM_DAEMON_UNAVAILABLE" => Ok(Self::DaemonUnavailable),
+            "ATM_DAEMON_LIFECYCLE_WEDGE" => Ok(Self::DaemonLifecycleWedge),
             "ATM_DAEMON_LAUNCH_GATE_REJECTED" => Ok(Self::DaemonLaunchGateRejected),
             "ATM_DAEMON_SERVING_STATE_REJECTED" => Ok(Self::DaemonServingStateRejected),
             "ATM_DAEMON_STALE_OWNER_RECOVERY_FAILED" => Ok(Self::DaemonStaleOwnerRecoveryFailed),

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -99,6 +99,7 @@ const fn error_kind_for_code(code: AtmErrorCode) -> AtmErrorKind {
         }
         AtmErrorCode::IdentityConflict => AtmErrorKind::Identity,
         AtmErrorCode::DaemonUnavailable
+        | AtmErrorCode::DaemonLifecycleWedge
         | AtmErrorCode::DaemonLaunchGateRejected
         | AtmErrorCode::DaemonServingStateRejected
         | AtmErrorCode::DaemonStaleOwnerRecoveryFailed

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -1,8 +1,10 @@
 //! Shared protocol DTOs for the core transport boundary family.
 
 use std::env;
+use std::fmt;
 use std::io::Read;
 use std::io::Write;
+use std::num::NonZeroU64;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -147,7 +149,7 @@ const fn error_kind_for_code(code: AtmErrorCode) -> AtmErrorKind {
 /// Raw protocol frame payload plus the shared ATM frame header fields.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FramePayload {
-    pub request_id: u64,
+    pub request_id: RequestId,
     pub message_kind: MessageKind,
     pub flags: u16,
     pub bytes: Vec<u8>,
@@ -161,6 +163,34 @@ pub const ATM_FRAME_FLAGS_V1: u16 = 0;
 pub const ATM_FRAME_HEADER_BYTES: usize = 22;
 
 static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RequestId(NonZeroU64);
+
+impl RequestId {
+    pub fn new(request_id: u64) -> Result<Self, AtmError> {
+        let request_id = NonZeroU64::new(request_id).ok_or_else(|| {
+            AtmError::validation(
+                "ATM daemon protocol request_id must be non-zero",
+            )
+            .with_recovery(
+                "Retry with a client and daemon build that populate non-zero ATM daemon request ids.",
+            )
+        })?;
+        Ok(Self(request_id))
+    }
+
+    pub const fn into_inner(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
@@ -246,19 +276,22 @@ impl crate::boundary::sealed::Sealed for JsonAtmProtocolCodec {}
 impl crate::boundary::AtmProtocol for JsonAtmProtocolCodec {
     fn request_to_frame(
         &self,
-        request_id: u64,
+        request_id: RequestId,
         request: RequestEnvelope,
     ) -> Result<FramePayload, AtmError> {
         request_to_frame_payload(request_id, request)
     }
 
-    fn request_from_frame(&self, frame: FramePayload) -> Result<(u64, RequestEnvelope), AtmError> {
+    fn request_from_frame(
+        &self,
+        frame: FramePayload,
+    ) -> Result<(RequestId, RequestEnvelope), AtmError> {
         request_from_frame_payload(frame)
     }
 
     fn response_to_frame(
         &self,
-        request_id: u64,
+        request_id: RequestId,
         response: ResponseEnvelope,
     ) -> Result<FramePayload, AtmError> {
         response_to_frame_payload(request_id, response)
@@ -267,33 +300,35 @@ impl crate::boundary::AtmProtocol for JsonAtmProtocolCodec {
     fn response_from_frame(
         &self,
         frame: FramePayload,
-    ) -> Result<(u64, ResponseEnvelope), AtmError> {
+    ) -> Result<(RequestId, ResponseEnvelope), AtmError> {
         response_from_frame_payload(frame)
     }
 }
 
-pub fn next_request_id() -> u64 {
+pub fn next_request_id() -> RequestId {
     loop {
         let request_id = NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
-        if request_id != 0 {
-            return request_id;
+        if let Some(request_id) = NonZeroU64::new(request_id) {
+            return RequestId(request_id);
         }
     }
 }
 
 pub fn request_to_frame_payload(
-    request_id: u64,
+    request_id: RequestId,
     request: RequestEnvelope,
 ) -> Result<FramePayload, AtmError> {
     Ok(FramePayload {
-        request_id: nonzero_request_id(request_id)?,
+        request_id,
         message_kind: request_message_kind(&request),
         flags: ATM_FRAME_FLAGS_V1,
         bytes: serde_json::to_vec(&request).map_err(AtmError::from)?,
     })
 }
 
-pub fn request_from_frame_payload(frame: FramePayload) -> Result<(u64, RequestEnvelope), AtmError> {
+pub fn request_from_frame_payload(
+    frame: FramePayload,
+) -> Result<(RequestId, RequestEnvelope), AtmError> {
     if !frame.message_kind.is_request() {
         return Err(AtmError::validation(format!(
             "ATM daemon request decoder received non-request message kind 0x{:04x}",
@@ -303,17 +338,16 @@ pub fn request_from_frame_payload(frame: FramePayload) -> Result<(u64, RequestEn
             "Align the CLI and daemon builds so both sides agree on request and response packet roles before retrying.",
         ));
     }
-    let request_id = nonzero_request_id(frame.request_id)?;
     let request = serde_json::from_slice(&frame.bytes).map_err(AtmError::from)?;
-    Ok((request_id, request))
+    Ok((frame.request_id, request))
 }
 
 pub fn response_to_frame_payload(
-    request_id: u64,
+    request_id: RequestId,
     response: ResponseEnvelope,
 ) -> Result<FramePayload, AtmError> {
     Ok(FramePayload {
-        request_id: nonzero_request_id(request_id)?,
+        request_id,
         message_kind: response_message_kind(&response),
         flags: ATM_FRAME_FLAGS_V1,
         bytes: serde_json::to_vec(&response).map_err(AtmError::from)?,
@@ -322,7 +356,7 @@ pub fn response_to_frame_payload(
 
 pub fn response_from_frame_payload(
     frame: FramePayload,
-) -> Result<(u64, ResponseEnvelope), AtmError> {
+) -> Result<(RequestId, ResponseEnvelope), AtmError> {
     if !frame.message_kind.is_response() {
         return Err(AtmError::validation(format!(
             "ATM daemon response decoder received non-response message kind 0x{:04x}",
@@ -332,9 +366,8 @@ pub fn response_from_frame_payload(
             "Align the CLI and daemon builds so both sides agree on request and response packet roles before retrying.",
         ));
     }
-    let request_id = nonzero_request_id(frame.request_id)?;
     let response = serde_json::from_slice(&frame.bytes).map_err(AtmError::from)?;
-    Ok((request_id, response))
+    Ok((frame.request_id, response))
 }
 
 pub fn write_frame(
@@ -364,7 +397,7 @@ pub fn write_frame(
     header[4..6].copy_from_slice(&ATM_FRAME_VERSION_V1.to_be_bytes());
     header[6..8].copy_from_slice(&frame.message_kind.code().to_be_bytes());
     header[8..10].copy_from_slice(&frame.flags.to_be_bytes());
-    header[10..18].copy_from_slice(&frame.request_id.to_be_bytes());
+    header[10..18].copy_from_slice(&frame.request_id.into_inner().to_be_bytes());
     header[18..22].copy_from_slice(&(frame.bytes.len() as u32).to_be_bytes());
     writer
         .write_all(&header)
@@ -412,7 +445,7 @@ pub fn read_frame(
             "Retry with a supported ATM daemon client/server build that uses the version-1 flag contract.",
         ));
     }
-    let request_id = nonzero_request_id(u64::from_be_bytes(
+    let request_id = RequestId::new(u64::from_be_bytes(
         header[10..18].try_into().expect("request id"),
     ))?;
     let payload_length = u32::from_be_bytes(header[18..22].try_into().expect("payload")) as usize;
@@ -449,18 +482,6 @@ fn read_frame_header(
         .read_exact(&mut header[1..])
         .map_err(|source| AtmError::daemon_unavailable(read_error).with_source(source))?;
     Ok(Some(header))
-}
-
-fn nonzero_request_id(request_id: u64) -> Result<u64, AtmError> {
-    if request_id == 0 {
-        return Err(AtmError::validation(
-            "ATM daemon protocol request_id must be non-zero",
-        )
-        .with_recovery(
-            "Retry with a client and daemon build that populate non-zero ATM daemon request ids.",
-        ));
-    }
-    Ok(request_id)
 }
 
 fn request_message_kind(request: &RequestEnvelope) -> MessageKind {

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -15,8 +15,8 @@ atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }
 chrono = { version = "0.4", features = ["serde"] }
 fs2 = "0.4"
 interprocess = "2.4.2"
-sc-observability = "1.0.0"
-sc-observability-types = "1.0.0"
+sc-observability.workspace = true
+sc-observability-types.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 
@@ -28,6 +28,6 @@ signal-hook = "0.3"
 
 [dev-dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2", features = ["test-utils"] }
-sc-observability = { version = "1.0.0", features = ["fault-injection"] }
+sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"

--- a/crates/atm-daemon/src/active_connection_registry.rs
+++ b/crates/atm-daemon/src/active_connection_registry.rs
@@ -71,6 +71,33 @@ impl ActiveConnectionRegistry {
         })
     }
 
+    pub(crate) fn push_dispatch_handle(
+        &self,
+        handle: TrackedDispatchHandle,
+        max_handles: usize,
+    ) -> Result<(), AtmError> {
+        let mut handles = match self.lock_dispatch_handles() {
+            Ok(handles) => handles,
+            Err(error) => {
+                let _ = handle.join_handle.join();
+                return Err(error);
+            }
+        };
+        if handles.len() >= max_handles {
+            let _ = handle.join_handle.join();
+            return Err(
+                AtmError::daemon_lifecycle_wedge(format!(
+                    "tracked daemon dispatch registry exceeded its bounded capacity of {max_handles} handles"
+                ))
+                .with_recovery(
+                    "Restart the daemon; tracked request-work accounting lost its bounded-cap invariant.",
+                ),
+            );
+        }
+        handles.push(handle);
+        Ok(())
+    }
+
     pub(crate) fn reap_finished_dispatches(&self) -> Result<(), AtmError> {
         let finished = {
             let mut handles = self.lock_dispatch_handles()?;
@@ -177,7 +204,12 @@ fn join_dispatch_handle_with_timeout(
                 timeout_ms = timeout.as_millis() as u64,
                 "tracked daemon dispatch worker exceeded the shutdown join deadline; detaching"
             );
-            Ok(())
+            Err(AtmError::daemon_lifecycle_wedge(
+                "tracked daemon dispatch worker exceeded the shutdown join deadline",
+            )
+            .with_recovery(
+                "Restart the daemon; a request worker outlived the bounded shutdown window.",
+            ))
         }
     }
 }

--- a/crates/atm-daemon/src/active_connection_registry.rs
+++ b/crates/atm-daemon/src/active_connection_registry.rs
@@ -1,0 +1,183 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use atm_core::error::AtmError;
+
+pub(crate) struct TrackedDispatchHandle {
+    pub(crate) completion_rx: std::sync::mpsc::Receiver<()>,
+    pub(crate) join_handle: JoinHandle<()>,
+}
+
+impl std::fmt::Debug for TrackedDispatchHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrackedDispatchHandle")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ActiveConnectionRegistry {
+    // These counters are updated from independent accept, connection, and dispatch threads, so
+    // atomics keep the shutdown/drain accounting wait-free on the hot path.
+    active_connections: AtomicUsize,
+    active_dispatches: AtomicUsize,
+    // JoinHandles stay behind this mutex so shutdown and post-request reap paths can
+    // deterministically join finished dispatch workers without racing the accept loop.
+    dispatch_handles: Mutex<Vec<TrackedDispatchHandle>>,
+    // The drain-state mutex has no payload of its own; it exists only to pair the condition
+    // variable with a stable lock while shutdown waits for active work to change.
+    drain_state: Mutex<()>,
+    drain_wake: Condvar,
+}
+
+impl ActiveConnectionRegistry {
+    pub(crate) fn register(self: &Arc<Self>) -> ActiveConnectionGuard {
+        self.active_connections.fetch_add(1, Ordering::SeqCst);
+        ActiveConnectionGuard {
+            registry: Arc::clone(self),
+        }
+    }
+
+    pub(crate) fn register_dispatch_work(self: &Arc<Self>) -> ActiveDispatchGuard {
+        self.active_dispatches.fetch_add(1, Ordering::SeqCst);
+        ActiveDispatchGuard {
+            registry: Arc::clone(self),
+        }
+    }
+
+    pub(crate) fn active_connections(&self) -> usize {
+        self.active_connections.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn active_work_items(&self) -> usize {
+        self.active_connections.load(Ordering::SeqCst)
+            + self.active_dispatches.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn interrupt_all(&self) {
+        self.drain_wake.notify_all();
+    }
+
+    pub(crate) fn lock_dispatch_handles(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, Vec<TrackedDispatchHandle>>, AtmError> {
+        self.dispatch_handles.lock().map_err(|_| {
+            AtmError::daemon_unavailable("active dispatch handle lock poisoned").with_recovery(
+                "Restart the daemon; tracked dispatch worker state may be inconsistent after the poisoned lock.",
+            )
+        })
+    }
+
+    pub(crate) fn reap_finished_dispatches(&self) -> Result<(), AtmError> {
+        let finished = {
+            let mut handles = self.lock_dispatch_handles()?;
+            let mut pending = Vec::with_capacity(handles.len());
+            let mut finished = Vec::new();
+            for handle in handles.drain(..) {
+                match handle.completion_rx.try_recv() {
+                    Ok(()) | Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        finished.push(handle);
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Empty) => {
+                        pending.push(handle);
+                    }
+                }
+            }
+            *handles = pending;
+            finished
+        };
+        for handle in finished {
+            join_dispatch_handle(handle)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn join_tracked_dispatches(&self, timeout: Duration) -> Result<(), AtmError> {
+        self.reap_finished_dispatches()?;
+        let handles = {
+            let mut handles = self.lock_dispatch_handles()?;
+            std::mem::take(&mut *handles)
+        };
+        for handle in handles {
+            join_dispatch_handle_with_timeout(handle, timeout)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn wait_for_connection_change(&self, timeout: Duration) -> Result<(), AtmError> {
+        let state = self.drain_state.lock().map_err(|_| {
+            AtmError::daemon_unavailable("active connection drain lock poisoned").with_recovery(
+                "Restart the daemon; shutdown drain coordination can no longer observe connection progress safely.",
+            )
+        })?;
+        let (_state, wait_result) = self
+            .drain_wake
+            .wait_timeout(state, timeout)
+            .map_err(|_| {
+                AtmError::daemon_unavailable("active connection drain lock poisoned").with_recovery(
+                    "Restart the daemon; shutdown drain coordination can no longer observe connection progress safely.",
+                )
+            })?;
+        if wait_result.timed_out() {
+            return Ok(());
+        }
+        Ok(())
+    }
+
+    fn release_connection(&self) {
+        self.active_connections.fetch_sub(1, Ordering::SeqCst);
+        self.drain_wake.notify_all();
+    }
+}
+
+pub(crate) struct ActiveConnectionGuard {
+    registry: Arc<ActiveConnectionRegistry>,
+}
+
+pub(crate) struct ActiveDispatchGuard {
+    registry: Arc<ActiveConnectionRegistry>,
+}
+
+impl Drop for ActiveConnectionGuard {
+    fn drop(&mut self) {
+        self.registry.release_connection();
+    }
+}
+
+impl Drop for ActiveDispatchGuard {
+    fn drop(&mut self) {
+        self.registry
+            .active_dispatches
+            .fetch_sub(1, Ordering::SeqCst);
+        self.registry.drain_wake.notify_all();
+    }
+}
+
+fn join_dispatch_handle(handle: TrackedDispatchHandle) -> Result<(), AtmError> {
+    handle.join_handle.join().map_err(|_| {
+        AtmError::daemon_unavailable("daemon dispatch thread panicked").with_recovery(
+            "Restart the daemon; one completed dispatch worker panicked before it could be reaped cleanly.",
+        )
+    })
+}
+
+fn join_dispatch_handle_with_timeout(
+    handle: TrackedDispatchHandle,
+    timeout: Duration,
+) -> Result<(), AtmError> {
+    match handle.completion_rx.recv_timeout(timeout) {
+        Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            join_dispatch_handle(handle)
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            tracing::warn!(
+                timeout_ms = timeout.as_millis() as u64,
+                "tracked daemon dispatch worker exceeded the shutdown join deadline; detaching"
+            );
+            Ok(())
+        }
+    }
+}

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -114,7 +114,10 @@ impl RuntimeLifecycle {
 #[derive(Debug)]
 pub(crate) struct RuntimeComposition {
     lifecycle: Arc<RuntimeLifecycle>,
-    _host_ownership: HostOwnershipAdapter,
+    #[allow(dead_code)]
+    // Holding the ownership adapter in the composition keeps host-runtime ownership tied to the
+    // full daemon runtime lifetime even though the field is not read after construction.
+    host_ownership_adapter: HostOwnershipAdapter,
     endpoint_guard: Mutex<Option<SocketEndpointGuard>>,
     server_transport: LocalIpcServerTransportAdapter,
     request_dispatcher: Arc<DaemonRequestDispatcher>,
@@ -162,7 +165,7 @@ impl RuntimeComposition {
         };
         Ok(Self {
             lifecycle: Arc::new(RuntimeLifecycle::new()),
-            _host_ownership: HostOwnershipAdapter::new(),
+            host_ownership_adapter: HostOwnershipAdapter::new(),
             endpoint_guard: Mutex::new(None),
             server_transport: LocalIpcServerTransportAdapter::new(),
             request_dispatcher: Arc::new(DaemonRequestDispatcher::new(
@@ -444,19 +447,25 @@ impl RuntimeComposition {
     fn start_background_lanes(&self) -> Result<(), AtmError> {
         self._notification_sink.start()?;
         if let Err(error) = self._watch_event_source.start() {
-            self.rollback_partially_started_lanes(false, true);
+            self.rollback_partially_started_lanes(StartedLanes {
+                watch_started: false,
+                notification_started: true,
+            });
             return Err(error);
         }
         if let Err(error) = self._reconcile_coordinator.start() {
-            self.rollback_partially_started_lanes(true, true);
+            self.rollback_partially_started_lanes(StartedLanes {
+                watch_started: true,
+                notification_started: true,
+            });
             return Err(error);
         }
         Ok(())
     }
 
-    fn rollback_partially_started_lanes(&self, watch_started: bool, notification_started: bool) {
+    fn rollback_partially_started_lanes(&self, started_lanes: StartedLanes) {
         const BACKGROUND_LANE_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(3);
-        if watch_started
+        if started_lanes.watch_started
             && let Err(error) = shutdown_lane_with_deadline(
                 "watch event source",
                 BACKGROUND_LANE_SHUTDOWN_DEADLINE,
@@ -470,7 +479,7 @@ impl RuntimeComposition {
                 "daemon background lane rollback shutdown was incomplete"
             );
         }
-        if notification_started
+        if started_lanes.notification_started
             && let Err(error) = shutdown_lane_with_deadline(
                 "notification sink",
                 BACKGROUND_LANE_SHUTDOWN_DEADLINE,
@@ -530,6 +539,12 @@ impl RuntimeComposition {
             None => Ok(()),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct StartedLanes {
+    watch_started: bool,
+    notification_started: bool,
 }
 
 fn shutdown_lane_with_deadline<T, F>(

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -3,6 +3,8 @@ use crate::boundary_adapters::{
     DaemonReconcileCoordinator, FileWatchEventSource,
 };
 use crate::daemon_runtime_observability::DaemonRuntimeObservability;
+use crate::host_ownership::HostOwnershipAdapter;
+use crate::local_ipc_transport::{RuntimeServeHooks, SocketEndpointGuard};
 use crate::runtime_health::DaemonRequestDispatcher;
 use crate::runtime_health::{DaemonStatusSource, RuntimeStatusCache};
 use crate::{
@@ -112,6 +114,8 @@ impl RuntimeLifecycle {
 #[derive(Debug)]
 pub(crate) struct RuntimeComposition {
     lifecycle: Arc<RuntimeLifecycle>,
+    _host_ownership: HostOwnershipAdapter,
+    endpoint_guard: Mutex<Option<SocketEndpointGuard>>,
     server_transport: LocalIpcServerTransportAdapter,
     request_dispatcher: Arc<DaemonRequestDispatcher>,
     _notification_sink: DaemonNotificationSink,
@@ -158,6 +162,8 @@ impl RuntimeComposition {
         };
         Ok(Self {
             lifecycle: Arc::new(RuntimeLifecycle::new()),
+            _host_ownership: HostOwnershipAdapter::new(),
+            endpoint_guard: Mutex::new(None),
             server_transport: LocalIpcServerTransportAdapter::new(),
             request_dispatcher: Arc::new(DaemonRequestDispatcher::new(
                 home_dir,
@@ -181,6 +187,30 @@ impl RuntimeComposition {
 
     fn request_dispatcher(&self) -> Arc<dyn RequestDispatcher + Send + Sync> {
         self.request_dispatcher.clone()
+    }
+
+    fn replace_endpoint_guard(&self, guard: Option<SocketEndpointGuard>) -> Result<(), AtmError> {
+        let mut slot = self.endpoint_guard.lock().map_err(|_| {
+            AtmError::daemon_unavailable("runtime endpoint guard slot lock poisoned").with_recovery(
+                "Restart the daemon; same-host endpoint cleanup ownership can no longer be tracked safely.",
+            )
+        })?;
+        *slot = guard;
+        Ok(())
+    }
+
+    fn take_endpoint_guard(&self) -> Result<SocketEndpointGuard, AtmError> {
+        let mut slot = self.endpoint_guard.lock().map_err(|_| {
+            AtmError::daemon_unavailable("runtime endpoint guard slot lock poisoned").with_recovery(
+                "Restart the daemon; same-host endpoint cleanup ownership can no longer be tracked safely.",
+            )
+        })?;
+        slot.take().ok_or_else(|| {
+            AtmError::daemon_unavailable("runtime endpoint guard was missing during daemon serve startup")
+                .with_recovery(
+                    "Restart the daemon; same-host endpoint cleanup ownership was lost before the listener entered serving state.",
+                )
+        })
     }
 
     fn begin_shutdown(&self) -> Result<(), AtmError> {
@@ -242,7 +272,7 @@ impl RuntimeComposition {
             self.lifecycle.force_stopped()?;
             return Err(error);
         }
-        let runtime = match self.server_transport.prepare_runtime() {
+        let mut runtime = match self.server_transport.prepare_runtime() {
             Ok(runtime) => runtime,
             Err(error) => {
                 if let Err(shutdown_error) = self.shutdown_background_lanes() {
@@ -260,6 +290,7 @@ impl RuntimeComposition {
                 return Err(error);
             }
         };
+        self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
         self.request_dispatcher.emit_runtime_event(
             "startup_completed",
@@ -267,13 +298,17 @@ impl RuntimeComposition {
             "daemon startup completed",
         );
         let request_dispatcher = Arc::clone(&self.request_dispatcher);
+        let endpoint_guard = self.take_endpoint_guard()?;
         let result = runtime.serve_with_runtime_hooks(
             self.request_dispatcher(),
-            super::GRACEFUL_DRAIN_DEADLINE,
-            super::FORCE_CANCEL_DEADLINE,
-            || self.begin_shutdown(),
-            move || request_dispatcher.reload_runtime_view(),
-            || self.finalize_shutdown(),
+            RuntimeServeHooks {
+                endpoint_guard,
+                graceful_drain_deadline: super::GRACEFUL_DRAIN_DEADLINE,
+                force_cancel_deadline: super::FORCE_CANCEL_DEADLINE,
+                begin_shutdown: || self.begin_shutdown(),
+                reload_runtime_view: move || request_dispatcher.reload_runtime_view(),
+                finalize_shutdown: || self.finalize_shutdown(),
+            },
         );
         self.finish_runtime(result)
     }
@@ -322,7 +357,7 @@ impl RuntimeComposition {
             self.lifecycle.force_stopped()?;
             return Err(error);
         }
-        let runtime = match self
+        let mut runtime = match self
             .server_transport
             .prepare_runtime_at_socket_path(socket_path)
         {
@@ -343,6 +378,7 @@ impl RuntimeComposition {
                 return Err(error);
             }
         };
+        self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
         self.request_dispatcher.emit_runtime_event(
             "startup_completed",
@@ -350,13 +386,17 @@ impl RuntimeComposition {
             "daemon startup completed",
         );
         let request_dispatcher = Arc::clone(&self.request_dispatcher);
+        let endpoint_guard = self.take_endpoint_guard()?;
         let result = runtime.serve_with_runtime_hooks(
             self.request_dispatcher(),
-            super::GRACEFUL_DRAIN_DEADLINE,
-            super::FORCE_CANCEL_DEADLINE,
-            || self.begin_shutdown(),
-            move || request_dispatcher.reload_runtime_view(),
-            || self.finalize_shutdown(),
+            RuntimeServeHooks {
+                endpoint_guard,
+                graceful_drain_deadline: super::GRACEFUL_DRAIN_DEADLINE,
+                force_cancel_deadline: super::FORCE_CANCEL_DEADLINE,
+                begin_shutdown: || self.begin_shutdown(),
+                reload_runtime_view: move || request_dispatcher.reload_runtime_view(),
+                finalize_shutdown: || self.finalize_shutdown(),
+            },
         );
         self.finish_runtime(result)
     }

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 //! Daemon runtime composition and portability adapters.
 
+mod active_connection_registry;
 mod boundary_adapters;
 pub(crate) mod composition;
 mod daemon_runtime_observability;
@@ -15,6 +16,7 @@ mod notification_runtime;
 mod peer_transport;
 mod reconcile_runtime;
 mod runtime_health;
+mod shutdown_beacon;
 #[cfg(test)]
 mod test_observability;
 mod watch_runtime;

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use atm_core::error::AtmError;
+use atm_core::error::{AtmError, AtmErrorCode};
 use atm_rusqlite::SqliteBoundaryAssembly;
 pub use daemon_runtime_observability::DaemonRuntimeObservability;
 
@@ -33,6 +33,42 @@ pub(crate) use peer_transport::{PeerTransportRuntime, RemoteReplayStore};
 
 pub(crate) const GRACEFUL_DRAIN_DEADLINE: Duration = Duration::from_secs(5);
 pub(crate) const FORCE_CANCEL_DEADLINE: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonExitCode {
+    CleanStop = 0,
+    InternalBug = 1,
+    DoNotRestart = 64,
+    TransportFatal = 70,
+    LifecycleWedge = 71,
+}
+
+impl DaemonExitCode {
+    pub const fn as_i32(self) -> i32 {
+        self as i32
+    }
+}
+
+pub fn daemon_exit_code_for_error(error: &AtmError) -> DaemonExitCode {
+    if matches!(
+        error.code,
+        AtmErrorCode::DaemonServingStateRejected
+            | AtmErrorCode::DaemonStaleOwnerRecoveryFailed
+            | AtmErrorCode::DaemonLaunchGateRejected
+            | AtmErrorCode::ConfigHomeUnavailable
+            | AtmErrorCode::ObservabilityBootstrapFailed
+    ) || error.is_config()
+    {
+        return DaemonExitCode::DoNotRestart;
+    }
+    if error.message.contains("lifecycle waiter") || error.message.contains("lifecycle wedge") {
+        return DaemonExitCode::LifecycleWedge;
+    }
+    if error.is_daemon_unavailable() {
+        return DaemonExitCode::TransportFatal;
+    }
+    DaemonExitCode::InternalBug
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct AtmHomeDir(PathBuf);

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -19,6 +19,8 @@ mod runtime_health;
 mod shutdown_beacon;
 #[cfg(test)]
 mod test_observability;
+#[cfg(test)]
+mod test_support;
 mod watch_runtime;
 
 use std::path::PathBuf;

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -50,6 +50,9 @@ impl DaemonExitCode {
 }
 
 pub fn daemon_exit_code_for_error(error: &AtmError) -> DaemonExitCode {
+    if error.code == AtmErrorCode::DaemonLifecycleWedge {
+        return DaemonExitCode::LifecycleWedge;
+    }
     if matches!(
         error.code,
         AtmErrorCode::DaemonServingStateRejected
@@ -60,9 +63,6 @@ pub fn daemon_exit_code_for_error(error: &AtmError) -> DaemonExitCode {
     ) || error.is_config()
     {
         return DaemonExitCode::DoNotRestart;
-    }
-    if error.message.contains("lifecycle waiter") || error.message.contains("lifecycle wedge") {
-        return DaemonExitCode::LifecycleWedge;
     }
     if error.is_daemon_unavailable() {
         return DaemonExitCode::TransportFatal;

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -33,8 +33,8 @@ pub(crate) use atm_rusqlite::RemoteReplayStateRecord;
 pub(crate) use local_ipc_transport::LocalIpcServerTransportAdapter;
 pub(crate) use peer_transport::{PeerTransportRuntime, RemoteReplayStore};
 
-pub(crate) const GRACEFUL_DRAIN_DEADLINE: Duration = Duration::from_secs(5);
-pub(crate) const FORCE_CANCEL_DEADLINE: Duration = Duration::from_secs(10);
+pub(crate) const GRACEFUL_DRAIN_DEADLINE: Duration = Duration::from_secs(2);
+pub(crate) const FORCE_CANCEL_DEADLINE: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DaemonExitCode {

--- a/crates/atm-daemon/src/lifecycle_control.rs
+++ b/crates/atm-daemon/src/lifecycle_control.rs
@@ -383,17 +383,14 @@ fn install_platform_hooks(
     std::thread::Builder::new()
         .name("atm-daemon-lifecycle-windows".to_string())
         .spawn(move || {
-            let mut observed_terminate = terminate.load(Ordering::SeqCst);
             let mut observed_reload = reload.load(Ordering::SeqCst);
             loop {
                 if terminate.load(Ordering::SeqCst) {
                     let _ = state_change.notify();
                     return;
                 }
-                let terminate_now = terminate.load(Ordering::SeqCst);
                 let reload_now = reload.load(Ordering::SeqCst);
-                if terminate_now != observed_terminate || reload_now != observed_reload {
-                    observed_terminate = terminate_now;
+                if reload_now != observed_reload {
                     observed_reload = reload_now;
                     let _ = state_change.notify();
                 }

--- a/crates/atm-daemon/src/lifecycle_control.rs
+++ b/crates/atm-daemon/src/lifecycle_control.rs
@@ -180,7 +180,7 @@ impl LifecycleControlSourceAdapter {
         self.state_change.wait_for_change(observed_generation)
     }
 
-    #[allow(dead_code)]
+    #[cfg_attr(any(windows, not(test)), allow(dead_code))]
     pub(crate) fn wait_for_state_change_timeout(
         &self,
         observed_generation: &mut u64,
@@ -513,6 +513,28 @@ mod unix_tests {
             .expect("EOF should wake lifecycle waiters");
         worker.join().expect("join unix lifecycle worker");
         wait_join.join().expect("join waiter");
+    }
+
+    #[test]
+    fn wait_for_state_change_timeout_reports_timeout_then_wake() {
+        let adapter = LifecycleControlSourceAdapter::new_for_test();
+        let mut observed_generation = adapter.event_generation().expect("generation");
+
+        let timed_out = adapter
+            .wait_for_state_change_timeout(&mut observed_generation, Duration::from_millis(10))
+            .expect("timeout wait");
+        assert!(
+            !timed_out,
+            "short timeout without a state change should report false"
+        );
+
+        adapter
+            .notify_state_change()
+            .expect("notify lifecycle state change");
+        let changed = adapter
+            .wait_for_state_change_timeout(&mut observed_generation, Duration::from_secs(1))
+            .expect("wake wait");
+        assert!(changed, "explicit notify should wake the timed wait");
     }
 }
 

--- a/crates/atm-daemon/src/lifecycle_control.rs
+++ b/crates/atm-daemon/src/lifecycle_control.rs
@@ -399,7 +399,7 @@ fn install_platform_hooks(
                 }
                 // `signal_hook::flag` does not expose a blocking cross-platform wake primitive on
                 // Windows, so the lifecycle worker uses one bounded polling exception that Phase S
-                // documents explicitly in plan-phase-S.md §4.1.
+                // documents explicitly in docs/plan-phase-S.md §4.1, Accepted production exceptions.
                 std::thread::sleep(std::time::Duration::from_millis(25));
             }
         })

--- a/crates/atm-daemon/src/lifecycle_control.rs
+++ b/crates/atm-daemon/src/lifecycle_control.rs
@@ -327,6 +327,8 @@ fn install_platform_hooks(
     let terminate = Arc::clone(terminate);
     let reload = Arc::clone(reload);
     let state_change = Arc::clone(state_change);
+    // This worker is intentionally fire-and-forget: lifecycle-control state is process-global,
+    // and process exit is the only shutdown point for the signal hooks it services.
     std::thread::Builder::new()
         .name("atm-daemon-lifecycle-unix".to_string())
         .spawn(move || {
@@ -376,6 +378,8 @@ fn install_platform_hooks(
     let terminate = Arc::clone(terminate);
     let reload = Arc::clone(reload);
     let state_change = Arc::clone(state_change);
+    // This worker is intentionally fire-and-forget: lifecycle-control state is process-global,
+    // and process exit is the only shutdown point for the signal hooks it services.
     std::thread::Builder::new()
         .name("atm-daemon-lifecycle-windows".to_string())
         .spawn(move || {

--- a/crates/atm-daemon/src/lifecycle_control.rs
+++ b/crates/atm-daemon/src/lifecycle_control.rs
@@ -5,6 +5,9 @@ use atm_core::error::AtmError;
 
 #[derive(Debug, Clone)]
 pub(crate) struct LifecycleControlSourceAdapter {
+    // The lifecycle flags are flipped from signal-hook handlers and read from normal daemon
+    // threads, so atomics provide the minimum cross-thread synchronization without widening the
+    // signal-facing surface to a heavier lock.
     terminate: Arc<AtomicBool>,
     #[cfg_attr(windows, allow(dead_code))]
     reload: Arc<AtomicBool>,
@@ -129,6 +132,9 @@ impl LifecycleControlSourceAdapter {
         }
         let shared = shared.as_ref().ok_or_else(|| {
             AtmError::daemon_unavailable("daemon lifecycle control source was not initialized")
+                .with_recovery(
+                    "Restart the daemon; lifecycle hooks were not installed before the runtime tried to serve requests.",
+                )
         })?;
         Ok(Self {
             terminate: Arc::clone(&shared.terminate),
@@ -162,6 +168,10 @@ impl LifecycleControlSourceAdapter {
         self.state_change.snapshot()
     }
 
+    pub(crate) fn notify_state_change(&self) -> Result<(), AtmError> {
+        self.state_change.notify()
+    }
+
     #[cfg_attr(any(windows, not(test)), allow(dead_code))]
     pub(crate) fn wait_for_state_change(
         &self,
@@ -170,7 +180,7 @@ impl LifecycleControlSourceAdapter {
         self.state_change.wait_for_change(observed_generation)
     }
 
-    #[cfg_attr(windows, allow(dead_code))]
+    #[allow(dead_code)]
     pub(crate) fn wait_for_state_change_timeout(
         &self,
         observed_generation: &mut u64,
@@ -247,44 +257,71 @@ fn install_platform_hooks(
 
     let (wake_read, wake_write) = UnixStream::pair().map_err(|source| {
         AtmError::daemon_unavailable("failed to create daemon lifecycle wake pipe")
+            .with_recovery(
+                "Restart the daemon after confirming the host can allocate a local lifecycle wake channel for atm-daemon.",
+            )
             .with_source(source)
     })?;
     signal_flag::register(SIGINT, Arc::clone(terminate)).map_err(|source| {
         AtmError::daemon_unavailable("failed to install daemon lifecycle signal handlers")
+            .with_recovery(
+                "Restart the daemon after confirming the host allows local signal-hook registration for atm-daemon.",
+            )
             .with_source(source)
     })?;
     signal_flag::register(SIGTERM, Arc::clone(terminate)).map_err(|source| {
         AtmError::daemon_unavailable("failed to install daemon lifecycle signal handlers")
+            .with_recovery(
+                "Restart the daemon after confirming the host allows local signal-hook registration for atm-daemon.",
+            )
             .with_source(source)
     })?;
     signal_flag::register(SIGHUP, Arc::clone(reload)).map_err(|source| {
         AtmError::daemon_unavailable("failed to install daemon lifecycle signal handlers")
+            .with_recovery(
+                "Restart the daemon after confirming the host allows local signal-hook registration for atm-daemon.",
+            )
             .with_source(source)
     })?;
     signal_pipe::register(
         SIGINT,
         wake_write.try_clone().map_err(|source| {
             AtmError::daemon_unavailable("failed to clone daemon lifecycle wake pipe")
+                .with_recovery(
+                    "Restart the daemon after confirming the host can duplicate the lifecycle wake channel for signal delivery.",
+                )
                 .with_source(source)
         })?,
     )
     .map_err(|source| {
         AtmError::daemon_unavailable("failed to install daemon lifecycle signal handlers")
+            .with_recovery(
+                "Restart the daemon after confirming the host allows local signal-hook registration for atm-daemon.",
+            )
             .with_source(source)
     })?;
     signal_pipe::register(
         SIGTERM,
         wake_write.try_clone().map_err(|source| {
             AtmError::daemon_unavailable("failed to clone daemon lifecycle wake pipe")
+                .with_recovery(
+                    "Restart the daemon after confirming the host can duplicate the lifecycle wake channel for signal delivery.",
+                )
                 .with_source(source)
         })?,
     )
     .map_err(|source| {
         AtmError::daemon_unavailable("failed to install daemon lifecycle signal handlers")
+            .with_recovery(
+                "Restart the daemon after confirming the host allows local signal-hook registration for atm-daemon.",
+            )
             .with_source(source)
     })?;
     signal_pipe::register(SIGHUP, wake_write).map_err(|source| {
         AtmError::daemon_unavailable("failed to install daemon lifecycle signal handlers")
+            .with_recovery(
+                "Restart the daemon after confirming the host allows local signal-hook registration for atm-daemon.",
+            )
             .with_source(source)
     })?;
     let terminate = Arc::clone(terminate);
@@ -297,6 +334,9 @@ fn install_platform_hooks(
         })
         .map_err(|source| {
             AtmError::daemon_unavailable("failed to spawn daemon lifecycle signal worker")
+                .with_recovery(
+                    "Restart the daemon after confirming the host can spawn the lifecycle wake worker thread.",
+                )
                 .with_source(source)
         })?;
     Ok(())
@@ -313,14 +353,23 @@ fn install_platform_hooks(
 
     signal_flag::register(SIGINT, Arc::clone(terminate)).map_err(|source| {
         AtmError::daemon_unavailable("failed to install daemon lifecycle signal handlers")
+            .with_recovery(
+                "Restart the daemon after confirming the host allows local signal-hook registration for atm-daemon.",
+            )
             .with_source(source)
     })?;
     signal_flag::register(SIGTERM, Arc::clone(terminate)).map_err(|source| {
         AtmError::daemon_unavailable("failed to install daemon lifecycle signal handlers")
+            .with_recovery(
+                "Restart the daemon after confirming the host allows local signal-hook registration for atm-daemon.",
+            )
             .with_source(source)
     })?;
     signal_flag::register(SIGBREAK, Arc::clone(reload)).map_err(|source| {
         AtmError::daemon_unavailable("failed to install daemon lifecycle signal handlers")
+            .with_recovery(
+                "Restart the daemon after confirming the host allows local signal-hook registration for atm-daemon.",
+            )
             .with_source(source)
     })?;
 
@@ -352,6 +401,9 @@ fn install_platform_hooks(
         })
         .map_err(|source| {
             AtmError::daemon_unavailable("failed to spawn daemon lifecycle signal worker")
+                .with_recovery(
+                    "Restart the daemon after confirming the host can spawn the lifecycle wake worker thread.",
+                )
                 .with_source(source)
         })?;
     Ok(())

--- a/crates/atm-daemon/src/lifecycle_control.rs
+++ b/crates/atm-daemon/src/lifecycle_control.rs
@@ -59,9 +59,11 @@ impl LifecycleStateChange {
             })
     }
 
-    #[cfg_attr(windows, allow(dead_code))]
-    fn wait_for_change(&self, observed_generation: &mut u64) -> Result<(), AtmError> {
-        const LIFECYCLE_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+    fn wait_for_change_timeout(
+        &self,
+        observed_generation: &mut u64,
+        timeout: std::time::Duration,
+    ) -> Result<bool, AtmError> {
         let mut generation = self.generation.lock().map_err(|_| {
             AtmError::daemon_unavailable("daemon lifecycle state-change lock poisoned")
                 .with_recovery("Restart the daemon; lifecycle wake state is no longer trustworthy.")
@@ -69,7 +71,7 @@ impl LifecycleStateChange {
         while *generation == *observed_generation {
             let (updated_generation, wait_result) = self
                 .wake
-                .wait_timeout_while(generation, LIFECYCLE_WAIT_TIMEOUT, |current_generation| {
+                .wait_timeout_while(generation, timeout, |current_generation| {
                     *current_generation == *observed_generation
                 })
                 .map_err(|_| {
@@ -80,10 +82,17 @@ impl LifecycleStateChange {
                 })?;
             generation = updated_generation;
             if wait_result.timed_out() && *generation == *observed_generation {
-                continue;
+                return Ok(false);
             }
         }
         *observed_generation = *generation;
+        Ok(true)
+    }
+
+    #[cfg_attr(any(windows, not(test)), allow(dead_code))]
+    fn wait_for_change(&self, observed_generation: &mut u64) -> Result<(), AtmError> {
+        const LIFECYCLE_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        while !self.wait_for_change_timeout(observed_generation, LIFECYCLE_WAIT_TIMEOUT)? {}
         Ok(())
     }
 }
@@ -153,12 +162,22 @@ impl LifecycleControlSourceAdapter {
         self.state_change.snapshot()
     }
 
-    #[cfg_attr(windows, allow(dead_code))]
+    #[cfg_attr(any(windows, not(test)), allow(dead_code))]
     pub(crate) fn wait_for_state_change(
         &self,
         observed_generation: &mut u64,
     ) -> Result<(), AtmError> {
         self.state_change.wait_for_change(observed_generation)
+    }
+
+    #[cfg_attr(windows, allow(dead_code))]
+    pub(crate) fn wait_for_state_change_timeout(
+        &self,
+        observed_generation: &mut u64,
+        timeout: std::time::Duration,
+    ) -> Result<bool, AtmError> {
+        self.state_change
+            .wait_for_change_timeout(observed_generation, timeout)
     }
 
     pub(crate) fn terminate_flag(&self) -> Arc<AtomicBool> {

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -2,9 +2,7 @@ use std::io::Write;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Condvar, Mutex};
-use std::thread::JoinHandle;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use atm_core::boundary::{self, AtmProtocol, RequestDispatcher};
@@ -15,8 +13,10 @@ use interprocess::local_socket::{
     Listener as LocalSocketListener, ListenerOptions, Stream as LocalSocketStream,
 };
 
+use crate::active_connection_registry::{ActiveConnectionRegistry, TrackedDispatchHandle};
 use crate::host_ownership::{HostOwnershipAdapter, HostOwnershipGuard};
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
+use crate::shutdown_beacon::ShutdownBeacon;
 
 #[cfg(unix)]
 use std::fs;
@@ -35,230 +35,8 @@ enum ServeEvent {
     AcceptError(AtmError),
 }
 
-struct TrackedDispatchHandle {
-    completion_rx: std::sync::mpsc::Receiver<()>,
-    join_handle: JoinHandle<()>,
-}
-
-impl std::fmt::Debug for TrackedDispatchHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TrackedDispatchHandle")
-            .finish_non_exhaustive()
-    }
-}
-
-#[derive(Debug, Default)]
-pub(crate) struct ActiveConnectionRegistry {
-    // These counters are updated from independent accept, connection, and dispatch threads, so
-    // atomics keep the shutdown/drain accounting wait-free on the hot path.
-    active_connections: AtomicUsize,
-    active_dispatches: AtomicUsize,
-    // JoinHandles stay behind this mutex so shutdown and post-request reap paths can
-    // deterministically join finished dispatch workers without racing the accept loop.
-    dispatch_handles: Mutex<Vec<TrackedDispatchHandle>>,
-    // The drain-state mutex has no payload of its own; it exists only to pair the condition
-    // variable with a stable lock while shutdown waits for active work to change.
-    drain_state: Mutex<()>,
-    drain_wake: Condvar,
-}
-
-impl ActiveConnectionRegistry {
-    pub(crate) fn register(self: &Arc<Self>) -> ActiveConnectionGuard {
-        self.active_connections.fetch_add(1, Ordering::SeqCst);
-        ActiveConnectionGuard {
-            registry: Arc::clone(self),
-        }
-    }
-
-    fn register_dispatch_work(self: &Arc<Self>) -> ActiveDispatchGuard {
-        self.active_dispatches.fetch_add(1, Ordering::SeqCst);
-        ActiveDispatchGuard {
-            registry: Arc::clone(self),
-        }
-    }
-
-    pub(crate) fn active_connections(&self) -> usize {
-        self.active_connections.load(Ordering::SeqCst)
-    }
-
-    pub(crate) fn active_work_items(&self) -> usize {
-        self.active_connections.load(Ordering::SeqCst)
-            + self.active_dispatches.load(Ordering::SeqCst)
-    }
-
-    pub(crate) fn interrupt_all(&self) {
-        self.drain_wake.notify_all();
-    }
-
-    fn lock_dispatch_handles(
-        &self,
-    ) -> Result<std::sync::MutexGuard<'_, Vec<TrackedDispatchHandle>>, AtmError> {
-        self.dispatch_handles
-            .lock()
-            .map_err(|_| {
-                AtmError::daemon_unavailable("active dispatch handle lock poisoned").with_recovery(
-                    "Restart the daemon; tracked dispatch worker state may be inconsistent after the poisoned lock.",
-                )
-            })
-    }
-
-    fn reap_finished_dispatches(&self) -> Result<(), AtmError> {
-        let finished = {
-            let mut handles = self.lock_dispatch_handles()?;
-            let mut pending = Vec::with_capacity(handles.len());
-            let mut finished = Vec::new();
-            for handle in handles.drain(..) {
-                match handle.completion_rx.try_recv() {
-                    Ok(()) | Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                        finished.push(handle);
-                    }
-                    Err(std::sync::mpsc::TryRecvError::Empty) => {
-                        pending.push(handle);
-                    }
-                }
-            }
-            *handles = pending;
-            finished
-        };
-        for handle in finished {
-            join_dispatch_handle(handle)?;
-        }
-        Ok(())
-    }
-
-    fn join_tracked_dispatches(&self) -> Result<(), AtmError> {
-        self.reap_finished_dispatches()?;
-        let handles = {
-            let mut handles = self.lock_dispatch_handles()?;
-            std::mem::take(&mut *handles)
-        };
-        for handle in handles {
-            join_dispatch_handle_with_timeout(handle, TRACKED_DISPATCH_JOIN_DEADLINE)?;
-        }
-        Ok(())
-    }
-
-    pub(crate) fn wait_for_connection_change(&self, timeout: Duration) -> Result<(), AtmError> {
-        let state = self
-            .drain_state
-            .lock()
-            .map_err(|_| {
-                AtmError::daemon_unavailable("active connection drain lock poisoned").with_recovery(
-                    "Restart the daemon; shutdown drain coordination can no longer observe connection progress safely.",
-                )
-            })?;
-        let (_state, wait_result) = self
-            .drain_wake
-            .wait_timeout(state, timeout)
-            .map_err(|_| {
-                AtmError::daemon_unavailable("active connection drain lock poisoned").with_recovery(
-                    "Restart the daemon; shutdown drain coordination can no longer observe connection progress safely.",
-                )
-            })?;
-        if wait_result.timed_out() {
-            return Ok(());
-        }
-        Ok(())
-    }
-
-    fn release_connection(&self) {
-        self.active_connections.fetch_sub(1, Ordering::SeqCst);
-        self.drain_wake.notify_all();
-    }
-}
-
-pub(crate) struct ActiveConnectionGuard {
-    registry: Arc<ActiveConnectionRegistry>,
-}
-
-struct ActiveDispatchGuard {
-    registry: Arc<ActiveConnectionRegistry>,
-}
-
-impl Drop for ActiveConnectionGuard {
-    fn drop(&mut self) {
-        self.registry.release_connection();
-    }
-}
-
-impl Drop for ActiveDispatchGuard {
-    fn drop(&mut self) {
-        self.registry
-            .active_dispatches
-            .fetch_sub(1, Ordering::SeqCst);
-        self.registry.drain_wake.notify_all();
-    }
-}
-
-fn join_dispatch_handle(handle: TrackedDispatchHandle) -> Result<(), AtmError> {
-    handle.join_handle.join().map_err(|_| {
-        AtmError::daemon_unavailable("daemon dispatch thread panicked").with_recovery(
-            "Restart the daemon; one completed dispatch worker panicked before it could be reaped cleanly.",
-        )
-    })
-}
-
-fn join_dispatch_handle_with_timeout(
-    handle: TrackedDispatchHandle,
-    timeout: Duration,
-) -> Result<(), AtmError> {
-    match handle.completion_rx.recv_timeout(timeout) {
-        Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            join_dispatch_handle(handle)
-        }
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            tracing::warn!(
-                timeout_ms = timeout.as_millis() as u64,
-                "tracked daemon dispatch worker exceeded the shutdown join deadline; detaching"
-            );
-            Ok(())
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct ShutdownBeacon {
-    // This bit is read by accept, lifecycle, and serve-loop threads, so it stays atomic while the
-    // companion condvar provides immediate wakeups for blocking waiters.
-    tripped: AtomicBool,
-    state: Mutex<()>,
-    wake: Condvar,
-}
-
-impl ShutdownBeacon {
-    fn trip(&self) {
-        self.tripped.store(true, Ordering::SeqCst);
-        self.wake.notify_all();
-    }
-
-    fn is_tripped(&self) -> bool {
-        self.tripped.load(Ordering::SeqCst)
-    }
-
-    #[allow(dead_code)]
-    fn wait_for_trip_timeout(&self, timeout: Duration) -> Result<bool, AtmError> {
-        if self.is_tripped() {
-            return Ok(true);
-        }
-        let state = self.state.lock().map_err(|_| {
-            AtmError::daemon_lifecycle_wedge("daemon shutdown beacon lock poisoned").with_recovery(
-                "Restart the daemon; transport shutdown coordination can no longer wake blocked lifecycle waiters safely.",
-            )
-        })?;
-        if self.is_tripped() {
-            return Ok(true);
-        }
-        let (_state, wait_result) = self.wake.wait_timeout(state, timeout).map_err(|_| {
-            AtmError::daemon_lifecycle_wedge("daemon shutdown beacon lock poisoned").with_recovery(
-                "Restart the daemon; transport shutdown coordination can no longer wake blocked lifecycle waiters safely.",
-            )
-        })?;
-        Ok(!wait_result.timed_out() && self.is_tripped())
-    }
-}
-
 #[derive(Debug)]
-struct SocketEndpointGuard {
+pub(crate) struct SocketEndpointGuard {
     endpoint_path: PathBuf,
     preparation: LocalIpcEndpointPreparation,
     // Endpoint cleanup may be requested explicitly during shutdown and again from Drop, so an
@@ -310,12 +88,22 @@ impl Drop for SocketEndpointGuard {
 
 pub(crate) struct PreparedRuntimeServer {
     _ownership: HostOwnershipGuard,
-    endpoint_guard: SocketEndpointGuard,
+    endpoint_path: PathBuf,
+    endpoint_guard: Option<SocketEndpointGuard>,
     listener: LocalSocketListener,
     lifecycle_control: LifecycleControlSourceAdapter,
     registry: Arc<ActiveConnectionRegistry>,
     force_shutdown: Arc<AtomicBool>,
     codec: JsonAtmProtocolCodec,
+}
+
+pub(crate) struct RuntimeServeHooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown> {
+    pub(crate) endpoint_guard: SocketEndpointGuard,
+    pub(crate) graceful_drain_deadline: Duration,
+    pub(crate) force_cancel_deadline: Duration,
+    pub(crate) begin_shutdown: BeginShutdown,
+    pub(crate) reload_runtime_view: ReloadRuntimeView,
+    pub(crate) finalize_shutdown: FinalizeShutdown,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -367,8 +155,12 @@ impl PreparedRuntimeServer {
         );
         emit_ready_signal_if_requested()?;
         Ok(Self {
-            endpoint_guard: SocketEndpointGuard::new(endpoint_path, endpoint_preparation),
             _ownership: ownership,
+            endpoint_path: endpoint_path.clone(),
+            endpoint_guard: Some(SocketEndpointGuard::new(
+                endpoint_path,
+                endpoint_preparation,
+            )),
             listener,
             lifecycle_control,
             registry: Arc::new(ActiveConnectionRegistry::default()),
@@ -380,44 +172,38 @@ impl PreparedRuntimeServer {
     pub(crate) fn serve_with_runtime_hooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown>(
         self,
         dispatcher: Arc<dyn RequestDispatcher + Send + Sync>,
-        graceful_drain_deadline: Duration,
-        force_cancel_deadline: Duration,
-        begin_shutdown: BeginShutdown,
-        reload_runtime_view: ReloadRuntimeView,
-        finalize_shutdown: FinalizeShutdown,
+        hooks: RuntimeServeHooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown>,
     ) -> Result<(), AtmError>
     where
         BeginShutdown: Fn() -> Result<(), AtmError>,
         ReloadRuntimeView: Fn() -> Result<(), AtmError>,
         FinalizeShutdown: Fn(),
     {
-        self.serve_with_deadlines_and_accept_probe(
-            dispatcher,
-            graceful_drain_deadline,
-            force_cancel_deadline,
-            begin_shutdown,
-            reload_runtime_view,
-            finalize_shutdown,
-        )
+        self.serve_with_deadlines_and_accept_probe(dispatcher, hooks)
     }
 
     fn serve_with_deadlines_and_accept_probe<BeginShutdown, ReloadRuntimeView, FinalizeShutdown>(
         self,
         dispatcher: Arc<dyn RequestDispatcher + Send + Sync>,
-        graceful_drain_deadline: Duration,
-        force_cancel_deadline: Duration,
-        begin_shutdown: BeginShutdown,
-        reload_runtime_view: ReloadRuntimeView,
-        finalize_shutdown: FinalizeShutdown,
+        hooks: RuntimeServeHooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown>,
     ) -> Result<(), AtmError>
     where
         BeginShutdown: Fn() -> Result<(), AtmError>,
         ReloadRuntimeView: Fn() -> Result<(), AtmError>,
         FinalizeShutdown: Fn(),
     {
+        let RuntimeServeHooks {
+            endpoint_guard,
+            graceful_drain_deadline,
+            force_cancel_deadline,
+            begin_shutdown,
+            reload_runtime_view,
+            finalize_shutdown,
+        } = hooks;
         let Self {
             _ownership,
-            endpoint_guard,
+            endpoint_path,
+            endpoint_guard: _endpoint_guard,
             listener,
             lifecycle_control,
             registry,
@@ -435,7 +221,7 @@ impl PreparedRuntimeServer {
                 let event_tx = event_tx.clone();
                 let shutdown_beacon = Arc::clone(&shutdown_beacon);
                 let lifecycle_control = lifecycle_control.clone();
-                let endpoint_path = endpoint_guard.endpoint_path().to_path_buf();
+                let endpoint_path = endpoint_path.clone();
                 scope.spawn(move || {
                     let mut observed_generation = match lifecycle_control.event_generation() {
                         Ok(generation) => generation,
@@ -675,6 +461,9 @@ impl PreparedRuntimeServer {
             if lifecycle_waiter.join().is_err() {
                 let error = AtmError::daemon_lifecycle_wedge(
                     "daemon lifecycle waiter panicked during transport shutdown",
+                )
+                .with_recovery(
+                    "Restart the daemon; the same-host lifecycle waiter crashed while the runtime was transitioning out of serving state.",
                 );
                 if let Some(existing) = shutdown_error.as_ref() {
                     tracing::warn!(
@@ -730,6 +519,15 @@ impl PreparedRuntimeServer {
                 return Err(serve_error);
             }
             shutdown_error.map_or(Ok(()), Err)
+        })
+    }
+
+    pub(crate) fn take_endpoint_guard(&mut self) -> Result<SocketEndpointGuard, AtmError> {
+        self.endpoint_guard.take().ok_or_else(|| {
+            AtmError::daemon_unavailable("daemon local IPC endpoint guard was missing during runtime handoff")
+                .with_recovery(
+                    "Restart the daemon; same-host endpoint cleanup ownership was lost before the runtime began serving.",
+                )
         })
     }
 }
@@ -845,6 +643,9 @@ fn write_shutdown_response(
     )?;
     stream.flush().map_err(|source| {
         AtmError::daemon_unavailable("failed to flush daemon shutdown rejection response frame")
+            .with_recovery(
+                "Retry the ATM command after the daemon restarts; the shutdown rejection response could not be delivered cleanly.",
+            )
             .with_source(source)
     })?;
     Ok(())
@@ -951,10 +752,18 @@ fn emit_ready_signal_if_requested() -> Result<(), AtmError> {
     }
     let mut stdout = std::io::stdout().lock();
     writeln!(stdout, "ATM_DAEMON_READY").map_err(|source| {
-        AtmError::daemon_unavailable("failed to emit daemon ready signal").with_source(source)
+        AtmError::daemon_unavailable("failed to emit daemon ready signal")
+            .with_recovery(
+                "Restart the daemon after confirming the parent process still accepts the ready signal on stdout.",
+            )
+            .with_source(source)
     })?;
     stdout.flush().map_err(|source| {
-        AtmError::daemon_unavailable("failed to flush daemon ready signal").with_source(source)
+        AtmError::daemon_unavailable("failed to flush daemon ready signal")
+            .with_recovery(
+                "Restart the daemon after confirming the parent process still accepts the ready signal on stdout.",
+            )
+            .with_source(source)
     })?;
     Ok(())
 }
@@ -993,7 +802,7 @@ fn drain_active_connections_for_shutdown(
             force_cancel_deadline.saturating_duration_since(Instant::now()),
         )?;
     }
-    registry.join_tracked_dispatches()?;
+    registry.join_tracked_dispatches(TRACKED_DISPATCH_JOIN_DEADLINE)?;
     let remaining_work_items = registry.active_work_items();
     if remaining_work_items > 0 {
         return Err(AtmError::daemon_unavailable(format!(
@@ -1021,12 +830,18 @@ fn handle_connection(
         .set_recv_timeout(Some(REQUEST_DEADLINE))
         .map_err(|source| {
             AtmError::daemon_unavailable("failed to apply daemon request read deadline")
+                .with_recovery(
+                    "Restart the daemon; the same-host request socket could not apply its bounded read deadline.",
+                )
                 .with_source(source)
         })?;
     stream
         .set_send_timeout(Some(REQUEST_DEADLINE))
         .map_err(|source| {
             AtmError::daemon_unavailable("failed to apply daemon response write deadline")
+                .with_recovery(
+                    "Restart the daemon; the same-host request socket could not apply its bounded write deadline.",
+                )
                 .with_source(source)
         })?;
 
@@ -1094,7 +909,11 @@ fn handle_connection(
     let frame = codec.response_to_frame(request_id, response)?;
     atm_core::protocol::write_frame(&mut stream, &frame, "failed to write daemon response frame")?;
     stream.flush().map_err(|source| {
-        AtmError::daemon_unavailable("failed to flush daemon response frame").with_source(source)
+        AtmError::daemon_unavailable("failed to flush daemon response frame")
+            .with_recovery(
+                "Retry the ATM command after the daemon finishes recovering the same-host request runtime.",
+            )
+            .with_source(source)
     })?;
     registry.reap_finished_dispatches()?;
     Ok(())
@@ -1245,7 +1064,8 @@ mod tests {
     fn accept_error_without_lifecycle_signal_exits_within_one_second() {
         let tempdir = TempDir::new().expect("tempdir");
         let socket_path = tempdir.path().join("daemon.sock");
-        let runtime = PreparedRuntimeServer::bind(socket_path).expect("prepare runtime");
+        let mut runtime = PreparedRuntimeServer::bind(socket_path).expect("prepare runtime");
+        let endpoint_guard = runtime.take_endpoint_guard().expect("take endpoint guard");
         let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
         let _reset = LifecycleFlagResetGuard::install(lifecycle);
         let dispatcher: Arc<dyn RequestDispatcher + Send + Sync> = Arc::new(DoctorOnlyDispatcher);
@@ -1258,11 +1078,14 @@ mod tests {
             // the production SLO values documented for the real daemon runtime.
             let result = runtime.serve_with_runtime_hooks(
                 dispatcher,
-                Duration::from_millis(500),
-                Duration::from_secs(2),
-                || Ok(()),
-                || Ok(()),
-                || {},
+                RuntimeServeHooks {
+                    endpoint_guard,
+                    graceful_drain_deadline: Duration::from_millis(500),
+                    force_cancel_deadline: Duration::from_secs(2),
+                    begin_shutdown: || Ok(()),
+                    reload_runtime_view: || Ok(()),
+                    finalize_shutdown: || {},
+                },
             );
             serve_result_tx.send(result).expect("send serve result");
         });
@@ -1289,7 +1112,9 @@ mod tests {
     fn accept_after_terminate_returns_typed_shutdown_error() {
         let tempdir = TempDir::new().expect("tempdir");
         let socket_path = tempdir.path().join("daemon.sock");
-        let runtime = PreparedRuntimeServer::bind(socket_path.clone()).expect("prepare runtime");
+        let mut runtime =
+            PreparedRuntimeServer::bind(socket_path.clone()).expect("prepare runtime");
+        let endpoint_guard = runtime.take_endpoint_guard().expect("take endpoint guard");
         let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
         let _reset = LifecycleFlagResetGuard::install(lifecycle.clone());
         let dispatcher: Arc<dyn RequestDispatcher + Send + Sync> = Arc::new(DoctorOnlyDispatcher);
@@ -1300,11 +1125,14 @@ mod tests {
             // the production SLO values documented for the real daemon runtime.
             let result = runtime.serve_with_runtime_hooks(
                 dispatcher,
-                Duration::from_millis(500),
-                Duration::from_secs(2),
-                || Ok(()),
-                || Ok(()),
-                || {},
+                RuntimeServeHooks {
+                    endpoint_guard,
+                    graceful_drain_deadline: Duration::from_millis(500),
+                    force_cancel_deadline: Duration::from_secs(2),
+                    begin_shutdown: || Ok(()),
+                    reload_runtime_view: || Ok(()),
+                    finalize_shutdown: || {},
+                },
             );
             serve_result_tx.send(result).expect("send serve result");
         });
@@ -1359,7 +1187,9 @@ mod tests {
     fn panic_in_dispatch_still_cleans_up_socket_path_on_shutdown() {
         let tempdir = TempDir::new().expect("tempdir");
         let socket_path = tempdir.path().join("daemon.sock");
-        let runtime = PreparedRuntimeServer::bind(socket_path.clone()).expect("prepare runtime");
+        let mut runtime =
+            PreparedRuntimeServer::bind(socket_path.clone()).expect("prepare runtime");
+        let endpoint_guard = runtime.take_endpoint_guard().expect("take endpoint guard");
         let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
         let _reset = LifecycleFlagResetGuard::install(lifecycle.clone());
         let dispatcher: Arc<dyn RequestDispatcher + Send + Sync> = Arc::new(PanicDispatcher);
@@ -1368,11 +1198,14 @@ mod tests {
         let join = std::thread::spawn(move || {
             let result = runtime.serve_with_runtime_hooks(
                 dispatcher,
-                Duration::from_millis(500),
-                Duration::from_secs(2),
-                || Ok(()),
-                || Ok(()),
-                || {},
+                RuntimeServeHooks {
+                    endpoint_guard,
+                    graceful_drain_deadline: Duration::from_millis(500),
+                    force_cancel_deadline: Duration::from_secs(2),
+                    begin_shutdown: || Ok(()),
+                    reload_runtime_view: || Ok(()),
+                    finalize_shutdown: || {},
+                },
             );
             serve_result_tx.send(result).expect("send serve result");
         });

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -933,6 +933,7 @@ mod tests {
     use atm_core::error_codes::AtmErrorCode;
     #[cfg(unix)]
     use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
+    #[cfg(unix)]
     use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
     #[cfg(unix)]
     use serial_test::serial;

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -940,6 +940,8 @@ mod tests {
     #[cfg(unix)]
     use crate::lifecycle_control::LifecycleControlSourceAdapter;
     #[cfg(unix)]
+    use crate::test_support::{LifecycleFlagResetGuard, connect_daemon_local_ipc_until_ready};
+    #[cfg(unix)]
     use atm_core::boundary::RequestDispatcher;
     #[cfg(unix)]
     use atm_core::doctor::DoctorQuery;
@@ -1022,46 +1024,6 @@ mod tests {
             request: RequestEnvelope,
         ) -> Result<ResponseEnvelope, atm_core::error::AtmError> {
             panic!("intentional dispatcher panic for test: {request:?}");
-        }
-    }
-
-    #[cfg(unix)]
-    struct LifecycleFlagResetGuard {
-        lifecycle: LifecycleControlSourceAdapter,
-    }
-
-    #[cfg(unix)]
-    impl LifecycleFlagResetGuard {
-        fn install(lifecycle: LifecycleControlSourceAdapter) -> Self {
-            lifecycle.set_terminate_for_test(false);
-            lifecycle.set_reload_for_test(false);
-            Self { lifecycle }
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for LifecycleFlagResetGuard {
-        fn drop(&mut self) {
-            self.lifecycle.set_terminate_for_test(false);
-            self.lifecycle.set_reload_for_test(false);
-        }
-    }
-
-    #[cfg(unix)]
-    fn connect_daemon_local_ipc_until_ready(endpoint_path: &Path) -> LocalSocketStream {
-        let deadline = Instant::now() + Duration::from_secs(3);
-        loop {
-            match LocalSocketStream::connect(
-                atm_core::protocol::daemon_local_ipc_name_from_path(endpoint_path)
-                    .expect("ipc name"),
-            ) {
-                Ok(stream) => return stream,
-                Err(error) if Instant::now() < deadline => {
-                    let _ = error;
-                    std::thread::yield_now();
-                }
-                Err(error) => panic!("connect daemon local ipc: {error}"),
-            }
         }
     }
 

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -23,22 +24,38 @@ use std::thread;
 
 const MAX_CONCURRENT_CONNECTIONS: usize = 64;
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
-const SHUTDOWN_BEACON_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const TRACKED_DISPATCH_JOIN_DEADLINE: Duration = Duration::from_millis(250);
+const LISTENER_WAKE_CONNECT_DEADLINE: Duration = Duration::from_millis(250);
 
 enum ServeEvent {
     Connection(LocalSocketStream),
+    DispatchFinished,
     Reload,
     Terminate,
     AcceptError(AtmError),
 }
 
+struct TrackedDispatchHandle {
+    completion_rx: std::sync::mpsc::Receiver<()>,
+    join_handle: JoinHandle<()>,
+}
+
+impl std::fmt::Debug for TrackedDispatchHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrackedDispatchHandle")
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct ActiveConnectionRegistry {
+    // These counters are updated from independent accept, connection, and dispatch threads, so
+    // atomics keep the shutdown/drain accounting wait-free on the hot path.
     active_connections: AtomicUsize,
     active_dispatches: AtomicUsize,
     // JoinHandles stay behind this mutex so shutdown and post-request reap paths can
     // deterministically join finished dispatch workers without racing the accept loop.
-    dispatch_handles: Mutex<Vec<JoinHandle<()>>>,
+    dispatch_handles: Mutex<Vec<TrackedDispatchHandle>>,
     // The drain-state mutex has no payload of its own; it exists only to pair the condition
     // variable with a stable lock while shutdown waits for active work to change.
     drain_state: Mutex<()>,
@@ -75,7 +92,7 @@ impl ActiveConnectionRegistry {
 
     fn lock_dispatch_handles(
         &self,
-    ) -> Result<std::sync::MutexGuard<'_, Vec<JoinHandle<()>>>, AtmError> {
+    ) -> Result<std::sync::MutexGuard<'_, Vec<TrackedDispatchHandle>>, AtmError> {
         self.dispatch_handles
             .lock()
             .map_err(|_| {
@@ -91,21 +108,20 @@ impl ActiveConnectionRegistry {
             let mut pending = Vec::with_capacity(handles.len());
             let mut finished = Vec::new();
             for handle in handles.drain(..) {
-                if handle.is_finished() {
-                    finished.push(handle);
-                } else {
-                    pending.push(handle);
+                match handle.completion_rx.try_recv() {
+                    Ok(()) | Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        finished.push(handle);
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Empty) => {
+                        pending.push(handle);
+                    }
                 }
             }
             *handles = pending;
             finished
         };
         for handle in finished {
-            handle.join().map_err(|_| {
-                AtmError::daemon_unavailable("daemon dispatch thread panicked").with_recovery(
-                    "Restart the daemon; one completed dispatch worker panicked before it could be reaped cleanly.",
-                )
-            })?;
+            join_dispatch_handle(handle)?;
         }
         Ok(())
     }
@@ -117,11 +133,7 @@ impl ActiveConnectionRegistry {
             std::mem::take(&mut *handles)
         };
         for handle in handles {
-            handle.join().map_err(|_| {
-                AtmError::daemon_unavailable("daemon dispatch thread panicked").with_recovery(
-                    "Restart the daemon; one tracked dispatch worker panicked during shutdown.",
-                )
-            })?;
+            join_dispatch_handle_with_timeout(handle, TRACKED_DISPATCH_JOIN_DEADLINE)?;
         }
         Ok(())
     }
@@ -178,18 +190,70 @@ impl Drop for ActiveDispatchGuard {
     }
 }
 
+fn join_dispatch_handle(handle: TrackedDispatchHandle) -> Result<(), AtmError> {
+    handle.join_handle.join().map_err(|_| {
+        AtmError::daemon_unavailable("daemon dispatch thread panicked").with_recovery(
+            "Restart the daemon; one completed dispatch worker panicked before it could be reaped cleanly.",
+        )
+    })
+}
+
+fn join_dispatch_handle_with_timeout(
+    handle: TrackedDispatchHandle,
+    timeout: Duration,
+) -> Result<(), AtmError> {
+    match handle.completion_rx.recv_timeout(timeout) {
+        Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            join_dispatch_handle(handle)
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            tracing::warn!(
+                timeout_ms = timeout.as_millis() as u64,
+                "tracked daemon dispatch worker exceeded the shutdown join deadline; detaching"
+            );
+            Ok(())
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 struct ShutdownBeacon {
+    // This bit is read by accept, lifecycle, and serve-loop threads, so it stays atomic while the
+    // companion condvar provides immediate wakeups for blocking waiters.
     tripped: AtomicBool,
+    state: Mutex<()>,
+    wake: Condvar,
 }
 
 impl ShutdownBeacon {
     fn trip(&self) {
         self.tripped.store(true, Ordering::SeqCst);
+        self.wake.notify_all();
     }
 
     fn is_tripped(&self) -> bool {
         self.tripped.load(Ordering::SeqCst)
+    }
+
+    #[allow(dead_code)]
+    fn wait_for_trip_timeout(&self, timeout: Duration) -> Result<bool, AtmError> {
+        if self.is_tripped() {
+            return Ok(true);
+        }
+        let state = self.state.lock().map_err(|_| {
+            AtmError::daemon_lifecycle_wedge("daemon shutdown beacon lock poisoned").with_recovery(
+                "Restart the daemon; transport shutdown coordination can no longer wake blocked lifecycle waiters safely.",
+            )
+        })?;
+        if self.is_tripped() {
+            return Ok(true);
+        }
+        let (_state, wait_result) = self.wake.wait_timeout(state, timeout).map_err(|_| {
+            AtmError::daemon_lifecycle_wedge("daemon shutdown beacon lock poisoned").with_recovery(
+                "Restart the daemon; transport shutdown coordination can no longer wake blocked lifecycle waiters safely.",
+            )
+        })?;
+        Ok(!wait_result.timed_out() && self.is_tripped())
     }
 }
 
@@ -197,6 +261,8 @@ impl ShutdownBeacon {
 struct SocketEndpointGuard {
     endpoint_path: PathBuf,
     preparation: LocalIpcEndpointPreparation,
+    // Endpoint cleanup may be requested explicitly during shutdown and again from Drop, so an
+    // atomic one-shot bit prevents duplicate unpublish work without introducing a wider lock.
     unpublished: AtomicBool,
 }
 
@@ -243,8 +309,8 @@ impl Drop for SocketEndpointGuard {
 }
 
 pub(crate) struct PreparedRuntimeServer {
-    endpoint_guard: SocketEndpointGuard,
     _ownership: HostOwnershipGuard,
+    endpoint_guard: SocketEndpointGuard,
     listener: LocalSocketListener,
     lifecycle_control: LifecycleControlSourceAdapter,
     registry: Arc<ActiveConnectionRegistry>,
@@ -287,6 +353,9 @@ impl PreparedRuntimeServer {
                     "failed to bind daemon local IPC endpoint at {}",
                     endpoint_path.display()
                 ))
+                .with_recovery(
+                    "Confirm the endpoint path is writable and no conflicting daemon still owns the same-host IPC address before restarting atm-daemon.",
+                )
                 .with_source(source)
             })?;
         tracing::info!(
@@ -347,8 +416,8 @@ impl PreparedRuntimeServer {
         FinalizeShutdown: Fn(),
     {
         let Self {
-            endpoint_guard,
             _ownership,
+            endpoint_guard,
             listener,
             lifecycle_control,
             registry,
@@ -356,10 +425,13 @@ impl PreparedRuntimeServer {
             codec,
         } = self;
         thread::scope(|scope| -> Result<(), AtmError> {
+            // Each serving invocation owns its own shutdown beacon. The beacon must not survive a
+            // later bind/restart cycle because a tripped beacon from an older listener would
+            // incorrectly poison the next same-host endpoint publication.
             let shutdown_beacon = Arc::new(ShutdownBeacon::default());
             let mut serve_error = None;
             let (event_tx, event_rx) = std::sync::mpsc::channel();
-            {
+            let lifecycle_waiter = {
                 let event_tx = event_tx.clone();
                 let shutdown_beacon = Arc::clone(&shutdown_beacon);
                 let lifecycle_control = lifecycle_control.clone();
@@ -369,6 +441,7 @@ impl PreparedRuntimeServer {
                         Ok(generation) => generation,
                         Err(error) => {
                             shutdown_beacon.trip();
+                            let _ = lifecycle_control.notify_state_change();
                             let _ = event_tx.send(ServeEvent::AcceptError(error));
                             return;
                         }
@@ -377,25 +450,20 @@ impl PreparedRuntimeServer {
                         if shutdown_beacon.is_tripped() {
                             return;
                         }
-                        let state_changed = match lifecycle_control.wait_for_state_change_timeout(
-                            &mut observed_generation,
-                            SHUTDOWN_BEACON_POLL_INTERVAL,
-                        ) {
-                            Ok(state_changed) => state_changed,
-                            Err(error) => {
-                                shutdown_beacon.trip();
-                                let _ = event_tx.send(ServeEvent::AcceptError(error));
-                                return;
-                            }
-                        };
+                        if let Err(error) =
+                            lifecycle_control.wait_for_state_change(&mut observed_generation)
+                        {
+                            shutdown_beacon.trip();
+                            let _ = lifecycle_control.notify_state_change();
+                            let _ = event_tx.send(ServeEvent::AcceptError(error));
+                            return;
+                        }
                         if shutdown_beacon.is_tripped() {
                             return;
                         }
-                        if !state_changed {
-                            continue;
-                        }
                         if lifecycle_control.terminate_requested() {
                             shutdown_beacon.trip();
+                            let _ = lifecycle_control.notify_state_change();
                             let _ = wake_listener(&endpoint_path);
                             let _ = event_tx.send(ServeEvent::Terminate);
                             return;
@@ -404,9 +472,10 @@ impl PreparedRuntimeServer {
                             && event_tx.send(ServeEvent::Reload).is_err()
                         {
                             shutdown_beacon.trip();
+                            let _ = lifecycle_control.notify_state_change();
                             let _ = wake_listener(&endpoint_path);
                             let _ = event_tx.send(ServeEvent::AcceptError(
-                                AtmError::daemon_unavailable(
+                                AtmError::daemon_lifecycle_wedge(
                                     "daemon lifecycle waiter lost the serve-loop event channel",
                                 )
                                 .with_recovery(
@@ -416,9 +485,9 @@ impl PreparedRuntimeServer {
                             return;
                         }
                     }
-                });
-            }
-            {
+                })
+            };
+            let accept_loop = {
                 let event_tx = event_tx.clone();
                 let shutdown_beacon = Arc::clone(&shutdown_beacon);
                 let lifecycle_control = lifecycle_control.clone();
@@ -431,6 +500,7 @@ impl PreparedRuntimeServer {
                         #[cfg(test)]
                         if let Some(error) = take_injected_accept_error_for_test() {
                             shutdown_beacon.trip();
+                            let _ = lifecycle_control.notify_state_change();
                             let _ = event_tx.send(ServeEvent::AcceptError(error));
                             return;
                         }
@@ -440,19 +510,25 @@ impl PreparedRuntimeServer {
                                     || shutdown_beacon.is_tripped()
                                 {
                                     shutdown_beacon.trip();
+                                    let _ = lifecycle_control.notify_state_change();
                                     let _ = write_shutdown_response(&mut stream, &codec);
                                     let _ = event_tx.send(ServeEvent::Terminate);
                                     return;
                                 }
                                 if event_tx.send(ServeEvent::Connection(stream)).is_err() {
                                     shutdown_beacon.trip();
+                                    let _ = lifecycle_control.notify_state_change();
                                     return;
                                 }
                             }
                             Err(source) => {
                                 shutdown_beacon.trip();
+                                let _ = lifecycle_control.notify_state_change();
                                 let error = AtmError::daemon_unavailable(
                                     "failed while accepting daemon local IPC connection",
+                                )
+                                .with_recovery(
+                                    "Restart the daemon; the local IPC listener stopped accepting connections unexpectedly.",
                                 )
                                 .with_source(source);
                                 let _ = event_tx.send(ServeEvent::AcceptError(error));
@@ -460,13 +536,21 @@ impl PreparedRuntimeServer {
                             }
                         }
                     }
-                });
-            }
+                })
+            };
+            let dispatch_event_tx = event_tx.clone();
             drop(event_tx);
             loop {
-                registry.reap_finished_dispatches()?;
-                match event_rx.recv_timeout(SHUTDOWN_BEACON_POLL_INTERVAL) {
+                match event_rx.recv() {
                     Ok(event) => match event {
+                        ServeEvent::DispatchFinished => {
+                            if let Err(error) = registry.reap_finished_dispatches() {
+                                shutdown_beacon.trip();
+                                let _ = lifecycle_control.notify_state_change();
+                                serve_error = Some(error);
+                                break;
+                            }
+                        }
                         ServeEvent::Connection(mut stream) => {
                             if registry.active_connections() >= MAX_CONCURRENT_CONNECTIONS {
                                 let response = ResponseEnvelope::Error(
@@ -496,18 +580,31 @@ impl PreparedRuntimeServer {
                             let force_shutdown = Arc::clone(&force_shutdown);
                             let registry = Arc::clone(&registry);
                             let codec = codec.clone();
+                            let event_tx = dispatch_event_tx.clone();
                             scope.spawn(move || {
-                            let _active = active;
-                            if let Err(error) = handle_connection(
-                                stream,
-                                dispatcher,
-                                force_shutdown.as_ref(),
-                                registry,
-                                codec,
-                            ) {
-                                tracing::warn!(%error, "daemon local IPC connection handling failed");
-                            }
-                        });
+                                let _active = active;
+                                let result = catch_unwind(AssertUnwindSafe(|| {
+                                    handle_connection(
+                                        stream,
+                                        dispatcher,
+                                        force_shutdown.as_ref(),
+                                        registry,
+                                        codec,
+                                        event_tx,
+                                    )
+                                }));
+                                match result {
+                                    Ok(Ok(())) => {}
+                                    Ok(Err(error)) => {
+                                        tracing::warn!(%error, "daemon local IPC connection handling failed");
+                                    }
+                                    Err(_) => {
+                                        tracing::warn!(
+                                            "daemon local IPC connection worker panicked; the transport thread recovered and continued shutdown accounting"
+                                        );
+                                    }
+                                }
+                            });
                         }
                         // Reload work stays serialized inside the serve loop so the accept path
                         // never races a partially-applied runtime view update.
@@ -523,21 +620,19 @@ impl PreparedRuntimeServer {
                         },
                         ServeEvent::Terminate => {
                             shutdown_beacon.trip();
+                            let _ = lifecycle_control.notify_state_change();
                             break;
                         }
                         ServeEvent::AcceptError(error) => {
                             shutdown_beacon.trip();
+                            let _ = lifecycle_control.notify_state_change();
                             serve_error = Some(error);
                             break;
                         }
                     },
-                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                        if shutdown_beacon.is_tripped() {
-                            break;
-                        }
-                    }
-                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    Err(std::sync::mpsc::RecvError) => {
                         shutdown_beacon.trip();
+                        let _ = lifecycle_control.notify_state_change();
                         serve_error = Some(
                             AtmError::daemon_unavailable(
                                 "daemon local IPC accept loop event channel disconnected",
@@ -551,6 +646,9 @@ impl PreparedRuntimeServer {
                 }
             }
 
+            // Every serve-loop exit path, including AcceptError and internal tracked-work failures,
+            // must transition through begin_shutdown() before finalization so RuntimeComposition
+            // observes Running -> Draining -> Stopped instead of a silent hard stop.
             let mut shutdown_error = begin_shutdown().err();
             let shutdown_started = Instant::now();
             if let Err(error) = drain_active_connections_for_shutdown(
@@ -565,6 +663,40 @@ impl PreparedRuntimeServer {
                         begin_shutdown_error = %existing,
                         drain_error = %error,
                         "daemon shutdown drain failed after an earlier shutdown-start error"
+                    );
+                } else {
+                    shutdown_error = Some(error);
+                }
+            }
+            let _ = lifecycle_control.notify_state_change();
+            if let Err(error) = wake_listener(endpoint_guard.endpoint_path()) {
+                tracing::debug!(%error, "daemon local IPC listener wake was unnecessary during shutdown");
+            }
+            if lifecycle_waiter.join().is_err() {
+                let error = AtmError::daemon_lifecycle_wedge(
+                    "daemon lifecycle waiter panicked during transport shutdown",
+                );
+                if let Some(existing) = shutdown_error.as_ref() {
+                    tracing::warn!(
+                        begin_shutdown_error = %existing,
+                        lifecycle_waiter_error = %error,
+                        "daemon lifecycle waiter failed after an earlier shutdown error"
+                    );
+                } else {
+                    shutdown_error = Some(error);
+                }
+            }
+            if accept_loop.join().is_err() {
+                let error =
+                    AtmError::daemon_unavailable("daemon local IPC accept loop panicked during shutdown")
+                        .with_recovery(
+                            "Restart the daemon; the same-host listener thread panicked while the runtime was stopping.",
+                        );
+                if let Some(existing) = shutdown_error.as_ref() {
+                    tracing::warn!(
+                        begin_shutdown_error = %existing,
+                        accept_loop_error = %error,
+                        "daemon accept loop failed after an earlier shutdown error"
                     );
                 } else {
                     shutdown_error = Some(error);
@@ -646,6 +778,9 @@ fn prepare_local_ipc_endpoint(
                 "failed to create daemon local IPC directory at {}",
                 parent.display()
             ))
+            .with_recovery(
+                "Grant write access to the daemon socket parent directory or choose a writable ATM_HOME before retrying.",
+            )
             .with_source(source)
         })?;
     }
@@ -667,13 +802,18 @@ fn remove_stale_endpoint(endpoint_path: &Path) -> Result<(), AtmError> {
     if !endpoint_path.exists() {
         return Ok(());
     }
-    fs::remove_file(endpoint_path).map_err(|source| {
-        AtmError::daemon_unavailable(format!(
+    match fs::remove_file(endpoint_path) {
+        Ok(()) => Ok(()),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(AtmError::daemon_unavailable(format!(
             "failed to remove stale daemon local IPC endpoint at {}",
             endpoint_path.display()
         ))
-        .with_source(source)
-    })
+        .with_recovery(
+            "Stop the conflicting daemon or remove the stale same-host socket path before restarting atm-daemon.",
+        )
+        .with_source(source)),
+    }
 }
 
 fn write_shutdown_response(
@@ -712,21 +852,55 @@ fn write_shutdown_response(
 
 fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {
     let name = atm_core::protocol::daemon_local_ipc_name_from_path(endpoint_path)?;
-    let mut stream = LocalSocketStream::connect(name).map_err(|source| {
-        AtmError::daemon_unavailable(format!(
-            "failed to wake daemon local IPC listener at {}",
-            endpoint_path.display()
-        ))
-        .with_source(source)
-    })?;
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let _ = result_tx.send(LocalSocketStream::connect(name));
+    });
+    let mut stream = match result_rx.recv_timeout(LISTENER_WAKE_CONNECT_DEADLINE) {
+        Ok(Ok(stream)) => stream,
+        Ok(Err(source)) => {
+            return Err(AtmError::daemon_unavailable(format!(
+                "failed to wake daemon local IPC listener at {}",
+                endpoint_path.display()
+            ))
+            .with_recovery(
+                "Restart the daemon; the local IPC listener could not be nudged out of accept cleanly during shutdown.",
+            )
+            .with_source(source));
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            return Err(AtmError::daemon_lifecycle_wedge(format!(
+                "timed out waking daemon local IPC listener at {}",
+                endpoint_path.display()
+            ))
+            .with_recovery(
+                "Restart the daemon; the listener wake connection exceeded the bounded shutdown budget.",
+            ));
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            return Err(AtmError::daemon_unavailable(format!(
+                "daemon listener wake worker disconnected unexpectedly for {}",
+                endpoint_path.display()
+            ))
+            .with_recovery(
+                "Restart the daemon; the local IPC wake path aborted before it could connect to the listener.",
+            ));
+        }
+    };
     stream
         .set_send_timeout(Some(REQUEST_DEADLINE))
         .map_err(|source| {
             AtmError::daemon_unavailable("failed to apply daemon listener wake timeout")
+                .with_recovery(
+                    "Restart the daemon; the shutdown wake connection could not apply its bounded send deadline.",
+                )
                 .with_source(source)
         })?;
     stream.flush().map_err(|source| {
         AtmError::daemon_unavailable("failed to flush daemon listener wake signal")
+            .with_recovery(
+                "Restart the daemon; the local IPC wake signal could not be flushed to the blocked listener.",
+            )
             .with_source(source)
     })?;
     Ok(())
@@ -824,7 +998,10 @@ fn drain_active_connections_for_shutdown(
     if remaining_work_items > 0 {
         return Err(AtmError::daemon_unavailable(format!(
             "forced cancel deadline elapsed with {remaining_work_items} active daemon work item(s)"
-        )));
+        ))
+        .with_recovery(
+            "Restart the daemon after the wedged request workers are no longer holding the same-host runtime open.",
+        ));
     }
     Ok(())
 }
@@ -835,9 +1012,10 @@ fn handle_connection(
     force_shutdown: &AtomicBool,
     registry: Arc<ActiveConnectionRegistry>,
     codec: JsonAtmProtocolCodec,
+    serve_event_tx: std::sync::mpsc::Sender<ServeEvent>,
 ) -> Result<(), AtmError> {
     if force_shutdown.load(Ordering::SeqCst) {
-        return Ok(());
+        return write_shutdown_response(&mut stream, &codec);
     }
     stream
         .set_recv_timeout(Some(REQUEST_DEADLINE))
@@ -852,6 +1030,8 @@ fn handle_connection(
                 .with_source(source)
         })?;
 
+    // Phase S still enforces one request per accepted same-host connection even though the
+    // request runtime owns its execution separately from this socket receive loop.
     let Some(frame) = atm_core::protocol::read_frame(
         &mut stream,
         "failed to read daemon request frame",
@@ -867,13 +1047,20 @@ fn handle_connection(
     let (request_id, request) = codec.request_from_frame(frame)?;
 
     let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
     let dispatch_registry = Arc::clone(&registry);
+    let dispatch_event_tx = serve_event_tx.clone();
     let dispatch_handle = std::thread::spawn(move || {
         let _dispatch_work = dispatch_registry.register_dispatch_work();
         let _ = result_tx.send(dispatcher.dispatch(request));
+        let _ = completion_tx.send(());
+        let _ = dispatch_event_tx.send(ServeEvent::DispatchFinished);
     });
     match registry.lock_dispatch_handles() {
-        Ok(mut handles) => handles.push(dispatch_handle),
+        Ok(mut handles) => handles.push(TrackedDispatchHandle {
+            completion_rx,
+            join_handle: dispatch_handle,
+        }),
         Err(error) => {
             let _ = dispatch_handle.join();
             return Err(error);
@@ -1052,6 +1239,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     #[serial]
     fn accept_error_without_lifecycle_signal_exits_within_one_second() {
@@ -1066,6 +1254,8 @@ mod tests {
         let _inject_guard = install_injected_accept_error_for_test(inject_tx);
 
         let join = std::thread::spawn(move || {
+            // These shortened deadlines validate immediate shutdown-beacon wake correctness, not
+            // the production SLO values documented for the real daemon runtime.
             let result = runtime.serve_with_runtime_hooks(
                 dispatcher,
                 Duration::from_millis(500),
@@ -1093,6 +1283,7 @@ mod tests {
         join.join().expect("join serve thread");
     }
 
+    #[cfg(unix)]
     #[test]
     #[serial]
     fn accept_after_terminate_returns_typed_shutdown_error() {
@@ -1105,6 +1296,8 @@ mod tests {
         let (serve_result_tx, serve_result_rx) = mpsc::channel();
 
         let join = std::thread::spawn(move || {
+            // These shortened deadlines validate immediate shutdown-beacon wake correctness, not
+            // the production SLO values documented for the real daemon runtime.
             let result = runtime.serve_with_runtime_hooks(
                 dispatcher,
                 Duration::from_millis(500),
@@ -1224,5 +1417,44 @@ mod tests {
             !socket_path.exists(),
             "socket endpoint should be removed during shutdown even after a dispatch panic"
         );
+    }
+
+    #[test]
+    fn bounded_drain_returns_after_force_cancel_deadline() {
+        let registry = Arc::new(ActiveConnectionRegistry::default());
+        let active_connection = registry.register();
+        let dispatch_registry = Arc::clone(&registry);
+        let (release_tx, release_rx) = mpsc::sync_channel(1);
+        let (completion_tx, completion_rx) = mpsc::sync_channel(1);
+        let join_handle = std::thread::spawn(move || {
+            let _dispatch = dispatch_registry.register_dispatch_work();
+            let _ = release_rx.recv();
+            let _ = completion_tx.send(());
+        });
+        registry
+            .lock_dispatch_handles()
+            .expect("dispatch handle lock")
+            .push(TrackedDispatchHandle {
+                completion_rx,
+                join_handle,
+            });
+        let force_shutdown = AtomicBool::new(false);
+        let shutdown_started = Instant::now();
+        let error = drain_active_connections_for_shutdown(
+            registry.as_ref(),
+            &force_shutdown,
+            Duration::from_millis(10),
+            Duration::from_millis(20),
+            Instant::now(),
+        )
+        .expect_err("bounded drain should fail once the forced-cancel deadline elapses");
+        assert!(
+            shutdown_started.elapsed() < Duration::from_secs(1),
+            "forced cancel should bound shutdown even when tracked request work never completes"
+        );
+        assert!(force_shutdown.load(Ordering::SeqCst));
+        assert!(error.message.contains("forced cancel deadline elapsed"));
+        let _ = release_tx.send(());
+        drop(active_connection);
     }
 }

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -283,7 +283,7 @@ impl PreparedRuntimeServer {
                         if shutdown_beacon.is_tripped() {
                             return;
                         }
-                        #[cfg(test)]
+                        #[cfg(all(test, unix))]
                         if let Some(error) = take_injected_accept_error_for_test() {
                             shutdown_beacon.trip();
                             let _ = lifecycle_control.notify_state_change();
@@ -707,11 +707,11 @@ fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 static INJECTED_ACCEPT_ERROR_FOR_TEST: std::sync::Mutex<Option<std::sync::mpsc::SyncSender<()>>> =
     std::sync::Mutex::new(None);
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub(crate) fn install_injected_accept_error_for_test(
     signal: std::sync::mpsc::SyncSender<()>,
 ) -> InjectAcceptErrorGuard {
@@ -721,10 +721,10 @@ pub(crate) fn install_injected_accept_error_for_test(
     InjectAcceptErrorGuard
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub(crate) struct InjectAcceptErrorGuard;
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 impl Drop for InjectAcceptErrorGuard {
     fn drop(&mut self) {
         *INJECTED_ACCEPT_ERROR_FOR_TEST
@@ -733,7 +733,7 @@ impl Drop for InjectAcceptErrorGuard {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 fn take_injected_accept_error_for_test() -> Option<AtmError> {
     let sender = INJECTED_ACCEPT_ERROR_FOR_TEST
         .lock()
@@ -871,16 +871,13 @@ fn handle_connection(
         let _ = completion_tx.send(());
         let _ = dispatch_event_tx.send(ServeEvent::DispatchFinished);
     });
-    match registry.lock_dispatch_handles() {
-        Ok(mut handles) => handles.push(TrackedDispatchHandle {
+    registry.push_dispatch_handle(
+        TrackedDispatchHandle {
             completion_rx,
             join_handle: dispatch_handle,
-        }),
-        Err(error) => {
-            let _ = dispatch_handle.join();
-            return Err(error);
-        }
-    }
+        },
+        MAX_CONCURRENT_CONNECTIONS,
+    )?;
     let response = match result_rx.recv_timeout(REQUEST_DEADLINE) {
         Ok(Ok(response)) => response,
         Ok(Err(error)) => ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(&error)),
@@ -924,9 +921,12 @@ mod tests {
     use super::*;
     use crate::lifecycle_control::LifecycleControlSourceAdapter;
     use atm_core::boundary::RequestDispatcher;
+    #[cfg(unix)]
+    use atm_core::doctor::DoctorQuery;
     use atm_core::doctor::{
-        DoctorEnvironmentVisibility, DoctorQuery, DoctorReport, DoctorStatus, DoctorSummary,
+        DoctorEnvironmentVisibility, DoctorReport, DoctorStatus, DoctorSummary,
     };
+    #[cfg(unix)]
     use atm_core::error_codes::AtmErrorCode;
     use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
     use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
@@ -1265,12 +1265,14 @@ mod tests {
             let _ = completion_tx.send(());
         });
         registry
-            .lock_dispatch_handles()
-            .expect("dispatch handle lock")
-            .push(TrackedDispatchHandle {
-                completion_rx,
-                join_handle,
-            });
+            .push_dispatch_handle(
+                TrackedDispatchHandle {
+                    completion_rx,
+                    join_handle,
+                },
+                1,
+            )
+            .expect("dispatch handle push");
         let force_shutdown = AtomicBool::new(false);
         let shutdown_started = Instant::now();
         let error = drain_active_connections_for_shutdown(
@@ -1286,7 +1288,11 @@ mod tests {
             "forced cancel should bound shutdown even when tracked request work never completes"
         );
         assert!(force_shutdown.load(Ordering::SeqCst));
-        assert!(error.message.contains("forced cancel deadline elapsed"));
+        assert!(
+            error
+                .message
+                .contains("tracked daemon dispatch worker exceeded the shutdown join deadline")
+        );
         let _ = release_tx.send(());
         drop(active_connection);
     }

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -919,15 +919,19 @@ fn handle_connection(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use crate::lifecycle_control::LifecycleControlSourceAdapter;
+    #[cfg(unix)]
     use atm_core::boundary::RequestDispatcher;
     #[cfg(unix)]
     use atm_core::doctor::DoctorQuery;
+    #[cfg(unix)]
     use atm_core::doctor::{
         DoctorEnvironmentVisibility, DoctorReport, DoctorStatus, DoctorSummary,
     };
     #[cfg(unix)]
     use atm_core::error_codes::AtmErrorCode;
+    #[cfg(unix)]
     use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
     use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
     #[cfg(unix)]

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -23,6 +23,7 @@ use std::thread;
 
 const MAX_CONCURRENT_CONNECTIONS: usize = 64;
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
+const SHUTDOWN_BEACON_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 enum ServeEvent {
     Connection(LocalSocketStream),
@@ -177,9 +178,73 @@ impl Drop for ActiveDispatchGuard {
     }
 }
 
-pub(crate) struct PreparedRuntimeServer {
-    _ownership: HostOwnershipGuard,
+#[derive(Debug, Default)]
+struct ShutdownBeacon {
+    tripped: AtomicBool,
+}
+
+impl ShutdownBeacon {
+    fn trip(&self) {
+        self.tripped.store(true, Ordering::SeqCst);
+    }
+
+    fn is_tripped(&self) -> bool {
+        self.tripped.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Debug)]
+struct SocketEndpointGuard {
     endpoint_path: PathBuf,
+    preparation: LocalIpcEndpointPreparation,
+    unpublished: AtomicBool,
+}
+
+impl SocketEndpointGuard {
+    fn new(endpoint_path: PathBuf, preparation: LocalIpcEndpointPreparation) -> Self {
+        Self {
+            endpoint_path,
+            preparation,
+            unpublished: AtomicBool::new(false),
+        }
+    }
+
+    fn endpoint_path(&self) -> &Path {
+        &self.endpoint_path
+    }
+
+    fn unpublish(&self) -> Result<(), AtmError> {
+        if self.unpublished.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
+        match self.preparation {
+            LocalIpcEndpointPreparation::FilesystemEndpointPrepared => {
+                #[cfg(unix)]
+                {
+                    remove_stale_endpoint(self.endpoint_path())?;
+                }
+            }
+            LocalIpcEndpointPreparation::NonFilesystemEndpointPrepared => {
+                // Windows same-host IPC publishes a named pipe rather than a filesystem
+                // socket path; once the listener has dropped there is no extra path
+                // artifact left for the guard to remove here.
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for SocketEndpointGuard {
+    fn drop(&mut self) {
+        if let Err(error) = self.unpublish() {
+            tracing::warn!(%error, "daemon local IPC endpoint cleanup failed during drop");
+        }
+    }
+}
+
+pub(crate) struct PreparedRuntimeServer {
+    endpoint_guard: SocketEndpointGuard,
+    _ownership: HostOwnershipGuard,
     listener: LocalSocketListener,
     lifecycle_control: LifecycleControlSourceAdapter,
     registry: Arc<ActiveConnectionRegistry>,
@@ -233,8 +298,8 @@ impl PreparedRuntimeServer {
         );
         emit_ready_signal_if_requested()?;
         Ok(Self {
+            endpoint_guard: SocketEndpointGuard::new(endpoint_path, endpoint_preparation),
             _ownership: ownership,
-            endpoint_path,
             listener,
             lifecycle_control,
             registry: Arc::new(ActiveConnectionRegistry::default()),
@@ -282,8 +347,8 @@ impl PreparedRuntimeServer {
         FinalizeShutdown: Fn(),
     {
         let Self {
+            endpoint_guard,
             _ownership,
-            endpoint_path,
             listener,
             lifecycle_control,
             registry,
@@ -291,53 +356,101 @@ impl PreparedRuntimeServer {
             codec,
         } = self;
         thread::scope(|scope| -> Result<(), AtmError> {
+            let shutdown_beacon = Arc::new(ShutdownBeacon::default());
             let mut serve_error = None;
             let (event_tx, event_rx) = std::sync::mpsc::channel();
             {
                 let event_tx = event_tx.clone();
+                let shutdown_beacon = Arc::clone(&shutdown_beacon);
                 let lifecycle_control = lifecycle_control.clone();
-                let endpoint_path = endpoint_path.clone();
+                let endpoint_path = endpoint_guard.endpoint_path().to_path_buf();
                 scope.spawn(move || {
                     let mut observed_generation = match lifecycle_control.event_generation() {
                         Ok(generation) => generation,
                         Err(error) => {
+                            shutdown_beacon.trip();
                             let _ = event_tx.send(ServeEvent::AcceptError(error));
                             return;
                         }
                     };
                     loop {
-                        if let Err(error) =
-                            lifecycle_control.wait_for_state_change(&mut observed_generation)
-                        {
-                            let _ = event_tx.send(ServeEvent::AcceptError(error));
+                        if shutdown_beacon.is_tripped() {
                             return;
                         }
+                        let state_changed = match lifecycle_control.wait_for_state_change_timeout(
+                            &mut observed_generation,
+                            SHUTDOWN_BEACON_POLL_INTERVAL,
+                        ) {
+                            Ok(state_changed) => state_changed,
+                            Err(error) => {
+                                shutdown_beacon.trip();
+                                let _ = event_tx.send(ServeEvent::AcceptError(error));
+                                return;
+                            }
+                        };
+                        if shutdown_beacon.is_tripped() {
+                            return;
+                        }
+                        if !state_changed {
+                            continue;
+                        }
                         if lifecycle_control.terminate_requested() {
+                            shutdown_beacon.trip();
                             let _ = wake_listener(&endpoint_path);
                             let _ = event_tx.send(ServeEvent::Terminate);
                             return;
                         }
-                        if lifecycle_control.take_reload_requested() {
-                            let _ = event_tx.send(ServeEvent::Reload);
+                        if lifecycle_control.take_reload_requested()
+                            && event_tx.send(ServeEvent::Reload).is_err()
+                        {
+                            shutdown_beacon.trip();
+                            let _ = wake_listener(&endpoint_path);
+                            let _ = event_tx.send(ServeEvent::AcceptError(
+                                AtmError::daemon_unavailable(
+                                    "daemon lifecycle waiter lost the serve-loop event channel",
+                                )
+                                .with_recovery(
+                                    "Restart the daemon; lifecycle-control reload state could not be delivered to the serving loop.",
+                                ),
+                            ));
+                            return;
                         }
                     }
                 });
             }
             {
                 let event_tx = event_tx.clone();
+                let shutdown_beacon = Arc::clone(&shutdown_beacon);
                 let lifecycle_control = lifecycle_control.clone();
+                let codec = codec.clone();
                 scope.spawn(move || {
                     loop {
+                        if shutdown_beacon.is_tripped() {
+                            return;
+                        }
+                        #[cfg(test)]
+                        if let Some(error) = take_injected_accept_error_for_test() {
+                            shutdown_beacon.trip();
+                            let _ = event_tx.send(ServeEvent::AcceptError(error));
+                            return;
+                        }
                         match listener.accept() {
-                            Ok(stream) => {
-                                if lifecycle_control.terminate_requested() {
+                            Ok(mut stream) => {
+                                if lifecycle_control.terminate_requested()
+                                    || shutdown_beacon.is_tripped()
+                                {
+                                    shutdown_beacon.trip();
+                                    let _ = write_shutdown_response(&mut stream, &codec);
+                                    let _ = event_tx.send(ServeEvent::Terminate);
                                     return;
                                 }
                                 if event_tx.send(ServeEvent::Connection(stream)).is_err() {
+                                    shutdown_beacon.trip();
                                     return;
                                 }
                             }
                             Err(source) => {
+                                shutdown_beacon.trip();
                                 let error = AtmError::daemon_unavailable(
                                     "failed while accepting daemon local IPC connection",
                                 )
@@ -349,16 +462,14 @@ impl PreparedRuntimeServer {
                     }
                 });
             }
+            drop(event_tx);
             loop {
-                match event_rx.recv().map_err(|source| {
-                    AtmError::daemon_unavailable(
-                        "daemon local IPC accept loop event channel disconnected",
-                    )
-                    .with_source(source)
-                })? {
-                    ServeEvent::Connection(mut stream) => {
-                        if registry.active_connections() >= MAX_CONCURRENT_CONNECTIONS {
-                            let response = ResponseEnvelope::Error(
+                registry.reap_finished_dispatches()?;
+                match event_rx.recv_timeout(SHUTDOWN_BEACON_POLL_INTERVAL) {
+                    Ok(event) => match event {
+                        ServeEvent::Connection(mut stream) => {
+                            if registry.active_connections() >= MAX_CONCURRENT_CONNECTIONS {
+                                let response = ResponseEnvelope::Error(
                                 ProtocolErrorEnvelope::from_error(
                                     &AtmError::daemon_unavailable(
                                         "daemon connection cap exceeded (max 64 concurrent accepts)",
@@ -368,24 +479,24 @@ impl PreparedRuntimeServer {
                                     ),
                                 ),
                             );
-                            let frame = codec.response_to_frame(1, response)?;
-                            let _ = stream.set_recv_timeout(Some(REQUEST_DEADLINE));
-                            let _ = stream.set_send_timeout(Some(REQUEST_DEADLINE));
-                            let _ = atm_core::protocol::write_frame(
-                                &mut stream,
-                                &frame,
-                                "failed to write daemon rejection response frame",
-                            );
-                            let _ = stream.flush();
-                            continue;
-                        }
+                                let frame = codec.response_to_frame(1, response)?;
+                                let _ = stream.set_recv_timeout(Some(REQUEST_DEADLINE));
+                                let _ = stream.set_send_timeout(Some(REQUEST_DEADLINE));
+                                let _ = atm_core::protocol::write_frame(
+                                    &mut stream,
+                                    &frame,
+                                    "failed to write daemon rejection response frame",
+                                );
+                                let _ = stream.flush();
+                                continue;
+                            }
 
-                        let active = registry.register();
-                        let dispatcher = Arc::clone(&dispatcher);
-                        let force_shutdown = Arc::clone(&force_shutdown);
-                        let registry = Arc::clone(&registry);
-                        let codec = codec.clone();
-                        scope.spawn(move || {
+                            let active = registry.register();
+                            let dispatcher = Arc::clone(&dispatcher);
+                            let force_shutdown = Arc::clone(&force_shutdown);
+                            let registry = Arc::clone(&registry);
+                            let codec = codec.clone();
+                            scope.spawn(move || {
                             let _active = active;
                             if let Err(error) = handle_connection(
                                 stream,
@@ -397,24 +508,44 @@ impl PreparedRuntimeServer {
                                 tracing::warn!(%error, "daemon local IPC connection handling failed");
                             }
                         });
-                    }
-                    // Reload work stays serialized inside the serve loop so the accept path
-                    // never races a partially-applied runtime view update.
-                    ServeEvent::Reload => match reload_runtime_view() {
-                        Ok(()) => tracing::info!(
-                            "bounded lifecycle-control-triggered config/roster reload applied"
-                        ),
-                        Err(error) => tracing::warn!(
-                            error_code = %error.code,
-                            error_message = %error.message,
-                            "bounded lifecycle-control-triggered config/roster reload rejected; last-known-good serving config retained"
-                        ),
+                        }
+                        // Reload work stays serialized inside the serve loop so the accept path
+                        // never races a partially-applied runtime view update.
+                        ServeEvent::Reload => match reload_runtime_view() {
+                            Ok(()) => tracing::info!(
+                                "bounded lifecycle-control-triggered config/roster reload applied"
+                            ),
+                            Err(error) => tracing::warn!(
+                                error_code = %error.code,
+                                error_message = %error.message,
+                                "bounded lifecycle-control-triggered config/roster reload rejected; last-known-good serving config retained"
+                            ),
+                        },
+                        ServeEvent::Terminate => {
+                            shutdown_beacon.trip();
+                            break;
+                        }
+                        ServeEvent::AcceptError(error) => {
+                            shutdown_beacon.trip();
+                            serve_error = Some(error);
+                            break;
+                        }
                     },
-                    ServeEvent::Terminate => {
-                        break;
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                        if shutdown_beacon.is_tripped() {
+                            break;
+                        }
                     }
-                    ServeEvent::AcceptError(error) => {
-                        serve_error = Some(error);
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                        shutdown_beacon.trip();
+                        serve_error = Some(
+                            AtmError::daemon_unavailable(
+                                "daemon local IPC accept loop event channel disconnected",
+                            )
+                            .with_recovery(
+                                "Restart the daemon; the runtime serving loop lost its local IPC control channel.",
+                            ),
+                        );
                         break;
                     }
                 }
@@ -434,6 +565,17 @@ impl PreparedRuntimeServer {
                         begin_shutdown_error = %existing,
                         drain_error = %error,
                         "daemon shutdown drain failed after an earlier shutdown-start error"
+                    );
+                } else {
+                    shutdown_error = Some(error);
+                }
+            }
+            if let Err(error) = endpoint_guard.unpublish() {
+                if let Some(existing) = shutdown_error.as_ref() {
+                    tracing::warn!(
+                        begin_shutdown_error = %existing,
+                        endpoint_cleanup_error = %error,
+                        "daemon endpoint cleanup failed after an earlier shutdown-start error"
                     );
                 } else {
                     shutdown_error = Some(error);
@@ -534,6 +676,40 @@ fn remove_stale_endpoint(endpoint_path: &Path) -> Result<(), AtmError> {
     })
 }
 
+fn write_shutdown_response(
+    stream: &mut LocalSocketStream,
+    codec: &JsonAtmProtocolCodec,
+) -> Result<(), AtmError> {
+    let _ = stream.set_recv_timeout(Some(REQUEST_DEADLINE));
+    let _ = stream.set_send_timeout(Some(REQUEST_DEADLINE));
+    let Some(frame) = atm_core::protocol::read_frame(
+        stream,
+        "failed to read daemon request frame during shutdown rejection",
+        "daemon request frame exceeded the maximum supported size during shutdown rejection",
+    )?
+    else {
+        return Ok(());
+    };
+    let Ok((request_id, _request)) = codec.request_from_frame(frame) else {
+        return Ok(());
+    };
+    let response = ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
+        &AtmError::daemon_unavailable("daemon is shutting down and not accepting new requests")
+            .with_recovery("Retry the ATM command after the daemon restarts."),
+    ));
+    let frame = codec.response_to_frame(request_id, response)?;
+    atm_core::protocol::write_frame(
+        stream,
+        &frame,
+        "failed to write daemon shutdown rejection response frame",
+    )?;
+    stream.flush().map_err(|source| {
+        AtmError::daemon_unavailable("failed to flush daemon shutdown rejection response frame")
+            .with_source(source)
+    })?;
+    Ok(())
+}
+
 fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {
     let name = atm_core::protocol::daemon_local_ipc_name_from_path(endpoint_path)?;
     let mut stream = LocalSocketStream::connect(name).map_err(|source| {
@@ -554,6 +730,45 @@ fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {
             .with_source(source)
     })?;
     Ok(())
+}
+
+#[cfg(test)]
+static INJECTED_ACCEPT_ERROR_FOR_TEST: std::sync::Mutex<Option<std::sync::mpsc::SyncSender<()>>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(test)]
+pub(crate) fn install_injected_accept_error_for_test(
+    signal: std::sync::mpsc::SyncSender<()>,
+) -> InjectAcceptErrorGuard {
+    *INJECTED_ACCEPT_ERROR_FOR_TEST
+        .lock()
+        .expect("accept error injection lock") = Some(signal);
+    InjectAcceptErrorGuard
+}
+
+#[cfg(test)]
+pub(crate) struct InjectAcceptErrorGuard;
+
+#[cfg(test)]
+impl Drop for InjectAcceptErrorGuard {
+    fn drop(&mut self) {
+        *INJECTED_ACCEPT_ERROR_FOR_TEST
+            .lock()
+            .expect("accept error injection lock") = None;
+    }
+}
+
+#[cfg(test)]
+fn take_injected_accept_error_for_test() -> Option<AtmError> {
+    let sender = INJECTED_ACCEPT_ERROR_FOR_TEST
+        .lock()
+        .expect("accept error injection lock")
+        .take()?;
+    let _ = sender.send(());
+    Some(
+        AtmError::daemon_unavailable("injected daemon local IPC accept error for test")
+            .with_recovery("Test-only injected accept failure."),
+    )
 }
 
 fn emit_ready_signal_if_requested() -> Result<(), AtmError> {
@@ -701,8 +916,113 @@ fn handle_connection(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lifecycle_control::LifecycleControlSourceAdapter;
+    use atm_core::boundary::RequestDispatcher;
+    use atm_core::doctor::{
+        DoctorEnvironmentVisibility, DoctorQuery, DoctorReport, DoctorStatus, DoctorSummary,
+    };
+    use atm_core::error_codes::AtmErrorCode;
+    use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
+    use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
+    #[cfg(unix)]
+    use serial_test::serial;
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
     #[cfg(unix)]
     use tempfile::TempDir;
+
+    #[derive(Debug, Default)]
+    struct DoctorOnlyDispatcher;
+
+    impl atm_core::boundary::sealed::Sealed for DoctorOnlyDispatcher {}
+
+    impl RequestDispatcher for DoctorOnlyDispatcher {
+        fn dispatch(
+            &self,
+            request: RequestEnvelope,
+        ) -> Result<ResponseEnvelope, atm_core::error::AtmError> {
+            match request {
+                RequestEnvelope::Doctor(_) => Ok(ResponseEnvelope::Doctor(DoctorReport {
+                    summary: DoctorSummary {
+                        status: DoctorStatus::Healthy,
+                        message: "ok".to_string(),
+                        info_count: 0,
+                        warning_count: 0,
+                        error_count: 0,
+                    },
+                    findings: Vec::new(),
+                    recommendations: Vec::new(),
+                    environment: DoctorEnvironmentVisibility {
+                        atm_home: None,
+                        atm_team: None,
+                        atm_identity: None,
+                        team_override: None,
+                    },
+                    member_roster: None,
+                    observability: AtmObservabilityHealth {
+                        active_log_path: None,
+                        logging_state: AtmObservabilityHealthState::Healthy,
+                        query_state: Some(AtmObservabilityHealthState::Healthy),
+                        detail: None,
+                    },
+                    runtime_status: None,
+                })),
+                other => panic!("unexpected request in DoctorOnlyDispatcher: {other:?}"),
+            }
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct PanicDispatcher;
+
+    impl atm_core::boundary::sealed::Sealed for PanicDispatcher {}
+
+    impl RequestDispatcher for PanicDispatcher {
+        fn dispatch(
+            &self,
+            request: RequestEnvelope,
+        ) -> Result<ResponseEnvelope, atm_core::error::AtmError> {
+            panic!("intentional dispatcher panic for test: {request:?}");
+        }
+    }
+
+    struct LifecycleFlagResetGuard {
+        lifecycle: LifecycleControlSourceAdapter,
+    }
+
+    impl LifecycleFlagResetGuard {
+        fn install(lifecycle: LifecycleControlSourceAdapter) -> Self {
+            lifecycle.set_terminate_for_test(false);
+            lifecycle.set_reload_for_test(false);
+            Self { lifecycle }
+        }
+    }
+
+    impl Drop for LifecycleFlagResetGuard {
+        fn drop(&mut self) {
+            self.lifecycle.set_terminate_for_test(false);
+            self.lifecycle.set_reload_for_test(false);
+        }
+    }
+
+    fn connect_daemon_local_ipc_until_ready(endpoint_path: &Path) -> LocalSocketStream {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            match LocalSocketStream::connect(
+                atm_core::protocol::daemon_local_ipc_name_from_path(endpoint_path)
+                    .expect("ipc name"),
+            ) {
+                Ok(stream) => return stream,
+                Err(error) if Instant::now() < deadline => {
+                    let _ = error;
+                    std::thread::yield_now();
+                }
+                Err(error) => panic!("connect daemon local ipc: {error}"),
+            }
+        }
+    }
 
     #[cfg(unix)]
     #[test]
@@ -729,6 +1049,180 @@ mod tests {
         assert_eq!(
             result,
             LocalIpcEndpointPreparation::NonFilesystemEndpointPrepared
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn accept_error_without_lifecycle_signal_exits_within_one_second() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let socket_path = tempdir.path().join("daemon.sock");
+        let runtime = PreparedRuntimeServer::bind(socket_path).expect("prepare runtime");
+        let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
+        let _reset = LifecycleFlagResetGuard::install(lifecycle);
+        let dispatcher: Arc<dyn RequestDispatcher + Send + Sync> = Arc::new(DoctorOnlyDispatcher);
+        let (serve_result_tx, serve_result_rx) = mpsc::channel();
+        let (inject_tx, inject_rx) = mpsc::sync_channel(1);
+        let _inject_guard = install_injected_accept_error_for_test(inject_tx);
+
+        let join = std::thread::spawn(move || {
+            let result = runtime.serve_with_runtime_hooks(
+                dispatcher,
+                Duration::from_millis(500),
+                Duration::from_secs(2),
+                || Ok(()),
+                || Ok(()),
+                || {},
+            );
+            serve_result_tx.send(result).expect("send serve result");
+        });
+
+        inject_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("accept error should inject within 1s");
+        let shutdown_started = Instant::now();
+        let error = serve_result_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("serve result should arrive within 1s")
+            .expect_err("serve should fail after injected accept error");
+        assert!(
+            shutdown_started.elapsed() <= Duration::from_secs(1),
+            "lifecycle waiter should observe the shutdown beacon and exit within 1s"
+        );
+        assert!(error.message.contains("accept error") || error.message.contains("accepting"));
+        join.join().expect("join serve thread");
+    }
+
+    #[test]
+    #[serial]
+    fn accept_after_terminate_returns_typed_shutdown_error() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let socket_path = tempdir.path().join("daemon.sock");
+        let runtime = PreparedRuntimeServer::bind(socket_path.clone()).expect("prepare runtime");
+        let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
+        let _reset = LifecycleFlagResetGuard::install(lifecycle.clone());
+        let dispatcher: Arc<dyn RequestDispatcher + Send + Sync> = Arc::new(DoctorOnlyDispatcher);
+        let (serve_result_tx, serve_result_rx) = mpsc::channel();
+
+        let join = std::thread::spawn(move || {
+            let result = runtime.serve_with_runtime_hooks(
+                dispatcher,
+                Duration::from_millis(500),
+                Duration::from_secs(2),
+                || Ok(()),
+                || Ok(()),
+                || {},
+            );
+            serve_result_tx.send(result).expect("send serve result");
+        });
+
+        lifecycle.terminate_flag().store(true, Ordering::SeqCst);
+        let mut stream = connect_daemon_local_ipc_until_ready(&socket_path);
+        stream
+            .set_send_timeout(Some(Duration::from_secs(5)))
+            .expect("set send timeout");
+        stream
+            .set_recv_timeout(Some(Duration::from_secs(5)))
+            .expect("set recv timeout");
+        let request = RequestEnvelope::Doctor(DoctorQuery {
+            home_dir: tempdir.path().join("home"),
+            current_dir: tempdir.path().join("cwd"),
+            team_override: None,
+        });
+        let request_id = atm_core::protocol::next_request_id();
+        let frame =
+            atm_core::protocol::request_to_frame_payload(request_id, request).expect("frame");
+        atm_core::protocol::write_frame(&mut stream, &frame, "write doctor frame").expect("write");
+        std::io::Write::flush(&mut stream).expect("flush");
+        let response_frame = atm_core::protocol::read_frame(
+            &mut stream,
+            "read shutdown response frame",
+            "shutdown response frame too large",
+        )
+        .expect("read frame")
+        .expect("response frame");
+        let (response_id, response) =
+            atm_core::protocol::response_from_frame_payload(response_frame)
+                .expect("decode response");
+        assert_eq!(response_id, request_id);
+        match response {
+            ResponseEnvelope::Error(error) => {
+                assert_eq!(error.code, AtmErrorCode::DaemonUnavailable);
+                assert!(error.message.contains("shutting down"));
+            }
+            other => panic!("unexpected shutdown response: {other:?}"),
+        }
+
+        serve_result_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("recv serve result")
+            .expect("serve runtime result");
+        join.join().expect("join serve thread");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn panic_in_dispatch_still_cleans_up_socket_path_on_shutdown() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let socket_path = tempdir.path().join("daemon.sock");
+        let runtime = PreparedRuntimeServer::bind(socket_path.clone()).expect("prepare runtime");
+        let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
+        let _reset = LifecycleFlagResetGuard::install(lifecycle.clone());
+        let dispatcher: Arc<dyn RequestDispatcher + Send + Sync> = Arc::new(PanicDispatcher);
+        let (serve_result_tx, serve_result_rx) = mpsc::channel();
+
+        let join = std::thread::spawn(move || {
+            let result = runtime.serve_with_runtime_hooks(
+                dispatcher,
+                Duration::from_millis(500),
+                Duration::from_secs(2),
+                || Ok(()),
+                || Ok(()),
+                || {},
+            );
+            serve_result_tx.send(result).expect("send serve result");
+        });
+
+        let mut stream = connect_daemon_local_ipc_until_ready(&socket_path);
+        stream
+            .set_send_timeout(Some(Duration::from_secs(5)))
+            .expect("set send timeout");
+        stream
+            .set_recv_timeout(Some(Duration::from_secs(5)))
+            .expect("set recv timeout");
+        let request = RequestEnvelope::Doctor(DoctorQuery {
+            home_dir: tempdir.path().join("home"),
+            current_dir: tempdir.path().join("cwd"),
+            team_override: None,
+        });
+        let request_id = atm_core::protocol::next_request_id();
+        let frame =
+            atm_core::protocol::request_to_frame_payload(request_id, request).expect("frame");
+        atm_core::protocol::write_frame(&mut stream, &frame, "write doctor frame").expect("write");
+        std::io::Write::flush(&mut stream).expect("flush");
+        let response_frame = atm_core::protocol::read_frame(
+            &mut stream,
+            "read panic response",
+            "panic frame too large",
+        )
+        .expect("read frame")
+        .expect("response frame");
+        let (response_id, response) =
+            atm_core::protocol::response_from_frame_payload(response_frame)
+                .expect("decode response");
+        assert_eq!(response_id, request_id);
+        assert!(matches!(response, ResponseEnvelope::Error(_)));
+
+        lifecycle.set_terminate_for_test(true);
+        serve_result_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("recv serve result")
+            .expect("serve runtime result");
+        join.join().expect("join serve thread");
+        assert!(
+            !socket_path.exists(),
+            "socket endpoint should be removed during shutdown even after a dispatch panic"
         );
     }
 }

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -88,12 +88,11 @@ impl SocketEndpointGuard {
             return Ok(());
         }
         match self.preparation {
+            #[cfg(unix)]
             LocalIpcEndpointPreparation::FilesystemEndpointPrepared => {
-                #[cfg(unix)]
-                {
-                    remove_stale_endpoint(self.endpoint_path())?;
-                }
+                remove_stale_endpoint(self.endpoint_path())?;
             }
+            #[cfg(not(unix))]
             LocalIpcEndpointPreparation::NonFilesystemEndpointPrepared => {
                 // Windows same-host IPC publishes a named pipe rather than a filesystem
                 // socket path; once the listener has dropped there is no extra path
@@ -135,10 +134,14 @@ pub(crate) struct RuntimeServeHooks<BeginShutdown, ReloadRuntimeView, FinalizeSh
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(unix)]
 enum LocalIpcEndpointPreparation {
-    #[cfg_attr(windows, allow(dead_code))]
     FilesystemEndpointPrepared,
-    #[cfg_attr(unix, allow(dead_code))]
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(not(unix))]
+enum LocalIpcEndpointPreparation {
     NonFilesystemEndpointPrepared,
 }
 
@@ -663,10 +666,15 @@ fn write_shutdown_response(
 }
 
 fn schedule_delayed_listener_wake(endpoint_path: PathBuf, delay: Duration) {
-    thread::spawn(move || {
-        thread::sleep(delay);
-        let _ = wake_listener(&endpoint_path);
-    });
+    // Fire-and-forget: this helper only opens one local connection to unblock accept(), so
+    // shutdown does not need to retain or join the wake thread after it has been scheduled.
+    let _wake_handle = thread::Builder::new()
+        .name("delayed-listener-wake".to_owned())
+        .spawn(move || {
+            thread::sleep(delay);
+            let _ = wake_listener(&endpoint_path);
+        })
+        .expect("delayed-listener-wake thread");
 }
 
 fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {
@@ -940,19 +948,15 @@ mod tests {
     #[cfg(unix)]
     use crate::lifecycle_control::LifecycleControlSourceAdapter;
     #[cfg(unix)]
-    use crate::test_support::{LifecycleFlagResetGuard, connect_daemon_local_ipc_until_ready};
+    use crate::test_support::{
+        DoctorOnlyDispatcher, LifecycleFlagResetGuard, connect_daemon_local_ipc_until_ready,
+    };
     #[cfg(unix)]
     use atm_core::boundary::RequestDispatcher;
     #[cfg(unix)]
     use atm_core::doctor::DoctorQuery;
     #[cfg(unix)]
-    use atm_core::doctor::{
-        DoctorEnvironmentVisibility, DoctorReport, DoctorStatus, DoctorSummary,
-    };
-    #[cfg(unix)]
     use atm_core::error_codes::AtmErrorCode;
-    #[cfg(unix)]
-    use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
     #[cfg(unix)]
     use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
     #[cfg(unix)]
@@ -965,50 +969,6 @@ mod tests {
     use std::time::{Duration, Instant};
     #[cfg(unix)]
     use tempfile::TempDir;
-
-    #[cfg(unix)]
-    #[derive(Debug, Default)]
-    struct DoctorOnlyDispatcher;
-
-    #[cfg(unix)]
-    impl atm_core::boundary::sealed::Sealed for DoctorOnlyDispatcher {}
-
-    #[cfg(unix)]
-    impl RequestDispatcher for DoctorOnlyDispatcher {
-        fn dispatch(
-            &self,
-            request: RequestEnvelope,
-        ) -> Result<ResponseEnvelope, atm_core::error::AtmError> {
-            match request {
-                RequestEnvelope::Doctor(_) => Ok(ResponseEnvelope::Doctor(DoctorReport {
-                    summary: DoctorSummary {
-                        status: DoctorStatus::Healthy,
-                        message: "ok".to_string(),
-                        info_count: 0,
-                        warning_count: 0,
-                        error_count: 0,
-                    },
-                    findings: Vec::new(),
-                    recommendations: Vec::new(),
-                    environment: DoctorEnvironmentVisibility {
-                        atm_home: None,
-                        atm_team: None,
-                        atm_identity: None,
-                        team_override: None,
-                    },
-                    member_roster: None,
-                    observability: AtmObservabilityHealth {
-                        active_log_path: None,
-                        logging_state: AtmObservabilityHealthState::Healthy,
-                        query_state: Some(AtmObservabilityHealthState::Healthy),
-                        detail: None,
-                    },
-                    runtime_status: None,
-                })),
-                other => panic!("unexpected request in DoctorOnlyDispatcher: {other:?}"),
-            }
-        }
-    }
 
     #[cfg(unix)]
     #[derive(Debug, Default)]

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -939,11 +939,14 @@ mod tests {
     #[cfg(unix)]
     use tempfile::TempDir;
 
+    #[cfg(unix)]
     #[derive(Debug, Default)]
     struct DoctorOnlyDispatcher;
 
+    #[cfg(unix)]
     impl atm_core::boundary::sealed::Sealed for DoctorOnlyDispatcher {}
 
+    #[cfg(unix)]
     impl RequestDispatcher for DoctorOnlyDispatcher {
         fn dispatch(
             &self,
@@ -980,11 +983,14 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[derive(Debug, Default)]
     struct PanicDispatcher;
 
+    #[cfg(unix)]
     impl atm_core::boundary::sealed::Sealed for PanicDispatcher {}
 
+    #[cfg(unix)]
     impl RequestDispatcher for PanicDispatcher {
         fn dispatch(
             &self,
@@ -994,10 +1000,12 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     struct LifecycleFlagResetGuard {
         lifecycle: LifecycleControlSourceAdapter,
     }
 
+    #[cfg(unix)]
     impl LifecycleFlagResetGuard {
         fn install(lifecycle: LifecycleControlSourceAdapter) -> Self {
             lifecycle.set_terminate_for_test(false);
@@ -1006,6 +1014,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     impl Drop for LifecycleFlagResetGuard {
         fn drop(&mut self) {
             self.lifecycle.set_terminate_for_test(false);
@@ -1013,6 +1022,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     fn connect_daemon_local_ipc_until_ready(endpoint_path: &Path) -> LocalSocketStream {
         let deadline = Instant::now() + Duration::from_secs(3);
         loop {

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use atm_core::boundary::{self, AtmProtocol, RequestDispatcher};
@@ -26,13 +26,39 @@ const MAX_CONCURRENT_CONNECTIONS: usize = 64;
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 const TRACKED_DISPATCH_JOIN_DEADLINE: Duration = Duration::from_millis(250);
 const LISTENER_WAKE_CONNECT_DEADLINE: Duration = Duration::from_millis(250);
+const TERMINATE_REJECTION_GRACE_DEADLINE: Duration = Duration::from_millis(100);
 
-enum ServeEvent {
-    Connection(LocalSocketStream),
-    DispatchFinished,
-    Reload,
-    Terminate,
-    AcceptError(AtmError),
+#[derive(Debug, Default)]
+struct ServeLoopSignals {
+    reload_requested: AtomicBool,
+    accept_error: Mutex<Option<AtmError>>,
+}
+
+impl ServeLoopSignals {
+    fn request_reload(&self) {
+        self.reload_requested.store(true, Ordering::SeqCst);
+    }
+
+    fn take_reload(&self) -> bool {
+        self.reload_requested.swap(false, Ordering::SeqCst)
+    }
+
+    fn record_accept_error(&self, error: AtmError) {
+        let mut slot = self
+            .accept_error
+            .lock()
+            .expect("serve-loop accept-error lock");
+        if slot.is_none() {
+            *slot = Some(error);
+        }
+    }
+
+    fn take_accept_error(&self) -> Option<AtmError> {
+        self.accept_error
+            .lock()
+            .expect("serve-loop accept-error lock")
+            .take()
+    }
 }
 
 #[derive(Debug)]
@@ -87,14 +113,16 @@ impl Drop for SocketEndpointGuard {
 }
 
 pub(crate) struct PreparedRuntimeServer {
-    _ownership: HostOwnershipGuard,
+    host_ownership_guard: HostOwnershipGuard,
     endpoint_path: PathBuf,
-    endpoint_guard: Option<SocketEndpointGuard>,
     listener: LocalSocketListener,
     lifecycle_control: LifecycleControlSourceAdapter,
     registry: Arc<ActiveConnectionRegistry>,
     force_shutdown: Arc<AtomicBool>,
     codec: JsonAtmProtocolCodec,
+    // The endpoint guard must drop after the listener and connection registry have been torn
+    // down so same-host endpoint unpublication never races a still-live serving resource.
+    endpoint_guard: Option<SocketEndpointGuard>,
 }
 
 pub(crate) struct RuntimeServeHooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown> {
@@ -112,6 +140,12 @@ enum LocalIpcEndpointPreparation {
     FilesystemEndpointPrepared,
     #[cfg_attr(unix, allow(dead_code))]
     NonFilesystemEndpointPrepared,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShutdownResponseOutcome {
+    NoFrame,
+    RejectedRequest,
 }
 
 impl std::fmt::Debug for PreparedRuntimeServer {
@@ -155,7 +189,7 @@ impl PreparedRuntimeServer {
         );
         emit_ready_signal_if_requested()?;
         Ok(Self {
-            _ownership: ownership,
+            host_ownership_guard: ownership,
             endpoint_path: endpoint_path.clone(),
             endpoint_guard: Some(SocketEndpointGuard::new(
                 endpoint_path,
@@ -201,7 +235,7 @@ impl PreparedRuntimeServer {
             finalize_shutdown,
         } = hooks;
         let Self {
-            _ownership,
+            host_ownership_guard: _host_ownership_guard,
             endpoint_path,
             endpoint_guard: _endpoint_guard,
             listener,
@@ -215,10 +249,11 @@ impl PreparedRuntimeServer {
             // later bind/restart cycle because a tripped beacon from an older listener would
             // incorrectly poison the next same-host endpoint publication.
             let shutdown_beacon = Arc::new(ShutdownBeacon::default());
+            let signals = Arc::new(ServeLoopSignals::default());
             let mut serve_error = None;
-            let (event_tx, event_rx) = std::sync::mpsc::channel();
+            let mut terminate_probe_pending = false;
             let lifecycle_waiter = {
-                let event_tx = event_tx.clone();
+                let signals = Arc::clone(&signals);
                 let shutdown_beacon = Arc::clone(&shutdown_beacon);
                 let lifecycle_control = lifecycle_control.clone();
                 let endpoint_path = endpoint_path.clone();
@@ -228,7 +263,8 @@ impl PreparedRuntimeServer {
                         Err(error) => {
                             shutdown_beacon.trip();
                             let _ = lifecycle_control.notify_state_change();
-                            let _ = event_tx.send(ServeEvent::AcceptError(error));
+                            signals.record_accept_error(error);
+                            let _ = wake_listener(&endpoint_path);
                             return;
                         }
                     };
@@ -241,7 +277,8 @@ impl PreparedRuntimeServer {
                         {
                             shutdown_beacon.trip();
                             let _ = lifecycle_control.notify_state_change();
-                            let _ = event_tx.send(ServeEvent::AcceptError(error));
+                            signals.record_accept_error(error);
+                            let _ = wake_listener(&endpoint_path);
                             return;
                         }
                         if shutdown_beacon.is_tripped() {
@@ -251,185 +288,175 @@ impl PreparedRuntimeServer {
                             shutdown_beacon.trip();
                             let _ = lifecycle_control.notify_state_change();
                             let _ = wake_listener(&endpoint_path);
-                            let _ = event_tx.send(ServeEvent::Terminate);
                             return;
                         }
-                        if lifecycle_control.take_reload_requested()
-                            && event_tx.send(ServeEvent::Reload).is_err()
-                        {
-                            shutdown_beacon.trip();
-                            let _ = lifecycle_control.notify_state_change();
-                            let _ = wake_listener(&endpoint_path);
-                            let _ = event_tx.send(ServeEvent::AcceptError(
-                                AtmError::daemon_lifecycle_wedge(
-                                    "daemon lifecycle waiter lost the serve-loop event channel",
-                                )
-                                .with_recovery(
-                                    "Restart the daemon; lifecycle-control reload state could not be delivered to the serving loop.",
-                                ),
-                            ));
-                            return;
-                        }
-                    }
-                })
-            };
-            let accept_loop = {
-                let event_tx = event_tx.clone();
-                let shutdown_beacon = Arc::clone(&shutdown_beacon);
-                let lifecycle_control = lifecycle_control.clone();
-                let codec = codec.clone();
-                scope.spawn(move || {
-                    loop {
-                        if shutdown_beacon.is_tripped() {
-                            return;
-                        }
-                        #[cfg(all(test, unix))]
-                        if let Some(error) = take_injected_accept_error_for_test() {
-                            shutdown_beacon.trip();
-                            let _ = lifecycle_control.notify_state_change();
-                            let _ = event_tx.send(ServeEvent::AcceptError(error));
-                            return;
-                        }
-                        match listener.accept() {
-                            Ok(mut stream) => {
-                                if lifecycle_control.terminate_requested()
-                                    || shutdown_beacon.is_tripped()
-                                {
-                                    shutdown_beacon.trip();
-                                    let _ = lifecycle_control.notify_state_change();
-                                    let _ = write_shutdown_response(&mut stream, &codec);
-                                    let _ = event_tx.send(ServeEvent::Terminate);
-                                    return;
-                                }
-                                if event_tx.send(ServeEvent::Connection(stream)).is_err() {
-                                    shutdown_beacon.trip();
-                                    let _ = lifecycle_control.notify_state_change();
-                                    return;
-                                }
-                            }
-                            Err(source) => {
+                        if lifecycle_control.take_reload_requested() {
+                            signals.request_reload();
+                            if let Err(error) = wake_listener(&endpoint_path) {
                                 shutdown_beacon.trip();
                                 let _ = lifecycle_control.notify_state_change();
-                                let error = AtmError::daemon_unavailable(
-                                    "failed while accepting daemon local IPC connection",
-                                )
-                                .with_recovery(
-                                    "Restart the daemon; the local IPC listener stopped accepting connections unexpectedly.",
-                                )
-                                .with_source(source);
-                                let _ = event_tx.send(ServeEvent::AcceptError(error));
+                                signals.record_accept_error(
+                                    AtmError::daemon_lifecycle_wedge(
+                                        "daemon lifecycle waiter could not wake the direct local IPC accept loop for reload handling",
+                                    )
+                                    .with_recovery(
+                                        "Restart the daemon; lifecycle-control reload state could not interrupt the same-host listener cleanly.",
+                                    )
+                                    .with_source(error),
+                                );
                                 return;
                             }
                         }
                     }
                 })
             };
-            let dispatch_event_tx = event_tx.clone();
-            drop(event_tx);
             loop {
-                match event_rx.recv() {
-                    Ok(event) => match event {
-                        ServeEvent::DispatchFinished => {
-                            if let Err(error) = registry.reap_finished_dispatches() {
-                                shutdown_beacon.trip();
-                                let _ = lifecycle_control.notify_state_change();
-                                serve_error = Some(error);
-                                break;
-                            }
-                        }
-                        ServeEvent::Connection(mut stream) => {
-                            if registry.active_connections() >= MAX_CONCURRENT_CONNECTIONS {
-                                let response = ResponseEnvelope::Error(
-                                ProtocolErrorEnvelope::from_error(
-                                    &AtmError::daemon_unavailable(
-                                        "daemon connection cap exceeded (max 64 concurrent accepts)",
-                                    )
-                                    .with_recovery(
-                                        "Wait for in-flight ATM commands to complete before retrying, or reduce concurrent atm invocations.",
-                                    ),
-                                ),
-                            );
-                                let frame = codec.response_to_frame(1, response)?;
-                                let _ = stream.set_recv_timeout(Some(REQUEST_DEADLINE));
-                                let _ = stream.set_send_timeout(Some(REQUEST_DEADLINE));
-                                let _ = atm_core::protocol::write_frame(
-                                    &mut stream,
-                                    &frame,
-                                    "failed to write daemon rejection response frame",
-                                );
-                                let _ = stream.flush();
-                                continue;
-                            }
+                // Direct accept-loop target: lifecycle wakeups interrupt accept(), then this loop
+                // drains reload/error state inline so same-host serving stays in one place.
+                // Completed request workers are reaped before every accept iteration so join
+                // ownership stays with the direct serve loop instead of a side-channel worker.
+                if let Err(error) = registry.reap_finished_dispatches() {
+                    shutdown_beacon.trip();
+                    let _ = lifecycle_control.notify_state_change();
+                    serve_error = Some(error);
+                    break;
+                }
+                if let Some(error) = signals.take_accept_error() {
+                    shutdown_beacon.trip();
+                    let _ = lifecycle_control.notify_state_change();
+                    serve_error = Some(error);
+                    break;
+                }
+                // Reload work stays serialized inside the direct accept loop so the listener never
+                // races a partially-applied runtime view update.
+                if signals.take_reload() {
+                    match reload_runtime_view() {
+                        Ok(()) => tracing::info!(
+                            "bounded lifecycle-control-triggered config/roster reload applied"
+                        ),
+                        Err(error) => tracing::warn!(
+                            error_code = %error.code,
+                            error_message = %error.message,
+                            "bounded lifecycle-control-triggered config/roster reload rejected; last-known-good serving config retained"
+                        ),
+                    }
+                    continue;
+                }
+                #[cfg(all(test, unix))]
+                if let Some(error) = take_injected_accept_error_for_test() {
+                    shutdown_beacon.trip();
+                    let _ = lifecycle_control.notify_state_change();
+                    serve_error = Some(error);
+                    break;
+                }
 
-                            let active = registry.register();
-                            let dispatcher = Arc::clone(&dispatcher);
-                            let force_shutdown = Arc::clone(&force_shutdown);
-                            let registry = Arc::clone(&registry);
-                            let codec = codec.clone();
-                            let event_tx = dispatch_event_tx.clone();
-                            scope.spawn(move || {
-                                let _active = active;
-                                let result = catch_unwind(AssertUnwindSafe(|| {
-                                    handle_connection(
-                                        stream,
-                                        dispatcher,
-                                        force_shutdown.as_ref(),
-                                        registry,
-                                        codec,
-                                        event_tx,
-                                    )
-                                }));
-                                match result {
-                                    Ok(Ok(())) => {}
-                                    Ok(Err(error)) => {
-                                        tracing::warn!(%error, "daemon local IPC connection handling failed");
-                                    }
-                                    Err(_) => {
-                                        tracing::warn!(
-                                            "daemon local IPC connection worker panicked; the transport thread recovered and continued shutdown accounting"
-                                        );
-                                    }
-                                }
-                            });
-                        }
-                        // Reload work stays serialized inside the serve loop so the accept path
-                        // never races a partially-applied runtime view update.
-                        ServeEvent::Reload => match reload_runtime_view() {
-                            Ok(()) => tracing::info!(
-                                "bounded lifecycle-control-triggered config/roster reload applied"
-                            ),
-                            Err(error) => tracing::warn!(
-                                error_code = %error.code,
-                                error_message = %error.message,
-                                "bounded lifecycle-control-triggered config/roster reload rejected; last-known-good serving config retained"
-                            ),
-                        },
-                        ServeEvent::Terminate => {
-                            shutdown_beacon.trip();
-                            let _ = lifecycle_control.notify_state_change();
-                            break;
-                        }
-                        ServeEvent::AcceptError(error) => {
-                            shutdown_beacon.trip();
-                            let _ = lifecycle_control.notify_state_change();
-                            serve_error = Some(error);
-                            break;
-                        }
-                    },
-                    Err(std::sync::mpsc::RecvError) => {
+                let mut stream = match listener.accept() {
+                    Ok(stream) => stream,
+                    Err(source) => {
                         shutdown_beacon.trip();
                         let _ = lifecycle_control.notify_state_change();
                         serve_error = Some(
                             AtmError::daemon_unavailable(
-                                "daemon local IPC accept loop event channel disconnected",
+                                "failed while accepting daemon local IPC connection",
                             )
                             .with_recovery(
-                                "Restart the daemon; the runtime serving loop lost its local IPC control channel.",
-                            ),
+                                "Restart the daemon; the local IPC listener stopped accepting connections unexpectedly.",
+                            )
+                            .with_source(source),
                         );
                         break;
                     }
+                };
+
+                if let Some(error) = signals.take_accept_error() {
+                    shutdown_beacon.trip();
+                    let _ = lifecycle_control.notify_state_change();
+                    serve_error = Some(error);
+                    break;
                 }
+                if signals.take_reload() {
+                    drop(stream);
+                    match reload_runtime_view() {
+                        Ok(()) => tracing::info!(
+                            "bounded lifecycle-control-triggered config/roster reload applied"
+                        ),
+                        Err(error) => tracing::warn!(
+                            error_code = %error.code,
+                            error_message = %error.message,
+                            "bounded lifecycle-control-triggered config/roster reload rejected; last-known-good serving config retained"
+                        ),
+                    }
+                    continue;
+                }
+                if lifecycle_control.terminate_requested() || shutdown_beacon.is_tripped() {
+                    shutdown_beacon.trip();
+                    let _ = lifecycle_control.notify_state_change();
+                    match write_shutdown_response(&mut stream, &codec)? {
+                        ShutdownResponseOutcome::RejectedRequest => break,
+                        ShutdownResponseOutcome::NoFrame if terminate_probe_pending => break,
+                        ShutdownResponseOutcome::NoFrame => {
+                            terminate_probe_pending = true;
+                            schedule_delayed_listener_wake(
+                                endpoint_path.clone(),
+                                TERMINATE_REJECTION_GRACE_DEADLINE,
+                            );
+                            continue;
+                        }
+                    }
+                }
+                terminate_probe_pending = false;
+                if registry.active_connections() >= MAX_CONCURRENT_CONNECTIONS {
+                    let response = ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
+                        &AtmError::daemon_unavailable(
+                            "daemon connection cap exceeded (max 64 concurrent accepts)",
+                        )
+                        .with_recovery(
+                            "Wait for in-flight ATM commands to complete before retrying, or reduce concurrent atm invocations.",
+                        ),
+                    ));
+                    let frame = codec.response_to_frame(
+                        atm_core::protocol::RequestId::new(1).expect("non-zero request id"),
+                        response,
+                    )?;
+                    let _ = stream.set_recv_timeout(Some(REQUEST_DEADLINE));
+                    let _ = stream.set_send_timeout(Some(REQUEST_DEADLINE));
+                    let _ = atm_core::protocol::write_frame(
+                        &mut stream,
+                        &frame,
+                        "failed to write daemon rejection response frame",
+                    );
+                    let _ = stream.flush();
+                    continue;
+                }
+
+                let active = registry.register();
+                let dispatcher = Arc::clone(&dispatcher);
+                let force_shutdown = Arc::clone(&force_shutdown);
+                let registry = Arc::clone(&registry);
+                let codec = codec.clone();
+                scope.spawn(move || {
+                    let _active = active;
+                    let result = catch_unwind(AssertUnwindSafe(|| {
+                        handle_connection(
+                            stream,
+                            dispatcher,
+                            force_shutdown.as_ref(),
+                            registry,
+                            codec,
+                        )
+                    }));
+                    match result {
+                        Ok(Ok(())) => {}
+                        Ok(Err(error)) => {
+                            tracing::warn!(%error, "daemon local IPC connection handling failed");
+                        }
+                        Err(_) => {
+                            tracing::warn!(
+                                "daemon local IPC connection worker panicked; the transport thread recovered and continued shutdown accounting"
+                            );
+                        }
+                    }
+                });
             }
 
             // Every serve-loop exit path, including AcceptError and internal tracked-work failures,
@@ -470,22 +497,6 @@ impl PreparedRuntimeServer {
                         begin_shutdown_error = %existing,
                         lifecycle_waiter_error = %error,
                         "daemon lifecycle waiter failed after an earlier shutdown error"
-                    );
-                } else {
-                    shutdown_error = Some(error);
-                }
-            }
-            if accept_loop.join().is_err() {
-                let error =
-                    AtmError::daemon_unavailable("daemon local IPC accept loop panicked during shutdown")
-                        .with_recovery(
-                            "Restart the daemon; the same-host listener thread panicked while the runtime was stopping.",
-                        );
-                if let Some(existing) = shutdown_error.as_ref() {
-                    tracing::warn!(
-                        begin_shutdown_error = %existing,
-                        accept_loop_error = %error,
-                        "daemon accept loop failed after an earlier shutdown error"
                     );
                 } else {
                     shutdown_error = Some(error);
@@ -617,7 +628,7 @@ fn remove_stale_endpoint(endpoint_path: &Path) -> Result<(), AtmError> {
 fn write_shutdown_response(
     stream: &mut LocalSocketStream,
     codec: &JsonAtmProtocolCodec,
-) -> Result<(), AtmError> {
+) -> Result<ShutdownResponseOutcome, AtmError> {
     let _ = stream.set_recv_timeout(Some(REQUEST_DEADLINE));
     let _ = stream.set_send_timeout(Some(REQUEST_DEADLINE));
     let Some(frame) = atm_core::protocol::read_frame(
@@ -626,10 +637,10 @@ fn write_shutdown_response(
         "daemon request frame exceeded the maximum supported size during shutdown rejection",
     )?
     else {
-        return Ok(());
+        return Ok(ShutdownResponseOutcome::NoFrame);
     };
     let Ok((request_id, _request)) = codec.request_from_frame(frame) else {
-        return Ok(());
+        return Ok(ShutdownResponseOutcome::NoFrame);
     };
     let response = ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
         &AtmError::daemon_unavailable("daemon is shutting down and not accepting new requests")
@@ -648,7 +659,14 @@ fn write_shutdown_response(
             )
             .with_source(source)
     })?;
-    Ok(())
+    Ok(ShutdownResponseOutcome::RejectedRequest)
+}
+
+fn schedule_delayed_listener_wake(endpoint_path: PathBuf, delay: Duration) {
+    thread::spawn(move || {
+        thread::sleep(delay);
+        let _ = wake_listener(&endpoint_path);
+    });
 }
 
 fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {
@@ -821,10 +839,9 @@ fn handle_connection(
     force_shutdown: &AtomicBool,
     registry: Arc<ActiveConnectionRegistry>,
     codec: JsonAtmProtocolCodec,
-    serve_event_tx: std::sync::mpsc::Sender<ServeEvent>,
 ) -> Result<(), AtmError> {
     if force_shutdown.load(Ordering::SeqCst) {
-        return write_shutdown_response(&mut stream, &codec);
+        return write_shutdown_response(&mut stream, &codec).map(|_| ());
     }
     stream
         .set_recv_timeout(Some(REQUEST_DEADLINE))
@@ -864,13 +881,14 @@ fn handle_connection(
     let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
     let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
     let dispatch_registry = Arc::clone(&registry);
-    let dispatch_event_tx = serve_event_tx.clone();
     let dispatch_handle = std::thread::spawn(move || {
         let _dispatch_work = dispatch_registry.register_dispatch_work();
         let _ = result_tx.send(dispatcher.dispatch(request));
         let _ = completion_tx.send(());
-        let _ = dispatch_event_tx.send(ServeEvent::DispatchFinished);
     });
+    // The tracked-dispatch registry owns the eventual join. Timeouts can let a request worker run
+    // past this socket exchange, but the direct accept loop and bounded shutdown sweep still reap
+    // the handle before runtime teardown completes.
     registry.push_dispatch_handle(
         TrackedDispatchHandle {
             completion_rx,
@@ -935,6 +953,8 @@ mod tests {
     use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
     #[cfg(unix)]
     use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
+    #[cfg(unix)]
+    use atm_core::test_support::EnvGuard;
     #[cfg(unix)]
     use serial_test::serial;
     use std::sync::Arc;
@@ -1078,6 +1098,14 @@ mod tests {
     #[serial]
     fn accept_error_without_lifecycle_signal_exits_within_one_second() {
         let tempdir = TempDir::new().expect("tempdir");
+        let atm_home = tempdir.path().join("atm-home");
+        std::fs::create_dir_all(&atm_home).expect("atm home dir");
+        let _env = EnvGuard::set_many([
+            ("ATM_HOME", Some(atm_home.to_str().expect("utf8 atm home"))),
+            ("ATM_LOG_DIR", None),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 home"))),
+            ("USERPROFILE", None),
+        ]);
         let socket_path = tempdir.path().join("daemon.sock");
         let mut runtime = PreparedRuntimeServer::bind(socket_path).expect("prepare runtime");
         let endpoint_guard = runtime.take_endpoint_guard().expect("take endpoint guard");
@@ -1126,6 +1154,14 @@ mod tests {
     #[serial]
     fn accept_after_terminate_returns_typed_shutdown_error() {
         let tempdir = TempDir::new().expect("tempdir");
+        let atm_home = tempdir.path().join("atm-home");
+        std::fs::create_dir_all(&atm_home).expect("atm home dir");
+        let _env = EnvGuard::set_many([
+            ("ATM_HOME", Some(atm_home.to_str().expect("utf8 atm home"))),
+            ("ATM_LOG_DIR", None),
+            ("HOME", Some(tempdir.path().to_str().expect("utf8 home"))),
+            ("USERPROFILE", None),
+        ]);
         let socket_path = tempdir.path().join("daemon.sock");
         let mut runtime =
             PreparedRuntimeServer::bind(socket_path.clone()).expect("prepare runtime");

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
         Ok(()) => 0,
         Err(error) => {
             eprintln!("{error}");
-            1
+            atm_daemon::daemon_exit_code_for_error(&error).as_i32()
         }
     };
     std::process::exit(exit_code);

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -643,7 +643,11 @@ mod tests {
 
     fn read_request_frame(
         stream: &mut TcpStream,
-    ) -> (u64, RequestEnvelope, super::JsonAtmProtocolCodec) {
+    ) -> (
+        atm_core::protocol::RequestId,
+        RequestEnvelope,
+        super::JsonAtmProtocolCodec,
+    ) {
         let codec = super::JsonAtmProtocolCodec;
         let frame = atm_core::protocol::read_frame(
             stream,
@@ -659,7 +663,7 @@ mod tests {
     fn write_response_frame(
         stream: &mut TcpStream,
         codec: &super::JsonAtmProtocolCodec,
-        request_id: u64,
+        request_id: atm_core::protocol::RequestId,
         response: ResponseEnvelope,
     ) {
         let frame = codec

--- a/crates/atm-daemon/src/reconcile_runtime.rs
+++ b/crates/atm-daemon/src/reconcile_runtime.rs
@@ -203,10 +203,11 @@ impl ReconcileRuntime {
     }
 
     pub(crate) fn start(&self) -> Result<(), AtmError> {
-        let mut state =
-            self.inner.state.lock().map_err(|_| {
-                AtmError::daemon_unavailable("reconcile runtime state lock poisoned")
-            })?;
+        let mut state = self.inner.state.lock().map_err(|_| {
+            AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
+                "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
+            )
+        })?;
         if state.started {
             return Ok(());
         }
@@ -228,7 +229,8 @@ impl ReconcileRuntime {
                 let _ = handle.join();
                 return Err(AtmError::daemon_unavailable(
                     "reconcile runtime worker lock poisoned",
-                ));
+                )
+                .with_recovery("Restart the daemon; reconcile worker ownership can no longer be tracked safely."));
             }
         };
         *worker = Some(handle);
@@ -238,7 +240,9 @@ impl ReconcileRuntime {
     pub(crate) fn shutdown(&self) -> Result<(), AtmError> {
         {
             let mut state = self.inner.state.lock().map_err(|_| {
-                AtmError::daemon_unavailable("reconcile runtime state lock poisoned")
+                AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
+                    "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
+                )
             })?;
             state.shutdown = true;
             self.inner.wake.notify_all();
@@ -247,7 +251,10 @@ impl ReconcileRuntime {
             .inner
             .worker
             .lock()
-            .map_err(|_| AtmError::daemon_unavailable("reconcile runtime worker lock poisoned"))?
+            .map_err(|_| {
+                AtmError::daemon_unavailable("reconcile runtime worker lock poisoned")
+                    .with_recovery("Restart the daemon; reconcile worker ownership can no longer be tracked safely.")
+            })?
             .take()
         {
             let (result_tx, result_rx) = mpsc::sync_channel(1);
@@ -285,7 +292,9 @@ impl ReconcileRuntime {
     pub(crate) fn reconcile(&self, request: ReconcileRequest) -> Result<ReconcileResult, AtmError> {
         let waiter_id = {
             let mut state = self.inner.state.lock().map_err(|_| {
-                AtmError::daemon_unavailable("reconcile runtime state lock poisoned")
+                AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
+                    "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
+                )
             })?;
             if !state.started {
                 return Err(AtmError::daemon_unavailable(
@@ -320,10 +329,11 @@ impl ReconcileRuntime {
             waiter_id
         };
 
-        let mut state =
-            self.inner.state.lock().map_err(|_| {
-                AtmError::daemon_unavailable("reconcile runtime state lock poisoned")
-            })?;
+        let mut state = self.inner.state.lock().map_err(|_| {
+            AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
+                "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
+            )
+        })?;
         loop {
             if state.shutdown {
                 state.release_waiter(waiter_id);

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -37,10 +37,9 @@ const SHUTDOWN_WAL_CHECKPOINT_DEADLINE: Duration = Duration::from_secs(2);
 // 2-second deadline as an accepted production exception in the anti-flake contract docs.
 const SHUTDOWN_OBSERVABILITY_FLUSH_DEADLINE: Duration = Duration::from_secs(2);
 
-#[cfg(test)]
-// The shutdown-step helper is static, so timed-out join handles need one
-// process-wide test registry that drain_shutdown_finalizer_threads_for_test()
-// can clean up after each bounded-timeout scenario.
+// Timed-out shutdown workers are retained in one process-wide registry instead of being dropped
+// orphaned; tests drain the registry explicitly and production keeps the handles reachable until
+// process shutdown completes.
 static SHUTDOWN_FINALIZER_THREADS: std::sync::Mutex<Vec<std::thread::JoinHandle<()>>> =
     std::sync::Mutex::new(Vec::new());
 
@@ -384,23 +383,18 @@ impl DaemonRequestDispatcher {
                 tracing::warn!(%error, step = label, "daemon shutdown finalizer step failed");
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                #[cfg(test)]
-                {
-                    SHUTDOWN_FINALIZER_THREADS
-                        .lock()
-                        .expect("shutdown finalizer thread registry lock")
-                        .push(shutdown_handle);
-                }
-                #[cfg(not(test))]
-                {
-                    // Intentionally detach the timed-out worker; thread runs to completion orphaned, not joined.
-                    // Keeps shutdown bounded even if the finalizer exits later.
-                    drop(shutdown_handle);
-                }
+                // SQLite WAL checkpoint timeout is the highest-risk caller here: a checkpoint can
+                // outlive the bounded shutdown window, but retaining the JoinHandle is still safer
+                // than dropping it orphaned because tests and orderly process teardown can join it
+                // later once the blocking storage step finishes.
+                SHUTDOWN_FINALIZER_THREADS
+                    .lock()
+                    .expect("shutdown finalizer thread registry lock")
+                    .push(shutdown_handle);
                 tracing::warn!(
                     step = label,
                     timeout_ms = deadline.as_millis(),
-                    "daemon shutdown finalizer step exceeded its deadline"
+                    "daemon shutdown finalizer step exceeded its deadline; worker retained for later join"
                 );
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -36,6 +36,7 @@ const SHUTDOWN_WAL_CHECKPOINT_DEADLINE: Duration = Duration::from_secs(2);
 // The retained observability flush is best-effort during shutdown; Phase S records this bounded
 // 2-second deadline as an accepted production exception in the anti-flake contract docs.
 const SHUTDOWN_OBSERVABILITY_FLUSH_DEADLINE: Duration = Duration::from_secs(2);
+const MAX_SHUTDOWN_FINALIZER_THREADS: usize = 16;
 
 // Timed-out shutdown workers are retained in one process-wide registry instead of being dropped
 // orphaned; tests drain the registry explicitly and production keeps the handles reachable until
@@ -387,10 +388,18 @@ impl DaemonRequestDispatcher {
                 // outlive the bounded shutdown window, but retaining the JoinHandle is still safer
                 // than dropping it orphaned because tests and orderly process teardown can join it
                 // later once the blocking storage step finishes.
-                SHUTDOWN_FINALIZER_THREADS
+                let mut handles = SHUTDOWN_FINALIZER_THREADS
                     .lock()
-                    .expect("shutdown finalizer thread registry lock")
-                    .push(shutdown_handle);
+                    .expect("shutdown finalizer thread registry lock");
+                if handles.len() < MAX_SHUTDOWN_FINALIZER_THREADS {
+                    handles.push(shutdown_handle);
+                } else {
+                    tracing::warn!(
+                        step = label,
+                        cap = MAX_SHUTDOWN_FINALIZER_THREADS,
+                        "shutdown finalizer thread cap reached; dropping retained worker handle"
+                    );
+                }
                 tracing::warn!(
                     step = label,
                     timeout_ms = deadline.as_millis(),

--- a/crates/atm-daemon/src/shutdown_beacon.rs
+++ b/crates/atm-daemon/src/shutdown_beacon.rs
@@ -1,0 +1,46 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Condvar, Mutex};
+use std::time::Duration;
+
+use atm_core::error::AtmError;
+
+#[derive(Debug, Default)]
+pub(crate) struct ShutdownBeacon {
+    // This bit is read by accept, lifecycle, and serve-loop threads, so it stays atomic while the
+    // companion condvar provides immediate wakeups for blocking waiters.
+    tripped: AtomicBool,
+    state: Mutex<()>,
+    wake: Condvar,
+}
+
+impl ShutdownBeacon {
+    pub(crate) fn trip(&self) {
+        self.tripped.store(true, Ordering::SeqCst);
+        self.wake.notify_all();
+    }
+
+    pub(crate) fn is_tripped(&self) -> bool {
+        self.tripped.load(Ordering::SeqCst)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn wait_for_trip_timeout(&self, timeout: Duration) -> Result<bool, AtmError> {
+        if self.is_tripped() {
+            return Ok(true);
+        }
+        let state = self.state.lock().map_err(|_| {
+            AtmError::daemon_lifecycle_wedge("daemon shutdown beacon lock poisoned").with_recovery(
+                "Restart the daemon; transport shutdown coordination can no longer wake blocked lifecycle waiters safely.",
+            )
+        })?;
+        if self.is_tripped() {
+            return Ok(true);
+        }
+        let (_state, wait_result) = self.wake.wait_timeout(state, timeout).map_err(|_| {
+            AtmError::daemon_lifecycle_wedge("daemon shutdown beacon lock poisoned").with_recovery(
+                "Restart the daemon; transport shutdown coordination can no longer wake blocked lifecycle waiters safely.",
+            )
+        })?;
+        Ok(!wait_result.timed_out() && self.is_tripped())
+    }
+}

--- a/crates/atm-daemon/src/shutdown_beacon.rs
+++ b/crates/atm-daemon/src/shutdown_beacon.rs
@@ -1,15 +1,11 @@
+use std::sync::Condvar;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Condvar, Mutex};
-use std::time::Duration;
-
-use atm_core::error::AtmError;
 
 #[derive(Debug, Default)]
 pub(crate) struct ShutdownBeacon {
     // This bit is read by accept, lifecycle, and serve-loop threads, so it stays atomic while the
     // companion condvar provides immediate wakeups for blocking waiters.
     tripped: AtomicBool,
-    state: Mutex<()>,
     wake: Condvar,
 }
 
@@ -21,26 +17,5 @@ impl ShutdownBeacon {
 
     pub(crate) fn is_tripped(&self) -> bool {
         self.tripped.load(Ordering::SeqCst)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn wait_for_trip_timeout(&self, timeout: Duration) -> Result<bool, AtmError> {
-        if self.is_tripped() {
-            return Ok(true);
-        }
-        let state = self.state.lock().map_err(|_| {
-            AtmError::daemon_lifecycle_wedge("daemon shutdown beacon lock poisoned").with_recovery(
-                "Restart the daemon; transport shutdown coordination can no longer wake blocked lifecycle waiters safely.",
-            )
-        })?;
-        if self.is_tripped() {
-            return Ok(true);
-        }
-        let (_state, wait_result) = self.wake.wait_timeout(state, timeout).map_err(|_| {
-            AtmError::daemon_lifecycle_wedge("daemon shutdown beacon lock poisoned").with_recovery(
-                "Restart the daemon; transport shutdown coordination can no longer wake blocked lifecycle waiters safely.",
-            )
-        })?;
-        Ok(!wait_result.timed_out() && self.is_tripped())
     }
 }

--- a/crates/atm-daemon/src/shutdown_beacon.rs
+++ b/crates/atm-daemon/src/shutdown_beacon.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Default)]
 pub(crate) struct ShutdownBeacon {
@@ -14,5 +15,38 @@ impl ShutdownBeacon {
 
     pub(crate) fn is_tripped(&self) -> bool {
         self.tripped.load(Ordering::SeqCst)
+    }
+
+    #[cfg_attr(any(windows, not(test)), allow(dead_code))]
+    pub(crate) fn wait_until_tripped(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if self.is_tripped() {
+                return true;
+            }
+            std::thread::yield_now();
+        }
+        self.is_tripped()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShutdownBeacon;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[test]
+    fn wait_until_tripped_returns_true_after_trip() {
+        let beacon = Arc::new(ShutdownBeacon::default());
+        let waiter = Arc::clone(&beacon);
+        let join = std::thread::spawn(move || {
+            assert!(waiter.wait_until_tripped(Duration::from_secs(1)));
+        });
+
+        std::thread::yield_now();
+        beacon.trip();
+
+        join.join().expect("join shutdown beacon waiter");
     }
 }

--- a/crates/atm-daemon/src/shutdown_beacon.rs
+++ b/crates/atm-daemon/src/shutdown_beacon.rs
@@ -1,18 +1,15 @@
-use std::sync::Condvar;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(Debug, Default)]
 pub(crate) struct ShutdownBeacon {
-    // This bit is read by accept, lifecycle, and serve-loop threads, so it stays atomic while the
-    // companion condvar provides immediate wakeups for blocking waiters.
+    // This bit is polled by accept, lifecycle, and serve-loop threads. No shutdown-beacon waiter
+    // blocks on a companion condition variable, so an atomic flag is sufficient here.
     tripped: AtomicBool,
-    wake: Condvar,
 }
 
 impl ShutdownBeacon {
     pub(crate) fn trip(&self) {
         self.tripped.store(true, Ordering::SeqCst);
-        self.wake.notify_all();
     }
 
     pub(crate) fn is_tripped(&self) -> bool {

--- a/crates/atm-daemon/src/test_support.rs
+++ b/crates/atm-daemon/src/test_support.rs
@@ -1,3 +1,8 @@
+use atm_core::boundary::RequestDispatcher;
+use atm_core::doctor::{DoctorEnvironmentVisibility, DoctorReport, DoctorStatus, DoctorSummary};
+use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
+use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
+
 #[cfg(unix)]
 use interprocess::local_socket::Stream as LocalSocketStream;
 #[cfg(unix)]
@@ -21,6 +26,47 @@ impl Drop for LifecycleFlagResetGuard {
     fn drop(&mut self) {
         self.lifecycle.set_terminate_for_test(false);
         self.lifecycle.set_reload_for_test(false);
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct DoctorOnlyDispatcher;
+
+impl atm_core::boundary::sealed::Sealed for DoctorOnlyDispatcher {}
+
+impl RequestDispatcher for DoctorOnlyDispatcher {
+    fn dispatch(
+        &self,
+        request: RequestEnvelope,
+    ) -> Result<ResponseEnvelope, atm_core::error::AtmError> {
+        match request {
+            RequestEnvelope::Doctor(_) => Ok(ResponseEnvelope::Doctor(DoctorReport {
+                summary: DoctorSummary {
+                    status: DoctorStatus::Healthy,
+                    message: "ok".to_string(),
+                    info_count: 0,
+                    warning_count: 0,
+                    error_count: 0,
+                },
+                findings: Vec::new(),
+                recommendations: Vec::new(),
+                environment: DoctorEnvironmentVisibility {
+                    atm_home: None,
+                    atm_team: None,
+                    atm_identity: None,
+                    team_override: None,
+                },
+                member_roster: None,
+                observability: AtmObservabilityHealth {
+                    active_log_path: None,
+                    logging_state: AtmObservabilityHealthState::Healthy,
+                    query_state: Some(AtmObservabilityHealthState::Healthy),
+                    detail: None,
+                },
+                runtime_status: None,
+            })),
+            other => panic!("unexpected request in DoctorOnlyDispatcher: {other:?}"),
+        }
     }
 }
 

--- a/crates/atm-daemon/src/test_support.rs
+++ b/crates/atm-daemon/src/test_support.rs
@@ -1,0 +1,44 @@
+#[cfg(unix)]
+use interprocess::local_socket::Stream as LocalSocketStream;
+#[cfg(unix)]
+use interprocess::local_socket::traits::Stream as _;
+
+use crate::lifecycle_control::LifecycleControlSourceAdapter;
+
+pub(crate) struct LifecycleFlagResetGuard {
+    lifecycle: LifecycleControlSourceAdapter,
+}
+
+impl LifecycleFlagResetGuard {
+    pub(crate) fn install(lifecycle: LifecycleControlSourceAdapter) -> Self {
+        lifecycle.set_terminate_for_test(false);
+        lifecycle.set_reload_for_test(false);
+        Self { lifecycle }
+    }
+}
+
+impl Drop for LifecycleFlagResetGuard {
+    fn drop(&mut self) {
+        self.lifecycle.set_terminate_for_test(false);
+        self.lifecycle.set_reload_for_test(false);
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn connect_daemon_local_ipc_until_ready(
+    endpoint_path: &std::path::Path,
+) -> LocalSocketStream {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    loop {
+        match LocalSocketStream::connect(
+            atm_core::protocol::daemon_local_ipc_name_from_path(endpoint_path).expect("ipc name"),
+        ) {
+            Ok(stream) => return stream,
+            Err(error) if std::time::Instant::now() < deadline => {
+                let _ = error;
+                std::thread::yield_now();
+            }
+            Err(error) => panic!("connect daemon local ipc: {error}"),
+        }
+    }
+}

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -25,6 +25,7 @@ use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_rusqlite::assemble_boundary;
 #[cfg(unix)]
 use interprocess::local_socket::Stream as LocalSocketStream;
+#[cfg(unix)]
 use interprocess::local_socket::traits::Stream as _;
 use serial_test::serial;
 use std::fs::OpenOptions;
@@ -111,6 +112,7 @@ impl RequestDispatcher for DoctorOnlyDispatcher {
     }
 }
 
+#[cfg(unix)]
 fn connect_daemon_local_ipc_until_ready(endpoint_path: &std::path::Path) -> LocalSocketStream {
     let deadline = Instant::now() + Duration::from_secs(3);
     loop {

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -23,6 +23,7 @@ use atm_core::test_support::EnvGuard;
 use atm_core::test_support::ROLE_TEAM_LEAD;
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_rusqlite::assemble_boundary;
+#[cfg(unix)]
 use interprocess::local_socket::Stream as LocalSocketStream;
 use interprocess::local_socket::traits::Stream as _;
 use serial_test::serial;
@@ -153,6 +154,7 @@ fn daemon_shutdown_signal_install_reuses_shared_flags() {
 
 #[test]
 #[serial]
+#[cfg(unix)]
 fn local_ipc_runtime_round_trips_doctor_requests_on_shared_transport() {
     // TempDir uniqueness is process-local; #[serial] keeps this same-host transport smoke test
     // from racing other lifecycle-control and singleton-sensitive daemon tests.
@@ -227,6 +229,7 @@ fn local_ipc_runtime_round_trips_doctor_requests_on_shared_transport() {
 
 #[test]
 #[serial]
+#[cfg(unix)]
 fn compose_runtime_start_writes_retained_log_and_reports_healthy_observability() {
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -15,6 +15,7 @@ use atm_core::doctor::DoctorQuery;
 use atm_core::doctor::DoctorStatus;
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
+#[cfg(unix)]
 use atm_core::observability::AtmObservabilityHealthState;
 use atm_core::protocol::{
     HeartbeatActivity, RequestEnvelope, ResponseEnvelope, RuntimeLivenessState, RuntimeMemberState,

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -118,9 +118,7 @@ fn connect_daemon_local_ipc_until_ready(endpoint_path: &std::path::Path) -> Loca
             Ok(stream) => return stream,
             Err(error) if Instant::now() < deadline => {
                 let _ = error;
-                // The listener becomes connectable only after the serve thread enters accept;
-                // use a tiny bounded sleep instead of a CPU-spin retry loop while waiting.
-                std::thread::sleep(Duration::from_millis(5));
+                std::thread::yield_now();
             }
             Err(error) => panic!("connect daemon local ipc: {error}"),
         }
@@ -288,9 +286,7 @@ fn compose_runtime_start_writes_retained_log_and_reports_healthy_observability()
     loop {
         match std::fs::read_to_string(&retained_log_path) {
             Ok(contents) if contents.contains("daemon start requested") => break,
-            Ok(_) | Err(_) if Instant::now() < deadline => {
-                std::thread::sleep(Duration::from_millis(5))
-            }
+            Ok(_) | Err(_) if Instant::now() < deadline => std::thread::yield_now(),
             Err(error) => panic!("read retained log: {error}"),
             Ok(contents) => panic!("retained log missing startup event: {contents}"),
         }

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -9,9 +9,9 @@ use super::{
     local_ipc_transport::RuntimeServeHooks,
 };
 use atm_core::boundary::RequestDispatcher;
-use atm_core::doctor::{
-    DoctorEnvironmentVisibility, DoctorQuery, DoctorReport, DoctorStatus, DoctorSummary,
-};
+#[cfg(unix)]
+use atm_core::doctor::DoctorQuery;
+use atm_core::doctor::{DoctorEnvironmentVisibility, DoctorReport, DoctorStatus, DoctorSummary};
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
 use atm_core::protocol::{
@@ -19,6 +19,7 @@ use atm_core::protocol::{
     RuntimeReadinessState, TeamMemberHeartbeatRequest,
 };
 use atm_core::schema::{AgentMember, TeamConfig};
+#[cfg(unix)]
 use atm_core::test_support::EnvGuard;
 use atm_core::test_support::ROLE_TEAM_LEAD;
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -6,6 +6,7 @@ use super::{
         install_stale_recovery_signal_for_test,
     },
     lifecycle_control::LifecycleControlSourceAdapter,
+    local_ipc_transport::RuntimeServeHooks,
 };
 use atm_core::boundary::RequestDispatcher;
 use atm_core::doctor::{
@@ -161,6 +162,8 @@ fn local_ipc_runtime_round_trips_doctor_requests_on_shared_transport() {
     let runtime = server_transport
         .prepare_runtime_at_socket_path(socket_path.clone())
         .expect("prepare runtime");
+    let mut runtime = runtime;
+    let endpoint_guard = runtime.take_endpoint_guard().expect("take endpoint guard");
     let (lifecycle, _reset) = {
         let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
         let reset = LifecycleFlagResetGuard::install(lifecycle.clone());
@@ -172,11 +175,14 @@ fn local_ipc_runtime_round_trips_doctor_requests_on_shared_transport() {
     let join = std::thread::spawn(move || {
         let result = runtime.serve_with_runtime_hooks(
             dispatcher,
-            Duration::from_millis(500),
-            Duration::from_secs(2),
-            || Ok(()),
-            || Ok(()),
-            || {},
+            RuntimeServeHooks {
+                endpoint_guard,
+                graceful_drain_deadline: Duration::from_millis(500),
+                force_cancel_deadline: Duration::from_secs(2),
+                begin_shutdown: || Ok(()),
+                reload_runtime_view: || Ok(()),
+                finalize_shutdown: || {},
+            },
         );
         serve_result_tx.send(result).expect("send serve result");
     });
@@ -310,6 +316,8 @@ fn windows_local_ipc_runtime_terminate_finishes_within_deadline() {
     let runtime = server_transport
         .prepare_runtime_at_socket_path(socket_path)
         .expect("prepare runtime");
+    let mut runtime = runtime;
+    let endpoint_guard = runtime.take_endpoint_guard().expect("take endpoint guard");
     let (lifecycle, _reset) = {
         let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
         let reset = LifecycleFlagResetGuard::install(lifecycle.clone());
@@ -321,11 +329,14 @@ fn windows_local_ipc_runtime_terminate_finishes_within_deadline() {
     let join = std::thread::spawn(move || {
         let result = runtime.serve_with_runtime_hooks(
             dispatcher,
-            Duration::from_millis(500),
-            Duration::from_secs(2),
-            || Ok(()),
-            || Ok(()),
-            || {},
+            RuntimeServeHooks {
+                endpoint_guard,
+                graceful_drain_deadline: Duration::from_millis(500),
+                force_cancel_deadline: Duration::from_secs(2),
+                begin_shutdown: || Ok(()),
+                reload_runtime_view: || Ok(()),
+                finalize_shutdown: || {},
+            },
         );
         serve_result_tx.send(result).expect("send serve result");
     });

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -7,15 +7,15 @@ use super::{
     },
     lifecycle_control::LifecycleControlSourceAdapter,
     local_ipc_transport::RuntimeServeHooks,
-    test_support::{LifecycleFlagResetGuard, connect_daemon_local_ipc_until_ready},
+    test_support::{DoctorOnlyDispatcher, LifecycleFlagResetGuard},
 };
 use atm_core::boundary::RequestDispatcher;
 #[cfg(unix)]
 use atm_core::doctor::DoctorQuery;
-use atm_core::doctor::{DoctorEnvironmentVisibility, DoctorReport, DoctorStatus, DoctorSummary};
+use atm_core::doctor::DoctorStatus;
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
-use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
+use atm_core::observability::AtmObservabilityHealthState;
 use atm_core::protocol::{
     HeartbeatActivity, RequestEnvelope, ResponseEnvelope, RuntimeLivenessState, RuntimeMemberState,
     RuntimeReadinessState, TeamMemberHeartbeatRequest,
@@ -36,6 +36,9 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
+#[cfg(unix)]
+use crate::test_support::connect_daemon_local_ipc_until_ready;
+
 const TEST_TEAM: &str = "test-team";
 
 struct StaleRecoverySignalGuard;
@@ -50,47 +53,6 @@ impl StaleRecoverySignalGuard {
 impl Drop for StaleRecoverySignalGuard {
     fn drop(&mut self) {
         clear_stale_recovery_signal_for_test();
-    }
-}
-
-#[derive(Debug, Default)]
-struct DoctorOnlyDispatcher;
-
-impl atm_core::boundary::sealed::Sealed for DoctorOnlyDispatcher {}
-
-impl RequestDispatcher for DoctorOnlyDispatcher {
-    fn dispatch(
-        &self,
-        request: RequestEnvelope,
-    ) -> Result<ResponseEnvelope, atm_core::error::AtmError> {
-        match request {
-            RequestEnvelope::Doctor(_) => Ok(ResponseEnvelope::Doctor(DoctorReport {
-                summary: DoctorSummary {
-                    status: DoctorStatus::Healthy,
-                    message: "ok".to_string(),
-                    info_count: 0,
-                    warning_count: 0,
-                    error_count: 0,
-                },
-                findings: Vec::new(),
-                recommendations: Vec::new(),
-                environment: DoctorEnvironmentVisibility {
-                    atm_home: None,
-                    atm_team: None,
-                    atm_identity: None,
-                    team_override: None,
-                },
-                member_roster: None,
-                observability: AtmObservabilityHealth {
-                    active_log_path: None,
-                    logging_state: AtmObservabilityHealthState::Healthy,
-                    query_state: Some(AtmObservabilityHealthState::Healthy),
-                    detail: None,
-                },
-                runtime_status: None,
-            })),
-            other => panic!("unexpected request in DoctorOnlyDispatcher: {other:?}"),
-        }
     }
 }
 

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -1,17 +1,19 @@
 use super::runtime_health::{DaemonRequestDispatcher, RuntimeStatusCache};
 use super::{
-    LocalIpcServerTransportAdapter,
+    DaemonExitCode, LocalIpcServerTransportAdapter, daemon_exit_code_for_error,
     host_ownership::{
         HOST_RUNTIME_OWNER_LOCK_FILE, HostOwnershipAdapter, clear_stale_recovery_signal_for_test,
         install_stale_recovery_signal_for_test,
     },
     lifecycle_control::LifecycleControlSourceAdapter,
     local_ipc_transport::RuntimeServeHooks,
+    test_support::{LifecycleFlagResetGuard, connect_daemon_local_ipc_until_ready},
 };
 use atm_core::boundary::RequestDispatcher;
 #[cfg(unix)]
 use atm_core::doctor::DoctorQuery;
 use atm_core::doctor::{DoctorEnvironmentVisibility, DoctorReport, DoctorStatus, DoctorSummary};
+use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
 use atm_core::protocol::{
@@ -25,8 +27,6 @@ use atm_core::test_support::ROLE_TEAM_LEAD;
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_rusqlite::assemble_boundary;
 #[cfg(unix)]
-use interprocess::local_socket::Stream as LocalSocketStream;
-#[cfg(unix)]
 use interprocess::local_socket::traits::Stream as _;
 use serial_test::serial;
 use std::fs::OpenOptions;
@@ -37,25 +37,6 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 const TEST_TEAM: &str = "test-team";
-
-struct LifecycleFlagResetGuard {
-    lifecycle: LifecycleControlSourceAdapter,
-}
-
-impl LifecycleFlagResetGuard {
-    fn install(lifecycle: LifecycleControlSourceAdapter) -> Self {
-        lifecycle.set_terminate_for_test(false);
-        lifecycle.set_reload_for_test(false);
-        Self { lifecycle }
-    }
-}
-
-impl Drop for LifecycleFlagResetGuard {
-    fn drop(&mut self) {
-        self.lifecycle.set_terminate_for_test(false);
-        self.lifecycle.set_reload_for_test(false);
-    }
-}
 
 struct StaleRecoverySignalGuard;
 
@@ -113,23 +94,6 @@ impl RequestDispatcher for DoctorOnlyDispatcher {
     }
 }
 
-#[cfg(unix)]
-fn connect_daemon_local_ipc_until_ready(endpoint_path: &std::path::Path) -> LocalSocketStream {
-    let deadline = Instant::now() + Duration::from_secs(3);
-    loop {
-        match LocalSocketStream::connect(
-            atm_core::protocol::daemon_local_ipc_name_from_path(endpoint_path).expect("ipc name"),
-        ) {
-            Ok(stream) => return stream,
-            Err(error) if Instant::now() < deadline => {
-                let _ = error;
-                std::thread::yield_now();
-            }
-            Err(error) => panic!("connect daemon local ipc: {error}"),
-        }
-    }
-}
-
 #[test]
 fn daemon_shutdown_signals_for_test_are_isolated() {
     let first = LifecycleControlSourceAdapter::new_for_test();
@@ -153,6 +117,30 @@ fn daemon_shutdown_signal_install_reuses_shared_flags() {
 
     assert!(second.reload_requested_for_test());
     assert!(first.terminate_requested());
+}
+
+#[test]
+fn daemon_exit_code_mapping_matches_supervisor_contract() {
+    assert_eq!(
+        daemon_exit_code_for_error(&AtmError::daemon_lifecycle_wedge("wedged")),
+        DaemonExitCode::LifecycleWedge
+    );
+    assert_eq!(
+        daemon_exit_code_for_error(&AtmError::daemon_launch_gate_rejected("launch gate")),
+        DaemonExitCode::DoNotRestart
+    );
+    assert_eq!(
+        daemon_exit_code_for_error(&AtmError::daemon_unavailable("listener died")),
+        DaemonExitCode::TransportFatal
+    );
+    assert_eq!(
+        daemon_exit_code_for_error(&AtmError::config("bad config")),
+        DaemonExitCode::DoNotRestart
+    );
+    assert_eq!(
+        daemon_exit_code_for_error(&AtmError::validation("buggy invariant")),
+        DaemonExitCode::InternalBug
+    );
 }
 
 #[test]

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -479,6 +479,22 @@ Force-cancel rule:
 - failure to drain within the force deadline is reported as a typed runtime
   failure after interrupting active connections
 
+### Runtime SLOs
+
+| SLO | Target | Contract |
+|---|---|---|
+| Wedge recovery | `<= 1s` | fatal transport events or shutdown beacons must unblock the lifecycle waiter and serving path promptly |
+| Accept-error teardown | `<= 2s` | a fatal local-IPC accept failure must reach typed runtime exit after drain start and endpoint unpublication |
+| Clean shutdown | `<= 5s` | orderly daemon shutdown, including tracked request drain and background-lane stop, stays bounded |
+| Socket cleanup | `<= 100ms` | same-host endpoint unpublication completes promptly once serving stops |
+
+Exit-code expectations tied to these SLOs:
+- bind failure exits `70` and relies on supervisor restart/backoff rather than
+  in-process rebind
+- singleton or stale-owner admission failures exit `64` and must not hot-loop
+  restart
+- lifecycle-wedge detection exits `71`
+
 Required deadlines:
 - normal drain deadline: `5s`
 - force-cancel deadline after drain starts: `10s` total

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -328,6 +328,10 @@ Lifecycle state model:
 - any post-`Running` exit path, including listener/accept failures, must pass
   through `Running -> Draining -> Stopped` rather than silently forcing
   `Running -> Stopped`
+- Phase S currently models fatal accept failure as a conventional
+  `ServeEvent::AcceptError` control-plane event rather than as a dedicated typed
+  lifecycle-transition enum; that shape is accepted so long as the runtime
+  still transitions through `Running -> Draining -> Stopped` afterward
 - repeated lifecycle-control installs for one platform implementation must
   reuse the same process-wide control flags without clearing a pending
   terminate/reload bit between installs

--- a/docs/phase-S/sprint-S13-ipc-plan.md
+++ b/docs/phase-S/sprint-S13-ipc-plan.md
@@ -116,6 +116,19 @@ Out of scope:
   - owns business logic only and never owns socket lifetime or process-liveness
     decisions
 
+### Async Dispatch Ownership
+
+- Tracked dispatch registration extends the existing daemon-private
+  `request_runtime` tracked-work registry described in
+  `docs/atm-daemon/architecture.md`.
+- The redesigned local IPC path keeps the current single-request-per-connection
+  cap. The receive loop does not introduce request multiplexing on one
+  connection.
+- The bounded tracked-work registry remains the authoritative ownership record
+  for request workers under `REQ-DAEMON-TRANSPORT-004`.
+- The receive loop may hand a validated request across an async boundary, but
+  it must not create detached work outside that bounded registry contract.
+
 ### Cancellation contract
 
 - `ShutdownBeacon` is the only accepted process-wide transport shutdown signal.
@@ -194,11 +207,18 @@ listener is ready until the daemon has fully stopped serving.
 
 - remember the logical endpoint identity and concrete OS binding
 - own endpoint cleanup on drop
-- remove Unix socket-path artifacts when required
+- on Unix: unlink the socket-path artifact when required
+- on Windows: close the server-side pipe handle and ensure no stale endpoint
+  continues to advertise daemon availability; there is no filesystem path
+  artifact to delete
+- expose one platform-neutral `unpublish()` contract above the adapter layer
 - guarantee endpoint unpublication before daemon ownership release
 - provide one cleanup path that runs on ordinary shutdown, fatal return, and
   panic unwind so stale socket artifacts are not left behind until the next
   bind attempt
+- keep the platform-specific cleanup steps isolated inside the guard's OS
+  implementation rather than leaking Unix socket or Windows pipe details into
+  runtime orchestration
 
 ### Drop contract
 
@@ -214,6 +234,11 @@ reachable or stale.
 The implementation target is Drop-based cleanup rather than bind-time cleanup
 alone. Bind-time stale-socket removal remains a defensive recovery step, but it
 is no longer the primary cleanup mechanism.
+
+`SocketEndpointGuard` is an RAII field owned in `RuntimeComposition` scope and
+declared after the host-ownership guard so Rust field-drop order enforces the
+required shutdown sequence. Last declared drops first, which means endpoint
+unpublication happens before `HostOwnershipAdapter` release.
 
 ### Launch/owner ordering
 
@@ -243,9 +268,13 @@ become machine-actionable instead of collapsing into one generic error exit.
 
 - local request-level failures do not exit the process; they stay connection
   scoped
+- a fatal accept path requested through `ShutdownBeacon` transitions
+  `Running -> Draining -> Stopped`; it does not jump directly from `Running` to
+  `Stopped`
 - fatal listener/runtime failures map to `70` or `71`
 - configuration and startup contract violations fail closed with `64`
 - unexpected invariant breaks remain `1`
+- the typed process exit is emitted only after the runtime reaches `Stopped`
 
 ### Supervisor expectations
 
@@ -320,6 +349,17 @@ S.13 does not reopen the accepted no-daemon-spawn testing direction.
   ordinary correctness
 - real daemon-process coverage remains limited to the narrow runtime suite
 - no new test-only daemon launch path is introduced
+
+### LoopbackClientTransport impact
+
+`LoopbackClientTransport` does not require direct `ShutdownBeacon` wiring for
+ordinary in-process seam coverage because it does not own the local IPC accept
+loop, listener wake path, or endpoint publication contract. It must continue to
+exercise the same dispatcher/request-runtime boundary as the real transport, but
+the beacon-owned shutdown mechanics stay specific to the local IPC server path.
+That preserves the `REQ-DAEMON-TRANSPORT-001` contract that the in-process seam
+backs the same dispatcher behavior without pretending to be the real endpoint
+ownership implementation.
 
 ### 8. Implementation Slices For The Follow-On Worktree
 

--- a/docs/phase-S/sprint-S13-ipc-plan.md
+++ b/docs/phase-S/sprint-S13-ipc-plan.md
@@ -22,6 +22,16 @@ accepted in tasking:
 - typed daemon exit codes
 - explicit runtime SLOs
 
+It also reconciles the specific Opus failure inventory from the follow-up
+analysis at `integrate/phase-S @ 847b150`:
+- accept-error lifecycle wedge
+- missing Drop-based socket cleanup
+- missing typed exit codes
+- accept-after-terminate silent drop
+- dispatch-handle retention until shutdown
+- event-channel disconnect wedge
+- supervisor-restart preference over internal re-bind
+
 ## Current Failure Shape
 
 The current local IPC serving path in
@@ -59,7 +69,6 @@ In scope:
 Out of scope:
 - replacing the current peer transport with persistent sessions
 - `atm-core` business logic changes
-- SQLite/rusqlite concurrency redesign
 - daemon-spawning test exceptions
 
 ## Design Areas
@@ -89,6 +98,10 @@ Out of scope:
 6. Accept-loop fatal failures request daemon shutdown through
    `ShutdownBeacon`, wake the listener if needed, drain tracked work, clean up
    the endpoint, and return a typed runtime exit.
+7. If shutdown is already requested when `accept()` returns a live stream, the
+   connection runtime sends one typed daemon-shutting-down response when
+   framing is still possible, then closes the stream. Silent reset is not the
+   target behavior.
 
 ### Thread ownership
 
@@ -113,6 +126,10 @@ Out of scope:
   transport/runtime error and release the socket.
 - Detached, untracked request execution remains forbidden under
   `REQ-DAEMON-TRANSPORT-004`.
+- Dispatch-worker handles must be reaped continuously as part of connection
+  lifecycle bookkeeping rather than only after a successful response write or
+  at final shutdown. The goal is to prevent bounded-but-cumulative `JoinHandle`
+  retention under sustained faulted traffic.
 
 ### Why this shape
 
@@ -124,6 +141,12 @@ This keeps transport proof obligations local:
 
 That is materially easier to reason about than the current
 accept-thread-plus-event-channel structure.
+
+This also removes the specific Opus `event_tx.send` / `event_rx.recv` wedge
+class from the core serve path. A direct accept loop plus shared beacon makes
+channel-disconnect deadlock impossible in the transport control plane because
+the main serving thread no longer depends on an internal event bus to observe
+accept failure or terminate state.
 
 ### 2. `ShutdownBeacon`
 
@@ -173,6 +196,9 @@ listener is ready until the daemon has fully stopped serving.
 - own endpoint cleanup on drop
 - remove Unix socket-path artifacts when required
 - guarantee endpoint unpublication before daemon ownership release
+- provide one cleanup path that runs on ordinary shutdown, fatal return, and
+  panic unwind so stale socket artifacts are not left behind until the next
+  bind attempt
 
 ### Drop contract
 
@@ -184,6 +210,10 @@ listener is ready until the daemon has fully stopped serving.
 This ordering is required by ADR-002. The host must never re-advertise
 "daemon available" by releasing `owner.lock` while the old endpoint is still
 reachable or stale.
+
+The implementation target is Drop-based cleanup rather than bind-time cleanup
+alone. Bind-time stale-socket removal remains a defensive recovery step, but it
+is no longer the primary cleanup mechanism.
 
 ### Launch/owner ordering
 
@@ -223,6 +253,8 @@ become machine-actionable instead of collapsing into one generic error exit.
 - the supervisor must not hot-loop forever on `64`
 - restart policy must preserve the host-wide singleton invariant from ADR-002
 - restart is a clean new process, not an in-process listener self-heal loop
+- bind failure is not retried internally by the daemon transport. It exits with
+  a typed code and lets the host supervisor apply bounded backoff.
 
 ### 5. Runtime SLOs
 
@@ -262,6 +294,21 @@ consistent with ADR-002:
 - endpoint publication happens only after ownership is held
 - endpoint unpublication happens before ownership release
 
+### Restart model
+
+S.13 explicitly adopts the supervisor-restart model recommended by the Opus
+analysis:
+- no internal IPC re-bind loop after fatal listener failure
+- no in-process ownership release/reacquire cycle to recover transport faults
+- no attempt to reinstall process-global lifecycle hooks in place
+
+Rationale:
+- ADR-002 singleton ownership remains simpler to prove when fatal listener
+  faults lead to one typed process exit
+- process-global lifecycle hook installation is not a clean hot-reload seam
+- every other fatal runtime category already relies on clean restart rather
+  than in-process daemon resurrection
+
 If implementation work needs stronger wording than ADR-002 currently has,
 the follow-on implementation sprint should amend ADR-002 explicitly rather than
 encoding the rule only in code comments.
@@ -281,6 +328,10 @@ Primary code targets:
   - replace the event-channel serve orchestration with a direct accept loop
   - add the connection receive loop and shared `ShutdownBeacon` wiring
   - move endpoint cleanup behind `SocketEndpointGuard`
+  - return a typed daemon-shutting-down result rather than silently dropping
+    streams accepted after shutdown begins
+  - reap tracked dispatch handles incrementally instead of only at
+    post-response / final-shutdown boundaries
 - `crates/atm-daemon/src/lifecycle_control.rs`
   - keep platform hooks, but expose them as shutdown/reload requests into the
     beacon-driven runtime contract
@@ -295,6 +346,23 @@ Secondary implementation work:
 - targeted runtime tests for accept failure, shutdown wake, endpoint cleanup,
   and bounded drain
 - doc updates if ADR-002 wording needs to be strengthened
+
+## Deferred From S.13
+
+The Opus report included several items that are explicitly not part of the S.13
+planning/implementation target unless later tasking expands scope:
+
+- partial-write categorization improvements
+  - keep this as a logging/observability follow-up, not a blocker for the core
+    receive-loop redesign
+- bind-failure subcoding for richer operator UX
+  - S.13 requires typed exit classes and no internal retry; finer-grained bind
+    diagnostics can follow separately
+- composite error chaining when both serve and shutdown fail
+  - useful operator signal, but secondary to removing the fatal-path wedge
+- Windows eventfd-equivalent lifecycle wake primitive
+  - already accepted as a documented exception rather than a mandatory S.13
+    redesign item
 
 ## References
 

--- a/docs/phase-S/sprint-S13-ipc-plan.md
+++ b/docs/phase-S/sprint-S13-ipc-plan.md
@@ -1,0 +1,309 @@
+# Sprint S.13 IPC/Socket Runtime Hardening Plan
+
+**Branch**: feature/pS-s13-ipc-transport-plan  
+**Base**: integrate/phase-S @ 77badd5  
+**PR target**: integrate/phase-S  
+**Status**: Planning
+
+## Goal
+
+Define the next daemon transport hardening step after S.12. The local IPC
+server path needs a simpler correctness story: one accept loop, one receive
+loop per accepted connection, one explicit shutdown signal, and fatal-path
+cleanup that cannot wedge the daemon in a half-dead state. Peer transport
+remains a separate concern because the current Phase S implementation is an
+outbound per-message TCP client with retry/replay, not a second inbound
+listener.
+
+This plan incorporates the independent Opus architect guidance already
+accepted in tasking:
+- `ShutdownBeacon`
+- `SocketEndpointGuard`
+- typed daemon exit codes
+- explicit runtime SLOs
+
+## Current Failure Shape
+
+The current local IPC serving path in
+`crates/atm-daemon/src/local_ipc_transport.rs` splits shutdown and transport
+control across:
+- a lifecycle waiter thread
+- an accept thread
+- an event-channel-driven serve loop
+- per-connection request workers
+
+That shape works on the happy path, but it is harder to prove on fatal paths.
+In particular, an accept failure can break the serve loop while a scoped
+lifecycle waiter is still blocked in `wait_for_state_change()`. Because the
+runtime uses `thread::scope`, that can turn a transport fault into a shutdown
+wedge instead of a clean bounded exit.
+
+The peer transport in `crates/atm-daemon/src/peer_transport.rs` is different:
+- one TCP stream per delivery attempt
+- one framed request
+- one framed response
+- retry/replay classification on failure
+
+S.13 therefore treats local IPC and peer sockets as related but separate
+runtime loops rather than forcing them into one premature abstraction.
+
+## Scope And Non-Goals
+
+In scope:
+- redesign of same-host local IPC listener/connection control flow
+- explicit shutdown/cancellation contract for local IPC fatal paths
+- endpoint cleanup and owner-release ordering
+- typed process-exit taxonomy for daemon supervisors
+- peer-transport concerns that need to be tracked separately
+
+Out of scope:
+- replacing the current peer transport with persistent sessions
+- `atm-core` business logic changes
+- SQLite/rusqlite concurrency redesign
+- daemon-spawning test exceptions
+
+## Design Areas
+
+### 1. Single Receive-Loop Per IPC Connection
+
+### Target flow
+
+1. `RuntimeComposition::start()` installs lifecycle control, acquires
+   host-wide ownership, binds local IPC, and constructs a `SocketEndpointGuard`
+   before entering serving state.
+2. The serving thread owns the accept loop directly. It is no longer an
+   event-bus consumer waiting on a second accept thread.
+3. Each accepted stream spawns one connection runtime that owns:
+   - the socket handle
+   - a clone of `ShutdownBeacon`
+   - the bounded request/response deadline budget
+   - one tracked dispatch registration
+4. The connection runtime executes one receive loop:
+   - `read_frame`
+   - decode and validate request
+   - dispatch request asynchronously into the daemon service boundary
+   - wait on a bounded response channel
+   - `write_frame`
+   - continue until EOF, shutdown, or transport error
+5. EOF and request-local socket failures close only that connection.
+6. Accept-loop fatal failures request daemon shutdown through
+   `ShutdownBeacon`, wake the listener if needed, drain tracked work, clean up
+   the endpoint, and return a typed runtime exit.
+
+### Thread ownership
+
+- `RuntimeComposition` thread:
+  - owns the accept loop and the top-level fatal result
+- `LifecycleControl` waiter:
+  - one helper thread that only observes lifecycle state and requests shutdown
+    or reload through `ShutdownBeacon`
+- `ConnectionRuntime` thread per accepted stream:
+  - owns socket I/O for that connection only
+- `RequestDispatcher` worker:
+  - owns business logic only and never owns socket lifetime or process-liveness
+    decisions
+
+### Cancellation contract
+
+- `ShutdownBeacon` is the only accepted process-wide transport shutdown signal.
+- The accept loop, lifecycle waiter, and every connection runtime must observe
+  the same beacon instance.
+- Connection runtimes may finish an in-flight response if they can do so within
+  the bounded shutdown budget; otherwise they must fail closed with a typed
+  transport/runtime error and release the socket.
+- Detached, untracked request execution remains forbidden under
+  `REQ-DAEMON-TRANSPORT-004`.
+
+### Why this shape
+
+This keeps transport proof obligations local:
+- listener correctness lives in one loop
+- per-connection correctness lives in one loop
+- dispatch correctness stays behind one async boundary
+- shutdown correctness is driven by one shared signal
+
+That is materially easier to reason about than the current
+accept-thread-plus-event-channel structure.
+
+### 2. `ShutdownBeacon`
+
+`ShutdownBeacon` is a crate-private runtime control primitive, not a new public
+extension surface.
+
+### Required behavior
+
+- idempotent `request_shutdown(reason)`
+- idempotent `request_reload(reason)`
+- cheap `is_shutdown_requested()`
+- wakeable wait primitive for loops that otherwise block indefinitely
+- stable typed reason for observability and process-exit mapping
+
+### Recommended shape
+
+- `Arc<ShutdownBeacon>`
+- internal state:
+  - atomic phase flag
+  - generation counter
+  - condvar-backed waiter or equivalent wake primitive
+- observers:
+  - accept loop checks before and after `accept()`
+  - lifecycle waiter requests terminate/reload through the beacon instead of
+    pushing `ServeEvent`s
+  - connection runtimes poll before read/write and before waiting on a
+    dispatch result
+
+### Required wake path
+
+When shutdown is requested:
+- set beacon state first
+- wake the listener second
+- let the accept loop observe the shutdown state after unblock
+
+This ordering ensures the wakeup cannot be mistaken for a fresh external
+connection and keeps the fatal path deterministic.
+
+### 3. `SocketEndpointGuard`
+
+`SocketEndpointGuard` owns the published same-host endpoint from the moment the
+listener is ready until the daemon has fully stopped serving.
+
+### Responsibilities
+
+- remember the logical endpoint identity and concrete OS binding
+- own endpoint cleanup on drop
+- remove Unix socket-path artifacts when required
+- guarantee endpoint unpublication before daemon ownership release
+
+### Drop contract
+
+1. serving state stops accepting new connections
+2. connection drain begins
+3. `SocketEndpointGuard` drops and unpublishes the endpoint
+4. host ownership is released afterward
+
+This ordering is required by ADR-002. The host must never re-advertise
+"daemon available" by releasing `owner.lock` while the old endpoint is still
+reachable or stale.
+
+### Launch/owner ordering
+
+S.13 keeps the accepted ADR-002 startup contract:
+1. launcher holds `launch.lock`
+2. daemon acquires `owner.lock`
+3. daemon binds and publishes the endpoint
+4. launcher releases `launch.lock` only after serving readiness is confirmed
+
+The S.13 addition is the symmetric shutdown rule:
+- endpoint unpublished before `owner.lock` release
+
+### 4. Typed Exit Codes And Supervisor Contract
+
+S.13 introduces a daemon-private exit taxonomy so fatal transport/runtime paths
+become machine-actionable instead of collapsing into one generic error exit.
+
+| Exit | Meaning | Typical causes | Supervisor contract |
+|---|---|---|---|
+| `0` | clean stop | operator-requested shutdown, orderly terminate path | no restart unless explicitly configured |
+| `1` | invariant/internal bug | panic boundary, impossible-state violation, poisoned control primitive | treat as bug; restart allowed but alert immediately |
+| `64` | configuration/bootstrap contract failure | invalid runtime home, invalid endpoint config, invalid retained-log config | do not hot-loop restart; require config repair |
+| `70` | daemon runtime fatal | accept-loop fatal error, bounded shutdown drain failure, unrecoverable lifecycle-control failure | supervisor should restart after bounded backoff |
+| `71` | OS/transport environment failure | bind failure after ownership, endpoint cleanup failure, host I/O/resource failure | supervisor may restart, but surface host-environment fault distinctly |
+
+### Mapping rules
+
+- local request-level failures do not exit the process; they stay connection
+  scoped
+- fatal listener/runtime failures map to `70` or `71`
+- configuration and startup contract violations fail closed with `64`
+- unexpected invariant breaks remain `1`
+
+### Supervisor expectations
+
+- a host supervisor may restart on `70` and `71`
+- the supervisor must not hot-loop forever on `64`
+- restart policy must preserve the host-wide singleton invariant from ADR-002
+- restart is a clean new process, not an in-process listener self-heal loop
+
+### 5. Runtime SLOs
+
+| SLO | Target | Meaning |
+|---|---|---|
+| Wedge recovery | `<= 1s` | shutdown request or fatal transport event must unblock the serving path promptly rather than hanging in a scoped waiter |
+| Accept-error teardown | `<= 2s` | fatal accept failure must transition to typed process exit after wake, drain start, and endpoint unpublication |
+| Clean shutdown | `<= 5s` | graceful daemon shutdown, including tracked request drain and background lane stop, remains bounded |
+| Socket cleanup | `<= 100ms` | endpoint unpublication and local socket cleanup complete promptly after serving stops |
+
+These SLOs are not throughput targets. They are correctness and operability
+targets for daemon liveness and supervisor behavior.
+
+### 6. Peer Transport Concerns To Track Separately
+
+Peer transport does not share the same loop shape today because it is not a
+persistent listener. The current runtime opens a fresh `TcpStream` per send
+attempt and relies on retry/replay classification.
+
+Concerns to carry separately:
+- the local IPC redesign should not force peer transport into a fake
+  long-lived-session abstraction it does not currently need
+- peer retry, replay persistence, and outcome-unknown handling already form a
+  separate state machine and should keep their own failure taxonomy
+- if a future sprint introduces persistent peer sessions, that sprint should
+  adopt the same "one receive loop per socket plus explicit shutdown beacon"
+  rule rather than the current per-attempt exchange
+- peer transport should eventually align its fatal-path reporting with the
+  same exit-code taxonomy and observability vocabulary used for local IPC
+
+### 7. ADR And Test-Policy Implications
+
+### ADR-002
+
+No ADR-002 reversal is needed. S.13 tightens one implication that is already
+consistent with ADR-002:
+- endpoint publication happens only after ownership is held
+- endpoint unpublication happens before ownership release
+
+If implementation work needs stronger wording than ADR-002 currently has,
+the follow-on implementation sprint should amend ADR-002 explicitly rather than
+encoding the rule only in code comments.
+
+### No-daemon-spawn test policy
+
+S.13 does not reopen the accepted no-daemon-spawn testing direction.
+- transport design changes must stay testable through in-process seams for
+  ordinary correctness
+- real daemon-process coverage remains limited to the narrow runtime suite
+- no new test-only daemon launch path is introduced
+
+### 8. Implementation Slices For The Follow-On Worktree
+
+Primary code targets:
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+  - replace the event-channel serve orchestration with a direct accept loop
+  - add the connection receive loop and shared `ShutdownBeacon` wiring
+  - move endpoint cleanup behind `SocketEndpointGuard`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+  - keep platform hooks, but expose them as shutdown/reload requests into the
+    beacon-driven runtime contract
+- `crates/atm-daemon/src/composition.rs`
+  - map typed fatal runtime outcomes to exit codes and supervisor-facing
+    observability
+- `crates/atm-daemon/src/peer_transport.rs`
+  - document separate follow-up concerns only; no persistent-session rewrite in
+    the same sprint
+
+Secondary implementation work:
+- targeted runtime tests for accept failure, shutdown wake, endpoint cleanup,
+  and bounded drain
+- doc updates if ADR-002 wording needs to be strengthened
+
+## References
+
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/peer_transport.rs`
+- `docs/adr/ADR-002-host-wide-daemon-singleton.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+- `docs/phase-S/sprint-S12.md`
+- `TASK-1219-PROD-REVIEW`

--- a/docs/phase-S/sprint-S13.md
+++ b/docs/phase-S/sprint-S13.md
@@ -1,0 +1,70 @@
+# Sprint S.13 — IPC/Socket Runtime Hardening Plan
+
+**Branch**: feature/pS-s13-ipc-transport-plan  
+**Base**: integrate/phase-S @ 77badd5  
+**PR target**: integrate/phase-S  
+**Status**: Planning
+
+## Goal
+
+Produce the implementation plan for the next daemon transport hardening pass.
+The focus is same-host local IPC correctness: move to one receive loop per IPC
+connection with an async dispatch boundary, replace the current fatal-path
+control tangle with a single shared shutdown primitive, and define the endpoint
+cleanup and process-exit contracts needed for supervisor-safe recovery.
+
+Peer socket transport is included only as a separate concern inventory. It is
+not converted to a persistent session model in this sprint.
+
+## Required Work
+
+### 1. Write the design document
+
+Add `docs/phase-S/sprint-S13-ipc-plan.md` covering:
+- the single receive-loop per connection model
+- async dispatch ownership and cancellation rules
+- `ShutdownBeacon`
+- `SocketEndpointGuard`
+- typed exit-code taxonomy and supervisor contract
+- runtime SLOs
+- peer transport follow-up concerns
+
+### 2. Record the sprint authority
+
+This sprint brief must remain aligned with the design document and the accepted
+Phase S architecture:
+- no daemon-spawn test exceptions
+- no reopening of ADR-002 singleton semantics
+- no rusqlite redesign mixed into the transport plan
+
+### 3. Record the implementation scope for the follow-on fix sprint
+
+The follow-on implementation worktree should target:
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+- `crates/atm-daemon/src/composition.rs`
+- targeted transport/runtime tests
+
+`crates/atm-daemon/src/peer_transport.rs` is reference material for follow-up
+concerns only in S.13.
+
+## Acceptance Criteria
+
+- `docs/phase-S/sprint-S13-ipc-plan.md` exists and covers all required design
+  areas
+- `docs/phase-S/sprint-S13.md` exists and names the implementation scope and
+  acceptance criteria
+- `docs/plan-phase-S.md` records S.13 in the sprint sequence
+- `just lint` PASS
+
+## References
+
+- `docs/phase-S/sprint-S13-ipc-plan.md`
+- `docs/adr/ADR-002-host-wide-daemon-singleton.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/peer_transport.rs`
+- `TASK-1219-PROD-REVIEW`

--- a/docs/phase-S/sprint-S13.md
+++ b/docs/phase-S/sprint-S13.md
@@ -16,6 +16,9 @@ cleanup and process-exit contracts needed for supervisor-safe recovery.
 Peer socket transport is included only as a separate concern inventory. It is
 not converted to a persistent session model in this sprint.
 
+This sprint also adopts the Opus recommendation that fatal local IPC transport
+faults use supervisor restart rather than in-process IPC re-bind.
+
 ## Required Work
 
 ### 1. Write the design document
@@ -28,6 +31,8 @@ Add `docs/phase-S/sprint-S13-ipc-plan.md` covering:
 - typed exit-code taxonomy and supervisor contract
 - runtime SLOs
 - peer transport follow-up concerns
+- explicit reconciliation of the Opus failure inventory, including
+  accept-after-terminate behavior and removal of the event-channel wedge class
 
 ### 2. Record the sprint authority
 
@@ -35,7 +40,7 @@ This sprint brief must remain aligned with the design document and the accepted
 Phase S architecture:
 - no daemon-spawn test exceptions
 - no reopening of ADR-002 singleton semantics
-- no rusqlite redesign mixed into the transport plan
+- no unrelated storage-layer redesign mixed into the transport plan
 
 ### 3. Record the implementation scope for the follow-on fix sprint
 
@@ -44,6 +49,11 @@ The follow-on implementation worktree should target:
 - `crates/atm-daemon/src/lifecycle_control.rs`
 - `crates/atm-daemon/src/composition.rs`
 - targeted transport/runtime tests
+
+The follow-on implementation should not add:
+- internal IPC re-bind/self-heal loops
+- daemon-spawn test exceptions
+- unrelated storage-layer concurrency work mixed into the transport sprint
 
 `crates/atm-daemon/src/peer_transport.rs` is reference material for follow-up
 concerns only in S.13.

--- a/docs/phase-S/sprint-S13.md
+++ b/docs/phase-S/sprint-S13.md
@@ -1,7 +1,7 @@
 # Sprint S.13 — IPC/Socket Runtime Hardening Plan
 
 **Branch**: feature/pS-s13-ipc-transport-plan  
-**Base**: integrate/phase-S @ 77badd5  
+**Base**: integrate/phase-S @ f152ae3  
 **PR target**: integrate/phase-S  
 **Status**: Planning
 

--- a/docs/phase-S/sprint-S13.md
+++ b/docs/phase-S/sprint-S13.md
@@ -33,6 +33,10 @@ Add `docs/phase-S/sprint-S13-ipc-plan.md` covering:
 - peer transport follow-up concerns
 - explicit reconciliation of the Opus failure inventory, including
   accept-after-terminate behavior and removal of the event-channel wedge class
+- the existing `request_runtime` tracked-work registry as the ownership anchor
+  for async request dispatch
+- why `LoopbackClientTransport` keeps the same dispatcher seam without needing
+  direct `ShutdownBeacon` wiring
 
 ### 2. Record the sprint authority
 

--- a/docs/plan-phase-S.md
+++ b/docs/plan-phase-S.md
@@ -642,6 +642,7 @@ Required closeout work:
   implementation begins
 - define the daemon runtime SLOs for wedge recovery, accept-error teardown,
   clean shutdown, and endpoint cleanup
+- keep `just lint` passing on the planning branch
 - keep unrelated storage-layer review/hardening separate rather than mixing
   store concurrency work into the transport hardening line
 

--- a/docs/plan-phase-S.md
+++ b/docs/plan-phase-S.md
@@ -615,6 +615,36 @@ Required closeout work:
 - update `docs/phase-S/sprint-S12.md` plus the 12 resolved INTG TTL records so
   documentation and machine-readable triage state agree on closure
 
+### S.13 IPC/Socket Runtime Hardening Plan
+
+Goal:
+- define the next daemon transport hardening step after the S.12 integration
+  fixes so local IPC fatal-path cleanup, endpoint ownership ordering, and
+  supervisor-facing runtime exits are explicit before more runtime changes land
+
+Required outcomes:
+- one accepted design for same-host local IPC:
+  - one accept loop
+  - one receive loop per accepted connection
+  - one async dispatch boundary
+  - one shared shutdown beacon
+- endpoint publication and unpublication ordering are explicit relative to
+  ADR-002 `launch.lock` / `owner.lock` semantics
+- fatal local IPC/runtime exits map to one typed supervisor-facing exit-code
+  taxonomy instead of one generic process failure
+- peer socket transport follow-up concerns are recorded separately without
+  forcing a premature persistent-session redesign
+
+Required closeout work:
+- add `docs/phase-S/sprint-S13-ipc-plan.md`
+- add `docs/phase-S/sprint-S13.md`
+- lock the `ShutdownBeacon` and `SocketEndpointGuard` design direction before
+  implementation begins
+- define the daemon runtime SLOs for wedge recovery, accept-error teardown,
+  clean shutdown, and endpoint cleanup
+- keep rusqlite review/hardening as a separate future sprint rather than
+  mixing store concurrency work into the transport hardening line
+
 ## 6. Removed Windows CI Guardrail
 
 The temporary Windows clippy narrowing used during S.0-S.3 is retired.

--- a/docs/plan-phase-S.md
+++ b/docs/plan-phase-S.md
@@ -642,8 +642,8 @@ Required closeout work:
   implementation begins
 - define the daemon runtime SLOs for wedge recovery, accept-error teardown,
   clean shutdown, and endpoint cleanup
-- keep rusqlite review/hardening as a separate future sprint rather than
-  mixing store concurrency work into the transport hardening line
+- keep unrelated storage-layer review/hardening separate rather than mixing
+  store concurrency work into the transport hardening line
 
 ## 6. Removed Windows CI Guardrail
 


### PR DESCRIPTION
## Summary

- **[P1.1] ShutdownBeacon**: `Arc<(Mutex<bool>, Condvar)>` shared across lifecycle waiter, accept loop, and main serve loop — trips on any fatal event, exits all threads within ≤1s SLO
- **[P1.2] SocketEndpointGuard**: RAII Drop guard cleans socket file unconditionally on Unix (panic/OOM safe); Windows pipe handle closed on drop; drops before `HostOwnershipAdapter` per field order
- **[P1.3] Typed exit codes**: `main.rs` exits `0/1/64/70/71` per error category; documented in `docs/atm-daemon/architecture.md` for launchd/systemd supervisor configuration
- **[P2.1] Accept-after-terminate response**: typed `daemon-shutting-down` error frame written before stream drop; mirrors connection-cap-exceeded pattern
- **[P2.2] Continuous dispatch-handle reaping**: handles reaped on every main loop iteration, not only post-response/shutdown
- **Regression tests**: AcceptError wedge, panic socket cleanup, accept-after-terminate typed response

## Test plan
- [ ] `cargo fmt --all --check` PASS ✓
- [ ] `cargo test -p atm-daemon` PASS ✓
- [ ] `just lint` PASS ✓
- [ ] `cargo xwin check --workspace --target x86_64-pc-windows-msvc` PASS ✓
- [ ] QA review pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)