### PR TITLE
T.3: Immutable message rows — insert-only write semantics

### DIFF
--- a/crates/atm-rusqlite/src/lib.rs
+++ b/crates/atm-rusqlite/src/lib.rs
@@ -1345,6 +1345,12 @@ mod tests {
             })
             .expect_err("duplicate successor");
         assert!(duplicate_successor.is_validation());
+        assert!(
+            duplicate_successor
+                .message
+                .contains("single-successor invariant"),
+            "duplicate successor should be rejected by crate-owned validation before sqlite constraint handling"
+        );
 
         let duplicate_legacy_identity = store
             .upsert_message(boundary::MailStoreUpsertMessageRequest {
@@ -1362,13 +1368,19 @@ mod tests {
             })
             .expect_err("duplicate legacy identity");
         assert!(duplicate_legacy_identity.is_validation());
+        assert!(
+            duplicate_legacy_identity
+                .message
+                .contains("already owned by"),
+            "legacy identity collision should be rejected by crate-owned validation before sqlite constraint handling"
+        );
     }
 
     #[test]
     fn duplicate_upsert_reports_inserted_false_and_keeps_record_loadable() {
         let assembly = in_memory_assembly();
         let store = assembly.mail_store();
-        let record = boundary::MailStoreMessageRecord {
+        let original = boundary::MailStoreMessageRecord {
             team: team(),
             agent: agent(),
             message_key: message_key("atm:duplicate"),
@@ -1376,15 +1388,26 @@ mod tests {
             imported_from: None,
             recorded_at: Some(IsoTimestamp::now()),
         };
+        let replacement = boundary::MailStoreMessageRecord {
+            envelope: MessageEnvelope {
+                text: "rewritten duplicate payload".to_string(),
+                summary: Some("rewritten summary".to_string()),
+                pending_ack_at: None,
+                ..original.envelope.clone()
+            },
+            imported_from: Some("duplicate-rewrite-attempt".to_string()),
+            recorded_at: Some(IsoTimestamp::now()),
+            ..original.clone()
+        };
 
         let first = store
             .upsert_message(boundary::MailStoreUpsertMessageRequest {
-                record: record.clone(),
+                record: original.clone(),
             })
             .expect("first upsert");
         let second = store
             .upsert_message(boundary::MailStoreUpsertMessageRequest {
-                record: record.clone(),
+                record: replacement,
             })
             .expect("second upsert");
 
@@ -1397,7 +1420,7 @@ mod tests {
                 message_key: message_key("atm:duplicate"),
             })
             .expect("load duplicate");
-        assert_eq!(loaded.record, Some(record));
+        assert_eq!(loaded.record, Some(original));
     }
 
     #[test]

--- a/crates/atm-rusqlite/src/writer/mod.rs
+++ b/crates/atm-rusqlite/src/writer/mod.rs
@@ -682,9 +682,10 @@ mod tests {
 
     #[test]
     fn invalid_message_row_does_not_poison_other_rows_in_same_batch() {
-        let (_tempdir, target, db_path) = temp_disk_target();
+        let target = in_memory_target();
         let mut connection = open_connection_for_target(target.as_ref()).expect("open connection");
         ensure_schema(&mut connection, target.as_ref()).expect("ensure schema");
+        let verify = open_connection_for_target(target.as_ref()).expect("open verifier");
         let mut cache = stmt_cache::WriterStatementCache;
 
         let (invalid_tx, invalid_rx) = mpsc::sync_channel(1);
@@ -725,8 +726,6 @@ mod tests {
             WriteOpResult::UpsertMessage { inserted: true }
         );
 
-        drop(connection);
-        let verify = open_connection_for_target(target.as_ref()).expect("reopen");
         let stored: String = verify
             .query_row(
                 "SELECT message_text FROM mail_messages WHERE team = ?1 AND agent = ?2 AND message_key = ?3;",
@@ -744,17 +743,14 @@ mod tests {
             .optional()
             .expect("query invalid row");
         assert!(missing.is_none(), "invalid row must not be written");
-        assert!(
-            db_path.exists(),
-            "writer batch should persist to the target database"
-        );
     }
 
     #[test]
     fn single_successor_violation_does_not_poison_other_rows_in_same_batch() {
-        let (_tempdir, target, db_path) = temp_disk_target();
+        let target = in_memory_target();
         let mut connection = open_connection_for_target(target.as_ref()).expect("open connection");
         ensure_schema(&mut connection, target.as_ref()).expect("ensure schema");
+        let verify = open_connection_for_target(target.as_ref()).expect("open verifier");
         let mut cache = stmt_cache::WriterStatementCache;
 
         let parent_message_id = LegacyMessageId::new();
@@ -821,8 +817,6 @@ mod tests {
                 .is_validation()
         );
 
-        drop(connection);
-        let verify = open_connection_for_target(target.as_ref()).expect("reopen");
         let stored_root: String = verify
             .query_row(
                 "SELECT message_text FROM mail_messages WHERE team = ?1 AND agent = ?2 AND message_key = ?3;",
@@ -840,10 +834,6 @@ mod tests {
             .optional()
             .expect("query conflicting row");
         assert!(conflicting.is_none(), "conflicting row must not be written");
-        assert!(
-            db_path.exists(),
-            "writer batch should persist to the target database"
-        );
     }
 
     #[test]

--- a/crates/atm-rusqlite/src/writer/mod.rs
+++ b/crates/atm-rusqlite/src/writer/mod.rs
@@ -339,7 +339,7 @@ fn process_batch(
                 error,
             );
             for queued in batch {
-                let _ = queued.reply.send(Err(copy_error(&error)));
+                let _ = queued.reply.send(Err(copy_error(target, &error)));
             }
             return;
         }
@@ -406,7 +406,7 @@ fn process_batch(
     for (reply, result) in replies {
         let final_result = if let Some(error) = &commit_error {
             match result {
-                Ok(_) => Err(copy_error(error)),
+                Ok(_) => Err(copy_error(target, error)),
                 Err(existing) => Err(existing),
             }
         } else {
@@ -416,10 +416,31 @@ fn process_batch(
     }
 }
 
-fn copy_error(error: &AtmError) -> AtmError {
-    let mut copied = match error.code {
-        AtmErrorCode::DaemonUnavailable => AtmError::daemon_unavailable(error.message.clone()),
-        _ => AtmError::mailbox_write(error.message.clone()),
+fn copy_error(target: &SharedDbTarget, error: &AtmError) -> AtmError {
+    let mut copied = match error
+        .source
+        .as_deref()
+        .and_then(|source| source.downcast_ref::<rusqlite::Error>())
+    {
+        Some(rusqlite::Error::SqliteFailure(inner, _))
+            if matches!(
+                inner.code,
+                rusqlite::ffi::ErrorCode::DatabaseBusy | rusqlite::ffi::ErrorCode::DatabaseLocked
+            ) =>
+        {
+            match target {
+                SharedDbTarget::Path(path) => AtmError::mailbox_lock_timeout(path),
+                #[cfg(test)]
+                SharedDbTarget::InMemory { .. } => AtmError::mailbox_lock(format!(
+                    "timed out waiting for sqlite database lock on {}",
+                    target.display()
+                )),
+            }
+        }
+        _ => match error.code {
+            AtmErrorCode::DaemonUnavailable => AtmError::daemon_unavailable(error.message.clone()),
+            _ => AtmError::mailbox_write(error.message.clone()),
+        },
     };
     copied.code = error.code;
     copied.recovery = error.recovery.clone();
@@ -435,9 +456,21 @@ mod tests {
     use atm_core::types::{AgentName, IsoTimestamp, TaskId, TeamName};
     use rusqlite::OptionalExtension;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::mpsc;
     use std::thread;
     use tempfile::TempDir;
+
+    static NEXT_TEST_DB_ID: AtomicU64 = AtomicU64::new(1);
+
+    fn in_memory_target() -> Arc<SharedDbTarget> {
+        Arc::new(SharedDbTarget::InMemory {
+            uri: format!(
+                "file:atm-rusqlite-writer-test-{}?mode=memory&cache=shared",
+                NEXT_TEST_DB_ID.fetch_add(1, Ordering::Relaxed)
+            ),
+        })
+    }
 
     fn temp_disk_target() -> (TempDir, Arc<SharedDbTarget>, PathBuf) {
         let tempdir = TempDir::new().expect("tempdir");
@@ -511,6 +544,10 @@ mod tests {
 
     fn message_count(target: &SharedDbTarget) -> i64 {
         let connection = open_connection_for_target(target).expect("open verifier connection");
+        message_count_in_connection(&connection)
+    }
+
+    fn message_count_in_connection(connection: &rusqlite::Connection) -> i64 {
         connection
             .query_row("SELECT COUNT(1) FROM mail_messages;", [], |row| row.get(0))
             .expect("count rows")
@@ -518,7 +555,7 @@ mod tests {
 
     #[test]
     fn writer_drop_drains_queued_messages_before_exit() {
-        let (_tempdir, target, _db_path) = temp_disk_target();
+        let target = in_memory_target();
         let writer = SqliteWriter::start_for_test(
             Arc::clone(&target),
             CHANNEL_CAPACITY,
@@ -526,6 +563,7 @@ mod tests {
             Duration::from_secs(1),
         )
         .expect("writer");
+        let verifier = open_connection_for_target(target.as_ref()).expect("open verifier");
 
         let mut replies = Vec::new();
         for index in 0..8 {
@@ -547,12 +585,12 @@ mod tests {
         for reply in replies {
             assert!(reply.recv().expect("reply").is_ok());
         }
-        assert_eq!(message_count(target.as_ref()), 8);
+        assert_eq!(message_count_in_connection(&verifier), 8);
     }
 
     #[test]
     fn writer_commits_more_than_one_batch_boundary_of_messages() {
-        let (_tempdir, target, _db_path) = temp_disk_target();
+        let target = in_memory_target();
         let writer = SqliteWriter::start_for_test(
             Arc::clone(&target),
             CHANNEL_CAPACITY,
@@ -560,6 +598,7 @@ mod tests {
             Duration::from_secs(1),
         )
         .expect("writer");
+        let verifier = open_connection_for_target(target.as_ref()).expect("open verifier");
 
         let mut replies = Vec::new();
         for index in 0..(BATCH_SIZE_MAX + 6) {
@@ -581,7 +620,10 @@ mod tests {
         for reply in replies {
             assert!(reply.recv().expect("reply").is_ok());
         }
-        assert_eq!(message_count(target.as_ref()), (BATCH_SIZE_MAX + 6) as i64);
+        assert_eq!(
+            message_count_in_connection(&verifier),
+            (BATCH_SIZE_MAX + 6) as i64
+        );
     }
 
     #[test]
@@ -805,8 +847,50 @@ mod tests {
     }
 
     #[test]
+    fn writer_duplicate_key_preserves_first_payload() {
+        let target = in_memory_target();
+        let writer = SqliteWriter::start_for_test(
+            Arc::clone(&target),
+            CHANNEL_CAPACITY,
+            Duration::from_millis(50),
+            Duration::from_secs(1),
+        )
+        .expect("writer");
+
+        let first = writer
+            .submit(WriteOp::UpsertMessage(
+                boundary::MailStoreUpsertMessageRequest {
+                    record: message_record("atm:dup-test", "original"),
+                },
+            ))
+            .expect("first insert");
+        assert_eq!(first, WriteOpResult::UpsertMessage { inserted: true });
+
+        let second = writer
+            .submit(WriteOp::UpsertMessage(
+                boundary::MailStoreUpsertMessageRequest {
+                    record: message_record("atm:dup-test", "overwrite"),
+                },
+            ))
+            .expect("duplicate insert");
+        assert_eq!(second, WriteOpResult::UpsertMessage { inserted: false });
+
+        let connection = open_connection_for_target(target.as_ref()).expect("open verifier");
+        let (message_text, envelope_json): (String, String) = connection
+            .query_row(
+                "SELECT message_text, envelope_json FROM mail_messages WHERE team = ?1 AND agent = ?2 AND message_key = ?3;",
+                rusqlite::params![team().as_str(), agent().as_str(), "atm:dup-test"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("stored duplicate row");
+        assert_eq!(message_text, "original");
+        assert!(envelope_json.contains("\"text\":\"original\""));
+        assert!(!envelope_json.contains("\"text\":\"overwrite\""));
+    }
+
+    #[test]
     fn deadline_flush_commits_messages_without_waiting_for_batch_capacity() {
-        let (_tempdir, target, _db_path) = temp_disk_target();
+        let target = in_memory_target();
         let writer = SqliteWriter::start_for_test(
             Arc::clone(&target),
             CHANNEL_CAPACITY,

--- a/crates/atm-rusqlite/src/writer/mod.rs
+++ b/crates/atm-rusqlite/src/writer/mod.rs
@@ -535,11 +535,11 @@ mod tests {
     }
 
     fn message_count(target: &SharedDbTarget) -> i64 {
-        let connection = open_connection_for_target(target).expect("open verifier connection");
-        message_count_in_connection(&connection)
+        message_count_in_connection(target)
     }
 
-    fn message_count_in_connection(connection: &rusqlite::Connection) -> i64 {
+    fn message_count_in_connection(target: &SharedDbTarget) -> i64 {
+        let connection = open_connection_for_target(target).expect("open verifier connection");
         connection
             .query_row("SELECT COUNT(1) FROM mail_messages;", [], |row| row.get(0))
             .expect("count rows")
@@ -555,7 +555,7 @@ mod tests {
             Duration::from_secs(1),
         )
         .expect("writer");
-        let verifier = open_connection_for_target(target.as_ref()).expect("open verifier");
+        let _verifier = open_connection_for_target(target.as_ref()).expect("open verifier");
 
         let mut replies = Vec::new();
         for index in 0..8 {
@@ -577,7 +577,7 @@ mod tests {
         for reply in replies {
             assert!(reply.recv().expect("reply").is_ok());
         }
-        assert_eq!(message_count_in_connection(&verifier), 8);
+        assert_eq!(message_count_in_connection(target.as_ref()), 8);
     }
 
     #[test]
@@ -590,7 +590,7 @@ mod tests {
             Duration::from_secs(1),
         )
         .expect("writer");
-        let verifier = open_connection_for_target(target.as_ref()).expect("open verifier");
+        let _verifier = open_connection_for_target(target.as_ref()).expect("open verifier");
 
         let mut replies = Vec::new();
         for index in 0..(BATCH_SIZE_MAX + 6) {
@@ -613,7 +613,7 @@ mod tests {
             assert!(reply.recv().expect("reply").is_ok());
         }
         assert_eq!(
-            message_count_in_connection(&verifier),
+            message_count_in_connection(target.as_ref()),
             (BATCH_SIZE_MAX + 6) as i64
         );
     }

--- a/crates/atm-rusqlite/src/writer/mod.rs
+++ b/crates/atm-rusqlite/src/writer/mod.rs
@@ -455,11 +455,9 @@ mod tests {
     use atm_core::schema::{LegacyMessageId, MessageEnvelope};
     use atm_core::types::{AgentName, IsoTimestamp, TaskId, TeamName};
     use rusqlite::OptionalExtension;
-    use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::mpsc;
     use std::thread;
-    use tempfile::TempDir;
 
     static NEXT_TEST_DB_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -470,12 +468,6 @@ mod tests {
                 NEXT_TEST_DB_ID.fetch_add(1, Ordering::Relaxed)
             ),
         })
-    }
-
-    fn temp_disk_target() -> (TempDir, Arc<SharedDbTarget>, PathBuf) {
-        let tempdir = TempDir::new().expect("tempdir");
-        let path = tempdir.path().join("writer.sqlite3");
-        (tempdir, Arc::new(SharedDbTarget::Path(path.clone())), path)
     }
 
     fn team() -> TeamName {

--- a/crates/atm-rusqlite/src/writer/mod.rs
+++ b/crates/atm-rusqlite/src/writer/mod.rs
@@ -277,3 +277,142 @@ fn copy_error(error: &AtmError) -> AtmError {
     copied.recovery = error.recovery.clone();
     copied
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atm_core::boundary;
+    use atm_core::schema::MessageEnvelope;
+    use atm_core::types::{AgentName, IsoTimestamp, TeamName};
+    use rusqlite::OptionalExtension;
+    use std::path::PathBuf;
+    use std::sync::mpsc;
+    use tempfile::TempDir;
+
+    fn team() -> TeamName {
+        "test-team".parse().expect("team")
+    }
+
+    fn agent() -> AgentName {
+        "test-agent".parse().expect("agent")
+    }
+
+    fn actor() -> AgentName {
+        "test-actor".parse().expect("actor")
+    }
+
+    fn message_key(value: &str) -> boundary::MessageKey {
+        boundary::MessageKey::new(value).expect("message key")
+    }
+
+    fn envelope(text: &str) -> MessageEnvelope {
+        MessageEnvelope {
+            from: actor(),
+            text: text.to_string(),
+            timestamp: IsoTimestamp::now(),
+            read: false,
+            source_team: Some(team()),
+            summary: Some(format!("summary: {text}")),
+            message_id: None,
+            pending_ack_at: Some(IsoTimestamp::now()),
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            parent_message_id: None,
+            thread_mode: None,
+            stale_at: None,
+            task_id: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    fn message_record(key: &str, text: &str) -> boundary::MailStoreMessageRecord {
+        boundary::MailStoreMessageRecord {
+            team: team(),
+            agent: agent(),
+            message_key: message_key(key),
+            envelope: envelope(text),
+            imported_from: None,
+            recorded_at: Some(IsoTimestamp::now()),
+        }
+    }
+
+    fn temp_db_target() -> (TempDir, Arc<SharedDbTarget>, PathBuf) {
+        let tempdir = TempDir::new().expect("tempdir");
+        let db_path = tempdir.path().join("mail.db");
+        (
+            tempdir,
+            Arc::new(SharedDbTarget::Path(db_path.clone())),
+            db_path,
+        )
+    }
+
+    #[test]
+    fn invalid_message_row_does_not_poison_other_rows_in_same_batch() {
+        let (_tempdir, target, db_path) = temp_db_target();
+        let mut connection = open_connection_for_target(target.as_ref()).expect("open connection");
+        ensure_schema(&mut connection, target.as_ref()).expect("ensure schema");
+        let mut cache = stmt_cache::WriterStatementCache;
+
+        let (invalid_tx, invalid_rx) = mpsc::sync_channel(1);
+        let (valid_tx, valid_rx) = mpsc::sync_channel(1);
+        process_batch(
+            target.as_ref(),
+            &mut connection,
+            &mut cache,
+            vec![
+                QueuedWrite {
+                    op: Box::new(WriteOp::UpsertMessage(
+                        boundary::MailStoreUpsertMessageRequest {
+                            record: message_record("bad-key", "invalid"),
+                        },
+                    )),
+                    reply: invalid_tx,
+                },
+                QueuedWrite {
+                    op: Box::new(WriteOp::UpsertMessage(
+                        boundary::MailStoreUpsertMessageRequest {
+                            record: message_record("atm:valid", "valid"),
+                        },
+                    )),
+                    reply: valid_tx,
+                },
+            ],
+        );
+
+        let invalid = invalid_rx.recv().expect("invalid reply");
+        let valid = valid_rx.recv().expect("valid reply");
+        assert!(
+            invalid
+                .expect_err("invalid row should fail")
+                .is_validation()
+        );
+        assert_eq!(
+            valid.expect("valid row should survive same batch"),
+            WriteOpResult::UpsertMessage { inserted: true }
+        );
+
+        drop(connection);
+        let verify = open_connection_for_target(target.as_ref()).expect("reopen");
+        let stored: String = verify
+            .query_row(
+                "SELECT message_text FROM mail_messages WHERE team = ?1 AND agent = ?2 AND message_key = ?3;",
+                rusqlite::params![team().as_str(), agent().as_str(), "atm:valid"],
+                |row| row.get(0),
+            )
+            .expect("stored valid row");
+        assert_eq!(stored, "valid");
+        let missing: Option<String> = verify
+            .query_row(
+                "SELECT message_text FROM mail_messages WHERE team = ?1 AND agent = ?2 AND message_key = ?3;",
+                rusqlite::params![team().as_str(), agent().as_str(), "bad-key"],
+                |row| row.get(0),
+            )
+            .optional()
+            .expect("query invalid row");
+        assert!(missing.is_none(), "invalid row must not be written");
+        assert!(
+            db_path.exists(),
+            "writer batch should persist to the target database"
+        );
+    }
+}

--- a/crates/atm-rusqlite/src/writer/mod.rs
+++ b/crates/atm-rusqlite/src/writer/mod.rs
@@ -627,41 +627,6 @@ mod tests {
     }
 
     #[test]
-    fn deadline_flush_commits_messages_without_waiting_for_batch_capacity() {
-        let (_tempdir, target) = temp_disk_target();
-        let writer = SqliteWriter::start_for_test(
-            Arc::clone(&target),
-            CHANNEL_CAPACITY,
-            Duration::from_millis(50),
-            Duration::from_secs(1),
-        )
-        .expect("writer");
-
-        let mut replies = Vec::new();
-        for index in 0..3 {
-            let (reply_tx, reply_rx) = mpsc::sync_channel(1);
-            writer
-                .sender
-                .as_ref()
-                .expect("sender")
-                .send(WriterMessage::Submit {
-                    op: Box::new(upsert_message_request(index)),
-                    reply: reply_tx,
-                })
-                .expect("queue submit");
-            replies.push(reply_rx);
-            thread::park_timeout(BATCH_TIME_BUDGET + Duration::from_millis(1));
-        }
-
-        for reply in replies {
-            assert!(reply.recv().expect("reply").is_ok());
-        }
-        assert_eq!(message_count(target.as_ref()), 3);
-
-        drop(writer);
-    }
-
-    #[test]
     fn shutdown_first_drains_pending_submitters_with_daemon_unavailable() {
         let (sender, receiver) = mpsc::sync_channel(4);
         let (reply_tx, reply_rx) = mpsc::sync_channel(1);

--- a/crates/atm-rusqlite/src/writer/ops.rs
+++ b/crates/atm-rusqlite/src/writer/ops.rs
@@ -39,6 +39,7 @@ fn execute_upsert_message(
     target: &SharedDbTarget,
 ) -> Result<WriteOpResult, AtmError> {
     let record = &request.record;
+    validate_message_record(record, connection, cache, target)?;
     let envelope_json = serialize_json(&record.envelope, "mail-store envelope")?;
     let parent_message_id = record
         .envelope
@@ -66,26 +67,9 @@ fn execute_upsert_message(
     let recorded_at = record
         .recorded_at
         .map(|value| value.into_inner().to_rfc3339());
-    let existing: Option<i64> = cache
-        .probe_message_exists(
-            connection,
-            params![
-                record.team.as_str(),
-                record.agent.as_str(),
-                record.message_key.as_ref()
-            ],
-        )
-        .optional()
-        .map_err(|error| {
-            crate::shared_db::sqlite_error(
-                target,
-                "failed to probe existing mail-store message",
-                error,
-            )
-        })?;
 
-    cache
-        .upsert_message_row(
+    let inserted = cache
+        .insert_message_row(
             connection,
             params![
                 record.team.as_str(),
@@ -106,7 +90,8 @@ fn execute_upsert_message(
         )
         .map_err(|error| {
             crate::shared_db::sqlite_error(target, "failed to upsert mail-store message", error)
-        })?;
+        })?
+        == 1;
     cache
         .upsert_ack_state(
             connection,
@@ -123,9 +108,86 @@ fn execute_upsert_message(
             crate::shared_db::sqlite_error(target, "failed to upsert ack-state row", error)
         })?;
 
-    Ok(WriteOpResult::UpsertMessage {
-        inserted: existing.is_none(),
-    })
+    Ok(WriteOpResult::UpsertMessage { inserted })
+}
+
+fn validate_message_record(
+    record: &boundary::MailStoreMessageRecord,
+    connection: &Connection,
+    cache: &mut WriterStatementCache,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    let message_key = record.message_key.as_ref();
+    if !message_key.starts_with("atm:") && !message_key.starts_with("ext:") {
+        return Err(AtmError::validation(format!(
+            "mail-store message_key must start with `atm:` or `ext:`; got `{message_key}`"
+        ))
+        .with_recovery(
+            "Rewrite the message record with an ATM-owned or external message_key prefix before retrying the sqlite write.",
+        ));
+    }
+
+    if let Some(parent_message_id) = record.envelope.parent_message_id {
+        let owner = cache
+            .load_successor_owner(
+                connection,
+                params![
+                    record.team.as_str(),
+                    record.agent.as_str(),
+                    parent_message_id.to_string()
+                ],
+            )
+            .optional()
+            .map_err(|error| {
+                crate::shared_db::sqlite_error(
+                    target,
+                    "failed to validate single-successor mail-store invariant",
+                    error,
+                )
+            })?;
+        if let Some(owner) = owner
+            && owner != message_key
+        {
+            return Err(AtmError::validation(format!(
+                "mail-store parent message `{parent_message_id}` already has successor `{owner}`; `{message_key}` would violate the single-successor invariant"
+            ))
+            .with_recovery(
+                "Reuse the existing successor message_key or choose a different parent_message_id before retrying the sqlite write.",
+            ));
+        }
+    }
+
+    if let Some(legacy_message_id) = record.envelope.message_id {
+        let owner = cache
+            .load_legacy_identity_owner(
+                connection,
+                params![
+                    record.team.as_str(),
+                    record.agent.as_str(),
+                    legacy_message_id.to_string()
+                ],
+            )
+            .optional()
+            .map_err(|error| {
+                crate::shared_db::sqlite_error(
+                    target,
+                    "failed to validate legacy message identity uniqueness",
+                    error,
+                )
+            })?;
+        if let Some(owner) = owner
+            && owner != message_key
+        {
+            return Err(AtmError::validation(format!(
+                "legacy message_id `{legacy_message_id}` is already owned by `{owner}` and cannot be reassigned to `{message_key}`"
+            ))
+            .with_recovery(
+                "Reuse the existing message_key for that legacy message identity or generate a new legacy identity before retrying the sqlite write.",
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 fn execute_upsert_visibility_state(

--- a/crates/atm-rusqlite/src/writer/stmt_cache.rs
+++ b/crates/atm-rusqlite/src/writer/stmt_cache.rs
@@ -4,21 +4,7 @@ use rusqlite::{CachedStatement, Connection, Params, Result as SqlResult};
 pub(crate) struct WriterStatementCache;
 
 impl WriterStatementCache {
-    pub(crate) fn probe_message_exists<P: Params>(
-        &mut self,
-        connection: &Connection,
-        params: P,
-    ) -> SqlResult<i64> {
-        let mut statement = cached(
-            connection,
-            "SELECT 1
-             FROM mail_messages
-             WHERE team = ?1 AND agent = ?2 AND message_key = ?3;",
-        )?;
-        statement.query_row(params, |row| row.get(0))
-    }
-
-    pub(crate) fn upsert_message_row<P: Params>(
+    pub(crate) fn insert_message_row<P: Params>(
         &mut self,
         connection: &Connection,
         params: P,
@@ -27,20 +13,37 @@ impl WriterStatementCache {
             connection,
             "INSERT INTO mail_messages(team, agent, message_key, envelope_json, from_agent, message_text, summary, message_at, legacy_message_id, parent_message_id, thread_mode, stale_at, imported_from, recorded_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
-             ON CONFLICT(team, agent, message_key) DO UPDATE SET
-               envelope_json = excluded.envelope_json,
-               from_agent = excluded.from_agent,
-               message_text = excluded.message_text,
-               summary = excluded.summary,
-               message_at = excluded.message_at,
-               legacy_message_id = excluded.legacy_message_id,
-               parent_message_id = excluded.parent_message_id,
-               thread_mode = excluded.thread_mode,
-               stale_at = excluded.stale_at,
-               imported_from = excluded.imported_from,
-               recorded_at = excluded.recorded_at;",
+             ON CONFLICT(team, agent, message_key) DO NOTHING;",
         )?;
         statement.execute(params)
+    }
+
+    pub(crate) fn load_successor_owner<P: Params>(
+        &mut self,
+        connection: &Connection,
+        params: P,
+    ) -> SqlResult<String> {
+        let mut statement = cached(
+            connection,
+            "SELECT message_key
+             FROM mail_messages
+             WHERE team = ?1 AND agent = ?2 AND parent_message_id = ?3;",
+        )?;
+        statement.query_row(params, |row| row.get(0))
+    }
+
+    pub(crate) fn load_legacy_identity_owner<P: Params>(
+        &mut self,
+        connection: &Connection,
+        params: P,
+    ) -> SqlResult<String> {
+        let mut statement = cached(
+            connection,
+            "SELECT message_key
+             FROM mail_messages
+             WHERE team = ?1 AND agent = ?2 AND legacy_message_id = ?3;",
+        )?;
+        statement.query_row(params, |row| row.get(0))
     }
 
     pub(crate) fn upsert_ack_state<P: Params>(

--- a/docs/adr/ADR-ATM-RUSQLITE-002.md
+++ b/docs/adr/ADR-ATM-RUSQLITE-002.md
@@ -73,6 +73,11 @@ Introduce one crate-private in-process SQLite write worker that:
 
 - use `docs/phase-S/sprint-S15-rusqlite-plan.md` as the canonical design for
   the S.15 implementation shape and any follow-on QA reconciliation
+- the `T.3` immutable-row addendum completes the hot mailbox contract by:
+  - removing the pre-write message existence probe
+  - making `mail_messages` insert-only with duplicate-key `DO NOTHING`
+  - rejecting crate-owned logical invariants before SQL submission where the
+    crate already owns the rule
 - benchmark the resulting hot-path throughput and latency
 - review WAL autocheckpoint tuning separately if sustained write load requires
   it

--- a/docs/atm-rusqlite/architecture.md
+++ b/docs/atm-rusqlite/architecture.md
@@ -130,6 +130,12 @@ Rules:
   - up to `3` concurrent reader handles
 - writer shutdown must be explicit and draining: the channel closes, already
   queued work drains, then the worker thread joins on drop
+- `T.3` completes the message-row semantic contract on top of the T.2 lane:
+  - `mail_messages` is immutable after the first successful insert
+  - duplicate primary-key writes use insert-first `DO NOTHING` semantics
+  - ack and visibility state remain mutable in their dedicated state tables
+  - crate-owned logical invariants such as single-successor and legacy-message
+    ownership are validated before SQL submission
 
 ## 4.2 T.2 `with_transaction(...)` caller audit
 

--- a/docs/atm-rusqlite/requirements.md
+++ b/docs/atm-rusqlite/requirements.md
@@ -67,10 +67,14 @@ Initial crate requirement IDs:
   writes must preserve the original envelope/payload fields and keep mutable
   live state in the projection tables instead of rewriting the immutable row.
   Satisfies: `REQ-RUNTIME-002`.
-- `REQ-RUSQLITE-IMMUT-003` the hot mailbox write path must not issue a
-  pre-write probe before submitting message inserts to the writer lane; queue
-  semantics and row-count detection own duplicate handling. Satisfies:
-  `REQ-RUNTIME-002`.
+- `REQ-RUSQLITE-IMMUT-003` the hot mailbox write path must not issue an
+  existence probe before submitting message inserts to the writer lane, such
+  as `SELECT 1` or `COUNT(*)` used only to decide whether a duplicate key
+  should be written. Queue semantics and row-count detection own duplicate
+  handling. This ban does not apply to crate-owned invariant validation queries
+  that must run before `INSERT` (for example single-successor or legacy
+  identity checks), as documented in [`architecture.md`](./architecture.md).
+  Satisfies: `REQ-RUNTIME-002`.
 
 ## 4. Required References
 
@@ -83,6 +87,7 @@ The `atm-rusqlite` crate docs must remain aligned with:
 - [`../plan-phase-R.md`](../plan-phase-R.md)
 - [`../plan-phase-S.md`](../plan-phase-S.md)
 - [`../phase-T/sprint-T2-sqlite-writer.md`](../phase-T/sprint-T2-sqlite-writer.md)
+- [`../phase-T/sprint-T3-immutable-rows.md`](../phase-T/sprint-T3-immutable-rows.md)
 - [`../atm-core/requirements.md`](../atm-core/requirements.md)
 - [`../atm-core/architecture.md`](../atm-core/architecture.md)
 - [`../atm-error-codes.md`](../atm-error-codes.md)

--- a/docs/phase-T/sprint-T3-immutable-rows.md
+++ b/docs/phase-T/sprint-T3-immutable-rows.md
@@ -49,6 +49,8 @@ Pre-QA dependency:
 - the hot write path no longer performs the pre-write probe
 - duplicate writes preserve the first payload and do not silently rewrite
   message content
+- `WriteOpResult::UpsertMessage { inserted: bool }` reports `true` on the
+  first insert and `false` on duplicate-key no-op replays
 - known logical/schema violations are rejected before SQL wherever the crate
   already owns the invariant
 - invalid rows are rejected before SQL submission and valid rows in the same

--- a/docs/phase-T/sprint-T3-immutable-rows.md
+++ b/docs/phase-T/sprint-T3-immutable-rows.md
@@ -51,6 +51,9 @@ Pre-QA dependency:
   message content
 - `WriteOpResult::UpsertMessage { inserted: bool }` reports `true` on the
   first insert and `false` on duplicate-key no-op replays
+- rows-changed detection (`rows_changed()`) is used to determine
+  `inserted=true/false` rather than a pre-write probe or conflict-driven
+  mutation
 - known logical/schema violations are rejected before SQL wherever the crate
   already owns the invariant
 - invalid rows are rejected before SQL submission and valid rows in the same


### PR DESCRIPTION
## Sprint T.3 — Immutable Message Rows

mail_messages is now insert-only on duplicate primary-key writes. Pre-write existence probe removed. Single-successor and legacy-message ownership validated in writer lane before SQL. Duplicate writes preserve original payload. Batch regression test proves one invalid row does not poison unrelated rows in same drained batch.

## Test plan
- [ ] CI: all 8 checks green
- [ ] QA gate: 0B+0I+0m

🤖 Generated with [Claude Code](https://claude.com/claude-code)