### PR TITLE
feat(pY-s5): mutable compatibility-field removal and dependency exposure

### DIFF
--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -173,6 +173,7 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
         &actor,
         request.message_id,
     )?;
+    let source_snapshot = delivery_policy.resolve_recipient_snapshot(runtime, &team, &actor)?;
     let reply_target = validate_reply_target(runtime, &request.home_dir, &source.record, &team)?;
     let reply_snapshot = delivery_policy.resolve_recipient_snapshot(
         runtime,
@@ -181,66 +182,30 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
     )?;
     let persisted = persist_ack_reply(
         runtime,
-        &request,
-        &actor,
-        &team,
-        &source,
-        &reply_target,
-        &reply_snapshot,
-    )?;
-
-    let mut outcome = AckOutcome {
-        action: CommandAction::Ack,
-        team: team.clone(),
-        agent: actor.clone(),
-        message_id: request.message_id,
-        task_id: persisted.task_id.clone(),
-        reply_target: reply_target.clone(),
-        reply_message_id: persisted.reply_message_id,
-        reply_text: persisted.reply_text.clone(),
-        warnings: Vec::new(),
-    };
-
-    outcome.warnings = collect_ack_hook_warnings(
-        runtime,
-        config,
-        AckHookDispatch {
+        AckPersistenceContext {
+            request: &request,
             actor: &actor,
             team: &team,
+            source: &source,
+            source_snapshot: &source_snapshot,
             reply_target: &reply_target,
             reply_snapshot: &reply_snapshot,
-            reply_message_id: persisted.reply_message_id,
-            task_id: outcome.task_id.as_ref(),
         },
-    );
-    let route =
-        delivery_policy.route_persisted_delivery(DeliveryEventFamily::AckReply, &reply_snapshot);
-    for transition in
-        persisted_success_transition_names(DeliveryEventFamily::AckReply, route.harness)
-    {
-        delivery_policy.emit_transition(
-            observability,
-            DeliveryTransitionEvent {
-                family: DeliveryEventFamily::AckReply,
-                outcome: transition,
-                team: &reply_target.team,
-                agent: &reply_target.agent,
-                sender: &actor,
-                message_id: Some(persisted.reply_message_id),
-                task_id: persisted.task_id.clone(),
-            },
-        );
-    }
-
-    record_ack_telemetry(
+    )?;
+    finalize_ack_outcome(
+        runtime,
         observability,
-        &actor,
-        team,
-        request.message_id,
-        persisted.task_id,
-    );
-
-    Ok(outcome)
+        config,
+        FinalizeAckContext {
+            delivery_policy: &delivery_policy,
+            actor: &actor,
+            team: &team,
+            request_message_id: request.message_id,
+            reply_target: &reply_target,
+            reply_snapshot: &reply_snapshot,
+            persisted: &persisted,
+        },
+    )
 }
 
 #[derive(Clone)]
@@ -253,6 +218,26 @@ struct PersistedAckReply {
     reply_message_id: AtmMessageId,
     reply_text: String,
     task_id: Option<TaskId>,
+}
+
+struct FinalizeAckContext<'a> {
+    delivery_policy: &'a DeliveryPolicyCoordinator,
+    actor: &'a AgentName,
+    team: &'a TeamName,
+    request_message_id: AtmMessageId,
+    reply_target: &'a ReplyTarget,
+    reply_snapshot: &'a crate::delivery_policy::DeliveryRecipientSnapshot,
+    persisted: &'a PersistedAckReply,
+}
+
+struct AckPersistenceContext<'a> {
+    request: &'a AckRequest,
+    actor: &'a AgentName,
+    team: &'a TeamName,
+    source: &'a LoadedAckSource,
+    source_snapshot: &'a crate::delivery_policy::DeliveryRecipientSnapshot,
+    reply_target: &'a ReplyTarget,
+    reply_snapshot: &'a crate::delivery_policy::DeliveryRecipientSnapshot,
 }
 
 fn load_ack_source<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
@@ -384,27 +369,22 @@ fn validate_reply_target<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
 
 fn persist_ack_reply<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
     runtime: &R,
-    request: &AckRequest,
-    actor: &AgentName,
-    team: &TeamName,
-    source: &LoadedAckSource,
-    reply_target: &ReplyTarget,
-    reply_snapshot: &crate::delivery_policy::DeliveryRecipientSnapshot,
+    context: AckPersistenceContext<'_>,
 ) -> Result<PersistedAckReply, AtmError> {
     let ack_timestamp = IsoTimestamp::now();
-    let reply_text = input::validate_message_text(request.reply_body.clone())?;
+    let reply_text = input::validate_message_text(context.request.reply_body.clone())?;
     let reply_message_id = AtmMessageId::new();
     let reply_message = MessageEnvelope {
-        from: actor.clone(),
+        from: context.actor.clone(),
         text: reply_text.clone(),
         timestamp: ack_timestamp,
         read: false,
-        source_team: Some(team.clone()),
+        source_team: Some(context.team.clone()),
         summary: Some(summary::build_summary(&reply_text, None)),
         message_id: Some(reply_message_id),
         pending_ack_at: None,
         acknowledged_at: None,
-        acknowledges_message_id: Some(request.message_id),
+        acknowledges_message_id: Some(context.request.message_id),
         parent_message_id: None,
         thread_mode: None,
         expires_at: None,
@@ -413,24 +393,28 @@ fn persist_ack_reply<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
     };
 
     runtime.persist_message_state(boundary::MailMessageState {
-        team: team.clone(),
-        agent: actor.clone(),
-        actor: actor.clone(),
-        message_key: source.row.message_key.clone(),
+        team: context.team.clone(),
+        agent: context.actor.clone(),
+        actor: context.actor.clone(),
+        message_key: context.source.row.message_key.clone(),
         read: true,
         pending_ack_at: None,
         acknowledged_at: Some(ack_timestamp),
-        expires_at: source.record.envelope.expires_at,
+        expires_at: context.source.record.envelope.expires_at,
         deleted_at: None,
         updated_at: Some(ack_timestamp),
     })?;
+    runtime.refresh_compat_inbox_projection(home_dir(context.request), context.source_snapshot)?;
 
-    let reply_inbox_path =
-        runtime.inbox_path(home_dir(request), &reply_target.team, &reply_target.agent)?;
+    let reply_inbox_path = runtime.inbox_path(
+        home_dir(context.request),
+        &context.reply_target.team,
+        &context.reply_target.agent,
+    )?;
     persist_message_and_seed_workflow(
         runtime,
-        home_dir(request),
-        reply_snapshot,
+        home_dir(context.request),
+        context.reply_snapshot,
         &reply_inbox_path,
         &reply_message,
         false,
@@ -439,12 +423,77 @@ fn persist_ack_reply<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
     Ok(PersistedAckReply {
         reply_message_id,
         reply_text,
-        task_id: source.record.envelope.task_id.clone(),
+        task_id: context.source.record.envelope.task_id.clone(),
     })
 }
 
 fn home_dir(request: &AckRequest) -> &std::path::Path {
     request.home_dir.as_path()
+}
+
+fn finalize_ack_outcome<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+    runtime: &R,
+    observability: &dyn ObservabilityPort,
+    config: Option<&crate::config::AtmConfig>,
+    context: FinalizeAckContext<'_>,
+) -> Result<AckOutcome, AtmError> {
+    let mut outcome = AckOutcome {
+        action: CommandAction::Ack,
+        team: context.team.clone(),
+        agent: context.actor.clone(),
+        message_id: context.request_message_id,
+        task_id: context.persisted.task_id.clone(),
+        reply_target: context.reply_target.clone(),
+        reply_message_id: context.persisted.reply_message_id,
+        reply_text: context.persisted.reply_text.clone(),
+        warnings: Vec::new(),
+    };
+    outcome.warnings = collect_ack_hook_warnings(
+        runtime,
+        config,
+        AckHookDispatch {
+            actor: context.actor,
+            team: context.team,
+            reply_target: context.reply_target,
+            reply_snapshot: context.reply_snapshot,
+            reply_message_id: context.persisted.reply_message_id,
+            task_id: outcome.task_id.as_ref(),
+        },
+    );
+    emit_ack_delivery_transitions(observability, &context);
+    record_ack_telemetry(
+        observability,
+        context.actor,
+        context.team.clone(),
+        context.request_message_id,
+        context.persisted.task_id.clone(),
+    );
+    Ok(outcome)
+}
+
+fn emit_ack_delivery_transitions(
+    observability: &dyn ObservabilityPort,
+    context: &FinalizeAckContext<'_>,
+) {
+    let route = context
+        .delivery_policy
+        .route_persisted_delivery(DeliveryEventFamily::AckReply, context.reply_snapshot);
+    for transition in
+        persisted_success_transition_names(DeliveryEventFamily::AckReply, route.harness)
+    {
+        context.delivery_policy.emit_transition(
+            observability,
+            DeliveryTransitionEvent {
+                family: DeliveryEventFamily::AckReply,
+                outcome: transition,
+                team: &context.reply_target.team,
+                agent: &context.reply_target.agent,
+                sender: context.actor,
+                message_id: Some(context.persisted.reply_message_id),
+                task_id: context.persisted.task_id.clone(),
+            },
+        );
+    }
 }
 
 fn collect_ack_hook_warnings<R: RetainedServiceRuntime + RetainedMailboxRuntime>(

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -414,7 +414,8 @@ fn persist_ack_reply<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
     persist_message_and_seed_workflow(
         runtime,
         home_dir(context.request),
-        context.reply_snapshot,
+        &context.reply_target.team,
+        &context.reply_target.agent,
         &reply_inbox_path,
         &reply_message,
         false,

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -189,7 +189,6 @@ fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRunti
             source: &source,
             source_snapshot: &source_snapshot,
             reply_target: &reply_target,
-            reply_snapshot: &reply_snapshot,
         },
     )?;
     finalize_ack_outcome(
@@ -237,7 +236,6 @@ struct AckPersistenceContext<'a> {
     source: &'a LoadedAckSource,
     source_snapshot: &'a crate::delivery_policy::DeliveryRecipientSnapshot,
     reply_target: &'a ReplyTarget,
-    reply_snapshot: &'a crate::delivery_policy::DeliveryRecipientSnapshot,
 }
 
 fn load_ack_source<R: RetainedServiceRuntime + RetainedMailboxRuntime>(

--- a/crates/atm-core/src/boundary/mail.rs
+++ b/crates/atm-core/src/boundary/mail.rs
@@ -74,6 +74,31 @@ pub struct MailMessageState {
     pub updated_at: Option<IsoTimestamp>,
 }
 
+/// Opaque hash or content-addressable identifier that marks the last
+/// successfully ingested message boundary for a replay source. Used by
+/// incremental ingest workflows to resume without re-processing already-seen
+/// messages.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MessageFingerprint(pub String);
+
+impl std::fmt::Display for MessageFingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for MessageFingerprint {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl AsRef<str> for MessageFingerprint {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MailStoreIngestReplayState {
     pub team: TeamName,
@@ -83,7 +108,7 @@ pub struct MailStoreIngestReplayState {
     /// synthesized from an empty or whitespace-only string.
     pub source: ReplaySource,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub last_fingerprint: Option<String>,
+    pub last_fingerprint: Option<MessageFingerprint>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_ingested_at: Option<IsoTimestamp>,
     #[serde(default)]

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -320,7 +320,10 @@ mod tests {
         assert_eq!(values.len(), 1);
         assert_eq!(values[0]["text"], "first");
         let read_back = load_compat_mailbox_messages(&path).expect("read back");
-        assert_eq!(read_back, vec![envelope]);
+        assert_eq!(read_back.len(), 1);
+        assert_eq!(read_back[0].text, envelope.text);
+        assert_eq!(read_back[0].message_id, envelope.message_id);
+        assert!(read_back[0].source_team.is_none());
     }
 
     #[test]
@@ -336,7 +339,7 @@ mod tests {
         let object = values[0].as_object().expect("message object");
         assert!(!object.contains_key("metadata"));
         assert!(object.contains_key("message_id"));
-        assert!(object.contains_key("source_team"));
+        assert!(!object.contains_key("source_team"));
     }
 
     #[test]
@@ -430,7 +433,13 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert!(raw.trim_start().starts_with('['));
         let messages = load_compat_mailbox_messages(&path).expect("read");
-        assert_eq!(messages, vec![first, second]);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].text, first.text);
+        assert_eq!(messages[0].message_id, first.message_id);
+        assert!(messages[0].source_team.is_none());
+        assert_eq!(messages[1].text, second.text);
+        assert_eq!(messages[1].message_id, second.message_id);
+        assert!(messages[1].source_team.is_none());
     }
 
     #[test]

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -82,8 +82,8 @@ mod tests {
     use crate::mailbox::source::SourceFile;
     use crate::roles::ROLE_TEAM_LEAD;
     use crate::schema::{AtmMessageId, MessageEnvelope};
-    use crate::test_support::{TEST_QA, TEST_SENDER, TEST_TEAM};
-    use crate::types::{AgentName, IsoTimestamp, TeamName};
+    use crate::test_support::{TEST_QA, TEST_SENDER};
+    use crate::types::{AgentName, IsoTimestamp};
 
     #[test]
     fn write_compat_mailbox_projection_rewrites_mailbox_array_with_only_new_messages() {
@@ -102,9 +102,19 @@ mod tests {
         let encoded: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("json array");
         assert_eq!(encoded.len(), 2);
         assert!(raw.ends_with('\n'));
-        assert_eq!(
-            load_compat_mailbox_messages(&path).expect("read mailbox"),
-            messages
+        let read_back = load_compat_mailbox_messages(&path).expect("read mailbox");
+        assert_eq!(read_back.len(), messages.len());
+        assert_eq!(read_back[0].text, messages[0].text);
+        assert_eq!(read_back[1].text, messages[1].text);
+        assert!(
+            read_back
+                .iter()
+                .all(|message| message.source_team.is_none())
+        );
+        assert!(
+            read_back.iter().all(
+                |message| message.pending_ack_at.is_none() && message.acknowledged_at.is_none()
+            )
         );
     }
 
@@ -159,14 +169,15 @@ mod tests {
         ])
         .expect("commit source files");
 
-        assert_eq!(
-            load_compat_mailbox_messages(&left_path).expect("left inbox"),
-            left_messages
-        );
-        assert_eq!(
-            load_compat_mailbox_messages(&right_path).expect("right inbox"),
-            right_messages
-        );
+        let left = load_compat_mailbox_messages(&left_path).expect("left inbox");
+        let right = load_compat_mailbox_messages(&right_path).expect("right inbox");
+        assert_eq!(left.len(), left_messages.len());
+        assert_eq!(right.len(), right_messages.len());
+        assert_eq!(left[0].text, left_messages[0].text);
+        assert_eq!(right[0].text, right_messages[0].text);
+        assert_eq!(right[1].text, right_messages[1].text);
+        assert!(left.iter().all(|message| message.source_team.is_none()));
+        assert!(right.iter().all(|message| message.source_team.is_none()));
     }
 
     #[test]
@@ -210,7 +221,7 @@ mod tests {
             text: text.to_string(),
             timestamp: IsoTimestamp::now(),
             read: false,
-            source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team name")),
+            source_team: None,
             summary: None,
             message_id: Some(message_id),
             pending_ack_at: None,

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -319,6 +319,18 @@ fn strip_metadata_atm_namespace(object: &mut Map<String, Value>) {
     }
 }
 
+fn strip_removed_compatibility_fields(object: &mut Map<String, Value>) {
+    for field in [
+        "source_team",
+        "pendingAckAt",
+        "acknowledgedAt",
+        "acknowledgesMessageId",
+        "expiresAt",
+    ] {
+        object.remove(field);
+    }
+}
+
 pub(crate) fn to_shared_inbox_value_with_policy(
     message: &MessageEnvelope,
     policy: SharedInboxExportPolicy,
@@ -342,6 +354,7 @@ pub(crate) fn to_shared_inbox_value_with_policy(
             )
         })?;
     strip_metadata_atm_namespace(object);
+    strip_removed_compatibility_fields(object);
     if should_export_retrieval_stub(message, policy)? {
         let retrieval_stub = retrieval_stub_text(message)?;
         object.insert("text".to_string(), Value::String(retrieval_stub));
@@ -556,7 +569,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_inbox_write_keeps_machine_fields_top_level() {
+    fn shared_inbox_write_keeps_only_approved_immutable_fields() {
         let envelope = MessageEnvelope {
             from: TEST_SENDER.parse().expect("agent"),
             text: "hello".into(),
@@ -586,8 +599,8 @@ mod tests {
         let encoded = to_shared_inbox_value(&envelope).expect("encode");
         let object = encoded.as_object().expect("object");
         assert!(object.contains_key("message_id"));
-        assert!(object.contains_key("source_team"));
-        assert!(object.contains_key("pendingAckAt"));
+        assert!(!object.contains_key("source_team"));
+        assert!(!object.contains_key("pendingAckAt"));
         assert!(object.contains_key("taskId"));
         assert!(
             object
@@ -599,7 +612,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_inbox_write_keeps_ack_fields_top_level() {
+    fn shared_inbox_write_strips_ack_workflow_fields_from_export() {
         let acknowledged_at = IsoTimestamp::from_datetime(
             Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 2)
                 .single()
@@ -629,11 +642,8 @@ mod tests {
 
         let encoded = to_shared_inbox_value(&envelope).expect("encode");
         let object = encoded.as_object().expect("object");
-        assert_eq!(
-            object.get("acknowledgedAt"),
-            Some(&json!("2026-03-30T00:00:02Z"))
-        );
-        assert!(object["acknowledgesMessageId"].as_str().is_some());
+        assert!(!object.contains_key("acknowledgedAt"));
+        assert!(!object.contains_key("acknowledgesMessageId"));
     }
 
     #[test]

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -405,7 +405,8 @@ mod tests {
 
     use super::{
         AlertKind, AtmMessageId, IsoTimestamp, MessageEnvelope, PendingAck,
-        SharedInboxExportPolicy, to_shared_inbox_value, to_shared_inbox_value_with_policy,
+        SharedInboxExportPolicy, ThreadMode, to_shared_inbox_value,
+        to_shared_inbox_value_with_policy,
     };
     use crate::config::types::ByteCount;
     use crate::roles::ROLE_TEAM_LEAD;
@@ -608,6 +609,82 @@ mod tests {
                 .and_then(Value::as_object)
                 .and_then(|metadata| metadata.get("atm"))
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn shared_inbox_write_keeps_parent_message_id_and_thread_mode_when_set() {
+        // parentMessageId and threadMode are approved immutable fields and must
+        // survive to_shared_inbox_value when they carry non-None values.
+        let envelope = MessageEnvelope {
+            from: TEST_SENDER.parse().expect("agent"),
+            text: "threaded message".into(),
+            timestamp: IsoTimestamp::from_datetime(
+                Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                    .single()
+                    .expect("timestamp"),
+            ),
+            read: false,
+            source_team: None,
+            summary: None,
+            message_id: Some(AtmMessageId::new()),
+            pending_ack_at: None,
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            parent_message_id: Some(AtmMessageId::new()),
+            thread_mode: Some(ThreadMode::AddDetails),
+            expires_at: None,
+            task_id: None,
+            extra: Map::new(),
+        };
+
+        let encoded = to_shared_inbox_value(&envelope).expect("encode");
+        let object = encoded.as_object().expect("object");
+        assert!(
+            object.contains_key("parentMessageId"),
+            "parentMessageId must be kept in shared inbox export"
+        );
+        assert!(
+            object.contains_key("threadMode"),
+            "threadMode must be kept in shared inbox export"
+        );
+    }
+
+    #[test]
+    fn shared_inbox_write_strips_expires_at() {
+        // expiresAt is a removed compatibility field and must not appear in the
+        // shared inbox export even when the envelope carries a non-None value.
+        let envelope = MessageEnvelope {
+            from: TEST_SENDER.parse().expect("agent"),
+            text: "expiring message".into(),
+            timestamp: IsoTimestamp::from_datetime(
+                Utc.with_ymd_and_hms(2026, 3, 30, 0, 0, 0)
+                    .single()
+                    .expect("timestamp"),
+            ),
+            read: false,
+            source_team: None,
+            summary: None,
+            message_id: Some(AtmMessageId::new()),
+            pending_ack_at: None,
+            acknowledged_at: None,
+            acknowledges_message_id: None,
+            parent_message_id: None,
+            thread_mode: None,
+            expires_at: Some(IsoTimestamp::from_datetime(
+                Utc.with_ymd_and_hms(2026, 3, 31, 0, 0, 0)
+                    .single()
+                    .expect("timestamp"),
+            )),
+            task_id: None,
+            extra: Map::new(),
+        };
+
+        let encoded = to_shared_inbox_value(&envelope).expect("encode");
+        let object = encoded.as_object().expect("object");
+        assert!(
+            !object.contains_key("expiresAt"),
+            "expiresAt must be stripped from shared inbox export"
         );
     }
 

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -244,7 +244,7 @@ fn load_projection_message(
 ) -> Result<MessageEnvelope, AtmError> {
     runtime
         .mail_store
-        .load_stored_message(crate::boundary::MailStoreLoadStoredMessageRequest {
+        .load_message(crate::boundary::MailStoreLoadMessageRequest {
             team: team.clone(),
             agent: agent.clone(),
             message_key: message_key.clone(),

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -257,10 +257,10 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
         arch_inbox
     );
     assert!(
-        arch_inbox.iter().any(|message| {
-            message.message_id == Some(pending_message_id) && message.acknowledged_at.is_none()
-        }),
-        "pending message was not acknowledged: {:?}",
+        arch_inbox
+            .iter()
+            .any(|message| message.message_id == Some(pending_message_id)),
+        "pending message disappeared from compatibility export: {:?}",
         arch_inbox
     );
     let arch_workflow = ack_fixture.workflow_state_contents(PRIMARY_AGENT);
@@ -326,7 +326,7 @@ fn concurrent_same_recipient_sends_preserve_mixed_payloads_and_workflow_state() 
         .expect("task inbox message");
     assert_eq!(task_message.task_id.as_deref(), Some("TASK-123"));
     assert_eq!(task_message.summary.as_deref(), Some("manual summary"));
-    assert!(task_message.pending_ack_at.is_some());
+    assert!(task_message.pending_ack_at.is_none());
     assert!(plain_message.task_id.is_none());
     assert!(plain_message.pending_ack_at.is_none());
 
@@ -450,7 +450,6 @@ fn missing_config_notice_seeds_team_lead_workflow_state() {
 
     let notice = fixture.wait_for_missing_config_notice("broken-dev");
     assert_eq!(notice.from, "atm-identity-missing");
-    assert_eq!(notice.source_team.as_deref(), Some("broken-dev"));
     let workflow = fixture.wait_for_workflow_state_for_message("broken-dev", TEAM_LEAD, &notice);
     assert!(
         workflow["messages"][message_workflow_key(&notice)]
@@ -1012,7 +1011,7 @@ impl Fixture {
                 .into_iter()
                 .find(|message| {
                     message.from.as_str() == "atm-identity-missing"
-                        && message.source_team.as_deref() == Some(team)
+                        && message.text.contains(&format!("{TEST_RECIPIENT}@{team}"))
                 })
             {
                 return notice;

--- a/crates/atm-rusqlite/src/writer/ops.rs
+++ b/crates/atm-rusqlite/src/writer/ops.rs
@@ -115,31 +115,51 @@ fn execute_upsert_message(
         })?
         == 1;
     if inserted {
-        cache
-            .upsert_message_state(
-                connection,
-                params![
-                    record.team.as_str(),
-                    record.agent.as_str(),
-                    record.message_key.as_ref(),
-                    i64::from(record.envelope.read),
-                    pending_ack_at,
-                    acknowledged_at,
-                    expires_at,
-                    Option::<String>::None,
-                    recorded_at,
-                ],
-            )
-            .map_err(|error| {
-                crate::shared_db::sqlite_error(
-                    target,
-                    "failed to upsert mail message state row",
-                    error,
-                )
-            })?;
+        let timestamps = InitialStateTimestamps {
+            pending_ack_at,
+            acknowledged_at,
+            expires_at,
+            recorded_at,
+        };
+        insert_initial_message_state(connection, cache, target, record, timestamps)?;
     }
 
     Ok(WriteOpResult::UpsertMessage { inserted })
+}
+
+struct InitialStateTimestamps {
+    pending_ack_at: Option<String>,
+    acknowledged_at: Option<String>,
+    expires_at: Option<String>,
+    recorded_at: String,
+}
+
+fn insert_initial_message_state(
+    connection: &Connection,
+    cache: &mut WriterStatementCache,
+    target: &SharedDbTarget,
+    record: &boundary::MailStoreMessageRecord,
+    timestamps: InitialStateTimestamps,
+) -> Result<(), AtmError> {
+    cache
+        .upsert_message_state(
+            connection,
+            params![
+                record.team.as_str(),
+                record.agent.as_str(),
+                record.message_key.as_ref(),
+                i64::from(record.envelope.read),
+                timestamps.pending_ack_at,
+                timestamps.acknowledged_at,
+                timestamps.expires_at,
+                Option::<String>::None,
+                timestamps.recorded_at,
+            ],
+        )
+        .map_err(|error| {
+            crate::shared_db::sqlite_error(target, "failed to upsert mail message state row", error)
+        })?;
+    Ok(())
 }
 
 fn validate_message_record(
@@ -168,6 +188,19 @@ fn validate_message_record(
         ));
     }
 
+    validate_single_successor_invariant(record, connection, cache, target)?;
+    validate_message_id_uniqueness(record, connection, cache, target)?;
+
+    Ok(())
+}
+
+fn validate_single_successor_invariant(
+    record: &boundary::MailStoreMessageRecord,
+    connection: &Connection,
+    cache: &mut WriterStatementCache,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    let message_key = record.message_key.as_ref();
     if let Some(parent_message_id) = record.envelope.parent_message_id {
         let owner = cache
             .load_successor_owner(
@@ -197,7 +230,16 @@ fn validate_message_record(
             ));
         }
     }
+    Ok(())
+}
 
+fn validate_message_id_uniqueness(
+    record: &boundary::MailStoreMessageRecord,
+    connection: &Connection,
+    cache: &mut WriterStatementCache,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    let message_key = record.message_key.as_ref();
     if let Some(message_id) = record.envelope.message_id {
         let owner = cache
             .load_message_id_owner(
@@ -227,7 +269,6 @@ fn validate_message_record(
             ));
         }
     }
-
     Ok(())
 }
 

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -890,7 +890,7 @@ mod tests {
             inbox[0].task_id.as_ref().map(|value| value.as_str()),
             Some("TASK-314")
         );
-        assert!(inbox[0].pending_ack_at.is_some());
+        assert!(inbox[0].pending_ack_at.is_none());
     }
 
     #[test]
@@ -1052,12 +1052,12 @@ mod tests {
 
         let sender_inbox = fixture.inbox_contents(TEST_SENDER);
         assert_eq!(sender_inbox.len(), 1);
-        assert!(sender_inbox[0].pending_ack_at.is_some());
+        assert!(sender_inbox[0].pending_ack_at.is_none());
         assert!(sender_inbox[0].acknowledged_at.is_none());
         let replies = fixture.inbox_contents(TEST_LEAD);
         assert_eq!(replies.len(), 1);
         assert_eq!(replies[0].text, "received and starting");
-        assert_eq!(replies[0].acknowledges_message_id, Some(message_id));
+        assert!(replies[0].acknowledges_message_id.is_none());
         assert!(replies[0].pending_ack_at.is_none());
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -694,10 +694,6 @@ Current persisted inbox superset may contain:
   - optional producer field `color`
 - ATM additive compatibility fields:
   - `message_id`
-  - `source_team`
-  - `pendingAckAt`
-  - `acknowledgedAt`
-  - `acknowledgesMessageId`
   - `parentMessageId`
   - `threadMode`
   - `taskId`
@@ -727,6 +723,9 @@ Architectural rules:
   compatibility wire form rather than as a second ATM-owned id.
 - Compatibility writes may preserve established top-level additive fields, but
   they must not become the place where new ATM-owned machine state accumulates.
+- removed compatibility fields such as `source_team`, `pendingAckAt`,
+  `acknowledgedAt`, `acknowledgesMessageId`, and `expiresAt` must stay
+  SQLite-only or workflow-only even if older inbox files still contain them.
 
 File-ownership rule:
 - the private watcher/import/export boundary is the only approved place that

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -208,6 +208,15 @@ Notes:
   `crates/atm-core/src/delivery_policy.rs`; retained `send` and `ack` now
   resolve roster snapshots through `RosterStore` before choosing whether
   compatibility export is allowed for the recipient harness.
+- `Y.5` removes mutable compatibility fields from the shared inbox export path
+  via two helper functions in
+  `crates/atm-core/src/schema/inbox_message.rs`:
+  - `strip_removed_compatibility_fields` — removes: `source_team`,
+    `pendingAckAt`, `acknowledgedAt`, `acknowledgesMessageId`, `expiresAt`
+  - `strip_metadata_atm_namespace` — removes the `atm` key from the
+    `metadata` object
+- See [docs/phase-Y/inbox-field-inventory.md](../phase-Y/inbox-field-inventory.md)
+  for the full field inventory.
 
 ## NotificationSink
 

--- a/docs/atm-message-schema.md
+++ b/docs/atm-message-schema.md
@@ -22,20 +22,15 @@ Enforcement model in this repo:
 
 ## 2. Supported Additive Compatibility Fields
 
-The shared Claude inbox surface may contain these ATM additive fields when ATM
-needs compatibility with existing Claude-side consumers:
+The shared Claude inbox surface may contain only these ATM additive fields:
 
 - `message_id`
-- `source_team`
-- `pendingAckAt`
-- `acknowledgedAt`
-- `acknowledgesMessageId`
 - `parentMessageId`
 - `threadMode`
 - `taskId`
 
-These fields are compatibility fields only. They are not the durable ATM-owned
-source of truth for mailbox state.
+These fields are immutable compatibility fields only. They are not the durable
+ATM-owned source of truth for mailbox state.
 
 Phase `Y` rule:
 
@@ -43,7 +38,8 @@ Phase `Y` rule:
   machine plus the central delivery-policy coordinator
 - fields must not persist merely because scattered command code still reads
   them
-- `Y.5` is the sprint that decides which of these fields actually survive
+- `Y.5` removed the mutable/shared-projection fields that previously leaked
+  workflow state into compatibility output
 
 ## 3. One Message Identity
 
@@ -94,7 +90,26 @@ Interpretation rules:
 The durable current-state meaning of those fields belongs in SQLite-backed read
 and workflow logic, not in repeated JSON reads.
 
-## 6. No Active `metadata.atm` Namespace
+## 6. Removed Compatibility Fields
+
+The following ATM-owned fields must not be emitted in ATM-authored shared inbox
+output:
+
+- `source_team`
+- `pendingAckAt`
+- `acknowledgedAt`
+- `acknowledgesMessageId`
+- `expiresAt`
+
+Rationale:
+
+- they are mutable workflow truth, delivery-side routing detail, or admin
+  lifecycle data rather than immutable shared-inbox correlation context
+- SQLite-backed query and workflow paths own their current-state meaning
+- if a consumer still depends on one of these fields, that dependency is
+  obsolete and must be removed or explicitly reapproved
+
+## 7. No Active `metadata.atm` Namespace
 
 `metadata.atm` is not an approved namespace in the Phase U architecture.
 

--- a/docs/phase-Y/delivery-state-machines.md
+++ b/docs/phase-Y/delivery-state-machines.md
@@ -52,6 +52,23 @@ Current `Y.4` landing points:
 - retained ack integration:
   - `crates/atm-core/src/ack/mod.rs`
 
+Current `Y.5` export contract:
+
+- ATM-authored shared inbox export keeps only immutable correlation/context
+  fields:
+  - `message_id`
+  - `parentMessageId`
+  - `threadMode`
+  - `taskId`
+- mutable workflow and lifecycle fields are stripped from compatibility export:
+  - `source_team`
+  - `pendingAckAt`
+  - `acknowledgedAt`
+  - `acknowledgesMessageId`
+  - `expiresAt`
+- compatibility export loads the stored message record, not the workflow-joined
+  projected envelope, so export no longer depends on read/ack projection state
+
 ## Synchronization Minimization
 
 Phase `Y` must remove or isolate broad application-level locking rather than

--- a/docs/phase-Y/inbox-field-inventory.md
+++ b/docs/phase-Y/inbox-field-inventory.md
@@ -22,10 +22,11 @@ Decision rule:
 | `parentMessageId` | immutable thread/update lineage pointer | `keep` | required to correlate thread/update records without reconstructing lineage heuristically |
 | `threadMode` | immutable thread/update mode (`add-details`, `supersede`, etc.) | `keep` | part of the authored message semantics, not mutable workflow state |
 | `taskId` | immutable task correlation id when present | `keep` | task linkage is correlation context, not mutable workflow truth |
-| `source_team` | sender/source routing context | `undecided` | keep only if a real shared-inbox consumer still needs it after Y.5 audit |
+| `source_team` | sender/source routing context | `remove` | recipient path plus SQLite lookup are sufficient; no approved shared-inbox consumer requires it |
 | `pendingAckAt` | mutable ack workflow state | `remove` | belongs in SQLite workflow truth |
 | `acknowledgedAt` | mutable ack workflow state | `remove` | belongs in SQLite workflow truth |
-| `acknowledgesMessageId` | reply/ack linkage emitted by ATM | `undecided` | may be retained as immutable correlation, but only if a concrete consumer still needs it |
+| `acknowledgesMessageId` | reply/ack linkage emitted by ATM | `remove` | no approved shared-inbox consumer requires it; SQLite/read outcomes already preserve ack linkage |
+| `expiresAt` | mutable expiry lifecycle state | `remove` | expiry truth belongs in SQLite lifecycle state, not compatibility output |
 | `metadata.atm.*` mutable workflow projections | legacy mutable ATM state carrier | `remove` | Phase Y target is to stop projecting mutable workflow truth into compatibility output |
 
 ## Decision Framework For Y.5
@@ -46,8 +47,8 @@ Disposition rules:
   - explicit consumer justification
   - written statement for why SQLite-only lookup is insufficient
 - `remove` is the default when the field carries mutable workflow truth
-- `undecided` is temporary and must be resolved during `Y.5`; it is not a
-  release-ready final state
+- no field remains `undecided` after `Y.5`; unresolved dependency is a blocking
+  finding, not an accepted release state
 
 ## Y.5 Expected Outcome
 

--- a/docs/phase-Y/sprint-Y5.md
+++ b/docs/phase-Y/sprint-Y5.md
@@ -1,7 +1,7 @@
 ---
 id: Y.5
 title: Mutable Compatibility-Field Removal And Dependency Exposure
-status: planned
+status: complete
 branch: feature/pY-s5-mutable-compatibility-field-removal
 worktree: ../atm-core-worktrees/feature/pY-s5-mutable-compatibility-field-removal
 target: integrate/phase-Y
@@ -122,3 +122,22 @@ whole point of `Y.5` is to expose hidden dependencies immediately.
 
 - “temporarily keep it” is usually how obsolete logic survives release prep
 - remove the data first; let the failures show you what still needs deletion
+
+## Completion Notes
+
+- complete on `feature/pY-s5-mutable-compatibility-field-removal`
+- compatibility export now keeps only:
+  - `message_id`
+  - `parentMessageId`
+  - `threadMode`
+  - `taskId`
+- compatibility export now strips:
+  - `source_team`
+  - `pendingAckAt`
+  - `acknowledgedAt`
+  - `acknowledgesMessageId`
+  - `expiresAt`
+  - `metadata.atm.*`
+- retained compatibility export now reloads stored message records instead of
+  workflow-joined projected envelopes so removed workflow fields cannot leak
+  back in through export joins

--- a/docs/plan-phase-Y.md
+++ b/docs/plan-phase-Y.md
@@ -217,6 +217,21 @@ Purpose:
 - keep field-removal logic inside the event-family state machines rather than
   in generic export conditionals
 
+Current status:
+
+- complete on `feature/pY-s5-mutable-compatibility-field-removal`
+- retained compatibility export now keeps only immutable correlation/context
+  fields: `message_id`, `parentMessageId`, `threadMode`, and `taskId`
+- retained compatibility export now strips:
+  - `source_team`
+  - `pendingAckAt`
+  - `acknowledgedAt`
+  - `acknowledgesMessageId`
+  - `expiresAt`
+  - `metadata.atm.*`
+- retained compatibility export now reloads stored message records instead of
+  workflow-joined projected envelopes before writing compatibility output
+
 ### Y.6 Append-Only Compatibility Export Cutover
 
 Purpose:

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3489,6 +3489,15 @@ Execution shape:
   - retained compatibility export now stays on the `Claude Code` harness path
     only; non-Claude harnesses skip ATM-authored JSONL export
 - `Y.5` mutable compatibility-field removal and hidden-dependency exposure
+  - complete on `feature/pY-s5-mutable-compatibility-field-removal`
+  - retained compatibility export now keeps only immutable correlation/context
+    fields: `message_id`, `parentMessageId`, `threadMode`, and `taskId`
+  - retained compatibility export now strips mutable/shared-projection fields:
+    `source_team`, `pendingAckAt`, `acknowledgedAt`,
+    `acknowledgesMessageId`, `expiresAt`, and `metadata.atm.*`
+  - retained compatibility export now reloads stored message records instead of
+    workflow-joined projected envelopes before writing Claude Code projection
+    files
 - `Y.6` append-only compatibility export cutover if the approved wire contract
   allows it
 


### PR DESCRIPTION
## Summary
- Removes mutable compatibility fields from shared inbox export
- Refreshes ack source projection after removal
- Updates sprint-Y5 doc with status: complete, branch, and worktree frontmatter

## Sprint
Y.5 — Mutable Compatibility-Field Removal And Dependency Exposure

## Validation
- cargo build --workspace ✅
- cargo test --workspace ✅
- python3 .just/run_lint.py all ✅
- cargo fmt --all --check ✅
- cargo clippy --workspace --all-features -- -D warnings ✅
- git diff --check ✅

## Test plan
- [ ] QA-1 gate (req-qa + arch-qa + rust-best-practices-agent)
- [ ] Merge gate: 0B+0I+0m

🤖 Generated with [Claude Code](https://claude.com/claude-code)