### PR TITLE
Phase T planning docs — T.1–T.5 sprint contracts

### DIFF
--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -56,7 +56,7 @@ Before dispatching reviewers, expand `review_targets` to the full sprint diff:
 
 ```bash
 cd <worktree_path>
-git diff integrate/phase-R...HEAD --name-only
+git diff <integration_branch>...HEAD --name-only
 ```
 
 Use the complete output as `review_targets` for every reviewer, regardless of the

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -96,6 +96,10 @@ TODO-specific rule:
    - when rechecking prior findings, pass `triage_records`, `round_limit`,
      `changed_files`, and `carry_forward_findings_json` through the rendered
      reviewer templates instead of wrapper prose
+   - for `req-qa`, also pass any explicit sprint `deliverables`,
+     `acceptance_criteria`, and named `expected_artifacts` when the task
+     assignment provides them; req-qa is responsible for presence checks, not
+     just drift detection
 6. Launch all selected reviewers as background Task agents. Never run cargo,
    clippy, or broad QA analysis yourself in the foreground.
 7. Collect the reviewer results and classify them as:
@@ -132,6 +136,14 @@ For docs-only plan review:
 - use the Rust supplement to decide whether `rust-best-practices-agent` or
   `rust-service-hardening-agent` should be added
 - do not run `rust-qa-agent` for docs-only review
+
+Reviewer ownership note:
+- `req-qa` owns verification that sprint deliverables, acceptance criteria,
+  and named artifacts are actually present in the implementation or planning
+  docs
+- `arch-qa` owns structural and boundary compliance of the code that exists
+- a branch is not merge-ready if req-qa cannot trace planned deliverables to
+  concrete repository evidence
 
 ## Output Format
 

--- a/.claude/agents/req-qa.md
+++ b/.claude/agents/req-qa.md
@@ -1,7 +1,7 @@
 ---
 name: req-qa
-version: 0.1.0
-description: Validates implementation and documentation against atm-core requirements, architecture/design, and project plan with strict compliance reporting.
+version: 0.2.0
+description: Validates implementation and documentation against atm-core requirements, architecture/design, project plan, sprint deliverables, and acceptance criteria with strict compliance reporting.
 tools: Glob, Grep, LS, Read, BashOutput
 model: sonnet
 color: orange
@@ -9,9 +9,9 @@ color: orange
 
 You are the compliance QA agent for the `atm-core` repository.
 
-Your mission is to verify strict adherence to project requirements, design, and
-plan documentation, and to detect inconsistencies or conflicts across docs and
-implementation.
+Your mission is to verify strict adherence to project requirements, design,
+plan documentation, sprint deliverables, and acceptance criteria, and to
+detect inconsistencies or conflicts across docs and implementation.
 
 ## Mandatory Baseline Sources (Read First)
 
@@ -39,8 +39,27 @@ with free-form input.
     "docs/path/to/design-or-plan-doc-1.md",
     "docs/path/to/design-or-plan-doc-2.md"
   ],
+  "worktree_path": "/absolute/path/to/worktree",
+  "branch": "optional branch name",
+  "commit": "optional commit sha",
   "review_targets": [
     "optional file/dir paths to inspect for implementation compliance"
+  ],
+  "deliverables": [
+    "optional explicit deliverable statements from the assignment"
+  ],
+  "acceptance_criteria": [
+    "optional explicit acceptance criteria from the assignment"
+  ],
+  "expected_artifacts": [
+    "optional files, modules, tests, or docs that must exist when the sprint lands"
+  ],
+  "triage_records": [
+    "optional prior finding records to recheck"
+  ],
+  "round_limit": false,
+  "changed_files": [
+    "optional changed-file hint for limited recheck rounds"
   ],
   "notes": "optional context"
 }
@@ -51,6 +70,9 @@ Rules:
   paths.
 - `phase_sprint_documents` is a supported alias; if both are provided, merge
   and de-duplicate.
+- `deliverables`, `acceptance_criteria`, and `expected_artifacts` are optional
+  assignment overlays. When present, treat them as mandatory verification
+  items, not as hints.
 - Treat provided phase or sprint docs as in-scope constraints that must align
   with baseline sources.
 - If required inputs are missing or malformed, return `FAIL` with an
@@ -72,7 +94,17 @@ Rules:
    - Flag work assigned out of sequence, missing dependencies, or unverifiable
      acceptance criteria.
 
-4. Cross-Document Consistency
+4. Deliverable Presence And Traceability
+   - Verify that every named sprint deliverable is present in code, tests, or
+     docs, or explicitly absent with a Blocking finding.
+   - Verify that every named acceptance criterion is satisfiable from concrete
+     repository evidence rather than inference.
+   - Trace sprint-doc required code targets, required artifacts, and closeout
+     requirements to implementation locations.
+   - Treat "planned but not implemented" and "implemented differently than
+     documented" as first-class failures.
+
+5. Cross-Document Consistency
    - Detect conflicting statements between:
      - baseline docs
      - input phase or sprint docs
@@ -83,10 +115,43 @@ Rules:
 
 - Enforce strict adherence to requirements, design, and plan; do not downgrade
   clear violations.
+- Never treat a missing planned artifact as compliant just because adjacent
+  code passes tests or appears directionally similar.
 - Report all findings as corrective actions; do not truncate to a small top-N.
 - Use file paths and line references whenever possible.
 - Do not assume unstated requirements; tie findings to explicit documented
   text.
+
+## Deliverable Verification Method
+
+For every req-qa review, explicitly perform these checks:
+
+1. Build an in-memory checklist from:
+   - sprint or phase docs
+   - explicit `deliverables`
+   - explicit `acceptance_criteria`
+   - explicit `expected_artifacts`
+2. For each checklist item, classify it as:
+   - `present`
+   - `partially-present`
+   - `absent`
+   - `not-verifiable`
+3. For every `partially-present`, `absent`, or `not-verifiable` item, emit a
+   finding.
+4. When a sprint doc names specific files, modules, tests, commands, or
+   artifacts, verify those concrete things exist and are wired into the actual
+   implementation path where required.
+5. When a sprint doc promises a behavior change, verify the behavior path in
+   code rather than only the surrounding documentation.
+
+Presence-check examples that must be treated as req-qa work:
+- "single-writer lane exists" means the named writer modules are present and
+  the hot write path actually flows through them
+- "remove pre-write probe" means the old probe is absent from the hot path
+- "real Windows runtime parity tests" means runtime tests exist, not just
+  compile coverage
+- "required artifact list" means the named files exist and contain the claimed
+  role
 
 ## Zero Tolerance for Pre-Existing Issues
 
@@ -121,11 +186,22 @@ Return fenced JSON only.
   "phase_or_sprint_docs_read": [
     "docs/path/from-input.md"
   ],
+  "deliverable_checks": [
+    {
+      "item": "named deliverable or acceptance criterion",
+      "status": "present | partially-present | absent | not-verifiable",
+      "evidence_refs": [
+        "docs/phase-X/sprint-X.md:10",
+        "crates/example/src/lib.rs:42"
+      ],
+      "notes": "short justification"
+    }
+  ],
   "findings": [
     {
       "id": "ATM-QA-001",
       "severity": "Blocking | Important | Minor",
-      "category": "requirements | design | plan | cross-doc-conflict | implementation-drift",
+      "category": "requirements | design | plan | deliverable-missing | acceptance-gap | cross-doc-conflict | implementation-drift",
       "source_refs": [
         "docs/requirements.md:123",
         "docs/project-plan.md:45"
@@ -151,5 +227,7 @@ Gate policy:
 - `FAIL` if any Blocking finding exists.
 - `FAIL` if required inputs are missing or invalid.
 - `FAIL` if baseline docs cannot be read.
+- `FAIL` if any named deliverable, required artifact, or acceptance criterion
+  is absent or not verifiable.
 - `PASS` only when no Blocking findings exist and no unresolved cross-document
   conflicts remain.

--- a/.claude/agents/scrum-master.md
+++ b/.claude/agents/scrum-master.md
@@ -193,10 +193,16 @@ Use JSON input containing:
 1. `scope.phase` and or `scope.sprint`
 2. `phase_or_sprint_docs` or `phase_sprint_documents`
 3. optional `review_targets`
-4. strict compliance against:
+4. optional `worktree_path`, `branch`, `commit`
+5. optional explicit `deliverables`, `acceptance_criteria`, and `expected_artifacts`
+6. strict compliance against:
    - `docs/requirements.md`
    - `docs/architecture.md`
    - `docs/project-plan.md`
+
+Use those explicit sprint fields whenever the assignment already names them.
+`req-qa` is responsible for proving that planned deliverables and acceptance
+criteria are present, not only for finding contradictions in code that exists.
 
 ## Worktree Discipline
 

--- a/.claude/skills/codex-orchestration/req-qa-assignment.json.j2
+++ b/.claude/skills/codex-orchestration/req-qa-assignment.json.j2
@@ -1,6 +1,6 @@
 ---
 name: req-qa-assignment
-version: 1.0.0
+version: 1.1.0
 description: Render a fenced-JSON assignment for req-qa.
 format: json
 required_variables:
@@ -8,7 +8,13 @@ required_variables:
 optional_variables:
   - phase
   - sprint
+  - worktree_path
+  - branch
+  - commit
   - review_targets
+  - deliverables
+  - acceptance_criteria
+  - expected_artifacts
   - round_limit
   - changed_files
   - carry_forward_findings_json
@@ -17,7 +23,13 @@ optional_variables:
 defaults:
   phase: ""
   sprint: ""
+  worktree_path: ""
+  branch: ""
+  commit: ""
   review_targets: []
+  deliverables: []
+  acceptance_criteria: []
+  expected_artifacts: []
   round_limit: false
   changed_files: []
   carry_forward_findings_json: "[]"
@@ -31,7 +43,13 @@ defaults:
   },
   "phase_or_sprint_docs": [{% for doc in reference_docs %}"{{ doc }}"{% if not loop.last %}, {% endif %}{% endfor %}],
   "phase_sprint_documents": [{% for doc in reference_docs %}"{{ doc }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "worktree_path": {% if worktree_path %}"{{ worktree_path }}"{% else %}null{% endif %},
+  "branch": {% if branch %}"{{ branch }}"{% else %}null{% endif %},
+  "commit": {% if commit %}"{{ commit }}"{% else %}null{% endif %},
   "review_targets": [{% for target in review_targets %}"{{ target }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "deliverables": [{% for item in deliverables %}"{{ item }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "acceptance_criteria": [{% for item in acceptance_criteria %}"{{ item }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+  "expected_artifacts": [{% for item in expected_artifacts %}"{{ item }}"{% if not loop.last %}, {% endif %}{% endfor %}],
   "round_limit": {% if round_limit %}true{% else %}false{% endif %},
   "changed_files": [{% for file in changed_files %}"{{ file }}"{% if not loop.last %}, {% endif %}{% endfor %}],
   "triage_records": [{% for record in triage_records %}"{{ record }}"{% if not loop.last %}, {% endif %}{% endfor %}],

--- a/.claude/skills/plan-hardening/SKILL.md
+++ b/.claude/skills/plan-hardening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-hardening
-version: 1.0.0
+version: 1.1.0
 description: >
   Team-lead delegates plan hardening to arch-ctm after the user has already
   discussed the plan details with arch-ctm.
@@ -34,7 +34,8 @@ The task must end with:
 - complete/consistent planning docs
 - a hardened sprint doc for every sprint still required to finish the phase
 - no unassigned in-scope implementation work
-- branch pushed, validation reported, and plan review requested
+- branch pushed, validation reported, team-lead critical review completed or
+  explicitly requested, and QA requested only after that review
 
 Any remaining in-scope work without sprint ownership is a `GAP`. If more
 sprints are needed, hardening must create them.
@@ -59,6 +60,16 @@ sprints are needed, hardening must create them.
    - every remaining work item is assigned to a sprint
    - missing sprint docs were created if needed
    - branch was pushed and validation reported
+5. Critically review the hardened plan before QA:
+   - read the updated phase plan and every new or changed sprint doc
+   - review sprint deliverables for concrete ownership and execution clarity
+   - review acceptance criteria for explicit, testable closeout gates
+   - push back on vague wording, missing deliverables, or unverifiable
+     acceptance criteria
+   - request another hardening pass from `arch-ctm` if the plan is still
+     ambiguous
+6. Only after the critical review passes, route the plan to `quality-mgr` for a
+   focused plan QA review.
 
 `source_of_truth` should point at the already-approved planning sources:
 - reviewed planning docs in the repo
@@ -71,6 +82,18 @@ If `questions_or_concerns` is present, `arch-ctm` should answer it in the ACK.
 The ACK should also include a brief outline of the plan/work that `arch-ctm`
 understands to be in scope. `team-lead` should wait for that ACK and outline
 before raising scope concerns or discussing adjustments with the user.
+
+After `arch-ctm` reports hardening complete, `team-lead` should do a second,
+critical review focused on whether:
+- sprint deliverables are concrete enough that a dev agent can prove presence
+- acceptance criteria are explicit enough that `req-qa` can verify them
+- any remaining residual work still lacks sprint ownership
+
+Do not treat the hardening pass itself as the final review. The handoff is:
+1. `team-lead` routes plan hardening to `arch-ctm`
+2. `arch-ctm` hardens the plan to zero findings
+3. `team-lead` critically reviews and pushes back if needed
+4. `quality-mgr` performs focused plan QA after that review
 
 Render:
 - `.claude/skills/plan-hardening/plan-hardening.xml.j2`
@@ -106,3 +129,5 @@ Suggested vars file shape:
 - do not rewrite the plan into a freeform summary
 - do not let the task stop while remaining work lacks sprint ownership
 - do not accept a phase plan that ends before the remaining work ends
+- do not send the hardened plan to QA before `team-lead` has critically
+  reviewed deliverables and acceptance criteria

--- a/.claude/skills/plan-hardening/plan-hardening.xml.j2
+++ b/.claude/skills/plan-hardening/plan-hardening.xml.j2
@@ -1,6 +1,6 @@
 ---
 name: plan-hardening-task
-version: 1.0.0
+version: 1.1.0
 description: team-lead assignment template for full phase-plan hardening before implementation.
 format: xml
 required_variables:
@@ -164,10 +164,11 @@ required_variables:
     <step id="a">ACK this message immediately. In the ACK, include a brief outline of the plan/work you understand to be in scope. If the task includes questions-or-concerns, address them explicitly in the same ACK before starting work. Team-lead should review that ACK and outline first, then discuss any scope concerns with the user after the ACK is received. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
     <step id="b">Immediately after ACK, begin executing the task in the same work session.</step>
     <step id="c">Before editing, update the worktree from the target branch and include prior fixes already merged to that target.</step>
-    <step id="d">As soon as the hardening changes are complete and the branch is pushable, commit and push immediately. Send branch name and commit hash right away so plan review can begin in parallel.</step>
+    <step id="d">As soon as the hardening changes are complete and the branch is pushable, commit and push immediately. Send branch name and commit hash right away so team-lead critical review can begin in parallel.</step>
     <step id="e">After the push report, run the required validation. Do not wait for PR creation before starting validation.</step>
     <step id="f">When validation completes, send a second report with PASS or FAIL, concrete failure details if any, and whether follow-up fixes are required.</step>
-    <step id="g">After the hardening loop converges, ensure all document updates are staged, committed, and pushed. Send the git commit hash to team-lead and request a quality-mgr critical plan review.</step>
-    <step id="h">After the validation report, read ATM again for follow-up work.</step>
+    <step id="g">After the hardening loop converges, ensure all document updates are staged, committed, and pushed. Send the git commit hash to team-lead and explicitly request a critical review of the hardened plan, with special focus on sprint deliverables and acceptance criteria. Team-lead should push back or request another hardening pass if those are still unclear.</step>
+    <step id="h">Only after team-lead critical review passes should team-lead route the hardened plan to quality-mgr for focused plan QA.</step>
+    <step id="i">After the validation report, read ATM again for follow-up work.</step>
   </workflow>
 </atm-task>

--- a/.triage/phase-S/findings/S8-QA2-001.ttl
+++ b/.triage/phase-S/findings/S8-QA2-001.ttl
@@ -12,7 +12,7 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-09T00:00:00Z"^^xsd:dateTime ;
   triage:highestOpenBranch "feature/pS-s8-jsonl-compat" ;
@@ -25,8 +25,8 @@
   triage:file "crates/atm-core/src/config/discovery.rs" ;
   triage:line 1 ;
   triage:snippet "No '// Issue #219' or '#219' reference present anywhere in discovery.rs, mod.rs, or types.rs" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
   triage:headSha "237c0ce" ;
   triage:branch "feature/pS-s8-jsonl-compat" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pS-s8-jsonl-compat/237c0ce> .

--- a/.triage/phase-S/findings/S8-QA2-002.ttl
+++ b/.triage/phase-S/findings/S8-QA2-002.ttl
@@ -12,7 +12,7 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-09T00:00:00Z"^^xsd:dateTime ;
   triage:highestOpenBranch "feature/pS-s8-jsonl-compat" ;
@@ -25,8 +25,8 @@
   triage:file "crates/atm-core/src/schema/inbox_message.rs" ;
   triage:line 464 ;
   triage:snippet "message.text.len() > export_cap — no test verifies text.len() == export_cap => full body exported (not stub)" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
   triage:headSha "237c0ce" ;
   triage:branch "feature/pS-s8-jsonl-compat" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pS-s8-jsonl-compat/237c0ce> .

--- a/.triage/phase-S/findings/S8-QA2-003.ttl
+++ b/.triage/phase-S/findings/S8-QA2-003.ttl
@@ -12,7 +12,7 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-09T00:00:00Z"^^xsd:dateTime ;
   triage:highestOpenBranch "feature/pS-s8-jsonl-compat" ;
@@ -25,8 +25,8 @@
   triage:file "crates/atm-core/src/config/types.rs" ;
   triage:line 11 ;
   triage:snippet "MAX_CLAUDE_JSONL_BODY_EXPORT_MAX_BYTES = 1_048_576 — upper cap not documented in ADR-010 or sprint-S8.md acceptance criteria" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
   triage:headSha "237c0ce" ;
   triage:branch "feature/pS-s8-jsonl-compat" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pS-s8-jsonl-compat/237c0ce> .

--- a/.triage/phase-S/findings/S8-QA2-004.ttl
+++ b/.triage/phase-S/findings/S8-QA2-004.ttl
@@ -12,7 +12,7 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-09T00:00:00Z"^^xsd:dateTime ;
   triage:highestOpenBranch "feature/pS-s8-jsonl-compat" ;
@@ -25,8 +25,8 @@
   triage:file "crates/atm-core/src/schema/inbox_message.rs" ;
   triage:line 907 ;
   triage:snippet "shared_inbox_write_stubs_oversized_atm_authored_messages covers oversized path; within-cap ATM-authored full-body path has no test" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
   triage:headSha "237c0ce" ;
   triage:branch "feature/pS-s8-jsonl-compat" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pS-s8-jsonl-compat/237c0ce> .

--- a/.triage/phase-S/findings/S8-QA2-005.ttl
+++ b/.triage/phase-S/findings/S8-QA2-005.ttl
@@ -12,7 +12,7 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-09T00:00:00Z"^^xsd:dateTime ;
   triage:highestOpenBranch "feature/pS-s8-jsonl-compat" ;
@@ -25,8 +25,8 @@
   triage:file "crates/atm-core/src/config/discovery.rs" ;
   triage:line 64 ;
   triage:snippet "has_home_tilde_prefix handles bare '~' but no test exercises command=[\"~\"] path in isolation" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
   triage:headSha "237c0ce" ;
   triage:branch "feature/pS-s8-jsonl-compat" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pS-s8-jsonl-compat/237c0ce> .

--- a/.triage/phase-S/findings/S8-QA2-006.ttl
+++ b/.triage/phase-S/findings/S8-QA2-006.ttl
@@ -12,7 +12,7 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-09T00:00:00Z"^^xsd:dateTime ;
   triage:highestOpenBranch "feature/pS-s8-jsonl-compat" ;
@@ -25,8 +25,8 @@
   triage:file "docs/adr/ADR-010-claude-jsonl-compatibility-envelope.md" ;
   triage:line 27 ;
   triage:snippet "'Phase S.5 therefore needs an explicit compatibility-envelope rule' — should read 'Phase S.8'" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
   triage:headSha "237c0ce" ;
   triage:branch "feature/pS-s8-jsonl-compat" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pS-s8-jsonl-compat/237c0ce> .

--- a/.triage/phase-S/findings/S8-QA2-007.ttl
+++ b/.triage/phase-S/findings/S8-QA2-007.ttl
@@ -12,7 +12,7 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-09T00:00:00Z"^^xsd:dateTime ;
   triage:highestOpenBranch "feature/pS-s8-jsonl-compat" ;
@@ -25,8 +25,8 @@
   triage:file "docs/phase-S/sprint-S8.md" ;
   triage:line 83 ;
   triage:snippet "§Required Code Targets lists boundary_adapters.rs but not reconcile_runtime.rs — plan out of sync with actual change surface" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
   triage:headSha "237c0ce" ;
   triage:branch "feature/pS-s8-jsonl-compat" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pS-s8-jsonl-compat/237c0ce> .

--- a/.triage/phase-S/findings/S8-QA2-008.ttl
+++ b/.triage/phase-S/findings/S8-QA2-008.ttl
@@ -12,7 +12,7 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-09T00:00:00Z"^^xsd:dateTime ;
   triage:highestOpenBranch "feature/pS-s8-jsonl-compat" ;
@@ -25,8 +25,8 @@
   triage:file "crates/atm-daemon/src/boundary_adapters.rs" ;
   triage:line 264 ;
   triage:snippet "inbox_projection_stub_reexport_preserves_logical_identity uses cap=0 (stub only); full-body re-export idempotency path has no test" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "closed" ;
+  triage:closed true ;
   triage:headSha "237c0ce" ;
   triage:branch "feature/pS-s8-jsonl-compat" ;
   triage:occursIn <urn:atm:triage:worktree/feature-pS-s8-jsonl-compat/237c0ce> .

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.1.2
+PackageVersion: 1.2.0
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.1.2/atm_1.1.2_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.2.0/atm_1.2.0_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
 ManifestVersion: 1.1.2

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -24,4 +24,4 @@ Installers:
     InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.2.0/atm_1.2.0_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.1.2
+ManifestVersion: 1.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2" }
-atm-rusqlite = { path = "../atm-rusqlite", version = "1.1.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0" }
+atm-rusqlite = { path = "../atm-rusqlite", version = "1.2.0" }
 chrono = { version = "0.4", features = ["serde"] }
 fs2 = "0.4"
 interprocess = "2.4.2"
@@ -27,7 +27,7 @@ signal-hook = "0.3"
 signal-hook = "0.3"
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0", features = ["test-utils"] }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"

--- a/crates/atm-rusqlite/Cargo.toml
+++ b/crates/atm-rusqlite/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 name = "atm_rusqlite"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0" }
 serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -19,7 +19,7 @@ name = "atm"
 path = "src/main.rs"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -33,7 +33,7 @@ tracing-subscriber.workspace = true
 fs2 = "0.4"
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.1.2", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0", features = ["test-utils"] }
 sc-observability = { version = "1.0.0", features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,6 +39,7 @@ moved into:
 - [`docs/atm/architecture.md`](./atm/architecture.md)
 - [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
 - [`docs/atm-daemon/architecture.md`](./atm-daemon/architecture.md)
+- [`docs/atm-graft/architecture.md`](./atm-graft/architecture.md)
 - [`docs/atm-rusqlite/architecture.md`](./atm-rusqlite/architecture.md)
 
 Phase-Q supersession note:
@@ -82,7 +83,7 @@ Phase-S portability note:
 
 ## 2. Crate Boundaries
 
-The post-Q product runtime is implemented by four crates:
+The post-Q product runtime is implemented by five crates:
 
 - `atm-core`
 - `atm`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,9 @@ The daemon/runtime expansion adds:
 - `atm-daemon`: daemon runtime binary / transport host
 - `atm-rusqlite`: first concrete SQLite store implementation
 
+The Phase T embedded-client expansion adds:
+- `atm-graft`: thin embedded ATM client for Rust host agents
+
 The CLI stays thin. Product logic moves into `atm-core`.
 
 The retained command surface is:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,7 @@ The post-Q product runtime is implemented by four crates:
 - `atm-core`
 - `atm`
 - `atm-daemon`
+- `atm-graft`
 - `atm-rusqlite`
 
 Product-level boundary rules:
@@ -96,17 +97,23 @@ Product-level boundary rules:
 - `atm` owns CLI parsing, dispatch, rendering, and bootstrap.
 - `atm-daemon` owns runtime composition, transport adapters, singleton
   enforcement, and live-status runtime state.
+- `atm-graft` owns embedded Rust host-agent daemon-client runtime behavior,
+  including registration, automatic nudge delivery, and host context-injection
+  bridging.
 - `atm-rusqlite` owns the first concrete SQLite implementation of the durable
   store boundaries.
 - `atm-core` must not own clap or terminal-formatting concerns.
 - `atm` must not own mailbox, workflow, log-query, or doctor business logic.
 - `atm-daemon` must not become a second business-logic crate.
+- `atm-graft` must not own daemon business logic or direct store / inbox I/O.
 - `atm-rusqlite` must not absorb workflow or command logic; it implements store
   contracts only.
 - crate-local boundary records in `docs/<crate>/boundaries.md` are the
   machine-readable contract used to drive architectural linting and review
 - thin-client workflow surfaces should be modeled around `send` and `receive`
   rather than a broad command inventory
+- Phase T adds `atm-graft` as the production thin-client line on top of the
+  existing daemon/IPC baseline rather than as a separate runtime architecture
 - `ack` may remain a retained CLI/user workflow, but thin-client protocol
   surfaces should carry it through send-shaped request data rather than a
   separate top-level method family
@@ -148,6 +155,8 @@ Crate-local boundary detail is owned by:
 - [`docs/atm/boundaries.md`](./atm/boundaries.md)
 - [`docs/atm-daemon/architecture.md`](./atm-daemon/architecture.md)
 - [`docs/atm-daemon/boundaries.md`](./atm-daemon/boundaries.md)
+- [`docs/atm-graft/architecture.md`](./atm-graft/architecture.md)
+- [`docs/atm-graft/boundaries.md`](./atm-graft/boundaries.md)
 - [`docs/atm-rusqlite/architecture.md`](./atm-rusqlite/architecture.md)
 - [`docs/atm-rusqlite/boundaries.md`](./atm-rusqlite/boundaries.md)
 

--- a/docs/atm-graft/architecture.md
+++ b/docs/atm-graft/architecture.md
@@ -14,6 +14,8 @@ pre-daemon workspace.
 ## 2. Architectural Rules
 
 - `atm-graft` is the embedded crate linked into a Rust host-agent executable.
+- the intended production host is a custom agent CLI with `atm-graft` linked
+  in-process so ATM nudges can be injected without terminal automation layers.
 - `atm-graft` depends on `atm-core` semantic types, request/result contracts,
   config semantics, and error vocabulary.
 - `atm-graft` must not depend on `atm-daemon` as a Rust crate; it talks to the
@@ -27,13 +29,15 @@ pre-daemon workspace.
   execution/spawn integration; optional adapters such as `tokio` may be
   provided as additive conveniences.
 - `atm-graft` must not own host-specific tool-loop surgery. It exposes a host
-  injection fetch/bridge; the embedding executable decides when to drain and
-  surface daemon-owned nudges.
+  injection bridge, but embedded mode must still perform automatic
+  between-tool-call nudge delivery rather than relying on manual polling.
+- external terminal automation such as `tmux send-keys` is explicitly out of
+  scope as a production graft-delivery mechanism
 
 ## 2.1 Implementation Target Snapshot
 
 The current planning target for this design is:
-- `integrate/phase-T @ 1232244`
+- `integrate/phase-T @ 75d341b`
 
 Current Phase T realities that this architecture must target:
 - the daemon/runtime baseline already exists and is no longer speculative
@@ -83,7 +87,9 @@ Required follow-on ownership in `atm-core`:
   - graft registration / unregistration
   - nudge drain / fetch
 - typed same-host client traits for request execution and session-facing
-  control, with an explicit sealed/open decision
+  control, with an explicit sealed/open decision:
+  - `AtmGraftClient`
+  - `GraftSessionPort`
 - typed daemon-originated event payloads needed by `atm-graft`, at minimum:
   - `NudgeEvent`
   - registration rejection / shutdown notices if surfaced to the client
@@ -126,9 +132,10 @@ The active runtime object is `GraftSession`.
 Responsibilities:
 - connect to the same-host daemon API
 - register the current host-agent identity and process context
-- receive daemon-originated nudge events or drain queued nudges through the
-  daemon-owned interface
-- expose fetched daemon-owned nudges to the embedding host executable
+- run one live receive task/thread for daemon-originated nudge events while the
+  session is active
+- expose daemon-originated nudges to the embedding host executable
+- drive automatic between-tool-call injection through the host bridge
 - shut down cleanly and unregister when appropriate
 
 Architectural rules:
@@ -137,6 +144,10 @@ Architectural rules:
   executable's business logic
 - session lifecycle failures remain typed and observable; they must not collapse
   into silent disabled behavior after activation succeeded
+- embedded mode must keep exactly one active receive task/thread per active
+  session; omitting the receive loop defeats the purpose of `atm-graft`
+- the host supplies the execution model for that receive loop, but `atm-graft`
+  must require the loop to exist
 
 Queue-ownership rule:
 - bounded pending-nudge state belongs in the daemon
@@ -165,17 +176,19 @@ Architectural rules:
 - the host-facing payload is structured and contains at least:
   - `from`
   - `message`
-- fetched nudge drain order must preserve daemon queue order from the
-  perspective of the embedding agent loop
+- nudge receipt and injection must be automatic in embedded mode; manual
+  polling alone is insufficient for `atm-graft`
+- delivered nudge order must preserve daemon queue order from the perspective
+  of the embedding agent loop
 - nudges are advisory delivery signals, not durable mail truth; authoritative
   message state remains behind daemon-backed `read` calls
 
-Alternate integration rule:
-- the same pending nudge state must also be accessible through a daemon poll /
-  drain request so hook-driven hosts can fetch insertion text without embedding
-  `atm-graft`
-- this hook-driven path belongs to the `atm` CLI surface, not to a separate
-  `atm-graft` executable
+Non-production companion rule:
+- the same pending nudge state may also be exposed through a daemon poll /
+  drain request on the `atm` CLI surface for debugging, migration, or
+  non-embedded environments
+- that CLI path is not a substitute for embedded-mode automatic injection and
+  must not be treated as production-complete `atm-graft` behavior
 
 ## 2.7 Client API Boundary
 
@@ -187,7 +200,7 @@ Required public capability groups:
   - `send`
   - `read`
   - `ack`
-- host-facing nudge fetch / drain access
+- host-facing automatic nudge injection integration
 
 Boundary rule:
 - a hook-facing command that prints insertion-ready nudge text is an `atm`
@@ -225,5 +238,9 @@ not true:
 - the daemon remains the sole owner of pending-nudge queue state
 - the hook/poll nudge path uses the same daemon API contract as the embedded
   session path
+- embedded mode includes one required receive task/thread and automatic
+  between-tool-call nudge injection
+- production graft delivery does not rely on `tmux send-keys` or equivalent
+  external terminal automation
 - the public `atm-graft` API remains limited to the documented thin embedded
   client surface rather than mirroring the full CLI

--- a/docs/atm-graft/architecture.md
+++ b/docs/atm-graft/architecture.md
@@ -88,6 +88,9 @@ Required follow-on ownership in `atm-core`:
   - `NudgeEvent`
   - registration rejection / shutdown notices if surfaced to the client
 - typed config models for `[atm.graft]`
+- protocol/interface documentation updates in
+  `docs/atm-daemon/protocol-icd.md` for every graft-facing request, response,
+  and daemon-originated event boundary added by T.6/T.7
 
 Rust boundary rules:
 - semantic request / response / event types must not remain raw
@@ -211,3 +214,16 @@ Architectural rules:
   dependency
 - registration, reconnect, queue-overflow, and daemon-unavailable paths must
   keep typed error identity with recovery guidance
+
+## 2.9 Boundary Verification Anchors
+
+`arch-qa` and `req-qa` should reject the graft line if any of the following are
+not true:
+
+- `atm-graft` has no Rust dependency on `atm-daemon`
+- `atm-graft` has no direct SQLite or inbox-JSONL access
+- the daemon remains the sole owner of pending-nudge queue state
+- the hook/poll nudge path uses the same daemon API contract as the embedded
+  session path
+- the public `atm-graft` API remains limited to the documented thin embedded
+  client surface rather than mirroring the full CLI

--- a/docs/atm-graft/architecture.md
+++ b/docs/atm-graft/architecture.md
@@ -1,0 +1,213 @@
+# ATM-Graft Crate Architecture
+
+## 1. Purpose
+
+This document defines the `atm-graft` crate architectural boundary.
+
+It complements the product architecture in
+[`../architecture.md`](../architecture.md) and owns only embedded Rust
+host-agent integration decisions.
+
+This crate is introduced by the Phase T follow-on line. It is not part of the
+pre-daemon workspace.
+
+## 2. Architectural Rules
+
+- `atm-graft` is the embedded crate linked into a Rust host-agent executable.
+- `atm-graft` depends on `atm-core` semantic types, request/result contracts,
+  config semantics, and error vocabulary.
+- `atm-graft` must not depend on `atm-daemon` as a Rust crate; it talks to the
+  daemon over the documented same-host protocol only.
+- `atm-graft` must not depend on `atm-rusqlite`; direct store access is outside
+  its boundary.
+- `atm-graft` owns graft-side observability behavior, but it must emit through
+  an injected ATM-owned boundary supplied by the embedding host rather than
+  requiring a direct public crate dependency.
+- `atm-graft` must remain runtime-neutral at its core. Host executables supply
+  execution/spawn integration; optional adapters such as `tokio` may be
+  provided as additive conveniences.
+- `atm-graft` must not own host-specific tool-loop surgery. It exposes a host
+  injection fetch/bridge; the embedding executable decides when to drain and
+  surface daemon-owned nudges.
+
+## 2.1 Implementation Target Snapshot
+
+The current planning target for this design is:
+- `integrate/phase-T @ 1232244`
+
+Current Phase T realities that this architecture must target:
+- the daemon/runtime baseline already exists and is no longer speculative
+- same-host client/server IPC is already a real product path, not a future
+  architectural placeholder
+- the remaining Phase T work should therefore treat `atm-graft` as a thin
+  embedded client extension rather than a second runtime system
+- the unresolved work is now mostly about:
+  - stabilizing the embeddable public client surface
+  - adding session registration and nudge drain behavior
+  - adding the minimal config and crate packaging around that surface
+
+Architectural consequence:
+- `atm-graft` planning must target additive follow-on work on top of the
+  current IPC/runtime baseline, not a replay of the older Phase Q protocol
+  extraction line
+
+## 2.2 Boundary Model
+
+The current runtime uses this split for embedded host-agent integration:
+
+- `atm-core` owns the semantic client protocol contract
+- `atm-daemon` owns request handling, registration/nudge runtime, and daemon
+  queue state
+- `atm-graft` owns the concrete same-host daemon client, graft-session
+  lifecycle, and host bridge
+
+Architectural rules:
+- first-party Rust host agents must not invent a parallel transport or
+  alternate daemon contract outside the `atm-core` client models consumed by
+  `atm-graft`
+- all structs, enums, and traits needed by `atm-graft` must live in
+  `atm-core`, even when the daemon is the concrete runtime peer
+- concrete socket/runtime code may remain outside `atm-core`, but it must bind
+  only to `atm-core` protocol and control-state models
+
+## 2.3 Required `atm-core` Surfaces
+
+The required `atm-core` ownership here is intentionally narrow.
+
+Required follow-on ownership in `atm-core`:
+- typed embeddable client request / response structs for the retained graft
+  operations:
+  - `send`
+  - `read`
+  - `ack`
+  - graft registration / unregistration
+  - nudge drain / fetch
+- typed same-host client traits for request execution and session-facing
+  control, with an explicit sealed/open decision
+- typed daemon-originated event payloads needed by `atm-graft`, at minimum:
+  - `NudgeEvent`
+  - registration rejection / shutdown notices if surfaced to the client
+- typed config models for `[atm.graft]`
+
+Rust boundary rules:
+- semantic request / response / event types must not remain raw
+  `serde_json::Value` payloads for the published `atm-graft` boundary
+- transport correlation ids and ATM mail ids must remain distinct semantic
+  types
+- new public client or session traits must make an explicit sealed/open
+  decision up front; default posture is sealed
+- stream-oriented traits intended for dynamic dispatch must remain object-safe
+
+## 2.4 Activation And Config Boundary
+
+`atm-graft` is active only inside an ATM-configured project.
+
+Architectural rules:
+- `.atm.toml` discovery gates whether graft mode is active at all
+- if `.atm.toml` is absent, `atm-graft` remains inert
+- runtime identity comes from `ATM_IDENTITY`; graft mode does not add a second
+  identity-resolution scheme
+- optional graft-specific config remains ATM-owned config semantics rather than
+  host-private settings
+- the initial graft config surface must stay small:
+  - `[atm.graft].enabled = true|false`
+
+Architectural consequence:
+- `atm-core` config loading must own the `[atm.graft]` model before
+  `atm-graft` activation logic can be implemented cleanly
+
+## 2.5 Graft Session
+
+The active runtime object is `GraftSession`.
+
+Responsibilities:
+- connect to the same-host daemon API
+- register the current host-agent identity and process context
+- receive daemon-originated nudge events or drain queued nudges through the
+  daemon-owned interface
+- expose fetched daemon-owned nudges to the embedding host executable
+- shut down cleanly and unregister when appropriate
+
+Architectural rules:
+- `GraftSession` registration is automatic by default when graft mode is active
+- disconnect / reconnect behavior belongs to `atm-graft`, not to the host
+  executable's business logic
+- session lifecycle failures remain typed and observable; they must not collapse
+  into silent disabled behavior after activation succeeded
+
+Queue-ownership rule:
+- bounded pending-nudge state belongs in the daemon
+- `atm-graft` may keep only transient fetched state needed to hand nudges to
+  the embedding host
+- any daemon-queue overflow/backpressure behavior must emit structured
+  observability and must not affect durable ATM mail truth
+
+State-model rule:
+- the runtime must keep the lifecycle explicit at least across:
+  - inactive
+  - connecting
+  - registered
+  - disconnected / retrying
+  - closed
+
+## 2.6 Nudge Delivery Model
+
+Nudges originate from the daemon, not from local shell hooks.
+
+Architectural rules:
+- the daemon emits one internal post-send runtime event after authoritative
+  message commit
+- daemon-owned notifier logic may transform that event into one or more nudge
+  payloads for registered graft sessions
+- the host-facing payload is structured and contains at least:
+  - `from`
+  - `message`
+- fetched nudge drain order must preserve daemon queue order from the
+  perspective of the embedding agent loop
+- nudges are advisory delivery signals, not durable mail truth; authoritative
+  message state remains behind daemon-backed `read` calls
+
+Alternate integration rule:
+- the same pending nudge state must also be accessible through a daemon poll /
+  drain request so hook-driven hosts can fetch insertion text without embedding
+  `atm-graft`
+- this hook-driven path belongs to the `atm` CLI surface, not to a separate
+  `atm-graft` executable
+
+## 2.7 Client API Boundary
+
+`atm-graft` should expose a deliberately small public surface.
+
+Required public capability groups:
+- graft-session lifecycle
+- same-host daemon client calls for:
+  - `send`
+  - `read`
+  - `ack`
+- host-facing nudge fetch / drain access
+
+Boundary rule:
+- a hook-facing command that prints insertion-ready nudge text is an `atm`
+  command built on the same daemon API, not a CLI owned by the `atm-graft`
+  crate itself
+
+Architectural rules:
+- `read` uses the daemon API rather than direct SQLite access
+- `send` and `ack` use the same daemon-backed semantic contract as `atm`
+- any optional runtime heartbeat or activity reporting must also use the daemon
+  API instead of side channels
+
+## 2.8 Observability Boundary
+
+`atm-graft` owns its own runtime/client observability.
+
+Architectural rules:
+- graft-side events emit through the embedding host's injected observability
+  boundary
+- graft-side events remain separate from daemon-owned runtime and transport
+  events
+- the embedding host provides the concrete observability adapter; `atm-graft`
+  consumes an injected ATM-owned trait surface rather than a direct public
+  dependency
+- registration, reconnect, queue-overflow, and daemon-unavailable paths must
+  keep typed error identity with recovery guidance

--- a/docs/atm-graft/boundaries.md
+++ b/docs/atm-graft/boundaries.md
@@ -1,0 +1,33 @@
+# ATM-Graft Boundary Inventory
+
+This document is the crate-local boundary inventory for `atm-graft`.
+
+`atm-graft` consumes public protocol/session boundaries owned by `atm-core`
+and must remain a thin embedded client crate rather than a second runtime or
+business-logic layer.
+
+## AtmGraftClient Consumer
+
+Purpose:
+- consume the public unary daemon-client boundary owned by `atm-core`
+- provide concrete embedded same-host client behavior for `send`, `read`, and
+  `ack`
+
+Rules:
+- `atm-graft` must not take a Rust dependency on `atm-daemon`
+- `atm-graft` must not re-mint a parallel public client trait duplicating
+  `atm_core::AtmGraftClient`
+
+## GraftSessionPort Consumer
+
+Purpose:
+- consume the public session boundary owned by `atm-core`
+- provide the concrete `GraftSession` implementation used by a custom host CLI
+
+Rules:
+- `atm-graft` must not define a parallel public session trait that duplicates
+  `atm_core::GraftSessionPort`
+- `atm-graft` must not own daemon queue state, direct SQLite access, or direct
+  inbox-JSONL access
+- automatic between-tool-call nudge injection belongs to this consumer layer,
+  but daemon-owned queue state remains outside it

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -78,6 +78,7 @@ The `atm-graft` crate docs must remain aligned with:
 - [`../atm-core/architecture.md`](../atm-core/architecture.md)
 - [`../atm-daemon/requirements.md`](../atm-daemon/requirements.md)
 - [`../atm-daemon/architecture.md`](../atm-daemon/architecture.md)
+- [`../atm-daemon/protocol-icd.md`](../atm-daemon/protocol-icd.md)
 
 ## 5. Phase T Embedded-Graft Rules
 
@@ -156,3 +157,23 @@ Scope-simplification rule for the first implementation pass:
   `GraftSession`, and host-facing nudge fetch/drain access
 - runtime heartbeat / activity reporting is explicitly deferred unless host
   integration proves it is needed in the same sprint
+
+## 5.2 Req-QA Verification Anchors
+
+`req-qa` should treat these as fail-closed presence checks:
+
+- `REQ-GRAFT-CONFIG-001`
+  - `[atm.graft].enabled` exists in ATM-owned config models and config loading
+  - `atm-graft` remains inert when `.atm.toml` is absent
+- `REQ-GRAFT-RUNTIME-001`
+  - a documented `GraftSession` lifecycle type exists
+  - registration and clean shutdown/unregistration are test-covered
+- `REQ-GRAFT-CLIENT-001`
+  - the public embedded client surface supports `send`, `read`, and `ack`
+  - `atm-graft` does not take a Rust dependency on `atm-daemon`
+- `REQ-GRAFT-NOTIFY-001`
+  - daemon-owned drain/fetch surfaces exist for nudges
+  - the host-facing nudge payload exposes at least `from` and `message`
+- `REQ-GRAFT-OBS-001`
+  - graft activation/connectivity/registration/nudge paths emit through an
+    injected ATM-owned observability boundary

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -1,0 +1,158 @@
+# ATM-Graft Crate Requirements
+
+## 1. Purpose
+
+This document defines the `atm-graft` crate requirements.
+
+The `atm-graft` crate owns the embedded Rust host-agent integration surface for
+the post-Phase-S daemon/runtime line. Product behavior remains defined in
+[`../requirements.md`](../requirements.md). `atm-graft` must satisfy those
+product requirements without re-owning `atm-core` service semantics,
+`atm-daemon` runtime behavior, or `atm-rusqlite` durability.
+
+## 2. Ownership
+
+`atm-graft` owns:
+
+- same-host daemon-client integration for linked Rust host-agent executables
+- graft-session registration and lifecycle
+- automatic daemon-originated nudge subscription when graft mode is active
+- host-facing nudge fetch / injection bridge for between-tool-call insertion
+- graft-mode activation rules based on discovered `.atm.toml`
+- graft-side observability through an ATM-owned injected boundary supplied by
+  the embedding host
+
+`atm-graft` does not own:
+
+- daemon business logic
+- daemon-owned pending-nudge queue state
+- direct SQLite access
+- direct inbox JSONL parsing or writes
+- direct ownership of ATM semantic types that already belong to `atm-core`
+- forced interruption of a running tool call inside the host executable
+
+## 3. Requirement Namespace
+
+The `atm-graft` crate uses the `REQ-GRAFT-*` namespace.
+
+Initial allocation:
+
+- `REQ-GRAFT-CONFIG-*`
+- `REQ-GRAFT-RUNTIME-*`
+- `REQ-GRAFT-CLIENT-*`
+- `REQ-GRAFT-NOTIFY-*`
+- `REQ-GRAFT-OBS-*`
+
+Initial crate requirement IDs:
+
+- `REQ-GRAFT-CONFIG-001` `atm-graft` owns graft-mode activation and embedded
+  config-loading behavior. Satisfies:
+  `REQ-P-GRAFT-001`, `REQ-P-IDENTITY-001`.
+- `REQ-GRAFT-RUNTIME-001` `atm-graft` owns the runtime-neutral graft-session
+  lifecycle used by linked Rust host agents. Satisfies:
+  `REQ-P-GRAFT-001`, `REQ-P-TEST-001`.
+- `REQ-GRAFT-CLIENT-001` `atm-graft` owns the embedded same-host daemon client
+  surface for first-party Rust host agents. Satisfies:
+  `REQ-P-GRAFT-001`, `REQ-CORE-TRANSPORT-001`.
+- `REQ-GRAFT-NOTIFY-001` `atm-graft` owns the host-facing nudge fetch/drain
+  contract and structured payload rendering used for between-tool-call
+  injection. Satisfies:
+  `REQ-P-GRAFT-001`.
+- `REQ-GRAFT-OBS-001` `atm-graft` owns graft-side structured observability
+  emission for activation, connectivity, registration, and nudge-queue
+  behavior. Satisfies:
+  `REQ-P-OBS-001`, `REQ-P-GRAFT-001`.
+
+## 4. Required References
+
+The `atm-graft` crate docs must remain aligned with:
+
+- [`../requirements.md`](../requirements.md)
+- [`../architecture.md`](../architecture.md)
+- [`../plan-phase-T.md`](../plan-phase-T.md)
+- [`../plan-atm-graft.md`](../plan-atm-graft.md)
+- [`../project-plan.md`](../project-plan.md)
+- [`../documentation-guidelines.md`](../documentation-guidelines.md)
+- [`../atm-error-codes.md`](../atm-error-codes.md)
+- [`../atm-core/requirements.md`](../atm-core/requirements.md)
+- [`../atm-core/architecture.md`](../atm-core/architecture.md)
+- [`../atm-daemon/requirements.md`](../atm-daemon/requirements.md)
+- [`../atm-daemon/architecture.md`](../atm-daemon/architecture.md)
+
+## 5. Phase T Embedded-Graft Rules
+
+Requirement IDs:
+- `REQ-GRAFT-CONFIG-001`
+- `REQ-GRAFT-RUNTIME-001`
+- `REQ-GRAFT-CLIENT-001`
+- `REQ-GRAFT-NOTIFY-001`
+- `REQ-GRAFT-OBS-001`
+
+Required rules:
+- if no `.atm.toml` is discovered, `atm-graft` remains inactive and performs no
+  daemon registration or nudge work
+- if graft mode is active, runtime identity comes from `ATM_IDENTITY`; graft
+  mode must not invent a separate identity source
+- graft mode is enabled by default when active and may be disabled only by
+  explicit config or runtime opt-out
+- `atm-graft` must use the same-host daemon API for:
+  - `send`
+  - `read`
+  - `ack`
+  - graft-session registration / unregistration
+  - daemon-originated nudge receipt
+  - optional runtime heartbeat / activity reporting when the host enables it
+- `atm-graft` must not bypass the daemon by talking directly to SQLite or inbox
+  JSONL
+- pending nudge state must remain daemon-owned so embedded and CLI/hook-based
+  consumers observe one queue
+- the host-facing nudge payload is structured and must contain at least:
+  - `from`
+  - `message`
+- the host executable owns the final insertion point between tool calls;
+  `atm-graft` owns only the fetch / bridge surface that makes those nudges
+  available
+- `atm-graft` must expose a small library surface rather than mirroring the
+  full CLI:
+  - daemon client operations for `send`, `read`, and `ack`
+  - graft-session lifecycle entrypoints
+  - host-facing nudge fetch/drain access
+- any hook-facing command that renders insertion-ready nudge text belongs on
+  the `atm` CLI surface and must call the same daemon API used by `atm-graft`
+- `atm-graft` must emit structured observability for:
+  - active / inactive graft mode
+  - daemon connect / reconnect
+  - registration success / failure
+  - nudge received / fetched
+  - daemon-reported nudge drop / backpressure signals when surfaced through the
+    shared API
+  - the observability boundary must be injected by the host binary; `atm-graft`
+    must not require a direct public dependency on `sc-observability`
+
+## 5.1 Current Phase T Baseline
+
+The current daemon/runtime line already satisfies more of the embedded-client
+baseline than the earlier Phase Q planning assumed.
+
+Current planning baseline:
+- `integrate/phase-T @ 1232244`
+
+Baseline assumptions for `atm-graft` planning:
+- same-host daemon singleton/runtime ownership already exists
+- same-host request/response transport already exists
+- retained CLI operations already route through the daemon/runtime line for the
+  transport-backed paths
+- Windows runtime parity, SQLite writer-lane hardening, and remaining daemon
+  shutdown/state hardening still complete first as `T.2`-`T.5`
+
+Remaining prerequisites specific to `atm-graft`:
+- a small embeddable client surface owned by `atm-core`
+- graft-session registration and unregistration
+- daemon-owned bounded nudge drain access for embedded and hook/poll consumers
+- minimal `[atm.graft]` config support in ATM-owned config loading
+
+Scope-simplification rule for the first implementation pass:
+- `atm-graft` v1 should keep its public API to `send`, `read`, `ack`,
+  `GraftSession`, and host-facing nudge fetch/drain access
+- runtime heartbeat / activity reporting is explicitly deferred unless host
+  integration proves it is needed in the same sprint

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -17,7 +17,7 @@ product requirements without re-owning `atm-core` service semantics,
 - same-host daemon-client integration for linked Rust host-agent executables
 - graft-session registration and lifecycle
 - automatic daemon-originated nudge subscription when graft mode is active
-- host-facing nudge fetch / injection bridge for between-tool-call insertion
+- automatic between-tool-call nudge injection bridge for the embedding host
 - graft-mode activation rules based on discovered `.atm.toml`
 - graft-side observability through an ATM-owned injected boundary supplied by
   the embedding host
@@ -110,16 +110,24 @@ Required rules:
 - the host-facing nudge payload is structured and must contain at least:
   - `from`
   - `message`
-- the host executable owns the final insertion point between tool calls;
-  `atm-graft` owns only the fetch / bridge surface that makes those nudges
-  available
+- in embedded mode, `atm-graft` must automatically surface daemon-originated
+  nudges into the host's between-tool-call context flow; manual polling is not
+  sufficient for `atm-graft` acceptance
+- production `atm-graft` acceptance must not depend on `tmux send-keys`,
+  shell-hook polling, or any equivalent external terminal-injection mechanism
+- the intended production integration is a custom host CLI with `atm-graft`
+  linked in-process so context injection happens without terminal automation
+- the host executable owns the final insertion point between tool calls, but
+  `atm-graft` must drive that path automatically through its session/runtime
+  bridge rather than exposing only a passive fetch API
 - `atm-graft` must expose a small library surface rather than mirroring the
   full CLI:
   - daemon client operations for `send`, `read`, and `ack`
   - graft-session lifecycle entrypoints
-  - host-facing nudge fetch/drain access
+  - host-facing automatic nudge-delivery integration points
 - any hook-facing command that renders insertion-ready nudge text belongs on
-  the `atm` CLI surface and must call the same daemon API used by `atm-graft`
+  the `atm` CLI surface and must call the same daemon API used by `atm-graft`,
+  but it is not a production substitute for embedded-mode automatic injection
 - `atm-graft` must emit structured observability for:
   - active / inactive graft mode
   - daemon connect / reconnect
@@ -136,7 +144,7 @@ The current daemon/runtime line already satisfies more of the embedded-client
 baseline than the earlier Phase Q planning assumed.
 
 Current planning baseline:
-- `integrate/phase-T @ 1232244`
+- `integrate/phase-T @ 75d341b`
 
 Baseline assumptions for `atm-graft` planning:
 - same-host daemon singleton/runtime ownership already exists
@@ -149,12 +157,13 @@ Baseline assumptions for `atm-graft` planning:
 Remaining prerequisites specific to `atm-graft`:
 - a small embeddable client surface owned by `atm-core`
 - graft-session registration and unregistration
-- daemon-owned bounded nudge drain access for embedded and hook/poll consumers
+- one live receive loop for embedded sessions plus daemon-owned bounded nudge
+  queue/drain access
 - minimal `[atm.graft]` config support in ATM-owned config loading
 
 Scope-simplification rule for the first implementation pass:
 - `atm-graft` v1 should keep its public API to `send`, `read`, `ack`,
-  `GraftSession`, and host-facing nudge fetch/drain access
+  `GraftSession`, and automatic host-facing nudge injection integration
 - runtime heartbeat / activity reporting is explicitly deferred unless host
   integration proves it is needed in the same sprint
 
@@ -167,13 +176,18 @@ Scope-simplification rule for the first implementation pass:
   - `atm-graft` remains inert when `.atm.toml` is absent
 - `REQ-GRAFT-RUNTIME-001`
   - a documented `GraftSession` lifecycle type exists
+  - embedded mode includes one live receive task/thread per active
+    `GraftSession`
   - registration and clean shutdown/unregistration are test-covered
 - `REQ-GRAFT-CLIENT-001`
   - the public embedded client surface supports `send`, `read`, and `ack`
   - `atm-graft` does not take a Rust dependency on `atm-daemon`
 - `REQ-GRAFT-NOTIFY-001`
-  - daemon-owned drain/fetch surfaces exist for nudges
-  - the host-facing nudge payload exposes at least `from` and `message`
+- daemon-originated nudge receipt is automatic in embedded mode
+- daemon-owned drain/fetch surfaces exist for the session/runtime bridge
+- the host-facing nudge payload exposes at least `from` and `message`
+- no acceptance path relies on `tmux send-keys` or external terminal key
+  injection as the delivery mechanism
 - `REQ-GRAFT-OBS-001`
   - graft activation/connectivity/registration/nudge paths emit through an
     injected ATM-owned observability boundary

--- a/docs/phase-T/sprint-T1-integration-gate.md
+++ b/docs/phase-T/sprint-T1-integration-gate.md
@@ -10,6 +10,13 @@
 Close the remaining open `INTG-*` findings already triaged on
 `integrate/phase-S` so the Phase S merge gate is clean.
 
+PR-target rationale:
+- `develop` is intentional here
+- `T.1` changes land on `integrate/phase-S`, are validated in the Phase S gate
+  PR, and then flow forward through the `integrate/phase-S -> develop ->
+  integrate/phase-T` sequence rather than opening a direct `integrate/phase-T`
+  implementation path
+
 ## Deliverables
 
 - close the open architecture findings:

--- a/docs/phase-T/sprint-T1-integration-gate.md
+++ b/docs/phase-T/sprint-T1-integration-gate.md
@@ -1,384 +1,66 @@
-# Sprint T.1 — Phase-S Integration Gate Patch
+# Sprint T.1 Integration Gate Patch
 
-```yaml
-plan_type: sprint_plan
-phase: phase-T
-sprint: T.1
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S
-branch: integrate/phase-S
-status: planned
-estimated_scope: medium (16 findings: 2B+6I+8m — code + doc fixes, no new features)
-```
+**Branch**: `integrate/phase-S`
+**Base**: `integrate/phase-S @ bdac03c`
+**PR target**: `develop`
+**Status**: Planning
 
 ## Goal
 
-Fix all 16 open INTG-* findings on `integrate/phase-S` so that PR #231
-(`integrate/phase-S → develop`) can clear the quality-mgr gate and merge.
-After this sprint merges, `integrate/phase-T` fast-forwards to pick up the
-fixes as the baseline for T.2–T.5.
-
-## Scope Summary
-
-All fixes target `integrate/phase-S` at `bdac03c`. The findings break into four
-groups: two architectural naming violations (blocking), five runtime-shutdown
-hardening gaps (important), three error-handling gaps (important), one doc
-baseline drift (important), and five doc consistency minors plus one code
-comment minor and one duplicate-fire-and-forget minor. One platform-limitation
-doc addendum (ATM-QA-018) is included as a doc minor.
-
-## Governing Requirements
-
-- RULE-002: `pub(crate) fn emit_*` naming prohibited on library-crate concrete
-  structs that are not trait impls
-- REQ-P-RUNTIME-002: daemon shutdown must be bounded and orderly
-- REQ-P-RUNTIME-003: multi-guard enforcement required for write-path correctness
-- docs/architecture.md §daemon-runtime: shutdown deadline contract
-
-## Governing ADRs
-
-- ADR-002 (`docs/adr/ADR-002-host-wide-daemon-singleton.md`): owner-lock and
-  serving-ownership separation — no changes, but INTG-RBP-003/004 fixes must not
-  break acquisition/release sequencing
-- ADR-ATM-RUSQLITE-002: single-writer design (informational for T.2, not T.1)
-
-## Governing Boundaries
-
-- `atm-daemon` crate: `DaemonRequestDispatcher` is a concrete internal struct;
-  its methods must not carry `emit_*` names per RULE-002
-- `crates/atm-daemon/src/runtime_health.rs`: `SHUTDOWN_FINALIZER_THREADS` is a
-  `static Lazy<Mutex<...>>`; any lock acquisition in production code must
-  propagate poison rather than panic
-
-## Prerequisites
-
-- `integrate/phase-S` worktree exists at
-  `/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S`
-- HEAD is `bdac03c` (all Phase S sprints merged: S.13 PR #226, S.14 PR #230,
-  S.15 PR #228)
-- All 16 INTG-* triage records committed at `bdac03c` under
-  `.triage/phase-S/findings/`
-
-## Hard Dependencies
-
-None. All 16 fixes are independent of each other and can be landed in a single
-commit. INTG-ARCH-002 auto-resolves when INTG-ARCH-001 rename is applied.
-
-## Non-Goals
-
-- SQLite single-writer lane implementation (T.2 / INTG-ARCH-001 is a rename
-  only — the writer architecture is T.2 scope)
-- Immutable message-row semantics (T.3)
-- Windows runtime parity tests (T.4)
-- RuntimeStatusCache all-conflict overflow fix (T.5)
-- Shutdown deadline contract reconciliation — code vs architecture doc (T.5)
-- Any new feature work
-
-## Sub-Tasks
-
-Each sub-task must be concrete and reviewable.
-
-### ST-1: Rename `emit_runtime_event` → `record_lifecycle_event` [INTG-ARCH-001, INTG-ARCH-002] *(blocking)*
-
-**Development work**
-
-- `crates/atm-daemon/src/runtime_health.rs:452` — rename
-  `pub(crate) fn emit_runtime_event` to `pub(crate) fn record_lifecycle_event`
-  on `impl DaemonRequestDispatcher`
-- `crates/atm-daemon/src/composition.rs:220` and all other call sites (~8 total)
-  — update every `self.request_dispatcher.emit_runtime_event(...)` call to
-  `self.request_dispatcher.record_lifecycle_event(...)`
-- `crates/atm-daemon/src/daemon_runtime_observability.rs` — verify the trait
-  `DaemonRuntimeObservability::emit_runtime_event` is a **trait method** (not
-  affected by RULE-002) and leave its name unchanged; only the concrete
-  free-standing wrapper on `DaemonRequestDispatcher` is renamed
-- Search workspace for any other `emit_runtime_event` references and update
-
-**Required tests**
-
-- Existing tests in `tests.rs` that exercise the lifecycle event path must
-  compile and pass with the new name — no new tests required for a pure rename
-- `cargo clippy --workspace -- -D warnings` must pass on Windows-target path
-
-**Doc/boundary updates**
-
-- None — rename is internal `pub(crate)`, no public API surface change
-
----
-
-### ST-2: Bounded join in `NotificationRuntime::shutdown` [INTG-RSH-005] *(important)*
-
-**Development work**
-
-- `crates/atm-daemon/src/notification_runtime.rs:105`
-- Replace unbounded `handle.join()` with a 3-second bounded join mirroring the
-  pattern used by other runtimes in the codebase:
-  ```rust
-  // current
-  let _ = handle.join();
-  // target
-  if handle.join_timeout(Duration::from_secs(3)).is_err() {
-      tracing::warn!("notification runtime thread did not exit within deadline");
-  }
-  ```
-  (Use the actual bounded-join API available in the codebase — match the pattern
-  in `WatchRuntime` or `ReconcileRuntime`.)
-
-**Required tests**
-
-- Add one unit test: `notification_runtime_shutdown_returns_within_bounded_deadline`
-  — spawns the runtime with a no-op worker, calls `shutdown()`, asserts elapsed
-  time is ≤ 5 s (same pattern as the bounded-shutdown tests in `tests.rs`)
-
----
-
-### ST-3: Terminate flag before TCP connect in peer transport [INTG-RSH-006] *(important)*
-
-**Development work**
-
-- `crates/atm-daemon/src/peer_transport.rs:249`
-- Add a terminate-flag check immediately before `send_once()` is called, so
-  that a shutdown in-flight skips the TCP connect entirely:
-  ```rust
-  if self.terminate.load(Ordering::Relaxed) {
-      return Err(AtmError::daemon_unavailable("peer transport shutting down"));
-  }
-  // existing send_once() call follows
-  ```
-- Verify the terminate flag is also checked between retry attempts (existing
-  check during backoff must remain)
-- Verify this covers the RSH-NEW-002 concern: terminate-flag gap before TCP
-  connect in the same file. If RSH-NEW-002 describes an additional gap beyond
-  this check, escalate as a separate minor item in the QA report.
-
-**Required tests**
-
-- Add one unit test or extend an existing test: assert that a peer transport
-  send started after the terminate flag is set returns immediately with an error
-  (does not block for the connect timeout)
-
----
-
-### ST-4: Replace `.expect()` on static mutex in `run_bounded_shutdown_step` [INTG-RBP-003] *(important)*
-
-**Development work**
-
-- `crates/atm-daemon/src/runtime_health.rs:393` and `:396`
-- Replace `.expect("shutdown finalizer threads")` with a pattern that propagates
-  lock poison as an `AtmError` rather than panicking:
-  ```rust
-  let handles = SHUTDOWN_FINALIZER_THREADS
-      .lock()
-      .unwrap_or_else(|e| e.into_inner());
-  ```
-  (Recovering from poison is acceptable here — the alternative of returning an
-  error from `run_bounded_shutdown_step` would require a signature change that
-  is out of scope. Use `unwrap_or_else(PoisonError::into_inner)` to recover
-  without panic.)
-
-**Required tests**
-
-- No new test required — the RAII guard in ST-5 prevents the poisoned-mutex
-  scenario in practice; this fix is defensive production hardening
-
----
-
-### ST-5: RAII drain guard for `SHUTDOWN_FINALIZER_THREADS` in tests [INTG-FTQ-008] *(important)*
-
-**Development work**
-
-- `crates/atm-daemon/src/runtime_health.rs` test section (or `test_support.rs`)
-- Add a RAII guard type that drains `SHUTDOWN_FINALIZER_THREADS` on drop, and
-  use it in `bounded_shutdown_step_does_not_exceed_retained_finalizer_cap` and
-  any other inline test that pushes to the registry:
-  ```rust
-  struct FinalizerGuard;
-  impl Drop for FinalizerGuard {
-      fn drop(&mut self) {
-          SHUTDOWN_FINALIZER_THREADS.lock().unwrap_or_else(|e| e.into_inner()).clear();
-      }
-  }
-  ```
-
-**Required tests**
-
-- The existing `bounded_shutdown_step_does_not_exceed_retained_finalizer_cap`
-  test must use the guard and must not leak state across parallel test runs
-
----
-
-### ST-6: Propagate thread spawn failure in `schedule_delayed_listener_wake` [INTG-RBP-004, INTG-RSH-008] *(important + minor)*
-
-**Development work**
-
-- `crates/atm-daemon/src/local_ipc_transport.rs:718` (RBP-004) and `:708`
-  (RSH-008)
-- Replace `.expect()` on `thread::Builder::new().spawn()` at line 718 with
-  `.map_err(|e| AtmError::daemon_unavailable(...).with_source(e))?`
-- This resolves both INTG-RBP-004 (`.expect()`) and INTG-RSH-008
-  (fire-and-forget silently swallowed) since the same spawn path covers both
-
-**Required tests**
-
-- No new test required — propagation is the correct behavior and is validated
-  by the existing local IPC transport tests; a mock-spawn-failure test would
-  require unsafe and is out of scope
-
----
-
-### ST-7: Add rationale comment to `SHUTDOWN_FINALIZER_THREADS` static [INTG-RBP-005] *(minor)*
-
-**Development work**
-
-- `crates/atm-daemon/src/runtime_health.rs:44`
-- Extend the existing comment to explain **why** a static is required (the
-  finalizer threads must outlive any particular `DaemonRequestDispatcher`
-  instance and must be drainable from the shutdown path regardless of ownership)
-
-**Required tests**
-
-- None — comment-only change
-
----
-
-### ST-8: Add debug log on orphan path in `shutdown_lane_with_deadline` [INTG-RSH-007] *(minor)*
-
-**Development work**
-
-- `crates/atm-daemon/src/composition.rs:563`
-- Add `tracing::debug!("shutdown_lane_with_deadline: thread {:?} orphaned on timeout", thread_id)`
-  on the timeout/orphan path so operators can identify stuck threads in logs
-
-**Required tests**
-
-- None — observability-only change
-
----
-
-### ST-9: Doc fixes — project-plan.md S.15 baseline [INTG-ATM-QA-001] *(important)*
-
-**Development work**
-
+Close the remaining open `INTG-*` findings already triaged on
+`integrate/phase-S` so the Phase S merge gate is clean.
+
+## Deliverables
+
+- close the open architecture findings:
+  - `INTG-ARCH-001`
+  - `INTG-ARCH-002`
+- close the open documentation-sync findings:
+  - `INTG-ATM-QA-001`
+  - `INTG-ATM-QA-002`
+  - `INTG-ATM-QA-003`
+  - `INTG-ATM-QA-004`
+  - `INTG-ATM-QA-005`
+  - `INTG-ATM-QA-006`
+- close the remaining test/runtime follow-up findings:
+  - `INTG-FTQ-008`
+  - `INTG-RBP-003`
+  - `INTG-RBP-004`
+  - `INTG-RBP-005`
+  - `INTG-RSH-005`
+  - `INTG-RSH-006`
+  - `INTG-RSH-007`
+  - `INTG-RSH-008`
+
+## Key File Targets
+
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/notification_runtime.rs`
+- `crates/atm-daemon/src/peer_transport.rs`
 - `docs/project-plan.md`
-- Add one entry for Sprint S.15 in the Phase S sprint table/list so the
-  top-level plan matches `docs/plan-phase-S.md §5`
-
-**Required tests**
-
-- None — doc-only
-
----
-
-### ST-10: Doc fixes — five Phase S consistency minors [INTG-ATM-QA-002…006] *(minor)*
-
-**Development work**
-
-- `docs/plan-phase-S.md §5`: fix title drift — align entry for S.15 with
-  `sprint-S15-rusqlite-hardening.md` title (INTG-ATM-QA-002); add
-  `sprint-S15-rusqlite-hardening.md` to S.15 artifact list (INTG-ATM-QA-005)
-- `docs/phase-S/sprint-S14-runtime-plan.md:49`: fix filename reference from
-  `daemon_observability.rs` → `daemon_runtime_observability.rs` (INTG-ATM-QA-003)
-- `docs/phase-S/` metadata format: add one comment or frontmatter note in the
-  earliest S.10 sprint doc acknowledging the format change from YAML frontmatter
-  (S.0–S.9) to flat bold headers (S.10–S.15); do not reformat all docs
-  (INTG-ATM-QA-004)
-- `docs/phase-S/sprint-S15-rusqlite-hardening.md`: add `REQ-P-RUNTIME-003`
-  to the requirements reference list (INTG-ATM-QA-006)
-
-**Required tests**
-
-- None — doc-only
-
----
-
-### ST-11: Platform-limitation note for SIGBREAK/console-only [ATM-QA-018] *(minor)*
-
-**Development work**
-
-- `docs/architecture.md` Windows section
-- Add one sentence: "On Windows, SIGBREAK (Ctrl+Break / reload signal) is only
-  delivered to console-attached processes; daemon instances running as a Windows
-  service or in a detached process will not receive SIGBREAK and must be
-  lifecycle-managed through the local IPC control port."
-
-**Required tests**
-
-- None — doc-only
-
-## Split Recommendation
-
-No split. All 16 fixes + 1 ATM-QA-018 addendum are independent, bounded, and
-deliverable in a single commit on `integrate/phase-S`. Code changes span 6
-files; doc changes span 5 files. Combined diff is well within one reviewable
-PR.
+- `docs/plan-phase-S.md`
+- `docs/phase-S/sprint-S14-runtime-plan.md`
+- `docs/phase-S/sprint-S15-rusqlite-hardening.md`
 
 ## Acceptance Criteria
 
-- `cargo check --workspace` passes on the integrate/phase-S worktree
-- `cargo clippy --workspace -- -D warnings` passes (including Windows-target
-  path via CI)
-- `cargo test --workspace` passes — no regressions
-- `emit_runtime_event` does not appear in any `impl DaemonRequestDispatcher`
-  block (grep confirms)
-- `NotificationRuntime::shutdown` join is bounded (≤ 3 s deadline)
-- `schedule_delayed_listener_wake` spawn failure propagates as `AtmError`
-- `SHUTDOWN_FINALIZER_THREADS.lock().expect(` does not appear in production
-  code paths (only in test panic-recovery paths if any)
-- `SHUTDOWN_FINALIZER_THREADS` RAII drain guard used in all inline tests that
-  push to registry
-- All doc files updated: `docs/project-plan.md`, `docs/plan-phase-S.md`,
-  `docs/phase-S/sprint-S14-runtime-plan.md`,
-  `docs/phase-S/sprint-S15-rusqlite-hardening.md`, `docs/architecture.md`
-- QA-2 verdict: 0B+0I+0m
+- every open `INTG-*` id listed above is either closed or explicitly re-triaged
+  with a replacement record and rationale
+- no `INTG-*` finding remains open because of missing ownership ambiguity
+- doc-only findings are resolved on `integrate/phase-S`, not deferred into
+  `integrate/phase-T`
 
-## Required Validation
+## QA Pointers
 
-```bash
-# From integrate/phase-S worktree
-cargo check --workspace
-cargo clippy --workspace -- -D warnings
-cargo test --workspace
+- run a focused integration-gate recheck against the triage records rather than
+  a new sprint-wide discovery pass
+- require `req-qa` to verify doc-sync fixes against `docs/project-plan.md`,
+  `docs/plan-phase-S.md`, and the affected sprint docs
+- require `arch-qa` / hardening review for the runtime and spawn-failure fixes
 
-# Confirm ARCH-001 rename complete
-grep -r 'emit_runtime_event' crates/atm-daemon/src/ --include='*.rs' \
-  | grep -v 'trait\|fn emit_runtime_event' \
-  | grep 'impl DaemonRequestDispatcher'
-# Expected: no output
+## Notes
 
-# Confirm no bare .expect() on static mutex in production code
-grep -n 'SHUTDOWN_FINALIZER_THREADS.*expect' crates/atm-daemon/src/runtime_health.rs
-# Expected: no matches outside #[cfg(test)] blocks
-
-just check  # if available in worktree
-```
-
-## Required Document Updates
-
-- `docs/project-plan.md` — add S.15 sprint entry under Phase S
-- `docs/plan-phase-S.md` — fix S.15 title drift + add sprint-S15 to artifact list
-- `docs/phase-S/sprint-S14-runtime-plan.md` — fix daemon_observability.rs filename
-- `docs/phase-S/sprint-S15-rusqlite-hardening.md` — add REQ-P-RUNTIME-003
-- `docs/architecture.md` — add SIGBREAK/console-only platform note
-- `docs/phase-S/sprint-S10-daemon-retained-logger.md` (or earliest S.10 doc) —
-  add metadata-format-change acknowledgement
-
-## Risks And Watchouts
-
-- **INTG-RSH-006 terminate check**: must not short-circuit sends when the flag
-  is not set — only skip when `terminate.load(Ordering::Relaxed)` returns true.
-  Existing retry-backoff check must remain in place.
-- **INTG-RBP-003 poison recovery**: `unwrap_or_else(PoisonError::into_inner)`
-  recovers from poison; if the recovered guard contains stale state, drain it
-  rather than using it. Verify no subsequent logic assumes a clean registry
-  after recovery.
-- **RSH-NEW-002 overlap**: after INTG-RSH-006 is fixed, quality-mgr will
-  verify whether the terminate-flag check before TCP connect fully covers the
-  RSH-NEW-002 concern. If it does not (e.g., RSH-NEW-002 describes a separate
-  gap later in the send path), quality-mgr will escalate as a new minor finding
-  at QA-2.
-- **INTG-ARCH-001 rename scope**: only rename the free-standing method on
-  `DaemonRequestDispatcher`. Do NOT rename `DaemonRuntimeObservability::emit_runtime_event`
-  — that is a trait method and is not prohibited by RULE-002. Renaming the
-  trait method would be a breaking change and is out of scope.
-- **CI xwin path**: after the rename, run a mental diff of all
-  `composition.rs` call sites to ensure no Windows-only conditional paths were
-  missed. The CI xwin job will catch any missed references.
+This sprint is intentionally narrow. New architectural work belongs in
+`T.2`–`T.5`, not here.

--- a/docs/phase-T/sprint-T1-integration-gate.md
+++ b/docs/phase-T/sprint-T1-integration-gate.md
@@ -1,0 +1,384 @@
+# Sprint T.1 — Phase-S Integration Gate Patch
+
+```yaml
+plan_type: sprint_plan
+phase: phase-T
+sprint: T.1
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S
+branch: integrate/phase-S
+status: planned
+estimated_scope: medium (16 findings: 2B+6I+8m — code + doc fixes, no new features)
+```
+
+## Goal
+
+Fix all 16 open INTG-* findings on `integrate/phase-S` so that PR #231
+(`integrate/phase-S → develop`) can clear the quality-mgr gate and merge.
+After this sprint merges, `integrate/phase-T` fast-forwards to pick up the
+fixes as the baseline for T.2–T.5.
+
+## Scope Summary
+
+All fixes target `integrate/phase-S` at `bdac03c`. The findings break into four
+groups: two architectural naming violations (blocking), five runtime-shutdown
+hardening gaps (important), three error-handling gaps (important), one doc
+baseline drift (important), and five doc consistency minors plus one code
+comment minor and one duplicate-fire-and-forget minor. One platform-limitation
+doc addendum (ATM-QA-018) is included as a doc minor.
+
+## Governing Requirements
+
+- RULE-002: `pub(crate) fn emit_*` naming prohibited on library-crate concrete
+  structs that are not trait impls
+- REQ-P-RUNTIME-002: daemon shutdown must be bounded and orderly
+- REQ-P-RUNTIME-003: multi-guard enforcement required for write-path correctness
+- docs/architecture.md §daemon-runtime: shutdown deadline contract
+
+## Governing ADRs
+
+- ADR-002 (`docs/adr/ADR-002-host-wide-daemon-singleton.md`): owner-lock and
+  serving-ownership separation — no changes, but INTG-RBP-003/004 fixes must not
+  break acquisition/release sequencing
+- ADR-ATM-RUSQLITE-002: single-writer design (informational for T.2, not T.1)
+
+## Governing Boundaries
+
+- `atm-daemon` crate: `DaemonRequestDispatcher` is a concrete internal struct;
+  its methods must not carry `emit_*` names per RULE-002
+- `crates/atm-daemon/src/runtime_health.rs`: `SHUTDOWN_FINALIZER_THREADS` is a
+  `static Lazy<Mutex<...>>`; any lock acquisition in production code must
+  propagate poison rather than panic
+
+## Prerequisites
+
+- `integrate/phase-S` worktree exists at
+  `/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S`
+- HEAD is `bdac03c` (all Phase S sprints merged: S.13 PR #226, S.14 PR #230,
+  S.15 PR #228)
+- All 16 INTG-* triage records committed at `bdac03c` under
+  `.triage/phase-S/findings/`
+
+## Hard Dependencies
+
+None. All 16 fixes are independent of each other and can be landed in a single
+commit. INTG-ARCH-002 auto-resolves when INTG-ARCH-001 rename is applied.
+
+## Non-Goals
+
+- SQLite single-writer lane implementation (T.2 / INTG-ARCH-001 is a rename
+  only — the writer architecture is T.2 scope)
+- Immutable message-row semantics (T.3)
+- Windows runtime parity tests (T.4)
+- RuntimeStatusCache all-conflict overflow fix (T.5)
+- Shutdown deadline contract reconciliation — code vs architecture doc (T.5)
+- Any new feature work
+
+## Sub-Tasks
+
+Each sub-task must be concrete and reviewable.
+
+### ST-1: Rename `emit_runtime_event` → `record_lifecycle_event` [INTG-ARCH-001, INTG-ARCH-002] *(blocking)*
+
+**Development work**
+
+- `crates/atm-daemon/src/runtime_health.rs:452` — rename
+  `pub(crate) fn emit_runtime_event` to `pub(crate) fn record_lifecycle_event`
+  on `impl DaemonRequestDispatcher`
+- `crates/atm-daemon/src/composition.rs:220` and all other call sites (~8 total)
+  — update every `self.request_dispatcher.emit_runtime_event(...)` call to
+  `self.request_dispatcher.record_lifecycle_event(...)`
+- `crates/atm-daemon/src/daemon_runtime_observability.rs` — verify the trait
+  `DaemonRuntimeObservability::emit_runtime_event` is a **trait method** (not
+  affected by RULE-002) and leave its name unchanged; only the concrete
+  free-standing wrapper on `DaemonRequestDispatcher` is renamed
+- Search workspace for any other `emit_runtime_event` references and update
+
+**Required tests**
+
+- Existing tests in `tests.rs` that exercise the lifecycle event path must
+  compile and pass with the new name — no new tests required for a pure rename
+- `cargo clippy --workspace -- -D warnings` must pass on Windows-target path
+
+**Doc/boundary updates**
+
+- None — rename is internal `pub(crate)`, no public API surface change
+
+---
+
+### ST-2: Bounded join in `NotificationRuntime::shutdown` [INTG-RSH-005] *(important)*
+
+**Development work**
+
+- `crates/atm-daemon/src/notification_runtime.rs:105`
+- Replace unbounded `handle.join()` with a 3-second bounded join mirroring the
+  pattern used by other runtimes in the codebase:
+  ```rust
+  // current
+  let _ = handle.join();
+  // target
+  if handle.join_timeout(Duration::from_secs(3)).is_err() {
+      tracing::warn!("notification runtime thread did not exit within deadline");
+  }
+  ```
+  (Use the actual bounded-join API available in the codebase — match the pattern
+  in `WatchRuntime` or `ReconcileRuntime`.)
+
+**Required tests**
+
+- Add one unit test: `notification_runtime_shutdown_returns_within_bounded_deadline`
+  — spawns the runtime with a no-op worker, calls `shutdown()`, asserts elapsed
+  time is ≤ 5 s (same pattern as the bounded-shutdown tests in `tests.rs`)
+
+---
+
+### ST-3: Terminate flag before TCP connect in peer transport [INTG-RSH-006] *(important)*
+
+**Development work**
+
+- `crates/atm-daemon/src/peer_transport.rs:249`
+- Add a terminate-flag check immediately before `send_once()` is called, so
+  that a shutdown in-flight skips the TCP connect entirely:
+  ```rust
+  if self.terminate.load(Ordering::Relaxed) {
+      return Err(AtmError::daemon_unavailable("peer transport shutting down"));
+  }
+  // existing send_once() call follows
+  ```
+- Verify the terminate flag is also checked between retry attempts (existing
+  check during backoff must remain)
+- Verify this covers the RSH-NEW-002 concern: terminate-flag gap before TCP
+  connect in the same file. If RSH-NEW-002 describes an additional gap beyond
+  this check, escalate as a separate minor item in the QA report.
+
+**Required tests**
+
+- Add one unit test or extend an existing test: assert that a peer transport
+  send started after the terminate flag is set returns immediately with an error
+  (does not block for the connect timeout)
+
+---
+
+### ST-4: Replace `.expect()` on static mutex in `run_bounded_shutdown_step` [INTG-RBP-003] *(important)*
+
+**Development work**
+
+- `crates/atm-daemon/src/runtime_health.rs:393` and `:396`
+- Replace `.expect("shutdown finalizer threads")` with a pattern that propagates
+  lock poison as an `AtmError` rather than panicking:
+  ```rust
+  let handles = SHUTDOWN_FINALIZER_THREADS
+      .lock()
+      .unwrap_or_else(|e| e.into_inner());
+  ```
+  (Recovering from poison is acceptable here — the alternative of returning an
+  error from `run_bounded_shutdown_step` would require a signature change that
+  is out of scope. Use `unwrap_or_else(PoisonError::into_inner)` to recover
+  without panic.)
+
+**Required tests**
+
+- No new test required — the RAII guard in ST-5 prevents the poisoned-mutex
+  scenario in practice; this fix is defensive production hardening
+
+---
+
+### ST-5: RAII drain guard for `SHUTDOWN_FINALIZER_THREADS` in tests [INTG-FTQ-008] *(important)*
+
+**Development work**
+
+- `crates/atm-daemon/src/runtime_health.rs` test section (or `test_support.rs`)
+- Add a RAII guard type that drains `SHUTDOWN_FINALIZER_THREADS` on drop, and
+  use it in `bounded_shutdown_step_does_not_exceed_retained_finalizer_cap` and
+  any other inline test that pushes to the registry:
+  ```rust
+  struct FinalizerGuard;
+  impl Drop for FinalizerGuard {
+      fn drop(&mut self) {
+          SHUTDOWN_FINALIZER_THREADS.lock().unwrap_or_else(|e| e.into_inner()).clear();
+      }
+  }
+  ```
+
+**Required tests**
+
+- The existing `bounded_shutdown_step_does_not_exceed_retained_finalizer_cap`
+  test must use the guard and must not leak state across parallel test runs
+
+---
+
+### ST-6: Propagate thread spawn failure in `schedule_delayed_listener_wake` [INTG-RBP-004, INTG-RSH-008] *(important + minor)*
+
+**Development work**
+
+- `crates/atm-daemon/src/local_ipc_transport.rs:718` (RBP-004) and `:708`
+  (RSH-008)
+- Replace `.expect()` on `thread::Builder::new().spawn()` at line 718 with
+  `.map_err(|e| AtmError::daemon_unavailable(...).with_source(e))?`
+- This resolves both INTG-RBP-004 (`.expect()`) and INTG-RSH-008
+  (fire-and-forget silently swallowed) since the same spawn path covers both
+
+**Required tests**
+
+- No new test required — propagation is the correct behavior and is validated
+  by the existing local IPC transport tests; a mock-spawn-failure test would
+  require unsafe and is out of scope
+
+---
+
+### ST-7: Add rationale comment to `SHUTDOWN_FINALIZER_THREADS` static [INTG-RBP-005] *(minor)*
+
+**Development work**
+
+- `crates/atm-daemon/src/runtime_health.rs:44`
+- Extend the existing comment to explain **why** a static is required (the
+  finalizer threads must outlive any particular `DaemonRequestDispatcher`
+  instance and must be drainable from the shutdown path regardless of ownership)
+
+**Required tests**
+
+- None — comment-only change
+
+---
+
+### ST-8: Add debug log on orphan path in `shutdown_lane_with_deadline` [INTG-RSH-007] *(minor)*
+
+**Development work**
+
+- `crates/atm-daemon/src/composition.rs:563`
+- Add `tracing::debug!("shutdown_lane_with_deadline: thread {:?} orphaned on timeout", thread_id)`
+  on the timeout/orphan path so operators can identify stuck threads in logs
+
+**Required tests**
+
+- None — observability-only change
+
+---
+
+### ST-9: Doc fixes — project-plan.md S.15 baseline [INTG-ATM-QA-001] *(important)*
+
+**Development work**
+
+- `docs/project-plan.md`
+- Add one entry for Sprint S.15 in the Phase S sprint table/list so the
+  top-level plan matches `docs/plan-phase-S.md §5`
+
+**Required tests**
+
+- None — doc-only
+
+---
+
+### ST-10: Doc fixes — five Phase S consistency minors [INTG-ATM-QA-002…006] *(minor)*
+
+**Development work**
+
+- `docs/plan-phase-S.md §5`: fix title drift — align entry for S.15 with
+  `sprint-S15-rusqlite-hardening.md` title (INTG-ATM-QA-002); add
+  `sprint-S15-rusqlite-hardening.md` to S.15 artifact list (INTG-ATM-QA-005)
+- `docs/phase-S/sprint-S14-runtime-plan.md:49`: fix filename reference from
+  `daemon_observability.rs` → `daemon_runtime_observability.rs` (INTG-ATM-QA-003)
+- `docs/phase-S/` metadata format: add one comment or frontmatter note in the
+  earliest S.10 sprint doc acknowledging the format change from YAML frontmatter
+  (S.0–S.9) to flat bold headers (S.10–S.15); do not reformat all docs
+  (INTG-ATM-QA-004)
+- `docs/phase-S/sprint-S15-rusqlite-hardening.md`: add `REQ-P-RUNTIME-003`
+  to the requirements reference list (INTG-ATM-QA-006)
+
+**Required tests**
+
+- None — doc-only
+
+---
+
+### ST-11: Platform-limitation note for SIGBREAK/console-only [ATM-QA-018] *(minor)*
+
+**Development work**
+
+- `docs/architecture.md` Windows section
+- Add one sentence: "On Windows, SIGBREAK (Ctrl+Break / reload signal) is only
+  delivered to console-attached processes; daemon instances running as a Windows
+  service or in a detached process will not receive SIGBREAK and must be
+  lifecycle-managed through the local IPC control port."
+
+**Required tests**
+
+- None — doc-only
+
+## Split Recommendation
+
+No split. All 16 fixes + 1 ATM-QA-018 addendum are independent, bounded, and
+deliverable in a single commit on `integrate/phase-S`. Code changes span 6
+files; doc changes span 5 files. Combined diff is well within one reviewable
+PR.
+
+## Acceptance Criteria
+
+- `cargo check --workspace` passes on the integrate/phase-S worktree
+- `cargo clippy --workspace -- -D warnings` passes (including Windows-target
+  path via CI)
+- `cargo test --workspace` passes — no regressions
+- `emit_runtime_event` does not appear in any `impl DaemonRequestDispatcher`
+  block (grep confirms)
+- `NotificationRuntime::shutdown` join is bounded (≤ 3 s deadline)
+- `schedule_delayed_listener_wake` spawn failure propagates as `AtmError`
+- `SHUTDOWN_FINALIZER_THREADS.lock().expect(` does not appear in production
+  code paths (only in test panic-recovery paths if any)
+- `SHUTDOWN_FINALIZER_THREADS` RAII drain guard used in all inline tests that
+  push to registry
+- All doc files updated: `docs/project-plan.md`, `docs/plan-phase-S.md`,
+  `docs/phase-S/sprint-S14-runtime-plan.md`,
+  `docs/phase-S/sprint-S15-rusqlite-hardening.md`, `docs/architecture.md`
+- QA-2 verdict: 0B+0I+0m
+
+## Required Validation
+
+```bash
+# From integrate/phase-S worktree
+cargo check --workspace
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+
+# Confirm ARCH-001 rename complete
+grep -r 'emit_runtime_event' crates/atm-daemon/src/ --include='*.rs' \
+  | grep -v 'trait\|fn emit_runtime_event' \
+  | grep 'impl DaemonRequestDispatcher'
+# Expected: no output
+
+# Confirm no bare .expect() on static mutex in production code
+grep -n 'SHUTDOWN_FINALIZER_THREADS.*expect' crates/atm-daemon/src/runtime_health.rs
+# Expected: no matches outside #[cfg(test)] blocks
+
+just check  # if available in worktree
+```
+
+## Required Document Updates
+
+- `docs/project-plan.md` — add S.15 sprint entry under Phase S
+- `docs/plan-phase-S.md` — fix S.15 title drift + add sprint-S15 to artifact list
+- `docs/phase-S/sprint-S14-runtime-plan.md` — fix daemon_observability.rs filename
+- `docs/phase-S/sprint-S15-rusqlite-hardening.md` — add REQ-P-RUNTIME-003
+- `docs/architecture.md` — add SIGBREAK/console-only platform note
+- `docs/phase-S/sprint-S10-daemon-retained-logger.md` (or earliest S.10 doc) —
+  add metadata-format-change acknowledgement
+
+## Risks And Watchouts
+
+- **INTG-RSH-006 terminate check**: must not short-circuit sends when the flag
+  is not set — only skip when `terminate.load(Ordering::Relaxed)` returns true.
+  Existing retry-backoff check must remain in place.
+- **INTG-RBP-003 poison recovery**: `unwrap_or_else(PoisonError::into_inner)`
+  recovers from poison; if the recovered guard contains stale state, drain it
+  rather than using it. Verify no subsequent logic assumes a clean registry
+  after recovery.
+- **RSH-NEW-002 overlap**: after INTG-RSH-006 is fixed, quality-mgr will
+  verify whether the terminate-flag check before TCP connect fully covers the
+  RSH-NEW-002 concern. If it does not (e.g., RSH-NEW-002 describes a separate
+  gap later in the send path), quality-mgr will escalate as a new minor finding
+  at QA-2.
+- **INTG-ARCH-001 rename scope**: only rename the free-standing method on
+  `DaemonRequestDispatcher`. Do NOT rename `DaemonRuntimeObservability::emit_runtime_event`
+  — that is a trait method and is not prohibited by RULE-002. Renaming the
+  trait method would be a breaking change and is out of scope.
+- **CI xwin path**: after the rename, run a mental diff of all
+  `composition.rs` call sites to ensure no Windows-only conditional paths were
+  missed. The CI xwin job will catch any missed references.

--- a/docs/phase-T/sprint-T1-integration-gate.md
+++ b/docs/phase-T/sprint-T1-integration-gate.md
@@ -1,7 +1,7 @@
 # Sprint T.1 Integration Gate Patch
 
-**Branch**: `integrate/phase-S`
-**Base**: `integrate/phase-S @ bdac03c`
+**Branch**: `integrate/phase-T`
+**Base**: `integrate/phase-T @ 1232244`
 **PR target**: `develop`
 **Status**: Planning
 

--- a/docs/phase-T/sprint-T2-sqlite-writer.md
+++ b/docs/phase-T/sprint-T2-sqlite-writer.md
@@ -11,6 +11,12 @@ Implement the real crate-private SQLite writer lane promised by
 `ADR-ATM-RUSQLITE-002` and the S.15 planning docs so the hot mailbox write path
 no longer depends on ad-hoc per-operation write transactions.
 
+## Preconditions
+
+- `ADR-ATM-RUSQLITE-002` must be accepted before implementation begins
+- this sprint owns the ADR update needed to move that ADR from `proposed` to
+  an accepted design decision with the final writer-lane contract recorded
+
 ## Deliverables
 
 - add a crate-private `SqliteWriter` implementation with:
@@ -23,6 +29,11 @@ no longer depends on ad-hoc per-operation write transactions.
   - `crates/atm-rusqlite/src/writer/mod.rs`
   - `crates/atm-rusqlite/src/writer/ops.rs`
   - `crates/atm-rusqlite/src/writer/stmt_cache.rs`
+- audit every surviving `SharedDb::with_transaction(...)` caller and classify it
+  explicitly as:
+  - read-only / not a migration target
+  - cold-path write allowed to stay on `with_transaction(...)`
+  - incorrectly left on the legacy path and therefore still in scope for T.2
 - migrate the hot-path write entry points through the writer-owned lane:
   - `MailStore::upsert_message`
   - `MailStore::upsert_visibility_state`
@@ -41,11 +52,14 @@ no longer depends on ad-hoc per-operation write transactions.
 - `docs/atm-rusqlite/architecture.md`
 - `docs/atm-rusqlite/requirements.md`
 - `docs/adr/ADR-ATM-RUSQLITE-002.md`
+- any doc or audit note that records the `SharedDb::with_transaction(...)`
+  caller classification
 
 ## Acceptance Criteria
 
 - the writer lane exists in code, not only in docs
 - the hot-path write calls actually flow through the writer lane
+- the `SharedDb::with_transaction(...)` caller audit is explicit and complete
 - the worker queue, batch drain, and shutdown path are bounded and test-covered
 - the crate does not widen the writer surface beyond `pub(crate)` ownership
 - async daemon callers do not block Tokio worker threads directly when
@@ -54,7 +68,8 @@ no longer depends on ad-hoc per-operation write transactions.
 ## QA Pointers
 
 - `req-qa` must verify the named writer modules exist and that the hot-path
-  methods route through them
+  methods route through them, and that the `with_transaction(...)` caller audit
+  is complete
 - `arch-qa` should verify the writer remains crate-private and does not loosen
   store boundaries
 - hardening review should focus on queue bounds, batch semantics, and shutdown

--- a/docs/phase-T/sprint-T2-sqlite-writer.md
+++ b/docs/phase-T/sprint-T2-sqlite-writer.md
@@ -1,0 +1,66 @@
+# Sprint T.2 SQLite Single-Writer Lane
+
+**Branch**: `integrate/phase-T`
+**Base**: `integrate/phase-T @ bdac03c`
+**PR target**: `develop`
+**Status**: Planning
+
+## Goal
+
+Implement the real crate-private SQLite writer lane promised by
+`ADR-ATM-RUSQLITE-002` and the S.15 planning docs so the hot mailbox write path
+no longer depends on ad-hoc per-operation write transactions.
+
+## Deliverables
+
+- add a crate-private `SqliteWriter` implementation with:
+  - one dedicated writer thread
+  - one long-lived write `Connection`
+  - one bounded submission queue
+  - one bounded batch-drain loop
+  - one explicit shutdown/drain path
+- add the writer module tree promised by the plan:
+  - `crates/atm-rusqlite/src/writer/mod.rs`
+  - `crates/atm-rusqlite/src/writer/ops.rs`
+  - `crates/atm-rusqlite/src/writer/stmt_cache.rs`
+- migrate the hot-path write entry points through the writer-owned lane:
+  - `MailStore::upsert_message`
+  - `MailStore::upsert_visibility_state`
+- preserve `SharedDb::with_transaction(...)` for remaining cold-path callers
+  during the incremental migration
+- define the bounded backpressure contract for blocking submitters and async
+  daemon call sites
+
+## Key File Targets
+
+- `crates/atm-rusqlite/src/shared_db.rs`
+- `crates/atm-rusqlite/src/lib.rs`
+- `crates/atm-rusqlite/src/writer/mod.rs`
+- `crates/atm-rusqlite/src/writer/ops.rs`
+- `crates/atm-rusqlite/src/writer/stmt_cache.rs`
+- `docs/atm-rusqlite/architecture.md`
+- `docs/atm-rusqlite/requirements.md`
+- `docs/adr/ADR-ATM-RUSQLITE-002.md`
+
+## Acceptance Criteria
+
+- the writer lane exists in code, not only in docs
+- the hot-path write calls actually flow through the writer lane
+- the worker queue, batch drain, and shutdown path are bounded and test-covered
+- the crate does not widen the writer surface beyond `pub(crate)` ownership
+- async daemon callers do not block Tokio worker threads directly when
+  submitting writes
+
+## QA Pointers
+
+- `req-qa` must verify the named writer modules exist and that the hot-path
+  methods route through them
+- `arch-qa` should verify the writer remains crate-private and does not loosen
+  store boundaries
+- hardening review should focus on queue bounds, batch semantics, and shutdown
+  behavior under load
+
+## Dependencies
+
+- may start independently of `T.4` and `T.5`
+- `T.3` depends on this sprint landing the writer-owned path first

--- a/docs/phase-T/sprint-T2-sqlite-writer.md
+++ b/docs/phase-T/sprint-T2-sqlite-writer.md
@@ -1,7 +1,7 @@
 # Sprint T.2 SQLite Single-Writer Lane
 
 **Branch**: `integrate/phase-T`
-**Base**: `integrate/phase-T @ bdac03c`
+**Base**: `integrate/phase-T @ 1232244`
 **PR target**: `develop`
 **Status**: Planning
 

--- a/docs/phase-T/sprint-T3-immutable-rows.md
+++ b/docs/phase-T/sprint-T3-immutable-rows.md
@@ -1,0 +1,58 @@
+# Sprint T.3 Immutable Message Rows
+
+**Branch**: `integrate/phase-T`
+**Base**: `integrate/phase-T @ bdac03c`
+**PR target**: `develop`
+**Status**: Planning
+
+## Goal
+
+Finish the mailbox hot-write contract by enforcing immutable `mail_messages`
+rows, removing the pre-write probe, and using writer-owned row-count semantics
+instead of conflict-driven row mutation.
+
+## Deliverables
+
+- remove the pre-write `SELECT 1 ...` probe from `MailStore::upsert_message`
+- stop using `ON CONFLICT DO UPDATE` to mutate message payload fields on
+  duplicate message keys
+- move message insertion semantics to insert-first / rows-changed detection
+- keep mutable live state in the appropriate state tables rather than in
+  `mail_messages`
+- reject known ATM-owned logical/schema violations before SQL submission so one
+  invalid queued row does not poison unrelated rows in the same batch
+- add regression tests for:
+  - duplicate message rows preserving the original payload
+  - one invalid row not failing unrelated rows in the same drained batch
+  - successor / logical invariant rejection before SQL execution
+
+## Key File Targets
+
+- `crates/atm-rusqlite/src/lib.rs`
+- `crates/atm-rusqlite/src/writer/ops.rs`
+- `crates/atm-rusqlite/src/tests.rs`
+- `docs/atm-rusqlite/architecture.md`
+- `docs/adr/ADR-ATM-RUSQLITE-002.md`
+
+## Acceptance Criteria
+
+- `mail_messages` rows are immutable after the initial insert
+- the hot write path no longer performs the pre-write probe
+- duplicate writes preserve the first payload and do not silently rewrite
+  message content
+- known logical/schema violations are rejected before SQL wherever the crate
+  already owns the invariant
+
+## QA Pointers
+
+- `req-qa` must verify both absence and presence:
+  - absence of the old probe and mutable-row conflict update
+  - presence of insert-first immutable-row semantics in the hot path
+- rust/service review should look closely at partial-batch isolation and
+  transaction semantics
+
+## Dependencies
+
+- depends on `T.2`
+- should be reviewed with `T.2` as one SQLite-correctness line even if they
+  land as separate commits

--- a/docs/phase-T/sprint-T3-immutable-rows.md
+++ b/docs/phase-T/sprint-T3-immutable-rows.md
@@ -1,7 +1,7 @@
 # Sprint T.3 Immutable Message Rows
 
 **Branch**: `integrate/phase-T`
-**Base**: `integrate/phase-T @ bdac03c`
+**Base**: `integrate/phase-T @ 1232244`
 **PR target**: `develop`
 **Status**: Planning
 

--- a/docs/phase-T/sprint-T3-immutable-rows.md
+++ b/docs/phase-T/sprint-T3-immutable-rows.md
@@ -11,6 +11,15 @@ Finish the mailbox hot-write contract by enforcing immutable `mail_messages`
 rows, removing the pre-write probe, and using writer-owned row-count semantics
 instead of conflict-driven row mutation.
 
+Ownership note:
+- `T.2` owns the main `ADR-ATM-RUSQLITE-002` writer-lane design update
+- `T.3` owns only the immutable-row addendum and the hot-path semantic
+  completion on top of the accepted `T.2` writer implementation
+
+Pre-QA dependency:
+- `crates/atm-rusqlite/src/writer/ops.rs` is a `T.2` deliverable
+- `T.3` QA must not proceed until that file exists on the accepted `T.2` base
+
 ## Deliverables
 
 - remove the pre-write `SELECT 1 ...` probe from `MailStore::upsert_message`
@@ -42,6 +51,8 @@ instead of conflict-driven row mutation.
   message content
 - known logical/schema violations are rejected before SQL wherever the crate
   already owns the invariant
+- invalid rows are rejected before SQL submission and valid rows in the same
+  drained batch are unaffected
 
 ## QA Pointers
 

--- a/docs/phase-T/sprint-T4-windows-runtime.md
+++ b/docs/phase-T/sprint-T4-windows-runtime.md
@@ -18,6 +18,13 @@ startup/shutdown.
   - daemon singleton admission and rejection
   - lifecycle terminate / bounded shutdown behavior
   - retained-log bootstrap and orderly shutdown on Windows
+- audit and remove compile-only Windows test guards and cfg-gated runtime skips
+  in the named daemon test files, replacing them with real runtime coverage
+  rather than layering runtime tests on top of lingering compile-only stubs:
+  - `crates/atm-daemon/src/tests.rs`
+  - `crates/atm-daemon/src/local_ipc_transport.rs`
+  - `crates/atm-daemon/src/test_observability.rs`
+  - `crates/atm-daemon/src/test_support.rs`
 - keep Unix parity tests intact while making the Windows runtime path a
   first-class execution lane
 - document any remaining accepted Windows-specific runtime exception explicitly
@@ -37,10 +44,13 @@ startup/shutdown.
 ## Acceptance Criteria
 
 - Windows parity is proven by runtime tests, not only by `cargo xwin check`
+  (`REQ-P-PLATFORM-001`, `REQ-P-PLATFORM-002`)
 - the same-host local IPC path, singleton path, and lifecycle shutdown path all
   have Windows runtime coverage
 - retained-log startup/shutdown is exercised on Windows through the real daemon
   flow
+- compile-only Windows runtime stubs in the named test files are removed or
+  explicitly reduced to non-runtime helper scope
 - any remaining platform exception is documented with explicit rationale
 
 ## QA Pointers

--- a/docs/phase-T/sprint-T4-windows-runtime.md
+++ b/docs/phase-T/sprint-T4-windows-runtime.md
@@ -1,0 +1,58 @@
+# Sprint T.4 Windows Runtime Parity
+
+**Branch**: `integrate/phase-T`
+**Base**: `integrate/phase-T @ bdac03c`
+**PR target**: `develop`
+**Status**: Planning
+
+## Goal
+
+Replace compile-only Windows confidence with real same-host daemon runtime proof
+for local IPC, lifecycle control, singleton ownership, and retained-log
+startup/shutdown.
+
+## Deliverables
+
+- add real Windows runtime coverage for:
+  - same-host local IPC request/response on the real transport
+  - daemon singleton admission and rejection
+  - lifecycle terminate / bounded shutdown behavior
+  - retained-log bootstrap and orderly shutdown on Windows
+- keep Unix parity tests intact while making the Windows runtime path a
+  first-class execution lane
+- document any remaining accepted Windows-specific runtime exception explicitly
+  in daemon architecture docs rather than hiding it in test comments
+
+## Key File Targets
+
+- `crates/atm-daemon/src/tests.rs`
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+- `crates/atm-daemon/src/host_ownership.rs`
+- `crates/atm-daemon/src/test_support.rs`
+- `docs/atm-daemon/architecture.md`
+- `docs/requirements.md`
+- `docs/plan-phase-S.md`
+
+## Acceptance Criteria
+
+- Windows parity is proven by runtime tests, not only by `cargo xwin check`
+- the same-host local IPC path, singleton path, and lifecycle shutdown path all
+  have Windows runtime coverage
+- retained-log startup/shutdown is exercised on Windows through the real daemon
+  flow
+- any remaining platform exception is documented with explicit rationale
+
+## QA Pointers
+
+- `req-qa` must reject compile-only substitutes for runtime-proof deliverables
+- `flaky-test-qa` should review the new Windows runtime coverage for bounded
+  waits and anti-sleep discipline
+- CI planning should include a Windows runtime lane, not only a Windows compile
+  lane
+
+## Dependencies
+
+- may run independently of `T.2` / `T.3`
+- should complete before any claim that daemon singleton and IPC behavior are
+  production-ready on Windows

--- a/docs/phase-T/sprint-T4-windows-runtime.md
+++ b/docs/phase-T/sprint-T4-windows-runtime.md
@@ -1,7 +1,7 @@
 # Sprint T.4 Windows Runtime Parity
 
 **Branch**: `integrate/phase-T`
-**Base**: `integrate/phase-T @ bdac03c`
+**Base**: `integrate/phase-T @ 1232244`
 **PR target**: `develop`
 **Status**: Planning
 

--- a/docs/phase-T/sprint-T5-hardening.md
+++ b/docs/phase-T/sprint-T5-hardening.md
@@ -1,7 +1,7 @@
 # Sprint T.5 Remaining Hardening
 
 **Branch**: `integrate/phase-T`
-**Base**: `integrate/phase-T @ bdac03c`
+**Base**: `integrate/phase-T @ 1232244`
 **PR target**: `develop`
 **Status**: Planning
 

--- a/docs/phase-T/sprint-T5-hardening.md
+++ b/docs/phase-T/sprint-T5-hardening.md
@@ -15,8 +15,17 @@ belong in the SQLite or Windows-parity sprints.
 
 - fix `RuntimeStatusCache` insert-time overflow and all-conflict eviction
   failure so the documented bound is always enforced
-- reconcile the daemon shutdown deadline contract between code and docs
+- obtain and record the authoritative shutdown deadline ruling for daemon
+  graceful drain and force-cancel budgets; if the ruling is still unresolved,
+  keep it as a named blocking gap in this sprint rather than silently choosing
+  values
 - bound reconcile fingerprint retention beyond key-count-only caps
+  by naming whether the bound is:
+  - per-key
+  - global
+  - or both
+  and by naming the enforcement form (for example, explicit eviction or a
+  bounded map/set contract)
 - harden remaining shutdown-lane follow-ups called out by the integration gate:
   - `NotificationRuntime::shutdown()` bounded join
   - pre-connect terminate checks in peer transport retries
@@ -39,13 +48,24 @@ belong in the SQLite or Windows-parity sprints.
 
 ## Acceptance Criteria
 
-- the runtime status cache cannot exceed its documented bound, including
-  conflict-heavy saturation cases
+- the runtime status cache cannot exceed the documented `4096`-entry cap,
+  including a regression test that saturates the cache at exactly `4096`
+  entries with all-conflict records
 - reconcile fingerprint retention is bounded by an explicit implementation
   contract and regression tests
-- code and docs agree on one shutdown deadline budget
+- `REQ-P-DAEMON-LANES-001` is satisfied by an explicit shutdown budget contract;
+  until the 2s/3s vs 5s/10s ruling is made, `GAP-T5-001` remains open and T.5
+  cannot claim closeout on that item
 - remaining open runtime/shutdown follow-ups from the production review and
   integration gate are closed or explicitly re-triaged with rationale
+
+## Named Gaps
+
+- `GAP-T5-001` — authoritative shutdown values unresolved:
+  - code currently uses `2s` / `3s`
+  - architecture docs currently state `5s` / `10s`
+  - T.5 must not invent values; it must either record the accepted ruling or
+    remain open on this item
 
 ## QA Pointers
 

--- a/docs/phase-T/sprint-T5-hardening.md
+++ b/docs/phase-T/sprint-T5-hardening.md
@@ -1,0 +1,61 @@
+# Sprint T.5 Remaining Hardening
+
+**Branch**: `integrate/phase-T`
+**Base**: `integrate/phase-T @ bdac03c`
+**PR target**: `develop`
+**Status**: Planning
+
+## Goal
+
+Close the remaining daemon bounded-state and shutdown-contract gaps left open
+after S.14 / S.15, including the production-review follow-up items that do not
+belong in the SQLite or Windows-parity sprints.
+
+## Deliverables
+
+- fix `RuntimeStatusCache` insert-time overflow and all-conflict eviction
+  failure so the documented bound is always enforced
+- reconcile the daemon shutdown deadline contract between code and docs
+- bound reconcile fingerprint retention beyond key-count-only caps
+- harden remaining shutdown-lane follow-ups called out by the integration gate:
+  - `NotificationRuntime::shutdown()` bounded join
+  - pre-connect terminate checks in peer transport retries
+  - orphaned shutdown-helper debug visibility
+  - `SHUTDOWN_FINALIZER_THREADS` poison and rationale hardening
+- keep the retained-log shutdown behavior and doctor/runtime projection aligned
+  with the documented operator contract
+
+## Key File Targets
+
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/reconcile_runtime.rs`
+- `crates/atm-daemon/src/notification_runtime.rs`
+- `crates/atm-daemon/src/peer_transport.rs`
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/lib.rs`
+- `docs/architecture.md`
+- `docs/atm-daemon/architecture.md`
+- `docs/requirements.md`
+
+## Acceptance Criteria
+
+- the runtime status cache cannot exceed its documented bound, including
+  conflict-heavy saturation cases
+- reconcile fingerprint retention is bounded by an explicit implementation
+  contract and regression tests
+- code and docs agree on one shutdown deadline budget
+- remaining open runtime/shutdown follow-ups from the production review and
+  integration gate are closed or explicitly re-triaged with rationale
+
+## QA Pointers
+
+- `req-qa` must verify the shutdown budget in code and docs matches exactly
+- service-hardening review should focus on bounded shutdown, poison handling,
+  and termination latency
+- `arch-qa` should confirm the fixes do not widen ownership or boundary scope
+
+## Dependencies
+
+- may run independently of `T.2` / `T.4`
+- should be reviewed with the open `INTG-RSH-*` and production-review findings
+  in hand rather than as a generic cleanup sprint

--- a/docs/phase-T/sprint-T6-graft-client-surface.md
+++ b/docs/phase-T/sprint-T6-graft-client-surface.md
@@ -2,7 +2,7 @@
 
 **Branch**: `integrate/phase-T`
 **Base**: `integrate/phase-T @ 1232244`
-**PR target**: `develop`
+**PR target**: `integrate/phase-T`
 **Status**: Planning
 
 ## Goal

--- a/docs/phase-T/sprint-T6-graft-client-surface.md
+++ b/docs/phase-T/sprint-T6-graft-client-surface.md
@@ -1,7 +1,7 @@
 # Sprint T.6 Graft Client Surface
 
 **Branch**: `integrate/phase-T`
-**Base**: `integrate/phase-T @ 1232244`
+**Base**: `integrate/phase-T @ 75d341b`
 **PR target**: `integrate/phase-T`
 **Status**: Planning
 
@@ -18,6 +18,9 @@ dependency on `atm-daemon`.
 
 ## Deliverables
 
+- name the concrete `atm-core` graft-facing traits:
+  - `AtmGraftClient`
+  - `GraftSessionPort`
 - add the public `atm-core` client-side models needed by embedded consumers
   for:
   - `send`
@@ -27,6 +30,9 @@ dependency on `atm-daemon`.
   - nudge drain / fetch
 - make the public client-facing types typed and explicit rather than
   CLI-composition-only
+- ensure `AtmGraftClient` owns the unary daemon request surface and
+  `GraftSessionPort` owns the session registration / receive-loop contract so
+  T.8 does not re-mint parallel trait names
 - keep the surface small enough that `atm-graft` behaves mostly like an ATM
   client embedded inside an agent
 - ensure the retained CLI can consume the same client surface where practical

--- a/docs/phase-T/sprint-T6-graft-client-surface.md
+++ b/docs/phase-T/sprint-T6-graft-client-surface.md
@@ -11,6 +11,11 @@ Define the small embeddable daemon-client surface needed by `atm-graft`
 without turning `atm-graft` into a second runtime stack or forcing a Rust
 dependency on `atm-daemon`.
 
+## Preconditions
+
+- `T.2` through `T.5` must be merged first so the daemon/runtime baseline is
+  stable before the graft-facing public client surface is locked
+
 ## Deliverables
 
 - add the public `atm-core` client-side models needed by embedded consumers
@@ -27,6 +32,8 @@ dependency on `atm-daemon`.
 - ensure the retained CLI can consume the same client surface where practical
   rather than diverging into a parallel contract
 - keep concrete daemon runtime details private to `atm-daemon`
+- update the public protocol/interface documentation for the graft-facing
+  client surface
 
 ## Key File Targets
 
@@ -36,6 +43,7 @@ dependency on `atm-daemon`.
   moved out or narrowed
 - `docs/atm-core/architecture.md`
 - `docs/atm-core/requirements.md`
+- `docs/atm-daemon/protocol-icd.md`
 - `docs/atm-graft/architecture.md`
 - `docs/atm-graft/requirements.md`
 
@@ -50,6 +58,14 @@ dependency on `atm-daemon`.
 - the graft-facing surface is small and embeddable rather than mirroring the
   entire CLI
 
+## Required Validation
+
+- `cargo fmt --all --check`
+- `just lint`
+- targeted `cargo test` for any new `atm-core` client-surface modules
+- targeted `cargo test` for any `atm` CLI wiring updated to consume the same
+  client surface
+
 ## QA Pointers
 
 - `req-qa` must verify the named client surface exists in code, not only in
@@ -60,6 +76,5 @@ dependency on `atm-daemon`.
 
 ## Dependencies
 
-- should begin only after `T.2`-`T.5` are stable enough that the daemon/runtime
-  baseline is not thrashing
+- depends on `T.2` through `T.5` merging first
 - `T.7` depends on this sprint defining the client-side contract

--- a/docs/phase-T/sprint-T6-graft-client-surface.md
+++ b/docs/phase-T/sprint-T6-graft-client-surface.md
@@ -1,0 +1,65 @@
+# Sprint T.6 Graft Client Surface
+
+**Branch**: `integrate/phase-T`
+**Base**: `integrate/phase-T @ 1232244`
+**PR target**: `develop`
+**Status**: Planning
+
+## Goal
+
+Define the small embeddable daemon-client surface needed by `atm-graft`
+without turning `atm-graft` into a second runtime stack or forcing a Rust
+dependency on `atm-daemon`.
+
+## Deliverables
+
+- add the public `atm-core` client-side models needed by embedded consumers
+  for:
+  - `send`
+  - `read`
+  - `ack`
+  - graft registration / unregistration
+  - nudge drain / fetch
+- make the public client-facing types typed and explicit rather than
+  CLI-composition-only
+- keep the surface small enough that `atm-graft` behaves mostly like an ATM
+  client embedded inside an agent
+- ensure the retained CLI can consume the same client surface where practical
+  rather than diverging into a parallel contract
+- keep concrete daemon runtime details private to `atm-daemon`
+
+## Key File Targets
+
+- `crates/atm-core/src/*`
+- `crates/atm/src/*`
+- `crates/atm-daemon/src/*` only where public client-surface ownership must be
+  moved out or narrowed
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-graft/architecture.md`
+- `docs/atm-graft/requirements.md`
+
+## Acceptance Criteria
+
+- `atm-graft` can depend on `atm-core` and the documented daemon protocol
+  surface without depending on `atm-daemon` as a crate
+- the new public client-side request / response / event surface is typed and
+  explicit
+- concrete daemon runtime/socket details remain outside the `atm-graft` public
+  boundary
+- the graft-facing surface is small and embeddable rather than mirroring the
+  entire CLI
+
+## QA Pointers
+
+- `req-qa` must verify the named client surface exists in code, not only in
+  planning docs
+- `arch-qa` should verify no `atm-daemon` crate dependency leaks into the
+  public graft boundary
+- hardening review should focus on keeping the surface minimal and typed
+
+## Dependencies
+
+- should begin only after `T.2`-`T.5` are stable enough that the daemon/runtime
+  baseline is not thrashing
+- `T.7` depends on this sprint defining the client-side contract

--- a/docs/phase-T/sprint-T7-graft-runtime.md
+++ b/docs/phase-T/sprint-T7-graft-runtime.md
@@ -1,15 +1,15 @@
 # Sprint T.7 Graft Runtime
 
 **Branch**: `integrate/phase-T`
-**Base**: `integrate/phase-T @ 1232244`
+**Base**: `integrate/phase-T @ 75d341b`
 **PR target**: `integrate/phase-T`
 **Status**: Planning
 
 ## Goal
 
 Add the small daemon-side runtime features embedded and hook/poll graft
-consumers actually need: registration, bounded nudge queueing, and drain/fetch
-access.
+consumers actually need: registration, bounded nudge queueing, one live
+embedded-session receive path, and drain/fetch access.
 
 ## Preconditions
 
@@ -20,11 +20,13 @@ access.
 
 - add graft registration / unregistration handling in the daemon/runtime line
 - add a daemon-owned bounded pending-nudge queue
+- add one live embedded-session receive path for daemon-originated nudges
 - add a typed drain/fetch API for embedded and hook/poll consumers
 - add explicit backpressure and queue-overflow behavior with structured error
   identity and observability
 - add the hook-facing `atm` command surface that consumes the same daemon API
-  rather than creating a separate binary
+  rather than creating a separate binary, while keeping that CLI path
+  explicitly out of the production `atm-graft` acceptance target
 - update the daemon protocol/interface docs for registration, drain/fetch, and
   nudge payload boundaries
 
@@ -36,18 +38,24 @@ access.
 - `docs/atm-daemon/architecture.md`
 - `docs/atm-daemon/requirements.md`
 - `docs/atm-daemon/protocol-icd.md`
-- `docs/atm-graft/architecture.md`
-- `docs/atm-graft/requirements.md`
+- `docs/atm-graft/architecture.md` §2.5 `GraftSession` and §2.6
+  `Nudge Delivery Model`
+- `docs/atm-graft/requirements.md` §5 `Phase T Embedded-Graft Rules` and §5.2
+  `Req-QA Verification Anchors`
 
 ## Acceptance Criteria
 
 - registration and unregistration paths exist and are test-covered
 - pending nudge queue ownership is daemon-side, not graft-side
+- embedded sessions automatically receive nudges through one live receive
+  task/thread per active session
 - the queue is bounded and its overflow/backpressure behavior is explicit
 - embedded consumers and hook/poll consumers use the same daemon-owned drain
   contract
 - the hook-facing path is on the `atm` CLI surface, not on a separate
   `atm-graft` executable
+- production acceptance does not rely on `tmux send-keys` or any equivalent
+  terminal automation path
 
 ## Required Validation
 

--- a/docs/phase-T/sprint-T7-graft-runtime.md
+++ b/docs/phase-T/sprint-T7-graft-runtime.md
@@ -2,7 +2,7 @@
 
 **Branch**: `integrate/phase-T`
 **Base**: `integrate/phase-T @ 1232244`
-**PR target**: `develop`
+**PR target**: `integrate/phase-T`
 **Status**: Planning
 
 ## Goal

--- a/docs/phase-T/sprint-T7-graft-runtime.md
+++ b/docs/phase-T/sprint-T7-graft-runtime.md
@@ -11,6 +11,11 @@ Add the small daemon-side runtime features embedded and hook/poll graft
 consumers actually need: registration, bounded nudge queueing, and drain/fetch
 access.
 
+## Preconditions
+
+- `T.6` must merge first so the daemon-side registration and drain surfaces are
+  implementing an already-defined public graft client contract
+
 ## Deliverables
 
 - add graft registration / unregistration handling in the daemon/runtime line
@@ -20,6 +25,8 @@ access.
   identity and observability
 - add the hook-facing `atm` command surface that consumes the same daemon API
   rather than creating a separate binary
+- update the daemon protocol/interface docs for registration, drain/fetch, and
+  nudge payload boundaries
 
 ## Key File Targets
 
@@ -28,6 +35,7 @@ access.
 - `crates/atm/src/commands/*`
 - `docs/atm-daemon/architecture.md`
 - `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/protocol-icd.md`
 - `docs/atm-graft/architecture.md`
 - `docs/atm-graft/requirements.md`
 
@@ -41,6 +49,14 @@ access.
 - the hook-facing path is on the `atm` CLI surface, not on a separate
   `atm-graft` executable
 
+## Required Validation
+
+- `cargo fmt --all --check`
+- `just lint`
+- `cargo test -p atm-daemon`
+- targeted `cargo test` for the hook-facing `atm` nudge-drain command surface
+- `cargo xwin check --workspace --target x86_64-pc-windows-msvc`
+
 ## QA Pointers
 
 - `req-qa` must verify queue/drain deliverables are present in code and not
@@ -52,4 +68,4 @@ access.
 ## Dependencies
 
 - depends on `T.6` defining the public graft client contract
-- should complete before `T.8` is considered API-stable
+- `T.8` depends on this sprint merging first

--- a/docs/phase-T/sprint-T7-graft-runtime.md
+++ b/docs/phase-T/sprint-T7-graft-runtime.md
@@ -1,0 +1,55 @@
+# Sprint T.7 Graft Runtime
+
+**Branch**: `integrate/phase-T`
+**Base**: `integrate/phase-T @ 1232244`
+**PR target**: `develop`
+**Status**: Planning
+
+## Goal
+
+Add the small daemon-side runtime features embedded and hook/poll graft
+consumers actually need: registration, bounded nudge queueing, and drain/fetch
+access.
+
+## Deliverables
+
+- add graft registration / unregistration handling in the daemon/runtime line
+- add a daemon-owned bounded pending-nudge queue
+- add a typed drain/fetch API for embedded and hook/poll consumers
+- add explicit backpressure and queue-overflow behavior with structured error
+  identity and observability
+- add the hook-facing `atm` command surface that consumes the same daemon API
+  rather than creating a separate binary
+
+## Key File Targets
+
+- `crates/atm-daemon/src/*`
+- `crates/atm-core/src/*`
+- `crates/atm/src/commands/*`
+- `docs/atm-daemon/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-graft/architecture.md`
+- `docs/atm-graft/requirements.md`
+
+## Acceptance Criteria
+
+- registration and unregistration paths exist and are test-covered
+- pending nudge queue ownership is daemon-side, not graft-side
+- the queue is bounded and its overflow/backpressure behavior is explicit
+- embedded consumers and hook/poll consumers use the same daemon-owned drain
+  contract
+- the hook-facing path is on the `atm` CLI surface, not on a separate
+  `atm-graft` executable
+
+## QA Pointers
+
+- `req-qa` must verify queue/drain deliverables are present in code and not
+  just described in docs
+- `arch-qa` should verify daemon queue ownership and the absence of duplicate
+  host-side queue logic
+- hardening review should focus on boundedness, shutdown, and backpressure
+
+## Dependencies
+
+- depends on `T.6` defining the public graft client contract
+- should complete before `T.8` is considered API-stable

--- a/docs/phase-T/sprint-T8-atm-graft-crate.md
+++ b/docs/phase-T/sprint-T8-atm-graft-crate.md
@@ -1,0 +1,59 @@
+# Sprint T.8 ATM-Graft Crate
+
+**Branch**: `integrate/phase-T`
+**Base**: `integrate/phase-T @ 1232244`
+**PR target**: `develop`
+**Status**: Planning
+
+## Goal
+
+Add `atm-graft` as a thin embedded ATM client crate for Rust host agents.
+
+## Deliverables
+
+- add the `atm-graft` crate
+- add minimal `[atm.graft]` activation support in ATM-owned config loading
+- add `GraftSession`
+- expose a small public API limited to:
+  - `send`
+  - `read`
+  - `ack`
+  - session lifecycle
+  - host-facing nudge fetch/drain
+- keep the crate runtime-neutral at its core
+- add any first convenience runtime adapter only if the host integration proves
+  it necessary
+
+## Key File Targets
+
+- `crates/atm-graft/*`
+- `crates/atm-core/src/config/*`
+- `docs/atm-graft/architecture.md`
+- `docs/atm-graft/requirements.md`
+- `docs/plan-atm-graft.md`
+
+## Acceptance Criteria
+
+- `atm-graft` builds as a thin embedded client crate with no `atm-daemon` Rust
+  dependency and no direct SQLite / inbox JSONL access
+- graft mode is inert when `.atm.toml` is absent and active only through the
+  ATM-owned config rules
+- `GraftSession` lifecycle is explicit and test-covered
+- the public API remains intentionally small and does not mirror the full CLI
+- the host-facing bridge is sufficient for between-tool-call insertion without
+  forcing host-specific tool-loop logic into the crate
+
+## QA Pointers
+
+- `req-qa` must verify that the crate exists, the config activation exists, and
+  the named public API is actually present
+- `arch-qa` should verify the crate stays thin and does not absorb daemon
+  business logic or direct I/O ownership
+- hardening review should focus on API minimalism, session lifecycle, and host
+  integration neutrality
+
+## Dependencies
+
+- depends on `T.6` and `T.7`
+- should not start until the daemon/runtime baseline from `T.2`-`T.5` is
+  considered stable enough to avoid API churn

--- a/docs/phase-T/sprint-T8-atm-graft-crate.md
+++ b/docs/phase-T/sprint-T8-atm-graft-crate.md
@@ -2,7 +2,7 @@
 
 **Branch**: `integrate/phase-T`
 **Base**: `integrate/phase-T @ 1232244`
-**PR target**: `develop`
+**PR target**: `integrate/phase-T`
 **Status**: Planning
 
 ## Goal

--- a/docs/phase-T/sprint-T8-atm-graft-crate.md
+++ b/docs/phase-T/sprint-T8-atm-graft-crate.md
@@ -1,7 +1,7 @@
 # Sprint T.8 ATM-Graft Crate
 
 **Branch**: `integrate/phase-T`
-**Base**: `integrate/phase-T @ 1232244`
+**Base**: `integrate/phase-T @ 75d341b`
 **PR target**: `integrate/phase-T`
 **Status**: Planning
 
@@ -18,13 +18,14 @@ Add `atm-graft` as a thin embedded ATM client crate for Rust host agents.
 
 - add the `atm-graft` crate
 - add minimal `[atm.graft]` activation support in ATM-owned config loading
-- add `GraftSession`
+- add `GraftSession` as the concrete implementation of the `atm_core`
+  `GraftSessionPort` trait
 - expose a small public API limited to:
   - `send`
   - `read`
   - `ack`
   - session lifecycle
-  - host-facing nudge fetch/drain
+  - host-facing automatic nudge injection integration
 - keep the crate runtime-neutral at its core
 - add any first convenience runtime adapter only if the host integration proves
   it necessary
@@ -44,9 +45,13 @@ Add `atm-graft` as a thin embedded ATM client crate for Rust host agents.
 - graft mode is inert when `.atm.toml` is absent and active only through the
   ATM-owned config rules
 - `GraftSession` lifecycle is explicit and test-covered
+- embedded mode automatically injects nudges into host context between tool
+  calls via one live receive task/thread
 - the public API remains intentionally small and does not mirror the full CLI
 - the host-facing bridge is sufficient for between-tool-call insertion without
   forcing host-specific tool-loop logic into the crate
+- no production acceptance path relies on `tmux send-keys`, shell-hook polling,
+  or other external terminal automation
 
 ## Required Validation
 

--- a/docs/phase-T/sprint-T8-atm-graft-crate.md
+++ b/docs/phase-T/sprint-T8-atm-graft-crate.md
@@ -9,6 +9,11 @@
 
 Add `atm-graft` as a thin embedded ATM client crate for Rust host agents.
 
+## Preconditions
+
+- `T.6` and `T.7` must merge first so the crate is built on the accepted
+  graft-facing client surface and daemon-owned runtime features
+
 ## Deliverables
 
 - add the `atm-graft` crate
@@ -43,6 +48,15 @@ Add `atm-graft` as a thin embedded ATM client crate for Rust host agents.
 - the host-facing bridge is sufficient for between-tool-call insertion without
   forcing host-specific tool-loop logic into the crate
 
+## Required Validation
+
+- `cargo fmt --all --check`
+- `just lint`
+- `cargo test -p atm-graft`
+- targeted `cargo test` for `atm-core` config loading that exercises
+  `[atm.graft].enabled`
+- `cargo xwin check --workspace --target x86_64-pc-windows-msvc`
+
 ## QA Pointers
 
 - `req-qa` must verify that the crate exists, the config activation exists, and
@@ -55,5 +69,4 @@ Add `atm-graft` as a thin embedded ATM client crate for Rust host agents.
 ## Dependencies
 
 - depends on `T.6` and `T.7`
-- should not start until the daemon/runtime baseline from `T.2`-`T.5` is
-  considered stable enough to avoid API churn
+- depends transitively on `T.2` through `T.5` through the `T.6` baseline gate

--- a/docs/plan-atm-graft.md
+++ b/docs/plan-atm-graft.md
@@ -1,0 +1,181 @@
+# ATM-Graft Implementation Plan
+
+## 1. Purpose
+
+This document turns the `atm-graft` requirements and architecture into an
+implementation-targeted plan aligned to the current Phase T daemon/runtime
+baseline rather than the older Phase Q planning line.
+
+Planning baseline:
+- `integrate/phase-T @ 1232244`
+
+## 2. Non-Negotiable Boundary Rules
+
+- `atm-graft` must not depend on `atm-daemon` as a Rust crate
+- `atm-graft` must not depend on `atm-rusqlite`
+- direct SQLite or inbox JSONL access is out of scope for `atm-graft`
+- all protocol structs, enums, and traits needed by `atm-graft` must live in
+  `atm-core`
+- the concrete daemon peer remains `atm-daemon`
+- the host executable owns the final between-tool-call injection point
+- pending nudge durability/queue ownership belongs in the daemon rather than
+  inside `atm-graft`
+
+## 3. Current Baseline
+
+Useful implementation already present:
+- durable mail/task/roster store contracts in `atm-core`
+- mature SQLite-backed record families in `atm-rusqlite`
+- same-host daemon runtime with singleton control and bounded shutdown
+- real same-host request handling as a product path, not a future placeholder
+- retained CLI paths already proving the daemon/client integration shape
+
+Remaining gaps relative to `atm-graft`:
+- no graft registration or daemon-to-client nudge stream exists yet
+- no daemon-owned pending-nudge queue or drain API exists yet
+- no `[atm.graft]` config surface exists in `atm-core`
+- no thin embedded crate packages the existing daemon client behavior for host
+  agents
+- the public client-facing `atm-core` surface still needs a dedicated
+  embeddable shape rather than exposing only CLI-oriented composition
+
+Planning consequence:
+- `atm-graft` is no longer a large protocol bootstrap effort
+- it is now a thin follow-on line on top of the current IPC/runtime baseline
+- the work should therefore live as three additive Phase T sprints
+
+## 4. Gap Analysis
+
+### G.1 Embeddable client-surface gap
+
+Current state:
+- same-host daemon IPC already exists
+- `atm` already proves the retained daemon-client path
+- there is not yet one small, explicit `atm-core` client surface tailored for
+  embedded host-agent consumers
+
+Required change:
+- define the public client-side request/response/session-facing models needed
+  by `atm-graft`
+- keep those models in `atm-core`
+- keep concrete runtime/socket behavior out of the public `atm-core` surface
+
+### G.2 Session/nudge runtime gap
+
+Current state:
+- the daemon is already the correct owner of runtime coordination
+- there is no graft registration / unregistration path
+- there is no daemon-owned bounded pending-nudge queue or drain request
+
+Required change:
+- add graft registration / unregistration handlers
+- add daemon-owned bounded nudge queueing
+- add nudge drain/fetch requests for embedded and hook/poll consumers
+- keep queue ownership and backpressure behavior entirely daemon-side
+
+### G.3 Thin crate gap
+
+Current state:
+- there is no `atm-graft` crate yet
+- host binaries therefore cannot consume a stable embedded ATM client surface
+
+Required change:
+- add the `atm-graft` crate as a thin wrapper over the `atm-core` client
+  contract
+- add minimal `[atm.graft]` activation
+- add `GraftSession`
+- add host-facing nudge fetch/drain bridging
+
+## 5. Phase T Work Packages
+
+### T.6: Embeddable Graft Client Surface
+
+Owning crates:
+- `atm-core`
+- `atm`
+- `atm-daemon`
+
+Deliverables:
+- typed `atm-core` client/request/response/session models used by embedded
+  consumers
+- explicit `atm-core` ownership of any public graft-facing protocol types
+- `atm` CLI use of that same client surface where appropriate
+- no `atm-daemon` crate dependency required for external graft consumers
+
+### T.7: Graft Runtime In Daemon
+
+Owning crates:
+- `atm-daemon`
+- `atm-core`
+- `atm`
+
+Deliverables:
+- graft registration / unregistration protocol
+- daemon-owned bounded pending-nudge queue
+- daemon-owned drain/fetch API
+- typed backpressure and queue-overflow behavior
+- hook-facing `atm` command surface for nudge drain on the same daemon API
+
+### T.8: `atm-graft` Crate
+
+Owning crates:
+- `atm-graft`
+- `atm-core`
+
+Deliverables:
+- `atm-graft` crate
+- minimal `[atm.graft]` config activation
+- `GraftSession`
+- public API limited to:
+  - `send`
+  - `read`
+  - `ack`
+  - session lifecycle
+  - nudge fetch/drain
+- optional runtime adapter convenience only if needed by the host integration
+
+## 6. Simplifications For V1
+
+To keep the first implementation tractable:
+- do not add direct SQLite reads
+- do not add daemon-private business logic to `atm-graft`
+- do not broaden config beyond `[atm.graft].enabled`
+- do not make heartbeat/activity reporting part of the initial must-have
+  surface unless host integration needs it immediately
+- do not turn nudge payloads into a large schema before the host proves the
+  need; `from` and `message` are the minimum
+- keep the embedded crate small; for the most part this is simply an ATM client
+  embedded in an agent process
+
+## 7. Integration Modes
+
+Embedded session mode:
+- a modified host binary links `atm-graft`
+- `GraftSession` registers with the daemon
+- nudges are delivered through the daemon session path
+- the host drains fetched nudges between tool calls
+
+Hook/poll mode:
+- the host binary is not modified for direct embedding
+- a post-tool-use hook invokes an `atm` command to fetch pending nudge text
+- the daemon returns pending nudges for the current `ATM_IDENTITY`
+- the command emits insertion-ready text and clears or advances the daemon queue
+
+Architectural consequence:
+- the queue must live in the daemon
+- `atm-graft` becomes one consumer path, not the owner of queued nudge state
+
+## 8. Phase T Dependency
+
+`atm-graft` now depends on the hardened Phase T shape, not on a replay of the
+older Phase Q wire-protocol plan.
+
+Required upstream outcomes before `atm-graft` implementation closes:
+- `T.2` and `T.3` stabilize the SQLite write-path correctness model
+- `T.4` and `T.5` close the remaining daemon runtime parity and shutdown/state
+  gaps
+- `T.6` lands the embeddable client surface
+- `T.7` lands registration and daemon-owned nudge queue/drain behavior
+
+The `atm-graft` crate itself is the `T.8` deliverable, not a separate future
+phase.

--- a/docs/plan-atm-graft.md
+++ b/docs/plan-atm-graft.md
@@ -7,7 +7,7 @@ implementation-targeted plan aligned to the current Phase T daemon/runtime
 baseline rather than the older Phase Q planning line.
 
 Planning baseline:
-- `integrate/phase-T @ 1232244`
+- `integrate/phase-T @ 75d341b`
 
 ## 2. Non-Negotiable Boundary Rules
 
@@ -38,6 +38,7 @@ Remaining gaps relative to `atm-graft`:
   agents
 - the public client-facing `atm-core` surface still needs a dedicated
   embeddable shape rather than exposing only CLI-oriented composition
+- no documented automatic embedded-mode injection loop exists yet
 
 Planning consequence:
 - `atm-graft` is no longer a large protocol bootstrap effort
@@ -73,6 +74,7 @@ Required change:
 - add graft registration / unregistration handlers
 - add daemon-owned bounded nudge queueing
 - add nudge drain/fetch requests for embedded and hook/poll consumers
+- add one live embedded-session receive loop per active `GraftSession`
 - keep queue ownership and backpressure behavior entirely daemon-side
 - update the protocol/interface docs for registration, drain/fetch, and daemon
   event payloads
@@ -94,12 +96,15 @@ Required change:
 
 ### T.6: Embeddable Graft Client Surface
 
-Owning crates:
+Implementation scope:
 - `atm-core`
 - `atm`
 - `atm-daemon`
 
 Deliverables:
+- name the concrete `atm-core` graft-facing traits:
+  - `AtmGraftClient`
+  - `GraftSessionPort`
 - typed `atm-core` client/request/response/session models used by embedded
   consumers
 - explicit `atm-core` ownership of any public graft-facing protocol types
@@ -108,7 +113,7 @@ Deliverables:
 
 ### T.7: Graft Runtime In Daemon
 
-Owning crates:
+Implementation scope:
 - `atm-daemon`
 - `atm-core`
 - `atm`
@@ -117,19 +122,27 @@ Deliverables:
 - graft registration / unregistration protocol
 - daemon-owned bounded pending-nudge queue
 - daemon-owned drain/fetch API
+- automatic embedded-session nudge receive/injection path
 - typed backpressure and queue-overflow behavior
 - hook-facing `atm` command surface for nudge drain on the same daemon API
 
+Documentation sections amended by T.7:
+- `docs/atm-graft/architecture.md` §2.5 `GraftSession`
+- `docs/atm-graft/architecture.md` §2.6 `Nudge Delivery Model`
+- `docs/atm-graft/requirements.md` §5 `Phase T Embedded-Graft Rules`
+- `docs/atm-graft/requirements.md` §5.2 `Req-QA Verification Anchors`
+
 ### T.8: `atm-graft` Crate
 
-Owning crates:
+Implementation scope:
 - `atm-graft`
 - `atm-core`
 
 Deliverables:
 - `atm-graft` crate
 - minimal `[atm.graft]` config activation
-- `GraftSession`
+- `GraftSession` as the concrete implementation of the `atm_core`
+  `GraftSessionPort` trait
 - public API limited to:
   - `send`
   - `read`
@@ -157,24 +170,31 @@ To keep the first implementation tractable:
   need; `from` and `message` are the minimum
 - keep the embedded crate small; for the most part this is simply an ATM client
   embedded in an agent process
+- do not treat manual poll-only behavior as sufficient for embedded mode;
+  automatic context injection is the point of `atm-graft`
+- do not treat `tmux send-keys` or related terminal automation as a
+  production-ready integration mechanism
 
 ## 7. Integration Modes
 
 Embedded session mode:
-- a modified host binary links `atm-graft`
+- a custom host CLI links `atm-graft` in-process
 - `GraftSession` registers with the daemon
 - nudges are delivered through the daemon session path
-- the host drains fetched nudges between tool calls
+- one live receive task/thread runs for the active session
+- the host receives automatic between-tool-call injection through the graft
+  bridge
 
-Hook/poll mode:
-- the host binary is not modified for direct embedding
-- a post-tool-use hook invokes an `atm` command to fetch pending nudge text
-- the daemon returns pending nudges for the current `ATM_IDENTITY`
-- the command emits insertion-ready text and clears or advances the daemon queue
+Non-production companion path:
+- a CLI drain/poll command may still exist for debugging, migration, or
+  non-embedded environments
+- that path is explicitly not the production completion target for
+  `atm-graft`
 
 Architectural consequence:
 - the queue must live in the daemon
 - `atm-graft` becomes one consumer path, not the owner of queued nudge state
+- external terminal automation is not part of the production acceptance path
 
 ## 8. Phase T Dependency
 

--- a/docs/plan-atm-graft.md
+++ b/docs/plan-atm-graft.md
@@ -59,6 +59,8 @@ Required change:
   by `atm-graft`
 - keep those models in `atm-core`
 - keep concrete runtime/socket behavior out of the public `atm-core` surface
+- update the protocol/interface docs that describe those client-facing request
+  and response boundaries
 
 ### G.2 Session/nudge runtime gap
 
@@ -72,6 +74,8 @@ Required change:
 - add daemon-owned bounded nudge queueing
 - add nudge drain/fetch requests for embedded and hook/poll consumers
 - keep queue ownership and backpressure behavior entirely daemon-side
+- update the protocol/interface docs for registration, drain/fetch, and daemon
+  event payloads
 
 ### G.3 Thin crate gap
 
@@ -134,6 +138,13 @@ Deliverables:
   - nudge fetch/drain
 - optional runtime adapter convenience only if needed by the host integration
 
+Sequencing rule:
+- `T.6` must land first because it defines the public graft-facing client
+  contract
+- `T.7` must land second because queue ownership and drain semantics belong in
+  the daemon rather than in the crate
+- `T.8` closes the line only after `T.6` and `T.7` are accepted
+
 ## 6. Simplifications For V1
 
 To keep the first implementation tractable:
@@ -179,3 +190,9 @@ Required upstream outcomes before `atm-graft` implementation closes:
 
 The `atm-graft` crate itself is the `T.8` deliverable, not a separate future
 phase.
+
+Required closeout checks across `T.6`-`T.8`:
+- every sprint doc includes explicit deliverables, dependencies, acceptance
+  criteria, QA pointers, and required validation
+- `docs/atm-graft/requirements.md` and `docs/atm-graft/architecture.md`
+  include concrete verification anchors for `req-qa` and `arch-qa`

--- a/docs/plan-phase-T.md
+++ b/docs/plan-phase-T.md
@@ -1,0 +1,141 @@
+# Phase T Task List
+
+## 1. Goal
+
+Close the production-readiness gaps left open at the end of Phase S without
+re-opening the completed daemon-baseline work unnecessarily.
+
+Phase S delivered the cross-platform daemon/runtime baseline and the first
+round of runtime hardening, but the final integrated review still found:
+- missing S.15 SQLite writer-lane architecture
+- missing immutable message-row enforcement on the hot mailbox write path
+- missing real Windows same-host runtime proof for daemon singleton and local
+  IPC behavior
+- remaining daemon bounded-state and shutdown-contract gaps
+- an integration-gate cleanup bucket on `integrate/phase-S`
+
+Phase T turns those residuals into explicit follow-up sprints with narrower
+acceptance gates than the overloaded S.14 / S.15 hardening branches.
+
+Planning baseline:
+- `integrate/phase-S` review baseline: `bdac03c`
+- Phase T planning worktree:
+  `/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-T`
+
+## 2. Scope
+
+Phase T is limited to:
+- closing the open integration-gate findings already triaged on
+  `integrate/phase-S`
+- implementing the real SQLite write-worker design promised by S.15
+- enforcing immutable message-row semantics on the hot mailbox write path
+- proving real Windows same-host runtime parity for daemon singleton and local
+  IPC behavior
+- finishing the remaining daemon bounded-state and shutdown-contract hardening
+
+Out of scope:
+- new CLI features
+- new peer-to-peer protocol features
+- re-architecting the daemon beyond the named residual gaps
+- broad SQLite tuning not required to land the single-writer and immutable-row
+  correctness work
+
+## 3. Why Phase T Exists
+
+The final Phase S review and integration gate exposed a process problem:
+- the major residual gaps were documented in the sprint docs and ADRs
+- some of those planned deliverables were still not present in the integrated
+  code
+- the follow-up work needs tighter sprint boundaries so QA can verify concrete
+  presence, not just directionally similar hardening
+
+Phase T therefore splits the residual work into:
+- one `integrate/phase-S` cleanup sprint (`T.1`)
+- four focused follow-up sprints on `integrate/phase-T` (`T.2`–`T.5`)
+
+## 4. Dependency Graph
+
+| Sprint | Purpose | Base | Depends on | Can run in parallel with |
+| --- | --- | --- | --- | --- |
+| `T.1` | integrate/phase-S gate patch cleanup | `integrate/phase-S @ bdac03c` | none | `T.2`–`T.5` planning only |
+| `T.2` | SQLite single-writer lane | `integrate/phase-T @ bdac03c` | none | `T.4`, `T.5` |
+| `T.3` | Immutable message rows + probe removal | `integrate/phase-T @ bdac03c` | `T.2` | `T.4`, `T.5` after `T.2` branch-cut |
+| `T.4` | Windows same-host runtime parity | `integrate/phase-T @ bdac03c` | none | `T.2`, `T.5` |
+| `T.5` | Remaining daemon hardening | `integrate/phase-T @ bdac03c` | none | `T.2`, `T.4` |
+
+Execution rule:
+- `T.1` closes the integration-gate residuals already tracked on
+  `integrate/phase-S`
+- `T.2` and `T.3` are a correctness pair; do not mark the SQLite write path
+  production-ready until both land
+- `T.4` and `T.5` may execute independently, but both must land before daemon
+  runtime promotion is considered complete
+
+## 5. Planned Sprint Sequence
+
+### T.1 Integration Gate Patch Sprint
+
+Goal:
+- close the open `INTG-*` findings already triaged on `integrate/phase-S`
+  without broadening scope into new architecture work
+
+Artifacts:
+- [`docs/phase-T/sprint-T1-integration-gate.md`](./phase-T/sprint-T1-integration-gate.md)
+
+### T.2 SQLite Single-Writer Lane
+
+Goal:
+- land the real crate-private `atm-rusqlite` single-writer lane promised by
+  S.15 and `ADR-ATM-RUSQLITE-002`
+
+Artifacts:
+- [`docs/phase-T/sprint-T2-sqlite-writer.md`](./phase-T/sprint-T2-sqlite-writer.md)
+
+### T.3 Immutable Message Rows
+
+Goal:
+- finish the hot mailbox write-path contract by removing mutable-row conflict
+  updates and removing the pre-write probe
+
+Artifacts:
+- [`docs/phase-T/sprint-T3-immutable-rows.md`](./phase-T/sprint-T3-immutable-rows.md)
+
+### T.4 Windows Runtime Parity
+
+Goal:
+- replace compile-only confidence with real Windows same-host runtime proof for
+  daemon singleton, lifecycle, local IPC, and retained-log startup/shutdown
+
+Artifacts:
+- [`docs/phase-T/sprint-T4-windows-runtime.md`](./phase-T/sprint-T4-windows-runtime.md)
+
+### T.5 Remaining Hardening
+
+Goal:
+- close the remaining daemon bounded-state and shutdown-contract follow-up
+  items left open after S.14 / S.15
+
+Artifacts:
+- [`docs/phase-T/sprint-T5-hardening.md`](./phase-T/sprint-T5-hardening.md)
+
+## 6. Cross-Sprint Acceptance
+
+Phase T is complete only when:
+- `T.1` closes the remaining open `INTG-*` findings on `integrate/phase-S`
+- `T.2` lands a real crate-private writer lane used by the hot write path
+- `T.3` enforces immutable message-row semantics and removes the probe from the
+  hot path
+- `T.4` proves real Windows same-host daemon parity through runtime tests, not
+  only `xwin` compile checks
+- `T.5` closes the remaining bounded-state and shutdown-contract gaps and
+  aligns docs with code
+
+## 7. Additional Follow-Up Watchlist
+
+These items are expected to be resolved inside the named T sprints rather than
+as a separate `T.6`, but they must still be tracked explicitly during QA:
+- `NotificationRuntime::shutdown()` bounded join semantics
+- pre-connect terminate checks in peer transport shutdown windows
+- orphaned shutdown-helper observability
+- `SHUTDOWN_FINALIZER_THREADS` poison and lifetime hardening
+- reconcile fingerprint-state bounds beyond key-count-only caps

--- a/docs/plan-phase-T.md
+++ b/docs/plan-phase-T.md
@@ -13,6 +13,8 @@ round of runtime hardening, but the final integrated review still found:
   IPC behavior
 - remaining daemon bounded-state and shutdown-contract gaps
 - an integration-gate cleanup bucket on `integrate/phase-S`
+- no thin embedded host-agent client line yet for the now-complete daemon/IPC
+  baseline
 
 Phase T turns those residuals into explicit follow-up sprints with narrower
 acceptance gates than the overloaded S.14 / S.15 hardening branches.
@@ -33,6 +35,8 @@ Phase T is limited to:
 - proving real Windows same-host runtime parity for daemon singleton and local
   IPC behavior
 - finishing the remaining daemon bounded-state and shutdown-contract hardening
+- planning and landing the thin `atm-graft` embedded-client follow-on once the
+  daemon/runtime baseline is stable
 
 Out of scope:
 - new CLI features
@@ -52,13 +56,18 @@ The final Phase S review and integration gate exposed a process problem:
 
 Phase T therefore splits the residual work into:
 - one `integrate/phase-S` cleanup sprint (`T.1`)
-- four focused follow-up sprints on `integrate/phase-T` (`T.2`–`T.5`)
+- four focused production-readiness sprints on `integrate/phase-T`
+  (`T.2`–`T.5`)
+- three additive embedded-client sprints on `integrate/phase-T`
+  (`T.6`–`T.8`)
 
 Forward-integration rule:
-- all T sprints (`T.1`–`T.5`) land directly on `integrate/phase-T`
+- all T sprints (`T.1`–`T.8`) land directly on `integrate/phase-T`
 - `integrate/phase-T` already incorporates `integrate/phase-S` at `c6847d1`
   via the develop forward-merge at `1232244`
 - `T.2`–`T.5` may start after `T.1` merges to `integrate/phase-T`
+- `T.6`–`T.8` build on the daemon/runtime baseline established by `T.2`–`T.5`
+  and should not destabilize those sprints' acceptance contracts
 
 ## 4. Dependency Graph
 
@@ -69,6 +78,9 @@ Forward-integration rule:
 | `T.3` | Immutable message rows + probe removal | `integrate/phase-T @ 1232244` | `T.2` merge | `T.4`, `T.5` |
 | `T.4` | Windows same-host runtime parity | `integrate/phase-T @ 1232244` | none | `T.2`, `T.5` |
 | `T.5` | Remaining daemon hardening | `integrate/phase-T @ 1232244` | none | `T.2`, `T.4` |
+| `T.6` | Embeddable graft client surface | `integrate/phase-T @ 1232244` | `T.2`–`T.5` merge | `T.7`, `T.8` planning only |
+| `T.7` | Graft runtime in daemon | `integrate/phase-T @ 1232244` | `T.6` merge | `T.8` planning only |
+| `T.8` | `atm-graft` crate | `integrate/phase-T @ 1232244` | `T.6`, `T.7` merge | none |
 
 Execution rule:
 - `T.1` closes the integration-gate residuals already tracked on
@@ -77,6 +89,9 @@ Execution rule:
   production-ready until both land
 - `T.4` and `T.5` may execute independently, but both must land before daemon
   runtime promotion is considered complete
+- `T.6` through `T.8` are intentionally thin follow-ons: treat them as “embed
+  the existing ATM client/runtime line in an agent,” not as a second runtime
+  architecture effort
 
 ## 5. Planned Sprint Sequence
 
@@ -125,6 +140,36 @@ Goal:
 Artifacts:
 - [`docs/phase-T/sprint-T5-hardening.md`](./phase-T/sprint-T5-hardening.md)
 
+### T.6 Graft Client Surface
+
+Goal:
+- define the small embeddable daemon-client surface needed by `atm-graft`
+
+Artifacts:
+- [`docs/phase-T/sprint-T6-graft-client-surface.md`](./phase-T/sprint-T6-graft-client-surface.md)
+- [`docs/atm-graft/requirements.md`](./atm-graft/requirements.md)
+- [`docs/atm-graft/architecture.md`](./atm-graft/architecture.md)
+- [`docs/plan-atm-graft.md`](./plan-atm-graft.md)
+
+### T.7 Graft Runtime
+
+Goal:
+- add daemon-side registration and daemon-owned bounded nudge queue/drain
+  behavior for embedded and hook/poll consumers
+
+Artifacts:
+- [`docs/phase-T/sprint-T7-graft-runtime.md`](./phase-T/sprint-T7-graft-runtime.md)
+- [`docs/plan-atm-graft.md`](./plan-atm-graft.md)
+
+### T.8 ATM-Graft Crate
+
+Goal:
+- land `atm-graft` as a thin ATM client embedded inside a Rust host agent
+
+Artifacts:
+- [`docs/phase-T/sprint-T8-atm-graft-crate.md`](./phase-T/sprint-T8-atm-graft-crate.md)
+- [`docs/plan-atm-graft.md`](./plan-atm-graft.md)
+
 ## 6. Cross-Sprint Acceptance
 
 Phase T is complete only when:
@@ -136,11 +181,16 @@ Phase T is complete only when:
   only `xwin` compile checks
 - `T.5` closes the remaining bounded-state and shutdown-contract gaps and
   aligns docs with code
+- `T.6` lands the embeddable client-facing daemon surface in `atm-core`
+- `T.7` lands daemon-owned graft registration and bounded nudge drain behavior
+- `T.8` lands `atm-graft` as a thin embedded client crate with no direct
+  daemon-crate, SQLite, or inbox-JSONL dependency
 
 ## 7. Additional Follow-Up Watchlist
 
 These items are expected to be resolved inside the named T sprints rather than
-as a separate `T.6`, but they must still be tracked explicitly during QA:
+as ad hoc follow-up hardening, but they must still be tracked explicitly during
+QA:
 - `NotificationRuntime::shutdown()` bounded join semantics
 - pre-connect terminate checks in peer transport shutdown windows
 - orphaned shutdown-helper observability

--- a/docs/plan-phase-T.md
+++ b/docs/plan-phase-T.md
@@ -55,25 +55,24 @@ Phase T therefore splits the residual work into:
 - four focused follow-up sprints on `integrate/phase-T` (`T.2`–`T.5`)
 
 Forward-integration rule:
-- `integrate/phase-T` was branched from `integrate/phase-S` at `bdac03c`
-- `T.1` lands on `integrate/phase-S` and reaches `integrate/phase-T` only by
-  forward-merge from `develop` after the `integrate/phase-S` gate PR merges
-- `T.2`–`T.5` must not open implementation PRs until that forward-merge brings
-  the accepted `T.1` fixes into `integrate/phase-T`
+- all T sprints (`T.1`–`T.5`) land directly on `integrate/phase-T`
+- `integrate/phase-T` already incorporates `integrate/phase-S` at `c6847d1`
+  via the develop forward-merge at `1232244`
+- `T.2`–`T.5` may start after `T.1` merges to `integrate/phase-T`
 
 ## 4. Dependency Graph
 
 | Sprint | Purpose | Base | Depends on | Can run in parallel with |
 | --- | --- | --- | --- | --- |
-| `T.1` | integrate/phase-S gate patch cleanup | `integrate/phase-S @ bdac03c` | none | `T.2`–`T.5` planning only |
-| `T.2` | SQLite single-writer lane | `integrate/phase-T @ bdac03c` | none | `T.4`, `T.5` |
-| `T.3` | Immutable message rows + probe removal | `integrate/phase-T @ bdac03c` | `T.2` merge | `T.4`, `T.5` |
-| `T.4` | Windows same-host runtime parity | `integrate/phase-T @ bdac03c` | none | `T.2`, `T.5` |
-| `T.5` | Remaining daemon hardening | `integrate/phase-T @ bdac03c` | none | `T.2`, `T.4` |
+| `T.1` | integrate/phase-S gate patch cleanup | `integrate/phase-T @ 1232244` | none | `T.2`–`T.5` planning only |
+| `T.2` | SQLite single-writer lane | `integrate/phase-T @ 1232244` | none | `T.4`, `T.5` |
+| `T.3` | Immutable message rows + probe removal | `integrate/phase-T @ 1232244` | `T.2` merge | `T.4`, `T.5` |
+| `T.4` | Windows same-host runtime parity | `integrate/phase-T @ 1232244` | none | `T.2`, `T.5` |
+| `T.5` | Remaining daemon hardening | `integrate/phase-T @ 1232244` | none | `T.2`, `T.4` |
 
 Execution rule:
 - `T.1` closes the integration-gate residuals already tracked on
-  `integrate/phase-S`
+  `integrate/phase-S`; fixes land on `integrate/phase-T`
 - `T.2` and `T.3` are a correctness pair; do not mark the SQLite write path
   production-ready until both land
 - `T.4` and `T.5` may execute independently, but both must land before daemon

--- a/docs/plan-phase-T.md
+++ b/docs/plan-phase-T.md
@@ -18,6 +18,7 @@ Phase T turns those residuals into explicit follow-up sprints with narrower
 acceptance gates than the overloaded S.14 / S.15 hardening branches.
 
 Planning baseline:
+- `docs/project-plan.md` §25 (Phase S) and §26 (Phase T)
 - `integrate/phase-S` review baseline: `bdac03c`
 - Phase T planning worktree:
   `/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-T`
@@ -53,13 +54,20 @@ Phase T therefore splits the residual work into:
 - one `integrate/phase-S` cleanup sprint (`T.1`)
 - four focused follow-up sprints on `integrate/phase-T` (`T.2`–`T.5`)
 
+Forward-integration rule:
+- `integrate/phase-T` was branched from `integrate/phase-S` at `bdac03c`
+- `T.1` lands on `integrate/phase-S` and reaches `integrate/phase-T` only by
+  forward-merge from `develop` after the `integrate/phase-S` gate PR merges
+- `T.2`–`T.5` must not open implementation PRs until that forward-merge brings
+  the accepted `T.1` fixes into `integrate/phase-T`
+
 ## 4. Dependency Graph
 
 | Sprint | Purpose | Base | Depends on | Can run in parallel with |
 | --- | --- | --- | --- | --- |
 | `T.1` | integrate/phase-S gate patch cleanup | `integrate/phase-S @ bdac03c` | none | `T.2`–`T.5` planning only |
 | `T.2` | SQLite single-writer lane | `integrate/phase-T @ bdac03c` | none | `T.4`, `T.5` |
-| `T.3` | Immutable message rows + probe removal | `integrate/phase-T @ bdac03c` | `T.2` | `T.4`, `T.5` after `T.2` branch-cut |
+| `T.3` | Immutable message rows + probe removal | `integrate/phase-T @ bdac03c` | `T.2` merge | `T.4`, `T.5` |
 | `T.4` | Windows same-host runtime parity | `integrate/phase-T @ bdac03c` | none | `T.2`, `T.5` |
 | `T.5` | Remaining daemon hardening | `integrate/phase-T @ bdac03c` | none | `T.2`, `T.4` |
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -129,6 +129,7 @@ The abandoned Phase Q target implementation was split across:
 - `crates/atm-core`
 - `crates/atm`
 - `crates/atm-daemon`
+- `crates/atm-graft`
 - `crates/atm-rusqlite`
 
 Crate-local scope detail is owned by:
@@ -142,6 +143,9 @@ Crate-local scope detail is owned by:
 - [`docs/atm-daemon/requirements.md`](./atm-daemon/requirements.md)
 - [`docs/atm-daemon/architecture.md`](./atm-daemon/architecture.md)
 - [`docs/atm-daemon/boundaries.md`](./atm-daemon/boundaries.md)
+- [`docs/atm-graft/requirements.md`](./atm-graft/requirements.md)
+- [`docs/atm-graft/architecture.md`](./atm-graft/architecture.md)
+- [`docs/atm-graft/boundaries.md`](./atm-graft/boundaries.md)
 - [`docs/atm-rusqlite/requirements.md`](./atm-rusqlite/requirements.md)
 - [`docs/atm-rusqlite/architecture.md`](./atm-rusqlite/architecture.md)
 - [`docs/atm-rusqlite/boundaries.md`](./atm-rusqlite/boundaries.md)

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -101,6 +101,7 @@ Status:
   - `crates/atm-core`
   - `crates/atm`
   - `crates/atm-daemon`
+  - `crates/atm-graft`
   - `crates/atm-rusqlite`
   - `crates/sc-lint-*` support crates
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2979,6 +2979,8 @@ Goal:
 - deliver the architectural work deferred from Phase S: SQLite single-writer
   lane, immutable message-row semantics, Windows same-host runtime parity
   tests, and remaining daemon/runtime hardening
+- add the thin embedded `atm-graft` follow-on on top of the now-complete
+  daemon/IPC baseline
 
 Sprints:
 - T.1 (integrate/phase-S): fix 16 open INTG-* findings to clear Phase S gate
@@ -2993,9 +2995,18 @@ Sprints:
 - T.5 (integrate/phase-T): close RuntimeStatusCache all-conflict overflow edge,
   bound reconcile fingerprint sets per mailbox key, reconcile shutdown deadline
   contract between code (2s/3s) and architecture doc (5s/10s)
+- T.6 (integrate/phase-T): define the embeddable graft-facing daemon client
+  surface in `atm-core` so a host agent can embed ATM as a thin client rather
+  than re-implementing transport/runtime logic
+- T.7 (integrate/phase-T): add daemon-side graft registration plus bounded
+  nudge queue/drain behavior for embedded and hook/poll consumers
+- T.8 (integrate/phase-T): add the `atm-graft` crate as a thin ATM client
+  embedded in a Rust host agent
 
 Integration branch: `integrate/phase-T`
 
 Cross-reference:
 - The authoritative sprint-by-sprint Phase T plan lives in
   [`docs/plan-phase-T.md`](./plan-phase-T.md).
+- The dedicated `atm-graft` implementation plan lives in
+  [`docs/plan-atm-graft.md`](./plan-atm-graft.md).

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2964,8 +2964,7 @@ Summary:
 - S.13–S.15 delivered the local IPC transport, Windows same-host runtime, and
   SQLite write-worker foundation
 - Integration branch `integrate/phase-S` carries all merged sprint work
-- PR #231 (`integrate/phase-S → develop`) is currently blocked by 16 open
-  INTG-* gate findings (2B+6I+8m); fixes are Sprint T.1 scope
+- PR #231 (`integrate/phase-S → develop`) merged at c6847d1; fixes are Sprint T.1 scope landing on `integrate/phase-T`
 
 Cross-reference:
 - The authoritative sprint-by-sprint Phase S plan lives in

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2948,3 +2948,54 @@ Acceptance:
   Python/CI glue
 - the migration boundary between `atm-core` and `sc-lint` is explicit rather
   than implied
+
+## 25. Phase S — Windows-Complete Daemon Parity And SQLite Durability [IN PROGRESS]
+
+Goal:
+- deliver a production-ready daemon that works correctly on both Unix and Windows
+  through the same-host local IPC transport and singleton lifecycle
+- add SQLite durability for remote replay state via `atm-rusqlite`
+
+Summary:
+- Sprints S.0–S.15 cover: Windows IPC transport, runtime control, daemon
+  hardening, policy lint, SQLite write-worker planning and implementation,
+  JSONL log compatibility, logging defaults, retained log bootstrap, and
+  integration gate cleanup
+- S.13–S.15 delivered the local IPC transport, Windows same-host runtime, and
+  SQLite write-worker foundation
+- Integration branch `integrate/phase-S` carries all merged sprint work
+- PR #231 (`integrate/phase-S → develop`) is currently blocked by 16 open
+  INTG-* gate findings (2B+6I+8m); fixes are Sprint T.1 scope
+
+Cross-reference:
+- The authoritative sprint-by-sprint Phase S plan lives in
+  [`docs/plan-phase-S.md`](./plan-phase-S.md).
+- Phase S gate findings: `.triage/phase-S/findings/INTG-*.ttl`
+
+## 26. Phase T — Integration Gate Closure And SQLite Writer-Lane Delivery [ACTIVE]
+
+Goal:
+- close the Phase S integration gate (PR #231) by fixing all 16 INTG-* findings
+- deliver the architectural work deferred from Phase S: SQLite single-writer
+  lane, immutable message-row semantics, Windows same-host runtime parity
+  tests, and remaining daemon/runtime hardening
+
+Sprints:
+- T.1 (integrate/phase-S): fix 16 open INTG-* findings to clear Phase S gate
+- T.2 (integrate/phase-T): implement crate-private SQLite single-writer lane
+  (long-lived connection, bounded queue, drain/shutdown) per ADR-ATM-RUSQLITE-002
+- T.3 (integrate/phase-T): enforce immutable message-row semantics — remove
+  pre-write SELECT probe, insert-first writer-owned semantics, rows-changed
+  detection, reject known invariant violations before SQL
+- T.4 (integrate/phase-T): add real Windows same-host runtime parity tests for
+  local IPC request/response, lifecycle control, singleton admission/rejection,
+  and orderly shutdown
+- T.5 (integrate/phase-T): close RuntimeStatusCache all-conflict overflow edge,
+  bound reconcile fingerprint sets per mailbox key, reconcile shutdown deadline
+  contract between code (2s/3s) and architecture doc (5s/10s)
+
+Integration branch: `integrate/phase-T`
+
+Cross-reference:
+- The authoritative sprint-by-sprint Phase T plan lives in
+  [`docs/plan-phase-T.md`](./plan-phase-T.md).

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -67,10 +67,13 @@ Crate-local ownership docs live under:
 - [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
 - [`docs/atm-daemon/requirements.md`](./atm-daemon/requirements.md)
 - [`docs/atm-daemon/architecture.md`](./atm-daemon/architecture.md)
+- [`docs/atm-graft/requirements.md`](./atm-graft/requirements.md)
+- [`docs/atm-graft/architecture.md`](./atm-graft/architecture.md)
 - [`docs/atm-rusqlite/requirements.md`](./atm-rusqlite/requirements.md)
 - [`docs/atm-rusqlite/architecture.md`](./atm-rusqlite/architecture.md)
 - [`docs/atm-core/boundaries.md`](./atm-core/boundaries.md)
 - [`docs/atm-daemon/boundaries.md`](./atm-daemon/boundaries.md)
+- [`docs/atm-graft/boundaries.md`](./atm-graft/boundaries.md)
 - [`docs/atm-rusqlite/boundaries.md`](./atm-rusqlite/boundaries.md)
 - [`docs/atm/boundaries.md`](./atm/boundaries.md)
 
@@ -2972,6 +2975,9 @@ mail correctness.
   - shared test infrastructure must exercise the same handler/dispatcher
     contract on Unix and Windows rather than maintaining separate product-level
     transport semantics per platform
+  - Phase T extension: this same logical daemon API also underpins the embedded
+    `atm-graft` client line; see
+    [`docs/atm-graft/requirements.md`](./atm-graft/requirements.md)
 
 - `REQ-CORE-TRANSPORT-001B` Request routing must live behind one explicit
   dispatcher boundary with injectable typed handlers.
@@ -3122,6 +3128,22 @@ mail correctness.
     of JSONL
   - the later agent plugin crate must align to this daemon API rather than
     introducing a parallel message transport
+
+- `REQ-P-GRAFT-001` First-party embedded Rust host-agent integration must use
+  one daemon-backed graft crate aligned to the Phase T runtime boundaries.
+
+  Required behavior:
+  - the first-party embedded Rust host-agent integration crate is `atm-graft`
+  - `atm-graft` uses the same-host daemon API for `send`, `read`, `ack`,
+    session registration, and automatic nudge delivery
+  - `atm-graft` must not access SQLite or inbox JSONL directly
+  - if no `.atm.toml` is discovered, `atm-graft` remains inactive
+  - when active, automatic daemon registration and automatic between-tool-call
+    context injection are enabled by default and may be disabled only by
+    explicit config or runtime opt-out
+  - the production target is a custom host CLI with `atm-graft` linked
+    in-process; production acceptance must not depend on `tmux send-keys` or
+    equivalent terminal automation
 
 ### 21.6 Lock Elimination Target
 


### PR DESCRIPTION
## Summary

- Adds Phase T planning documents: `docs/plan-phase-T.md` and `docs/phase-T/sprint-T1-integration-gate.md` through `sprint-T5-hardening.md`
- Tightens `req-qa` deliverable-verification prompt (`3c199f2`)
- Adds Phase S/T sections to `docs/project-plan.md`
- Hardens `plan-hardening` skill with explicit team-lead critical review step
- Fixes `quality-mgr.md` stale `integrate/phase-R` integration branch reference
- All sprints target `integrate/phase-T @ 1232244` directly

## Sprints

| Sprint | Scope |
|--------|-------|
| T.1 | Close 16 open INTG-* findings (2B+6I+8m) from Phase S gate |
| T.2 | SQLite single-writer lane (ADR-ATM-RUSQLITE-002) |
| T.3 | Immutable message rows + pre-write probe removal |
| T.4 | Windows same-host runtime parity (real tests, not xwin-only) |
| T.5 | Remaining daemon bounded-state + shutdown-contract hardening |

## Test plan

- [ ] Review sprint docs for completeness and accuracy
- [ ] Approve plan before dispatching T.1 implementation to arch-ctm

🤖 Generated with [Claude Code](https://claude.com/claude-code)