### PR TITLE
feat(U.1): delete metadata.atm read-path dependence

### DIFF
--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -11,7 +11,7 @@ use crate::mailbox::source::{SourceFile, SourcedMessage};
 use crate::mailbox::surface::dedupe_legacy_message_id_surface;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::read::state;
-use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
+use crate::schema::{LegacyMessageId, MessageEnvelope};
 use crate::send::{PostSendHookContext, ResolvedRecipient, input, summary};
 use crate::service_runtime::{LocalServiceRuntime, RetainedServiceRuntime};
 use crate::service_runtime_store::RetainedMailboxRuntime;
@@ -195,12 +195,10 @@ fn ack_mail_with_runtime<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
         return Err(AtmError::agent_not_found(&reply_agent, &reply_team));
     }
 
-    let (reply_atm_message_id, ack_timestamp) = AtmMessageId::new_with_timestamp();
+    let ack_timestamp = IsoTimestamp::now();
     let reply_text = input::validate_message_text(request.reply_body)?;
     let reply_message_id = LegacyMessageId::new();
     let source_task_id = source_message.envelope.task_id.clone();
-    let mut reply_extra = Map::new();
-    workflow::set_atm_message_id(&mut reply_extra, reply_atm_message_id);
     let reply_message = MessageEnvelope {
         from: actor.clone(),
         text: reply_text.clone(),
@@ -216,7 +214,7 @@ fn ack_mail_with_runtime<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
         thread_mode: None,
         stale_at: None,
         task_id: None,
-        extra: reply_extra,
+        extra: Map::new(),
     };
 
     let reply_inbox_path = runtime.inbox_path(&request.home_dir, &reply_team, &reply_agent)?;
@@ -530,8 +528,6 @@ fn append_reply_message(
 mod tests {
     use std::path::PathBuf;
 
-    use serde_json::json;
-
     use super::{canonical_sender_identity, reject_non_terminal_ack, resolve_reply_target};
     use crate::mailbox::source::SourceFile;
     use crate::roles::ROLE_TEAM_LEAD;
@@ -585,24 +581,15 @@ mod tests {
     }
 
     #[test]
-    fn canonical_sender_identity_reads_metadata_override() {
-        let mut message = message_with_from("lead");
-        message.extra.insert(
-            "metadata".to_string(),
-            json!({"atm": {"fromIdentity": ROLE_TEAM_LEAD}}),
-        );
-
+    fn canonical_sender_identity_uses_from_field() {
+        let message = message_with_from(ROLE_TEAM_LEAD);
         assert_eq!(canonical_sender_identity(&message).as_str(), ROLE_TEAM_LEAD);
     }
 
     #[test]
-    fn resolve_reply_target_prefers_canonical_sender_identity_metadata() {
-        let mut message = message_with_from("lead");
+    fn resolve_reply_target_uses_from_field() {
+        let mut message = message_with_from(ROLE_TEAM_LEAD);
         message.source_team = Some(TEST_TEAM.parse::<TeamName>().expect("team"));
-        message.extra.insert(
-            "metadata".to_string(),
-            json!({"atm": {"fromIdentity": ROLE_TEAM_LEAD}}),
-        );
 
         let target = resolve_reply_target(&message, &TeamName::from_validated(TEST_TEAM))
             .expect("reply target");

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -11,7 +11,7 @@ use std::borrow::Cow;
 use std::fs;
 use std::path::Path;
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 use tracing::warn;
 
@@ -246,23 +246,7 @@ fn parse_mailbox_summary_array(
 
     Ok(records
         .into_iter()
-        .enumerate()
-        .filter_map(
-            |(index, record)| match summarize_mailbox_record(record, contains_filter) {
-                Ok(Some(message)) => Some(message),
-                Ok(None) => None,
-                Err(error) => {
-                    warn!(
-                        code = %AtmErrorCode::WarningMailboxRecordSkipped,
-                        line = index + 1,
-                        mailbox_path = %path.display(),
-                        %error,
-                        "skipping malformed mailbox record during bounded list projection"
-                    );
-                    None
-                }
-            },
-        )
+        .map(|record| summarize_mailbox_record(record, contains_filter))
         .collect())
 }
 
@@ -317,10 +301,9 @@ fn parse_mailbox_summary_jsonl(
                     )
                     .with_source(error)
                 })
-                .and_then(|record| summarize_mailbox_record(record, contains_filter))
+                .map(|record| summarize_mailbox_record(record, contains_filter))
             {
-                Ok(Some(message)) => Some(message),
-                Ok(None) => None,
+                Ok(message) => Some(message),
                 Err(error) => {
                     warn!(
                         code = %AtmErrorCode::WarningMailboxRecordSkipped,
@@ -393,16 +376,28 @@ struct SummaryMailboxRecord<'a> {
     source_team: Option<TeamName>,
     #[serde(default)]
     summary: Option<String>,
-    #[serde(rename = "message_id", default)]
-    message_id: Option<String>,
+    #[serde(
+        rename = "message_id",
+        default,
+        deserialize_with = "deserialize_optional_legacy_message_id"
+    )]
+    message_id: Option<LegacyMessageId>,
     #[serde(rename = "pendingAckAt", default)]
     pending_ack_at: Option<IsoTimestamp>,
     #[serde(rename = "acknowledgedAt", default)]
     acknowledged_at: Option<IsoTimestamp>,
-    #[serde(rename = "acknowledgesMessageId", default)]
-    acknowledges_message_id: Option<String>,
-    #[serde(rename = "parentMessageId", default)]
-    parent_message_id: Option<String>,
+    #[serde(
+        rename = "acknowledgesMessageId",
+        default,
+        deserialize_with = "deserialize_optional_legacy_message_id"
+    )]
+    acknowledges_message_id: Option<LegacyMessageId>,
+    #[serde(
+        rename = "parentMessageId",
+        default,
+        deserialize_with = "deserialize_optional_legacy_message_id"
+    )]
+    parent_message_id: Option<LegacyMessageId>,
     #[serde(rename = "threadMode", default)]
     thread_mode: Option<ThreadMode>,
     #[serde(rename = "staleAt", default)]
@@ -414,10 +409,7 @@ struct SummaryMailboxRecord<'a> {
 fn summarize_mailbox_record(
     record: SummaryMailboxRecord<'_>,
     contains_filter: Option<&str>,
-) -> Result<Option<SummaryMessage>, AtmError> {
-    let message_id = parse_legacy_id(record.message_id.as_deref());
-    let acknowledges_message_id = parse_legacy_id(record.acknowledges_message_id.as_deref());
-    let parent_message_id = parse_legacy_id(record.parent_message_id.as_deref());
+) -> SummaryMessage {
     let summary_preview = summarize_text(record.summary.as_deref(), record.text.as_ref());
     let body_contains_match = contains_filter
         .map(str::trim)
@@ -425,7 +417,7 @@ fn summarize_mailbox_record(
         .is_some_and(|needle| ascii_case_insensitive_contains(record.text.as_ref(), needle));
     let idle_notification_sender = idle_notification_sender_from_text(record.text.as_ref());
 
-    Ok(Some(SummaryMessage {
+    SummaryMessage {
         envelope: MessageEnvelope {
             from: record.from,
             text: String::new(),
@@ -433,11 +425,11 @@ fn summarize_mailbox_record(
             read: record.read,
             source_team: record.source_team,
             summary: record.summary,
-            message_id,
+            message_id: record.message_id,
             pending_ack_at: record.pending_ack_at,
             acknowledged_at: record.acknowledged_at,
-            acknowledges_message_id,
-            parent_message_id,
+            acknowledges_message_id: record.acknowledges_message_id,
+            parent_message_id: record.parent_message_id,
             thread_mode: record.thread_mode,
             stale_at: record.stale_at,
             task_id: record.task_id,
@@ -446,11 +438,23 @@ fn summarize_mailbox_record(
         summary_preview,
         body_contains_match,
         idle_notification_sender,
-    }))
+    }
 }
 
-fn parse_legacy_id(value: Option<&str>) -> Option<LegacyMessageId> {
-    value.and_then(|value| value.parse::<LegacyMessageId>().ok())
+fn deserialize_optional_legacy_message_id<'de, D>(
+    deserializer: D,
+) -> Result<Option<LegacyMessageId>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Option::<Value>::deserialize(deserializer)?;
+    Ok(raw.and_then(|value| {
+        if value.is_null() {
+            None
+        } else {
+            serde_json::from_value::<LegacyMessageId>(value).ok()
+        }
+    }))
 }
 
 fn summarize_text(summary: Option<&str>, text: &str) -> String {
@@ -729,6 +733,45 @@ mod tests {
         assert_eq!(
             messages[0].task_id.as_ref().map(|task_id| task_id.as_str()),
             Some("TASK-123")
+        );
+    }
+
+    #[test]
+    fn read_messages_preserves_metadata_atm_as_opaque_extra() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("metadata-atm-pass-through.jsonl");
+        let contents = serde_json::json!({
+            "from": ROLE_TEAM_LEAD,
+            "text": "hello",
+            "timestamp": "2026-03-30T00:00:00Z",
+            "read": false,
+            "metadata": {
+                "atm": {
+                    "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
+                    "sourceTeam": TEST_TEAM
+                },
+                "foreign": {
+                    "keep": true
+                }
+            }
+        });
+        fs::write(&path, serde_json::to_vec(&contents).expect("json")).expect("write");
+
+        let messages = read_messages(&path).expect("read");
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].message_id.is_none());
+        assert!(messages[0].source_team.is_none());
+        assert_eq!(
+            messages[0].extra.get("metadata"),
+            Some(&serde_json::json!({
+                "atm": {
+                    "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
+                    "sourceTeam": TEST_TEAM
+                },
+                "foreign": {
+                    "keep": true
+                }
+            }))
         );
     }
 

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -17,8 +17,7 @@ use tracing::warn;
 
 use crate::error::{AtmError, AtmErrorCode, AtmErrorKind};
 use crate::mailbox::source::SummaryMessage;
-use crate::schema::inbox_message::hydrate_legacy_fields_from_metadata;
-use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope, ThreadMode};
+use crate::schema::{LegacyMessageId, MessageEnvelope, ThreadMode};
 use crate::types::{AgentName, IsoTimestamp, TaskId, TeamName};
 
 const MAX_MAILBOX_READ_BYTES: u64 = 10 * 1024 * 1024;
@@ -352,7 +351,6 @@ fn parse_mailbox_value(
     path: &Path,
     line_number: usize,
 ) -> Result<Option<MessageEnvelope>, serde_json::Error> {
-    hydrate_legacy_fields_from_metadata(value);
     sanitize_legacy_message_id(value, path, line_number);
     serde_json::from_value::<MessageEnvelope>(value.take()).map(Some)
 }
@@ -411,52 +409,15 @@ struct SummaryMailboxRecord<'a> {
     stale_at: Option<IsoTimestamp>,
     #[serde(rename = "taskId", default)]
     task_id: Option<TaskId>,
-    #[serde(default)]
-    metadata: Option<SummaryMailboxMetadata>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct SummaryMailboxMetadata {
-    #[serde(default)]
-    atm: Option<SummaryAtmMetadata>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct SummaryAtmMetadata {
-    #[serde(rename = "messageId", default)]
-    message_id: Option<String>,
-    #[serde(rename = "sourceTeam", default)]
-    source_team: Option<TeamName>,
-    #[serde(rename = "pendingAckAt", default)]
-    pending_ack_at: Option<IsoTimestamp>,
-    #[serde(rename = "acknowledgedAt", default)]
-    acknowledged_at: Option<IsoTimestamp>,
-    #[serde(rename = "acknowledgesMessageId", default)]
-    acknowledges_message_id: Option<String>,
-    #[serde(rename = "parentMessageId", default)]
-    parent_message_id: Option<String>,
-    #[serde(rename = "threadMode", default)]
-    thread_mode: Option<ThreadMode>,
-    #[serde(rename = "staleAt", default)]
-    stale_at: Option<IsoTimestamp>,
-    #[serde(rename = "taskId", default)]
-    task_id: Option<TaskId>,
 }
 
 fn summarize_mailbox_record(
     record: SummaryMailboxRecord<'_>,
     contains_filter: Option<&str>,
 ) -> Result<Option<SummaryMessage>, AtmError> {
-    let atm = record
-        .metadata
-        .as_ref()
-        .and_then(|metadata| metadata.atm.as_ref());
-    let message_id = parse_legacy_id(record.message_id.as_deref())
-        .or_else(|| parse_atm_id(atm.and_then(|value| value.message_id.as_deref())));
-    let acknowledges_message_id = parse_legacy_id(record.acknowledges_message_id.as_deref())
-        .or_else(|| parse_atm_id(atm.and_then(|value| value.acknowledges_message_id.as_deref())));
-    let parent_message_id = parse_legacy_id(record.parent_message_id.as_deref())
-        .or_else(|| parse_atm_id(atm.and_then(|value| value.parent_message_id.as_deref())));
+    let message_id = parse_legacy_id(record.message_id.as_deref());
+    let acknowledges_message_id = parse_legacy_id(record.acknowledges_message_id.as_deref());
+    let parent_message_id = parse_legacy_id(record.parent_message_id.as_deref());
     let summary_preview = summarize_text(record.summary.as_deref(), record.text.as_ref());
     let body_contains_match = contains_filter
         .map(str::trim)
@@ -470,28 +431,16 @@ fn summarize_mailbox_record(
             text: String::new(),
             timestamp: record.timestamp,
             read: record.read,
-            source_team: record
-                .source_team
-                .or_else(|| atm.and_then(|value| value.source_team.clone())),
+            source_team: record.source_team,
             summary: record.summary,
             message_id,
-            pending_ack_at: record
-                .pending_ack_at
-                .or_else(|| atm.and_then(|value| value.pending_ack_at)),
-            acknowledged_at: record
-                .acknowledged_at
-                .or_else(|| atm.and_then(|value| value.acknowledged_at)),
+            pending_ack_at: record.pending_ack_at,
+            acknowledged_at: record.acknowledged_at,
             acknowledges_message_id,
             parent_message_id,
-            thread_mode: record
-                .thread_mode
-                .or_else(|| atm.and_then(|value| value.thread_mode)),
-            stale_at: record
-                .stale_at
-                .or_else(|| atm.and_then(|value| value.stale_at)),
-            task_id: record
-                .task_id
-                .or_else(|| atm.and_then(|value| value.task_id.clone())),
+            thread_mode: record.thread_mode,
+            stale_at: record.stale_at,
+            task_id: record.task_id,
             extra: serde_json::Map::new(),
         },
         summary_preview,
@@ -502,12 +451,6 @@ fn summarize_mailbox_record(
 
 fn parse_legacy_id(value: Option<&str>) -> Option<LegacyMessageId> {
     value.and_then(|value| value.parse::<LegacyMessageId>().ok())
-}
-
-fn parse_atm_id(value: Option<&str>) -> Option<LegacyMessageId> {
-    value
-        .and_then(|value| value.parse::<AtmMessageId>().ok())
-        .map(LegacyMessageId::from_atm_message_id)
 }
 
 fn summarize_text(summary: Option<&str>, text: &str) -> String {
@@ -587,9 +530,9 @@ mod tests {
     }
 
     #[test]
-    fn append_message_serializes_metadata_atm_without_top_level_machine_fields() {
+    fn append_message_keeps_approved_machine_fields_top_level() {
         let tempdir = TempDir::new().expect("tempdir");
-        let path = tempdir.path().join("append-message-metadata.json");
+        let path = tempdir.path().join("append-message-top-level.json");
         let envelope = sample_message(Uuid::new_v4(), "first");
 
         append_message(&path, &envelope).expect("append");
@@ -597,9 +540,9 @@ mod tests {
         let raw = fs::read_to_string(&path).expect("raw contents");
         let values: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("json array");
         let object = values[0].as_object().expect("message object");
-        assert!(object.contains_key("metadata"));
-        assert!(!object.contains_key("message_id"));
-        assert!(!object.contains_key("source_team"));
+        assert!(!object.contains_key("metadata"));
+        assert!(object.contains_key("message_id"));
+        assert!(object.contains_key("source_team"));
     }
 
     #[test]
@@ -762,23 +705,19 @@ mod tests {
     }
 
     #[test]
-    fn read_messages_hydrates_fields_from_metadata_atm() {
+    fn read_messages_use_top_level_compatibility_fields() {
         let tempdir = TempDir::new().expect("tempdir");
-        let path = tempdir.path().join("metadata-atm.json");
+        let path = tempdir.path().join("top-level-compatibility.json");
         let contents = serde_json::json!({
             "from": ROLE_TEAM_LEAD,
             "text": "hello",
             "timestamp": "2026-03-30T00:00:00Z",
             "read": false,
             "summary": "hello",
-            "metadata": {
-                "atm": {
-                    "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
-                    "sourceTeam": TEST_TEAM,
-                    "pendingAckAt": "2026-03-30T00:00:01Z",
-                    "taskId": "TASK-123"
-                }
-            }
+            "message_id": "11111111-1111-4111-8111-111111111111",
+            "source_team": TEST_TEAM,
+            "pendingAckAt": "2026-03-30T00:00:01Z",
+            "taskId": "TASK-123"
         });
         fs::write(&path, serde_json::to_vec(&contents).expect("json")).expect("write");
 
@@ -823,21 +762,6 @@ mod tests {
 
     fn sample_message(message_id: Uuid, body: &str) -> MessageEnvelope {
         let legacy_message_id = crate::schema::LegacyMessageId::from(message_id);
-        let atm_message_id = legacy_message_id.into_atm_message_id();
-        let message_id = crate::schema::LegacyMessageId::from_atm_message_id(atm_message_id);
-        let mut extra = serde_json::Map::new();
-        let mut metadata = serde_json::Map::new();
-        let mut atm = serde_json::Map::new();
-        atm.insert(
-            "messageId".to_string(),
-            serde_json::Value::String(atm_message_id.to_string()),
-        );
-        atm.insert(
-            "sourceTeam".to_string(),
-            serde_json::Value::String(TEST_TEAM.to_string()),
-        );
-        metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
-        extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
 
         MessageEnvelope {
             from: TEST_SENDER.parse::<AgentName>().expect("agent"),
@@ -850,7 +774,7 @@ mod tests {
             read: false,
             source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team")),
             summary: None,
-            message_id: Some(message_id),
+            message_id: Some(legacy_message_id),
             pending_ack_at: None,
             acknowledged_at: None,
             acknowledges_message_id: None,
@@ -858,7 +782,7 @@ mod tests {
             thread_mode: None,
             stale_at: None,
             task_id: None,
-            extra,
+            extra: serde_json::Map::new(),
         }
     }
 }

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -145,7 +145,7 @@ mod tests {
     use crate::mailbox::read_messages;
     use crate::mailbox::source::SourceFile;
     use crate::roles::ROLE_TEAM_LEAD;
-    use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
+    use crate::schema::{LegacyMessageId, MessageEnvelope};
     use crate::test_support::{TEST_QA, TEST_SENDER, TEST_TEAM};
     use crate::types::{AgentName, IsoTimestamp, TeamName};
 
@@ -179,7 +179,7 @@ mod tests {
         .expect("config");
         let path = tempdir.path().join(format!("{TEST_SENDER}.json"));
         let mut message = sample_message(ROLE_TEAM_LEAD, "full body retained elsewhere");
-        let atm_message_id = message.atm_message_id().expect("atm message id");
+        let message_id = message.message_id.expect("message id");
         message.summary = Some("stub summary".to_string());
 
         commit_mailbox_state(&path, std::slice::from_ref(&message)).expect("commit mailbox");
@@ -188,7 +188,7 @@ mod tests {
         let encoded: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("json array");
         assert_eq!(
             encoded[0]["text"],
-            serde_json::Value::String(format!("atm read --message-id {atm_message_id}"))
+            serde_json::Value::String(format!("atm read --message-id {message_id}"))
         );
         assert_eq!(
             encoded[0]["summary"],
@@ -300,21 +300,7 @@ mod tests {
     }
 
     fn sample_message(from: &str, text: &str) -> MessageEnvelope {
-        let atm_message_id = AtmMessageId::new();
-        let message_id = LegacyMessageId::from_atm_message_id(atm_message_id);
-        let mut extra = serde_json::Map::new();
-        let mut metadata = serde_json::Map::new();
-        let mut atm = serde_json::Map::new();
-        atm.insert(
-            "messageId".to_string(),
-            serde_json::Value::String(atm_message_id.to_string()),
-        );
-        atm.insert(
-            "sourceTeam".to_string(),
-            serde_json::Value::String(TEST_TEAM.to_string()),
-        );
-        metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
-        extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
+        let message_id = LegacyMessageId::new();
 
         MessageEnvelope {
             from: from.parse::<AgentName>().expect("agent name"),
@@ -331,7 +317,7 @@ mod tests {
             thread_mode: None,
             stale_at: None,
             task_id: None,
-            extra,
+            extra: serde_json::Map::new(),
         }
     }
 }

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -4,7 +4,6 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::fmt;
-use tracing::warn;
 use ulid::Ulid;
 use uuid::Uuid;
 
@@ -70,7 +69,8 @@ impl fmt::Display for LegacyMessageId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-/// ULID-based forward ATM identifier for `metadata.atm.messageId`.
+/// Historical ULID-based ATM identifier retained until Phase U identity
+/// cleanup removes the extra ATM-owned message-id layer.
 pub struct AtmMessageId(Ulid);
 
 impl AtmMessageId {
@@ -185,81 +185,13 @@ impl<'de> Deserialize<'de> for AlertKind {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-/// ATM-owned machine metadata planned for the forward `metadata.atm` namespace.
-pub struct AtmMetadataFields {
-    #[serde(rename = "messageId", skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<AtmMessageId>,
-
-    #[serde(rename = "sourceTeam", skip_serializing_if = "Option::is_none")]
-    pub source_team: Option<TeamName>,
-
-    #[serde(rename = "fromIdentity", skip_serializing_if = "Option::is_none")]
-    pub from_identity: Option<AgentName>,
-
-    #[serde(rename = "pendingAckAt", skip_serializing_if = "Option::is_none")]
-    pub pending_ack_at: Option<IsoTimestamp>,
-
-    #[serde(rename = "acknowledgedAt", skip_serializing_if = "Option::is_none")]
-    pub acknowledged_at: Option<IsoTimestamp>,
-
-    #[serde(
-        rename = "acknowledgesMessageId",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub acknowledges_message_id: Option<AtmMessageId>,
-
-    #[serde(rename = "parentMessageId", skip_serializing_if = "Option::is_none")]
-    pub parent_message_id: Option<AtmMessageId>,
-
-    #[serde(rename = "threadMode", skip_serializing_if = "Option::is_none")]
-    pub thread_mode: Option<ThreadMode>,
-
-    #[serde(rename = "staleAt", skip_serializing_if = "Option::is_none")]
-    pub stale_at: Option<IsoTimestamp>,
-
-    #[serde(rename = "taskId", skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<TaskId>,
-
-    #[serde(rename = "alertKind", skip_serializing_if = "Option::is_none")]
-    pub alert_kind: Option<AlertKind>,
-
-    // This advisory diagnostic field preserves platform-native path encoding
-    // (including backslashes on Windows) rather than normalizing JSON output to
-    // forward-slash-only form.
-    #[serde(rename = "missingConfigPath", skip_serializing_if = "Option::is_none")]
-    pub missing_config_path: Option<std::path::PathBuf>,
-
-    #[serde(flatten)]
-    pub extra: Map<String, Value>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-/// Top-level metadata container preserving ATM-owned and foreign metadata keys.
-pub struct MessageMetadata {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub atm: Option<AtmMetadataFields>,
-
-    // Preserve unknown producer-owned fields so ATM does not accidentally
-    // redefine external schemas by dropping or rewriting them.
-    #[serde(flatten)]
-    pub extra: Map<String, Value>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-/// Minimal forward-schema projection used to validate metadata/timestamp rules.
-pub struct ForwardMetadataEnvelope {
-    pub timestamp: IsoTimestamp,
-    pub metadata: MessageMetadata,
-}
-
 /// Persisted inbox superset used by ATM.
 ///
 /// Native Claude Code message shape is owned externally and documented in
 /// `docs/claude-code-message-schema.md`. Do not repurpose or rename Claude-owned
 /// fields in this struct. Historical top-level ATM additions are documented in
-/// `docs/legacy-atm-message-schema.md`, and forward ATM machine metadata is
-/// documented in `docs/atm-message-schema.md`.
+/// `docs/legacy-atm-message-schema.md`, and the approved additive compatibility
+/// fields are documented in `docs/atm-message-schema.md`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MessageEnvelope {
     // Claude Code-native fields. Do not change these as if ATM owned the
@@ -335,22 +267,19 @@ impl Default for SharedInboxExportPolicy {
     }
 }
 
-fn ensure_object<'a>(parent: &'a mut Map<String, Value>, key: &str) -> &'a mut Map<String, Value> {
-    let entry = parent
-        .entry(key.to_string())
-        .or_insert_with(|| Value::Object(Map::new()));
-    if !entry.is_object() {
-        *entry = Value::Object(Map::new());
-    }
-    let Some(entry) = entry.as_object_mut() else {
-        unreachable!("entry was just normalized into an object")
-    };
-    entry
-}
-
 #[cfg(test)]
 pub(crate) fn to_shared_inbox_value(message: &MessageEnvelope) -> Result<Value, AtmError> {
     to_shared_inbox_value_with_policy(message, SharedInboxExportPolicy::default())
+}
+
+fn strip_metadata_atm_namespace(object: &mut Map<String, Value>) {
+    let Some(metadata) = object.get_mut("metadata").and_then(Value::as_object_mut) else {
+        return;
+    };
+    metadata.remove("atm");
+    if metadata.is_empty() {
+        object.remove("metadata");
+    }
 }
 
 pub(crate) fn to_shared_inbox_value_with_policy(
@@ -375,67 +304,7 @@ pub(crate) fn to_shared_inbox_value_with_policy(
                 "Preserve the ATM shared-inbox envelope shape so serialization produces one JSON object per message before retrying mailbox export.",
             )
         })?;
-    // The legacy UUID `message_id` is stripped here but deliberately not
-    // forwarded. Forwarded ATM message ids must remain ULID-authored per
-    // architecture §5.2 rather than being derived from compatibility UUIDs.
-    let _ = object.remove("message_id");
-    let source_team = object.remove("source_team");
-    let pending_ack_at = object.remove("pendingAckAt");
-    let acknowledged_at = object.remove("acknowledgedAt");
-    let acknowledges_message_id =
-        object
-            .remove("acknowledgesMessageId")
-            .and_then(|value| match value {
-                Value::String(_) => message
-                    .acknowledges_message_id
-                    // This forwarding path preserves the legacy UUID bytes
-                    // exactly, but the resulting shared-inbox value is still a
-                    // compatibility reinterpretation of those bytes as a ULID.
-                    .map(LegacyMessageId::into_atm_message_id)
-                    .map(|message_id| Value::String(message_id.to_string())),
-                _ => None,
-            });
-    let parent_message_id = object
-        .remove("parentMessageId")
-        .and_then(|value| match value {
-            Value::String(_) => message
-                .parent_message_id
-                .map(LegacyMessageId::into_atm_message_id)
-                .map(|message_id| Value::String(message_id.to_string())),
-            _ => None,
-        });
-    let thread_mode = object.remove("threadMode");
-    let stale_at = object.remove("staleAt");
-    let task_id = object.remove("taskId");
-
-    let metadata = ensure_object(object, "metadata");
-    let atm = ensure_object(metadata, "atm");
-
-    if let Some(value) = source_team {
-        atm.entry("sourceTeam".to_string()).or_insert(value);
-    }
-    if let Some(value) = pending_ack_at {
-        atm.entry("pendingAckAt".to_string()).or_insert(value);
-    }
-    if let Some(value) = acknowledged_at {
-        atm.entry("acknowledgedAt".to_string()).or_insert(value);
-    }
-    if let Some(value) = acknowledges_message_id {
-        atm.entry("acknowledgesMessageId".to_string())
-            .or_insert(value);
-    }
-    if let Some(value) = parent_message_id {
-        atm.entry("parentMessageId".to_string()).or_insert(value);
-    }
-    if let Some(value) = thread_mode {
-        atm.entry("threadMode".to_string()).or_insert(value);
-    }
-    if let Some(value) = stale_at {
-        atm.entry("staleAt".to_string()).or_insert(value);
-    }
-    if let Some(value) = task_id {
-        atm.entry("taskId".to_string()).or_insert(value);
-    }
+    strip_metadata_atm_namespace(object);
     if should_export_retrieval_stub(message, policy)? {
         let retrieval_stub = retrieval_stub_text(message)?;
         object.insert("text".to_string(), Value::String(retrieval_stub));
@@ -460,145 +329,21 @@ fn should_export_retrieval_stub(
             )
         })?;
 
-    Ok(message.atm_message_id().is_some()
+    Ok(message.message_id.is_some()
         && (policy.atm_authored_body_export_max_bytes.is_zero() || message.text.len() > export_cap))
 }
 
 fn retrieval_stub_text(message: &MessageEnvelope) -> Result<String, AtmError> {
-    let Some(message_id) = message.atm_message_id() else {
+    let Some(message_id) = message.message_id else {
         return Err(AtmError::mailbox_write(format!(
-            "failed to project shared inbox retrieval stub for {} at {:?}: ATM-authored message is missing metadata.atm.messageId",
+            "failed to project shared inbox retrieval stub for {} at {:?}: ATM-authored message is missing message_id",
             message.from, message.timestamp
         ))
         .with_recovery(
-            "Ensure ATM-authored messages retain metadata.atm.messageId so the retrieval stub can reference the durable ATM message id.",
+            "Ensure ATM-authored messages retain message_id so the retrieval stub can reference the shared compatibility message id.",
         ));
     };
     Ok(format!("atm read --message-id {message_id}"))
-}
-
-impl MessageEnvelope {
-    pub fn atm_message_id(&self) -> Option<AtmMessageId> {
-        self.extra
-            .get("metadata")
-            .and_then(Value::as_object)
-            .and_then(|metadata| metadata.get("atm"))
-            .and_then(Value::as_object)
-            .and_then(|atm| atm.get("messageId"))
-            .and_then(Value::as_str)
-            .and_then(|value| value.parse().ok())
-    }
-}
-
-pub fn hydrate_legacy_fields_from_metadata(value: &mut Value) {
-    let Some(object) = value.as_object_mut() else {
-        return;
-    };
-    let Some(atm) = object
-        .get("metadata")
-        .and_then(Value::as_object)
-        .and_then(|metadata| metadata.get("atm"))
-        .and_then(Value::as_object)
-    else {
-        return;
-    };
-
-    let message_id = if object.contains_key("message_id") {
-        None
-    } else if let Some(raw) = atm.get("messageId").and_then(Value::as_str) {
-        match raw.parse::<AtmMessageId>() {
-            Ok(message_id) => Some(Value::String(
-                LegacyMessageId::from_atm_message_id(message_id).to_string(),
-            )),
-            Err(error) => {
-                warn!(%error, raw, "ignoring malformed metadata.atm.messageId");
-                None
-            }
-        }
-    } else {
-        None
-    };
-
-    let source_team = (!object.contains_key("source_team"))
-        .then(|| atm.get("sourceTeam").cloned())
-        .flatten();
-    let pending_ack_at = (!object.contains_key("pendingAckAt"))
-        .then(|| atm.get("pendingAckAt").cloned())
-        .flatten();
-    let acknowledged_at = (!object.contains_key("acknowledgedAt"))
-        .then(|| atm.get("acknowledgedAt").cloned())
-        .flatten();
-    let acknowledges_message_id = if object.contains_key("acknowledgesMessageId") {
-        None
-    } else if let Some(raw) = atm.get("acknowledgesMessageId").and_then(Value::as_str) {
-        match raw.parse::<AtmMessageId>() {
-            Ok(message_id) => Some(Value::String(
-                LegacyMessageId::from_atm_message_id(message_id).to_string(),
-            )),
-            Err(error) => {
-                warn!(
-                    %error,
-                    raw,
-                    "ignoring malformed metadata.atm.acknowledgesMessageId"
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
-    let parent_message_id = if object.contains_key("parentMessageId") {
-        None
-    } else if let Some(raw) = atm.get("parentMessageId").and_then(Value::as_str) {
-        match raw.parse::<AtmMessageId>() {
-            Ok(message_id) => Some(Value::String(
-                LegacyMessageId::from_atm_message_id(message_id).to_string(),
-            )),
-            Err(error) => {
-                warn!(%error, raw, "ignoring malformed metadata.atm.parentMessageId");
-                None
-            }
-        }
-    } else {
-        None
-    };
-    let thread_mode = (!object.contains_key("threadMode"))
-        .then(|| atm.get("threadMode").cloned())
-        .flatten();
-    let stale_at = (!object.contains_key("staleAt"))
-        .then(|| atm.get("staleAt").cloned())
-        .flatten();
-    let task_id = (!object.contains_key("taskId"))
-        .then(|| atm.get("taskId").cloned())
-        .flatten();
-
-    if let Some(value) = message_id {
-        object.insert("message_id".to_string(), value);
-    }
-    if let Some(value) = source_team {
-        object.insert("source_team".to_string(), value);
-    }
-    if let Some(value) = pending_ack_at {
-        object.insert("pendingAckAt".to_string(), value);
-    }
-    if let Some(value) = acknowledged_at {
-        object.insert("acknowledgedAt".to_string(), value);
-    }
-    if let Some(value) = acknowledges_message_id {
-        object.insert("acknowledgesMessageId".to_string(), value);
-    }
-    if let Some(value) = parent_message_id {
-        object.insert("parentMessageId".to_string(), value);
-    }
-    if let Some(value) = thread_mode {
-        object.insert("threadMode".to_string(), value);
-    }
-    if let Some(value) = stale_at {
-        object.insert("staleAt".to_string(), value);
-    }
-    if let Some(value) = task_id {
-        object.insert("taskId".to_string(), value);
-    }
 }
 
 #[cfg(test)]
@@ -609,10 +354,8 @@ mod tests {
     use chrono::Utc;
 
     use super::{
-        AlertKind, AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, IsoTimestamp,
-        LegacyMessageId, MessageEnvelope, MessageMetadata, PendingAck, SharedInboxExportPolicy,
-        hydrate_legacy_fields_from_metadata, to_shared_inbox_value,
-        to_shared_inbox_value_with_policy,
+        AlertKind, AtmMessageId, IsoTimestamp, LegacyMessageId, MessageEnvelope, PendingAck,
+        SharedInboxExportPolicy, to_shared_inbox_value, to_shared_inbox_value_with_policy,
     };
     use crate::config::types::ByteCount;
     use crate::roles::ROLE_TEAM_LEAD;
@@ -743,53 +486,6 @@ mod tests {
     }
 
     #[test]
-    fn forward_metadata_envelope_uses_atm_message_id() {
-        let (message_id, timestamp) = AtmMessageId::new_with_timestamp();
-        let envelope = ForwardMetadataEnvelope {
-            timestamp,
-            metadata: MessageMetadata {
-                atm: Some(AtmMetadataFields {
-                    message_id: Some(message_id),
-                    source_team: Some(TEST_TEAM.parse().expect("team name")),
-                    from_identity: None,
-                    pending_ack_at: None,
-                    acknowledged_at: None,
-                    acknowledges_message_id: None,
-                    parent_message_id: None,
-                    thread_mode: None,
-                    stale_at: None,
-                    task_id: None,
-                    alert_kind: None,
-                    missing_config_path: None,
-                    extra: Map::new(),
-                }),
-                extra: Map::new(),
-            },
-        };
-
-        let encoded = serde_json::to_string(&envelope).expect("encode");
-        let decoded: ForwardMetadataEnvelope = serde_json::from_str(&encoded).expect("decode");
-        assert_eq!(decoded, envelope);
-    }
-
-    #[test]
-    fn forward_metadata_source_team_rejects_blank_team_name() {
-        let json = json!({
-            "timestamp": "2026-03-30T00:00:00Z",
-            "metadata": {
-                "atm": {
-                    "sourceTeam": "   "
-                }
-            }
-        });
-
-        let error =
-            serde_json::from_value::<ForwardMetadataEnvelope>(json).expect_err("blank sourceTeam");
-
-        assert!(error.to_string().contains("team"));
-    }
-
-    #[test]
     fn atm_message_id_timestamp_matches_derived_timestamp() {
         let (message_id, timestamp) = AtmMessageId::new_with_timestamp();
         assert_eq!(message_id.timestamp(), timestamp);
@@ -811,7 +507,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_inbox_write_shape_moves_machine_fields_into_metadata() {
+    fn shared_inbox_write_keeps_machine_fields_top_level() {
         let envelope = MessageEnvelope {
             from: TEST_SENDER.parse().expect("agent"),
             text: "hello".into(),
@@ -840,24 +536,21 @@ mod tests {
 
         let encoded = to_shared_inbox_value(&envelope).expect("encode");
         let object = encoded.as_object().expect("object");
-        assert!(!object.contains_key("message_id"));
-        assert!(!object.contains_key("source_team"));
-        assert!(!object.contains_key("pendingAckAt"));
-        assert!(!object.contains_key("taskId"));
-
-        let atm = object
-            .get("metadata")
-            .and_then(Value::as_object)
-            .and_then(|metadata| metadata.get("atm"))
-            .and_then(Value::as_object)
-            .expect("metadata.atm");
-        assert!(!atm.contains_key("messageId"));
-        assert_eq!(atm.get("sourceTeam"), Some(&json!(TEST_TEAM)));
-        assert_eq!(atm.get("taskId"), Some(&json!("TASK-123")));
+        assert!(object.contains_key("message_id"));
+        assert!(object.contains_key("source_team"));
+        assert!(object.contains_key("pendingAckAt"));
+        assert!(object.contains_key("taskId"));
+        assert!(
+            object
+                .get("metadata")
+                .and_then(Value::as_object)
+                .and_then(|metadata| metadata.get("atm"))
+                .is_none()
+        );
     }
 
     #[test]
-    fn shared_inbox_write_shape_moves_ack_machine_fields_into_metadata() {
+    fn shared_inbox_write_keeps_ack_fields_top_level() {
         let acknowledged_at = IsoTimestamp::from_datetime(
             Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 2)
                 .single()
@@ -887,32 +580,16 @@ mod tests {
 
         let encoded = to_shared_inbox_value(&envelope).expect("encode");
         let object = encoded.as_object().expect("object");
-        assert!(!object.contains_key("acknowledgedAt"));
-        assert!(!object.contains_key("acknowledgesMessageId"));
-
-        let atm = object
-            .get("metadata")
-            .and_then(Value::as_object)
-            .and_then(|metadata| metadata.get("atm"))
-            .and_then(Value::as_object)
-            .expect("metadata.atm");
         assert_eq!(
-            atm.get("acknowledgedAt"),
+            object.get("acknowledgedAt"),
             Some(&json!("2026-03-30T00:00:02Z"))
         );
-        assert!(atm["acknowledgesMessageId"].as_str().is_some());
+        assert!(object["acknowledgesMessageId"].as_str().is_some());
     }
 
     #[test]
     fn shared_inbox_write_stubs_oversized_atm_authored_messages() {
-        let atm_message_id = AtmMessageId::new();
-        let legacy_message_id = LegacyMessageId::from_atm_message_id(atm_message_id);
-        let mut metadata = Map::new();
-        let mut atm = Map::new();
-        atm.insert("messageId".to_string(), json!(atm_message_id.to_string()));
-        metadata.insert("atm".to_string(), Value::Object(atm));
-        let mut extra = Map::new();
-        extra.insert("metadata".to_string(), Value::Object(metadata));
+        let legacy_message_id = LegacyMessageId::new();
         let envelope = MessageEnvelope {
             from: TEST_SENDER.parse().expect("agent"),
             text: "x".repeat(32),
@@ -932,7 +609,7 @@ mod tests {
             thread_mode: None,
             stale_at: None,
             task_id: None,
-            extra,
+            extra: Map::new(),
         };
 
         let encoded = to_shared_inbox_value_with_policy(
@@ -945,26 +622,16 @@ mod tests {
 
         assert_eq!(
             encoded["text"],
-            json!(format!("atm read --message-id {atm_message_id}"))
+            json!(format!("atm read --message-id {legacy_message_id}"))
         );
         assert_eq!(encoded["summary"], json!("oversized"));
-        assert_eq!(
-            encoded["metadata"]["atm"]["messageId"],
-            json!(atm_message_id.to_string())
-        );
+        assert_eq!(encoded["message_id"], json!(legacy_message_id.to_string()));
     }
 
     #[test]
     fn shared_inbox_write_exports_full_body_at_exact_cap() {
-        let atm_message_id = AtmMessageId::new();
-        let legacy_message_id = LegacyMessageId::from_atm_message_id(atm_message_id);
+        let legacy_message_id = LegacyMessageId::new();
         let text = "x".repeat(32);
-        let mut metadata = Map::new();
-        let mut atm = Map::new();
-        atm.insert("messageId".to_string(), json!(atm_message_id.to_string()));
-        metadata.insert("atm".to_string(), Value::Object(atm));
-        let mut extra = Map::new();
-        extra.insert("metadata".to_string(), Value::Object(metadata));
         let envelope = MessageEnvelope {
             from: TEST_SENDER.parse().expect("agent"),
             text: text.clone(),
@@ -984,7 +651,7 @@ mod tests {
             thread_mode: None,
             stale_at: None,
             task_id: None,
-            extra,
+            extra: Map::new(),
         };
 
         let encoded = to_shared_inbox_value_with_policy(
@@ -1000,15 +667,8 @@ mod tests {
 
     #[test]
     fn shared_inbox_write_exports_stub_above_cap() {
-        let atm_message_id = AtmMessageId::new();
-        let legacy_message_id = LegacyMessageId::from_atm_message_id(atm_message_id);
+        let legacy_message_id = LegacyMessageId::new();
         let text = "x".repeat(32);
-        let mut metadata = Map::new();
-        let mut atm = Map::new();
-        atm.insert("messageId".to_string(), json!(atm_message_id.to_string()));
-        metadata.insert("atm".to_string(), Value::Object(atm));
-        let mut extra = Map::new();
-        extra.insert("metadata".to_string(), Value::Object(metadata));
         let envelope = MessageEnvelope {
             from: TEST_SENDER.parse().expect("agent"),
             text,
@@ -1028,7 +688,7 @@ mod tests {
             thread_mode: None,
             stale_at: None,
             task_id: None,
-            extra,
+            extra: Map::new(),
         };
 
         let encoded = to_shared_inbox_value_with_policy(
@@ -1041,7 +701,7 @@ mod tests {
 
         assert_eq!(
             encoded["text"],
-            json!(format!("atm read --message-id {atm_message_id}"))
+            json!(format!("atm read --message-id {legacy_message_id}"))
         );
     }
 
@@ -1081,98 +741,43 @@ mod tests {
     }
 
     #[test]
-    fn metadata_fields_hydrate_legacy_internal_shape() {
-        let mut value = json!({
-            "from": TEST_SENDER,
-            "text": "hello",
-            "timestamp": "2026-03-30T00:00:00Z",
-            "read": false,
-            "summary": "hello",
-            "metadata": {
-                "atm": {
-                    "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
-                    "sourceTeam": TEST_TEAM,
-                    "pendingAckAt": "2026-03-30T00:00:01Z",
-                    "taskId": "TASK-123"
-                }
-            }
-        });
-
-        hydrate_legacy_fields_from_metadata(&mut value);
-        let object = value.as_object().expect("object");
-        assert!(object.contains_key("message_id"));
-        assert_eq!(object.get("source_team"), Some(&json!(TEST_TEAM)));
-        assert_eq!(object.get("taskId"), Some(&json!("TASK-123")));
-    }
-
-    #[test]
-    fn metadata_fields_hydrate_legacy_ack_fields() {
-        let mut value = json!({
-            "from": TEST_SENDER,
-            "text": "ack reply",
-            "timestamp": "2026-03-30T00:00:00Z",
-            "read": false,
-            "metadata": {
-                "atm": {
-                    "acknowledgedAt": "2026-03-30T00:00:02Z",
-                    "acknowledgesMessageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M"
-                }
-            }
-        });
-
-        hydrate_legacy_fields_from_metadata(&mut value);
-        let object = value.as_object().expect("object");
-        assert_eq!(
-            object.get("acknowledgedAt"),
-            Some(&json!("2026-03-30T00:00:02Z"))
+    fn shared_inbox_write_strips_metadata_atm_namespace() {
+        let mut extra = Map::new();
+        extra.insert(
+            "metadata".to_string(),
+            json!({
+                "atm": { "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M" },
+                "foreign": { "keep": true }
+            }),
         );
-        assert!(object["acknowledgesMessageId"].as_str().is_some());
-    }
+        let envelope = MessageEnvelope {
+            from: TEST_SENDER.parse().expect("agent"),
+            text: "hello".into(),
+            timestamp: IsoTimestamp::from_datetime(
+                Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                    .single()
+                    .expect("timestamp"),
+            ),
+            read: false,
+            source_team: None,
+            summary: None,
+            message_id: Some(LegacyMessageId::new()),
+            pending_ack_at: None,
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            parent_message_id: None,
+            thread_mode: None,
+            stale_at: None,
+            task_id: None,
+            extra,
+        };
 
-    #[test]
-    fn hydrate_legacy_fields_ignores_malformed_metadata_without_panic() {
-        let mut value = json!({
-            "from": TEST_SENDER,
-            "text": "hello",
-            "timestamp": "2026-03-30T00:00:00Z",
-            "read": false,
-            "metadata": {
-                "atm": {
-                    "messageId": "not-a-ulid",
-                    "acknowledgesMessageId": "also-not-a-ulid"
-                }
-            }
-        });
-
-        hydrate_legacy_fields_from_metadata(&mut value);
-        let object = value.as_object().expect("object");
-        assert!(!object.contains_key("message_id"));
-        assert!(!object.contains_key("acknowledgesMessageId"));
-    }
-
-    #[test]
-    fn hydrate_legacy_fields_handles_partially_migrated_envelope() {
-        let mut value = json!({
-            "from": TEST_SENDER,
-            "text": "hello",
-            "timestamp": "2026-03-30T00:00:00Z",
-            "read": false,
-            "source_team": "legacy-team",
-            "metadata": {
-                "atm": {
-                    "messageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
-                    "pendingAckAt": "2026-03-30T00:00:01Z"
-                }
-            }
-        });
-
-        hydrate_legacy_fields_from_metadata(&mut value);
-        let object = value.as_object().expect("object");
-        assert_eq!(object.get("source_team"), Some(&json!("legacy-team")));
-        assert!(object["message_id"].as_str().is_some());
-        assert_eq!(
-            object.get("pendingAckAt"),
-            Some(&json!("2026-03-30T00:00:01Z"))
+        let encoded = to_shared_inbox_value(&envelope).expect("encode");
+        assert!(
+            encoded["metadata"]["foreign"]["keep"]
+                .as_bool()
+                .unwrap_or(false)
         );
+        assert!(encoded["metadata"]["atm"].is_null());
     }
 }

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -1,4 +1,4 @@
-//! Shared inbox compatibility schema for Claude-native envelopes plus ATM metadata.
+//! Shared inbox compatibility schema for Claude-native envelopes with ATM additive compatibility fields.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/crates/atm-core/src/schema/mod.rs
+++ b/crates/atm-core/src/schema/mod.rs
@@ -5,8 +5,5 @@ pub mod settings;
 pub mod team_config;
 
 pub use agent_member::AgentMember;
-pub use inbox_message::{
-    AtmMessageId, AtmMetadataFields, ForwardMetadataEnvelope, LegacyMessageId, MessageEnvelope,
-    MessageMetadata, PendingAck, ThreadMode, hydrate_legacy_fields_from_metadata,
-};
+pub use inbox_message::{AtmMessageId, LegacyMessageId, MessageEnvelope, PendingAck, ThreadMode};
 pub use team_config::TeamConfig;

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -12,11 +12,11 @@ use crate::error::{AtmError, AtmErrorCode};
 use crate::identity;
 use crate::observability::{CommandEvent, ObservabilityPort};
 use crate::roles::ROLE_TEAM_LEAD;
-use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope, ThreadMode};
+use crate::schema::{LegacyMessageId, MessageEnvelope, ThreadMode};
 use crate::service_runtime::{LocalServiceRuntime, RetainedServiceRuntime};
 use crate::service_runtime_store::RetainedMailboxRuntime;
 use crate::threading::{ThreadIndex, canonical_sender_identity, is_ephemeral};
-use crate::types::{AgentName, CommandAction, TaskId, TeamName};
+use crate::types::{AgentName, CommandAction, IsoTimestamp, TaskId, TeamName};
 use crate::workflow;
 
 mod alert_state;
@@ -248,14 +248,9 @@ fn send_mail_with_runtime<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
     )?;
     let summary = summary::build_summary(&body, request.summary_override);
     let message_id = LegacyMessageId::new();
-    let (atm_message_id, timestamp) = AtmMessageId::new_with_timestamp();
+    let timestamp = IsoTimestamp::now();
 
     if !request.dry_run {
-        let mut extra = Map::new();
-        workflow::set_atm_message_id(&mut extra, atm_message_id);
-        if display_sender != canonical_sender.clone() {
-            set_canonical_sender_metadata(&mut extra, &canonical_sender);
-        }
         let envelope = MessageEnvelope {
             from: display_sender.clone(),
             text: body.clone(),
@@ -271,7 +266,7 @@ fn send_mail_with_runtime<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
             thread_mode: request.thread_mode,
             stale_at: request.stale_at,
             task_id: task_id.clone(),
-            extra,
+            extra: Map::new(),
         };
         append_mailbox_message_and_seed_workflow(
             runtime,
@@ -424,17 +419,7 @@ fn notify_team_lead_missing_config(
     };
 
     let config_path = team_dir.join("config.json");
-    let (atm_message_id, timestamp) = AtmMessageId::new_with_timestamp();
-    let mut extra = Map::new();
-    workflow::set_atm_message_id(&mut extra, atm_message_id);
-    extra.insert(
-        "atmAlertKind".into(),
-        serde_json::Value::String("missing_team_config".into()),
-    );
-    extra.insert(
-        "missingConfigPath".into(),
-        serde_json::Value::String(config_path.display().to_string()),
-    );
+    let timestamp = IsoTimestamp::now();
 
     let notice = MessageEnvelope {
         from: AgentName::from_validated("atm-identity-missing"),
@@ -456,7 +441,7 @@ fn notify_team_lead_missing_config(
         thread_mode: None,
         stale_at: None,
         task_id: None,
-        extra,
+        extra: Map::new(),
     };
 
     if let Err(error) = append_mailbox_message_and_seed_workflow(
@@ -635,34 +620,6 @@ pub(super) fn qualified_sender_identity(
     sender_team
         .map(|team| format!("{sender}@{team}"))
         .unwrap_or_else(|| sender.to_string())
-}
-
-fn set_canonical_sender_metadata(
-    extra: &mut Map<String, serde_json::Value>,
-    canonical_from: &AgentName,
-) {
-    let metadata = extra
-        .entry("metadata".to_string())
-        .or_insert_with(|| serde_json::Value::Object(Map::new()));
-    if !metadata.is_object() {
-        *metadata = serde_json::Value::Object(Map::new());
-    }
-    let Some(metadata) = metadata.as_object_mut() else {
-        return;
-    };
-    let atm = metadata
-        .entry("atm".to_string())
-        .or_insert_with(|| serde_json::Value::Object(Map::new()));
-    if !atm.is_object() {
-        *atm = serde_json::Value::Object(Map::new());
-    }
-    let Some(atm) = atm.as_object_mut() else {
-        return;
-    };
-    atm.insert(
-        "fromIdentity".to_string(),
-        serde_json::Value::String(canonical_from.to_string()),
-    );
 }
 
 pub(crate) fn maybe_run_post_send_hook(

--- a/crates/atm-core/src/threading.rs
+++ b/crates/atm-core/src/threading.rs
@@ -4,16 +4,7 @@ use crate::schema::{LegacyMessageId, MessageEnvelope};
 use crate::types::{AgentName, IsoTimestamp};
 
 pub(crate) fn canonical_sender_identity(message: &MessageEnvelope) -> AgentName {
-    message
-        .extra
-        .get("metadata")
-        .and_then(serde_json::Value::as_object)
-        .and_then(|metadata| metadata.get("atm"))
-        .and_then(serde_json::Value::as_object)
-        .and_then(|atm| atm.get("fromIdentity"))
-        .cloned()
-        .and_then(|value| serde_json::from_value(value).ok())
-        .unwrap_or_else(|| message.from.clone())
+    message.from.clone()
 }
 
 pub(crate) fn is_ephemeral(message: &MessageEnvelope) -> bool {
@@ -172,17 +163,10 @@ mod tests {
     }
 
     #[test]
-    fn canonical_sender_identity_prefers_metadata_override() {
-        let mut message = message(TEST_SENDER, LegacyMessageId::new(), None, None);
-        message.extra.insert(
-            "metadata".to_string(),
-            serde_json::json!({"atm": {"fromIdentity": "canonical-sender"}}),
-        );
+    fn canonical_sender_identity_uses_from_field() {
+        let message = message(TEST_SENDER, LegacyMessageId::new(), None, None);
 
-        assert_eq!(
-            canonical_sender_identity(&message).as_str(),
-            "canonical-sender"
-        );
+        assert_eq!(canonical_sender_identity(&message).as_str(), TEST_SENDER);
     }
 
     #[test]

--- a/crates/atm-core/src/workflow.rs
+++ b/crates/atm-core/src/workflow.rs
@@ -10,15 +10,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
-
 use crate::error::{AtmError, AtmErrorKind};
 use crate::home;
 use crate::mailbox::lock;
 use crate::persistence;
-use crate::schema::{AtmMessageId, MessageEnvelope};
+use crate::schema::MessageEnvelope;
 use crate::types::{AgentName, IsoTimestamp, TeamName};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub(crate) struct WorkflowStateFile {
@@ -186,50 +184,9 @@ pub(crate) fn remove_message_state(
 }
 
 pub(crate) fn workflow_key(envelope: &MessageEnvelope) -> Option<String> {
-    atm_message_id(envelope)
-        .map(|message_id| format!("atm:{message_id}"))
-        .or_else(|| {
-            envelope
-                .message_id
-                .map(|message_id| format!("legacy:{message_id}"))
-        })
-}
-
-pub(crate) fn atm_message_id(envelope: &MessageEnvelope) -> Option<AtmMessageId> {
     envelope
-        .extra
-        .get("metadata")
-        .and_then(Value::as_object)
-        .and_then(|metadata| metadata.get("atm"))
-        .and_then(Value::as_object)
-        .and_then(|atm| atm.get("messageId"))
-        .and_then(Value::as_str)
-        .and_then(|value| value.parse().ok())
-}
-
-pub(crate) fn set_atm_message_id(extra: &mut Map<String, Value>, message_id: AtmMessageId) {
-    let metadata = extra
-        .entry("metadata".to_string())
-        .or_insert_with(|| Value::Object(Map::new()));
-    if !metadata.is_object() {
-        *metadata = Value::Object(Map::new());
-    }
-    let Some(metadata) = metadata.as_object_mut() else {
-        return;
-    };
-    let atm = metadata
-        .entry("atm".to_string())
-        .or_insert_with(|| Value::Object(Map::new()));
-    if !atm.is_object() {
-        *atm = Value::Object(Map::new());
-    }
-    let Some(atm) = atm.as_object_mut() else {
-        return;
-    };
-    atm.insert(
-        "messageId".to_string(),
-        Value::String(message_id.to_string()),
-    );
+        .message_id
+        .map(|message_id| format!("legacy:{message_id}"))
 }
 
 pub(crate) fn initial_state_for_envelope(envelope: &MessageEnvelope) -> WorkflowMessageState {
@@ -257,15 +214,13 @@ pub(crate) fn remember_initial_state(
 
 #[cfg(test)]
 mod tests {
-    use serde_json::Map;
     use tempfile::TempDir;
 
     use super::{
-        WorkflowMessageState, apply_projected_state, atm_message_id, load_workflow_state,
-        project_envelope, remember_initial_state, remove_message_state, save_workflow_state,
-        set_atm_message_id, workflow_key,
+        WorkflowMessageState, apply_projected_state, load_workflow_state, project_envelope,
+        remember_initial_state, remove_message_state, save_workflow_state, workflow_key,
     };
-    use crate::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
+    use crate::schema::{LegacyMessageId, MessageEnvelope};
     use crate::test_support::{TEST_LEAD, TEST_SENDER, TEST_TEAM};
     use crate::types::{AgentName, IsoTimestamp, TeamName};
 
@@ -285,7 +240,7 @@ mod tests {
             thread_mode: None,
             stale_at: None,
             task_id: None,
-            extra: Map::new(),
+            extra: serde_json::Map::new(),
         }
     }
 
@@ -319,23 +274,24 @@ mod tests {
     }
 
     #[test]
-    fn workflow_key_prefers_forward_atm_message_id() {
-        let mut message = sample_message();
-        let atm_id = AtmMessageId::new();
-        set_atm_message_id(&mut message.extra, atm_id);
+    fn workflow_key_uses_legacy_message_id() {
+        let message = sample_message();
 
-        assert_eq!(atm_message_id(&message), Some(atm_id));
-        assert_eq!(workflow_key(&message), Some(format!("atm:{atm_id}")));
+        assert_eq!(
+            workflow_key(&message),
+            message
+                .message_id
+                .map(|message_id| format!("legacy:{message_id}"))
+        );
     }
 
     #[test]
     fn project_envelope_prefers_sidecar_state() {
-        let mut message = sample_message();
-        let atm_id = AtmMessageId::new();
-        set_atm_message_id(&mut message.extra, atm_id);
+        let message = sample_message();
+        let message_id = message.message_id.expect("legacy message id");
         let mut state = super::WorkflowStateFile::default();
         state.messages.insert(
-            format!("atm:{atm_id}"),
+            format!("legacy:{message_id}"),
             WorkflowMessageState {
                 read: true,
                 pending_ack_at: Some(IsoTimestamp::now()),

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -18,10 +18,7 @@ use atm_core::error::AtmErrorCode;
 use atm_core::observability::NullObservability;
 use atm_core::read::{ReadQuery, read_mail};
 use atm_core::roles::ROLE_TEAM_LEAD;
-use atm_core::schema::{
-    AgentMember, AtmMessageId, LegacyMessageId, MessageEnvelope, TeamConfig,
-    hydrate_legacy_fields_from_metadata,
-};
+use atm_core::schema::{AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig};
 use atm_core::send::{SendMessageSource, SendRequest, send_mail};
 use atm_core::types::{AckActivationMode, AgentName, IsoTimestamp, ReadSelection, TeamName};
 use chrono::Utc;
@@ -246,11 +243,7 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
     assert!(
         arch_workflow["messages"][format!("legacy:{pending_message_id}")]["acknowledgedAt"]
             .as_str()
-            .is_some()
-            || arch_workflow["messages"]
-                [format!("atm:{}", pending_message_id.into_atm_message_id())]["acknowledgedAt"]
-                .as_str()
-                .is_some(),
+            .is_some(),
         "pending message was not acknowledged in workflow state: {arch_workflow:?}"
     );
     let qa_inbox = ack_fixture.inbox_contents(SECONDARY_AGENT);
@@ -313,21 +306,21 @@ fn concurrent_same_recipient_sends_preserve_mixed_payloads_and_workflow_state() 
     assert!(plain_message.task_id.is_none());
     assert!(plain_message.pending_ack_at.is_none());
 
-    let plain_atm_id = message_atm_id(plain_message);
-    let task_atm_id = message_atm_id(task_message);
+    let plain_workflow_key = message_workflow_key(plain_message);
+    let task_workflow_key = message_workflow_key(task_message);
     let workflow = fixture.workflow_state_contents(PRIMARY_AGENT);
     assert!(
-        workflow["messages"][format!("atm:{plain_atm_id}")]
+        workflow["messages"][plain_workflow_key.clone()]
             .as_object()
             .is_some(),
         "plain workflow entry missing: {workflow:?}"
     );
     assert!(
-        workflow["messages"][format!("atm:{plain_atm_id}")]["pendingAckAt"].is_null(),
+        workflow["messages"][plain_workflow_key]["pendingAckAt"].is_null(),
         "plain workflow state should not require ack: {workflow:?}"
     );
     assert!(
-        workflow["messages"][format!("atm:{task_atm_id}")]["pendingAckAt"]
+        workflow["messages"][task_workflow_key]["pendingAckAt"]
             .as_str()
             .is_some(),
         "task workflow state should preserve pending ack: {workflow:?}"
@@ -398,13 +391,13 @@ fn concurrent_same_recipient_sends_preserve_preseeded_workflow_entries() {
         "preseeded workflow entry was dropped: {workflow:?}"
     );
     assert!(
-        workflow["messages"][format!("atm:{}", message_atm_id(first_message))]
+        workflow["messages"][message_workflow_key(first_message)]
             .as_object()
             .is_some(),
         "first send workflow entry missing after concurrent update: {workflow:?}"
     );
     assert!(
-        workflow["messages"][format!("atm:{}", message_atm_id(second_message))]
+        workflow["messages"][message_workflow_key(second_message)]
             .as_object()
             .is_some(),
         "second send workflow entry missing after concurrent update: {workflow:?}"
@@ -435,9 +428,8 @@ fn missing_config_notice_seeds_team_lead_workflow_state() {
     assert_eq!(notice.from, "atm-identity-missing");
     assert_eq!(notice.source_team.as_deref(), Some("broken-dev"));
     let workflow = fixture.workflow_state_contents_for_team("broken-dev", TEAM_LEAD);
-    let notice_atm_id = message_atm_id(notice);
     assert!(
-        workflow["messages"][format!("atm:{notice_atm_id}")]
+        workflow["messages"][message_workflow_key(notice)]
             .as_object()
             .is_some(),
         "missing-config workflow entry missing: {workflow:?}"
@@ -501,9 +493,8 @@ fn concurrent_normal_send_and_missing_config_notice_complete_without_data_loss()
     let notices = fixture.inbox_contents_for_team("broken-dev", TEAM_LEAD);
     let notice = notices.first().expect("missing-config notice");
     let workflow = fixture.workflow_state_contents_for_team("broken-dev", TEAM_LEAD);
-    let notice_atm_id = message_atm_id(notice);
     assert!(
-        workflow["messages"][format!("atm:{notice_atm_id}")]["pendingAckAt"].is_null(),
+        workflow["messages"][message_workflow_key(notice)]["pendingAckAt"].is_null(),
         "missing-config notice workflow state missing after concurrent send: {workflow:?}"
     );
 }
@@ -735,9 +726,6 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
     let fixture = Fixture::new();
     let observability = NullObservability;
 
-    // Criterion (a) is verified through the standard send path rather than a
-    // direct helper call: send_mail internally assigns metadata.atm.messageId
-    // via the private workflow::set_atm_message_id path before read_mail runs.
     send_mail(
         fixture.send_request(TEAM_LEAD, &qualified(PRIMARY_AGENT), "hello sidecar"),
         &observability,
@@ -747,9 +735,9 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
     let inbox_before = fs::read_to_string(fixture.primary_inbox_path(PRIMARY_AGENT))
         .expect("raw inbox before read");
     let physical_before = find_inbox_json_line(&inbox_before, "hello sidecar");
-    let atm_message_id = physical_before["metadata"]["atm"]["messageId"]
+    let message_id = physical_before["message_id"]
         .as_str()
-        .expect("atm message id")
+        .expect("message id")
         .to_string();
     assert_eq!(physical_before["read"], false);
 
@@ -768,10 +756,7 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
         .expect("raw inbox after read");
     assert_eq!(inbox_after, inbox_before);
     let physical_after = find_inbox_json_line(&inbox_after, "hello sidecar");
-    assert_eq!(
-        physical_after["metadata"]["atm"]["messageId"],
-        atm_message_id
-    );
+    assert_eq!(physical_after["message_id"], message_id);
     assert_eq!(physical_after["read"], false);
     assert!(
         !sentinel_path(&fixture.primary_inbox_path(PRIMARY_AGENT)).exists(),
@@ -780,7 +765,7 @@ fn read_mail_updates_sidecar_for_ulid_authored_message_without_mutating_inbox() 
 
     let workflow = fixture.workflow_state_contents(PRIMARY_AGENT);
     assert_eq!(
-        workflow["messages"][format!("atm:{atm_message_id}")]["read"],
+        workflow["messages"][format!("legacy:{message_id}")]["read"],
         true
     );
 }
@@ -919,8 +904,8 @@ impl Fixture {
             &[TEAM_LEAD, PRIMARY_AGENT, SECONDARY_AGENT],
         );
 
-        let arch_message_id = LegacyMessageId::from_atm_message_id(AtmMessageId::new());
-        let qa_message_id = LegacyMessageId::from_atm_message_id(AtmMessageId::new());
+        let arch_message_id = LegacyMessageId::new();
+        let qa_message_id = LegacyMessageId::new();
 
         let fixture = Self {
             tempdir,
@@ -1117,12 +1102,12 @@ fn create_team_with_config(home_dir: &std::path::Path, team: &str, members: &[&s
     .expect("write team config");
 }
 
-fn message_atm_id(message: &MessageEnvelope) -> String {
+fn message_workflow_key(message: &MessageEnvelope) -> String {
     message
-        .atm_message_id()
-        .map(|message_id| message_id.to_string())
+        .message_id
+        .map(|message_id| format!("legacy:{message_id}"))
         .as_deref()
-        .expect("atm message id")
+        .expect("message id")
         .to_string()
 }
 
@@ -1142,10 +1127,7 @@ fn read_jsonl(path: std::path::PathBuf) -> Vec<MessageEnvelope> {
 
     values
         .into_iter()
-        .map(|mut value| {
-            hydrate_legacy_fields_from_metadata(&mut value);
-            serde_json::from_value(value).expect("message envelope")
-        })
+        .map(|value| serde_json::from_value(value).expect("message envelope"))
         .collect()
 }
 
@@ -1195,26 +1177,6 @@ fn pending_ack_message_at(
     source_team: &str,
     timestamp: chrono::DateTime<Utc>,
 ) -> MessageEnvelope {
-    let mut extra = serde_json::Map::new();
-    let mut metadata = serde_json::Map::new();
-    let mut atm = serde_json::Map::new();
-    let atm_message_id = message_id.into_atm_message_id();
-    atm.insert(
-        "messageId".to_string(),
-        serde_json::Value::String(atm_message_id.to_string()),
-    );
-    atm.insert(
-        "sourceTeam".to_string(),
-        serde_json::Value::String(source_team.to_string()),
-    );
-    metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
-    extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
-    assert_eq!(
-        LegacyMessageId::from_atm_message_id(message_atm_id_from_extra(&extra).expect("atm id")),
-        message_id,
-        "mailbox fixture metadata.atm.messageId must match legacy message_id",
-    );
-
     MessageEnvelope {
         from: from.parse::<AgentName>().expect("agent"),
         text: text.to_string(),
@@ -1230,7 +1192,7 @@ fn pending_ack_message_at(
         thread_mode: None,
         stale_at: None,
         task_id: None,
-        extra,
+        extra: serde_json::Map::new(),
     }
 }
 
@@ -1244,26 +1206,6 @@ fn read_message_at(
     message_id: LegacyMessageId,
     timestamp: chrono::DateTime<Utc>,
 ) -> MessageEnvelope {
-    let mut extra = serde_json::Map::new();
-    let mut metadata = serde_json::Map::new();
-    let mut atm = serde_json::Map::new();
-    let atm_message_id = message_id.into_atm_message_id();
-    atm.insert(
-        "messageId".to_string(),
-        serde_json::Value::String(atm_message_id.to_string()),
-    );
-    atm.insert(
-        "sourceTeam".to_string(),
-        serde_json::Value::String(PRIMARY_TEAM.to_string()),
-    );
-    metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
-    extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
-    assert_eq!(
-        LegacyMessageId::from_atm_message_id(message_atm_id_from_extra(&extra).expect("atm id")),
-        message_id,
-        "mailbox fixture metadata.atm.messageId must match legacy message_id",
-    );
-
     MessageEnvelope {
         from: from.parse::<AgentName>().expect("agent"),
         text: text.to_string(),
@@ -1279,31 +1221,11 @@ fn read_message_at(
         thread_mode: None,
         stale_at: None,
         task_id: None,
-        extra,
+        extra: serde_json::Map::new(),
     }
 }
 
 fn unread_message(from: &str, text: &str, message_id: LegacyMessageId) -> MessageEnvelope {
-    let mut extra = serde_json::Map::new();
-    let mut metadata = serde_json::Map::new();
-    let mut atm = serde_json::Map::new();
-    let atm_message_id = message_id.into_atm_message_id();
-    atm.insert(
-        "messageId".to_string(),
-        serde_json::Value::String(atm_message_id.to_string()),
-    );
-    atm.insert(
-        "sourceTeam".to_string(),
-        serde_json::Value::String(PRIMARY_TEAM.to_string()),
-    );
-    metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
-    extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
-    assert_eq!(
-        LegacyMessageId::from_atm_message_id(message_atm_id_from_extra(&extra).expect("atm id")),
-        message_id,
-        "mailbox fixture metadata.atm.messageId must match legacy message_id",
-    );
-
     MessageEnvelope {
         from: from.parse::<AgentName>().expect("agent"),
         text: text.to_string(),
@@ -1319,19 +1241,6 @@ fn unread_message(from: &str, text: &str, message_id: LegacyMessageId) -> Messag
         thread_mode: None,
         stale_at: None,
         task_id: None,
-        extra,
+        extra: serde_json::Map::new(),
     }
-}
-
-fn message_atm_id_from_extra(
-    extra: &serde_json::Map<String, serde_json::Value>,
-) -> Option<AtmMessageId> {
-    extra
-        .get("metadata")
-        .and_then(serde_json::Value::as_object)
-        .and_then(|metadata| metadata.get("atm"))
-        .and_then(serde_json::Value::as_object)
-        .and_then(|atm| atm.get("messageId"))
-        .and_then(serde_json::Value::as_str)
-        .and_then(|value| value.parse().ok())
 }

--- a/crates/atm-daemon/src/boundary_adapters.rs
+++ b/crates/atm-daemon/src/boundary_adapters.rs
@@ -231,7 +231,7 @@ mod tests {
     };
     use atm_core::protocol::NotificationEvent;
     use atm_core::roles::ROLE_TEAM_LEAD;
-    use atm_core::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
+    use atm_core::schema::{LegacyMessageId, MessageEnvelope};
     use atm_core::test_support::{TEST_SENDER, TEST_TEAM};
     use atm_core::types::{AgentName, IsoTimestamp};
     use std::sync::Arc;
@@ -319,7 +319,7 @@ mod tests {
             imported.text,
             format!(
                 "atm read --message-id {}",
-                message.atm_message_id().expect("atm message id")
+                message.message_id.expect("message id")
             )
         );
 
@@ -394,17 +394,7 @@ mod tests {
     }
 
     fn sample_message(from: &str, text: &str) -> MessageEnvelope {
-        let atm_message_id = AtmMessageId::new();
-        let message_id = LegacyMessageId::from_atm_message_id(atm_message_id);
-        let mut atm = serde_json::Map::new();
-        atm.insert(
-            "messageId".to_string(),
-            serde_json::Value::String(atm_message_id.to_string()),
-        );
-        let mut metadata = serde_json::Map::new();
-        metadata.insert("atm".to_string(), serde_json::Value::Object(atm));
-        let mut extra = serde_json::Map::new();
-        extra.insert("metadata".to_string(), serde_json::Value::Object(metadata));
+        let message_id = LegacyMessageId::new();
 
         MessageEnvelope {
             from: from.parse::<AgentName>().expect("agent"),
@@ -421,7 +411,7 @@ mod tests {
             thread_mode: None,
             stale_at: None,
             task_id: None,
-            extra,
+            extra: serde_json::Map::new(),
         }
     }
 }

--- a/crates/atm-daemon/src/reconcile_runtime.rs
+++ b/crates/atm-daemon/src/reconcile_runtime.rs
@@ -677,10 +677,10 @@ mod tests {
     };
     use atm_core::protocol::ReconcileResult;
     use atm_core::roles::ROLE_TEAM_LEAD;
-    use atm_core::schema::{AtmMessageId, LegacyMessageId, MessageEnvelope};
+    use atm_core::schema::{LegacyMessageId, MessageEnvelope};
     use atm_core::types::IsoTimestamp;
     use chrono::Utc;
-    use serde_json::{Map, Value};
+    use serde_json::Map;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::time::Duration;
@@ -1168,17 +1168,7 @@ mod tests {
     }
 
     fn sample_message(text: &str) -> MessageEnvelope {
-        let atm_message_id = AtmMessageId::new();
-        let message_id = LegacyMessageId::from_atm_message_id(atm_message_id);
-        let mut atm = Map::new();
-        atm.insert(
-            "messageId".to_string(),
-            Value::String(atm_message_id.to_string()),
-        );
-        let mut metadata = Map::new();
-        metadata.insert("atm".to_string(), Value::Object(atm));
-        let mut extra = Map::new();
-        extra.insert("metadata".to_string(), Value::Object(metadata));
+        let message_id = LegacyMessageId::new();
 
         MessageEnvelope {
             from: ROLE_TEAM_LEAD.parse().expect("agent"),
@@ -1195,7 +1185,7 @@ mod tests {
             thread_mode: None,
             stale_at: None,
             task_id: None,
-            extra,
+            extra: Map::new(),
         }
     }
 }

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -365,10 +365,7 @@ mod tests {
         ProtocolErrorEnvelope, RequestEnvelope, ResponseEnvelope, SendRequestEnvelope,
     };
     use atm_core::read::ReadQuery;
-    use atm_core::schema::{
-        AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig,
-        hydrate_legacy_fields_from_metadata,
-    };
+    use atm_core::schema::{AgentMember, LegacyMessageId, MessageEnvelope, TeamConfig};
     use atm_core::send::{SendMessageSource, SendRequest};
     use atm_core::test_support::{
         ROLE_TEAM_LEAD, TEST_LEAD, TEST_RECIPIENT, TEST_RECIPIENT_ADDRESS, TEST_SENDER, TEST_TEAM,
@@ -455,10 +452,7 @@ mod tests {
             let values: Vec<Value> = serde_json::from_str(&raw).expect("json array");
             values
                 .into_iter()
-                .map(|mut value| {
-                    hydrate_legacy_fields_from_metadata(&mut value);
-                    serde_json::from_value(value).expect("message envelope")
-                })
+                .map(|value| serde_json::from_value(value).expect("message envelope"))
                 .collect()
         }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -692,7 +692,8 @@ Architectural rules:
 - Claude JSON is a compatibility surface, not ATM-owned durable truth.
 - No normal ATM runtime/query path may read machine state from Claude JSON.
 - ATM-owned machine state belongs in SQLite-backed state and projections.
-- `metadata.atm` is not an approved active machine-state namespace.
+- `metadata.atm` is not an approved namespace and must not survive in active
+  compatibility output.
 - ATM keeps one logical message identity; shared inbox `message_id` is the
   compatibility wire encoding of that identity.
 - Compatibility writes may preserve established top-level additive fields, but

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -403,7 +403,7 @@ ATM-authored alert metadata belongs to the send/schema boundary in `atm-core`.
 
 Architectural rule:
 - ATM-owned repair/alert machine state belongs in SQLite-owned state and typed
-  diagnostics, not in an active `metadata.atm` namespace
+  diagnostics, not in shared inbox metadata namespaces
 - legacy top-level alert fields such as `atmAlertKind` and
   `missingConfigPath` remain read-compatible only until removed
 

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -99,12 +99,20 @@ Initial crate requirement IDs:
   `REQ-P-CONTRACT-001`, `REQ-P-SEND-001`, `REQ-P-LIST-001`, `REQ-P-READ-001`,
   `REQ-P-ACK-001`, `REQ-P-CLEAR-001`, `REQ-P-RELIABILITY-001`,
   `REQ-P-IDLE-001`.
+  Phase-U note: active compatibility reads no longer depend on `metadata.atm`;
+  inbound shared-inbox records strip that namespace through
+  `strip_metadata_atm_namespace()` in
+  `crates/atm-core/src/schema/inbox_message.rs`.
 - `REQ-CORE-COMPAT-001` `atm-core` owns the Claude JSONL compatibility
   projection contract for ATM-authored exports and inbound compatibility
   ingestion, including the bounded export cap, retrieval-stub rule, and
   idempotent watcher/reconcile projection handling for the same logical
   message. Satisfies:
   `REQ-P-CONTRACT-001`, `REQ-P-RELIABILITY-001`.
+  Phase-U note: the active compatibility contract strips inbound
+  `metadata.atm` rather than preserving it as a live schema surface; the
+  production enforcement point is `strip_metadata_atm_namespace()` in
+  `crates/atm-core/src/schema/inbox_message.rs`.
 - `REQ-CORE-WORKFLOW-001` `atm-core` owns the two-axis workflow model and legal
   transitions. Satisfies the state-classification and legal-transition aspects
   of:
@@ -251,6 +259,8 @@ The `atm-core` crate docs must remain aligned with:
 - [`../documentation-guidelines.md`](../documentation-guidelines.md)
 - [`../atm-message-schema.md`](../atm-message-schema.md)
 - [`../legacy-atm-message-schema.md`](../legacy-atm-message-schema.md)
+  (historical only; its `metadata.atm` coverage was superseded and removed
+  from the active compatibility design in Phase U)
 - [`../atm-error-codes.md`](../atm-error-codes.md)
 - [`../plan-phase-R.md`](../plan-phase-R.md)
 - [`../plan-phase-S.md`](../plan-phase-S.md)

--- a/docs/atm-message-schema.md
+++ b/docs/atm-message-schema.md
@@ -60,8 +60,8 @@ Claude JSON:
 - canonical sender projection
 - repair/alert machine metadata
 
-If ATM still exports compatibility hints for an older consumer, those writes
-must remain output-only and must not become a runtime read dependency again.
+If an older compatibility shape is ever reconsidered, it requires explicit
+approval; the active Phase U design preserves no `metadata.atm` namespace.
 
 ## 5. Threading And Task Semantics
 
@@ -84,12 +84,10 @@ and workflow logic, not in repeated JSON reads.
 
 ## 6. No Active `metadata.atm` Namespace
 
-`metadata.atm` is not an approved active machine-state namespace in the Phase U
-architecture.
+`metadata.atm` is not an approved namespace in the Phase U architecture.
 
 Rules:
 
-- ATM must not add new product-critical runtime state under `metadata.atm`.
+- ATM must not add or preserve machine-state fields under `metadata.atm`.
 - ATM must not rely on `metadata.atm` reads for normal mailbox behavior.
-- Any leftover `metadata.atm` writes are compatibility debt and should be
-  removed or kept only with explicit approval.
+- The active implementation must expose zero surviving `metadata.atm` fields.

--- a/docs/atm-message-schema.md
+++ b/docs/atm-message-schema.md
@@ -91,3 +91,5 @@ Rules:
 - ATM must not add or preserve machine-state fields under `metadata.atm`.
 - ATM must not rely on `metadata.atm` reads for normal mailbox behavior.
 - The active implementation must expose zero surviving `metadata.atm` fields.
+- inbound shared-inbox records that still carry `metadata.atm` for backward
+  compatibility are silently stripped, not rejected

--- a/docs/atm/commands/send.md
+++ b/docs/atm/commands/send.md
@@ -16,7 +16,6 @@ References:
 - `REQ-ATM-CMD-001`
 - `REQ-ATM-OUT-001`
 - `REQ-CORE-CONFIG-002` for alias rewrite before canonical target resolution
-- `REQ-CORE-SEND-002` for cross-team `from` projection with
-  `metadata.atm.fromIdentity`
+- `REQ-CORE-SEND-002` for cross-team canonical `from` projection
 - Product architecture: `docs/architecture.md`
 - Core module: `docs/atm-core/modules/send.md`

--- a/docs/phase-U/sprint-U1.md
+++ b/docs/phase-U/sprint-U1.md
@@ -79,7 +79,8 @@ Required shape for every sub-task:
      every surviving approved read
    Required doc or boundary updates:
    - update `docs/architecture.md` and `docs/atm-message-schema.md` to state
-     which `metadata.atm` fields, if any, remain output-only
+     that the active implementation preserves zero surviving `metadata.atm`
+     fields
 
 2. Redirect or delete runtime reads
    Development work:
@@ -95,7 +96,7 @@ Required shape for every sub-task:
 
 3. Compatibility output hardening
    Development work:
-   - keep only explicitly justified compatibility output under `metadata.atm`
+   - remove the `metadata.atm` namespace from active compatibility output
    - delete dead helper code that writes unapproved ATM-owned metadata
    Required tests:
    - serialization tests proving remaining compatibility output is bounded and
@@ -105,9 +106,8 @@ Required shape for every sub-task:
 
 ## Split Recommendation
 
-Do not split unless a single remaining `metadata.atm` field proves to require a
-separate approved product decision. The default outcome of this sprint should
-be deletion, not deferral.
+Do not split around compatibility output. The default outcome of this sprint
+should be zero surviving `metadata.atm` fields, not deferral.
 
 ## Acceptance Criteria
 

--- a/docs/plan-phase-U.md
+++ b/docs/plan-phase-U.md
@@ -33,7 +33,8 @@ Authoritative sprint sequence:
 
 Sprint summary:
 - `U.0` remove the old `atm-graft` implementation line (`completed by team-lead`)
-- `U.1` delete `metadata.atm` read-path dependence
+- `U.1` delete `metadata.atm` read-path dependence and remove the namespace
+  from active compatibility output
 - `U.2` one message identity ADR and implementation cleanup
 - `U.3` thread/update/supersede hardening
 - `U.4` unified mutable message state

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2727,8 +2727,7 @@ Scope:
 
 Acceptance:
 - no normal ATM read/query/runtime path depends on `metadata.atm.*`
-- any surviving `metadata.atm` write is explicitly justified as compatibility
-  output only, not an ATM-owned read source
+- the active implementation exposes zero surviving `metadata.atm` fields
 - dead compatibility helpers and tests that only exist to preserve
   `metadata.atm` reads are removed
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -414,7 +414,7 @@ Required rules:
   - ATM top-level additive compatibility messages
 - no normal ATM runtime/query path may depend on ATM-owned machine-state reads
   from Claude JSON
-- new ATM-owned machine state must not be introduced under `metadata.atm`
+- no `metadata.atm` namespace may survive in active compatibility output
 - shared inbox `message_id` is the compatibility wire encoding of the one
   logical ATM message identity
 - ATM-owned workflow, delete/close, expiry, sender-projection, and repair

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -44,6 +44,8 @@ Schema ownership references:
   [`atm-message-schema.md`](./atm-message-schema.md)
 - legacy ATM read-compatibility schema:
   [`legacy-atm-message-schema.md`](./legacy-atm-message-schema.md)
+  (historical only; Phase U removed its `metadata.atm` coverage from the
+  active compatibility design)
 - `sc-observability` schema ownership pointer:
   [`sc-observability-schema.md`](./sc-observability-schema.md)
 - ATM-owned error-code registry:
@@ -120,6 +122,10 @@ Phase-S portability note:
 - the thin-client extension surface should center on `send` and `receive`
   over the shared ATM protocol, while the retained CLI may continue to expose
   `ack` as a user-facing workflow
+- Phase U removed the active `metadata.atm` namespace from the approved
+  compatibility schema; the authoritative schema is
+  [`atm-message-schema.md`](./atm-message-schema.md) and the planning record is
+  [`plan-phase-U.md`](./plan-phase-U.md)
 
 ## 2. Scope
 
@@ -430,6 +436,8 @@ Required rules:
 - [`claude-code-message-schema.md`](./claude-code-message-schema.md)
 - [`atm-message-schema.md`](./atm-message-schema.md)
 - [`legacy-atm-message-schema.md`](./legacy-atm-message-schema.md)
+  (historical only; its `metadata.atm` coverage was superseded and removed
+  from the active compatibility design in Phase U)
 - [`atm-core/design/dedup-metadata-schema.md`](./atm-core/design/dedup-metadata-schema.md)
   §2.2 and §3.3 for forward ATM alert-field placement and sender-side dedup
   semantics


### PR DESCRIPTION
## Summary
- Remove all ATM-owned runtime/query reads of `metadata.atm.*` from production paths
- Strip metadata.atm compatibility output; namespace fully removed
- Rewrite affected core/daemon/integration tests; update Phase U/schema/architecture docs

## Sprint
U.1 — Delete `metadata.atm` Read-Path Dependence

## Validation
- cargo test --workspace: PASS
- cargo xwin check (windows): PASS
- just lint: PASS
- git diff --check: PASS

## QA gate
0B+0I+0m required before merge to integrate/phase-U

🤖 Generated with [Claude Code](https://claude.com/claude-code)