### PR TITLE
V.2: observability migration into subsystems

### DIFF
--- a/crates/atm-daemon/src/advisory_runtime.rs
+++ b/crates/atm-daemon/src/advisory_runtime.rs
@@ -15,15 +15,18 @@ use atm_core::protocol::ResponseEnvelope;
 use atm_core::send::SendOutcome;
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 const MAX_ADVISORY_SESSIONS: usize = 128;
 const MAX_ADVISORY_EVENTS_PER_SESSION: usize = 256;
 const STREAM_IDLE_WAIT: Duration = Duration::from_millis(100);
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct AdvisoryRuntime {
     state: RwLock<AdvisoryRuntimeState>,
     max_sessions: usize,
     max_nudges_per_session: usize,
+    observability: SubsystemObservability,
 }
 
 #[derive(Debug, Default)]
@@ -43,11 +46,19 @@ struct RegisteredAdvisorySession {
 }
 
 impl AdvisoryRuntime {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::AdvisoryRuntime,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
             state: RwLock::new(AdvisoryRuntimeState::default()),
             max_sessions: MAX_ADVISORY_SESSIONS,
             max_nudges_per_session: MAX_ADVISORY_EVENTS_PER_SESSION,
+            observability,
         }
     }
 
@@ -57,6 +68,7 @@ impl AdvisoryRuntime {
             state: RwLock::new(AdvisoryRuntimeState::default()),
             max_sessions,
             max_nudges_per_session,
+            observability: SubsystemObservability::disabled(DaemonSubsystem::AdvisoryRuntime),
         }
     }
 
@@ -66,6 +78,16 @@ impl AdvisoryRuntime {
     ) -> Result<AdvisorySessionRegistrationResponse, AtmError> {
         let mut state = self.lock_state_write()?;
         if state.sessions.contains_key(&request.session_id) {
+            let event = self
+                .observability
+                .event(
+                    "register_session",
+                    "rejected",
+                    "advisory session registration reused an existing session id",
+                )
+                .with_team(request.team.clone())
+                .with_agent(request.agent.clone());
+            let _ = self.observability.emit_event(event);
             return Err(AtmError::daemon_advisory_session_already_registered(format!(
                 "advisory session {} is already registered",
                 request.session_id
@@ -75,6 +97,16 @@ impl AdvisoryRuntime {
             ));
         }
         if state.sessions.len() >= self.max_sessions {
+            let event = self
+                .observability
+                .event(
+                    "register_session",
+                    "rejected",
+                    "advisory session registration hit the bounded session cap",
+                )
+                .with_team(request.team.clone())
+                .with_agent(request.agent.clone());
+            let _ = self.observability.emit_event(event);
             return Err(AtmError::daemon_unavailable(format!(
                 "advisory session registration rejected because the daemon session cap {} is exhausted",
                 self.max_sessions
@@ -97,6 +129,12 @@ impl AdvisoryRuntime {
                 dropped_count: 0,
             },
         );
+        let event = self
+            .observability
+            .event("register_session", "ok", "advisory session registered")
+            .with_team(request.team.clone())
+            .with_agent(request.agent.clone());
+        let _ = self.observability.emit_event(event);
 
         Ok(AdvisorySessionRegistrationResponse {
             team: request.team,
@@ -113,6 +151,15 @@ impl AdvisoryRuntime {
     ) -> Result<AdvisorySessionUnregistrationResponse, AtmError> {
         let mut state = self.lock_state_write()?;
         let closed = state.sessions.remove(&request.session_id).is_some();
+        let _ = self.observability.emit(
+            "unregister_session",
+            if closed { "ok" } else { "noop" },
+            if closed {
+                "advisory session unregistered"
+            } else {
+                "advisory session unregistration found no registered session"
+            },
+        );
         Ok(AdvisorySessionUnregistrationResponse {
             session_id: request.session_id,
             closed,
@@ -239,6 +286,20 @@ impl AdvisoryRuntime {
                 if session.nudges.len() >= self.max_nudges_per_session {
                     session.dropped_count = session.dropped_count.saturating_add(1);
                     overflowed = true;
+                    let mut event = self
+                        .observability
+                        .event(
+                            "enqueue_nudge",
+                            "degraded",
+                            "advisory queue rejected an event because the bounded session queue is full",
+                        )
+                        .with_team(outcome.team.clone())
+                        .with_agent(outcome.agent.clone());
+                    event = event.with_message_id(outcome.message_id);
+                    if let Some(task_id) = outcome.task_id.clone() {
+                        event = event.with_task_id(task_id);
+                    }
+                    let _ = self.observability.emit_event(event);
                     tracing::debug!(
                         session_id = %session_id,
                         team = %outcome.team,
@@ -253,6 +314,26 @@ impl AdvisoryRuntime {
             }
         }
         if matched {
+            let mut event = self
+                .observability
+                .event(
+                    "enqueue_nudge",
+                    if overflowed { "degraded" } else { "ok" },
+                    if overflowed {
+                        "advisory runtime enqueued at least one nudge and dropped at least one due to queue pressure"
+                    } else {
+                        "advisory runtime queued a nudge for a registered session"
+                    },
+                )
+                .with_team(outcome.team.clone())
+                .with_agent(outcome.agent.clone())
+                .with_recipient(outcome.agent.clone())
+                .with_sender(outcome.sender.clone());
+            event = event.with_message_id(outcome.message_id);
+            if let Some(task_id) = outcome.task_id.clone() {
+                event = event.with_task_id(task_id);
+            }
+            let _ = self.observability.emit_event(event);
             tracing::debug!(
                 team = %outcome.team,
                 agent = %outcome.agent,

--- a/crates/atm-daemon/src/boundary_adapters.rs
+++ b/crates/atm-daemon/src/boundary_adapters.rs
@@ -12,8 +12,6 @@ use atm_core::{
 };
 use std::sync::Arc;
 
-#[cfg(test)]
-use crate::DaemonSubsystem;
 use crate::SubsystemObservability;
 use crate::direct_boundaries;
 use crate::notification_runtime::NotificationRuntime;
@@ -32,13 +30,6 @@ impl std::fmt::Debug for DaemonNotificationSink {
 }
 
 impl DaemonNotificationSink {
-    #[cfg(test)]
-    pub(crate) fn new() -> Self {
-        Self::new_with_observability(SubsystemObservability::disabled(
-            DaemonSubsystem::NotificationRuntime,
-        ))
-    }
-
     pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
             runtime: NotificationRuntime::new_with_observability(observability),
@@ -81,13 +72,6 @@ impl std::fmt::Debug for FileWatchEventSource {
 }
 
 impl FileWatchEventSource {
-    #[cfg(test)]
-    pub(crate) fn new() -> Self {
-        Self::new_with_observability(SubsystemObservability::disabled(
-            DaemonSubsystem::WatchRuntime,
-        ))
-    }
-
     pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
             runtime: WatchRuntime::new_with_observability(observability),
@@ -123,20 +107,6 @@ impl std::fmt::Debug for DaemonReconcileCoordinator {
 }
 
 impl DaemonReconcileCoordinator {
-    #[cfg(test)]
-    pub(crate) fn new(
-        watch_event_source: FileWatchEventSource,
-        inbox_ingress: DaemonInboxIngress,
-        notification_sink: DaemonNotificationSink,
-    ) -> Self {
-        Self::new_with_observability(
-            watch_event_source,
-            inbox_ingress,
-            notification_sink,
-            SubsystemObservability::disabled(DaemonSubsystem::ReconcileRuntime),
-        )
-    }
-
     pub(crate) fn new_with_observability(
         watch_event_source: FileWatchEventSource,
         inbox_ingress: DaemonInboxIngress,

--- a/crates/atm-daemon/src/boundary_adapters.rs
+++ b/crates/atm-daemon/src/boundary_adapters.rs
@@ -16,6 +16,7 @@ use crate::direct_boundaries;
 use crate::notification_runtime::NotificationRuntime;
 use crate::reconcile_runtime::ReconcileRuntime;
 use crate::watch_runtime::WatchRuntime;
+use crate::{DaemonSubsystem, SubsystemObservability};
 
 #[derive(Clone)]
 pub(crate) struct DaemonNotificationSink {
@@ -29,9 +30,16 @@ impl std::fmt::Debug for DaemonNotificationSink {
 }
 
 impl DaemonNotificationSink {
+    #[allow(dead_code)]
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::NotificationRuntime,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
-            runtime: NotificationRuntime::new(),
+            runtime: NotificationRuntime::new_with_observability(observability),
         }
     }
 
@@ -71,9 +79,16 @@ impl std::fmt::Debug for FileWatchEventSource {
 }
 
 impl FileWatchEventSource {
+    #[allow(dead_code)]
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::WatchRuntime,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
-            runtime: WatchRuntime::new(),
+            runtime: WatchRuntime::new_with_observability(observability),
         }
     }
 
@@ -106,16 +121,32 @@ impl std::fmt::Debug for DaemonReconcileCoordinator {
 }
 
 impl DaemonReconcileCoordinator {
+    #[allow(dead_code)]
     pub(crate) fn new(
         watch_event_source: FileWatchEventSource,
         inbox_ingress: DaemonInboxIngress,
         notification_sink: DaemonNotificationSink,
     ) -> Self {
+        Self::new_with_observability(
+            watch_event_source,
+            inbox_ingress,
+            notification_sink,
+            SubsystemObservability::disabled(DaemonSubsystem::ReconcileRuntime),
+        )
+    }
+
+    pub(crate) fn new_with_observability(
+        watch_event_source: FileWatchEventSource,
+        inbox_ingress: DaemonInboxIngress,
+        notification_sink: DaemonNotificationSink,
+        observability: SubsystemObservability,
+    ) -> Self {
         Self {
-            runtime: ReconcileRuntime::new(
+            runtime: ReconcileRuntime::new_with_observability(
                 Arc::new(watch_event_source),
                 Arc::new(inbox_ingress),
                 Arc::new(notification_sink),
+                observability,
             ),
         }
     }

--- a/crates/atm-daemon/src/boundary_adapters.rs
+++ b/crates/atm-daemon/src/boundary_adapters.rs
@@ -12,11 +12,13 @@ use atm_core::{
 };
 use std::sync::Arc;
 
+#[cfg(test)]
+use crate::DaemonSubsystem;
+use crate::SubsystemObservability;
 use crate::direct_boundaries;
 use crate::notification_runtime::NotificationRuntime;
 use crate::reconcile_runtime::ReconcileRuntime;
 use crate::watch_runtime::WatchRuntime;
-use crate::{DaemonSubsystem, SubsystemObservability};
 
 #[derive(Clone)]
 pub(crate) struct DaemonNotificationSink {
@@ -30,7 +32,7 @@ impl std::fmt::Debug for DaemonNotificationSink {
 }
 
 impl DaemonNotificationSink {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::new_with_observability(SubsystemObservability::disabled(
             DaemonSubsystem::NotificationRuntime,
@@ -79,7 +81,7 @@ impl std::fmt::Debug for FileWatchEventSource {
 }
 
 impl FileWatchEventSource {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::new_with_observability(SubsystemObservability::disabled(
             DaemonSubsystem::WatchRuntime,
@@ -121,7 +123,7 @@ impl std::fmt::Debug for DaemonReconcileCoordinator {
 }
 
 impl DaemonReconcileCoordinator {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn new(
         watch_event_source: FileWatchEventSource,
         inbox_ingress: DaemonInboxIngress,

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -627,7 +627,15 @@ where
         .spawn(move || {
             let _ = result_tx.send(shutdown(lane));
         })
-        .expect("spawn shutdown lane deadline helper");
+        .map_err(|source| {
+            AtmError::daemon_unavailable(format!(
+                "failed to spawn daemon {lane_name} shutdown deadline helper"
+            ))
+            .with_recovery(
+                "Restart atm-daemon; the bounded background-lane shutdown helper could not be created.",
+            )
+            .with_source(source)
+        })?;
     let shutdown_thread_id = shutdown_handle.thread().id();
     match result_rx.recv_timeout(deadline) {
         Ok(result) => {

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -2,13 +2,13 @@ use crate::boundary_adapters::{
     DaemonConfigIngress, DaemonInboxExport, DaemonInboxIngress, DaemonNotificationSink,
     DaemonReconcileCoordinator, FileWatchEventSource,
 };
-use crate::daemon_runtime_observability::DaemonRuntimeObservability;
+use crate::daemon_runtime_observability::{DaemonRuntimeObservability, SubsystemObservability};
 use crate::host_ownership::HostOwnershipAdapter;
 use crate::local_ipc_transport::{RuntimeServeHooks, SocketEndpointGuard};
 use crate::runtime_health::DaemonRequestDispatcher;
 use crate::runtime_health::{DaemonStatusSource, RuntimeStatusCache};
 use crate::{
-    AtmHomeDir, LocalIpcServerTransportAdapter, PeerTransportRuntime,
+    AtmHomeDir, DaemonSubsystem, LocalIpcServerTransportAdapter, PeerTransportRuntime,
     sqlite_remote_replay_store_from_path,
 };
 use atm_core::boundary::RequestDispatcher;
@@ -153,9 +153,20 @@ impl RuntimeComposition {
         replay_store_path: PathBuf,
         observability: Arc<dyn DaemonRuntimeObservability>,
     ) -> Result<Self, AtmError> {
-        let status_cache = RuntimeStatusCache::new();
-        let notification_sink = DaemonNotificationSink::new();
-        let watch_event_source = FileWatchEventSource::new();
+        let status_cache = RuntimeStatusCache::new_with_observability(SubsystemObservability::new(
+            DaemonSubsystem::RuntimeStatusCache,
+            Arc::clone(&observability),
+        ));
+        let notification_sink =
+            DaemonNotificationSink::new_with_observability(SubsystemObservability::new(
+                DaemonSubsystem::NotificationRuntime,
+                Arc::clone(&observability),
+            ));
+        let watch_event_source =
+            FileWatchEventSource::new_with_observability(SubsystemObservability::new(
+                DaemonSubsystem::WatchRuntime,
+                Arc::clone(&observability),
+            ));
         let inbox_ingress = DaemonInboxIngress::new();
         let replay_store = match sqlite_remote_replay_store_from_path(replay_store_path) {
             Ok(store) => Some(store),
@@ -169,26 +180,51 @@ impl RuntimeComposition {
         };
         Ok(Self {
             lifecycle: Arc::new(RuntimeLifecycle::new()),
-            host_ownership_adapter: HostOwnershipAdapter::new(),
+            host_ownership_adapter: HostOwnershipAdapter::new_with_observability(
+                SubsystemObservability::new(
+                    DaemonSubsystem::HostOwnership,
+                    Arc::clone(&observability),
+                ),
+            ),
             endpoint_guard: Mutex::new(None),
-            server_transport: LocalIpcServerTransportAdapter::new(),
+            server_transport: LocalIpcServerTransportAdapter::new_with_observability(
+                SubsystemObservability::new(
+                    DaemonSubsystem::LocalIpcTransport,
+                    Arc::clone(&observability),
+                ),
+                SubsystemObservability::new(
+                    DaemonSubsystem::HostOwnership,
+                    Arc::clone(&observability),
+                ),
+                SubsystemObservability::new(
+                    DaemonSubsystem::LifecycleControl,
+                    Arc::clone(&observability),
+                ),
+            ),
             request_dispatcher: Arc::new(DaemonRequestDispatcher::new(
                 home_dir,
                 status_cache.clone(),
-                observability,
+                Arc::clone(&observability),
             )),
             _notification_sink: notification_sink.clone(),
             _status_source: DaemonStatusSource::new(status_cache),
             _watch_event_source: watch_event_source.clone(),
-            _reconcile_coordinator: DaemonReconcileCoordinator::new(
+            _reconcile_coordinator: DaemonReconcileCoordinator::new_with_observability(
                 watch_event_source,
                 inbox_ingress.clone(),
                 notification_sink,
+                SubsystemObservability::new(
+                    DaemonSubsystem::ReconcileRuntime,
+                    Arc::clone(&observability),
+                ),
             ),
             _config_ingress: DaemonConfigIngress::new(),
             _inbox_ingress: inbox_ingress,
             _inbox_export: DaemonInboxExport::new(),
-            peer_transport_runtime: PeerTransportRuntime::new(replay_store),
+            peer_transport_runtime: PeerTransportRuntime::new_with_observability(
+                replay_store,
+                SubsystemObservability::new(DaemonSubsystem::PeerTransport, observability),
+            ),
         })
     }
 
@@ -221,7 +257,8 @@ impl RuntimeComposition {
     }
 
     fn begin_shutdown(&self) -> Result<(), AtmError> {
-        self.request_dispatcher.record_runtime_event(
+        self.request_dispatcher.record_daemon_event(
+            DaemonSubsystem::Composition,
             "shutdown_requested",
             "ok",
             "daemon shutdown requested",
@@ -239,7 +276,8 @@ impl RuntimeComposition {
     }
 
     pub(crate) fn start(&self) -> Result<(), AtmError> {
-        self.request_dispatcher.record_runtime_event(
+        self.request_dispatcher.record_daemon_event(
+            DaemonSubsystem::Composition,
             "start_requested",
             "ok",
             "daemon start requested",
@@ -250,7 +288,8 @@ impl RuntimeComposition {
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.request_dispatcher.record_runtime_event(
+                self.request_dispatcher.record_daemon_event(
+                    DaemonSubsystem::Composition,
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -271,7 +310,8 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.request_dispatcher.record_runtime_event(
+            self.request_dispatcher.record_daemon_event(
+                DaemonSubsystem::Composition,
                 "startup_failed",
                 "failed",
                 "daemon startup failed",
@@ -288,7 +328,8 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during runtime preparation rollback"
                     );
                 }
-                self.request_dispatcher.record_runtime_event(
+                self.request_dispatcher.record_daemon_event(
+                    DaemonSubsystem::Composition,
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -299,7 +340,8 @@ impl RuntimeComposition {
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.request_dispatcher.record_runtime_event(
+        self.request_dispatcher.record_daemon_event(
+            DaemonSubsystem::Composition,
             "startup_completed",
             "ok",
             "daemon startup completed",
@@ -328,7 +370,8 @@ impl RuntimeComposition {
         socket_path: PathBuf,
         ready_signal: Option<std::sync::mpsc::SyncSender<()>>,
     ) -> Result<(), AtmError> {
-        self.request_dispatcher.record_runtime_event(
+        self.request_dispatcher.record_daemon_event(
+            DaemonSubsystem::Composition,
             "start_requested",
             "ok",
             "daemon start requested",
@@ -337,7 +380,8 @@ impl RuntimeComposition {
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.request_dispatcher.record_runtime_event(
+                self.request_dispatcher.record_daemon_event(
+                    DaemonSubsystem::Composition,
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -358,7 +402,8 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.request_dispatcher.record_runtime_event(
+            self.request_dispatcher.record_daemon_event(
+                DaemonSubsystem::Composition,
                 "startup_failed",
                 "failed",
                 "daemon startup failed",
@@ -378,7 +423,8 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during test runtime preparation rollback"
                     );
                 }
-                self.request_dispatcher.record_runtime_event(
+                self.request_dispatcher.record_daemon_event(
+                    DaemonSubsystem::Composition,
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -389,7 +435,8 @@ impl RuntimeComposition {
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.request_dispatcher.record_runtime_event(
+        self.request_dispatcher.record_daemon_event(
+            DaemonSubsystem::Composition,
             "startup_completed",
             "ok",
             "daemon startup completed",
@@ -449,12 +496,14 @@ impl RuntimeComposition {
             };
         }
         match result.as_ref() {
-            Ok(()) => self.request_dispatcher.record_runtime_event(
+            Ok(()) => self.request_dispatcher.record_daemon_event(
+                DaemonSubsystem::Composition,
                 "shutdown_completed",
                 "ok",
                 "daemon shutdown completed",
             ),
-            Err(_) => self.request_dispatcher.record_runtime_event(
+            Err(_) => self.request_dispatcher.record_daemon_event(
+                DaemonSubsystem::Composition,
                 "shutdown_failed",
                 "failed",
                 "daemon shutdown failed",

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -162,11 +162,9 @@ impl RuntimeComposition {
                 DaemonSubsystem::NotificationRuntime,
                 Arc::clone(&observability),
             ));
-        let watch_event_source =
-            FileWatchEventSource::new_with_observability(SubsystemObservability::new(
-                DaemonSubsystem::WatchRuntime,
-                Arc::clone(&observability),
-            ));
+        let watch_event_source = FileWatchEventSource::new_with_observability(
+            SubsystemObservability::new(DaemonSubsystem::WatchRuntime, Arc::clone(&observability)),
+        );
         let inbox_ingress = DaemonInboxIngress::new();
         let replay_store = match sqlite_remote_replay_store_from_path(replay_store_path) {
             Ok(store) => Some(store),

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -10,11 +10,11 @@ use std::{fs, fs::OpenOptions};
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::home;
-use atm_core::schema::AtmMessageId;
 use atm_core::observability::{
     AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState, CommandEvent,
     LogTailSession, ObservabilityPort, RetainedSinkFaultMode,
 };
+use atm_core::schema::AtmMessageId;
 use sc_observability::{
     LogSink, Logger, LoggerConfig, RetentionPolicy, RotationPolicy, SinkRegistration,
 };
@@ -333,10 +333,12 @@ impl RetainedJsonlFileSink {
     fn schedule_prune_old_files(&self) {
         let now = SystemTime::now();
         {
-            let mut last_request_at = self
-                .last_prune_request_at
-                .lock()
-                .expect("retained sink prune request lock poisoned");
+            let Ok(mut last_request_at) = self.last_prune_request_at.lock() else {
+                tracing::warn!(
+                    "retained sink prune request lock poisoned; skipping one prune scheduling attempt"
+                );
+                return;
+            };
             if let Some(last_request_at) = *last_request_at
                 && now
                     .duration_since(last_request_at)
@@ -384,9 +386,12 @@ impl RetainedJsonlFileSink {
         )
         .cause(message)
         .source(Box::new(error));
-        let mut health = self.health.lock().expect("file sink health poisoned");
-        health.state = SinkHealthState::DegradedDropping;
-        health.last_error = Some(DiagnosticSummary::from(diagnostic.diagnostic()));
+        if let Ok(mut health) = self.health.lock() {
+            health.state = SinkHealthState::DegradedDropping;
+            health.last_error = Some(DiagnosticSummary::from(diagnostic.diagnostic()));
+        } else {
+            tracing::warn!("file sink health lock poisoned while recording sink failure");
+        }
         LogSinkError(Box::new(diagnostic))
     }
 }
@@ -439,20 +444,24 @@ impl LogSink for RetainedJsonlFileSink {
         file.write_all(&line)
             .and_then(|()| file.flush())
             .map_err(|error| self.mark_failure(error))?;
-        *self
-            .last_written_file
-            .lock()
-            .expect("retained sink file handle poisoned") = Some(file);
-        let mut health = self.health.lock().expect("file sink health poisoned");
+        *self.last_written_file.lock().map_err(|_| {
+            self.mark_failure(std::io::Error::other(
+                "retained sink file handle lock poisoned",
+            ))
+        })? = Some(file);
+        let mut health = self.health.lock().map_err(|_| {
+            self.mark_failure(std::io::Error::other("file sink health lock poisoned"))
+        })?;
         health.state = SinkHealthState::Healthy;
         Ok(())
     }
 
     fn flush(&self) -> Result<(), LogSinkError> {
-        let mut last_written = self
-            .last_written_file
-            .lock()
-            .expect("retained sink file handle poisoned");
+        let mut last_written = self.last_written_file.lock().map_err(|_| {
+            self.mark_failure(std::io::Error::other(
+                "retained sink file handle lock poisoned",
+            ))
+        })?;
         if let Some(file) = last_written.as_mut() {
             file.flush().map_err(|error| self.mark_failure(error))?;
         }
@@ -460,10 +469,17 @@ impl LogSink for RetainedJsonlFileSink {
     }
 
     fn health(&self) -> SinkHealth {
-        self.health
-            .lock()
-            .expect("file sink health poisoned")
-            .clone()
+        match self.health.lock() {
+            Ok(health) => health.clone(),
+            Err(_) => {
+                tracing::warn!("file sink health lock poisoned; reporting unavailable sink health");
+                SinkHealth {
+                    name: SinkName::new("jsonl_file_sink").expect("jsonl sink constant is valid"),
+                    state: SinkHealthState::Unavailable,
+                    last_error: None,
+                }
+            }
+        }
     }
 }
 
@@ -679,10 +695,16 @@ fn map_daemon_event(
     );
     match &event.team {
         TeamScope::Team(team) => {
-            fields.insert("team".to_string(), serde_json::Value::String(team.to_string()));
+            fields.insert(
+                "team".to_string(),
+                serde_json::Value::String(team.to_string()),
+            );
         }
         TeamScope::None => {
-            fields.insert("team_scope".to_string(), serde_json::Value::String("none".to_string()));
+            fields.insert(
+                "team_scope".to_string(),
+                serde_json::Value::String("none".to_string()),
+            );
         }
     }
     if let Some(agent) = event.agent.as_ref() {
@@ -843,7 +865,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::DaemonObservability;
-    use atm_daemon::{DaemonEvent, DaemonSubsystem, TeamScope};
+    use atm_daemon::observability_test_event;
 
     #[test]
     #[serial]
@@ -859,32 +881,18 @@ mod tests {
 
         let observability = DaemonObservability::bootstrap().expect("bootstrap");
         observability
-            .emit_daemon_event(DaemonEvent {
-                subsystem: DaemonSubsystem::Composition,
-                action: "start_requested",
-                outcome: "ok",
-                team: TeamScope::None,
-                agent: None,
-                sender: None,
-                recipient: None,
-                message_id: None,
-                task_id: None,
-                detail: "daemon start requested".into(),
-            })
+            .emit_daemon_event(observability_test_event(
+                "start_requested",
+                "ok",
+                "daemon start requested",
+            ))
             .expect("emit start");
         observability
-            .emit_daemon_event(DaemonEvent {
-                subsystem: DaemonSubsystem::Composition,
-                action: "shutdown_completed",
-                outcome: "ok",
-                team: TeamScope::None,
-                agent: None,
-                sender: None,
-                recipient: None,
-                message_id: None,
-                task_id: None,
-                detail: "daemon shutdown completed".into(),
-            })
+            .emit_daemon_event(observability_test_event(
+                "shutdown_completed",
+                "ok",
+                "daemon shutdown completed",
+            ))
             .expect("emit shutdown");
         observability
             .best_effort_flush_blocking()
@@ -988,18 +996,11 @@ mod tests {
             )
             .expect("bootstrap");
         observability
-            .emit_daemon_event(DaemonEvent {
-                subsystem: DaemonSubsystem::Composition,
-                action: "start_requested",
-                outcome: "ok",
-                team: TeamScope::None,
-                agent: None,
-                sender: None,
-                recipient: None,
-                message_id: None,
-                task_id: None,
-                detail: "daemon start requested".into(),
-            })
+            .emit_daemon_event(observability_test_event(
+                "start_requested",
+                "ok",
+                "daemon start requested",
+            ))
             .expect("emit");
 
         let active_log_path = log_dir.join("atm.log.jsonl");

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -26,6 +26,8 @@ use sc_observability_types::{
 };
 use serde_json::Map;
 
+#[cfg(test)]
+use atm_daemon::DaemonSubsystem;
 use atm_daemon::{DaemonEvent, TeamScope};
 
 const ATM_SERVICE_NAME: &str = "atm";
@@ -491,6 +493,26 @@ fn rename_if_present(src: &Path, dest: &Path) -> std::io::Result<()> {
     }
 }
 
+#[cfg(test)]
+fn observability_test_event(
+    action: &'static str,
+    outcome: &'static str,
+    detail: impl Into<std::borrow::Cow<'static, str>>,
+) -> DaemonEvent {
+    DaemonEvent {
+        subsystem: DaemonSubsystem::Composition,
+        action,
+        outcome,
+        team: TeamScope::None,
+        agent: None,
+        sender: None,
+        recipient: None,
+        message_id: None,
+        task_id: None,
+        detail: detail.into(),
+    }
+}
+
 fn logger_level_override() -> Result<Option<SharedLevelFilter>, AtmError> {
     let Some(value) = std::env::var(ATM_LOG_LEVEL_ENV)
         .ok()
@@ -864,8 +886,7 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
-    use super::DaemonObservability;
-    use atm_daemon::observability_test_event;
+    use super::{DaemonObservability, observability_test_event};
 
     #[test]
     #[serial]

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -10,6 +10,7 @@ use std::{fs, fs::OpenOptions};
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::home;
+use atm_core::schema::AtmMessageId;
 use atm_core::observability::{
     AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState, CommandEvent,
     LogTailSession, ObservabilityPort, RetainedSinkFaultMode,
@@ -24,6 +25,8 @@ use sc_observability_types::{
     Timestamp,
 };
 use serde_json::Map;
+
+use atm_daemon::{DaemonEvent, TeamScope};
 
 const ATM_SERVICE_NAME: &str = "atm";
 const ATM_DAEMON_TARGET: &str = "atm.daemon";
@@ -110,19 +113,8 @@ impl DaemonObservability {
         Self::bootstrap_at_log_dir_with_rotation(log_dir, rotation_max_bytes)
     }
 
-    pub(crate) fn emit_runtime_event(
-        &self,
-        action: &'static str,
-        outcome: &'static str,
-        message: &'static str,
-    ) -> Result<(), AtmError> {
-        let event = map_runtime_event(
-            &self.service_name,
-            &self.target_category,
-            action,
-            outcome,
-            message,
-        )?;
+    pub(crate) fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
+        let event = map_daemon_event(&self.service_name, &self.target_category, event)?;
         self.logger.emit(event).map_err(|source| {
             let code = source.diagnostic().code.as_str().to_string();
             AtmError::observability_emit(format!(
@@ -199,13 +191,8 @@ impl ObservabilityPort for DaemonObservability {
 }
 
 impl atm_daemon::DaemonRuntimeObservability for DaemonObservability {
-    fn emit_runtime_event(
-        &self,
-        action: &'static str,
-        outcome: &'static str,
-        message: &'static str,
-    ) -> Result<(), AtmError> {
-        Self::emit_runtime_event(self, action, outcome, message)
+    fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
+        Self::emit_daemon_event(self, event)
     }
 
     fn best_effort_flush_blocking(&self) -> Result<(), AtmError> {
@@ -646,12 +633,10 @@ fn map_command_event(
     })
 }
 
-fn map_runtime_event(
+fn map_daemon_event(
     service_name: &ServiceName,
     target_category: &TargetCategory,
-    action: &'static str,
-    outcome: &'static str,
-    message: &'static str,
+    event: DaemonEvent,
 ) -> Result<LogEvent, AtmError> {
     let schema_version =
         SchemaVersion::new(sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION)
@@ -661,31 +646,88 @@ fn map_runtime_event(
                 )
                 .with_source(source)
             })?;
-    let action = ActionName::new(action).map_err(|source| {
+    let action = ActionName::new(event.action).map_err(|source| {
         AtmError::observability_emit("failed to validate ATM daemon lifecycle action")
             .with_source(source)
     })?;
-    let outcome = OutcomeLabel::new(outcome).map_err(|source| {
+    let outcome = OutcomeLabel::new(event.outcome).map_err(|source| {
         AtmError::observability_emit("failed to validate ATM daemon lifecycle outcome")
             .with_source(source)
     })?;
-    let fields = Map::from_iter([(
-        "component".to_string(),
-        serde_json::Value::String("daemon_runtime".to_string()),
-    )]);
+    let request_id = event
+        .message_id
+        .as_ref()
+        .map(|value: &AtmMessageId| CorrelationId::new(value.to_string()))
+        .transpose()
+        .map_err(|source| {
+            AtmError::observability_emit("failed to validate ATM daemon request id")
+                .with_source(source)
+        })?;
+    let correlation_id = event
+        .task_id
+        .as_ref()
+        .map(|value: &atm_core::types::TaskId| CorrelationId::new(value.as_str()))
+        .transpose()
+        .map_err(|source| {
+            AtmError::observability_emit("failed to validate ATM daemon correlation id")
+                .with_source(source)
+        })?;
+    let mut fields = Map::new();
+    fields.insert(
+        "subsystem".to_string(),
+        serde_json::Value::String(event.subsystem.as_str().to_string()),
+    );
+    match &event.team {
+        TeamScope::Team(team) => {
+            fields.insert("team".to_string(), serde_json::Value::String(team.to_string()));
+        }
+        TeamScope::None => {
+            fields.insert("team_scope".to_string(), serde_json::Value::String("none".to_string()));
+        }
+    }
+    if let Some(agent) = event.agent.as_ref() {
+        fields.insert(
+            "agent".to_string(),
+            serde_json::Value::String(agent.to_string()),
+        );
+    }
+    if let Some(sender) = event.sender.as_ref() {
+        fields.insert(
+            "sender".to_string(),
+            serde_json::Value::String(sender.to_string()),
+        );
+    }
+    if let Some(recipient) = event.recipient.as_ref() {
+        fields.insert(
+            "recipient".to_string(),
+            serde_json::Value::String(recipient.to_string()),
+        );
+    }
+    if let Some(message_id) = event.message_id.as_ref() {
+        fields.insert(
+            "message_id".to_string(),
+            serde_json::Value::String(message_id.to_string()),
+        );
+    }
+    if let Some(task_id) = event.task_id.as_ref() {
+        fields.insert(
+            "task_id".to_string(),
+            serde_json::Value::String(task_id.to_string()),
+        );
+    }
 
     Ok(LogEvent {
         version: schema_version,
         timestamp: Timestamp::now_utc(),
-        level: level_for_outcome(outcome.as_str()),
+        level: level_for_outcome(event.outcome),
         service: service_name.clone(),
         target: target_category.clone(),
         action,
-        message: Some(message.to_string()),
+        message: Some(event.detail.into_owned()),
         identity: ProcessIdentity::default(),
         trace: None,
-        request_id: None,
-        correlation_id: None,
+        request_id,
+        correlation_id,
         outcome: Some(outcome),
         diagnostic: None,
         state_transition: None,
@@ -721,7 +763,7 @@ fn level_for_outcome(outcome: &str) -> Level {
         "error" | "failed" => Level::Error,
         other => {
             // No global tracing subscriber is installed in production; daemon lifecycle records
-            // route through emit_runtime_event(), so this unknown-outcome warning is intentionally silent.
+            // route through emit_daemon_event(), so this unknown-outcome warning is intentionally silent.
             tracing::warn!(
                 code = %AtmErrorCode::ObservabilityEmitFailed,
                 outcome = other,
@@ -801,6 +843,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::DaemonObservability;
+    use atm_daemon::{DaemonEvent, DaemonSubsystem, TeamScope};
 
     #[test]
     #[serial]
@@ -816,10 +859,32 @@ mod tests {
 
         let observability = DaemonObservability::bootstrap().expect("bootstrap");
         observability
-            .emit_runtime_event("start_requested", "ok", "daemon start requested")
+            .emit_daemon_event(DaemonEvent {
+                subsystem: DaemonSubsystem::Composition,
+                action: "start_requested",
+                outcome: "ok",
+                team: TeamScope::None,
+                agent: None,
+                sender: None,
+                recipient: None,
+                message_id: None,
+                task_id: None,
+                detail: "daemon start requested".into(),
+            })
             .expect("emit start");
         observability
-            .emit_runtime_event("shutdown_completed", "ok", "daemon shutdown completed")
+            .emit_daemon_event(DaemonEvent {
+                subsystem: DaemonSubsystem::Composition,
+                action: "shutdown_completed",
+                outcome: "ok",
+                team: TeamScope::None,
+                agent: None,
+                sender: None,
+                recipient: None,
+                message_id: None,
+                task_id: None,
+                detail: "daemon shutdown completed".into(),
+            })
             .expect("emit shutdown");
         observability
             .best_effort_flush_blocking()
@@ -923,7 +988,18 @@ mod tests {
             )
             .expect("bootstrap");
         observability
-            .emit_runtime_event("start_requested", "ok", "daemon start requested")
+            .emit_daemon_event(DaemonEvent {
+                subsystem: DaemonSubsystem::Composition,
+                action: "start_requested",
+                outcome: "ok",
+                team: TeamScope::None,
+                agent: None,
+                sender: None,
+                recipient: None,
+                message_id: None,
+                task_id: None,
+                detail: "daemon start requested".into(),
+            })
             .expect("emit");
 
         let active_log_path = log_dir.join("atm.log.jsonl");

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -170,6 +170,9 @@ impl SubsystemObservability {
         outcome: &'static str,
         detail: impl Into<Cow<'static, str>>,
     ) -> DaemonEvent {
+        // Shared subsystem emit helpers deliberately start with no team scope because the thin
+        // sink cannot infer mailbox ownership; callers that know team context attach it
+        // explicitly on the returned event instead of relying on logger-held mutable state.
         DaemonEvent::new(self.subsystem(), action, outcome, detail)
     }
 
@@ -188,4 +191,13 @@ impl SubsystemObservability {
     ) -> Result<(), AtmError> {
         self.emit_event(self.event(action, outcome, detail))
     }
+}
+
+#[cfg(test)]
+pub(crate) fn observability_test_event(
+    action: &'static str,
+    outcome: &'static str,
+    detail: impl Into<Cow<'static, str>>,
+) -> DaemonEvent {
+    DaemonEvent::new(DaemonSubsystem::Composition, action, outcome, detail)
 }

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -192,12 +192,3 @@ impl SubsystemObservability {
         self.emit_event(self.event(action, outcome, detail))
     }
 }
-
-#[cfg(test)]
-pub(crate) fn observability_test_event(
-    action: &'static str,
-    outcome: &'static str,
-    detail: impl Into<Cow<'static, str>>,
-) -> DaemonEvent {
-    DaemonEvent::new(DaemonSubsystem::Composition, action, outcome, detail)
-}

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -1,17 +1,191 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
 use atm_core::error::AtmError;
 use atm_core::observability::ObservabilityPort;
+use atm_core::schema::AtmMessageId;
+use atm_core::types::{AgentName, TaskId, TeamName};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DaemonSubsystem {
+    Bootstrap,
+    Composition,
+    LocalIpcTransport,
+    AdvisoryRuntime,
+    NotificationRuntime,
+    PeerTransport,
+    WatchRuntime,
+    ReconcileRuntime,
+    RuntimeHealth,
+    HostOwnership,
+    LifecycleControl,
+    RuntimeStatusCache,
+    ObservabilitySink,
+}
+
+impl DaemonSubsystem {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Bootstrap => "bootstrap",
+            Self::Composition => "composition",
+            Self::LocalIpcTransport => "local_ipc_transport",
+            Self::AdvisoryRuntime => "advisory_runtime",
+            Self::NotificationRuntime => "notification_runtime",
+            Self::PeerTransport => "peer_transport",
+            Self::WatchRuntime => "watch_runtime",
+            Self::ReconcileRuntime => "reconcile_runtime",
+            Self::RuntimeHealth => "runtime_health",
+            Self::HostOwnership => "host_ownership",
+            Self::LifecycleControl => "lifecycle_control",
+            Self::RuntimeStatusCache => "runtime_status_cache",
+            Self::ObservabilitySink => "observability_sink",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TeamScope {
+    Team(TeamName),
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonEvent {
+    pub subsystem: DaemonSubsystem,
+    pub action: &'static str,
+    pub outcome: &'static str,
+    pub team: TeamScope,
+    pub agent: Option<AgentName>,
+    pub sender: Option<AgentName>,
+    pub recipient: Option<AgentName>,
+    pub message_id: Option<AtmMessageId>,
+    pub task_id: Option<TaskId>,
+    pub detail: Cow<'static, str>,
+}
+
+impl DaemonEvent {
+    pub(crate) fn new(
+        subsystem: DaemonSubsystem,
+        action: &'static str,
+        outcome: &'static str,
+        detail: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        Self {
+            subsystem,
+            action,
+            outcome,
+            team: TeamScope::None,
+            agent: None,
+            sender: None,
+            recipient: None,
+            message_id: None,
+            task_id: None,
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn with_team(mut self, team: TeamName) -> Self {
+        self.team = TeamScope::Team(team);
+        self
+    }
+
+    pub(crate) fn with_agent(mut self, agent: AgentName) -> Self {
+        self.agent = Some(agent);
+        self
+    }
+
+    pub(crate) fn with_sender(mut self, sender: AgentName) -> Self {
+        self.sender = Some(sender);
+        self
+    }
+
+    pub(crate) fn with_recipient(mut self, recipient: AgentName) -> Self {
+        self.recipient = Some(recipient);
+        self
+    }
+
+    pub(crate) fn with_message_id(mut self, message_id: AtmMessageId) -> Self {
+        self.message_id = Some(message_id);
+        self
+    }
+
+    pub(crate) fn with_task_id(mut self, task_id: TaskId) -> Self {
+        self.task_id = Some(task_id);
+        self
+    }
+}
 
 /// Daemon-runtime observability operations that stay daemon-specific above the
 /// shared ATM observability boundary.
-pub trait DaemonRuntimeObservability: ObservabilityPort + Send + Sync {
-    /// Emit one daemon lifecycle/runtime event into the retained sink.
-    fn emit_runtime_event(
-        &self,
-        action: &'static str,
-        outcome: &'static str,
-        message: &'static str,
-    ) -> Result<(), AtmError>;
+pub trait DaemonRuntimeObservability:
+    atm_core::boundary::sealed::Sealed + ObservabilityPort + Send + Sync
+{
+    /// Emit one daemon subsystem event into the retained sink.
+    fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError>;
 
     /// Attempt one best-effort synchronous flush during daemon shutdown.
     fn best_effort_flush_blocking(&self) -> Result<(), AtmError>;
+}
+
+#[derive(Clone)]
+pub(crate) struct SubsystemObservability {
+    subsystem: DaemonSubsystem,
+    inner: Option<Arc<dyn DaemonRuntimeObservability>>,
+}
+
+impl std::fmt::Debug for SubsystemObservability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubsystemObservability")
+            .field("subsystem", &self.subsystem)
+            .field("enabled", &self.inner.is_some())
+            .finish()
+    }
+}
+
+impl SubsystemObservability {
+    pub(crate) fn new(
+        subsystem: DaemonSubsystem,
+        inner: Arc<dyn DaemonRuntimeObservability>,
+    ) -> Self {
+        Self {
+            subsystem,
+            inner: Some(inner),
+        }
+    }
+
+    pub(crate) fn disabled(subsystem: DaemonSubsystem) -> Self {
+        Self {
+            subsystem,
+            inner: None,
+        }
+    }
+
+    pub(crate) fn subsystem(&self) -> DaemonSubsystem {
+        self.subsystem.clone()
+    }
+
+    pub(crate) fn event(
+        &self,
+        action: &'static str,
+        outcome: &'static str,
+        detail: impl Into<Cow<'static, str>>,
+    ) -> DaemonEvent {
+        DaemonEvent::new(self.subsystem(), action, outcome, detail)
+    }
+
+    pub(crate) fn emit_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
+        if let Some(inner) = &self.inner {
+            inner.emit_daemon_event(event)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn emit(
+        &self,
+        action: &'static str,
+        outcome: &'static str,
+        detail: impl Into<Cow<'static, str>>,
+    ) -> Result<(), AtmError> {
+        self.emit_event(self.event(action, outcome, detail))
+    }
 }

--- a/crates/atm-daemon/src/host_ownership.rs
+++ b/crates/atm-daemon/src/host_ownership.rs
@@ -7,6 +7,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use atm_core::error::AtmError;
 use fs2::FileExt;
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 #[cfg_attr(windows, allow(dead_code))]
 const STALE_OWNER_RECOVERY_RETRY_ATTEMPTS: usize = 3;
 #[cfg_attr(windows, allow(dead_code))]
@@ -25,8 +27,10 @@ static STALE_RECOVERY_OBSERVED_SIGNAL: std::sync::Mutex<Option<StaleRecoverySign
     std::sync::Mutex::new(None);
 
 #[cfg_attr(windows, allow(dead_code))]
-#[derive(Debug, Default, Clone, Copy)]
-pub(crate) struct HostOwnershipAdapter;
+#[derive(Debug, Clone)]
+pub(crate) struct HostOwnershipAdapter {
+    observability: SubsystemObservability,
+}
 
 #[cfg_attr(windows, allow(dead_code))]
 #[derive(Debug)]
@@ -36,17 +40,30 @@ pub(crate) struct HostOwnershipGuard {
 
 #[cfg_attr(windows, allow(dead_code))]
 impl HostOwnershipAdapter {
-    pub(crate) const fn new() -> Self {
-        Self
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::HostOwnership,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
+        Self { observability }
     }
 
     pub(crate) fn acquire(&self) -> Result<HostOwnershipGuard, AtmError> {
-        Self::acquire_at(atm_core::home::host_runtime_lock_path(
+        self.acquire_at_with_observability(atm_core::home::host_runtime_lock_path(
             HOST_RUNTIME_OWNER_LOCK_FILE,
         )?)
     }
 
-    pub(crate) fn acquire_at(
+    #[allow(dead_code)]
+    pub(crate) fn acquire_at(lock_path: std::path::PathBuf) -> Result<HostOwnershipGuard, AtmError> {
+        Self::new().acquire_at_with_observability(lock_path)
+    }
+
+    fn acquire_at_with_observability(
+        &self,
         lock_path: std::path::PathBuf,
     ) -> Result<HostOwnershipGuard, AtmError> {
         let mut lock_file = open_lock_file(&lock_path)?;
@@ -64,8 +81,18 @@ impl HostOwnershipAdapter {
                     drop(lock_file);
                     lock_file = recover_stale_owner_lock(&lock_path, pid, &token)?;
                     recovered = true;
+                    let _ = self.observability.emit(
+                        "recover_stale_owner",
+                        "degraded",
+                        "daemon recovered a stale host-runtime owner lock",
+                    );
                 }
                 if !recovered {
+                    let _ = self.observability.emit(
+                        "acquire_owner_lock",
+                        "rejected",
+                        "daemon host-runtime owner lock is already held by a live process",
+                    );
                     return Err(AtmError::daemon_serving_state_rejected(format!(
                         "a live ATM daemon already owns {}",
                         lock_path.display()
@@ -77,6 +104,11 @@ impl HostOwnershipAdapter {
                 }
             }
             Err(source) => {
+                let _ = self.observability.emit(
+                    "acquire_owner_lock",
+                    "failed",
+                    "daemon failed to acquire the host-runtime owner lock",
+                );
                 return Err(AtmError::daemon_unavailable(format!(
                     "failed to acquire daemon ownership lock at {}",
                     lock_path.display()
@@ -85,6 +117,11 @@ impl HostOwnershipAdapter {
             }
         }
         write_owner_record(&mut lock_file)?;
+        let _ = self.observability.emit(
+            "acquire_owner_lock",
+            "ok",
+            "daemon acquired the host-runtime owner lock",
+        );
         Ok(HostOwnershipGuard { lock_file })
     }
 }

--- a/crates/atm-daemon/src/host_ownership.rs
+++ b/crates/atm-daemon/src/host_ownership.rs
@@ -7,7 +7,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use atm_core::error::AtmError;
 use fs2::FileExt;
 
-use crate::{DaemonSubsystem, SubsystemObservability};
+#[cfg(test)]
+use crate::DaemonSubsystem;
+use crate::SubsystemObservability;
 
 #[cfg_attr(windows, allow(dead_code))]
 const STALE_OWNER_RECOVERY_RETRY_ATTEMPTS: usize = 3;
@@ -40,7 +42,7 @@ pub(crate) struct HostOwnershipGuard {
 
 #[cfg_attr(windows, allow(dead_code))]
 impl HostOwnershipAdapter {
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::new_with_observability(SubsystemObservability::disabled(
             DaemonSubsystem::HostOwnership,
@@ -57,8 +59,10 @@ impl HostOwnershipAdapter {
         )?)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn acquire_at(lock_path: std::path::PathBuf) -> Result<HostOwnershipGuard, AtmError> {
+    #[cfg(test)]
+    pub(crate) fn acquire_at(
+        lock_path: std::path::PathBuf,
+    ) -> Result<HostOwnershipGuard, AtmError> {
         Self::new().acquire_at_with_observability(lock_path)
     }
 

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -40,8 +40,6 @@ use std::time::Duration;
 
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_rusqlite::SqliteBoundaryAssembly;
-#[cfg(test)]
-pub(crate) use daemon_runtime_observability::observability_test_event;
 pub use daemon_runtime_observability::{
     DaemonEvent, DaemonRuntimeObservability, DaemonSubsystem, TeamScope,
 };

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -40,6 +40,8 @@ use std::time::Duration;
 
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_rusqlite::SqliteBoundaryAssembly;
+#[cfg(test)]
+pub(crate) use daemon_runtime_observability::observability_test_event;
 pub use daemon_runtime_observability::{
     DaemonEvent, DaemonRuntimeObservability, DaemonSubsystem, TeamScope,
 };

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -40,7 +40,11 @@ use std::time::Duration;
 
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_rusqlite::SqliteBoundaryAssembly;
-pub use daemon_runtime_observability::DaemonRuntimeObservability;
+pub use daemon_runtime_observability::{
+    DaemonEvent, DaemonRuntimeObservability, DaemonSubsystem, TeamScope,
+};
+
+pub(crate) use daemon_runtime_observability::SubsystemObservability;
 
 pub(crate) use atm_rusqlite::RemoteReplayStateRecord;
 pub(crate) use local_ipc_transport::LocalIpcServerTransportAdapter;

--- a/crates/atm-daemon/src/lifecycle_control.rs
+++ b/crates/atm-daemon/src/lifecycle_control.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use atm_core::error::AtmError;
 use signal_hook::SigId;
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 const LIFECYCLE_WORKER_JOIN_DEADLINE: Duration = Duration::from_secs(5);
 
 // Installation takes this global slot only after the outer install lock so concurrent daemon
@@ -24,6 +26,7 @@ pub(crate) struct LifecycleControlSourceAdapter {
     reload: Arc<AtomicBool>,
     #[cfg_attr(windows, allow(dead_code))]
     state_change: Arc<LifecycleStateChange>,
+    observability: SubsystemObservability,
 }
 
 #[derive(Debug)]
@@ -124,6 +127,14 @@ impl LifecycleStateChange {
 
 impl LifecycleControlSourceAdapter {
     pub(crate) fn install() -> Result<Self, AtmError> {
+        Self::install_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::LifecycleControl,
+        ))
+    }
+
+    pub(crate) fn install_with_observability(
+        observability: SubsystemObservability,
+    ) -> Result<Self, AtmError> {
         let _guard = INSTALL_LOCK
             .lock()
             .map_err(|_| {
@@ -162,10 +173,16 @@ impl LifecycleControlSourceAdapter {
                 &shared.state_change,
             )?);
         }
+        let _ = observability.emit(
+            "install_hooks",
+            "ok",
+            "daemon lifecycle-control hooks are installed",
+        );
         Ok(Self {
             terminate: Arc::clone(&shared.terminate),
             reload: Arc::clone(&shared.reload),
             state_change: Arc::clone(&shared.state_change),
+            observability,
         })
     }
 
@@ -176,6 +193,7 @@ impl LifecycleControlSourceAdapter {
             terminate: Arc::new(AtomicBool::new(false)),
             reload: Arc::new(AtomicBool::new(false)),
             state_change,
+            observability: SubsystemObservability::disabled(DaemonSubsystem::LifecycleControl),
         }
     }
 
@@ -259,10 +277,20 @@ impl LifecycleControlSourceAdapter {
         match result_rx.recv_timeout(LIFECYCLE_WORKER_JOIN_DEADLINE) {
             Ok(Ok(())) => {
                 let _ = join_helper.join();
+                let _ = self.observability.emit(
+                    "shutdown_worker",
+                    "ok",
+                    "daemon lifecycle-control worker shut down cleanly",
+                );
                 Ok(())
             }
             Ok(Err(_)) => {
                 let _ = join_helper.join();
+                let _ = self.observability.emit(
+                    "shutdown_worker",
+                    "failed",
+                    "daemon lifecycle-control worker panicked during shutdown",
+                );
                 Err(AtmError::daemon_unavailable(
                     "daemon lifecycle wake worker panicked during runtime teardown",
                 )
@@ -272,6 +300,11 @@ impl LifecycleControlSourceAdapter {
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                 let _ = join_helper.join();
+                let _ = self.observability.emit(
+                    "shutdown_worker",
+                    "degraded",
+                    "daemon lifecycle-control worker exceeded its shutdown deadline",
+                );
                 Err(AtmError::daemon_unavailable(
                     "daemon lifecycle wake worker exceeded the bounded shutdown deadline",
                 )
@@ -281,6 +314,11 @@ impl LifecycleControlSourceAdapter {
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 let _ = join_helper.join();
+                let _ = self.observability.emit(
+                    "shutdown_worker",
+                    "failed",
+                    "daemon lifecycle-control join coordination disconnected during shutdown",
+                );
                 Err(AtmError::daemon_unavailable(
                     "daemon lifecycle wake worker join coordination disconnected during runtime teardown",
                 )

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -871,6 +871,7 @@ fn emit_ready_signal_if_requested() -> Result<(), AtmError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::active_connection_registry::TrackedDispatchHandle;
     #[cfg(unix)]
     use crate::lifecycle_control::LifecycleControlSourceAdapter;
     #[cfg(unix)]

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -22,6 +22,7 @@ use crate::lifecycle_control::LifecycleControlSourceAdapter;
 use crate::local_ipc_connection::drain_active_connections_for_shutdown;
 use crate::local_ipc_wake::{schedule_delayed_listener_wake, wake_listener};
 use crate::shutdown_beacon::ShutdownBeacon;
+use crate::{DaemonSubsystem, SubsystemObservability};
 
 #[cfg(unix)]
 use std::fs;
@@ -142,6 +143,7 @@ pub(crate) struct PreparedRuntimeServer {
     registry: Arc<ActiveConnectionRegistry>,
     force_shutdown: Arc<AtomicBool>,
     codec: JsonAtmProtocolCodec,
+    observability: SubsystemObservability,
     // The endpoint guard must drop after the listener and connection registry have been torn
     // down so same-host endpoint unpublication never races a still-live serving resource.
     endpoint_guard: Option<SocketEndpointGuard>,
@@ -189,13 +191,30 @@ impl std::fmt::Debug for PreparedRuntimeServer {
 }
 
 impl PreparedRuntimeServer {
+    #[allow(dead_code)]
     fn bind(endpoint_path: PathBuf) -> Result<Self, AtmError> {
+        Self::bind_with_observability(
+            endpoint_path,
+            SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
+            SubsystemObservability::disabled(DaemonSubsystem::HostOwnership),
+            SubsystemObservability::disabled(DaemonSubsystem::LifecycleControl),
+        )
+    }
+
+    fn bind_with_observability(
+        endpoint_path: PathBuf,
+        observability: SubsystemObservability,
+        host_ownership_observability: SubsystemObservability,
+        lifecycle_observability: SubsystemObservability,
+    ) -> Result<Self, AtmError> {
         // Install lifecycle control before singleton ownership so daemon startup never
         // claims the host-wide owner lock unless shutdown/reload hooks are ready too.
         // Reversing this order can transiently block a healthy daemon restart behind an
         // instance that failed before it could service lifecycle-control requests.
-        let lifecycle_control = LifecycleControlSourceAdapter::install()?;
-        let ownership = HostOwnershipAdapter::new().acquire()?;
+        let lifecycle_control =
+            LifecycleControlSourceAdapter::install_with_observability(lifecycle_observability)?;
+        let ownership =
+            HostOwnershipAdapter::new_with_observability(host_ownership_observability).acquire()?;
         let endpoint_preparation = prepare_local_ipc_endpoint(&endpoint_path)?;
         let listener = ListenerOptions::new()
             .name(atm_core::protocol::daemon_local_ipc_name_from_path(
@@ -219,6 +238,11 @@ impl PreparedRuntimeServer {
             endpoint_preparation = ?endpoint_preparation,
             "daemon local IPC transport limits configured"
         );
+        let _ = observability.emit(
+            "bind_listener",
+            "ok",
+            "daemon local IPC transport prepared the runtime listener",
+        );
         emit_ready_signal_if_requested()?;
         Ok(Self {
             host_ownership_guard: ownership,
@@ -234,6 +258,7 @@ impl PreparedRuntimeServer {
             registry: Arc::new(ActiveConnectionRegistry::default()),
             force_shutdown: Arc::new(AtomicBool::new(false)),
             codec: JsonAtmProtocolCodec,
+            observability,
         })
     }
 
@@ -292,6 +317,7 @@ impl PreparedRuntimeServer {
             registry,
             force_shutdown,
             codec,
+            observability,
         } = self;
         thread::scope(|scope| -> Result<(), AtmError> {
             // Each serving invocation owns its own shutdown beacon. The beacon must not survive a
@@ -399,9 +425,16 @@ impl PreparedRuntimeServer {
                 // races a partially-applied runtime view update.
                 if signals.take_reload() {
                     match reload_runtime_view() {
-                        Ok(()) => tracing::info!(
-                            "bounded lifecycle-control-triggered config/roster reload applied"
-                        ),
+                        Ok(()) => {
+                            let _ = observability.emit(
+                                "reload_runtime_view",
+                                "ok",
+                                "bounded lifecycle-control-triggered config or roster reload applied",
+                            );
+                            tracing::info!(
+                                "bounded lifecycle-control-triggered config/roster reload applied"
+                            )
+                        }
                         Err(error) => tracing::warn!(
                             error_code = %error.code,
                             error_message = %error.message,
@@ -460,9 +493,16 @@ impl PreparedRuntimeServer {
                 if signals.take_reload() {
                     drop(stream);
                     match reload_runtime_view() {
-                        Ok(()) => tracing::info!(
-                            "bounded lifecycle-control-triggered config/roster reload applied"
-                        ),
+                        Ok(()) => {
+                            let _ = observability.emit(
+                                "reload_runtime_view",
+                                "ok",
+                                "bounded lifecycle-control-triggered config or roster reload applied",
+                            );
+                            tracing::info!(
+                                "bounded lifecycle-control-triggered config/roster reload applied"
+                            )
+                        }
                         Err(error) => tracing::warn!(
                             error_code = %error.code,
                             error_message = %error.message,
@@ -655,12 +695,33 @@ impl PreparedRuntimeServer {
     }
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct LocalIpcServerTransportAdapter;
+#[derive(Debug, Clone)]
+pub(crate) struct LocalIpcServerTransportAdapter {
+    observability: SubsystemObservability,
+    host_ownership_observability: SubsystemObservability,
+    lifecycle_observability: SubsystemObservability,
+}
 
 impl LocalIpcServerTransportAdapter {
-    pub(crate) const fn new() -> Self {
-        Self
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn new() -> Self {
+        Self::new_with_observability(
+            SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
+            SubsystemObservability::disabled(DaemonSubsystem::HostOwnership),
+            SubsystemObservability::disabled(DaemonSubsystem::LifecycleControl),
+        )
+    }
+
+    pub(crate) fn new_with_observability(
+        observability: SubsystemObservability,
+        host_ownership_observability: SubsystemObservability,
+        lifecycle_observability: SubsystemObservability,
+    ) -> Self {
+        Self {
+            observability,
+            host_ownership_observability,
+            lifecycle_observability,
+        }
     }
 
     pub(crate) fn prepare_runtime(&self) -> Result<PreparedRuntimeServer, AtmError> {
@@ -672,7 +733,12 @@ impl LocalIpcServerTransportAdapter {
         &self,
         endpoint_path: PathBuf,
     ) -> Result<PreparedRuntimeServer, AtmError> {
-        PreparedRuntimeServer::bind(endpoint_path)
+        PreparedRuntimeServer::bind_with_observability(
+            endpoint_path,
+            self.observability.clone(),
+            self.host_ownership_observability.clone(),
+            self.lifecycle_observability.clone(),
+        )
     }
 }
 

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -8,25 +8,31 @@ use std::time::{Duration, Instant};
 
 use atm_core::boundary::{self, AtmProtocol, RequestDispatcher};
 use atm_core::error::AtmError;
-use atm_core::protocol::{
-    JsonAtmProtocolCodec, ProtocolErrorEnvelope, RequestEnvelope, RequestId, ResponseEnvelope,
-};
+use atm_core::protocol::{JsonAtmProtocolCodec, ProtocolErrorEnvelope, ResponseEnvelope};
 use interprocess::local_socket::prelude::*;
 use interprocess::local_socket::{
     Listener as LocalSocketListener, ListenerOptions, Stream as LocalSocketStream,
 };
 
-use crate::active_connection_registry::{ActiveConnectionRegistry, TrackedDispatchHandle};
+#[cfg(test)]
+use crate::DaemonSubsystem;
+use crate::SubsystemObservability;
+use crate::active_connection_registry::ActiveConnectionRegistry;
 use crate::host_ownership::{HostOwnershipAdapter, HostOwnershipGuard};
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
 use crate::local_ipc_connection::drain_active_connections_for_shutdown;
 use crate::local_ipc_wake::{schedule_delayed_listener_wake, wake_listener};
 use crate::shutdown_beacon::ShutdownBeacon;
-use crate::{DaemonSubsystem, SubsystemObservability};
+
+mod request_worker;
 
 #[cfg(unix)]
 use std::fs;
 use std::thread;
+
+use request_worker::handle_connection;
+#[cfg(test)]
+use request_worker::install_injected_accept_error_for_test;
 
 const MAX_CONCURRENT_CONNECTIONS: usize = 64;
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
@@ -191,7 +197,7 @@ impl std::fmt::Debug for PreparedRuntimeServer {
 }
 
 impl PreparedRuntimeServer {
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn bind(endpoint_path: PathBuf) -> Result<Self, AtmError> {
         Self::bind_with_observability(
             endpoint_path,
@@ -703,7 +709,7 @@ pub(crate) struct LocalIpcServerTransportAdapter {
 }
 
 impl LocalIpcServerTransportAdapter {
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::new_with_observability(
             SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
@@ -840,15 +846,6 @@ fn write_shutdown_response(
     Ok(ShutdownResponseOutcome::RejectedRequest)
 }
 
-#[cfg(test)]
-#[cfg_attr(not(unix), allow(dead_code))]
-pub(crate) fn install_injected_accept_error_for_test(
-    runtime: &mut PreparedRuntimeServer,
-    signal: std::sync::mpsc::SyncSender<()>,
-) {
-    runtime.accept_error_inject = Some(signal);
-}
-
 fn emit_ready_signal_if_requested() -> Result<(), AtmError> {
     if std::env::var_os("ATM_DAEMON_READY_STDOUT").is_none() {
         return Ok(());
@@ -869,164 +866,6 @@ fn emit_ready_signal_if_requested() -> Result<(), AtmError> {
             .with_source(source)
     })?;
     Ok(())
-}
-
-fn handle_connection(
-    mut stream: LocalSocketStream,
-    dispatcher: Arc<dyn RequestDispatcher + Send + Sync>,
-    force_shutdown: &AtomicBool,
-    registry: Arc<ActiveConnectionRegistry>,
-    codec: JsonAtmProtocolCodec,
-) -> Result<(), AtmError> {
-    if force_shutdown.load(Ordering::SeqCst) {
-        return write_shutdown_response(&mut stream, &codec).map(|_| ());
-    }
-    stream
-        .set_recv_timeout(Some(REQUEST_DEADLINE))
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to apply daemon request read deadline")
-                .with_recovery(
-                    "Restart the daemon; the same-host request socket could not apply its bounded read deadline.",
-                )
-                .with_source(source)
-        })?;
-    stream
-        .set_send_timeout(Some(REQUEST_DEADLINE))
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to apply daemon response write deadline")
-                .with_recovery(
-                    "Restart the daemon; the same-host request socket could not apply its bounded write deadline.",
-                )
-                .with_source(source)
-        })?;
-
-    // Phase S still enforces one request per accepted same-host connection even though the
-    // request runtime owns its execution separately from this socket receive loop.
-    let Some(frame) = atm_core::protocol::read_frame(
-        &mut stream,
-        "failed to read daemon request frame",
-        "daemon request frame exceeded the maximum supported size",
-    )?
-    else {
-        return Ok(());
-    };
-    tracing::debug!(
-        max_daemon_frame_bytes = atm_core::protocol::MAX_DAEMON_FRAME_BYTES,
-        "daemon request frame accepted under configured size cap"
-    );
-    let (request_id, request) = codec.request_from_frame(frame)?;
-    if let RequestEnvelope::AdvisoryStream(request) = request {
-        stream.set_send_timeout(None).map_err(|source| {
-            AtmError::daemon_unavailable(
-                "failed to clear daemon advisory-stream write deadline",
-            )
-            .with_recovery(
-                "Restart the daemon; the same-host advisory stream socket could not switch into long-lived streaming mode.",
-            )
-            .with_source(source)
-        })?;
-        let mut sink = LocalIpcAdvisoryStreamSink {
-            stream: &mut stream,
-            codec: &codec,
-            request_id,
-            force_shutdown,
-        };
-        return dispatcher.dispatch_advisory_stream(request, &mut sink);
-    }
-
-    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
-    let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
-    let dispatch_registry = Arc::clone(&registry);
-    let dispatch_handle = std::thread::Builder::new()
-        .name("local-ipc-dispatch".to_string())
-        .spawn(move || {
-            let _dispatch_work = dispatch_registry.register_dispatch_work();
-            let _ = result_tx.send(dispatcher.dispatch(request));
-            let _ = completion_tx.send(());
-        })
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to spawn daemon local IPC dispatch worker")
-                .with_recovery(
-                    "Retry the ATM command after atm-daemon restarts; the same-host request worker could not be created.",
-                )
-                .with_source(source)
-        })?;
-    // The tracked-dispatch registry owns the eventual join. Timeouts can let a request worker run
-    // past this socket exchange, but the direct accept loop and bounded shutdown sweep still reap
-    // the handle before runtime teardown completes.
-    registry.push_dispatch_handle(
-        TrackedDispatchHandle {
-            completion_rx,
-            join_handle: dispatch_handle,
-        },
-        MAX_CONCURRENT_CONNECTIONS,
-    )?;
-    let response = match result_rx.recv_timeout(REQUEST_DEADLINE) {
-        Ok(Ok(response)) => response,
-        Ok(Err(error)) => ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(&error)),
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            tracing::warn!("daemon request dispatcher exceeded the runtime deadline");
-            ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
-                &AtmError::daemon_unavailable(
-                    "daemon request exceeded the 3s runtime deadline; the operation may still complete in the background",
-                )
-                .with_recovery(
-                    "Check the destination mailbox or service-side effects before retrying this ATM command.",
-                ),
-            ))
-        }
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
-                &AtmError::daemon_unavailable(
-                    "daemon request dispatcher stopped before returning a response",
-                )
-                .with_recovery(
-                    "Retry the ATM command after the daemon finishes recovering the request runtime.",
-                ),
-            ))
-        }
-    };
-    let frame = codec.response_to_frame(request_id, response)?;
-    atm_core::protocol::write_frame(&mut stream, &frame, "failed to write daemon response frame")?;
-    stream.flush().map_err(|source| {
-        AtmError::daemon_unavailable("failed to flush daemon response frame")
-            .with_recovery(
-                "Retry the ATM command after the daemon finishes recovering the same-host request runtime.",
-            )
-            .with_source(source)
-    })?;
-    registry.reap_finished_dispatches()?;
-    Ok(())
-}
-
-struct LocalIpcAdvisoryStreamSink<'a> {
-    stream: &'a mut LocalSocketStream,
-    codec: &'a JsonAtmProtocolCodec,
-    request_id: RequestId,
-    force_shutdown: &'a std::sync::atomic::AtomicBool,
-}
-
-impl boundary::AdvisoryStreamSink for LocalIpcAdvisoryStreamSink<'_> {
-    fn emit(&mut self, response: ResponseEnvelope) -> Result<(), AtmError> {
-        let frame = self.codec.response_to_frame(self.request_id, response)?;
-        atm_core::protocol::write_frame(
-            self.stream,
-            &frame,
-            "failed to write daemon advisory-stream response frame",
-        )?;
-        self.stream.flush().map_err(|source| {
-            AtmError::daemon_unavailable("failed to flush daemon advisory-stream response frame")
-                .with_recovery(
-                    "Retry graft activation after atm-daemon returns to a healthy serving state.",
-                )
-                .with_source(source)
-        })
-    }
-
-    fn stop_requested(&self) -> bool {
-        self.force_shutdown
-            .load(std::sync::atomic::Ordering::SeqCst)
-    }
 }
 
 #[cfg(test)]

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -1,0 +1,177 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use atm_core::boundary::{AdvisoryStreamSink, AtmProtocol, RequestDispatcher};
+use atm_core::error::AtmError;
+use atm_core::protocol::{
+    JsonAtmProtocolCodec, ProtocolErrorEnvelope, RequestEnvelope, RequestId, ResponseEnvelope,
+};
+use interprocess::local_socket::Stream as LocalSocketStream;
+use interprocess::local_socket::traits::Stream;
+
+use crate::active_connection_registry::{ActiveConnectionRegistry, TrackedDispatchHandle};
+
+#[cfg(test)]
+use super::PreparedRuntimeServer;
+use super::{MAX_CONCURRENT_CONNECTIONS, REQUEST_DEADLINE, write_shutdown_response};
+
+pub(super) fn handle_connection(
+    mut stream: LocalSocketStream,
+    dispatcher: Arc<dyn RequestDispatcher + Send + Sync>,
+    force_shutdown: &AtomicBool,
+    registry: Arc<ActiveConnectionRegistry>,
+    codec: JsonAtmProtocolCodec,
+) -> Result<(), AtmError> {
+    if force_shutdown.load(Ordering::SeqCst) {
+        return write_shutdown_response(&mut stream, &codec).map(|_| ());
+    }
+    stream
+        .set_recv_timeout(Some(REQUEST_DEADLINE))
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to apply daemon request read deadline")
+                .with_recovery(
+                    "Restart the daemon; the same-host request socket could not apply its bounded read deadline.",
+                )
+                .with_source(source)
+        })?;
+    stream
+        .set_send_timeout(Some(REQUEST_DEADLINE))
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to apply daemon response write deadline")
+                .with_recovery(
+                    "Restart the daemon; the same-host request socket could not apply its bounded write deadline.",
+                )
+                .with_source(source)
+        })?;
+
+    let Some(frame) = atm_core::protocol::read_frame(
+        &mut stream,
+        "failed to read daemon request frame",
+        "daemon request frame exceeded the maximum supported size",
+    )?
+    else {
+        return Ok(());
+    };
+    tracing::debug!(
+        max_daemon_frame_bytes = atm_core::protocol::MAX_DAEMON_FRAME_BYTES,
+        "daemon request frame accepted under configured size cap"
+    );
+    let (request_id, request) = codec.request_from_frame(frame)?;
+    if let RequestEnvelope::AdvisoryStream(request) = request {
+        stream.set_send_timeout(None).map_err(|source| {
+            AtmError::daemon_unavailable(
+                "failed to clear daemon advisory-stream write deadline",
+            )
+            .with_recovery(
+                "Restart the daemon; the same-host advisory stream socket could not switch into long-lived streaming mode.",
+            )
+            .with_source(source)
+        })?;
+        let mut sink = LocalIpcAdvisoryStreamSink {
+            stream: &mut stream,
+            codec: &codec,
+            request_id,
+            force_shutdown,
+        };
+        return dispatcher.dispatch_advisory_stream(request, &mut sink);
+    }
+
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
+    let dispatch_registry = Arc::clone(&registry);
+    let dispatch_handle = std::thread::Builder::new()
+        .name("local-ipc-dispatch".to_string())
+        .spawn(move || {
+            let _dispatch_work = dispatch_registry.register_dispatch_work();
+            let _ = result_tx.send(dispatcher.dispatch(request));
+            let _ = completion_tx.send(());
+        })
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to spawn daemon local IPC dispatch worker")
+                .with_recovery(
+                    "Retry the ATM command after atm-daemon restarts; the same-host request worker could not be created.",
+                )
+                .with_source(source)
+        })?;
+    registry.push_dispatch_handle(
+        TrackedDispatchHandle {
+            completion_rx,
+            join_handle: dispatch_handle,
+        },
+        MAX_CONCURRENT_CONNECTIONS,
+    )?;
+    let response = match result_rx.recv_timeout(REQUEST_DEADLINE) {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(&error)),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            tracing::warn!("daemon request dispatcher exceeded the runtime deadline");
+            ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
+                &AtmError::daemon_unavailable(
+                    "daemon request exceeded the 3s runtime deadline; the operation may still complete in the background",
+                )
+                .with_recovery(
+                    "Check the destination mailbox or service-side effects before retrying this ATM command.",
+                ),
+            ))
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
+                &AtmError::daemon_unavailable(
+                    "daemon request dispatcher stopped before returning a response",
+                )
+                .with_recovery(
+                    "Retry the ATM command after the daemon finishes recovering the request runtime.",
+                ),
+            ))
+        }
+    };
+    let frame = codec.response_to_frame(request_id, response)?;
+    atm_core::protocol::write_frame(&mut stream, &frame, "failed to write daemon response frame")?;
+    std::io::Write::flush(&mut stream).map_err(|source| {
+        AtmError::daemon_unavailable("failed to flush daemon response frame")
+            .with_recovery(
+                "Retry the ATM command after the daemon finishes recovering the same-host request runtime.",
+            )
+            .with_source(source)
+    })?;
+    registry.reap_finished_dispatches()?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[cfg_attr(not(unix), allow(dead_code))]
+pub(super) fn install_injected_accept_error_for_test(
+    runtime: &mut PreparedRuntimeServer,
+    signal: std::sync::mpsc::SyncSender<()>,
+) {
+    runtime.accept_error_inject = Some(signal);
+}
+
+struct LocalIpcAdvisoryStreamSink<'a> {
+    stream: &'a mut LocalSocketStream,
+    codec: &'a JsonAtmProtocolCodec,
+    request_id: RequestId,
+    force_shutdown: &'a AtomicBool,
+}
+
+impl AdvisoryStreamSink for LocalIpcAdvisoryStreamSink<'_> {
+    fn emit(&mut self, response: ResponseEnvelope) -> Result<(), AtmError> {
+        let frame = self.codec.response_to_frame(self.request_id, response)?;
+        atm_core::protocol::write_frame(
+            self.stream,
+            &frame,
+            "failed to write daemon advisory-stream response frame",
+        )?;
+        std::io::Write::flush(&mut self.stream).map_err(|source| {
+            AtmError::daemon_unavailable("failed to flush daemon advisory-stream response frame")
+                .with_recovery(
+                    "Retry graft activation after atm-daemon returns to a healthy serving state.",
+                )
+                .with_source(source)
+        })
+    }
+
+    fn stop_requested(&self) -> bool {
+        self.force_shutdown.load(Ordering::SeqCst)
+    }
+}

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -45,13 +45,6 @@ struct NotificationState {
 }
 
 impl NotificationRuntime {
-    #[cfg(test)]
-    pub(crate) fn new() -> Self {
-        Self::new_with_observability(SubsystemObservability::disabled(
-            DaemonSubsystem::NotificationRuntime,
-        ))
-    }
-
     pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self::new_with_path_factory(
             Arc::new(|| Ok(atm_core::home::host_runtime_dir()?.join("notifications.jsonl"))),

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -9,7 +9,9 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use crate::{DaemonSubsystem, SubsystemObservability};
+#[cfg(test)]
+use crate::DaemonSubsystem;
+use crate::SubsystemObservability;
 
 const DEFAULT_NOTIFICATION_QUEUE_CAPACITY: usize = 64;
 const DEFAULT_NOTIFICATION_IDLE_INTERVAL: Duration = Duration::from_millis(50);
@@ -43,7 +45,7 @@ struct NotificationState {
 }
 
 impl NotificationRuntime {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::new_with_observability(SubsystemObservability::disabled(
             DaemonSubsystem::NotificationRuntime,
@@ -92,10 +94,11 @@ impl NotificationRuntime {
             .name("atm-daemon-notifier".to_string())
             .spawn(move || notification_worker_loop(inner))
             .map_err(|source| {
-                let _ = self
-                    .inner
-                    .observability
-                    .emit("start", "failed", "failed to spawn notification runtime worker");
+                let _ = self.inner.observability.emit(
+                    "start",
+                    "failed",
+                    "failed to spawn notification runtime worker",
+                );
                 AtmError::daemon_unavailable("failed to spawn notification runtime worker")
                     .with_source(source)
             })?;

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -9,6 +9,8 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 const DEFAULT_NOTIFICATION_QUEUE_CAPACITY: usize = 64;
 const DEFAULT_NOTIFICATION_IDLE_INTERVAL: Duration = Duration::from_millis(50);
 const NOTIFICATION_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(3);
@@ -28,6 +30,7 @@ struct NotificationRuntimeInner {
     wake: Condvar,
     path_factory: NotificationPathFactory,
     queue_capacity: usize,
+    observability: SubsystemObservability,
 }
 
 #[derive(Default)]
@@ -40,20 +43,33 @@ struct NotificationState {
 }
 
 impl NotificationRuntime {
+    #[allow(dead_code)]
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::NotificationRuntime,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self::new_with_path_factory(
             Arc::new(|| Ok(atm_core::home::host_runtime_dir()?.join("notifications.jsonl"))),
             DEFAULT_NOTIFICATION_QUEUE_CAPACITY,
+            observability,
         )
     }
 
-    fn new_with_path_factory(path_factory: NotificationPathFactory, queue_capacity: usize) -> Self {
+    fn new_with_path_factory(
+        path_factory: NotificationPathFactory,
+        queue_capacity: usize,
+        observability: SubsystemObservability,
+    ) -> Self {
         Self {
             inner: Arc::new(NotificationRuntimeInner {
                 state: Mutex::new(NotificationState::default()),
                 wake: Condvar::new(),
                 path_factory,
                 queue_capacity,
+                observability,
             }),
         }
     }
@@ -76,6 +92,10 @@ impl NotificationRuntime {
             .name("atm-daemon-notifier".to_string())
             .spawn(move || notification_worker_loop(inner))
             .map_err(|source| {
+                let _ = self
+                    .inner
+                    .observability
+                    .emit("start", "failed", "failed to spawn notification runtime worker");
                 AtmError::daemon_unavailable("failed to spawn notification runtime worker")
                     .with_source(source)
             })?;
@@ -92,6 +112,10 @@ impl NotificationRuntime {
             }
         };
         state.worker = Some(handle);
+        let _ = self
+            .inner
+            .observability
+            .emit("start", "ok", "notification runtime worker started");
         Ok(())
     }
 
@@ -127,9 +151,19 @@ impl NotificationRuntime {
             match result_rx.recv_timeout(NOTIFICATION_SHUTDOWN_DEADLINE) {
                 Ok(Ok(())) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "ok",
+                        "notification runtime worker shut down cleanly",
+                    );
                 }
                 Ok(Err(_)) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "notification runtime worker panicked during shutdown",
+                    );
                     return Err(AtmError::daemon_unavailable(
                         "notification runtime worker panicked during shutdown",
                     )
@@ -139,6 +173,11 @@ impl NotificationRuntime {
                 }
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                     drop(join_helper);
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "degraded",
+                        "notification runtime worker exceeded its shutdown deadline",
+                    );
                     tracing::warn!(
                         thread_id = ?worker_thread_id,
                         timeout_ms = NOTIFICATION_SHUTDOWN_DEADLINE.as_millis(),
@@ -154,6 +193,11 @@ impl NotificationRuntime {
                 }
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "notification runtime join helper disconnected during shutdown",
+                    );
                     tracing::warn!(
                         thread_id = ?worker_thread_id,
                         "notification runtime join helper exited before reporting shutdown status"
@@ -187,9 +231,19 @@ impl NotificationRuntime {
             ));
         }
         if let Some(message) = &state.degraded_message {
+            let _ = self.inner.observability.emit(
+                "deliver",
+                "degraded",
+                "notification runtime is degraded and rejecting delivery",
+            );
             return Err(AtmError::daemon_unavailable(message.as_str()));
         }
         if state.queue.len() >= self.inner.queue_capacity {
+            let _ = self.inner.observability.emit(
+                "deliver",
+                "rejected",
+                "notification runtime queue is full",
+            );
             return Err(AtmError::daemon_unavailable(
                 "notification runtime queue is full; delivery is backpressured",
             ));
@@ -201,7 +255,11 @@ impl NotificationRuntime {
 
     #[cfg(test)]
     pub(crate) fn new_for_test_with_path(path: PathBuf, queue_capacity: usize) -> Self {
-        Self::new_with_path_factory(Arc::new(move || Ok(path.clone())), queue_capacity)
+        Self::new_with_path_factory(
+            Arc::new(move || Ok(path.clone())),
+            queue_capacity,
+            SubsystemObservability::disabled(DaemonSubsystem::NotificationRuntime),
+        )
     }
 }
 
@@ -236,6 +294,11 @@ fn notification_worker_loop(inner: Arc<NotificationRuntimeInner>) {
                 state.degraded_message = Some(error.message);
                 state.queue.clear();
             }
+            let _ = inner.observability.emit(
+                "persist_notification",
+                "degraded",
+                "notification runtime persistence failed and the runtime entered a degraded state",
+            );
             return;
         }
     }

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -105,14 +105,6 @@ struct PeerClientTransport {
 }
 
 impl PeerClientTransport {
-    #[allow(dead_code)]
-    fn new(replay_store: Option<Arc<dyn RemoteReplayStore>>) -> Self {
-        Self::new_with_observability(
-            replay_store,
-            SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
-        )
-    }
-
     fn new_with_observability(
         replay_store: Option<Arc<dyn RemoteReplayStore>>,
         observability: SubsystemObservability,
@@ -551,7 +543,6 @@ impl Default for PeerTransportRuntime {
 }
 
 impl PeerTransportRuntime {
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(replay_store: Option<Arc<dyn RemoteReplayStore>>) -> Self {
         Self::new_with_observability(
             replay_store,
@@ -569,7 +560,6 @@ impl PeerTransportRuntime {
     }
 
     #[cfg(test)]
-    #[allow(dead_code)]
     pub(crate) fn client_transport(&self) -> &dyn ClientTransport {
         &self.client
     }

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -16,6 +16,8 @@ use atm_core::protocol::{
 };
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 // Architecture authority: docs/architecture.md §21.6.4 daemon operational
 // defaults and remote peer transport rules.
 const PEER_CONNECT_DEADLINE: Duration = Duration::from_secs(5);
@@ -99,10 +101,22 @@ struct PeerClientTransport {
     config: PeerTransportConfig,
     replay_store: Option<Arc<dyn RemoteReplayStore>>,
     codec: JsonAtmProtocolCodec,
+    observability: SubsystemObservability,
 }
 
 impl PeerClientTransport {
+    #[allow(dead_code)]
     fn new(replay_store: Option<Arc<dyn RemoteReplayStore>>) -> Self {
+        Self::new_with_observability(
+            replay_store,
+            SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
+        )
+    }
+
+    fn new_with_observability(
+        replay_store: Option<Arc<dyn RemoteReplayStore>>,
+        observability: SubsystemObservability,
+    ) -> Self {
         let endpoint = daemon_peer_endpoint_from_env();
         let config = std::env::current_dir()
             .ok()
@@ -125,6 +139,7 @@ impl PeerClientTransport {
             config,
             replay_store,
             codec: JsonAtmProtocolCodec,
+            observability,
         }
     }
 
@@ -141,6 +156,7 @@ impl PeerClientTransport {
             config,
             replay_store: Some(replay_store),
             codec: JsonAtmProtocolCodec,
+            observability: SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
         }
     }
 
@@ -168,6 +184,11 @@ impl PeerClientTransport {
                         replay_attempt_count = record.attempt_count,
                         "daemon remote replay delivered successfully"
                     );
+                    let _ = self.observability.emit(
+                        "resume_pending_replay",
+                        "ok",
+                        "daemon remote replay delivered a retained record",
+                    );
                     delivered += 1;
                 }
                 Err(error) => {
@@ -181,6 +202,11 @@ impl PeerClientTransport {
                         error_code = %error.code,
                         error_message = %error.message,
                         "daemon remote replay delivery attempt failed; retaining record"
+                    );
+                    let _ = self.observability.emit(
+                        "resume_pending_replay",
+                        "degraded",
+                        "daemon remote replay delivery failed and retained the record for retry",
                     );
                     replay_store.enqueue(record)?;
                     retained += 1;
@@ -276,6 +302,11 @@ impl PeerClientTransport {
                         attempt,
                         "daemon peer delivery succeeded"
                     );
+                    let _ = self.observability.emit(
+                        "send_to_endpoint",
+                        "ok",
+                        "daemon peer delivery succeeded",
+                    );
                     return Ok(response);
                 }
                 Err(failure) if failure.kind == AttemptFailureKind::Retryable => {
@@ -287,6 +318,11 @@ impl PeerClientTransport {
                             error_code = %failure.error.code,
                             error_message = %failure.error.message,
                             "daemon peer delivery exhausted retry budget"
+                        );
+                        let _ = self.observability.emit(
+                            "send_to_endpoint",
+                            "failed",
+                            "daemon peer delivery exhausted its retry budget",
                         );
                         return Err(failure.error);
                     }
@@ -300,6 +336,11 @@ impl PeerClientTransport {
                         error_code = %failure.error.code,
                         error_message = %failure.error.message,
                         "daemon peer delivery hit retryable failure"
+                    );
+                    let _ = self.observability.emit(
+                        "send_to_endpoint",
+                        "degraded",
+                        "daemon peer delivery hit a retryable failure",
                     );
                     if wait_for_retry_backoff(&terminate, sleep_for) {
                         return Err(
@@ -327,6 +368,11 @@ impl PeerClientTransport {
                         error_code = %failure.error.code,
                         error_message = %failure.error.message,
                         "daemon peer delivery failed"
+                    );
+                    let _ = self.observability.emit(
+                        "send_to_endpoint",
+                        "failed",
+                        "daemon peer delivery failed with a non-retryable or outcome-unknown error",
                     );
                     return Err(failure.error);
                 }
@@ -505,9 +551,20 @@ impl Default for PeerTransportRuntime {
 }
 
 impl PeerTransportRuntime {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(replay_store: Option<Arc<dyn RemoteReplayStore>>) -> Self {
+        Self::new_with_observability(
+            replay_store,
+            SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
+        )
+    }
+
+    pub(crate) fn new_with_observability(
+        replay_store: Option<Arc<dyn RemoteReplayStore>>,
+        observability: SubsystemObservability,
+    ) -> Self {
         Self {
-            client: PeerClientTransport::new(replay_store),
+            client: PeerClientTransport::new_with_observability(replay_store, observability),
         }
     }
 

--- a/crates/atm-daemon/src/reconcile_runtime.rs
+++ b/crates/atm-daemon/src/reconcile_runtime.rs
@@ -10,6 +10,8 @@ use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 const DEFAULT_RECONCILE_DEBOUNCE: Duration = Duration::from_millis(25);
 const DEFAULT_RECONCILE_COMPLETION_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_RECONCILE_IDLE_INTERVAL: Duration = Duration::from_millis(50);
@@ -39,6 +41,7 @@ struct ReconcileRuntimeInner {
     pending_changed: Condvar,
     debounce: Duration,
     executor: ReconcileExecutor,
+    observability: SubsystemObservability,
     // Lock ordering invariant: if code ever needs both runtime state and the
     // fingerprint registry, it must drop `state` before locking this mutex.
     // The registry is ancillary reconcile-emission state and must never nest
@@ -157,10 +160,25 @@ impl ReconcileKey {
 }
 
 impl ReconcileRuntime {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(
         watch_source: Arc<dyn WatchEventSource + Send + Sync>,
         inbox_ingress: Arc<dyn InboxIngress + Send + Sync>,
         notification_sink: Arc<dyn NotificationSink + Send + Sync>,
+    ) -> Self {
+        Self::new_with_observability(
+            watch_source,
+            inbox_ingress,
+            notification_sink,
+            SubsystemObservability::disabled(DaemonSubsystem::ReconcileRuntime),
+        )
+    }
+
+    pub(crate) fn new_with_observability(
+        watch_source: Arc<dyn WatchEventSource + Send + Sync>,
+        inbox_ingress: Arc<dyn InboxIngress + Send + Sync>,
+        notification_sink: Arc<dyn NotificationSink + Send + Sync>,
+        observability: SubsystemObservability,
     ) -> Self {
         // Fingerprints must survive across executor invocations so duplicate
         // reconcile cycles can compare the newest inbox projection with the
@@ -206,6 +224,7 @@ impl ReconcileRuntime {
             }),
             DEFAULT_RECONCILE_DEBOUNCE,
             notification_fingerprints,
+            observability,
         )
     }
 
@@ -213,6 +232,7 @@ impl ReconcileRuntime {
         executor: ReconcileExecutor,
         debounce: Duration,
         notification_fingerprints: Arc<Mutex<NotificationFingerprintRegistry>>,
+        observability: SubsystemObservability,
     ) -> Self {
         Self {
             inner: Arc::new(ReconcileRuntimeInner {
@@ -222,6 +242,7 @@ impl ReconcileRuntime {
                 pending_changed: Condvar::new(),
                 debounce,
                 executor,
+                observability,
                 notification_fingerprints,
             }),
         }
@@ -245,6 +266,11 @@ impl ReconcileRuntime {
             .name("atm-daemon-reconcile".to_string())
             .spawn(move || reconcile_worker_loop(inner))
             .map_err(|source| {
+                let _ = self.inner.observability.emit(
+                    "start",
+                    "failed",
+                    "failed to spawn reconcile runtime worker",
+                );
                 AtmError::daemon_unavailable("failed to spawn reconcile runtime worker")
                     .with_source(source)
             })?;
@@ -261,6 +287,10 @@ impl ReconcileRuntime {
             }
         };
         state.worker = Some(handle);
+        let _ = self
+            .inner
+            .observability
+            .emit("start", "ok", "reconcile runtime worker started");
         Ok(())
     }
 
@@ -295,9 +325,19 @@ impl ReconcileRuntime {
             match result_rx.recv_timeout(RECONCILE_SHUTDOWN_DEADLINE) {
                 Ok(Ok(())) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "ok",
+                        "reconcile runtime worker shut down cleanly",
+                    );
                 }
                 Ok(Err(_)) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "reconcile runtime worker panicked during shutdown",
+                    );
                     return Err(AtmError::daemon_unavailable(
                         "reconcile runtime worker panicked during shutdown",
                     )
@@ -314,6 +354,11 @@ impl ReconcileRuntime {
                         timeout_ms = RECONCILE_SHUTDOWN_DEADLINE.as_millis(),
                         "reconcile runtime worker exceeded shutdown deadline; detaching join helper"
                     );
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "degraded",
+                        "reconcile runtime worker exceeded its shutdown deadline",
+                    );
                     return Err(AtmError::daemon_unavailable(
                         "reconcile runtime worker exceeded the bounded shutdown deadline",
                     )
@@ -323,6 +368,11 @@ impl ReconcileRuntime {
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "reconcile runtime join helper disconnected during shutdown",
+                    );
                     tracing::warn!(
                         thread_id = ?worker_thread_id,
                         "reconcile runtime worker join helper exited before reporting shutdown status"
@@ -340,6 +390,8 @@ impl ReconcileRuntime {
     }
 
     pub(crate) fn reconcile(&self, request: ReconcileRequest) -> Result<ReconcileResult, AtmError> {
+        let request_team = request.team.clone();
+        let request_agent = request.agent.clone();
         let waiter_id = {
             let mut state = self.inner.state.lock().map_err(|_| {
                 AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
@@ -347,11 +399,33 @@ impl ReconcileRuntime {
                 )
             })?;
             if !state.started {
+                let event = self
+                    .inner
+                    .observability
+                    .event(
+                        "reconcile",
+                        "rejected",
+                        "reconcile runtime is unavailable before daemon startup",
+                    )
+                    .with_team(request_team.clone())
+                    .with_agent(request_agent.clone());
+                let _ = self.inner.observability.emit_event(event);
                 return Err(AtmError::daemon_unavailable(
                     "reconcile runtime is unavailable before daemon startup",
                 ));
             }
             if state.shutdown {
+                let event = self
+                    .inner
+                    .observability
+                    .event(
+                        "reconcile",
+                        "rejected",
+                        "reconcile runtime is unavailable during daemon shutdown",
+                    )
+                    .with_team(request_team.clone())
+                    .with_agent(request_agent.clone());
+                let _ = self.inner.observability.emit_event(event);
                 return Err(AtmError::daemon_unavailable(
                     "reconcile runtime is unavailable during daemon shutdown",
                 ));
@@ -388,6 +462,17 @@ impl ReconcileRuntime {
         loop {
             if state.shutdown {
                 state.release_waiter(waiter_id);
+                let event = self
+                    .inner
+                    .observability
+                    .event(
+                        "reconcile",
+                        "degraded",
+                        "reconcile runtime shut down before completion",
+                    )
+                    .with_team(request_team.clone())
+                    .with_agent(request_agent.clone());
+                let _ = self.inner.observability.emit_event(event);
                 return Err(AtmError::daemon_unavailable(
                     "reconcile runtime shut down before completion",
                 ));
@@ -409,6 +494,17 @@ impl ReconcileRuntime {
             state = wait.0;
             if wait.1.timed_out() {
                 state.release_waiter(waiter_id);
+                let event = self
+                    .inner
+                    .observability
+                    .event(
+                        "reconcile",
+                        "degraded",
+                        "reconcile runtime timed out waiting for background completion",
+                    )
+                    .with_team(request_team.clone())
+                    .with_agent(request_agent.clone());
+                let _ = self.inner.observability.emit_event(event);
                 return Err(AtmError::daemon_unavailable(
                     "reconcile runtime timed out waiting for background completion",
                 ));
@@ -422,6 +518,7 @@ impl ReconcileRuntime {
             executor,
             debounce,
             Arc::new(Mutex::new(NotificationFingerprintRegistry::default())),
+            SubsystemObservability::disabled(DaemonSubsystem::ReconcileRuntime),
         )
     }
 

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -30,7 +30,9 @@ use atm_rusqlite::{SqliteBoundaryAssembly, assemble_default_boundary};
 
 use crate::AtmHomeDir;
 use crate::advisory_runtime::AdvisoryRuntime;
-use crate::daemon_runtime_observability::DaemonRuntimeObservability;
+use crate::daemon_runtime_observability::{
+    DaemonEvent, DaemonRuntimeObservability, DaemonSubsystem,
+};
 #[cfg(test)]
 pub(crate) use crate::runtime_status_cache::MAX_STATUS_CACHE_ENTRIES;
 pub(crate) use crate::runtime_status_cache::RuntimeStatusCache;
@@ -204,22 +206,28 @@ impl DaemonRequestDispatcher {
         };
         Self {
             home_dir: home_dir.clone(),
-            observability,
+            observability: Arc::clone(&observability),
             status_cache,
             sqlite_boundary,
-            advisory_runtime: AdvisoryRuntime::new(),
+            advisory_runtime: AdvisoryRuntime::new_with_observability(
+                crate::SubsystemObservability::new(
+                    crate::DaemonSubsystem::AdvisoryRuntime,
+                    Arc::clone(&observability),
+                ),
+            ),
         }
     }
 
-    pub(crate) fn record_runtime_event(
+    pub(crate) fn record_daemon_event(
         &self,
+        subsystem: DaemonSubsystem,
         action: &'static str,
         outcome: &'static str,
         message: &'static str,
     ) {
         if let Err(error) = self
             .observability
-            .emit_runtime_event(action, outcome, message)
+            .emit_daemon_event(DaemonEvent::new(subsystem, action, outcome, message))
         {
             tracing::warn!(%error, action, outcome, "daemon runtime lifecycle emission failed");
         }
@@ -251,7 +259,8 @@ impl boundary::RequestDispatcher for DaemonRequestDispatcher {
             RequestEnvelope::Send(SendRequestEnvelope::Compose(request)) => {
                 let outcome = send_mail(request, self.observability.as_ref())?;
                 if let Err(error) = self.advisory_runtime.enqueue_nudge_for_recipient(&outcome) {
-                    self.record_runtime_event(
+                    self.record_daemon_event(
+                        DaemonSubsystem::AdvisoryRuntime,
                         "advisory_enqueue",
                         "degraded",
                         "advisory queue overflowed",

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -109,7 +109,7 @@ impl DaemonRequestDispatcher {
     fn spawn_shutdown_step(
         label: &'static str,
         step: impl FnOnce() -> Result<(), AtmError> + Send + 'static,
-    ) -> std::thread::JoinHandle<()> {
+    ) -> Result<std::thread::JoinHandle<()>, AtmError> {
         std::thread::Builder::new()
             .name(format!("shutdown-finalizer-{label}"))
             .spawn(move || {
@@ -117,7 +117,15 @@ impl DaemonRequestDispatcher {
                     tracing::warn!(%error, step = label, "daemon shutdown finalizer step failed");
                 });
             })
-            .expect("spawn daemon shutdown finalizer step")
+            .map_err(|source| {
+                AtmError::daemon_unavailable(format!(
+                    "failed to spawn daemon shutdown finalizer step `{label}`"
+                ))
+                .with_recovery(
+                    "Restart atm-daemon; the bounded shutdown finalizer helper could not be created.",
+                )
+                .with_source(source)
+            })
     }
 
     fn complete_shutdown_step(label: &'static str, shutdown_handle: std::thread::JoinHandle<()>) {
@@ -161,7 +169,17 @@ impl DaemonRequestDispatcher {
         deadline: Duration,
         step: impl FnOnce() -> Result<(), AtmError> + Send + 'static,
     ) {
-        let shutdown_handle = Self::spawn_shutdown_step(label, step);
+        let shutdown_handle = match Self::spawn_shutdown_step(label, step) {
+            Ok(handle) => handle,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    step = label,
+                    "daemon shutdown finalizer step could not start"
+                );
+                return;
+            }
+        };
         let started = std::time::Instant::now();
         loop {
             if shutdown_handle.is_finished() {

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -12,6 +12,8 @@ use atm_core::protocol::{
 };
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 pub(crate) const MAX_STATUS_CACHE_ENTRIES: usize = 4096;
 const MAX_RELOAD_TEAMS: usize = 256;
 
@@ -45,19 +47,33 @@ impl RuntimeStatusCacheState {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub(crate) struct RuntimeStatusCache {
     state: Arc<Mutex<RuntimeStatusCacheState>>,
+    observability: SubsystemObservability,
+}
+
+impl Default for RuntimeStatusCache {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RuntimeStatusCache {
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::RuntimeStatusCache,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
             state: Arc::new(Mutex::new(RuntimeStatusCacheState {
                 members: HashMap::new(),
                 sqlite_ready: true,
                 degraded_ingest: false,
             })),
+            observability,
         }
     }
 
@@ -96,7 +112,7 @@ impl RuntimeStatusCache {
             .state
             .lock()
             .map_err(|_| AtmError::daemon_unavailable("runtime status cache lock poisoned"))?;
-        evict_status_cache_entry_if_needed(&mut cache, &key);
+        evict_status_cache_entry_if_needed(&mut cache, &key, &self.observability);
         cache.members.insert(
             key,
             RuntimeMemberRecord {
@@ -129,7 +145,7 @@ impl RuntimeStatusCache {
             .state
             .lock()
             .map_err(|_| AtmError::daemon_unavailable("runtime status cache lock poisoned"))?;
-        evict_status_cache_entry_if_needed(&mut cache, &key);
+        evict_status_cache_entry_if_needed(&mut cache, &key, &self.observability);
         let last_active_at = cache
             .members
             .get(&key)
@@ -142,6 +158,16 @@ impl RuntimeStatusCache {
                 last_active_at,
             },
         );
+        let event = self
+            .observability
+            .event(
+                "record_identity_conflict",
+                "degraded",
+                "runtime status cache recorded an identity conflict",
+            )
+            .with_team(request.team.clone())
+            .with_agent(request.member.clone());
+        let _ = self.observability.emit_event(event);
         Ok(())
     }
 
@@ -165,7 +191,14 @@ impl RuntimeStatusCache {
 
     pub(crate) fn mark_sqlite_unavailable(&self) {
         match self.state.lock() {
-            Ok(mut cache) => cache.sqlite_ready = false,
+            Ok(mut cache) => {
+                cache.sqlite_ready = false;
+                let _ = self.observability.emit(
+                    "mark_sqlite_unavailable",
+                    "degraded",
+                    "runtime status cache marked sqlite unavailable",
+                );
+            }
             Err(_) => {
                 tracing::error!(
                     "runtime status cache lock poisoned while marking sqlite unavailable"
@@ -197,6 +230,7 @@ impl RuntimeStatusCache {
 fn evict_status_cache_entry_if_needed(
     cache: &mut RuntimeStatusCacheState,
     incoming_key: &RuntimeMemberKey,
+    observability: &SubsystemObservability,
 ) {
     let is_new_key = !cache.members.contains_key(incoming_key);
     if !is_new_key || cache.members.len() < MAX_STATUS_CACHE_ENTRIES {
@@ -223,6 +257,15 @@ fn evict_status_cache_entry_if_needed(
         .map(|(key, record)| (key.clone(), record.clone()));
     if let Some((evicted_key, evicted_record)) = eviction_candidate {
         cache.members.remove(&evicted_key);
+        let event = observability
+            .event(
+                "evict_entry",
+                "degraded",
+                "runtime status cache evicted an entry at the bounded cap",
+            )
+            .with_team(evicted_key.team.clone())
+            .with_agent(evicted_key.member.clone());
+        let _ = observability.emit_event(event);
         tracing::warn!(
             team = %evicted_key.team,
             member = %evicted_key.member,

--- a/crates/atm-daemon/src/test_observability.rs
+++ b/crates/atm-daemon/src/test_observability.rs
@@ -11,7 +11,7 @@ use atm_core::observability::{
     LogTailSession, ObservabilityPort,
 };
 
-use crate::DaemonRuntimeObservability;
+use crate::{DaemonEvent, DaemonRuntimeObservability};
 
 #[derive(Debug)]
 pub(crate) struct TestDaemonObservability {
@@ -173,14 +173,13 @@ impl ObservabilityPort for TestDaemonObservability {
 }
 
 impl DaemonRuntimeObservability for TestDaemonObservability {
-    fn emit_runtime_event(
-        &self,
-        action: &'static str,
-        outcome: &'static str,
-        message: &'static str,
-    ) -> Result<(), AtmError> {
+    fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
         self.append_message(format!(
-            "{{\"action\":\"{action}\",\"outcome\":\"{outcome}\",\"message\":\"{message}\"}}"
+            "{{\"subsystem\":\"{}\",\"action\":\"{}\",\"outcome\":\"{}\",\"message\":\"{}\"}}",
+            event.subsystem.as_str(),
+            event.action,
+            event.outcome,
+            event.detail
         ))
     }
 

--- a/crates/atm-daemon/src/watch_runtime.rs
+++ b/crates/atm-daemon/src/watch_runtime.rs
@@ -205,10 +205,11 @@ impl WatchRuntime {
             .name("atm-daemon-watch".to_string())
             .spawn(move || watch_worker_loop(inner))
             .map_err(|source| {
-                let _ = self
-                    .inner
-                    .observability
-                    .emit("start", "failed", "failed to spawn watch runtime worker");
+                let _ = self.inner.observability.emit(
+                    "start",
+                    "failed",
+                    "failed to spawn watch runtime worker",
+                );
                 AtmError::daemon_unavailable("failed to spawn watch runtime worker")
                     .with_source(source)
             })?;
@@ -250,14 +251,28 @@ impl WatchRuntime {
                 .spawn(move || {
                     let _ = result_tx.send(handle.join());
                 })
-                .expect("failed to spawn watch join helper");
+                .map_err(|source| {
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "failed to spawn watch runtime join helper",
+                    );
+                    AtmError::daemon_unavailable(
+                        "failed to spawn watch runtime join helper during shutdown",
+                    )
+                    .with_recovery(
+                        "Restart atm-daemon; watch shutdown could not create its bounded join helper.",
+                    )
+                    .with_source(source)
+                })?;
             match result_rx.recv_timeout(WATCH_SHUTDOWN_DEADLINE) {
                 Ok(Ok(())) => {
                     let _ = join_helper.join();
-                    let _ = self
-                        .inner
-                        .observability
-                        .emit("shutdown", "ok", "watch runtime worker shut down cleanly");
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "ok",
+                        "watch runtime worker shut down cleanly",
+                    );
                 }
                 Ok(Err(_)) => {
                     let _ = join_helper.join();

--- a/crates/atm-daemon/src/watch_runtime.rs
+++ b/crates/atm-daemon/src/watch_runtime.rs
@@ -8,6 +8,8 @@ use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 const DEFAULT_WATCH_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_WATCH_SUBSCRIPTIONS: usize = 256;
 const WATCH_POLL_HEALTH_TIMEOUT_MULTIPLIER: u32 = 5;
@@ -32,6 +34,7 @@ struct WatchRuntimeInner {
     wake: Condvar,
     poller: WatchPoller,
     poll_interval: Duration,
+    observability: SubsystemObservability,
 }
 
 #[derive(Default)]
@@ -104,7 +107,14 @@ impl WatchKey {
 }
 
 impl WatchRuntime {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::WatchRuntime,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self::new_with_poller(
             Arc::new(|request| {
                 let inbox_path = atm_core::home::inbox_path_from_home(
@@ -157,16 +167,22 @@ impl WatchRuntime {
                 Ok(WatchEventBatch { paths })
             }),
             DEFAULT_WATCH_POLL_INTERVAL,
+            observability,
         )
     }
 
-    fn new_with_poller(poller: WatchPoller, poll_interval: Duration) -> Self {
+    fn new_with_poller(
+        poller: WatchPoller,
+        poll_interval: Duration,
+        observability: SubsystemObservability,
+    ) -> Self {
         Self {
             inner: Arc::new(WatchRuntimeInner {
                 state: Mutex::new(WatchState::default()),
                 wake: Condvar::new(),
                 poller,
                 poll_interval,
+                observability,
             }),
         }
     }
@@ -189,6 +205,10 @@ impl WatchRuntime {
             .name("atm-daemon-watch".to_string())
             .spawn(move || watch_worker_loop(inner))
             .map_err(|source| {
+                let _ = self
+                    .inner
+                    .observability
+                    .emit("start", "failed", "failed to spawn watch runtime worker");
                 AtmError::daemon_unavailable("failed to spawn watch runtime worker")
                     .with_source(source)
             })?;
@@ -205,6 +225,10 @@ impl WatchRuntime {
             }
         };
         state.worker = Some(handle);
+        let _ = self
+            .inner
+            .observability
+            .emit("start", "ok", "watch runtime worker started");
         Ok(())
     }
 
@@ -230,9 +254,18 @@ impl WatchRuntime {
             match result_rx.recv_timeout(WATCH_SHUTDOWN_DEADLINE) {
                 Ok(Ok(())) => {
                     let _ = join_helper.join();
+                    let _ = self
+                        .inner
+                        .observability
+                        .emit("shutdown", "ok", "watch runtime worker shut down cleanly");
                 }
                 Ok(Err(_)) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "watch runtime worker panicked during shutdown",
+                    );
                     return Err(AtmError::daemon_unavailable(
                         "watch runtime worker panicked during shutdown",
                     )
@@ -248,6 +281,11 @@ impl WatchRuntime {
                         timeout_ms = WATCH_SHUTDOWN_DEADLINE.as_millis(),
                         "watch runtime worker exceeded shutdown deadline; detaching join helper"
                     );
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "degraded",
+                        "watch runtime worker exceeded its shutdown deadline",
+                    );
                     return Err(AtmError::daemon_unavailable(
                         "watch runtime worker exceeded the bounded shutdown deadline",
                     )
@@ -257,6 +295,11 @@ impl WatchRuntime {
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "watch runtime join helper disconnected during shutdown",
+                    );
                     tracing::warn!(
                         "watch runtime worker join helper exited before reporting shutdown status"
                     );
@@ -270,6 +313,8 @@ impl WatchRuntime {
         &self,
         request: WatchSubscriptionRequest,
     ) -> Result<WatchEventBatch, AtmError> {
+        let request_team = request.team.clone();
+        let request_agent = request.agent.clone();
         let key = WatchKey::from_request(&request);
         let mut state = self.inner.state.lock().map_err(|_| {
             AtmError::daemon_unavailable("watch runtime state lock poisoned").with_recovery(
@@ -294,6 +339,17 @@ impl WatchRuntime {
             }
             None => {
                 if state.subscriptions.len() >= MAX_WATCH_SUBSCRIPTIONS {
+                    let event = self
+                        .inner
+                        .observability
+                        .event(
+                            "poll",
+                            "rejected",
+                            "watch runtime refused a new subscription at the bounded registry cap",
+                        )
+                        .with_team(request_team.clone())
+                        .with_agent(request_agent.clone());
+                    let _ = self.inner.observability.emit_event(event);
                     return Err(
                         AtmError::daemon_unavailable(format!(
                             "watch runtime refused a new subscription because the bounded registry capacity of {MAX_WATCH_SUBSCRIPTIONS} entries was reached"
@@ -346,6 +402,17 @@ impl WatchRuntime {
                 })?;
             state = wait.0;
             if wait.1.timed_out() {
+                let event = self
+                    .inner
+                    .observability
+                    .event(
+                        "poll",
+                        "degraded",
+                        "watch runtime did not deliver an updated batch before the worker health timeout elapsed",
+                    )
+                    .with_team(request_team.clone())
+                    .with_agent(request_agent.clone());
+                let _ = self.inner.observability.emit_event(event);
                 return Err(
                     AtmError::daemon_unavailable(
                         "watch runtime did not deliver an updated batch before the worker health timeout elapsed",
@@ -360,7 +427,11 @@ impl WatchRuntime {
 
     #[cfg(test)]
     pub(crate) fn new_for_test(poller: WatchPoller, poll_interval: Duration) -> Self {
-        Self::new_with_poller(poller, poll_interval)
+        Self::new_with_poller(
+            poller,
+            poll_interval,
+            SubsystemObservability::disabled(DaemonSubsystem::WatchRuntime),
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Inject `DaemonObservability` trait into all 10 daemon subsystems
- Move event construction into owning subsystems; subsystems use typed `DaemonSubsystem` enum, `AtmMessageId`/`TaskId` identifiers
- Reduce `daemon_observability.rs` to generic sink mapping (V.3 prep)
- Hard boundary enforced: observability layer imports no daemon subsystem types
- ARCH-PU-002/RULE-002 materially advanced

## Test plan
- [ ] cargo build --workspace clean
- [ ] cargo test --workspace clean
- [ ] cargo clippy --workspace -- -D warnings clean
- [ ] QA-1: req-qa + arch-qa + rust-qa-agent + rust-best-practices-agent + flaky-test-qa

🤖 Generated with [Claude Code](https://claude.com/claude-code)