### PR TITLE
docs: sync phase Yc plan docs into integrate/phase-Y

### DIFF
--- a/docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md
+++ b/docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md
@@ -7,6 +7,17 @@ Accepted
 Accepted note: Implementation complete through `Phase Yb Y.8`
 (`feature/pYb-s8-policy-cleanup-and-impossible-path-removal`).
 
+Follow-on note:
+- the architectural direction in this ADR remains authoritative
+- later `integrate/phase-Y` production-readiness review reopened two remaining
+  runtime gaps:
+  - recovered Claude SQLite-failure delivery still allows partial logical
+    message-set success
+  - production notification execution still bypasses `NotificationSink`
+- those final closeout items are owned by `Phase Yc`:
+  - `Y.12` closes the recovered Claude logical-message-set contract
+  - `Y.13` closes the production `NotificationSink` boundary bypass
+
 ## Context
 
 The accepted `integrate/phase-Y` implementation still leaves message-path
@@ -123,3 +134,10 @@ The documented lintable boundary plan must forbid direct calls from:
 - `docs/phase-Yb/sprint-Y8.md`
 - `docs/phase-Yb/sprint-Y9.md`
 - `docs/phase-Yb/sprint-Y10.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
+- `docs/phase-Yc/plan-phase-Yc.md`
+- `docs/phase-Yc/issues.md`
+- `docs/phase-Yc/readiness.md`
+- `docs/phase-Yc/sprint-Y12.md`
+- `docs/phase-Yc/sprint-Y13.md`

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -228,6 +228,14 @@ Notes:
   - see:
     - [../phase-Yb/lintable-boundary-plan.md](../phase-Yb/lintable-boundary-plan.md)
     - [../adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md](../adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md)
+- `Phase Yc` adds one final recovered-Claude seam requirement:
+  - `Y.12` introduces one explicit recovered logical-message-set export seam
+    for `DeliveryPlanDisposition::SqliteFailedRecovered` through
+    `InboxExport::append_message_set(...)`
+  - the recovered Claude path must not loop one message at a time through the
+    normal append helper while degrading to warnings after partial success
+  - persisted single-message Claude append remains on the existing append-only
+    path and is not reopened onto this boundary
 
 ## NotificationSink
 
@@ -251,6 +259,11 @@ Notes:
     reaches this sink
   - the current proof surface for non-Claude delivery lives in
     `NonClaudeOutboundDeliveryRequest`, not in `ATM_POST_SEND` metadata
+- `Phase Yc` finalizes the production-path ownership rule:
+  - `Y.13` must remove the direct
+    `PostSendNotificationExecutor -> maybe_run_post_send_hook(...)` bypass
+  - the surviving production notification path must execute through
+    `NotificationSink::deliver(...)`
 
 ## NonClaudeOutbound
 

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -326,6 +326,13 @@ Notes:
   - see:
     - [../phase-Yb/plan-phase-Yb.md](../phase-Yb/plan-phase-Yb.md)
     - [../phase-Yb/lintable-boundary-plan.md](../phase-Yb/lintable-boundary-plan.md)
+- `Phase Yc` adds one final recovered-Claude seam requirement:
+  - `Y.12` must document the daemon-side adapter behavior for the recovered
+    logical-message-set seam through
+    `InboxExport::append_message_set(...)` rather than treating
+    `DaemonInboxExportAdapter` as append-only by implication
+  - the daemon adapter must expose the recovered Claude message-set export as
+    one owned `InboxExport` operation, not as repeated single-message appends
 
 ## Policy Placement
 
@@ -372,6 +379,15 @@ Notes:
   - callers outside `RuntimeComposition` must use
     `NotificationSink::deliver(...)` only and must not open plugin/agent
     delivery paths directly
+- `Phase Yc` closes the last daemon/runtime consistency gap for this boundary:
+  - `Y.13` must ensure the retained runtime factory installs the daemon-owned
+    `NotificationSink` adapter on the live send/ack executor path rather than
+    allowing direct helper-owned notification execution to survive
+  - shutdown remains bounded by the current `3s`
+    `NotificationRuntime::shutdown()` deadline; if exceeded, the adapter emits
+    a structured warning, returns `AtmErrorCode::DaemonUnavailable`
+    (`ATM_DAEMON_UNAVAILABLE`), detaches the join helper, and any still-pending
+    queued notification events are treated as dropped
 
 ## DaemonNonClaudeOutboundAdapter
 

--- a/docs/phase-Yc/issues.md
+++ b/docs/phase-Yc/issues.md
@@ -1,0 +1,42 @@
+# Phase Yc Issues Inventory
+
+## Goal
+
+Track the exact `Yc` production-readiness blockers and record what is
+intentionally out of scope so later hardening or QA passes do not rewrite the
+runtime sprint deliverables.
+
+## In-Scope Blockers
+
+1. Claude recovered degraded delivery still allows partial logical-message-set
+   success on the SQLite-failure path.
+   - owning sprint: `Y.12`
+   - primary runtime seam:
+     - `crates/atm-core/src/delivery_execution.rs`
+   - required closeout:
+     - the recovered Claude path either materializes the full logical message
+       set or fails hard
+
+2. Production notification execution still bypasses `NotificationSink`.
+   - owning sprint: `Y.13`
+   - primary runtime seams:
+     - `crates/atm-core/src/delivery_execution.rs`
+     - `crates/atm-core/src/service_runtime.rs`
+     - `crates/atm-daemon/src/runtime_health.rs`
+   - required closeout:
+     - the production notification path executes through
+       `NotificationSink::deliver(...)` and no direct
+       `maybe_run_post_send_hook(...)` helper path remains on the live
+       executor/runtime path
+
+## Explicitly Out Of Scope For Y.12 And Y.13
+
+- post-mortem lint recommendations in
+  `integrate/phase-Y/.triage/phase-Yb/post-mortem.md`
+- new lint-rule work
+- new boundary-rule enforcement work unrelated to the two runtime blockers
+- docs-only or lint-only reinterpretations of `Y.12` or `Y.13`
+
+If any later task or review attempts to convert `Y.12` or `Y.13` into
+lint-only, docs-only, or otherwise non-runtime implementation work, treat that
+as a scope conflict and require user discussion before changing the plan.

--- a/docs/phase-Yc/plan-phase-Yc.md
+++ b/docs/phase-Yc/plan-phase-Yc.md
@@ -1,0 +1,122 @@
+# Phase Yc Plan
+
+## Goal
+
+Close the final production-readiness gaps left on `integrate/phase-Y` after the
+merged `Yb` line so `Phase Z` smoke/dogfood work resumes only after the
+remaining delivery-contract and notification-boundary issues are actually
+closed.
+
+This is a planning-only phase on a worktree off `develop`. It does not start
+implementation.
+
+## Baseline
+
+- planning branch: `plan/phase-Yc-y12-y13`
+- planning worktree:
+  `../atm-core-worktrees/plan/phase-Yc-y12-y13`
+- branch base: `develop` at `812059b8`
+- implementation baseline under review:
+  `integrate/phase-Y` at `4d6bd883`
+- `integrate/phase-Y` already includes:
+  - merged `Yb` work through `Y.11`
+  - the `PYB-PRR-1` retained-runtime factory wiring fix
+- implementation target for approved `Yc` work remains:
+  `integrate/phase-Y`
+
+## Planning Rule
+
+- every deliverable committed by `Yc` must land at a production-ready level for
+  the scope its sprint claims
+- no deliverable may be dropped, weakened into prose-only guidance, or silently
+  deferred after implementation begins
+- if a sprint cannot carry all of its deliverables at that level, the sprint
+  must be split before implementation begins
+- important traits, features, enums, protocol types, and boundary contracts
+  must be shown with explicit code samples in the sprint docs
+
+## Scope Guard
+
+- `Y.12` and `Y.13` are runtime/code sprints against `integrate/phase-Y`
+- `Y.12` owns the recovered Claude SQLite-failure delivery contract gap in
+  `delivery_execution.rs`
+- `Y.13` owns the production `NotificationSink` boundary wiring and readiness
+  gate
+- post-mortem lint recommendations, rule additions, and docs-only cleanup from
+  `integrate/phase-Y/.triage/phase-Yb/post-mortem.md` are not `Y.12` or
+  `Y.13` deliverables and must not be imported into these sprint scopes
+- if a later review or task tries to convert either sprint into lint-only or
+  docs-only work, that is a scope conflict and requires user discussion before
+  the plan changes
+
+## Remaining Production-Readiness Blockers
+
+1. `crates/atm-core/src/delivery_execution.rs` still allows partial Claude
+   degraded delivery after SQLite failure.
+   - `message[1]` can append
+   - `message[2]` can fail
+   - the runtime warns and continues
+   - this violates the ADR-013 identical logical payload contract
+   - concrete path to delete:
+     - the recovered-path per-message append loop in
+       `execute_claude_delivery(...)`
+2. `crates/atm-core/src/delivery_execution.rs` still routes notification side
+   effects through `maybe_run_post_send_hook(...)` directly instead of the
+   `NotificationSink` boundary.
+   - the architecture already says notification is a boundary-owned side effect
+   - the live executor path still bypasses that boundary
+   - concrete paths to delete:
+     - the direct `maybe_run_post_send_hook(...)` call inside
+       `PostSendNotificationExecutor`
+     - the retained-runtime-only constructor shape that injects
+       `NonClaudeOutbound` but not `NotificationSink`
+   - scope-tightening rule:
+     - `Y.13` must not promise a crate-visibility reduction that current
+       cross-crate runtime assembly cannot support
+     - instead, it must delete the current multiple-constructor surface and
+       replace it with one approved public composition constructor that
+       requires the full delivery-boundary set
+
+## Sprint Sequence
+
+### Y.12 Claude Degraded Delivery Set Closure
+
+Purpose:
+
+- close the last remaining behavioral hole in the Claude compatibility path
+- require one explicit compatibility-export seam that either materializes the
+  full logical message set after SQLite failure or fails hard before the sprint
+  can claim success
+
+Authoritative sprint doc:
+- [sprint-Y12.md](./sprint-Y12.md)
+
+### Y.13 Notification Boundary Closure And Final Readiness Gate
+
+Purpose:
+
+- move production notification execution onto `NotificationSink`
+- remove the direct post-send-hook helper bypass from the delivery executor
+- prove the integrated `Phase Y` line is ready to hand back to `Phase Z`
+
+Authoritative sprint doc:
+- [sprint-Y13.md](./sprint-Y13.md)
+
+Supporting issues inventory for the whole `Yc` line:
+- [issues.md](./issues.md)
+
+Named readiness record produced by `Y.13`:
+- [readiness.md](./readiness.md)
+
+## Exit Condition
+
+Phase `Yc` closes only when:
+
+- `Y.12` proves Claude SQLite-failure degraded delivery cannot partially emit a
+  logical message set while still claiming success
+- `Y.13` proves the production notification path executes through
+  `NotificationSink`, not direct hook helpers
+- `Y.13` leaves the named readiness record artifact that records both closure
+  invariants and the `Phase Z` smoke gate
+- the integrated line can pass a focused production-readiness review without
+  reopening the same two issues

--- a/docs/phase-Yc/readiness.md
+++ b/docs/phase-Yc/readiness.md
@@ -1,0 +1,38 @@
+# Phase Yc Readiness Record
+
+## Purpose
+
+This artifact is the named readiness record that `Y.13` must complete before
+`Phase Z` smoke resumes.
+
+## Yc Closure Invariants
+
+`Y.12` must record that:
+- the recovered Claude SQLite-failure path cannot partially emit a logical
+  message set while still claiming success
+
+`Y.13` must record that:
+- the production notification path executes through
+  `NotificationSink::deliver(...)` rather than direct hook helpers
+
+## Phase Z Smoke Gate
+
+`Phase Z` smoke remains blocked until this record is updated to state that:
+- both `Yc` closure invariants above are proven on the merged
+  `integrate/phase-Y` line
+- the focused `Yc` readiness validation passed
+- smoke may resume
+
+## Startup Liveness Requirement
+
+The `Y.13` readiness closeout must state that:
+- the production retained runtime can construct a live `NotificationSink`
+- the send/ack execution path can submit at least one notification request
+  through `NotificationSink::deliver(...)`
+- this liveness proof satisfies the explicit startup/liveness acceptance
+  requirement in `docs/phase-Yc/sprint-Y13.md`
+
+## Planned Ownership
+
+- planned by: `plan/phase-Yc-y12-y13`
+- completed by: `feature/pYc-s13-notification-boundary-and-readiness-gate`

--- a/docs/phase-Yc/sprint-Y12.md
+++ b/docs/phase-Yc/sprint-Y12.md
@@ -1,0 +1,239 @@
+---
+id: Y.12
+title: Claude Degraded Delivery Set Closure
+status: planned
+branch: feature/pYc-s12-claude-degraded-delivery-set-closure
+worktree: ../atm-core-worktrees/feature/pYc-s12-claude-degraded-delivery-set-closure
+target: integrate/phase-Y
+---
+
+# Sprint Y.12 — Claude Degraded Delivery Set Closure
+
+## Goal
+
+- close the final behavioral gap in the Claude compatibility delivery path
+- make the SQLite-failure recovered Claude path land at a production-ready
+  level
+- prohibit partial `message[1]` success with missing `message[2]` while still
+  claiming delivery success
+
+## Hard Dependencies
+
+- `integrate/phase-Y` at `4d6bd883` is the authoritative implementation
+  baseline
+- `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+- `docs/phase-Yc/plan-phase-Yc.md`
+- the existing `Yb` line is a dependency, not a reopen target
+- `Y.12` is the first implementation sprint in the new `Yc` line
+
+## Exact Targets
+
+- `crates/atm-core/src/delivery_execution.rs`
+- `crates/atm-core/src/service_runtime.rs`
+- `crates/atm-core/src/boundary/store.rs`
+- `crates/atm-core/src/direct_boundaries.rs`
+- `crates/atm-core/src/boundary_support.rs`
+- `crates/atm-core/src/mailbox/atomic.rs`
+- `crates/atm-core/src/mailbox/store.rs`
+- `crates/atm-daemon/src/boundary_adapters.rs`
+- `crates/atm-daemon/src/direct_boundaries.rs`
+- `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
+
+## Deliverables
+
+Every listed deliverable is expected to land at a production-ready level for
+the scope this sprint claims. If that cannot be done cleanly in one sprint, the
+sprint must be split before implementation begins. No deliverable may be
+silently dropped or partially deferred.
+
+- the Claude compatibility path owns one explicit logical-message-set delivery
+  seam for `DeliveryPlanDisposition::SqliteFailedRecovered`
+- the recovered Claude path either materializes the full logical message set or
+  returns a hard error; it must not warn-and-continue after a partial outward
+  append
+- the implementation exposes one explicit batch/message-set compatibility export
+  contract instead of hiding the behavior in `execute_claude_delivery(...)`
+- named tests prove that `message[1]` and `message[2]` are treated as one
+  behavioral unit on the recovered Claude path
+- the plan names the translation seam from
+  `DeliveryPlanDisposition::SqliteFailedRecovered` into the recovered Claude
+  compatibility export mode explicitly, rather than leaving that mapping
+  implicit in executor control flow
+
+## Required Work
+
+- replace the current per-message recovered-path append loop in
+  `execute_claude_delivery(...)` with one explicit message-set execution seam
+- add the necessary `InboxExport`/runtime helper surface so the Claude
+  compatibility path can materialize the recovered logical message set through
+  one owned contract
+- narrow the `service_runtime.rs` role to the runtime-facing helper seam that
+  forwards the recovered message-set request into `InboxExport`; it must not
+  retain per-message recovered-path policy
+- keep normal persisted Claude append delivery explicit and separate from the
+  recovered message-set path; do not reopen silent full-mailbox rewrite on the
+  normal path
+- update the daemon adapter and low-level mailbox helpers only as far as needed
+  to support the owned recovered message-set seam
+- update ADR/boundary docs so the recovered Claude message-set rule is
+  documented as an explicit contract, not an inferred behavior
+
+## Paths To Delete
+
+- `crates/atm-core/src/delivery_execution.rs`
+  - delete the recovered-path behavior that loops over `messages` and mutates
+    `AppendDegraded` warning state one message at a time inside
+    `execute_claude_delivery(...)`
+  - delete the recovered-path `break` behavior that allows `message[1]` to
+    append, `message[2]` to fail, and the executor to return without a hard
+    delivery failure
+- `crates/atm-core/src/delivery_execution.rs`
+  - delete the blanket `ClaudeInboxWriter` implementation detail that only
+    exposes one-message append semantics through
+    `self.append_compat_inbox_message(inbox_path, message)`
+    when the active disposition is `SqliteFailedRecovered`
+  - replace the recovered-path branch rather than extending it in parallel;
+    the persisted one-message append path survives, but the recovered one
+    message-at-a-time implementation must be removed
+
+## Approved Surviving Paths
+
+- persisted Claude append delivery may continue to use:
+  - `RetainedServiceRuntime::append_compat_inbox_message(...)`
+  - `crate::mailbox::store::append_compat_mailbox_message(...)`
+- explicit repair/rebuild projection may continue to use:
+  - `RetainedServiceRuntime::rebuild_compat_inbox_projection(...)`
+  - `crate::direct_boundaries::reexport_messages(...)`
+- the new recovered Claude path must survive only as one explicit owned
+  message-set seam documented in `InboxExport` and consumed by the shared
+  delivery executor
+
+## Explicit Code Samples
+
+If the sprint introduces or changes important traits, features, enums, protocol
+types, boundary contracts, or execution seams, this section must include
+explicit code samples or signatures showing the intended end state.
+
+```rust
+pub enum ClaudeCompatibilityDeliveryMode {
+    RecoveredLogicalMessageSet,
+}
+
+pub struct InboxExportAppendMessageSetRequest {
+    pub path: PathBuf,
+    pub messages: Vec<MessageEnvelope>,
+    pub mode: ClaudeCompatibilityDeliveryMode,
+}
+
+pub struct InboxExportAppendMessageSetResponse {
+    pub wrote_messages: usize,
+}
+
+pub trait InboxExport: sealed::Sealed {
+    fn export_record(
+        &self,
+        request: InboxExportRecordRequest,
+    ) -> Result<InboxExportRecordResponse, AtmError>;
+
+    fn reexport_message(
+        &self,
+        request: InboxExportReexportMessageRequest,
+    ) -> Result<InboxExportReexportMessageResponse, AtmError>;
+
+    fn append_message_set(
+        &self,
+        request: InboxExportAppendMessageSetRequest,
+    ) -> Result<InboxExportAppendMessageSetResponse, AtmError>;
+}
+```
+
+```rust
+fn claude_compatibility_delivery_mode_for_disposition(
+    disposition: DeliveryPlanDisposition,
+) -> Result<ClaudeCompatibilityDeliveryMode, AtmError>;
+```
+
+```rust
+pub(crate) trait ClaudeInboxWriter {
+    fn append_claude_message_set(
+        &self,
+        inbox_path: &Path,
+        recipient: &DeliveryRecipientSnapshot,
+        disposition: DeliveryPlanDisposition,
+        messages: &[LogicalMessage],
+    ) -> Result<(), AtmError>;
+}
+```
+
+```rust
+fn execute_claude_delivery<R: ClaudeInboxWriter + ?Sized>(
+    runtime: &R,
+    disposition: DeliveryPlanDisposition,
+    inbox_path: &Path,
+    recipient: &DeliveryRecipientSnapshot,
+    messages: &[LogicalMessage],
+    result: &mut DeliveryExecutionResult,
+) -> Result<(), AtmError>;
+```
+
+## Error Inventory
+
+- `InboxExport::append_message_set(...)` returns `AtmError` when:
+  - the recovered logical message set cannot be projected to the compatibility
+    inbox/export surface at all
+  - the target inbox/export path is unavailable or invalid for recovered
+    export
+  - the export fails before the full logical message set is materialized
+- recovered Claude export must not degrade a partial `message[1]` write into an
+  `AppendDegraded` warning and continue
+- persisted append degradation remains separate:
+  - it may still surface the existing typed append warning on the persisted
+    append path
+  - it must not be reused as proof that recovered logical-message-set export is
+    allowed to partially succeed
+- `claude_compatibility_delivery_mode_for_disposition(...)` returns
+  `AtmError::validation(...)` with `AtmErrorCode::MessageValidationFailed`
+  when called with any `DeliveryPlanDisposition` other than
+  `DeliveryPlanDisposition::SqliteFailedRecovered`; non-recovered dispositions
+  are invalid inputs for the recovered Claude message-set mapping seam
+
+## This Sprint Does Not Close
+
+- the `NotificationSink` boundary bypass in the post-send notification path
+- final integrated production-readiness sign-off for the whole `Phase Y` line
+- any new smoke/dogfood execution work in `Phase Z`
+- post-mortem lint recommendations or rule additions from
+  `integrate/phase-Y/.triage/phase-Yb/post-mortem.md`
+
+## Acceptance Criteria
+
+- `rg -n "if disposition == DeliveryPlanDisposition::SqliteFailedRecovered \\{[[:space:]]*break;" crates/atm-core/src/delivery_execution.rs`
+  returns no matches
+- `rg -n "append_claude_inbox_message\\(inbox_path, recipient, &message\\.envelope\\)" crates/atm-core/src/delivery_execution.rs`
+  no longer shows the recovered Claude path implemented as a one-message loop
+- the recovered Claude path no longer reports success after a partial outward
+  logical-message-set append
+- the sprint introduces exactly one approved message-set compatibility export
+  seam for the recovered Claude path, and that seam is documented in both
+  `atm-core` and `atm-daemon` boundary docs
+- named tests prove all-or-nothing recovered Claude logical-message-set
+  behavior:
+  - `sqlite_failure_for_claude_requires_full_logical_message_set_delivery`
+  - `sqlite_failure_for_claude_does_not_emit_message1_without_message2`
+  - `persisted_claude_append_degradation_remains_explicit_and_warning_typed`
+    must prove that the persisted append-only path still emits the existing
+    typed warning entry on append degradation and never silently drops the
+    failure
+- no acceptance criterion relies on “shared shape” alone; the runtime behavior
+  must be proven by the tests above
+
+## Required Validation
+
+- `rg -n "if disposition == DeliveryPlanDisposition::SqliteFailedRecovered \\{[[:space:]]*break;" crates/atm-core/src/delivery_execution.rs`
+- `rg -n "append_claude_inbox_message\\(inbox_path, recipient, &message\\.envelope\\)" crates/atm-core/src/delivery_execution.rs`
+- `cargo build --workspace`
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `git diff --check`

--- a/docs/phase-Yc/sprint-Y13.md
+++ b/docs/phase-Yc/sprint-Y13.md
@@ -1,0 +1,298 @@
+---
+id: Y.13
+title: Notification Boundary Closure And Final Readiness Gate
+status: planned
+branch: feature/pYc-s13-notification-boundary-and-readiness-gate
+worktree: ../atm-core-worktrees/feature/pYc-s13-notification-boundary-and-readiness-gate
+target: integrate/phase-Y
+---
+
+# Sprint Y.13 — Notification Boundary Closure And Final Readiness Gate
+
+## Goal
+
+- close the remaining architectural bypass in production notification execution
+- make the delivery executor use `NotificationSink` on the live runtime path
+- end the `Yc` line with one focused production-readiness proof for the merged
+  `Phase Y` baseline
+
+## Hard Dependencies
+
+- `docs/phase-Yc/sprint-Y12.md` must close first
+- `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+- `docs/phase-Yc/plan-phase-Yc.md`
+- the authoritative implementation baseline is `integrate/phase-Y` plus the
+  landed `Y.12` branch
+
+## Exact Targets
+
+- `crates/atm-core/src/delivery_execution.rs`
+- `crates/atm-core/src/service_runtime.rs`
+- `crates/atm-core/src/boundary/mod.rs`
+- `crates/atm-core/src/delivery_plan.rs`
+- `crates/atm-core/src/protocol.rs`
+- `crates/atm-daemon/src/boundary_adapters.rs`
+- `crates/atm-daemon/src/notification_runtime.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-rusqlite/src/boundary_assembly.rs`
+- `crates/atm-rusqlite/src/lib.rs`
+- `crates/atm-runtime-test-support/src/lib.rs`
+- `crates/atm-daemon/src/tests.rs`
+- `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
+- `docs/project-plan.md` (Section 33, `Phase Yc Final Production-Readiness Closure`)
+- `docs/phase-Yc/readiness.md`
+
+## Deliverables
+
+Every listed deliverable is expected to land at a production-ready level for
+the scope this sprint claims. If that cannot be done cleanly in one sprint, the
+sprint must be split before implementation begins. No deliverable may be
+silently dropped or partially deferred.
+
+- `delivery_execution.rs` no longer calls `maybe_run_post_send_hook(...)`
+  directly on the production path
+- the shared notification executor uses `NotificationSink::deliver(...)` through
+  a typed `NotificationEvent` translation seam
+- notification failure semantics are explicit and tested; unavailable or
+  backpressured notification delivery must degrade through typed warnings or
+  errors rather than hidden helper behavior
+- the integrated `Phase Y` line gets a focused production-readiness gate that
+  specifically rechecks the two `Yc` closure invariants before `Phase Z`
+  resumes
+- the sprint leaves one explicit readiness record artifact,
+  `docs/phase-Yc/readiness.md`, naming both `Yc` closure invariants and the
+  `Phase Z` smoke gate
+
+## Required Work
+
+- install `NotificationSink` into the retained runtime/executor path used by
+  send and ack delivery execution
+- replace the direct `maybe_run_post_send_hook(...)` call in
+  `PostSendNotificationExecutor` with typed `NotificationTarget ->
+  NotificationEvent` translation plus `NotificationSink::deliver(...)`
+- make notification degradation behavior explicit in the shared executor path;
+  do not bury it inside `service_runtime.rs`
+- delete `LocalServiceRuntime::new(...)` and
+  `LocalServiceRuntime::new_with_non_claude_outbound(...)`
+- replace the current multiple-constructor surface with one public composition
+  constructor that requires the full delivery-boundary set needed by the
+  retained runtime
+- update every cross-crate runtime assembly site to use that one constructor:
+  - `atm-daemon` production retained runtime
+  - `atm-daemon/src/runtime_health.rs` runtime-health retained runtime wiring
+  - `atm-rusqlite` default retained runtime
+  - `atm-runtime-test-support` cached test runtimes
+  - daemon/unit integration tests that build `LocalServiceRuntime` directly
+- update ADR/boundary docs so the production notification path is documented as
+  boundary-owned and no longer helper-owned
+- update the project plan/status docs so `Phase Z` smoke is blocked until the
+  `Yc` readiness gate passes and allowed again once it does
+
+## Paths To Delete
+
+- `crates/atm-core/src/delivery_execution.rs`
+  - delete the blanket `PostSendNotificationExecutor` implementation path that
+    calls `self.maybe_run_post_send_hook(...)` directly
+- `crates/atm-core/src/service_runtime.rs`
+  - delete `RetainedServiceRuntime::maybe_run_post_send_hook(...)` from the
+    retained runtime trait once the shared executor no longer depends on it
+  - delete the `LocalServiceRuntime` implementation of
+    `maybe_run_post_send_hook(...)` as a production delivery path
+  - delete `LocalServiceRuntime::new(...)`
+  - delete `LocalServiceRuntime::new_with_non_claude_outbound(...)`
+- `crates/atm-daemon/src/runtime_health.rs`
+  - delete the retained-runtime factory constructor path that installs
+    `LocalServiceRuntime::new_with_non_claude_outbound(...)` without also
+    wiring the production `NotificationSink`
+- `crates/atm-rusqlite/src/boundary_assembly.rs`
+  - delete constructor callsites that still assemble `LocalServiceRuntime`
+    without an explicit `NotificationSink`
+- `crates/atm-runtime-test-support/src/lib.rs`
+  - delete constructor callsites that still assemble `LocalServiceRuntime`
+    through the legacy constructor surface
+- `crates/atm-daemon/src/tests.rs`
+  - delete constructor callsites that still assemble `LocalServiceRuntime`
+    through the legacy constructor surface
+- `crates/atm-rusqlite/src/lib.rs`
+  - delete retained test/runtime callsites that still construct
+    `LocalServiceRuntime` through `new(...)` or
+    `new_with_non_claude_outbound(...)`
+
+## Approved Surviving Paths
+
+- production notification delivery may survive only through:
+  - `atm_core::boundary::NotificationSink::deliver(...)`
+  - `atm_daemon::boundary_adapters::DaemonNotificationSink`
+  - `atm_daemon::notification_runtime::NotificationRuntime::deliver(...)`
+- reconcile/runtime notification side effects already using
+  `NotificationSink::deliver(...)` remain valid and must not be rewritten back
+  to helper-owned hooks
+- daemon retained-runtime composition must survive as one explicit constructor
+  that installs:
+  - `MailStore`
+  - `TaskStore`
+  - `RosterStore`
+  - `NonClaudeOutbound`
+  - `NotificationSink`
+- non-daemon local runtime assembly may survive only through that same
+  constructor shape with explicit fallback/test adapters supplied by the caller
+- the surviving constructor remains public because current runtime assembly is
+  cross-crate:
+  - `atm-daemon` composes the production retained runtime
+  - `atm-rusqlite` composes the default retained runtime
+  - `atm-runtime-test-support` composes cached test runtimes
+- `Y.13` does not close constructor visibility reduction; it closes
+  constructor-shape narrowing to one approved public composition path
+
+## Explicit Code Samples
+
+If the sprint introduces or changes important traits, features, enums, protocol
+types, boundary contracts, or execution seams, this section must include
+explicit code samples or signatures showing the intended end state.
+
+```rust
+pub(crate) trait PostSendNotificationExecutor {
+    fn deliver_notifications(
+        &self,
+        warnings: &mut Vec<WarningEntry>,
+        recipient: &ResolvedRecipient,
+        // `recipient_pane_id` stays as `Option<&str>` for Y.13 because the
+        // canonical pane identifier type-normalization line is separate work;
+        // this sprint closes notification-boundary ownership, not pane-id
+        // type redesign.
+        recipient_pane_id: Option<&str>,
+        notifications: &[NotificationTarget],
+    );
+}
+```
+
+```rust
+pub trait NotificationSink: sealed::Sealed {
+    fn deliver(&self, event: NotificationEvent) -> Result<(), AtmError>;
+}
+```
+
+```rust
+pub struct LocalServiceRuntime {
+    pub(crate) mail_store: Arc<dyn MailStore + Send + Sync>,
+    pub(crate) task_store: Arc<dyn TaskStore + Send + Sync>,
+    pub(crate) roster_store: Arc<dyn RosterStore + Send + Sync>,
+    pub(crate) non_claude_outbound: Arc<dyn NonClaudeOutbound + Send + Sync>,
+    pub(crate) notification_sink: Arc<dyn NotificationSink + Send + Sync>,
+}
+```
+
+```rust
+pub fn new_with_delivery_boundaries(
+    mail_store: Arc<dyn MailStore + Send + Sync>,
+    task_store: Arc<dyn TaskStore + Send + Sync>,
+    roster_store: Arc<dyn RosterStore + Send + Sync>,
+    non_claude_outbound: Arc<dyn NonClaudeOutbound + Send + Sync>,
+    notification_sink: Arc<dyn NotificationSink + Send + Sync>,
+) -> Self;
+```
+
+```rust
+pub struct LocalFileNotificationSink {
+    path: PathBuf,
+}
+
+impl LocalFileNotificationSink {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+// Owned by `atm_core::direct_boundaries`.
+// Role: fallback non-daemon `NotificationSink` adapter for local/test runtime
+// assembly. Non-daemon callers construct it explicitly with
+// `LocalFileNotificationSink::new(path)` and it appends newline-delimited
+// serialized `NotificationEvent` payloads to that path, returning typed
+// `AtmError` on file open/write failure rather than swallowing the event.
+```
+
+```rust
+fn notification_event_from_target(
+    recipient: &ResolvedRecipient,
+    recipient_pane_id: Option<&str>,
+    target: &NotificationTarget,
+) -> NotificationEvent;
+```
+
+## Error Inventory
+
+- `NotificationSink::deliver(...)` returns `AtmError` when:
+  - the daemon-backed notification queue is unavailable
+  - the daemon-backed notification queue is full and delivery is
+    backpressured; this path currently returns
+    `AtmErrorCode::DaemonUnavailable` (`ATM_DAEMON_UNAVAILABLE`)
+  - the fallback local file sink cannot persist the notification event
+- ack-path notification failure policy:
+  - notification failure on the ack path degrades to a typed warning entry and
+    does not silently drop the event
+  - it must not revert the already-valid ack outcome solely because the
+    side-effect sink is unavailable
+- backpressure handling must log a structured warning/observability event in
+  addition to surfacing the typed warning result
+- shutdown/drain policy remains bounded:
+  - already-accepted queued notification events are drained during normal
+    shutdown up to the existing `3s` runtime shutdown deadline
+  - if that `3s` deadline is exceeded, the runtime emits a structured warning,
+    returns `AtmErrorCode::DaemonUnavailable`
+    (`ATM_DAEMON_UNAVAILABLE`), detaches the join helper, and any still-pending
+    queued notification events are treated as dropped
+  - Y.13 must not introduce an unbounded flush loop
+- startup/liveness check:
+  - the readiness record must state that the production retained runtime can
+    construct a live `NotificationSink` and accept at least one notification
+    request on the send/ack path
+
+## This Sprint Does Not Close
+
+- constructor visibility reduction to `pub(crate)` or private factory-only
+  assembly
+- any new event-family state-machine design beyond the already approved `Phase Y`
+  and `Phase Yb` delivery-plan seam
+- any new smoke/dogfood execution work inside `Phase Z` itself
+- any unrelated daemon transport or roster-store redesign
+- post-mortem lint recommendations or rule additions from
+  `integrate/phase-Y/.triage/phase-Yb/post-mortem.md`
+
+## Acceptance Criteria
+
+- `rg -n "maybe_run_post_send_hook" crates/atm-core/src/delivery_execution.rs`
+  returns no matches
+- `rg -n "fn maybe_run_post_send_hook" crates/atm-core/src/service_runtime.rs`
+  returns no matches
+- `rg -n "pub fn new\\(" crates/atm-core/src/service_runtime.rs`
+  returns no matches
+- `rg -n "new_with_non_claude_outbound" crates/atm-daemon/src/runtime_health.rs`
+  returns no matches
+- `rg -n "new_with_non_claude_outbound" crates` returns no matches
+- the production notification path is reachable only through
+  `NotificationSink::deliver(...)` from the shared executor seam
+- `LocalServiceRuntime` exposes exactly one approved public constructor for the
+  retained delivery-boundary composition shape
+- named tests prove notification translation and degradation behavior:
+  - `delivery_notifications_use_notification_sink_boundary`
+  - `notification_sink_failure_is_explicit_in_delivery_warnings`
+    must prove that a warning entry is populated and the failure is not
+    swallowed by direct helper-owned behavior
+  - `notification_sink_backpressure_does_not_reopen_hook_helper_bypass`
+- the sprint leaves one explicit readiness record in the docs that says:
+  - `Y.12` closed the Claude recovered-message-set contract
+  - `Y.13` closed the notification boundary bypass
+  - `Phase Z` smoke may resume only after both proofs pass
+
+## Required Validation
+
+- `rg -n "maybe_run_post_send_hook" crates/atm-core/src/delivery_execution.rs`
+- `rg -n "fn maybe_run_post_send_hook" crates/atm-core/src/service_runtime.rs`
+- `rg -n "pub fn new\\(" crates/atm-core/src/service_runtime.rs`
+- `rg -n "new_with_non_claude_outbound" crates/atm-daemon/src/runtime_health.rs`
+- `rg -n "new_with_non_claude_outbound" crates`
+- `cargo build --workspace`
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `git diff --check`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3558,8 +3558,11 @@ Status summary:
   `DeliveryHarnessPath::NonClaude`
 - an explicit repair/rebuild projection seam that no longer accepts a generic
   recipient snapshot with a non-Claude no-op branch
-- smoke/dogfood work may now resume on the follow-on line without reopening the
-  same message-path consolidation issues.
+- a later focused production-readiness review still reopened two final blockers:
+  - partial Claude recovered degraded delivery remained possible
+  - production notification execution still bypassed `NotificationSink`
+- those blockers are tracked in `Phase Yc`; smoke/dogfood work must not resume
+  until `Phase Yc` closes.
 
 Goal:
 - lock down the exact message-path consolidation work needed after `Phase Y`
@@ -3595,3 +3598,49 @@ Immediate planning outputs:
 - `docs/phase-Yb/sprint-Y10.md`
 - `docs/phase-Yb/sprint-Y11.md`
 - `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+
+## 33. Phase Yc Final Production-Readiness Closure
+
+Status summary:
+- `integrate/phase-Y` is close enough to resume smoke only after two final
+  production-readiness blockers are explicitly closed.
+- `Phase Yc` is the dedicated follow-on for those blockers.
+- `Phase Yc` is intentionally split into two sprints so each deliverable lands
+  at a production-ready level without mixing behavioral and boundary closure.
+
+Goal:
+- close the final Claude recovered degraded-delivery contract gap
+- close the final `NotificationSink` boundary bypass
+- hand the merged `Phase Y` line back to `Phase Z` only after a focused
+  readiness gate passes
+- keep `Y.12` and `Y.13` on their user-discussed runtime/code scope; later
+  post-mortem lint recommendations are separate follow-up work, not substitute
+  deliverables for these two sprints
+
+Execution shape:
+- planning-only branch: `plan/phase-Yc-y12-y13`
+- implementation target branch: `integrate/phase-Y`
+- implementation sequence:
+  - `Y.12` Claude degraded delivery set closure
+    - branch: `feature/pYc-s12-claude-degraded-delivery-set-closure`
+  - `Y.13` notification boundary closure and readiness gate
+    - branch: `feature/pYc-s13-notification-boundary-and-readiness-gate`
+
+Immediate planning outputs:
+- `docs/phase-Yc/plan-phase-Yc.md`
+- `docs/phase-Yc/issues.md`
+- `docs/phase-Yc/readiness.md`
+- `docs/phase-Yc/sprint-Y12.md`
+- `docs/phase-Yc/sprint-Y13.md`
+
+Acceptance / Phase Z Smoke Gate:
+- `Phase Z` smoke and dogfood work remain blocked while either `Y.12` or
+  `Y.13` is still open.
+- `Phase Z` smoke may resume only after the `Yc` readiness record explicitly
+  states that:
+  - the recovered Claude SQLite-failure path cannot partially emit a logical
+    message set while still claiming success
+  - the production notification path executes through
+    `NotificationSink::deliver(...)` rather than direct hook helpers
+  - the focused `Yc` readiness validation has passed on the merged
+    `integrate/phase-Y` line


### PR DESCRIPTION
## Summary

- Syncs `docs/phase-Yc/` (plan-phase-Yc.md, sprint-Y12.md, sprint-Y13.md, issues.md, readiness.md) from `plan/phase-Yc-y12-y13` @ 2b0c5592
- Updates `docs/project-plan.md` with Phase Z smoke gate (REQ-QA-001)
- Updates ADR-013 and both boundary docs with Y.12/Y.13 seam notes

This makes authoritative sprint docs available on `integrate/phase-Y` before Y.12 implementation starts.

Plan QA: 3 rounds, final PASS at 0B+0I+0m (PR #310 merged to develop at 9d567ae7).

## Test plan
- [ ] Verify `docs/phase-Yc/` contains all 5 plan doc files
- [ ] No Rust code changes — docs-only sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)