### PR TITLE
fix(phase-Y-eop): RULE-006 structured logging, bounded shutdown, DeliveryPlan consolidation, sealed traits

### DIFF
--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -6,8 +6,8 @@ use crate::delivery_execution::{
     DeliveryTransitionContext, emit_reply_delivery_plan_transitions, execute_reply_delivery_plan,
 };
 use crate::delivery_plan::{
-    LogicalMessage, ReplyDeliveryPlan, delivery_plan_disposition, delivery_target_for_snapshot,
-    logical_messages_from_persistence,
+    DeliveryPlan, DeliveryPlanKind, LogicalMessage, delivery_plan_disposition,
+    delivery_target_for_snapshot, logical_messages_from_persistence,
 };
 use crate::delivery_policy::{DeliveryEventFamily, DeliveryPolicyCoordinator};
 use crate::error::AtmError;
@@ -126,7 +126,9 @@ pub fn ack_mail_with_runtime(
     ack_mail_with_runtime_impl(request, observability, runtime)
 }
 
-fn ack_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+fn ack_mail_with_runtime_impl<
+    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
+>(
     request: AckRequest,
     observability: &dyn ObservabilityPort,
     runtime: &R,
@@ -159,7 +161,9 @@ fn ack_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntime
     )
 }
 
-fn ack_mail_with_runtime_sqlite<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+fn ack_mail_with_runtime_sqlite<
+    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
+>(
     request: AckRequest,
     observability: &dyn ObservabilityPort,
     runtime: &R,
@@ -434,7 +438,9 @@ fn home_dir(request: &AckRequest) -> &std::path::Path {
     request.home_dir.as_path()
 }
 
-fn finalize_ack_outcome<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+fn finalize_ack_outcome<
+    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
+>(
     runtime: &R,
     observability: &dyn ObservabilityPort,
     config: Option<&crate::config::AtmConfig>,
@@ -518,7 +524,7 @@ impl AckReplyStateMachine {
         reply_target: &ReplyTarget,
         reply_snapshot: &crate::delivery_policy::DeliveryRecipientSnapshot,
         reply_inbox_path: &std::path::Path,
-    ) -> ReplyDeliveryPlan {
+    ) -> DeliveryPlan {
         let (disposition, messages, warnings) = match self {
             Self::Persisted { messages, warnings } => (
                 crate::send::DeliveryPersistenceDisposition::Persisted,
@@ -531,7 +537,8 @@ impl AckReplyStateMachine {
                 warnings,
             ),
         };
-        ReplyDeliveryPlan::new(
+        DeliveryPlan::new(
+            DeliveryPlanKind::Reply,
             delivery_plan_disposition(disposition),
             delivery_target_for_snapshot(reply_inbox_path, reply_snapshot),
             ResolvedRecipient {
@@ -545,9 +552,7 @@ impl AckReplyStateMachine {
     }
 }
 
-fn build_reply_delivery_plan(
-    context: &FinalizeAckContext<'_>,
-) -> Result<ReplyDeliveryPlan, AtmError> {
+fn build_reply_delivery_plan(context: &FinalizeAckContext<'_>) -> Result<DeliveryPlan, AtmError> {
     Ok(
         AckReplyStateMachine::from_persistence(&context.persisted.persistence)?
             .into_reply_delivery_plan(

--- a/crates/atm-core/src/delivery_execution.rs
+++ b/crates/atm-core/src/delivery_execution.rs
@@ -126,6 +126,9 @@ where
             let event = notification_event_from_target(recipient, recipient_pane_id, notification);
             if let Err(error) = self.deliver_notification_event(event) {
                 tracing::warn!(
+                    subsystem = "delivery_execution",
+                    action = "deliver_notifications",
+                    outcome = "failed",
                     recipient = %recipient.agent,
                     team = %recipient.team,
                     %error,

--- a/crates/atm-core/src/delivery_execution.rs
+++ b/crates/atm-core/src/delivery_execution.rs
@@ -4,7 +4,6 @@ use crate::boundary::ClaudeCompatibilityDeliveryMode;
 use crate::config::AtmConfig;
 use crate::delivery_plan::{
     DeliveryPlan, DeliveryPlanDisposition, DeliveryTarget, LogicalMessage, NotificationTarget,
-    ReplyDeliveryPlan,
 };
 use crate::delivery_policy::{
     DeliveryEventFamily, DeliveryHarnessPath, claude_append_failure_transition_names,
@@ -49,7 +48,7 @@ pub(crate) struct DeliveryTransitionContext<'a> {
     pub(crate) task_id: Option<TaskId>,
 }
 
-pub(crate) trait ClaudeInboxWriter {
+pub(crate) trait ClaudeInboxWriter: crate::boundary::sealed::Sealed {
     fn append_claude_inbox_message(
         &self,
         inbox_path: &Path,
@@ -67,7 +66,7 @@ pub(crate) trait ClaudeInboxWriter {
 
 impl<T> ClaudeInboxWriter for T
 where
-    T: RetainedServiceRuntime + ?Sized,
+    T: RetainedServiceRuntime + crate::boundary::sealed::Sealed + ?Sized,
 {
     fn append_claude_inbox_message(
         &self,
@@ -86,6 +85,8 @@ where
         messages: &[LogicalMessage],
     ) -> Result<(), AtmError> {
         let mode = claude_compatibility_delivery_mode_for_disposition(disposition)?;
+        // The retained runtime boundary still accepts owned envelopes, so this
+        // delivery seam must clone until the boundary contract is widened.
         self.append_compat_inbox_message_set(
             inbox_path,
             mode,
@@ -97,7 +98,7 @@ where
     }
 }
 
-pub(crate) trait PostSendNotificationExecutor {
+pub(crate) trait PostSendNotificationExecutor: crate::boundary::sealed::Sealed {
     /// Notification delivery is a best-effort side effect: failures must be
     /// surfaced as typed warnings, not as silent drops or primary delivery
     /// failures.
@@ -112,7 +113,7 @@ pub(crate) trait PostSendNotificationExecutor {
 
 impl<T> PostSendNotificationExecutor for T
 where
-    T: RetainedServiceRuntime + ?Sized,
+    T: RetainedServiceRuntime + crate::boundary::sealed::Sealed + ?Sized,
 {
     fn deliver_notifications(
         &self,
@@ -142,7 +143,7 @@ where
     }
 }
 
-pub(crate) trait NonClaudeOutboundDeliveryWriter {
+pub(crate) trait NonClaudeOutboundDeliveryWriter: crate::boundary::sealed::Sealed {
     fn deliver_non_claude_payloads(
         &self,
         recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
@@ -152,13 +153,16 @@ pub(crate) trait NonClaudeOutboundDeliveryWriter {
 
 impl<T> NonClaudeOutboundDeliveryWriter for T
 where
-    T: RetainedServiceRuntime + ?Sized,
+    T: RetainedServiceRuntime + crate::boundary::sealed::Sealed + ?Sized,
 {
     fn deliver_non_claude_payloads(
         &self,
         recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
         messages: &[LogicalMessage],
     ) -> Result<(), AtmError> {
+        // NonClaudeOutbound is still defined in terms of owned envelopes at
+        // the retained runtime boundary, so this path clones until that
+        // boundary contract changes.
         RetainedServiceRuntime::deliver_non_claude_payloads(
             self,
             recipient,
@@ -195,7 +199,7 @@ where
 pub(crate) fn execute_reply_delivery_plan<R>(
     runtime: &R,
     config: Option<&AtmConfig>,
-    plan: &ReplyDeliveryPlan,
+    plan: &DeliveryPlan,
 ) -> Result<DeliveryExecutionResult, AtmError>
 where
     R: ClaudeInboxWriter + NonClaudeOutboundDeliveryWriter + PostSendNotificationExecutor,
@@ -301,7 +305,7 @@ pub(crate) fn emit_delivery_plan_transitions(
 pub(crate) fn emit_reply_delivery_plan_transitions(
     observability: &dyn ObservabilityPort,
     context: DeliveryTransitionContext<'_>,
-    plan: &ReplyDeliveryPlan,
+    plan: &DeliveryPlan,
     execution: &DeliveryExecutionResult,
 ) -> Result<(), AtmError> {
     emit_plan_transitions(
@@ -475,7 +479,8 @@ mod tests {
         emit_delivery_plan_transitions, execute_delivery_plan,
     };
     use crate::delivery_plan::{
-        DeliveryPlan, DeliveryPlanDisposition, DeliveryTarget, LogicalMessage, NotificationTarget,
+        DeliveryPlan, DeliveryPlanDisposition, DeliveryPlanKind, DeliveryTarget, LogicalMessage,
+        NotificationTarget,
     };
     use crate::delivery_policy::{
         DeliveryEventFamily, DeliveryHarnessPath, DeliveryRecipientSnapshot,
@@ -492,6 +497,8 @@ mod tests {
     use crate::types::{AgentName, IsoTimestamp, TeamName};
 
     struct NoopRuntime;
+
+    impl crate::boundary::sealed::Sealed for NoopRuntime {}
 
     impl ClaudeInboxWriter for NoopRuntime {
         fn append_claude_inbox_message(
@@ -609,7 +616,7 @@ mod tests {
         single_append_texts: std::sync::Mutex<Vec<String>>,
         message_set_texts: std::sync::Mutex<Vec<Vec<String>>>,
         fail_message_set: bool,
-        fail_single_append_indexes: std::sync::Mutex<Vec<usize>>,
+        fail_single_append_indexes: Vec<usize>,
         single_append_calls: std::sync::Mutex<usize>,
         notification_events: std::sync::Mutex<Vec<NotificationEvent>>,
         notification_error_message: Option<&'static str>,
@@ -625,7 +632,7 @@ mod tests {
 
         fn with_single_append_failures(indexes: &[usize]) -> Self {
             Self {
-                fail_single_append_indexes: std::sync::Mutex::new(indexes.to_vec()),
+                fail_single_append_indexes: indexes.to_vec(),
                 ..Self::default()
             }
         }
@@ -638,6 +645,8 @@ mod tests {
         }
     }
 
+    impl crate::boundary::sealed::Sealed for RecordingRuntime {}
+
     impl ClaudeInboxWriter for RecordingRuntime {
         fn append_claude_inbox_message(
             &self,
@@ -649,12 +658,7 @@ mod tests {
             let current_index = *call_count;
             *call_count += 1;
 
-            if self
-                .fail_single_append_indexes
-                .lock()
-                .expect("fail indexes")
-                .contains(&current_index)
-            {
+            if self.fail_single_append_indexes.contains(&current_index) {
                 return Err(AtmError::mailbox_write(format!(
                     "single append failure for message[{}]",
                     current_index + 1
@@ -764,6 +768,7 @@ mod tests {
         let runtime = NoopRuntime;
         let message = logical_message();
         let plan = DeliveryPlan::new(
+            DeliveryPlanKind::Send,
             DeliveryPlanDisposition::Persisted,
             DeliveryTarget::ClaudeCode {
                 inbox_path: PathBuf::from("recipient.jsonl"),
@@ -788,11 +793,40 @@ mod tests {
     }
 
     #[test]
+    fn execute_delivery_plan_rejects_non_claude_target_for_claude_harness() {
+        let runtime = NoopRuntime;
+        let message = logical_message();
+        let plan = DeliveryPlan::new(
+            DeliveryPlanKind::Send,
+            DeliveryPlanDisposition::Persisted,
+            DeliveryTarget::NonClaude {
+                recipient: recipient_snapshot(DeliveryHarnessPath::ClaudeCode),
+            },
+            ResolvedRecipient {
+                agent: AgentName::from_validated("recipient"),
+                team: TeamName::from_validated(TEST_TEAM),
+            },
+            None,
+            vec![message],
+            Vec::new(),
+        );
+
+        let error = execute_delivery_plan(&runtime, None, &plan).expect_err("fail closed");
+        assert!(error.is_validation());
+        assert!(
+            error
+                .message
+                .contains("NonClaude target for Claude Code harness")
+        );
+    }
+
+    #[test]
     fn emit_delivery_plan_transitions_rejects_non_claude_append_degraded_state() {
         let observability = RecordingObservability::default();
         let message = logical_message();
         let message_id = message.message_id();
         let plan = DeliveryPlan::new(
+            DeliveryPlanKind::Send,
             DeliveryPlanDisposition::Persisted,
             DeliveryTarget::NonClaude {
                 recipient: recipient_snapshot(DeliveryHarnessPath::NonClaude),
@@ -825,9 +859,48 @@ mod tests {
     }
 
     #[test]
+    fn emit_reply_delivery_plan_transitions_rejects_non_claude_append_degraded_state() {
+        let observability = RecordingObservability::default();
+        let message = logical_message();
+        let message_id = message.message_id();
+        let plan = DeliveryPlan::new(
+            DeliveryPlanKind::Reply,
+            DeliveryPlanDisposition::Persisted,
+            DeliveryTarget::NonClaude {
+                recipient: recipient_snapshot(DeliveryHarnessPath::NonClaude),
+            },
+            ResolvedRecipient {
+                agent: AgentName::from_validated("recipient"),
+                team: TeamName::from_validated(TEST_TEAM),
+            },
+            None,
+            vec![message],
+            Vec::new(),
+        );
+
+        let error = super::emit_reply_delivery_plan_transitions(
+            &observability,
+            transition_context(message_id),
+            &plan,
+            &super::DeliveryExecutionResult {
+                disposition: DeliveryExecutionDisposition::AppendDegraded,
+                warnings: Vec::new(),
+            },
+        )
+        .expect_err("reject impossible append-degraded non-claude reply transition");
+        assert!(error.is_validation());
+        assert!(
+            error
+                .message
+                .contains("unsupported for DeliveryHarnessPath::NonClaude")
+        );
+    }
+
+    #[test]
     fn sqlite_failure_for_claude_requires_full_logical_message_set_delivery() {
         let runtime = RecordingRuntime::with_message_set_failure();
         let plan = DeliveryPlan::new(
+            DeliveryPlanKind::Send,
             DeliveryPlanDisposition::SqliteFailedRecovered,
             DeliveryTarget::ClaudeCode {
                 inbox_path: PathBuf::from("recipient.jsonl"),
@@ -868,6 +941,7 @@ mod tests {
     fn sqlite_failure_for_claude_does_not_emit_message1_without_message2() {
         let runtime = RecordingRuntime::with_message_set_failure();
         let plan = DeliveryPlan::new(
+            DeliveryPlanKind::Send,
             DeliveryPlanDisposition::SqliteFailedRecovered,
             DeliveryTarget::ClaudeCode {
                 inbox_path: PathBuf::from("recipient.jsonl"),
@@ -906,6 +980,7 @@ mod tests {
     fn persisted_claude_append_degradation_remains_explicit_and_warning_typed() {
         let runtime = RecordingRuntime::with_single_append_failures(&[0]);
         let plan = DeliveryPlan::new(
+            DeliveryPlanKind::Send,
             DeliveryPlanDisposition::Persisted,
             DeliveryTarget::ClaudeCode {
                 inbox_path: PathBuf::from("recipient.jsonl"),
@@ -951,6 +1026,7 @@ mod tests {
         let runtime = RecordingRuntime::default();
         let message_id = AtmMessageId::new();
         let mut plan = DeliveryPlan::new(
+            DeliveryPlanKind::Send,
             DeliveryPlanDisposition::Persisted,
             DeliveryTarget::ClaudeCode {
                 inbox_path: PathBuf::from("recipient.jsonl"),
@@ -1016,6 +1092,7 @@ mod tests {
     fn notification_sink_failure_is_explicit_in_delivery_warnings() {
         let runtime = RecordingRuntime::with_notification_failure("notification sink unavailable");
         let mut plan = DeliveryPlan::new(
+            DeliveryPlanKind::Send,
             DeliveryPlanDisposition::Persisted,
             DeliveryTarget::NonClaude {
                 recipient: recipient_snapshot(DeliveryHarnessPath::NonClaude),
@@ -1062,6 +1139,7 @@ mod tests {
         let runtime =
             RecordingRuntime::with_notification_failure("notification sink queue is saturated");
         let mut plan = DeliveryPlan::new(
+            DeliveryPlanKind::Send,
             DeliveryPlanDisposition::Persisted,
             DeliveryTarget::ClaudeCode {
                 inbox_path: PathBuf::from("recipient.jsonl"),

--- a/crates/atm-core/src/delivery_plan.rs
+++ b/crates/atm-core/src/delivery_plan.rs
@@ -22,6 +22,7 @@ pub(crate) enum DeliveryPlanKind {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct LogicalMessage {
+    pub(crate) message_id: AtmMessageId,
     pub(crate) envelope: MessageEnvelope,
     pub(crate) requires_ack: bool,
     pub(crate) is_ack: bool,
@@ -48,10 +49,11 @@ impl LogicalMessage {
         requires_ack: bool,
         is_ack: bool,
     ) -> Result<Self, LogicalMessageError> {
-        if envelope.message_id.is_none() {
-            return Err(LogicalMessageError::MissingMessageId);
-        }
+        let message_id = envelope
+            .message_id
+            .ok_or(LogicalMessageError::MissingMessageId)?;
         Ok(Self {
+            message_id,
             envelope,
             requires_ack,
             is_ack,
@@ -59,12 +61,7 @@ impl LogicalMessage {
     }
 
     pub(crate) fn message_id(&self) -> AtmMessageId {
-        // Invariant: `LogicalMessage::new` rejects envelopes without a message
-        // id, and every constructor path in this module goes through that
-        // validation before a message ever reaches a delivery plan.
-        self.envelope
-            .message_id
-            .expect("validated logical delivery messages always have a message id")
+        self.message_id
     }
 }
 

--- a/crates/atm-core/src/delivery_plan.rs
+++ b/crates/atm-core/src/delivery_plan.rs
@@ -14,6 +14,12 @@ pub(crate) enum DeliveryPlanDisposition {
     SqliteFailedRecovered,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeliveryPlanKind {
+    Send,
+    Reply,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct LogicalMessage {
     pub(crate) envelope: MessageEnvelope,
@@ -53,6 +59,9 @@ impl LogicalMessage {
     }
 
     pub(crate) fn message_id(&self) -> AtmMessageId {
+        // Invariant: `LogicalMessage::new` rejects envelopes without a message
+        // id, and every constructor path in this module goes through that
+        // validation before a message ever reaches a delivery plan.
         self.envelope
             .message_id
             .expect("validated logical delivery messages always have a message id")
@@ -151,6 +160,7 @@ impl NotificationTarget {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct DeliveryPlan {
+    pub(crate) kind: DeliveryPlanKind,
     pub(crate) disposition: DeliveryPlanDisposition,
     pub(crate) delivery_target: DeliveryTarget,
     pub(crate) recipient: ResolvedRecipient,
@@ -162,6 +172,7 @@ pub(crate) struct DeliveryPlan {
 
 impl DeliveryPlan {
     pub(crate) fn new(
+        kind: DeliveryPlanKind,
         disposition: DeliveryPlanDisposition,
         delivery_target: DeliveryTarget,
         recipient: ResolvedRecipient,
@@ -174,42 +185,7 @@ impl DeliveryPlan {
             .map(NotificationTarget::from_logical_message)
             .collect();
         Self {
-            disposition,
-            delivery_target,
-            recipient,
-            recipient_pane_id,
-            messages,
-            notifications,
-            warnings,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct ReplyDeliveryPlan {
-    pub(crate) disposition: DeliveryPlanDisposition,
-    pub(crate) delivery_target: DeliveryTarget,
-    pub(crate) recipient: ResolvedRecipient,
-    pub(crate) recipient_pane_id: Option<String>,
-    pub(crate) messages: Vec<LogicalMessage>,
-    pub(crate) notifications: Vec<NotificationTarget>,
-    pub(crate) warnings: Vec<WarningEntry>,
-}
-
-impl ReplyDeliveryPlan {
-    pub(crate) fn new(
-        disposition: DeliveryPlanDisposition,
-        delivery_target: DeliveryTarget,
-        recipient: ResolvedRecipient,
-        recipient_pane_id: Option<String>,
-        messages: Vec<LogicalMessage>,
-        warnings: Vec<WarningEntry>,
-    ) -> Self {
-        let notifications = messages
-            .iter()
-            .map(NotificationTarget::from_logical_message)
-            .collect();
-        Self {
+            kind,
             disposition,
             delivery_target,
             recipient,

--- a/crates/atm-core/src/delivery_policy.rs
+++ b/crates/atm-core/src/delivery_policy.rs
@@ -71,6 +71,11 @@ impl DeliveryRecipientSnapshot {
     dead_code,
     reason = "Phase Y.4 keeps the full documented coordinator-state inventory explicit even before every branch is exercised by runtime callers."
 )]
+// Harness-target compatibility is still validated at runtime by
+// `validate_delivery_target(...)`; this state enum documents the coordinator
+// flow, but it does not yet encode harness pairing as a typestate invariant.
+// A future typestate pass can tighten that contract without widening the live
+// delivery surface during Phase Y closeout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum NewMessageCoordinatorState {
     Received,

--- a/crates/atm-core/src/send/missing_config_notice.rs
+++ b/crates/atm-core/src/send/missing_config_notice.rs
@@ -21,7 +21,9 @@ use super::{
     persist_message_and_seed_workflow,
 };
 
-pub(super) fn warn_missing_team_config<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+pub(super) fn warn_missing_team_config<
+    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
+>(
     runtime: &R,
     request: &SendRequest,
     recipient: &ResolvedRecipient,
@@ -76,7 +78,7 @@ fn missing_config_warning(recipient: &ResolvedRecipient, team_dir: &Path) -> War
 }
 
 fn notify_team_lead_missing_config(
-    runtime: &(impl RetainedServiceRuntime + RetainedMailboxRuntime),
+    runtime: &(impl RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed),
     home_dir: &Path,
     team_dir: &Path,
     team: &TeamName,
@@ -174,7 +176,7 @@ fn resolve_team_lead_snapshot(
 }
 
 fn persist_missing_config_notice(
-    runtime: &(impl RetainedServiceRuntime + RetainedMailboxRuntime),
+    runtime: &(impl RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed),
     home_dir: &Path,
     snapshot: &DeliveryRecipientSnapshot,
     team_lead_inbox: &Path,
@@ -205,6 +207,7 @@ fn build_missing_config_delivery_plan(
     persistence: &DeliveryPersistenceResult,
 ) -> Result<DeliveryPlan, AtmError> {
     Ok(DeliveryPlan::new(
+        crate::delivery_plan::DeliveryPlanKind::Send,
         delivery_plan_disposition(persistence.disposition),
         delivery_target_for_snapshot(team_lead_inbox, snapshot),
         ResolvedRecipient {

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -194,7 +194,9 @@ pub fn send_mail_with_runtime(
     send_mail_with_runtime_impl(request, observability, runtime)
 }
 
-fn send_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+fn send_mail_with_runtime_impl<
+    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
+>(
     request: SendRequest,
     observability: &dyn ObservabilityPort,
     runtime: &R,
@@ -241,7 +243,9 @@ fn send_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
     clippy::too_many_arguments,
     reason = "Y.6 closeout keeps the explicit send outcome pieces visible at the sprint seam."
 )]
-fn finalize_send_outcome<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+fn finalize_send_outcome<
+    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
+>(
     runtime: &R,
     observability: &dyn ObservabilityPort,
     request: &SendRequest,
@@ -338,6 +342,7 @@ fn build_send_delivery_plan(
     persistence: &DeliveryPersistenceResult,
 ) -> Result<DeliveryPlan, AtmError> {
     Ok(DeliveryPlan::new(
+        crate::delivery_plan::DeliveryPlanKind::Send,
         delivery_plan_disposition(persistence.disposition),
         crate::delivery_plan::delivery_target_for_snapshot(
             &context.inbox_path,
@@ -367,7 +372,9 @@ struct SendExecutionContext {
     warnings: Vec<WarningEntry>,
 }
 
-fn prepare_send_context<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+fn prepare_send_context<
+    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
+>(
     runtime: &R,
     request: &SendRequest,
 ) -> Result<SendExecutionContext, AtmError> {
@@ -421,7 +428,9 @@ fn prepare_send_context<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
     })
 }
 
-fn validate_send_target<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
+fn validate_send_target<
+    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
+>(
     runtime: &R,
     request: &SendRequest,
     recipient: &ResolvedRecipient,

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -65,6 +65,22 @@ fn notification_detail(event: &NotificationEvent) -> Value {
     serde_json::from_str(&event.detail).expect("structured notification detail")
 }
 
+fn assert_recovered_payload_texts(
+    original: &MessageEnvelope,
+    companion: &MessageEnvelope,
+    expected_original: &str,
+) {
+    assert_eq!(original.text, expected_original);
+    assert_eq!(companion.from.as_str(), "atm-system");
+    assert!(
+        companion
+            .text
+            .contains("ATM error: SQLite persistence failed"),
+        "expected sqlite failure companion message, got: {}",
+        companion.text
+    );
+}
+
 struct TestRuntime {
     commit_error_message: Option<&'static str>,
     append_error_message: Option<&'static str>,
@@ -93,6 +109,8 @@ impl TestRuntime {
         }
     }
 }
+
+impl crate::boundary::sealed::Sealed for TestRuntime {}
 
 impl RetainedServiceRuntime for TestRuntime {
     fn load_config(&self, _current_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
@@ -378,6 +396,7 @@ fn load_send_alert_state_parse_errors_are_config_errors() {
 
 #[test]
 fn sqlite_failure_for_claude_preserves_original_and_companion_error_payloads() {
+    let outbound = outbound_message();
     let runtime = TestRuntime::new(
         Some("sqlite write failed"),
         None,
@@ -391,7 +410,7 @@ fn sqlite_failure_for_claude_preserves_original_and_companion_error_payloads() {
         tempdir.path(),
         &delivery_snapshot(DeliveryHarnessPath::ClaudeCode),
         &inbox_path,
-        &outbound_message(),
+        &outbound,
         false,
     )
     .expect("sqlite fallback recovery");
@@ -402,19 +421,16 @@ fn sqlite_failure_for_claude_preserves_original_and_companion_error_payloads() {
     );
     assert_eq!(result.warnings.len(), 1);
     assert_eq!(result.original_message.from.as_str(), TEST_SENDER);
-    assert_eq!(
-        result
-            .companion_message
-            .as_ref()
-            .expect("companion")
-            .from
-            .as_str(),
-        "atm-system"
+    assert_recovered_payload_texts(
+        &result.original_message,
+        result.companion_message.as_ref().expect("companion"),
+        &outbound.text,
     );
 }
 
 #[test]
 fn sqlite_failure_for_non_claude_preserves_original_and_companion_payloads() {
+    let outbound = outbound_message();
     let runtime = TestRuntime::new(
         Some("sqlite write failed"),
         None,
@@ -428,7 +444,7 @@ fn sqlite_failure_for_non_claude_preserves_original_and_companion_payloads() {
         tempdir.path(),
         &delivery_snapshot(DeliveryHarnessPath::NonClaude),
         &inbox_path,
-        &outbound_message(),
+        &outbound,
         false,
     )
     .expect("sqlite fallback recovery");
@@ -438,14 +454,10 @@ fn sqlite_failure_for_non_claude_preserves_original_and_companion_payloads() {
         DeliveryPersistenceDisposition::SqliteFailedRecovered
     );
     assert_eq!(result.original_message.from.as_str(), TEST_SENDER);
-    assert_eq!(
-        result
-            .companion_message
-            .as_ref()
-            .expect("companion")
-            .from
-            .as_str(),
-        "atm-system"
+    assert_recovered_payload_texts(
+        &result.original_message,
+        result.companion_message.as_ref().expect("companion"),
+        &outbound.text,
     );
 }
 
@@ -557,22 +569,7 @@ fn recovered_claude_append_failure_after_sqlite_failure_returns_hard_error() {
     assert!(error.message.contains("append failed"));
 }
 
-#[test]
-fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_boundary() {
-    let runtime = TestRuntime::new(
-        Some("sqlite write failed"),
-        None,
-        DeliveryHarnessPath::NonClaude,
-    );
-    let observability = RecordingObservability::default();
-    let tempdir = tempdir().expect("tempdir");
-
-    let outcome =
-        super::send_mail_with_runtime_impl(send_request(tempdir.path()), &observability, &runtime)
-            .expect("send outcome");
-
-    assert_eq!(outcome.outcome, SendCommandOutcome::Sent);
-    assert_eq!(outcome.warnings.len(), 1);
+fn assert_non_claude_sqlite_failure_delivery(runtime: &TestRuntime) {
     assert!(
         runtime
             .appended_messages
@@ -588,9 +585,14 @@ fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_bound
     assert_eq!(deliveries[0].team.as_str(), TEST_TEAM);
     assert_eq!(deliveries[0].agent.as_str(), "recipient");
     assert_eq!(deliveries[0].messages.len(), 2);
-    assert_eq!(deliveries[0].messages[0].from.as_str(), TEST_SENDER);
-    assert_eq!(deliveries[0].messages[1].from.as_str(), "atm-system");
-    drop(deliveries);
+    assert_recovered_payload_texts(
+        &deliveries[0].messages[0],
+        &deliveries[0].messages[1],
+        "hello",
+    );
+}
+
+fn assert_non_claude_sqlite_failure_notifications(runtime: &TestRuntime) {
     let events = runtime
         .notification_events
         .lock()
@@ -641,8 +643,9 @@ fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_bound
         original_detail.get("task_id").and_then(Value::as_str),
         Some("task-123")
     );
-    drop(events);
+}
 
+fn assert_non_claude_sqlite_failure_observability(observability: &RecordingObservability) {
     let observability_events = observability.events.lock().expect("events lock");
     assert!(observability_events.iter().any(|event| {
         event.command == "delivery_policy"
@@ -652,6 +655,27 @@ fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_bound
         event.command == "delivery_policy"
             && event.outcome == "delivery_policy.new_message.non_claude_error"
     }));
+}
+
+#[test]
+fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_boundary() {
+    let runtime = TestRuntime::new(
+        Some("sqlite write failed"),
+        None,
+        DeliveryHarnessPath::NonClaude,
+    );
+    let observability = RecordingObservability::default();
+    let tempdir = tempdir().expect("tempdir");
+
+    let outcome =
+        super::send_mail_with_runtime_impl(send_request(tempdir.path()), &observability, &runtime)
+            .expect("send outcome");
+
+    assert_eq!(outcome.outcome, SendCommandOutcome::Sent);
+    assert_eq!(outcome.warnings.len(), 1);
+    assert_non_claude_sqlite_failure_delivery(&runtime);
+    assert_non_claude_sqlite_failure_notifications(&runtime);
+    assert_non_claude_sqlite_failure_observability(&observability);
 }
 
 #[test]

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -142,6 +142,8 @@ impl fmt::Debug for LocalServiceRuntime {
     }
 }
 
+impl crate::boundary::sealed::Sealed for LocalServiceRuntime {}
+
 #[derive(Debug, Clone, Copy, Default)]
 /// Production fallback boundary used when the daemon runtime is not composing
 /// a dedicated non-Claude outbound adapter. This is not a test double.

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -327,7 +327,13 @@ impl RuntimeComposition {
     {
         prepare_runtime(&self.server_transport).inspect_err(|_| {
             if let Err(shutdown_error) = self.shutdown_background_lanes() {
-                tracing::warn!(%shutdown_error, "{rollback_message}");
+                tracing::warn!(
+                    subsystem = "composition",
+                    action = "rollback_startup",
+                    outcome = "lane_shutdown_failed",
+                    %shutdown_error,
+                    "{rollback_message}"
+                );
             }
         })
     }
@@ -486,6 +492,9 @@ impl RuntimeComposition {
             )
         {
             tracing::warn!(
+                subsystem = "composition",
+                action = "rollback_lane",
+                outcome = "incomplete",
                 %error,
                 lane = "watch event source",
                 "daemon background lane rollback shutdown was incomplete"
@@ -500,6 +509,9 @@ impl RuntimeComposition {
             )
         {
             tracing::warn!(
+                subsystem = "composition",
+                action = "rollback_lane",
+                outcome = "incomplete",
                 %error,
                 lane = "notification sink",
                 "daemon background lane rollback shutdown was incomplete"
@@ -564,6 +576,9 @@ fn replay_store_assembly_failed(
     observability: &SubsystemObservability,
 ) -> AtmError {
     tracing::error!(
+        subsystem = "composition",
+        action = "replay_store_assembly",
+        outcome = "failed",
         %error,
         "remote replay store assembly failed; daemon startup is fail-closed"
     );
@@ -756,6 +771,9 @@ fn validate_runtime_home_dir(home_dir: &std::path::Path) -> Result<(), AtmError>
         })?;
     if let Err(error) = std::fs::remove_file(&probe_path) {
         tracing::warn!(
+            subsystem = "composition",
+            action = "home_probe_cleanup",
+            outcome = "failed",
             path = %probe_path.display(),
             %error,
             "failed to remove atm-daemon home write probe file"

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -434,6 +434,9 @@ impl RuntimeComposition {
             && let Err(force_error) = self.lifecycle.force_stopped()
         {
             tracing::error!(
+                subsystem = "composition",
+                action = "force_lifecycle_stop",
+                outcome = "failed",
                 state_error = %state_error,
                 force_error = %force_error,
                 serve_error = result.as_ref().err().map(|error| error.to_string()),

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -51,7 +51,7 @@ pub(super) fn handle_connection(
         );
     }
 
-    let response = dispatch_request(request, dispatcher, &registry)?;
+    let response = dispatch_request(request_id, request, dispatcher, &registry)?;
     write_response(&mut stream, &codec, request_id, response)?;
     registry.reap_finished_dispatches()?;
     Ok(())
@@ -113,6 +113,7 @@ fn dispatch_advisory_stream(
 }
 
 fn dispatch_request(
+    request_id: RequestId,
     request: RequestEnvelope,
     dispatcher: Arc<dyn RequestDispatcher + Send + Sync>,
     registry: &Arc<ActiveConnectionRegistry>,
@@ -126,7 +127,7 @@ fn dispatch_request(
         },
         MAX_CONCURRENT_CONNECTIONS,
     )?;
-    Ok(await_dispatch_response(result_rx))
+    Ok(await_dispatch_response(request_id, result_rx))
 }
 
 fn spawn_dispatch_worker(
@@ -154,6 +155,7 @@ fn spawn_dispatch_worker(
 }
 
 fn await_dispatch_response(
+    request_id: RequestId,
     result_rx: std::sync::mpsc::Receiver<Result<ResponseEnvelope, AtmError>>,
 ) -> ResponseEnvelope {
     match result_rx.recv_timeout(REQUEST_DEADLINE) {
@@ -163,6 +165,8 @@ fn await_dispatch_response(
             tracing::warn!(
                 subsystem = "local_ipc",
                 action = "dispatch",
+                outcome = "deadline_exceeded",
+                request_id = %request_id,
                 deadline_ms = REQUEST_DEADLINE.as_millis(),
                 "daemon request dispatcher exceeded the runtime deadline"
             );

--- a/crates/atm-daemon/src/local_ipc_transport/shutdown.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/shutdown.rs
@@ -58,12 +58,18 @@ pub(super) fn finish_serve_shutdown(
     if let Some(serve_error) = serve_error {
         if let Some(shutdown_error) = shutdown_error {
             tracing::warn!(
+                subsystem = "ipc_shutdown",
+                action = "finish_serve_shutdown",
+                outcome = "serve_and_shutdown_error",
                 %shutdown_error,
                 %serve_error,
                 "daemon shutdown encountered an additional error after a serve error"
             );
         } else {
             tracing::warn!(
+                subsystem = "ipc_shutdown",
+                action = "finish_serve_shutdown",
+                outcome = "serve_error",
                 %serve_error,
                 "daemon serve loop exited with an error after shutdown finalization"
             );
@@ -76,6 +82,9 @@ pub(super) fn finish_serve_shutdown(
 fn append_shutdown_error(shutdown_error: &mut Option<AtmError>, field_name: &str, error: AtmError) {
     if let Some(existing) = shutdown_error.as_ref() {
         tracing::warn!(
+            subsystem = "ipc_shutdown",
+            action = "append_shutdown_error",
+            outcome = "additional_error",
             begin_shutdown_error = %existing,
             error_field = field_name,
             additional_error = %error,

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -575,6 +575,9 @@ impl PeerClientTransport {
             AttemptFailureKind::Retryable => "retryable",
         };
         tracing::error!(
+            subsystem = "peer_transport",
+            action = "send_to_endpoint",
+            outcome = "terminal_failure",
             peer_addr = %endpoint,
             attempt,
             failure_kind,

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -21,6 +21,9 @@ use crate::{DaemonSubsystem, SubsystemObservability};
 
 // Architecture authority: docs/architecture.md §21.6.4 daemon operational
 // defaults and remote peer transport rules.
+// These deadlines are intentionally fixed operational constants. Phase Y keeps
+// connect and I/O timeouts non-configurable so remote peer delivery behavior
+// stays bounded and auditable across every host.
 const PEER_CONNECT_DEADLINE: Duration = Duration::from_secs(5);
 const PEER_IO_DEADLINE: Duration = Duration::from_secs(5);
 const DEFAULT_REMOTE_RETRY_BUDGET: Duration = Duration::from_secs(30);
@@ -510,6 +513,9 @@ impl PeerClientTransport {
         let now = Instant::now();
         if now >= retry_state.deadline {
             tracing::error!(
+                subsystem = "peer_transport",
+                action = "send_to_endpoint",
+                outcome = "retry_exhausted",
                 peer_addr = %endpoint,
                 attempt,
                 error_code = %error.code,

--- a/crates/atm-daemon/src/reconcile_runtime.rs
+++ b/crates/atm-daemon/src/reconcile_runtime.rs
@@ -666,6 +666,9 @@ fn should_emit_reconcile_notification(
         ordered.truncate(MAX_RECONCILE_FINGERPRINTS_PER_KEY);
         current_fingerprints.extend(ordered);
         tracing::warn!(
+            subsystem = "reconcile",
+            action = "fingerprint_truncate",
+            outcome = "cap_exceeded",
             team = %key.team,
             agent = %key.agent,
             retained = MAX_RECONCILE_FINGERPRINTS_PER_KEY,
@@ -686,6 +689,9 @@ fn should_emit_reconcile_notification(
         while let Some(evicted_key) = fingerprints.order.pop_front() {
             if fingerprints.entries.remove(&evicted_key).is_some() {
                 tracing::warn!(
+                    subsystem = "reconcile",
+                    action = "fingerprint_evict",
+                    outcome = "cap_exceeded",
                     team = %evicted_key.team,
                     agent = %evicted_key.agent,
                     cap = MAX_RECONCILE_FINGERPRINT_KEYS,
@@ -714,6 +720,9 @@ fn reconcile_worker_loop(inner: Arc<ReconcileRuntimeInner>) {
                 Ok(result) => ReconcileOutcome::Success(result),
                 Err(error) => {
                     tracing::warn!(
+                        subsystem = "reconcile",
+                        action = "executor",
+                        outcome = "failed",
                         team = %pending_request.request.team,
                         agent = %pending_request.request.agent,
                         %error,

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 use atm_core::{
@@ -246,26 +247,18 @@ impl DaemonRequestDispatcher {
                 return;
             }
         };
+        Self::handle_bounded_shutdown_result(label, deadline, result_rx, join_helper);
+    }
+
+    fn handle_bounded_shutdown_result(
+        label: &'static str,
+        deadline: Duration,
+        result_rx: std::sync::mpsc::Receiver<std::thread::Result<()>>,
+        join_helper: JoinHandle<()>,
+    ) {
         match result_rx.recv_timeout(deadline) {
             Ok(join_result) => {
-                if join_helper.join().is_err() {
-                    tracing::warn!(
-                        subsystem = "runtime_health",
-                        action = "shutdown_join_helper",
-                        outcome = "panic",
-                        step = label,
-                        "daemon shutdown finalizer join helper panicked before reporting completion"
-                    );
-                }
-                if join_result.is_err() {
-                    tracing::warn!(
-                        subsystem = "runtime_health",
-                        action = "shutdown_finalize",
-                        outcome = "panic",
-                        step = label,
-                        "daemon shutdown finalizer step panicked before reporting completion; restart atm-daemon and inspect the retained observability log for the failing shutdown step"
-                    );
-                }
+                Self::finalize_bounded_shutdown_result(label, join_result, join_helper)
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                 // SQLite WAL checkpoint timeout is the highest-risk caller here: a checkpoint can
@@ -275,25 +268,46 @@ impl DaemonRequestDispatcher {
                 Self::retain_shutdown_step(label, join_helper, deadline);
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                if join_helper.join().is_err() {
-                    tracing::warn!(
-                        subsystem = "runtime_health",
-                        action = "shutdown_join_helper",
-                        outcome = "panic",
-                        step = label,
-                        "daemon shutdown finalizer join helper panicked before reporting completion"
-                    );
-                } else {
-                    tracing::warn!(
-                        subsystem = "runtime_health",
-                        action = "shutdown_join_helper",
-                        outcome = "disconnected",
-                        step = label,
-                        "daemon shutdown finalizer join helper disconnected before reporting completion"
-                    );
-                }
+                Self::report_bounded_shutdown_disconnect(label, join_helper);
             }
         }
+    }
+
+    fn finalize_bounded_shutdown_result(
+        label: &'static str,
+        join_result: std::thread::Result<()>,
+        join_helper: JoinHandle<()>,
+    ) {
+        if join_helper.join().is_err() {
+            Self::warn_shutdown_join_helper(label, "panic");
+        }
+        if join_result.is_err() {
+            tracing::warn!(
+                subsystem = "runtime_health",
+                action = "shutdown_finalize",
+                outcome = "panic",
+                step = label,
+                "daemon shutdown finalizer step panicked before reporting completion; restart atm-daemon and inspect the retained observability log for the failing shutdown step"
+            );
+        }
+    }
+
+    fn report_bounded_shutdown_disconnect(label: &'static str, join_helper: JoinHandle<()>) {
+        if join_helper.join().is_err() {
+            Self::warn_shutdown_join_helper(label, "panic");
+        } else {
+            Self::warn_shutdown_join_helper(label, "disconnected");
+        }
+    }
+
+    fn warn_shutdown_join_helper(label: &'static str, outcome: &'static str) {
+        tracing::warn!(
+            subsystem = "runtime_health",
+            action = "shutdown_join_helper",
+            outcome,
+            step = label,
+            "daemon shutdown finalizer join helper failed before reporting completion"
+        );
     }
 
     pub(crate) fn new(

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -149,18 +149,6 @@ impl DaemonRequestDispatcher {
             })
     }
 
-    fn complete_shutdown_step(label: &'static str, shutdown_handle: std::thread::JoinHandle<()>) {
-        if shutdown_handle.join().is_err() {
-            tracing::warn!(
-                subsystem = "runtime_health",
-                action = "shutdown_finalize",
-                outcome = "panic",
-                step = label,
-                "daemon shutdown finalizer step panicked before reporting completion; restart atm-daemon and inspect the retained observability log for the failing shutdown step"
-            );
-        }
-    }
-
     fn retain_shutdown_step(
         label: &'static str,
         shutdown_handle: std::thread::JoinHandle<()>,
@@ -194,6 +182,34 @@ impl DaemonRequestDispatcher {
         );
     }
 
+    fn spawn_shutdown_join_helper(
+        label: &'static str,
+        shutdown_handle: std::thread::JoinHandle<()>,
+    ) -> Result<
+        (
+            std::sync::mpsc::Receiver<std::thread::Result<()>>,
+            std::thread::JoinHandle<()>,
+        ),
+        AtmError,
+    > {
+        let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+        let join_helper = std::thread::Builder::new()
+            .name(format!("shutdown-finalizer-join-{label}"))
+            .spawn(move || {
+                let _ = result_tx.send(shutdown_handle.join());
+            })
+            .map_err(|source| {
+                AtmError::daemon_unavailable(format!(
+                    "failed to spawn daemon shutdown finalizer join helper `{label}`"
+                ))
+                .with_recovery(
+                    "Restart atm-daemon; the bounded shutdown finalizer join helper could not be created.",
+                )
+                .with_source(source)
+            })?;
+        Ok((result_rx, join_helper))
+    }
+
     fn run_bounded_shutdown_step(
         label: &'static str,
         deadline: Duration,
@@ -213,21 +229,70 @@ impl DaemonRequestDispatcher {
                 return;
             }
         };
-        let started = std::time::Instant::now();
-        loop {
-            if shutdown_handle.is_finished() {
-                Self::complete_shutdown_step(label, shutdown_handle);
+        let (result_rx, join_helper) = match Self::spawn_shutdown_join_helper(
+            label,
+            shutdown_handle,
+        ) {
+            Ok(helper) => helper,
+            Err(error) => {
+                tracing::warn!(
+                    subsystem = "runtime_health",
+                    action = "shutdown_join_helper_spawn",
+                    outcome = "failed",
+                    %error,
+                    step = label,
+                    "daemon shutdown finalizer step could not start its bounded join helper; restart atm-daemon because shutdown cleanup could not be monitored"
+                );
                 return;
             }
-            if started.elapsed() >= deadline {
+        };
+        match result_rx.recv_timeout(deadline) {
+            Ok(join_result) => {
+                if join_helper.join().is_err() {
+                    tracing::warn!(
+                        subsystem = "runtime_health",
+                        action = "shutdown_join_helper",
+                        outcome = "panic",
+                        step = label,
+                        "daemon shutdown finalizer join helper panicked before reporting completion"
+                    );
+                }
+                if join_result.is_err() {
+                    tracing::warn!(
+                        subsystem = "runtime_health",
+                        action = "shutdown_finalize",
+                        outcome = "panic",
+                        step = label,
+                        "daemon shutdown finalizer step panicked before reporting completion; restart atm-daemon and inspect the retained observability log for the failing shutdown step"
+                    );
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                 // SQLite WAL checkpoint timeout is the highest-risk caller here: a checkpoint can
-                // outlive the bounded shutdown window, but retaining the JoinHandle is still safer
-                // than dropping it orphaned because tests and orderly process teardown can join it
-                // later once the blocking storage step finishes.
-                Self::retain_shutdown_step(label, shutdown_handle, deadline);
-                return;
+                // outlive the bounded shutdown window, but retaining the worker JoinHandle is still
+                // safer than dropping it orphaned because tests and orderly process teardown can
+                // join it later once the blocking storage step finishes.
+                Self::retain_shutdown_step(label, join_helper, deadline);
             }
-            std::thread::sleep(Duration::from_millis(10));
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                if join_helper.join().is_err() {
+                    tracing::warn!(
+                        subsystem = "runtime_health",
+                        action = "shutdown_join_helper",
+                        outcome = "panic",
+                        step = label,
+                        "daemon shutdown finalizer join helper panicked before reporting completion"
+                    );
+                } else {
+                    tracing::warn!(
+                        subsystem = "runtime_health",
+                        action = "shutdown_join_helper",
+                        outcome = "disconnected",
+                        step = label,
+                        "daemon shutdown finalizer join helper disconnected before reporting completion"
+                    );
+                }
+            }
         }
     }
 

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -205,6 +205,9 @@ impl RuntimeStatusCache {
             Err(_) => {
                 // Cannot propagate: fn returns (), tracing::error! is max-severity available at this boundary.
                 tracing::error!(
+                    subsystem = "runtime_status_cache",
+                    action = "mark_sqlite_unavailable",
+                    outcome = "lock_poisoned",
                     "runtime status cache lock poisoned while marking sqlite unavailable"
                 );
             }
@@ -223,6 +226,9 @@ impl RuntimeStatusCache {
             }
             Err(_) => {
                 tracing::error!(
+                    subsystem = "runtime_status_cache",
+                    action = "mark_sqlite_unavailable_with_detail",
+                    outcome = "lock_poisoned",
                     "runtime status cache lock poisoned while recording sqlite degradation detail"
                 );
             }
@@ -289,6 +295,9 @@ fn evict_status_cache_entry_if_needed(
             .with_agent(evicted_key.member.clone());
         observability.emit_event_or_warn(event);
         tracing::warn!(
+            subsystem = "runtime_status_cache",
+            action = "evict_entry",
+            outcome = "cap_exceeded",
             team = %evicted_key.team,
             member = %evicted_key.member,
             pid = evicted_record.pid,

--- a/docs/phase-Yb/sprint-Y9.md
+++ b/docs/phase-Yb/sprint-Y9.md
@@ -29,7 +29,7 @@ is no longer encoded as hook metadata plus implied behavior.
 
 ## Exact Code And Document Targets
 
-- `crates/atm-core/src/boundary.rs`
+- `crates/atm-core/src/boundary/mod.rs`
 - `crates/atm-core/src/delivery_execution.rs`
 - `crates/atm-daemon/src/non_claude_outbound_runtime.rs`
 - `boundaries/atm-core/non-claude-outbound.toml`

--- a/docs/phase-Yc/sprint-Y13.md
+++ b/docs/phase-Yc/sprint-Y13.md
@@ -32,7 +32,6 @@ target: integrate/phase-Y
 - `crates/atm-core/src/delivery_plan.rs`
 - `crates/atm-core/src/protocol.rs`
 - `crates/atm-daemon/src/boundary_adapters.rs`
-- `crates/atm-daemon/src/notification_runtime.rs`
 - `crates/atm-daemon/src/runtime_health.rs`
 - `crates/atm-rusqlite/src/boundary_assembly.rs`
 - `crates/atm-rusqlite/src/lib.rs`


### PR DESCRIPTION
## Summary
- Add subsystem=/action=/outcome= to all 16 production warn!/error! call sites (ARCH-001–012 + RSH-001 in shutdown.rs) — RULE-006
- Replace spin-poll in run_bounded_shutdown_step with join-helper + recv_timeout pattern (RSH-004)
- Consolidate DeliveryPlan/ReplyDeliveryPlan duplication (RBP-F003)
- Add sealed::Sealed supertrait to delivery execution traits (RBP-F007)
- Add logical payload assertions on SQLite-failure tests; extract helper to meet RULE-002 (QA-001/002)
- Add test cases for validate_delivery_target and emit_reply_delivery_plan_transitions branches (QA-003)
- Fix doc attribution errors in sprint-Y13.md (ATM-QA-001/002)
- RBP-F002/004/005/006 + RSH-005/006 minor fixes

## Test plan
- [ ] cargo fmt --all PASS
- [ ] cargo clippy --workspace -D warnings PASS
- [ ] cargo test --workspace PASS

Fixes PY-PHASE-END-QA-1 findings on integrate/phase-Y @ e00c7036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)