### PR TITLE
fix: PY-TRIVIAL-FIX-1 — observability const, ack derive, arch.md stale text

### DIFF
--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -194,7 +194,7 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
         outcome.task_id.as_ref(),
     );
 
-    emit_ack_command_event(
+    record_ack_telemetry(
         observability,
         &actor,
         team,
@@ -227,7 +227,7 @@ fn load_ack_source<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
     let metadata_rows = runtime.query_mailbox_metadata_rows(home_dir, team, actor, None)?;
     let source_row = find_ack_source_row(&metadata_rows, message_id, actor, team)?;
     ensure_ack_target_is_terminal(&metadata_rows, message_id)?;
-    let source_record = load_ack_source_record(runtime, home_dir, team, actor, &source_row)?;
+    let source_record = load_ack_source_record(runtime, home_dir, team, actor, source_row)?;
     ensure_ack_is_pending(message_id, &source_record.envelope)?;
     Ok(LoadedAckSource {
         row: source_row.clone(),
@@ -443,7 +443,7 @@ fn collect_ack_hook_warnings<R: RetainedServiceRuntime + RetainedMailboxRuntime>
         .collect()
 }
 
-fn emit_ack_command_event(
+fn record_ack_telemetry(
     observability: &dyn ObservabilityPort,
     actor: &AgentName,
     team: TeamName,

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -202,12 +202,9 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
             )
         })?;
 
-    match (
-        state::derive_read_state(&source_record.envelope),
-        state::derive_ack_state(&source_record.envelope),
-    ) {
-        (crate::types::ReadState::Read, crate::types::AckState::PendingAck) => {}
-        (_, crate::types::AckState::Acknowledged) => {
+    match state::derive_ack_state(&source_record.envelope) {
+        crate::types::AckState::PendingAck => {}
+        crate::types::AckState::Acknowledged => {
             return Err(AtmError::validation(format!(
                 "message {} is already acknowledged",
                 request.message_id
@@ -216,9 +213,9 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
                 "Refresh the mailbox with `atm read` and choose a message that is still pending acknowledgement.",
             ));
         }
-        _ => {
+        crate::types::AckState::NoAckRequired => {
             return Err(AtmError::validation(format!(
-                "message {} is not in the (read, pending_ack) state",
+                "message {} is not pending acknowledgement",
                 request.message_id
             ))
             .with_recovery(

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -224,7 +224,7 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
         }
     }
 
-    let (reply_agent, reply_team) = resolve_reply_target(&source_record.envelope, &team)?;
+    let (reply_agent, reply_team) = resolve_reply_target(&source_record.envelope, &team);
     let reply_team_dir = runtime.team_dir(&request.home_dir, &reply_team)?;
     if !reply_team_dir.exists() {
         return Err(AtmError::team_not_found(&reply_team));
@@ -337,7 +337,14 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
         error_code: None,
         error_message: None,
     }) {
-        tracing::warn!(%error, command = "ack", action = "ack", "failed to emit ack command event");
+        tracing::warn!(
+            %error,
+            subsystem = "ack",
+            outcome = "emit_failed",
+            command = "ack",
+            action = "ack",
+            "failed to emit ack command event"
+        );
     }
 
     Ok(outcome)
@@ -346,14 +353,13 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
 fn resolve_reply_target(
     message: &MessageEnvelope,
     current_team: &TeamName,
-) -> Result<(AgentName, TeamName), AtmError> {
+) -> (AgentName, TeamName) {
     let identity = canonical_sender_identity(message);
     let team = message
         .source_team
         .clone()
-        .or_else(|| Some(current_team.clone()))
-        .ok_or_else(AtmError::team_unavailable)?;
-    Ok((identity, team))
+        .unwrap_or_else(|| current_team.clone());
+    (identity, team)
 }
 
 fn canonical_sender_identity(message: &MessageEnvelope) -> AgentName {
@@ -399,8 +405,7 @@ mod tests {
         let mut message = message_with_from(ROLE_TEAM_LEAD);
         message.source_team = Some(TEST_TEAM.parse::<TeamName>().expect("team"));
 
-        let target = resolve_reply_target(&message, &TeamName::from_validated(TEST_TEAM))
-            .expect("reply target");
+        let target = resolve_reply_target(&message, &TeamName::from_validated(TEST_TEAM));
         assert_eq!(
             target,
             (

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -162,70 +162,172 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
     actor: AgentName,
     team: TeamName,
 ) -> Result<AckOutcome, AtmError> {
-    let metadata_rows =
-        runtime.query_mailbox_metadata_rows(&request.home_dir, &team, &actor, None)?;
-    let source_row = metadata_rows
+    let source = load_ack_source(
+        runtime,
+        &request.home_dir,
+        &team,
+        &actor,
+        request.message_id,
+    )?;
+    let reply_target = validate_reply_target(runtime, &request.home_dir, &source.record, &team)?;
+    let persisted = persist_ack_reply(runtime, &request, &actor, &team, &source, &reply_target)?;
+
+    let mut outcome = AckOutcome {
+        action: CommandAction::Ack,
+        team: team.clone(),
+        agent: actor.clone(),
+        message_id: request.message_id,
+        task_id: persisted.task_id.clone(),
+        reply_target: reply_target.clone(),
+        reply_message_id: persisted.reply_message_id,
+        reply_text: persisted.reply_text.clone(),
+        warnings: Vec::new(),
+    };
+
+    outcome.warnings = collect_ack_hook_warnings(
+        runtime,
+        config,
+        &actor,
+        &team,
+        &reply_target,
+        persisted.reply_message_id,
+        outcome.task_id.as_ref(),
+    );
+
+    emit_ack_command_event(
+        observability,
+        &actor,
+        team,
+        request.message_id,
+        persisted.task_id,
+    );
+
+    Ok(outcome)
+}
+
+#[derive(Clone)]
+struct LoadedAckSource {
+    row: boundary::MailStoreMailboxMetadataRow,
+    record: boundary::MailStoreMessageRecord,
+}
+
+struct PersistedAckReply {
+    reply_message_id: AtmMessageId,
+    reply_text: String,
+    task_id: Option<TaskId>,
+}
+
+fn load_ack_source<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+    runtime: &R,
+    home_dir: &std::path::Path,
+    team: &TeamName,
+    actor: &AgentName,
+    message_id: AtmMessageId,
+) -> Result<LoadedAckSource, AtmError> {
+    let metadata_rows = runtime.query_mailbox_metadata_rows(home_dir, team, actor, None)?;
+    let source_row = find_ack_source_row(&metadata_rows, message_id, actor, team)?;
+    ensure_ack_target_is_terminal(&metadata_rows, message_id)?;
+    let source_record = load_ack_source_record(runtime, home_dir, team, actor, &source_row)?;
+    ensure_ack_is_pending(message_id, &source_record.envelope)?;
+    Ok(LoadedAckSource {
+        row: source_row.clone(),
+        record: source_record,
+    })
+}
+
+fn find_ack_source_row<'a>(
+    metadata_rows: &'a [boundary::MailStoreMailboxMetadataRow],
+    message_id: AtmMessageId,
+    actor: &AgentName,
+    team: &TeamName,
+) -> Result<&'a boundary::MailStoreMailboxMetadataRow, AtmError> {
+    metadata_rows
         .iter()
-        .find(|row| row.message_id == Some(request.message_id))
+        .find(|row| row.message_id == Some(message_id))
         .ok_or_else(|| {
             AtmError::validation(format!(
                 "message {} was not found in {}@{}",
-                request.message_id, actor, team
+                message_id, actor, team
             ))
             .with_recovery(
                 "Refresh the mailbox with `atm read` and choose a message that is still present in the pending-ack surface.",
             )
-        })?;
+        })
+}
 
+fn ensure_ack_target_is_terminal(
+    metadata_rows: &[boundary::MailStoreMailboxMetadataRow],
+    message_id: AtmMessageId,
+) -> Result<(), AtmError> {
     if metadata_rows
         .iter()
-        .any(|row| row.parent_message_id == Some(request.message_id))
+        .any(|row| row.parent_message_id == Some(message_id))
     {
         return Err(AtmError::validation(format!(
             "message {} has been updated; acknowledge the current terminal message instead",
-            request.message_id
+            message_id
         ))
         .with_recovery(
             "Refresh the mailbox with `atm read` and acknowledge the latest message in the thread instead of an older parent message.",
         ));
     }
+    Ok(())
+}
 
-    let source_record = runtime
-        .load_message_record(&request.home_dir, &team, &actor, &source_row.message_key)?
+fn load_ack_source_record<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+    runtime: &R,
+    home_dir: &std::path::Path,
+    team: &TeamName,
+    actor: &AgentName,
+    source_row: &boundary::MailStoreMailboxMetadataRow,
+) -> Result<boundary::MailStoreMessageRecord, AtmError> {
+    runtime
+        .load_message_record(home_dir, team, actor, &source_row.message_key)?
         .ok_or_else(|| {
             AtmError::validation(format!(
                 "message {} metadata could not be reloaded from sqlite",
-                request.message_id
+                source_row
+                    .message_id
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|| "<unknown>".to_string())
             ))
             .with_recovery(
                 "Repair or remove the malformed sqlite mailbox row before retrying `atm ack`.",
             )
-        })?;
+        })
+}
 
-    match state::derive_ack_state(&source_record.envelope) {
-        crate::types::AckState::PendingAck => {}
-        crate::types::AckState::Acknowledged => {
-            return Err(AtmError::validation(format!(
-                "message {} is already acknowledged",
-                request.message_id
-            ))
-            .with_recovery(
-                "Refresh the mailbox with `atm read` and choose a message that is still pending acknowledgement.",
-            ));
-        }
-        crate::types::AckState::NoAckRequired => {
-            return Err(AtmError::validation(format!(
-                "message {} is not pending acknowledgement",
-                request.message_id
-            ))
-            .with_recovery(
-                "Refresh the mailbox with `atm read` and choose a message that is still pending acknowledgement.",
-            ));
-        }
+fn ensure_ack_is_pending(
+    message_id: AtmMessageId,
+    source: &MessageEnvelope,
+) -> Result<(), AtmError> {
+    match state::derive_ack_state(source) {
+        crate::types::AckState::PendingAck => Ok(()),
+        crate::types::AckState::Acknowledged => Err(AtmError::validation(format!(
+            "message {} is already acknowledged",
+            message_id
+        ))
+        .with_recovery(
+            "Refresh the mailbox with `atm read` and choose a message that is still pending acknowledgement.",
+        )),
+        crate::types::AckState::NoAckRequired => Err(AtmError::validation(format!(
+            "message {} is not pending acknowledgement",
+            message_id
+        ))
+        .with_recovery(
+            "Refresh the mailbox with `atm read` and choose a message that is still pending acknowledgement.",
+        )),
     }
+}
 
-    let (reply_agent, reply_team) = resolve_reply_target(&source_record.envelope, &team);
-    let reply_team_dir = runtime.team_dir(&request.home_dir, &reply_team)?;
+fn validate_reply_target<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+    runtime: &R,
+    home_dir: &std::path::Path,
+    source_record: &boundary::MailStoreMessageRecord,
+    current_team: &TeamName,
+) -> Result<ReplyTarget, AtmError> {
+    let (reply_agent, reply_team) = resolve_reply_target(&source_record.envelope, current_team);
+    let reply_team_dir = runtime.team_dir(home_dir, &reply_team)?;
     if !reply_team_dir.exists() {
         return Err(AtmError::team_not_found(&reply_team));
     }
@@ -239,10 +341,20 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
         return Err(AtmError::agent_not_found(&reply_agent, &reply_team));
     }
 
+    Ok(ReplyTarget::new(reply_agent, reply_team))
+}
+
+fn persist_ack_reply<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+    runtime: &R,
+    request: &AckRequest,
+    actor: &AgentName,
+    team: &TeamName,
+    source: &LoadedAckSource,
+    reply_target: &ReplyTarget,
+) -> Result<PersistedAckReply, AtmError> {
     let ack_timestamp = IsoTimestamp::now();
-    let reply_text = input::validate_message_text(request.reply_body)?;
+    let reply_text = input::validate_message_text(request.reply_body.clone())?;
     let reply_message_id = AtmMessageId::new();
-    let source_task_id = source_record.envelope.task_id.clone();
     let reply_message = MessageEnvelope {
         from: actor.clone(),
         text: reply_text.clone(),
@@ -265,75 +377,90 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
         team: team.clone(),
         agent: actor.clone(),
         actor: actor.clone(),
-        message_key: source_row.message_key.clone(),
+        message_key: source.row.message_key.clone(),
         read: true,
         pending_ack_at: None,
         acknowledged_at: Some(ack_timestamp),
-        expires_at: source_record.envelope.expires_at,
+        expires_at: source.record.envelope.expires_at,
         deleted_at: None,
         updated_at: Some(ack_timestamp),
     })?;
 
-    let reply_inbox_path = runtime.inbox_path(&request.home_dir, &reply_team, &reply_agent)?;
+    let reply_inbox_path =
+        runtime.inbox_path(home_dir(request), &reply_target.team, &reply_target.agent)?;
     append_mailbox_message_and_seed_workflow(
         runtime,
-        &request.home_dir,
-        &reply_team,
-        &reply_agent,
+        home_dir(request),
+        &reply_target.team,
+        &reply_target.agent,
         &reply_inbox_path,
         &reply_message,
         false,
     )?;
 
-    let hook_reply_agent = reply_agent.clone();
-    let hook_reply_team = reply_team.clone();
-    let mut outcome = AckOutcome {
-        action: CommandAction::Ack,
-        team: team.clone(),
-        agent: actor.clone(),
-        message_id: request.message_id,
-        task_id: source_task_id.clone(),
-        reply_target: ReplyTarget::new(reply_agent, reply_team),
+    Ok(PersistedAckReply {
         reply_message_id,
-        reply_text: reply_text.clone(),
-        warnings: Vec::new(),
-    };
+        reply_text,
+        task_id: source.record.envelope.task_id.clone(),
+    })
+}
 
-    let hook_reply_recipient = ResolvedRecipient {
-        agent: hook_reply_agent,
-        team: hook_reply_team,
+fn home_dir(request: &AckRequest) -> &std::path::Path {
+    request.home_dir.as_path()
+}
+
+fn collect_ack_hook_warnings<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+    runtime: &R,
+    config: Option<&crate::config::AtmConfig>,
+    actor: &AgentName,
+    team: &TeamName,
+    reply_target: &ReplyTarget,
+    reply_message_id: AtmMessageId,
+    task_id: Option<&TaskId>,
+) -> Vec<String> {
+    let reply_recipient = ResolvedRecipient {
+        agent: reply_target.agent.clone(),
+        team: reply_target.team.clone(),
     };
-    let mut hook_warnings = Vec::new();
+    let mut warnings = Vec::new();
     runtime.maybe_run_post_send_hook(
-        &mut hook_warnings,
+        &mut warnings,
         config,
         PostSendHookContext {
-            sender: &actor,
-            sender_team: Some(&team),
-            recipient: &hook_reply_recipient,
+            sender: actor,
+            sender_team: Some(team),
+            recipient: &reply_recipient,
             recipient_pane_id: None,
             message_id: reply_message_id,
             requires_ack: false,
             is_ack: true,
-            task_id: outcome.task_id.as_ref(),
+            task_id,
         },
     );
-    outcome.warnings = hook_warnings
+    warnings
         .into_iter()
         .map(|warning| warning.render())
-        .collect();
+        .collect()
+}
 
+fn emit_ack_command_event(
+    observability: &dyn ObservabilityPort,
+    actor: &AgentName,
+    team: TeamName,
+    message_id: AtmMessageId,
+    task_id: Option<TaskId>,
+) {
     if let Err(error) = observability.emit(CommandEvent {
         command: "ack",
         action: "ack",
         outcome: "ok",
         team,
         agent: actor.clone(),
-        sender: actor,
-        message_id: Some(request.message_id),
+        sender: actor.clone(),
+        message_id: Some(message_id),
         requires_ack: false,
         dry_run: false,
-        task_id: source_task_id,
+        task_id,
         error_code: None,
         error_message: None,
     }) {
@@ -346,8 +473,6 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
             "failed to emit ack command event"
         );
     }
-
-    Ok(outcome)
 }
 
 fn resolve_reply_target(

--- a/crates/atm-core/src/error.rs
+++ b/crates/atm-core/src/error.rs
@@ -17,6 +17,7 @@ pub(crate) enum AtmErrorKind {
     MailboxRead,
     MailboxWrite,
     FilePolicy,
+    Internal,
     Validation,
     Serialization,
     Timeout,
@@ -99,6 +100,10 @@ impl AtmError {
 
     pub fn is_file_policy(&self) -> bool {
         self.kind == AtmErrorKind::FilePolicy
+    }
+
+    pub fn is_internal(&self) -> bool {
+        self.kind == AtmErrorKind::Internal
     }
 
     pub fn is_validation(&self) -> bool {
@@ -479,6 +484,7 @@ impl AtmErrorKind {
             Self::MailboxRead => AtmErrorCode::MailboxReadFailed,
             Self::MailboxWrite => AtmErrorCode::MailboxWriteFailed,
             Self::FilePolicy => AtmErrorCode::FilePolicyRejected,
+            Self::Internal => AtmErrorCode::InternalError,
             Self::Validation => AtmErrorCode::MessageValidationFailed,
             Self::Serialization => AtmErrorCode::SerializationFailed,
             Self::Timeout => AtmErrorCode::WaitTimeout,

--- a/crates/atm-core/src/error_codes.rs
+++ b/crates/atm-core/src/error_codes.rs
@@ -63,6 +63,8 @@ pub enum AtmErrorCode {
     MailboxLockReadOnlyFilesystem,
     /// Acquiring a mailbox lock timed out.
     MailboxLockTimeout,
+    /// An unexpected non-ATM internal failure occurred.
+    InternalError,
     /// Message validation failed.
     MessageValidationFailed,
     /// Serialization or deserialization failed.
@@ -154,6 +156,7 @@ impl AtmErrorCode {
             Self::MailboxLockFailed => "ATM_MAILBOX_LOCK_FAILED",
             Self::MailboxLockReadOnlyFilesystem => "ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM",
             Self::MailboxLockTimeout => "ATM_MAILBOX_LOCK_TIMEOUT",
+            Self::InternalError => "ATM_INTERNAL_ERROR",
             Self::MessageValidationFailed => "ATM_MESSAGE_VALIDATION_FAILED",
             Self::SerializationFailed => "ATM_SERIALIZATION_FAILED",
             Self::FilePolicyRejected => "ATM_FILE_POLICY_REJECTED",
@@ -221,6 +224,7 @@ impl FromStr for AtmErrorCode {
             "ATM_MAILBOX_LOCK_FAILED" => Ok(Self::MailboxLockFailed),
             "ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM" => Ok(Self::MailboxLockReadOnlyFilesystem),
             "ATM_MAILBOX_LOCK_TIMEOUT" => Ok(Self::MailboxLockTimeout),
+            "ATM_INTERNAL_ERROR" => Ok(Self::InternalError),
             "ATM_MESSAGE_VALIDATION_FAILED" => Ok(Self::MessageValidationFailed),
             "ATM_SERIALIZATION_FAILED" => Ok(Self::SerializationFailed),
             "ATM_FILE_POLICY_REJECTED" => Ok(Self::FilePolicyRejected),

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -70,6 +70,9 @@ where
     let _guard = lock::acquire_many_sorted([path.to_path_buf()], timeout)?;
     let mut messages = load_compat_mailbox_messages(path)?;
     mutate(&mut messages)?;
+    // ATM accepts Claude-authored JSONL as ingress, but test-only mutations
+    // rewrite through the same array-shaped compatibility projection ATM uses
+    // for its own exports.
     store::write_compat_mailbox_projection(path, &messages)
 }
 
@@ -389,6 +392,45 @@ mod tests {
         let messages = load_compat_mailbox_messages(&path).expect("read");
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].text, "valid");
+    }
+
+    #[test]
+    fn read_messages_jsonl_format_still_works() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("jsonl-ingress-still-works.jsonl");
+        let first = sample_message(Uuid::new_v4(), "first");
+        let second = sample_message(Uuid::new_v4(), "second");
+        let contents = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&first).expect("json"),
+            serde_json::to_string(&second).expect("json")
+        );
+        fs::write(&path, contents).expect("write");
+
+        let messages = load_compat_mailbox_messages(&path).expect("read");
+        assert_eq!(messages, vec![first, second]);
+    }
+
+    #[test]
+    fn json_array_inbox_remains_array_on_first_append() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("array-remains-array-on-append.json");
+        let first = sample_message(Uuid::new_v4(), "first");
+        let second = sample_message(Uuid::new_v4(), "second");
+        fs::write(
+            &path,
+            serde_json::to_vec(&vec![first.clone()]).expect("json array"),
+        )
+        .expect("write");
+
+        append_message(&path, &second).expect("append");
+
+        let raw = fs::read_to_string(&path).expect("raw contents");
+        let values: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("json array");
+        assert_eq!(values.len(), 2);
+        assert!(raw.trim_start().starts_with('['));
+        let messages = load_compat_mailbox_messages(&path).expect("read");
+        assert_eq!(messages, vec![first, second]);
     }
 
     #[test]

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -139,6 +139,7 @@ const fn error_kind_for_code(code: AtmErrorCode) -> AtmErrorKind {
         AtmErrorCode::FilePolicyRejected | AtmErrorCode::FileReferenceRewriteFailed => {
             AtmErrorKind::FilePolicy
         }
+        AtmErrorCode::InternalError => AtmErrorKind::Internal,
         AtmErrorCode::SerializationFailed => AtmErrorKind::Serialization,
         AtmErrorCode::WaitTimeout => AtmErrorKind::Timeout,
         AtmErrorCode::ObservabilityEmitFailed => AtmErrorKind::ObservabilityEmit,

--- a/crates/atm/src/constants.rs
+++ b/crates/atm/src/constants.rs
@@ -1,0 +1,1 @@
+pub(crate) const ATM_SERVICE_NAME: &str = "atm";

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod composition;
+mod constants;
 mod observability;
 mod output;
 
@@ -31,7 +32,6 @@ use serde_json::Map;
 use time::OffsetDateTime;
 use tracing_subscriber::filter::LevelFilter as TracingLevelFilter;
 
-const ATM_SERVICE_NAME: &str = "atm";
 const ATM_COMMAND_TARGET: &str = "atm.command";
 const ATM_LOG_LEVEL_ENV: &str = "ATM_LOG";
 const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAINED_SINK_FAULT";
@@ -103,7 +103,7 @@ fn init_observability(stderr_logs: bool) -> Result<observability::CliObservabili
     } else {
         ConsoleLogRoute::Disabled
     };
-    let service_name = ServiceName::new(ATM_SERVICE_NAME).map_err(|source| {
+    let service_name = ServiceName::new(constants::ATM_SERVICE_NAME).map_err(|source| {
         AtmError::observability_bootstrap("failed to validate ATM service name").with_source(source)
     })?;
     let target_category = TargetCategory::new(ATM_COMMAND_TARGET).map_err(|source| {
@@ -681,7 +681,7 @@ pub(crate) fn new_adapter_port(
     home_dir: &std::path::Path,
     stderr_logs: bool,
 ) -> Result<Box<dyn ObservabilityPort + Send + Sync>, AtmError> {
-    let service_name = ServiceName::new(ATM_SERVICE_NAME).map_err(|source| {
+    let service_name = ServiceName::new(constants::ATM_SERVICE_NAME).map_err(|source| {
         AtmError::observability_bootstrap("failed to validate ATM service name").with_source(source)
     })?;
     let target_category = TargetCategory::new(ATM_COMMAND_TARGET).map_err(|source| {

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -4,6 +4,8 @@ use atm_core::observability::{
     ObservabilityPort,
 };
 use atm_core::types::{AgentName, TeamName};
+
+use crate::constants::ATM_SERVICE_NAME;
 /// Structured CLI-owned observability construction options.
 ///
 /// L.5 intentionally keeps the release surface narrow: one explicit
@@ -67,7 +69,7 @@ impl CliObservability {
         };
         let agent = identity.parse().unwrap_or(fallback_agent);
         if let Err(emit_error) = self.emit(CommandEvent {
-            command: "atm",
+            command: ATM_SERVICE_NAME,
             action: stage,
             outcome: "error",
             team: team.parse().unwrap_or(fallback_team),

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -54,7 +54,7 @@ impl CliObservability {
         let (code, message) = if let Some(atm_error) = error.downcast_ref::<AtmError>() {
             (atm_error.code, atm_error.to_string())
         } else {
-            (AtmErrorCode::MessageValidationFailed, error.to_string())
+            (AtmErrorCode::InternalError, error.to_string())
         };
 
         let identity = std::env::var("ATM_IDENTITY").unwrap_or_else(|_| "unknown".to_string());

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1241,7 +1241,7 @@ The clear pipeline stages are:
 1. resolve actor identity and target inbox
 2. load the persisted inbox surface
 3. classify each message into read axis and ack axis
-4. compute clear eligibility from the two-axis model plus pending-ack override
+4. compute clear eligibility from the two-axis read and acknowledgement model
 5. apply optional age and idle-only filters
 6. atomically persist the kept set when not in dry-run mode
 7. emit command lifecycle records

--- a/docs/phase-Y/sprint-Y0-pre-smoke-trivial-fixes.md
+++ b/docs/phase-Y/sprint-Y0-pre-smoke-trivial-fixes.md
@@ -1,0 +1,35 @@
+---
+id: Y.0
+title: Sprint Y.0 — Pre-Smoke Trivial Fixes
+status: complete
+branch: feature/pY-trivial-fixes
+worktree: ../atm-core-worktrees/feature/pY-trivial-fixes
+target: develop
+---
+
+# Sprint Y.0 — Pre-Smoke Trivial Fixes
+
+## Goal
+
+- land the small pre-`Y.1` cleanup items on `develop` before the heavier
+  daemon-release smoke and dogfood work starts
+
+## Delivered
+
+- replaced the raw `command: "atm"` literal in
+  `crates/atm/src/observability.rs` with the shared `ATM_SERVICE_NAME`
+  constant
+- removed the redundant dual read/ack state derivation in
+  `crates/atm-core/src/ack/mod.rs` so the `atm ack` validation path derives
+  only acknowledgement state
+- removed the stale `pending-ack override` phrase from `docs/architecture.md`
+  so the documented clear pipeline matches the current two-axis eligibility
+  model
+- reviewed GitHub issues `#78` and `#83` and sent the requested design
+  proposals to `team-lead` before any implementation work for those issues
+
+## Validation
+
+- `cargo build --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `git diff --check`

--- a/docs/phase-Y/sprint-Y0-pre-smoke-trivial-fixes.md
+++ b/docs/phase-Y/sprint-Y0-pre-smoke-trivial-fixes.md
@@ -38,10 +38,17 @@ target: develop
     rewrites through the ATM-owned compatibility projection path
 - recorded that `#83` (`atm help`) remains deferred to Phase `Y` Sprint `Y.1`
   and is not part of this trivial-fixes branch
+- closed the trivial-fixes QA-1 follow-up on the same branch:
+  - non-ATM fatal-error fallback logging now uses a generic internal code
+    instead of `MessageValidationFailed`
+  - `resolve_reply_target(...)` now exposes its infallible contract directly
+  - the `atm ack` observability `warn!` path now carries `subsystem` and
+    `outcome` fields
 
 ## Validation
 
 - `cargo build --workspace`
 - `cargo clippy --workspace -- -D warnings`
+- `cargo test --workspace`
 - `cargo test -p agent-team-mail-core mailbox:: -- --nocapture`
 - `git diff --check`

--- a/docs/phase-Y/sprint-Y0-pre-smoke-trivial-fixes.md
+++ b/docs/phase-Y/sprint-Y0-pre-smoke-trivial-fixes.md
@@ -27,9 +27,21 @@ target: develop
   model
 - reviewed GitHub issues `#78` and `#83` and sent the requested design
   proposals to `team-lead` before any implementation work for those issues
+- landed the approved `#78` follow-up safely against the current release
+  contract:
+  - added explicit regression coverage that Claude-style JSONL ingress still
+    reads correctly
+  - added explicit regression coverage that the current ATM compatibility write
+    path continues to rewrite back to the existing array-shaped file format on
+    first mutation
+  - documented that `locked_read_modify_write(...)` reads JSONL ingress but
+    rewrites through the ATM-owned compatibility projection path
+- recorded that `#83` (`atm help`) remains deferred to Phase `Y` Sprint `Y.1`
+  and is not part of this trivial-fixes branch
 
 ## Validation
 
 - `cargo build --workspace`
 - `cargo clippy --workspace -- -D warnings`
+- `cargo test -p agent-team-mail-core mailbox:: -- --nocapture`
 - `git diff --check`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3419,3 +3419,8 @@ Delivered:
 - `atm ack` validation cleanup to remove redundant dual state derivation
 - architecture wording cleanup for the current clear-eligibility model
 - design proposals for GitHub issues `#78` and `#83` sent to `team-lead`
+- safe `#78` follow-up landed on the same branch:
+  - JSONL ingress regression coverage added
+  - current array-shaped ATM compatibility rewrite behavior documented and
+    regression-tested
+- `#83` implementation intentionally deferred to Phase `Y` Sprint `Y.1`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3397,3 +3397,25 @@ Execution rules:
   QA scope; each restarted sprint must pass QA as a full sprint
 - `docs/phase-X/plan-phase-X.md` remains the authoritative execution plan for
   the Phase `X` sprint line
+
+## 30. Phase Y Pre-Smoke Trivial Fixes
+
+Branch:
+- `feature/pY-trivial-fixes`
+
+Target:
+- `develop`
+
+Status:
+- complete
+
+Scope:
+- small pre-Phase-`Y` cleanup items that should land before the dedicated
+  Phase `Y` planning and smoke-testing line starts
+
+Delivered:
+- shared `ATM_SERVICE_NAME` constant reuse in CLI observability fatal-event
+  emission
+- `atm ack` validation cleanup to remove redundant dual state derivation
+- architecture wording cleanup for the current clear-eligibility model
+- design proposals for GitHub issues `#78` and `#83` sent to `team-lead`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3423,4 +3423,8 @@ Delivered:
   - JSONL ingress regression coverage added
   - current array-shaped ATM compatibility rewrite behavior documented and
     regression-tested
+- trivial-fixes QA-1 follow-up landed on the same branch:
+  - generic internal fallback code for non-ATM fatal-error logging
+  - infallible `resolve_reply_target(...)` contract cleanup
+  - `atm ack` structured warn-field completion
 - `#83` implementation intentionally deferred to Phase `Y` Sprint `Y.1`


### PR DESCRIPTION
## Summary

- Fix #81: `crates/atm/src/observability.rs:70` — replace raw `"atm"` literal with `ATM_SERVICE_NAME` const
- Fix #36: `crates/atm-core/src/ack/mod.rs:206-207` — collapse redundant `derive_read_state`/`derive_ack_state` tuple-match
- Fix #20: `docs/architecture.md:1244` — remove stale "pending-ack override" phrase

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo clippy --workspace -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] `git diff --check`
- [ ] Grep verify: `rg "command: \"atm\"" crates/atm/src/observability.rs` returns nothing
- [ ] Grep verify: `rg "pending-ack override" docs/architecture.md` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)