### PR TITLE
Phase W planning docs: observability findings (W.1-W.4)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,8 +53,8 @@ Phase-R redesign note:
 - the Phase R redesign starts from crate-local boundary inventories and ADRs,
   then rebuilds the implementation under lint/visibility guardrails
 - Phase R treats thin-client extension pressure as a first-class architectural
-  input (`atm-graft` was implemented in T.6–T.8 and removed in pU-s0 as
-  out-of-scope for the 1.0 surface)
+  input (`atm-graft` was implemented in T.6–T.8, then completed and narrowed
+  through Phase U as the supported thin-client host line rather than removed)
 - for the boundary / adapter model, Phase R supersedes any earlier
   pre-Phase-R architecture statements in this document that conflict with the
   crate-local boundary inventories, ADRs, or `docs/plan-phase-R.md`
@@ -108,7 +108,8 @@ Product-level boundary rules:
   machine-readable contract used to drive architectural linting and review
 - thin-client workflow surfaces should be modeled around `send` and `receive`
   rather than a broad command inventory
-- Phase T added `atm-graft` as a thin-client line (T.6–T.8); removed in pU-s0
+- Phase T added `atm-graft` as a thin-client line (T.6–T.8); Phase U later
+  completed and tightened that supported line rather than deleting it
   as out-of-scope for the 1.0 surface
 - `ack` may remain a retained CLI/user workflow, but thin-client protocol
   surfaces should carry it through send-shaped request data rather than a

--- a/docs/atm-daemon/recovery-text-rules.md
+++ b/docs/atm-daemon/recovery-text-rules.md
@@ -1,0 +1,124 @@
+# ATM Daemon Recovery Text Rules
+
+## Purpose
+
+This document is the persistent recovery-guidance reference started in Phase
+V.1 and extended in `V.4`.
+
+It exists so daemon/client runtime recovery rules do not live only in sprint
+notes.
+
+## Rule
+
+Daemon/client/runtime failures that a user or operator can act on must include
+specific recovery text.
+
+Recovery text must:
+- name the failing surface
+- describe the next action
+- avoid generic “try again later” wording when the user can fix the issue
+
+Recovery text is mandatory for:
+- daemon unavailable paths
+- socket connect failures
+- daemon start failures
+- local IPC runtime failures
+
+Stable error code namespace is mandatory for each required recovery category.
+`V.1` reserves the namespace and `V.4` must bind each category to concrete
+codes in the final daemon/client error surface.
+
+Reserved category codes:
+- `ATM_DAEMON_UNAVAILABLE`
+- `ATM_SOCKET_CONNECT_FAILED`
+- `ATM_DAEMON_START_FAILED`
+- `ATM_IPC_RUNTIME_FAILED`
+
+If existing `ErrorCode` enum variants already cover a category, `V.4` may bind
+that category to the established variant instead of inventing a second name.
+What is forbidden is category drift or ad hoc string-only recovery labels.
+
+## V.4 Category Binding
+
+Phase `V.4` binds the required recovery categories to the existing ATM error
+surface rather than inventing a second parallel code family:
+
+| Recovery category | Bound ATM error code / variant | Notes |
+|---|---|---|
+| `ATM_DAEMON_UNAVAILABLE` | `AtmErrorCode::DaemonUnavailable` via `AtmError::daemon_unavailable(...)` | default daemon/client reachability and runtime coordination failures |
+| `ATM_SOCKET_CONNECT_FAILED` | `AtmErrorCode::DaemonUnavailable` via socket/open/bind/connect flavored `AtmError::daemon_unavailable(...)` messages | same code, but the recovery text must explicitly mention the socket/connect surface |
+| `ATM_DAEMON_START_FAILED` | `AtmErrorCode::DaemonAutoStartFailed` via `AtmError::daemon_auto_start_failed(...)` | daemon binary missing, spawn failures, publish-timeout auto-start failures |
+| `ATM_IPC_RUNTIME_FAILED` | `AtmErrorCode::DaemonUnavailable` or `AtmErrorCode::DaemonLifecycleWedge` depending on whether the failure is one-shot runtime I/O vs lifecycle wedge | local IPC deadlines, dispatch/worker/join-helper failures, lifecycle teardown wedges |
+
+Concrete related variants that remain valid in the final daemon/client error
+surface:
+- `AtmErrorCode::DaemonLaunchGateRejected`
+- `AtmErrorCode::DaemonLifecycleWedge`
+- `AtmErrorCode::DaemonServingStateRejected`
+
+`V.4` therefore hardens category-specific `.with_recovery(...)` text on the
+concrete variants above instead of renaming the underlying ATM error codes.
+
+Recovery text may be omitted only when:
+- the failure is purely internal and no user action exists
+- a lower boundary already emitted the exact actionable recovery guidance and
+  the higher layer preserves it unchanged
+
+## File Ownership Map
+
+Primary files in scope:
+- `crates/atm-daemon-client/src/lib.rs`
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/local_ipc_connection.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+
+Category ownership:
+- daemon unavailable:
+  - `crates/atm-daemon-client/src/lib.rs`
+  - `crates/atm-daemon/src/composition.rs`
+- socket connect failures:
+  - `crates/atm-daemon-client/src/lib.rs`
+  - `crates/atm-daemon/src/local_ipc_transport.rs`
+- daemon start failures:
+  - `crates/atm-daemon-client/src/lib.rs`
+  - `crates/atm-daemon/src/composition.rs`
+- local IPC runtime failures:
+  - `crates/atm-daemon/src/local_ipc_transport.rs`
+  - `crates/atm-daemon/src/local_ipc_connection.rs`
+  - `crates/atm-daemon/src/lifecycle_control.rs`
+
+## Recovery Text Checklist
+
+Each required path should answer:
+- what failed
+- what the operator should inspect or restart
+- whether retry is appropriate
+- whether the daemon or host runtime must be restarted
+
+Good examples:
+- “Build or install atm-daemon, or set ATM_DAEMON_BIN to the correct executable before retrying.”
+- “Restart the daemon; the local IPC listener stopped accepting connections unexpectedly.”
+- “Grant write access to the daemon socket parent directory or choose a writable ATM_HOME before retrying.”
+
+Bad examples:
+- “operation failed”
+- “unexpected error”
+- “retry later”
+
+Coverage strategy for `V.4`:
+- enumerate the required source files in the sprint plan and this document
+- require `.with_recovery(...)` on every daemon-unavailable, socket-connect,
+  daemon-start, and local-IPC runtime path in those files unless a lower layer
+  already preserves the exact same actionable guidance
+- verify `.with_recovery(...)` coverage in QA with checklist review of the
+  enumerated paths
+- use workspace `cargo clippy -- -D warnings` only for Rust hygiene after the
+  recovery-text edits land
+
+## Phase Ownership
+
+- `V.1` establishes this persistent rule set and file ownership map
+- `V.1` reserves the stable recovery code namespace for the mandatory
+  categories listed above
+- `V.4` hardens the concrete rule set, checklist, and enforcement strategy

--- a/docs/phase-W/sprint-W1.md
+++ b/docs/phase-W/sprint-W1.md
@@ -1,0 +1,117 @@
+---
+id: W.1
+title: Daemon Emit Failure Visibility
+status: planned
+branch: TBD
+worktree: TBD
+---
+
+# Sprint W.1 — Emit Silent Discard Fix
+
+## Goals
+
+- replace daemon-side silent `emit()` / `emit_event()` discards with an
+  explicit fallback rule
+- ensure observability sink failure is visible instead of disappearing behind
+  `let _ = ...`
+- restore the existing reporting contract where sink degradation must be
+  diagnosable through the ATM surfaces that already exist
+- keep the fix on the shared observability path; this sprint must not invent
+  subsystem-specific fallback/reporting implementations
+- define how sink degradation becomes visible through:
+  - concise ATM CLI failure output when it affects command execution
+  - `atm doctor` degraded-health diagnostics when the sink is impaired but the
+    command path still succeeds
+
+## Acceptance Criteria
+
+- every `let _ = ...emit(...)` and `let _ = ...emit_event(...)` call in the
+  current path inventory is replaced; no daemon-side silent-discard callsite
+  remains in the listed files
+- the final rule replaces silent discard with
+  `if let Err(error) = ... { tracing::warn!(...) }` or a stricter approved
+  policy; silent loss is forbidden
+- the fix uses shared observability/reporting behavior rather than
+  subsystem-specific custom fallback pipelines
+- the sprint defines which emit failures remain best-effort warnings versus
+  which failures must mark runtime health degraded
+- the sprint names how doctor will surface observability impairment
+- the sprint verifies whether any ATM CLI commands already surface an adequate
+  warning/failure and names the exact regressions that must be restored where
+  they do not
+- every file/function inventory item listed below is treated as required scope,
+  not as a best-effort review target
+
+## Implementation Notes
+
+Observed silent-discard inventory on `origin/integrate/phase-V`:
+- `crates/atm-daemon/src/advisory_runtime.rs` — 6 call sites
+- `crates/atm-daemon/src/composition.rs` — 11 call sites
+- `crates/atm-daemon/src/host_ownership.rs` — 4 call sites
+- `crates/atm-daemon/src/lifecycle_control.rs` — 5 call sites
+- `crates/atm-daemon/src/local_ipc_transport.rs` — 3 call sites
+- `crates/atm-daemon/src/notification_runtime.rs` — 8 call sites
+- `crates/atm-daemon/src/peer_transport.rs` — 6 call sites
+- `crates/atm-daemon/src/reconcile_runtime.rs` — 9 call sites
+- `crates/atm-daemon/src/runtime_health.rs` — 5 call sites
+- `crates/atm-daemon/src/runtime_status_cache.rs` — 3 call sites
+- `crates/atm-daemon/src/watch_runtime.rs` — 8 call sites
+
+Total currently identified daemon-side silent-discard call sites:
+- `68`
+
+Current path inventory:
+- `crates/atm-daemon/src/advisory_runtime.rs`
+  - startup/registration emit paths
+  - session-activation success/failure emit paths
+  - advisory drain / receive loop event emission
+- `crates/atm-daemon/src/composition.rs`
+  - startup transition events
+  - lane start/stop events
+  - rollback / shutdown / finalize events
+- `crates/atm-daemon/src/host_ownership.rs`
+  - owner acquire / stale owner / release events
+- `crates/atm-daemon/src/lifecycle_control.rs`
+  - worker install / join / wake / teardown events
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+  - listener start / accept failure / connection-cap events
+- `crates/atm-daemon/src/notification_runtime.rs`
+  - notification worker start / timeout / shutdown / dispatch events
+- `crates/atm-daemon/src/peer_transport.rs`
+  - remote delivery success / retry / failure events
+- `crates/atm-daemon/src/reconcile_runtime.rs`
+  - queue admission / completion / timeout / worker events
+- `crates/atm-daemon/src/runtime_health.rs`
+  - health projection / advisory state / sqlite checkpoint events
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+  - sqlite degraded / status replacement events
+- `crates/atm-daemon/src/watch_runtime.rs`
+  - watch batch delivery / timeout / shutdown events
+
+Required execution shape:
+- replace each silent discard with an explicit fallback block
+- standardize fallback fields:
+  - subsystem
+  - action
+  - original emit error code/message
+  - whether the command/runtime path continued
+- add or update doctor/runtime-health surfaces so sustained observability sink
+  failure becomes diagnosable after the fact
+
+Files in scope:
+- all files listed in the inventory above
+- `crates/atm-daemon/src/daemon_observability.rs`
+- `crates/atm-daemon/src/daemon_runtime_observability.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/tests.rs`
+- `crates/atm-daemon/src/test_observability.rs`
+
+Critical issue classes covered directly by this sprint:
+- observability sink degradation
+- daemon runtime incidents whose evidence would otherwise be silently dropped
+
+## Out of Scope
+
+- daemon-client connection tracing
+- SQLite subsystem observability
+- replay persistence recovery text outside the sink-failure policy

--- a/docs/phase-W/sprint-W1.md
+++ b/docs/phase-W/sprint-W1.md
@@ -23,6 +23,24 @@ worktree: TBD
   - `atm doctor` degraded-health diagnostics when the sink is impaired but the
     command path still succeeds
 
+## Hard Dependencies
+
+- none on `W.2`, `W.3`, or `W.4`
+- shared observability trait and doctor/runtime-health paths remain the only
+  allowed reporting surfaces
+
+## Required Work
+
+- replace every daemon-side silent `emit()` / `emit_event()` discard in the
+  required path inventory
+- define the common fallback behavior once and apply it consistently
+- define how sustained sink degradation becomes visible through doctor or
+  runtime health instead of being silently dropped
+- explicitly document whether any emit failure is allowed to remain
+  non-blocking and why
+- identify the shared daemon surfaces that own the fallback and degraded-health
+  projection so no subsystem grows its own reporting side channel
+
 ## Acceptance Criteria
 
 - every `let _ = ...emit(...)` and `let _ = ...emit_event(...)` call in the
@@ -39,8 +57,13 @@ worktree: TBD
 - the sprint verifies whether any ATM CLI commands already surface an adequate
   warning/failure and names the exact regressions that must be restored where
   they do not
+- the sprint names the shared runtime-health / doctor projection points that
+  carry observability impairment across CLI, graft, and peer-triggered
+  diagnostics
 - every file/function inventory item listed below is treated as required scope,
-  not as a best-effort review target
+  not as an optional review target
+- req-qa can verify from the sprint doc alone that daemon-client tracing is
+  intentionally owned by `W.2`, not omitted from Phase W
 
 ## Implementation Notes
 
@@ -103,8 +126,26 @@ Files in scope:
 - `crates/atm-daemon/src/daemon_observability.rs`
 - `crates/atm-daemon/src/daemon_runtime_observability.rs`
 - `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/runtime_status_cache.rs`
 - `crates/atm-daemon/src/tests.rs`
 - `crates/atm-daemon/src/test_observability.rs`
+
+Shared reporting paths that must be reused:
+- `crates/atm-daemon/src/daemon_observability.rs`
+- `crates/atm-daemon/src/daemon_runtime_observability.rs`
+- `crates/atm-core/src/doctor/mod.rs`
+- `crates/atm/src/commands/doctor.rs`
+- `crates/atm/src/output.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+- `crates/atm-core/src/error.rs`
+
+Current main baseline to preserve:
+- degraded daemon conditions should continue to be surfaced through the shared
+  ATM error / doctor paths rather than hidden behind daemon-only warnings
+- this sprint must verify whether any CLI-facing command currently reports
+  observability impairment directly or only through doctor/runtime health, and
+  must preserve that behavior while removing silent discard
 
 Critical issue classes covered directly by this sprint:
 - observability sink degradation
@@ -115,3 +156,16 @@ Critical issue classes covered directly by this sprint:
 - daemon-client connection tracing
 - SQLite subsystem observability
 - replay persistence recovery text outside the sink-failure policy
+
+## Required Validation
+
+Plan-auditable now:
+- inventory completeness against the listed daemon files
+- ownership split between `W.1` and `W.2`
+- explicit shared-path rule and non-silent fallback requirement
+
+Implementation validation later:
+- grep or lint proof that no listed daemon-side silent-discard callsite remains
+- tests showing doctor/runtime-health can surface observability impairment
+- proof that the final fallback/reporting path is shared rather than
+  subsystem-specific

--- a/docs/phase-W/sprint-W1.md
+++ b/docs/phase-W/sprint-W1.md
@@ -49,6 +49,9 @@ worktree: TBD
 - the final rule replaces silent discard with
   `if let Err(error) = ... { tracing::warn!(...) }` or a stricter approved
   policy; silent loss is forbidden
+- any `tracing::warn!(...)` fallback is daemon-local reporting about a failed
+  shared-port emit; it must not become a replacement observability pipeline or
+  bypass successful `ObservabilityPort` emission
 - the fix uses shared observability/reporting behavior rather than
   subsystem-specific custom fallback pipelines
 - the sprint defines which emit failures remain non-blocking warnings versus
@@ -57,6 +60,8 @@ worktree: TBD
 - the sprint verifies whether any ATM CLI commands already surface an adequate
   warning/failure and names the exact regressions that must be restored where
   they do not
+- the sprint reconciles its local code inventory with the shared Phase `W`
+  ATM code inventory in `docs/plan-phase-W.md`
 - the sprint names the shared runtime-health / doctor projection points that
   carry observability impairment across CLI, graft, and peer-triggered
   diagnostics
@@ -64,6 +69,12 @@ worktree: TBD
   not as an optional review target
 - req-qa can verify from the sprint doc alone that daemon-client tracing is
   intentionally owned by `W.2`, not omitted from Phase W
+- the sprint documents the shared observability trait decision explicitly:
+  object-safe `dyn ObservabilityPort` dispatch remains the model and the
+  existing sealed/open boundary is unchanged
+- fallback metadata for the 68 daemon emit sites is typed:
+  stable subsystem and action identifiers must come from a shared enum/newtype
+  set rather than ad hoc per-callsite strings
 
 ## Implementation Notes
 
@@ -124,11 +135,26 @@ Required execution shape:
 Files in scope:
 - all files listed in the inventory above
 - `crates/atm-daemon/src/daemon_observability.rs`
+  - `DaemonObservability::emit_runtime_event(...)`
+  - `impl ObservabilityPort for DaemonObservability::emit(...)`
+  - `impl ObservabilityPort for DaemonObservability::health(...)`
+  - `RetainedLogEmitter::mark_failure(...)`
 - `crates/atm-daemon/src/daemon_runtime_observability.rs`
+  - `DaemonRuntimeObservability::emit_runtime_event(...)`
 - `crates/atm-daemon/src/runtime_health.rs`
+  - `DaemonRequestDispatcher::project_doctor_report(...)`
 - `crates/atm-daemon/src/runtime_status_cache.rs`
+  - `RuntimeStatusCache::replace_state(...)`
+  - `RuntimeStatusCache::mark_sqlite_unavailable(...)`
+- `crates/atm-core/src/error.rs`
+  - observability emit / health constructors and stable code bindings
 - `crates/atm-daemon/src/tests.rs`
+  - doctor / degraded runtime projection tests covering observability health
 - `crates/atm-daemon/src/test_observability.rs`
+  - `TestDaemonObservability::append_message(...)`
+  - `impl ObservabilityPort for TestDaemonObservability::emit(...)`
+  - `impl ObservabilityPort for TestDaemonObservability::health(...)`
+  - `impl DaemonRuntimeObservability for TestDaemonObservability::emit_runtime_event(...)`
 
 Shared reporting paths that must be reused:
 - `crates/atm-daemon/src/daemon_observability.rs`
@@ -146,6 +172,13 @@ Current main baseline to preserve:
 - this sprint must verify whether any CLI-facing command currently reports
   observability impairment directly or only through doctor/runtime health, and
   must preserve that behavior while removing silent discard
+
+Stable ATM code inventory for this sprint:
+- final operator/doctor-visible sink degradation uses existing codes:
+  - `AtmErrorCode::ObservabilityEmitFailed`
+  - `AtmErrorCode::WarningObservabilityHealthDegraded`
+  - `AtmErrorCode::ObservabilityHealthFailed`
+- no new `AtmErrorKind` or `AtmErrorCode` variants are planned for `W.1`
 
 Critical issue classes covered directly by this sprint:
 - observability sink degradation

--- a/docs/phase-W/sprint-W1.md
+++ b/docs/phase-W/sprint-W1.md
@@ -33,7 +33,7 @@ worktree: TBD
   policy; silent loss is forbidden
 - the fix uses shared observability/reporting behavior rather than
   subsystem-specific custom fallback pipelines
-- the sprint defines which emit failures remain best-effort warnings versus
+- the sprint defines which emit failures remain non-blocking warnings versus
   which failures must mark runtime health degraded
 - the sprint names how doctor will surface observability impairment
 - the sprint verifies whether any ATM CLI commands already surface an adequate

--- a/docs/phase-W/sprint-W2.md
+++ b/docs/phase-W/sprint-W2.md
@@ -18,6 +18,8 @@ worktree: TBD
   - richer `atm doctor` diagnostics and degraded-health evidence
 - keep emission/reporting on shared paths rather than creating a daemon-client
   specific reporting stack
+- preserve interface parity so the same daemon-availability failure class uses
+  the same ATM code/recovery semantics on CLI and `atm-graft` same-host flows
 
 ## Acceptance Criteria
 
@@ -36,6 +38,12 @@ worktree: TBD
   output aligned is treated as required scope, not a deferred follow-up
 - the sprint reuses shared observability and doctor reporting paths; only the
   daemon-client event semantics and insertion points are local
+- the sprint verifies same-host interface parity between CLI and `atm-graft`
+  for daemon-unavailable, auto-start-failed, launch-gate, and advisory-stream
+  setup failures
+- where CLI and `atm-graft` currently duplicate error-mapping or reporting
+  code for the same same-host failure class, the sprint should collapse those
+  paths onto one shared implementation
 
 ## Implementation Notes
 
@@ -53,6 +61,13 @@ Primary insertion points:
   - `CliComposition::bootstrap(...)`
   - command entrypoints that already surface final ATM errors for
     `send/read/ack/clear/list`
+- `crates/atm-graft/src/lib.rs`
+  - same-host bootstrap through `DaemonSupervisor`
+  - live advisory stream setup and receive-loop startup
+- `crates/atm-graft/src/transport.rs`
+  - advisory-stream connect / write / flush / timeout setup
+- `crates/atm-graft/src/runtime.rs`
+  - advisory-stream receive / reconnect / response validation failures
 
 Current path inventory:
 - `crates/atm-daemon-client/src/lib.rs`
@@ -85,6 +100,17 @@ Current path inventory:
     - response `request_id` mismatch
   - `CliComposition::bootstrap(...)`
     - end-to-end daemon-availability bootstrap failure before command dispatch
+- `crates/atm-graft/src/lib.rs`
+  - same-host daemon-availability bootstrap before graft runtime start
+  - advisory-stream unsupported-path failure
+- `crates/atm-graft/src/transport.rs`
+  - advisory-stream write-timeout failure
+  - advisory-stream flush failure
+  - advisory-stream bounded read-timeout failure
+- `crates/atm-graft/src/runtime.rs`
+  - advisory-stream frame read failure
+  - advisory-stream request-id mismatch
+  - advisory-stream reconnect/open failure
 - CLI command surface that must preserve concise failure output:
   - `atm send`
   - `atm read`
@@ -114,6 +140,9 @@ CLI / doctor split required by this sprint:
   - keep concise returned failure output with stable error code and next action
   - close any drift where the final ATM failure is present but the path-specific
     signal is no longer available
+- `atm-graft` host:
+  - must receive the same ATM error code and aligned recovery intent for the
+    same same-host daemon/connect failure classes
 - `atm doctor`:
   - expose the deeper connect / launch / publish trail so operators can
     distinguish “daemon absent,” “daemon spawn failed,” “daemon started but

--- a/docs/phase-W/sprint-W2.md
+++ b/docs/phase-W/sprint-W2.md
@@ -1,0 +1,130 @@
+---
+id: W.2
+title: Daemon Client Traceability
+status: planned
+branch: TBD
+worktree: TBD
+---
+
+# Sprint W.2 — Daemon-Client Traceability
+
+## Goals
+
+- add per-attempt and exhaustion observability to daemon-client connect and
+  auto-start flows
+- restore the existing expectation that daemon startup/connect/publish failure
+  is visible as a critical issue through both:
+  - concise ATM CLI failure output
+  - richer `atm doctor` diagnostics and degraded-health evidence
+- keep emission/reporting on shared paths rather than creating a daemon-client
+  specific reporting stack
+
+## Acceptance Criteria
+
+- every path listed in the current path inventory is addressed directly; the
+  sprint is not allowed to leave “follow-up discovery” inside daemon-client or
+  CLI bootstrap handling
+- attempt-level events exist for connect retry, launch-gate contention,
+  successful spawn attempt, publish wait, and exhaustion
+- final daemon-start/connect failures preserve concise operator-facing ATM
+  errors
+- `atm doctor` has a documented way to expose the richer daemon-start/connect
+  diagnostic trail
+- the sprint distinguishes between paths that already satisfy the contract and
+  paths that regressed into under-instrumented final failures
+- any ATM CLI integration point needed to keep command failures and doctor
+  output aligned is treated as required scope, not a deferred follow-up
+- the sprint reuses shared observability and doctor reporting paths; only the
+  daemon-client event semantics and insertion points are local
+
+## Implementation Notes
+
+Primary insertion points:
+- `crates/atm-daemon-client/src/lib.rs`
+  - `DaemonSupervisor::ensure_daemon_available(...)`
+  - `DaemonSupervisor::ensure_daemon_available_with_timeout(...)`
+  - `DaemonSupervisor::ensure_daemon_available_with_lock_path(...)`
+  - `DaemonSupervisor::spawn_daemon(...)`
+  - `LaunchGateGuard::rejected_error(...)`
+  - `LaunchGateGuard::try_acquire_at(...)`
+- `crates/atm/src/composition.rs`
+  - `LocalIpcClientTransportAdapter::try_connect(...)`
+  - `LocalIpcClientTransportAdapter::exchange(...)`
+  - `CliComposition::bootstrap(...)`
+  - command entrypoints that already surface final ATM errors for
+    `send/read/ack/clear/list`
+
+Current path inventory:
+- `crates/atm-daemon-client/src/lib.rs`
+  - `validate_daemon_path(...)`
+    - empty-path validation
+    - non-UTF-8 path validation
+  - `DaemonSupervisor::ensure_daemon_available_with_lock_path(...)`
+    - initial `try_connect()` miss
+    - retry-loop `try_connect()` miss
+    - launch-gate acquisition success
+    - launch-gate contention timeout
+    - post-spawn publish wait
+    - auto-start exhaustion
+  - `DaemonSupervisor::spawn_daemon(...)`
+    - daemon binary missing
+    - `Command::spawn()` failure
+  - `LaunchGateGuard::rejected_error(...)`
+  - `LaunchGateGuard::try_acquire_at(...)`
+    - lock-dir create failure
+    - launch-gate open failure
+    - launch-gate acquire failure
+- `crates/atm/src/composition.rs`
+  - `LocalIpcClientTransportAdapter::try_connect(...)`
+    - final same-host connect failure returned to CLI
+  - `LocalIpcClientTransportAdapter::exchange(...)`
+    - write-timeout setup failure
+    - read-timeout setup failure
+    - request flush failure
+    - daemon closed before response
+    - response `request_id` mismatch
+  - `CliComposition::bootstrap(...)`
+    - end-to-end daemon-availability bootstrap failure before command dispatch
+- CLI command surface that must preserve concise failure output:
+  - `atm send`
+  - `atm read`
+  - `atm ack`
+  - `atm clear`
+  - `atm list`
+
+Traceability events to add:
+- initial same-host connect miss
+- repeated connect retry
+- launch-gate acquired vs contended
+- daemon spawn attempted
+- daemon spawn failed
+- publish wait continuing
+- auto-start timeout exhausted
+- launch-gate timeout exhausted while another launch owns the gate
+
+Critical issue classes covered directly by this sprint:
+- daemon startup failure
+- daemon connect failure
+- daemon publish failure
+- ATM command failure on the daemon path, especially `atm send` and `atm read`
+  when the daemon is unavailable
+
+CLI / doctor split required by this sprint:
+- ATM CLI:
+  - keep concise returned failure output with stable error code and next action
+  - close any drift where the final ATM failure is present but the path-specific
+    signal is no longer available
+- `atm doctor`:
+  - expose the deeper connect / launch / publish trail so operators can
+    distinguish “daemon absent,” “daemon spawn failed,” “daemon started but
+    never published,” and “launch gate stuck”
+
+Cross-sprint dependency:
+- this sprint should reuse the W.1 emit-fallback rule so traceability events
+  are not silently lost when the sink is degraded
+
+## Out of Scope
+
+- SQLite writer instrumentation
+- peer replay recovery text
+- large ATM CLI output redesign beyond what is required for concise failures

--- a/docs/phase-W/sprint-W2.md
+++ b/docs/phase-W/sprint-W2.md
@@ -45,10 +45,6 @@ worktree: TBD
   CLI bootstrap handling
 - attempt-level events exist for connect retry, launch-gate contention,
   successful spawn attempt, publish wait, and exhaustion
-- final daemon-start/connect failures preserve concise operator-facing ATM
-  errors
-- `atm doctor` has a documented way to expose the richer daemon-start/connect
-  diagnostic trail
 - the sprint distinguishes between paths that already satisfy the contract and
   paths that regressed into under-instrumented final failures
 - any ATM CLI integration point needed to keep command failures and doctor
@@ -65,6 +61,9 @@ worktree: TBD
   become the single source of truth for each touched same-host failure class
 - `W.1` is a hard gate for any new same-host traceability emit site; `W.2`
   cannot land new emit paths against a silent-discard daemon sink policy
+- any new `emit()` call introduced by this sprint in
+  `crates/atm-daemon-client/src/lib.rs` must apply the `W.1` fallback rule; no
+  silent `let _ =` discard is permitted in the added traceability sites
 - the sprint reconciles its local code inventory with the shared Phase `W`
   ATM code inventory in `docs/plan-phase-W.md`
 - the sprint documents the LaunchGateGuard ownership decision explicitly:
@@ -245,7 +244,11 @@ Plan-auditable now:
 Implementation validation later:
 - same ATM code/recovery semantics demonstrated for equivalent same-host
   failure classes across CLI and `atm-graft`
+- final daemon-start/connect failures preserve concise operator-facing ATM
+  errors
 - runtime proof that doctor exposes the deeper daemon-start/connect trail
+- `atm doctor` has a documented way to expose the richer daemon-start/connect
+  diagnostic trail
 - proof that duplicate same-host mapping/reporting logic was collapsed onto the
   shared ATM error / doctor paths where the touched failure class existed in
   parallel before

--- a/docs/phase-W/sprint-W2.md
+++ b/docs/phase-W/sprint-W2.md
@@ -63,6 +63,14 @@ worktree: TBD
   paths onto one shared implementation
 - the sprint identifies the shared ATM error/protocol/doctor functions that
   become the single source of truth for each touched same-host failure class
+- `W.1` is a hard gate for any new same-host traceability emit site; `W.2`
+  cannot land new emit paths against a silent-discard daemon sink policy
+- the sprint reconciles its local code inventory with the shared Phase `W`
+  ATM code inventory in `docs/plan-phase-W.md`
+- the sprint documents the LaunchGateGuard ownership decision explicitly:
+  `W.2` does not introduce a new public typestate/`PhantomData` guard; it keeps
+  the existing single-owner runtime lock model and limits scope to reporting
+  parity and duplicate-path consolidation
 - req-qa can verify from the sprint doc exactly which same-host surfaces are
   in scope and that CLI-side path tracing is explicitly owned here
 
@@ -114,7 +122,31 @@ Current main CLI baseline to preserve:
   - current ATM error constructors and recovery text remain the baseline for
     daemon-unavailable and auto-start failure classes
 
+Stable ATM code inventory for this sprint:
+- `validate_daemon_path(...)`
+  - existing validation failures remain on the current validation code path; no
+    daemon-specific reclassification is planned
+- initial or repeated same-host connect miss:
+  - `AtmErrorCode::DaemonUnavailable`
+- daemon binary missing before spawn:
+  - `AtmErrorCode::DaemonUnavailable`
+- daemon spawn failure:
+  - `AtmErrorCode::DaemonAutoStartFailed`
+- publish wait exhausted after spawn:
+  - `AtmErrorCode::DaemonAutoStartFailed`
+- launch-gate remained owned until timeout:
+  - `AtmErrorCode::DaemonLaunchGateRejected`
+- launch-gate create/open/acquire I/O failure:
+  - `AtmErrorCode::DaemonUnavailable`
+- advisory-stream open / write / read / request-id mismatch failure on
+  same-host graft path:
+  - `AtmErrorCode::DaemonUnavailable`
+- no new `AtmErrorKind` or `AtmErrorCode` variants are planned for `W.2`
+
 Current path inventory:
+- `crates/atm-core/src/error.rs`
+  - daemon-unavailable / auto-start / launch-gate constructors and stable code
+    bindings used by same-host CLI and graft flows
 - `crates/atm-daemon-client/src/lib.rs`
   - `validate_daemon_path(...)`
     - empty-path validation

--- a/docs/phase-W/sprint-W2.md
+++ b/docs/phase-W/sprint-W2.md
@@ -21,6 +21,23 @@ worktree: TBD
 - preserve interface parity so the same daemon-availability failure class uses
   the same ATM code/recovery semantics on CLI and `atm-graft` same-host flows
 
+## Hard Dependencies
+
+- depends on `W.1` for the final daemon-side sink-failure rule when new
+  traceability events are emitted
+- no hard dependency on `W.3` or `W.4`
+
+## Required Work
+
+- add attempt-level tracing for same-host daemon bootstrap/connect paths
+- audit current CLI-facing same-host errors against `atm-graft` same-host
+  errors and recovery text
+- collapse duplicate same-host error/reporting paths when they describe the
+  same daemon failure class
+- preserve one doctor-facing diagnostic story for same-host failures
+- compare every touched same-host failure class against the current `main` CLI
+  contract before finalizing any refactor
+
 ## Acceptance Criteria
 
 - every path listed in the current path inventory is addressed directly; the
@@ -44,6 +61,10 @@ worktree: TBD
 - where CLI and `atm-graft` currently duplicate error-mapping or reporting
   code for the same same-host failure class, the sprint should collapse those
   paths onto one shared implementation
+- the sprint identifies the shared ATM error/protocol/doctor functions that
+  become the single source of truth for each touched same-host failure class
+- req-qa can verify from the sprint doc exactly which same-host surfaces are
+  in scope and that CLI-side path tracing is explicitly owned here
 
 ## Implementation Notes
 
@@ -68,6 +89,30 @@ Primary insertion points:
   - advisory-stream connect / write / flush / timeout setup
 - `crates/atm-graft/src/runtime.rs`
   - advisory-stream receive / reconnect / response validation failures
+
+Shared paths that must be reused or consolidated:
+- `crates/atm-core/src/error.rs`
+  - `AtmError::daemon_unavailable(...)`
+  - `AtmError::daemon_auto_start_failed(...)`
+- `crates/atm-core/src/protocol.rs`
+  - protocol-envelope mapping for same-host daemon failures returned through
+    non-CLI consumers
+- `crates/atm-core/src/doctor/mod.rs`
+- `crates/atm/src/commands/doctor.rs`
+- `crates/atm/src/output.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+
+Current main CLI baseline to preserve:
+- `crates/atm-daemon-client/src/lib.rs`
+  - final same-host daemon-availability failures already return ATM errors
+    through the shared daemon-client bootstrap path
+- `crates/atm/src/composition.rs`
+  - CLI bootstrap and exchange failures already terminate commands with
+    concise ATM errors
+- `crates/atm-core/src/error.rs`
+  - current ATM error constructors and recovery text remain the baseline for
+    daemon-unavailable and auto-start failure classes
 
 Current path inventory:
 - `crates/atm-daemon-client/src/lib.rs`
@@ -157,3 +202,18 @@ Cross-sprint dependency:
 - SQLite writer instrumentation
 - peer replay recovery text
 - large ATM CLI output redesign beyond what is required for concise failures
+
+## Required Validation
+
+Plan-auditable now:
+- explicit ownership of CLI, daemon-client, and `atm-graft` same-host paths
+- explicit duplicate-path collapse responsibility
+- explicit interface-parity contract
+
+Implementation validation later:
+- same ATM code/recovery semantics demonstrated for equivalent same-host
+  failure classes across CLI and `atm-graft`
+- runtime proof that doctor exposes the deeper daemon-start/connect trail
+- proof that duplicate same-host mapping/reporting logic was collapsed onto the
+  shared ATM error / doctor paths where the touched failure class existed in
+  parallel before

--- a/docs/phase-W/sprint-W3.md
+++ b/docs/phase-W/sprint-W3.md
@@ -52,12 +52,6 @@ worktree: TBD
   - shared reader-budget exhaustion
 - the sprint identifies the daemon wiring needed to expose SQLite health
   through doctor
-- the sprint makes the reporting split explicit:
-  - CLI gets concise failure output
-  - doctor gets the fuller diagnostic surface
-- the sprint identifies where the current implementation already returns
-  adequate ATM errors versus where the doctor/observability side regressed or
-  never completed
 - the sprint keeps SQLite observability bottom-of-stack and does not re-create
   daemon-side semantic reconstruction
 - `W.1` is a hard gate for any new SQLite observability emit site; `W.3`
@@ -241,6 +235,12 @@ Plan-auditable now:
 - explicit separation from same-host daemon-client tracing and peer replay text
 
 Implementation validation later:
+- the reporting split remains intact:
+  - CLI gets concise failure output
+  - doctor gets the fuller diagnostic surface
+- the sprint identifies where the current implementation already returns
+  adequate ATM errors versus where the doctor/observability side regressed or
+  never completed
 - runtime proof that doctor exposes queue backlog, reply timeout, WAL, and
   reader-budget diagnostics
 - parity proof that equivalent SQLite-backed failures preserve the same ATM

--- a/docs/phase-W/sprint-W3.md
+++ b/docs/phase-W/sprint-W3.md
@@ -1,0 +1,131 @@
+---
+id: W.3
+title: SQLite Subsystem Observability
+status: planned
+branch: TBD
+worktree: TBD
+---
+
+# Sprint W.3 — SQLite Observability
+
+## Goals
+
+- add real subsystem observability for SQLite writer and connection-budget
+  failures
+- restore the existing expectation that SQLite failure is a first-class
+  critical issue visible through:
+  - concise ATM CLI failure output when a command hits the failure
+  - fuller `atm doctor` diagnostics for queue backlog, reply timeout, WAL
+    health, and reader-budget exhaustion
+- keep emission/reporting on shared paths; SQLite-specific work should be about
+  event content and insertion points, not a separate reporting implementation
+
+## Acceptance Criteria
+
+- every SQLite path listed in the current path inventory is addressed directly
+  in the implementation scope
+- the sprint covers the exact SQLite insertion points for:
+  - writer queue timeout
+  - writer reply timeout
+  - writer shutdown / final WAL checkpoint
+  - shared reader-budget exhaustion
+- the sprint identifies the daemon wiring needed to expose SQLite health
+  through doctor
+- the sprint makes the reporting split explicit:
+  - CLI gets concise failure output
+  - doctor gets the fuller diagnostic surface
+- the sprint identifies where the current implementation already returns
+  adequate ATM errors versus where the doctor/observability side regressed or
+  never completed
+- the sprint keeps SQLite observability bottom-of-stack and does not re-create
+  daemon-side semantic reconstruction
+- the sprint preserves one shared doctor/reporting pipeline rather than
+  introducing SQLite-specific output plumbing
+
+## Implementation Notes
+
+Primary SQLite insertion points:
+- `crates/atm-rusqlite/src/writer/mod.rs`
+  - `SqliteWriter::start_with_settings(...)`
+  - `SqliteWriter::submit(...)`
+  - `checkpoint_writer_connection(...)`
+  - shutdown join-helper branches in `Drop for SqliteWriter`
+- `crates/atm-rusqlite/src/shared_db.rs`
+  - `SharedDb::checkpoint_wal(...)`
+  - `SharedDb::acquire_connection_guard(...)`
+- `crates/atm-rusqlite/src/lib.rs`
+  - `SqliteBoundaryAssembly::new(...)`
+  - `SqliteBoundaryAssembly::checkpoint_wal(...)`
+
+Current path inventory:
+- `crates/atm-rusqlite/src/writer/mod.rs`
+  - `SqliteWriter::start_with_settings(...)`
+    - writer thread spawn failure
+  - `SqliteWriter::submit(...)`
+    - submission channel closed
+    - submission queue timeout
+    - submission channel disconnected
+    - reply timeout
+    - reply channel disconnected
+  - `Drop for SqliteWriter`
+    - shutdown signal skipped because queue is full
+    - writer thread panic during shutdown
+    - shutdown join timeout
+    - join-helper disconnected
+  - `checkpoint_writer_connection(...)`
+    - final WAL checkpoint warning
+- `crates/atm-rusqlite/src/shared_db.rs`
+  - `SharedDb::checkpoint_wal(...)`
+    - daemon-shutdown checkpoint failure
+  - `SharedDb::acquire_connection_guard(...)`
+    - connection-budget state lock poisoned
+    - reader-budget exhausted
+- `crates/atm-rusqlite/src/lib.rs`
+  - `SqliteBoundaryAssembly::new(...)`
+    - boundary open/assemble failure
+  - `SqliteBoundaryAssembly::checkpoint_wal(...)`
+    - top-level WAL checkpoint propagation
+- `crates/atm-daemon/src/composition.rs`
+  - replay-store assembly failure currently logged as warning-only
+- `crates/atm-daemon/src/runtime_health.rs`
+  - `finalize_shutdown()` bounded `sqlite_wal_checkpoint` step
+
+Daemon-side integration points:
+- `crates/atm-daemon/src/composition.rs`
+  - SQLite boundary assembly wiring
+  - remote replay store assembly failure path
+- `crates/atm-daemon/src/runtime_health.rs`
+  - bounded shutdown WAL checkpoint path
+  - doctor/runtime-health projections that can expose SQLite degraded state
+
+Event families required:
+- writer queue backlog / timeout
+- writer reply timeout
+- writer lane shutdown degradation
+- WAL checkpoint success/failure
+- reader-budget exhaustion
+- SQLite boundary assembly unavailable
+
+Critical issue classes covered directly by this sprint:
+- SQLite writer queue failure
+- SQLite reply timeout
+- SQLite WAL checkpoint failure
+- SQLite reader-budget exhaustion
+- ATM command failure caused by SQLite unavailability or SQLite backpressure
+
+Doctor/CLI reporting contract:
+- ATM CLI must keep command failure concise and actionable for SQLite-backed
+  failures
+- `atm doctor` must expose the deeper subsystem details so an operator can tell
+  whether the problem is queue saturation, reply timeout, checkpoint failure,
+  or connection-budget exhaustion
+
+Cross-sprint dependency:
+- if `atm-rusqlite` needs a new thin observability port, it must follow the
+  Phase V bottom-of-stack rule and stay free of daemon-owned semantic types
+
+## Out of Scope
+
+- unrelated SQLite schema work
+- daemon-client startup tracing
+- peer replay recovery text

--- a/docs/phase-W/sprint-W3.md
+++ b/docs/phase-W/sprint-W3.md
@@ -19,6 +19,9 @@ worktree: TBD
     health, and reader-budget exhaustion
 - keep emission/reporting on shared paths; SQLite-specific work should be about
   event content and insertion points, not a separate reporting implementation
+- preserve interface parity so the same SQLite-backed failure class returns the
+  same ATM error code/recovery semantics whether reached from CLI, graft host,
+  or peer-transport-triggered daemon work
 
 ## Acceptance Criteria
 
@@ -41,6 +44,11 @@ worktree: TBD
   daemon-side semantic reconstruction
 - the sprint preserves one shared doctor/reporting pipeline rather than
   introducing SQLite-specific output plumbing
+- the sprint verifies that shared ATM errors returned from SQLite-backed paths
+  are preserved consistently through protocol envelopes and non-CLI consumers
+- where SQLite-backed error mapping/reporting has duplicated interface-specific
+  handling, the sprint should collapse those paths onto one shared
+  implementation
 
 ## Implementation Notes
 
@@ -56,6 +64,8 @@ Primary SQLite insertion points:
 - `crates/atm-rusqlite/src/lib.rs`
   - `SqliteBoundaryAssembly::new(...)`
   - `SqliteBoundaryAssembly::checkpoint_wal(...)`
+- `crates/atm-core/src/protocol.rs`
+  - protocol error-envelope preservation for SQLite-backed failures
 
 Current path inventory:
 - `crates/atm-rusqlite/src/writer/mod.rs`
@@ -89,6 +99,9 @@ Current path inventory:
   - replay-store assembly failure currently logged as warning-only
 - `crates/atm-daemon/src/runtime_health.rs`
   - `finalize_shutdown()` bounded `sqlite_wal_checkpoint` step
+- `crates/atm-core/src/protocol.rs`
+  - `ProtocolErrorEnvelope::{from_error,into_atm_error}` parity for non-CLI
+    consumers
 
 Daemon-side integration points:
 - `crates/atm-daemon/src/composition.rs`
@@ -116,6 +129,8 @@ Critical issue classes covered directly by this sprint:
 Doctor/CLI reporting contract:
 - ATM CLI must keep command failure concise and actionable for SQLite-backed
   failures
+- `atm-graft` host and peer-triggered consumers must receive the same ATM error
+  code/recovery intent for the same SQLite-backed failure class
 - `atm doctor` must expose the deeper subsystem details so an operator can tell
   whether the problem is queue saturation, reply timeout, checkpoint failure,
   or connection-budget exhaustion

--- a/docs/phase-W/sprint-W3.md
+++ b/docs/phase-W/sprint-W3.md
@@ -60,6 +60,8 @@ worktree: TBD
   never completed
 - the sprint keeps SQLite observability bottom-of-stack and does not re-create
   daemon-side semantic reconstruction
+- `W.1` is a hard gate for any new SQLite observability emit site; `W.3`
+  cannot land SQLite event emission against a silent-discard daemon sink policy
 - the sprint preserves one shared doctor/reporting pipeline rather than
   introducing SQLite-specific output plumbing
 - the sprint verifies that shared ATM errors returned from SQLite-backed paths
@@ -70,6 +72,8 @@ worktree: TBD
 - the sprint identifies the shared ATM error/protocol/doctor functions that
   become the single source of truth for each touched SQLite-backed failure
   class
+- the sprint reconciles its local code inventory with the shared Phase `W`
+  ATM code inventory in `docs/plan-phase-W.md`
 - req-qa can verify from the sprint doc that SQLite-backed parity and protocol
   envelope preservation are explicitly owned here
 
@@ -91,6 +95,9 @@ Primary SQLite insertion points:
   - protocol error-envelope preservation for SQLite-backed failures
 
 Current path inventory:
+- `crates/atm-core/src/error.rs`
+  - shared daemon-unavailable / lifecycle-wedge constructors and stable code
+    bindings reused by SQLite-backed command/runtime failures
 - `crates/atm-rusqlite/src/writer/mod.rs`
   - `SqliteWriter::start_with_settings(...)`
     - writer thread spawn failure
@@ -125,6 +132,9 @@ Current path inventory:
 - `crates/atm-core/src/protocol.rs`
   - `ProtocolErrorEnvelope::{from_error,into_atm_error}` parity for non-CLI
     consumers
+- `crates/atm-daemon/src/peer_transport.rs`
+  - remote peer request/response propagation where SQLite-backed daemon errors
+    must survive protocol-envelope projection unchanged
 
 Daemon-side integration points:
 - `crates/atm-daemon/src/composition.rs`
@@ -151,6 +161,38 @@ Current main CLI baseline to preserve:
   code and recovery intent when surfaced to CLI, graft host, or peer-triggered
   consumers
 
+Concrete duplicate-path collapse sites to resolve:
+- `crates/atm-rusqlite/src/writer/mod.rs::submit(...)`
+  and `crates/atm-rusqlite/src/shared_db.rs::acquire_connection_guard(...)`
+  both mint queue/budget `DaemonUnavailable` failures with SQLite-specific
+  wording; where the recovery contract is the same, they should converge on one
+  shared ATM error/recovery helper instead of duplicated strings
+- `crates/atm-rusqlite/src/shared_db.rs::checkpoint_wal(...)`
+  and `crates/atm-daemon/src/runtime_health.rs::finalize_shutdown(...)`
+  both describe shutdown-time WAL degradation; doctor/runtime-health projection
+  should be shared rather than independently narrated
+- `crates/atm-core/src/protocol.rs::ProtocolErrorEnvelope::{from_error,into_atm_error}`
+  and CLI/peer response handling must remain the single mapping path for
+  SQLite-backed ATM errors; `W.3` must not leave a second interface-specific
+  SQLite error envelope
+
+Stable ATM code inventory for this sprint:
+- sqlite writer thread spawn failure:
+  - `AtmErrorCode::DaemonUnavailable`
+- sqlite writer submission queue timeout:
+  - `AtmErrorCode::DaemonUnavailable`
+- sqlite writer reply timeout or reply channel disconnect:
+  - `AtmErrorCode::DaemonUnavailable`
+- sqlite writer shutdown / final WAL checkpoint degradation:
+  - operator-facing returned error remains `AtmErrorCode::DaemonUnavailable`
+    where the current shared path returns one; doctor/runtime health carries the
+    deeper checkpoint degradation detail
+- sqlite reader-budget exhaustion:
+  - `AtmErrorCode::DaemonUnavailable`
+- sqlite boundary assembly / replay-store assembly unavailable:
+  - `AtmErrorCode::DaemonUnavailable`
+- no new `AtmErrorKind` or `AtmErrorCode` variants are planned for `W.3`
+
 Event families required:
 - writer queue backlog / timeout
 - writer reply timeout
@@ -174,10 +216,16 @@ Doctor/CLI reporting contract:
 - `atm doctor` must expose the deeper subsystem details so an operator can tell
   whether the problem is queue saturation, reply timeout, checkpoint failure,
   or connection-budget exhaustion
+- peer-triggered daemon work must preserve the same SQLite-backed ATM code
+  through `ProtocolErrorEnvelope::{from_error,into_atm_error}` as the same
+  failure class would on same-host CLI
 
 Cross-sprint dependency:
 - if `atm-rusqlite` needs a new thin observability port, it must follow the
   Phase V bottom-of-stack rule and stay free of daemon-owned semantic types
+- if `W.4` is running in parallel, any `crates/atm-core/src/protocol.rs`
+  change here must stay limited to SQLite-backed envelope parity and be
+  merge-forwarded before either branch pushes a final head
 
 ## Out of Scope
 

--- a/docs/phase-W/sprint-W3.md
+++ b/docs/phase-W/sprint-W3.md
@@ -23,6 +23,24 @@ worktree: TBD
   same ATM error code/recovery semantics whether reached from CLI, graft host,
   or peer-transport-triggered daemon work
 
+## Hard Dependencies
+
+- depends on `W.1` for non-silent daemon-side event emission when SQLite
+  subsystem signals are forwarded through daemon observability
+- no hard dependency on `W.2`
+- no code dependency on `W.4`; only ordinary merge-forward discipline applies
+
+## Required Work
+
+- add SQLite subsystem signals at the listed queue, reply, WAL, and budget
+  paths
+- define exactly how SQLite-backed failures project into doctor/runtime health
+- verify protocol envelope parity for non-CLI consumers
+- collapse duplicate interface-specific SQLite error/reporting paths if they
+  exist
+- compare every touched SQLite-backed failure class against the current `main`
+  CLI command-failure contract before finalizing any refactor
+
 ## Acceptance Criteria
 
 - every SQLite path listed in the current path inventory is addressed directly
@@ -49,6 +67,11 @@ worktree: TBD
 - where SQLite-backed error mapping/reporting has duplicated interface-specific
   handling, the sprint should collapse those paths onto one shared
   implementation
+- the sprint identifies the shared ATM error/protocol/doctor functions that
+  become the single source of truth for each touched SQLite-backed failure
+  class
+- req-qa can verify from the sprint doc that SQLite-backed parity and protocol
+  envelope preservation are explicitly owned here
 
 ## Implementation Notes
 
@@ -111,6 +134,23 @@ Daemon-side integration points:
   - bounded shutdown WAL checkpoint path
   - doctor/runtime-health projections that can expose SQLite degraded state
 
+Shared paths that must be reused or consolidated:
+- `crates/atm-core/src/error.rs`
+- `crates/atm-core/src/protocol.rs`
+  - `ProtocolErrorEnvelope::{from_error,into_atm_error}`
+- `crates/atm-core/src/doctor/mod.rs`
+- `crates/atm/src/commands/doctor.rs`
+- `crates/atm/src/output.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+
+Current main CLI baseline to preserve:
+- SQLite-backed ATM command failures already terminate through the shared ATM
+  error surface rather than a SQLite-specific CLI formatter
+- the touched SQLite-backed failure classes must continue to use the same ATM
+  code and recovery intent when surfaced to CLI, graft host, or peer-triggered
+  consumers
+
 Event families required:
 - writer queue backlog / timeout
 - writer reply timeout
@@ -144,3 +184,18 @@ Cross-sprint dependency:
 - unrelated SQLite schema work
 - daemon-client startup tracing
 - peer replay recovery text
+
+## Required Validation
+
+Plan-auditable now:
+- explicit ownership of SQLite-backed doctor projection and protocol parity
+- explicit duplicate-path collapse responsibility
+- explicit separation from same-host daemon-client tracing and peer replay text
+
+Implementation validation later:
+- runtime proof that doctor exposes queue backlog, reply timeout, WAL, and
+  reader-budget diagnostics
+- parity proof that equivalent SQLite-backed failures preserve the same ATM
+  code/recovery intent across CLI and non-CLI consumers
+- proof that duplicate SQLite-specific reporting or mapping paths were
+  collapsed onto shared ATM error / protocol / doctor implementations

--- a/docs/phase-W/sprint-W3.md
+++ b/docs/phase-W/sprint-W3.md
@@ -63,6 +63,11 @@ worktree: TBD
 - where SQLite-backed error mapping/reporting has duplicated interface-specific
   handling, the sprint should collapse those paths onto one shared
   implementation
+- the sprint names the concrete collapse pairs
+  `SqliteWriter::submit(...)` / `SharedDb::acquire_connection_guard(...)` and
+  `SharedDb::checkpoint_wal(...)` / `DaemonRequestDispatcher::finalize_shutdown(...)`,
+  and verifies parity for the three consumer interfaces:
+  CLI, `atm-graft` host, and peer-triggered daemon work
 - the sprint identifies the shared ATM error/protocol/doctor functions that
   become the single source of truth for each touched SQLite-backed failure
   class
@@ -217,6 +222,9 @@ Doctor/CLI reporting contract:
 Cross-sprint dependency:
 - if `atm-rusqlite` needs a new thin observability port, it must follow the
   Phase V bottom-of-stack rule and stay free of daemon-owned semantic types
+- any new SQLite observability emit site must also satisfy the `W.1`
+  non-silent emit-fallback rule in addition to the Phase V bottom-of-stack
+  constraint
 - if `W.4` is running in parallel, any `crates/atm-core/src/protocol.rs`
   change here must stay limited to SQLite-backed envelope parity and be
   merge-forwarded before either branch pushes a final head

--- a/docs/phase-W/sprint-W4.md
+++ b/docs/phase-W/sprint-W4.md
@@ -1,0 +1,76 @@
+---
+id: W.4
+title: Peer Replay Recovery Text
+status: planned
+branch: TBD
+worktree: TBD
+---
+
+# Sprint W.4 — Peer Replay Recovery Text
+
+## Goals
+
+- close the remaining uncovered replay-persistence recovery branches in
+  `peer_transport`
+- ensure peer replay persistence failures remain actionable when remote
+  delivery outcome is unknown
+- keep replay failure reporting on the shared ATM error and doctor surfaces;
+  this sprint must not add a bespoke peer-reporting path
+
+## Acceptance Criteria
+
+- the sprint covers the exact uncovered replay-persistence branches listed in
+  the current path inventory
+- each uncovered branch gains `.with_recovery(...)` coverage or an explicit
+  ruling that the lower layer already preserves the exact operator guidance
+- the sprint reuses the Phase V recovery-text rules and does not invent a
+  parallel policy
+
+## Implementation Notes
+
+Primary file in scope:
+- `crates/atm-daemon/src/peer_transport.rs`
+
+Targeted functions:
+- `PeerClientTransport::persist_replay_request(...)`
+- `PeerClientTransport::persist_outcome_unknown_request(...)`
+
+Current branch-level insertion candidates:
+- replay store missing branch
+- peer endpoint missing branch
+- retry-budget to expiry conversion failure branch
+
+Current path inventory:
+- `crates/atm-daemon/src/peer_transport.rs`
+  - `PeerClientTransport::persist_replay_request(...)`
+    - replay store missing
+    - peer endpoint missing
+    - retry-budget to expiry conversion failure
+  - `PeerClientTransport::persist_outcome_unknown_request(...)`
+    - replay metadata unsupported branch
+    - durable replay persistence follow-through
+  - `PeerTransportRuntime::persist_replay_request(...)`
+    - runtime wrapper propagation path
+
+Supporting verification paths:
+- replay persistence tests in `crates/atm-daemon/src/peer_transport.rs`
+- any doctor/runtime-health text that refers to remote replay durability
+
+Critical issue classes covered directly by this sprint:
+- ATM send failure where remote delivery outcome is unknown
+- replay persistence failure that would otherwise leave the operator unsure
+  whether retry is safe
+
+CLI / doctor split:
+- ATM CLI must keep the immediate send failure concise and tell the operator
+  whether durable replay did or did not persist
+- `atm doctor` should remain able to explain replay-store configuration and
+  retained pending replay state if that information is already available
+- this sprint is primarily a regression-closure check on uncovered recovery
+  branches, not a redesign of how send failure is reported
+
+## Out of Scope
+
+- broad peer transport redesign
+- daemon-client startup tracing
+- SQLite subsystem instrumentation

--- a/docs/phase-W/sprint-W4.md
+++ b/docs/phase-W/sprint-W4.md
@@ -53,6 +53,11 @@ worktree: TBD
 - the sprint identifies the shared ATM error/protocol/doctor functions that
   become the single source of truth for each touched replay-persistence
   failure class
+- the sprint reconciles its local code inventory with the shared Phase `W`
+  ATM code inventory in `docs/plan-phase-W.md`
+- the sprint makes the CLI / doctor split verifiable in acceptance criteria:
+  concise send failure at the command surface, deeper replay durability detail
+  through the shared doctor/runtime-health surfaces
 - req-qa can verify from the sprint doc that `W.4` is independently executable
   and does not hide an undocumented dependency on `W.2` or `W.3`
 
@@ -82,6 +87,24 @@ Current main CLI baseline to preserve:
   persisted, that guidance must stay aligned across CLI, cross-daemon
   consumers, and doctor follow-through
 
+Stable ATM code inventory for this sprint:
+- replay store missing during outcome-unknown persistence:
+  - final operator-facing ATM code remains
+    `AtmErrorCode::RemoteDeliveryOutcomeUnknown`
+  - lower-layer persistence prerequisite failure remains
+    `AtmErrorCode::DaemonUnavailable` as the wrapped source
+- peer endpoint missing during outcome-unknown persistence:
+  - final operator-facing ATM code remains
+    `AtmErrorCode::RemoteDeliveryOutcomeUnknown`
+  - lower-layer persistence prerequisite failure remains
+    `AtmErrorCode::DaemonUnavailable` as the wrapped source
+- retry-budget to expiry conversion failure during replay persistence:
+  - final operator-facing ATM code remains
+    `AtmErrorCode::RemoteDeliveryOutcomeUnknown`
+  - lower-layer persistence prerequisite failure remains
+    `AtmErrorCode::DaemonUnavailable` as the wrapped source
+- no new `AtmErrorKind` or `AtmErrorCode` variants are planned for `W.4`
+
 Targeted functions:
 - `PeerClientTransport::persist_replay_request(...)`
 - `PeerClientTransport::persist_outcome_unknown_request(...)`
@@ -92,6 +115,9 @@ Current branch-level insertion candidates:
 - retry-budget to expiry conversion failure branch
 
 Current path inventory:
+- `crates/atm-core/src/error.rs`
+  - remote-delivery-outcome-unknown and daemon-unavailable constructors/stable
+    code bindings reused by replay-persistence failures
 - `crates/atm-daemon/src/peer_transport.rs`
   - `PeerClientTransport::persist_replay_request(...)`
     - replay store missing
@@ -125,6 +151,11 @@ CLI / doctor split:
   retained pending replay state if that information is already available
 - this sprint is primarily a regression-closure check on uncovered recovery
   branches, not a redesign of how send failure is reported
+
+Cross-sprint dependency:
+- if `W.3` is running in parallel, any `crates/atm-core/src/protocol.rs`
+  change here must stay limited to peer replay / remote-delivery envelope
+  parity and be merge-forwarded before either branch pushes a final head
 
 ## Out of Scope
 

--- a/docs/phase-W/sprint-W4.md
+++ b/docs/phase-W/sprint-W4.md
@@ -16,6 +16,9 @@ worktree: TBD
   delivery outcome is unknown
 - keep replay failure reporting on the shared ATM error and doctor surfaces;
   this sprint must not add a bespoke peer-reporting path
+- preserve parity between cross-daemon peer transport and the other ATM
+  interfaces so remote-delivery failure classes do not drift from the shared
+  ATM error model
 
 ## Acceptance Criteria
 
@@ -25,11 +28,19 @@ worktree: TBD
   ruling that the lower layer already preserves the exact operator guidance
 - the sprint reuses the Phase V recovery-text rules and does not invent a
   parallel policy
+- the sprint verifies protocol-envelope parity so cross-daemon failures preserve
+  the same ATM error code and recovery intent seen by other participants
+- where peer transport currently duplicates shared error-mapping/reporting
+  behavior for the same failure class, the sprint should collapse those paths
+  onto one shared implementation
 
 ## Implementation Notes
 
 Primary file in scope:
 - `crates/atm-daemon/src/peer_transport.rs`
+
+Shared parity file in scope:
+- `crates/atm-core/src/protocol.rs`
 
 Targeted functions:
 - `PeerClientTransport::persist_replay_request(...)`
@@ -51,6 +62,9 @@ Current path inventory:
     - durable replay persistence follow-through
   - `PeerTransportRuntime::persist_replay_request(...)`
     - runtime wrapper propagation path
+- `crates/atm-core/src/protocol.rs`
+  - `ProtocolErrorEnvelope::{from_error,into_atm_error}` propagation for remote
+    delivery / replay persistence failures
 
 Supporting verification paths:
 - replay persistence tests in `crates/atm-daemon/src/peer_transport.rs`
@@ -64,6 +78,9 @@ Critical issue classes covered directly by this sprint:
 CLI / doctor split:
 - ATM CLI must keep the immediate send failure concise and tell the operator
   whether durable replay did or did not persist
+- cross-daemon consumers must receive the same ATM error code and aligned
+  recovery intent for the same remote-delivery / replay-persistence failure
+  class
 - `atm doctor` should remain able to explain replay-store configuration and
   retained pending replay state if that information is already available
 - this sprint is primarily a regression-closure check on uncovered recovery

--- a/docs/phase-W/sprint-W4.md
+++ b/docs/phase-W/sprint-W4.md
@@ -43,8 +43,9 @@ worktree: TBD
   the current path inventory
 - each uncovered branch gains `.with_recovery(...)` coverage or an explicit
   ruling that the lower layer already preserves the exact operator guidance
-- the sprint reuses the Phase V recovery-text rules and does not invent a
-  parallel policy
+- the sprint applies the `V.4 Category Binding` table and satisfies the
+  `Recovery Text Checklist` in `docs/atm-daemon/recovery-text-rules.md` for
+  each covered branch; it does not invent a parallel policy
 - the sprint verifies protocol-envelope parity so cross-daemon failures preserve
   the same ATM error code and recovery intent seen by other participants
 - where peer transport currently duplicates shared error-mapping/reporting

--- a/docs/phase-W/sprint-W4.md
+++ b/docs/phase-W/sprint-W4.md
@@ -20,6 +20,23 @@ worktree: TBD
   interfaces so remote-delivery failure classes do not drift from the shared
   ATM error model
 
+## Hard Dependencies
+
+- no hard dependency on `W.2` or `W.3`
+- must reuse the existing shared protocol/error contract and the persistent
+  recovery-text rules document
+
+## Required Work
+
+- add missing replay-persistence recovery text on the listed peer branches
+- verify shared protocol-envelope parity for peer-side failures
+- collapse duplicate peer-specific error/reporting paths when they restate the
+  same shared failure class
+- make the independence/ordering rule explicit so implementation can proceed
+  without waiting on unrelated same-host or SQLite work
+- compare every touched peer replay failure class against the current `main`
+  send-failure contract before finalizing any refactor
+
 ## Acceptance Criteria
 
 - the sprint covers the exact uncovered replay-persistence branches listed in
@@ -33,6 +50,11 @@ worktree: TBD
 - where peer transport currently duplicates shared error-mapping/reporting
   behavior for the same failure class, the sprint should collapse those paths
   onto one shared implementation
+- the sprint identifies the shared ATM error/protocol/doctor functions that
+  become the single source of truth for each touched replay-persistence
+  failure class
+- req-qa can verify from the sprint doc that `W.4` is independently executable
+  and does not hide an undocumented dependency on `W.2` or `W.3`
 
 ## Implementation Notes
 
@@ -41,6 +63,24 @@ Primary file in scope:
 
 Shared parity file in scope:
 - `crates/atm-core/src/protocol.rs`
+
+Shared paths that must be reused or consolidated:
+- `crates/atm-core/src/error.rs`
+- `crates/atm-core/src/protocol.rs`
+  - `ProtocolErrorEnvelope::{from_error,into_atm_error}`
+- `crates/atm-core/src/doctor/mod.rs`
+- `crates/atm/src/commands/doctor.rs`
+- `crates/atm/src/output.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+
+Current main CLI baseline to preserve:
+- remote-delivery and replay-persistence failures must continue to surface
+  through the shared ATM error surface rather than a peer-specific CLI
+  formatter
+- if the operator is told whether retry is safe or whether durable replay
+  persisted, that guidance must stay aligned across CLI, cross-daemon
+  consumers, and doctor follow-through
 
 Targeted functions:
 - `PeerClientTransport::persist_replay_request(...)`
@@ -91,3 +131,17 @@ CLI / doctor split:
 - broad peer transport redesign
 - daemon-client startup tracing
 - SQLite subsystem instrumentation
+
+## Required Validation
+
+Plan-auditable now:
+- explicit independence from `W.2` and `W.3`
+- explicit shared-protocol parity ownership
+- explicit duplicate-path collapse responsibility
+
+Implementation validation later:
+- parity proof that equivalent peer replay failure classes preserve the same
+  ATM code/recovery intent through protocol envelopes
+- test coverage for the listed replay-persistence branches
+- proof that duplicate peer-specific mapping/reporting logic was collapsed
+  onto shared ATM error / protocol / doctor implementations

--- a/docs/plan-phase-W.md
+++ b/docs/plan-phase-W.md
@@ -1,0 +1,99 @@
+# Phase W — Production Readiness Follow-Up
+
+Goal:
+- close the four production-readiness gaps identified in `TASK-1477` before
+  broader system testing depends on the new daemon/runtime line
+- verify and restore the existing ATM error-reporting contract for critical
+  daemon, command, and SQLite failures:
+  - concise operator-facing ATM command failure output
+  - deeper diagnostic detail available through `atm doctor`
+- remove silent observability loss in daemon subsystems so incident evidence is
+  not discarded when the sink is degraded
+
+Planning branch:
+- `feature/observability-findings-planning`
+
+Critical issue reporting contract:
+- Phase W treats the following as critical issue classes that must already be
+  identified explicitly and surfaced in both operator and diagnostic channels:
+  - daemon startup / daemon connect / daemon publish failure
+  - ATM command execution failure on the daemon path, especially
+    `atm send`, `atm read`, `atm ack`, `atm clear`, and `atm list`
+  - SQLite writer / queue / reply / WAL / reader-budget failure
+  - observability sink degradation severe enough to hide subsystem events
+- operator-facing ATM commands must return concise failure output that names the
+  failing surface and next action
+- `atm doctor` must expose the richer diagnostic explanation, degraded-health
+  evidence, and any retained observability trail for the same issue class
+- Phase W is a no-regression audit for this contract:
+  it closes places where the implemented daemon/runtime line drifted from the
+  existing expectation that CLI and doctor both report critical failures
+- shared reporting rule:
+  - subsystem semantics stay local
+  - logging emission, retained observability output, and doctor-facing
+    reporting stay on shared paths
+  - Phase W must not create separate per-subsystem reporting stacks
+
+Execution shape:
+- `W.1` removes daemon-side silent `emit()` discards and defines the fallback
+  rule for sink degradation
+- `W.2` adds daemon-client connection and auto-start traceability so daemon
+  startup/connect failures are diagnosable
+- `W.3` adds SQLite subsystem observability for writer queue, reply timeout,
+  WAL lifecycle, and reader-budget exhaustion
+- `W.4` closes the remaining peer replay recovery-text holes
+
+Execution sequence:
+- `W.1` must land first because the sink-failure rule affects every later
+  observability change
+- `W.2` and `W.3` both depend on `W.1`
+- `W.4` can land in parallel with late `W.3` work if the replay-recovery
+  branches remain isolated
+
+Critical path rationale:
+- without `W.1`, subsystem event loss is still silent
+- without `W.2`, daemon-start/connect failures still collapse into an end
+  error without enough attempt-level evidence for system testing
+- without `W.3`, SQLite failures remain under-observed even though SQLite is
+  the durable-state owner
+- `W.4` is narrower, but it closes the remaining actionable recovery gaps in
+  peer replay persistence and prevents ambiguous retry behavior
+
+Authoritative sprint sequence:
+- `docs/phase-W/sprint-W1.md`
+- `docs/phase-W/sprint-W2.md`
+- `docs/phase-W/sprint-W3.md`
+- `docs/phase-W/sprint-W4.md`
+
+Deliverables:
+- `docs/phase-W/sprint-W1.md` — daemon `emit()` silent discard fix plan
+- `docs/phase-W/sprint-W2.md` — daemon-client traceability plan
+- `docs/phase-W/sprint-W3.md` — SQLite observability plan
+- `docs/phase-W/sprint-W4.md` — peer replay recovery-text plan
+
+Cross-sprint dependencies:
+- `W.2` and `W.3` must both define how new signals map to:
+  - concise ATM CLI failure output
+  - detailed `atm doctor` findings or degraded-health reporting
+- `W.3` may require a thin observability boundary extension into
+  `atm-rusqlite`; the sprint doc must keep that extension bottom-of-stack and
+  must not reintroduce daemon-owned semantic reconstruction
+- `W.4` must reuse the Phase V recovery-text rules in
+  `docs/atm-daemon/recovery-text-rules.md`
+- every sprint must preserve one shared observability/reporting path:
+  - shared observability trait for event emission
+  - shared ATM CLI error surface for concise operator failures
+  - shared `atm doctor` / runtime-health path for deeper diagnostics
+
+Current path inventory requirement:
+- every Phase W sprint doc must itemize the current log/error paths it will
+  change
+- path inventories must name concrete files and current functions or branch
+  sites, not only modules
+- no separate discovery or planning sprint is part of Phase W; the sprint docs
+  themselves are the implementation-ready path inventories
+
+Out of scope for Phase W:
+- unrelated daemon redesign work
+- broad new ATM product features
+- replacing the current observability stack

--- a/docs/plan-phase-W.md
+++ b/docs/plan-phase-W.md
@@ -19,6 +19,17 @@ Phase scope note:
 Planning branch:
 - `feature/observability-findings-planning`
 
+Base branch:
+- `origin/develop`
+
+Integration branch:
+- `integrate/phase-W`
+
+Predecessor gate:
+- all Phase `V` implementation branches are merged and validated on
+  `integrate/phase-V` before `integrate/phase-W` starts taking implementation
+  work
+
 Critical issue reporting contract:
 - Phase W treats the following as critical issue classes that must already be
   identified explicitly and surfaced in both operator and diagnostic channels:
@@ -73,6 +84,22 @@ Shared implementation boundary:
   - separate doctor reporting logic per participant
   - duplicate per-interface string formatting for the same failure class when a
     shared ATM error or protocol-envelope path can own it once
+
+Shared observability trait decision:
+- Phase `W` keeps `atm_core::observability::ObservabilityPort` as the one
+  shared observability boundary for CLI, daemon, graft, and doctor-facing
+  paths.
+- Dispatch model:
+  - object-safe trait
+  - `dyn ObservabilityPort` / `Arc<dyn ObservabilityPort>` style runtime
+    dispatch remains the shared model
+  - Phase `W` must not fork into generic per-subsystem logger traits
+- Sealing/open decision:
+  - keep the existing `crate::boundary::sealed::Sealed` supertrait model in
+    `atm-core`
+  - Phase `W` does not widen the implementation surface or change the sealing
+    decision
+  - any sealing redesign is out of scope and would require ADR review
 
 Interface parity matrix:
 - same-host CLI:
@@ -149,6 +176,34 @@ Critical failure ownership matrix:
     - `crates/atm-core/src/doctor/mod.rs`
     - `crates/atm-daemon/src/runtime_health.rs`
 
+Shared ATM error inventory:
+- `W.1` sink degradation uses existing ATM codes:
+  - `ATM_OBSERVABILITY_EMIT_FAILED`
+  - `ATM_WARNING_OBSERVABILITY_HEALTH_DEGRADED`
+  - `ATM_OBSERVABILITY_HEALTH_FAILED`
+- `W.2` same-host daemon bootstrap/connect uses existing ATM codes:
+  - `ATM_DAEMON_UNAVAILABLE`
+  - `ATM_DAEMON_AUTO_START_FAILED`
+  - `ATM_DAEMON_LAUNCH_GATE_REJECTED`
+  - `ATM_DAEMON_LIFECYCLE_WEDGE` when the current shared error surface already
+    routes a lifecycle wedge rather than a generic unavailable failure
+- `W.3` SQLite-backed command/runtime failures reuse existing ATM codes:
+  - `ATM_DAEMON_UNAVAILABLE` for queue, reply, WAL, budget, and assembly
+    failures that currently project through daemon/runtime availability
+  - `ATM_DAEMON_LIFECYCLE_WEDGE` only where the existing shared error path
+    already promotes the failure to a lifecycle wedge
+- `W.4` remote replay persistence uses existing ATM codes:
+  - `ATM_REMOTE_OUTCOME_UNKNOWN` for final operator-facing send failures where
+    delivery outcome cannot be proven
+  - `ATM_DAEMON_UNAVAILABLE` for lower-layer persistence prerequisites that are
+    wrapped into the final remote-outcome-unknown error
+- Phase `W` default decision:
+  - no new `AtmErrorKind` variants are planned
+  - no new `AtmErrorCode` variants are planned unless implementation proves an
+    existing shared code cannot express the failure class without ambiguity
+  - if that proof appears, the owning sprint must update this inventory and its
+    own sprint-local error table in the same change
+
 Execution shape:
 - `W.1` removes daemon-side silent `emit()` discards and defines the fallback
   rule for sink degradation
@@ -210,6 +265,12 @@ Cross-sprint dependencies:
   ordinary merge-forward discipline.
 - `W.1` does not own daemon-client tracing or CLI-side path narration; those
   same-host path gaps are owned by `W.2`.
+- if `W.3` and `W.4` run in parallel, `crates/atm-core/src/protocol.rs`
+  changes must be partitioned by failure family:
+  - `W.3` owns SQLite-backed envelope parity
+  - `W.4` owns peer replay / remote-delivery envelope parity
+  - both branches must merge-forward before push if `protocol.rs` changed on
+    the other line; no parallel fork of protocol error taxonomy is allowed
 - if audit finds any critical-failure path not assignable to `W.1` through
   `W.4`, the plan must add the missing sprint rather than leave it implicit.
 
@@ -229,6 +290,16 @@ Plan QA boundary:
   daemon only if each sprint doc clearly separates:
   - document-auditable acceptance criteria
   - implementation/runtime validation that the future sprint must run
+
+Phase closeout gate:
+- Phase `W` is not complete until:
+  - all critical failure classes above are implemented on `integrate/phase-W`
+  - shared CLI / graft / peer ATM error-code parity is revalidated
+  - `atm doctor` coverage for the touched failure classes is revalidated
+  - no duplicate interface-specific reporting path remains for the touched
+    failure classes
+  - the final Phase `W` sprint docs and `docs/project-plan.md` status reflect
+    the merged implementation state
 
 Out of scope for Phase W:
 - unrelated daemon redesign work

--- a/docs/plan-phase-W.md
+++ b/docs/plan-phase-W.md
@@ -33,6 +33,33 @@ Critical issue reporting contract:
   - logging emission, retained observability output, and doctor-facing
     reporting stay on shared paths
   - Phase W must not create separate per-subsystem reporting stacks
+  - if duplicate interface-specific error/reporting paths already exist, Phase
+    W should collapse them onto one shared implementation rather than preserve
+    parallel code
+- interface parity rule:
+  - same critical failures must preserve the same ATM error codes and the same
+    recovery intent across:
+    - same-host ATM CLI
+    - same-host `atm-graft` host flows
+    - cross-daemon socket / peer transport flows
+  - doctor/runtimե-health diagnostics remain one shared diagnostic surface even
+    when the failing interface differs
+
+Interface parity matrix:
+- same-host CLI:
+  - `crates/atm/src/composition.rs`
+  - `crates/atm-daemon-client/src/lib.rs`
+- same-host graft host:
+  - `crates/atm-graft/src/lib.rs`
+  - `crates/atm-graft/src/runtime.rs`
+  - `crates/atm-graft/src/transport.rs`
+- cross-daemon socket / peer transport:
+  - `crates/atm-daemon/src/peer_transport.rs`
+- shared error-envelope / doctor surfaces:
+  - `crates/atm-core/src/error.rs`
+  - `crates/atm-core/src/protocol.rs`
+  - `crates/atm-daemon/src/runtime_health.rs`
+  - `crates/atm-daemon/src/runtime_status_cache.rs`
 
 Execution shape:
 - `W.1` removes daemon-side silent `emit()` discards and defines the fallback
@@ -84,6 +111,12 @@ Cross-sprint dependencies:
   - shared observability trait for event emission
   - shared ATM CLI error surface for concise operator failures
   - shared `atm doctor` / runtime-health path for deeper diagnostics
+- every sprint must preserve one shared error contract across interfaces:
+  - no interface-specific replacement error taxonomy
+  - no drift where CLI, graft, and peer transport describe the same failure
+    class with incompatible ATM codes or contradictory recovery guidance
+  - duplicate error-mapping or reporting code paths for the same failure class
+    should be collapsed when the sprint touches them
 
 Current path inventory requirement:
 - every Phase W sprint doc must itemize the current log/error paths it will

--- a/docs/plan-phase-W.md
+++ b/docs/plan-phase-W.md
@@ -10,6 +10,12 @@ Goal:
 - remove silent observability loss in daemon subsystems so incident evidence is
   not discarded when the sink is degraded
 
+Phase scope note:
+- Phase W is implementation planning only.
+- It is not a discovery line and not a runtime-proof line by itself.
+- Sprint docs must be detailed enough that implementation agents can execute
+  them without adding a separate planning sprint.
+
 Planning branch:
 - `feature/observability-findings-planning`
 
@@ -42,8 +48,31 @@ Critical issue reporting contract:
     - same-host ATM CLI
     - same-host `atm-graft` host flows
     - cross-daemon socket / peer transport flows
-  - doctor/runtimե-health diagnostics remain one shared diagnostic surface even
+  - doctor/runtime-health diagnostics remain one shared diagnostic surface even
     when the failing interface differs
+
+Shared implementation boundary:
+- Phase W must converge the touched failure classes onto shared implementations
+  rather than preserve parallel interface-specific handling.
+- Shared code paths that should be reused or tightened when the touched failure
+  class already exists there:
+  - ATM error construction in `crates/atm-core/src/error.rs`
+  - protocol-envelope mapping in `crates/atm-core/src/protocol.rs`
+  - shared doctor engine in `crates/atm-core/src/doctor/mod.rs`
+  - same-host daemon bootstrap/connect logic in
+    `crates/atm-daemon-client/src/lib.rs`
+  - CLI-facing command bootstrap/reporting in `crates/atm/src/composition.rs`
+  - doctor command/output entrypoints in:
+    - `crates/atm/src/commands/doctor.rs`
+    - `crates/atm/src/output.rs`
+  - doctor/runtime-health projection in:
+    - `crates/atm-daemon/src/runtime_health.rs`
+    - `crates/atm-daemon/src/runtime_status_cache.rs`
+- Forbidden outcomes:
+  - a new interface-specific error taxonomy
+  - separate doctor reporting logic per participant
+  - duplicate per-interface string formatting for the same failure class when a
+    shared ATM error or protocol-envelope path can own it once
 
 Interface parity matrix:
 - same-host CLI:
@@ -58,8 +87,67 @@ Interface parity matrix:
 - shared error-envelope / doctor surfaces:
   - `crates/atm-core/src/error.rs`
   - `crates/atm-core/src/protocol.rs`
+  - `crates/atm-core/src/doctor/mod.rs`
+  - `crates/atm/src/commands/doctor.rs`
+  - `crates/atm/src/output.rs`
   - `crates/atm-daemon/src/runtime_health.rs`
   - `crates/atm-daemon/src/runtime_status_cache.rs`
+
+Sprint ownership map:
+- `W.1` owns daemon-side observability sink failure behavior and doctor/runtime
+  degradation signaling for lost daemon subsystem events.
+- `W.2` owns same-host interface parity and consolidation across:
+  - `atm`
+  - `atm-daemon-client`
+  - `atm-graft`
+- `W.3` owns SQLite-backed failure signaling, doctor projection, and protocol
+  envelope parity for non-CLI consumers.
+- `W.4` owns cross-daemon peer replay recovery text and peer-side parity
+  through the shared protocol envelope.
+
+Critical failure ownership matrix:
+- daemon startup / connect / publish failure:
+  - sprint owner: `W.2`
+  - shared paths:
+    - `crates/atm-daemon-client/src/lib.rs`
+    - `crates/atm/src/composition.rs`
+    - `crates/atm-core/src/error.rs`
+    - `crates/atm-core/src/doctor/mod.rs`
+    - `crates/atm/src/commands/doctor.rs`
+    - `crates/atm-daemon/src/runtime_health.rs`
+- ATM command failure on same-host daemon path:
+  - sprint owner: `W.2`
+  - shared paths:
+    - `crates/atm/src/composition.rs`
+    - `crates/atm-daemon-client/src/lib.rs`
+    - `crates/atm-core/src/error.rs`
+    - `crates/atm-core/src/doctor/mod.rs`
+- SQLite writer / queue / reply / WAL / reader-budget failure:
+  - sprint owner: `W.3`
+  - shared paths:
+    - `crates/atm-rusqlite/src/writer/mod.rs`
+    - `crates/atm-rusqlite/src/shared_db.rs`
+    - `crates/atm-rusqlite/src/lib.rs`
+    - `crates/atm-core/src/error.rs`
+    - `crates/atm-core/src/protocol.rs`
+    - `crates/atm-core/src/doctor/mod.rs`
+    - `crates/atm-daemon/src/runtime_health.rs`
+- observability sink degradation:
+  - sprint owner: `W.1`
+  - shared paths:
+    - `crates/atm-daemon/src/daemon_observability.rs`
+    - `crates/atm-daemon/src/daemon_runtime_observability.rs`
+    - `crates/atm-core/src/doctor/mod.rs`
+    - `crates/atm-daemon/src/runtime_health.rs`
+    - `crates/atm-daemon/src/runtime_status_cache.rs`
+- remote delivery outcome unknown / replay persistence failure:
+  - sprint owner: `W.4`
+  - shared paths:
+    - `crates/atm-daemon/src/peer_transport.rs`
+    - `crates/atm-core/src/error.rs`
+    - `crates/atm-core/src/protocol.rs`
+    - `crates/atm-core/src/doctor/mod.rs`
+    - `crates/atm-daemon/src/runtime_health.rs`
 
 Execution shape:
 - `W.1` removes daemon-side silent `emit()` discards and defines the fallback
@@ -117,14 +205,30 @@ Cross-sprint dependencies:
     class with incompatible ATM codes or contradictory recovery guidance
   - duplicate error-mapping or reporting code paths for the same failure class
     should be collapsed when the sprint touches them
+- `W.4` is independently executable from `W.2` and `W.3` at the code-scope
+  level; it depends only on the existing shared protocol/error contract and on
+  ordinary merge-forward discipline.
+- `W.1` does not own daemon-client tracing or CLI-side path narration; those
+  same-host path gaps are owned by `W.2`.
+- if audit finds any critical-failure path not assignable to `W.1` through
+  `W.4`, the plan must add the missing sprint rather than leave it implicit.
 
 Current path inventory requirement:
 - every Phase W sprint doc must itemize the current log/error paths it will
   change
 - path inventories must name concrete files and current functions or branch
   sites, not only modules
+- for every touched critical failure class, the sprint doc must also name the
+  current shared CLI/doctor/error baseline that exists on `main` so
+  implementation can verify no regression while collapsing duplicate paths
 - no separate discovery or planning sprint is part of Phase W; the sprint docs
   themselves are the implementation-ready path inventories
+
+Plan QA boundary:
+- req-qa can fully validate this plan as a document set without running the
+  daemon only if each sprint doc clearly separates:
+  - document-auditable acceptance criteria
+  - implementation/runtime validation that the future sprint must run
 
 Out of scope for Phase W:
 - unrelated daemon redesign work

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3053,6 +3053,16 @@ Deferred backlog:
 Planning branch:
 - `feature/observability-findings-planning`
 
+Base branch:
+- `origin/develop`
+
+Integration branch:
+- `integrate/phase-W`
+
+Predecessor gate:
+- all Phase `V` implementation work is merged and validated on
+  `integrate/phase-V` before `integrate/phase-W` begins implementation
+
 Goal:
 - close the remaining production-readiness gaps identified after Phase V before
   implementation starts
@@ -3086,3 +3096,5 @@ Acceptance:
 - duplicate interface-specific error/reporting implementations for the same
   touched failure class are marked for consolidation rather than preservation
 - no Phase W scope item relies on an implicit discovery sprint
+- Phase `W` closes only when shared CLI / graft / peer ATM error-code parity
+  and shared `atm doctor` diagnostics are revalidated on `integrate/phase-W`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3047,3 +3047,42 @@ Deferred backlog:
 - sprint-close hygiene gate
   - create GH issue from `ATM-QA-PU-001` through `ATM-QA-PU-005`
   - GH issue: `#261`
+
+## 27. Phase W Production Readiness Follow-Up
+
+Planning branch:
+- `feature/observability-findings-planning`
+
+Goal:
+- close the remaining production-readiness gaps identified after Phase V before
+  implementation starts
+- preserve one shared operator/diagnostic contract across ATM CLI, `atm-graft`,
+  and cross-daemon peer transport
+- collapse duplicate interface-specific error/reporting paths when the same
+  failure class is currently implemented in parallel
+
+Execution shape:
+- `W.1` daemon-side observability sink failure visibility
+- `W.2` same-host daemon traceability and interface parity
+- `W.3` SQLite subsystem observability and protocol parity
+- `W.4` peer replay recovery text and peer-side protocol parity
+
+Execution rules:
+- `W.1` defines the daemon-side sink-failure behavior for later emitted events
+- `W.2` owns same-host parity across `atm`, `atm-daemon-client`, and
+  `atm-graft`
+- `W.3` owns SQLite-backed doctor projection and non-CLI protocol-envelope
+  parity
+- `W.4` is independently executable from `W.2` and `W.3`; it owns peer replay
+  recovery text and peer-side parity through the shared protocol envelope
+
+Acceptance:
+- every critical failure class named in `docs/plan-phase-W.md` is assigned to a
+  specific sprint
+- each sprint has explicit hard dependencies, required work, acceptance
+  criteria, and required validation
+- each sprint names the shared ATM error / protocol / doctor paths it must
+  reuse and the current `main` CLI baseline it must preserve
+- duplicate interface-specific error/reporting implementations for the same
+  touched failure class are marked for consolidation rather than preservation
+- no Phase W scope item relies on an implicit discovery sprint


### PR DESCRIPTION
## Summary
- Adds Phase W sprint plan docs covering 4 production readiness gaps from TASK-1477
- `docs/plan-phase-W.md` — phase overview and sprint dependency graph
- `docs/phase-W/sprint-W1.md` — emit() silent-discard fallback rule
- `docs/phase-W/sprint-W2.md` — daemon-client connection/auto-start traceability
- `docs/phase-W/sprint-W3.md` — SQLite writer/WAL/reader-budget observability
- `docs/phase-W/sprint-W4.md` — peer replay recovery text (.with_recovery() 3 uncovered branches)

## Test plan
- [ ] QA-1: req-qa + arch-qa verify all 4 finding clusters covered with concrete ACs and file-level scope
- [ ] CI green (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)