### PR TITLE
feat(daemon): V.4 recovery context hardening

### DIFF
--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -141,7 +141,10 @@ impl DaemonSupervisor {
                 return Err(AtmError::daemon_auto_start_failed(format!(
                     "failed to connect to daemon local IPC endpoint at {} after auto-start",
                     self.endpoint.display()
-                )));
+                ))
+                .with_recovery(
+                    "Inspect atm-daemon startup logs, confirm the daemon publishes its local IPC endpoint, and retry only after the same-host socket becomes reachable.",
+                ));
             }
             if Instant::now() >= deadline {
                 return Err(LaunchGateGuard::rejected_error(&self.endpoint));
@@ -174,6 +177,9 @@ impl DaemonSupervisor {
                 "failed to spawn daemon binary at {}",
                 self.daemon_bin.display()
             ))
+            .with_recovery(
+                "Confirm ATM_DAEMON_BIN points to an executable atm-daemon binary and retry after fixing the daemon launch environment.",
+            )
             .with_source(source)
         })?;
         Ok(())
@@ -196,6 +202,9 @@ impl LaunchGateGuard {
             "daemon launch gate remained owned while connecting to {}",
             endpoint.display()
         ))
+        .with_recovery(
+            "Wait for the in-flight daemon launch to finish, then retry the same-host connection. If the launch gate stays owned, inspect the launch-lock owner and clear stale launch state before retrying.",
+        )
     }
 
     pub fn try_acquire_at(lock_path: PathBuf) -> Result<Option<Self>, AtmError> {
@@ -205,6 +214,9 @@ impl LaunchGateGuard {
                     "failed to create daemon launch lock directory at {}",
                     parent.display()
                 ))
+                .with_recovery(
+                    "Create or grant write access to the daemon launch-lock directory before retrying daemon auto-start.",
+                )
                 .with_source(source)
             })?;
         }
@@ -219,6 +231,9 @@ impl LaunchGateGuard {
                     "failed to open daemon launch gate at {}",
                     lock_path.display()
                 ))
+                .with_recovery(
+                    "Confirm the daemon launch-lock path is writable and not blocked by another process before retrying daemon auto-start.",
+                )
                 .with_source(source)
             })?;
 
@@ -229,6 +244,9 @@ impl LaunchGateGuard {
                 "failed to acquire daemon launch gate at {}",
                 lock_path.display()
             ))
+            .with_recovery(
+                "Inspect the daemon launch-lock owner and repair stale lock state before retrying daemon auto-start.",
+            )
             .with_source(source)),
         }
     }

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -65,7 +65,12 @@ impl RuntimeLifecycle {
         let mut state = self
             .state
             .lock()
-            .map_err(|_| AtmError::daemon_unavailable("runtime lifecycle state lock poisoned"))?;
+            .map_err(|_| {
+                AtmError::daemon_unavailable("runtime lifecycle state lock poisoned")
+                    .with_recovery(
+                        "Restart atm-daemon; runtime lifecycle transitions can no longer be trusted after the poisoned state lock.",
+                    )
+            })?;
         let current = *state;
         if !matches!(
             (current, next),
@@ -106,7 +111,12 @@ impl RuntimeLifecycle {
         let mut state = self
             .state
             .lock()
-            .map_err(|_| AtmError::daemon_unavailable("runtime lifecycle state lock poisoned"))?;
+            .map_err(|_| {
+                AtmError::daemon_unavailable("runtime lifecycle state lock poisoned")
+                    .with_recovery(
+                        "Restart atm-daemon; runtime lifecycle transitions can no longer be trusted after the poisoned state lock.",
+                    )
+            })?;
         *state = RuntimeLifecycleState::Stopped;
         Ok(())
     }
@@ -600,6 +610,9 @@ where
                 AtmError::daemon_unavailable(format!(
                     "daemon {lane_name} shutdown worker panicked unexpectedly"
                 ))
+                .with_recovery(
+                    "Restart atm-daemon; one shutdown lane crashed while the runtime was draining background work.",
+                )
             })?;
             result
         }
@@ -612,18 +625,27 @@ where
             );
             Err(AtmError::daemon_unavailable(format!(
                 "daemon {lane_name} shutdown exceeded the {deadline:?} per-lane deadline"
-            )))
+            ))
+            .with_recovery(
+                "Restart atm-daemon after the stalled background lane stops holding runtime shutdown open.",
+            ))
         }
         Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => shutdown_handle.join().map_or_else(
             |_| {
                 Err(AtmError::daemon_unavailable(format!(
                     "daemon {lane_name} shutdown worker panicked unexpectedly"
-                )))
+                ))
+                .with_recovery(
+                    "Restart atm-daemon; one shutdown lane crashed while the runtime was draining background work.",
+                ))
             },
             |_| {
                 Err(AtmError::daemon_unavailable(format!(
                     "daemon {lane_name} shutdown worker disconnected unexpectedly"
-                )))
+                ))
+                .with_recovery(
+                    "Restart atm-daemon; one shutdown lane stopped reporting progress during runtime teardown.",
+                ))
             },
         ),
     }

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -287,24 +287,21 @@ impl RuntimeComposition {
         self.request_dispatcher.finalize_shutdown();
     }
 
-    fn emit_composition_event(
-        &self,
-        action: &'static str,
-        outcome: &'static str,
-        detail: &'static str,
-    ) {
-        let _ = self.composition_observability.emit(action, outcome, detail);
-    }
-
     pub(crate) fn start(&self) -> Result<(), AtmError> {
-        self.emit_composition_event("start_requested", "ok", "daemon start requested");
+        let _ =
+            self.composition_observability
+                .emit("start_requested", "ok", "daemon start requested");
         self.lifecycle.transition(RuntimeLifecycleState::Starting)?;
         // Startup replay must finish before the daemon binds its socket so
         // crash-recovered work cannot race newly accepted requests.
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+                let _ = self.composition_observability.emit(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
@@ -321,7 +318,11 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+            let _ = self.composition_observability.emit(
+                "startup_failed",
+                "failed",
+                "daemon startup failed",
+            );
             self.lifecycle.force_stopped()?;
             return Err(error);
         }
@@ -334,14 +335,22 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during runtime preparation rollback"
                     );
                 }
-                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+                let _ = self.composition_observability.emit(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.emit_composition_event("startup_completed", "ok", "daemon startup completed");
+        let _ = self.composition_observability.emit(
+            "startup_completed",
+            "ok",
+            "daemon startup completed",
+        );
         let request_dispatcher = Arc::clone(&self.request_dispatcher);
         let endpoint_guard = self.take_endpoint_guard()?;
         let result = runtime.serve_with_runtime_hooks(
@@ -366,12 +375,18 @@ impl RuntimeComposition {
         socket_path: PathBuf,
         ready_signal: Option<std::sync::mpsc::SyncSender<()>>,
     ) -> Result<(), AtmError> {
-        self.emit_composition_event("start_requested", "ok", "daemon start requested");
+        let _ =
+            self.composition_observability
+                .emit("start_requested", "ok", "daemon start requested");
         self.lifecycle.transition(RuntimeLifecycleState::Starting)?;
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+                let _ = self.composition_observability.emit(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
@@ -388,7 +403,11 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+            let _ = self.composition_observability.emit(
+                "startup_failed",
+                "failed",
+                "daemon startup failed",
+            );
             self.lifecycle.force_stopped()?;
             return Err(error);
         }
@@ -404,14 +423,22 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during test runtime preparation rollback"
                     );
                 }
-                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+                let _ = self.composition_observability.emit(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.emit_composition_event("startup_completed", "ok", "daemon startup completed");
+        let _ = self.composition_observability.emit(
+            "startup_completed",
+            "ok",
+            "daemon startup completed",
+        );
         let request_dispatcher = Arc::clone(&self.request_dispatcher);
         let endpoint_guard = self.take_endpoint_guard()?;
         let result = runtime.serve_with_runtime_hooks(
@@ -468,10 +495,18 @@ impl RuntimeComposition {
         }
         match result.as_ref() {
             Ok(()) => {
-                self.emit_composition_event("shutdown_completed", "ok", "daemon shutdown completed")
+                let _ = self.composition_observability.emit(
+                    "shutdown_completed",
+                    "ok",
+                    "daemon shutdown completed",
+                );
             }
             Err(_) => {
-                self.emit_composition_event("shutdown_failed", "failed", "daemon shutdown failed")
+                let _ = self.composition_observability.emit(
+                    "shutdown_failed",
+                    "failed",
+                    "daemon shutdown failed",
+                );
             }
         }
         result

--- a/crates/atm-daemon/src/lifecycle_control.rs
+++ b/crates/atm-daemon/src/lifecycle_control.rs
@@ -273,7 +273,13 @@ impl LifecycleControlSourceAdapter {
             .spawn(move || {
                 let _ = result_tx.send(worker.join_handle.join());
             })
-            .expect("failed to spawn lifecycle join helper");
+            .map_err(|source| {
+                AtmError::daemon_unavailable("failed to spawn lifecycle join helper")
+                    .with_recovery(
+                        "Restart the daemon; the lifecycle worker could not create its bounded shutdown join helper.",
+                    )
+                    .with_source(source)
+            })?;
         match result_rx.recv_timeout(LIFECYCLE_WORKER_JOIN_DEADLINE) {
             Ok(Ok(())) => {
                 let _ = join_helper.join();

--- a/docs/atm-daemon/recovery-text-rules.md
+++ b/docs/atm-daemon/recovery-text-rules.md
@@ -38,6 +38,27 @@ If existing `ErrorCode` enum variants already cover a category, `V.4` may bind
 that category to the established variant instead of inventing a second name.
 What is forbidden is category drift or ad hoc string-only recovery labels.
 
+## V.4 Category Binding
+
+Phase `V.4` binds the required recovery categories to the existing ATM error
+surface rather than inventing a second parallel code family:
+
+| Recovery category | Bound ATM error code / variant | Notes |
+|---|---|---|
+| `ATM_DAEMON_UNAVAILABLE` | `AtmErrorCode::DaemonUnavailable` via `AtmError::daemon_unavailable(...)` | default daemon/client reachability and runtime coordination failures |
+| `ATM_SOCKET_CONNECT_FAILED` | `AtmErrorCode::DaemonUnavailable` via socket/open/bind/connect flavored `AtmError::daemon_unavailable(...)` messages | same code, but the recovery text must explicitly mention the socket/connect surface |
+| `ATM_DAEMON_START_FAILED` | `AtmErrorCode::DaemonAutoStartFailed` via `AtmError::daemon_auto_start_failed(...)` | daemon binary missing, spawn failures, publish-timeout auto-start failures |
+| `ATM_IPC_RUNTIME_FAILED` | `AtmErrorCode::DaemonUnavailable` or `AtmErrorCode::DaemonLifecycleWedge` depending on whether the failure is one-shot runtime I/O vs lifecycle wedge | local IPC deadlines, dispatch/worker/join-helper failures, lifecycle teardown wedges |
+
+Concrete related variants that remain valid in the final daemon/client error
+surface:
+- `AtmErrorCode::DaemonLaunchGateRejected`
+- `AtmErrorCode::DaemonLifecycleWedge`
+- `AtmErrorCode::DaemonServingStateRejected`
+
+`V.4` therefore hardens category-specific `.with_recovery(...)` text on the
+concrete variants above instead of renaming the underlying ATM error codes.
+
 Recovery text may be omitted only when:
 - the failure is purely internal and no user action exists
 - a lower boundary already emitted the exact actionable recovery guidance and
@@ -84,6 +105,14 @@ Bad examples:
 - “operation failed”
 - “unexpected error”
 - “retry later”
+
+Coverage strategy for `V.4`:
+- enumerate the required source files in the sprint plan and this document
+- require `.with_recovery(...)` on every daemon-unavailable, socket-connect,
+  daemon-start, and local-IPC runtime path in those files unless a lower layer
+  already preserves the exact same actionable guidance
+- verify coverage in QA with code review of the enumerated paths plus
+  workspace `cargo clippy -- -D warnings`
 
 ## Phase Ownership
 

--- a/docs/atm-daemon/recovery-text-rules.md
+++ b/docs/atm-daemon/recovery-text-rules.md
@@ -111,8 +111,10 @@ Coverage strategy for `V.4`:
 - require `.with_recovery(...)` on every daemon-unavailable, socket-connect,
   daemon-start, and local-IPC runtime path in those files unless a lower layer
   already preserves the exact same actionable guidance
-- verify coverage in QA with code review of the enumerated paths plus
-  workspace `cargo clippy -- -D warnings`
+- verify `.with_recovery(...)` coverage in QA with checklist review of the
+  enumerated paths
+- use workspace `cargo clippy -- -D warnings` only for Rust hygiene after the
+  recovery-text edits land
 
 ## Phase Ownership
 

--- a/docs/phase-V/sprint-V4.md
+++ b/docs/phase-V/sprint-V4.md
@@ -4,9 +4,9 @@
 plan_type: sprint_plan
 phase: V
 sprint: "V.4"
-status: planned
-worktree: TBD
-branch: TBD
+status: implemented
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s4-recovery-hardening
+branch: feature/pV-s4-recovery-hardening
 estimated_scope: M
 ```
 
@@ -80,6 +80,17 @@ Concrete targets:
 - the sprint plan names the concrete daemon-client and daemon source files that
   own the prioritized daemon-unavailable, socket-connect, daemon-start, and
   local-IPC runtime failure paths
+
+## Implementation Record
+
+Concrete V.4 closures:
+- `RBP-PU-001`: disconnected and publish-timeout daemon-unavailable paths now
+  carry path-specific recovery text in daemon-client auto-start/connect flows
+- `RBP-PU-002`: lifecycle join-helper spawn now degrades through typed
+  `AtmError` recovery instead of panicking
+- `QA-U-002`: daemon-unavailable and launch-gate retry/backoff failures now
+  document the exact operator action instead of relying on generic default
+  daemon guidance
 
 ## Out Of Scope
 


### PR DESCRIPTION
## Summary
- Add `.with_recovery()` coverage on 4 daemon error categories: daemon-unavailable, socket-connect, daemon-start, local-IPC-runtime
- Bind stable error codes (ATM_DAEMON_UNAVAILABLE, ATM_SOCKET_CONNECT_FAILED, ATM_DAEMON_START_FAILED, ATM_IPC_RUNTIME_FAILED) to concrete error variants
- Update docs/atm-daemon/recovery-text-rules.md as persistent reference
- Address carry-forwards RBP-PU-001, RBP-PU-002, QA-U-002

## Test plan
- [ ] cargo build --workspace clean
- [ ] cargo test --workspace clean
- [ ] cargo clippy --workspace -- -D warnings clean
- [ ] All sprint-V4.md AC items verified by quality-mgr QA-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)