### PR TITLE
W.6: sqlite degradation ordering + error code + DaemonEvent typed labels

### DIFF
--- a/crates/atm-core/src/error_codes.rs
+++ b/crates/atm-core/src/error_codes.rs
@@ -97,6 +97,8 @@ pub enum AtmErrorCode {
     WarningMalformedAtmFieldIgnored,
     /// Observability health is degraded.
     WarningObservabilityHealthDegraded,
+    /// SQLite-backed daemon runtime health is degraded.
+    WarningSqliteHealthDegraded,
     /// An origin inbox entry was skipped.
     WarningOriginInboxEntrySkipped,
     /// Send fell back because the team config was missing.
@@ -169,6 +171,7 @@ impl AtmErrorCode {
             Self::WarningMailboxRecordSkipped => "ATM_WARNING_MAILBOX_RECORD_SKIPPED",
             Self::WarningMalformedAtmFieldIgnored => "ATM_WARNING_MALFORMED_ATM_FIELD_IGNORED",
             Self::WarningObservabilityHealthDegraded => "ATM_WARNING_OBSERVABILITY_HEALTH_DEGRADED",
+            Self::WarningSqliteHealthDegraded => "ATM_WARNING_SQLITE_HEALTH_DEGRADED",
             Self::WarningOriginInboxEntrySkipped => "ATM_WARNING_ORIGIN_INBOX_ENTRY_SKIPPED",
             Self::WarningMissingTeamConfigFallback => "ATM_WARNING_MISSING_TEAM_CONFIG_FALLBACK",
             Self::WarningSendAlertStateDegraded => "ATM_WARNING_SEND_ALERT_STATE_DEGRADED",
@@ -237,6 +240,7 @@ impl FromStr for AtmErrorCode {
             "ATM_WARNING_OBSERVABILITY_HEALTH_DEGRADED" => {
                 Ok(Self::WarningObservabilityHealthDegraded)
             }
+            "ATM_WARNING_SQLITE_HEALTH_DEGRADED" => Ok(Self::WarningSqliteHealthDegraded),
             "ATM_WARNING_ORIGIN_INBOX_ENTRY_SKIPPED" => Ok(Self::WarningOriginInboxEntrySkipped),
             "ATM_WARNING_MISSING_TEAM_CONFIG_FALLBACK" => {
                 Ok(Self::WarningMissingTeamConfigFallback)

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -147,6 +147,7 @@ const fn error_kind_for_code(code: AtmErrorCode) -> AtmErrorKind {
         AtmErrorCode::ObservabilityHealthFailed
         | AtmErrorCode::ObservabilityHealthOk
         | AtmErrorCode::WarningObservabilityHealthDegraded => AtmErrorKind::ObservabilityHealth,
+        AtmErrorCode::WarningSqliteHealthDegraded => AtmErrorKind::DaemonUnavailable,
         AtmErrorCode::ObservabilityBootstrapFailed => AtmErrorKind::ObservabilityBootstrap,
         AtmErrorCode::MessageValidationFailed
         | AtmErrorCode::AckInvalidState

--- a/crates/atm-daemon/bin_support/daemon_observability.rs
+++ b/crates/atm-daemon/bin_support/daemon_observability.rs
@@ -752,8 +752,10 @@ fn observability_test_event(
 ) -> DaemonEvent {
     DaemonEvent {
         subsystem: DaemonSubsystem::Composition,
-        action,
-        outcome,
+        action: ActionName::new(action)
+            .expect("daemon observability test actions must be valid ActionName literals"),
+        outcome: OutcomeLabel::new(outcome)
+            .expect("daemon observability test outcomes must be valid OutcomeLabel literals"),
         team: TeamScope::None,
         agent: None,
         sender: None,

--- a/crates/atm-daemon/bin_support/daemon_observability.rs
+++ b/crates/atm-daemon/bin_support/daemon_observability.rs
@@ -177,8 +177,8 @@ impl DaemonObservability {
 
         self.emit_log_event(EmitLogEvent {
             scope: "lifecycle",
-            action: event.action,
-            outcome: event.outcome,
+            action: event.action.as_str().to_string(),
+            outcome: event.outcome.as_str().to_string(),
             message: Some(event.detail.into_owned()),
             request_id: event.message_id.as_ref().map(|value| value.to_string()),
             correlation_id: event
@@ -293,8 +293,8 @@ impl ObservabilityPort for DaemonObservability {
 
         self.emit_log_event(EmitLogEvent {
             scope: "observability",
-            action: event.action,
-            outcome: event.outcome,
+            action: event.action.to_string(),
+            outcome: event.outcome.to_string(),
             message: Some(format!(
                 "ATM daemon handled {} with outcome {}",
                 event.command, event.outcome
@@ -364,8 +364,8 @@ impl atm_daemon::DaemonRuntimeObservability for DaemonObservability {
 
 struct EmitLogEvent {
     scope: &'static str,
-    action: &'static str,
-    outcome: &'static str,
+    action: String,
+    outcome: String,
     message: Option<String>,
     request_id: Option<String>,
     correlation_id: Option<String>,
@@ -386,10 +386,10 @@ impl DaemonObservability {
                 .with_source(source)
             })?,
             timestamp: Timestamp::now_utc(),
-            level: level_for_outcome(event.outcome),
+            level: level_for_outcome(&event.outcome),
             service: self.service_name.clone(),
             target: self.target_category.clone(),
-            action: ActionName::new(event.action).map_err(|source| {
+            action: ActionName::new(&event.action).map_err(|source| {
                 AtmError::observability_emit(format!(
                     "failed to validate ATM daemon {} action",
                     event.scope
@@ -417,7 +417,7 @@ impl DaemonObservability {
                     AtmError::observability_emit("failed to validate ATM daemon correlation id")
                         .with_source(source)
                 })?,
-            outcome: Some(OutcomeLabel::new(event.outcome).map_err(|source| {
+            outcome: Some(OutcomeLabel::new(&event.outcome).map_err(|source| {
                 AtmError::observability_emit(format!(
                     "failed to validate ATM daemon {} outcome",
                     event.scope

--- a/crates/atm-daemon/bin_support/daemon_observability.rs
+++ b/crates/atm-daemon/bin_support/daemon_observability.rs
@@ -177,8 +177,8 @@ impl DaemonObservability {
 
         self.emit_log_event(EmitLogEvent {
             scope: "lifecycle",
-            action: event.action.as_str().to_string(),
-            outcome: event.outcome.as_str().to_string(),
+            action: event.action,
+            outcome: event.outcome,
             message: Some(event.detail.into_owned()),
             request_id: event.message_id.as_ref().map(|value| value.to_string()),
             correlation_id: event
@@ -293,8 +293,14 @@ impl ObservabilityPort for DaemonObservability {
 
         self.emit_log_event(EmitLogEvent {
             scope: "observability",
-            action: event.action.to_string(),
-            outcome: event.outcome.to_string(),
+            action: ActionName::new(event.action).map_err(|source| {
+                AtmError::observability_emit("failed to validate ATM daemon observability action")
+                    .with_source(source)
+            })?,
+            outcome: OutcomeLabel::new(event.outcome).map_err(|source| {
+                AtmError::observability_emit("failed to validate ATM daemon observability outcome")
+                    .with_source(source)
+            })?,
             message: Some(format!(
                 "ATM daemon handled {} with outcome {}",
                 event.command, event.outcome
@@ -364,8 +370,8 @@ impl atm_daemon::DaemonRuntimeObservability for DaemonObservability {
 
 struct EmitLogEvent {
     scope: &'static str,
-    action: String,
-    outcome: String,
+    action: ActionName,
+    outcome: OutcomeLabel,
     message: Option<String>,
     request_id: Option<String>,
     correlation_id: Option<String>,
@@ -386,16 +392,10 @@ impl DaemonObservability {
                 .with_source(source)
             })?,
             timestamp: Timestamp::now_utc(),
-            level: level_for_outcome(&event.outcome),
+            level: level_for_outcome(event.outcome.as_str()),
             service: self.service_name.clone(),
             target: self.target_category.clone(),
-            action: ActionName::new(&event.action).map_err(|source| {
-                AtmError::observability_emit(format!(
-                    "failed to validate ATM daemon {} action",
-                    event.scope
-                ))
-                .with_source(source)
-            })?,
+            action: event.action,
             message: event.message,
             identity: ProcessIdentity::default(),
             trace: None,
@@ -417,13 +417,7 @@ impl DaemonObservability {
                     AtmError::observability_emit("failed to validate ATM daemon correlation id")
                         .with_source(source)
                 })?,
-            outcome: Some(OutcomeLabel::new(&event.outcome).map_err(|source| {
-                AtmError::observability_emit(format!(
-                    "failed to validate ATM daemon {} outcome",
-                    event.scope
-                ))
-                .with_source(source)
-            })?),
+            outcome: Some(event.outcome),
             diagnostic: None,
             state_transition: None,
             fields: event.fields,
@@ -516,6 +510,10 @@ fn ensure_retained_log_ready(log_dir: &Path, active_log_path: &Path) -> Result<(
 }
 
 #[derive(Debug)]
+// The retained sink keeps three separate mutexes because the health state is read and updated on
+// the hot path, while the last-written file handle and prune timestamp are touched far less often.
+// Keeping them independent avoids serializing unrelated reads/writes behind one coarse lock.
+// Lock order matters when more than one is needed: write() updates last_written_file before health.
 struct RetainedJsonlFileSink {
     path: PathBuf,
     rotation: sc_observability::RotationPolicy,

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -70,16 +70,14 @@ pub struct DaemonEvent {
 impl DaemonEvent {
     pub(crate) fn new(
         subsystem: DaemonSubsystem,
-        action: &'static str,
-        outcome: &'static str,
+        action: ActionName,
+        outcome: OutcomeLabel,
         detail: impl Into<Cow<'static, str>>,
     ) -> Self {
         Self {
             subsystem,
-            action: ActionName::new(action)
-                .expect("daemon subsystem action literals must satisfy ActionName validation"),
-            outcome: OutcomeLabel::new(outcome)
-                .expect("daemon subsystem outcome literals must satisfy OutcomeLabel validation"),
+            action,
+            outcome,
             team: TeamScope::None,
             agent: None,
             sender: None,
@@ -195,7 +193,14 @@ impl SubsystemObservability {
         // Shared subsystem emit helpers deliberately start with no team scope because the thin
         // sink cannot infer mailbox ownership; callers that know team context attach it
         // explicitly on the returned event instead of relying on logger-held mutable state.
-        DaemonEvent::new(self.subsystem(), action, outcome, detail)
+        DaemonEvent::new(
+            self.subsystem(),
+            ActionName::new(action)
+                .expect("daemon subsystem action literals must satisfy ActionName validation"),
+            OutcomeLabel::new(outcome)
+                .expect("daemon subsystem outcome literals must satisfy OutcomeLabel validation"),
+            detail,
+        )
     }
 
     pub(crate) fn emit_event(&self, event: DaemonEvent) -> Result<(), AtmError> {

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -56,8 +56,8 @@ pub enum TeamScope {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DaemonEvent {
     pub subsystem: DaemonSubsystem,
-    pub action: &'static str,
-    pub outcome: &'static str,
+    pub action: ActionName,
+    pub outcome: OutcomeLabel,
     pub team: TeamScope,
     pub agent: Option<AgentName>,
     pub sender: Option<AgentName>,
@@ -76,8 +76,10 @@ impl DaemonEvent {
     ) -> Self {
         Self {
             subsystem,
-            action,
-            outcome,
+            action: ActionName::new(action)
+                .expect("daemon subsystem action literals must satisfy ActionName validation"),
+            outcome: OutcomeLabel::new(outcome)
+                .expect("daemon subsystem outcome literals must satisfy OutcomeLabel validation"),
             team: TeamScope::None,
             agent: None,
             sender: None,
@@ -205,15 +207,15 @@ impl SubsystemObservability {
 
     pub(crate) fn emit_event_or_warn(&self, event: DaemonEvent) {
         let subsystem = event.subsystem.as_str();
-        let action = event.action;
-        let outcome = event.outcome;
+        let action = event.action.as_str().to_string();
+        let outcome = event.outcome.as_str().to_string();
         let detail = event.detail.clone();
         if let Err(error) = self.emit_event(event) {
             tracing::warn!(
                 %error,
                 subsystem,
-                action,
-                outcome,
+                action = %action,
+                outcome = %outcome,
                 detail = %detail,
                 "failed to emit daemon observability event"
             );

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -212,6 +212,10 @@ impl RuntimeStatusCache {
         }
     }
 
+    /// Record SQLite degradation detail after the caller has decided which
+    /// higher-level subsystem event to emit. Callers must emit the associated
+    /// observability event independently; this helper only updates the cached
+    /// doctor/runtime-health projection state.
     pub(crate) fn mark_sqlite_unavailable_with_detail(&self, detail: impl Into<String>) {
         match self.state.lock() {
             Ok(mut cache) => {
@@ -508,6 +512,8 @@ pub(crate) fn runtime_status_finding(snapshot: &RuntimeStatusSnapshot) -> Doctor
         },
         RuntimeReadinessState::Degraded => DoctorFinding {
             severity: DoctorSeverity::Warning,
+            // SQLite readiness takes priority over ingest degradation in the combined case so
+            // doctor surfaces the most actionable operator code first.
             code: if !snapshot.sqlite_ready {
                 atm_core::error_codes::AtmErrorCode::WarningSqliteHealthDegraded
             } else {

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -508,7 +508,11 @@ pub(crate) fn runtime_status_finding(snapshot: &RuntimeStatusSnapshot) -> Doctor
         },
         RuntimeReadinessState::Degraded => DoctorFinding {
             severity: DoctorSeverity::Warning,
-            code: atm_core::error_codes::AtmErrorCode::WarningObservabilityHealthDegraded,
+            code: if !snapshot.sqlite_ready {
+                atm_core::error_codes::AtmErrorCode::WarningSqliteHealthDegraded
+            } else {
+                atm_core::error_codes::AtmErrorCode::WarningObservabilityHealthDegraded
+            },
             message: summary,
             remediation: snapshot.detail.clone().or(Some(
                 "Restore daemon runtime backing services and rerun `atm doctor`.".to_string(),

--- a/crates/atm-daemon/src/sqlite_observability.rs
+++ b/crates/atm-daemon/src/sqlite_observability.rs
@@ -37,6 +37,16 @@ impl DaemonSqliteObservability {
 
 impl SqliteObservability for DaemonSqliteObservability {
     fn emit(&self, event: SqliteObservabilityEvent) -> Result<(), AtmError> {
+        match event.outcome {
+            SqliteObservabilityOutcome::Ok => {}
+            SqliteObservabilityOutcome::Failed | SqliteObservabilityOutcome::Timeout => {
+                self.status_cache
+                    .mark_sqlite_unavailable_with_detail(format!(
+                        "[{}] {}",
+                        event.action, event.message
+                    ));
+            }
+        }
         let action = ActionName::new(event.action).map_err(|source| {
             AtmError::observability_emit("failed to validate ATM daemon sqlite subsystem action")
                 .with_source(source)
@@ -51,18 +61,7 @@ impl SqliteObservability for DaemonSqliteObservability {
             &outcome,
             &event.message,
             event.error_code,
-        )?;
-        match event.outcome {
-            SqliteObservabilityOutcome::Ok => {}
-            SqliteObservabilityOutcome::Failed | SqliteObservabilityOutcome::Timeout => {
-                self.status_cache
-                    .mark_sqlite_unavailable_with_detail(format!(
-                        "[{}] {}",
-                        event.action, event.message
-                    ));
-            }
-        }
-        Ok(())
+        )
     }
 }
 

--- a/crates/atm-daemon/src/test_observability.rs
+++ b/crates/atm-daemon/src/test_observability.rs
@@ -177,8 +177,8 @@ impl DaemonRuntimeObservability for TestDaemonObservability {
         self.append_message(format!(
             "{{\"subsystem\":\"{}\",\"action\":\"{}\",\"outcome\":\"{}\",\"message\":\"{}\"}}",
             event.subsystem.as_str(),
-            event.action,
-            event.outcome,
+            event.action.as_str(),
+            event.outcome.as_str(),
             event.detail
         ))
     }

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -816,8 +816,7 @@ fn doctor_projects_degraded_runtime_when_sqlite_is_unavailable() {
                 .findings
                 .iter()
                 .find(|finding| {
-                    finding.code
-                        == atm_core::error_codes::AtmErrorCode::WarningObservabilityHealthDegraded
+                    finding.code == atm_core::error_codes::AtmErrorCode::WarningSqliteHealthDegraded
                 })
                 .expect("runtime finding");
             assert!(finding.message.contains("sqlite_ready=false"));

--- a/docs/phase-W/sprint-W6.md
+++ b/docs/phase-W/sprint-W6.md
@@ -1,0 +1,50 @@
+---
+id: W.6
+title: SQLite Error Contract Cleanup
+status: completed
+branch: feature/pW-s6-sqlite-error-contract
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s6-sqlite-error-contract
+---
+
+# Sprint W.6 — SQLite Error Contract Cleanup
+
+## Goal
+
+- close the remaining Phase `W` design-review mismatches around SQLite
+  degradation projection and typed daemon event metadata
+
+## Design Decisions
+
+- `DESIGN-002-W`
+  - SQLite degradation state must be recorded before retained-sink emission so
+    `atm doctor` and runtime-health remain authoritative even when the sink is
+    degraded
+- `DESIGN-003-W`
+  - daemon runtime degradation caused by SQLite must project through a
+    dedicated ATM warning code, not the observability-health warning code
+- `DESIGN-004-W`
+  - `DaemonEvent` stores typed validated action/outcome labels instead of raw
+    string fields
+
+## Files Changed
+
+- `crates/atm-core/src/error_codes.rs`
+- `crates/atm-core/src/protocol.rs`
+- `crates/atm-daemon/src/daemon_runtime_observability.rs`
+- `crates/atm-daemon/src/sqlite_observability.rs`
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+- `crates/atm-daemon/src/tests.rs`
+- `crates/atm-daemon/src/test_observability.rs`
+- `crates/atm-daemon/bin_support/daemon_observability.rs`
+- `docs/phase-W/sprint-W6.md`
+
+## Acceptance Criteria
+
+- SQLite degradation is recorded in runtime status before retained-sink emit
+  succeeds or fails
+- degraded SQLite doctor/runtime-health findings use a dedicated SQLite ATM
+  warning code
+- `DaemonEvent` action/outcome fields are typed validated labels
+- `cargo build --workspace` passes
+- `cargo test --workspace` passes
+- `cargo clippy --workspace -- -D warnings` passes

--- a/docs/plan-phase-W.md
+++ b/docs/plan-phase-W.md
@@ -212,6 +212,8 @@ Execution shape:
 - `W.3` adds SQLite subsystem observability for writer queue, reply timeout,
   WAL lifecycle, and reader-budget exhaustion
 - `W.4` closes the remaining peer replay recovery-text holes
+- `W.6` closes the remaining SQLite error-contract and typed daemon-event gaps
+  discovered during the Phase `W` design review
 
 Execution sequence:
 - `W.1` must land first because the sink-failure rule affects every later
@@ -234,12 +236,14 @@ Authoritative sprint sequence:
 - `docs/phase-W/sprint-W2.md`
 - `docs/phase-W/sprint-W3.md`
 - `docs/phase-W/sprint-W4.md`
+- `docs/phase-W/sprint-W6.md`
 
 Deliverables:
 - `docs/phase-W/sprint-W1.md` — daemon `emit()` silent discard fix plan
 - `docs/phase-W/sprint-W2.md` — daemon-client traceability plan
 - `docs/phase-W/sprint-W3.md` — SQLite observability plan
 - `docs/phase-W/sprint-W4.md` — peer replay recovery-text plan
+- `docs/phase-W/sprint-W6.md` — SQLite error-contract and typed daemon-event cleanup
 
 Cross-sprint dependencies:
 - `W.2` and `W.3` must both define how new signals map to:


### PR DESCRIPTION
## Summary

- **DESIGN-002-W**: sqlite degradation detail is now recorded in runtime-status cache *before* the sink emit; a prior `?` short-circuit on emit could silently skip `mark_sqlite_unavailable_with_detail`
- **DESIGN-003-W**: degraded sqlite doctor projection uses dedicated `ATM_WARNING_SQLITE_HEALTH_DEGRADED` error code instead of the generic `WarningObservabilityHealthDegraded`; adds new sqlite-specific variant to `AtmErrorCode`
- **DESIGN-004-W**: `DaemonEvent` action/outcome fields stored as typed `ActionName` / `OutcomeLabel` validated labels, replacing raw `&'static str` at 6 call sites in `daemon_runtime_observability.rs`
- `docs/phase-W/sprint-W6.md` added; `docs/plan-phase-W.md` sprint sequence/deliverables updated with W.6 entry

Closes: DESIGN-002-W, DESIGN-003-W, DESIGN-004-W (integrate/phase-W triage records)

## Test plan
- [ ] cargo build --workspace PASS
- [ ] cargo test --workspace PASS
- [ ] cargo clippy --workspace -- -D warnings PASS
- [ ] W.6 QA-1 dispatched to quality-mgr

🤖 Generated with [Claude Code](https://claude.com/claude-code)