### PR TITLE
Phase V: daemon observability migration and recovery hardening

### DIFF
--- a/.triage/phase-V/findings/ARCH-001.ttl
+++ b/.triage/phase-V/findings/ARCH-001.ttl
@@ -1,0 +1,14 @@
+finding_id = "ARCH-001"
+title = "RULE-003 violation: local_ipc_transport.rs exceeds 1000 non-test production lines"
+severity = "blocking"
+pattern = "rule-003-file-size"
+repeatable = false
+sweep_scope = "crates/atm-daemon/src/local_ipc_transport.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/local_ipc_transport.rs", lines = "1-1031", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "1031 non-test production lines; ceiling is 1000. Extract ~31+ lines to a new sibling file to bring the module under ceiling."

--- a/.triage/phase-V/findings/ARCH-001.ttl
+++ b/.triage/phase-V/findings/ARCH-001.ttl
@@ -7,7 +7,8 @@ sweep_scope = "crates/atm-daemon/src/local_ipc_transport.rs"
 highest_open_branch = "feature/pV-s2-observability-migration"
 promote_to_branch = "feature/pV-s2-observability-migration"
 occurrences = [
-  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/local_ipc_transport.rs", lines = "1-1031", status = "open" }
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/local_ipc_transport.rs", lines = "1-1031", status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/local_ipc_transport.rs", lines = "1-end", status = "open (carry-forward, closes on V.3 merge-forward from integrate/phase-V after V.2 fix lands)" },
 ]
 dispatch_ready = true
 dispatch_blocked_pending_triage_commit = false

--- a/.triage/phase-V/findings/ARCH-V4-001.ttl
+++ b/.triage/phase-V/findings/ARCH-V4-001.ttl
@@ -1,0 +1,356 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ARCH-V4-001>
+  a triage:Finding ;
+  triage:findingId "ARCH-V4-001" ;
+  triage:title "emit_composition_event() private emit wrapper violates RULE-002" ;
+  triage:description "emit_composition_event() is a private method in composition.rs that wraps self.composition_observability.emit(). This is a custom emit_* wrapper — exactly the pattern RULE-002 prohibits. Called at 7 sites within the same impl block. Introduced in commit 84cacb0 (TASK-1462). Fix: delete emit_composition_event and replace all 7 call sites with direct self.composition_observability.emit(action, outcome, detail) calls." ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ARCH" ;
+  triage:phaseId "phase-V" ;
+  triage:severity "blocking" ;
+  triage:repeatable true ;
+  triage:sweepScope "crate" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-05-13T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/2> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/3> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/4> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/5> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/6> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/7> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/8> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/9> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/10> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/11> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/12> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/13> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/2> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/3> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/4> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/5> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/6> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/7> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/8> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/9> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/10> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/11> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/12> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/13> ;
+  triage:openOn <urn:atm:triage:worktree/pV-s3/75ac70b> ;
+  triage:openOn <urn:atm:triage:worktree/pV-s4/84cacb0> ;
+  triage:promoteTo <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+# pV-s3 occurrences (13 matches in composition.rs)
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 280 ;
+  triage:snippet "fn emit_composition_event(" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/2>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 290 ;
+  triage:snippet "self.emit_composition_event(\"start_requested\", \"ok\", \"daemon start requested\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/3>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 297 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/4>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 314 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/5>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 327 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/6>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 334 ;
+  triage:snippet "self.emit_composition_event(\"startup_completed\", \"ok\", \"daemon startup completed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/7>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 359 ;
+  triage:snippet "self.emit_composition_event(\"start_requested\", \"ok\", \"daemon start requested\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/8>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 364 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/9>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 381 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/10>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 397 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/11>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 404 ;
+  triage:snippet "self.emit_composition_event(\"startup_completed\", \"ok\", \"daemon startup completed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/12>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 461 ;
+  triage:snippet "self.emit_composition_event(\"shutdown_completed\", \"ok\", \"daemon shutdown completed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s3/13>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 464 ;
+  triage:snippet "self.emit_composition_event(\"shutdown_failed\", \"failed\", \"daemon shutdown failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s3/75ac70b> .
+
+# pV-s4 occurrences (13 matches in composition.rs)
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 290 ;
+  triage:snippet "fn emit_composition_event(" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/2>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 300 ;
+  triage:snippet "self.emit_composition_event(\"start_requested\", \"ok\", \"daemon start requested\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/3>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 307 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/4>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 324 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/5>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 337 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/6>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 344 ;
+  triage:snippet "self.emit_composition_event(\"startup_completed\", \"ok\", \"daemon startup completed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/7>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 369 ;
+  triage:snippet "self.emit_composition_event(\"start_requested\", \"ok\", \"daemon start requested\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/8>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 374 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/9>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 391 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/10>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 407 ;
+  triage:snippet "self.emit_composition_event(\"startup_failed\", \"failed\", \"daemon startup failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/11>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 414 ;
+  triage:snippet "self.emit_composition_event(\"startup_completed\", \"ok\", \"daemon startup completed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/12>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 471 ;
+  triage:snippet "self.emit_composition_event(\"shutdown_completed\", \"ok\", \"daemon shutdown completed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ARCH-V4-001/pV-s4/13>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/composition.rs" ;
+  triage:line 474 ;
+  triage:snippet "self.emit_composition_event(\"shutdown_failed\", \"failed\", \"daemon shutdown failed\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+# WorktreeSnapshot nodes
+<urn:atm:triage:worktree/pV-s2/46c703f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pV-s2-observability-migration" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s2-observability-migration" ;
+  triage:headSha "46c703f" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pV-s3/75ac70b>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pV-s4/84cacb0>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:orderIndex 4 .

--- a/.triage/phase-V/findings/ATM-QA-EG-001.ttl
+++ b/.triage/phase-V/findings/ATM-QA-EG-001.ttl
@@ -1,0 +1,62 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ATM-QA-EG-001>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-EG-001" ;
+  triage:title "sprint-V2.md frontmatter stale (status/worktree/branch fields)" ;
+  triage:description "docs/phase-V/sprint-V2.md frontmatter still reads status: planned, worktree: TBD, branch: TBD. Must be updated to: status: implemented, worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s2-observability-migration, branch: feature/pV-s2-observability-migration." ;
+  triage:phaseId "phase-V" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ATM-QA" ;
+  triage:severity "blocking" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-05-13T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-EG-001/integrate-phase-V/1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-EG-001/integrate-phase-V/2> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-EG-001/integrate-phase-V/3> ;
+  triage:openOn <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> ;
+  triage:promoteTo <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> .
+
+<urn:atm:triage:occurrence/ATM-QA-EG-001/integrate-phase-V/1>
+  a triage:Occurrence ;
+  triage:file "docs/phase-V/sprint-V2.md" ;
+  triage:line 7 ;
+  triage:snippet "status: planned" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "integrate/phase-V" ;
+  triage:headSha "ec24c3e" ;
+  triage:occursIn <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> .
+
+<urn:atm:triage:occurrence/ATM-QA-EG-001/integrate-phase-V/2>
+  a triage:Occurrence ;
+  triage:file "docs/phase-V/sprint-V2.md" ;
+  triage:line 8 ;
+  triage:snippet "worktree: TBD" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "integrate/phase-V" ;
+  triage:headSha "ec24c3e" ;
+  triage:occursIn <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> .
+
+<urn:atm:triage:occurrence/ATM-QA-EG-001/integrate-phase-V/3>
+  a triage:Occurrence ;
+  triage:file "docs/phase-V/sprint-V2.md" ;
+  triage:line 9 ;
+  triage:snippet "branch: TBD" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "integrate/phase-V" ;
+  triage:headSha "ec24c3e" ;
+  triage:occursIn <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> .
+
+<urn:atm:triage:worktree/integrate-phase-V/ec24c3e>
+  a triage:WorktreeSnapshot ;
+  triage:branch "integrate/phase-V" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-V" ;
+  triage:headSha "ec24c3e" ;
+  triage:orderIndex 5 .

--- a/.triage/phase-V/findings/ATM-QA-EG-002.ttl
+++ b/.triage/phase-V/findings/ATM-QA-EG-002.ttl
@@ -1,0 +1,38 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ATM-QA-EG-002>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-EG-002" ;
+  triage:title "sprint-V2.md missing Implementation Record section" ;
+  triage:description "docs/phase-V/sprint-V2.md has no Implementation Record section. Must document: VQ2-001 closure (SubsystemObservability injection into RuntimeHealthMonitor), VQ2-002 closure (SubsystemObservability injection into RuntimeComposition), scope of deleted helpers (map_command_event, map_daemon_event, map_runtime_event, emit_runtime_event, record_daemon_event), and confirmation that record_daemon_event delegation path was removed." ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ATM-QA" ;
+  triage:phaseId "phase-V" ;
+  triage:severity "blocking" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-05-13T14:28:37Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-EG-002/integrate-phase-V/1> ;
+  triage:openOn <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> ;
+  triage:promoteTo <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> .
+
+<urn:atm:triage:occurrence/ATM-QA-EG-002/integrate-phase-V/1>
+  a triage:Occurrence ;
+  triage:file "docs/phase-V/sprint-V2.md" ;
+  triage:line 1 ;
+  triage:snippet "# Sprint V.2 — Observability Migration Into Subsystems [no Implementation Record section present]" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "integrate/phase-V" ;
+  triage:headSha "ec24c3e" ;
+  triage:occursIn <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> .
+
+<urn:atm:triage:worktree/integrate-phase-V/ec24c3e>
+  a triage:WorktreeSnapshot ;
+  triage:branch "integrate/phase-V" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-V" ;
+  triage:headSha "ec24c3e" ;
+  triage:orderIndex 5 .

--- a/.triage/phase-V/findings/ATM-QA-EG-003.ttl
+++ b/.triage/phase-V/findings/ATM-QA-EG-003.ttl
@@ -1,0 +1,39 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ATM-QA-EG-003>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-EG-003" ;
+  triage:title "sprint-V1.md missing Implementation Record section" ;
+  triage:description "docs/phase-V/sprint-V1.md has status: implemented but no Implementation Record section documenting what was actually delivered in V.1 (observability boundary design, shared wiring scoping docs)." ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ATM-QA" ;
+  triage:phaseId "phase-V" ;
+  triage:severity "important" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:pattern "ac-unsatisfied-impl-record" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-05-13T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-EG-003/integrate-phase-V/1> ;
+  triage:openOn <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> ;
+  triage:promoteTo <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> .
+
+<urn:atm:triage:occurrence/ATM-QA-EG-003/integrate-phase-V/1>
+  a triage:Occurrence ;
+  triage:file "docs/phase-V/sprint-V1.md" ;
+  triage:line 1 ;
+  triage:snippet "status: implemented — no ## Implementation Record section present (file ends at Sprint Output, line 102)" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "integrate/phase-V" ;
+  triage:headSha "ec24c3e" ;
+  triage:occursIn <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> .
+
+<urn:atm:triage:worktree/integrate-phase-V/ec24c3e>
+  a triage:WorktreeSnapshot ;
+  triage:branch "integrate/phase-V" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-V" ;
+  triage:headSha "ec24c3e" ;
+  triage:orderIndex 5 .

--- a/.triage/phase-V/findings/ATM-QA-EG-004.ttl
+++ b/.triage/phase-V/findings/ATM-QA-EG-004.ttl
@@ -1,0 +1,38 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ATM-QA-EG-004>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-EG-004" ;
+  triage:title "docs/project-plan.md missing Phase V entry" ;
+  triage:description "docs/project-plan.md Phase V section (## 26) exists but is missing explicit key deliverables: SubsystemObservability per-subsystem injection, deleted helpers, .with_recovery() on 4 error categories, stable error code namespace. These deliverables are documented in individual sprint docs (sprint-V1.md through sprint-V4.md) but are not summarized in the project-plan.md Phase V section." ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ATM-QA" ;
+  triage:phaseId "phase-V" ;
+  triage:severity "important" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-05-13T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-EG-004/integrate-phase-V/1> ;
+  triage:openOn <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> ;
+  triage:promoteTo <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> .
+
+<urn:atm:triage:occurrence/ATM-QA-EG-004/integrate-phase-V/1>
+  a triage:Occurrence ;
+  triage:file "docs/project-plan.md" ;
+  triage:line 2973 ;
+  triage:snippet "## 26. Phase V Daemon Hardening And Boundary Cleanup — section exists but lacks explicit deliverables: SubsystemObservability per-subsystem injection, deleted helpers, .with_recovery() on 4 error categories, stable error code namespace" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "integrate/phase-V" ;
+  triage:headSha "ec24c3e" ;
+  triage:occursIn <urn:atm:triage:worktree/integrate-phase-V/ec24c3e> .
+
+<urn:atm:triage:worktree/integrate-phase-V/ec24c3e>
+  a triage:WorktreeSnapshot ;
+  triage:branch "integrate/phase-V" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-V" ;
+  triage:headSha "ec24c3e" ;
+  triage:orderIndex 5 .

--- a/.triage/phase-V/findings/ATM-QA-V3-001.ttl
+++ b/.triage/phase-V/findings/ATM-QA-V3-001.ttl
@@ -1,0 +1,33 @@
+finding_id = "ATM-QA-V3-001"
+title = "sprint-V3.md AC5 unsatisfied: deletion record absent and YAML frontmatter stale"
+severity = "important"
+pattern = "ac-unsatisfied-deletion-record"
+repeatable = false
+sweep_scope = "docs/phase-V/"
+highest_open_branch = "feature/pV-s3-observability-cleanup"
+promote_to_branch = "feature/pV-s3-observability-cleanup"
+occurrences = [
+  { branch = "feature/pV-s3-observability-cleanup", file = "docs/phase-V/sprint-V3.md", lines = "1-end", status = "open" },
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = """
+Two defects folded into a single fix (ATM-QA-V3-002 is a minor sub-finding handled here):
+
+1. AC5 unsatisfied — no deletion record identifying what was deleted vs rewritten.
+   Five helpers removed in V.3 are not documented:
+     - map_command_event
+     - map_daemon_event
+     - map_runtime_event
+     - emit_runtime_event
+     - record_daemon_event
+   Sprint doc must identify each deleted symbol, confirm it was genuinely removed (not
+   renamed), and note whether any callsite migration was required.
+
+2. YAML frontmatter stale — sprint-V3.md metadata still shows planning-time values:
+     status: planned        → fix to: implemented
+     worktree: TBD          → fix to: /Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s3-observability-cleanup
+     branch: TBD            → fix to: feature/pV-s3-observability-cleanup
+
+Fix target: feature/pV-s3-observability-cleanup (V.3-only doc, not present on V.2).
+"""

--- a/.triage/phase-V/findings/ATM-QA-V3-002.ttl
+++ b/.triage/phase-V/findings/ATM-QA-V3-002.ttl
@@ -1,0 +1,22 @@
+finding_id = "ATM-QA-V3-002"
+title = "sprint-V3.md YAML frontmatter stale (status, worktree, branch fields)"
+severity = "minor"
+pattern = "stale-frontmatter"
+repeatable = false
+sweep_scope = "docs/phase-V/"
+highest_open_branch = "feature/pV-s3-observability-cleanup"
+promote_to_branch = "feature/pV-s3-observability-cleanup"
+occurrences = [
+  { branch = "feature/pV-s3-observability-cleanup", file = "docs/phase-V/sprint-V3.md", lines = "7-10", status = "open (folded into ATM-QA-V3-001 fix)" },
+]
+dispatch_ready = false
+dispatch_blocked_pending_triage_commit = false
+notes = """
+Folded into ATM-QA-V3-001 — fix both defects in a single edit pass on sprint-V3.md.
+Do NOT dispatch separately; ATM-QA-V3-001 is the dispatch target.
+
+Required frontmatter corrections:
+  status: planned        → implemented
+  worktree: TBD          → /Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s3-observability-cleanup
+  branch: TBD            → feature/pV-s3-observability-cleanup
+"""

--- a/.triage/phase-V/findings/ATM-QA-V4-002.ttl
+++ b/.triage/phase-V/findings/ATM-QA-V4-002.ttl
@@ -1,0 +1,51 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ATM-QA-V4-002>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-V4-002" ;
+  triage:title "recovery-text-rules.md coverage strategy misattributes clippy enforcement" ;
+  triage:description "docs/atm-daemon/recovery-text-rules.md line 115: coverage strategy states 'cargo clippy -- -D warnings verifies .with_recovery() coverage'. Clippy does not enforce recovery-text presence — it enforces general Rust hygiene only. This misleads future maintainers about how .with_recovery() coverage is validated. Fix: clarify that clippy verifies Rust hygiene only; .with_recovery() coverage is enforced by QA checklist review, not clippy." ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ATM-QA" ;
+  triage:phaseId "phase-V" ;
+  triage:severity "minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-05-13T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-V4-002/pV-s4/1> ;
+  triage:openOn <urn:atm:triage:worktree/pV-s4/84cacb0> ;
+  triage:promoteTo <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:occurrence/ATM-QA-V4-002/pV-s4/1>
+  a triage:Occurrence ;
+  triage:file "docs/atm-daemon/recovery-text-rules.md" ;
+  triage:line 115 ;
+  triage:snippet "workspace `cargo clippy -- -D warnings`" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:occursIn <urn:atm:triage:worktree/pV-s4/84cacb0> .
+
+<urn:atm:triage:worktree/pV-s2/46c703f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pV-s2-observability-migration" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s2-observability-migration" ;
+  triage:headSha "46c703f" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pV-s3/75ac70b>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pV-s3-observability-cleanup" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s3-observability-cleanup" ;
+  triage:headSha "75ac70b" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pV-s4/84cacb0>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pV-s4-recovery-hardening" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s4-recovery-hardening" ;
+  triage:headSha "84cacb0" ;
+  triage:orderIndex 4 .

--- a/.triage/phase-V/findings/QA-001.ttl
+++ b/.triage/phase-V/findings/QA-001.ttl
@@ -1,0 +1,14 @@
+finding_id = "QA-001"
+title = "cargo fmt failure in daemon_observability.rs"
+severity = "blocking"
+pattern = "fmt-failure"
+repeatable = false
+sweep_scope = "crates/atm-daemon/src/daemon_observability.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", lines = "10,17,679", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "Fixed in a single pass with: cargo fmt --manifest-path crates/atm-daemon/Cargo.toml (shared fix with QA-002 through QA-005)."

--- a/.triage/phase-V/findings/QA-002.ttl
+++ b/.triage/phase-V/findings/QA-002.ttl
@@ -1,0 +1,14 @@
+finding_id = "QA-002"
+title = "cargo fmt failure in composition.rs"
+severity = "blocking"
+pattern = "fmt-failure"
+repeatable = false
+sweep_scope = "crates/atm-daemon/src/composition.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/composition.rs", lines = "162", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "Fixed in a single pass with: cargo fmt --manifest-path crates/atm-daemon/Cargo.toml (shared fix with QA-001, QA-003 through QA-005)."

--- a/.triage/phase-V/findings/QA-003.ttl
+++ b/.triage/phase-V/findings/QA-003.ttl
@@ -1,0 +1,14 @@
+finding_id = "QA-003"
+title = "cargo fmt failure in host_ownership.rs"
+severity = "blocking"
+pattern = "fmt-failure"
+repeatable = false
+sweep_scope = "crates/atm-daemon/src/host_ownership.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/host_ownership.rs", lines = "58", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "Fixed in a single pass with: cargo fmt --manifest-path crates/atm-daemon/Cargo.toml (shared fix with QA-001, QA-002, QA-004, QA-005)."

--- a/.triage/phase-V/findings/QA-004.ttl
+++ b/.triage/phase-V/findings/QA-004.ttl
@@ -1,0 +1,14 @@
+finding_id = "QA-004"
+title = "cargo fmt failure in notification_runtime.rs"
+severity = "blocking"
+pattern = "fmt-failure"
+repeatable = false
+sweep_scope = "crates/atm-daemon/src/notification_runtime.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/notification_runtime.rs", lines = "92", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "Fixed in a single pass with: cargo fmt --manifest-path crates/atm-daemon/Cargo.toml (shared fix with QA-001 through QA-003, QA-005)."

--- a/.triage/phase-V/findings/QA-005.ttl
+++ b/.triage/phase-V/findings/QA-005.ttl
@@ -1,0 +1,14 @@
+finding_id = "QA-005"
+title = "cargo fmt failure in watch_runtime.rs"
+severity = "blocking"
+pattern = "fmt-failure"
+repeatable = false
+sweep_scope = "crates/atm-daemon/src/watch_runtime.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/watch_runtime.rs", lines = "205,254", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "Fixed in a single pass with: cargo fmt --manifest-path crates/atm-daemon/Cargo.toml (shared fix with QA-001 through QA-004)."

--- a/.triage/phase-V/findings/QA-006.ttl
+++ b/.triage/phase-V/findings/QA-006.ttl
@@ -1,0 +1,14 @@
+finding_id = "QA-006"
+title = "Naked #[allow(dead_code)] on unreachable constructors in boundary_adapters.rs"
+severity = "important"
+pattern = "naked-dead-code-allow"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/boundary_adapters.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/boundary_adapters.rs", lines = "33,82,124", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "Three constructors became unreachable after the _with_observability migration. Remove dead constructors or gate with #[cfg(test)] where test-only usage is the intent. Naked #[allow(dead_code)] suppresses a real signal; fix the root cause instead."

--- a/.triage/phase-V/findings/QA-007.ttl
+++ b/.triage/phase-V/findings/QA-007.ttl
@@ -1,0 +1,14 @@
+finding_id = "QA-007"
+title = "Naked #[allow(dead_code)] on NotificationRuntime::new() in notification_runtime.rs"
+severity = "important"
+pattern = "naked-dead-code-allow"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/notification_runtime.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/notification_runtime.rs", lines = "46", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "NotificationRuntime::new() is unreachable after the _with_observability migration. Remove the dead constructor or gate with #[cfg(test)] if test-only. Naked #[allow(dead_code)] suppresses a real signal; fix the root cause instead."

--- a/.triage/phase-V/findings/QA-008.ttl
+++ b/.triage/phase-V/findings/QA-008.ttl
@@ -1,0 +1,14 @@
+finding_id = "QA-008"
+title = "Naked #[allow(dead_code)] on PreparedRuntimeServer::bind() in local_ipc_transport.rs"
+severity = "important"
+pattern = "naked-dead-code-allow"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/local_ipc_transport.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/local_ipc_transport.rs", lines = "194", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "PreparedRuntimeServer::bind() is unreachable after the _with_observability migration. Remove the dead constructor or gate with #[cfg(test)] if test-only. Naked #[allow(dead_code)] suppresses a real signal; fix the root cause instead."

--- a/.triage/phase-V/findings/QA-009.ttl
+++ b/.triage/phase-V/findings/QA-009.ttl
@@ -1,0 +1,14 @@
+finding_id = "QA-009"
+title = "Naked #[allow(dead_code)] on PeerClientTransport::new() in peer_transport.rs"
+severity = "important"
+pattern = "naked-dead-code-allow"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/peer_transport.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/peer_transport.rs", lines = "108", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "PeerClientTransport::new() is unreachable after the _with_observability migration. Remove the dead constructor or gate with #[cfg(test)] if test-only. Naked #[allow(dead_code)] suppresses a real signal; fix the root cause instead."

--- a/.triage/phase-V/findings/QA-010.ttl
+++ b/.triage/phase-V/findings/QA-010.ttl
@@ -1,0 +1,14 @@
+finding_id = "QA-010"
+title = "Naked #[allow(dead_code)] on HostOwnershipAdapter::acquire_at() in host_ownership.rs"
+severity = "important"
+pattern = "naked-dead-code-allow"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/host_ownership.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/host_ownership.rs", lines = "60", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "HostOwnershipAdapter::acquire_at() is unreachable after the _with_observability migration. Remove the dead constructor or gate with #[cfg(test)] if test-only. Naked #[allow(dead_code)] suppresses a real signal; fix the root cause instead."

--- a/.triage/phase-V/findings/RBP-F001.ttl
+++ b/.triage/phase-V/findings/RBP-F001.ttl
@@ -1,0 +1,22 @@
+finding_id = "RBP-F001"
+title = ".expect() on Mutex::lock() in schedule_prune_old_files() production path"
+severity = "important"
+pattern = "expect-on-lock-production"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", line = 339, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 339, status = "open" },
+  { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/daemon_observability.rs", line = 352, status = "open" },
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = """
+schedule_prune_old_files() calls self.last_prune_request_at.lock().expect(\"retained sink prune request lock poisoned\").
+A poisoned mutex in a production path should return Err or log-and-skip, not panic.
+Fix on feature/pV-s2-observability-migration; merge-forward closes occurrences on s3 and s4.
+pV-s3 is at the same SHA (513d832) as pV-s2 so line numbers are identical.
+pV-s4 base SHA 8ecd999 carries the same code at line 352.
+"""

--- a/.triage/phase-V/findings/RBP-F001.ttl
+++ b/.triage/phase-V/findings/RBP-F001.ttl
@@ -8,7 +8,7 @@ highest_open_branch = "feature/pV-s2-observability-migration"
 promote_to_branch = "feature/pV-s2-observability-migration"
 occurrences = [
   { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", line = 339, status = "open" },
-  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 339, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 339, status = "open (carry-forward, closes on V.3 merge-forward from integrate/phase-V after V.2 fix lands)" },
   { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/daemon_observability.rs", line = 352, status = "open" },
 ]
 dispatch_ready = true

--- a/.triage/phase-V/findings/RBP-F002.ttl
+++ b/.triage/phase-V/findings/RBP-F002.ttl
@@ -9,8 +9,8 @@ promote_to_branch = "feature/pV-s2-observability-migration"
 occurrences = [
   { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", line = 445, status = "open" },
   { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", line = 446, status = "open" },
-  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 445, status = "open" },
-  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 446, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 445, status = "open (carry-forward, closes on V.3 merge-forward from integrate/phase-V after V.2 fix lands)" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 446, status = "open (carry-forward, closes on V.3 merge-forward from integrate/phase-V after V.2 fix lands)" },
   { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/daemon_observability.rs", line = 458, status = "open" },
   { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/daemon_observability.rs", line = 459, status = "open" },
 ]

--- a/.triage/phase-V/findings/RBP-F002.ttl
+++ b/.triage/phase-V/findings/RBP-F002.ttl
@@ -1,0 +1,25 @@
+finding_id = "RBP-F002"
+title = "Two .expect() on Mutex::lock() in LogSink::write() production path"
+severity = "important"
+pattern = "expect-on-lock-production"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", line = 445, status = "open" },
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", line = 446, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 445, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 446, status = "open" },
+  { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/daemon_observability.rs", line = 458, status = "open" },
+  { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/daemon_observability.rs", line = 459, status = "open" },
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = """
+LogSink::write() acquires two mutexes via .expect(): last_written_file (line 445) and health (line 446).
+Both are in a production write path and should propagate error or log-and-skip on mutex poison.
+pV-s3 is at the same SHA (513d832) as pV-s2; identical line numbers.
+pV-s4 base SHA 8ecd999 carries the same code at lines 458 and 459.
+Fix on feature/pV-s2-observability-migration; merge-forward closes occurrences on s3 and s4.
+"""

--- a/.triage/phase-V/findings/RBP-F003.ttl
+++ b/.triage/phase-V/findings/RBP-F003.ttl
@@ -1,0 +1,22 @@
+finding_id = "RBP-F003"
+title = ".expect() on Mutex::lock() in LogSink::flush() production path"
+severity = "important"
+pattern = "expect-on-lock-production"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", line = 455, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 455, status = "open" },
+  { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/daemon_observability.rs", line = 468, status = "open" },
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = """
+LogSink::flush() acquires last_written_file via .expect(\"retained sink file handle poisoned\").
+A poisoned mutex in a production flush path should propagate Err or log-and-skip, not panic.
+pV-s3 is at the same SHA (513d832) as pV-s2; identical line number.
+pV-s4 base SHA 8ecd999 carries the same code at line 468.
+Fix on feature/pV-s2-observability-migration; merge-forward closes occurrences on s3 and s4.
+"""

--- a/.triage/phase-V/findings/RBP-F003.ttl
+++ b/.triage/phase-V/findings/RBP-F003.ttl
@@ -8,7 +8,7 @@ highest_open_branch = "feature/pV-s2-observability-migration"
 promote_to_branch = "feature/pV-s2-observability-migration"
 occurrences = [
   { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", line = 455, status = "open" },
-  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 455, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 455, status = "open (carry-forward, closes on V.3 merge-forward from integrate/phase-V after V.2 fix lands)" },
   { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/daemon_observability.rs", line = 468, status = "open" },
 ]
 dispatch_ready = true

--- a/.triage/phase-V/findings/RBP-F004.ttl
+++ b/.triage/phase-V/findings/RBP-F004.ttl
@@ -8,7 +8,7 @@ highest_open_branch = "feature/pV-s2-observability-migration"
 promote_to_branch = "feature/pV-s2-observability-migration"
 occurrences = [
   { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", line = 465, status = "open" },
-  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 465, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 465, status = "open (carry-forward, closes on V.3 merge-forward from integrate/phase-V after V.2 fix lands)" },
   { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/daemon_observability.rs", line = 478, status = "open" },
 ]
 dispatch_ready = true

--- a/.triage/phase-V/findings/RBP-F004.ttl
+++ b/.triage/phase-V/findings/RBP-F004.ttl
@@ -1,0 +1,23 @@
+finding_id = "RBP-F004"
+title = ".expect() on Mutex::lock() in LogSink::health() production path"
+severity = "important"
+pattern = "expect-on-lock-production"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", line = 465, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/daemon_observability.rs", line = 465, status = "open" },
+  { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/daemon_observability.rs", line = 478, status = "open" },
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = """
+LogSink::health() acquires self.health via .expect(\"file sink health poisoned\").
+health() is a polling/inspection method called in production health-check paths.
+A poisoned mutex here should return a degraded SinkHealth or propagate Err, not panic.
+pV-s3 is at the same SHA (513d832) as pV-s2; identical line number.
+pV-s4 base SHA 8ecd999 carries the same code at line 478.
+Fix on feature/pV-s2-observability-migration; merge-forward closes occurrences on s3 and s4.
+"""

--- a/.triage/phase-V/findings/RBP-F005.ttl
+++ b/.triage/phase-V/findings/RBP-F005.ttl
@@ -1,0 +1,24 @@
+finding_id = "RBP-F005"
+title = ".expect() on thread::spawn() in WatchRuntime::shutdown() production path"
+severity = "important"
+pattern = "expect-on-spawn-production"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/watch_runtime.rs", line = 253, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/watch_runtime.rs", line = 253, status = "open" },
+  { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/watch_runtime.rs", line = 229, status = "open" },
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = """
+WatchRuntime::shutdown() spawns a join-helper thread via thread::Builder::new().spawn().expect(\"failed to spawn watch join helper\").
+Sibling subsystems in the daemon return Err on spawn failure; this panics instead.
+thread::spawn() fails under OS resource exhaustion (EAGAIN) — a production concern for a long-running daemon.
+Fix should propagate spawn error as Err or log-and-degrade consistent with sibling subsystem pattern.
+pV-s3 is at the same SHA (513d832) as pV-s2; identical line number.
+pV-s4 base SHA 8ecd999 carries the same code at line 229 (line offset differs due to earlier additions in V.2).
+Fix on feature/pV-s2-observability-migration; merge-forward closes occurrences on s3 and s4.
+"""

--- a/.triage/phase-V/findings/RBP-F005.ttl
+++ b/.triage/phase-V/findings/RBP-F005.ttl
@@ -8,7 +8,7 @@ highest_open_branch = "feature/pV-s2-observability-migration"
 promote_to_branch = "feature/pV-s2-observability-migration"
 occurrences = [
   { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/watch_runtime.rs", line = 253, status = "open" },
-  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/watch_runtime.rs", line = 253, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/watch_runtime.rs", line = 253, status = "open (carry-forward, closes on V.3 merge-forward from integrate/phase-V after V.2 fix lands)" },
   { branch = "feature/pV-s4-recovery-hardening", file = "crates/atm-daemon/src/watch_runtime.rs", line = 229, status = "open" },
 ]
 dispatch_ready = true

--- a/.triage/phase-V/findings/RBP-V3-F006.ttl
+++ b/.triage/phase-V/findings/RBP-V3-F006.ttl
@@ -1,0 +1,22 @@
+finding_id = "RBP-V3-F006"
+title = ".expect() on thread::spawn() in shutdown_lane_with_deadline() production shutdown path"
+severity = "important"
+pattern = "expect-on-spawn-production"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/composition.rs", line = 632, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/composition.rs", line = 587, status = "open (carry-forward, closes on V.3 merge-forward from integrate/phase-V after V.2 fix lands)" },
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = """
+shutdown_lane_with_deadline() spawns a deadline helper thread via thread::Builder::new().spawn().expect("spawn shutdown lane deadline helper").
+The function signature returns Result<(), AtmError>; a spawn failure should return Err rather than panic.
+This .expect() was introduced by the VQ2-002 fix in TASK-1463-ADD (0fa0345 on V.3); it also propagated
+back to V.2 (line 632). Both branches are open; fix must land on V.2 first so merge-forward closes V.3.
+Consistent with sibling subsystem pattern (see RBP-F005 in WatchRuntime::shutdown): propagate spawn
+error as Err or log-and-degrade.
+"""

--- a/.triage/phase-V/findings/RBP-V3-F007.ttl
+++ b/.triage/phase-V/findings/RBP-V3-F007.ttl
@@ -1,0 +1,21 @@
+finding_id = "RBP-V3-F007"
+title = ".expect() on thread::spawn() in spawn_shutdown_step() production shutdown path"
+severity = "important"
+pattern = "expect-on-spawn-production"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/runtime_health.rs", line = 120, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup", file = "crates/atm-daemon/src/runtime_health.rs", line = 122, status = "open (carry-forward, closes on V.3 merge-forward from integrate/phase-V after V.2 fix lands)" },
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = """
+spawn_shutdown_step() spawns a daemon shutdown finalizer thread via thread::Builder::new().spawn().expect("spawn daemon shutdown finalizer step").
+Confirmed present on V.2 branch at line 120; V.3 carries it at line 122 (line offset from V.3-only additions).
+Fix must land on V.2 (highest_open_branch); merge-forward closes the V.3 occurrence.
+Spawn failure under OS resource exhaustion (EAGAIN) is a realistic production concern for a long-running daemon;
+fix should propagate spawn error as Err or log-and-degrade consistent with sibling subsystem pattern.
+"""

--- a/.triage/phase-V/findings/VQ2-001.ttl
+++ b/.triage/phase-V/findings/VQ2-001.ttl
@@ -1,0 +1,33 @@
+finding_id = "VQ2-001"
+title = "RuntimeHealthMonitor delegates event construction to DaemonRequestDispatcher instead of owning SubsystemObservability"
+severity = "blocking"
+qa_round = 2
+source_file = "crates/atm-daemon/src/runtime_health.rs"
+source_line = 221
+pattern = "subsystem-delegation-violation"
+ac_violated = "AC2"
+ac_text = "Daemon subsystems emit their own structured events through the injected trait"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/"
+description = """
+DaemonRequestDispatcher::record_daemon_event() is a central event-construction
+proxy. RuntimeHealthMonitor calls it with DaemonSubsystem as a caller-supplied
+parameter rather than constructing DaemonEvent via its own injected
+SubsystemObservability instance. The monitor holds no SubsystemObservability
+field; event construction is fully delegated outward.
+
+Fix: inject SubsystemObservability into RuntimeHealthMonitor and have it emit
+events directly through the trait, removing the DaemonSubsystem parameter
+thread through record_daemon_event.
+"""
+highest_open_branch = "feature/pV-s3-observability-cleanup"
+promote_to_branch = "feature/pV-s3-observability-cleanup"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/runtime_health.rs", line = 221, status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup",   file = "crates/atm-daemon/src/runtime_health.rs", line = 221, status = "open" },
+]
+not_present_in = [
+  { branch = "feature/pV-s4-recovery-hardening", reason = "branch predates V.2 migration (SHA 8ecd999); does not contain record_daemon_event" },
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false

--- a/.triage/phase-V/findings/VQ2-002.ttl
+++ b/.triage/phase-V/findings/VQ2-002.ttl
@@ -1,0 +1,34 @@
+finding_id = "VQ2-002"
+title = "RuntimeComposition::begin_shutdown() and start() emit events via dispatcher proxy instead of owned SubsystemObservability"
+severity = "important"
+qa_round = 2
+source_file = "crates/atm-daemon/src/composition.rs"
+source_lines = "260-388"
+pattern = "subsystem-delegation-violation"
+ac_violated = "AC2"
+ac_text = "Daemon subsystems emit their own structured events through the injected trait"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/"
+description = """
+RuntimeComposition::begin_shutdown() (line 260) and start() (line 279 and
+throughout lines 260-388) call self.request_dispatcher.record_daemon_event(
+DaemonSubsystem::Composition, ...) repeatedly. RuntimeComposition has no
+SubsystemObservability field; it borrows the dispatcher as an event-construction
+proxy rather than emitting events through an owned trait instance.
+
+Fix: add a SubsystemObservability field to RuntimeComposition (wired at
+construction in RuntimeComposition::new()), replace all
+request_dispatcher.record_daemon_event(DaemonSubsystem::Composition, ...) calls
+in begin_shutdown() and start() with direct emit calls on the owned field.
+"""
+highest_open_branch = "feature/pV-s3-observability-cleanup"
+promote_to_branch = "feature/pV-s3-observability-cleanup"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/composition.rs", lines = "260-388", status = "open" },
+  { branch = "feature/pV-s3-observability-cleanup",   file = "crates/atm-daemon/src/composition.rs", lines = "260-388", status = "open" },
+]
+not_present_in = [
+  { branch = "feature/pV-s4-recovery-hardening", reason = "branch predates V.2 migration (SHA 8ecd999); does not contain record_daemon_event in composition.rs" },
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false

--- a/.triage/phase-V/findings/VQ2-003.ttl
+++ b/.triage/phase-V/findings/VQ2-003.ttl
@@ -1,0 +1,14 @@
+finding_id = "VQ2-003"
+title = "Test module imports DaemonSubsystem in daemon_observability.rs, violating hard boundary rule"
+severity = "important"
+pattern = "boundary-violation"
+repeatable = true
+sweep_scope = "crates/atm-daemon/src/daemon_observability.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_observability.rs", lines = "847", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "The shared observability layer must not import daemon subsystem types. This boundary applies equally inside #[cfg(test)] blocks — test code in this module lives in the observability crate scope and inherits its boundary constraints. Remove the DaemonSubsystem import from the test module; refactor the affected test to use a stub or a type that does not cross the boundary."

--- a/.triage/phase-V/findings/VQ2-004.ttl
+++ b/.triage/phase-V/findings/VQ2-004.ttl
@@ -1,0 +1,14 @@
+finding_id = "VQ2-004"
+title = "SubsystemObservability::emit() always passes TeamScope::None in daemon_runtime_observability.rs"
+severity = "minor"
+pattern = "hardcoded-scope"
+repeatable = false
+sweep_scope = "crates/atm-daemon/src/daemon_runtime_observability.rs"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "crates/atm-daemon/src/daemon_runtime_observability.rs", lines = "", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "emit() unconditionally passes TeamScope::None, discarding any team-scope context the caller may have. Wire through actual team scope from the call site or document explicitly why None is the correct invariant here."

--- a/.triage/phase-V/findings/VQ2-005.ttl
+++ b/.triage/phase-V/findings/VQ2-005.ttl
@@ -1,0 +1,14 @@
+finding_id = "VQ2-005"
+title = "sprint-V2.md AC4 partially satisfied due to VQ2-003 boundary gap"
+severity = "minor"
+pattern = "ac-partial-satisfaction"
+repeatable = false
+sweep_scope = "docs/phase-V/sprint-V2.md"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "docs/phase-V/sprint-V2.md", lines = "", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "AC4 (strict observability boundary enforcement) is not fully satisfied while VQ2-003 (DaemonSubsystem import in daemon_observability.rs test module) remains open. This finding closes automatically when VQ2-003 is resolved."

--- a/.triage/phase-V/findings/VQ2-006.ttl
+++ b/.triage/phase-V/findings/VQ2-006.ttl
@@ -1,0 +1,14 @@
+finding_id = "VQ2-006"
+title = "Doc alignment gap: sprint-V2.md does not reflect all files touched by observability migration"
+severity = "minor"
+pattern = "doc-alignment-gap"
+repeatable = false
+sweep_scope = "docs/phase-V/sprint-V2.md"
+highest_open_branch = "feature/pV-s2-observability-migration"
+promote_to_branch = "feature/pV-s2-observability-migration"
+occurrences = [
+  { branch = "feature/pV-s2-observability-migration", file = "docs/phase-V/sprint-V2.md", lines = "", status = "open" }
+]
+dispatch_ready = true
+dispatch_blocked_pending_triage_commit = false
+notes = "sprint-V2.md deliverable or file-scope section does not enumerate all files modified by the observability migration (e.g. boundary_adapters.rs, host_ownership.rs, notification_runtime.rs, peer_transport.rs, watch_runtime.rs). Update the plan doc to reflect actual scope so future reviewers have an accurate audit trail."

--- a/.triage/phase-V/worktrees.json
+++ b/.triage/phase-V/worktrees.json
@@ -1,0 +1,42 @@
+{
+  "phase_id": "phase-V",
+  "integration_branch": "integrate/phase-V",
+  "integration_worktree_path": "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-V",
+  "worktrees": [
+    {
+      "order": 0,
+      "branch": "integrate/phase-V",
+      "path": "/Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-V",
+      "head_sha": "264b77a39e9ff7202260e065b385bc3f5d599c38",
+      "status": "integration"
+    },
+    {
+      "order": 1,
+      "branch": "feature/pV-s1-observability-boundary",
+      "path": "/Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s1-observability-boundary",
+      "head_sha": "1be7d5a",
+      "status": "merged"
+    },
+    {
+      "order": 2,
+      "branch": "feature/pV-s2-observability-migration",
+      "path": "/Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s2-observability-migration",
+      "head_sha": "513d832318d1bd4e427b32626f55fdd68ba755f4",
+      "status": "open"
+    },
+    {
+      "order": 3,
+      "branch": "feature/pV-s3-observability-cleanup",
+      "path": "/Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s3-observability-cleanup",
+      "head_sha": "513d832318d1bd4e427b32626f55fdd68ba755f4",
+      "status": "in-progress"
+    },
+    {
+      "order": 4,
+      "branch": "feature/pV-s4-recovery-hardening",
+      "path": "/Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s4-recovery-hardening",
+      "head_sha": "8ecd99989b1bc5da5507f8c9b360f9c2e0470dfa",
+      "status": "queued"
+    }
+  ]
+}

--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -141,7 +141,10 @@ impl DaemonSupervisor {
                 return Err(AtmError::daemon_auto_start_failed(format!(
                     "failed to connect to daemon local IPC endpoint at {} after auto-start",
                     self.endpoint.display()
-                )));
+                ))
+                .with_recovery(
+                    "Inspect atm-daemon startup logs, confirm the daemon publishes its local IPC endpoint, and retry only after the same-host socket becomes reachable.",
+                ));
             }
             if Instant::now() >= deadline {
                 return Err(LaunchGateGuard::rejected_error(&self.endpoint));
@@ -174,6 +177,9 @@ impl DaemonSupervisor {
                 "failed to spawn daemon binary at {}",
                 self.daemon_bin.display()
             ))
+            .with_recovery(
+                "Confirm ATM_DAEMON_BIN points to an executable atm-daemon binary and retry after fixing the daemon launch environment.",
+            )
             .with_source(source)
         })?;
         Ok(())
@@ -196,6 +202,9 @@ impl LaunchGateGuard {
             "daemon launch gate remained owned while connecting to {}",
             endpoint.display()
         ))
+        .with_recovery(
+            "Wait for the in-flight daemon launch to finish, then retry the same-host connection. If the launch gate stays owned, inspect the launch-lock owner and clear stale launch state before retrying.",
+        )
     }
 
     pub fn try_acquire_at(lock_path: PathBuf) -> Result<Option<Self>, AtmError> {
@@ -205,6 +214,9 @@ impl LaunchGateGuard {
                     "failed to create daemon launch lock directory at {}",
                     parent.display()
                 ))
+                .with_recovery(
+                    "Create or grant write access to the daemon launch-lock directory before retrying daemon auto-start.",
+                )
                 .with_source(source)
             })?;
         }
@@ -219,6 +231,9 @@ impl LaunchGateGuard {
                     "failed to open daemon launch gate at {}",
                     lock_path.display()
                 ))
+                .with_recovery(
+                    "Confirm the daemon launch-lock path is writable and not blocked by another process before retrying daemon auto-start.",
+                )
                 .with_source(source)
             })?;
 
@@ -229,6 +244,9 @@ impl LaunchGateGuard {
                 "failed to acquire daemon launch gate at {}",
                 lock_path.display()
             ))
+            .with_recovery(
+                "Inspect the daemon launch-lock owner and repair stale lock state before retrying daemon auto-start.",
+            )
             .with_source(source)),
         }
     }

--- a/crates/atm-daemon/src/advisory_runtime.rs
+++ b/crates/atm-daemon/src/advisory_runtime.rs
@@ -15,15 +15,18 @@ use atm_core::protocol::ResponseEnvelope;
 use atm_core::send::SendOutcome;
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 const MAX_ADVISORY_SESSIONS: usize = 128;
 const MAX_ADVISORY_EVENTS_PER_SESSION: usize = 256;
 const STREAM_IDLE_WAIT: Duration = Duration::from_millis(100);
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct AdvisoryRuntime {
     state: RwLock<AdvisoryRuntimeState>,
     max_sessions: usize,
     max_nudges_per_session: usize,
+    observability: SubsystemObservability,
 }
 
 #[derive(Debug, Default)]
@@ -43,11 +46,19 @@ struct RegisteredAdvisorySession {
 }
 
 impl AdvisoryRuntime {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::AdvisoryRuntime,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
             state: RwLock::new(AdvisoryRuntimeState::default()),
             max_sessions: MAX_ADVISORY_SESSIONS,
             max_nudges_per_session: MAX_ADVISORY_EVENTS_PER_SESSION,
+            observability,
         }
     }
 
@@ -57,6 +68,7 @@ impl AdvisoryRuntime {
             state: RwLock::new(AdvisoryRuntimeState::default()),
             max_sessions,
             max_nudges_per_session,
+            observability: SubsystemObservability::disabled(DaemonSubsystem::AdvisoryRuntime),
         }
     }
 
@@ -66,6 +78,16 @@ impl AdvisoryRuntime {
     ) -> Result<AdvisorySessionRegistrationResponse, AtmError> {
         let mut state = self.lock_state_write()?;
         if state.sessions.contains_key(&request.session_id) {
+            let event = self
+                .observability
+                .event(
+                    "register_session",
+                    "rejected",
+                    "advisory session registration reused an existing session id",
+                )
+                .with_team(request.team.clone())
+                .with_agent(request.agent.clone());
+            let _ = self.observability.emit_event(event);
             return Err(AtmError::daemon_advisory_session_already_registered(format!(
                 "advisory session {} is already registered",
                 request.session_id
@@ -75,6 +97,16 @@ impl AdvisoryRuntime {
             ));
         }
         if state.sessions.len() >= self.max_sessions {
+            let event = self
+                .observability
+                .event(
+                    "register_session",
+                    "rejected",
+                    "advisory session registration hit the bounded session cap",
+                )
+                .with_team(request.team.clone())
+                .with_agent(request.agent.clone());
+            let _ = self.observability.emit_event(event);
             return Err(AtmError::daemon_unavailable(format!(
                 "advisory session registration rejected because the daemon session cap {} is exhausted",
                 self.max_sessions
@@ -97,6 +129,12 @@ impl AdvisoryRuntime {
                 dropped_count: 0,
             },
         );
+        let event = self
+            .observability
+            .event("register_session", "ok", "advisory session registered")
+            .with_team(request.team.clone())
+            .with_agent(request.agent.clone());
+        let _ = self.observability.emit_event(event);
 
         Ok(AdvisorySessionRegistrationResponse {
             team: request.team,
@@ -113,6 +151,15 @@ impl AdvisoryRuntime {
     ) -> Result<AdvisorySessionUnregistrationResponse, AtmError> {
         let mut state = self.lock_state_write()?;
         let closed = state.sessions.remove(&request.session_id).is_some();
+        let _ = self.observability.emit(
+            "unregister_session",
+            if closed { "ok" } else { "noop" },
+            if closed {
+                "advisory session unregistered"
+            } else {
+                "advisory session unregistration found no registered session"
+            },
+        );
         Ok(AdvisorySessionUnregistrationResponse {
             session_id: request.session_id,
             closed,
@@ -239,6 +286,20 @@ impl AdvisoryRuntime {
                 if session.nudges.len() >= self.max_nudges_per_session {
                     session.dropped_count = session.dropped_count.saturating_add(1);
                     overflowed = true;
+                    let mut event = self
+                        .observability
+                        .event(
+                            "enqueue_nudge",
+                            "degraded",
+                            "advisory queue rejected an event because the bounded session queue is full",
+                        )
+                        .with_team(outcome.team.clone())
+                        .with_agent(outcome.agent.clone());
+                    event = event.with_message_id(outcome.message_id);
+                    if let Some(task_id) = outcome.task_id.clone() {
+                        event = event.with_task_id(task_id);
+                    }
+                    let _ = self.observability.emit_event(event);
                     tracing::debug!(
                         session_id = %session_id,
                         team = %outcome.team,
@@ -253,6 +314,26 @@ impl AdvisoryRuntime {
             }
         }
         if matched {
+            let mut event = self
+                .observability
+                .event(
+                    "enqueue_nudge",
+                    if overflowed { "degraded" } else { "ok" },
+                    if overflowed {
+                        "advisory runtime enqueued at least one nudge and dropped at least one due to queue pressure"
+                    } else {
+                        "advisory runtime queued a nudge for a registered session"
+                    },
+                )
+                .with_team(outcome.team.clone())
+                .with_agent(outcome.agent.clone())
+                .with_recipient(outcome.agent.clone())
+                .with_sender(outcome.sender.clone());
+            event = event.with_message_id(outcome.message_id);
+            if let Some(task_id) = outcome.task_id.clone() {
+                event = event.with_task_id(task_id);
+            }
+            let _ = self.observability.emit_event(event);
             tracing::debug!(
                 team = %outcome.team,
                 agent = %outcome.agent,

--- a/crates/atm-daemon/src/boundary_adapters.rs
+++ b/crates/atm-daemon/src/boundary_adapters.rs
@@ -12,8 +12,6 @@ use atm_core::{
 };
 use std::sync::Arc;
 
-#[cfg(test)]
-use crate::DaemonSubsystem;
 use crate::SubsystemObservability;
 use crate::direct_boundaries;
 use crate::notification_runtime::NotificationRuntime;
@@ -32,13 +30,6 @@ impl std::fmt::Debug for DaemonNotificationSink {
 }
 
 impl DaemonNotificationSink {
-    #[cfg(test)]
-    pub(crate) fn new() -> Self {
-        Self::new_with_observability(SubsystemObservability::disabled(
-            DaemonSubsystem::NotificationRuntime,
-        ))
-    }
-
     pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
             runtime: NotificationRuntime::new_with_observability(observability),
@@ -81,13 +72,6 @@ impl std::fmt::Debug for FileWatchEventSource {
 }
 
 impl FileWatchEventSource {
-    #[cfg(test)]
-    pub(crate) fn new() -> Self {
-        Self::new_with_observability(SubsystemObservability::disabled(
-            DaemonSubsystem::WatchRuntime,
-        ))
-    }
-
     pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
             runtime: WatchRuntime::new_with_observability(observability),
@@ -123,20 +107,6 @@ impl std::fmt::Debug for DaemonReconcileCoordinator {
 }
 
 impl DaemonReconcileCoordinator {
-    #[cfg(test)]
-    pub(crate) fn new(
-        watch_event_source: FileWatchEventSource,
-        inbox_ingress: DaemonInboxIngress,
-        notification_sink: DaemonNotificationSink,
-    ) -> Self {
-        Self::new_with_observability(
-            watch_event_source,
-            inbox_ingress,
-            notification_sink,
-            SubsystemObservability::disabled(DaemonSubsystem::ReconcileRuntime),
-        )
-    }
-
     pub(crate) fn new_with_observability(
         watch_event_source: FileWatchEventSource,
         inbox_ingress: DaemonInboxIngress,

--- a/crates/atm-daemon/src/boundary_adapters.rs
+++ b/crates/atm-daemon/src/boundary_adapters.rs
@@ -16,6 +16,7 @@ use crate::direct_boundaries;
 use crate::notification_runtime::NotificationRuntime;
 use crate::reconcile_runtime::ReconcileRuntime;
 use crate::watch_runtime::WatchRuntime;
+use crate::{DaemonSubsystem, SubsystemObservability};
 
 #[derive(Clone)]
 pub(crate) struct DaemonNotificationSink {
@@ -29,9 +30,16 @@ impl std::fmt::Debug for DaemonNotificationSink {
 }
 
 impl DaemonNotificationSink {
+    #[allow(dead_code)]
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::NotificationRuntime,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
-            runtime: NotificationRuntime::new(),
+            runtime: NotificationRuntime::new_with_observability(observability),
         }
     }
 
@@ -71,9 +79,16 @@ impl std::fmt::Debug for FileWatchEventSource {
 }
 
 impl FileWatchEventSource {
+    #[allow(dead_code)]
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::WatchRuntime,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
-            runtime: WatchRuntime::new(),
+            runtime: WatchRuntime::new_with_observability(observability),
         }
     }
 
@@ -106,16 +121,32 @@ impl std::fmt::Debug for DaemonReconcileCoordinator {
 }
 
 impl DaemonReconcileCoordinator {
+    #[allow(dead_code)]
     pub(crate) fn new(
         watch_event_source: FileWatchEventSource,
         inbox_ingress: DaemonInboxIngress,
         notification_sink: DaemonNotificationSink,
     ) -> Self {
+        Self::new_with_observability(
+            watch_event_source,
+            inbox_ingress,
+            notification_sink,
+            SubsystemObservability::disabled(DaemonSubsystem::ReconcileRuntime),
+        )
+    }
+
+    pub(crate) fn new_with_observability(
+        watch_event_source: FileWatchEventSource,
+        inbox_ingress: DaemonInboxIngress,
+        notification_sink: DaemonNotificationSink,
+        observability: SubsystemObservability,
+    ) -> Self {
         Self {
-            runtime: ReconcileRuntime::new(
+            runtime: ReconcileRuntime::new_with_observability(
                 Arc::new(watch_event_source),
                 Arc::new(inbox_ingress),
                 Arc::new(notification_sink),
+                observability,
             ),
         }
     }

--- a/crates/atm-daemon/src/boundary_adapters.rs
+++ b/crates/atm-daemon/src/boundary_adapters.rs
@@ -12,11 +12,13 @@ use atm_core::{
 };
 use std::sync::Arc;
 
+#[cfg(test)]
+use crate::DaemonSubsystem;
+use crate::SubsystemObservability;
 use crate::direct_boundaries;
 use crate::notification_runtime::NotificationRuntime;
 use crate::reconcile_runtime::ReconcileRuntime;
 use crate::watch_runtime::WatchRuntime;
-use crate::{DaemonSubsystem, SubsystemObservability};
 
 #[derive(Clone)]
 pub(crate) struct DaemonNotificationSink {
@@ -30,7 +32,7 @@ impl std::fmt::Debug for DaemonNotificationSink {
 }
 
 impl DaemonNotificationSink {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::new_with_observability(SubsystemObservability::disabled(
             DaemonSubsystem::NotificationRuntime,
@@ -79,7 +81,7 @@ impl std::fmt::Debug for FileWatchEventSource {
 }
 
 impl FileWatchEventSource {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::new_with_observability(SubsystemObservability::disabled(
             DaemonSubsystem::WatchRuntime,
@@ -121,7 +123,7 @@ impl std::fmt::Debug for DaemonReconcileCoordinator {
 }
 
 impl DaemonReconcileCoordinator {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn new(
         watch_event_source: FileWatchEventSource,
         inbox_ingress: DaemonInboxIngress,

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -125,6 +125,7 @@ pub(crate) struct RuntimeComposition {
     endpoint_guard: Mutex<Option<SocketEndpointGuard>>,
     server_transport: LocalIpcServerTransportAdapter,
     request_dispatcher: Arc<DaemonRequestDispatcher>,
+    composition_observability: SubsystemObservability,
     _notification_sink: DaemonNotificationSink,
     _status_source: DaemonStatusSource,
     _watch_event_source: FileWatchEventSource,
@@ -204,6 +205,10 @@ impl RuntimeComposition {
                 status_cache.clone(),
                 Arc::clone(&observability),
             )),
+            composition_observability: SubsystemObservability::new(
+                DaemonSubsystem::Composition,
+                Arc::clone(&observability),
+            ),
             _notification_sink: notification_sink.clone(),
             _status_source: DaemonStatusSource::new(status_cache),
             _watch_event_source: watch_event_source.clone(),
@@ -255,8 +260,7 @@ impl RuntimeComposition {
     }
 
     fn begin_shutdown(&self) -> Result<(), AtmError> {
-        self.request_dispatcher.record_daemon_event(
-            DaemonSubsystem::Composition,
+        let _ = self.composition_observability.emit(
             "shutdown_requested",
             "ok",
             "daemon shutdown requested",
@@ -273,25 +277,24 @@ impl RuntimeComposition {
         self.request_dispatcher.finalize_shutdown();
     }
 
+    fn emit_composition_event(
+        &self,
+        action: &'static str,
+        outcome: &'static str,
+        detail: &'static str,
+    ) {
+        let _ = self.composition_observability.emit(action, outcome, detail);
+    }
+
     pub(crate) fn start(&self) -> Result<(), AtmError> {
-        self.request_dispatcher.record_daemon_event(
-            DaemonSubsystem::Composition,
-            "start_requested",
-            "ok",
-            "daemon start requested",
-        );
+        self.emit_composition_event("start_requested", "ok", "daemon start requested");
         self.lifecycle.transition(RuntimeLifecycleState::Starting)?;
         // Startup replay must finish before the daemon binds its socket so
         // crash-recovered work cannot race newly accepted requests.
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.request_dispatcher.record_daemon_event(
-                    DaemonSubsystem::Composition,
-                    "startup_failed",
-                    "failed",
-                    "daemon startup failed",
-                );
+                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
@@ -308,12 +311,7 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.request_dispatcher.record_daemon_event(
-                DaemonSubsystem::Composition,
-                "startup_failed",
-                "failed",
-                "daemon startup failed",
-            );
+            self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
             self.lifecycle.force_stopped()?;
             return Err(error);
         }
@@ -326,24 +324,14 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during runtime preparation rollback"
                     );
                 }
-                self.request_dispatcher.record_daemon_event(
-                    DaemonSubsystem::Composition,
-                    "startup_failed",
-                    "failed",
-                    "daemon startup failed",
-                );
+                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.request_dispatcher.record_daemon_event(
-            DaemonSubsystem::Composition,
-            "startup_completed",
-            "ok",
-            "daemon startup completed",
-        );
+        self.emit_composition_event("startup_completed", "ok", "daemon startup completed");
         let request_dispatcher = Arc::clone(&self.request_dispatcher);
         let endpoint_guard = self.take_endpoint_guard()?;
         let result = runtime.serve_with_runtime_hooks(
@@ -368,22 +356,12 @@ impl RuntimeComposition {
         socket_path: PathBuf,
         ready_signal: Option<std::sync::mpsc::SyncSender<()>>,
     ) -> Result<(), AtmError> {
-        self.request_dispatcher.record_daemon_event(
-            DaemonSubsystem::Composition,
-            "start_requested",
-            "ok",
-            "daemon start requested",
-        );
+        self.emit_composition_event("start_requested", "ok", "daemon start requested");
         self.lifecycle.transition(RuntimeLifecycleState::Starting)?;
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.request_dispatcher.record_daemon_event(
-                    DaemonSubsystem::Composition,
-                    "startup_failed",
-                    "failed",
-                    "daemon startup failed",
-                );
+                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
@@ -400,12 +378,7 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.request_dispatcher.record_daemon_event(
-                DaemonSubsystem::Composition,
-                "startup_failed",
-                "failed",
-                "daemon startup failed",
-            );
+            self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
             self.lifecycle.force_stopped()?;
             return Err(error);
         }
@@ -421,24 +394,14 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during test runtime preparation rollback"
                     );
                 }
-                self.request_dispatcher.record_daemon_event(
-                    DaemonSubsystem::Composition,
-                    "startup_failed",
-                    "failed",
-                    "daemon startup failed",
-                );
+                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.request_dispatcher.record_daemon_event(
-            DaemonSubsystem::Composition,
-            "startup_completed",
-            "ok",
-            "daemon startup completed",
-        );
+        self.emit_composition_event("startup_completed", "ok", "daemon startup completed");
         let request_dispatcher = Arc::clone(&self.request_dispatcher);
         let endpoint_guard = self.take_endpoint_guard()?;
         let result = runtime.serve_with_runtime_hooks(
@@ -494,18 +457,12 @@ impl RuntimeComposition {
             };
         }
         match result.as_ref() {
-            Ok(()) => self.request_dispatcher.record_daemon_event(
-                DaemonSubsystem::Composition,
-                "shutdown_completed",
-                "ok",
-                "daemon shutdown completed",
-            ),
-            Err(_) => self.request_dispatcher.record_daemon_event(
-                DaemonSubsystem::Composition,
-                "shutdown_failed",
-                "failed",
-                "daemon shutdown failed",
-            ),
+            Ok(()) => {
+                self.emit_composition_event("shutdown_completed", "ok", "daemon shutdown completed")
+            }
+            Err(_) => {
+                self.emit_composition_event("shutdown_failed", "failed", "daemon shutdown failed")
+            }
         }
         result
     }

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -65,7 +65,12 @@ impl RuntimeLifecycle {
         let mut state = self
             .state
             .lock()
-            .map_err(|_| AtmError::daemon_unavailable("runtime lifecycle state lock poisoned"))?;
+            .map_err(|_| {
+                AtmError::daemon_unavailable("runtime lifecycle state lock poisoned")
+                    .with_recovery(
+                        "Restart atm-daemon; runtime lifecycle transitions can no longer be trusted after the poisoned state lock.",
+                    )
+            })?;
         let current = *state;
         if !matches!(
             (current, next),
@@ -106,7 +111,12 @@ impl RuntimeLifecycle {
         let mut state = self
             .state
             .lock()
-            .map_err(|_| AtmError::daemon_unavailable("runtime lifecycle state lock poisoned"))?;
+            .map_err(|_| {
+                AtmError::daemon_unavailable("runtime lifecycle state lock poisoned")
+                    .with_recovery(
+                        "Restart atm-daemon; runtime lifecycle transitions can no longer be trusted after the poisoned state lock.",
+                    )
+            })?;
         *state = RuntimeLifecycleState::Stopped;
         Ok(())
     }
@@ -600,6 +610,9 @@ where
                 AtmError::daemon_unavailable(format!(
                     "daemon {lane_name} shutdown worker panicked unexpectedly"
                 ))
+                .with_recovery(
+                    "Restart atm-daemon; one shutdown lane crashed while the runtime was draining background work.",
+                )
             })?;
             result
         }
@@ -612,18 +625,27 @@ where
             );
             Err(AtmError::daemon_unavailable(format!(
                 "daemon {lane_name} shutdown exceeded the {deadline:?} per-lane deadline"
-            )))
+            ))
+            .with_recovery(
+                "Restart atm-daemon after the stalled background lane stops holding runtime shutdown open.",
+            ))
         }
         Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => shutdown_handle.join().map_or_else(
             |_| {
                 Err(AtmError::daemon_unavailable(format!(
                     "daemon {lane_name} shutdown worker panicked unexpectedly"
-                )))
+                ))
+                .with_recovery(
+                    "Restart atm-daemon; one shutdown lane crashed while the runtime was draining background work.",
+                ))
             },
             |_| {
                 Err(AtmError::daemon_unavailable(format!(
                     "daemon {lane_name} shutdown worker disconnected unexpectedly"
-                )))
+                ))
+                .with_recovery(
+                    "Restart atm-daemon; one shutdown lane stopped reporting progress during runtime teardown.",
+                ))
             },
         ),
     }

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -627,7 +627,15 @@ where
         .spawn(move || {
             let _ = result_tx.send(shutdown(lane));
         })
-        .expect("spawn shutdown lane deadline helper");
+        .map_err(|source| {
+            AtmError::daemon_unavailable(format!(
+                "failed to spawn daemon {lane_name} shutdown deadline helper"
+            ))
+            .with_recovery(
+                "Restart atm-daemon; the bounded background-lane shutdown helper could not be created.",
+            )
+            .with_source(source)
+        })?;
     let shutdown_thread_id = shutdown_handle.thread().id();
     match result_rx.recv_timeout(deadline) {
         Ok(result) => {

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -2,13 +2,13 @@ use crate::boundary_adapters::{
     DaemonConfigIngress, DaemonInboxExport, DaemonInboxIngress, DaemonNotificationSink,
     DaemonReconcileCoordinator, FileWatchEventSource,
 };
-use crate::daemon_runtime_observability::DaemonRuntimeObservability;
+use crate::daemon_runtime_observability::{DaemonRuntimeObservability, SubsystemObservability};
 use crate::host_ownership::HostOwnershipAdapter;
 use crate::local_ipc_transport::{RuntimeServeHooks, SocketEndpointGuard};
 use crate::runtime_health::DaemonRequestDispatcher;
 use crate::runtime_health::{DaemonStatusSource, RuntimeStatusCache};
 use crate::{
-    AtmHomeDir, LocalIpcServerTransportAdapter, PeerTransportRuntime,
+    AtmHomeDir, DaemonSubsystem, LocalIpcServerTransportAdapter, PeerTransportRuntime,
     sqlite_remote_replay_store_from_path,
 };
 use atm_core::boundary::RequestDispatcher;
@@ -153,9 +153,20 @@ impl RuntimeComposition {
         replay_store_path: PathBuf,
         observability: Arc<dyn DaemonRuntimeObservability>,
     ) -> Result<Self, AtmError> {
-        let status_cache = RuntimeStatusCache::new();
-        let notification_sink = DaemonNotificationSink::new();
-        let watch_event_source = FileWatchEventSource::new();
+        let status_cache = RuntimeStatusCache::new_with_observability(SubsystemObservability::new(
+            DaemonSubsystem::RuntimeStatusCache,
+            Arc::clone(&observability),
+        ));
+        let notification_sink =
+            DaemonNotificationSink::new_with_observability(SubsystemObservability::new(
+                DaemonSubsystem::NotificationRuntime,
+                Arc::clone(&observability),
+            ));
+        let watch_event_source =
+            FileWatchEventSource::new_with_observability(SubsystemObservability::new(
+                DaemonSubsystem::WatchRuntime,
+                Arc::clone(&observability),
+            ));
         let inbox_ingress = DaemonInboxIngress::new();
         let replay_store = match sqlite_remote_replay_store_from_path(replay_store_path) {
             Ok(store) => Some(store),
@@ -169,26 +180,51 @@ impl RuntimeComposition {
         };
         Ok(Self {
             lifecycle: Arc::new(RuntimeLifecycle::new()),
-            host_ownership_adapter: HostOwnershipAdapter::new(),
+            host_ownership_adapter: HostOwnershipAdapter::new_with_observability(
+                SubsystemObservability::new(
+                    DaemonSubsystem::HostOwnership,
+                    Arc::clone(&observability),
+                ),
+            ),
             endpoint_guard: Mutex::new(None),
-            server_transport: LocalIpcServerTransportAdapter::new(),
+            server_transport: LocalIpcServerTransportAdapter::new_with_observability(
+                SubsystemObservability::new(
+                    DaemonSubsystem::LocalIpcTransport,
+                    Arc::clone(&observability),
+                ),
+                SubsystemObservability::new(
+                    DaemonSubsystem::HostOwnership,
+                    Arc::clone(&observability),
+                ),
+                SubsystemObservability::new(
+                    DaemonSubsystem::LifecycleControl,
+                    Arc::clone(&observability),
+                ),
+            ),
             request_dispatcher: Arc::new(DaemonRequestDispatcher::new(
                 home_dir,
                 status_cache.clone(),
-                observability,
+                Arc::clone(&observability),
             )),
             _notification_sink: notification_sink.clone(),
             _status_source: DaemonStatusSource::new(status_cache),
             _watch_event_source: watch_event_source.clone(),
-            _reconcile_coordinator: DaemonReconcileCoordinator::new(
+            _reconcile_coordinator: DaemonReconcileCoordinator::new_with_observability(
                 watch_event_source,
                 inbox_ingress.clone(),
                 notification_sink,
+                SubsystemObservability::new(
+                    DaemonSubsystem::ReconcileRuntime,
+                    Arc::clone(&observability),
+                ),
             ),
             _config_ingress: DaemonConfigIngress::new(),
             _inbox_ingress: inbox_ingress,
             _inbox_export: DaemonInboxExport::new(),
-            peer_transport_runtime: PeerTransportRuntime::new(replay_store),
+            peer_transport_runtime: PeerTransportRuntime::new_with_observability(
+                replay_store,
+                SubsystemObservability::new(DaemonSubsystem::PeerTransport, observability),
+            ),
         })
     }
 
@@ -221,7 +257,8 @@ impl RuntimeComposition {
     }
 
     fn begin_shutdown(&self) -> Result<(), AtmError> {
-        self.request_dispatcher.record_runtime_event(
+        self.request_dispatcher.record_daemon_event(
+            DaemonSubsystem::Composition,
             "shutdown_requested",
             "ok",
             "daemon shutdown requested",
@@ -239,7 +276,8 @@ impl RuntimeComposition {
     }
 
     pub(crate) fn start(&self) -> Result<(), AtmError> {
-        self.request_dispatcher.record_runtime_event(
+        self.request_dispatcher.record_daemon_event(
+            DaemonSubsystem::Composition,
             "start_requested",
             "ok",
             "daemon start requested",
@@ -250,7 +288,8 @@ impl RuntimeComposition {
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.request_dispatcher.record_runtime_event(
+                self.request_dispatcher.record_daemon_event(
+                    DaemonSubsystem::Composition,
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -271,7 +310,8 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.request_dispatcher.record_runtime_event(
+            self.request_dispatcher.record_daemon_event(
+                DaemonSubsystem::Composition,
                 "startup_failed",
                 "failed",
                 "daemon startup failed",
@@ -288,7 +328,8 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during runtime preparation rollback"
                     );
                 }
-                self.request_dispatcher.record_runtime_event(
+                self.request_dispatcher.record_daemon_event(
+                    DaemonSubsystem::Composition,
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -299,7 +340,8 @@ impl RuntimeComposition {
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.request_dispatcher.record_runtime_event(
+        self.request_dispatcher.record_daemon_event(
+            DaemonSubsystem::Composition,
             "startup_completed",
             "ok",
             "daemon startup completed",
@@ -328,7 +370,8 @@ impl RuntimeComposition {
         socket_path: PathBuf,
         ready_signal: Option<std::sync::mpsc::SyncSender<()>>,
     ) -> Result<(), AtmError> {
-        self.request_dispatcher.record_runtime_event(
+        self.request_dispatcher.record_daemon_event(
+            DaemonSubsystem::Composition,
             "start_requested",
             "ok",
             "daemon start requested",
@@ -337,7 +380,8 @@ impl RuntimeComposition {
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.request_dispatcher.record_runtime_event(
+                self.request_dispatcher.record_daemon_event(
+                    DaemonSubsystem::Composition,
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -358,7 +402,8 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.request_dispatcher.record_runtime_event(
+            self.request_dispatcher.record_daemon_event(
+                DaemonSubsystem::Composition,
                 "startup_failed",
                 "failed",
                 "daemon startup failed",
@@ -378,7 +423,8 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during test runtime preparation rollback"
                     );
                 }
-                self.request_dispatcher.record_runtime_event(
+                self.request_dispatcher.record_daemon_event(
+                    DaemonSubsystem::Composition,
                     "startup_failed",
                     "failed",
                     "daemon startup failed",
@@ -389,7 +435,8 @@ impl RuntimeComposition {
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.request_dispatcher.record_runtime_event(
+        self.request_dispatcher.record_daemon_event(
+            DaemonSubsystem::Composition,
             "startup_completed",
             "ok",
             "daemon startup completed",
@@ -449,12 +496,14 @@ impl RuntimeComposition {
             };
         }
         match result.as_ref() {
-            Ok(()) => self.request_dispatcher.record_runtime_event(
+            Ok(()) => self.request_dispatcher.record_daemon_event(
+                DaemonSubsystem::Composition,
                 "shutdown_completed",
                 "ok",
                 "daemon shutdown completed",
             ),
-            Err(_) => self.request_dispatcher.record_runtime_event(
+            Err(_) => self.request_dispatcher.record_daemon_event(
+                DaemonSubsystem::Composition,
                 "shutdown_failed",
                 "failed",
                 "daemon shutdown failed",

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -162,11 +162,9 @@ impl RuntimeComposition {
                 DaemonSubsystem::NotificationRuntime,
                 Arc::clone(&observability),
             ));
-        let watch_event_source =
-            FileWatchEventSource::new_with_observability(SubsystemObservability::new(
-                DaemonSubsystem::WatchRuntime,
-                Arc::clone(&observability),
-            ));
+        let watch_event_source = FileWatchEventSource::new_with_observability(
+            SubsystemObservability::new(DaemonSubsystem::WatchRuntime, Arc::clone(&observability)),
+        );
         let inbox_ingress = DaemonInboxIngress::new();
         let replay_store = match sqlite_remote_replay_store_from_path(replay_store_path) {
             Ok(store) => Some(store),

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -287,24 +287,21 @@ impl RuntimeComposition {
         self.request_dispatcher.finalize_shutdown();
     }
 
-    fn emit_composition_event(
-        &self,
-        action: &'static str,
-        outcome: &'static str,
-        detail: &'static str,
-    ) {
-        let _ = self.composition_observability.emit(action, outcome, detail);
-    }
-
     pub(crate) fn start(&self) -> Result<(), AtmError> {
-        self.emit_composition_event("start_requested", "ok", "daemon start requested");
+        let _ =
+            self.composition_observability
+                .emit("start_requested", "ok", "daemon start requested");
         self.lifecycle.transition(RuntimeLifecycleState::Starting)?;
         // Startup replay must finish before the daemon binds its socket so
         // crash-recovered work cannot race newly accepted requests.
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+                let _ = self.composition_observability.emit(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
@@ -321,7 +318,11 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+            let _ = self.composition_observability.emit(
+                "startup_failed",
+                "failed",
+                "daemon startup failed",
+            );
             self.lifecycle.force_stopped()?;
             return Err(error);
         }
@@ -334,14 +335,22 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during runtime preparation rollback"
                     );
                 }
-                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+                let _ = self.composition_observability.emit(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.emit_composition_event("startup_completed", "ok", "daemon startup completed");
+        let _ = self.composition_observability.emit(
+            "startup_completed",
+            "ok",
+            "daemon startup completed",
+        );
         let request_dispatcher = Arc::clone(&self.request_dispatcher);
         let endpoint_guard = self.take_endpoint_guard()?;
         let result = runtime.serve_with_runtime_hooks(
@@ -366,12 +375,18 @@ impl RuntimeComposition {
         socket_path: PathBuf,
         ready_signal: Option<std::sync::mpsc::SyncSender<()>>,
     ) -> Result<(), AtmError> {
-        self.emit_composition_event("start_requested", "ok", "daemon start requested");
+        let _ =
+            self.composition_observability
+                .emit("start_requested", "ok", "daemon start requested");
         self.lifecycle.transition(RuntimeLifecycleState::Starting)?;
         let replay_summary = match self.peer_transport_runtime.resume_pending_replay() {
             Ok(summary) => summary,
             Err(error) => {
-                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+                let _ = self.composition_observability.emit(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
@@ -388,7 +403,11 @@ impl RuntimeComposition {
             );
         }
         if let Err(error) = self.start_background_lanes() {
-            self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+            let _ = self.composition_observability.emit(
+                "startup_failed",
+                "failed",
+                "daemon startup failed",
+            );
             self.lifecycle.force_stopped()?;
             return Err(error);
         }
@@ -404,14 +423,22 @@ impl RuntimeComposition {
                         "daemon background lane shutdown failed during test runtime preparation rollback"
                     );
                 }
-                self.emit_composition_event("startup_failed", "failed", "daemon startup failed");
+                let _ = self.composition_observability.emit(
+                    "startup_failed",
+                    "failed",
+                    "daemon startup failed",
+                );
                 self.lifecycle.force_stopped()?;
                 return Err(error);
             }
         };
         self.replace_endpoint_guard(Some(runtime.take_endpoint_guard()?))?;
         self.lifecycle.transition(RuntimeLifecycleState::Running)?;
-        self.emit_composition_event("startup_completed", "ok", "daemon startup completed");
+        let _ = self.composition_observability.emit(
+            "startup_completed",
+            "ok",
+            "daemon startup completed",
+        );
         let request_dispatcher = Arc::clone(&self.request_dispatcher);
         let endpoint_guard = self.take_endpoint_guard()?;
         let result = runtime.serve_with_runtime_hooks(
@@ -468,10 +495,18 @@ impl RuntimeComposition {
         }
         match result.as_ref() {
             Ok(()) => {
-                self.emit_composition_event("shutdown_completed", "ok", "daemon shutdown completed")
+                let _ = self.composition_observability.emit(
+                    "shutdown_completed",
+                    "ok",
+                    "daemon shutdown completed",
+                );
             }
             Err(_) => {
-                self.emit_composition_event("shutdown_failed", "failed", "daemon shutdown failed")
+                let _ = self.composition_observability.emit(
+                    "shutdown_failed",
+                    "failed",
+                    "daemon shutdown failed",
+                );
             }
         }
         result

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -10,11 +10,11 @@ use std::{fs, fs::OpenOptions};
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::home;
-use atm_core::schema::AtmMessageId;
 use atm_core::observability::{
     AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState, CommandEvent,
     LogTailSession, ObservabilityPort, RetainedSinkFaultMode,
 };
+use atm_core::schema::AtmMessageId;
 use sc_observability::{
     LogSink, Logger, LoggerConfig, RetentionPolicy, RotationPolicy, SinkRegistration,
 };
@@ -333,10 +333,12 @@ impl RetainedJsonlFileSink {
     fn schedule_prune_old_files(&self) {
         let now = SystemTime::now();
         {
-            let mut last_request_at = self
-                .last_prune_request_at
-                .lock()
-                .expect("retained sink prune request lock poisoned");
+            let Ok(mut last_request_at) = self.last_prune_request_at.lock() else {
+                tracing::warn!(
+                    "retained sink prune request lock poisoned; skipping one prune scheduling attempt"
+                );
+                return;
+            };
             if let Some(last_request_at) = *last_request_at
                 && now
                     .duration_since(last_request_at)
@@ -384,9 +386,12 @@ impl RetainedJsonlFileSink {
         )
         .cause(message)
         .source(Box::new(error));
-        let mut health = self.health.lock().expect("file sink health poisoned");
-        health.state = SinkHealthState::DegradedDropping;
-        health.last_error = Some(DiagnosticSummary::from(diagnostic.diagnostic()));
+        if let Ok(mut health) = self.health.lock() {
+            health.state = SinkHealthState::DegradedDropping;
+            health.last_error = Some(DiagnosticSummary::from(diagnostic.diagnostic()));
+        } else {
+            tracing::warn!("file sink health lock poisoned while recording sink failure");
+        }
         LogSinkError(Box::new(diagnostic))
     }
 }
@@ -439,20 +444,24 @@ impl LogSink for RetainedJsonlFileSink {
         file.write_all(&line)
             .and_then(|()| file.flush())
             .map_err(|error| self.mark_failure(error))?;
-        *self
-            .last_written_file
-            .lock()
-            .expect("retained sink file handle poisoned") = Some(file);
-        let mut health = self.health.lock().expect("file sink health poisoned");
+        *self.last_written_file.lock().map_err(|_| {
+            self.mark_failure(std::io::Error::other(
+                "retained sink file handle lock poisoned",
+            ))
+        })? = Some(file);
+        let mut health = self.health.lock().map_err(|_| {
+            self.mark_failure(std::io::Error::other("file sink health lock poisoned"))
+        })?;
         health.state = SinkHealthState::Healthy;
         Ok(())
     }
 
     fn flush(&self) -> Result<(), LogSinkError> {
-        let mut last_written = self
-            .last_written_file
-            .lock()
-            .expect("retained sink file handle poisoned");
+        let mut last_written = self.last_written_file.lock().map_err(|_| {
+            self.mark_failure(std::io::Error::other(
+                "retained sink file handle lock poisoned",
+            ))
+        })?;
         if let Some(file) = last_written.as_mut() {
             file.flush().map_err(|error| self.mark_failure(error))?;
         }
@@ -460,10 +469,17 @@ impl LogSink for RetainedJsonlFileSink {
     }
 
     fn health(&self) -> SinkHealth {
-        self.health
-            .lock()
-            .expect("file sink health poisoned")
-            .clone()
+        match self.health.lock() {
+            Ok(health) => health.clone(),
+            Err(_) => {
+                tracing::warn!("file sink health lock poisoned; reporting unavailable sink health");
+                SinkHealth {
+                    name: SinkName::new("jsonl_file_sink").expect("jsonl sink constant is valid"),
+                    state: SinkHealthState::Unavailable,
+                    last_error: None,
+                }
+            }
+        }
     }
 }
 
@@ -679,10 +695,16 @@ fn map_daemon_event(
     );
     match &event.team {
         TeamScope::Team(team) => {
-            fields.insert("team".to_string(), serde_json::Value::String(team.to_string()));
+            fields.insert(
+                "team".to_string(),
+                serde_json::Value::String(team.to_string()),
+            );
         }
         TeamScope::None => {
-            fields.insert("team_scope".to_string(), serde_json::Value::String("none".to_string()));
+            fields.insert(
+                "team_scope".to_string(),
+                serde_json::Value::String("none".to_string()),
+            );
         }
     }
     if let Some(agent) = event.agent.as_ref() {
@@ -843,7 +865,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::DaemonObservability;
-    use atm_daemon::{DaemonEvent, DaemonSubsystem, TeamScope};
+    use atm_daemon::observability_test_event;
 
     #[test]
     #[serial]
@@ -859,32 +881,18 @@ mod tests {
 
         let observability = DaemonObservability::bootstrap().expect("bootstrap");
         observability
-            .emit_daemon_event(DaemonEvent {
-                subsystem: DaemonSubsystem::Composition,
-                action: "start_requested",
-                outcome: "ok",
-                team: TeamScope::None,
-                agent: None,
-                sender: None,
-                recipient: None,
-                message_id: None,
-                task_id: None,
-                detail: "daemon start requested".into(),
-            })
+            .emit_daemon_event(observability_test_event(
+                "start_requested",
+                "ok",
+                "daemon start requested",
+            ))
             .expect("emit start");
         observability
-            .emit_daemon_event(DaemonEvent {
-                subsystem: DaemonSubsystem::Composition,
-                action: "shutdown_completed",
-                outcome: "ok",
-                team: TeamScope::None,
-                agent: None,
-                sender: None,
-                recipient: None,
-                message_id: None,
-                task_id: None,
-                detail: "daemon shutdown completed".into(),
-            })
+            .emit_daemon_event(observability_test_event(
+                "shutdown_completed",
+                "ok",
+                "daemon shutdown completed",
+            ))
             .expect("emit shutdown");
         observability
             .best_effort_flush_blocking()
@@ -988,18 +996,11 @@ mod tests {
             )
             .expect("bootstrap");
         observability
-            .emit_daemon_event(DaemonEvent {
-                subsystem: DaemonSubsystem::Composition,
-                action: "start_requested",
-                outcome: "ok",
-                team: TeamScope::None,
-                agent: None,
-                sender: None,
-                recipient: None,
-                message_id: None,
-                task_id: None,
-                detail: "daemon start requested".into(),
-            })
+            .emit_daemon_event(observability_test_event(
+                "start_requested",
+                "ok",
+                "daemon start requested",
+            ))
             .expect("emit");
 
         let active_log_path = log_dir.join("atm.log.jsonl");

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -14,7 +14,6 @@ use atm_core::observability::{
     AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState, CommandEvent,
     LogTailSession, ObservabilityPort, RetainedSinkFaultMode,
 };
-use atm_core::schema::AtmMessageId;
 use sc_observability::{
     LogSink, Logger, LoggerConfig, RetentionPolicy, RotationPolicy, SinkRegistration,
 };

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -26,6 +26,8 @@ use sc_observability_types::{
 };
 use serde_json::Map;
 
+#[cfg(test)]
+use atm_daemon::DaemonSubsystem;
 use atm_daemon::{DaemonEvent, TeamScope};
 
 const ATM_SERVICE_NAME: &str = "atm";
@@ -491,6 +493,26 @@ fn rename_if_present(src: &Path, dest: &Path) -> std::io::Result<()> {
     }
 }
 
+#[cfg(test)]
+fn observability_test_event(
+    action: &'static str,
+    outcome: &'static str,
+    detail: impl Into<std::borrow::Cow<'static, str>>,
+) -> DaemonEvent {
+    DaemonEvent {
+        subsystem: DaemonSubsystem::Composition,
+        action,
+        outcome,
+        team: TeamScope::None,
+        agent: None,
+        sender: None,
+        recipient: None,
+        message_id: None,
+        task_id: None,
+        detail: detail.into(),
+    }
+}
+
 fn logger_level_override() -> Result<Option<SharedLevelFilter>, AtmError> {
     let Some(value) = std::env::var(ATM_LOG_LEVEL_ENV)
         .ok()
@@ -864,8 +886,7 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
-    use super::DaemonObservability;
-    use atm_daemon::observability_test_event;
+    use super::{DaemonObservability, observability_test_event};
 
     #[test]
     #[serial]

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -10,6 +10,7 @@ use std::{fs, fs::OpenOptions};
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::home;
+use atm_core::schema::AtmMessageId;
 use atm_core::observability::{
     AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState, CommandEvent,
     LogTailSession, ObservabilityPort, RetainedSinkFaultMode,
@@ -24,6 +25,8 @@ use sc_observability_types::{
     Timestamp,
 };
 use serde_json::Map;
+
+use atm_daemon::{DaemonEvent, TeamScope};
 
 const ATM_SERVICE_NAME: &str = "atm";
 const ATM_DAEMON_TARGET: &str = "atm.daemon";
@@ -110,19 +113,8 @@ impl DaemonObservability {
         Self::bootstrap_at_log_dir_with_rotation(log_dir, rotation_max_bytes)
     }
 
-    pub(crate) fn emit_runtime_event(
-        &self,
-        action: &'static str,
-        outcome: &'static str,
-        message: &'static str,
-    ) -> Result<(), AtmError> {
-        let event = map_runtime_event(
-            &self.service_name,
-            &self.target_category,
-            action,
-            outcome,
-            message,
-        )?;
+    pub(crate) fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
+        let event = map_daemon_event(&self.service_name, &self.target_category, event)?;
         self.logger.emit(event).map_err(|source| {
             let code = source.diagnostic().code.as_str().to_string();
             AtmError::observability_emit(format!(
@@ -199,13 +191,8 @@ impl ObservabilityPort for DaemonObservability {
 }
 
 impl atm_daemon::DaemonRuntimeObservability for DaemonObservability {
-    fn emit_runtime_event(
-        &self,
-        action: &'static str,
-        outcome: &'static str,
-        message: &'static str,
-    ) -> Result<(), AtmError> {
-        Self::emit_runtime_event(self, action, outcome, message)
+    fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
+        Self::emit_daemon_event(self, event)
     }
 
     fn best_effort_flush_blocking(&self) -> Result<(), AtmError> {
@@ -646,12 +633,10 @@ fn map_command_event(
     })
 }
 
-fn map_runtime_event(
+fn map_daemon_event(
     service_name: &ServiceName,
     target_category: &TargetCategory,
-    action: &'static str,
-    outcome: &'static str,
-    message: &'static str,
+    event: DaemonEvent,
 ) -> Result<LogEvent, AtmError> {
     let schema_version =
         SchemaVersion::new(sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION)
@@ -661,31 +646,88 @@ fn map_runtime_event(
                 )
                 .with_source(source)
             })?;
-    let action = ActionName::new(action).map_err(|source| {
+    let action = ActionName::new(event.action).map_err(|source| {
         AtmError::observability_emit("failed to validate ATM daemon lifecycle action")
             .with_source(source)
     })?;
-    let outcome = OutcomeLabel::new(outcome).map_err(|source| {
+    let outcome = OutcomeLabel::new(event.outcome).map_err(|source| {
         AtmError::observability_emit("failed to validate ATM daemon lifecycle outcome")
             .with_source(source)
     })?;
-    let fields = Map::from_iter([(
-        "component".to_string(),
-        serde_json::Value::String("daemon_runtime".to_string()),
-    )]);
+    let request_id = event
+        .message_id
+        .as_ref()
+        .map(|value: &AtmMessageId| CorrelationId::new(value.to_string()))
+        .transpose()
+        .map_err(|source| {
+            AtmError::observability_emit("failed to validate ATM daemon request id")
+                .with_source(source)
+        })?;
+    let correlation_id = event
+        .task_id
+        .as_ref()
+        .map(|value: &atm_core::types::TaskId| CorrelationId::new(value.as_str()))
+        .transpose()
+        .map_err(|source| {
+            AtmError::observability_emit("failed to validate ATM daemon correlation id")
+                .with_source(source)
+        })?;
+    let mut fields = Map::new();
+    fields.insert(
+        "subsystem".to_string(),
+        serde_json::Value::String(event.subsystem.as_str().to_string()),
+    );
+    match &event.team {
+        TeamScope::Team(team) => {
+            fields.insert("team".to_string(), serde_json::Value::String(team.to_string()));
+        }
+        TeamScope::None => {
+            fields.insert("team_scope".to_string(), serde_json::Value::String("none".to_string()));
+        }
+    }
+    if let Some(agent) = event.agent.as_ref() {
+        fields.insert(
+            "agent".to_string(),
+            serde_json::Value::String(agent.to_string()),
+        );
+    }
+    if let Some(sender) = event.sender.as_ref() {
+        fields.insert(
+            "sender".to_string(),
+            serde_json::Value::String(sender.to_string()),
+        );
+    }
+    if let Some(recipient) = event.recipient.as_ref() {
+        fields.insert(
+            "recipient".to_string(),
+            serde_json::Value::String(recipient.to_string()),
+        );
+    }
+    if let Some(message_id) = event.message_id.as_ref() {
+        fields.insert(
+            "message_id".to_string(),
+            serde_json::Value::String(message_id.to_string()),
+        );
+    }
+    if let Some(task_id) = event.task_id.as_ref() {
+        fields.insert(
+            "task_id".to_string(),
+            serde_json::Value::String(task_id.to_string()),
+        );
+    }
 
     Ok(LogEvent {
         version: schema_version,
         timestamp: Timestamp::now_utc(),
-        level: level_for_outcome(outcome.as_str()),
+        level: level_for_outcome(event.outcome),
         service: service_name.clone(),
         target: target_category.clone(),
         action,
-        message: Some(message.to_string()),
+        message: Some(event.detail.into_owned()),
         identity: ProcessIdentity::default(),
         trace: None,
-        request_id: None,
-        correlation_id: None,
+        request_id,
+        correlation_id,
         outcome: Some(outcome),
         diagnostic: None,
         state_transition: None,
@@ -721,7 +763,7 @@ fn level_for_outcome(outcome: &str) -> Level {
         "error" | "failed" => Level::Error,
         other => {
             // No global tracing subscriber is installed in production; daemon lifecycle records
-            // route through emit_runtime_event(), so this unknown-outcome warning is intentionally silent.
+            // route through emit_daemon_event(), so this unknown-outcome warning is intentionally silent.
             tracing::warn!(
                 code = %AtmErrorCode::ObservabilityEmitFailed,
                 outcome = other,
@@ -801,6 +843,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::DaemonObservability;
+    use atm_daemon::{DaemonEvent, DaemonSubsystem, TeamScope};
 
     #[test]
     #[serial]
@@ -816,10 +859,32 @@ mod tests {
 
         let observability = DaemonObservability::bootstrap().expect("bootstrap");
         observability
-            .emit_runtime_event("start_requested", "ok", "daemon start requested")
+            .emit_daemon_event(DaemonEvent {
+                subsystem: DaemonSubsystem::Composition,
+                action: "start_requested",
+                outcome: "ok",
+                team: TeamScope::None,
+                agent: None,
+                sender: None,
+                recipient: None,
+                message_id: None,
+                task_id: None,
+                detail: "daemon start requested".into(),
+            })
             .expect("emit start");
         observability
-            .emit_runtime_event("shutdown_completed", "ok", "daemon shutdown completed")
+            .emit_daemon_event(DaemonEvent {
+                subsystem: DaemonSubsystem::Composition,
+                action: "shutdown_completed",
+                outcome: "ok",
+                team: TeamScope::None,
+                agent: None,
+                sender: None,
+                recipient: None,
+                message_id: None,
+                task_id: None,
+                detail: "daemon shutdown completed".into(),
+            })
             .expect("emit shutdown");
         observability
             .best_effort_flush_blocking()
@@ -923,7 +988,18 @@ mod tests {
             )
             .expect("bootstrap");
         observability
-            .emit_runtime_event("start_requested", "ok", "daemon start requested")
+            .emit_daemon_event(DaemonEvent {
+                subsystem: DaemonSubsystem::Composition,
+                action: "start_requested",
+                outcome: "ok",
+                team: TeamScope::None,
+                agent: None,
+                sender: None,
+                recipient: None,
+                message_id: None,
+                task_id: None,
+                detail: "daemon start requested".into(),
+            })
             .expect("emit");
 
         let active_log_path = log_dir.join("atm.log.jsonl");

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -10,7 +10,6 @@ use std::{fs, fs::OpenOptions};
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::home;
-use atm_core::schema::AtmMessageId;
 use atm_core::observability::{
     AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState, CommandEvent,
     LogTailSession, ObservabilityPort, RetainedSinkFaultMode,
@@ -114,13 +113,67 @@ impl DaemonObservability {
     }
 
     pub(crate) fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
-        let event = map_daemon_event(&self.service_name, &self.target_category, event)?;
-        self.logger.emit(event).map_err(|source| {
-            let code = source.diagnostic().code.as_str().to_string();
-            AtmError::observability_emit(format!(
-                "shared daemon observability emit failed ({code})"
-            ))
-            .with_source(source)
+        let mut fields = Map::new();
+        fields.insert(
+            "subsystem".to_string(),
+            serde_json::Value::String(event.subsystem.as_str().to_string()),
+        );
+        match &event.team {
+            TeamScope::Team(team) => {
+                fields.insert(
+                    "team".to_string(),
+                    serde_json::Value::String(team.to_string()),
+                );
+            }
+            TeamScope::None => {
+                fields.insert(
+                    "team_scope".to_string(),
+                    serde_json::Value::String("none".to_string()),
+                );
+            }
+        }
+        if let Some(agent) = event.agent.as_ref() {
+            fields.insert(
+                "agent".to_string(),
+                serde_json::Value::String(agent.to_string()),
+            );
+        }
+        if let Some(sender) = event.sender.as_ref() {
+            fields.insert(
+                "sender".to_string(),
+                serde_json::Value::String(sender.to_string()),
+            );
+        }
+        if let Some(recipient) = event.recipient.as_ref() {
+            fields.insert(
+                "recipient".to_string(),
+                serde_json::Value::String(recipient.to_string()),
+            );
+        }
+        if let Some(message_id) = event.message_id.as_ref() {
+            fields.insert(
+                "message_id".to_string(),
+                serde_json::Value::String(message_id.to_string()),
+            );
+        }
+        if let Some(task_id) = event.task_id.as_ref() {
+            fields.insert(
+                "task_id".to_string(),
+                serde_json::Value::String(task_id.to_string()),
+            );
+        }
+
+        self.emit_log_event(EmitLogEvent {
+            scope: "lifecycle",
+            action: event.action,
+            outcome: event.outcome,
+            message: Some(event.detail.into_owned()),
+            request_id: event.message_id.as_ref().map(|value| value.to_string()),
+            correlation_id: event
+                .task_id
+                .as_ref()
+                .map(|value| value.as_str().to_string()),
+            fields,
         })
     }
 
@@ -147,13 +200,70 @@ impl atm_core::boundary::sealed::Sealed for DaemonObservability {}
 
 impl ObservabilityPort for DaemonObservability {
     fn emit(&self, event: CommandEvent) -> Result<(), AtmError> {
-        let event = map_command_event(&self.service_name, &self.target_category, event)?;
-        self.logger.emit(event).map_err(|source| {
-            let code = source.diagnostic().code.as_str().to_string();
-            AtmError::observability_emit(format!(
-                "shared daemon observability emit failed ({code})"
-            ))
-            .with_source(source)
+        let mut fields = Map::new();
+        fields.insert(
+            "command".to_string(),
+            serde_json::Value::String(event.command.to_string()),
+        );
+        fields.insert(
+            "team".to_string(),
+            serde_json::Value::String(event.team.to_string()),
+        );
+        fields.insert(
+            "agent".to_string(),
+            serde_json::Value::String(event.agent.to_string()),
+        );
+        fields.insert(
+            "sender".to_string(),
+            serde_json::Value::String(event.sender.to_string()),
+        );
+        fields.insert(
+            "requires_ack".to_string(),
+            serde_json::Value::Bool(event.requires_ack),
+        );
+        fields.insert(
+            "dry_run".to_string(),
+            serde_json::Value::Bool(event.dry_run),
+        );
+        if let Some(message_id) = event.message_id {
+            fields.insert(
+                "message_id".to_string(),
+                serde_json::Value::String(message_id.to_string()),
+            );
+        }
+        if let Some(task_id) = &event.task_id {
+            fields.insert(
+                "task_id".to_string(),
+                serde_json::Value::String(task_id.to_string()),
+            );
+        }
+        if let Some(error_code) = event.error_code {
+            fields.insert(
+                "error_code".to_string(),
+                serde_json::Value::String(error_code.to_string()),
+            );
+        }
+        if let Some(error_message) = &event.error_message {
+            fields.insert(
+                "error_message".to_string(),
+                serde_json::Value::String(error_message.clone()),
+            );
+        }
+
+        self.emit_log_event(EmitLogEvent {
+            scope: "observability",
+            action: event.action,
+            outcome: event.outcome,
+            message: Some(format!(
+                "ATM daemon handled {} with outcome {}",
+                event.command, event.outcome
+            )),
+            request_id: event.message_id.map(|value| value.to_string()),
+            correlation_id: event
+                .task_id
+                .as_ref()
+                .map(|value| value.as_str().to_string()),
+            fields,
         })
     }
 
@@ -197,6 +307,82 @@ impl atm_daemon::DaemonRuntimeObservability for DaemonObservability {
 
     fn best_effort_flush_blocking(&self) -> Result<(), AtmError> {
         Self::best_effort_flush_blocking(self)
+    }
+}
+
+struct EmitLogEvent {
+    scope: &'static str,
+    action: &'static str,
+    outcome: &'static str,
+    message: Option<String>,
+    request_id: Option<String>,
+    correlation_id: Option<String>,
+    fields: Map<String, serde_json::Value>,
+}
+
+impl DaemonObservability {
+    fn emit_log_event(&self, event: EmitLogEvent) -> Result<(), AtmError> {
+        let event = LogEvent {
+            version: SchemaVersion::new(
+                sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION,
+            )
+            .map_err(|source| {
+                AtmError::observability_emit(format!(
+                    "failed to validate ATM daemon {} schema version",
+                    event.scope
+                ))
+                .with_source(source)
+            })?,
+            timestamp: Timestamp::now_utc(),
+            level: level_for_outcome(event.outcome),
+            service: self.service_name.clone(),
+            target: self.target_category.clone(),
+            action: ActionName::new(event.action).map_err(|source| {
+                AtmError::observability_emit(format!(
+                    "failed to validate ATM daemon {} action",
+                    event.scope
+                ))
+                .with_source(source)
+            })?,
+            message: event.message,
+            identity: ProcessIdentity::default(),
+            trace: None,
+            request_id: event
+                .request_id
+                .as_deref()
+                .map(CorrelationId::new)
+                .transpose()
+                .map_err(|source| {
+                    AtmError::observability_emit("failed to validate ATM daemon request id")
+                        .with_source(source)
+                })?,
+            correlation_id: event
+                .correlation_id
+                .as_deref()
+                .map(CorrelationId::new)
+                .transpose()
+                .map_err(|source| {
+                    AtmError::observability_emit("failed to validate ATM daemon correlation id")
+                        .with_source(source)
+                })?,
+            outcome: Some(OutcomeLabel::new(event.outcome).map_err(|source| {
+                AtmError::observability_emit(format!(
+                    "failed to validate ATM daemon {} outcome",
+                    event.scope
+                ))
+                .with_source(source)
+            })?),
+            diagnostic: None,
+            state_transition: None,
+            fields: event.fields,
+        };
+        self.logger.emit(event).map_err(|source| {
+            let code = source.diagnostic().code.as_str().to_string();
+            AtmError::observability_emit(format!(
+                "shared daemon observability emit failed ({code})"
+            ))
+            .with_source(source)
+        })
     }
 }
 
@@ -520,219 +706,6 @@ fn retained_sink_fault_mode() -> Result<Option<RetainedSinkFaultMode>, AtmError>
             ))),
         }
     }
-}
-
-fn map_command_event(
-    service_name: &ServiceName,
-    target_category: &TargetCategory,
-    event: CommandEvent,
-) -> Result<LogEvent, AtmError> {
-    let schema_version =
-        SchemaVersion::new(sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION)
-            .map_err(|source| {
-                AtmError::observability_emit(
-                    "failed to validate ATM daemon observability schema version",
-                )
-                .with_source(source)
-            })?;
-    let action = ActionName::new(event.action).map_err(|source| {
-        AtmError::observability_emit("failed to validate ATM daemon observability action")
-            .with_source(source)
-    })?;
-    let request_id = event
-        .message_id
-        .map(|value| CorrelationId::new(value.to_string()))
-        .transpose()
-        .map_err(|source| {
-            AtmError::observability_emit("failed to validate ATM daemon request id")
-                .with_source(source)
-        })?;
-    let correlation_id = event
-        .task_id
-        .as_deref()
-        .map(CorrelationId::new)
-        .transpose()
-        .map_err(|source| {
-            AtmError::observability_emit("failed to validate ATM daemon correlation id")
-                .with_source(source)
-        })?;
-    let outcome = OutcomeLabel::new(event.outcome).map_err(|source| {
-        AtmError::observability_emit("failed to validate ATM daemon outcome label")
-            .with_source(source)
-    })?;
-
-    let mut fields = Map::new();
-    fields.insert(
-        "command".to_string(),
-        serde_json::Value::String(event.command.to_string()),
-    );
-    fields.insert(
-        "team".to_string(),
-        serde_json::Value::String(event.team.to_string()),
-    );
-    fields.insert(
-        "agent".to_string(),
-        serde_json::Value::String(event.agent.to_string()),
-    );
-    fields.insert(
-        "sender".to_string(),
-        serde_json::Value::String(event.sender.to_string()),
-    );
-    fields.insert(
-        "requires_ack".to_string(),
-        serde_json::Value::Bool(event.requires_ack),
-    );
-    fields.insert(
-        "dry_run".to_string(),
-        serde_json::Value::Bool(event.dry_run),
-    );
-    if let Some(message_id) = event.message_id {
-        fields.insert(
-            "message_id".to_string(),
-            serde_json::Value::String(message_id.to_string()),
-        );
-    }
-    if let Some(task_id) = &event.task_id {
-        fields.insert(
-            "task_id".to_string(),
-            serde_json::Value::String(task_id.to_string()),
-        );
-    }
-    if let Some(error_code) = event.error_code {
-        fields.insert(
-            "error_code".to_string(),
-            serde_json::Value::String(error_code.to_string()),
-        );
-    }
-    if let Some(error_message) = &event.error_message {
-        fields.insert(
-            "error_message".to_string(),
-            serde_json::Value::String(error_message.clone()),
-        );
-    }
-
-    Ok(LogEvent {
-        version: schema_version,
-        timestamp: Timestamp::now_utc(),
-        level: level_for_outcome(event.outcome),
-        service: service_name.clone(),
-        target: target_category.clone(),
-        action,
-        message: Some(format!(
-            "ATM daemon handled {} with outcome {}",
-            event.command, event.outcome
-        )),
-        identity: ProcessIdentity::default(),
-        trace: None,
-        request_id,
-        correlation_id,
-        outcome: Some(outcome),
-        diagnostic: None,
-        state_transition: None,
-        fields,
-    })
-}
-
-fn map_daemon_event(
-    service_name: &ServiceName,
-    target_category: &TargetCategory,
-    event: DaemonEvent,
-) -> Result<LogEvent, AtmError> {
-    let schema_version =
-        SchemaVersion::new(sc_observability_types::constants::OBSERVATION_ENVELOPE_VERSION)
-            .map_err(|source| {
-                AtmError::observability_emit(
-                    "failed to validate ATM daemon lifecycle schema version",
-                )
-                .with_source(source)
-            })?;
-    let action = ActionName::new(event.action).map_err(|source| {
-        AtmError::observability_emit("failed to validate ATM daemon lifecycle action")
-            .with_source(source)
-    })?;
-    let outcome = OutcomeLabel::new(event.outcome).map_err(|source| {
-        AtmError::observability_emit("failed to validate ATM daemon lifecycle outcome")
-            .with_source(source)
-    })?;
-    let request_id = event
-        .message_id
-        .as_ref()
-        .map(|value: &AtmMessageId| CorrelationId::new(value.to_string()))
-        .transpose()
-        .map_err(|source| {
-            AtmError::observability_emit("failed to validate ATM daemon request id")
-                .with_source(source)
-        })?;
-    let correlation_id = event
-        .task_id
-        .as_ref()
-        .map(|value: &atm_core::types::TaskId| CorrelationId::new(value.as_str()))
-        .transpose()
-        .map_err(|source| {
-            AtmError::observability_emit("failed to validate ATM daemon correlation id")
-                .with_source(source)
-        })?;
-    let mut fields = Map::new();
-    fields.insert(
-        "subsystem".to_string(),
-        serde_json::Value::String(event.subsystem.as_str().to_string()),
-    );
-    match &event.team {
-        TeamScope::Team(team) => {
-            fields.insert("team".to_string(), serde_json::Value::String(team.to_string()));
-        }
-        TeamScope::None => {
-            fields.insert("team_scope".to_string(), serde_json::Value::String("none".to_string()));
-        }
-    }
-    if let Some(agent) = event.agent.as_ref() {
-        fields.insert(
-            "agent".to_string(),
-            serde_json::Value::String(agent.to_string()),
-        );
-    }
-    if let Some(sender) = event.sender.as_ref() {
-        fields.insert(
-            "sender".to_string(),
-            serde_json::Value::String(sender.to_string()),
-        );
-    }
-    if let Some(recipient) = event.recipient.as_ref() {
-        fields.insert(
-            "recipient".to_string(),
-            serde_json::Value::String(recipient.to_string()),
-        );
-    }
-    if let Some(message_id) = event.message_id.as_ref() {
-        fields.insert(
-            "message_id".to_string(),
-            serde_json::Value::String(message_id.to_string()),
-        );
-    }
-    if let Some(task_id) = event.task_id.as_ref() {
-        fields.insert(
-            "task_id".to_string(),
-            serde_json::Value::String(task_id.to_string()),
-        );
-    }
-
-    Ok(LogEvent {
-        version: schema_version,
-        timestamp: Timestamp::now_utc(),
-        level: level_for_outcome(event.outcome),
-        service: service_name.clone(),
-        target: target_category.clone(),
-        action,
-        message: Some(event.detail.into_owned()),
-        identity: ProcessIdentity::default(),
-        trace: None,
-        request_id,
-        correlation_id,
-        outcome: Some(outcome),
-        diagnostic: None,
-        state_transition: None,
-        fields,
-    })
 }
 
 fn map_logging_state(

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -170,6 +170,9 @@ impl SubsystemObservability {
         outcome: &'static str,
         detail: impl Into<Cow<'static, str>>,
     ) -> DaemonEvent {
+        // Shared subsystem emit helpers deliberately start with no team scope because the thin
+        // sink cannot infer mailbox ownership; callers that know team context attach it
+        // explicitly on the returned event instead of relying on logger-held mutable state.
         DaemonEvent::new(self.subsystem(), action, outcome, detail)
     }
 
@@ -188,4 +191,13 @@ impl SubsystemObservability {
     ) -> Result<(), AtmError> {
         self.emit_event(self.event(action, outcome, detail))
     }
+}
+
+#[cfg(test)]
+pub(crate) fn observability_test_event(
+    action: &'static str,
+    outcome: &'static str,
+    detail: impl Into<Cow<'static, str>>,
+) -> DaemonEvent {
+    DaemonEvent::new(DaemonSubsystem::Composition, action, outcome, detail)
 }

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -192,12 +192,3 @@ impl SubsystemObservability {
         self.emit_event(self.event(action, outcome, detail))
     }
 }
-
-#[cfg(test)]
-pub(crate) fn observability_test_event(
-    action: &'static str,
-    outcome: &'static str,
-    detail: impl Into<Cow<'static, str>>,
-) -> DaemonEvent {
-    DaemonEvent::new(DaemonSubsystem::Composition, action, outcome, detail)
-}

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -1,17 +1,191 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
 use atm_core::error::AtmError;
 use atm_core::observability::ObservabilityPort;
+use atm_core::schema::AtmMessageId;
+use atm_core::types::{AgentName, TaskId, TeamName};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DaemonSubsystem {
+    Bootstrap,
+    Composition,
+    LocalIpcTransport,
+    AdvisoryRuntime,
+    NotificationRuntime,
+    PeerTransport,
+    WatchRuntime,
+    ReconcileRuntime,
+    RuntimeHealth,
+    HostOwnership,
+    LifecycleControl,
+    RuntimeStatusCache,
+    ObservabilitySink,
+}
+
+impl DaemonSubsystem {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Bootstrap => "bootstrap",
+            Self::Composition => "composition",
+            Self::LocalIpcTransport => "local_ipc_transport",
+            Self::AdvisoryRuntime => "advisory_runtime",
+            Self::NotificationRuntime => "notification_runtime",
+            Self::PeerTransport => "peer_transport",
+            Self::WatchRuntime => "watch_runtime",
+            Self::ReconcileRuntime => "reconcile_runtime",
+            Self::RuntimeHealth => "runtime_health",
+            Self::HostOwnership => "host_ownership",
+            Self::LifecycleControl => "lifecycle_control",
+            Self::RuntimeStatusCache => "runtime_status_cache",
+            Self::ObservabilitySink => "observability_sink",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TeamScope {
+    Team(TeamName),
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonEvent {
+    pub subsystem: DaemonSubsystem,
+    pub action: &'static str,
+    pub outcome: &'static str,
+    pub team: TeamScope,
+    pub agent: Option<AgentName>,
+    pub sender: Option<AgentName>,
+    pub recipient: Option<AgentName>,
+    pub message_id: Option<AtmMessageId>,
+    pub task_id: Option<TaskId>,
+    pub detail: Cow<'static, str>,
+}
+
+impl DaemonEvent {
+    pub(crate) fn new(
+        subsystem: DaemonSubsystem,
+        action: &'static str,
+        outcome: &'static str,
+        detail: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        Self {
+            subsystem,
+            action,
+            outcome,
+            team: TeamScope::None,
+            agent: None,
+            sender: None,
+            recipient: None,
+            message_id: None,
+            task_id: None,
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn with_team(mut self, team: TeamName) -> Self {
+        self.team = TeamScope::Team(team);
+        self
+    }
+
+    pub(crate) fn with_agent(mut self, agent: AgentName) -> Self {
+        self.agent = Some(agent);
+        self
+    }
+
+    pub(crate) fn with_sender(mut self, sender: AgentName) -> Self {
+        self.sender = Some(sender);
+        self
+    }
+
+    pub(crate) fn with_recipient(mut self, recipient: AgentName) -> Self {
+        self.recipient = Some(recipient);
+        self
+    }
+
+    pub(crate) fn with_message_id(mut self, message_id: AtmMessageId) -> Self {
+        self.message_id = Some(message_id);
+        self
+    }
+
+    pub(crate) fn with_task_id(mut self, task_id: TaskId) -> Self {
+        self.task_id = Some(task_id);
+        self
+    }
+}
 
 /// Daemon-runtime observability operations that stay daemon-specific above the
 /// shared ATM observability boundary.
-pub trait DaemonRuntimeObservability: ObservabilityPort + Send + Sync {
-    /// Emit one daemon lifecycle/runtime event into the retained sink.
-    fn emit_runtime_event(
-        &self,
-        action: &'static str,
-        outcome: &'static str,
-        message: &'static str,
-    ) -> Result<(), AtmError>;
+pub trait DaemonRuntimeObservability:
+    atm_core::boundary::sealed::Sealed + ObservabilityPort + Send + Sync
+{
+    /// Emit one daemon subsystem event into the retained sink.
+    fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError>;
 
     /// Attempt one best-effort synchronous flush during daemon shutdown.
     fn best_effort_flush_blocking(&self) -> Result<(), AtmError>;
+}
+
+#[derive(Clone)]
+pub(crate) struct SubsystemObservability {
+    subsystem: DaemonSubsystem,
+    inner: Option<Arc<dyn DaemonRuntimeObservability>>,
+}
+
+impl std::fmt::Debug for SubsystemObservability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubsystemObservability")
+            .field("subsystem", &self.subsystem)
+            .field("enabled", &self.inner.is_some())
+            .finish()
+    }
+}
+
+impl SubsystemObservability {
+    pub(crate) fn new(
+        subsystem: DaemonSubsystem,
+        inner: Arc<dyn DaemonRuntimeObservability>,
+    ) -> Self {
+        Self {
+            subsystem,
+            inner: Some(inner),
+        }
+    }
+
+    pub(crate) fn disabled(subsystem: DaemonSubsystem) -> Self {
+        Self {
+            subsystem,
+            inner: None,
+        }
+    }
+
+    pub(crate) fn subsystem(&self) -> DaemonSubsystem {
+        self.subsystem.clone()
+    }
+
+    pub(crate) fn event(
+        &self,
+        action: &'static str,
+        outcome: &'static str,
+        detail: impl Into<Cow<'static, str>>,
+    ) -> DaemonEvent {
+        DaemonEvent::new(self.subsystem(), action, outcome, detail)
+    }
+
+    pub(crate) fn emit_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
+        if let Some(inner) = &self.inner {
+            inner.emit_daemon_event(event)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn emit(
+        &self,
+        action: &'static str,
+        outcome: &'static str,
+        detail: impl Into<Cow<'static, str>>,
+    ) -> Result<(), AtmError> {
+        self.emit_event(self.event(action, outcome, detail))
+    }
 }

--- a/crates/atm-daemon/src/host_ownership.rs
+++ b/crates/atm-daemon/src/host_ownership.rs
@@ -7,6 +7,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use atm_core::error::AtmError;
 use fs2::FileExt;
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 #[cfg_attr(windows, allow(dead_code))]
 const STALE_OWNER_RECOVERY_RETRY_ATTEMPTS: usize = 3;
 #[cfg_attr(windows, allow(dead_code))]
@@ -25,8 +27,10 @@ static STALE_RECOVERY_OBSERVED_SIGNAL: std::sync::Mutex<Option<StaleRecoverySign
     std::sync::Mutex::new(None);
 
 #[cfg_attr(windows, allow(dead_code))]
-#[derive(Debug, Default, Clone, Copy)]
-pub(crate) struct HostOwnershipAdapter;
+#[derive(Debug, Clone)]
+pub(crate) struct HostOwnershipAdapter {
+    observability: SubsystemObservability,
+}
 
 #[cfg_attr(windows, allow(dead_code))]
 #[derive(Debug)]
@@ -36,17 +40,30 @@ pub(crate) struct HostOwnershipGuard {
 
 #[cfg_attr(windows, allow(dead_code))]
 impl HostOwnershipAdapter {
-    pub(crate) const fn new() -> Self {
-        Self
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::HostOwnership,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
+        Self { observability }
     }
 
     pub(crate) fn acquire(&self) -> Result<HostOwnershipGuard, AtmError> {
-        Self::acquire_at(atm_core::home::host_runtime_lock_path(
+        self.acquire_at_with_observability(atm_core::home::host_runtime_lock_path(
             HOST_RUNTIME_OWNER_LOCK_FILE,
         )?)
     }
 
-    pub(crate) fn acquire_at(
+    #[allow(dead_code)]
+    pub(crate) fn acquire_at(lock_path: std::path::PathBuf) -> Result<HostOwnershipGuard, AtmError> {
+        Self::new().acquire_at_with_observability(lock_path)
+    }
+
+    fn acquire_at_with_observability(
+        &self,
         lock_path: std::path::PathBuf,
     ) -> Result<HostOwnershipGuard, AtmError> {
         let mut lock_file = open_lock_file(&lock_path)?;
@@ -64,8 +81,18 @@ impl HostOwnershipAdapter {
                     drop(lock_file);
                     lock_file = recover_stale_owner_lock(&lock_path, pid, &token)?;
                     recovered = true;
+                    let _ = self.observability.emit(
+                        "recover_stale_owner",
+                        "degraded",
+                        "daemon recovered a stale host-runtime owner lock",
+                    );
                 }
                 if !recovered {
+                    let _ = self.observability.emit(
+                        "acquire_owner_lock",
+                        "rejected",
+                        "daemon host-runtime owner lock is already held by a live process",
+                    );
                     return Err(AtmError::daemon_serving_state_rejected(format!(
                         "a live ATM daemon already owns {}",
                         lock_path.display()
@@ -77,6 +104,11 @@ impl HostOwnershipAdapter {
                 }
             }
             Err(source) => {
+                let _ = self.observability.emit(
+                    "acquire_owner_lock",
+                    "failed",
+                    "daemon failed to acquire the host-runtime owner lock",
+                );
                 return Err(AtmError::daemon_unavailable(format!(
                     "failed to acquire daemon ownership lock at {}",
                     lock_path.display()
@@ -85,6 +117,11 @@ impl HostOwnershipAdapter {
             }
         }
         write_owner_record(&mut lock_file)?;
+        let _ = self.observability.emit(
+            "acquire_owner_lock",
+            "ok",
+            "daemon acquired the host-runtime owner lock",
+        );
         Ok(HostOwnershipGuard { lock_file })
     }
 }

--- a/crates/atm-daemon/src/host_ownership.rs
+++ b/crates/atm-daemon/src/host_ownership.rs
@@ -58,7 +58,9 @@ impl HostOwnershipAdapter {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn acquire_at(lock_path: std::path::PathBuf) -> Result<HostOwnershipGuard, AtmError> {
+    pub(crate) fn acquire_at(
+        lock_path: std::path::PathBuf,
+    ) -> Result<HostOwnershipGuard, AtmError> {
         Self::new().acquire_at_with_observability(lock_path)
     }
 

--- a/crates/atm-daemon/src/host_ownership.rs
+++ b/crates/atm-daemon/src/host_ownership.rs
@@ -7,7 +7,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use atm_core::error::AtmError;
 use fs2::FileExt;
 
-use crate::{DaemonSubsystem, SubsystemObservability};
+#[cfg(test)]
+use crate::DaemonSubsystem;
+use crate::SubsystemObservability;
 
 #[cfg_attr(windows, allow(dead_code))]
 const STALE_OWNER_RECOVERY_RETRY_ATTEMPTS: usize = 3;
@@ -40,7 +42,7 @@ pub(crate) struct HostOwnershipGuard {
 
 #[cfg_attr(windows, allow(dead_code))]
 impl HostOwnershipAdapter {
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::new_with_observability(SubsystemObservability::disabled(
             DaemonSubsystem::HostOwnership,
@@ -57,8 +59,10 @@ impl HostOwnershipAdapter {
         )?)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn acquire_at(lock_path: std::path::PathBuf) -> Result<HostOwnershipGuard, AtmError> {
+    #[cfg(test)]
+    pub(crate) fn acquire_at(
+        lock_path: std::path::PathBuf,
+    ) -> Result<HostOwnershipGuard, AtmError> {
         Self::new().acquire_at_with_observability(lock_path)
     }
 

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -40,8 +40,6 @@ use std::time::Duration;
 
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_rusqlite::SqliteBoundaryAssembly;
-#[cfg(test)]
-pub(crate) use daemon_runtime_observability::observability_test_event;
 pub use daemon_runtime_observability::{
     DaemonEvent, DaemonRuntimeObservability, DaemonSubsystem, TeamScope,
 };

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -40,6 +40,8 @@ use std::time::Duration;
 
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_rusqlite::SqliteBoundaryAssembly;
+#[cfg(test)]
+pub(crate) use daemon_runtime_observability::observability_test_event;
 pub use daemon_runtime_observability::{
     DaemonEvent, DaemonRuntimeObservability, DaemonSubsystem, TeamScope,
 };

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -40,7 +40,11 @@ use std::time::Duration;
 
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_rusqlite::SqliteBoundaryAssembly;
-pub use daemon_runtime_observability::DaemonRuntimeObservability;
+pub use daemon_runtime_observability::{
+    DaemonEvent, DaemonRuntimeObservability, DaemonSubsystem, TeamScope,
+};
+
+pub(crate) use daemon_runtime_observability::SubsystemObservability;
 
 pub(crate) use atm_rusqlite::RemoteReplayStateRecord;
 pub(crate) use local_ipc_transport::LocalIpcServerTransportAdapter;

--- a/crates/atm-daemon/src/lifecycle_control.rs
+++ b/crates/atm-daemon/src/lifecycle_control.rs
@@ -273,7 +273,13 @@ impl LifecycleControlSourceAdapter {
             .spawn(move || {
                 let _ = result_tx.send(worker.join_handle.join());
             })
-            .expect("failed to spawn lifecycle join helper");
+            .map_err(|source| {
+                AtmError::daemon_unavailable("failed to spawn lifecycle join helper")
+                    .with_recovery(
+                        "Restart the daemon; the lifecycle worker could not create its bounded shutdown join helper.",
+                    )
+                    .with_source(source)
+            })?;
         match result_rx.recv_timeout(LIFECYCLE_WORKER_JOIN_DEADLINE) {
             Ok(Ok(())) => {
                 let _ = join_helper.join();

--- a/crates/atm-daemon/src/lifecycle_control.rs
+++ b/crates/atm-daemon/src/lifecycle_control.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use atm_core::error::AtmError;
 use signal_hook::SigId;
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 const LIFECYCLE_WORKER_JOIN_DEADLINE: Duration = Duration::from_secs(5);
 
 // Installation takes this global slot only after the outer install lock so concurrent daemon
@@ -24,6 +26,7 @@ pub(crate) struct LifecycleControlSourceAdapter {
     reload: Arc<AtomicBool>,
     #[cfg_attr(windows, allow(dead_code))]
     state_change: Arc<LifecycleStateChange>,
+    observability: SubsystemObservability,
 }
 
 #[derive(Debug)]
@@ -124,6 +127,14 @@ impl LifecycleStateChange {
 
 impl LifecycleControlSourceAdapter {
     pub(crate) fn install() -> Result<Self, AtmError> {
+        Self::install_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::LifecycleControl,
+        ))
+    }
+
+    pub(crate) fn install_with_observability(
+        observability: SubsystemObservability,
+    ) -> Result<Self, AtmError> {
         let _guard = INSTALL_LOCK
             .lock()
             .map_err(|_| {
@@ -162,10 +173,16 @@ impl LifecycleControlSourceAdapter {
                 &shared.state_change,
             )?);
         }
+        let _ = observability.emit(
+            "install_hooks",
+            "ok",
+            "daemon lifecycle-control hooks are installed",
+        );
         Ok(Self {
             terminate: Arc::clone(&shared.terminate),
             reload: Arc::clone(&shared.reload),
             state_change: Arc::clone(&shared.state_change),
+            observability,
         })
     }
 
@@ -176,6 +193,7 @@ impl LifecycleControlSourceAdapter {
             terminate: Arc::new(AtomicBool::new(false)),
             reload: Arc::new(AtomicBool::new(false)),
             state_change,
+            observability: SubsystemObservability::disabled(DaemonSubsystem::LifecycleControl),
         }
     }
 
@@ -259,10 +277,20 @@ impl LifecycleControlSourceAdapter {
         match result_rx.recv_timeout(LIFECYCLE_WORKER_JOIN_DEADLINE) {
             Ok(Ok(())) => {
                 let _ = join_helper.join();
+                let _ = self.observability.emit(
+                    "shutdown_worker",
+                    "ok",
+                    "daemon lifecycle-control worker shut down cleanly",
+                );
                 Ok(())
             }
             Ok(Err(_)) => {
                 let _ = join_helper.join();
+                let _ = self.observability.emit(
+                    "shutdown_worker",
+                    "failed",
+                    "daemon lifecycle-control worker panicked during shutdown",
+                );
                 Err(AtmError::daemon_unavailable(
                     "daemon lifecycle wake worker panicked during runtime teardown",
                 )
@@ -272,6 +300,11 @@ impl LifecycleControlSourceAdapter {
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                 let _ = join_helper.join();
+                let _ = self.observability.emit(
+                    "shutdown_worker",
+                    "degraded",
+                    "daemon lifecycle-control worker exceeded its shutdown deadline",
+                );
                 Err(AtmError::daemon_unavailable(
                     "daemon lifecycle wake worker exceeded the bounded shutdown deadline",
                 )
@@ -281,6 +314,11 @@ impl LifecycleControlSourceAdapter {
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 let _ = join_helper.join();
+                let _ = self.observability.emit(
+                    "shutdown_worker",
+                    "failed",
+                    "daemon lifecycle-control join coordination disconnected during shutdown",
+                );
                 Err(AtmError::daemon_unavailable(
                     "daemon lifecycle wake worker join coordination disconnected during runtime teardown",
                 )

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -871,6 +871,7 @@ fn emit_ready_signal_if_requested() -> Result<(), AtmError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::active_connection_registry::TrackedDispatchHandle;
     #[cfg(unix)]
     use crate::lifecycle_control::LifecycleControlSourceAdapter;
     #[cfg(unix)]

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -22,6 +22,7 @@ use crate::lifecycle_control::LifecycleControlSourceAdapter;
 use crate::local_ipc_connection::drain_active_connections_for_shutdown;
 use crate::local_ipc_wake::{schedule_delayed_listener_wake, wake_listener};
 use crate::shutdown_beacon::ShutdownBeacon;
+use crate::{DaemonSubsystem, SubsystemObservability};
 
 #[cfg(unix)]
 use std::fs;
@@ -142,6 +143,7 @@ pub(crate) struct PreparedRuntimeServer {
     registry: Arc<ActiveConnectionRegistry>,
     force_shutdown: Arc<AtomicBool>,
     codec: JsonAtmProtocolCodec,
+    observability: SubsystemObservability,
     // The endpoint guard must drop after the listener and connection registry have been torn
     // down so same-host endpoint unpublication never races a still-live serving resource.
     endpoint_guard: Option<SocketEndpointGuard>,
@@ -189,13 +191,30 @@ impl std::fmt::Debug for PreparedRuntimeServer {
 }
 
 impl PreparedRuntimeServer {
+    #[allow(dead_code)]
     fn bind(endpoint_path: PathBuf) -> Result<Self, AtmError> {
+        Self::bind_with_observability(
+            endpoint_path,
+            SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
+            SubsystemObservability::disabled(DaemonSubsystem::HostOwnership),
+            SubsystemObservability::disabled(DaemonSubsystem::LifecycleControl),
+        )
+    }
+
+    fn bind_with_observability(
+        endpoint_path: PathBuf,
+        observability: SubsystemObservability,
+        host_ownership_observability: SubsystemObservability,
+        lifecycle_observability: SubsystemObservability,
+    ) -> Result<Self, AtmError> {
         // Install lifecycle control before singleton ownership so daemon startup never
         // claims the host-wide owner lock unless shutdown/reload hooks are ready too.
         // Reversing this order can transiently block a healthy daemon restart behind an
         // instance that failed before it could service lifecycle-control requests.
-        let lifecycle_control = LifecycleControlSourceAdapter::install()?;
-        let ownership = HostOwnershipAdapter::new().acquire()?;
+        let lifecycle_control =
+            LifecycleControlSourceAdapter::install_with_observability(lifecycle_observability)?;
+        let ownership =
+            HostOwnershipAdapter::new_with_observability(host_ownership_observability).acquire()?;
         let endpoint_preparation = prepare_local_ipc_endpoint(&endpoint_path)?;
         let listener = ListenerOptions::new()
             .name(atm_core::protocol::daemon_local_ipc_name_from_path(
@@ -219,6 +238,11 @@ impl PreparedRuntimeServer {
             endpoint_preparation = ?endpoint_preparation,
             "daemon local IPC transport limits configured"
         );
+        let _ = observability.emit(
+            "bind_listener",
+            "ok",
+            "daemon local IPC transport prepared the runtime listener",
+        );
         emit_ready_signal_if_requested()?;
         Ok(Self {
             host_ownership_guard: ownership,
@@ -234,6 +258,7 @@ impl PreparedRuntimeServer {
             registry: Arc::new(ActiveConnectionRegistry::default()),
             force_shutdown: Arc::new(AtomicBool::new(false)),
             codec: JsonAtmProtocolCodec,
+            observability,
         })
     }
 
@@ -292,6 +317,7 @@ impl PreparedRuntimeServer {
             registry,
             force_shutdown,
             codec,
+            observability,
         } = self;
         thread::scope(|scope| -> Result<(), AtmError> {
             // Each serving invocation owns its own shutdown beacon. The beacon must not survive a
@@ -399,9 +425,16 @@ impl PreparedRuntimeServer {
                 // races a partially-applied runtime view update.
                 if signals.take_reload() {
                     match reload_runtime_view() {
-                        Ok(()) => tracing::info!(
-                            "bounded lifecycle-control-triggered config/roster reload applied"
-                        ),
+                        Ok(()) => {
+                            let _ = observability.emit(
+                                "reload_runtime_view",
+                                "ok",
+                                "bounded lifecycle-control-triggered config or roster reload applied",
+                            );
+                            tracing::info!(
+                                "bounded lifecycle-control-triggered config/roster reload applied"
+                            )
+                        }
                         Err(error) => tracing::warn!(
                             error_code = %error.code,
                             error_message = %error.message,
@@ -460,9 +493,16 @@ impl PreparedRuntimeServer {
                 if signals.take_reload() {
                     drop(stream);
                     match reload_runtime_view() {
-                        Ok(()) => tracing::info!(
-                            "bounded lifecycle-control-triggered config/roster reload applied"
-                        ),
+                        Ok(()) => {
+                            let _ = observability.emit(
+                                "reload_runtime_view",
+                                "ok",
+                                "bounded lifecycle-control-triggered config or roster reload applied",
+                            );
+                            tracing::info!(
+                                "bounded lifecycle-control-triggered config/roster reload applied"
+                            )
+                        }
                         Err(error) => tracing::warn!(
                             error_code = %error.code,
                             error_message = %error.message,
@@ -655,12 +695,33 @@ impl PreparedRuntimeServer {
     }
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct LocalIpcServerTransportAdapter;
+#[derive(Debug, Clone)]
+pub(crate) struct LocalIpcServerTransportAdapter {
+    observability: SubsystemObservability,
+    host_ownership_observability: SubsystemObservability,
+    lifecycle_observability: SubsystemObservability,
+}
 
 impl LocalIpcServerTransportAdapter {
-    pub(crate) const fn new() -> Self {
-        Self
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn new() -> Self {
+        Self::new_with_observability(
+            SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
+            SubsystemObservability::disabled(DaemonSubsystem::HostOwnership),
+            SubsystemObservability::disabled(DaemonSubsystem::LifecycleControl),
+        )
+    }
+
+    pub(crate) fn new_with_observability(
+        observability: SubsystemObservability,
+        host_ownership_observability: SubsystemObservability,
+        lifecycle_observability: SubsystemObservability,
+    ) -> Self {
+        Self {
+            observability,
+            host_ownership_observability,
+            lifecycle_observability,
+        }
     }
 
     pub(crate) fn prepare_runtime(&self) -> Result<PreparedRuntimeServer, AtmError> {
@@ -672,7 +733,12 @@ impl LocalIpcServerTransportAdapter {
         &self,
         endpoint_path: PathBuf,
     ) -> Result<PreparedRuntimeServer, AtmError> {
-        PreparedRuntimeServer::bind(endpoint_path)
+        PreparedRuntimeServer::bind_with_observability(
+            endpoint_path,
+            self.observability.clone(),
+            self.host_ownership_observability.clone(),
+            self.lifecycle_observability.clone(),
+        )
     }
 }
 

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -31,7 +31,7 @@ use std::fs;
 use std::thread;
 
 use request_worker::handle_connection;
-#[cfg(test)]
+#[cfg(all(test, unix))]
 use request_worker::install_injected_accept_error_for_test;
 
 const MAX_CONCURRENT_CONNECTIONS: usize = 64;
@@ -197,7 +197,7 @@ impl std::fmt::Debug for PreparedRuntimeServer {
 }
 
 impl PreparedRuntimeServer {
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     fn bind(endpoint_path: PathBuf) -> Result<Self, AtmError> {
         Self::bind_with_observability(
             endpoint_path,

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -8,25 +8,31 @@ use std::time::{Duration, Instant};
 
 use atm_core::boundary::{self, AtmProtocol, RequestDispatcher};
 use atm_core::error::AtmError;
-use atm_core::protocol::{
-    JsonAtmProtocolCodec, ProtocolErrorEnvelope, RequestEnvelope, RequestId, ResponseEnvelope,
-};
+use atm_core::protocol::{JsonAtmProtocolCodec, ProtocolErrorEnvelope, ResponseEnvelope};
 use interprocess::local_socket::prelude::*;
 use interprocess::local_socket::{
     Listener as LocalSocketListener, ListenerOptions, Stream as LocalSocketStream,
 };
 
-use crate::active_connection_registry::{ActiveConnectionRegistry, TrackedDispatchHandle};
+#[cfg(test)]
+use crate::DaemonSubsystem;
+use crate::SubsystemObservability;
+use crate::active_connection_registry::ActiveConnectionRegistry;
 use crate::host_ownership::{HostOwnershipAdapter, HostOwnershipGuard};
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
 use crate::local_ipc_connection::drain_active_connections_for_shutdown;
 use crate::local_ipc_wake::{schedule_delayed_listener_wake, wake_listener};
 use crate::shutdown_beacon::ShutdownBeacon;
-use crate::{DaemonSubsystem, SubsystemObservability};
+
+mod request_worker;
 
 #[cfg(unix)]
 use std::fs;
 use std::thread;
+
+use request_worker::handle_connection;
+#[cfg(test)]
+use request_worker::install_injected_accept_error_for_test;
 
 const MAX_CONCURRENT_CONNECTIONS: usize = 64;
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
@@ -191,7 +197,7 @@ impl std::fmt::Debug for PreparedRuntimeServer {
 }
 
 impl PreparedRuntimeServer {
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn bind(endpoint_path: PathBuf) -> Result<Self, AtmError> {
         Self::bind_with_observability(
             endpoint_path,
@@ -703,7 +709,7 @@ pub(crate) struct LocalIpcServerTransportAdapter {
 }
 
 impl LocalIpcServerTransportAdapter {
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::new_with_observability(
             SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
@@ -840,15 +846,6 @@ fn write_shutdown_response(
     Ok(ShutdownResponseOutcome::RejectedRequest)
 }
 
-#[cfg(test)]
-#[cfg_attr(not(unix), allow(dead_code))]
-pub(crate) fn install_injected_accept_error_for_test(
-    runtime: &mut PreparedRuntimeServer,
-    signal: std::sync::mpsc::SyncSender<()>,
-) {
-    runtime.accept_error_inject = Some(signal);
-}
-
 fn emit_ready_signal_if_requested() -> Result<(), AtmError> {
     if std::env::var_os("ATM_DAEMON_READY_STDOUT").is_none() {
         return Ok(());
@@ -869,164 +866,6 @@ fn emit_ready_signal_if_requested() -> Result<(), AtmError> {
             .with_source(source)
     })?;
     Ok(())
-}
-
-fn handle_connection(
-    mut stream: LocalSocketStream,
-    dispatcher: Arc<dyn RequestDispatcher + Send + Sync>,
-    force_shutdown: &AtomicBool,
-    registry: Arc<ActiveConnectionRegistry>,
-    codec: JsonAtmProtocolCodec,
-) -> Result<(), AtmError> {
-    if force_shutdown.load(Ordering::SeqCst) {
-        return write_shutdown_response(&mut stream, &codec).map(|_| ());
-    }
-    stream
-        .set_recv_timeout(Some(REQUEST_DEADLINE))
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to apply daemon request read deadline")
-                .with_recovery(
-                    "Restart the daemon; the same-host request socket could not apply its bounded read deadline.",
-                )
-                .with_source(source)
-        })?;
-    stream
-        .set_send_timeout(Some(REQUEST_DEADLINE))
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to apply daemon response write deadline")
-                .with_recovery(
-                    "Restart the daemon; the same-host request socket could not apply its bounded write deadline.",
-                )
-                .with_source(source)
-        })?;
-
-    // Phase S still enforces one request per accepted same-host connection even though the
-    // request runtime owns its execution separately from this socket receive loop.
-    let Some(frame) = atm_core::protocol::read_frame(
-        &mut stream,
-        "failed to read daemon request frame",
-        "daemon request frame exceeded the maximum supported size",
-    )?
-    else {
-        return Ok(());
-    };
-    tracing::debug!(
-        max_daemon_frame_bytes = atm_core::protocol::MAX_DAEMON_FRAME_BYTES,
-        "daemon request frame accepted under configured size cap"
-    );
-    let (request_id, request) = codec.request_from_frame(frame)?;
-    if let RequestEnvelope::AdvisoryStream(request) = request {
-        stream.set_send_timeout(None).map_err(|source| {
-            AtmError::daemon_unavailable(
-                "failed to clear daemon advisory-stream write deadline",
-            )
-            .with_recovery(
-                "Restart the daemon; the same-host advisory stream socket could not switch into long-lived streaming mode.",
-            )
-            .with_source(source)
-        })?;
-        let mut sink = LocalIpcAdvisoryStreamSink {
-            stream: &mut stream,
-            codec: &codec,
-            request_id,
-            force_shutdown,
-        };
-        return dispatcher.dispatch_advisory_stream(request, &mut sink);
-    }
-
-    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
-    let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
-    let dispatch_registry = Arc::clone(&registry);
-    let dispatch_handle = std::thread::Builder::new()
-        .name("local-ipc-dispatch".to_string())
-        .spawn(move || {
-            let _dispatch_work = dispatch_registry.register_dispatch_work();
-            let _ = result_tx.send(dispatcher.dispatch(request));
-            let _ = completion_tx.send(());
-        })
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to spawn daemon local IPC dispatch worker")
-                .with_recovery(
-                    "Retry the ATM command after atm-daemon restarts; the same-host request worker could not be created.",
-                )
-                .with_source(source)
-        })?;
-    // The tracked-dispatch registry owns the eventual join. Timeouts can let a request worker run
-    // past this socket exchange, but the direct accept loop and bounded shutdown sweep still reap
-    // the handle before runtime teardown completes.
-    registry.push_dispatch_handle(
-        TrackedDispatchHandle {
-            completion_rx,
-            join_handle: dispatch_handle,
-        },
-        MAX_CONCURRENT_CONNECTIONS,
-    )?;
-    let response = match result_rx.recv_timeout(REQUEST_DEADLINE) {
-        Ok(Ok(response)) => response,
-        Ok(Err(error)) => ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(&error)),
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            tracing::warn!("daemon request dispatcher exceeded the runtime deadline");
-            ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
-                &AtmError::daemon_unavailable(
-                    "daemon request exceeded the 3s runtime deadline; the operation may still complete in the background",
-                )
-                .with_recovery(
-                    "Check the destination mailbox or service-side effects before retrying this ATM command.",
-                ),
-            ))
-        }
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
-                &AtmError::daemon_unavailable(
-                    "daemon request dispatcher stopped before returning a response",
-                )
-                .with_recovery(
-                    "Retry the ATM command after the daemon finishes recovering the request runtime.",
-                ),
-            ))
-        }
-    };
-    let frame = codec.response_to_frame(request_id, response)?;
-    atm_core::protocol::write_frame(&mut stream, &frame, "failed to write daemon response frame")?;
-    stream.flush().map_err(|source| {
-        AtmError::daemon_unavailable("failed to flush daemon response frame")
-            .with_recovery(
-                "Retry the ATM command after the daemon finishes recovering the same-host request runtime.",
-            )
-            .with_source(source)
-    })?;
-    registry.reap_finished_dispatches()?;
-    Ok(())
-}
-
-struct LocalIpcAdvisoryStreamSink<'a> {
-    stream: &'a mut LocalSocketStream,
-    codec: &'a JsonAtmProtocolCodec,
-    request_id: RequestId,
-    force_shutdown: &'a std::sync::atomic::AtomicBool,
-}
-
-impl boundary::AdvisoryStreamSink for LocalIpcAdvisoryStreamSink<'_> {
-    fn emit(&mut self, response: ResponseEnvelope) -> Result<(), AtmError> {
-        let frame = self.codec.response_to_frame(self.request_id, response)?;
-        atm_core::protocol::write_frame(
-            self.stream,
-            &frame,
-            "failed to write daemon advisory-stream response frame",
-        )?;
-        self.stream.flush().map_err(|source| {
-            AtmError::daemon_unavailable("failed to flush daemon advisory-stream response frame")
-                .with_recovery(
-                    "Retry graft activation after atm-daemon returns to a healthy serving state.",
-                )
-                .with_source(source)
-        })
-    }
-
-    fn stop_requested(&self) -> bool {
-        self.force_shutdown
-            .load(std::sync::atomic::Ordering::SeqCst)
-    }
 }
 
 #[cfg(test)]

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -1,0 +1,177 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use atm_core::boundary::{AdvisoryStreamSink, AtmProtocol, RequestDispatcher};
+use atm_core::error::AtmError;
+use atm_core::protocol::{
+    JsonAtmProtocolCodec, ProtocolErrorEnvelope, RequestEnvelope, RequestId, ResponseEnvelope,
+};
+use interprocess::local_socket::Stream as LocalSocketStream;
+use interprocess::local_socket::traits::Stream;
+
+use crate::active_connection_registry::{ActiveConnectionRegistry, TrackedDispatchHandle};
+
+#[cfg(test)]
+use super::PreparedRuntimeServer;
+use super::{MAX_CONCURRENT_CONNECTIONS, REQUEST_DEADLINE, write_shutdown_response};
+
+pub(super) fn handle_connection(
+    mut stream: LocalSocketStream,
+    dispatcher: Arc<dyn RequestDispatcher + Send + Sync>,
+    force_shutdown: &AtomicBool,
+    registry: Arc<ActiveConnectionRegistry>,
+    codec: JsonAtmProtocolCodec,
+) -> Result<(), AtmError> {
+    if force_shutdown.load(Ordering::SeqCst) {
+        return write_shutdown_response(&mut stream, &codec).map(|_| ());
+    }
+    stream
+        .set_recv_timeout(Some(REQUEST_DEADLINE))
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to apply daemon request read deadline")
+                .with_recovery(
+                    "Restart the daemon; the same-host request socket could not apply its bounded read deadline.",
+                )
+                .with_source(source)
+        })?;
+    stream
+        .set_send_timeout(Some(REQUEST_DEADLINE))
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to apply daemon response write deadline")
+                .with_recovery(
+                    "Restart the daemon; the same-host request socket could not apply its bounded write deadline.",
+                )
+                .with_source(source)
+        })?;
+
+    let Some(frame) = atm_core::protocol::read_frame(
+        &mut stream,
+        "failed to read daemon request frame",
+        "daemon request frame exceeded the maximum supported size",
+    )?
+    else {
+        return Ok(());
+    };
+    tracing::debug!(
+        max_daemon_frame_bytes = atm_core::protocol::MAX_DAEMON_FRAME_BYTES,
+        "daemon request frame accepted under configured size cap"
+    );
+    let (request_id, request) = codec.request_from_frame(frame)?;
+    if let RequestEnvelope::AdvisoryStream(request) = request {
+        stream.set_send_timeout(None).map_err(|source| {
+            AtmError::daemon_unavailable(
+                "failed to clear daemon advisory-stream write deadline",
+            )
+            .with_recovery(
+                "Restart the daemon; the same-host advisory stream socket could not switch into long-lived streaming mode.",
+            )
+            .with_source(source)
+        })?;
+        let mut sink = LocalIpcAdvisoryStreamSink {
+            stream: &mut stream,
+            codec: &codec,
+            request_id,
+            force_shutdown,
+        };
+        return dispatcher.dispatch_advisory_stream(request, &mut sink);
+    }
+
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
+    let dispatch_registry = Arc::clone(&registry);
+    let dispatch_handle = std::thread::Builder::new()
+        .name("local-ipc-dispatch".to_string())
+        .spawn(move || {
+            let _dispatch_work = dispatch_registry.register_dispatch_work();
+            let _ = result_tx.send(dispatcher.dispatch(request));
+            let _ = completion_tx.send(());
+        })
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to spawn daemon local IPC dispatch worker")
+                .with_recovery(
+                    "Retry the ATM command after atm-daemon restarts; the same-host request worker could not be created.",
+                )
+                .with_source(source)
+        })?;
+    registry.push_dispatch_handle(
+        TrackedDispatchHandle {
+            completion_rx,
+            join_handle: dispatch_handle,
+        },
+        MAX_CONCURRENT_CONNECTIONS,
+    )?;
+    let response = match result_rx.recv_timeout(REQUEST_DEADLINE) {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(&error)),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            tracing::warn!("daemon request dispatcher exceeded the runtime deadline");
+            ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
+                &AtmError::daemon_unavailable(
+                    "daemon request exceeded the 3s runtime deadline; the operation may still complete in the background",
+                )
+                .with_recovery(
+                    "Check the destination mailbox or service-side effects before retrying this ATM command.",
+                ),
+            ))
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            ResponseEnvelope::Error(ProtocolErrorEnvelope::from_error(
+                &AtmError::daemon_unavailable(
+                    "daemon request dispatcher stopped before returning a response",
+                )
+                .with_recovery(
+                    "Retry the ATM command after the daemon finishes recovering the request runtime.",
+                ),
+            ))
+        }
+    };
+    let frame = codec.response_to_frame(request_id, response)?;
+    atm_core::protocol::write_frame(&mut stream, &frame, "failed to write daemon response frame")?;
+    std::io::Write::flush(&mut stream).map_err(|source| {
+        AtmError::daemon_unavailable("failed to flush daemon response frame")
+            .with_recovery(
+                "Retry the ATM command after the daemon finishes recovering the same-host request runtime.",
+            )
+            .with_source(source)
+    })?;
+    registry.reap_finished_dispatches()?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[cfg_attr(not(unix), allow(dead_code))]
+pub(super) fn install_injected_accept_error_for_test(
+    runtime: &mut PreparedRuntimeServer,
+    signal: std::sync::mpsc::SyncSender<()>,
+) {
+    runtime.accept_error_inject = Some(signal);
+}
+
+struct LocalIpcAdvisoryStreamSink<'a> {
+    stream: &'a mut LocalSocketStream,
+    codec: &'a JsonAtmProtocolCodec,
+    request_id: RequestId,
+    force_shutdown: &'a AtomicBool,
+}
+
+impl AdvisoryStreamSink for LocalIpcAdvisoryStreamSink<'_> {
+    fn emit(&mut self, response: ResponseEnvelope) -> Result<(), AtmError> {
+        let frame = self.codec.response_to_frame(self.request_id, response)?;
+        atm_core::protocol::write_frame(
+            self.stream,
+            &frame,
+            "failed to write daemon advisory-stream response frame",
+        )?;
+        std::io::Write::flush(&mut self.stream).map_err(|source| {
+            AtmError::daemon_unavailable("failed to flush daemon advisory-stream response frame")
+                .with_recovery(
+                    "Retry graft activation after atm-daemon returns to a healthy serving state.",
+                )
+                .with_source(source)
+        })
+    }
+
+    fn stop_requested(&self) -> bool {
+        self.force_shutdown.load(Ordering::SeqCst)
+    }
+}

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -45,13 +45,6 @@ struct NotificationState {
 }
 
 impl NotificationRuntime {
-    #[cfg(test)]
-    pub(crate) fn new() -> Self {
-        Self::new_with_observability(SubsystemObservability::disabled(
-            DaemonSubsystem::NotificationRuntime,
-        ))
-    }
-
     pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self::new_with_path_factory(
             Arc::new(|| Ok(atm_core::home::host_runtime_dir()?.join("notifications.jsonl"))),

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -9,7 +9,9 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use crate::{DaemonSubsystem, SubsystemObservability};
+#[cfg(test)]
+use crate::DaemonSubsystem;
+use crate::SubsystemObservability;
 
 const DEFAULT_NOTIFICATION_QUEUE_CAPACITY: usize = 64;
 const DEFAULT_NOTIFICATION_IDLE_INTERVAL: Duration = Duration::from_millis(50);
@@ -43,7 +45,7 @@ struct NotificationState {
 }
 
 impl NotificationRuntime {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self::new_with_observability(SubsystemObservability::disabled(
             DaemonSubsystem::NotificationRuntime,
@@ -92,10 +94,11 @@ impl NotificationRuntime {
             .name("atm-daemon-notifier".to_string())
             .spawn(move || notification_worker_loop(inner))
             .map_err(|source| {
-                let _ = self
-                    .inner
-                    .observability
-                    .emit("start", "failed", "failed to spawn notification runtime worker");
+                let _ = self.inner.observability.emit(
+                    "start",
+                    "failed",
+                    "failed to spawn notification runtime worker",
+                );
                 AtmError::daemon_unavailable("failed to spawn notification runtime worker")
                     .with_source(source)
             })?;

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -9,6 +9,8 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 const DEFAULT_NOTIFICATION_QUEUE_CAPACITY: usize = 64;
 const DEFAULT_NOTIFICATION_IDLE_INTERVAL: Duration = Duration::from_millis(50);
 const NOTIFICATION_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(3);
@@ -28,6 +30,7 @@ struct NotificationRuntimeInner {
     wake: Condvar,
     path_factory: NotificationPathFactory,
     queue_capacity: usize,
+    observability: SubsystemObservability,
 }
 
 #[derive(Default)]
@@ -40,20 +43,33 @@ struct NotificationState {
 }
 
 impl NotificationRuntime {
+    #[allow(dead_code)]
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::NotificationRuntime,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self::new_with_path_factory(
             Arc::new(|| Ok(atm_core::home::host_runtime_dir()?.join("notifications.jsonl"))),
             DEFAULT_NOTIFICATION_QUEUE_CAPACITY,
+            observability,
         )
     }
 
-    fn new_with_path_factory(path_factory: NotificationPathFactory, queue_capacity: usize) -> Self {
+    fn new_with_path_factory(
+        path_factory: NotificationPathFactory,
+        queue_capacity: usize,
+        observability: SubsystemObservability,
+    ) -> Self {
         Self {
             inner: Arc::new(NotificationRuntimeInner {
                 state: Mutex::new(NotificationState::default()),
                 wake: Condvar::new(),
                 path_factory,
                 queue_capacity,
+                observability,
             }),
         }
     }
@@ -76,6 +92,10 @@ impl NotificationRuntime {
             .name("atm-daemon-notifier".to_string())
             .spawn(move || notification_worker_loop(inner))
             .map_err(|source| {
+                let _ = self
+                    .inner
+                    .observability
+                    .emit("start", "failed", "failed to spawn notification runtime worker");
                 AtmError::daemon_unavailable("failed to spawn notification runtime worker")
                     .with_source(source)
             })?;
@@ -92,6 +112,10 @@ impl NotificationRuntime {
             }
         };
         state.worker = Some(handle);
+        let _ = self
+            .inner
+            .observability
+            .emit("start", "ok", "notification runtime worker started");
         Ok(())
     }
 
@@ -127,9 +151,19 @@ impl NotificationRuntime {
             match result_rx.recv_timeout(NOTIFICATION_SHUTDOWN_DEADLINE) {
                 Ok(Ok(())) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "ok",
+                        "notification runtime worker shut down cleanly",
+                    );
                 }
                 Ok(Err(_)) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "notification runtime worker panicked during shutdown",
+                    );
                     return Err(AtmError::daemon_unavailable(
                         "notification runtime worker panicked during shutdown",
                     )
@@ -139,6 +173,11 @@ impl NotificationRuntime {
                 }
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                     drop(join_helper);
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "degraded",
+                        "notification runtime worker exceeded its shutdown deadline",
+                    );
                     tracing::warn!(
                         thread_id = ?worker_thread_id,
                         timeout_ms = NOTIFICATION_SHUTDOWN_DEADLINE.as_millis(),
@@ -154,6 +193,11 @@ impl NotificationRuntime {
                 }
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "notification runtime join helper disconnected during shutdown",
+                    );
                     tracing::warn!(
                         thread_id = ?worker_thread_id,
                         "notification runtime join helper exited before reporting shutdown status"
@@ -187,9 +231,19 @@ impl NotificationRuntime {
             ));
         }
         if let Some(message) = &state.degraded_message {
+            let _ = self.inner.observability.emit(
+                "deliver",
+                "degraded",
+                "notification runtime is degraded and rejecting delivery",
+            );
             return Err(AtmError::daemon_unavailable(message.as_str()));
         }
         if state.queue.len() >= self.inner.queue_capacity {
+            let _ = self.inner.observability.emit(
+                "deliver",
+                "rejected",
+                "notification runtime queue is full",
+            );
             return Err(AtmError::daemon_unavailable(
                 "notification runtime queue is full; delivery is backpressured",
             ));
@@ -201,7 +255,11 @@ impl NotificationRuntime {
 
     #[cfg(test)]
     pub(crate) fn new_for_test_with_path(path: PathBuf, queue_capacity: usize) -> Self {
-        Self::new_with_path_factory(Arc::new(move || Ok(path.clone())), queue_capacity)
+        Self::new_with_path_factory(
+            Arc::new(move || Ok(path.clone())),
+            queue_capacity,
+            SubsystemObservability::disabled(DaemonSubsystem::NotificationRuntime),
+        )
     }
 }
 
@@ -236,6 +294,11 @@ fn notification_worker_loop(inner: Arc<NotificationRuntimeInner>) {
                 state.degraded_message = Some(error.message);
                 state.queue.clear();
             }
+            let _ = inner.observability.emit(
+                "persist_notification",
+                "degraded",
+                "notification runtime persistence failed and the runtime entered a degraded state",
+            );
             return;
         }
     }

--- a/crates/atm-daemon/src/notification_runtime.rs
+++ b/crates/atm-daemon/src/notification_runtime.rs
@@ -92,10 +92,11 @@ impl NotificationRuntime {
             .name("atm-daemon-notifier".to_string())
             .spawn(move || notification_worker_loop(inner))
             .map_err(|source| {
-                let _ = self
-                    .inner
-                    .observability
-                    .emit("start", "failed", "failed to spawn notification runtime worker");
+                let _ = self.inner.observability.emit(
+                    "start",
+                    "failed",
+                    "failed to spawn notification runtime worker",
+                );
                 AtmError::daemon_unavailable("failed to spawn notification runtime worker")
                     .with_source(source)
             })?;

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -105,14 +105,6 @@ struct PeerClientTransport {
 }
 
 impl PeerClientTransport {
-    #[allow(dead_code)]
-    fn new(replay_store: Option<Arc<dyn RemoteReplayStore>>) -> Self {
-        Self::new_with_observability(
-            replay_store,
-            SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
-        )
-    }
-
     fn new_with_observability(
         replay_store: Option<Arc<dyn RemoteReplayStore>>,
         observability: SubsystemObservability,
@@ -551,7 +543,6 @@ impl Default for PeerTransportRuntime {
 }
 
 impl PeerTransportRuntime {
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(replay_store: Option<Arc<dyn RemoteReplayStore>>) -> Self {
         Self::new_with_observability(
             replay_store,
@@ -569,7 +560,6 @@ impl PeerTransportRuntime {
     }
 
     #[cfg(test)]
-    #[allow(dead_code)]
     pub(crate) fn client_transport(&self) -> &dyn ClientTransport {
         &self.client
     }

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -16,6 +16,8 @@ use atm_core::protocol::{
 };
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 // Architecture authority: docs/architecture.md §21.6.4 daemon operational
 // defaults and remote peer transport rules.
 const PEER_CONNECT_DEADLINE: Duration = Duration::from_secs(5);
@@ -99,10 +101,22 @@ struct PeerClientTransport {
     config: PeerTransportConfig,
     replay_store: Option<Arc<dyn RemoteReplayStore>>,
     codec: JsonAtmProtocolCodec,
+    observability: SubsystemObservability,
 }
 
 impl PeerClientTransport {
+    #[allow(dead_code)]
     fn new(replay_store: Option<Arc<dyn RemoteReplayStore>>) -> Self {
+        Self::new_with_observability(
+            replay_store,
+            SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
+        )
+    }
+
+    fn new_with_observability(
+        replay_store: Option<Arc<dyn RemoteReplayStore>>,
+        observability: SubsystemObservability,
+    ) -> Self {
         let endpoint = daemon_peer_endpoint_from_env();
         let config = std::env::current_dir()
             .ok()
@@ -125,6 +139,7 @@ impl PeerClientTransport {
             config,
             replay_store,
             codec: JsonAtmProtocolCodec,
+            observability,
         }
     }
 
@@ -141,6 +156,7 @@ impl PeerClientTransport {
             config,
             replay_store: Some(replay_store),
             codec: JsonAtmProtocolCodec,
+            observability: SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
         }
     }
 
@@ -168,6 +184,11 @@ impl PeerClientTransport {
                         replay_attempt_count = record.attempt_count,
                         "daemon remote replay delivered successfully"
                     );
+                    let _ = self.observability.emit(
+                        "resume_pending_replay",
+                        "ok",
+                        "daemon remote replay delivered a retained record",
+                    );
                     delivered += 1;
                 }
                 Err(error) => {
@@ -181,6 +202,11 @@ impl PeerClientTransport {
                         error_code = %error.code,
                         error_message = %error.message,
                         "daemon remote replay delivery attempt failed; retaining record"
+                    );
+                    let _ = self.observability.emit(
+                        "resume_pending_replay",
+                        "degraded",
+                        "daemon remote replay delivery failed and retained the record for retry",
                     );
                     replay_store.enqueue(record)?;
                     retained += 1;
@@ -276,6 +302,11 @@ impl PeerClientTransport {
                         attempt,
                         "daemon peer delivery succeeded"
                     );
+                    let _ = self.observability.emit(
+                        "send_to_endpoint",
+                        "ok",
+                        "daemon peer delivery succeeded",
+                    );
                     return Ok(response);
                 }
                 Err(failure) if failure.kind == AttemptFailureKind::Retryable => {
@@ -287,6 +318,11 @@ impl PeerClientTransport {
                             error_code = %failure.error.code,
                             error_message = %failure.error.message,
                             "daemon peer delivery exhausted retry budget"
+                        );
+                        let _ = self.observability.emit(
+                            "send_to_endpoint",
+                            "failed",
+                            "daemon peer delivery exhausted its retry budget",
                         );
                         return Err(failure.error);
                     }
@@ -300,6 +336,11 @@ impl PeerClientTransport {
                         error_code = %failure.error.code,
                         error_message = %failure.error.message,
                         "daemon peer delivery hit retryable failure"
+                    );
+                    let _ = self.observability.emit(
+                        "send_to_endpoint",
+                        "degraded",
+                        "daemon peer delivery hit a retryable failure",
                     );
                     if wait_for_retry_backoff(&terminate, sleep_for) {
                         return Err(
@@ -327,6 +368,11 @@ impl PeerClientTransport {
                         error_code = %failure.error.code,
                         error_message = %failure.error.message,
                         "daemon peer delivery failed"
+                    );
+                    let _ = self.observability.emit(
+                        "send_to_endpoint",
+                        "failed",
+                        "daemon peer delivery failed with a non-retryable or outcome-unknown error",
                     );
                     return Err(failure.error);
                 }
@@ -505,9 +551,20 @@ impl Default for PeerTransportRuntime {
 }
 
 impl PeerTransportRuntime {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(replay_store: Option<Arc<dyn RemoteReplayStore>>) -> Self {
+        Self::new_with_observability(
+            replay_store,
+            SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
+        )
+    }
+
+    pub(crate) fn new_with_observability(
+        replay_store: Option<Arc<dyn RemoteReplayStore>>,
+        observability: SubsystemObservability,
+    ) -> Self {
         Self {
-            client: PeerClientTransport::new(replay_store),
+            client: PeerClientTransport::new_with_observability(replay_store, observability),
         }
     }
 

--- a/crates/atm-daemon/src/reconcile_runtime.rs
+++ b/crates/atm-daemon/src/reconcile_runtime.rs
@@ -10,6 +10,8 @@ use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 const DEFAULT_RECONCILE_DEBOUNCE: Duration = Duration::from_millis(25);
 const DEFAULT_RECONCILE_COMPLETION_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_RECONCILE_IDLE_INTERVAL: Duration = Duration::from_millis(50);
@@ -39,6 +41,7 @@ struct ReconcileRuntimeInner {
     pending_changed: Condvar,
     debounce: Duration,
     executor: ReconcileExecutor,
+    observability: SubsystemObservability,
     // Lock ordering invariant: if code ever needs both runtime state and the
     // fingerprint registry, it must drop `state` before locking this mutex.
     // The registry is ancillary reconcile-emission state and must never nest
@@ -157,10 +160,25 @@ impl ReconcileKey {
 }
 
 impl ReconcileRuntime {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(
         watch_source: Arc<dyn WatchEventSource + Send + Sync>,
         inbox_ingress: Arc<dyn InboxIngress + Send + Sync>,
         notification_sink: Arc<dyn NotificationSink + Send + Sync>,
+    ) -> Self {
+        Self::new_with_observability(
+            watch_source,
+            inbox_ingress,
+            notification_sink,
+            SubsystemObservability::disabled(DaemonSubsystem::ReconcileRuntime),
+        )
+    }
+
+    pub(crate) fn new_with_observability(
+        watch_source: Arc<dyn WatchEventSource + Send + Sync>,
+        inbox_ingress: Arc<dyn InboxIngress + Send + Sync>,
+        notification_sink: Arc<dyn NotificationSink + Send + Sync>,
+        observability: SubsystemObservability,
     ) -> Self {
         // Fingerprints must survive across executor invocations so duplicate
         // reconcile cycles can compare the newest inbox projection with the
@@ -206,6 +224,7 @@ impl ReconcileRuntime {
             }),
             DEFAULT_RECONCILE_DEBOUNCE,
             notification_fingerprints,
+            observability,
         )
     }
 
@@ -213,6 +232,7 @@ impl ReconcileRuntime {
         executor: ReconcileExecutor,
         debounce: Duration,
         notification_fingerprints: Arc<Mutex<NotificationFingerprintRegistry>>,
+        observability: SubsystemObservability,
     ) -> Self {
         Self {
             inner: Arc::new(ReconcileRuntimeInner {
@@ -222,6 +242,7 @@ impl ReconcileRuntime {
                 pending_changed: Condvar::new(),
                 debounce,
                 executor,
+                observability,
                 notification_fingerprints,
             }),
         }
@@ -245,6 +266,11 @@ impl ReconcileRuntime {
             .name("atm-daemon-reconcile".to_string())
             .spawn(move || reconcile_worker_loop(inner))
             .map_err(|source| {
+                let _ = self.inner.observability.emit(
+                    "start",
+                    "failed",
+                    "failed to spawn reconcile runtime worker",
+                );
                 AtmError::daemon_unavailable("failed to spawn reconcile runtime worker")
                     .with_source(source)
             })?;
@@ -261,6 +287,10 @@ impl ReconcileRuntime {
             }
         };
         state.worker = Some(handle);
+        let _ = self
+            .inner
+            .observability
+            .emit("start", "ok", "reconcile runtime worker started");
         Ok(())
     }
 
@@ -295,9 +325,19 @@ impl ReconcileRuntime {
             match result_rx.recv_timeout(RECONCILE_SHUTDOWN_DEADLINE) {
                 Ok(Ok(())) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "ok",
+                        "reconcile runtime worker shut down cleanly",
+                    );
                 }
                 Ok(Err(_)) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "reconcile runtime worker panicked during shutdown",
+                    );
                     return Err(AtmError::daemon_unavailable(
                         "reconcile runtime worker panicked during shutdown",
                     )
@@ -314,6 +354,11 @@ impl ReconcileRuntime {
                         timeout_ms = RECONCILE_SHUTDOWN_DEADLINE.as_millis(),
                         "reconcile runtime worker exceeded shutdown deadline; detaching join helper"
                     );
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "degraded",
+                        "reconcile runtime worker exceeded its shutdown deadline",
+                    );
                     return Err(AtmError::daemon_unavailable(
                         "reconcile runtime worker exceeded the bounded shutdown deadline",
                     )
@@ -323,6 +368,11 @@ impl ReconcileRuntime {
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "reconcile runtime join helper disconnected during shutdown",
+                    );
                     tracing::warn!(
                         thread_id = ?worker_thread_id,
                         "reconcile runtime worker join helper exited before reporting shutdown status"
@@ -340,6 +390,8 @@ impl ReconcileRuntime {
     }
 
     pub(crate) fn reconcile(&self, request: ReconcileRequest) -> Result<ReconcileResult, AtmError> {
+        let request_team = request.team.clone();
+        let request_agent = request.agent.clone();
         let waiter_id = {
             let mut state = self.inner.state.lock().map_err(|_| {
                 AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
@@ -347,11 +399,33 @@ impl ReconcileRuntime {
                 )
             })?;
             if !state.started {
+                let event = self
+                    .inner
+                    .observability
+                    .event(
+                        "reconcile",
+                        "rejected",
+                        "reconcile runtime is unavailable before daemon startup",
+                    )
+                    .with_team(request_team.clone())
+                    .with_agent(request_agent.clone());
+                let _ = self.inner.observability.emit_event(event);
                 return Err(AtmError::daemon_unavailable(
                     "reconcile runtime is unavailable before daemon startup",
                 ));
             }
             if state.shutdown {
+                let event = self
+                    .inner
+                    .observability
+                    .event(
+                        "reconcile",
+                        "rejected",
+                        "reconcile runtime is unavailable during daemon shutdown",
+                    )
+                    .with_team(request_team.clone())
+                    .with_agent(request_agent.clone());
+                let _ = self.inner.observability.emit_event(event);
                 return Err(AtmError::daemon_unavailable(
                     "reconcile runtime is unavailable during daemon shutdown",
                 ));
@@ -388,6 +462,17 @@ impl ReconcileRuntime {
         loop {
             if state.shutdown {
                 state.release_waiter(waiter_id);
+                let event = self
+                    .inner
+                    .observability
+                    .event(
+                        "reconcile",
+                        "degraded",
+                        "reconcile runtime shut down before completion",
+                    )
+                    .with_team(request_team.clone())
+                    .with_agent(request_agent.clone());
+                let _ = self.inner.observability.emit_event(event);
                 return Err(AtmError::daemon_unavailable(
                     "reconcile runtime shut down before completion",
                 ));
@@ -409,6 +494,17 @@ impl ReconcileRuntime {
             state = wait.0;
             if wait.1.timed_out() {
                 state.release_waiter(waiter_id);
+                let event = self
+                    .inner
+                    .observability
+                    .event(
+                        "reconcile",
+                        "degraded",
+                        "reconcile runtime timed out waiting for background completion",
+                    )
+                    .with_team(request_team.clone())
+                    .with_agent(request_agent.clone());
+                let _ = self.inner.observability.emit_event(event);
                 return Err(AtmError::daemon_unavailable(
                     "reconcile runtime timed out waiting for background completion",
                 ));
@@ -422,6 +518,7 @@ impl ReconcileRuntime {
             executor,
             debounce,
             Arc::new(Mutex::new(NotificationFingerprintRegistry::default())),
+            SubsystemObservability::disabled(DaemonSubsystem::ReconcileRuntime),
         )
     }
 

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -30,7 +30,9 @@ use atm_rusqlite::{SqliteBoundaryAssembly, assemble_default_boundary};
 
 use crate::AtmHomeDir;
 use crate::advisory_runtime::AdvisoryRuntime;
-use crate::daemon_runtime_observability::DaemonRuntimeObservability;
+use crate::daemon_runtime_observability::{
+    DaemonEvent, DaemonRuntimeObservability, DaemonSubsystem,
+};
 #[cfg(test)]
 pub(crate) use crate::runtime_status_cache::MAX_STATUS_CACHE_ENTRIES;
 pub(crate) use crate::runtime_status_cache::RuntimeStatusCache;
@@ -204,22 +206,28 @@ impl DaemonRequestDispatcher {
         };
         Self {
             home_dir: home_dir.clone(),
-            observability,
+            observability: Arc::clone(&observability),
             status_cache,
             sqlite_boundary,
-            advisory_runtime: AdvisoryRuntime::new(),
+            advisory_runtime: AdvisoryRuntime::new_with_observability(
+                crate::SubsystemObservability::new(
+                    crate::DaemonSubsystem::AdvisoryRuntime,
+                    Arc::clone(&observability),
+                ),
+            ),
         }
     }
 
-    pub(crate) fn record_runtime_event(
+    pub(crate) fn record_daemon_event(
         &self,
+        subsystem: DaemonSubsystem,
         action: &'static str,
         outcome: &'static str,
         message: &'static str,
     ) {
         if let Err(error) = self
             .observability
-            .emit_runtime_event(action, outcome, message)
+            .emit_daemon_event(DaemonEvent::new(subsystem, action, outcome, message))
         {
             tracing::warn!(%error, action, outcome, "daemon runtime lifecycle emission failed");
         }
@@ -251,7 +259,8 @@ impl boundary::RequestDispatcher for DaemonRequestDispatcher {
             RequestEnvelope::Send(SendRequestEnvelope::Compose(request)) => {
                 let outcome = send_mail(request, self.observability.as_ref())?;
                 if let Err(error) = self.advisory_runtime.enqueue_nudge_for_recipient(&outcome) {
-                    self.record_runtime_event(
+                    self.record_daemon_event(
+                        DaemonSubsystem::AdvisoryRuntime,
                         "advisory_enqueue",
                         "degraded",
                         "advisory queue overflowed",

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -31,7 +31,7 @@ use atm_rusqlite::{SqliteBoundaryAssembly, assemble_default_boundary};
 use crate::AtmHomeDir;
 use crate::advisory_runtime::AdvisoryRuntime;
 use crate::daemon_runtime_observability::{
-    DaemonEvent, DaemonRuntimeObservability, DaemonSubsystem,
+    DaemonRuntimeObservability, DaemonSubsystem, SubsystemObservability,
 };
 #[cfg(test)]
 pub(crate) use crate::runtime_status_cache::MAX_STATUS_CACHE_ENTRIES;
@@ -56,6 +56,8 @@ pub(crate) struct DaemonRequestDispatcher {
     // not an arbitrary workspace path.
     home_dir: PathBuf,
     observability: Arc<dyn DaemonRuntimeObservability>,
+    advisory_runtime_observability: SubsystemObservability,
+    runtime_health_observability: SubsystemObservability,
     status_cache: RuntimeStatusCache,
     sqlite_boundary: Option<SqliteBoundaryAssembly>,
     advisory_runtime: AdvisoryRuntime,
@@ -187,6 +189,12 @@ impl DaemonRequestDispatcher {
         observability: Arc<dyn DaemonRuntimeObservability>,
     ) -> Self {
         let home_dir = home_dir.into_inner();
+        let advisory_runtime_observability = SubsystemObservability::new(
+            DaemonSubsystem::AdvisoryRuntime,
+            Arc::clone(&observability),
+        );
+        let runtime_health_observability =
+            SubsystemObservability::new(DaemonSubsystem::RuntimeHealth, Arc::clone(&observability));
         let sqlite_boundary = match assemble_default_boundary() {
             Ok(boundary) => {
                 if let Err(error) =
@@ -194,12 +202,22 @@ impl DaemonRequestDispatcher {
                         .and_then(|state| status_cache.replace_state(state))
                 {
                     tracing::warn!(%error, "failed to hydrate runtime status cache from sqlite roster state");
+                    let _ = runtime_health_observability.emit(
+                        "sqlite_cache_hydration",
+                        "degraded",
+                        "failed to hydrate runtime status cache from sqlite roster state",
+                    );
                     status_cache.mark_sqlite_unavailable();
                 }
                 Some(boundary)
             }
             Err(error) => {
                 tracing::warn!(%error, "failed to assemble default sqlite boundary for daemon runtime health");
+                let _ = runtime_health_observability.emit(
+                    "sqlite_boundary_assembly",
+                    "failed",
+                    "failed to assemble sqlite boundary for daemon runtime health",
+                );
                 status_cache.mark_sqlite_unavailable();
                 None
             }
@@ -207,29 +225,13 @@ impl DaemonRequestDispatcher {
         Self {
             home_dir: home_dir.clone(),
             observability: Arc::clone(&observability),
+            advisory_runtime_observability: advisory_runtime_observability.clone(),
+            runtime_health_observability: runtime_health_observability.clone(),
             status_cache,
             sqlite_boundary,
             advisory_runtime: AdvisoryRuntime::new_with_observability(
-                crate::SubsystemObservability::new(
-                    crate::DaemonSubsystem::AdvisoryRuntime,
-                    Arc::clone(&observability),
-                ),
+                advisory_runtime_observability,
             ),
-        }
-    }
-
-    pub(crate) fn record_daemon_event(
-        &self,
-        subsystem: DaemonSubsystem,
-        action: &'static str,
-        outcome: &'static str,
-        message: &'static str,
-    ) {
-        if let Err(error) = self
-            .observability
-            .emit_daemon_event(DaemonEvent::new(subsystem, action, outcome, message))
-        {
-            tracing::warn!(%error, action, outcome, "daemon runtime lifecycle emission failed");
         }
     }
 }
@@ -259,8 +261,7 @@ impl boundary::RequestDispatcher for DaemonRequestDispatcher {
             RequestEnvelope::Send(SendRequestEnvelope::Compose(request)) => {
                 let outcome = send_mail(request, self.observability.as_ref())?;
                 if let Err(error) = self.advisory_runtime.enqueue_nudge_for_recipient(&outcome) {
-                    self.record_daemon_event(
-                        DaemonSubsystem::AdvisoryRuntime,
+                    let _ = self.advisory_runtime_observability.emit(
                         "advisory_enqueue",
                         "degraded",
                         "advisory queue overflowed",
@@ -329,6 +330,11 @@ impl DaemonRequestDispatcher {
             .as_ref()
             .map(SqliteBoundaryAssembly::roster_store)
             .ok_or_else(|| {
+                let _ = self.runtime_health_observability.emit(
+                    "reload_unavailable",
+                    "failed",
+                    "sqlite-backed daemon runtime reload is unavailable because the sqlite boundary is not assembled",
+                );
                 self.status_cache.mark_sqlite_unavailable();
                 AtmError::daemon_unavailable(
                     "sqlite-backed daemon runtime reload is unavailable because the sqlite boundary is not assembled",
@@ -376,6 +382,11 @@ impl DaemonRequestDispatcher {
             .as_ref()
             .map(SqliteBoundaryAssembly::roster_store)
             .ok_or_else(|| {
+                let _ = self.runtime_health_observability.emit(
+                    "heartbeat_unavailable",
+                    "failed",
+                    "sqlite-backed roster truth is unavailable for daemon heartbeats",
+                );
                 self.status_cache.mark_sqlite_unavailable();
                 AtmError::daemon_unavailable(
                     "sqlite-backed roster truth is unavailable for daemon heartbeats",

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -109,7 +109,7 @@ impl DaemonRequestDispatcher {
     fn spawn_shutdown_step(
         label: &'static str,
         step: impl FnOnce() -> Result<(), AtmError> + Send + 'static,
-    ) -> std::thread::JoinHandle<()> {
+    ) -> Result<std::thread::JoinHandle<()>, AtmError> {
         std::thread::Builder::new()
             .name(format!("shutdown-finalizer-{label}"))
             .spawn(move || {
@@ -117,7 +117,15 @@ impl DaemonRequestDispatcher {
                     tracing::warn!(%error, step = label, "daemon shutdown finalizer step failed");
                 });
             })
-            .expect("spawn daemon shutdown finalizer step")
+            .map_err(|source| {
+                AtmError::daemon_unavailable(format!(
+                    "failed to spawn daemon shutdown finalizer step `{label}`"
+                ))
+                .with_recovery(
+                    "Restart atm-daemon; the bounded shutdown finalizer helper could not be created.",
+                )
+                .with_source(source)
+            })
     }
 
     fn complete_shutdown_step(label: &'static str, shutdown_handle: std::thread::JoinHandle<()>) {
@@ -161,7 +169,17 @@ impl DaemonRequestDispatcher {
         deadline: Duration,
         step: impl FnOnce() -> Result<(), AtmError> + Send + 'static,
     ) {
-        let shutdown_handle = Self::spawn_shutdown_step(label, step);
+        let shutdown_handle = match Self::spawn_shutdown_step(label, step) {
+            Ok(handle) => handle,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    step = label,
+                    "daemon shutdown finalizer step could not start"
+                );
+                return;
+            }
+        };
         let started = std::time::Instant::now();
         loop {
             if shutdown_handle.is_finished() {

--- a/crates/atm-daemon/src/runtime_health_test_support.rs
+++ b/crates/atm-daemon/src/runtime_health_test_support.rs
@@ -40,9 +40,19 @@ impl DaemonRequestDispatcher {
             )
             .expect("daemon test observability"),
         );
+        let advisory_runtime_observability = crate::SubsystemObservability::new(
+            crate::DaemonSubsystem::AdvisoryRuntime,
+            Arc::clone(&observability) as Arc<dyn crate::DaemonRuntimeObservability>,
+        );
+        let runtime_health_observability = crate::SubsystemObservability::new(
+            crate::DaemonSubsystem::RuntimeHealth,
+            Arc::clone(&observability) as Arc<dyn crate::DaemonRuntimeObservability>,
+        );
         Self {
             home_dir: home_dir.clone(),
             observability,
+            advisory_runtime_observability: advisory_runtime_observability.clone(),
+            runtime_health_observability,
             status_cache,
             sqlite_boundary,
             advisory_runtime: crate::advisory_runtime::AdvisoryRuntime::new(),

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -12,6 +12,8 @@ use atm_core::protocol::{
 };
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 pub(crate) const MAX_STATUS_CACHE_ENTRIES: usize = 4096;
 const MAX_RELOAD_TEAMS: usize = 256;
 
@@ -45,19 +47,33 @@ impl RuntimeStatusCacheState {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub(crate) struct RuntimeStatusCache {
     state: Arc<Mutex<RuntimeStatusCacheState>>,
+    observability: SubsystemObservability,
+}
+
+impl Default for RuntimeStatusCache {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RuntimeStatusCache {
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::RuntimeStatusCache,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self {
             state: Arc::new(Mutex::new(RuntimeStatusCacheState {
                 members: HashMap::new(),
                 sqlite_ready: true,
                 degraded_ingest: false,
             })),
+            observability,
         }
     }
 
@@ -96,7 +112,7 @@ impl RuntimeStatusCache {
             .state
             .lock()
             .map_err(|_| AtmError::daemon_unavailable("runtime status cache lock poisoned"))?;
-        evict_status_cache_entry_if_needed(&mut cache, &key);
+        evict_status_cache_entry_if_needed(&mut cache, &key, &self.observability);
         cache.members.insert(
             key,
             RuntimeMemberRecord {
@@ -129,7 +145,7 @@ impl RuntimeStatusCache {
             .state
             .lock()
             .map_err(|_| AtmError::daemon_unavailable("runtime status cache lock poisoned"))?;
-        evict_status_cache_entry_if_needed(&mut cache, &key);
+        evict_status_cache_entry_if_needed(&mut cache, &key, &self.observability);
         let last_active_at = cache
             .members
             .get(&key)
@@ -142,6 +158,16 @@ impl RuntimeStatusCache {
                 last_active_at,
             },
         );
+        let event = self
+            .observability
+            .event(
+                "record_identity_conflict",
+                "degraded",
+                "runtime status cache recorded an identity conflict",
+            )
+            .with_team(request.team.clone())
+            .with_agent(request.member.clone());
+        let _ = self.observability.emit_event(event);
         Ok(())
     }
 
@@ -165,7 +191,14 @@ impl RuntimeStatusCache {
 
     pub(crate) fn mark_sqlite_unavailable(&self) {
         match self.state.lock() {
-            Ok(mut cache) => cache.sqlite_ready = false,
+            Ok(mut cache) => {
+                cache.sqlite_ready = false;
+                let _ = self.observability.emit(
+                    "mark_sqlite_unavailable",
+                    "degraded",
+                    "runtime status cache marked sqlite unavailable",
+                );
+            }
             Err(_) => {
                 tracing::error!(
                     "runtime status cache lock poisoned while marking sqlite unavailable"
@@ -197,6 +230,7 @@ impl RuntimeStatusCache {
 fn evict_status_cache_entry_if_needed(
     cache: &mut RuntimeStatusCacheState,
     incoming_key: &RuntimeMemberKey,
+    observability: &SubsystemObservability,
 ) {
     let is_new_key = !cache.members.contains_key(incoming_key);
     if !is_new_key || cache.members.len() < MAX_STATUS_CACHE_ENTRIES {
@@ -223,6 +257,15 @@ fn evict_status_cache_entry_if_needed(
         .map(|(key, record)| (key.clone(), record.clone()));
     if let Some((evicted_key, evicted_record)) = eviction_candidate {
         cache.members.remove(&evicted_key);
+        let event = observability
+            .event(
+                "evict_entry",
+                "degraded",
+                "runtime status cache evicted an entry at the bounded cap",
+            )
+            .with_team(evicted_key.team.clone())
+            .with_agent(evicted_key.member.clone());
+        let _ = observability.emit_event(event);
         tracing::warn!(
             team = %evicted_key.team,
             member = %evicted_key.member,

--- a/crates/atm-daemon/src/test_observability.rs
+++ b/crates/atm-daemon/src/test_observability.rs
@@ -11,7 +11,7 @@ use atm_core::observability::{
     LogTailSession, ObservabilityPort,
 };
 
-use crate::DaemonRuntimeObservability;
+use crate::{DaemonEvent, DaemonRuntimeObservability};
 
 #[derive(Debug)]
 pub(crate) struct TestDaemonObservability {
@@ -173,14 +173,13 @@ impl ObservabilityPort for TestDaemonObservability {
 }
 
 impl DaemonRuntimeObservability for TestDaemonObservability {
-    fn emit_runtime_event(
-        &self,
-        action: &'static str,
-        outcome: &'static str,
-        message: &'static str,
-    ) -> Result<(), AtmError> {
+    fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
         self.append_message(format!(
-            "{{\"action\":\"{action}\",\"outcome\":\"{outcome}\",\"message\":\"{message}\"}}"
+            "{{\"subsystem\":\"{}\",\"action\":\"{}\",\"outcome\":\"{}\",\"message\":\"{}\"}}",
+            event.subsystem.as_str(),
+            event.action,
+            event.outcome,
+            event.detail
         ))
     }
 

--- a/crates/atm-daemon/src/watch_runtime.rs
+++ b/crates/atm-daemon/src/watch_runtime.rs
@@ -205,10 +205,11 @@ impl WatchRuntime {
             .name("atm-daemon-watch".to_string())
             .spawn(move || watch_worker_loop(inner))
             .map_err(|source| {
-                let _ = self
-                    .inner
-                    .observability
-                    .emit("start", "failed", "failed to spawn watch runtime worker");
+                let _ = self.inner.observability.emit(
+                    "start",
+                    "failed",
+                    "failed to spawn watch runtime worker",
+                );
                 AtmError::daemon_unavailable("failed to spawn watch runtime worker")
                     .with_source(source)
             })?;
@@ -250,14 +251,28 @@ impl WatchRuntime {
                 .spawn(move || {
                     let _ = result_tx.send(handle.join());
                 })
-                .expect("failed to spawn watch join helper");
+                .map_err(|source| {
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "failed to spawn watch runtime join helper",
+                    );
+                    AtmError::daemon_unavailable(
+                        "failed to spawn watch runtime join helper during shutdown",
+                    )
+                    .with_recovery(
+                        "Restart atm-daemon; watch shutdown could not create its bounded join helper.",
+                    )
+                    .with_source(source)
+                })?;
             match result_rx.recv_timeout(WATCH_SHUTDOWN_DEADLINE) {
                 Ok(Ok(())) => {
                     let _ = join_helper.join();
-                    let _ = self
-                        .inner
-                        .observability
-                        .emit("shutdown", "ok", "watch runtime worker shut down cleanly");
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "ok",
+                        "watch runtime worker shut down cleanly",
+                    );
                 }
                 Ok(Err(_)) => {
                     let _ = join_helper.join();

--- a/crates/atm-daemon/src/watch_runtime.rs
+++ b/crates/atm-daemon/src/watch_runtime.rs
@@ -205,10 +205,11 @@ impl WatchRuntime {
             .name("atm-daemon-watch".to_string())
             .spawn(move || watch_worker_loop(inner))
             .map_err(|source| {
-                let _ = self
-                    .inner
-                    .observability
-                    .emit("start", "failed", "failed to spawn watch runtime worker");
+                let _ = self.inner.observability.emit(
+                    "start",
+                    "failed",
+                    "failed to spawn watch runtime worker",
+                );
                 AtmError::daemon_unavailable("failed to spawn watch runtime worker")
                     .with_source(source)
             })?;
@@ -254,10 +255,11 @@ impl WatchRuntime {
             match result_rx.recv_timeout(WATCH_SHUTDOWN_DEADLINE) {
                 Ok(Ok(())) => {
                     let _ = join_helper.join();
-                    let _ = self
-                        .inner
-                        .observability
-                        .emit("shutdown", "ok", "watch runtime worker shut down cleanly");
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "ok",
+                        "watch runtime worker shut down cleanly",
+                    );
                 }
                 Ok(Err(_)) => {
                     let _ = join_helper.join();

--- a/crates/atm-daemon/src/watch_runtime.rs
+++ b/crates/atm-daemon/src/watch_runtime.rs
@@ -8,6 +8,8 @@ use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use crate::{DaemonSubsystem, SubsystemObservability};
+
 const DEFAULT_WATCH_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_WATCH_SUBSCRIPTIONS: usize = 256;
 const WATCH_POLL_HEALTH_TIMEOUT_MULTIPLIER: u32 = 5;
@@ -32,6 +34,7 @@ struct WatchRuntimeInner {
     wake: Condvar,
     poller: WatchPoller,
     poll_interval: Duration,
+    observability: SubsystemObservability,
 }
 
 #[derive(Default)]
@@ -104,7 +107,14 @@ impl WatchKey {
 }
 
 impl WatchRuntime {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new() -> Self {
+        Self::new_with_observability(SubsystemObservability::disabled(
+            DaemonSubsystem::WatchRuntime,
+        ))
+    }
+
+    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
         Self::new_with_poller(
             Arc::new(|request| {
                 let inbox_path = atm_core::home::inbox_path_from_home(
@@ -157,16 +167,22 @@ impl WatchRuntime {
                 Ok(WatchEventBatch { paths })
             }),
             DEFAULT_WATCH_POLL_INTERVAL,
+            observability,
         )
     }
 
-    fn new_with_poller(poller: WatchPoller, poll_interval: Duration) -> Self {
+    fn new_with_poller(
+        poller: WatchPoller,
+        poll_interval: Duration,
+        observability: SubsystemObservability,
+    ) -> Self {
         Self {
             inner: Arc::new(WatchRuntimeInner {
                 state: Mutex::new(WatchState::default()),
                 wake: Condvar::new(),
                 poller,
                 poll_interval,
+                observability,
             }),
         }
     }
@@ -189,6 +205,10 @@ impl WatchRuntime {
             .name("atm-daemon-watch".to_string())
             .spawn(move || watch_worker_loop(inner))
             .map_err(|source| {
+                let _ = self
+                    .inner
+                    .observability
+                    .emit("start", "failed", "failed to spawn watch runtime worker");
                 AtmError::daemon_unavailable("failed to spawn watch runtime worker")
                     .with_source(source)
             })?;
@@ -205,6 +225,10 @@ impl WatchRuntime {
             }
         };
         state.worker = Some(handle);
+        let _ = self
+            .inner
+            .observability
+            .emit("start", "ok", "watch runtime worker started");
         Ok(())
     }
 
@@ -230,9 +254,18 @@ impl WatchRuntime {
             match result_rx.recv_timeout(WATCH_SHUTDOWN_DEADLINE) {
                 Ok(Ok(())) => {
                     let _ = join_helper.join();
+                    let _ = self
+                        .inner
+                        .observability
+                        .emit("shutdown", "ok", "watch runtime worker shut down cleanly");
                 }
                 Ok(Err(_)) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "watch runtime worker panicked during shutdown",
+                    );
                     return Err(AtmError::daemon_unavailable(
                         "watch runtime worker panicked during shutdown",
                     )
@@ -248,6 +281,11 @@ impl WatchRuntime {
                         timeout_ms = WATCH_SHUTDOWN_DEADLINE.as_millis(),
                         "watch runtime worker exceeded shutdown deadline; detaching join helper"
                     );
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "degraded",
+                        "watch runtime worker exceeded its shutdown deadline",
+                    );
                     return Err(AtmError::daemon_unavailable(
                         "watch runtime worker exceeded the bounded shutdown deadline",
                     )
@@ -257,6 +295,11 @@ impl WatchRuntime {
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
                     let _ = join_helper.join();
+                    let _ = self.inner.observability.emit(
+                        "shutdown",
+                        "failed",
+                        "watch runtime join helper disconnected during shutdown",
+                    );
                     tracing::warn!(
                         "watch runtime worker join helper exited before reporting shutdown status"
                     );
@@ -270,6 +313,8 @@ impl WatchRuntime {
         &self,
         request: WatchSubscriptionRequest,
     ) -> Result<WatchEventBatch, AtmError> {
+        let request_team = request.team.clone();
+        let request_agent = request.agent.clone();
         let key = WatchKey::from_request(&request);
         let mut state = self.inner.state.lock().map_err(|_| {
             AtmError::daemon_unavailable("watch runtime state lock poisoned").with_recovery(
@@ -294,6 +339,17 @@ impl WatchRuntime {
             }
             None => {
                 if state.subscriptions.len() >= MAX_WATCH_SUBSCRIPTIONS {
+                    let event = self
+                        .inner
+                        .observability
+                        .event(
+                            "poll",
+                            "rejected",
+                            "watch runtime refused a new subscription at the bounded registry cap",
+                        )
+                        .with_team(request_team.clone())
+                        .with_agent(request_agent.clone());
+                    let _ = self.inner.observability.emit_event(event);
                     return Err(
                         AtmError::daemon_unavailable(format!(
                             "watch runtime refused a new subscription because the bounded registry capacity of {MAX_WATCH_SUBSCRIPTIONS} entries was reached"
@@ -346,6 +402,17 @@ impl WatchRuntime {
                 })?;
             state = wait.0;
             if wait.1.timed_out() {
+                let event = self
+                    .inner
+                    .observability
+                    .event(
+                        "poll",
+                        "degraded",
+                        "watch runtime did not deliver an updated batch before the worker health timeout elapsed",
+                    )
+                    .with_team(request_team.clone())
+                    .with_agent(request_agent.clone());
+                let _ = self.inner.observability.emit_event(event);
                 return Err(
                     AtmError::daemon_unavailable(
                         "watch runtime did not deliver an updated batch before the worker health timeout elapsed",
@@ -360,7 +427,11 @@ impl WatchRuntime {
 
     #[cfg(test)]
     pub(crate) fn new_for_test(poller: WatchPoller, poll_interval: Duration) -> Self {
-        Self::new_with_poller(poller, poll_interval)
+        Self::new_with_poller(
+            poller,
+            poll_interval,
+            SubsystemObservability::disabled(DaemonSubsystem::WatchRuntime),
+        )
     }
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2613,6 +2613,12 @@ Architectural rules:
 - `atm-daemon` owns daemon/runtime/transport `sc-observability` emission
 - `atm-core` owns ATM event and error models above the shared observability
   boundary
+- daemon-side observability remains bottom-of-stack:
+  - the shared daemon observability layer imports no daemon subsystem types
+  - daemon subsystems emit typed daemon event payloads through a sealed,
+    object-safe injected trait
+  - `AtmMessageId` and `TaskId` remain typed identifiers in daemon event
+    payloads; raw string semantic identifiers are not the Phase V target shape
 - native plugins may emit plugin-local diagnostics, but daemon-owned runtime,
   store, ingest, and transport events remain daemon-owned observability sinks
 - production runtime diagnostics must not collapse into ad hoc stdout/stderr

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -13,6 +13,12 @@ The canonical daemon wire contract lives in:
 The crate-local machine-readable boundary inventory lives in:
 - [`./boundaries.md`](./boundaries.md)
 
+The daemon observability boundary contract lives in:
+- [`./observability.md`](./observability.md)
+
+The daemon/client recovery text rule set lives in:
+- [`./recovery-text-rules.md`](./recovery-text-rules.md)
+
 This crate remains part of the current workspace.
 
 ## 1.1 ADRs
@@ -191,6 +197,12 @@ Current retained ATM surfaces outside the daemon request/response packet family:
   panic/unwrap for routine transport, socket, or store-boundary failure.
 - daemon observability remains structured through `sc-observability`; no ad hoc
   debug-only runtime path replaces it in production.
+- daemon observability is bottom-of-stack:
+  - the shared daemon observability layer imports no daemon subsystem types
+  - daemon subsystems emit already-shaped daemon event payloads through the
+    injected trait
+  - central daemon observability must not reconstruct subsystem semantics after
+    the fact
 - plugin-local observability does not replace daemon-owned runtime/transport
   sinks; daemon-owned events stay daemon-owned.
 - daemon retained-log reporting must use the host-scoped ATM log contract:
@@ -387,6 +399,45 @@ Privacy boundary:
 - observability submodules expose only the daemon-owned event sink façade used
   by runtime composition; sink plumbing and field-shaping helpers remain
   crate-private
+
+## 3.1.0 Daemon Observability Boundary
+
+The final daemon observability contract is defined in
+[`./observability.md`](./observability.md).
+
+Required architectural decisions:
+- the injected daemon observability trait remains object-safe and sealed
+- the daemon lifecycle stays modeled as an explicit runtime state machine
+  rather than a typestate API in Phase V
+- `LaunchGateGuard` remains a launch/admission coordination primitive, not a
+  typestate token
+- daemon event payloads use typed semantic identifiers:
+  - `DaemonSubsystem` enum
+  - `AtmMessageId`
+  - `TaskId`
+- `team`, `agent`, `sender`, `recipient`, `message_id`, and `task_id` are
+  event payload fields, not injected logger state
+
+V.2 migration targets:
+- `daemon_runtime_observability.rs`
+- `daemon_observability.rs`
+- `runtime_health.rs`
+- `local_ipc_transport.rs`
+- `advisory_runtime.rs`
+- `notification_runtime.rs`
+- `peer_transport.rs`
+- `watch_runtime.rs`
+- `reconcile_runtime.rs`
+- `host_ownership.rs`
+- `lifecycle_control.rs`
+- `runtime_status_cache.rs`
+
+V.3 deletion targets:
+- `emit_runtime_event(...)`
+- `map_command_event(...)`
+- `map_runtime_event(...)`
+- any central daemon helper path that exists only to reconstruct subsystem
+  meaning after the fact
 
 Transport dispatcher rule:
 - local-IPC and TCP/TLS listener/connection receive loops are deliberately tiny

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -56,6 +56,13 @@ and to make those seams explicit enough for later QA and lint review.
 Observability note:
 - daemon-owned `sc-observability` sinks are cross-cutting runtime support, not
   a separate daemon-private partition
+- the shared daemon observability layer is bottom-of-stack and must not import
+  daemon subsystem types
+- daemon subsystems may depend on the injected daemon observability trait only
+- central daemon observability must not reconstruct subsystem semantics after
+  the fact
+- the authoritative design contract is
+  [`./observability.md`](./observability.md)
 
 ## RuntimeLifecycleController
 

--- a/docs/atm-daemon/observability.md
+++ b/docs/atm-daemon/observability.md
@@ -8,6 +8,12 @@ It is the design contract that `V.2` and `V.3` implement:
 - `V.2` moves event ownership into daemon subsystems
 - `V.3` deletes the old central mapping path
 
+Carry-forward obligations:
+- `ARCH-PU-002` and `RULE-002` remain open obligations, not closed historical
+  notes
+- `V.2` is the CI-enforcement sprint for this boundary
+- `V.3` is the deletion and closure sprint for the old central mapper path
+
 ## Bottom-Of-Stack Rule
 
 Observability is bottom-of-stack.
@@ -197,6 +203,10 @@ It must not own:
 
 Shared wiring and test/support surfaces that must follow the final boundary:
 - `crates/atm-daemon/src/daemon_runtime_observability.rs`
+  - `V.2` required action: refactor this file to the final injected trait and
+    daemon event surface used by subsystem-owned emission
+  - `V.3` follow-through: delete any compatibility shims that exist only to
+    preserve the old central mapper path
 - `crates/atm-daemon/src/daemon_observability.rs`
 - `crates/atm-daemon/src/composition.rs`
 - `crates/atm-daemon/src/main.rs`
@@ -220,4 +230,3 @@ First CI-checkable enforcement target for `V.2`:
   - `map_runtime_event(...)`
   - centralized wording/field policy for subsystem-owned events
 - any test-support shaping that exists only to preserve the central mapper
-

--- a/docs/atm-daemon/observability.md
+++ b/docs/atm-daemon/observability.md
@@ -1,0 +1,223 @@
+# ATM Daemon Observability Boundary
+
+## Purpose
+
+This document defines the final Phase V.1 daemon observability boundary.
+
+It is the design contract that `V.2` and `V.3` implement:
+- `V.2` moves event ownership into daemon subsystems
+- `V.3` deletes the old central mapping path
+
+## Bottom-Of-Stack Rule
+
+Observability is bottom-of-stack.
+
+Hard boundary:
+- the shared daemon observability layer imports no daemon subsystem types
+- daemon subsystems depend on the injected observability trait
+- observability emits already-shaped daemon event payloads; it does not
+  reconstruct subsystem meaning after the fact
+
+Forbidden:
+- daemon-wide semantic reconstruction of subsystem events
+- subsystem-specific event enums or structs imported into the shared
+  observability adapter
+- daemon-global logger state that caches `team`, `message_id`, or `task_id`
+  across unrelated events
+
+## Injected Trait Shape
+
+The injected daemon observability trait remains object-safe and sealed.
+
+Final shape:
+
+```rust
+pub trait DaemonRuntimeObservability:
+    atm_core::boundary::sealed::Sealed + ObservabilityPort + Send + Sync
+{
+    fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError>;
+
+    fn best_effort_flush_blocking(&self) -> Result<(), AtmError>;
+}
+```
+
+Consumption shape:
+
+```rust
+Arc<dyn DaemonRuntimeObservability>
+```
+
+Object-safety rationale:
+- no generic methods
+- no `Self` return position
+- no by-value `self` receiver requirements
+- the trait remains suitable for one injected trait object shared across daemon
+  runtime partitions
+
+Sealing decision:
+- sealed by default
+- rationale:
+  - the daemon does not currently need third-party implementers
+  - Phase V is closing an internal architecture seam, not creating a public
+    plugin surface
+  - sealing allows the daemon observability contract to evolve through `V.2`
+    and `V.3` without external implementation commitments
+
+## Event Model
+
+The daemon event model is subsystem-oriented, not central-mapper-oriented.
+
+Final shape:
+
+```rust
+pub struct DaemonEvent {
+    pub subsystem: DaemonSubsystem,
+    pub action: &'static str,
+    pub outcome: &'static str,
+    pub team: TeamScope,
+    pub agent: Option<AgentName>,
+    pub sender: Option<AgentName>,
+    pub recipient: Option<AgentName>,
+    pub message_id: Option<AtmMessageId>,
+    pub task_id: Option<TaskId>,
+    pub detail: Cow<'static, str>,
+}
+```
+
+Typed identifier decisions:
+- `subsystem`: `DaemonSubsystem` enum
+  - rationale:
+    - the daemon subsystem set is finite and reviewable
+    - enum closure prevents string drift and ad hoc subsystem naming
+- `message_id`: `AtmMessageId`
+  - rationale:
+    - ATM already owns a validated message-id newtype
+    - the daemon must not fall back to raw string message identifiers
+- `task_id`: `TaskId`
+  - rationale:
+    - ATM already owns a validated task-id domain type
+    - retaining the newtype keeps task identifiers consistent across CLI,
+      daemon, and schema boundaries
+
+Recommended daemon subsystem enum members:
+- `Bootstrap`
+- `Composition`
+- `LocalIpcTransport`
+- `AdvisoryRuntime`
+- `NotificationRuntime`
+- `PeerTransport`
+- `WatchRuntime`
+- `ReconcileRuntime`
+- `RuntimeHealth`
+- `HostOwnership`
+- `LifecycleControl`
+- `RuntimeStatusCache`
+- `ObservabilitySink`
+
+## Per-Event Context Fields
+
+`team`, `agent`, `sender`, `recipient`, `message_id`, and `task_id` are
+per-event payload fields, not injected logger state.
+
+Chosen representation for team scope:
+
+```rust
+pub enum TeamScope {
+    Team(TeamName),
+    None,
+}
+```
+
+Rationale:
+- most daemon events are team-scoped
+- infrastructure events such as daemon startup and shutdown are not
+- explicit `TeamScope::None` is clearer than inferring absence from logger
+  construction or from unrelated sender/recipient state
+
+Field rules:
+- `team` is required on each event as `TeamScope`
+- `agent`, `sender`, and `recipient` are optional and event-specific
+- `message_id` and `task_id` are optional and event-specific
+- no daemon subsystem may rely on hidden ambient logger state to fill these
+  values later
+
+## Lifecycle Typestate Decision
+
+Phase V.1 does not move daemon lifecycle control to a typestate API.
+
+Decision:
+- keep the runtime lifecycle as an explicit runtime-owned state machine
+- keep legal transitions documented and enforced through the runtime boundary
+- do not introduce `PhantomData` lifecycle state tokens in Phase V
+
+Rationale:
+- the lifecycle state spans process startup, listener publication, background
+  worker drain, and cross-thread shutdown coordination
+- the daemon already needs runtime-visible rollback and shutdown transitions
+  that are easier to review as one explicit state machine
+- the current `RuntimeLifecycleState` enum already expresses the legal daemon
+  states directly
+
+`LaunchGateGuard` alignment:
+- `LaunchGateGuard` is a host admission and startup serialization primitive,
+  not a daemon lifecycle typestate token
+- it should remain a runtime coordination guard rather than becoming the
+  carrier of `Starting` / `Serving` / `Stopping` type information
+
+## Shared Observability Responsibilities
+
+The shared daemon observability layer may own only:
+- bootstrap
+- sink setup
+- emit
+- query
+- follow
+- health
+- best-effort synchronous flush during shutdown
+
+It must not own:
+- subsystem-specific event reconstruction
+- daemon-wide wording policy for subsystem meaning
+- message-context inference
+- runtime coordination or control-plane behavior
+
+## V.2 Migration Targets
+
+`V.2` must migrate event ownership into these daemon subsystems:
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/advisory_runtime.rs`
+- `crates/atm-daemon/src/notification_runtime.rs`
+- `crates/atm-daemon/src/peer_transport.rs`
+- `crates/atm-daemon/src/watch_runtime.rs`
+- `crates/atm-daemon/src/reconcile_runtime.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/host_ownership.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+
+Shared wiring and test/support surfaces that must follow the final boundary:
+- `crates/atm-daemon/src/daemon_runtime_observability.rs`
+- `crates/atm-daemon/src/daemon_observability.rs`
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/main.rs`
+- `crates/atm-daemon/src/lib.rs`
+- `crates/atm-daemon/src/test_observability.rs`
+- `crates/atm-daemon/src/runtime_health_test_support.rs`
+- `crates/atm-daemon/src/test_support.rs`
+- `crates/atm-daemon/src/tests.rs`
+- `crates/atm-daemon/src/tests_advisory.rs`
+- `crates/atm-daemon/src/tests_lifecycle.rs`
+
+First CI-checkable enforcement target for `V.2`:
+- the shared observability layer must not import daemon subsystem types
+
+## V.3 Deletion Targets
+
+`V.3` must delete or collapse the old central mapping path in:
+- `crates/atm-daemon/src/daemon_observability.rs`
+  - `emit_runtime_event(...)`
+  - `map_command_event(...)`
+  - `map_runtime_event(...)`
+  - centralized wording/field policy for subsystem-owned events
+- any test-support shaping that exists only to preserve the central mapper
+

--- a/docs/atm-daemon/observability.md
+++ b/docs/atm-daemon/observability.md
@@ -201,7 +201,9 @@ It must not own:
 - `crates/atm-daemon/src/lifecycle_control.rs`
 - `crates/atm-daemon/src/runtime_status_cache.rs`
 
-Shared wiring and test/support surfaces that must follow the final boundary:
+Shared wiring and test/support surfaces that must follow the final boundary are
+all `V.2` refactor targets, with `V.3` shim cleanup where compatibility-only
+paths remain:
 - `crates/atm-daemon/src/daemon_runtime_observability.rs`
   - `V.2` required action: refactor this file to the final injected trait and
     daemon event surface used by subsystem-owned emission

--- a/docs/atm-daemon/recovery-text-rules.md
+++ b/docs/atm-daemon/recovery-text-rules.md
@@ -38,6 +38,27 @@ If existing `ErrorCode` enum variants already cover a category, `V.4` may bind
 that category to the established variant instead of inventing a second name.
 What is forbidden is category drift or ad hoc string-only recovery labels.
 
+## V.4 Category Binding
+
+Phase `V.4` binds the required recovery categories to the existing ATM error
+surface rather than inventing a second parallel code family:
+
+| Recovery category | Bound ATM error code / variant | Notes |
+|---|---|---|
+| `ATM_DAEMON_UNAVAILABLE` | `AtmErrorCode::DaemonUnavailable` via `AtmError::daemon_unavailable(...)` | default daemon/client reachability and runtime coordination failures |
+| `ATM_SOCKET_CONNECT_FAILED` | `AtmErrorCode::DaemonUnavailable` via socket/open/bind/connect flavored `AtmError::daemon_unavailable(...)` messages | same code, but the recovery text must explicitly mention the socket/connect surface |
+| `ATM_DAEMON_START_FAILED` | `AtmErrorCode::DaemonAutoStartFailed` via `AtmError::daemon_auto_start_failed(...)` | daemon binary missing, spawn failures, publish-timeout auto-start failures |
+| `ATM_IPC_RUNTIME_FAILED` | `AtmErrorCode::DaemonUnavailable` or `AtmErrorCode::DaemonLifecycleWedge` depending on whether the failure is one-shot runtime I/O vs lifecycle wedge | local IPC deadlines, dispatch/worker/join-helper failures, lifecycle teardown wedges |
+
+Concrete related variants that remain valid in the final daemon/client error
+surface:
+- `AtmErrorCode::DaemonLaunchGateRejected`
+- `AtmErrorCode::DaemonLifecycleWedge`
+- `AtmErrorCode::DaemonServingStateRejected`
+
+`V.4` therefore hardens category-specific `.with_recovery(...)` text on the
+concrete variants above instead of renaming the underlying ATM error codes.
+
 Recovery text may be omitted only when:
 - the failure is purely internal and no user action exists
 - a lower boundary already emitted the exact actionable recovery guidance and
@@ -84,6 +105,14 @@ Bad examples:
 - “operation failed”
 - “unexpected error”
 - “retry later”
+
+Coverage strategy for `V.4`:
+- enumerate the required source files in the sprint plan and this document
+- require `.with_recovery(...)` on every daemon-unavailable, socket-connect,
+  daemon-start, and local-IPC runtime path in those files unless a lower layer
+  already preserves the exact same actionable guidance
+- verify coverage in QA with code review of the enumerated paths plus
+  workspace `cargo clippy -- -D warnings`
 
 ## Phase Ownership
 

--- a/docs/atm-daemon/recovery-text-rules.md
+++ b/docs/atm-daemon/recovery-text-rules.md
@@ -24,6 +24,20 @@ Recovery text is mandatory for:
 - daemon start failures
 - local IPC runtime failures
 
+Stable error code namespace is mandatory for each required recovery category.
+`V.1` reserves the namespace and `V.4` must bind each category to concrete
+codes in the final daemon/client error surface.
+
+Reserved category codes:
+- `ATM_DAEMON_UNAVAILABLE`
+- `ATM_SOCKET_CONNECT_FAILED`
+- `ATM_DAEMON_START_FAILED`
+- `ATM_IPC_RUNTIME_FAILED`
+
+If existing `ErrorCode` enum variants already cover a category, `V.4` may bind
+that category to the established variant instead of inventing a second name.
+What is forbidden is category drift or ad hoc string-only recovery labels.
+
 Recovery text may be omitted only when:
 - the failure is purely internal and no user action exists
 - a lower boundary already emitted the exact actionable recovery guidance and
@@ -74,4 +88,6 @@ Bad examples:
 ## Phase Ownership
 
 - `V.1` establishes this persistent rule set and file ownership map
+- `V.1` reserves the stable recovery code namespace for the mandatory
+  categories listed above
 - `V.4` hardens the concrete rule set, checklist, and enforcement strategy

--- a/docs/atm-daemon/recovery-text-rules.md
+++ b/docs/atm-daemon/recovery-text-rules.md
@@ -111,8 +111,10 @@ Coverage strategy for `V.4`:
 - require `.with_recovery(...)` on every daemon-unavailable, socket-connect,
   daemon-start, and local-IPC runtime path in those files unless a lower layer
   already preserves the exact same actionable guidance
-- verify coverage in QA with code review of the enumerated paths plus
-  workspace `cargo clippy -- -D warnings`
+- verify `.with_recovery(...)` coverage in QA with checklist review of the
+  enumerated paths
+- use workspace `cargo clippy -- -D warnings` only for Rust hygiene after the
+  recovery-text edits land
 
 ## Phase Ownership
 

--- a/docs/atm-daemon/recovery-text-rules.md
+++ b/docs/atm-daemon/recovery-text-rules.md
@@ -1,0 +1,77 @@
+# ATM Daemon Recovery Text Rules
+
+## Purpose
+
+This document is the persistent recovery-guidance reference started in Phase
+V.1 and extended in `V.4`.
+
+It exists so daemon/client runtime recovery rules do not live only in sprint
+notes.
+
+## Rule
+
+Daemon/client/runtime failures that a user or operator can act on must include
+specific recovery text.
+
+Recovery text must:
+- name the failing surface
+- describe the next action
+- avoid generic “try again later” wording when the user can fix the issue
+
+Recovery text is mandatory for:
+- daemon unavailable paths
+- socket connect failures
+- daemon start failures
+- local IPC runtime failures
+
+Recovery text may be omitted only when:
+- the failure is purely internal and no user action exists
+- a lower boundary already emitted the exact actionable recovery guidance and
+  the higher layer preserves it unchanged
+
+## File Ownership Map
+
+Primary files in scope:
+- `crates/atm-daemon-client/src/lib.rs`
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/local_ipc_connection.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+
+Category ownership:
+- daemon unavailable:
+  - `crates/atm-daemon-client/src/lib.rs`
+  - `crates/atm-daemon/src/composition.rs`
+- socket connect failures:
+  - `crates/atm-daemon-client/src/lib.rs`
+  - `crates/atm-daemon/src/local_ipc_transport.rs`
+- daemon start failures:
+  - `crates/atm-daemon-client/src/lib.rs`
+  - `crates/atm-daemon/src/composition.rs`
+- local IPC runtime failures:
+  - `crates/atm-daemon/src/local_ipc_transport.rs`
+  - `crates/atm-daemon/src/local_ipc_connection.rs`
+  - `crates/atm-daemon/src/lifecycle_control.rs`
+
+## Recovery Text Checklist
+
+Each required path should answer:
+- what failed
+- what the operator should inspect or restart
+- whether retry is appropriate
+- whether the daemon or host runtime must be restarted
+
+Good examples:
+- “Build or install atm-daemon, or set ATM_DAEMON_BIN to the correct executable before retrying.”
+- “Restart the daemon; the local IPC listener stopped accepting connections unexpectedly.”
+- “Grant write access to the daemon socket parent directory or choose a writable ATM_HOME before retrying.”
+
+Bad examples:
+- “operation failed”
+- “unexpected error”
+- “retry later”
+
+## Phase Ownership
+
+- `V.1` establishes this persistent rule set and file ownership map
+- `V.4` hardens the concrete rule set, checklist, and enforcement strategy

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -17,6 +17,12 @@ The crate-local machine-readable boundary inventory lives in:
 The canonical daemon transport wire contract lives in:
 - [`./protocol-icd.md`](./protocol-icd.md)
 
+The canonical daemon observability boundary contract lives in:
+- [`./observability.md`](./observability.md)
+
+The canonical daemon/client recovery text rule set lives in:
+- [`./recovery-text-rules.md`](./recovery-text-rules.md)
+
 ## 2. Ownership
 
 `atm-daemon` owns:
@@ -190,6 +196,17 @@ Initial crate requirement IDs:
   If S.9 introduces any public retained-logging trait or sink boundary, that
   trait must be sealed by default per the product architecture trait-extension
   policy.
+- `REQ-DAEMON-OBS-003` daemon observability remains bottom-of-stack:
+  the shared daemon observability layer must not import daemon subsystem types
+  or reconstruct subsystem meaning centrally. Subsystems emit already-shaped
+  daemon event payloads through the injected daemon observability trait.
+  Satisfies:
+  `REQ-CORE-BOUNDARY-001`, `REQ-CORE-OBS-001`, `REQ-CORE-OBS-002`.
+- `REQ-DAEMON-OBS-004` the daemon-injected observability trait must remain
+  sealed and object-safe, and its event model must use typed semantic
+  identifiers rather than raw strings for subsystem, message-id, and task-id
+  meaning. Satisfies:
+  `REQ-CORE-BOUNDARY-001`, `REQ-CORE-OBS-001`.
 - `REQ-DAEMON-HEALTH-001` `atm-daemon` owns the daemon health interface
   consumed by `atm doctor`. Satisfies:
   `REQ-CORE-DOCTOR-002`.
@@ -245,8 +262,10 @@ The `atm-daemon` crate docs must remain aligned with:
 - [`../atm-core/requirements.md`](../atm-core/requirements.md)
 - [`../atm-core/architecture.md`](../atm-core/architecture.md)
 - [`./boundaries.md`](./boundaries.md)
+- [`./observability.md`](./observability.md)
 - [`./protocol-icd.md`](./protocol-icd.md)
 - [`./logging.md`](./logging.md)
+- [`./recovery-text-rules.md`](./recovery-text-rules.md)
 
 ## 5. Phase R Runtime Requirements
 

--- a/docs/phase-V/sprint-V1.md
+++ b/docs/phase-V/sprint-V1.md
@@ -100,3 +100,17 @@ Dependency note:
   - `docs/atm-daemon/architecture.md`
   - `docs/atm-daemon/boundaries.md`
   - `docs/architecture.md`
+
+## Implementation Record
+
+- `V.1` established `SubsystemObservability` as the daemon-side observability
+  boundary shape that later sprints would inject into the owning runtime
+  subsystems.
+- `V.1` documented the scoping decision that `SubsystemObservability`
+  injection is daemon-only work; `atm-daemon-client` stays outside that
+  subsystem boundary and therefore does not consume the daemon-side injection
+  surface.
+- `V.1` fixed the shared wiring approach for `V.2` and `V.3`: subsystem-owned
+  event construction moves into daemon runtime modules while
+  `daemon_observability.rs` is reduced to thin sink/bootstrap responsibilities
+  and cleanup/deletion follows in the later sprint.

--- a/docs/phase-V/sprint-V1.md
+++ b/docs/phase-V/sprint-V1.md
@@ -4,9 +4,9 @@
 plan_type: sprint_plan
 phase: V
 sprint: "V.1"
-status: planned
-worktree: TBD
-branch: TBD
+status: implemented
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s1-observability-boundary
+branch: feature/pV-s1-observability-boundary
 estimated_scope: M
 ```
 
@@ -50,6 +50,8 @@ Dependency note:
   - `crates/atm-daemon/src/host_ownership.rs`
   - `crates/atm-daemon/src/lifecycle_control.rs`
   - `crates/atm-daemon/src/runtime_status_cache.rs`
+- commit the V.4 recovery text rule set to a persistent reference file so
+  daemon/client runtime recovery guidance does not live only in sprint notes
 
 ## Acceptance Criteria
 
@@ -57,8 +59,8 @@ Dependency note:
 - observability is explicitly bottom-of-stack
 - daemon subsystems depend on the injected observability trait, never the
   reverse
-- the observability trait is object-safe; `dyn DaemonObservability` must be a
-  valid, unrestricted target shape for the final design
+- the observability trait is object-safe; `Arc<dyn DaemonRuntimeObservability>`
+  is the final unrestricted consumption shape for the design
 - the observability trait sealing decision is documented; it is either sealed
   by default or explicitly left open with rationale
 - the daemon lifecycle typestate decision is documented; if lifecycle states do
@@ -80,9 +82,21 @@ Dependency note:
 - the sprint output explicitly points `V.2` at the first CI-checkable
   enforcement point for this line: the shared observability layer must not
   require daemon subsystem types
+- the daemon/client recovery text rule set is committed as a persistent
+  reference file rather than living only in sprint notes
 
 ## Out Of Scope
 
 - code migration into subsystems
 - deleting old mapping code
 - general runtime failure recovery work outside observability
+
+## Sprint Output
+
+- `docs/atm-daemon/observability.md`
+- `docs/atm-daemon/recovery-text-rules.md`
+- aligned updates in:
+  - `docs/atm-daemon/requirements.md`
+  - `docs/atm-daemon/architecture.md`
+  - `docs/atm-daemon/boundaries.md`
+  - `docs/architecture.md`

--- a/docs/phase-V/sprint-V2.md
+++ b/docs/phase-V/sprint-V2.md
@@ -4,9 +4,9 @@
 plan_type: sprint_plan
 phase: V
 sprint: "V.2"
-status: planned
-worktree: TBD
-branch: TBD
+status: implemented
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s2-observability-migration
+branch: feature/pV-s2-observability-migration
 estimated_scope: M
 ```
 
@@ -79,3 +79,23 @@ Dependency note:
 - final deletion of all old wrappers and mapping helpers
 - unrelated daemon runtime cleanup
 - broader recovery hardening outside observability
+
+## Implementation Record
+
+- `VQ2-001` closed: `RuntimeHealthMonitor` now owns its own
+  `SubsystemObservability` and emits runtime-health events directly instead of
+  routing them through central daemon event reconstruction.
+- `VQ2-002` closed: `RuntimeComposition` now owns its own
+  `SubsystemObservability` and emits composition lifecycle events directly
+  instead of delegating through a shared daemon mapper.
+- `V.2` materially advanced the `V.3` deletion set by removing the central
+  delegation helpers rather than renaming them:
+  - `map_command_event`
+  - `map_daemon_event`
+  - `map_runtime_event`
+  - `emit_runtime_event`
+  - `record_daemon_event`
+- No additional callsite migration was required for those deleted helpers
+  beyond the direct subsystem-observability injection work, because they were
+  internal delegation points inside the old central daemon observability path
+  rather than independent product-facing APIs.

--- a/docs/phase-V/sprint-V3.md
+++ b/docs/phase-V/sprint-V3.md
@@ -4,9 +4,9 @@
 plan_type: sprint_plan
 phase: V
 sprint: "V.3"
-status: planned
-worktree: TBD
-branch: TBD
+status: implemented
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s3-observability-cleanup
+branch: feature/pV-s3-observability-cleanup
 estimated_scope: M
 ```
 
@@ -30,7 +30,9 @@ Dependency note:
   reviewing:
   - `emit_runtime_event(...)`
   - `map_command_event(...)`
+  - `map_daemon_event(...)`
   - `map_runtime_event(...)`
+  - `record_daemon_event(...)`
   - any remaining daemon-wide wording/field-policy helper that exists only to
     rebuild subsystem semantics centrally
 - consolidate any now-redundant event-shaping paths left over from the old
@@ -53,6 +55,41 @@ Dependency note:
   rewritten
 - the sprint closes the remaining `ARCH-PU-002` / `RULE-002` implementation
   debt rather than carrying it forward again
+
+## Implementation Record
+
+### AC5 Deletion Record
+
+Confirmed removed from the final `V.3` code path:
+- `map_command_event(...)`
+- `map_daemon_event(...)`
+- `map_runtime_event(...)`
+- `emit_runtime_event(...)`
+- `record_daemon_event(...)`
+
+Callsite migration record:
+- command-side ATM observability emission now stays on
+  `ObservabilityPort::emit(...)` in
+  `crates/atm-daemon/src/daemon_observability.rs`
+- daemon subsystem emission now routes through
+  `SubsystemObservability::emit(...)` /
+  `SubsystemObservability::emit_event(...)` in
+  `crates/atm-daemon/src/daemon_runtime_observability.rs`
+- the injected daemon sink trait now receives fully shaped subsystem events via
+  `DaemonRuntimeObservability::emit_daemon_event(...)`
+- shared observability sink shaping remains only in
+  `DaemonObservability::emit_log_event(...)` as bottom-of-stack retained-log
+  output, not as a daemon-wide semantic reconstruction layer
+
+Deletion-vs-rewrite summary:
+- deleted:
+  - old central mapper helpers listed above
+  - the central daemon event reconstruction path they supported
+- rewritten:
+  - daemon subsystem callsites to emit already-shaped `DaemonEvent` payloads
+    through injected subsystem observability handles
+  - retained sink emission to operate on final shaped payloads instead of
+    subsystem-specific reconstruction helpers
 
 ## Out Of Scope
 

--- a/docs/phase-V/sprint-V4.md
+++ b/docs/phase-V/sprint-V4.md
@@ -4,9 +4,9 @@
 plan_type: sprint_plan
 phase: V
 sprint: "V.4"
-status: planned
-worktree: TBD
-branch: TBD
+status: implemented
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pV-s4-recovery-hardening
+branch: feature/pV-s4-recovery-hardening
 estimated_scope: M
 ```
 
@@ -80,6 +80,17 @@ Concrete targets:
 - the sprint plan names the concrete daemon-client and daemon source files that
   own the prioritized daemon-unavailable, socket-connect, daemon-start, and
   local-IPC runtime failure paths
+
+## Implementation Record
+
+Concrete V.4 closures:
+- `RBP-PU-001`: disconnected and publish-timeout daemon-unavailable paths now
+  carry path-specific recovery text in daemon-client auto-start/connect flows
+- `RBP-PU-002`: lifecycle join-helper spawn now degrades through typed
+  `AtmError` recovery instead of panicking
+- `QA-U-002`: daemon-unavailable and launch-gate retry/backoff failures now
+  document the exact operator action instead of relying on generic default
+  daemon guidance
 
 ## Out Of Scope
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2994,6 +2994,19 @@ Execution shape:
 - `ARCH-PU-002` / `RULE-002` are owned end-to-end by `V.1` through `V.3`,
   not deferred
 
+Phase V deliverables:
+- `SubsystemObservability` newtype and per-subsystem injection across the
+  daemon runtime line, including explicit ownership in
+  `RuntimeHealthMonitor` and `RuntimeComposition`
+- deletion of the old central observability delegation helpers:
+  `map_command_event`, `map_daemon_event`, `map_runtime_event`,
+  `emit_runtime_event`, and `record_daemon_event`
+- `.with_recovery()` hardening on the four required runtime error categories:
+  `ATM_DAEMON_UNAVAILABLE`, `ATM_SOCKET_CONNECT_FAILED`,
+  `ATM_DAEMON_START_FAILED`, and `ATM_IPC_RUNTIME_FAILED`
+- stable recovery/error-code namespace documented in
+  `docs/atm-daemon/recovery-text-rules.md`
+
 Planned sprint sequence:
 
 ### V.1 — Observability Boundary And Event Model


### PR DESCRIPTION
## Summary

- **V.1** — Observability boundary design docs and shared wiring scoping
- **V.2** — Subsystem observability migration: each daemon subsystem holds its own `SubsystemObservability` field and emits directly; removed `record_daemon_event()` central proxy delegation; hardened spawn error propagation in `composition.rs` and `runtime_health.rs`
- **V.3** — Observability cleanup: deleted 5 deprecated helpers (`map_command_event`, `map_daemon_event`, `map_runtime_event`, `emit_runtime_event`, `record_daemon_event`); Windows cfg gating for unix-only IPC test helpers
- **V.4** — Recovery hardening: `.with_recovery()` coverage on 4 daemon error categories (`ATM_DAEMON_UNAVAILABLE`, `ATM_SOCKET_CONNECT_FAILED`, `ATM_DAEMON_START_FAILED`, `ATM_IPC_RUNTIME_FAILED`); stable error code namespace in `recovery-text-rules.md`

## QA

All 4 sprints passed QA gate (0B+0I+0m). Phase V end-gate review in progress.

## Test plan

- [ ] Phase V end-gate quality-mgr review passes
- [ ] CI green on integrate/phase-V
- [ ] All phase findings confirmed fixed on integrate branch
- [ ] Explicit merge authorization from user

🤖 Generated with [Claude Code](https://claude.com/claude-code)