### PR TITLE
fix: PHI-PLAN-HARDENING-QA-1 findings (6B+2I+2m)

### DIFF
--- a/.claude/skills/plan-hardening/01-plan-scope-review.xml.j2
+++ b/.claude/skills/plan-hardening/01-plan-scope-review.xml.j2
@@ -22,7 +22,7 @@ required_variables:
   <worktree>{{ worktree_path }}</worktree>
   <branch>{{ branch }}</branch>
   <pr-target>{{ pr_target }}</pr-target>
-  <round id="{{ round_id }}" index="{{ round_index }}" reviewer="plan-scope-reviewer" supersedes="{{ supersedes_task_id | default('') }}"/>
+  <round id="{{ round_id }}" index="{{ round_index }}" reviewed-commit="{{ reviewed_commit | default('') }}" reviewer="plan-scope-reviewer" supersedes="{{ supersedes_task_id | default('') }}"/>
   <replay-nonce>{{ replay_nonce }}</replay-nonce>
 
   <source-of-truth>

--- a/.claude/skills/plan-hardening/examples/plan-hardening-vars.example.json
+++ b/.claude/skills/plan-hardening/examples/plan-hardening-vars.example.json
@@ -7,7 +7,6 @@
   "pr_target": "develop",
   "round_id": "STEP1-R1",
   "round_index": 1,
-  "reviewer": "plan-scope-reviewer",
   "reviewed_commit": "",
   "previous_reviewed_commit": "",
   "findings_hash": "",

--- a/.claude/skills/plan-hardening/steps/step-3.md
+++ b/.claude/skills/plan-hardening/steps/step-3.md
@@ -1,5 +1,16 @@
 # Step 3 — Sprint Scope Hardening (`arch-ctm`)
 
+## Stale Replay Detection
+
+A new step-3 task is valid only when **at least one** of the following is true:
+
+- `reviewed_commit` differs from `previous_reviewed_commit`, OR
+- `findings_hash` of the new step-4 JSON differs from the prior round's `findings_hash`
+
+If neither condition is met, do not dispatch. Update `round_id` (increment suffix) and set `replay_nonce` to the current UTC timestamp before re-rendering.
+
+**replay_nonce enforcement**: `replay_nonce` MUST be set to the current UTC timestamp (e.g., `2026-05-20T06:19:00Z`) before every render. A stale or repeated `replay_nonce` value silently defeats the anti-replay guarantee. Never reuse a `replay_nonce` between rounds.
+
 ## Execute
 
 **1. Render the message**
@@ -51,6 +62,8 @@ Maintain the round table after every Step 3 / Step 4 loop:
 
 | Round | Step | Reviewer | reviewed_commit | status | blocking | important | minor | findings_hash | supersedes | Note |
 |-------|------|----------|-----------------|--------|----------|-----------|-------|---------------|------------|------|
+
+**Non-convergence escalation**: If round N has `Total >= round N-2` (i.e., total finding count has not decreased over two rounds), team-lead **must escalate to the user** before dispatching round N+1.
 
 ## Hard stops
 

--- a/.claude/skills/plan-hardening/steps/step-4.md
+++ b/.claude/skills/plan-hardening/steps/step-4.md
@@ -90,6 +90,37 @@ The reviewer output schema includes:
 - `minor_wording` for wording-only cleanup
 - `findings_hash` as the stable round fingerprint
 
+The fenced JSON output **must** include these fields:
+
+```json
+{
+  "status": "PASS | FAIL",
+  "mode": "sprint-scope-hardening",
+  "findings": [
+    {
+      "id": "ARCH-001",
+      "severity": "Blocking | Important | Minor",
+      "file": "path/to/file.md",
+      "line": 42,
+      "description": "...",
+      "fix": "...",
+      "affects_ac": true
+    }
+  ],
+  "minor_wording": [
+    {
+      "id": "ARCH-MW-001",
+      "severity": "Minor",
+      "file": "path/to/file.md",
+      "line": 10,
+      "description": "...",
+      "fix": "...",
+      "affects_ac": false
+    }
+  ]
+}
+```
+
 Update the round table after every Step 4 response:
 
 | Round | Step | Reviewer | reviewed_commit | status | blocking | important | minor | findings_hash | supersedes | Note |

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3700,3 +3700,11 @@ Acceptance / Develop And Phase Z Gate:
   - the `Phase Y` blocker set is closed
   - `Phase Y` may land on `develop`
   - `Phase Z` may begin
+
+## Phase PHI — Plan Infrastructure Hardening
+
+### PHI-PLAN-HARDENING-LOOP-CLEANUP-1 — Plan-Hardening Loop Cleanup
+
+- **Branch**: plan/plan-hardening-improvements
+- **Status**: complete
+- **Deliverables**: Round-tracking fields, stale replay detection, reviewer prompt tightening, convergence tracking, finding classification separation

--- a/plans/2026-05-20-phi-plan-hardening-loop-cleanup-1.md
+++ b/plans/2026-05-20-phi-plan-hardening-loop-cleanup-1.md
@@ -1,0 +1,104 @@
+---
+id: PHI-PLAN-HARDENING-LOOP-CLEANUP-1
+status: complete
+branch: plan/plan-hardening-improvements
+worktree: ../atm-core-worktrees/plan/plan-hardening-improvements
+created: 2026-05-20
+---
+
+# PHI-PLAN-HARDENING-LOOP-CLEANUP-1: Plan-Hardening Loop Cleanup
+
+## Motivation
+
+Phase Yd plan-hardening ran 5 critical-plan-reviewer rounds before QA handoff, with two recurring failure modes:
+1. **Stale replay**: arch-ctm pattern-matched new step-3 task messages as historical backlog and dismissed them (happened once per session).
+2. **Incremental churn**: minor wording findings mixed with structural blockers, inflating round counts. Round 4 introduced new minor findings (net +1), round 5 converged slowly.
+
+## Scope
+
+Improve `.claude/skills/plan-hardening/` templates, step docs, and vars example so that:
+- Stale replays are prevented by construction (not by workaround)
+- Reviewer passes return all remaining B+I findings in one sweep
+- Minor wording findings are separated from structural blockers
+- Team-lead has a round-tracking table to detect non-convergence early
+
+## Deliverables
+
+### D1 — Round-tracking fields in vars template
+
+Add to `examples/plan-hardening-vars.example.json`:
+```json
+"round_id": "STEP3A",
+"round_index": 1,
+"reviewer": "critical-plan-reviewer",
+"reviewed_commit": "<sha>",
+"previous_reviewed_commit": "",
+"findings_hash": "",
+"supersedes_task_id": ""
+```
+
+Add to `02-sprint-scope-hardening.xml.j2` template body (inside `<atm-task>`):
+```xml
+<round id="{{ round_id }}" index="{{ round_index }}" reviewed-commit="{{ reviewed_commit }}" supersedes="{{ supersedes_task_id }}"/>
+```
+
+### D2 — Stale replay detection in step-3
+
+Update `.claude/skills/plan-hardening/steps/step-3.md`:
+- Add rule: a new step-3 task is valid only when `reviewed_commit` differs from `previous_reviewed_commit` OR `findings_hash` of the new step-4 JSON differs from the prior round's findings_hash.
+- Add rule: if arch-ctm ACKs but returns "already closed" or similar without a new fenced JSON, team-lead must re-send with an updated `round_id` (increment suffix) and an explicit `<replay-nonce>` field containing the current UTC timestamp.
+- Add `<replay-nonce>{{ replay_nonce }}</replay-nonce>` to `02-sprint-scope-hardening.xml.j2` so every render produces a structurally unique message.
+
+### D3 — Reviewer prompt tightening in step-4
+
+Update `.claude/skills/plan-hardening/steps/step-4.md`:
+- Add rule: reviewer must return **all** open Blocking + Important findings in a single pass. Returning a subset (finding new issues after prior ones close) is only permitted if the sprint doc changed between rounds.
+- Add rule: Minor findings that do not affect implementability (pure wording, formatting, non-normative prose) must be collected into a separate `minor_wording` array in the fenced JSON and do NOT contribute to FAIL status unless the reviewer flags them as `affects_ac: true`.
+- Update the fenced JSON schema in step-4 to include `minor_wording: []` array and `affects_ac` per-finding flag.
+
+### D4 — Team-lead convergence table in step-3
+
+Update `.claude/skills/plan-hardening/steps/step-3.md`:
+- Add a "round convergence tracking" section with a template table:
+  ```
+  | Round | reviewed_commit | B | I | m | Total | Δ |
+  ```
+- Add rule: if round N has Total >= round N-2 (non-convergence), team-lead must escalate to user before dispatching round N+1.
+
+### D5 — Separate structural from wording in sprint-planning-guidelines
+
+Update `.claude/skills/plan-hardening/sprint-planning-guidelines.md`:
+- Add section "Finding classification":
+  - Structural: missing AC gate, incorrect rg command, uncovered call site, missing function, false-closure — always Blocking or Important, always FAIL
+  - Wording: prose ambiguity, optional formatting, non-normative text — Minor, does NOT FAIL unless affects_ac: true
+- Add rule: reviewers must classify each finding as structural or wording before assigning severity.
+
+## Acceptance Criteria
+
+- `examples/plan-hardening-vars.example.json` includes all 7 new round-tracking fields
+- `02-sprint-scope-hardening.xml.j2` includes `<round .../>` and `<replay-nonce>` elements
+- `steps/step-3.md` includes stale replay detection rule and convergence tracking table template
+- `steps/step-4.md` includes "return all B+I in one pass" rule and `minor_wording` array schema
+- `sprint-planning-guidelines.md` includes finding classification section
+- `git diff --check` clean
+- No regressions to existing template rendering (verify with `python3 -c "from jinja2 import Template; ..."` spot check)
+
+## Required Validation
+
+```bash
+# Verify all target files modified
+git -C /Users/randlee/Documents/github/atm-core-worktrees/plan/plan-hardening-improvements diff --name-only HEAD
+
+# Verify no whitespace errors
+git -C /Users/randlee/Documents/github/atm-core-worktrees/plan/plan-hardening-improvements diff --check HEAD
+
+# Spot-check template renders without error
+python3 -c "
+from jinja2 import Template
+import json
+with open('.claude/skills/plan-hardening/02-sprint-scope-hardening.xml.j2') as f:
+    t = f.read().split('---\n', 2)[-1]
+Template(t).render(task_id='TEST', phase='test', description='test', worktree_path='/tmp', branch='test', pr_target='develop', source_of_truth='', references='', previous_step_json='{}', round_id='STEP3A', round_index=1, reviewed_commit='abc', supersedes_task_id='')
+print('Template render OK')
+"
+```


### PR DESCRIPTION
## Summary

Addresses all 10 QA-1 findings from PHI-PLAN-HARDENING-QA-1 on a new branch from develop (original `plan/plan-hardening-improvements` branch already merged at c5b3d57c).

- ATM-QA-001: sprint doc `status: in-progress` → `status: complete`
- ATM-QA-002: added Phase PHI section + sprint entry to `docs/project-plan.md`
- ATM-QA-003/ARCH-001: added "Stale Replay Detection" subsection to `step-3.md` with pre-dispatch validity gate
- ATM-QA-004/ARCH-002: added non-convergence escalation rule to `step-3.md` convergence table
- ARCH-003/ATM-QA-005: added fenced JSON schema block to `step-4.md` (minor_wording[] + affects_ac)
- ARCH-004: added replay_nonce enforcement note in step-3.md
- ARCH-005: added `reviewed-commit` attribute to `01-plan-scope-review.xml.j2` round element
- ARCH-006: removed dead `reviewer` field from vars example JSON
- ATM-QA-006: AC field count corrected 6→7
- ATM-QA-007: replay-nonce closing tag and variable name corrected

## Test plan

- [ ] PHI-PLAN-HARDENING-QA-2 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)