### PR TITLE
fix: remove unauthorized backlog deferral from codex-orchestration RBP gate

### DIFF
--- a/.claude/skills/codex-orchestration/SKILL.md
+++ b/.claude/skills/codex-orchestration/SKILL.md
@@ -38,11 +38,11 @@ Before starting a sprint:
    - installed Rust reviewers from `sc-rust`
 5. The following QA reporting skill exists in `.claude/skills/`:
    - `quality-management-gh/`
-5. `quality-mgr` must read:
+6. `quality-mgr` must read:
    - `.claude/assets/sc-rust/quality-mgr/quality-mgr.rust.md`
-6. `quality-mgr` must also read:
+7. `quality-mgr` must also read:
    - `.claude/skills/quality-management-gh/SKILL.md`
-7. `sc-compose` is available for rendering the JSON and markdown templates.
+8. `sc-compose` is available for rendering the JSON and markdown templates.
 
 ## Sprint Flow
 
@@ -64,6 +64,8 @@ Before starting a sprint:
 7. QA-2 and later rounds must omit `rust-best-practices-agent`. All RBP
    findings from QA-1 must be fixed before merge — merge gate is 0B+0I+0m
    with no exceptions and no backlog deferral.
+   QA-1 RBP findings route back to `arch-ctm` via `fix-assignment.xml.j2`
+   before QA-2, following the standard triage-and-fix path.
 8. If QA passes and CI is green, merge may proceed.
 9. If QA fails, `team-lead` first runs `/triaging-findings` to correlate the
    findings across worktrees and determine the promoted fix branch.

--- a/.claude/skills/codex-orchestration/SKILL.md
+++ b/.claude/skills/codex-orchestration/SKILL.md
@@ -61,10 +61,9 @@ Before starting a sprint:
    - `rust-best-practices-agent` in QA-1 only
    - `rust-service-hardening-agent` when service-runtime review is in scope
    - `flaky-test-qa` when test instability risk is present
-7. QA-2 and later rounds must omit `rust-best-practices-agent`. Any unresolved
-   QA-1 RBP findings that are not fixed in the first fix round carry to the
-   next phase backlog automatically and are not re-raised in later QA rounds on
-   the same sprint branch.
+7. QA-2 and later rounds must omit `rust-best-practices-agent`. All RBP
+   findings from QA-1 must be fixed before merge — merge gate is 0B+0I+0m
+   with no exceptions and no backlog deferral.
 8. If QA passes and CI is green, merge may proceed.
 9. If QA fails, `team-lead` first runs `/triaging-findings` to correlate the
    findings across worktrees and determine the promoted fix branch.


### PR DESCRIPTION
## Summary

- Removes unauthorized backlog deferral clause from codex-orchestration SKILL.md
- Merge gate is 0B+0I+0m, no exceptions, no backlog path for RBP findings
- QA-2+ still omits `rust-best-practices-agent` reviewer to avoid new findings, but all QA-1 RBP findings must be fixed before merge

## Test plan
- [ ] SKILL.md wording reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Out-of-band authorization**: This sprint (skill-fixes) is an authorized out-of-band tooling fix, not a sequenced Phase S implementation sprint. It corrects an unauthorized backlog-deferral clause introduced into .claude/skills/codex-orchestration/SKILL.md. Authority: team-lead, user-confirmed policy correction. Exempt from plan-phase-S.md sequencing per team-lead discretion.