### PR TITLE
W.8: close phase W closeout gaps

### DIFF
--- a/crates/atm-daemon/bin_support/daemon_observability.rs
+++ b/crates/atm-daemon/bin_support/daemon_observability.rs
@@ -16,7 +16,6 @@ use atm_core::observability::{
 };
 use serde_json::Map;
 
-#[cfg(test)]
 use atm_daemon::DaemonSubsystem;
 use atm_daemon::{DaemonEvent, TeamScope};
 
@@ -191,7 +190,7 @@ impl DaemonObservability {
 
     pub(crate) fn emit_subsystem_event(
         &self,
-        subsystem: &'static str,
+        subsystem: DaemonSubsystem,
         action: &ActionName,
         outcome: &OutcomeLabel,
         message: &str,
@@ -354,7 +353,7 @@ impl atm_daemon::DaemonRuntimeObservability for DaemonObservability {
 
     fn emit_subsystem_event(
         &self,
-        subsystem: &'static str,
+        subsystem: DaemonSubsystem,
         action: &ActionName,
         outcome: &OutcomeLabel,
         message: &str,
@@ -814,7 +813,7 @@ fn retained_sink_fault_mode() -> Result<Option<RetainedSinkFaultMode>, AtmError>
 fn map_subsystem_event(
     service_name: &ServiceName,
     target_category: &TargetCategory,
-    subsystem: &'static str,
+    subsystem: DaemonSubsystem,
     action: &ActionName,
     outcome: &OutcomeLabel,
     message: &str,
@@ -830,7 +829,7 @@ fn map_subsystem_event(
             })?;
     let mut fields = Map::from_iter([(
         "component".to_string(),
-        serde_json::Value::String(subsystem.to_string()),
+        serde_json::Value::String(subsystem.as_str().to_string()),
     )]);
     if let Some(error_code) = error_code {
         fields.insert(

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -186,6 +186,12 @@ impl SubsystemObservability {
         self.subsystem.clone()
     }
 
+    /// Internal convenience builder for daemon-owned `'static` literals.
+    ///
+    /// This helper intentionally remains separate from the typed
+    /// `emit_subsystem_event(...)` boundary: it validates one internal static
+    /// literal at call time for subsystem-local event construction rather than
+    /// requiring pre-allocated typed labels at every internal call site.
     pub(crate) fn event(
         &self,
         action: &'static str,

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -14,6 +14,7 @@ type OutcomeLabel = sc_observability_types::OutcomeLabel;
 pub enum DaemonSubsystem {
     Bootstrap,
     Composition,
+    Sqlite,
     LocalIpcTransport,
     AdvisoryRuntime,
     NotificationRuntime,
@@ -32,6 +33,7 @@ impl DaemonSubsystem {
         match self {
             Self::Bootstrap => "bootstrap",
             Self::Composition => "composition",
+            Self::Sqlite => "sqlite",
             Self::LocalIpcTransport => "local_ipc_transport",
             Self::AdvisoryRuntime => "advisory_runtime",
             Self::NotificationRuntime => "notification_runtime",
@@ -136,7 +138,7 @@ pub trait DaemonRuntimeObservability:
     /// action/outcome use the shared validated observability types.
     fn emit_subsystem_event(
         &self,
-        subsystem: &'static str,
+        subsystem: DaemonSubsystem,
         action: &ActionName,
         outcome: &OutcomeLabel,
         message: &str,

--- a/crates/atm-daemon/src/sqlite_observability.rs
+++ b/crates/atm-daemon/src/sqlite_observability.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use atm_core::error::AtmError;
 use atm_rusqlite::{SqliteObservability, SqliteObservabilityEvent, SqliteObservabilityOutcome};
 
-use crate::DaemonSubsystem;
 use crate::DaemonRuntimeObservability;
+use crate::DaemonSubsystem;
 use crate::runtime_status_cache::RuntimeStatusCache;
 
 type ActionName = sc_observability_types::ActionName;

--- a/crates/atm-daemon/src/sqlite_observability.rs
+++ b/crates/atm-daemon/src/sqlite_observability.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use atm_core::error::AtmError;
 use atm_rusqlite::{SqliteObservability, SqliteObservabilityEvent, SqliteObservabilityOutcome};
 
+use crate::DaemonSubsystem;
 use crate::DaemonRuntimeObservability;
 use crate::runtime_status_cache::RuntimeStatusCache;
 
@@ -56,7 +57,7 @@ impl SqliteObservability for DaemonSqliteObservability {
                 .with_source(source)
         })?;
         self.observability.emit_subsystem_event(
-            "sqlite",
+            DaemonSubsystem::Sqlite,
             &action,
             &outcome,
             &event.message,

--- a/crates/atm-daemon/src/test_observability.rs
+++ b/crates/atm-daemon/src/test_observability.rs
@@ -21,6 +21,9 @@ type OutcomeLabel = sc_observability_types::OutcomeLabel;
 pub(crate) struct TestDaemonObservability {
     active_log_path: PathBuf,
     detail: Option<String>,
+    // append_message() pushes under the Mutex while wait_for_message_contains()
+    // re-acquires it on each Condvar wake, so the pair stays co-located to keep
+    // the shared lock/wake discipline explicit in test support.
     recorded_messages: (Mutex<Vec<String>>, Condvar),
 }
 

--- a/crates/atm-daemon/src/test_observability.rs
+++ b/crates/atm-daemon/src/test_observability.rs
@@ -12,7 +12,7 @@ use atm_core::observability::{
     LogTailSession, ObservabilityPort,
 };
 
-use crate::{DaemonEvent, DaemonRuntimeObservability};
+use crate::{DaemonEvent, DaemonRuntimeObservability, DaemonSubsystem};
 
 type ActionName = sc_observability_types::ActionName;
 type OutcomeLabel = sc_observability_types::OutcomeLabel;
@@ -185,7 +185,7 @@ impl DaemonRuntimeObservability for TestDaemonObservability {
 
     fn emit_subsystem_event(
         &self,
-        subsystem: &'static str,
+        subsystem: DaemonSubsystem,
         action: &ActionName,
         outcome: &OutcomeLabel,
         message: &str,
@@ -194,6 +194,7 @@ impl DaemonRuntimeObservability for TestDaemonObservability {
         self.append_message(format!(
             "{{\"subsystem\":\"{subsystem}\",\"action\":\"{action}\",\"outcome\":\"{outcome}\",\"message\":\"{message}\",\"error_code\":{:?}}}",
             error_code.map(|value| value.to_string()),
+            subsystem = subsystem.as_str(),
             action = action.as_str(),
             outcome = outcome.as_str()
         ))

--- a/docs/phase-W/sprint-W1.md
+++ b/docs/phase-W/sprint-W1.md
@@ -74,7 +74,8 @@ worktree: TBD
   existing sealed/open boundary is unchanged
 - fallback metadata for the 68 daemon emit sites is typed:
   stable subsystem and action identifiers must come from a shared enum/newtype
-  set rather than ad hoc per-callsite strings
+  set rather than ad hoc per-callsite strings, including the SQLite subsystem
+  observability path
 
 ## Implementation Notes
 

--- a/docs/phase-W/sprint-W1.md
+++ b/docs/phase-W/sprint-W1.md
@@ -1,9 +1,9 @@
 ---
 id: W.1
 title: Daemon Emit Failure Visibility
-status: planned
-branch: TBD
-worktree: TBD
+status: complete
+branch: feature/pW-s1-emit-fallback
+worktree: ../atm-core-worktrees/feature/pW-s1-emit-fallback
 ---
 
 # Sprint W.1 — Emit Silent Discard Fix

--- a/docs/phase-W/sprint-W3.md
+++ b/docs/phase-W/sprint-W3.md
@@ -3,7 +3,7 @@ id: W.3
 title: SQLite Subsystem Observability
 status: complete
 branch: feature/pW-s3-sqlite-observability
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s3-sqlite-observability
+worktree: ../atm-core-worktrees/feature/pW-s3-sqlite-observability
 ---
 
 # Sprint W.3 — SQLite Observability

--- a/docs/phase-W/sprint-W4.md
+++ b/docs/phase-W/sprint-W4.md
@@ -3,7 +3,7 @@ id: W.4
 title: Peer Replay Recovery Text
 status: complete
 branch: feature/pW-s4-peer-replay-recovery
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s4-peer-replay-recovery
+worktree: ../atm-core-worktrees/feature/pW-s4-peer-replay-recovery
 ---
 
 # Sprint W.4 — Peer Replay Recovery Text

--- a/docs/phase-W/sprint-W5.md
+++ b/docs/phase-W/sprint-W5.md
@@ -3,7 +3,7 @@ id: W.5
 title: Doctor Projection
 status: completed
 branch: feature/pW-s5-doctor-projection
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s5-doctor-projection
+worktree: ../atm-core-worktrees/feature/pW-s5-doctor-projection
 ---
 
 # Sprint W.5 — Doctor Projection Gap

--- a/docs/phase-W/sprint-W6.md
+++ b/docs/phase-W/sprint-W6.md
@@ -3,7 +3,7 @@ id: W.6
 title: SQLite Error Contract Cleanup
 status: completed
 branch: feature/pW-s6-sqlite-error-contract
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s6-sqlite-error-contract
+worktree: ../atm-core-worktrees/feature/pW-s6-sqlite-error-contract
 ---
 
 # Sprint W.6 — SQLite Error Contract Cleanup

--- a/docs/phase-W/sprint-W7.md
+++ b/docs/phase-W/sprint-W7.md
@@ -3,7 +3,7 @@ id: W.7
 title: Triage Closeout
 status: completed
 branch: feature/pW-s7-triage-closeout
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s7-triage-closeout
+worktree: ../atm-core-worktrees/feature/pW-s7-triage-closeout
 ---
 
 # Sprint W.7 — Triage Closeout

--- a/docs/phase-W/sprint-W8.md
+++ b/docs/phase-W/sprint-W8.md
@@ -1,0 +1,64 @@
+---
+id: W.8
+title: Phase W Closeout Gaps
+status: completed
+branch: feature/pW-s8-phase-w-closeout
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s8-phase-w-closeout
+---
+
+# Sprint W.8 — Phase W Closeout Gaps
+
+## Goals
+
+- close the remaining plan-audit gaps left after the original `W.8`
+  implementation landed
+- make the Phase `W` sequence, deliverables, and project-plan status block
+  reflect the actual SQLite error-contract follow-through on this branch
+- finish the typed SQLite subsystem identity closeout without reverting back to
+  a raw retained-log subsystem string
+
+## Implementation Notes
+
+- `docs/plan-phase-W.md` now records `W.8` in the authoritative sprint
+  sequence and deliverables list
+- `docs/project-plan.md` section 27 now carries the `W.8` pending-merge status
+  entry for `feature/pW-s8-phase-w-closeout` / PR `#277`
+- `docs/project-plan.md` execution shape now includes both:
+  - `W.7` Phase `W` carry-forward triage loop and phase closeout record
+  - `W.8` phase closeout: typed SQLite subsystem identity and ATM error
+    inventory correction
+- this sprint closes the gap called out in
+  [sprint-W1.md](/Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s8-phase-w-closeout/docs/phase-W/sprint-W1.md:75):
+  `DaemonSubsystem::Sqlite` was added and
+  `emit_subsystem_event(...)` was tightened from `&'static str` subsystem ids
+  to typed `DaemonSubsystem` on the retained-log path
+- `SubsystemObservability::event(...)` remains an internal literal-based
+  convenience builder; `W.8` documents that distinction rather than widening
+  the typed boundary unnecessarily
+- `TestDaemonObservability` now documents the `Mutex<Vec<String>>` +
+  `Condvar` pairing so the shared lock discipline is explicit in test support
+
+## Acceptance Criteria
+
+- `docs/phase-W/sprint-W8.md` exists with goals, implementation notes, and
+  acceptance criteria
+- `docs/plan-phase-W.md` includes `W.8` in the authoritative sprint sequence
+  and deliverables list
+- `docs/project-plan.md` section 27 records the merged `W.7` status and the
+  pending `W.8` status
+- `docs/project-plan.md` section 27 execution shape includes both `W.7` and
+  `W.8`
+- the shared ATM error inventory includes
+  `ATM_WARNING_SQLITE_HEALTH_DEGRADED` for degraded SQLite readiness
+- the SQLite retained-log emission path uses typed
+  `DaemonSubsystem::Sqlite`, not a raw subsystem string literal
+- `SubsystemObservability::event(...)` documents why it remains an internal
+  literal-based convenience builder distinct from the typed
+  `emit_subsystem_event(...)` boundary
+- `TestDaemonObservability` documents the `Mutex` + `Condvar` rationale for
+  recorded retained-log messages
+- `cargo build --workspace` passes
+- `cargo test --workspace` passes
+- `cargo clippy --workspace -- -D warnings` passes
+- `cargo fmt --all --check` passes
+- `git diff --check` passes

--- a/docs/phase-W/sprint-W8.md
+++ b/docs/phase-W/sprint-W8.md
@@ -3,7 +3,7 @@ id: W.8
 title: Phase W Closeout Gaps
 status: completed
 branch: feature/pW-s8-phase-w-closeout
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s8-phase-w-closeout
+worktree: ../atm-core-worktrees/feature/pW-s8-phase-w-closeout
 ---
 
 # Sprint W.8 — Phase W Closeout Gaps

--- a/docs/phase-W/sprint-W8.md
+++ b/docs/phase-W/sprint-W8.md
@@ -28,7 +28,7 @@ worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s8-phase
   - `W.8` phase closeout: typed SQLite subsystem identity and ATM error
     inventory correction
 - this sprint closes the gap called out in
-  [sprint-W1.md](/Users/randlee/Documents/github/atm-core-worktrees/feature/pW-s8-phase-w-closeout/docs/phase-W/sprint-W1.md:75):
+  `docs/phase-W/sprint-W1.md` lines 75-78:
   `DaemonSubsystem::Sqlite` was added and
   `emit_subsystem_event(...)` was tightened from `&'static str` subsystem ids
   to typed `DaemonSubsystem` on the retained-log path

--- a/docs/plan-phase-W.md
+++ b/docs/plan-phase-W.md
@@ -268,6 +268,7 @@ Authoritative sprint sequence:
 - `docs/phase-W/sprint-W5.md`
 - `docs/phase-W/sprint-W6.md`
 - `docs/phase-W/sprint-W7.md`
+- `docs/phase-W/sprint-W8.md`
 
 Deliverables:
 - `docs/phase-W/sprint-W1.md` — daemon `emit()` silent discard fix plan
@@ -279,6 +280,8 @@ Deliverables:
   cleanup
 - `docs/phase-W/sprint-W7.md` — final triage closeout and merged-status
   registry
+- `docs/phase-W/sprint-W8.md` — Phase `W` closeout audit fixes for typed
+  SQLite subsystem identity and shared ATM error inventory alignment
 
 Cross-sprint dependencies:
 - `W.2` and `W.3` must both define how new signals map to:

--- a/docs/plan-phase-W.md
+++ b/docs/plan-phase-W.md
@@ -197,6 +197,9 @@ Shared ATM error inventory:
 - `W.3` SQLite-backed command/runtime failures reuse existing ATM codes:
   - `ATM_DAEMON_UNAVAILABLE` for queue, reply, WAL, budget, and assembly
     failures that currently project through daemon/runtime availability
+  - `ATM_WARNING_SQLITE_HEALTH_DEGRADED` for degraded SQLite readiness that
+    still leaves the daemon running but not fully healthy in doctor/runtime
+    health output
   - `ATM_DAEMON_LIFECYCLE_WEDGE` only where the existing shared error path
     already promotes the failure to a lifecycle wedge
 - `W.4` remote replay persistence uses existing ATM codes:

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3109,6 +3109,10 @@ Status note:
   - branch: `feature/pW-s6-sqlite-error-contract`
   - PR: `#275`
   - merge commit: `c8af6e7`
+- `W.7` merged to `integrate/phase-W`
+  - branch: `feature/pW-s7-triage-closeout`
+  - PR: `#276`
+  - merge commit: `d655d45`
 
 Execution shape:
 - `W.1` daemon-side observability sink failure visibility

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3113,6 +3113,9 @@ Status note:
   - branch: `feature/pW-s7-triage-closeout`
   - PR: `#276`
   - merge commit: `d655d45`
+- `W.8` pending merge to `integrate/phase-W`
+  - branch: `feature/pW-s8-phase-w-closeout`
+  - PR: `#277`
 
 Execution shape:
 - `W.1` daemon-side observability sink failure visibility
@@ -3121,6 +3124,9 @@ Execution shape:
 - `W.4` peer replay recovery text and peer-side protocol parity
 - `W.5` doctor projection of same-host bootstrap traceability
 - `W.6` SQLite degradation/error-contract cleanup and typed daemon event labels
+- `W.7` Phase `W` carry-forward triage loop and phase closeout record
+- `W.8` phase closeout: typed SQLite subsystem identity and ATM error
+  inventory correction
 
 Execution rules:
 - `W.1` defines the daemon-side sink-failure behavior for later emitted events


### PR DESCRIPTION
## Summary
- add typed `DaemonSubsystem::Sqlite` coverage to the generic daemon subsystem emit path
- remove the raw `"sqlite"` retained-log subsystem literal from the SQLite observability path
- update the Phase W shared ATM error inventory for `ATM_WARNING_SQLITE_HEALTH_DEGRADED`

## Validation
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- git diff --check