### PR TITLE
T.1 Integration gate patch — close all 16 INTG-* findings

### DIFF
--- a/.triage/phase-S/findings/INTG-ARCH-001.ttl
+++ b/.triage/phase-S/findings/INTG-ARCH-001.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "crates/atm-daemon/src/runtime_health.rs" ;
   triage:line 452 ;
   triage:snippet "pub(crate) fn emit_runtime_event" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-ARCH-002.ttl
+++ b/.triage/phase-S/findings/INTG-ARCH-002.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "crates/atm-daemon/src/composition.rs" ;
   triage:line 220 ;
   triage:snippet "dispatcher.emit_runtime_event" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-ATM-QA-001.ttl
+++ b/.triage/phase-S/findings/INTG-ATM-QA-001.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "docs/project-plan.md" ;
   triage:line 1 ;
   triage:snippet "Phase S sprint scope" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-ATM-QA-002.ttl
+++ b/.triage/phase-S/findings/INTG-ATM-QA-002.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "docs/plan-phase-S.md" ;
   triage:line 1 ;
   triage:snippet "SQLite Write-Worker / MessageAppendQueue Planning" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-ATM-QA-003.ttl
+++ b/.triage/phase-S/findings/INTG-ATM-QA-003.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "docs/phase-S/sprint-S14-runtime-plan.md" ;
   triage:line 49 ;
   triage:snippet "daemon_observability.rs" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-ATM-QA-004.ttl
+++ b/.triage/phase-S/findings/INTG-ATM-QA-004.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "docs/phase-S/" ;
   triage:line 1 ;
   triage:snippet "S.10–S.15 sprint docs missing YAML frontmatter" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-ATM-QA-005.ttl
+++ b/.triage/phase-S/findings/INTG-ATM-QA-005.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "docs/plan-phase-S.md" ;
   triage:line 1 ;
   triage:snippet "S.15 artifact list" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-ATM-QA-006.ttl
+++ b/.triage/phase-S/findings/INTG-ATM-QA-006.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "docs/phase-S/sprint-S15-rusqlite-hardening.md" ;
   triage:line 1 ;
   triage:snippet "REQ-P-RUNTIME-002" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-FTQ-008.ttl
+++ b/.triage/phase-S/findings/INTG-FTQ-008.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "crates/atm-daemon/src/runtime_health.rs" ;
   triage:line 44 ;
   triage:snippet "static SHUTDOWN_FINALIZER_THREADS: Mutex<Vec<JoinHandle<()>>>" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-RBP-003.ttl
+++ b/.triage/phase-S/findings/INTG-RBP-003.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "crates/atm-daemon/src/runtime_health.rs" ;
   triage:line 393 ;
   triage:snippet "SHUTDOWN_FINALIZER_THREADS.lock().expect(" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-RBP-004.ttl
+++ b/.triage/phase-S/findings/INTG-RBP-004.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "crates/atm-daemon/src/local_ipc_transport.rs" ;
   triage:line 718 ;
   triage:snippet "thread::Builder::new().spawn(...).expect(" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-RBP-005.ttl
+++ b/.triage/phase-S/findings/INTG-RBP-005.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "crates/atm-daemon/src/runtime_health.rs" ;
   triage:line 44 ;
   triage:snippet "static SHUTDOWN_FINALIZER_THREADS: Mutex<Vec<JoinHandle<()>>>" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-RSH-005.ttl
+++ b/.triage/phase-S/findings/INTG-RSH-005.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "crates/atm-daemon/src/notification_runtime.rs" ;
   triage:line 105 ;
   triage:snippet "handle.join()" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-RSH-006.ttl
+++ b/.triage/phase-S/findings/INTG-RSH-006.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "crates/atm-daemon/src/peer_transport.rs" ;
   triage:line 249 ;
   triage:snippet "send_once(" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-RSH-007.ttl
+++ b/.triage/phase-S/findings/INTG-RSH-007.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "crates/atm-daemon/src/composition.rs" ;
   triage:line 563 ;
   triage:snippet "shutdown_lane_with_deadline" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.triage/phase-S/findings/INTG-RSH-008.ttl
+++ b/.triage/phase-S/findings/INTG-RSH-008.ttl
@@ -13,9 +13,10 @@
   triage:phaseId "phase-S" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "closed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-05-11T01:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-05-11T02:11:06Z"^^xsd:dateTime ;
   triage:highestOpenBranch "integrate/phase-S" ;
   triage:promoteToBranch "integrate/phase-S" ;
   triage:mergeForwardNeeded false ;
@@ -30,9 +31,9 @@
   triage:file "crates/atm-daemon/src/local_ipc_transport.rs" ;
   triage:line 708 ;
   triage:snippet "schedule_delayed_listener_wake" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:headSha "4118b27" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:headSha "67d6c90" ;
   triage:branch "integrate/phase-S" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-S/4118b27> .
 
@@ -40,6 +41,6 @@
   a triage:WorktreeSnapshot ;
   triage:branch "integrate/phase-S" ;
   triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-S" ;
-  triage:headSha "4118b27" ;
+  triage:headSha "67d6c90" ;
   triage:orderIndex 1 ;
   triage:branchState "open" .

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -24,4 +24,4 @@ Installers:
     InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.2.0/atm_1.2.0_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.1.2
+ManifestVersion: 1.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -110,7 +110,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "atm-daemon"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "agent-team-mail-core",
  "atm-rusqlite",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "atm-rusqlite"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "agent-team-mail-core",
  "chrono",

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -313,6 +313,7 @@ impl RuntimeComposition {
                 begin_shutdown: || self.begin_shutdown(),
                 reload_runtime_view: move || request_dispatcher.reload_runtime_view(),
                 finalize_shutdown: || self.finalize_shutdown(),
+                publish_ready: || Ok(()),
             },
         );
         self.finish_runtime(result)
@@ -323,6 +324,7 @@ impl RuntimeComposition {
     pub(crate) fn start_with_socket_path_for_test(
         &self,
         socket_path: PathBuf,
+        ready_signal: Option<std::sync::mpsc::SyncSender<()>>,
     ) -> Result<(), AtmError> {
         self.request_dispatcher.record_runtime_event(
             "start_requested",
@@ -401,6 +403,19 @@ impl RuntimeComposition {
                 begin_shutdown: || self.begin_shutdown(),
                 reload_runtime_view: move || request_dispatcher.reload_runtime_view(),
                 finalize_shutdown: || self.finalize_shutdown(),
+                publish_ready: move || {
+                    if let Some(signal) = ready_signal.as_ref() {
+                        signal.send(()).map_err(|_| {
+                            AtmError::daemon_unavailable(
+                                "test runtime failed to publish the daemon ready signal",
+                            )
+                            .with_recovery(
+                                "Restore the bounded ready-signal handshake before retrying the same-host daemon runtime test.",
+                            )
+                        })?;
+                    }
+                    Ok(())
+                },
             },
         );
         self.finish_runtime(result)
@@ -752,7 +767,7 @@ mod tests {
         let runtime = RuntimeComposition::new(tempdir.path().to_path_buf()).expect("runtime");
 
         let error = runtime
-            .start_with_socket_path_for_test(socket_path)
+            .start_with_socket_path_for_test(socket_path, None)
             .expect_err("startup should fail");
 
         assert!(error.is_daemon_unavailable());

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -219,7 +219,7 @@ impl RuntimeComposition {
     }
 
     fn begin_shutdown(&self) -> Result<(), AtmError> {
-        self.request_dispatcher.emit_runtime_event(
+        self.request_dispatcher.record_runtime_event(
             "shutdown_requested",
             "ok",
             "daemon shutdown requested",
@@ -237,7 +237,7 @@ impl RuntimeComposition {
     }
 
     pub(crate) fn start(&self) -> Result<(), AtmError> {
-        self.request_dispatcher.emit_runtime_event(
+        self.request_dispatcher.record_runtime_event(
             "start_requested",
             "ok",
             "daemon start requested",
@@ -248,7 +248,7 @@ impl RuntimeComposition {
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.request_dispatcher.emit_runtime_event(
+                self.request_dispatcher.record_runtime_event(
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -269,7 +269,7 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.request_dispatcher.emit_runtime_event(
+            self.request_dispatcher.record_runtime_event(
                 "startup_failed",
                 "failed",
                 "daemon startup failed",
@@ -286,7 +286,7 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during runtime preparation rollback"
                     );
                 }
-                self.request_dispatcher.emit_runtime_event(
+                self.request_dispatcher.record_runtime_event(
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -297,7 +297,7 @@ impl RuntimeComposition {
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.request_dispatcher.emit_runtime_event(
+        self.request_dispatcher.record_runtime_event(
             "startup_completed",
             "ok",
             "daemon startup completed",
@@ -324,7 +324,7 @@ impl RuntimeComposition {
         &self,
         socket_path: PathBuf,
     ) -> Result<(), AtmError> {
-        self.request_dispatcher.emit_runtime_event(
+        self.request_dispatcher.record_runtime_event(
             "start_requested",
             "ok",
             "daemon start requested",
@@ -333,7 +333,7 @@ impl RuntimeComposition {
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.request_dispatcher.emit_runtime_event(
+                self.request_dispatcher.record_runtime_event(
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -354,7 +354,7 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.request_dispatcher.emit_runtime_event(
+            self.request_dispatcher.record_runtime_event(
                 "startup_failed",
                 "failed",
                 "daemon startup failed",
@@ -374,7 +374,7 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during test runtime preparation rollback"
                     );
                 }
-                self.request_dispatcher.emit_runtime_event(
+                self.request_dispatcher.record_runtime_event(
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -385,7 +385,7 @@ impl RuntimeComposition {
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.request_dispatcher.emit_runtime_event(
+        self.request_dispatcher.record_runtime_event(
             "startup_completed",
             "ok",
             "daemon startup completed",
@@ -432,12 +432,12 @@ impl RuntimeComposition {
             };
         }
         match result.as_ref() {
-            Ok(()) => self.request_dispatcher.emit_runtime_event(
+            Ok(()) => self.request_dispatcher.record_runtime_event(
                 "shutdown_completed",
                 "ok",
                 "daemon shutdown completed",
             ),
-            Err(_) => self.request_dispatcher.emit_runtime_event(
+            Err(_) => self.request_dispatcher.record_runtime_event(
                 "shutdown_failed",
                 "failed",
                 "daemon shutdown failed",
@@ -563,6 +563,7 @@ where
     let shutdown_handle = std::thread::spawn(move || {
         let _ = result_tx.send(shutdown(lane));
     });
+    let shutdown_thread_id = shutdown_handle.thread().id();
     match result_rx.recv_timeout(deadline) {
         Ok(result) => {
             shutdown_handle.join().map_err(|_| {
@@ -572,9 +573,17 @@ where
             })?;
             result
         }
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(AtmError::daemon_unavailable(
-            format!("daemon {lane_name} shutdown exceeded the {deadline:?} per-lane deadline"),
-        )),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            tracing::debug!(
+                lane = lane_name,
+                timeout_ms = deadline.as_millis(),
+                thread_id = ?shutdown_thread_id,
+                "daemon shutdown lane timed out; join worker left detached after deadline"
+            );
+            Err(AtmError::daemon_unavailable(format!(
+                "daemon {lane_name} shutdown exceeded the {deadline:?} per-lane deadline"
+            )))
+        }
         Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => shutdown_handle.join().map_or_else(
             |_| {
                 Err(AtmError::daemon_unavailable(format!(

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -12,6 +12,7 @@ mod direct_boundaries;
 // tests::host_ownership_record_uses_pid_and_token_while_held_and_clears_on_release.
 mod host_ownership;
 mod lifecycle_control;
+mod local_ipc_connection;
 mod local_ipc_transport;
 mod notification_runtime;
 mod peer_transport;

--- a/crates/atm-daemon/src/local_ipc_connection.rs
+++ b/crates/atm-daemon/src/local_ipc_connection.rs
@@ -1,0 +1,54 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use atm_core::error::AtmError;
+
+use crate::active_connection_registry::ActiveConnectionRegistry;
+
+pub(crate) fn drain_active_connections_for_shutdown(
+    registry: &ActiveConnectionRegistry,
+    force_shutdown: &AtomicBool,
+    graceful_drain_deadline: Duration,
+    force_cancel_deadline: Duration,
+    shutdown_started: Instant,
+    tracked_dispatch_join_deadline: Duration,
+) -> Result<(), AtmError> {
+    tracing::info!(
+        active_connections = registry.active_connections(),
+        active_work_items = registry.active_work_items(),
+        "daemon shutdown signal received; starting graceful drain"
+    );
+    let graceful_deadline = shutdown_started + graceful_drain_deadline;
+    let force_cancel_deadline = shutdown_started + force_cancel_deadline;
+    while registry.active_work_items() > 0 && Instant::now() < graceful_deadline {
+        registry.wait_for_connection_change(
+            graceful_deadline.saturating_duration_since(Instant::now()),
+        )?;
+    }
+    if registry.active_work_items() > 0 {
+        tracing::info!(
+            active_work_items = registry.active_work_items(),
+            "daemon graceful drain hit deadline; continuing toward forced cancel"
+        );
+        force_shutdown.store(true, Ordering::SeqCst);
+        registry.interrupt_all();
+    } else {
+        tracing::info!("daemon graceful drain completed cleanly");
+    }
+    while registry.active_work_items() > 0 && Instant::now() < force_cancel_deadline {
+        registry.wait_for_connection_change(
+            force_cancel_deadline.saturating_duration_since(Instant::now()),
+        )?;
+    }
+    registry.join_tracked_dispatches(tracked_dispatch_join_deadline)?;
+    let remaining_work_items = registry.active_work_items();
+    if remaining_work_items > 0 {
+        return Err(AtmError::daemon_unavailable(format!(
+            "forced cancel deadline elapsed with {remaining_work_items} active daemon work item(s)"
+        ))
+        .with_recovery(
+            "Restart the daemon after the wedged request workers are no longer holding the same-host runtime open.",
+        ));
+    }
+    Ok(())
+}

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::num::NonZeroU64;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -27,6 +28,7 @@ const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 const TRACKED_DISPATCH_JOIN_DEADLINE: Duration = Duration::from_millis(250);
 const LISTENER_WAKE_CONNECT_DEADLINE: Duration = Duration::from_millis(250);
 const TERMINATE_REJECTION_GRACE_DEADLINE: Duration = Duration::from_millis(100);
+const TERMINATE_REJECTION_REQUEST_ID: u64 = NonZeroU64::MIN.get();
 
 #[derive(Debug, Default)]
 struct ServeLoopSignals {
@@ -455,7 +457,7 @@ impl PreparedRuntimeServer {
                         ),
                     ));
                     let frame = codec.response_to_frame(
-                        atm_core::protocol::RequestId::new(1).expect("non-zero request id"),
+                        atm_core::protocol::RequestId::new(TERMINATE_REJECTION_REQUEST_ID)?,
                         response,
                     )?;
                     let _ = stream.set_recv_timeout(Some(REQUEST_DEADLINE));

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -138,13 +138,19 @@ pub(crate) struct PreparedRuntimeServer {
     endpoint_guard: Option<SocketEndpointGuard>,
 }
 
-pub(crate) struct RuntimeServeHooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown> {
+pub(crate) struct RuntimeServeHooks<
+    BeginShutdown,
+    ReloadRuntimeView,
+    FinalizeShutdown,
+    PublishReady,
+> {
     pub(crate) endpoint_guard: SocketEndpointGuard,
     pub(crate) graceful_drain_deadline: Duration,
     pub(crate) force_cancel_deadline: Duration,
     pub(crate) begin_shutdown: BeginShutdown,
     pub(crate) reload_runtime_view: ReloadRuntimeView,
     pub(crate) finalize_shutdown: FinalizeShutdown,
+    pub(crate) publish_ready: PublishReady,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -220,28 +226,40 @@ impl PreparedRuntimeServer {
         })
     }
 
-    pub(crate) fn serve_with_runtime_hooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown>(
+    pub(crate) fn serve_with_runtime_hooks<
+        BeginShutdown,
+        ReloadRuntimeView,
+        FinalizeShutdown,
+        PublishReady,
+    >(
         self,
         dispatcher: Arc<dyn RequestDispatcher + Send + Sync>,
-        hooks: RuntimeServeHooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown>,
+        hooks: RuntimeServeHooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown, PublishReady>,
     ) -> Result<(), AtmError>
     where
         BeginShutdown: Fn() -> Result<(), AtmError>,
         ReloadRuntimeView: Fn() -> Result<(), AtmError>,
         FinalizeShutdown: Fn(),
+        PublishReady: Fn() -> Result<(), AtmError>,
     {
         self.serve_with_deadlines_and_accept_probe(dispatcher, hooks)
     }
 
-    fn serve_with_deadlines_and_accept_probe<BeginShutdown, ReloadRuntimeView, FinalizeShutdown>(
+    fn serve_with_deadlines_and_accept_probe<
+        BeginShutdown,
+        ReloadRuntimeView,
+        FinalizeShutdown,
+        PublishReady,
+    >(
         self,
         dispatcher: Arc<dyn RequestDispatcher + Send + Sync>,
-        hooks: RuntimeServeHooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown>,
+        hooks: RuntimeServeHooks<BeginShutdown, ReloadRuntimeView, FinalizeShutdown, PublishReady>,
     ) -> Result<(), AtmError>
     where
         BeginShutdown: Fn() -> Result<(), AtmError>,
         ReloadRuntimeView: Fn() -> Result<(), AtmError>,
         FinalizeShutdown: Fn(),
+        PublishReady: Fn() -> Result<(), AtmError>,
     {
         let RuntimeServeHooks {
             endpoint_guard,
@@ -250,6 +268,7 @@ impl PreparedRuntimeServer {
             begin_shutdown,
             reload_runtime_view,
             finalize_shutdown,
+            publish_ready,
         } = hooks;
         let Self {
             host_ownership_guard: _host_ownership_guard,
@@ -327,6 +346,7 @@ impl PreparedRuntimeServer {
                     }
                 })
             };
+            publish_ready()?;
             loop {
                 // Direct accept-loop target: lifecycle wakeups interrupt accept(), then this loop
                 // drains reload/error state inline so same-host serving stays in one place.
@@ -368,7 +388,7 @@ impl PreparedRuntimeServer {
                     }
                     continue;
                 }
-                #[cfg(all(test, unix))]
+                #[cfg(test)]
                 if let Some(error) = take_injected_accept_error_for_test() {
                     shutdown_beacon.trip();
                     let _ = lifecycle_control.notify_state_change();
@@ -793,11 +813,12 @@ fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {
     Ok(())
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 static INJECTED_ACCEPT_ERROR_FOR_TEST: std::sync::Mutex<Option<std::sync::mpsc::SyncSender<()>>> =
     std::sync::Mutex::new(None);
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
+#[cfg_attr(not(unix), allow(dead_code))]
 pub(crate) fn install_injected_accept_error_for_test(
     signal: std::sync::mpsc::SyncSender<()>,
 ) -> InjectAcceptErrorGuard {
@@ -807,10 +828,11 @@ pub(crate) fn install_injected_accept_error_for_test(
     InjectAcceptErrorGuard
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
+#[cfg_attr(not(unix), allow(dead_code))]
 pub(crate) struct InjectAcceptErrorGuard;
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 impl Drop for InjectAcceptErrorGuard {
     fn drop(&mut self) {
         *INJECTED_ACCEPT_ERROR_FOR_TEST
@@ -819,7 +841,7 @@ impl Drop for InjectAcceptErrorGuard {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 fn take_injected_accept_error_for_test() -> Option<AtmError> {
     let sender = INJECTED_ACCEPT_ERROR_FOR_TEST
         .lock()
@@ -1063,6 +1085,7 @@ mod tests {
                     begin_shutdown: || Ok(()),
                     reload_runtime_view: || Ok(()),
                     finalize_shutdown: || {},
+                    publish_ready: || Ok(()),
                 },
             );
             serve_result_tx.send(result).expect("send serve result");
@@ -1105,6 +1128,7 @@ mod tests {
         let _reset = LifecycleFlagResetGuard::install(lifecycle.clone());
         let dispatcher: Arc<dyn RequestDispatcher + Send + Sync> = Arc::new(DoctorOnlyDispatcher);
         let (serve_result_tx, serve_result_rx) = mpsc::channel();
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
 
         let join = std::thread::spawn(move || {
             // These shortened deadlines validate immediate shutdown-beacon wake correctness, not
@@ -1118,13 +1142,23 @@ mod tests {
                     begin_shutdown: || Ok(()),
                     reload_runtime_view: || Ok(()),
                     finalize_shutdown: || {},
+                    publish_ready: move || {
+                        ready_tx.send(()).map_err(|_| {
+                            AtmError::daemon_unavailable(
+                                "shutdown rejection test failed to observe the daemon ready signal",
+                            )
+                            .with_recovery(
+                                "Restore the bounded ready-signal handshake before retrying the same-host daemon shutdown rejection test.",
+                            )
+                        })
+                    },
                 },
             );
             serve_result_tx.send(result).expect("send serve result");
         });
 
         lifecycle.terminate_flag().store(true, Ordering::SeqCst);
-        let mut stream = connect_daemon_local_ipc_until_ready(&socket_path);
+        let mut stream = connect_daemon_local_ipc_until_ready(&socket_path, ready_rx);
         stream
             .set_send_timeout(Some(Duration::from_secs(5)))
             .expect("set send timeout");
@@ -1180,6 +1214,7 @@ mod tests {
         let _reset = LifecycleFlagResetGuard::install(lifecycle.clone());
         let dispatcher: Arc<dyn RequestDispatcher + Send + Sync> = Arc::new(PanicDispatcher);
         let (serve_result_tx, serve_result_rx) = mpsc::channel();
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
 
         let join = std::thread::spawn(move || {
             let result = runtime.serve_with_runtime_hooks(
@@ -1191,12 +1226,22 @@ mod tests {
                     begin_shutdown: || Ok(()),
                     reload_runtime_view: || Ok(()),
                     finalize_shutdown: || {},
+                    publish_ready: move || {
+                        ready_tx.send(()).map_err(|_| {
+                            AtmError::daemon_unavailable(
+                                "panic recovery test failed to observe the daemon ready signal",
+                            )
+                            .with_recovery(
+                                "Restore the bounded ready-signal handshake before retrying the same-host panic recovery test.",
+                            )
+                        })
+                    },
                 },
             );
             serve_result_tx.send(result).expect("send serve result");
         });
 
-        let mut stream = connect_daemon_local_ipc_until_ready(&socket_path);
+        let mut stream = connect_daemon_local_ipc_until_ready(&socket_path, ready_rx);
         stream
             .set_send_timeout(Some(Duration::from_secs(5)))
             .expect("set send timeout");

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -17,6 +17,7 @@ use interprocess::local_socket::{
 use crate::active_connection_registry::{ActiveConnectionRegistry, TrackedDispatchHandle};
 use crate::host_ownership::{HostOwnershipAdapter, HostOwnershipGuard};
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
+use crate::local_ipc_connection::drain_active_connections_for_shutdown;
 use crate::shutdown_beacon::ShutdownBeacon;
 
 #[cfg(unix)]
@@ -512,6 +513,7 @@ impl PreparedRuntimeServer {
                 graceful_drain_deadline,
                 force_cancel_deadline,
                 shutdown_started,
+                TRACKED_DISPATCH_JOIN_DEADLINE,
             ) {
                 if let Some(existing) = shutdown_error.as_ref() {
                     tracing::warn!(
@@ -849,53 +851,6 @@ fn emit_ready_signal_if_requested() -> Result<(), AtmError> {
             )
             .with_source(source)
     })?;
-    Ok(())
-}
-
-fn drain_active_connections_for_shutdown(
-    registry: &ActiveConnectionRegistry,
-    force_shutdown: &AtomicBool,
-    graceful_drain_deadline: Duration,
-    force_cancel_deadline: Duration,
-    shutdown_started: Instant,
-) -> Result<(), AtmError> {
-    tracing::info!(
-        active_connections = registry.active_connections(),
-        active_work_items = registry.active_work_items(),
-        "daemon shutdown signal received; starting graceful drain"
-    );
-    let graceful_deadline = shutdown_started + graceful_drain_deadline;
-    let force_cancel_deadline = shutdown_started + force_cancel_deadline;
-    while registry.active_work_items() > 0 && Instant::now() < graceful_deadline {
-        registry.wait_for_connection_change(
-            graceful_deadline.saturating_duration_since(Instant::now()),
-        )?;
-    }
-    if registry.active_work_items() > 0 {
-        tracing::info!(
-            active_work_items = registry.active_work_items(),
-            "daemon graceful drain hit deadline; continuing toward forced cancel"
-        );
-        force_shutdown.store(true, Ordering::SeqCst);
-        registry.interrupt_all();
-    } else {
-        tracing::info!("daemon graceful drain completed cleanly");
-    }
-    while registry.active_work_items() > 0 && Instant::now() < force_cancel_deadline {
-        registry.wait_for_connection_change(
-            force_cancel_deadline.saturating_duration_since(Instant::now()),
-        )?;
-    }
-    registry.join_tracked_dispatches(TRACKED_DISPATCH_JOIN_DEADLINE)?;
-    let remaining_work_items = registry.active_work_items();
-    if remaining_work_items > 0 {
-        return Err(AtmError::daemon_unavailable(format!(
-            "forced cancel deadline elapsed with {remaining_work_items} active daemon work item(s)"
-        ))
-        .with_recovery(
-            "Restart the daemon after the wedged request workers are no longer holding the same-host runtime open.",
-        ));
-    }
     Ok(())
 }
 
@@ -1312,6 +1267,7 @@ mod tests {
             Duration::from_millis(10),
             Duration::from_millis(20),
             Instant::now(),
+            TRACKED_DISPATCH_JOIN_DEADLINE,
         )
         .expect_err("bounded drain should fail once the forced-cancel deadline elapses");
         assert!(

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -428,10 +428,18 @@ impl PreparedRuntimeServer {
                         ShutdownResponseOutcome::NoFrame if terminate_probe_pending => break,
                         ShutdownResponseOutcome::NoFrame => {
                             terminate_probe_pending = true;
-                            schedule_delayed_listener_wake(
+                            if let Err(error) = schedule_delayed_listener_wake(
                                 endpoint_path.clone(),
                                 TERMINATE_REJECTION_GRACE_DEADLINE,
-                            );
+                            ) {
+                                tracing::warn!(
+                                    %error,
+                                    path = %endpoint_path.display(),
+                                    "failed to schedule delayed listener wake during shutdown probe"
+                                );
+                                let _ = wake_listener(&endpoint_path);
+                                break;
+                            }
                             continue;
                         }
                     }
@@ -705,7 +713,7 @@ fn write_shutdown_response(
     Ok(ShutdownResponseOutcome::RejectedRequest)
 }
 
-fn schedule_delayed_listener_wake(endpoint_path: PathBuf, delay: Duration) {
+fn schedule_delayed_listener_wake(endpoint_path: PathBuf, delay: Duration) -> Result<(), AtmError> {
     // Fire-and-forget: this helper only opens one local connection to unblock accept(), so
     // shutdown does not need to retain or join the wake thread after it has been scheduled.
     // The `_wake_handle` binding makes that intentional detach explicit at the call site.
@@ -715,7 +723,14 @@ fn schedule_delayed_listener_wake(endpoint_path: PathBuf, delay: Duration) {
             thread::sleep(delay);
             let _ = wake_listener(&endpoint_path);
         })
-        .expect("delayed-listener-wake thread");
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to spawn delayed listener wake helper")
+                .with_recovery(
+                    "Retry the ATM command after atm-daemon restarts; the shutdown wake helper could not be scheduled.",
+                )
+                .with_source(source)
+        })?;
+    Ok(())
 }
 
 fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -60,7 +60,9 @@ impl NotificationRuntime {
 
     pub(crate) fn start(&self) -> Result<(), AtmError> {
         let mut state = self.inner.state.lock().map_err(|_| {
-            AtmError::daemon_unavailable("notification runtime state lock poisoned")
+            AtmError::daemon_unavailable("notification runtime state lock poisoned").with_recovery(
+                "Restart the daemon; notification lifecycle state can no longer be trusted.",
+            )
         })?;
         if state.started {
             return Ok(());
@@ -135,7 +137,9 @@ impl NotificationRuntime {
 
     pub(crate) fn deliver(&self, event: NotificationEvent) -> Result<(), AtmError> {
         let mut state = self.inner.state.lock().map_err(|_| {
-            AtmError::daemon_unavailable("notification runtime state lock poisoned")
+            AtmError::daemon_unavailable("notification runtime state lock poisoned").with_recovery(
+                "Restart the daemon; notification lifecycle state can no longer be trusted.",
+            )
         })?;
         if !state.started {
             return Err(AtmError::daemon_unavailable(

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -21,8 +21,14 @@ pub(crate) struct NotificationRuntime {
 type NotificationPathFactory = Arc<dyn Fn() -> Result<PathBuf, AtmError> + Send + Sync>;
 
 struct NotificationRuntimeInner {
+    // State transitions, degradation, and the bounded queue must be updated
+    // atomically with respect to wakeups, so the queue and lifecycle flags live
+    // behind one mutex paired with the condvar below.
     state: Mutex<NotificationState>,
     wake: Condvar,
+    // The worker join handle is handed off exactly once between `start()` and
+    // `shutdown()`, so a separate mutex keeps that exclusive ownership transfer
+    // explicit without widening the main state critical section.
     worker: Mutex<Option<JoinHandle<()>>>,
     path_factory: NotificationPathFactory,
     queue_capacity: usize,

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -26,10 +26,6 @@ struct NotificationRuntimeInner {
     // behind one mutex paired with the condvar below.
     state: Mutex<NotificationState>,
     wake: Condvar,
-    // The worker join handle is handed off exactly once between `start()` and
-    // `shutdown()`, so a separate mutex keeps that exclusive ownership transfer
-    // explicit without widening the main state critical section.
-    worker: Mutex<Option<JoinHandle<()>>>,
     path_factory: NotificationPathFactory,
     queue_capacity: usize,
 }
@@ -40,6 +36,7 @@ struct NotificationState {
     shutdown: bool,
     degraded_message: Option<String>,
     queue: VecDeque<NotificationEvent>,
+    worker: Option<JoinHandle<()>>,
 }
 
 impl NotificationRuntime {
@@ -55,7 +52,6 @@ impl NotificationRuntime {
             inner: Arc::new(NotificationRuntimeInner {
                 state: Mutex::new(NotificationState::default()),
                 wake: Condvar::new(),
-                worker: Mutex::new(None),
                 path_factory,
                 queue_capacity,
             }),
@@ -81,34 +77,35 @@ impl NotificationRuntime {
                 AtmError::daemon_unavailable("failed to spawn notification runtime worker")
                     .with_source(source)
             })?;
-        let mut worker = match self.inner.worker.lock() {
-            Ok(worker) => worker,
+        let mut state = match self.inner.state.lock() {
+            Ok(state) => state,
             Err(_) => {
                 let _ = handle.join();
                 return Err(AtmError::daemon_unavailable(
-                    "notification runtime worker lock poisoned",
+                    "notification runtime state lock poisoned",
+                )
+                .with_recovery(
+                    "Restart the daemon; notification lifecycle state can no longer be trusted.",
                 ));
             }
         };
-        *worker = Some(handle);
+        state.worker = Some(handle);
         Ok(())
     }
 
     pub(crate) fn shutdown(&self) -> Result<(), AtmError> {
-        {
+        let handle = {
             let mut state = self.inner.state.lock().map_err(|_| {
                 AtmError::daemon_unavailable("notification runtime state lock poisoned")
+                    .with_recovery(
+                        "Restart the daemon; notification lifecycle state can no longer be trusted.",
+                    )
             })?;
             state.shutdown = true;
             self.inner.wake.notify_all();
-        }
-        if let Some(handle) = self
-            .inner
-            .worker
-            .lock()
-            .map_err(|_| AtmError::daemon_unavailable("notification runtime worker lock poisoned"))?
-            .take()
-        {
+            state.worker.take()
+        };
+        if let Some(handle) = handle {
             let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
             std::thread::spawn(move || {
                 let _ = result_tx.send(handle.join());

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 const DEFAULT_NOTIFICATION_QUEUE_CAPACITY: usize = 64;
 const DEFAULT_NOTIFICATION_IDLE_INTERVAL: Duration = Duration::from_millis(50);
+const NOTIFICATION_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(3);
 
 #[derive(Clone)]
 pub(crate) struct NotificationRuntime {
@@ -102,9 +103,29 @@ impl NotificationRuntime {
             .map_err(|_| AtmError::daemon_unavailable("notification runtime worker lock poisoned"))?
             .take()
         {
-            handle.join().map_err(|_| {
-                AtmError::daemon_unavailable("notification runtime worker panicked during shutdown")
-            })?;
+            let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+            std::thread::spawn(move || {
+                let _ = result_tx.send(handle.join());
+            });
+            match result_rx.recv_timeout(NOTIFICATION_SHUTDOWN_DEADLINE) {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {
+                    return Err(AtmError::daemon_unavailable(
+                        "notification runtime worker panicked during shutdown",
+                    ));
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    return Err(AtmError::daemon_unavailable(format!(
+                        "notification runtime shutdown exceeded the {:?} deadline",
+                        NOTIFICATION_SHUTDOWN_DEADLINE
+                    )));
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    return Err(AtmError::daemon_unavailable(
+                        "notification runtime join helper disconnected during shutdown",
+                    ));
+                }
+            }
         }
         Ok(())
     }

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -248,11 +248,12 @@ impl PeerClientTransport {
         let started = Instant::now();
         let deadline = started + self.config.remote_retry_budget;
         let terminate = daemon_terminate_flag()?;
+        let terminate_before_first_attempt = terminate.load(Ordering::SeqCst);
         let mut backoff = INITIAL_RETRY_BACKOFF;
         let mut attempt = 0u32;
 
         loop {
-            if terminate.load(Ordering::SeqCst) {
+            if attempt == 0 && terminate_before_first_attempt {
                 return Err(
                     AtmError::daemon_unavailable(
                         "daemon shutdown interrupted remote peer delivery before the next network attempt",

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -647,6 +647,7 @@ mod tests {
         RuntimeMemberState, TeamMemberHeartbeatRequest, TeamMemberHeartbeatResponse,
     };
     use atm_core::types::{AgentName, IsoTimestamp, TeamName};
+    use serial_test::serial;
     use std::io::{self, Read, Write};
     use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
     use std::sync::mpsc;
@@ -750,6 +751,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn peer_transport_round_trips_one_heartbeat_request() {
         let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
@@ -797,6 +799,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn peer_transport_uses_port_zero_listener_handoff_without_rebind_race() {
         let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
@@ -860,6 +863,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn peer_transport_reports_outcome_unknown_after_send_without_response() {
         let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
@@ -893,6 +897,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn peer_transport_treats_remote_error_envelope_as_non_retryable() {
         let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
@@ -933,6 +938,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn replay_resume_replays_and_deletes_delivered_rows() {
         let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
@@ -986,6 +992,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn outcome_unknown_persists_replay_request_for_restart_resume() {
         let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
@@ -1027,6 +1034,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn replay_resume_after_restart_delivers_once_and_clears_duplicate_delivery() {
         let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -252,6 +252,16 @@ impl PeerClientTransport {
         let mut attempt = 0u32;
 
         loop {
+            if terminate.load(Ordering::SeqCst) {
+                return Err(
+                    AtmError::daemon_unavailable(
+                        "daemon shutdown interrupted remote peer delivery before the next network attempt",
+                    )
+                    .with_recovery(
+                        "Retry the daemon operation after atm-daemon restarts and resumes pending remote replay work.",
+                    ),
+                );
+            }
             match self.send_once(endpoint, &frame) {
                 Ok(response) => {
                     tracing::info!(
@@ -627,6 +637,8 @@ mod tests {
         AttemptFailureKind, PeerTransportConfig, PeerTransportRuntime, classify_io_error,
         jittered_backoff,
     };
+    use crate::lifecycle_control::LifecycleControlSourceAdapter;
+    use crate::test_support::LifecycleFlagResetGuard;
     use atm_core::boundary::{AtmProtocol, ClientTransport, MessageKey};
     use atm_core::error::AtmErrorCode;
     use atm_core::protocol::{
@@ -671,6 +683,11 @@ mod tests {
             .expect("response frame");
         atm_core::protocol::write_frame(stream, &frame, "write response").expect("write response");
         stream.flush().expect("flush response");
+    }
+
+    fn install_shared_lifecycle_reset_guard() -> LifecycleFlagResetGuard {
+        let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
+        LifecycleFlagResetGuard::install(lifecycle)
     }
 
     #[test]
@@ -733,6 +750,7 @@ mod tests {
 
     #[test]
     fn peer_transport_round_trips_one_heartbeat_request() {
+        let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
         let endpoint = listener.local_addr().expect("addr");
@@ -779,6 +797,7 @@ mod tests {
 
     #[test]
     fn peer_transport_uses_port_zero_listener_handoff_without_rebind_race() {
+        let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
         let (endpoint_tx, endpoint_rx) = mpsc::channel();
         let team: TeamName = "test-team".parse().expect("team");
@@ -841,6 +860,7 @@ mod tests {
 
     #[test]
     fn peer_transport_reports_outcome_unknown_after_send_without_response() {
+        let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
         let endpoint = listener.local_addr().expect("addr");
@@ -873,6 +893,7 @@ mod tests {
 
     #[test]
     fn peer_transport_treats_remote_error_envelope_as_non_retryable() {
+        let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
         let endpoint = listener.local_addr().expect("addr");
@@ -912,6 +933,7 @@ mod tests {
 
     #[test]
     fn replay_resume_replays_and_deletes_delivered_rows() {
+        let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
         let endpoint = listener.local_addr().expect("addr");
@@ -964,6 +986,7 @@ mod tests {
 
     #[test]
     fn outcome_unknown_persists_replay_request_for_restart_resume() {
+        let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
         let endpoint = listener.local_addr().expect("addr");
@@ -1004,6 +1027,7 @@ mod tests {
 
     #[test]
     fn replay_resume_after_restart_delivers_once_and_clears_duplicate_delivery() {
+        let _reset = install_shared_lifecycle_reset_guard();
         let tempdir = TempDir::new().expect("tempdir");
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
         let endpoint = listener.local_addr().expect("addr");

--- a/crates/atm-daemon/src/reconcile_runtime.rs
+++ b/crates/atm-daemon/src/reconcile_runtime.rs
@@ -36,7 +36,6 @@ struct ReconcileRuntimeInner {
     wake: Condvar,
     #[cfg(test)]
     pending_changed: Condvar,
-    worker: Mutex<Option<JoinHandle<()>>>,
     debounce: Duration,
     executor: ReconcileExecutor,
     #[cfg_attr(not(test), allow(dead_code))]
@@ -47,6 +46,7 @@ struct ReconcileRuntimeInner {
 struct ReconcileState {
     started: bool,
     shutdown: bool,
+    worker: Option<JoinHandle<()>>,
     next_waiter_id: u64,
     pending_epoch: u64,
     pending: HashMap<ReconcileKey, PendingReconcile>,
@@ -212,7 +212,6 @@ impl ReconcileRuntime {
                 wake: Condvar::new(),
                 #[cfg(test)]
                 pending_changed: Condvar::new(),
-                worker: Mutex::new(None),
                 debounce,
                 executor,
                 notification_fingerprints,
@@ -241,22 +240,24 @@ impl ReconcileRuntime {
                 AtmError::daemon_unavailable("failed to spawn reconcile runtime worker")
                     .with_source(source)
             })?;
-        let mut worker = match self.inner.worker.lock() {
-            Ok(worker) => worker,
+        let mut state = match self.inner.state.lock() {
+            Ok(state) => state,
             Err(_) => {
                 let _ = handle.join();
-                return Err(AtmError::daemon_unavailable(
-                    "reconcile runtime worker lock poisoned",
-                )
-                .with_recovery("Restart the daemon; reconcile worker ownership can no longer be tracked safely."));
+                return Err(
+                    AtmError::daemon_unavailable("reconcile runtime state lock poisoned")
+                        .with_recovery(
+                            "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
+                        ),
+                );
             }
         };
-        *worker = Some(handle);
+        state.worker = Some(handle);
         Ok(())
     }
 
     pub(crate) fn shutdown(&self) -> Result<(), AtmError> {
-        {
+        let handle = {
             let mut state = self.inner.state.lock().map_err(|_| {
                 AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
                     "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
@@ -264,17 +265,9 @@ impl ReconcileRuntime {
             })?;
             state.shutdown = true;
             self.inner.wake.notify_all();
-        }
-        if let Some(handle) = self
-            .inner
-            .worker
-            .lock()
-            .map_err(|_| {
-                AtmError::daemon_unavailable("reconcile runtime worker lock poisoned")
-                    .with_recovery("Restart the daemon; reconcile worker ownership can no longer be tracked safely.")
-            })?
-            .take()
-        {
+            state.worker.take()
+        };
+        if let Some(handle) = handle {
             let (result_tx, result_rx) = mpsc::sync_channel(1);
             let join_helper = thread::spawn(move || {
                 let _ = result_tx.send(handle.join());

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -39,8 +39,9 @@ const SHUTDOWN_OBSERVABILITY_FLUSH_DEADLINE: Duration = Duration::from_secs(2);
 const MAX_SHUTDOWN_FINALIZER_THREADS: usize = 16;
 
 // Timed-out shutdown workers are retained in one process-wide registry instead of being dropped
-// orphaned; tests drain the registry explicitly and production keeps the handles reachable until
-// process shutdown completes.
+// orphaned; this must be static because the bounded finalizer helper can outlive any one
+// dispatcher instance after timeout, while orderly shutdown and serial tests still need one place
+// to recover and join those retained workers later.
 static SHUTDOWN_FINALIZER_THREADS: std::sync::Mutex<Vec<std::thread::JoinHandle<()>>> =
     std::sync::Mutex::new(Vec::new());
 
@@ -389,17 +390,24 @@ impl DaemonRequestDispatcher {
                 // outlive the bounded shutdown window, but retaining the JoinHandle is still safer
                 // than dropping it orphaned because tests and orderly process teardown can join it
                 // later once the blocking storage step finishes.
-                let mut handles = SHUTDOWN_FINALIZER_THREADS
-                    .lock()
-                    .expect("shutdown finalizer thread registry lock");
-                if handles.len() < MAX_SHUTDOWN_FINALIZER_THREADS {
-                    handles.push(shutdown_handle);
-                } else {
-                    tracing::warn!(
-                        step = label,
-                        cap = MAX_SHUTDOWN_FINALIZER_THREADS,
-                        "shutdown finalizer thread cap reached; dropping retained worker handle"
-                    );
+                match SHUTDOWN_FINALIZER_THREADS.lock() {
+                    Ok(mut handles) => {
+                        if handles.len() < MAX_SHUTDOWN_FINALIZER_THREADS {
+                            handles.push(shutdown_handle);
+                        } else {
+                            tracing::warn!(
+                                step = label,
+                                cap = MAX_SHUTDOWN_FINALIZER_THREADS,
+                                "shutdown finalizer thread cap reached; dropping retained worker handle"
+                            );
+                        }
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            step = label,
+                            "shutdown finalizer thread registry lock poisoned; dropping retained worker handle"
+                        );
+                    }
                 }
                 tracing::warn!(
                     step = label,
@@ -449,7 +457,7 @@ impl DaemonRequestDispatcher {
         }
     }
 
-    pub(crate) fn emit_runtime_event(
+    pub(crate) fn record_runtime_event(
         &self,
         action: &'static str,
         outcome: &'static str,
@@ -883,9 +891,18 @@ mod tests {
     use std::sync::{Arc, Condvar, Mutex};
     use std::time::{Duration, Instant};
 
+    struct ShutdownFinalizerDrainGuard;
+
+    impl Drop for ShutdownFinalizerDrainGuard {
+        fn drop(&mut self) {
+            DaemonRequestDispatcher::drain_shutdown_finalizer_threads_for_test();
+        }
+    }
+
     #[test]
     #[serial]
     fn bounded_shutdown_step_returns_after_deadline() {
+        let _drain_guard = ShutdownFinalizerDrainGuard;
         let release = Arc::new((Mutex::new(false), Condvar::new()));
         let blocker = Arc::clone(&release);
         let started = Instant::now();
@@ -913,12 +930,12 @@ mod tests {
         let (released, wake) = &*release;
         *released.lock().expect("released") = true;
         wake.notify_all();
-        DaemonRequestDispatcher::drain_shutdown_finalizer_threads_for_test();
     }
 
     #[test]
     #[serial]
     fn bounded_shutdown_step_does_not_exceed_retained_finalizer_cap() {
+        let _drain_guard = ShutdownFinalizerDrainGuard;
         DaemonRequestDispatcher::drain_shutdown_finalizer_threads_for_test();
 
         let retained_release = Arc::new((Mutex::new(false), Condvar::new()));
@@ -976,7 +993,6 @@ mod tests {
         let (released, wake) = &*retained_release;
         *released.lock().expect("retained release") = true;
         wake.notify_all();
-        DaemonRequestDispatcher::drain_shutdown_finalizer_threads_for_test();
     }
 }
 

--- a/crates/atm-daemon/src/test_observability.rs
+++ b/crates/atm-daemon/src/test_observability.rs
@@ -69,10 +69,9 @@ impl TestDaemonObservability {
             .with_source(source)
         })?;
         let (recorded, wake) = &self.recorded_messages;
-        recorded
-            .lock()
-            .expect("test observability messages")
-            .push(message);
+        let mut recorded = recorded.lock().expect("test observability messages");
+        recorded.push(message);
+        drop(recorded);
         wake.notify_all();
         Ok(())
     }
@@ -82,7 +81,7 @@ impl TestDaemonObservability {
         &self,
         needle: &str,
         timeout: Duration,
-    ) -> Result<(), String> {
+    ) -> Result<(), AtmError> {
         let deadline = Instant::now() + timeout;
         let (recorded, wake) = &self.recorded_messages;
         let mut recorded = recorded.lock().expect("test observability messages");
@@ -92,9 +91,14 @@ impl TestDaemonObservability {
             }
             let now = Instant::now();
             if now >= deadline {
-                return Err(format!(
-                    "timed out waiting for retained test log message containing {needle:?}"
-                ));
+                return Err(
+                    AtmError::observability_health(format!(
+                        "timed out waiting for retained test log message containing {needle:?}"
+                    ))
+                    .with_recovery(
+                        "Retry the daemon observability test after verifying the retained-log adapter emitted the expected startup event.",
+                    ),
+                );
             }
             let wait = wake
                 .wait_timeout(recorded, deadline.saturating_duration_since(now))

--- a/crates/atm-daemon/src/test_support.rs
+++ b/crates/atm-daemon/src/test_support.rs
@@ -79,18 +79,13 @@ impl RequestDispatcher for DoctorOnlyDispatcher {
 #[cfg(unix)]
 pub(crate) fn connect_daemon_local_ipc_until_ready(
     endpoint_path: &std::path::Path,
+    ready_rx: std::sync::mpsc::Receiver<()>,
 ) -> LocalSocketStream {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-    loop {
-        match LocalSocketStream::connect(
-            atm_core::protocol::daemon_local_ipc_name_from_path(endpoint_path).expect("ipc name"),
-        ) {
-            Ok(stream) => return stream,
-            Err(error) if std::time::Instant::now() < deadline => {
-                let _ = error;
-                std::thread::sleep(std::time::Duration::from_millis(5));
-            }
-            Err(error) => panic!("connect daemon local ipc: {error}"),
-        }
-    }
+    ready_rx
+        .recv_timeout(std::time::Duration::from_secs(3))
+        .expect("daemon local ipc ready signal");
+    LocalSocketStream::connect(
+        atm_core::protocol::daemon_local_ipc_name_from_path(endpoint_path).expect("ipc name"),
+    )
+    .unwrap_or_else(|error| panic!("connect daemon local ipc after ready signal: {error}"))
 }

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -44,6 +44,14 @@ use crate::test_support::connect_daemon_local_ipc_until_ready;
 
 const TEST_TEAM: &str = "test-team";
 
+struct ShutdownFinalizerDrainGuard;
+
+impl Drop for ShutdownFinalizerDrainGuard {
+    fn drop(&mut self) {
+        DaemonRequestDispatcher::drain_shutdown_finalizer_threads_for_test();
+    }
+}
+
 struct StaleRecoverySignalGuard;
 
 impl StaleRecoverySignalGuard {
@@ -194,6 +202,7 @@ fn local_ipc_runtime_round_trips_doctor_requests_on_shared_transport() {
 #[serial]
 #[cfg(unix)]
 fn compose_runtime_start_writes_retained_log_and_reports_healthy_observability() {
+    let _drain_guard = ShutdownFinalizerDrainGuard;
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
     std::fs::create_dir_all(&atm_home).expect("atm home dir");
@@ -693,6 +702,7 @@ fn reload_runtime_view_rejects_invalid_config_and_preserves_last_known_good_stat
 #[test]
 #[serial]
 fn finalize_shutdown_drains_test_tracked_finalizer_threads() {
+    let _drain_guard = ShutdownFinalizerDrainGuard;
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
     std::fs::create_dir_all(&atm_home).expect("atm home dir");

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -33,6 +33,7 @@ use serial_test::serial;
 use std::fs::OpenOptions;
 use std::io::{Seek, SeekFrom, Write};
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::mpsc;
 use std::time::Duration;
 #[cfg(windows)]
@@ -43,6 +44,11 @@ use tempfile::TempDir;
 use crate::test_support::connect_daemon_local_ipc_until_ready;
 
 const TEST_TEAM: &str = "test-team";
+
+fn test_team() -> &'static TeamName {
+    static TEST_TEAM_NAME: OnceLock<TeamName> = OnceLock::new();
+    TEST_TEAM_NAME.get_or_init(|| TEST_TEAM.parse().expect("team"))
+}
 
 struct ShutdownFinalizerDrainGuard;
 
@@ -144,6 +150,7 @@ fn local_ipc_runtime_round_trips_doctor_requests_on_shared_transport() {
     };
     let dispatcher: Arc<dyn RequestDispatcher + Send + Sync> = Arc::new(DoctorOnlyDispatcher);
     let (serve_result_tx, serve_result_rx) = mpsc::channel();
+    let (ready_tx, ready_rx) = mpsc::sync_channel(1);
 
     let join = std::thread::spawn(move || {
         let result = runtime.serve_with_runtime_hooks(
@@ -155,12 +162,22 @@ fn local_ipc_runtime_round_trips_doctor_requests_on_shared_transport() {
                 begin_shutdown: || Ok(()),
                 reload_runtime_view: || Ok(()),
                 finalize_shutdown: || {},
+                publish_ready: move || {
+                    ready_tx.send(()).map_err(|_| {
+                        AtmError::daemon_unavailable(
+                            "doctor round-trip test failed to observe the daemon ready signal",
+                        )
+                        .with_recovery(
+                            "Rerun the same-host daemon test after restoring the bounded ready-signal handshake.",
+                        )
+                    })
+                },
             },
         );
         serve_result_tx.send(result).expect("send serve result");
     });
 
-    let mut stream = connect_daemon_local_ipc_until_ready(&socket_path);
+    let mut stream = connect_daemon_local_ipc_until_ready(&socket_path, ready_rx);
     stream
         .set_send_timeout(Some(Duration::from_secs(5)))
         .expect("set send timeout");
@@ -225,14 +242,15 @@ fn compose_runtime_start_writes_retained_log_and_reports_healthy_observability()
     let runtime =
         crate::composition::compose_runtime(observability.clone()).expect("compose runtime");
     let (result_tx, result_rx) = mpsc::channel();
+    let (ready_tx, ready_rx) = mpsc::sync_channel(1);
     let runtime_socket_path = socket_path.clone();
 
     let join = std::thread::spawn(move || {
-        let result = runtime.start_with_socket_path_for_test(runtime_socket_path);
+        let result = runtime.start_with_socket_path_for_test(runtime_socket_path, Some(ready_tx));
         result_tx.send(result).expect("send runtime result");
     });
 
-    let mut stream = connect_daemon_local_ipc_until_ready(&socket_path);
+    let mut stream = connect_daemon_local_ipc_until_ready(&socket_path, ready_rx);
     stream
         .set_send_timeout(Some(Duration::from_secs(5)))
         .expect("set send timeout");
@@ -308,6 +326,7 @@ fn windows_local_ipc_runtime_terminate_finishes_within_deadline() {
                 begin_shutdown: || Ok(()),
                 reload_runtime_view: || Ok(()),
                 finalize_shutdown: || {},
+                publish_ready: || Ok(()),
             },
         );
         serve_result_tx.send(result).expect("send serve result");
@@ -491,7 +510,7 @@ fn install_test_roster(db_path: &std::path::Path, members: &[&str]) {
     assembly
         .roster_store()
         .replace_roster(atm_core::boundary::RosterStoreReplaceRosterRequest {
-            team: TEST_TEAM.parse().expect("team"),
+            team: test_team().clone(),
             roster: TeamConfig {
                 members: members
                     .iter()
@@ -534,7 +553,7 @@ fn heartbeat_updates_status_cache_and_doctor_projection() {
     let status_cache = RuntimeStatusCache::new();
     let dispatcher =
         DaemonRequestDispatcher::new_for_test(atm_home.clone(), status_cache.clone(), db_path);
-    let team: TeamName = TEST_TEAM.parse().expect("team");
+    let team = test_team().clone();
     let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
 
     let response = dispatcher
@@ -618,7 +637,7 @@ fn reload_runtime_view_applies_updated_team_config_and_preserves_live_state() {
         status_cache.clone(),
         db_path.clone(),
     );
-    let team: TeamName = TEST_TEAM.parse().expect("team");
+    let team = test_team().clone();
     let leader: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
     let qa: AgentName = "qa-a".parse().expect("member");
 
@@ -666,7 +685,7 @@ fn reload_runtime_view_rejects_invalid_config_and_preserves_last_known_good_stat
     let status_cache = RuntimeStatusCache::new();
     let dispatcher =
         DaemonRequestDispatcher::new_for_test(atm_home.clone(), status_cache.clone(), db_path);
-    let team: TeamName = TEST_TEAM.parse().expect("team");
+    let team = test_team().clone();
     let leader: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
 
     dispatcher
@@ -727,7 +746,7 @@ fn heartbeat_rejects_live_pid_conflict() {
 
     let status_cache = RuntimeStatusCache::new();
     let dispatcher = DaemonRequestDispatcher::new_for_test(atm_home, status_cache.clone(), db_path);
-    let team: TeamName = TEST_TEAM.parse().expect("team");
+    let team = test_team().clone();
     let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
 
     dispatcher
@@ -782,7 +801,7 @@ fn heartbeat_accepts_pid_takeover_when_previous_pid_is_dead() {
 
     let dispatcher =
         DaemonRequestDispatcher::new_for_test(atm_home, RuntimeStatusCache::new(), db_path);
-    let team: TeamName = TEST_TEAM.parse().expect("team");
+    let team = test_team().clone();
     let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
 
     dispatcher
@@ -823,7 +842,7 @@ fn heartbeat_evicts_oldest_member_and_projects_missing_roster_entries_as_unknown
     use chrono::{Duration as ChronoDuration, Utc};
 
     let status_cache = RuntimeStatusCache::new();
-    let team: TeamName = TEST_TEAM.parse().expect("team");
+    let team = test_team().clone();
     let member: AgentName = "qa-a".parse().expect("member");
     let base = Utc::now();
     status_cache
@@ -899,7 +918,7 @@ fn heartbeat_retries_identity_conflict_after_old_pid_dies() {
 
     let status_cache = RuntimeStatusCache::new();
     let dispatcher = DaemonRequestDispatcher::new_for_test(atm_home, status_cache.clone(), db_path);
-    let team: TeamName = TEST_TEAM.parse().expect("team");
+    let team = test_team().clone();
     let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
 
     status_cache
@@ -950,7 +969,7 @@ fn doctor_projects_degraded_runtime_when_sqlite_is_unavailable() {
         .dispatch(RequestEnvelope::Doctor(atm_core::doctor::DoctorQuery {
             home_dir: atm_home.clone(),
             current_dir: atm_home,
-            team_override: Some(TEST_TEAM.parse().expect("team")),
+            team_override: Some(test_team().clone()),
         }))
         .expect("doctor response");
 
@@ -989,7 +1008,7 @@ fn doctor_projects_unavailable_runtime_when_all_members_are_offline() {
 
     let doctor = dispatcher
         .dispatch(RequestEnvelope::Heartbeat(TeamMemberHeartbeatRequest {
-            team: TEST_TEAM.parse().expect("team"),
+            team: test_team().clone(),
             member: ROLE_TEAM_LEAD.parse().expect("member"),
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
@@ -999,7 +1018,7 @@ fn doctor_projects_unavailable_runtime_when_all_members_are_offline() {
             dispatcher.dispatch(RequestEnvelope::Doctor(atm_core::doctor::DoctorQuery {
                 home_dir: atm_home.clone(),
                 current_dir: atm_home,
-                team_override: Some(TEST_TEAM.parse().expect("team")),
+                team_override: Some(test_team().clone()),
             }))
         })
         .expect("doctor response");

--- a/crates/atm-daemon/src/watch_runtime.rs
+++ b/crates/atm-daemon/src/watch_runtime.rs
@@ -30,7 +30,6 @@ struct WatchRuntimeInner {
     // registry.
     state: Mutex<WatchState>,
     wake: Condvar,
-    worker: Mutex<Option<JoinHandle<()>>>,
     poller: WatchPoller,
     poll_interval: Duration,
 }
@@ -39,6 +38,7 @@ struct WatchRuntimeInner {
 struct WatchState {
     started: bool,
     shutdown: bool,
+    worker: Option<JoinHandle<()>>,
     subscriptions: HashMap<WatchKey, WatchSnapshot>,
 }
 
@@ -165,7 +165,6 @@ impl WatchRuntime {
             inner: Arc::new(WatchRuntimeInner {
                 state: Mutex::new(WatchState::default()),
                 wake: Condvar::new(),
-                worker: Mutex::new(None),
                 poller,
                 poll_interval,
             }),
@@ -193,35 +192,34 @@ impl WatchRuntime {
                 AtmError::daemon_unavailable("failed to spawn watch runtime worker")
                     .with_source(source)
             })?;
-        let mut worker = match self.inner.worker.lock() {
-            Ok(worker) => worker,
+        let mut state = match self.inner.state.lock() {
+            Ok(state) => state,
             Err(_) => {
                 let _ = handle.join();
-                return Err(AtmError::daemon_unavailable(
-                    "watch runtime worker lock poisoned",
-                ));
+                return Err(
+                    AtmError::daemon_unavailable("watch runtime state lock poisoned")
+                        .with_recovery(
+                            "Restart the daemon; watch lifecycle state can no longer be trusted.",
+                        ),
+                );
             }
         };
-        *worker = Some(handle);
+        state.worker = Some(handle);
         Ok(())
     }
 
     pub(crate) fn shutdown(&self) -> Result<(), AtmError> {
-        {
-            let mut state =
-                self.inner.state.lock().map_err(|_| {
-                    AtmError::daemon_unavailable("watch runtime state lock poisoned")
-                })?;
+        let handle = {
+            let mut state = self.inner.state.lock().map_err(|_| {
+                AtmError::daemon_unavailable("watch runtime state lock poisoned").with_recovery(
+                    "Restart the daemon; watch lifecycle state can no longer be trusted.",
+                )
+            })?;
             state.shutdown = true;
             self.inner.wake.notify_all();
-        }
-        if let Some(handle) = self
-            .inner
-            .worker
-            .lock()
-            .map_err(|_| AtmError::daemon_unavailable("watch runtime worker lock poisoned"))?
-            .take()
-        {
+            state.worker.take()
+        };
+        if let Some(handle) = handle {
             let (result_tx, result_rx) = mpsc::sync_channel(1);
             let join_helper = thread::spawn(move || {
                 let _ = result_tx.send(handle.join());

--- a/crates/atm-daemon/src/watch_runtime.rs
+++ b/crates/atm-daemon/src/watch_runtime.rs
@@ -172,11 +172,11 @@ impl WatchRuntime {
     }
 
     pub(crate) fn start(&self) -> Result<(), AtmError> {
-        let mut state = self
-            .inner
-            .state
-            .lock()
-            .map_err(|_| AtmError::daemon_unavailable("watch runtime state lock poisoned"))?;
+        let mut state = self.inner.state.lock().map_err(|_| {
+            AtmError::daemon_unavailable("watch runtime state lock poisoned").with_recovery(
+                "Restart the daemon; watch lifecycle state can no longer be trusted.",
+            )
+        })?;
         if state.started {
             return Ok(());
         }
@@ -268,11 +268,11 @@ impl WatchRuntime {
         request: WatchSubscriptionRequest,
     ) -> Result<WatchEventBatch, AtmError> {
         let key = WatchKey::from_request(&request);
-        let mut state = self
-            .inner
-            .state
-            .lock()
-            .map_err(|_| AtmError::daemon_unavailable("watch runtime state lock poisoned"))?;
+        let mut state = self.inner.state.lock().map_err(|_| {
+            AtmError::daemon_unavailable("watch runtime state lock poisoned").with_recovery(
+                "Restart the daemon; watch lifecycle state can no longer be trusted.",
+            )
+        })?;
         if !state.started {
             return Err(AtmError::daemon_unavailable(
                 "watch runtime is unavailable before daemon startup",
@@ -336,7 +336,11 @@ impl WatchRuntime {
                 .inner
                 .wake
                 .wait_timeout(state, wait_timeout)
-                .map_err(|_| AtmError::daemon_unavailable("watch runtime state lock poisoned"))?;
+                .map_err(|_| {
+                    AtmError::daemon_unavailable("watch runtime state lock poisoned").with_recovery(
+                        "Restart the daemon; watch lifecycle state can no longer be trusted.",
+                    )
+                })?;
             state = wait.0;
             if wait.1.timed_out() {
                 return Err(

--- a/crates/atm-rusqlite/src/shared_db.rs
+++ b/crates/atm-rusqlite/src/shared_db.rs
@@ -149,6 +149,9 @@ impl SharedDbTarget {
 #[derive(Clone)]
 pub(crate) struct SharedDb {
     target: Arc<SharedDbTarget>,
+    // Reader handles are budgeted across cloned SharedDb adapters, so the
+    // counter must be shared and synchronized independently of any one
+    // connection instance.
     connection_count: Arc<Mutex<usize>>,
     #[cfg(test)]
     // In-memory test fixtures must share one retained connection so each
@@ -157,6 +160,8 @@ pub(crate) struct SharedDb {
 }
 
 struct SharedDbConnectionGuard {
+    // Connection release can happen on whichever clone drops the guard, so the
+    // shared counter uses the same synchronized ownership model as SharedDb.
     connection_count: Arc<Mutex<usize>>,
 }
 
@@ -225,6 +230,9 @@ impl SharedDb {
         if let Some(connection) = &self.test_connection {
             let mut connection = connection.lock().map_err(|_| {
                 AtmError::daemon_unavailable("sqlite test connection lock poisoned")
+                    .with_recovery(
+                        "Recreate the in-memory sqlite test assembly before retrying the shared test connection path.",
+                    )
             })?;
             return operation(&mut connection);
         }
@@ -288,6 +296,9 @@ impl SharedDb {
     fn acquire_connection_guard(&self) -> Result<SharedDbConnectionGuard, AtmError> {
         let mut connection_count = self.connection_count.lock().map_err(|_| {
             AtmError::daemon_unavailable("sqlite connection budget state lock poisoned")
+                .with_recovery(
+                    "Restart the daemon or recreate the sqlite boundary assembly before retrying the shared connection budget path.",
+                )
         })?;
         if *connection_count >= MAX_SQLITE_CONNECTIONS {
             return Err(AtmError::daemon_unavailable(format!(

--- a/docs/phase-S/sprint-S14-runtime-plan.md
+++ b/docs/phase-S/sprint-S14-runtime-plan.md
@@ -138,7 +138,7 @@ Out of scope:
 
 #### `S14-004`
 
-- File: `crates/atm-daemon/src/daemon_observability.rs:107-131`
+- File: `crates/atm-daemon/src/daemon_runtime_observability.rs:107-131`
 - Problem:
   - `best_effort_flush_blocking()` flushes the logger, then reopens
     `active_log_path` and `sync_all()`s that reopened file.

--- a/docs/phase-S/sprint-S15-rusqlite-hardening.md
+++ b/docs/phase-S/sprint-S15-rusqlite-hardening.md
@@ -38,6 +38,7 @@ This sprint hardens:
 - ensure one invalid queued write row does not fail unrelated rows in the same batch
 - reject known ATM-owned logical/schema invariant violations before SQL rather than on the hot path
 - preserve `REQ-P-RUNTIME-002` by keeping the daemon singleton as the only writer-process invariant
+- preserve `REQ-P-RUNTIME-003` by keeping the writer lane subordinate to the full multi-guard daemon-singleton enforcement contract
 - drain pending queued writes on writer shutdown before returning
 
 ## Validation

--- a/docs/phase-S/sprint-S15.md
+++ b/docs/phase-S/sprint-S15.md
@@ -1,4 +1,4 @@
-# Sprint S.15 — SQLite Write-Worker Plan
+# Sprint S.15 — SQLite Write-Worker / MessageAppendQueue Planning
 
 **Branch**: feature/pS-s15-rusqlite-hardening  
 **Base**: integrate/phase-S @ 77badd5  

--- a/docs/plan-phase-S.md
+++ b/docs/plan-phase-S.md
@@ -664,7 +664,7 @@ Required closeout work:
 - keep daemon architecture and phase-plan docs aligned on the accepted
   resource-cap and eviction contracts
 
-### S.15 SQLite Write-Worker / MessageAppendQueue Planning
+### S.15 SQLite Write-Worker Plan
 
 Goal:
 - define the next `atm-rusqlite` hardening pass around one in-process
@@ -682,11 +682,15 @@ Required outcomes:
 Required closeout work:
 - produce `docs/phase-S/sprint-S15.md`,
   `docs/phase-S/sprint-S15-rusqlite-plan.md`, and
+  `docs/phase-S/sprint-S15-rusqlite-hardening.md`, and
   `docs/adr/ADR-ATM-RUSQLITE-002.md` as the governing S.15 planning set
 - document queue capacity, batching constants, `spawn_blocking` requirements,
   and per-batch isolation semantics for the future implementation sprint
 - keep S.15 sequenced after the S.13/S.14 runtime hardening line so the writer
   plan can depend on the already-accepted daemon singleton/runtime contracts
+- Phase S accepts the flat bold-header sprint metadata format used by S.10-S.15
+  as the late-phase documentation pattern; YAML frontmatter remains the earlier
+  S.0-S.9 style and does not require back-conversion for closeout
 
 ## 6. Removed Windows CI Guardrail
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -50,6 +50,8 @@ Phase-S planning note:
 - Phase S implementation details must come either from `docs/plan-phase-S.md`
   or from the governing requirements, architecture, ADR, and ICD documents it
   names; the project plan does not override those lower-level sources of truth
+- Phase S was extended through `S.15` (SQLite write-worker / rusqlite
+  hardening); see `docs/plan-phase-S.md` §5
 - the planning baseline is `integrate/phase-R` at `6a072c1`
 - S.5 is the follow-on planning slice that tightens the no-flaky-test policy,
   defines which anti-flake guardrails belong in the default lint path, and

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2966,6 +2966,8 @@ Summary:
   hardening, policy lint, SQLite write-worker planning and implementation,
   JSONL log compatibility, logging defaults, retained log bootstrap, and
   integration gate cleanup
+- Phase S was originally scoped through S.14, then explicitly extended through
+  S.15 for the SQLite write-worker planning and hardening line
 - S.13–S.15 delivered the local IPC transport, Windows same-host runtime, and
   SQLite write-worker foundation
 - Integration branch `integrate/phase-S` carries all merged sprint work


### PR DESCRIPTION
## Summary

- Closes all 16 open INTG-* findings from the Phase S integration gate
- Implementation fixes in 67d6c90; triage record closures in 2785580
- Findings closed: INTG-ARCH-001/002, INTG-ATM-QA-001–006, INTG-FTQ-008, INTG-RBP-003–005, INTG-RSH-005–008

## Test plan

- [ ] `cargo test -p atm-daemon` — PASS (arch-ctm validated)
- [ ] `cargo xwin check --workspace --target x86_64-pc-windows-msvc` — PASS
- [ ] `just lint` — PASS
- [ ] QA: req-qa + arch-qa + rust-qa-agent + rust-best-practices-agent + rust-service-hardening-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)