### PR TITLE
docs: Phase Yd plan hardening — develop-gate closeout sprints Y.14–Y.18

### DIFF
--- a/boundaries/atm-daemon/daemon-notification-sink.toml
+++ b/boundaries/atm-daemon/daemon-notification-sink.toml
@@ -8,7 +8,7 @@ trait = "NotificationSink"
 
 [implementation]
 type = "DaemonNotificationSink"
-module = "atm_daemon"
+module = "atm_daemon::notification_runtime"
 visibility = "pub(crate)"
 constructor = "pub(crate)"
 

--- a/boundaries/atm-daemon/daemon-status-source.toml
+++ b/boundaries/atm-daemon/daemon-status-source.toml
@@ -30,7 +30,7 @@ forbidden = ["DaemonStatusSource"]
 
 [contracts]
 request_types = ["status source requests"]
-response_types = ["status snapshot batches"]
+response_types = ["status snapshot batches", "NotificationWorkerLiveness", "RuntimeHealthSnapshot"]
 error_types = ["AtmError"]
 
 [testing]

--- a/docs/adr/ADR-014-runtime-health-projection-and-liveness-signal-ownership.md
+++ b/docs/adr/ADR-014-runtime-health-projection-and-liveness-signal-ownership.md
@@ -1,0 +1,61 @@
+# ADR-014: Runtime Health Projection And Liveness Signal Ownership
+
+## Status
+
+Accepted
+
+## Context
+
+`Phase Y` closeout needs one final answer for notification-worker liveness on
+the accepted `integrate/phase-Y` candidate line.
+
+The production-readiness review identified a legitimate gap: runtime health did
+not directly model notification-worker liveness. But the same review also
+showed a design risk: `runtime_health` must not become a compensating recovery
+layer that reconstructs subsystem behavior by polling queue internals, retry
+state, or daemon-private control logic.
+
+`Phase Yd` therefore needs an explicit rule for how health reporting consumes
+subsystem liveness.
+
+## Decision
+
+`runtime_health` is a projection layer only.
+
+It may report subsystem liveness only through thin owner-provided signals.
+For notification-worker liveness, the owning runtime subsystem is
+`NotificationRuntime`, and the accepted shape is a direct projection such as:
+
+- `NotificationRuntime::worker_liveness() -> NotificationWorkerLiveness`
+
+`runtime_health` may read that signal and include it in the health snapshot,
+but it must not infer or reconstruct liveness by:
+
+- replaying queue state
+- recomputing retry semantics
+- inspecting worker internals through ad hoc logic
+- adding subsystem-specific recovery behavior inside the health layer
+
+## Alternatives Considered
+
+1. Make `runtime_health` infer liveness directly from queue and worker state.
+- rejected because it couples health reporting to subsystem-private logic and
+  invites compensating behavior in the wrong layer
+
+2. Add a separate health-check service that polls the notification subsystem.
+- rejected for `Phase Yd` because it expands scope and introduces a second
+  ownership surface for the same readiness question
+
+3. Reclassify notification-worker liveness as non-blocking.
+- accepted only as an explicit documented fallback if the final accepted line
+  cannot close the signal cleanly without violating the projection-only rule
+
+## Consequences
+
+- subsystem owners must expose thin liveness signals directly when liveness is
+  part of a readiness gate
+- `runtime_health` remains simple and projection-only
+- future health additions must follow the same rule unless a later ADR changes
+  the contract
+- any attempt to add compensating recovery logic to `runtime_health` is a
+  design regression and must be rejected in review

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -18,6 +18,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-011 — Host-Scoped Retained Log Root](./ADR-011-host-scoped-retained-log-root.md)
 - [ADR-012 — One Message Identity](./ADR-012-one-message-identity.md)
 - [ADR-013 — Unified Delivery Plan And State-Machine-Owned Path Decisions](./ADR-013-unified-delivery-plan-and-state-machine-ownership.md)
+- [ADR-014 — Runtime Health Projection And Liveness Signal Ownership](./ADR-014-runtime-health-projection-and-liveness-signal-ownership.md)
 
 ## Extracted Crate-Local ADRs
 

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -424,3 +424,13 @@ Notes:
   dispatcher and projected into `atm doctor`.
 - The cache-cap rule must bound actual retained entries, not only member-state
   labels.
+- `Phase Yd` adds one daemon-private liveness DTO family owned by
+  `atm_daemon::runtime_health` for final `Phase Y` closeout:
+  - `NotificationWorkerLiveness`
+  - `RuntimeHealthSnapshot`
+  - `project_runtime_health(...)`
+- these are daemon-private health projection artifacts, not public cross-crate
+  boundary exports
+- `runtime_health` may project the owner-provided
+  `NotificationRuntime::worker_liveness()` signal directly, but it must not
+  inspect queue internals or retry state to reconstruct liveness

--- a/docs/phase-Y/issues.md
+++ b/docs/phase-Y/issues.md
@@ -112,9 +112,11 @@ These items are explicitly not reasons to delay `Phase Y` landing on
 
 - `Y.14` closes the recovered Claude logical-message-set blocker.
 - `Y.15` closes the production notification boundary bypass blocker.
-- `Y.16` closes the retained-runtime composition blocker and validates the
-  accepted merge candidate with the required phase-end fix line present.
-- `Y.17` closes or explicitly reclassifies the final liveness/readiness
+- `Y.16` closes the retained-runtime composition blocker.
+- `Y.17` closes the accepted merge-candidate blocker by proving the required
+  phase-end fix line is present on the accepted candidate and the candidate is
+  validation-clean.
+- `Y.18` closes or explicitly reclassifies the final liveness/readiness
   blocker, leaves the named `develop`-gate record, and explicitly authorizes
   `Phase Z` to begin only if the line is actually ready.
 

--- a/docs/phase-Y/issues.md
+++ b/docs/phase-Y/issues.md
@@ -110,10 +110,13 @@ These items are explicitly not reasons to delay `Phase Y` landing on
 
 ## Sprint Mapping
 
-- `Y.14` must close the runtime, boundary, composition, and accepted
-  phase-end-fix merge-candidate blockers.
-- `Y.15` must close the thin liveness/readiness proof, leave the named
-  `develop`-gate record, and explicitly authorize `Phase Z` to begin.
+- `Y.14` closes the recovered Claude logical-message-set blocker.
+- `Y.15` closes the production notification boundary bypass blocker.
+- `Y.16` closes the retained-runtime composition blocker and validates the
+  accepted merge candidate with the required phase-end fix line present.
+- `Y.17` closes or explicitly reclassifies the final liveness/readiness
+  blocker, leaves the named `develop`-gate record, and explicitly authorizes
+  `Phase Z` to begin only if the line is actually ready.
 
 ## Phase Z Rule
 

--- a/docs/phase-Y/issues.md
+++ b/docs/phase-Y/issues.md
@@ -1,0 +1,121 @@
+# Phase Y Blocking Issues
+
+## Purpose
+
+Record the remaining `Phase Y` issues that block landing the line on
+`develop`, separate those from non-blocking follow-up hardening, and map each
+blocking item to the sprint that must close it.
+
+This is a planning artifact on a worktree off `develop`. It does not imply
+that `Phase Z` may begin. `Phase Z` stays blocked until every blocking item in
+this ledger is closed and the `Phase Yd` readiness record says the line is
+ready for `develop`.
+
+## Review Source
+
+Primary production-readiness review:
+
+- verdict: `NOT READY`
+- review scope: `integrate/phase-Y @ 75444082`
+- report sent to `team-lead` as:
+  - `7b7ef1d5-80dc-427b-95dd-d89dbd2efeeb`
+
+Key findings from that review:
+
+1. `delivery_execution.rs`: recovered Claude SQLite-failure path could
+   partially deliver `message[1]` while `message[2]` failed, violating the
+   identical logical-payload-set contract.
+2. `delivery_execution.rs`: production send/ack notification delivery still
+   bypassed the `NotificationSink` boundary through
+   `maybe_run_post_send_hook(...)`.
+3. `runtime_health.rs`: daemon retained-runtime factory did not wire
+   `NotificationSink` on the live production path.
+4. `notification_runtime.rs`: shutdown was bounded to `3s`, but not fully
+   deterministic once synchronous persistence was stalled.
+5. `runtime_health.rs`: health reporting did not directly model
+   notification-worker liveness.
+
+## Blocking Before Develop
+
+These items block `Phase Y` from landing on `develop`.
+
+1. Recovered Claude logical-message-set closure is not yet proven on the final
+   accepted line.
+   - issue class:
+     - behavioral correctness
+   - historical owner:
+     - `Y.12`
+   - closure requirement:
+     - the recovered Claude SQLite-failure path either materializes the full
+       logical message set or fails hard
+
+2. Production notification execution still bypasses the owned notification
+   boundary.
+   - issue class:
+     - boundary ownership
+   - historical owner:
+     - `Y.13`
+   - closure requirement:
+     - send/ack notification execution must route through
+       `NotificationSink::deliver(...)`
+     - no production-path direct `maybe_run_post_send_hook(...)` bypass may
+       remain
+
+3. Daemon retained-runtime composition must install the live
+   `NotificationSink`.
+   - issue class:
+     - production composition
+   - historical owner:
+     - `Y.13`
+   - closure requirement:
+     - the live retained runtime used by the daemon must construct and install
+       the daemon-owned `NotificationSink`
+
+4. The final accepted `Phase Y` line must be lint-clean, test-clean, and
+   phase-end-review clean on the candidate merge line.
+   - issue class:
+     - release gate / phase-end closure
+   - evidence source:
+     - post-review fix batches `PY-EOP-FIX-1` and `PY-EOP-FIX-R2`
+   - closure requirement:
+     - the accepted merge candidate must include the end-of-phase fixes and
+       pass the required validation stack before the line is proposed for
+       `develop`
+
+5. Health reporting must expose notification-worker liveness through a thin
+   owner-provided signal, not through compensating logic inside
+   `runtime_health`.
+   - issue class:
+     - operational readiness
+   - closure rule:
+     - if this remains a `develop` blocker, it must close with a simple
+       runtime-owned liveness signal that `runtime_health` projects directly
+     - do not grow `runtime_health` into a logic-heavy recovery layer
+
+## Non-Blocking Follow-Up
+
+These items are explicitly not reasons to delay `Phase Y` landing on
+`develop`.
+
+1. Notification shutdown determinism beyond the bounded production contract.
+   - the `3s` bounded-shutdown concern from the original review is not itself a
+     `develop` blocker for this line
+   - follow-up hardening may tighten it later, but it must not be used to
+     reopen the `Phase Y` scope indefinitely
+
+2. Broad lint-rule or docs-only reinterpretations of `Y.12` / `Y.13`.
+   - they may be valid later work
+   - they are not substitutes for the blocking runtime, boundary, composition,
+     and readiness issues listed above
+
+## Sprint Mapping
+
+- `Y.14` must close the runtime, boundary, composition, and accepted
+  phase-end-fix merge-candidate blockers.
+- `Y.15` must close the thin liveness/readiness proof, leave the named
+  `develop`-gate record, and explicitly authorize `Phase Z` to begin.
+
+## Phase Z Rule
+
+`Phase Z` does not begin while any item in **Blocking Before Develop** remains
+open.

--- a/docs/phase-Yc/plan-phase-Yc.md
+++ b/docs/phase-Yc/plan-phase-Yc.md
@@ -3,9 +3,9 @@
 ## Goal
 
 Close the final production-readiness gaps left on `integrate/phase-Y` after the
-merged `Yb` line so `Phase Z` smoke/dogfood work resumes only after the
-remaining delivery-contract and notification-boundary issues are actually
-closed.
+merged `Yb` line so the remaining delivery-contract and
+notification-boundary issues are actually closed before the broader
+develop-gate closeout proceeds.
 
 This is a planning-only phase on a worktree off `develop`. It does not start
 implementation.
@@ -97,7 +97,8 @@ Purpose:
 
 - move production notification execution onto `NotificationSink`
 - remove the direct post-send-hook helper bypass from the delivery executor
-- prove the integrated `Phase Y` line is ready to hand back to `Phase Z`
+- leave the focused `Yc` readiness record that the later `Phase Yd`
+  develop-gate closeout consumes
 
 Authoritative sprint doc:
 - [sprint-Y13.md](./sprint-Y13.md)
@@ -108,6 +109,12 @@ Supporting issues inventory for the whole `Yc` line:
 Named readiness record produced by `Y.13`:
 - [readiness.md](./readiness.md)
 
+`Yc` is necessary but not sufficient for `Phase Z`.
+
+Even after both `Y.12` and `Y.13` close, `Phase Z` remains blocked until the
+later `Phase Yd` readiness record says `Phase Y` may land on `develop` and
+`Phase Z` may begin.
+
 ## Exit Condition
 
 Phase `Yc` closes only when:
@@ -116,7 +123,8 @@ Phase `Yc` closes only when:
   logical message set while still claiming success
 - `Y.13` proves the production notification path executes through
   `NotificationSink`, not direct hook helpers
-- `Y.13` leaves the named readiness record artifact that records both closure
-  invariants and the `Phase Z` smoke gate
+- `Y.13` leaves the named readiness record artifact that records both `Yc`
+  closure invariants for later `Phase Yd` use during the develop-gate
+  closeout
 - the integrated line can pass a focused production-readiness review without
   reopening the same two issues

--- a/docs/phase-Yc/readiness.md
+++ b/docs/phase-Yc/readiness.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 This artifact is the named readiness record that `Y.13` must complete before
-`Phase Z` smoke resumes.
+the later `Phase Yd` develop-gate closeout proceeds.
+
+This record does **not** by itself authorize `Phase Z` to begin.
 
 ## Yc Closure Invariants
 
@@ -15,13 +17,21 @@ This artifact is the named readiness record that `Y.13` must complete before
 - the production notification path executes through
   `NotificationSink::deliver(...)` rather than direct hook helpers
 
-## Phase Z Smoke Gate
+## Handoff To Phase Yd
 
-`Phase Z` smoke remains blocked until this record is updated to state that:
+This record must be updated to state that:
 - both `Yc` closure invariants above are proven on the merged
   `integrate/phase-Y` line
 - the focused `Yc` readiness validation passed
-- smoke may resume
+- the line is ready to enter the broader `Phase Yd` develop-gate closeout
+
+## Phase Z Gate
+
+`Phase Z` still remains blocked after `Yc` closes.
+
+Only the later `docs/phase-Yd/readiness.md` record may state that:
+- `Phase Y` may land on `develop`
+- `Phase Z` may begin
 
 ## Startup Liveness Requirement
 

--- a/docs/phase-Yc/readiness.md
+++ b/docs/phase-Yc/readiness.md
@@ -19,6 +19,8 @@ This record does **not** by itself authorize `Phase Z` to begin.
 
 ## Handoff To Phase Yd
 
+This record is a valid focused close on the `Yc` line.
+
 This record must be updated to state that:
 - both `Yc` closure invariants above are proven on the merged
   `integrate/phase-Y` line
@@ -29,6 +31,10 @@ The later `Phase Yd` line is required to re-prove those same two invariants on
 the final accepted merge-candidate line after subsequent accepted line-state
 changes. That re-proof does not mean `Yc` failed; it means `Yc` is the focused
 closure line and `Yd` is the final develop-gate line.
+
+This record is not the final `develop`-gate authorization. The same closure
+invariants proved here are required to be re-proved by `Phase Yd` on the final
+accepted `Phase Y` merge-candidate line before landing on `develop`.
 
 ## Phase Z Gate
 

--- a/docs/phase-Yc/readiness.md
+++ b/docs/phase-Yc/readiness.md
@@ -25,6 +25,11 @@ This record must be updated to state that:
 - the focused `Yc` readiness validation passed
 - the line is ready to enter the broader `Phase Yd` develop-gate closeout
 
+The later `Phase Yd` line is required to re-prove those same two invariants on
+the final accepted merge-candidate line after subsequent accepted line-state
+changes. That re-proof does not mean `Yc` failed; it means `Yc` is the focused
+closure line and `Yd` is the final develop-gate line.
+
 ## Phase Z Gate
 
 `Phase Z` still remains blocked after `Yc` closes.

--- a/docs/phase-Yc/sprint-Y13.md
+++ b/docs/phase-Yc/sprint-Y13.md
@@ -59,11 +59,11 @@ silently dropped or partially deferred.
   backpressured notification delivery must degrade through typed warnings or
   errors rather than hidden helper behavior
 - the integrated `Phase Y` line gets a focused production-readiness gate that
-  specifically rechecks the two `Yc` closure invariants before `Phase Z`
-  resumes
+  specifically rechecks the two `Yc` closure invariants before the later
+  `Phase Yd` develop-gate closeout proceeds
 - the sprint leaves one explicit readiness record artifact,
   `docs/phase-Yc/readiness.md`, naming both `Yc` closure invariants and the
-  `Phase Z` smoke gate
+  handoff into `Phase Yd`
 
 ## Required Work
 
@@ -87,8 +87,9 @@ silently dropped or partially deferred.
   - daemon/unit integration tests that build `LocalServiceRuntime` directly
 - update ADR/boundary docs so the production notification path is documented as
   boundary-owned and no longer helper-owned
-- update the project plan/status docs so `Phase Z` smoke is blocked until the
-  `Yc` readiness gate passes and allowed again once it does
+- update the project plan/status docs so `Yc` closes the two original runtime
+  blockers but `Phase Z` stays blocked until the later `Phase Yd`
+  develop-gate record says it may begin
 
 ## Paths To Delete
 
@@ -283,7 +284,9 @@ fn notification_event_from_target(
 - the sprint leaves one explicit readiness record in the docs that says:
   - `Y.12` closed the Claude recovered-message-set contract
   - `Y.13` closed the notification boundary bypass
-  - `Phase Z` smoke may resume only after both proofs pass
+  - `Phase Yd` may now consume the focused `Yc` readiness result, but
+    `Phase Z` remains blocked until `docs/phase-Yd/readiness.md` says it may
+    begin
 
 ## Required Validation
 

--- a/docs/phase-Yd/plan-phase-Yd.md
+++ b/docs/phase-Yd/plan-phase-Yd.md
@@ -37,6 +37,7 @@ Phase `Yd` hardening and implementation must remain aligned with:
 - ADR inventory and controlling decisions:
   - `docs/adr/INDEX.md`
   - `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+  - `docs/adr/ADR-014-runtime-health-projection-and-liveness-signal-ownership.md`
 - machine-readable boundary definitions for the concrete closures in scope:
   - `boundaries/atm-core/inbox-export.toml`
   - `boundaries/atm-core/notification-sink.toml`
@@ -71,6 +72,34 @@ It does not exist to:
 - reopen broad `Phase Z` rollout planning inside the closeout sprints
 - add unrelated lint-only or docs-only reinterpretations of prior `Y.12` /
   `Y.13` runtime deliverables
+
+## Relationship To Phase Yc
+
+`Phase Yc` (`Y.12` and `Y.13`) was the first focused closure attempt for the
+two original production-readiness blockers:
+
+- `Y.12` proved the recovered Claude logical-message-set closure shape on the
+  accepted `Yc` line
+- `Y.13` proved the production `NotificationSink` boundary closure shape on
+  the accepted `Yc` line
+
+`Phase Yd` does not redefine those closures. It exists because the
+develop-gate closeout must prove those same blockers on the final accepted
+`Phase Y` candidate line after later accepted line-state changes, including
+the end-of-phase fix line and the final merge-candidate assembly.
+
+So:
+
+- `Y.14` is a re-proof sprint for the `Y.12` closure invariant on the final
+  accepted candidate line
+- `Y.15` is a re-proof sprint for the `Y.13` closure invariant on the final
+  accepted candidate line
+- `Yc` therefore remains a valid historical closure line, but not the final
+  `develop` authorization line
+
+`docs/phase-Yc/readiness.md` must describe this as a valid focused close on
+the `Yc` line whose invariants are consumed and re-proved by `Phase Yd`, not
+as the final `develop` gate itself.
 
 ## Sprint Sequence
 

--- a/docs/phase-Yd/plan-phase-Yd.md
+++ b/docs/phase-Yd/plan-phase-Yd.md
@@ -64,19 +64,28 @@ Authoritative sprint doc:
 
 - [sprint-Y15.md](./sprint-Y15.md)
 
-### Y.16 Retained-Runtime Composition And Candidate Closure
+### Y.16 Retained-Runtime Composition Closure
 
 Purpose:
 
 - close the retained-runtime composition blocker
-- verify the accepted `Phase Y` merge candidate includes the required
-  end-of-phase fix line and is validation-clean
 
 Authoritative sprint doc:
 
 - [sprint-Y16.md](./sprint-Y16.md)
 
-### Y.17 Thin Liveness Closure And Final Develop Gate
+### Y.17 Candidate Closure
+
+Purpose:
+
+- verify the accepted `Phase Y` merge candidate includes the required
+  end-of-phase fix line and is validation-clean
+
+Authoritative sprint doc:
+
+- [sprint-Y17.md](./sprint-Y17.md)
+
+### Y.18 Thin Liveness Closure And Final Develop Gate
 
 Purpose:
 
@@ -87,9 +96,9 @@ Purpose:
 
 Authoritative sprint doc:
 
-- [sprint-Y17.md](./sprint-Y17.md)
+- [sprint-Y18.md](./sprint-Y18.md)
 
-Named readiness record produced by `Y.17`:
+Named readiness record produced by `Y.18`:
 
 - [readiness.md](./readiness.md)
 

--- a/docs/phase-Yd/plan-phase-Yd.md
+++ b/docs/phase-Yd/plan-phase-Yd.md
@@ -20,6 +20,38 @@ implementation on this branch.
 - blocking issue inventory:
   - [../phase-Y/issues.md](../phase-Y/issues.md)
 
+## Governing Documents
+
+Phase `Yd` hardening and implementation must remain aligned with:
+
+- product requirements and architecture:
+  - `docs/requirements.md`
+  - `docs/architecture.md`
+- crate requirements, architecture, and boundary inventories:
+  - `docs/atm-core/requirements.md`
+  - `docs/atm-core/architecture.md`
+  - `docs/atm-core/boundaries.md`
+  - `docs/atm-daemon/requirements.md`
+  - `docs/atm-daemon/architecture.md`
+  - `docs/atm-daemon/boundaries.md`
+- ADR inventory and controlling decisions:
+  - `docs/adr/INDEX.md`
+  - `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+- machine-readable boundary definitions for the concrete closures in scope:
+  - `boundaries/atm-core/inbox-export.toml`
+  - `boundaries/atm-core/notification-sink.toml`
+  - `boundaries/atm-core/status-source.toml`
+  - `boundaries/atm-daemon/daemon-notification-sink.toml`
+  - `boundaries/atm-daemon/daemon-status-source.toml`
+- testing and validation guidance:
+  - `docs/testing-guidelines.md`
+- issue and readiness tracking:
+  - `docs/phase-Y/issues.md`
+  - `docs/phase-Yd/readiness.md`
+
+If any sprint-level deliverable cannot be justified against this governing set,
+the sprint is not hardened yet.
+
 ## Scope
 
 `Phase Yd` is not a new architecture line. It is a develop-gate closeout line.

--- a/docs/phase-Yd/plan-phase-Yd.md
+++ b/docs/phase-Yd/plan-phase-Yd.md
@@ -42,31 +42,54 @@ It does not exist to:
 
 ## Sprint Sequence
 
-### Y.14 Develop-Gate Runtime And Boundary Closure
+### Y.14 Recovered Claude Logical-Message-Set Closure
 
 Purpose:
 
-- close the remaining runtime, boundary, composition, and accepted phase-end
-  fix blockers on the `Phase Y` line
+- close the recovered Claude behavioral correctness blocker on the final
+  `Phase Y` line
 
 Authoritative sprint doc:
 
 - [sprint-Y14.md](./sprint-Y14.md)
 
-### Y.15 Thin Liveness Proof And Final Develop Gate
+### Y.15 Production Notification Boundary Closure
 
 Purpose:
 
-- leave the final `Phase Y` develop-gate readiness record
-- prove the minimal operational/liveness requirements without adding logic
-  bloat to `runtime_health`
-- explicitly unblock `Phase Z` only if the line is actually ready
+- close the production `NotificationSink` boundary bypass on the final
+  `Phase Y` line
 
 Authoritative sprint doc:
 
 - [sprint-Y15.md](./sprint-Y15.md)
 
-Named readiness record produced by `Y.15`:
+### Y.16 Retained-Runtime Composition And Candidate Closure
+
+Purpose:
+
+- close the retained-runtime composition blocker
+- verify the accepted `Phase Y` merge candidate includes the required
+  end-of-phase fix line and is validation-clean
+
+Authoritative sprint doc:
+
+- [sprint-Y16.md](./sprint-Y16.md)
+
+### Y.17 Thin Liveness Closure And Final Develop Gate
+
+Purpose:
+
+- leave the final `Phase Y` develop-gate readiness record
+- prove or explicitly reclassify the minimal operational/liveness requirement
+  without adding logic bloat to `runtime_health`
+- explicitly unblock `Phase Z` only if the line is actually ready
+
+Authoritative sprint doc:
+
+- [sprint-Y17.md](./sprint-Y17.md)
+
+Named readiness record produced by `Y.17`:
 
 - [readiness.md](./readiness.md)
 

--- a/docs/phase-Yd/plan-phase-Yd.md
+++ b/docs/phase-Yd/plan-phase-Yd.md
@@ -1,0 +1,82 @@
+# Phase Yd Plan
+
+## Goal
+
+Close the remaining `Phase Y` blockers before the line lands on `develop`, and
+leave one explicit readiness record that unblocks `Phase Z`.
+
+This is a planning-only phase on a worktree off `develop`. It does not start
+implementation on this branch.
+
+## Baseline
+
+- planning branch: `plan/phase-Yd-z-gate`
+- planning worktree:
+  - `../atm-core-worktrees/plan/phase-Yd-z-gate`
+- branch base:
+  - `develop` at `fa6428bb`
+- implementation baseline under review:
+  - `integrate/phase-Y`
+- blocking issue inventory:
+  - [../phase-Y/issues.md](../phase-Y/issues.md)
+
+## Scope
+
+`Phase Yd` is not a new architecture line. It is a develop-gate closeout line.
+
+It exists to:
+
+- close the remaining `Phase Y` runtime, boundary, composition, and readiness
+  blockers
+- absorb the accepted end-of-phase fix line into the final merge candidate
+- leave a named readiness record that says whether `Phase Y` may land on
+  `develop`
+- keep `Phase Z` blocked until that record says the line is ready
+
+It does not exist to:
+
+- redesign the `Phase Y` architecture again
+- reopen broad `Phase Z` rollout planning inside the closeout sprints
+- add unrelated lint-only or docs-only reinterpretations of prior `Y.12` /
+  `Y.13` runtime deliverables
+
+## Sprint Sequence
+
+### Y.14 Develop-Gate Runtime And Boundary Closure
+
+Purpose:
+
+- close the remaining runtime, boundary, composition, and accepted phase-end
+  fix blockers on the `Phase Y` line
+
+Authoritative sprint doc:
+
+- [sprint-Y14.md](./sprint-Y14.md)
+
+### Y.15 Thin Liveness Proof And Final Develop Gate
+
+Purpose:
+
+- leave the final `Phase Y` develop-gate readiness record
+- prove the minimal operational/liveness requirements without adding logic
+  bloat to `runtime_health`
+- explicitly unblock `Phase Z` only if the line is actually ready
+
+Authoritative sprint doc:
+
+- [sprint-Y15.md](./sprint-Y15.md)
+
+Named readiness record produced by `Y.15`:
+
+- [readiness.md](./readiness.md)
+
+## Exit Condition
+
+`Phase Yd` closes only when:
+
+- the blockers in [../phase-Y/issues.md](../phase-Y/issues.md) are either
+  closed or explicitly reclassified as non-blocking with documented rationale
+- the final accepted `Phase Y` merge candidate includes the required
+  end-of-phase fixes
+- the `Phase Yd` readiness record says the line is ready to land on `develop`
+- `Phase Z` is explicitly unblocked by that readiness record

--- a/docs/phase-Yd/readiness.md
+++ b/docs/phase-Yd/readiness.md
@@ -7,6 +7,26 @@ This artifact is the final `Phase Y` develop-gate record.
 `Phase Y` does not land on `develop`, and `Phase Z` does not begin, until this
 record explicitly says the line is ready.
 
+## Per-Sprint Closure Results
+
+| Sprint | Closure Result | Date | Candidate Commit | Notes |
+| --- | --- | --- | --- | --- |
+| `Y.14` | `PENDING` | `TBD` | `TBD` | recovered Claude logical-message-set closure on final accepted candidate line |
+| `Y.15` | `PENDING` | `TBD` | `TBD` | production `NotificationSink` boundary closure on final accepted candidate line |
+| `Y.16` | `PENDING` | `TBD` | `TBD` | retained-runtime composition installs live production `NotificationSink` |
+| `Y.17` | `PENDING` | `TBD` | `TBD` | accepted merge candidate includes required end-of-phase fix line and passes validation |
+| `Y.18` | `PENDING` | `TBD` | `TBD` | thin liveness closure or explicit reclassification with final develop-gate result |
+
+Allowed closure-result values:
+
+- `PENDING`
+- `PASS`
+- `FAIL`
+- `RECLASSIFIED`
+
+Every `Y.14` through `Y.18` sprint acceptance update must populate its row in
+this table.
+
 ## Required Closure Invariants
 
 `Y.14` must prove that:
@@ -45,6 +65,11 @@ that:
 
 - all required `Y.14` through `Y.18` closure invariants above passed
 - the final accepted `Phase Y` candidate is ready for merge to `develop`
+
+Final develop-gate verdict:
+
+- `NOT AUTHORIZED`
+- final accepted candidate line: `TBD`
 
 ## Phase Z Gate
 

--- a/docs/phase-Yd/readiness.md
+++ b/docs/phase-Yd/readiness.md
@@ -23,10 +23,13 @@ record explicitly says the line is ready.
 
 - the daemon retained-runtime factory installs the live `NotificationSink` on
   the production path
+
+`Y.17` must prove that:
+
 - the accepted merge candidate includes the required end-of-phase fix line and
   passes the required validation stack
 
-`Y.17` must prove that:
+`Y.18` must prove that:
 
 - any remaining notification-worker liveness requirement is either:
   - closed by a thin runtime-owned signal projected by `runtime_health`
@@ -40,7 +43,7 @@ record explicitly says the line is ready.
 `Phase Y` may land on `develop` only after this record is updated to state
 that:
 
-- all required `Y.14` through `Y.17` closure invariants above passed
+- all required `Y.14` through `Y.18` closure invariants above passed
 - the final accepted `Phase Y` candidate is ready for merge to `develop`
 
 ## Phase Z Gate

--- a/docs/phase-Yd/readiness.md
+++ b/docs/phase-Yd/readiness.md
@@ -13,14 +13,20 @@ record explicitly says the line is ready.
 
 - the recovered Claude SQLite-failure path cannot partially emit a logical
   message set while still claiming success
+
+`Y.15` must prove that:
+
 - the production send/ack notification path executes through
   `NotificationSink::deliver(...)`
+
+`Y.16` must prove that:
+
 - the daemon retained-runtime factory installs the live `NotificationSink` on
   the production path
 - the accepted merge candidate includes the required end-of-phase fix line and
   passes the required validation stack
 
-`Y.15` must prove that:
+`Y.17` must prove that:
 
 - any remaining notification-worker liveness requirement is either:
   - closed by a thin runtime-owned signal projected by `runtime_health`
@@ -34,7 +40,7 @@ record explicitly says the line is ready.
 `Phase Y` may land on `develop` only after this record is updated to state
 that:
 
-- all required `Y.14` and `Y.15` closure invariants above passed
+- all required `Y.14` through `Y.17` closure invariants above passed
 - the final accepted `Phase Y` candidate is ready for merge to `develop`
 
 ## Phase Z Gate

--- a/docs/phase-Yd/readiness.md
+++ b/docs/phase-Yd/readiness.md
@@ -1,0 +1,45 @@
+# Phase Yd Readiness Record
+
+## Purpose
+
+This artifact is the final `Phase Y` develop-gate record.
+
+`Phase Y` does not land on `develop`, and `Phase Z` does not begin, until this
+record explicitly says the line is ready.
+
+## Required Closure Invariants
+
+`Y.14` must prove that:
+
+- the recovered Claude SQLite-failure path cannot partially emit a logical
+  message set while still claiming success
+- the production send/ack notification path executes through
+  `NotificationSink::deliver(...)`
+- the daemon retained-runtime factory installs the live `NotificationSink` on
+  the production path
+- the accepted merge candidate includes the required end-of-phase fix line and
+  passes the required validation stack
+
+`Y.15` must prove that:
+
+- any remaining notification-worker liveness requirement is either:
+  - closed by a thin runtime-owned signal projected by `runtime_health`
+  - or explicitly reclassified as non-blocking with documented rationale in
+    `docs/phase-Y/issues.md`
+- `runtime_health` did not grow compensating recovery logic merely to satisfy
+  the liveness requirement
+
+## Develop Gate
+
+`Phase Y` may land on `develop` only after this record is updated to state
+that:
+
+- all required `Y.14` and `Y.15` closure invariants above passed
+- the final accepted `Phase Y` candidate is ready for merge to `develop`
+
+## Phase Z Gate
+
+`Phase Z` remains blocked until this record is updated to state that:
+
+- `Phase Y` is ready to land on `develop`
+- `Phase Z` may begin

--- a/docs/phase-Yd/sprint-Y14.md
+++ b/docs/phase-Yd/sprint-Y14.md
@@ -18,7 +18,15 @@ target: integrate/phase-Y
 
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/plan-phase-Yd.md`
+- `docs/phase-Yd/readiness.md`
 - `docs/phase-Yc/plan-phase-Yc.md`
+- `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/phase-Y/delivery-state-machines.md`
 - the authoritative implementation baseline remains `integrate/phase-Y`
 
 ## Exact Targets
@@ -44,7 +52,7 @@ target: integrate/phase-Y
   `docs/phase-Y/issues.md`
 - update the blocker inventory and readiness record to reflect the closure
   state
-- keep `Phase Z` blocked while the later `Y.15` through `Y.17` closures remain
+- keep `Phase Z` blocked while the later `Y.15` through `Y.18` closures remain
   open
 
 ## This Sprint Does Not Close
@@ -60,6 +68,8 @@ target: integrate/phase-Y
 
 - the recovered Claude blocker assigned to `Y.14` in `docs/phase-Y/issues.md`
   is closed or explicitly reclassified with documented rationale
+- the recovered Claude path either materializes the full logical message set
+  or fails hard; no partial outward success remains on the accepted line
 - the final accepted `Phase Y` merge candidate is behavioral-clean for the
   recovered Claude scope
 - `docs/phase-Yd/readiness.md` is updated with the `Y.14` closure result

--- a/docs/phase-Yd/sprint-Y14.md
+++ b/docs/phase-Yd/sprint-Y14.md
@@ -49,6 +49,16 @@ target: integrate/phase-Y
 - the blocker inventory and readiness record explicitly record the `Y.14`
   closure result
 
+## Relationship To Phase Yc
+
+`Y.12` already defined and first proved the recovered Claude
+logical-message-set closure invariant on the focused `Yc` line.
+
+`Y.14` does not silently reopen that design. It re-proves the same invariant on
+the final accepted `Phase Y` candidate line after later accepted line-state
+changes. `Y.14` is therefore a final-candidate behavioral re-proof sprint, not
+a new semantic redesign of the recovered Claude path.
+
 ## Required Work
 
 - close the recovered Claude logical-message-set blocker recorded in
@@ -101,14 +111,24 @@ match disposition {
 
 - the recovered Claude blocker assigned to `Y.14` in `docs/phase-Y/issues.md`
   is closed or explicitly reclassified with documented rationale
+- `rg -n "if disposition == DeliveryPlanDisposition::SqliteFailedRecovered \\{[[:space:]]*break;" crates/atm-core/src/delivery_execution.rs`
+  returns no matches
+- `rg -n "append_claude_inbox_message\\(inbox_path, recipient, &message\\.envelope\\)" crates/atm-core/src/delivery_execution.rs`
+  no longer shows the recovered Claude path implemented as a one-message loop
 - the recovered Claude path either materializes the full logical message set
   or fails hard; no partial outward success remains on the accepted line
+- named tests prove all-or-nothing recovered Claude logical-message-set
+  behavior on the final accepted line:
+  - `sqlite_failure_for_claude_requires_full_logical_message_set_delivery`
+  - `sqlite_failure_for_claude_does_not_emit_message1_without_message2`
 - the final accepted `Phase Y` merge candidate is behavioral-clean for the
   recovered Claude scope
 - `docs/phase-Yd/readiness.md` is updated with the `Y.14` closure result
 
 ## Required Validation
 
+- `rg -n "if disposition == DeliveryPlanDisposition::SqliteFailedRecovered \\{[[:space:]]*break;" crates/atm-core/src/delivery_execution.rs`
+- `rg -n "append_claude_inbox_message\\(inbox_path, recipient, &message\\.envelope\\)" crates/atm-core/src/delivery_execution.rs`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y14.md
+++ b/docs/phase-Yd/sprint-Y14.md
@@ -1,0 +1,79 @@
+---
+id: Y.14
+title: Develop-Gate Runtime And Boundary Closure
+status: planned
+branch: feature/pYd-s14-develop-gate-runtime-and-boundary-closure
+worktree: ../atm-core-worktrees/feature/pYd-s14-develop-gate-runtime-and-boundary-closure
+target: integrate/phase-Y
+---
+
+# Sprint Y.14 — Develop-Gate Runtime And Boundary Closure
+
+## Goal
+
+- close the remaining runtime, boundary, composition, and accepted phase-end
+  fix blockers on the `Phase Y` line before it is proposed for `develop`
+
+## Hard Dependencies
+
+- `docs/phase-Y/issues.md`
+- `docs/phase-Yd/plan-phase-Yd.md`
+- `docs/phase-Yc/plan-phase-Yc.md`
+- the authoritative implementation baseline remains `integrate/phase-Y`
+
+## Exact Targets
+
+- `crates/atm-core/src/delivery_execution.rs`
+- `crates/atm-core/src/service_runtime.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/boundary_adapters.rs`
+- any files required to absorb the accepted phase-end fix line on the final
+  merge candidate
+- `docs/phase-Y/issues.md`
+- `docs/phase-Yd/readiness.md`
+- `docs/project-plan.md`
+- `docs/plan-phase-Z.md`
+
+## Deliverables
+
+- recovered Claude SQLite-failure delivery either emits the full logical
+  message set or fails hard
+- production send/ack notification execution uses `NotificationSink` with no
+  direct helper bypass
+- daemon retained-runtime composition installs the live production
+  `NotificationSink`
+- the final accepted merge candidate includes the required phase-end fix line
+  and passes the required validation stack
+
+## Required Work
+
+- close the runtime, boundary, and composition blockers recorded in
+  `docs/phase-Y/issues.md`
+- verify the accepted merge candidate includes the end-of-phase fix line, not
+  just the original `Phase Y` integration baseline
+- update the blocker inventory and readiness record to reflect the closure
+  state
+- keep `Phase Z` blocked while any `Y.14` blocker remains open
+
+## This Sprint Does Not Close
+
+- final `develop`-gate authorization
+- any broad `Phase Z` rollout or dogfood execution work
+- notification shutdown determinism hardening beyond the bounded accepted
+  production contract
+
+## Acceptance Criteria
+
+- the blockers assigned to `Y.14` in `docs/phase-Y/issues.md` are closed or
+  explicitly reclassified with documented rationale
+- the final accepted `Phase Y` merge candidate is runtime-clean, boundary-clean,
+  composition-clean, and validation-clean for the `Y.14` scope
+- `docs/phase-Yd/readiness.md` is updated with the `Y.14` closure results
+
+## Required Validation
+
+- `cargo fmt --all`
+- `python3 .just/run_lint.py all`
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `git diff --check`

--- a/docs/phase-Yd/sprint-Y14.md
+++ b/docs/phase-Yd/sprint-Y14.md
@@ -129,6 +129,8 @@ match disposition {
 
 - `rg -n "if disposition == DeliveryPlanDisposition::SqliteFailedRecovered \\{[[:space:]]*break;" crates/atm-core/src/delivery_execution.rs`
 - `rg -n "append_claude_inbox_message\\(inbox_path, recipient, &message\\.envelope\\)" crates/atm-core/src/delivery_execution.rs`
+- `cargo test --workspace sqlite_failure_for_claude_requires_full_logical_message_set_delivery`
+- `cargo test --workspace sqlite_failure_for_claude_does_not_emit_message1_without_message2`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y14.md
+++ b/docs/phase-Yd/sprint-Y14.md
@@ -20,13 +20,16 @@ target: integrate/phase-Y
 - `docs/phase-Yd/plan-phase-Yd.md`
 - `docs/phase-Yd/readiness.md`
 - `docs/phase-Yc/plan-phase-Yc.md`
+- `docs/adr/INDEX.md`
 - `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
 - `docs/requirements.md`
 - `docs/architecture.md`
 - `docs/atm-core/requirements.md`
 - `docs/atm-core/architecture.md`
 - `docs/atm-core/boundaries.md`
+- `boundaries/atm-core/inbox-export.toml`
 - `docs/phase-Y/delivery-state-machines.md`
+- `docs/testing-guidelines.md`
 - the authoritative implementation baseline remains `integrate/phase-Y`
 
 ## Exact Targets
@@ -54,6 +57,36 @@ target: integrate/phase-Y
   state
 - keep `Phase Z` blocked while the later `Y.15` through `Y.18` closures remain
   open
+
+## Explicit Code Samples
+
+```rust
+pub enum DeliveryPlanDisposition {
+    SqliteFailedRecovered {
+        logical_message_set: Vec<CompatInboxMessage>,
+        recovery_error: AtmError,
+    },
+}
+```
+
+```rust
+match disposition {
+    DeliveryPlanDisposition::SqliteFailedRecovered {
+        logical_message_set,
+        recovery_error,
+    } => {
+        inbox_export.append_message_set(&logical_message_set)?;
+        return Err(recovery_error);
+    }
+}
+```
+
+```rust
+// Required Y.14 behavior:
+// either the full logical message set is emitted or the path fails hard.
+// Forbidden behavior:
+// emit message[1], fail on message[2], and still report outward success.
+```
 
 ## This Sprint Does Not Close
 

--- a/docs/phase-Yd/sprint-Y14.md
+++ b/docs/phase-Yd/sprint-Y14.md
@@ -1,18 +1,18 @@
 ---
 id: Y.14
-title: Develop-Gate Runtime And Boundary Closure
+title: Recovered Claude Logical-Message-Set Closure
 status: planned
-branch: feature/pYd-s14-develop-gate-runtime-and-boundary-closure
-worktree: ../atm-core-worktrees/feature/pYd-s14-develop-gate-runtime-and-boundary-closure
+branch: feature/pYd-s14-recovered-claude-logical-message-set-closure
+worktree: ../atm-core-worktrees/feature/pYd-s14-recovered-claude-logical-message-set-closure
 target: integrate/phase-Y
 ---
 
-# Sprint Y.14 — Develop-Gate Runtime And Boundary Closure
+# Sprint Y.14 — Recovered Claude Logical-Message-Set Closure
 
 ## Goal
 
-- close the remaining runtime, boundary, composition, and accepted phase-end
-  fix blockers on the `Phase Y` line before it is proposed for `develop`
+- close the remaining recovered Claude behavioral correctness blocker before
+  the `Phase Y` line is proposed for `develop`
 
 ## Hard Dependencies
 
@@ -24,51 +24,45 @@ target: integrate/phase-Y
 ## Exact Targets
 
 - `crates/atm-core/src/delivery_execution.rs`
-- `crates/atm-core/src/service_runtime.rs`
-- `crates/atm-daemon/src/runtime_health.rs`
-- `crates/atm-daemon/src/boundary_adapters.rs`
-- any files required to absorb the accepted phase-end fix line on the final
-  merge candidate
+- any directly supporting `atm-core` files required to close the recovered
+  Claude message-set contract cleanly
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/readiness.md`
 - `docs/project-plan.md`
-- `docs/plan-phase-Z.md`
 
 ## Deliverables
 
 - recovered Claude SQLite-failure delivery either emits the full logical
   message set or fails hard
-- production send/ack notification execution uses `NotificationSink` with no
-  direct helper bypass
-- daemon retained-runtime composition installs the live production
-  `NotificationSink`
-- the final accepted merge candidate includes the required phase-end fix line
-  and passes the required validation stack
+- no partial outward success may survive on the recovered Claude path
+- the blocker inventory and readiness record explicitly record the `Y.14`
+  closure result
 
 ## Required Work
 
-- close the runtime, boundary, and composition blockers recorded in
+- close the recovered Claude logical-message-set blocker recorded in
   `docs/phase-Y/issues.md`
-- verify the accepted merge candidate includes the end-of-phase fix line, not
-  just the original `Phase Y` integration baseline
 - update the blocker inventory and readiness record to reflect the closure
   state
-- keep `Phase Z` blocked while any `Y.14` blocker remains open
+- keep `Phase Z` blocked while the later `Y.15` through `Y.17` closures remain
+  open
 
 ## This Sprint Does Not Close
 
+- production `NotificationSink` boundary closure
+- daemon retained-runtime `NotificationSink` installation
+- accepted phase-end fix candidate absorption
 - final `develop`-gate authorization
-- any broad `Phase Z` rollout or dogfood execution work
 - notification shutdown determinism hardening beyond the bounded accepted
   production contract
 
 ## Acceptance Criteria
 
-- the blockers assigned to `Y.14` in `docs/phase-Y/issues.md` are closed or
-  explicitly reclassified with documented rationale
-- the final accepted `Phase Y` merge candidate is runtime-clean, boundary-clean,
-  composition-clean, and validation-clean for the `Y.14` scope
-- `docs/phase-Yd/readiness.md` is updated with the `Y.14` closure results
+- the recovered Claude blocker assigned to `Y.14` in `docs/phase-Y/issues.md`
+  is closed or explicitly reclassified with documented rationale
+- the final accepted `Phase Y` merge candidate is behavioral-clean for the
+  recovered Claude scope
+- `docs/phase-Yd/readiness.md` is updated with the `Y.14` closure result
 
 ## Required Validation
 

--- a/docs/phase-Yd/sprint-Y15.md
+++ b/docs/phase-Yd/sprint-Y15.md
@@ -83,9 +83,7 @@ new notification ownership redesign.
 - the production notification path executes only through
   `NotificationSink::deliver(...)` and no direct helper bypass remains on the
   accepted line
-- `rg -n "maybe_run_post_send_hook" crates/atm-core/src/delivery_execution.rs`
-  returns no matches
-- `rg -n "fn maybe_run_post_send_hook" crates/atm-core/src/service_runtime.rs`
+- `rg -rn "maybe_run_post_send_hook" crates/atm-core/src/`
   returns no matches
 - named tests from `Y.13` survive and pass on the final accepted candidate
   line:
@@ -122,8 +120,7 @@ notification_sink.deliver(notification_event)?;
 
 ## Required Validation
 
-- `rg -n "maybe_run_post_send_hook" crates/atm-core/src/delivery_execution.rs`
-- `rg -n "fn maybe_run_post_send_hook" crates/atm-core/src/service_runtime.rs`
+- `rg -rn "maybe_run_post_send_hook" crates/atm-core/src/`
 - `cargo test --workspace delivery_notifications_use_notification_sink_boundary`
 - `cargo test --workspace notification_sink_failure_is_explicit_in_delivery_warnings`
 - `cargo test --workspace notification_sink_backpressure_does_not_reopen_hook_helper_bypass`

--- a/docs/phase-Yd/sprint-Y15.md
+++ b/docs/phase-Yd/sprint-Y15.md
@@ -1,70 +1,71 @@
 ---
 id: Y.15
-title: Thin Liveness Proof And Final Develop Gate
+title: Production Notification Boundary Closure
 status: planned
-branch: feature/pYd-s15-thin-liveness-proof-and-final-develop-gate
-worktree: ../atm-core-worktrees/feature/pYd-s15-thin-liveness-proof-and-final-develop-gate
+branch: feature/pYd-s15-production-notification-boundary-closure
+worktree: ../atm-core-worktrees/feature/pYd-s15-production-notification-boundary-closure
 target: integrate/phase-Y
 ---
 
-# Sprint Y.15 — Thin Liveness Proof And Final Develop Gate
+# Sprint Y.15 — Production Notification Boundary Closure
 
 ## Goal
 
-- close the remaining minimal operational/liveness gate for `Phase Y`
-- leave the final `develop`-gate record
-- explicitly unblock `Phase Z` only after the line is ready
+- close the production notification boundary bypass on the `Phase Y` line
 
 ## Hard Dependencies
 
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/plan-phase-Yd.md`
-- `docs/phase-Yd/readiness.md`
+- `docs/phase-Yc/plan-phase-Yc.md`
 - `Y.14` must close first
 
 ## Exact Targets
 
-- `crates/atm-daemon/src/runtime_health.rs`
-- any runtime-owned liveness signal source required by the accepted design
+- `crates/atm-core/src/delivery_execution.rs`
+- `crates/atm-core/src/service_runtime.rs`
+- any directly supporting `atm-core` files required to route notifications
+  through the approved boundary cleanly
+- `docs/phase-Y/issues.md`
 - `docs/phase-Yd/readiness.md`
 - `docs/project-plan.md`
-- `docs/plan-phase-Z.md`
 
 ## Deliverables
 
-- the notification-worker liveness blocker is resolved either by:
-  - a thin runtime-owned signal that `runtime_health` projects directly
-  - or an explicit documented reclassification to non-blocking in
-    `docs/phase-Y/issues.md`
-- `runtime_health` remains a projection layer, not a compensating recovery
-  engine
-- one explicit readiness record states whether `Phase Y` may land on `develop`
-  and whether `Phase Z` may begin
+- production send/ack notification execution uses `NotificationSink` with no
+  direct helper bypass
+- the blocker inventory and readiness record explicitly record the `Y.15`
+  closure result
 
 ## Required Work
 
-- close or explicitly reclassify the final liveness/readiness blocker from
-  `docs/phase-Y/issues.md` without growing logic-heavy inference inside
-  `runtime_health`
-- update the readiness record with the final `develop`-gate verdict
-- update `Phase Z` docs so they remain blocked until that verdict is positive
+- close the production notification execution blocker recorded in
+  `docs/phase-Y/issues.md`
+- update the blocker inventory and readiness record to reflect the closure
+  state
+- keep `Phase Z` blocked while the later `Y.16` and `Y.17` closures remain
+  open
 
 ## This Sprint Does Not Close
 
-- new `Phase Z` rollout execution
-- unrelated daemon hardening or broad observability redesign
+- daemon retained-runtime `NotificationSink` installation
+- accepted phase-end fix candidate absorption
+- final `develop`-gate authorization
+- unrelated daemon transport or roster-store redesign
 
 ## Acceptance Criteria
 
-- the final `Phase Y` blocker set is closed or explicitly reclassified with
+- the production notification boundary blocker assigned to `Y.15` in
+  `docs/phase-Y/issues.md` is closed or explicitly reclassified with
   documented rationale
-- any liveness closure uses a thin runtime-owned signal rather than
-  compensating logic inside `runtime_health`
-- `docs/phase-Yd/readiness.md` says whether `Phase Y` may land on `develop`
-- `docs/plan-phase-Z.md` reflects the final `Phase Z` gate state accurately
+- the final accepted `Phase Y` merge candidate is boundary-clean for the
+  `Y.15` scope
+- `docs/phase-Yd/readiness.md` is updated with the `Y.15` closure result
 
 ## Required Validation
 
-- focused readiness validation for the accepted liveness signal
+- `cargo fmt --all`
+- `python3 .just/run_lint.py all`
 - `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
 - `git diff --check`

--- a/docs/phase-Yd/sprint-Y15.md
+++ b/docs/phase-Yd/sprint-Y15.md
@@ -17,7 +17,15 @@ target: integrate/phase-Y
 
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/plan-phase-Yd.md`
+- `docs/phase-Yd/readiness.md`
 - `docs/phase-Yc/plan-phase-Yc.md`
+- `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
 - `Y.14` must close first
 
 ## Exact Targets
@@ -43,7 +51,7 @@ target: integrate/phase-Y
   `docs/phase-Y/issues.md`
 - update the blocker inventory and readiness record to reflect the closure
   state
-- keep `Phase Z` blocked while the later `Y.16` and `Y.17` closures remain
+- keep `Phase Z` blocked while the later `Y.16` through `Y.18` closures remain
   open
 
 ## This Sprint Does Not Close
@@ -58,6 +66,9 @@ target: integrate/phase-Y
 - the production notification boundary blocker assigned to `Y.15` in
   `docs/phase-Y/issues.md` is closed or explicitly reclassified with
   documented rationale
+- the production notification path executes only through
+  `NotificationSink::deliver(...)` and no direct helper bypass remains on the
+  accepted line
 - the final accepted `Phase Y` merge candidate is boundary-clean for the
   `Y.15` scope
 - `docs/phase-Yd/readiness.md` is updated with the `Y.15` closure result

--- a/docs/phase-Yd/sprint-Y15.md
+++ b/docs/phase-Yd/sprint-Y15.md
@@ -1,0 +1,70 @@
+---
+id: Y.15
+title: Thin Liveness Proof And Final Develop Gate
+status: planned
+branch: feature/pYd-s15-thin-liveness-proof-and-final-develop-gate
+worktree: ../atm-core-worktrees/feature/pYd-s15-thin-liveness-proof-and-final-develop-gate
+target: integrate/phase-Y
+---
+
+# Sprint Y.15 — Thin Liveness Proof And Final Develop Gate
+
+## Goal
+
+- close the remaining minimal operational/liveness gate for `Phase Y`
+- leave the final `develop`-gate record
+- explicitly unblock `Phase Z` only after the line is ready
+
+## Hard Dependencies
+
+- `docs/phase-Y/issues.md`
+- `docs/phase-Yd/plan-phase-Yd.md`
+- `docs/phase-Yd/readiness.md`
+- `Y.14` must close first
+
+## Exact Targets
+
+- `crates/atm-daemon/src/runtime_health.rs`
+- any runtime-owned liveness signal source required by the accepted design
+- `docs/phase-Yd/readiness.md`
+- `docs/project-plan.md`
+- `docs/plan-phase-Z.md`
+
+## Deliverables
+
+- the notification-worker liveness blocker is resolved either by:
+  - a thin runtime-owned signal that `runtime_health` projects directly
+  - or an explicit documented reclassification to non-blocking in
+    `docs/phase-Y/issues.md`
+- `runtime_health` remains a projection layer, not a compensating recovery
+  engine
+- one explicit readiness record states whether `Phase Y` may land on `develop`
+  and whether `Phase Z` may begin
+
+## Required Work
+
+- close or explicitly reclassify the final liveness/readiness blocker from
+  `docs/phase-Y/issues.md` without growing logic-heavy inference inside
+  `runtime_health`
+- update the readiness record with the final `develop`-gate verdict
+- update `Phase Z` docs so they remain blocked until that verdict is positive
+
+## This Sprint Does Not Close
+
+- new `Phase Z` rollout execution
+- unrelated daemon hardening or broad observability redesign
+
+## Acceptance Criteria
+
+- the final `Phase Y` blocker set is closed or explicitly reclassified with
+  documented rationale
+- any liveness closure uses a thin runtime-owned signal rather than
+  compensating logic inside `runtime_health`
+- `docs/phase-Yd/readiness.md` says whether `Phase Y` may land on `develop`
+- `docs/plan-phase-Z.md` reflects the final `Phase Z` gate state accurately
+
+## Required Validation
+
+- focused readiness validation for the accepted liveness signal
+- `cargo test --workspace`
+- `git diff --check`

--- a/docs/phase-Yd/sprint-Y15.md
+++ b/docs/phase-Yd/sprint-Y15.md
@@ -124,6 +124,9 @@ notification_sink.deliver(notification_event)?;
 
 - `rg -n "maybe_run_post_send_hook" crates/atm-core/src/delivery_execution.rs`
 - `rg -n "fn maybe_run_post_send_hook" crates/atm-core/src/service_runtime.rs`
+- `cargo test --workspace delivery_notifications_use_notification_sink_boundary`
+- `cargo test --workspace notification_sink_failure_is_explicit_in_delivery_warnings`
+- `cargo test --workspace notification_sink_backpressure_does_not_reopen_hook_helper_bypass`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y15.md
+++ b/docs/phase-Yd/sprint-Y15.md
@@ -49,6 +49,16 @@ target: integrate/phase-Y
 - the blocker inventory and readiness record explicitly record the `Y.15`
   closure result
 
+## Relationship To Phase Yc
+
+`Y.13` already defined and first proved the `NotificationSink` boundary-closure
+shape on the focused `Yc` line.
+
+`Y.15` does not silently reopen that design. It re-proves the same invariant on
+the final accepted `Phase Y` candidate line after later accepted line-state
+changes. `Y.15` is therefore a final-candidate boundary re-proof sprint, not a
+new notification ownership redesign.
+
 ## Required Work
 
 - close the production notification execution blocker recorded in
@@ -73,6 +83,10 @@ target: integrate/phase-Y
 - the production notification path executes only through
   `NotificationSink::deliver(...)` and no direct helper bypass remains on the
   accepted line
+- `rg -n "maybe_run_post_send_hook" crates/atm-core/src/delivery_execution.rs`
+  returns no matches
+- `rg -n "fn maybe_run_post_send_hook" crates/atm-core/src/service_runtime.rs`
+  returns no matches
 - the final accepted `Phase Y` merge candidate is boundary-clean for the
   `Y.15` scope
 - `docs/phase-Yd/readiness.md` is updated with the `Y.15` closure result
@@ -103,6 +117,8 @@ notification_sink.deliver(notification_event)?;
 
 ## Required Validation
 
+- `rg -n "maybe_run_post_send_hook" crates/atm-core/src/delivery_execution.rs`
+- `rg -n "fn maybe_run_post_send_hook" crates/atm-core/src/service_runtime.rs`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y15.md
+++ b/docs/phase-Yd/sprint-Y15.md
@@ -87,6 +87,11 @@ new notification ownership redesign.
   returns no matches
 - `rg -n "fn maybe_run_post_send_hook" crates/atm-core/src/service_runtime.rs`
   returns no matches
+- named tests from `Y.13` survive and pass on the final accepted candidate
+  line:
+  - `delivery_notifications_use_notification_sink_boundary`
+  - `notification_sink_failure_is_explicit_in_delivery_warnings`
+  - `notification_sink_backpressure_does_not_reopen_hook_helper_bypass`
 - the final accepted `Phase Y` merge candidate is boundary-clean for the
   `Y.15` scope
 - `docs/phase-Yd/readiness.md` is updated with the `Y.15` closure result

--- a/docs/phase-Yd/sprint-Y15.md
+++ b/docs/phase-Yd/sprint-Y15.md
@@ -19,6 +19,7 @@ target: integrate/phase-Y
 - `docs/phase-Yd/plan-phase-Yd.md`
 - `docs/phase-Yd/readiness.md`
 - `docs/phase-Yc/plan-phase-Yc.md`
+- `docs/adr/INDEX.md`
 - `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
 - `docs/requirements.md`
 - `docs/architecture.md`
@@ -26,6 +27,9 @@ target: integrate/phase-Y
 - `docs/atm-core/architecture.md`
 - `docs/atm-core/boundaries.md`
 - `docs/atm-daemon/boundaries.md`
+- `boundaries/atm-core/notification-sink.toml`
+- `boundaries/atm-daemon/daemon-notification-sink.toml`
+- `docs/testing-guidelines.md`
 - `Y.14` must close first
 
 ## Exact Targets

--- a/docs/phase-Yd/sprint-Y15.md
+++ b/docs/phase-Yd/sprint-Y15.md
@@ -73,6 +73,30 @@ target: integrate/phase-Y
   `Y.15` scope
 - `docs/phase-Yd/readiness.md` is updated with the `Y.15` closure result
 
+## Explicit Code Samples
+
+```rust
+pub trait NotificationSink: sealed::Sealed {
+    fn deliver(&self, event: NotificationEvent) -> Result<(), AtmError>;
+}
+```
+
+```rust
+fn deliver_notifications(
+    notification_sink: &dyn NotificationSink,
+    event: NotificationEvent,
+) -> Result<(), AtmError> {
+    notification_sink.deliver(event)
+}
+```
+
+```rust
+// Required call-site shape on the production path:
+notification_sink.deliver(notification_event)?;
+// Forbidden bypass shape:
+// maybe_run_post_send_hook(...)
+```
+
 ## Required Validation
 
 - `cargo fmt --all`

--- a/docs/phase-Yd/sprint-Y16.md
+++ b/docs/phase-Yd/sprint-Y16.md
@@ -18,6 +18,7 @@ target: integrate/phase-Y
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/plan-phase-Yd.md`
 - `docs/phase-Yd/readiness.md`
+- `docs/adr/INDEX.md`
 - `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
 - `docs/requirements.md`
 - `docs/architecture.md`
@@ -25,6 +26,10 @@ target: integrate/phase-Y
 - `docs/atm-daemon/architecture.md`
 - `docs/atm-core/boundaries.md`
 - `docs/atm-daemon/boundaries.md`
+- `boundaries/atm-core/notification-sink.toml`
+- `boundaries/atm-daemon/daemon-notification-sink.toml`
+- `boundaries/atm-daemon/runtime-lifecycle-daemon.toml`
+- `docs/testing-guidelines.md`
 - `Y.15` must close first
 
 ## Exact Targets

--- a/docs/phase-Yd/sprint-Y16.md
+++ b/docs/phase-Yd/sprint-Y16.md
@@ -91,7 +91,7 @@ target: integrate/phase-Y
 
 ```rust
 // Owned by `atm_daemon::composition`.
-pub fn build_production_runtime(
+pub(crate) fn build_production_runtime(
     mail_store: Arc<dyn MailStore + Send + Sync>,
     task_store: Arc<dyn TaskStore + Send + Sync>,
     roster_store: Arc<dyn RosterStore + Send + Sync>,

--- a/docs/phase-Yd/sprint-Y16.md
+++ b/docs/phase-Yd/sprint-Y16.md
@@ -69,6 +69,39 @@ target: integrate/phase-Y
   without fallback/helper-owned bypass behavior
 - `docs/phase-Yd/readiness.md` is updated with the `Y.16` closure result
 
+## Explicit Code Samples
+
+```rust
+pub fn build_production_runtime(
+    mail_store: Arc<dyn MailStore + Send + Sync>,
+    task_store: Arc<dyn TaskStore + Send + Sync>,
+    roster_store: Arc<dyn RosterStore + Send + Sync>,
+    non_claude_outbound: Arc<dyn NonClaudeOutbound + Send + Sync>,
+    notification_sink: Arc<dyn NotificationSink + Send + Sync>,
+) -> LocalServiceRuntime {
+    LocalServiceRuntime::new_with_delivery_boundaries(
+        mail_store,
+        task_store,
+        roster_store,
+        non_claude_outbound,
+        notification_sink,
+    )
+}
+```
+
+```rust
+let notification_sink: Arc<dyn NotificationSink + Send + Sync> =
+    Arc::new(DaemonNotificationSink::new(notification_runtime.clone()));
+
+let runtime = build_production_runtime(
+    mail_store,
+    task_store,
+    roster_store,
+    non_claude_outbound,
+    notification_sink,
+);
+```
+
 ## Required Validation
 
 - `cargo fmt --all`

--- a/docs/phase-Yd/sprint-Y16.md
+++ b/docs/phase-Yd/sprint-Y16.md
@@ -1,31 +1,38 @@
 ---
 id: Y.16
-title: Retained-Runtime Composition And Candidate Closure
+title: Retained-Runtime Composition Closure
 status: planned
-branch: feature/pYd-s16-retained-runtime-composition-and-candidate-closure
-worktree: ../atm-core-worktrees/feature/pYd-s16-retained-runtime-composition-and-candidate-closure
+branch: feature/pYd-s16-retained-runtime-composition-closure
+worktree: ../atm-core-worktrees/feature/pYd-s16-retained-runtime-composition-closure
 target: integrate/phase-Y
 ---
 
-# Sprint Y.16 — Retained-Runtime Composition And Candidate Closure
+# Sprint Y.16 — Retained-Runtime Composition Closure
 
 ## Goal
 
-- close the remaining production composition blocker and produce the accepted
-  `Phase Y` merge candidate line with the required end-of-phase fixes present
+- close the remaining production composition blocker on the `Phase Y` line
 
 ## Hard Dependencies
 
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/plan-phase-Yd.md`
+- `docs/phase-Yd/readiness.md`
+- `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
 - `Y.15` must close first
 
 ## Exact Targets
 
 - `crates/atm-daemon/src/runtime_health.rs`
 - `crates/atm-daemon/src/boundary_adapters.rs`
-- any files required to absorb the accepted phase-end fix line on the final
-  merge candidate
+- any directly supporting daemon/runtime assembly files required to install the
+  live production `NotificationSink`
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/readiness.md`
 - `docs/project-plan.md`
@@ -34,8 +41,6 @@ target: integrate/phase-Y
 
 - daemon retained-runtime composition installs the live production
   `NotificationSink`
-- the final accepted merge candidate includes the required phase-end fix line
-  and passes the required validation stack
 - the blocker inventory and readiness record explicitly record the `Y.16`
   closure result
 
@@ -43,14 +48,14 @@ target: integrate/phase-Y
 
 - close the retained-runtime composition blocker recorded in
   `docs/phase-Y/issues.md`
-- verify the accepted merge candidate includes the end-of-phase fix line, not
-  just the original `Phase Y` integration baseline
 - update the blocker inventory and readiness record to reflect the closure
   state
-- keep `Phase Z` blocked while the final `Y.17` gate remains open
+- keep `Phase Z` blocked while the later `Y.17` and `Y.18` closures remain
+  open
 
 ## This Sprint Does Not Close
 
+- accepted phase-end fix candidate absorption
 - final liveness/readiness closure
 - final `develop`-gate authorization itself
 - any broad `Phase Z` rollout or dogfood execution work
@@ -60,8 +65,8 @@ target: integrate/phase-Y
 - the retained-runtime composition blocker assigned to `Y.16` in
   `docs/phase-Y/issues.md` is closed or explicitly reclassified with
   documented rationale
-- the accepted merge candidate includes the required phase-end fix line and is
-  validation-clean for the `Y.16` scope
+- the production retained-runtime path installs the live `NotificationSink`
+  without fallback/helper-owned bypass behavior
 - `docs/phase-Yd/readiness.md` is updated with the `Y.16` closure result
 
 ## Required Validation

--- a/docs/phase-Yd/sprint-Y16.md
+++ b/docs/phase-Yd/sprint-Y16.md
@@ -1,0 +1,73 @@
+---
+id: Y.16
+title: Retained-Runtime Composition And Candidate Closure
+status: planned
+branch: feature/pYd-s16-retained-runtime-composition-and-candidate-closure
+worktree: ../atm-core-worktrees/feature/pYd-s16-retained-runtime-composition-and-candidate-closure
+target: integrate/phase-Y
+---
+
+# Sprint Y.16 — Retained-Runtime Composition And Candidate Closure
+
+## Goal
+
+- close the remaining production composition blocker and produce the accepted
+  `Phase Y` merge candidate line with the required end-of-phase fixes present
+
+## Hard Dependencies
+
+- `docs/phase-Y/issues.md`
+- `docs/phase-Yd/plan-phase-Yd.md`
+- `Y.15` must close first
+
+## Exact Targets
+
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/boundary_adapters.rs`
+- any files required to absorb the accepted phase-end fix line on the final
+  merge candidate
+- `docs/phase-Y/issues.md`
+- `docs/phase-Yd/readiness.md`
+- `docs/project-plan.md`
+
+## Deliverables
+
+- daemon retained-runtime composition installs the live production
+  `NotificationSink`
+- the final accepted merge candidate includes the required phase-end fix line
+  and passes the required validation stack
+- the blocker inventory and readiness record explicitly record the `Y.16`
+  closure result
+
+## Required Work
+
+- close the retained-runtime composition blocker recorded in
+  `docs/phase-Y/issues.md`
+- verify the accepted merge candidate includes the end-of-phase fix line, not
+  just the original `Phase Y` integration baseline
+- update the blocker inventory and readiness record to reflect the closure
+  state
+- keep `Phase Z` blocked while the final `Y.17` gate remains open
+
+## This Sprint Does Not Close
+
+- final liveness/readiness closure
+- final `develop`-gate authorization itself
+- any broad `Phase Z` rollout or dogfood execution work
+
+## Acceptance Criteria
+
+- the retained-runtime composition blocker assigned to `Y.16` in
+  `docs/phase-Y/issues.md` is closed or explicitly reclassified with
+  documented rationale
+- the accepted merge candidate includes the required phase-end fix line and is
+  validation-clean for the `Y.16` scope
+- `docs/phase-Yd/readiness.md` is updated with the `Y.16` closure result
+
+## Required Validation
+
+- `cargo fmt --all`
+- `python3 .just/run_lint.py all`
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `git diff --check`

--- a/docs/phase-Yd/sprint-Y16.md
+++ b/docs/phase-Yd/sprint-Y16.md
@@ -125,23 +125,11 @@ pub fn compose_runtime(/* ... */) -> RuntimeComposition {
 }
 ```
 
-```rust
-let notification_sink: Arc<dyn NotificationSink + Send + Sync> =
-    Arc::new(DaemonNotificationSink::new(notification_runtime.clone()));
-
-let runtime = atm_daemon::composition::build_production_runtime(
-    mail_store,
-    task_store,
-    roster_store,
-    non_claude_outbound,
-    notification_sink,
-);
-```
-
 ## Required Validation
 
 - `rg -n "DaemonNotificationSink::new" crates/atm-daemon/src/composition.rs`
 - `rg -n "compose_runtime|build_production_runtime" crates/atm-daemon/src/composition.rs`
+- `cargo test --workspace production_runtime_installs_daemon_notification_sink`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y16.md
+++ b/docs/phase-Yd/sprint-Y16.md
@@ -34,8 +34,10 @@ target: integrate/phase-Y
 
 ## Exact Targets
 
+- `crates/atm-daemon/src/composition.rs`
 - `crates/atm-daemon/src/runtime_health.rs`
 - `crates/atm-daemon/src/boundary_adapters.rs`
+- `crates/atm-daemon/src/notification_runtime.rs`
 - any directly supporting daemon/runtime assembly files required to install the
   live production `NotificationSink`
 - `docs/phase-Y/issues.md`
@@ -72,11 +74,17 @@ target: integrate/phase-Y
   documented rationale
 - the production retained-runtime path installs the live `NotificationSink`
   without fallback/helper-owned bypass behavior
+- `rg -n "DaemonNotificationSink::new" crates/atm-daemon/src/composition.rs`
+  returns at least one match on the production factory path
+- named test proves production retained-runtime composition installs the live
+  notification sink:
+  - `production_runtime_installs_daemon_notification_sink`
 - `docs/phase-Yd/readiness.md` is updated with the `Y.16` closure result
 
 ## Explicit Code Samples
 
 ```rust
+// Owned by `atm_daemon::composition`.
 pub fn build_production_runtime(
     mail_store: Arc<dyn MailStore + Send + Sync>,
     task_store: Arc<dyn TaskStore + Send + Sync>,
@@ -98,7 +106,7 @@ pub fn build_production_runtime(
 let notification_sink: Arc<dyn NotificationSink + Send + Sync> =
     Arc::new(DaemonNotificationSink::new(notification_runtime.clone()));
 
-let runtime = build_production_runtime(
+let runtime = atm_daemon::composition::build_production_runtime(
     mail_store,
     task_store,
     roster_store,
@@ -109,6 +117,7 @@ let runtime = build_production_runtime(
 
 ## Required Validation
 
+- `rg -n "DaemonNotificationSink::new" crates/atm-daemon/src/composition.rs`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y16.md
+++ b/docs/phase-Yd/sprint-Y16.md
@@ -55,6 +55,9 @@ target: integrate/phase-Y
 
 - close the retained-runtime composition blocker recorded in
   `docs/phase-Y/issues.md`
+- keep `atm_daemon::composition::compose_runtime` as the machine-readable
+  composition root and treat `build_production_runtime(...)` as an internal
+  helper that is called from within `compose_runtime(...)`
 - update the blocker inventory and readiness record to reflect the closure
   state
 - keep `Phase Z` blocked while the later `Y.17` and `Y.18` closures remain
@@ -76,6 +79,9 @@ target: integrate/phase-Y
   without fallback/helper-owned bypass behavior
 - `rg -n "DaemonNotificationSink::new" crates/atm-daemon/src/composition.rs`
   returns at least one match on the production factory path
+- `rg -n "compose_runtime|build_production_runtime" crates/atm-daemon/src/composition.rs`
+  shows `compose_runtime(...)` calling `build_production_runtime(...)` so the
+  declared TOML composition root remains authoritative
 - named test proves production retained-runtime composition installs the live
   notification sink:
   - `production_runtime_installs_daemon_notification_sink`
@@ -103,6 +109,23 @@ pub fn build_production_runtime(
 ```
 
 ```rust
+pub fn compose_runtime(/* ... */) -> RuntimeComposition {
+    let notification_sink: Arc<dyn NotificationSink + Send + Sync> =
+        Arc::new(DaemonNotificationSink::new(notification_runtime.clone()));
+
+    let runtime = build_production_runtime(
+        mail_store,
+        task_store,
+        roster_store,
+        non_claude_outbound,
+        notification_sink,
+    );
+
+    RuntimeComposition::from_runtime(runtime)
+}
+```
+
+```rust
 let notification_sink: Arc<dyn NotificationSink + Send + Sync> =
     Arc::new(DaemonNotificationSink::new(notification_runtime.clone()));
 
@@ -118,6 +141,7 @@ let runtime = atm_daemon::composition::build_production_runtime(
 ## Required Validation
 
 - `rg -n "DaemonNotificationSink::new" crates/atm-daemon/src/composition.rs`
+- `rg -n "compose_runtime|build_production_runtime" crates/atm-daemon/src/composition.rs`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y17.md
+++ b/docs/phase-Yd/sprint-Y17.md
@@ -1,19 +1,18 @@
 ---
 id: Y.17
-title: Thin Liveness Closure And Final Develop Gate
+title: Candidate Closure
 status: planned
-branch: feature/pYd-s17-thin-liveness-closure-and-final-develop-gate
-worktree: ../atm-core-worktrees/feature/pYd-s17-thin-liveness-closure-and-final-develop-gate
+branch: feature/pYd-s17-candidate-closure
+worktree: ../atm-core-worktrees/feature/pYd-s17-candidate-closure
 target: integrate/phase-Y
 ---
 
-# Sprint Y.17 — Thin Liveness Closure And Final Develop Gate
+# Sprint Y.17 — Candidate Closure
 
 ## Goal
 
-- close the remaining minimal operational/liveness gate for `Phase Y`
-- leave the final `develop`-gate record
-- explicitly unblock `Phase Z` only after the line is ready
+- produce the accepted `Phase Y` merge candidate line with the required
+  end-of-phase fixes present and validation-clean
 
 ## Hard Dependencies
 
@@ -24,48 +23,44 @@ target: integrate/phase-Y
 
 ## Exact Targets
 
-- `crates/atm-daemon/src/runtime_health.rs`
-- any runtime-owned liveness signal source required by the accepted design
+- any files required to absorb the accepted phase-end fix line on the final
+  merge candidate
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/readiness.md`
 - `docs/project-plan.md`
-- `docs/plan-phase-Z.md`
 
 ## Deliverables
 
-- the notification-worker liveness blocker is resolved either by:
-  - a thin runtime-owned signal that `runtime_health` projects directly
-  - or an explicit documented reclassification to non-blocking in
-    `docs/phase-Y/issues.md`
-- `runtime_health` remains a projection layer, not a compensating recovery
-  engine
-- one explicit readiness record states whether `Phase Y` may land on `develop`
-  and whether `Phase Z` may begin
+- the final accepted merge candidate includes the required phase-end fix line
+- the accepted merge candidate passes the required validation stack
+- the blocker inventory and readiness record explicitly record the `Y.17`
+  closure result
 
 ## Required Work
 
-- close or explicitly reclassify the final liveness/readiness blocker from
-  `docs/phase-Y/issues.md` without growing logic-heavy inference inside
-  `runtime_health`
-- update the readiness record with the final `develop`-gate verdict
-- update `Phase Z` docs so they remain blocked until that verdict is positive
+- verify the accepted merge candidate includes the end-of-phase fix line, not
+  just the original `Phase Y` integration baseline
+- validate the accepted candidate line cleanly
+- update the blocker inventory and readiness record to reflect the closure
+  state
+- keep `Phase Z` blocked while the final `Y.18` gate remains open
 
 ## This Sprint Does Not Close
 
-- new `Phase Z` rollout execution
-- unrelated daemon hardening or broad observability redesign
+- final liveness/readiness closure
+- final `develop`-gate authorization itself
+- any broad `Phase Z` rollout or dogfood execution work
 
 ## Acceptance Criteria
 
-- the final `Phase Y` blocker set is closed or explicitly reclassified with
-  documented rationale
-- any liveness closure uses a thin runtime-owned signal rather than
-  compensating logic inside `runtime_health`
-- `docs/phase-Yd/readiness.md` says whether `Phase Y` may land on `develop`
-- `docs/plan-phase-Z.md` reflects the final `Phase Z` gate state accurately
+- the accepted merge candidate includes the required phase-end fix line and is
+  validation-clean for the `Y.17` scope
+- `docs/phase-Yd/readiness.md` is updated with the `Y.17` closure result
 
 ## Required Validation
 
-- focused readiness validation for the accepted liveness signal
+- `cargo fmt --all`
+- `python3 .just/run_lint.py all`
 - `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
 - `git diff --check`

--- a/docs/phase-Yd/sprint-Y17.md
+++ b/docs/phase-Yd/sprint-Y17.md
@@ -20,14 +20,27 @@ target: integrate/phase-Y
 - `docs/phase-Yd/plan-phase-Yd.md`
 - `docs/phase-Yd/readiness.md`
 - accepted phase-end fix evidence from:
-  - `PY-EOP-FIX-1`
-  - `PY-EOP-FIX-R2`
+  - `feature/pY-eop-fix-1` at `fe28ad75169d1ec0bf3c40f8e356c9499917501f`
+    (`PY-EOP-FIX-1`)
+  - `feature/pY-eop-fix-1` at `243e473a` (`PY-EOP-FIX-R2`)
 - `Y.16` must close first
 
 ## Exact Targets
 
-- any files required to absorb the accepted phase-end fix line on the final
-  merge candidate
+- accepted merge candidate branch:
+  - `integrate/phase-Y`
+- accepted phase-end fix line source:
+  - `feature/pY-eop-fix-1`
+- files changed by accepted phase-end fix evidence:
+  - `crates/atm-daemon/src/composition.rs`
+  - `crates/atm-daemon/src/peer_transport.rs`
+  - `crates/atm-core/src/delivery_execution.rs`
+  - `crates/atm-daemon/src/reconcile_runtime.rs`
+  - `crates/atm-daemon/src/tests.rs`
+  - `crates/atm-daemon/src/composition/lifecycle.rs`
+  - `crates/atm-daemon/src/runtime_status.rs`
+  - any directly adjacent files required to merge those accepted fixes onto the
+    final candidate line cleanly
 - the accepted merge candidate branch state itself
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/readiness.md`
@@ -45,8 +58,8 @@ target: integrate/phase-Y
 - verify the accepted merge candidate includes the end-of-phase fix line, not
   just the original `Phase Y` integration baseline
 - validate the accepted candidate line cleanly
-- record the accepted candidate commit identity in the readiness record or
-  adjacent project-plan status update so QA does not have to infer which line
+- record the accepted candidate commit identity in
+  `docs/phase-Yd/readiness.md` so QA does not have to infer which line
   satisfied the candidate gate
 - update the blocker inventory and readiness record to reflect the closure
   state
@@ -62,8 +75,8 @@ target: integrate/phase-Y
 
 - the accepted merge candidate includes the required phase-end fix line and is
   validation-clean for the `Y.17` scope
-- the accepted candidate commit used for the `Y.17` gate is named explicitly in
-  the updated readiness/project-plan docs
+- the accepted candidate commit used for the `Y.17` gate is named explicitly
+  in `docs/phase-Yd/readiness.md`
 - `docs/phase-Yd/readiness.md` is updated with the `Y.17` closure result
 
 ## Required Validation

--- a/docs/phase-Yd/sprint-Y17.md
+++ b/docs/phase-Yd/sprint-Y17.md
@@ -19,6 +19,8 @@ target: integrate/phase-Y
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/plan-phase-Yd.md`
 - `docs/phase-Yd/readiness.md`
+- `docs/adr/INDEX.md`
+- `docs/testing-guidelines.md`
 - accepted phase-end fix evidence from:
   - `feature/pY-eop-fix-1` at `fe28ad75169d1ec0bf3c40f8e356c9499917501f`
     (`PY-EOP-FIX-1`)

--- a/docs/phase-Yd/sprint-Y17.md
+++ b/docs/phase-Yd/sprint-Y17.md
@@ -78,12 +78,15 @@ target: integrate/phase-Y
 
 - the accepted merge candidate includes the required phase-end fix line and is
   validation-clean for the `Y.17` scope
+- git confirms commit `243e473a` (`PY-EOP-FIX-R2`) is an ancestor of the
+  accepted merge candidate
 - the accepted candidate commit used for the `Y.17` gate is named explicitly
   in `docs/phase-Yd/readiness.md`
 - `docs/phase-Yd/readiness.md` is updated with the `Y.17` closure result
 
 ## Required Validation
 
+- `git merge-base --is-ancestor 243e473a integrate/phase-Y && echo PASS || echo FAIL`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y17.md
+++ b/docs/phase-Yd/sprint-Y17.md
@@ -22,9 +22,7 @@ target: integrate/phase-Y
 - `docs/adr/INDEX.md`
 - `docs/testing-guidelines.md`
 - accepted phase-end fix evidence from:
-  - `feature/pY-eop-fix-1` at `fe28ad75169d1ec0bf3c40f8e356c9499917501f`
-    (`PY-EOP-FIX-1`)
-  - `feature/pY-eop-fix-1` at `243e473a` (`PY-EOP-FIX-R2`)
+  - `feature/pY-eop-fix-1` through tip commit `243e473a` (`PY-EOP-FIX-R2`)
 - `Y.16` must close first
 
 ## Exact Targets
@@ -59,6 +57,9 @@ target: integrate/phase-Y
 
 - verify the accepted merge candidate includes the end-of-phase fix line, not
   just the original `Phase Y` integration baseline
+- treat `PY-EOP-FIX-R2` at `243e473a` as the authoritative superseding tip of
+  `feature/pY-eop-fix-1`; `PY-EOP-FIX-1` remains historical context only and
+  does not stay as a second independent candidate gate
 - validate the accepted candidate line cleanly
 - record the accepted candidate commit identity in
   `docs/phase-Yd/readiness.md` so QA does not have to infer which line

--- a/docs/phase-Yd/sprint-Y17.md
+++ b/docs/phase-Yd/sprint-Y17.md
@@ -20,6 +20,7 @@ target: integrate/phase-Y
 - `docs/phase-Yd/plan-phase-Yd.md`
 - `docs/phase-Yd/readiness.md`
 - `docs/adr/INDEX.md`
+- `docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md`
 - `docs/testing-guidelines.md`
 - accepted phase-end fix evidence from:
   - `feature/pY-eop-fix-1` through tip commit `243e473a` (`PY-EOP-FIX-R2`)

--- a/docs/phase-Yd/sprint-Y17.md
+++ b/docs/phase-Yd/sprint-Y17.md
@@ -19,12 +19,16 @@ target: integrate/phase-Y
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/plan-phase-Yd.md`
 - `docs/phase-Yd/readiness.md`
+- accepted phase-end fix evidence from:
+  - `PY-EOP-FIX-1`
+  - `PY-EOP-FIX-R2`
 - `Y.16` must close first
 
 ## Exact Targets
 
 - any files required to absorb the accepted phase-end fix line on the final
   merge candidate
+- the accepted merge candidate branch state itself
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/readiness.md`
 - `docs/project-plan.md`
@@ -41,6 +45,9 @@ target: integrate/phase-Y
 - verify the accepted merge candidate includes the end-of-phase fix line, not
   just the original `Phase Y` integration baseline
 - validate the accepted candidate line cleanly
+- record the accepted candidate commit identity in the readiness record or
+  adjacent project-plan status update so QA does not have to infer which line
+  satisfied the candidate gate
 - update the blocker inventory and readiness record to reflect the closure
   state
 - keep `Phase Z` blocked while the final `Y.18` gate remains open
@@ -55,6 +62,8 @@ target: integrate/phase-Y
 
 - the accepted merge candidate includes the required phase-end fix line and is
   validation-clean for the `Y.17` scope
+- the accepted candidate commit used for the `Y.17` gate is named explicitly in
+  the updated readiness/project-plan docs
 - `docs/phase-Yd/readiness.md` is updated with the `Y.17` closure result
 
 ## Required Validation

--- a/docs/phase-Yd/sprint-Y17.md
+++ b/docs/phase-Yd/sprint-Y17.md
@@ -1,0 +1,71 @@
+---
+id: Y.17
+title: Thin Liveness Closure And Final Develop Gate
+status: planned
+branch: feature/pYd-s17-thin-liveness-closure-and-final-develop-gate
+worktree: ../atm-core-worktrees/feature/pYd-s17-thin-liveness-closure-and-final-develop-gate
+target: integrate/phase-Y
+---
+
+# Sprint Y.17 — Thin Liveness Closure And Final Develop Gate
+
+## Goal
+
+- close the remaining minimal operational/liveness gate for `Phase Y`
+- leave the final `develop`-gate record
+- explicitly unblock `Phase Z` only after the line is ready
+
+## Hard Dependencies
+
+- `docs/phase-Y/issues.md`
+- `docs/phase-Yd/plan-phase-Yd.md`
+- `docs/phase-Yd/readiness.md`
+- `Y.16` must close first
+
+## Exact Targets
+
+- `crates/atm-daemon/src/runtime_health.rs`
+- any runtime-owned liveness signal source required by the accepted design
+- `docs/phase-Y/issues.md`
+- `docs/phase-Yd/readiness.md`
+- `docs/project-plan.md`
+- `docs/plan-phase-Z.md`
+
+## Deliverables
+
+- the notification-worker liveness blocker is resolved either by:
+  - a thin runtime-owned signal that `runtime_health` projects directly
+  - or an explicit documented reclassification to non-blocking in
+    `docs/phase-Y/issues.md`
+- `runtime_health` remains a projection layer, not a compensating recovery
+  engine
+- one explicit readiness record states whether `Phase Y` may land on `develop`
+  and whether `Phase Z` may begin
+
+## Required Work
+
+- close or explicitly reclassify the final liveness/readiness blocker from
+  `docs/phase-Y/issues.md` without growing logic-heavy inference inside
+  `runtime_health`
+- update the readiness record with the final `develop`-gate verdict
+- update `Phase Z` docs so they remain blocked until that verdict is positive
+
+## This Sprint Does Not Close
+
+- new `Phase Z` rollout execution
+- unrelated daemon hardening or broad observability redesign
+
+## Acceptance Criteria
+
+- the final `Phase Y` blocker set is closed or explicitly reclassified with
+  documented rationale
+- any liveness closure uses a thin runtime-owned signal rather than
+  compensating logic inside `runtime_health`
+- `docs/phase-Yd/readiness.md` says whether `Phase Y` may land on `develop`
+- `docs/plan-phase-Z.md` reflects the final `Phase Z` gate state accurately
+
+## Required Validation
+
+- focused readiness validation for the accepted liveness signal
+- `cargo test --workspace`
+- `git diff --check`

--- a/docs/phase-Yd/sprint-Y18.md
+++ b/docs/phase-Yd/sprint-Y18.md
@@ -21,6 +21,7 @@ target: integrate/phase-Y
 - `docs/phase-Yd/plan-phase-Yd.md`
 - `docs/phase-Yd/readiness.md`
 - `docs/adr/INDEX.md`
+- `docs/adr/ADR-014-runtime-health-projection-and-liveness-signal-ownership.md`
 - `docs/requirements.md`
 - `docs/architecture.md`
 - `docs/atm-daemon/requirements.md`
@@ -34,6 +35,7 @@ target: integrate/phase-Y
 ## Exact Targets
 
 - `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/notification_runtime.rs`
 - any runtime-owned liveness signal source required by the accepted design
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/readiness.md`
@@ -54,6 +56,8 @@ target: integrate/phase-Y
 ## Explicit Code Samples
 
 ```rust
+// `NotificationWorkerLiveness` is a daemon-owned health DTO that lands in
+// `crates/atm-daemon/src/runtime_health.rs`.
 pub enum NotificationWorkerLiveness {
     Live,
     Degraded,
@@ -64,6 +68,13 @@ pub enum NotificationWorkerLiveness {
 ```rust
 pub struct RuntimeHealthSnapshot {
     pub notification_worker_liveness: NotificationWorkerLiveness,
+}
+```
+
+```rust
+// New method on `crates/atm-daemon/src/notification_runtime.rs`.
+impl NotificationRuntime {
+    pub fn worker_liveness(&self) -> NotificationWorkerLiveness;
 }
 ```
 

--- a/docs/phase-Yd/sprint-Y18.md
+++ b/docs/phase-Yd/sprint-Y18.md
@@ -117,10 +117,15 @@ fn project_runtime_health(
 - any explicit reclassification path must be recorded in `docs/phase-Y/issues.md`
   under the blocker entry with rationale stating why it no longer blocks
   landing on `develop`
+- if the explicit reclassification path is taken, `arch-qa` must verify
+  `docs/phase-Y/issues.md` contains the reclassification entry and rationale
 - any liveness closure uses a thin runtime-owned signal rather than
   compensating logic inside `runtime_health`
 - `rg -n "queue\\.len|retry_count|pending_events" crates/atm-daemon/src/runtime_health.rs`
   returns no matches
+- named test proves the projection sources worker liveness from the runtime
+  seam rather than a default or inferred unit value:
+  - `runtime_health_projects_worker_liveness_from_notification_runtime`
 - named test proves the health projection does not inspect queue internals:
   - `runtime_health_projection_does_not_inspect_queue_internals`
 - `docs/phase-Yd/readiness.md` says whether `Phase Y` may land on `develop`
@@ -131,6 +136,7 @@ fn project_runtime_health(
 ## Required Validation
 
 - `rg -n "queue\\.len|retry_count|pending_events" crates/atm-daemon/src/runtime_health.rs`
+- `cargo test --workspace runtime_health_projects_worker_liveness_from_notification_runtime runtime_health_projection_does_not_inspect_queue_internals`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y18.md
+++ b/docs/phase-Yd/sprint-Y18.md
@@ -66,6 +66,8 @@ target: integrate/phase-Y
 - any liveness closure uses a thin runtime-owned signal rather than
   compensating logic inside `runtime_health`
 - `docs/phase-Yd/readiness.md` says whether `Phase Y` may land on `develop`
+- `docs/phase-Yd/readiness.md` names the final accepted candidate line that is
+  authorized for merge to `develop`
 - `docs/plan-phase-Z.md` reflects the final `Phase Z` gate state accurately
 
 ## Required Validation

--- a/docs/phase-Yd/sprint-Y18.md
+++ b/docs/phase-Yd/sprint-Y18.md
@@ -20,10 +20,15 @@ target: integrate/phase-Y
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/plan-phase-Yd.md`
 - `docs/phase-Yd/readiness.md`
+- `docs/adr/INDEX.md`
 - `docs/requirements.md`
 - `docs/architecture.md`
 - `docs/atm-daemon/requirements.md`
 - `docs/atm-daemon/architecture.md`
+- `docs/atm-daemon/boundaries.md`
+- `boundaries/atm-core/status-source.toml`
+- `boundaries/atm-daemon/daemon-status-source.toml`
+- `docs/testing-guidelines.md`
 - `Y.17` must close first
 
 ## Exact Targets

--- a/docs/phase-Yd/sprint-Y18.md
+++ b/docs/phase-Yd/sprint-Y18.md
@@ -112,22 +112,26 @@ fn project_runtime_health(
 
 ## Acceptance Criteria
 
-- the final `Phase Y` blocker set is closed or explicitly reclassified with
-  documented rationale
-- any explicit reclassification path must be recorded in `docs/phase-Y/issues.md`
-  under the blocker entry with rationale stating why it no longer blocks
-  landing on `develop`
-- if the explicit reclassification path is taken, `arch-qa` must verify
-  `docs/phase-Y/issues.md` contains the reclassification entry and rationale
-- any liveness closure uses a thin runtime-owned signal rather than
-  compensating logic inside `runtime_health`
 - `rg -n "queue\\.len|retry_count|pending_events" crates/atm-daemon/src/runtime_health.rs`
   returns no matches
-- named test proves the projection sources worker liveness from the runtime
-  seam rather than a default or inferred unit value:
-  - `runtime_health_projects_worker_liveness_from_notification_runtime`
-- named test proves the health projection does not inspect queue internals:
-  - `runtime_health_projection_does_not_inspect_queue_internals`
+- the final `Phase Y` blocker set is closed or explicitly reclassified with
+  documented rationale
+- exactly one of the following closure paths is taken:
+  - thin-signal path
+  - reclassification path
+- thin-signal path:
+  - any liveness closure uses a thin runtime-owned signal rather than
+    compensating logic inside `runtime_health`
+  - named test proves the projection sources worker liveness from the runtime
+    seam rather than a default or inferred unit value:
+    - `runtime_health_projects_worker_liveness_from_notification_runtime`
+  - named test proves the health projection does not inspect queue internals:
+    - `runtime_health_projection_does_not_inspect_queue_internals`
+- reclassification path:
+  - `docs/phase-Y/issues.md` contains the reclassification entry and rationale
+    stating why the issue no longer blocks landing on `develop`
+  - `arch-qa` verifies that reclassification entry and rationale
+  - named runtime-health liveness tests are not required for this path
 - `docs/phase-Yd/readiness.md` says whether `Phase Y` may land on `develop`
 - `docs/phase-Yd/readiness.md` names the final accepted candidate line that is
   authorized for merge to `develop`
@@ -136,7 +140,9 @@ fn project_runtime_health(
 ## Required Validation
 
 - `rg -n "queue\\.len|retry_count|pending_events" crates/atm-daemon/src/runtime_health.rs`
-- `cargo test --workspace runtime_health_projects_worker_liveness_from_notification_runtime runtime_health_projection_does_not_inspect_queue_internals`
+- thin-signal path only:
+  - `cargo test --workspace runtime_health_projects_worker_liveness_from_notification_runtime`
+  - `cargo test --workspace runtime_health_projection_does_not_inspect_queue_internals`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y18.md
+++ b/docs/phase-Yd/sprint-Y18.md
@@ -27,6 +27,7 @@ target: integrate/phase-Y
 - `docs/atm-daemon/requirements.md`
 - `docs/atm-daemon/architecture.md`
 - `docs/atm-daemon/boundaries.md`
+- `docs/plan-phase-Z.md`
 - `boundaries/atm-core/status-source.toml`
 - `boundaries/atm-daemon/daemon-status-source.toml`
 - `docs/testing-guidelines.md`
@@ -37,6 +38,8 @@ target: integrate/phase-Y
 - `crates/atm-daemon/src/runtime_health.rs`
 - `crates/atm-daemon/src/notification_runtime.rs`
 - any runtime-owned liveness signal source required by the accepted design
+- `docs/atm-daemon/boundaries.md`
+- `boundaries/atm-daemon/daemon-status-source.toml`
 - `docs/phase-Y/issues.md`
 - `docs/phase-Yd/readiness.md`
 - `docs/project-plan.md`
@@ -116,6 +119,10 @@ fn project_runtime_health(
   landing on `develop`
 - any liveness closure uses a thin runtime-owned signal rather than
   compensating logic inside `runtime_health`
+- `rg -n "queue\\.len|retry_count|pending_events" crates/atm-daemon/src/runtime_health.rs`
+  returns no matches
+- named test proves the health projection does not inspect queue internals:
+  - `runtime_health_projection_does_not_inspect_queue_internals`
 - `docs/phase-Yd/readiness.md` says whether `Phase Y` may land on `develop`
 - `docs/phase-Yd/readiness.md` names the final accepted candidate line that is
   authorized for merge to `develop`
@@ -123,6 +130,7 @@ fn project_runtime_health(
 
 ## Required Validation
 
+- `rg -n "queue\\.len|retry_count|pending_events" crates/atm-daemon/src/runtime_health.rs`
 - `cargo fmt --all`
 - `python3 .just/run_lint.py all`
 - `cargo test --workspace`

--- a/docs/phase-Yd/sprint-Y18.md
+++ b/docs/phase-Yd/sprint-Y18.md
@@ -46,6 +46,38 @@ target: integrate/phase-Y
 - one explicit readiness record states whether `Phase Y` may land on `develop`
   and whether `Phase Z` may begin
 
+## Explicit Code Samples
+
+```rust
+pub enum NotificationWorkerLiveness {
+    Live,
+    Degraded,
+    Stopped,
+}
+```
+
+```rust
+pub struct RuntimeHealthSnapshot {
+    pub notification_worker_liveness: NotificationWorkerLiveness,
+}
+```
+
+```rust
+fn project_runtime_health(
+    runtime: &NotificationRuntime,
+) -> RuntimeHealthSnapshot {
+    RuntimeHealthSnapshot {
+        notification_worker_liveness: runtime.worker_liveness(),
+    }
+}
+```
+
+```rust
+// Maximum acceptable complexity boundary for Y.18:
+// runtime_health projects one runtime-owned signal directly.
+// It does not infer liveness by reconstructing queue, retry, or worker logic.
+```
+
 ## Required Work
 
 - close or explicitly reclassify the final liveness/readiness blocker from
@@ -63,6 +95,9 @@ target: integrate/phase-Y
 
 - the final `Phase Y` blocker set is closed or explicitly reclassified with
   documented rationale
+- any explicit reclassification path must be recorded in `docs/phase-Y/issues.md`
+  under the blocker entry with rationale stating why it no longer blocks
+  landing on `develop`
 - any liveness closure uses a thin runtime-owned signal rather than
   compensating logic inside `runtime_health`
 - `docs/phase-Yd/readiness.md` says whether `Phase Y` may land on `develop`
@@ -72,6 +107,8 @@ target: integrate/phase-Y
 
 ## Required Validation
 
-- focused readiness validation for the accepted liveness signal
+- `cargo fmt --all`
+- `python3 .just/run_lint.py all`
 - `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
 - `git diff --check`

--- a/docs/phase-Yd/sprint-Y18.md
+++ b/docs/phase-Yd/sprint-Y18.md
@@ -1,0 +1,75 @@
+---
+id: Y.18
+title: Thin Liveness Closure And Final Develop Gate
+status: planned
+branch: feature/pYd-s18-thin-liveness-closure-and-final-develop-gate
+worktree: ../atm-core-worktrees/feature/pYd-s18-thin-liveness-closure-and-final-develop-gate
+target: integrate/phase-Y
+---
+
+# Sprint Y.18 — Thin Liveness Closure And Final Develop Gate
+
+## Goal
+
+- close the remaining minimal operational/liveness gate for `Phase Y`
+- leave the final `develop`-gate record
+- explicitly unblock `Phase Z` only after the line is ready
+
+## Hard Dependencies
+
+- `docs/phase-Y/issues.md`
+- `docs/phase-Yd/plan-phase-Yd.md`
+- `docs/phase-Yd/readiness.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+- `Y.17` must close first
+
+## Exact Targets
+
+- `crates/atm-daemon/src/runtime_health.rs`
+- any runtime-owned liveness signal source required by the accepted design
+- `docs/phase-Y/issues.md`
+- `docs/phase-Yd/readiness.md`
+- `docs/project-plan.md`
+- `docs/plan-phase-Z.md`
+
+## Deliverables
+
+- the notification-worker liveness blocker is resolved either by:
+  - a thin runtime-owned signal that `runtime_health` projects directly
+  - or an explicit documented reclassification to non-blocking in
+    `docs/phase-Y/issues.md`
+- `runtime_health` remains a projection layer, not a compensating recovery
+  engine
+- one explicit readiness record states whether `Phase Y` may land on `develop`
+  and whether `Phase Z` may begin
+
+## Required Work
+
+- close or explicitly reclassify the final liveness/readiness blocker from
+  `docs/phase-Y/issues.md` without growing logic-heavy inference inside
+  `runtime_health`
+- update the readiness record with the final `develop`-gate verdict
+- update `Phase Z` docs so they remain blocked until that verdict is positive
+
+## This Sprint Does Not Close
+
+- new `Phase Z` rollout execution
+- unrelated daemon hardening or broad observability redesign
+
+## Acceptance Criteria
+
+- the final `Phase Y` blocker set is closed or explicitly reclassified with
+  documented rationale
+- any liveness closure uses a thin runtime-owned signal rather than
+  compensating logic inside `runtime_health`
+- `docs/phase-Yd/readiness.md` says whether `Phase Y` may land on `develop`
+- `docs/plan-phase-Z.md` reflects the final `Phase Z` gate state accurately
+
+## Required Validation
+
+- focused readiness validation for the accepted liveness signal
+- `cargo test --workspace`
+- `git diff --check`

--- a/docs/plan-phase-Y.md
+++ b/docs/plan-phase-Y.md
@@ -22,7 +22,8 @@ dogfood work:
   explicit and QA-auditable
 
 Executable smoke, canary dogfood, and release sign-off move to `Phase Z`
-after the `Phase Y` implementation line closes.
+only after the `Phase Y` implementation line closes **and** the later
+develop-gate closeout record explicitly authorizes `Phase Z` to begin.
 
 ## Baseline
 

--- a/docs/plan-phase-Z.md
+++ b/docs/plan-phase-Z.md
@@ -3,7 +3,8 @@
 ## Goal
 
 Validate the first daemon + SQLite mail-SSOT release in real executable use
-after the `Phase Y` implementation line closes.
+after the `Phase Y` implementation line closes and the final `develop` gate is
+explicitly opened.
 
 Phase `Z` owns the progressive rollout and release-readiness work that should
 not be mixed into the architectural cleanup history:
@@ -18,11 +19,14 @@ not be mixed into the architectural cleanup history:
 
 - planning branch: `feature/pY-s0-planning`
 - prerequisite implementation line: completed `Phase Y`
+- blocking closeout line before `Phase Z` may begin:
+  - `Phase Yd`
 - future integration branch: `integrate/phase-Z`
 
 ## Phase Entry Criteria
 
-`Phase Z` does not begin until `Phase Y` is closed:
+`Phase Z` does not begin until `Phase Y` is closed and `Phase Yd` says the line
+may land on `develop`:
 
 - the write-owner boundary is enforced
 - the delivery-policy coordinator and required state machines are landed
@@ -30,6 +34,10 @@ not be mixed into the architectural cleanup history:
 - the append-only/export contract decision is complete
 - `Y.0` trivial fixes and `Y.1` through `Y.6` implementation work are merged
   onto the authoritative integration line
+- the blocking issues in `docs/phase-Y/issues.md` are closed
+- the readiness record in `docs/phase-Yd/readiness.md` explicitly states:
+  - `Phase Y` may land on `develop`
+  - `Phase Z` may begin
 
 ## Pre-Phase JSON I/O Status
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3671,10 +3671,14 @@ Execution shape:
 - planning-only branch: `plan/phase-Yd-z-gate`
 - implementation target branch: `integrate/phase-Y`
 - implementation sequence:
-  - `Y.14` develop-gate runtime and boundary closure
-    - branch: `feature/pYd-s14-develop-gate-runtime-and-boundary-closure`
-  - `Y.15` thin liveness proof and final develop gate
-    - branch: `feature/pYd-s15-thin-liveness-proof-and-final-develop-gate`
+  - `Y.14` recovered Claude logical-message-set closure
+    - branch: `feature/pYd-s14-recovered-claude-logical-message-set-closure`
+  - `Y.15` production notification boundary closure
+    - branch: `feature/pYd-s15-production-notification-boundary-closure`
+  - `Y.16` retained-runtime composition and candidate closure
+    - branch: `feature/pYd-s16-retained-runtime-composition-and-candidate-closure`
+  - `Y.17` thin liveness closure and final develop gate
+    - branch: `feature/pYd-s17-thin-liveness-closure-and-final-develop-gate`
 
 Immediate planning outputs:
 - `docs/phase-Y/issues.md`
@@ -3682,6 +3686,8 @@ Immediate planning outputs:
 - `docs/phase-Yd/readiness.md`
 - `docs/phase-Yd/sprint-Y14.md`
 - `docs/phase-Yd/sprint-Y15.md`
+- `docs/phase-Yd/sprint-Y16.md`
+- `docs/phase-Yd/sprint-Y17.md`
 
 Acceptance / Develop And Phase Z Gate:
 - `Phase Y` does not land on `develop` while any blocking item in

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3562,7 +3562,8 @@ Status summary:
   - partial Claude recovered degraded delivery remained possible
   - production notification execution still bypassed `NotificationSink`
 - those blockers are tracked in `Phase Yc`; smoke/dogfood work must not resume
-  until `Phase Yc` closes.
+  until `Phase Yc` closes **and** the later `Phase Yd` develop-gate record
+  says `Phase Z` may begin.
 
 Goal:
 - lock down the exact message-path consolidation work needed after `Phase Y`
@@ -3602,8 +3603,8 @@ Immediate planning outputs:
 ## 33. Phase Yc Final Production-Readiness Closure
 
 Status summary:
-- `integrate/phase-Y` is close enough to resume smoke only after two final
-  production-readiness blockers are explicitly closed.
+- `integrate/phase-Y` still had two final runtime production-readiness
+  blockers reopened by focused review.
 - `Phase Yc` is the dedicated follow-on for those blockers.
 - `Phase Yc` is intentionally split into two sprints so each deliverable lands
   at a production-ready level without mixing behavioral and boundary closure.
@@ -3611,8 +3612,9 @@ Status summary:
 Goal:
 - close the final Claude recovered degraded-delivery contract gap
 - close the final `NotificationSink` boundary bypass
-- hand the merged `Phase Y` line back to `Phase Z` only after a focused
-  readiness gate passes
+- leave the focused readiness record that proves those two original runtime
+  blockers are closed before the broader `Phase Yd` develop-gate closeout
+  begins
 - keep `Y.12` and `Y.13` on their user-discussed runtime/code scope; later
   post-mortem lint recommendations are separate follow-up work, not substitute
   deliverables for these two sprints
@@ -3636,11 +3638,56 @@ Immediate planning outputs:
 Acceptance / Phase Z Smoke Gate:
 - `Phase Z` smoke and dogfood work remain blocked while either `Y.12` or
   `Y.13` is still open.
-- `Phase Z` smoke may resume only after the `Yc` readiness record explicitly
-  states that:
+- the `Yc` readiness record must explicitly state that:
   - the recovered Claude SQLite-failure path cannot partially emit a logical
     message set while still claiming success
   - the production notification path executes through
     `NotificationSink::deliver(...)` rather than direct hook helpers
   - the focused `Yc` readiness validation has passed on the merged
     `integrate/phase-Y` line
+- `Yc` closure alone is not sufficient to start `Phase Z`; the later
+  `Phase Yd` readiness record still controls whether `Phase Z` may begin
+
+## 34. Phase Yd Develop-Gate Closure
+
+Status summary:
+- `Phase Yc` captured the two original runtime blockers reopened by the focused
+  production-readiness review.
+- before `integrate/phase-Y` lands on `develop`, the broader `Phase Y`
+  blocker set must be documented explicitly and closed on a final
+  develop-gate line.
+- `Phase Z` remains blocked until that closeout line says `Phase Y` is ready
+  for `develop`.
+
+Goal:
+- document the full `Phase Y` blocker set, not only the original two `Yc`
+  runtime gaps
+- close the remaining runtime, boundary, composition, accepted phase-end-fix,
+  and thin-liveness blockers before `develop`
+- leave one readiness record that explicitly authorizes `Phase Y` to land on
+  `develop` and `Phase Z` to begin
+
+Execution shape:
+- planning-only branch: `plan/phase-Yd-z-gate`
+- implementation target branch: `integrate/phase-Y`
+- implementation sequence:
+  - `Y.14` develop-gate runtime and boundary closure
+    - branch: `feature/pYd-s14-develop-gate-runtime-and-boundary-closure`
+  - `Y.15` thin liveness proof and final develop gate
+    - branch: `feature/pYd-s15-thin-liveness-proof-and-final-develop-gate`
+
+Immediate planning outputs:
+- `docs/phase-Y/issues.md`
+- `docs/phase-Yd/plan-phase-Yd.md`
+- `docs/phase-Yd/readiness.md`
+- `docs/phase-Yd/sprint-Y14.md`
+- `docs/phase-Yd/sprint-Y15.md`
+
+Acceptance / Develop And Phase Z Gate:
+- `Phase Y` does not land on `develop` while any blocking item in
+  `docs/phase-Y/issues.md` remains open.
+- `Phase Z` remains blocked until `docs/phase-Yd/readiness.md` explicitly
+  states that:
+  - the `Phase Y` blocker set is closed
+  - `Phase Y` may land on `develop`
+  - `Phase Z` may begin

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3675,10 +3675,12 @@ Execution shape:
     - branch: `feature/pYd-s14-recovered-claude-logical-message-set-closure`
   - `Y.15` production notification boundary closure
     - branch: `feature/pYd-s15-production-notification-boundary-closure`
-  - `Y.16` retained-runtime composition and candidate closure
-    - branch: `feature/pYd-s16-retained-runtime-composition-and-candidate-closure`
-  - `Y.17` thin liveness closure and final develop gate
-    - branch: `feature/pYd-s17-thin-liveness-closure-and-final-develop-gate`
+  - `Y.16` retained-runtime composition closure
+    - branch: `feature/pYd-s16-retained-runtime-composition-closure`
+  - `Y.17` candidate closure
+    - branch: `feature/pYd-s17-candidate-closure`
+  - `Y.18` thin liveness closure and final develop gate
+    - branch: `feature/pYd-s18-thin-liveness-closure-and-final-develop-gate`
 
 Immediate planning outputs:
 - `docs/phase-Y/issues.md`
@@ -3688,6 +3690,7 @@ Immediate planning outputs:
 - `docs/phase-Yd/sprint-Y15.md`
 - `docs/phase-Yd/sprint-Y16.md`
 - `docs/phase-Yd/sprint-Y17.md`
+- `docs/phase-Yd/sprint-Y18.md`
 
 Acceptance / Develop And Phase Z Gate:
 - `Phase Y` does not land on `develop` while any blocking item in


### PR DESCRIPTION
## Summary

- Phase Yd plan hardening: sprints Y.14–Y.18 (develop-gate closeout)
- 5 critical-plan-reviewer rounds; PLAN-CRIT-002 closed, PLAN-CRIT-001 fix-r1 in progress
- QA-1 verdict: 1B+1I+1m (fix-r1 dispatched to arch-ctm)

## Changes

- `docs/phase-Yd/plan-phase-Yd.md` — plan document
- `docs/phase-Yd/sprint-Y14.md` through `sprint-Y18.md` — sprint scope + AC hardening
- `boundaries/atm-daemon/daemon-notification-sink.toml` — module path correction

## Test plan

- [ ] quality-mgr plan review PASS (req-qa + arch-qa)
- [ ] 0B+0I+0m before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)