### PR TITLE
docs: sync phase-Yb documentation from integrate/phase-Y

### DIFF
--- a/docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md
+++ b/docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Proposed
+Accepted
+
+Accepted note: Implementation complete through `Phase Yb Y.8`
+(`feature/pYb-s8-policy-cleanup-and-impossible-path-removal`).
 
 ## Context
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,8 @@ The retained command surface is:
 
 Approved additive CLI feature for the Phase `Y` line:
 - `help`
+- the `help` addition stays on the CLI conceptual-help surface only; it does
+  not reopen mailbox-truth or boundary-ownership work inside `Y.1`
 
 ## 1.1 Documentation Structure
 
@@ -692,10 +694,6 @@ Current persisted inbox superset may contain:
   - optional producer field `color`
 - ATM additive compatibility fields:
   - `message_id`
-  - `source_team`
-  - `pendingAckAt`
-  - `acknowledgedAt`
-  - `acknowledgesMessageId`
   - `parentMessageId`
   - `threadMode`
   - `taskId`
@@ -725,6 +723,9 @@ Architectural rules:
   compatibility wire form rather than as a second ATM-owned id.
 - Compatibility writes may preserve established top-level additive fields, but
   they must not become the place where new ATM-owned machine state accumulates.
+- removed compatibility fields such as `source_team`, `pendingAckAt`,
+  `acknowledgedAt`, `acknowledgesMessageId`, and `expiresAt` must stay
+  SQLite-only or workflow-only even if older inbox files still contain them.
 
 File-ownership rule:
 - the private watcher/import/export boundary is the only approved place that
@@ -2382,6 +2383,8 @@ Phase `Yb` therefore tightens the architecture further:
   - `atm_core::delivery_plan::ReplyDeliveryPlan`
   - `atm_core::delivery_execution::execute_delivery_plan(...)`
   - `atm_core::delivery_execution::execute_reply_delivery_plan(...)`
+  - `atm_core::delivery_execution::NonClaudeOutboundDeliveryWriter`
+  - `atm_core::boundary::NonClaudeOutbound`
 - no command, ack, or persistence layer may branch on harness after the
   machine has produced its delivery plan
 - post-send-hook execution remains notification-only and must not stand in for

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -485,6 +485,10 @@ Architectural rules:
   - `atm_core::delivery_plan::ReplyDeliveryPlan`
   - `atm_core::delivery_execution::execute_delivery_plan(...)`
   - `atm_core::delivery_execution::execute_reply_delivery_plan(...)`
+- Phase `Yb` also adds the shared non-Claude execution handoff:
+  - `atm_core::delivery_execution::NonClaudeOutboundDeliveryWriter`
+  - `atm_core::service_runtime::RetainedServiceRuntime::deliver_non_claude_payloads(...)`
+  - `atm_core::boundary::NonClaudeOutbound`
 - `atm-core` owns the plan types and machine outputs; it must not allow outer
   send/ack/persistence modules to reintroduce harness policy after plan
   creation

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -129,6 +129,9 @@ Notes:
   errors instead of selecting a second mailbox backend.
 - Compatibility inbox files remain ingress/export surfaces, not a parallel
   durable mailbox implementation behind retained command logic.
+- After `Y.3`, retained `send` reaches compatibility rewrite only through the
+  post-commit runtime refresh owner; retained `ack` and `clear` no longer own
+  source-inbox compatibility rewrites.
 
 ## TaskStore
 
@@ -201,10 +204,27 @@ Notes:
 - Harness-specific export policy belongs in one central delivery-policy
   coordinator and event-family state machines above this boundary, not in
   scattered command callers.
+- `Y.4` lands that retained-command coordinator seam in
+  `crates/atm-core/src/delivery_policy.rs`; retained `send` and `ack` now
+  resolve roster snapshots through `RosterStore` before choosing whether
+  compatibility export is allowed for the recipient harness.
+- `Y.5` removes mutable compatibility fields from the shared inbox export path
+  via two helper functions in
+  `crates/atm-core/src/schema/inbox_message.rs`:
+  - `strip_removed_compatibility_fields` — removes: `source_team`,
+    `pendingAckAt`, `acknowledgedAt`, `acknowledgesMessageId`, `expiresAt`
+  - `strip_metadata_atm_namespace` — removes the `atm` key from the
+    `metadata` object
+- See [docs/phase-Y/inbox-field-inventory.md](../phase-Y/inbox-field-inventory.md)
+  for the full field inventory.
 - Phase `Yb` adds a stricter rule:
   - only approved delivery executors may call the write-facing export/append
     primitives behind this boundary
   - send/ack/persistence modules must not call them directly
+  - delivery-target construction and transition translation must stay in the
+    shared plan/execution seam:
+    - `crates/atm-core/src/delivery_plan.rs`
+    - `crates/atm-core/src/delivery_execution.rs`
   - see:
     - [../phase-Yb/lintable-boundary-plan.md](../phase-Yb/lintable-boundary-plan.md)
     - [../adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md](../adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md)
@@ -227,6 +247,10 @@ Notes:
   - hook or notifier invocation is not proof of logical message delivery
   - non-Claude outbound payload delivery must use a dedicated delivery
     boundary, not NotificationSink as a stand-in
+  - impossible non-Claude append-degraded routing must fail closed before it
+    reaches this sink
+  - the current proof surface for non-Claude delivery lives in
+    `NonClaudeOutboundDeliveryRequest`, not in `ATM_POST_SEND` metadata
 
 ## NonClaudeOutbound
 
@@ -243,6 +267,9 @@ Notes:
   Claude path receives; only transport target differs.
 - `NotificationSink` must not be used as a substitute for this boundary.
 - only approved delivery executors may call this boundary directly.
+- the active `atm-core` handoff seam is:
+  - `atm_core::delivery_execution::NonClaudeOutboundDeliveryWriter`
+  - `atm_core::service_runtime::RetainedServiceRuntime::deliver_non_claude_payloads(...)`
 
 ## StatusSource
 

--- a/docs/atm-core/modules/team_admin.md
+++ b/docs/atm-core/modules/team_admin.md
@@ -14,6 +14,45 @@ It must not own:
 - daemon orchestration
 - runtime spawning or launch coordination
 
+## Retained Exceptional Write Paths
+
+The following two private functions in `crates/atm-core/src/team_admin.rs` perform
+file-system writes and are **approved exceptions** to the hard-write boundary
+consolidation rule established in Phase Y Sprint 3.
+
+### `ensure_inbox_exists` (lines 313, 455)
+
+```
+fn ensure_inbox_exists(inbox_path: &Path) -> Result<bool, AtmError>
+```
+
+Called from `add_member` (line 313) and defined at line 455. Creates the inbox
+file for a new team member if it does not already exist. This is an initial
+provisioning write: it runs exactly once per member, only during `add-member`,
+and is guarded by an existence check (`inbox_path.exists()` returns early). It
+is **not** part of the normal send / ack / clear message-flow.
+
+### `write_team_config` (lines 333, 486)
+
+```
+fn write_team_config(team_dir: &Path, config: &TeamConfig) -> Result<(), AtmError>
+```
+
+Called from `add_member` (line 333) and defined at line 486. Persists the
+updated `config.json` after a new member is appended to the in-memory
+`TeamConfig`. Like `ensure_inbox_exists`, this write occurs only during team
+setup commands (`add-member`, team create/restore). It is **not** invoked on
+the normal send / ack / clear path.
+
+### Rationale
+
+Both functions handle **initial setup and configuration writes** — specifically
+inbox provisioning and team config persistence — which are structurally distinct
+from the message-flow rewrites targeted by the boundary consolidation. They are
+the **only approved owner paths** in `team_admin` for direct file-system write
+operations post-consolidation. Any future write added to this module must be
+reviewed against this boundary and justified here before merging.
+
 References:
 
 - Product requirements: `docs/requirements.md` §12 and §13
@@ -23,3 +62,4 @@ References:
 - CLI surfaces:
   - `docs/atm/commands/teams.md`
   - `docs/atm/commands/members.md`
+- [inbox-write-path-audit.md §5](../../../docs/phase-Y/inbox-write-path-audit.md) — retained exceptional write paths policy

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -132,6 +132,8 @@ Current retained ATM surfaces outside the daemon request/response packet family:
   - Claude delivery uses the `InboxExport` adapter only
   - non-Claude delivery uses the `NonClaudeOutbound` adapter only
   - notification remains a separate `NotificationSink` side effect
+  - the daemon-owned non-Claude adapter is
+    `atm_daemon::non_claude_outbound_runtime::DaemonNonClaudeOutbound`
 - daemon runtime-health/status assembly must discover teams and members only
   through the installed `RosterStore`; `ATM_HOME/.claude/teams` is a config
   ingress surface, not a runtime-truth discovery path

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -10,6 +10,13 @@ Current design assumption:
 - Runtime test doubles now exist for the watch/reconcile/notifier lanes so
   boundary tests can exercise the daemon-owned runtimes without bypassing the
   declared contracts.
+- Phase `Y.3` tightened the retained runtime shape so normal compatibility
+  rewrites now hang off one post-durability runtime refresh owner; `ack` and
+  `clear` state transitions must not reintroduce daemon-bypassing source-inbox
+  rewrite paths.
+- Phase `Y.4` adds the retained delivery-policy coordinator/state-machine seam
+  above that owner boundary; harness-specific compatibility-export policy must
+  now stay centralized there rather than leaking back into command callers.
 
 Important daemon-private control-plane structs that must stay visible in review,
 even though they are not public cross-crate traits:
@@ -339,6 +346,9 @@ Compatibility and recovery policy placement for daemon-owned config/inbox adapte
   - the daemon must not branch on harness outside that plan-to-executor seam
   - notification fallback remains a side effect after the plan, not a second
     delivery policy surface
+  - plan-to-target translation and transition emission must remain in the
+    shared `atm_core` plan/execution seam rather than reappearing in daemon
+    adapters
 
 ## DaemonNotificationSinkAdapter
 
@@ -377,6 +387,11 @@ Notes:
   Claude path receives.
 - It must not downgrade message delivery into notification-only metadata.
 - Its callers are limited to the approved delivery executor seam.
+- the current daemon-owned adapter is
+  `atm_daemon::non_claude_outbound_runtime::DaemonNonClaudeOutbound`
+- the current runtime-owned sink is `~/.atm/non_claude_outbound.jsonl`, which
+  records the typed non-Claude outbound payload requests for the daemon-owned
+  delivery lane
 
 ## DaemonStatusSourceAdapter
 

--- a/docs/atm-message-schema.md
+++ b/docs/atm-message-schema.md
@@ -22,20 +22,15 @@ Enforcement model in this repo:
 
 ## 2. Supported Additive Compatibility Fields
 
-The shared Claude inbox surface may contain these ATM additive fields when ATM
-needs compatibility with existing Claude-side consumers:
+The shared Claude inbox surface may contain only these ATM additive fields:
 
 - `message_id`
-- `source_team`
-- `pendingAckAt`
-- `acknowledgedAt`
-- `acknowledgesMessageId`
 - `parentMessageId`
 - `threadMode`
 - `taskId`
 
-These fields are compatibility fields only. They are not the durable ATM-owned
-source of truth for mailbox state.
+These fields are immutable compatibility fields only. They are not the durable
+ATM-owned source of truth for mailbox state.
 
 Phase `Y` rule:
 
@@ -43,7 +38,8 @@ Phase `Y` rule:
   machine plus the central delivery-policy coordinator
 - fields must not persist merely because scattered command code still reads
   them
-- `Y.5` is the sprint that decides which of these fields actually survive
+- `Y.5` removed the mutable/shared-projection fields that previously leaked
+  workflow state into compatibility output
 
 ## 3. One Message Identity
 
@@ -94,7 +90,26 @@ Interpretation rules:
 The durable current-state meaning of those fields belongs in SQLite-backed read
 and workflow logic, not in repeated JSON reads.
 
-## 6. No Active `metadata.atm` Namespace
+## 6. Removed Compatibility Fields
+
+The following ATM-owned fields must not be emitted in ATM-authored shared inbox
+output:
+
+- `source_team`
+- `pendingAckAt`
+- `acknowledgedAt`
+- `acknowledgesMessageId`
+- `expiresAt`
+
+Rationale:
+
+- they are mutable workflow truth, delivery-side routing detail, or admin
+  lifecycle data rather than immutable shared-inbox correlation context
+- SQLite-backed query and workflow paths own their current-state meaning
+- if a consumer still depends on one of these fields, that dependency is
+  obsolete and must be removed or explicitly reapproved
+
+## 7. No Active `metadata.atm` Namespace
 
 `metadata.atm` is not an approved namespace in the Phase U architecture.
 

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -112,6 +112,9 @@ Follow-up work:
 - `atm` owns retained-log bootstrap against the host-scoped ATM log directory
   contract (`~/.atm/logs/` by default, `ATM_LOG_DIR` when overridden) rather
   than `.local/share/logs` or any `ATM_HOME`-derived path.
+- `atm help` is CLI-owned conceptual help layered over clap command help and
+  must delegate command flag truth to clap output instead of maintaining a
+  parallel flag-documentation source.
 - `atm` owns the structured construction contract for the concrete adapter:
   `CliObservability::new(home_dir, CliObservabilityOptions)`.
 - `atm` may retain `init(...)` only as a delegating helper.

--- a/docs/atm/commands/help.md
+++ b/docs/atm/commands/help.md
@@ -3,6 +3,7 @@
 CLI ownership for `atm help`:
 
 - conceptual-help topic parsing
+- overview and `--list` rendering
 - `--list` parsing
 - mapping subcommand targets into clap-generated `--help` rendering
 - typed topic-registry dispatch for ATM-owned concept topics
@@ -28,6 +29,13 @@ First-delivery topic scope:
   - `identity`
   - `skills`
 
+Y.2 follow-up scope:
+
+- replace the tier-2 placeholder text with concrete operator examples and
+  troubleshooting guidance
+- keep the command surface unchanged: no new flags, no JSON-input mode, and no
+  compatibility-writer behavior changes
+
 Output contract:
 
 - human output distinguishes command-help vs concept-topic results clearly
@@ -38,6 +46,8 @@ JSON contract notes:
 
 - `atm help <topic> --json` extends the existing CLI JSON-output pattern to
   the new help command
+- retained commands already expose JSON output; `atm help` extends that
+  established surface rather than introducing CLI JSON output for the first time
 - general structured JSON input remains out of scope for `Phase Y` and
   `Phase Z`
 

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -171,6 +171,9 @@ Required Phase R rules:
 - `atm` must not contain business logic that duplicates `atm-core`
 - `atm` test coverage must be able to use in-process harnesses rather than
   depending on daemon process spawning
+- `atm help` remains an additive CLI-owned conceptual-help surface layered on
+  top of the retained command set; it must not become a general structured
+  JSON-input expansion point inside `Phase Y`
 - `atm` owns legacy queue-flag deprecation warnings and the exact
   `atm read --message-id <id>` retrieval guidance shown for ATM-authored JSONL
   body stubs

--- a/docs/phase-Y/delivery-state-machines.md
+++ b/docs/phase-Y/delivery-state-machines.md
@@ -41,6 +41,34 @@ But the write/nudge behavior is still spread across:
 
 That is the policy leakage Phase `Y` must remove.
 
+Current `Y.4` landing points:
+
+- coordinator + state inventory:
+  - `crates/atm-core/src/delivery_policy.rs`
+- retained runtime roster snapshot + compatibility export gate:
+  - `crates/atm-core/src/service_runtime.rs`
+- retained send integration:
+  - `crates/atm-core/src/send/mod.rs`
+- retained ack integration:
+  - `crates/atm-core/src/ack/mod.rs`
+
+Current `Y.5` export contract:
+
+- ATM-authored shared inbox export keeps only immutable correlation/context
+  fields:
+  - `message_id`
+  - `parentMessageId`
+  - `threadMode`
+  - `taskId`
+- mutable workflow and lifecycle fields are stripped from compatibility export:
+  - `source_team`
+  - `pendingAckAt`
+  - `acknowledgedAt`
+  - `acknowledgesMessageId`
+  - `expiresAt`
+- compatibility export loads the stored message record, not the workflow-joined
+  projected envelope, so export no longer depends on read/ack projection state
+
 ## Synchronization Minimization
 
 Phase `Y` must remove or isolate broad application-level locking rather than
@@ -92,6 +120,15 @@ Harness-resolution rule:
   - model strings
   - ad hoc command flags
   - stale config-side compatibility fields
+
+Current transitional compatibility note:
+
+- the landed `Y.4` implementation still falls back to `ClaudeCode` behavior
+  when no canonical roster row exists for the recipient
+- this is a compatibility-preserving interim rule for retained CLI paths, not
+  the long-term architectural target
+- later phases must remove that fallback once roster hydration is guaranteed on
+  every active delivery path
 
 Synchronization rule:
 

--- a/docs/phase-Y/help.md
+++ b/docs/phase-Y/help.md
@@ -9,10 +9,14 @@ Purpose:
 Scope:
 
 - `atm help` is the approved additive CLI feature for `Y.1`
+- `Y.2` closes the intentionally deferred tier-2 topic examples without
+  broadening the command surface
 - `atm --help` remains clap-generated syntax help
 - `atm help` is ATM-owned conceptual/product help
 - `atm help <subcommand>` must begin with the authoritative clap `--help`
   output for that subcommand
+- `atm help --list` and `atm help` overview output are part of the first
+  delivery, not follow-up scope
 - `atm help <topic> --json` is allowed because it extends the existing public
   JSON-output pattern to the new help command
 - structured JSON input is not part of `Y.1`, `Phase Y`, or `Phase Z`
@@ -26,6 +30,13 @@ Required first-delivery topics:
   - `hooks`
   - `identity`
   - `skills`
+
+Y.2 follow-up scope:
+
+- replace the tier-2 placeholder notes with concrete operator examples
+- keep the follow-up limited to help text and adjacent docs
+- do not add JSON input, write-boundary refactors, or compatibility-format
+  changes in this phase slice
 
 Ownership split:
 
@@ -43,3 +54,4 @@ References:
 - `GH #83`
 - `docs/phase-Y/sprint-Y1.md`
 - `docs/atm/commands/help.md`
+- `docs/phase-Z/cli-json-io-audit.md` (planned)

--- a/docs/phase-Y/inbox-field-inventory.md
+++ b/docs/phase-Y/inbox-field-inventory.md
@@ -22,10 +22,11 @@ Decision rule:
 | `parentMessageId` | immutable thread/update lineage pointer | `keep` | required to correlate thread/update records without reconstructing lineage heuristically |
 | `threadMode` | immutable thread/update mode (`add-details`, `supersede`, etc.) | `keep` | part of the authored message semantics, not mutable workflow state |
 | `taskId` | immutable task correlation id when present | `keep` | task linkage is correlation context, not mutable workflow truth |
-| `source_team` | sender/source routing context | `undecided` | keep only if a real shared-inbox consumer still needs it after Y.5 audit |
+| `source_team` | sender/source routing context | `remove` | recipient path plus SQLite lookup are sufficient; no approved shared-inbox consumer requires it |
 | `pendingAckAt` | mutable ack workflow state | `remove` | belongs in SQLite workflow truth |
 | `acknowledgedAt` | mutable ack workflow state | `remove` | belongs in SQLite workflow truth |
-| `acknowledgesMessageId` | reply/ack linkage emitted by ATM | `undecided` | may be retained as immutable correlation, but only if a concrete consumer still needs it |
+| `acknowledgesMessageId` | reply/ack linkage emitted by ATM | `remove` | no approved shared-inbox consumer requires it; SQLite/read outcomes already preserve ack linkage |
+| `expiresAt` | mutable expiry lifecycle state | `remove` | expiry truth belongs in SQLite lifecycle state, not compatibility output |
 | `metadata.atm.*` mutable workflow projections | legacy mutable ATM state carrier | `remove` | Phase Y target is to stop projecting mutable workflow truth into compatibility output |
 
 ## Decision Framework For Y.5
@@ -46,8 +47,8 @@ Disposition rules:
   - explicit consumer justification
   - written statement for why SQLite-only lookup is insufficient
 - `remove` is the default when the field carries mutable workflow truth
-- `undecided` is temporary and must be resolved during `Y.5`; it is not a
-  release-ready final state
+- no field remains `undecided` after `Y.5`; unresolved dependency is a blocking
+  finding, not an accepted release state
 
 ## Y.5 Expected Outcome
 

--- a/docs/phase-Y/inbox-write-path-audit.md
+++ b/docs/phase-Y/inbox-write-path-audit.md
@@ -3,7 +3,7 @@
 Baseline:
 
 - planning branch: `feature/pY-s0-planning`
-- implementation branch sampled: `feature/pY-trivial-fixes` at `31373a1`
+- implementation branch sampled: `feature/pY-s3-hard-write-boundary-consolidation`
 
 ## 1. Current Production ATM-Authored Claude-Inbox Write Paths
 
@@ -11,7 +11,7 @@ Baseline:
 
 Code:
 
-- `crates/atm-core/src/send/mod.rs::append_mailbox_message_and_seed_workflow(...)`
+- `crates/atm-core/src/send/mod.rs::persist_message_and_seed_workflow(...)`
 - callers:
   - normal send path
   - missing-config notice path
@@ -20,55 +20,65 @@ Behavior:
 
 - load the current mailbox projection from SQLite metadata/records
 - prepare threading/supersede state against that projected mailbox
-- rewrite the full compatibility inbox file through
-  `mailbox::store::write_compat_mailbox_projection(...)`
 - mirror the new message into the SQLite store
 - persist workflow state in the same coordinated write block
+- trigger a post-commit runtime-owned compatibility refresh through
+  `crates/atm-core/src/service_runtime.rs::refresh_compat_inbox_projection(...)`
 
 Current assessment:
 
-- this is a direct command-layer compatibility inbox write path
-- this path should not survive the final Phase `Y` boundary
+- this is no longer a direct command-layer compatibility rewrite path
+- command code now owns SQLite/workflow persistence only and reaches the
+  compatibility writer through the retained runtime refresh owner
 
 ### Path B — Command Ack Reply Path
 
 Code:
 
 - `crates/atm-core/src/ack/mod.rs`
-- reply emission calls `append_mailbox_message_and_seed_workflow(...)`
+- reply emission calls `persist_message_and_seed_workflow(...)`
 
 Behavior:
 
 - update the acked message state in SQLite
-- emit the reply message through the same compatibility inbox rewrite helper
-  used by send
+- emit the reply message through the same narrowed persistence helper used by
+  send
+- do not rewrite the original source inbox merely because ack state changed
 
 Current assessment:
 
-- this is not a separate low-level writer, but it is a separate production
-  command path that can trigger a compatibility inbox rewrite
-- this path should not survive the final Phase `Y` boundary
+- this is not a separate low-level writer
+- the surviving behavior is the send-shaped reply append, not a source-inbox
+  state rewrite path
 
 ### Path C — Compatibility Export / Source Projection Path
 
 Code:
 
-- `crates/atm-core/src/boundary_support.rs::export_source_files(...)`
-- `crates/atm-core/src/mailbox/mod.rs::export_compat_source_projections(...)`
-- `crates/atm-core/src/mailbox/store.rs::write_compat_source_projections(...)`
+- `crates/atm-core/src/service_runtime.rs::refresh_compat_inbox_projection(...)`
+- `crates/atm-core/src/direct_boundaries.rs::reexport_messages(...)`
+- `crates/atm-core/src/boundary_support.rs::reexport_messages(...)`
+- `crates/atm-core/src/mailbox/mod.rs::export_compat_mailbox_projection(...)`
 - `crates/atm-core/src/mailbox/store.rs::write_compat_mailbox_projection(...)`
+- repair/rebuild path retained separately:
+  - `crates/atm-core/src/boundary_support.rs::export_source_files(...)`
+  - `crates/atm-core/src/mailbox/mod.rs::export_compat_source_projections(...)`
+  - `crates/atm-core/src/mailbox/store.rs::write_compat_source_projections(...)`
 
 Behavior:
 
-- accept already-loaded source projections
-- write the compatibility inbox projection through the mailbox owner layer
+- normal runtime flow:
+  - reload immutable stored envelopes from SQLite
+  - rewrite one compatibility inbox projection through the mailbox owner layer
+- repair/rebuild flow:
+  - accept already-loaded source projections
+  - write compatibility projections through the same mailbox owner layer
 
 Current assessment:
 
-- this is the path that most closely matches the intended daemon-private
-  watcher/import/export ownership model
-- this is the best candidate to survive as the sole normal runtime writer
-  shape after boundary cleanup
+- `refresh_compat_inbox_projection(...) -> reexport_messages(...)` is the sole
+  normal runtime compatibility writer shape after `Y.3`
+- `export_source_files(...)` survives only as the explicit repair/rebuild owner
 
 ### Path D — Team-Admin Inbox Creation Path
 
@@ -115,16 +125,17 @@ Current assessment:
 
 ## 2. Current Write Semantics
 
-- ATM-authored compatibility inbox writes are currently full-file atomic
+- before `Y.6`, ATM-authored compatibility inbox writes were full-file atomic
   rewrites, not append-only writes
-- the current writer emits one JSON array document, not one appended JSONL
-  record per write
-- workflow + mailbox writes are still lock-coordinated through
-  `workflow::commit_workflow_state(...)`
-- the low-level Claude-surface writer is `mailbox::atomic::write_messages(...)`,
-  which serializes the full mailbox projection and atomically replaces the file
-- with the current array-shaped wire format, append-only lock-free writes are
-  not available without a compatibility-contract change
+- after `Y.6`, normal retained Claude Code compatibility output appends one
+  JSONL record at a time through `mailbox::atomic::append_message(...)`
+- explicit repair/rebuild flows and first-write legacy-array migration still
+  use the staged rewrite/re-export path
+- workflow + mailbox writes no longer keep normal runtime compatibility output
+  on the hot rewrite path; the durable SQLite/workflow step happens first and
+  the compatibility append follows afterward
+- the low-level Claude-surface rewrite helper `mailbox::atomic::write_messages(...)`
+  now survives only for explicit repair/rebuild and legacy-array migration
 
 ## 3. Agreed Phase Y Runtime Rules
 
@@ -162,7 +173,7 @@ Current assessment:
 
 ## 4. Final Allowed Write Classes
 
-Phase `Y` should converge on only these approved ATM-authored Claude-inbox
+Phase `Y` converges on only these approved ATM-authored Claude-inbox
 write classes:
 
 1. append one message to a Claude Code inbox
@@ -185,64 +196,71 @@ write classes:
 
 1. Send command compatibility rewrite stack
    - caller: `crates/atm-core/src/send/mod.rs:280`
-     - `append_mailbox_message_and_seed_workflow(...)`
-     - status: delete command ownership in `Y.3`
-   - missing-config caller: `crates/atm-core/src/send/mod.rs:463`
-     - `append_mailbox_message_and_seed_workflow(...)`
-     - status: delete command ownership in `Y.3`
-   - shared helper: `crates/atm-core/src/send/mod.rs:482`
-     - `append_mailbox_message_and_seed_workflow(...)`
-     - status: delete or reduce to pure SQLite/workflow helper in `Y.3`
-   - projection loader: `crates/atm-core/src/send/mod.rs:516`
+     - `persist_message_and_seed_workflow(...)`
+     - status: direct compatibility rewrite removed in `Y.3`
+   - missing-config caller: `crates/atm-core/src/send/mod.rs:464`
+     - `persist_message_and_seed_workflow(...)`
+     - status: direct compatibility rewrite removed in `Y.3`
+   - shared helper: `crates/atm-core/src/send/mod.rs:483`
+     - `persist_message_and_seed_workflow(...)`
+     - status: narrowed to SQLite/workflow persistence plus post-commit runtime refresh in `Y.3`
+   - projection loader: `crates/atm-core/src/send/mod.rs:517`
      - `load_store_backed_mailbox_projection(...)`
-     - status: delete from the runtime write stack in `Y.3`; retain only if a
-       non-write read/projection use remains justified separately
-   - SQLite mirror helper: `crates/atm-core/src/send/mod.rs:548`
+     - status: retained only as send-side read/projection input for thread preparation
+   - SQLite mirror helper: `crates/atm-core/src/send/mod.rs:549`
      - `mirror_message_to_store(...)`
-     - status: retain or move as SQLite-only persistence helper after inbox
-       rewrite ownership is removed
+     - status: retained as SQLite-only persistence helper after inbox rewrite
+       ownership removal
    - lock owner: `crates/atm-core/src/workflow.rs:166`
      - `commit_workflow_state(...)`
      - status: remove inbox-file ownership from this stack in `Y.3`
+   - runtime refresh owner: `crates/atm-core/src/service_runtime.rs:51`
+     - `refresh_compat_inbox_projection(...)`
+     - status: retained as the sole normal runtime compatibility rewrite owner
+   - runtime projection loader: `crates/atm-core/src/service_runtime.rs:192`
+     - `load_store_backed_mailbox_projection(...)`
+     - status: retained behind runtime refresh owner; loads immutable stored envelopes
    - mailbox projection writer: `crates/atm-core/src/mailbox/store.rs:19`
      - `write_compat_mailbox_projection(...)`
-     - status: command stack must stop calling this in `Y.3`
+     - status: retained in `Y.6` for repair/rebuild use only; not reachable
+       from normal runtime send or ack paths
    - mailbox projection policy helper: `crates/atm-core/src/mailbox/store.rs:27`
      - `write_compat_mailbox_projection_with_policy(...)`
-     - status: command stack must stop reaching this helper through mailbox
-       projection writes in `Y.3`
+     - status: retained in `Y.6` for repair/rebuild use only; not reachable
+       from normal runtime send or ack paths
    - low-level serializer: `crates/atm-core/src/mailbox/atomic.rs:28`
      - `write_messages(...)`
-     - status: retained only behind the surviving owner boundary or deleted in
-       `Y.6` if append-only cutover replaces array rewrite
+     - status: retained in `Y.6` for repair/rebuild use only; not reachable
+       from normal runtime send or ack paths
 
 2. Ack reply compatibility rewrite stack
-   - caller: `crates/atm-core/src/ack/mod.rs:391`
-     - `append_mailbox_message_and_seed_workflow(...)`
-     - status: delete command ownership in `Y.3`
-   - shared helper: `crates/atm-core/src/send/mod.rs:482`
-     - `append_mailbox_message_and_seed_workflow(...)`
-     - status: same removal target as send path
-   - projection loader: `crates/atm-core/src/send/mod.rs:516`
+   - caller: `crates/atm-core/src/ack/mod.rs:347`
+     - `persist_message_and_seed_workflow(...)`
+     - status: retained only for send-shaped reply append in `Y.3`
+   - shared helper: `crates/atm-core/src/send/mod.rs:483`
+     - `persist_message_and_seed_workflow(...)`
+     - status: same narrowed helper as send path
+   - projection loader: `crates/atm-core/src/send/mod.rs:517`
      - `load_store_backed_mailbox_projection(...)`
-     - status: same removal target as send path
-   - SQLite mirror helper: `crates/atm-core/src/send/mod.rs:548`
+     - status: same retained send-side read/projection input as send path
+   - SQLite mirror helper: `crates/atm-core/src/send/mod.rs:549`
      - `mirror_message_to_store(...)`
      - status: same retention/move target as send path
    - lock owner: `crates/atm-core/src/workflow.rs:166`
      - `commit_workflow_state(...)`
-     - status: remove inbox-file ownership from this stack in `Y.3`
+     - status: ack reply path no longer gives this stack inbox-file ownership in `Y.3`
    - mailbox projection writer: `crates/atm-core/src/mailbox/store.rs:19`
      - `write_compat_mailbox_projection(...)`
-     - status: ack stack must stop calling this in `Y.3`
+     - status: ack stack no longer reaches this directly in `Y.3`; retained in
+       `Y.6` for repair/rebuild use only
    - mailbox projection policy helper: `crates/atm-core/src/mailbox/store.rs:27`
      - `write_compat_mailbox_projection_with_policy(...)`
-     - status: ack stack must stop reaching this helper through mailbox
-       projection writes in `Y.3`
+     - status: ack stack no longer reaches this directly in `Y.3`; retained in
+       `Y.6` for repair/rebuild use only
    - low-level serializer: `crates/atm-core/src/mailbox/atomic.rs:28`
      - `write_messages(...)`
-     - status: retained only behind surviving owner boundary or deleted in
-       `Y.6`
+     - status: retained in `Y.6` for repair/rebuild use only; not reachable
+       from normal runtime send or ack paths
 
 ### Retain Behind One Owned Boundary
 
@@ -261,10 +279,12 @@ write classes:
      - status: retain behind one owner in `Y.3`; reevaluate in `Y.6`
    - mailbox projection policy helper: `crates/atm-core/src/mailbox/store.rs:27`
      - `write_compat_mailbox_projection_with_policy(...)`
-     - status: retain only behind the sole runtime owner until `Y.6`
+     - status: retained in `Y.6` for repair/rebuild use only; not reachable
+       from normal runtime send or ack paths
    - low-level serializer: `crates/atm-core/src/mailbox/atomic.rs:28`
      - `write_messages(...)`
-     - status: retained only until append-only cutover lands
+     - status: retained in `Y.6` for repair/rebuild use only; not reachable
+       from normal runtime send or ack paths
 
 ### Retain As Notification / Fallback Side-Effect Stack
 
@@ -347,7 +367,7 @@ consistent with the sampled implementation branch.
 Production caller census used for this audit:
 
 ```bash
-rg -n "append_mailbox_message_and_seed_workflow|write_compat_mailbox_projection\\(|write_compat_mailbox_projection_with_policy\\(|write_compat_source_projections\\(|export_source_files\\(|reexport_messages\\(|ensure_inbox_exists\\(|write_team_config\\(|maybe_run_post_send_hook\\(|execute_post_send_hook\\(" \
+rg -n "persist_message_and_seed_workflow|refresh_compat_inbox_projection|write_compat_mailbox_projection\\(|write_compat_mailbox_projection_with_policy\\(|write_compat_source_projections\\(|export_source_files\\(|reexport_messages\\(|ensure_inbox_exists\\(|write_team_config\\(|maybe_run_post_send_hook\\(|execute_post_send_hook\\(" \
   crates/atm-core/src
 ```
 
@@ -374,9 +394,10 @@ Normal runtime completion rule for `Y.3`:
 
 - after command-owned rewrite removal, the same caller census must show no
   `send` or `ack` production path reaching:
-  - `append_mailbox_message_and_seed_workflow(...)`
-  - `write_compat_mailbox_projection(...)`
-  - `write_compat_mailbox_projection_with_policy(...)`
+  - `write_compat_mailbox_projection(...)` except through
+    `refresh_compat_inbox_projection(...)`
+  - `write_compat_mailbox_projection_with_policy(...)` except through
+    `refresh_compat_inbox_projection(...)`
 - `crates/atm-core/src/team_admin/restore.rs:450`
   - `apply_restored_inboxes(...)`
   - status: retain as bulk inbox rebuild/install owner

--- a/docs/phase-Y/sprint-Y1.md
+++ b/docs/phase-Y/sprint-Y1.md
@@ -1,7 +1,7 @@
 ---
 id: Y.1
 title: ATM Help And UX Improvements
-status: planned
+status: complete
 branch: feature/pY-s1-atm-help-and-ux
 worktree: ../atm-core-worktrees/feature/pY-s1-atm-help-and-ux
 target: integrate/phase-Y
@@ -98,3 +98,9 @@ target: integrate/phase-Y
 - `cargo build --workspace`
 - `cargo test --workspace`
 - `git diff --check`
+
+## Deferred Y.2 UX Items
+
+- add worked troubleshooting examples for post-send hook authoring and failure diagnosis
+- expand identity/actor/team override examples for operator-facing help
+- expand skills-topic examples for team workflow guidance without broadening CLI surface area

--- a/docs/phase-Y/sprint-Y2.md
+++ b/docs/phase-Y/sprint-Y2.md
@@ -1,7 +1,7 @@
 ---
 id: Y.2
 title: Pre-Smoke Easy Fixes And Validation
-status: planned
+status: complete
 branch: feature/pY-s2-pre-smoke-easy-fixes
 worktree: ../atm-core-worktrees/feature/pY-s2-pre-smoke-easy-fixes
 target: integrate/phase-Y
@@ -27,27 +27,35 @@ target: integrate/phase-Y
 
 ## Exact Targets
 
-- implementation files owned by the approved `Y.2` easy-fix set
-- user-facing docs touched by those easy fixes
+- `crates/atm/src/commands/help.rs`
+- `docs/phase-Y/help.md`
+- `docs/atm/commands/help.md`
 - `docs/phase-Y/sprint-Y2.md`
 - `docs/project-plan.md`
 
 ## Required Work
 
-- land only small, approved pre-smoke fixes
+- complete the explicitly deferred `Y.1` tier-2 help follow-ups only:
+  - add worked `hooks` authoring/troubleshooting examples
+  - add operator-facing `identity` precedence and override examples
+  - add `skills` workflow examples while keeping harness-vs-model boundaries explicit
 - keep scope tight enough that `Y.3` still owns the first serious
   compatibility-write boundary refactor
 - validate that `Y.1` and `Y.2` together do not change the working inbox wire
   contract accidentally
 - record any larger architectural leftovers for `Y.3+` instead of absorbing
   them here
+- do not introduce JSON input work, compatibility writer changes, or boundary
+  refactors in this sprint
 
 ## Acceptance Criteria
 
-- only explicitly approved easy fixes land
+- only the approved tier-2 help/UX easy fixes land
 - no accidental compatibility-inbox format change is introduced
 - larger boundary work remains queued for `Y.3` rather than partially started
   here
+- the three tier-2 topics no longer contain `Y.2 will ...` placeholder language
+- the docs clearly record that `Y.2` completed the deferred `Y.1` help follow-ups
 
 ## Required Validation
 

--- a/docs/phase-Y/sprint-Y3.md
+++ b/docs/phase-Y/sprint-Y3.md
@@ -1,7 +1,7 @@
 ---
 id: Y.3
 title: Hard Write-Boundary Consolidation
-status: planned
+status: complete
 branch: feature/pY-s3-hard-write-boundary-consolidation
 worktree: ../atm-core-worktrees/feature/pY-s3-hard-write-boundary-consolidation
 target: integrate/phase-Y
@@ -53,7 +53,7 @@ before append-only work or smoke testing begins.
 ## Hard Dependencies
 
 - `docs/phase-Y/inbox-write-path-audit.md`
-- the current `feature/pY-trivial-fixes` call stacks sampled in that audit
+- the current sampled implementation call stacks recorded in that audit
 
 ## Non-Goals
 
@@ -69,10 +69,10 @@ before append-only work or smoke testing begins.
 Development work:
 - remove direct compatibility inbox ownership from:
   - `crates/atm-core/src/send/mod.rs:280`
-  - `crates/atm-core/src/send/mod.rs:463`
-  - `crates/atm-core/src/ack/mod.rs:391`
-- delete or narrow the shared helper at:
-  - `crates/atm-core/src/send/mod.rs:482`
+  - `crates/atm-core/src/send/mod.rs:464`
+  - `crates/atm-core/src/ack/mod.rs:347`
+- narrow the shared helper at:
+  - `crates/atm-core/src/send/mod.rs:483`
 - ensure `crates/atm-core/src/workflow.rs:166` no longer coordinates mailbox
   file writes for normal runtime send/ack
 
@@ -133,27 +133,33 @@ Keep/delete/move decisions are authoritative and must be traced by file,
 function, and line number.
 
 - `crates/atm-core/src/send/mod.rs:280`
-  - `append_mailbox_message_and_seed_workflow(...)`
-  - decision: delete command ownership
-- `crates/atm-core/src/send/mod.rs:463`
-  - `append_mailbox_message_and_seed_workflow(...)`
-  - decision: delete command ownership
-- `crates/atm-core/src/ack/mod.rs:391`
-  - `append_mailbox_message_and_seed_workflow(...)`
-  - decision: delete command ownership
-- `crates/atm-core/src/send/mod.rs:482`
-  - `append_mailbox_message_and_seed_workflow(...)`
-  - decision: delete or narrow to non-compatibility persistence only
-- `crates/atm-core/src/send/mod.rs:516`
+  - `persist_message_and_seed_workflow(...)`
+  - decision: direct compatibility rewrite deleted; post-commit runtime refresh only
+- `crates/atm-core/src/send/mod.rs:464`
+  - `persist_message_and_seed_workflow(...)`
+  - decision: direct compatibility rewrite deleted; post-commit runtime refresh only
+- `crates/atm-core/src/ack/mod.rs:347`
+  - `persist_message_and_seed_workflow(...)`
+  - decision: reply emission retained as send-shaped persistence only
+- `crates/atm-core/src/send/mod.rs:483`
+  - `persist_message_and_seed_workflow(...)`
+  - decision: narrowed to SQLite/workflow persistence plus post-commit runtime refresh
+- `crates/atm-core/src/send/mod.rs:517`
   - `load_store_backed_mailbox_projection(...)`
   - decision: remove from the runtime write stack unless a separate read-only
     projection use remains justified
-- `crates/atm-core/src/send/mod.rs:548`
+- `crates/atm-core/src/send/mod.rs:549`
   - `mirror_message_to_store(...)`
   - decision: retain or move as SQLite-only persistence helper
 - `crates/atm-core/src/workflow.rs:166`
   - `commit_workflow_state(...)`
   - decision: stop coordinating normal runtime inbox-file writes
+- `crates/atm-core/src/service_runtime.rs:51`
+  - `refresh_compat_inbox_projection(...)`
+  - decision: retain as the sole normal runtime compatibility rewrite owner
+- `crates/atm-core/src/service_runtime.rs:192`
+  - `load_store_backed_mailbox_projection(...)`
+  - decision: retain behind the runtime refresh owner and load immutable stored envelopes
 - `crates/atm-core/src/mailbox/store.rs:19`
   - `write_compat_mailbox_projection(...)`
   - decision: retain for repair/rebuild only after Y.3
@@ -238,5 +244,16 @@ second, but do not leave the repo in a mixed command-owned state between them.
 
 - this sprint must not invent a second runtime writer under a different name
 - keep harness gating explicit; model-based branching is incorrect
+
+## Completion Notes
+
+- normal `send` and missing-config notice flows now persist SQLite/workflow
+  state first and reach compatibility rewrite only through
+  `RetainedServiceRuntime::refresh_compat_inbox_projection(...)`
+- `ack` no longer owns source-inbox compatibility rewrites; only reply emission
+  reuses the narrowed send-shaped persistence helper
+- `clear` remains SQLite/state-only and does not own a compatibility rewrite
+- the retained runtime refresh path now exports immutable stored envelopes so
+  post-send state transitions do not rewrite prior compatibility message state
 - if an old dependency appears, remove or document it now rather than preserving
   it silently for later

--- a/docs/phase-Y/sprint-Y4.md
+++ b/docs/phase-Y/sprint-Y4.md
@@ -1,7 +1,7 @@
 ---
 id: Y.4
 title: Delivery Coordinator And Event-Family State Machines
-status: planned
+status: complete
 branch: feature/pY-s4-delivery-coordinator-and-state-machines
 worktree: ../atm-core-worktrees/feature/pY-s4-delivery-coordinator-and-state-machines
 target: integrate/phase-Y
@@ -26,6 +26,25 @@ command and daemon code.
 - land explicit enums and transition tables for every required write-affecting
   event family before any implementation-specific simplification is considered
 - make state transitions observable and QA-auditable
+
+## Completion Notes
+
+- complete on `feature/pY-s4-delivery-coordinator-and-state-machines`
+- retained send/ack delivery routing now resolves a copied roster snapshot
+  through `crates/atm-core/src/delivery_policy.rs`
+- retained send/ack compatibility rewrites now route through one coordinator
+  decision:
+  - `Claude Code` harness keeps compatibility export
+  - non-Claude harness skips ATM-authored JSONL export
+- post-send hook dispatch now receives `recipient_pane_id` from the roster
+  snapshot when present
+- the explicit event-family/state-machine inventory now exists in code and
+  targeted tests under `crates/atm-core/src/delivery_policy.rs`
+- one transitional compatibility rule remains explicit in code and docs:
+  - when no canonical roster row exists yet for the recipient, the
+    coordinator falls back to `Claude Code` compatibility behavior to preserve
+    retained CLI compatibility until roster hydration is guaranteed on every
+    active path
 
 ## Governing Requirements
 

--- a/docs/phase-Y/sprint-Y5.md
+++ b/docs/phase-Y/sprint-Y5.md
@@ -1,7 +1,7 @@
 ---
 id: Y.5
 title: Mutable Compatibility-Field Removal And Dependency Exposure
-status: planned
+status: complete
 branch: feature/pY-s5-mutable-compatibility-field-removal
 worktree: ../atm-core-worktrees/feature/pY-s5-mutable-compatibility-field-removal
 target: integrate/phase-Y
@@ -122,3 +122,22 @@ whole point of `Y.5` is to expose hidden dependencies immediately.
 
 - “temporarily keep it” is usually how obsolete logic survives release prep
 - remove the data first; let the failures show you what still needs deletion
+
+## Completion Notes
+
+- complete on `feature/pY-s5-mutable-compatibility-field-removal`
+- compatibility export now keeps only:
+  - `message_id`
+  - `parentMessageId`
+  - `threadMode`
+  - `taskId`
+- compatibility export now strips:
+  - `source_team`
+  - `pendingAckAt`
+  - `acknowledgedAt`
+  - `acknowledgesMessageId`
+  - `expiresAt`
+  - `metadata.atm.*`
+- retained compatibility export now reloads stored message records instead of
+  workflow-joined projected envelopes so removed workflow fields cannot leak
+  back in through export joins

--- a/docs/phase-Y/sprint-Y6.md
+++ b/docs/phase-Y/sprint-Y6.md
@@ -1,7 +1,7 @@
 ---
 id: Y.6
 title: Append-Only Compatibility Export Cutover
-status: planned
+status: complete
 branch: feature/pY-s6-append-only-compatibility-export
 worktree: ../atm-core-worktrees/feature/pY-s6-append-only-compatibility-export
 target: integrate/phase-Y
@@ -14,6 +14,22 @@ target: integrate/phase-Y
 If the approved wire contract allows it, replace array-style compatibility
 rewrites with append-only Claude-Code-compatible output and eliminate normal
 runtime lock dependence on inbox-file rewrites.
+
+## Current Status
+
+- complete on `feature/pY-s6-append-only-compatibility-export`
+- normal retained Claude Code compatibility writes now append one JSONL record
+  at a time after the durable SQLite/workflow step succeeds
+- non-Claude harnesses still never receive ATM-authored JSONL append output
+- legacy array inboxes are migrated through explicit rebuild/re-export the
+  first time the retained runtime encounters them
+- SQLite failure now follows the approved degraded outward-delivery contract:
+  - Claude Code harnesses append the original message plus an
+    `atm-system@<team>` companion error message
+  - non-Claude harnesses skip JSONL append but still emit the mirrored
+    companion nudge plan
+- append degradation after successful SQLite persistence stays on the
+  post-send-hook fallback path
 
 ## Scope Summary
 

--- a/docs/phase-Y/state-diagrams.md
+++ b/docs/phase-Y/state-diagrams.md
@@ -11,6 +11,9 @@ Source of truth:
 Generation:
 - `python3 docs/reports/generate_diagram_pages.py`
 
+Current implementation seam:
+- `crates/atm-core/src/delivery_policy.rs`
+
 Diagrams:
 - coordinator:
   [delivery-policy-coordinator.mmd](./delivery-policy-coordinator.mmd)

--- a/docs/phase-Y/state-machine-coverage-audit.md
+++ b/docs/phase-Y/state-machine-coverage-audit.md
@@ -95,6 +95,12 @@ Current gap notes:
   - ack-reply legality and delegated reply-delivery flow
   - inbox-repair staged rebuild flow
   - restore-inbox-rebuild staged publish flow
+- `Y.4` code now lands the matching retained-command coordinator/state-machine
+  seam in:
+  - `crates/atm-core/src/delivery_policy.rs`
+  - `crates/atm-core/src/service_runtime.rs`
+  - `crates/atm-core/src/send/mod.rs`
+  - `crates/atm-core/src/ack/mod.rs`
 
 ## 3. SQLite Query Diagrams Already Documented
 

--- a/docs/phase-Yb/lintable-boundary-plan.md
+++ b/docs/phase-Yb/lintable-boundary-plan.md
@@ -67,6 +67,9 @@ Rules:
 1. concrete daemon adapters remain `pub(crate)` only
 2. state-machine-owned output types live in `atm_core::delivery_plan`
 3. outer callers receive typed plans, not direct writer handles
+4. delivery-target construction and transition translation live only in:
+   - `atm_core::delivery_plan`
+   - `atm_core::delivery_execution`
 
 ### 2. `sc-lint` / boundary rules
 
@@ -75,24 +78,54 @@ Enforcement point:
 - boundary TOML allowlists plus `python3 .just/run_lint.py all`
 - rule families owned by `sc_lint_boundary`
 
+Primitive caller allowlist:
+
+| Primitive | Approved callers | Enforcement stance |
+| --- | --- | --- |
+| `RetainedServiceRuntime::append_compat_inbox_message(...)` | `atm_core::delivery_execution::ClaudeInboxWriter` | `LINT-BOUNDARY-INBOX-EXPORT-REFERENCES` plus runtime fail-closed checks |
+| `mailbox::store::append_compat_mailbox_message(...)` | `atm_core::service_runtime::RetainedServiceRuntime::append_compat_inbox_message(...)` | internal implementation detail below the Claude executor seam |
+| `RetainedServiceRuntime::deliver_non_claude_payloads(...)` | `atm_core::delivery_execution::NonClaudeOutboundDeliveryWriter` | `LINT-BOUNDARY-NON-CLAUDE-OUTBOUND-REFERENCES` |
+| `atm_core::boundary::NonClaudeOutbound::deliver_payloads(...)` | `atm_core::service_runtime::RetainedServiceRuntime::deliver_non_claude_payloads(...)` | daemon/runtime adapter seam only |
+| `RetainedServiceRuntime::maybe_run_post_send_hook(...)` | `atm_core::delivery_execution::PostSendNotificationExecutor` | notification-only seam; not accepted as delivery proof |
+| `send::hook::maybe_run_post_send_hook(...)` | `atm_core::service_runtime::LocalServiceRuntime` | pub(crate) required — caller is outside the send/ module; pub(super) would break the cross-module RetainedServiceRuntime trait-impl call pattern (introduced Y.8, documented Y.12) |
+| `mailbox::store::write_compat_mailbox_projection(...)` | explicit repair/rebuild-only seams | runtime delivery path forbidden |
+| `direct_boundaries::reexport_messages(...)` | explicit repair/rebuild-only seams | runtime delivery path forbidden |
+
 1. only the approved Claude executor module may call:
    - `RetainedServiceRuntime::append_compat_inbox_message(...)`
    - `mailbox::store::append_compat_mailbox_message(...)`
+   - approved owner:
+     `atm_core::delivery_execution::ClaudeInboxWriter`
 2. only the approved non-Claude executor module may call:
    - `atm_core::boundary::NonClaudeOutbound`
-2. only approved repair/rebuild modules may call:
+   - approved owner:
+     `atm_core::delivery_execution::NonClaudeOutboundDeliveryWriter`
+3. only approved repair/rebuild modules may call:
    - `mailbox::store::write_compat_mailbox_projection(...)`
    - `direct_boundaries::reexport_messages(...)`
-3. `send/persistence.rs` must not call:
+   - approved owners:
+     - `atm_core::service_runtime::RetainedServiceRuntime::rebuild_compat_inbox_projection(...)`
+     - `atm_core::direct_boundaries::reexport_messages(...)`
+     - `atm_daemon::boundary_adapters::DaemonInboxExport::reexport_message(...)`
+4. `send/persistence.rs` must not call:
    - any compatibility append/write primitive
    - any post-send notification primitive
-4. `send/mod.rs` and `ack/mod.rs` must not:
+5. `send/mod.rs` and `ack/mod.rs` must not:
    - branch on `DeliveryHarnessPath`
-   - branch on `allows_claude_jsonl_append()`
    - translate persistence dispositions into state-machine outcomes
-5. `send/hook.rs` must not:
+   - translate execution dispositions into transition names
+6. `send/hook.rs` must not:
    - accept full `MessageEnvelope` delivery authority
    - become a second outbound payload boundary
+7. `service_runtime::append_compat_inbox_message(...)` must:
+   - fail closed on legacy array mailboxes
+   - direct callers to the explicit repair/rebuild projection seam
+   - never trigger `direct_boundaries::reexport_messages(...)` from the normal
+     append-only runtime path
+8. the retained repair/rebuild refresh seam must not:
+   - accept `DeliveryHarnessPath::NonClaude` and silently no-op
+   - present a generic recipient-routed runtime helper shape when the allowed
+     ownership is actually repair/rebuild-only
 
 ### 3. Runtime fail-closed checks
 
@@ -107,6 +140,14 @@ Rules:
 2. a non-Claude-targeted plan fails closed if routed to `InboxExport`
 3. `NotificationSink` rejects any attempt to serve as the sole message-delivery
    proof surface
+4. append-degraded transition emission for `DeliveryHarnessPath::NonClaude`
+   fails closed inside `delivery_execution` because non-Claude append
+   degradation is not a valid runtime concept
+5. legacy array inboxes fail closed from the normal Claude append path and can
+   be rewritten only through the explicit repair/rebuild seam
+6. the retained Claude append seam fails closed before execution if a
+   `DeliveryHarnessPath::NonClaude` route is attempted; the low-level writer is
+   not itself the place where that route is supposed to be discovered
 
 ### Module-ownership documentation
 
@@ -126,6 +167,8 @@ Required shape:
 - execution modules:
   - perform payload delivery
   - perform notification
+  - translate typed delivery outcomes into transition emissions
+  - reject impossible target/execution combinations
 - repair modules:
   - perform rebuild/reexport only
 

--- a/docs/phase-Yb/message-path-call-stacks.md
+++ b/docs/phase-Yb/message-path-call-stacks.md
@@ -5,42 +5,42 @@ Baseline:
 - planning branch: `message-path-consolidation-plan-Yb`
 - implementation baseline under review: `integrate/phase-Y` at `b8785617`
 
-This document traces the current production call stacks that Yb must simplify
-or replace.
+This document records the current `Y.8` implementation seam after degraded
+delivery contract hardening and outer-policy cleanup landed on:
 
-## 1. New Message Success, Claude Harness
+- `feature/pYb-s7-degraded-delivery-contract-hardening`
+- `feature/pYb-s8-policy-cleanup-and-impossible-path-removal`
+
+## 1. Current Y.7 Stack: New Message Success, `DeliveryHarnessPath::ClaudeCode`
 
 Current stack:
 
 1. `crates/atm-core/src/send/mod.rs:190`
    - `send_mail_with_runtime_impl(...)`
-2. `crates/atm-core/src/send/mod.rs:369`
+2. `crates/atm-core/src/send/mod.rs:365`
    - `prepare_send_context(...)`
-3. `crates/atm-core/src/send/mod.rs:515`
+3. `crates/atm-core/src/send/mod.rs:511`
    - `persist_send_message(...)`
-4. `crates/atm-core/src/send/persistence.rs:19`
+4. `crates/atm-core/src/send/persistence.rs:17`
    - `persist_message_and_seed_workflow(...)`
-5. `crates/atm-core/src/send/persistence.rs:36`
-   - `runtime.commit_workflow_state(...)`
-6. `crates/atm-core/src/send/persistence.rs:51`
-   - `runtime.append_compat_inbox_message(...)`
-7. `crates/atm-core/src/service_runtime.rs:196`
-   - `append_compat_inbox_message(...)`
-8. `crates/atm-core/src/mailbox/store.rs:29`
-   - `append_compat_mailbox_message(...)`
-9. `crates/atm-core/src/send/mod.rs:238`
-   - `finalize_send_outcome(...)`
-10. `crates/atm-core/src/send/mod.rs:322`
-    - `run_send_post_send_hooks(...)`
-11. `crates/atm-core/src/send/hook.rs:57`
-    - `maybe_run_post_send_hook(...)`
+5. `runtime.commit_workflow_state(...)`
+6. `crates/atm-core/src/send/mod.rs:323`
+   - `build_send_delivery_plan(...)`
+7. `crates/atm-core/src/delivery_execution.rs:97`
+   - `execute_delivery_plan(...)`
+8. `crates/atm-core/src/delivery_execution.rs:188`
+   - `execute_claude_delivery(...)`
+9. `runtime.append_compat_inbox_message(...)`
+10. `crates/atm-core/src/delivery_execution.rs:175`
+    - shared notification execution
 
-Issue:
+Current ownership:
 
-- the outer send flow still owns post-persist notification branching and
-  transition emission
+- payload construction, delivery-target construction, execution, and
+  transition emission now all happen inside the typed plan/execution seam
+- outer send code supplies only command-local context and telemetry emission
 
-## 2. New Message Success, Non-Claude Harness
+## 2. Current Y.9 Stack: New Message Success, `DeliveryHarnessPath::NonClaude`
 
 Current stack:
 
@@ -49,44 +49,45 @@ Current stack:
 3. `persist_send_message(...)`
 4. `persist_message_and_seed_workflow(...)`
 5. `runtime.commit_workflow_state(...)`
-6. `runtime.append_compat_inbox_message(...)`
-7. `crates/atm-core/src/service_runtime.rs:202`
-   - immediate non-Claude no-op return
-8. `finalize_send_outcome(...)`
-9. `run_send_post_send_hooks(...)`
-10. `maybe_run_post_send_hook(...)`
+6. `build_send_delivery_plan(...)`
+7. `execute_delivery_plan(...)`
+8. `DeliveryTarget::NonClaude` selects
+   `NonClaudeOutboundDeliveryWriter::deliver_non_claude_payloads(...)`
+9. `RetainedServiceRuntime::deliver_non_claude_payloads(...)`
+10. `atm_core::boundary::NonClaudeOutbound::deliver_payloads(...)`
+11. shared notification execution
 
-Issue:
+Current ownership:
 
-- the non-Claude path shares the outer send flow, but the low-level Claude
-  writer silently no-ops instead of never being selected in the first place
+- the outer call graph is shared with the Claude path
+- the non-Claude path now emits a first-class typed payload request rather than
+  relying on post-send-hook metadata
+- notification remains a separate side effect after payload delivery
 
-## 3. SQLite Failure, Claude Harness
+## 3. Current Y.7 Stack: SQLite Failure, `DeliveryHarnessPath::ClaudeCode`
 
 Current stack:
 
 1. `persist_send_message(...)`
 2. `persist_message_and_seed_workflow(...)`
 3. `runtime.commit_workflow_state(...)` returns mailbox-write error
-4. `crates/atm-core/src/send/persistence.rs:72`
+4. `crates/atm-core/src/send/persistence.rs:57`
    - `recover_after_sqlite_failure(...)`
-5. `crates/atm-core/src/send/persistence.rs:85`
-   - `recipient.allows_claude_jsonl_append()`
-6. `crates/atm-core/src/send/persistence.rs:86`
-   - append original message directly
-7. `crates/atm-core/src/send/persistence.rs:87`
-   - append companion error directly
-8. `finalize_send_outcome(...)`
-9. `run_send_post_send_hooks(...)`
-10. original hook + companion hook path
+5. `recover_after_sqlite_failure(...)` constructs original + companion typed
+   payloads
+6. `build_send_delivery_plan(...)`
+7. `execute_delivery_plan(...)`
+8. `execute_claude_delivery(...)`
+9. original notification + companion notification via shared notification
+   executor
 
-Issue:
+Current ownership:
 
-- two outward deliveries happen inside persistence code
-- partial append is possible between steps 6 and 7
-- the contract is not atomic at the plan level
+- the degraded payload contract is explicit and symmetric
+- partial Claude append is an execution-level warning surface
+- transition ownership now lives with the shared execution seam
 
-## 4. SQLite Failure, Non-Claude Harness
+## 4. Current Y.9 Stack: SQLite Failure, `DeliveryHarnessPath::NonClaude`
 
 Current stack:
 
@@ -94,60 +95,91 @@ Current stack:
 2. `persist_message_and_seed_workflow(...)`
 3. `runtime.commit_workflow_state(...)` returns mailbox-write error
 4. `recover_after_sqlite_failure(...)`
-5. no outward payload delivery occurs in persistence
-6. `DeliveryPersistenceResult::sqlite_failed_recovered(...)`
-   returns `CompanionNudgePlan`
-7. `finalize_send_outcome(...)`
-8. `run_send_post_send_hooks(...)`
-9. original post-send hook + companion post-send hook
+5. persistence returns original + companion typed payloads in
+   `DeliveryPersistenceResult`
+6. `build_send_delivery_plan(...)`
+7. `execute_delivery_plan(...)`
+8. `DeliveryTarget::NonClaude` selects
+   `NonClaudeOutboundDeliveryWriter::deliver_non_claude_payloads(...)`
+9. `RetainedServiceRuntime::deliver_non_claude_payloads(...)`
+10. `atm_core::boundary::NonClaudeOutbound::deliver_payloads(...)` receives
+    the same logical `message[1]` / `message[2]` payload set as the Claude
+    path
+11. original notification + companion notification via shared notification
+    executor
 
-Issue:
+Current ownership:
 
-- the plan produces two hook invocations, not two explicitly delivered logical
-  messages
-- hook payloads are metadata only and therefore cannot prove identical payload
-  semantics with the Claude path
+- the typed degraded payload contract is identical across harness families
+- only the delivery target differs
+- post-send-hook execution remains notification-only and is not used as
+  delivery proof
 
-## 5. Append Degraded After SQLite Success
+## 5. Current Y.7 Stack: Append Degraded After SQLite Success
 
 Current stack:
 
 1. `persist_message_and_seed_workflow(...)`
 2. SQLite workflow commit succeeds
-3. `runtime.append_compat_inbox_message(...)` fails
-4. `DeliveryPersistenceResult::append_degraded(...)`
-5. `finalize_send_outcome(...)`
-6. `run_send_post_send_hooks(...)`
-7. `emit_delivery_transitions(...)`
-8. `append_failure_transition_names(...)`
+3. `build_send_delivery_plan(...)`
+4. `execute_delivery_plan(...)`
+5. `DeliveryExecutionResult::AppendDegraded`
+6. shared notification execution
+7. `delivery_execution::emit_delivery_plan_transitions(...)`
 
-Issue:
+Current ownership:
 
-- append degradation is translated in outer send code instead of being emitted
-  by the machine/executor that owns the actual path
+- execution degradation is executor-owned
+- impossible non-Claude append-degraded transition requests now fail closed in
+  `delivery_execution.rs`
 
-## 6. Ack Reply Delivery
+## 6. Current Y.7 Stack: Ack Reply Delivery
 
 Current stack:
 
 1. `crates/atm-core/src/ack/mod.rs:368`
    - `persist_ack_reply(...)`
 2. ack state persisted in SQLite
-3. `crates/atm-core/src/ack/mod.rs:416`
+3. `crates/atm-core/src/ack/mod.rs:417`
    - `persist_message_and_seed_workflow(...)`
-4. same new-message persistence and degraded-delivery logic as send
-5. `crates/atm-core/src/ack/mod.rs:442`
-   - `finalize_ack_outcome(...)`
-6. `crates/atm-core/src/ack/mod.rs:511`
-   - `collect_ack_hook_warnings(...)`
-7. original hook + optional companion hook
+4. shared persistence result seam returns typed payloads
+5. `crates/atm-core/src/ack/mod.rs:514`
+   - `AckReplyStateMachine::from_persistence(...)`
+6. `crates/atm-core/src/ack/mod.rs:545`
+   - `AckReplyStateMachine::into_reply_delivery_plan(...)`
+7. `crates/atm-core/src/delivery_execution.rs:119`
+   - `execute_reply_delivery_plan(...)`
+8. shared notification execution
 
-Issue:
+Current ownership:
 
-- ack reply still depends on the same shared degraded-delivery helper and the
-  same hook semantics, but through a separate outer call graph
+- ack reply shares the typed reply-plan seam
+- shared execution owns transition translation and fail-closed checks
 
-## 7. Required End-State
+## 7. Y.7 Closure Summary
+
+`Y.7` replaced persistence-owned degraded outward delivery with:
+
+- typed payload construction in `DeliveryPersistenceResult`
+- `DeliveryPlan` / `ReplyDeliveryPlan`
+- shared execution in `delivery_execution.rs`
+- explicit `crates/atm-core/src/ack/mod.rs::AckReplyStateMachine` ownership
+  for reply-plan construction
+
+Note:
+
+- `crates/atm-core/src/ack/mod.rs::AckReplyStateMachine` is the typed
+  reply-plan constructor seam
+- `crates/atm-core/src/delivery_policy.rs::AckReplyStateMachine` remains the
+  documented transition inventory
+
+`Y.9` finishes the non-Claude outbound payload boundary. `Y.10` still owns:
+
+- low-level repair/rebuild boundary cleanup
+
+Those remaining items are intentionally deferred to `Y.9` and `Y.10`.
+
+## 8. Required End-State
 
 After Yb:
 
@@ -164,6 +196,8 @@ Approved executor ownership:
 
 - `atm_core::delivery_execution::execute_delivery_plan(...)`
 - `atm_core::delivery_execution::execute_reply_delivery_plan(...)`
+- `atm_core::delivery_execution::emit_delivery_plan_transitions(...)`
+- `atm_core::delivery_execution::emit_reply_delivery_plan_transitions(...)`
 - `atm_core::delivery_execution::ClaudeInboxWriter`
   - introduced in `Y.7`
 - `atm_core::delivery_execution::PostSendNotificationExecutor`

--- a/docs/phase-Yb/plan-phase-Yb.md
+++ b/docs/phase-Yb/plan-phase-Yb.md
@@ -13,7 +13,7 @@ implementation.
 
 - planning branch: `message-path-consolidation-plan-Yb`
 - planning worktree:
-  `/Users/randlee/Documents/github/atm-core-worktrees/message-path-consolidation-plan-Yb`
+  `../atm-core-worktrees/message-path-consolidation-plan-Yb`
 - branch base: `develop` at `292b8e38`
 - implementation baseline under review:
   `integrate/phase-Y` at `b8785617`
@@ -242,6 +242,8 @@ message-path contract underspecified or implemented in the wrong layers:
 - `Y.9`: `DeliveryHarnessPath::NonClaude` outbound boundary formalization
 - `Y.10`: boundary enforcement, validation closure, and smoke-handoff
   preparation
+- `Y.11`: post-`Y.10` boundary gap closure for the two remaining mixed-seam
+  runtime entrypoints and the shared validation-doc drift
 - Later sprints as needed for migration, validation, and smoke/dogfood
 
 ## Sprint Sequence
@@ -320,6 +322,28 @@ Hard dependency:
 - [sprint-Y9.md](./sprint-Y9.md) must close first because Y.10 enforces the
   final caller allowlists only after the non-Claude boundary exists
 
+### Y.11 Post-Y.10 Boundary Gap Closure
+
+Purpose:
+
+- remove the last two mixed-seam runtime entrypoints discovered by the
+  sprint-plan-to-implementation review
+- make the repair/rebuild rewrite seam explicit by construction rather than by
+  internal harness guards
+- sync the shared validation docs to the actual outbound-boundary proof model
+- re-close the Yb implementation line only after those review findings are
+  resolved
+
+Authoritative sprint doc:
+
+- [sprint-Y11.md](./sprint-Y11.md)
+
+Hard dependency:
+
+- [sprint-Y10.md](./sprint-Y10.md) must close first because Y.11 is a focused
+  follow-up on the remaining Y.10/Y.9 seam mismatches rather than a new
+  independent implementation line
+
 ## Planning Outputs
 
 - [plan-phase-Yb.md](./plan-phase-Yb.md)
@@ -327,6 +351,7 @@ Hard dependency:
 - [sprint-Y8.md](./sprint-Y8.md)
 - [sprint-Y9.md](./sprint-Y9.md)
 - [sprint-Y10.md](./sprint-Y10.md)
+- [sprint-Y11.md](./sprint-Y11.md)
 - [removal-ledger.md](./removal-ledger.md)
 - [message-path-call-stacks.md](./message-path-call-stacks.md)
 - [lintable-boundary-plan.md](./lintable-boundary-plan.md)
@@ -343,4 +368,6 @@ Hard dependency:
   relevant
 - any newly discovered runtime path that violates the Yb contract is a
   blocking planning miss until documented
-- smoke/dogfood work must not resume until the Yb implementation line closes
+- smoke/dogfood work must not resume until the Yb implementation line closes,
+  including any post-review closure sprint required to remove reopened seam
+  issues

--- a/docs/phase-Yb/qa-handoff.md
+++ b/docs/phase-Yb/qa-handoff.md
@@ -70,10 +70,30 @@ For Y.7 and later, QA must verify named tests or test families for:
 
 ### 5. Phase-end closure
 
-Y.10 is not complete unless QA can prove:
+Final Yb closeout through Y.11 is not complete unless QA can prove:
 
 - all removal-ledger items are closed or explicitly tracked as blockers
 - only approved executor/coordinator modules can call the low-level delivery
   primitives
 - smoke/dogfood planning can resume without reopening Yb path-consolidation
   work
+- normal Claude append delivery fails closed on legacy array inboxes instead of
+  silently rewriting them through the rebuild seam
+- rebuild/reexport rewrite remains available only through the explicit
+  repair/rebuild boundary path
+- the low-level Claude append seam is never selected for
+  `DeliveryHarnessPath::NonClaude`
+- the repair/rebuild refresh seam is explicit by construction and not a generic
+  recipient-routed helper that silently ignores non-Claude requests
+
+#### Evidence mapping
+
+| Closure condition | Satisfying artifact |
+| --- | --- |
+| All removal-ledger items closed or tracked | `docs/phase-Yb/removal-ledger.md` — every row has a `closed-by` sprint entry or an explicit `BLOCKER` annotation |
+| Only approved executors call low-level delivery primitives | `docs/phase-Yb/lintable-boundary-plan.md` caller allowlist table; `python3 .just/run_lint.py all` passes |
+| Smoke/dogfood planning can resume | Sprint Y.11 closeout sign-off in `docs/phase-Yb/sprint-Y11.md` §Completion |
+| Claude append fails closed on legacy array inboxes | `service_runtime::tests::append_compat_inbox_message_rejects_legacy_array_mailbox_from_runtime_path` |
+| Rebuild/reexport only through explicit repair/rebuild path | `service_runtime::tests::rebuild_compat_inbox_projection_reexports_store_backed_mailbox`; lintable-boundary-plan allowlist row for `mailbox::store::write_compat_mailbox_projection` |
+| Claude append seam not selected for `DeliveryHarnessPath::NonClaude` | `delivery_execution` runtime fail-closed checks; lintable-boundary-plan §3 rule 6 |
+| Repair/rebuild seam is explicit, not a generic helper | `RetainedServiceRuntime::rebuild_compat_inbox_projection` scoped as repair-only seam; lintable-boundary-plan §2 rule 3 |

--- a/docs/phase-Yb/removal-ledger.md
+++ b/docs/phase-Yb/removal-ledger.md
@@ -39,6 +39,8 @@ corresponding implementation sprint starts.
 | `YB-RM-026` | `Y.7` | `crates/atm-core/src/ack/mod.rs` | 416 | `persist_message_and_seed_workflow` in `persist_ack_reply` | `Move` through reply delivery plan | `AckReplyStateMachine -> ReplyDeliveryPlan` | Ack reply must use the same shared execution model as new-message. |
 | `YB-RM-027` | `Y.7` | `crates/atm-core/src/ack/mod.rs` | 442 | `finalize_ack_outcome` | `Move` / narrow | `delivery_execution::execute_reply_delivery_plan(...)` | Ack should not own a second outer disposition-to-notification translation path. |
 | `YB-RM-028` | `Y.7` | `crates/atm-core/src/ack/mod.rs` | 511 | `collect_ack_hook_warnings` | `Move` behind shared executor boundary | `PostSendNotificationExecutor` | Ack path should not own separate notification logic shape. |
+| `YB-RM-029` | `Y.11` | `crates/atm-core/src/service_runtime.rs` | 238 | non-Claude no-op branch in `refresh_compat_inbox_projection` | `Delete` from mixed runtime seam | explicit Claude repair/rebuild seam only | The refresh seam must be repair/rebuild-only by construction, not a generic recipient-routed helper that silently ignores non-Claude requests. |
+| `YB-RM-030` | `Y.11` | `crates/atm-core/src/service_runtime.rs` | 259 | non-Claude validation branch in `append_compat_inbox_message` | `Delete` from low-level Claude writer | no call at all for non-Claude plans | The Claude append primitive must never be selected for `DeliveryHarnessPath::NonClaude`; rejecting that route inside the low-level writer still leaves policy at the wrong seam. |
 
 ## Keep Rules
 
@@ -56,3 +58,201 @@ What must not survive:
 - metadata-only hook invocation used as proof of message delivery
 - direct persistence-to-outward-delivery coupling
 - implicit fallback from unknown/missing roster data to Claude append
+
+## Y.7 Closure Notes
+
+`feature/pYb-s7-degraded-delivery-contract-hardening` closes the required
+`Y.7` rows by replacing persistence-owned delivery with typed plan/executor
+seams.
+
+Closed rows:
+
+- `YB-RM-001`
+- `YB-RM-002`
+- `YB-RM-003`
+- `YB-RM-004`
+- `YB-RM-005`
+- `YB-RM-008`
+- `YB-RM-026`
+- `YB-RM-027`
+- `YB-RM-028`
+
+Implemented seam on this branch:
+
+- [send/persistence.rs:17](../../crates/atm-core/src/send/persistence.rs)
+  now persists only and returns typed degraded payloads
+- [send/mod.rs:323](../../crates/atm-core/src/send/mod.rs)
+  builds `DeliveryPlan`
+- [delivery_execution.rs:97](../../crates/atm-core/src/delivery_execution.rs)
+  executes `DeliveryPlan`
+- [ack/mod.rs:514](../../crates/atm-core/src/ack/mod.rs)
+  routes reply delivery through
+  `crates/atm-core/src/ack/mod.rs::AckReplyStateMachine -> ReplyDeliveryPlan`
+
+Rows that remain intentionally open after `Y.7`:
+
+- `YB-RM-006` through `YB-RM-016`
+- `YB-RM-017` through `YB-RM-025`
+
+Those remaining rows are deferred to `Y.8` through `Y.10` exactly as assigned
+above; they are not regressions in `Y.7`.
+
+## Y.8 Closure Notes
+
+`feature/pYb-s8-policy-cleanup-and-impossible-path-removal` closes the
+required `Y.8` rows by moving target construction and transition translation
+out of outer send/ack callers and into `delivery_plan.rs` /
+`delivery_execution.rs`.
+
+Closed rows:
+
+- `YB-RM-006`
+- `YB-RM-007`
+- `YB-RM-009`
+- `YB-RM-010`
+- `YB-RM-011`
+
+Implemented seam on this branch:
+
+- `crates/atm-core/src/delivery_plan.rs`
+  - `delivery_target_for_snapshot(...)` now owns typed
+    `DeliveryTarget::{ClaudeCode,NonClaude}` construction
+- `crates/atm-core/src/delivery_execution.rs`
+  - `emit_delivery_plan_transitions(...)`
+  - `emit_reply_delivery_plan_transitions(...)`
+  - `validate_delivery_target(...)`
+- `crates/atm-core/src/send/mod.rs`
+  - no longer translates persistence/execution outcomes into transition names
+- `crates/atm-core/src/ack/mod.rs`
+  - no longer translates persistence/execution outcomes into transition names
+
+Rows that remain intentionally open after `Y.8`:
+
+- `YB-RM-012` through `YB-RM-016`
+- `YB-RM-017` through `YB-RM-025`
+
+Those remaining rows are deferred to `Y.9` and `Y.10` exactly as assigned
+above; they are not regressions in `Y.8`.
+
+## Y.9 Closure Notes
+
+`feature/pYb-s9-non-claude-outbound-boundary-formalization` closes the
+required `Y.9` rows by making non-Claude delivery a first-class payload
+boundary and removing the remaining fallback surfaces.
+
+Closed rows:
+
+- `YB-RM-012`
+- `YB-RM-013`
+- `YB-RM-014`
+- `YB-RM-015`
+- `YB-RM-016`
+- `YB-RM-019`
+
+Implemented seam on this branch:
+
+- [delivery_execution.rs:112](../../crates/atm-core/src/delivery_execution.rs)
+  now owns `NonClaudeOutboundDeliveryWriter`
+- [service_runtime.rs:295](../../crates/atm-core/src/service_runtime.rs)
+  now hands typed non-Claude payloads to
+  `atm_core::boundary::NonClaudeOutbound`
+- [non_claude_outbound_runtime.rs:14](../../crates/atm-daemon/src/non_claude_outbound_runtime.rs)
+  now provides the daemon-owned
+  `atm_daemon::non_claude_outbound_runtime::DaemonNonClaudeOutbound` adapter
+- [delivery_policy.rs:300](../../crates/atm-core/src/delivery_policy.rs)
+  now fails closed when roster-backed harness data is missing
+- [delivery_policy.rs:506](../../crates/atm-core/src/delivery_policy.rs)
+  now keeps append-degraded transitions Claude-only
+- [send/mod.rs:1538](../../crates/atm-core/src/send/mod.rs)
+  now proves non-Claude delivery through the outbound payload boundary rather
+  than through hook metadata alone
+
+Rows that remain intentionally open after `Y.9`:
+
+- `YB-RM-017`
+- `YB-RM-018`
+- `YB-RM-020`
+- `YB-RM-021`
+- `YB-RM-022`
+- `YB-RM-023`
+- `YB-RM-024`
+- `YB-RM-025`
+
+Those remaining rows are deferred to `Y.10` exactly as assigned above; they
+are not regressions in `Y.9`.
+
+## Y.10 Closure Notes
+
+`feature/pYb-s10-boundary-enforcement-and-smoke-handoff` closes the original
+`Y.10` rows by isolating full mailbox rewrite behind the explicit
+repair/rebuild seam and removing the last silent runtime fallback from append
+delivery into full re-export, but the post-sprint review reopened two
+mixed-seam runtime issues for follow-up in `Y.11`.
+
+Closed rows:
+
+- `YB-RM-017`
+- `YB-RM-018`
+- `YB-RM-020`
+- `YB-RM-021`
+- `YB-RM-022`
+- `YB-RM-023`
+- `YB-RM-024`
+- `YB-RM-025`
+
+Implemented seam on this branch:
+
+- `crates/atm-core/src/service_runtime.rs`
+  - `refresh_compat_inbox_projection(...)` remained the explicit
+    repair/rebuild-only rewrite seam
+  - `append_compat_inbox_message(...)` now fails closed on legacy array
+    inboxes instead of silently triggering full mailbox rewrite
+- `crates/atm-core/src/direct_boundaries.rs`
+  - `reexport_messages(...)` is now documented as repair/rebuild-only
+- `crates/atm-core/src/boundary_support.rs`
+  - `reexport_messages(...)` remains the low-level rebuild/write bridge only
+- `crates/atm-core/src/mailbox/mod.rs`
+  - `export_compat_mailbox_projection(...)` is now explicitly documented as
+    the repair/rebuild-only rewrite seam
+- `boundaries/atm-core/inbox-export.toml`
+  - final caller allowlists and repair/rebuild-only rewrite contract are
+    declared for the `InboxExport` boundary
+- `boundaries/atm-daemon/daemon-inbox-export.toml`
+  - final daemon adapter allowlists and repair/rebuild-only rewrite contract
+    are declared for the daemon `InboxExport` adapter
+
+Phase-end review after `Y.10` reopened two mixed-seam runtime issues:
+
+- `YB-RM-029`
+- `YB-RM-030`
+
+Those rows are assigned to `Y.11`. Yb is not fully closed until they are
+resolved.
+
+## Y.11 Closure Notes
+
+`feature/pYb-s11-y10-gap-closure` closes the reopened post-`Y.10` seam issues
+by tightening the retained runtime helper shapes to match the actual executor
+and repair/rebuild ownership model.
+
+Closed rows:
+
+- `YB-RM-029`
+- `YB-RM-030`
+
+Implemented seam on this branch:
+
+- `crates/atm-core/src/service_runtime.rs`
+  - `rebuild_compat_inbox_projection(...)` now requires explicit
+    `inbox_path` / `team` / `agent` inputs instead of a generic recipient
+    snapshot and no longer carries a non-Claude no-op branch
+  - `append_compat_inbox_message(...)` is now Claude-only by seam shape and no
+    longer contains a non-Claude rejection branch
+- `crates/atm-core/src/delivery_execution.rs`
+  - `ClaudeInboxWriter` now delegates to the narrowed Claude append seam
+    without route checking in the low-level runtime helper
+- `docs/phase-Yb/testing-and-validation.md`
+  - the shared validation matrix now names outbound-boundary proof instead of
+    the obsolete hook-path wording
+
+No Yb removal-ledger rows remain open after `Y.11`.

--- a/docs/phase-Yb/sprint-Y10.md
+++ b/docs/phase-Yb/sprint-Y10.md
@@ -1,7 +1,7 @@
 ---
 id: Y.10
 title: Boundary Enforcement And Smoke Handoff
-status: planned
+status: complete
 branch: feature/pYb-s10-boundary-enforcement-and-smoke-handoff
 worktree: ../atm-core-worktrees/feature/pYb-s10-boundary-enforcement-and-smoke-handoff
 target: integrate/phase-Yb
@@ -29,8 +29,8 @@ are verified.
 
 ## Exact Code And Document Targets
 
-- `boundaries/atm-core/non-claude-outbound.toml`
-- `boundaries/atm-daemon/daemon-non-claude-outbound.toml`
+- `boundaries/atm-core/inbox-export.toml`
+- `boundaries/atm-daemon/daemon-inbox-export.toml`
 - `docs/phase-Yb/removal-ledger.md`
 - `docs/phase-Yb/lintable-boundary-plan.md`
 - `docs/phase-Yb/qa-handoff.md`
@@ -76,3 +76,14 @@ cargo build --workspace
 cargo test --workspace
 git diff --check
 ```
+
+## Validation Record
+
+- branch closeout validated with:
+  - `cargo fmt --all --check`
+  - `python3 .just/run_lint.py all`
+  - `cargo build --workspace`
+  - `cargo test --workspace`
+  - `git diff --check`
+- post-sprint review reopened `YB-RM-029` and `YB-RM-030`; those are tracked
+  explicitly in `Y.11` rather than being silently ignored at `Y.10` closeout

--- a/docs/phase-Yb/sprint-Y11.md
+++ b/docs/phase-Yb/sprint-Y11.md
@@ -1,0 +1,111 @@
+---
+id: Y.11
+title: Post-Y.10 Boundary Gap Closure
+status: complete
+branch: feature/pYb-s11-y10-gap-closure
+worktree: ../atm-core-worktrees/feature/pYb-s11-y10-gap-closure
+target: integrate/phase-Yb
+---
+
+# Sprint Y.11 — Post-Y.10 Boundary Gap Closure
+
+## Goal
+
+Close the post-`Y.10` review findings by removing the last mixed-seam runtime
+entrypoints and syncing the final validation docs to the actual hardened
+message-path contract.
+
+## Hard Dependencies
+
+- `docs/phase-Yb/sprint-Y10.md` must be complete first
+- the `Y.10` implementation review findings are authoritative for this sprint:
+  - low-level Claude append seam still receives `DeliveryHarnessPath::NonClaude`
+    traffic and rejects it internally
+  - repair/rebuild refresh seam still accepts a general recipient snapshot and
+    silently no-ops for non-Claude requests
+  - shared validation docs still name the pre-`Y.9` hook-path proof instead of
+    the final outbound-boundary proof
+
+## Governing Requirements
+
+- `docs/phase-Yb/plan-phase-Yb.md`
+- `docs/phase-Yb/removal-ledger.md`
+- `docs/phase-Yb/lintable-boundary-plan.md`
+- `docs/phase-Yb/qa-handoff.md`
+- `docs/phase-Yb/testing-and-validation.md`
+- `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+
+## Exact Code And Document Targets
+
+- `crates/atm-core/src/service_runtime.rs`
+- `crates/atm-core/src/delivery_execution.rs`
+- `crates/atm-core/src/send/mod.rs`
+- `docs/phase-Yb/removal-ledger.md`
+- `docs/phase-Yb/lintable-boundary-plan.md`
+- `docs/phase-Yb/qa-handoff.md`
+- `docs/phase-Yb/testing-and-validation.md`
+- `docs/phase-Yb/plan-phase-Yb.md`
+- `docs/project-plan.md`
+
+## Required Work
+
+1. Delete the retained non-Claude rejection branch from
+   `RetainedServiceRuntime::append_compat_inbox_message(...)` so the low-level
+   Claude append seam is never selected for `DeliveryHarnessPath::NonClaude`.
+2. Narrow or replace `RetainedServiceRuntime::rebuild_compat_inbox_projection(...)`
+   so the repair/rebuild seam is explicit by construction and no longer accepts
+   a general `DeliveryRecipientSnapshot` plus a non-Claude no-op branch.
+3. Keep the low-level Claude append primitive executor-only and the rewrite
+   seam repair/rebuild-only, but make those seam contracts explicit in the
+   runtime trait shape and callers rather than in internal harness guards.
+4. Update named validation and QA docs so they refer to outbound-boundary proof
+   instead of the obsolete hook-path wording.
+5. Restate final Yb closure only after the reopened seam issues are actually
+   removed and the shared docs match the implemented boundary model.
+
+## Acceptance Criteria
+
+- `rg -n "append_compat_inbox_message is unsupported for non-Claude"
+  crates/atm-core/src` returns no matches
+- `rg -n "if !recipient\\.allows_claude_jsonl_append\\(\\)"
+  crates/atm-core/src/service_runtime.rs` returns no mixed-seam harness gating
+  in the retained append/refresh helpers
+- the sprint closes ledger rows:
+  - `YB-RM-029`
+  - `YB-RM-030`
+- low-level Claude append remains reachable only through
+  `atm_core::delivery_execution::ClaudeInboxWriter`
+- repair/rebuild rewrite remains reachable only through the explicit
+  repair/rebuild seam and not through a generic recipient-routed runtime helper
+- `docs/phase-Yb/testing-and-validation.md` no longer cites the obsolete
+  hook-path non-Claude proof name
+- final Yb closeout docs do not claim the line is complete until these reopened
+  issues are closed
+
+## Required Document Updates
+
+- `docs/phase-Yb/removal-ledger.md`
+- `docs/phase-Yb/lintable-boundary-plan.md`
+- `docs/phase-Yb/qa-handoff.md`
+- `docs/phase-Yb/testing-and-validation.md`
+- `docs/phase-Yb/plan-phase-Yb.md`
+- `docs/project-plan.md`
+
+## Required Validation
+
+```bash
+cargo fmt --all --check
+python3 .just/run_lint.py all
+cargo build --workspace
+cargo test --workspace
+git diff --check
+```
+
+## Validation Record
+
+- branch closeout validated with:
+  - `cargo fmt --all --check`
+  - `python3 .just/run_lint.py all`
+  - `cargo build --workspace`
+  - `cargo test --workspace`
+  - `git diff --check`

--- a/docs/phase-Yb/sprint-Y7.md
+++ b/docs/phase-Yb/sprint-Y7.md
@@ -1,7 +1,7 @@
 ---
 id: Y.7
 title: Degraded Delivery Contract Hardening
-status: planned
+status: complete
 branch: feature/pYb-s7-degraded-delivery-contract-hardening
 worktree: ../atm-core-worktrees/feature/pYb-s7-degraded-delivery-contract-hardening
 target: integrate/phase-Yb
@@ -61,8 +61,11 @@ Make the degraded-delivery contract exact and symmetric across
 3. Introduce in `crates/atm-core/src/delivery_execution.rs`:
    - `atm_core::delivery_execution::ClaudeInboxWriter`
    - `atm_core::delivery_execution::PostSendNotificationExecutor`
-4. Introduce `AckReplyStateMachine` for reply execution in the same Y.7
-   implementation seam as `ReplyDeliveryPlan`.
+4. Introduce `crates/atm-core/src/ack/mod.rs::AckReplyStateMachine` for reply
+   execution in the same Y.7 implementation seam as `ReplyDeliveryPlan`.
+   This is distinct from the older
+   `crates/atm-core/src/delivery_policy.rs::AckReplyStateMachine` transition
+   inventory.
 5. Ensure both `DeliveryHarnessPath::ClaudeCode` and
    `DeliveryHarnessPath::NonClaude` produce the same logical payload set:
    - success -> original message only
@@ -90,22 +93,22 @@ policy. These are listed here as context for Y.7 developers. Only item 2 is a
 Y.7 removal obligation; items 1, 3, and 4 are addressed in later sprints as
 assigned in the removal ledger.
 
-1. [delivery_policy.rs](</Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-Y/crates/atm-core/src/delivery_policy.rs:61>)
+1. `crates/atm-core/src/delivery_policy.rs:61`
    - `DeliveryRecipientSnapshot::fallback_claude`
    - ledger: `YB-RM-014`, sprint: `Y.9`
    - inconsistency: the name and behavior silently default an unresolved route
      to `DeliveryHarnessPath::ClaudeCode`
-2. [send/persistence.rs](</Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-Y/crates/atm-core/src/send/persistence.rs:85>)
+2. `crates/atm-core/src/send/persistence.rs:85`
    - `recipient.allows_claude_jsonl_append()` branch inside
      `recover_after_sqlite_failure(...)`
    - ledger: `YB-RM-002` / `YB-RM-003`, sprint: `Y.7`
    - inconsistency: persistence still decides a harness-specific outward path
-3. [service_runtime.rs](</Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-Y/crates/atm-core/src/service_runtime.rs:181>)
+3. `crates/atm-core/src/service_runtime.rs:181`
    - early return in `refresh_compat_inbox_projection(...)`
    - ledger: `YB-RM-017`, sprint: `Y.10`
    - inconsistency: the Claude writer is still asked to inspect a non-Claude
      request and no-op
-4. [service_runtime.rs](</Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-Y/crates/atm-core/src/service_runtime.rs:202>)
+4. `crates/atm-core/src/service_runtime.rs:202`
    - early return in `append_compat_inbox_message(...)`
    - ledger: `YB-RM-019`, sprint: `Y.9`
    - inconsistency: the low-level Claude append seam still receives
@@ -162,7 +165,8 @@ implementation that preserves convenience helpers with hidden policy.
   `ReplyDeliveryPlan`
 - `crates/atm-core/src/delivery_execution.rs` defines `ClaudeInboxWriter` and
   `PostSendNotificationExecutor`
-- `AckReplyStateMachine` is introduced in Y.7 and wired to `ReplyDeliveryPlan`
+- `crates/atm-core/src/ack/mod.rs::AckReplyStateMachine` is introduced in Y.7
+  and wired to `ReplyDeliveryPlan`
 - the sprint closes ledger rows:
   - `YB-RM-001` through `YB-RM-005`
   - `YB-RM-008`
@@ -219,3 +223,12 @@ cargo build --workspace
 cargo test --workspace
 git diff --check
 ```
+
+## Validation Record
+
+- branch closeout validated with:
+  - `cargo fmt --all --check`
+  - `python3 .just/run_lint.py all`
+  - `cargo build --workspace`
+  - `cargo test --workspace`
+  - `git diff --check`

--- a/docs/phase-Yb/sprint-Y8.md
+++ b/docs/phase-Yb/sprint-Y8.md
@@ -1,7 +1,7 @@
 ---
 id: Y.8
 title: Policy Cleanup And Impossible-Path Removal
-status: planned
+status: complete
 branch: feature/pYb-s8-policy-cleanup-and-impossible-path-removal
 worktree: ../atm-core-worktrees/feature/pYb-s8-policy-cleanup-and-impossible-path-removal
 target: integrate/phase-Yb
@@ -80,6 +80,16 @@ transition surfaces from the runtime.
 - `docs/atm-core/boundaries.md`
 - `docs/atm-daemon/boundaries.md`
 
+## Intentional Carry-Forwards
+
+- `YB-001` and `YB-004` are not Y.8-native implementation work and do not
+  close on this branch; triage keeps both promoted through `Y.11`.
+- `YB-003` defers to `Y.9`, where the dedicated
+  `NonClaudeOutboundDeliveryWriter` boundary makes real outbound payload proof
+  possible.
+- `YB-005` defers to `Y.11` per triage promotion, where the remaining
+  post-send-hook escape hatch is closed on the final boundary-hardening line.
+
 ## Required Validation
 
 ```bash
@@ -89,3 +99,20 @@ cargo build --workspace
 cargo test --workspace
 git diff --check
 ```
+
+## Validation Record
+
+- branch closeout validated with:
+  - `cargo fmt --all --check`
+  - `python3 .just/run_lint.py all`
+  - `cargo build --workspace`
+  - `cargo test --workspace`
+  - `git diff --check`
+- acceptance grep proof:
+  - command:
+    `rg -n 'DeliveryHarnessPath|allows_claude_jsonl_append' crates/atm-core/src/send/mod.rs crates/atm-core/src/send/persistence.rs crates/atm-core/src/ack/mod.rs`
+  - output:
+    `crates/atm-core/src/ack/mod.rs:674:            harness: crate::delivery_policy::DeliveryHarnessPath::ClaudeCode,`
+  - interpretation:
+    the remaining hit is a test-only fixture snapshot, not a production
+    harness-policy branch outside approved machine/executor modules

--- a/docs/phase-Yb/sprint-Y9.md
+++ b/docs/phase-Yb/sprint-Y9.md
@@ -1,7 +1,7 @@
 ---
 id: Y.9
 title: Non-Claude Outbound Boundary Formalization
-status: planned
+status: complete
 branch: feature/pYb-s9-non-claude-outbound-boundary-formalization
 worktree: ../atm-core-worktrees/feature/pYb-s9-non-claude-outbound-boundary-formalization
 target: integrate/phase-Yb
@@ -90,3 +90,21 @@ cargo build --workspace
 cargo test --workspace
 git diff --check
 ```
+
+## Validation Record
+
+- branch closeout validated with:
+  - `cargo fmt --all --check`
+  - `python3 .just/run_lint.py all`
+  - `cargo build --workspace`
+  - `cargo test --workspace`
+  - `git diff --check`
+- follow-up hardening notes:
+  - `RSH-Y9-001` is waived because `NonClaudeOutbound::deliver_payloads(...)`
+    is a synchronous trait seam; blocking filesystem I/O is the intended
+    execution model and `spawn_blocking` is not applicable there
+  - `RSH-Y9-002` is closed with
+    `MAX_NON_CLAUDE_PAYLOAD_BYTES = 1024 * 1024` in
+    `crates/atm-daemon/src/non_claude_outbound_runtime.rs`
+  - `RSH-001` is closed with the in-code `MAX_CONCURRENT_CONNECTIONS`
+    comments beside the retained `write_all(...)` and `sync_data(...)` calls

--- a/docs/phase-Yb/testing-and-validation.md
+++ b/docs/phase-Yb/testing-and-validation.md
@@ -26,6 +26,19 @@ Required proof:
 - named tests for each degraded-delivery branch
 - assertions over logical payload content and ordering
 - no reliance on hook invocation count as delivery proof
+- required named tests on the `Y.7` branch:
+  - `sqlite_failure_for_claude_preserves_original_and_companion_error_payloads`
+  - `sqlite_failure_for_non_claude_preserves_original_and_companion_payloads`
+  - `append_failure_after_sqlite_commit_is_execution_only`
+  - `named_plan_builder_proves_payload_equality_across_harnesses`
+  - `named_companion_error_failure_handling_adds_explicit_warning`
+  - `send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_boundary`
+  - `send_append_failure_routes_to_post_send_hook_fallback`
+- the `Y.7` closeout branch must also prove:
+  - `crates/atm-core/src/ack/mod.rs::AckReplyStateMachine` constructs
+    `ReplyDeliveryPlan` from the same typed persistence result surface as send
+  - `ReplyDeliveryPlan` executes through
+    `execute_reply_delivery_plan(...)`, not an ack-only notification shim
 
 ### Y.8
 
@@ -49,6 +62,20 @@ Required proof:
 - boundary TOML files and docs match the final caller allowlists
 - removal-ledger closure is complete or tracked as an explicit blocker set
 - smoke-handoff docs are updated only after Yb enforcement passes
+- normal Claude append delivery rejects legacy array inboxes and points callers
+  at the explicit repair/rebuild seam
+- full mailbox rewrite remains reachable only through the repair/rebuild path,
+  not as a silent runtime append fallback
+
+### Y.11
+
+Required proof:
+
+- the low-level Claude append seam is never selected for
+  `DeliveryHarnessPath::NonClaude`
+- the repair/rebuild refresh seam is explicit and no longer encoded as a
+  generic recipient-routed helper with a non-Claude no-op branch
+- shared validation docs name the final outbound-boundary proof model
 
 ## Cross-Platform Note
 

--- a/docs/plan-phase-Y.md
+++ b/docs/plan-phase-Y.md
@@ -48,14 +48,14 @@ The current code does **not** satisfy the desired end-state yet.
 Observed production ATM-authored inbox write entrypoints:
 
 1. `send` command path
-   - `crates/atm-core/src/send/mod.rs::append_mailbox_message_and_seed_workflow(...)`
-   - rebuilds the mailbox projection from SQLite metadata/records
-   - rewrites the full compatibility inbox file
+   - `crates/atm-core/src/send/mod.rs::persist_message_and_seed_workflow(...)`
+   - persists SQLite/workflow state first
+   - reaches compatibility rewrite only through the retained runtime refresh owner
 
 2. `ack` reply path
    - `crates/atm-core/src/ack/mod.rs`
-   - emits the reply through the same helper
-   - therefore still rewrites the compatibility inbox file
+   - emits the reply through the same narrowed helper
+   - does not rewrite the original source inbox merely because ack state changed
 
 3. compatibility export/source-projection path
    - `crates/atm-core/src/mailbox/store.rs::write_compat_source_projections(...)`
@@ -177,6 +177,14 @@ Purpose:
 - execute the line-numbered removal ledger from
   `docs/phase-Y/inbox-write-path-audit.md`
 
+Current status:
+
+- complete on `feature/pY-s3-hard-write-boundary-consolidation`
+- normal retained `send` now persists SQLite/workflow state first and reaches
+  compatibility rewrite only through
+  `RetainedServiceRuntime::refresh_compat_inbox_projection(...)`
+- `ack` and `clear` no longer own source-inbox compatibility rewrites
+
 ### Y.4 Delivery Coordinator And Event-Family State Machines
 
 Purpose:
@@ -187,6 +195,16 @@ Purpose:
   event-family state machines
 - make harness routing, failure behavior, and transition observability auditable
   in one place
+
+Current status:
+
+- complete on `feature/pY-s4-delivery-coordinator-and-state-machines`
+- the retained coordinator/state-machine seam now lives in
+  `crates/atm-core/src/delivery_policy.rs`
+- retained `send` and `ack` now resolve copied roster snapshots through
+  `RetainedServiceRuntime::load_roster_member(...)`
+- retained compatibility export now remains enabled only for `Claude Code`
+  harnesses; non-Claude harnesses skip ATM-authored JSONL export
 
 ### Y.5 Mutable Compatibility-Field Removal And Dependency Exposure
 
@@ -199,6 +217,21 @@ Purpose:
 - keep field-removal logic inside the event-family state machines rather than
   in generic export conditionals
 
+Current status:
+
+- complete on `feature/pY-s5-mutable-compatibility-field-removal`
+- retained compatibility export now keeps only immutable correlation/context
+  fields: `message_id`, `parentMessageId`, `threadMode`, and `taskId`
+- retained compatibility export now strips:
+  - `source_team`
+  - `pendingAckAt`
+  - `acknowledgedAt`
+  - `acknowledgesMessageId`
+  - `expiresAt`
+  - `metadata.atm.*`
+- retained compatibility export now reloads stored message records instead of
+  workflow-joined projected envelopes before writing compatibility output
+
 ### Y.6 Append-Only Compatibility Export Cutover
 
 Purpose:
@@ -209,6 +242,18 @@ Purpose:
 - keep restore/repair flows separate if they still require staged rewrites
 - keep the append/no-append decision inside the harness-specific new-message
   state machines rather than in scattered writer call sites
+
+Current status:
+
+- complete on `feature/pY-s6-append-only-compatibility-export`
+- retained normal-runtime Claude Code compatibility writes now append one JSONL
+  record at a time after the durable SQLite/workflow step
+- retained non-Claude harnesses still never receive ATM-authored JSONL append
+  output
+- retained runtime legacy array inboxes now rebuild/re-export once before they
+  join the append-only path
+- retained SQLite-failure recovery now emits the documented original-plus-error
+  outward delivery contract instead of silently downgrading to a warning only
 
 ## Phase Boundary
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3443,7 +3443,13 @@ Target:
 - `integrate/phase-Y` for the execution line
 
 Status:
-- planning
+- complete
+
+Status note:
+- `Y.1` merged to `integrate/phase-Y`
+  - branch: `feature/pY-s1-pre-smoke-scaffolding`
+  - PR: `#296`
+  - merge commit: `c63574cb`
 
 Authoritative plans:
 - `docs/plan-phase-Y.md`
@@ -3467,12 +3473,41 @@ Execution shape:
 - planning-branch audits and the shared-inbox field decision framework
   complete before numbered sprint execution begins
 - `Y.1` `atm help` and UX improvements
+  - deliver `atm help`, `atm help --list`, typed concept-topic help, and
+    delegated clap subcommand help without broadening into general JSON-input work
 - `Y.2` pre-smoke easy fixes and validation
+  - close the deferred `Y.1` tier-2 help follow-ups for `hooks`, `identity`,
+    and `skills` without changing the compatibility inbox wire contract
 - `Y.3` hard write-boundary consolidation
+  - complete on `feature/pY-s3-hard-write-boundary-consolidation`
+  - normal retained compatibility rewrite now routes only through
+    `RetainedServiceRuntime::refresh_compat_inbox_projection(...)`
 - `Y.4` delivery coordinator and event-family state machines
+  - complete on `feature/pY-s4-delivery-coordinator-and-state-machines`
+  - retained send/ack harness routing now resolves a copied roster snapshot in
+    `crates/atm-core/src/delivery_policy.rs`
+  - retained compatibility export now stays on the `Claude Code` harness path
+    only; non-Claude harnesses skip ATM-authored JSONL export
 - `Y.5` mutable compatibility-field removal and hidden-dependency exposure
+  - complete on `feature/pY-s5-mutable-compatibility-field-removal`
+  - retained compatibility export now keeps only immutable correlation/context
+    fields: `message_id`, `parentMessageId`, `threadMode`, and `taskId`
+  - retained compatibility export now strips mutable/shared-projection fields:
+    `source_team`, `pendingAckAt`, `acknowledgedAt`,
+    `acknowledgesMessageId`, `expiresAt`, and `metadata.atm.*`
+  - retained compatibility export now reloads stored message records instead of
+    workflow-joined projected envelopes before writing Claude Code projection
+    files
 - `Y.6` append-only compatibility export cutover if the approved wire contract
   allows it
+  - complete on `feature/pY-s6-append-only-compatibility-export`
+  - retained normal-runtime Claude Code compatibility writes now append one
+    JSONL record at a time after the durable SQLite/workflow step
+  - retained non-Claude harnesses still never receive ATM-authored JSONL
+    append output
+  - retained SQLite-failure recovery now emits the documented
+    original-plus-`atm-system@<team>` companion contract instead of silently
+    downgrading to a warning-only path
 
 Follow-on validation phase:
 - completed CLI JSON I/O audit recorded in
@@ -3513,7 +3548,18 @@ Status summary:
   line, but the production-readiness review still found structural message-path
   issues that must be planned and implemented before broad smoke/dogfood work
   resumes.
-- Phase `Yb` is a planning-first correction line off `develop`.
+- Phase `Yb` is now fully implemented through `Y.11`.
+- the line closes with:
+  - shared delivery plans across Claude/non-Claude harness paths
+  - a dedicated `NonClaudeOutbound` payload boundary
+  - fail-closed handling for missing roster harness data
+  - repair/rebuild-only mailbox rewrite seams
+- an explicit Claude-only append seam that is never selected for
+  `DeliveryHarnessPath::NonClaude`
+- an explicit repair/rebuild projection seam that no longer accepts a generic
+  recipient snapshot with a non-Claude no-op branch
+- smoke/dogfood work may now resume on the follow-on line without reopening the
+  same message-path consolidation issues.
 
 Goal:
 - lock down the exact message-path consolidation work needed after `Phase Y`
@@ -3525,9 +3571,15 @@ Execution shape:
 - future implementation integration branch: `integrate/phase-Yb`
 - implementation sequence:
   - `Y.7` degraded delivery contract hardening
+    - branch: `feature/pYb-s7-degraded-delivery-contract-hardening`
   - `Y.8` policy cleanup and impossible-path removal
+    - branch: `feature/pYb-s8-policy-cleanup-and-impossible-path-removal`
   - `Y.9` non-Claude outbound boundary formalization
+    - branch: `feature/pYb-s9-non-claude-outbound-boundary-formalization`
   - `Y.10` boundary enforcement and smoke handoff
+    - branch: `feature/pYb-s10-boundary-enforcement-and-smoke-handoff`
+  - `Y.11` post-`Y.10` boundary gap closure
+    - branch: `feature/pYb-s11-y10-gap-closure`
 
 Immediate planning outputs:
 - `docs/phase-Yb/plan-phase-Yb.md`
@@ -3541,4 +3593,5 @@ Immediate planning outputs:
 - `docs/phase-Yb/sprint-Y8.md`
 - `docs/phase-Yb/sprint-Y9.md`
 - `docs/phase-Yb/sprint-Y10.md`
+- `docs/phase-Yb/sprint-Y11.md`
 - `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1744,7 +1744,7 @@ Each member object must expose at least:
 - `name`
 - persisted local member metadata when present
 
-## 13.5 `atm help` (Phase Y additive CLI feature)
+## 14. `atm help` (Phase Y additive CLI feature)
 
 Product requirement ID:
 - `REQ-P-HELP-001` `atm help` must satisfy the documented conceptual-help
@@ -1754,13 +1754,13 @@ Satisfied by:
 - `REQ-ATM-CMD-001` for CLI entry, parsing, and dispatch aspects
 - `REQ-ATM-OUT-001` for human-readable and JSON output aspects
 
-### 13.5.1 Purpose
+### 14.1 Purpose
 
 Provide one ATM-owned conceptual help surface that complements clap-generated
 syntax help without duplicating the flag/argument contract already exposed by
 `--help`.
 
-### 13.5.2 Required Behavior
+### 14.2 Required Behavior
 
 `atm help` must:
 - remain a separate subcommand from clap-generated `atm --help`
@@ -1773,6 +1773,8 @@ syntax help without duplicating the flag/argument contract already exposed by
   documentation
 - keep concept topics in one typed topic registry rather than scattered prose
   fragments
+- keep this Phase `Y` slice narrowly on conceptual help plus wording cleanup
+  rather than broadening into general structured JSON-input work
 
 Tier-1 concept topics for the first delivery:
 - `config`
@@ -1783,7 +1785,7 @@ Tier-2 concept topics for the first delivery:
 - `identity`
 - `skills`
 
-### 13.5.3 Output Contract
+### 14.3 Output Contract
 
 Human output must:
 - clearly distinguish concept topics from command syntax help
@@ -1792,11 +1794,13 @@ Human output must:
 JSON output must:
 - expose the requested topic or command target
 - identify whether the result is:
+  - `overview`
+  - `topic_list`
   - `concept_topic`
   - `command_help`
 - include the rendered help body in a structured field suitable for agent use
 
-## 14. Message And Workflow Model
+## 15. Message And Workflow Model
 
 Product requirement ID:
 - `REQ-P-WORKFLOW-001` The message/workflow model must satisfy the documented
@@ -1806,7 +1810,7 @@ Satisfied by:
 - `REQ-CORE-WORKFLOW-001` for the canonical two-axis model and legal
   transitions
 
-### 14.1 Persisted Message Fields
+### 15.1 Persisted Message Fields
 
 Required fields:
 - `from`
@@ -1841,7 +1845,7 @@ For ATM-authored messages:
 Legacy or externally imported records may still omit `message_id`; the rewrite
 must preserve such records without inventing synthetic ids during read.
 
-### 14.2 Two-Axis Canonical Model
+### 15.2 Two-Axis Canonical Model
 
 The canonical model has two independent axes.
 
@@ -1871,7 +1875,7 @@ Derived message class for queue logic:
 
 The canonical two-axis model is distinct from the read command’s display buckets.
 
-### 14.3 Required State Transitions
+### 15.3 Required State Transitions
 
 ```text
 Send normal message
@@ -1918,7 +1922,7 @@ Disallowed transitions:
 
 The implementation must encode legal transitions in code structure, not only in comments or tests.
 
-### 14.4 Task Metadata Rule
+### 15.4 Task Metadata Rule
 
 Messages with `taskId` are task-linked messages.
 
@@ -1928,7 +1932,7 @@ Required rules:
 - a task-linked message must continue to appear in `atm read` until acknowledged
 - a task-linked message must never be removed by `atm clear` before acknowledgement
 
-## 15. Observability Requirements
+## 16. Observability Requirements
 
 Product requirement ID:
 - `REQ-P-OBS-001` ATM observability must satisfy the documented best-effort
@@ -2025,7 +2029,7 @@ Diagnostic logging rules:
 - they are explicit observability consumers
 - if shared query/health APIs are unavailable, they must fail with clear structured errors
 
-## 16. Error Requirements
+## 17. Error Requirements
 
 Product requirement ID:
 - `REQ-P-ERROR-001` Public command failures must satisfy the documented
@@ -2102,7 +2106,7 @@ Mutation failures must be fail-safe:
 - no partial read-mark updates
 - no illegal state transitions after failed persistence
 
-## 17. Reliability Requirements
+## 18. Reliability Requirements
 
 Product requirement ID:
 - `REQ-P-RELIABILITY-001` The retained command surface must satisfy the
@@ -2127,7 +2131,7 @@ Satisfied by:
 - seen-state races must not corrupt mailbox data
 - observability emission failures must not corrupt command behavior
 
-## 18. Testing Requirements
+## 19. Testing Requirements
 
 Product requirement ID:
 - `REQ-P-TEST-001` The rewrite must satisfy the documented testing obligations.
@@ -2202,7 +2206,7 @@ Required testing architecture:
   suite and must never become the default validation path for CLI or core
   business correctness
 
-## 19. Acceptance Criteria
+## 20. Acceptance Criteria
 
 Product requirement ID:
 - `REQ-P-ACCEPTANCE-001` The rewrite is complete only when the documented
@@ -2247,13 +2251,13 @@ Cross-document invariants that must remain true:
 - `atm read --timeout` returns immediately when the requested selection is already non-empty
 
 
-## 20. Phase M: Mailbox Concurrency And Restore Atomicity
+## 21. Phase M: Mailbox Concurrency And Restore Atomicity
 
 Phase M addresses blocking and important findings from the Phase L code review
 (ARCH-CR-001 through ARCH-CR-004 and associated QA findings) that must be
 closed before the 1.0 release.
 
-### 20.1 Mailbox Concurrency Safety
+### 21.1 Mailbox Concurrency Safety
 
 - `REQ-CORE-MAILBOX-LOCK-001` All mailbox read-modify-write operations must
   hold an exclusive advisory file lock for the duration of the operation.
@@ -2470,7 +2474,7 @@ closed before the 1.0 release.
     `MailboxLockReadOnlyFilesystem`
     / `ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM`, never as `MailboxLockTimeout`
 
-### 20.2 Shared Mutable File Atomicity
+### 21.2 Shared Mutable File Atomicity
 
 - `REQ-CORE-PERSIST-ATOMIC-001` Every shared mutable ATM-owned structured state
   file must be persisted atomically.
@@ -2602,7 +2606,7 @@ closed before the 1.0 release.
     equivalent in-place rewrites of live shared mutable structured files and
     either remove them or document why the path is not in scope
 
-### 20.2.1 Shared Commit And Freshness Validation
+### 21.2.1 Shared Commit And Freshness Validation
 
 The required shared commit protocol is:
 
@@ -2622,7 +2626,7 @@ The intentionally forbidden shape is:
 - acquire late lock
 - rename blindly over a newer live file
 
-### 20.2.2 Locking Failure-Path Test Contract
+### 21.2.2 Locking Failure-Path Test Contract
 
 - `REQ-CORE-MAILBOX-TEST-001` Phase M follow-up coverage must include
   deterministic failure-path locking tests in addition to success-path
@@ -2661,7 +2665,7 @@ The intentionally forbidden shape is:
     - sleeps used as the primary correctness mechanism
     - race-dependent stress loops expected to pass only "most of the time"
 
-### 20.3 Restore Transaction Atomicity
+### 21.3 Restore Transaction Atomicity
 
 - `REQ-CORE-RESTORE-ATOMIC-001` `teams restore` must write `config.json` as
   the last mutation step, only after all other restore mutations succeed.
@@ -2706,7 +2710,7 @@ The intentionally forbidden shape is:
   - the finding must include recovery guidance telling the operator to rerun
     `atm teams restore` or remove the marker after manual verification
 
-### 20.4 Error Display And Diagnostics
+### 21.4 Error Display And Diagnostics
 
 - `REQ-CORE-ERROR-DISPLAY-001` `AtmError::Display` must remain concise and
   must not emit multi-KB backtrace output.
@@ -2773,7 +2777,7 @@ The intentionally forbidden shape is:
   - sites already covered by L.7/L.8 recovery work do not need duplicate edits
   - internal invariant violations do not require recovery guidance
 
-### 20.5 Code Consolidation And Documentation
+### 21.5 Code Consolidation And Documentation
 
 - `REQ-CORE-IDENTITY-CONSOLIDATE-001` The duplicated `resolve_actor_identity`
   function must be consolidated into a single shared implementation.
@@ -2797,7 +2801,7 @@ The intentionally forbidden shape is:
     parse failure or unsupported exponent range instead of panicking
   - a library function must not panic on potentially untrusted input
 
-## 21. Current SQLite Mail SSOT, Runtime Boundaries, And Lock Elimination
+## 22. Current SQLite Mail SSOT, Runtime Boundaries, And Lock Elimination
 
 The current SQLite/daemon architecture supersedes the mailbox-lock line as the target architecture for ATM
 mail correctness. The `REQ-CORE-MAILBOX-LOCK-*` requirements remain
@@ -2805,7 +2809,7 @@ transitional compatibility constraints only for the interim file-based line.
 The release-complete target is elimination of mailbox-lock dependence from ATM
 mail correctness.
 
-### 21.1 SQLite Mail And Roster Ownership
+### 22.1 SQLite Mail And Roster Ownership
 
 - `REQ-CORE-RUNTIME-001` ATM mail and team roster state must move to SQLite as
   the authoritative source of truth.
@@ -2895,7 +2899,7 @@ mail correctness.
 - `pid` is transient daemon-owned runtime state rather than durable roster
   truth and must not be persisted in SQLite
 
-### 21.2 Singleton Daemon Runtime
+### 22.2 Singleton Daemon Runtime
 
 - `REQ-CORE-DAEMON-001` ATM must run exactly one daemon per host in the current architecture
   runtime.
@@ -2954,7 +2958,7 @@ mail correctness.
     documented `32` per-connection inflight ceiling is satisfied by structure
     until framed multiplexing is introduced
 
-### 21.2.1 Phase S Daemon Parity Traceability
+### 22.2.1 Phase S Daemon Parity Traceability
 
 - `REQ-DAEMON-PLATFORM-001` is the `atm-daemon` crate traceability record for
   the same-host daemon parity requirement carried by:
@@ -2968,7 +2972,7 @@ mail correctness.
   - `REQ-P-PLATFORM-002`
   - `REQ-CORE-BOUNDARY-001`
 
-### 21.3 Strict I/O Ownership Boundaries
+### 22.3 Strict I/O Ownership Boundaries
 
 - `REQ-CORE-BOUNDARY-001` Every subsystem must be behind a strict trait
   boundary for all external I/O.
@@ -2991,7 +2995,7 @@ mail correctness.
   - violation of any ownership rule above is a direct QA failure for the Phase
     Q implementation line
 
-### 21.3.1 Structured Error Boundaries
+### 22.3.1 Structured Error Boundaries
 
 - `REQ-CORE-BOUNDARY-002` Production runtime code must model fallible runtime
   behavior with discriminated error unions and explicit `Result` propagation.
@@ -3014,7 +3018,7 @@ mail correctness.
   - violation of these structured-error rules is a direct QA failure for the
     current SQLite/daemon implementation line
 
-### 21.4 Transport And Routing Model
+### 22.4 Transport And Routing Model
 
 - `REQ-CORE-TRANSPORT-001` ATM must use one logical daemon API with two
   production transport implementations and one test transport.
@@ -3164,7 +3168,7 @@ mail correctness.
     daemon must require bounded reload/rebind through the documented reload
     path and must surface degraded status until rebind succeeds
 
-### 21.5 Claude Compatibility And Native Agent Path
+### 22.5 Claude Compatibility And Native Agent Path
 
 - `REQ-CORE-COMPAT-001` Claude inbox JSONL remains the required compatibility
   path for Claude context injection.
@@ -3283,7 +3287,7 @@ mail correctness.
   - `NotificationSink` remains notification-only and must not stand in for
     non-Claude message delivery
 
-### 21.6 Lock Elimination Target
+### 22.6 Lock Elimination Target
 
 - `REQ-CORE-LOCK-RETIRE-001` ATM mail correctness must stop depending on
   mailbox lock artifacts.
@@ -3296,7 +3300,7 @@ mail correctness.
   - completion of the current architecture requires that stale lock artifacts can no longer wedge
     normal ATM mail flows
 
-### 21.7 Test Strategy Constraints
+### 22.7 Test Strategy Constraints
 
 - `REQ-CORE-TEST-RUNTIME-001` Core target daemon-runtime behavior must be
   testable without daemon process spawning.
@@ -3313,7 +3317,7 @@ mail correctness.
   - ordinary tests must not depend on socket publication timing, retry sleeps,
     parent-process environment mutation, or auto-start side effects
 
-### 21.8 Observability Requirements
+### 22.8 Observability Requirements
 
 - `REQ-CORE-OBS-002` The target daemon-runtime architecture must keep
   structured observability first-class at both CLI and daemon boundaries.
@@ -3332,7 +3336,7 @@ mail correctness.
   - observability must not be implemented as ad hoc println/debug output in
     production paths
 
-### 21.8.1 Doctor Health Interface
+### 22.8.1 Doctor Health Interface
 
 - `REQ-CORE-DOCTOR-002` The target daemon runtime must expose a daemon health
   query interface consumable by `atm doctor`.
@@ -3350,7 +3354,7 @@ mail correctness.
     - ingest backlog / degraded-ingest state when present
     - SQLite open/readiness state
 
-### 21.9 QA Invariants
+### 22.9 QA Invariants
 
 - `REQ-CORE-QA-RUNTIME-001` Every QA pass for the current runtime must verify the daemon
   and boundary invariants.
@@ -3375,7 +3379,7 @@ mail correctness.
   - Claude compatibility export remains a compatibility projection only and is
     never the ATM-owned runtime truth
 
-### 21.10 Postmortem Lint Backfill
+### 22.10 Postmortem Lint Backfill
 
 - `REQ-P-LINT-POSTMORTEM-001` Mechanically-detectable postmortem finding
   families must become repository lint or CI gates rather than recurring QA


### PR DESCRIPTION
## Summary

- Forward-port all `docs/` changes from `integrate/phase-Y` to `develop`
- Adds `sprint-Y11.md` (was missing from develop)
- Updates architecture docs, boundary docs, ADR-013, removal-ledger, sprint notes for Y7–Y10
- Docs-only change; no code changes

## Context

`integrate/phase-Y` → `develop` (PR #302) is under MERGE HOLD pending user authorization. This PR syncs the documentation forward so planning work can begin off an up-to-date `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)