### PR TITLE
W.5: doctor projection — BootstrapTraceability outcomes in DoctorReport

### DIFF
--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -17,8 +17,9 @@ use crate::team_admin::{MemberSummary, MembersList};
 use crate::types::{AgentName, TeamName};
 
 pub use report::{
-    DoctorEnvironmentVisibility, DoctorFinding, DoctorReport, DoctorSeverity, DoctorStatus,
-    DoctorSummary,
+    BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
+    BootstrapTraceReport, DoctorEnvironmentVisibility, DoctorFinding, DoctorReport, DoctorSeverity,
+    DoctorStatus, DoctorSummary,
 };
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -126,6 +127,7 @@ pub fn run_doctor_with_runtime(
         member_roster,
         observability: observability_health,
         runtime_status: None,
+        bootstrap_trace: None,
     })
 }
 

--- a/crates/atm-core/src/doctor/report.rs
+++ b/crates/atm-core/src/doctor/report.rs
@@ -49,6 +49,44 @@ pub struct DoctorEnvironmentVisibility {
     pub team_override: Option<TeamName>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BootstrapConnectOutcome {
+    Connected,
+    NotFound,
+    Timeout,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BootstrapLaunchGateOutcome {
+    Launched,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BootstrapAutoStartOutcome {
+    AutoStarted,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BootstrapTraceReport {
+    pub daemon_connect: BootstrapConnectOutcome,
+    pub daemon_launch_gate: BootstrapLaunchGateOutcome,
+    pub daemon_auto_start: BootstrapAutoStartOutcome,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connect_detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launch_gate_detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_start_detail: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DoctorReport {
     pub summary: DoctorSummary,
@@ -60,6 +98,8 @@ pub struct DoctorReport {
     pub observability: AtmObservabilityHealth,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_status: Option<RuntimeStatusSnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bootstrap_trace: Option<BootstrapTraceReport>,
 }
 
 impl DoctorReport {

--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -5,6 +5,10 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 use std::{fmt, thread};
 
+use atm_core::doctor::{
+    BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
+    BootstrapTraceReport,
+};
 use atm_core::error::AtmError;
 use atm_core::observability::{CommandEvent, ObservabilityPort};
 use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
@@ -12,6 +16,7 @@ use atm_core::types::{AgentName, TeamName};
 use fs2::FileExt;
 use interprocess::local_socket::Stream as LocalSocketStream;
 use interprocess::local_socket::traits::Stream as _;
+use std::sync::Mutex;
 
 pub const AUTO_START_PUBLISH_TIMEOUT: Duration = Duration::from_secs(10);
 pub const HOST_RUNTIME_LAUNCH_LOCK_FILE: &str = "launch.lock";
@@ -84,6 +89,7 @@ pub struct BootstrapTraceability<'a> {
     observability: &'a (dyn ObservabilityPort + Send + Sync),
     team: TeamName,
     agent: AgentName,
+    state: Mutex<BootstrapTraceState>,
 }
 
 impl<'a> BootstrapTraceability<'a> {
@@ -98,10 +104,12 @@ impl<'a> BootstrapTraceability<'a> {
             observability,
             team,
             agent,
+            state: Mutex::new(BootstrapTraceState::default()),
         }
     }
 
     fn emit(&self, action: &'static str, outcome: &'static str, error: Option<&AtmError>) {
+        self.record(action, outcome, error);
         let event = CommandEvent {
             command: self.command,
             action,
@@ -124,6 +132,111 @@ impl<'a> BootstrapTraceability<'a> {
                 error = ?emit_error,
                 "emit failed"
             );
+        }
+    }
+
+    pub fn snapshot(&self) -> BootstrapTraceReport {
+        let mut state = self
+            .state
+            .lock()
+            .expect("bootstrap trace state lock poisoned");
+        state.finalize()
+    }
+
+    fn record(&self, action: &'static str, outcome: &'static str, error: Option<&AtmError>) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("bootstrap trace state lock poisoned");
+        match action {
+            "daemon_connect" => match outcome {
+                "connected" => {
+                    state.connect = Some(BootstrapConnectOutcome::Connected);
+                    state.connect_detail = None;
+                    if state.saw_spawn_requested {
+                        state.auto_start = Some(BootstrapAutoStartOutcome::AutoStarted);
+                        state.auto_start_detail = None;
+                    }
+                }
+                "initial_miss" | "retry_attempt" | "pending" => {
+                    if !matches!(state.connect, Some(BootstrapConnectOutcome::Connected)) {
+                        state.connect = Some(BootstrapConnectOutcome::NotFound);
+                    }
+                    if let Some(error) = error {
+                        state.connect_detail = Some(error.message.clone());
+                    }
+                }
+                "error" => {
+                    state.connect = Some(BootstrapConnectOutcome::Failed);
+                    state.connect_detail = error.map(|value| value.message.clone());
+                }
+                _ => {}
+            },
+            "daemon_launch_gate" => match outcome {
+                "acquired" => {
+                    state.launch_gate = Some(BootstrapLaunchGateOutcome::Launched);
+                    state.launch_gate_detail = None;
+                }
+                "contended" => {
+                    if state.launch_gate.is_none() {
+                        state.launch_gate = Some(BootstrapLaunchGateOutcome::Skipped);
+                    }
+                }
+                "timeout_exhausted" => {
+                    state.launch_gate = Some(BootstrapLaunchGateOutcome::Failed);
+                    state.launch_gate_detail = error.map(|value| value.message.clone());
+                    state.connect = Some(BootstrapConnectOutcome::Timeout);
+                    state.connect_detail = error.map(|value| value.message.clone());
+                }
+                "error" => {
+                    state.launch_gate = Some(BootstrapLaunchGateOutcome::Failed);
+                    state.launch_gate_detail = error.map(|value| value.message.clone());
+                }
+                _ => {}
+            },
+            "daemon_auto_start" => match outcome {
+                "spawn_requested" => {
+                    state.saw_spawn_requested = true;
+                }
+                "error" | "timeout_exhausted" => {
+                    state.auto_start = Some(BootstrapAutoStartOutcome::Failed);
+                    state.auto_start_detail = error.map(|value| value.message.clone());
+                    if outcome == "timeout_exhausted" {
+                        state.connect = Some(BootstrapConnectOutcome::Timeout);
+                        state.connect_detail = error.map(|value| value.message.clone());
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct BootstrapTraceState {
+    connect: Option<BootstrapConnectOutcome>,
+    launch_gate: Option<BootstrapLaunchGateOutcome>,
+    auto_start: Option<BootstrapAutoStartOutcome>,
+    connect_detail: Option<String>,
+    launch_gate_detail: Option<String>,
+    auto_start_detail: Option<String>,
+    saw_spawn_requested: bool,
+}
+
+impl BootstrapTraceState {
+    fn finalize(&mut self) -> BootstrapTraceReport {
+        BootstrapTraceReport {
+            daemon_connect: self.connect.unwrap_or(BootstrapConnectOutcome::NotFound),
+            daemon_launch_gate: self
+                .launch_gate
+                .unwrap_or(BootstrapLaunchGateOutcome::Skipped),
+            daemon_auto_start: self
+                .auto_start
+                .unwrap_or(BootstrapAutoStartOutcome::Skipped),
+            connect_detail: self.connect_detail.clone(),
+            launch_gate_detail: self.launch_gate_detail.clone(),
+            auto_start_detail: self.auto_start_detail.clone(),
         }
     }
 }
@@ -536,6 +649,10 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
+    use atm_core::doctor::{
+        BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
+        BootstrapTraceReport,
+    };
     use atm_core::error::{AtmError, AtmErrorCode};
     use atm_core::observability::{
         AtmLogQuery, AtmLogSnapshot, AtmObservabilityHealth, AtmObservabilityHealthState,
@@ -651,6 +768,17 @@ mod tests {
         assert_eq!(events[2].outcome, "connected");
         assert_eq!(events[2].team.as_str(), "trace-team");
         assert_eq!(events[2].agent.as_str(), "trace-agent");
+        assert_eq!(
+            traceability.snapshot(),
+            BootstrapTraceReport {
+                daemon_connect: BootstrapConnectOutcome::Connected,
+                daemon_launch_gate: BootstrapLaunchGateOutcome::Skipped,
+                daemon_auto_start: BootstrapAutoStartOutcome::Skipped,
+                connect_detail: None,
+                launch_gate_detail: None,
+                auto_start_detail: None,
+            }
+        );
     }
 
     #[test]
@@ -698,6 +826,10 @@ mod tests {
                 .as_deref()
                 .expect("error message")
                 .contains("daemon binary is missing")
+        );
+        assert_eq!(
+            traceability.snapshot().daemon_auto_start,
+            BootstrapAutoStartOutcome::Failed
         );
     }
 

--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -89,6 +89,8 @@ pub struct BootstrapTraceability<'a> {
     observability: &'a (dyn ObservabilityPort + Send + Sync),
     team: TeamName,
     agent: AgentName,
+    // Mutex required: BootstrapTraceability must be Sync (holds
+    // &'a dyn ObservabilityPort + Send + Sync); RefCell would be unsound.
     state: Mutex<BootstrapTraceState>,
 }
 
@@ -163,12 +165,12 @@ impl<'a> BootstrapTraceability<'a> {
                         state.connect = Some(BootstrapConnectOutcome::NotFound);
                     }
                     if let Some(error) = error {
-                        state.connect_detail = Some(error.message.clone());
+                        state.connect_detail = Some(format_bootstrap_error_detail(error));
                     }
                 }
                 "error" => {
                     state.connect = Some(BootstrapConnectOutcome::Failed);
-                    state.connect_detail = error.map(|value| value.message.clone());
+                    state.connect_detail = error.map(format_bootstrap_error_detail);
                 }
                 _ => {}
             },
@@ -184,13 +186,13 @@ impl<'a> BootstrapTraceability<'a> {
                 }
                 "timeout_exhausted" => {
                     state.launch_gate = Some(BootstrapLaunchGateOutcome::Failed);
-                    state.launch_gate_detail = error.map(|value| value.message.clone());
+                    state.launch_gate_detail = error.map(format_bootstrap_error_detail);
                     state.connect = Some(BootstrapConnectOutcome::Timeout);
-                    state.connect_detail = error.map(|value| value.message.clone());
+                    state.connect_detail = error.map(format_bootstrap_error_detail);
                 }
                 "error" => {
                     state.launch_gate = Some(BootstrapLaunchGateOutcome::Failed);
-                    state.launch_gate_detail = error.map(|value| value.message.clone());
+                    state.launch_gate_detail = error.map(format_bootstrap_error_detail);
                 }
                 _ => {}
             },
@@ -200,10 +202,10 @@ impl<'a> BootstrapTraceability<'a> {
                 }
                 "error" | "timeout_exhausted" => {
                     state.auto_start = Some(BootstrapAutoStartOutcome::Failed);
-                    state.auto_start_detail = error.map(|value| value.message.clone());
+                    state.auto_start_detail = error.map(format_bootstrap_error_detail);
                     if outcome == "timeout_exhausted" {
                         state.connect = Some(BootstrapConnectOutcome::Timeout);
-                        state.connect_detail = error.map(|value| value.message.clone());
+                        state.connect_detail = error.map(format_bootstrap_error_detail);
                     }
                 }
                 _ => {}
@@ -238,6 +240,13 @@ impl BootstrapTraceState {
             launch_gate_detail: self.launch_gate_detail.clone(),
             auto_start_detail: self.auto_start_detail.clone(),
         }
+    }
+}
+
+fn format_bootstrap_error_detail(error: &AtmError) -> String {
+    match &error.recovery {
+        Some(recovery) => format!("{} Recovery: {}", error.message, recovery),
+        None => error.message.clone(),
     }
 }
 
@@ -830,6 +839,14 @@ mod tests {
         assert_eq!(
             traceability.snapshot().daemon_auto_start,
             BootstrapAutoStartOutcome::Failed
+        );
+        assert!(
+            traceability
+                .snapshot()
+                .auto_start_detail
+                .as_deref()
+                .expect("auto-start detail")
+                .contains("Build or install atm-daemon")
         );
     }
 

--- a/crates/atm-daemon/src/test_support.rs
+++ b/crates/atm-daemon/src/test_support.rs
@@ -68,6 +68,7 @@ impl RequestDispatcher for DoctorOnlyDispatcher {
                     detail: None,
                 },
                 runtime_status: None,
+                bootstrap_trace: None,
             })),
             other => panic!("unexpected request in DoctorOnlyDispatcher: {other:?}"),
         }

--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -111,6 +111,7 @@ mod tests {
                 detail: None,
             },
             runtime_status: None,
+            bootstrap_trace: None,
         }
     }
 

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -886,6 +886,45 @@ mod tests {
     }
 
     #[test]
+    fn bootstrap_propagates_daemon_availability_failure() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let _env = EnvGuard::set_many([
+            ("ATM_TEAM", Some(TEST_TEAM)),
+            ("ATM_IDENTITY", Some(TEST_SENDER)),
+            (
+                "ATM_DAEMON_SOCKET",
+                Some(
+                    tempdir
+                        .path()
+                        .join("daemon.sock")
+                        .to_string_lossy()
+                        .as_ref(),
+                ),
+            ),
+            (
+                "ATM_DAEMON_BIN",
+                Some(
+                    tempdir
+                        .path()
+                        .join("missing-atm-daemon")
+                        .to_string_lossy()
+                        .as_ref(),
+                ),
+            ),
+        ]);
+        let observability = CliObservability::fallback();
+
+        let error = CliComposition::bootstrap("doctor", &observability)
+            .expect_err("bootstrap should fail when daemon auto-start cannot launch");
+
+        assert_eq!(
+            error.code,
+            atm_core::error_codes::AtmErrorCode::DaemonUnavailable
+        );
+        assert!(error.to_string().contains("daemon binary is missing"));
+    }
+
+    #[test]
     fn loopback_transport_ack_appends_reply_without_daemon() {
         let fixture = LoopbackFixture::new(TEST_RECIPIENT);
         let (message_id, pending_ack) = fixture.pending_ack_message("please ack");

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -5,7 +5,7 @@ use atm_core::ack::{AckOutcome, AckRequest};
 use atm_core::boundary;
 use atm_core::boundary::ClientTransport;
 use atm_core::clear::{ClearOutcome, ClearQuery};
-use atm_core::doctor::{DoctorQuery, DoctorReport};
+use atm_core::doctor::{BootstrapTraceReport, DoctorQuery, DoctorReport};
 use atm_core::error::AtmError;
 use atm_core::graft::{
     AdvisoryDrainRequest, AdvisoryDrainResponse, AdvisoryFetchRequest, AdvisoryFetchResponse,
@@ -84,6 +84,7 @@ impl ClientTransport for LocalIpcClientTransportAdapter {
 pub(crate) struct CliComposition<'a> {
     transport: Arc<dyn ClientTransport + Send + Sync + 'a>,
     observability_port: &'a CliObservability,
+    bootstrap_trace: Option<BootstrapTraceReport>,
     send_command: SendCommandEntryPoint,
     receive_command: ReceiveCommandEntryPoint,
 }
@@ -93,6 +94,7 @@ impl fmt::Debug for CliComposition<'_> {
         f.debug_struct("CliComposition")
             .field("transport", &"dyn ClientTransport")
             .field("observability_port", &"dyn ObservabilityPort")
+            .field("bootstrap_trace", &self.bootstrap_trace)
             .field("send_command", &self.send_command)
             .field("receive_command", &self.receive_command)
             .finish()
@@ -107,6 +109,22 @@ impl<'a> CliComposition<'a> {
         Self {
             transport,
             observability_port,
+            bootstrap_trace: None,
+            send_command: SendCommandEntryPoint::new(),
+            receive_command: ReceiveCommandEntryPoint::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_transport_with_bootstrap_trace(
+        transport: Arc<dyn ClientTransport + Send + Sync + 'a>,
+        observability_port: &'a CliObservability,
+        bootstrap_trace: BootstrapTraceReport,
+    ) -> Self {
+        Self {
+            transport,
+            observability_port,
+            bootstrap_trace: Some(bootstrap_trace),
             send_command: SendCommandEntryPoint::new(),
             receive_command: ReceiveCommandEntryPoint::new(),
         }
@@ -261,7 +279,10 @@ impl<'a> CliComposition<'a> {
 
     pub(crate) fn doctor(&self, query: DoctorQuery) -> Result<DoctorReport, AtmError> {
         match self.send_request(RequestEnvelope::Doctor(query))? {
-            ResponseEnvelope::Doctor(report) => Ok(report),
+            ResponseEnvelope::Doctor(mut report) => {
+                report.bootstrap_trace = self.bootstrap_trace.clone();
+                Ok(report)
+            }
             other => Err(unexpected_response("doctor", other)),
         }
     }
@@ -323,7 +344,9 @@ impl<'a> CliComposition<'a> {
         supervisor.ensure_daemon_available_with_traceability(&traceability, || {
             transport.try_connect().map(|_| ())
         })?;
-        Ok(Self::from_transport(transport, observability))
+        let mut composition = Self::from_transport(transport, observability);
+        composition.bootstrap_trace = Some(traceability.snapshot());
+        Ok(composition)
     }
 }
 
@@ -398,7 +421,10 @@ mod tests {
     use atm_core::ack::AckRequest;
     use atm_core::boundary::ClientTransport;
     use atm_core::clear::ClearQuery;
-    use atm_core::doctor::{DoctorQuery, DoctorStatus};
+    use atm_core::doctor::{
+        BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
+        BootstrapTraceReport, DoctorQuery, DoctorStatus,
+    };
     use atm_core::error::AtmError;
     use atm_core::graft::AtmGraftClient;
     use atm_core::protocol::{
@@ -822,6 +848,41 @@ mod tests {
 
         assert_eq!(report.summary.status, DoctorStatus::Healthy);
         assert_eq!(report.summary.error_count, 0);
+    }
+
+    #[test]
+    fn doctor_projects_bootstrap_trace_into_report() {
+        let fixture = LoopbackFixture::new(TEST_RECIPIENT);
+        let observability = Arc::new(HealthyObservability);
+        let composition_observability = CliObservability::fallback();
+        let composition = CliComposition::from_transport_with_bootstrap_trace(
+            Arc::new(LoopbackClientTransport::new(observability)),
+            &composition_observability,
+            BootstrapTraceReport {
+                daemon_connect: BootstrapConnectOutcome::Connected,
+                daemon_launch_gate: BootstrapLaunchGateOutcome::Skipped,
+                daemon_auto_start: BootstrapAutoStartOutcome::Skipped,
+                connect_detail: None,
+                launch_gate_detail: None,
+                auto_start_detail: None,
+            },
+        );
+
+        let report = composition
+            .doctor(fixture.doctor_query())
+            .expect("doctor report");
+
+        assert_eq!(
+            report.bootstrap_trace.as_ref().expect("bootstrap trace"),
+            &BootstrapTraceReport {
+                daemon_connect: BootstrapConnectOutcome::Connected,
+                daemon_launch_gate: BootstrapLaunchGateOutcome::Skipped,
+                daemon_auto_start: BootstrapAutoStartOutcome::Skipped,
+                connect_detail: None,
+                launch_gate_detail: None,
+                auto_start_detail: None,
+            }
+        );
     }
 
     #[test]

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use atm_core::ack::AckOutcome;
 use atm_core::clear::ClearOutcome;
-use atm_core::doctor::{DoctorReport, DoctorSeverity, DoctorStatus};
+use atm_core::doctor::{
+    BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
+    BootstrapTraceReport, DoctorReport, DoctorSeverity, DoctorStatus,
+};
 use atm_core::list::ListOutcome;
 use atm_core::observability::{AtmLogRecord, AtmLogSnapshot};
 use atm_core::protocol::{
@@ -251,6 +254,9 @@ pub fn print_doctor_result(report: &DoctorReport, json: bool) -> Result<()> {
     if let Some(runtime_status) = &report.runtime_status {
         print_runtime_status(runtime_status);
     }
+    if let Some(bootstrap_trace) = &report.bootstrap_trace {
+        print_bootstrap_trace(bootstrap_trace);
+    }
 
     if report.environment.atm_home.is_some()
         || report.environment.atm_team.is_some()
@@ -490,6 +496,32 @@ fn print_runtime_status(runtime_status: &RuntimeStatusSnapshot) {
     }
 }
 
+fn print_bootstrap_trace(trace: &BootstrapTraceReport) {
+    println!();
+    println!("Bootstrap trace:");
+    println!(
+        "  Daemon connect: {}",
+        render_bootstrap_connect(trace.daemon_connect)
+    );
+    println!(
+        "  Launch gate: {}",
+        render_bootstrap_launch_gate(trace.daemon_launch_gate)
+    );
+    println!(
+        "  Auto-start: {}",
+        render_bootstrap_auto_start(trace.daemon_auto_start)
+    );
+    if let Some(detail) = &trace.connect_detail {
+        println!("  Connect detail: {detail}");
+    }
+    if let Some(detail) = &trace.launch_gate_detail {
+        println!("  Launch-gate detail: {detail}");
+    }
+    if let Some(detail) = &trace.auto_start_detail {
+        println!("  Auto-start detail: {detail}");
+    }
+}
+
 fn render_runtime_liveness(state: RuntimeLivenessState) -> &'static str {
     match state {
         RuntimeLivenessState::Running => "running",
@@ -502,6 +534,31 @@ fn render_runtime_readiness(state: RuntimeReadinessState) -> &'static str {
         RuntimeReadinessState::Ready => "ready",
         RuntimeReadinessState::Degraded => "degraded",
         RuntimeReadinessState::Unavailable => "unavailable",
+    }
+}
+
+fn render_bootstrap_connect(state: BootstrapConnectOutcome) -> &'static str {
+    match state {
+        BootstrapConnectOutcome::Connected => "connected",
+        BootstrapConnectOutcome::NotFound => "not_found",
+        BootstrapConnectOutcome::Timeout => "timeout",
+        BootstrapConnectOutcome::Failed => "failed",
+    }
+}
+
+fn render_bootstrap_launch_gate(state: BootstrapLaunchGateOutcome) -> &'static str {
+    match state {
+        BootstrapLaunchGateOutcome::Launched => "launched",
+        BootstrapLaunchGateOutcome::Failed => "failed",
+        BootstrapLaunchGateOutcome::Skipped => "skipped",
+    }
+}
+
+fn render_bootstrap_auto_start(state: BootstrapAutoStartOutcome) -> &'static str {
+    match state {
+        BootstrapAutoStartOutcome::AutoStarted => "auto_started",
+        BootstrapAutoStartOutcome::Failed => "failed",
+        BootstrapAutoStartOutcome::Skipped => "skipped",
     }
 }
 

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -497,29 +497,7 @@ fn print_runtime_status(runtime_status: &RuntimeStatusSnapshot) {
 }
 
 fn print_bootstrap_trace(trace: &BootstrapTraceReport) {
-    println!();
-    println!("Bootstrap trace:");
-    println!(
-        "  Daemon connect: {}",
-        render_bootstrap_connect(trace.daemon_connect)
-    );
-    println!(
-        "  Launch gate: {}",
-        render_bootstrap_launch_gate(trace.daemon_launch_gate)
-    );
-    println!(
-        "  Auto-start: {}",
-        render_bootstrap_auto_start(trace.daemon_auto_start)
-    );
-    if let Some(detail) = &trace.connect_detail {
-        println!("  Connect detail: {detail}");
-    }
-    if let Some(detail) = &trace.launch_gate_detail {
-        println!("  Launch-gate detail: {detail}");
-    }
-    if let Some(detail) = &trace.auto_start_detail {
-        println!("  Auto-start detail: {detail}");
-    }
+    print!("{}", render_bootstrap_trace_section(trace));
 }
 
 fn render_runtime_liveness(state: RuntimeLivenessState) -> &'static str {
@@ -575,4 +553,59 @@ fn render_runtime_member_state(state: RuntimeMemberState) -> &'static str {
 
 fn render_bool(value: bool) -> &'static str {
     if value { "yes" } else { "no" }
+}
+
+fn render_bootstrap_trace_section(trace: &BootstrapTraceReport) -> String {
+    let mut output = String::from("\nBootstrap trace:\n");
+    output.push_str(&format!(
+        "  Daemon connect: {}\n",
+        render_bootstrap_connect(trace.daemon_connect)
+    ));
+    output.push_str(&format!(
+        "  Launch gate: {}\n",
+        render_bootstrap_launch_gate(trace.daemon_launch_gate)
+    ));
+    output.push_str(&format!(
+        "  Auto-start: {}\n",
+        render_bootstrap_auto_start(trace.daemon_auto_start)
+    ));
+    if let Some(detail) = &trace.connect_detail {
+        output.push_str(&format!("  Connect detail: {detail}\n"));
+    }
+    if let Some(detail) = &trace.launch_gate_detail {
+        output.push_str(&format!("  Launch-gate detail: {detail}\n"));
+    }
+    if let Some(detail) = &trace.auto_start_detail {
+        output.push_str(&format!("  Auto-start detail: {detail}\n"));
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use atm_core::doctor::{
+        BootstrapAutoStartOutcome, BootstrapConnectOutcome, BootstrapLaunchGateOutcome,
+        BootstrapTraceReport,
+    };
+
+    use super::render_bootstrap_trace_section;
+
+    #[test]
+    fn bootstrap_trace_section_renders_doctor_output_block() {
+        let rendered = render_bootstrap_trace_section(&BootstrapTraceReport {
+            daemon_connect: BootstrapConnectOutcome::Connected,
+            daemon_launch_gate: BootstrapLaunchGateOutcome::Launched,
+            daemon_auto_start: BootstrapAutoStartOutcome::AutoStarted,
+            connect_detail: Some("connect detail".to_string()),
+            launch_gate_detail: None,
+            auto_start_detail: Some("auto-start detail".to_string()),
+        });
+
+        assert!(rendered.contains("Bootstrap trace:"));
+        assert!(rendered.contains("Daemon connect: connected"));
+        assert!(rendered.contains("Launch gate: launched"));
+        assert!(rendered.contains("Auto-start: auto_started"));
+        assert!(rendered.contains("Connect detail: connect detail"));
+        assert!(rendered.contains("Auto-start detail: auto-start detail"));
+    }
 }

--- a/docs/phase-W/sprint-W5.md
+++ b/docs/phase-W/sprint-W5.md
@@ -34,6 +34,8 @@ worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s5-docto
 - `crates/atm/src/output.rs`
 - `crates/atm/src/commands/doctor.rs`
 - `crates/atm-daemon/src/test_support.rs`
+  - keep `DoctorOnlyDispatcher` construction aligned with the extended
+    `DoctorReport` shape by setting `bootstrap_trace: None`
 
 ## Acceptance Criteria
 

--- a/docs/phase-W/sprint-W5.md
+++ b/docs/phase-W/sprint-W5.md
@@ -1,0 +1,50 @@
+---
+id: W.5
+title: Doctor Projection
+status: completed
+branch: feature/pW-s5-doctor-projection
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s5-doctor-projection
+---
+
+# Sprint W.5 — Doctor Projection Gap
+
+## Goal
+
+- project daemon bootstrap traceability into the shared `atm doctor` report so
+  same-host daemon connect, launch-gate, and auto-start outcomes are visible
+  outside retained-log inspection
+
+## Design Decision
+
+- use the `DoctorReport` projection path, not `RuntimeStatusSnapshot`
+- rationale:
+  - bootstrap traceability is CLI-owned same-host bootstrap state, not
+    daemon-owned runtime state
+  - `CliComposition::bootstrap(...)` already owns `BootstrapTraceability`
+  - attaching the snapshot to `DoctorReport` preserves one shared doctor
+    surface without adding a second daemon-side cache or forcing daemon runtime
+    status to represent pre-daemon bootstrap work
+
+## Files Changed
+
+- `crates/atm-core/src/doctor/report.rs`
+- `crates/atm-core/src/doctor/mod.rs`
+- `crates/atm-daemon-client/src/lib.rs`
+- `crates/atm/src/composition.rs`
+- `crates/atm/src/output.rs`
+- `crates/atm/src/commands/doctor.rs`
+- `crates/atm-daemon/src/test_support.rs`
+
+## Acceptance Criteria
+
+- `DoctorReport` carries a typed bootstrap trace projection
+- `CliComposition::bootstrap(...)` captures bootstrap trace outcomes after
+  successful daemon availability
+- `CliComposition::doctor(...)` attaches the captured bootstrap trace to the
+  returned report
+- human-readable `atm doctor` output prints daemon connect, launch-gate, and
+  auto-start outcomes plus any recorded detail strings
+- `cargo build --workspace` passes
+- `cargo test --workspace` passes
+- `cargo clippy --workspace -- -D warnings` passes
+- `grep -rn 'use sc_observability' crates/atm-daemon/` returns `0` results

--- a/docs/plan-phase-W.md
+++ b/docs/plan-phase-W.md
@@ -131,24 +131,31 @@ Sprint ownership map:
   envelope parity for non-CLI consumers.
 - `W.4` owns cross-daemon peer replay recovery text and peer-side parity
   through the shared protocol envelope.
+- `W.5` owns doctor projection of same-host bootstrap traceability after `W.2`
+  established the emitted daemon connect / launch-gate / auto-start trail.
 
 Critical failure ownership matrix:
 - daemon startup / connect / publish failure:
-  - sprint owner: `W.2`
+  - sprint owner: `W.2` for emission and interface parity, `W.5` for shared
+    `atm doctor` projection
   - shared paths:
     - `crates/atm-daemon-client/src/lib.rs`
     - `crates/atm/src/composition.rs`
     - `crates/atm-core/src/error.rs`
     - `crates/atm-core/src/doctor/mod.rs`
     - `crates/atm/src/commands/doctor.rs`
+    - `crates/atm/src/output.rs`
     - `crates/atm-daemon/src/runtime_health.rs`
 - ATM command failure on same-host daemon path:
-  - sprint owner: `W.2`
+  - sprint owner: `W.2` for concise CLI parity, `W.5` where bootstrap failure
+    evidence must be projected through the shared doctor surface
   - shared paths:
     - `crates/atm/src/composition.rs`
     - `crates/atm-daemon-client/src/lib.rs`
     - `crates/atm-core/src/error.rs`
     - `crates/atm-core/src/doctor/mod.rs`
+    - `crates/atm/src/commands/doctor.rs`
+    - `crates/atm/src/output.rs`
 - SQLite writer / queue / reply / WAL / reader-budget failure:
   - sprint owner: `W.3`
   - shared paths:
@@ -212,6 +219,9 @@ Execution shape:
 - `W.3` adds SQLite subsystem observability for writer queue, reply timeout,
   WAL lifecycle, and reader-budget exhaustion
 - `W.4` closes the remaining peer replay recovery-text holes
+- `W.5` projects the `W.2` bootstrap trace trail through shared
+  `DoctorReport` / `atm doctor` output so the same evidence is visible without
+  retained-log inspection
 
 Execution sequence:
 - `W.1` must land first because the sink-failure rule affects every later
@@ -224,6 +234,12 @@ Critical path rationale:
 - without `W.1`, subsystem event loss is still silent
 - without `W.2`, daemon-start/connect failures still collapse into an end
   error without enough attempt-level evidence for system testing
+- DESIGN-001-W:
+  - `W.2` restored the emitted bootstrap trail, but that evidence still stayed
+    inside observability records rather than the shared doctor surface
+  - `W.5` exists because system testing needs the same daemon
+    connect/launch/publish trail available from `atm doctor`, not only from
+    retained-log inspection
 - without `W.3`, SQLite failures remain under-observed even though SQLite is
   the durable-state owner
 - `W.4` is narrower, but it closes the remaining actionable recovery gaps in
@@ -234,12 +250,14 @@ Authoritative sprint sequence:
 - `docs/phase-W/sprint-W2.md`
 - `docs/phase-W/sprint-W3.md`
 - `docs/phase-W/sprint-W4.md`
+- `docs/phase-W/sprint-W5.md`
 
 Deliverables:
 - `docs/phase-W/sprint-W1.md` — daemon `emit()` silent discard fix plan
 - `docs/phase-W/sprint-W2.md` — daemon-client traceability plan
 - `docs/phase-W/sprint-W3.md` — SQLite observability plan
 - `docs/phase-W/sprint-W4.md` — peer replay recovery-text plan
+- `docs/phase-W/sprint-W5.md` — doctor projection of bootstrap traceability
 
 Cross-sprint dependencies:
 - `W.2` and `W.3` must both define how new signals map to:
@@ -265,6 +283,8 @@ Cross-sprint dependencies:
   ordinary merge-forward discipline.
 - `W.1` does not own daemon-client tracing or CLI-side path narration; those
   same-host path gaps are owned by `W.2`.
+- `W.5` depends on `W.2`; it must project the bootstrap evidence that `W.2`
+  emits rather than invent a second same-host trace taxonomy.
 - if `W.3` and `W.4` run in parallel, `crates/atm-core/src/protocol.rs`
   changes must be partitioned by failure family:
   - `W.3` owns SQLite-backed envelope parity


### PR DESCRIPTION
## Summary
- Adds typed `bootstrap_trace` block to `DoctorReport` model (atm-core)
- Captures `BootstrapTraceability` connect/launch-gate/auto-start outcomes in atm-daemon-client
- Attaches snapshot in `CliComposition::doctor()`
- Renders bootstrap trace state in `atm doctor` human output
- Fixes DESIGN-001-W: daemon-client trace events now projected to DoctorReport

## Triage
- DESIGN-001-W (important) — `.triage/phase-W/findings/DESIGN-001-W.ttl`

## Test plan
- [ ] `cargo build --workspace` PASS
- [ ] `cargo test --workspace` PASS
- [ ] `cargo clippy --workspace -- -D warnings` PASS
- [ ] `atm doctor` output includes bootstrap trace state
- [ ] `grep -rn 'use sc_observability' crates/atm-daemon/` returns 0 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)