### PR TITLE
Y.15: Production notification boundary closure

### DIFF
--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -648,6 +648,15 @@ mod tests {
 
     impl crate::boundary::sealed::Sealed for AckRuntime {}
 
+    impl crate::boundary::NotificationSink for AckRuntime {
+        fn deliver(
+            &self,
+            _event: crate::protocol::NotificationEvent,
+        ) -> Result<(), crate::error::AtmError> {
+            Ok(())
+        }
+    }
+
     impl RetainedServiceRuntime for AckRuntime {
         fn load_config(
             &self,
@@ -738,13 +747,6 @@ mod tests {
             _messages: &[MessageEnvelope],
         ) -> Result<(), crate::error::AtmError> {
             panic!("ack writer-path test should not route through non-Claude delivery")
-        }
-
-        fn deliver_notification_event(
-            &self,
-            _event: crate::protocol::NotificationEvent,
-        ) -> Result<(), crate::error::AtmError> {
-            Ok(())
         }
 
         fn load_roster_member(

--- a/crates/atm-core/src/delivery_execution.rs
+++ b/crates/atm-core/src/delivery_execution.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use serde::Serialize;
+
 use crate::boundary::ClaudeCompatibilityDeliveryMode;
 use crate::config::AtmConfig;
 use crate::delivery_plan::{
@@ -46,6 +48,17 @@ pub(crate) struct DeliveryTransitionContext<'a> {
     pub(crate) sender: &'a AgentName,
     pub(crate) message_id: AtmMessageId,
     pub(crate) task_id: Option<TaskId>,
+}
+
+#[derive(Debug, Serialize)]
+struct DeliveryNotificationDetail<'a> {
+    sender: String,
+    sender_team: Option<String>,
+    message_id: String,
+    requires_ack: bool,
+    is_ack: bool,
+    task_id: Option<String>,
+    recipient_pane_id: Option<&'a str>,
 }
 
 pub(crate) trait ClaudeInboxWriter: crate::boundary::sealed::Sealed {
@@ -256,18 +269,19 @@ fn notification_event_from_target(
     recipient_pane_id: Option<&str>,
     notification: &NotificationTarget,
 ) -> NotificationEvent {
+    let detail = DeliveryNotificationDetail {
+        sender: notification.sender.to_string(),
+        sender_team: notification.sender_team.as_ref().map(ToString::to_string),
+        message_id: notification.message_id.to_string(),
+        requires_ack: notification.requires_ack,
+        is_ack: notification.is_ack,
+        task_id: notification.task_id.as_ref().map(ToString::to_string),
+        recipient_pane_id,
+    };
     NotificationEvent {
         kind: NotificationKind::Delivery,
-        detail: serde_json::json!({
-            "sender": notification.sender.to_string(),
-            "sender_team": notification.sender_team.as_ref().map(ToString::to_string),
-            "message_id": notification.message_id.to_string(),
-            "requires_ack": notification.requires_ack,
-            "is_ack": notification.is_ack,
-            "task_id": notification.task_id.as_ref().map(ToString::to_string),
-            "recipient_pane_id": recipient_pane_id,
-        })
-        .to_string(),
+        detail: serde_json::to_string(&detail)
+            .expect("delivery notification detail must serialize to valid JSON"),
         team: Some(recipient.team.clone()),
         agent: Some(recipient.agent.clone()),
     }

--- a/crates/atm-core/src/delivery_execution.rs
+++ b/crates/atm-core/src/delivery_execution.rs
@@ -98,50 +98,32 @@ where
     }
 }
 
-pub(crate) trait PostSendNotificationExecutor: crate::boundary::sealed::Sealed {
-    /// Notification delivery is a best-effort side effect: failures must be
-    /// surfaced as typed warnings, not as silent drops or primary delivery
-    /// failures.
-    fn deliver_notifications(
-        &self,
-        warnings: &mut Vec<WarningEntry>,
-        recipient: &crate::send::ResolvedRecipient,
-        recipient_pane_id: Option<&str>,
-        notifications: &[NotificationTarget],
-    );
-}
-
-impl<T> PostSendNotificationExecutor for T
-where
-    T: RetainedServiceRuntime + crate::boundary::sealed::Sealed + ?Sized,
-{
-    fn deliver_notifications(
-        &self,
-        warnings: &mut Vec<WarningEntry>,
-        recipient: &crate::send::ResolvedRecipient,
-        recipient_pane_id: Option<&str>,
-        notifications: &[NotificationTarget],
-    ) {
-        for notification in notifications {
-            let event = notification_event_from_target(recipient, recipient_pane_id, notification);
-            if let Err(error) = self.deliver_notification_event(event) {
-                tracing::warn!(
-                    subsystem = "delivery_execution",
-                    action = "deliver_notifications",
-                    outcome = "failed",
-                    recipient = %recipient.agent,
-                    team = %recipient.team,
-                    %error,
-                    "notification delivery failed"
-                );
-                warnings.push(WarningEntry::new(
-                    format!(
-                        "warning: notification delivery failed for {}@{}: {error}",
-                        recipient.agent, recipient.team
-                    ),
-                    error.recovery.clone(),
-                ));
-            }
+pub(crate) fn deliver_notifications(
+    notification_sink: &dyn crate::boundary::NotificationSink,
+    warnings: &mut Vec<WarningEntry>,
+    recipient: &crate::send::ResolvedRecipient,
+    recipient_pane_id: Option<&str>,
+    notifications: &[NotificationTarget],
+) {
+    for notification in notifications {
+        let event = notification_event_from_target(recipient, recipient_pane_id, notification);
+        if let Err(error) = notification_sink.deliver(event) {
+            tracing::warn!(
+                subsystem = "delivery_execution",
+                action = "deliver_notifications",
+                outcome = "failed",
+                recipient = %recipient.agent,
+                team = %recipient.team,
+                %error,
+                "notification delivery failed"
+            );
+            warnings.push(WarningEntry::new(
+                format!(
+                    "warning: notification delivery failed for {}@{}: {error}",
+                    recipient.agent, recipient.team
+                ),
+                error.recovery.clone(),
+            ));
         }
     }
 }
@@ -183,7 +165,7 @@ pub(crate) fn execute_delivery_plan<R>(
     plan: &DeliveryPlan,
 ) -> Result<DeliveryExecutionResult, AtmError>
 where
-    R: ClaudeInboxWriter + NonClaudeOutboundDeliveryWriter + PostSendNotificationExecutor,
+    R: ClaudeInboxWriter + NonClaudeOutboundDeliveryWriter + crate::boundary::NotificationSink,
 {
     execute_messages(
         runtime,
@@ -205,7 +187,7 @@ pub(crate) fn execute_reply_delivery_plan<R>(
     plan: &DeliveryPlan,
 ) -> Result<DeliveryExecutionResult, AtmError>
 where
-    R: ClaudeInboxWriter + NonClaudeOutboundDeliveryWriter + PostSendNotificationExecutor,
+    R: ClaudeInboxWriter + NonClaudeOutboundDeliveryWriter + crate::boundary::NotificationSink,
 {
     execute_messages(
         runtime,
@@ -236,7 +218,7 @@ fn execute_messages<R>(
     view: ExecutionView<'_>,
 ) -> Result<DeliveryExecutionResult, AtmError>
 where
-    R: ClaudeInboxWriter + NonClaudeOutboundDeliveryWriter + PostSendNotificationExecutor,
+    R: ClaudeInboxWriter + NonClaudeOutboundDeliveryWriter + crate::boundary::NotificationSink,
 {
     validate_delivery_target(view.delivery_target)?;
     let mut result = DeliveryExecutionResult::delivered();
@@ -258,7 +240,8 @@ where
         }
     }
 
-    runtime.deliver_notifications(
+    deliver_notifications(
+        runtime,
         &mut result.warnings,
         view.recipient,
         view.recipient_pane_id,
@@ -478,8 +461,7 @@ mod tests {
 
     use super::{
         ClaudeInboxWriter, DeliveryExecutionDisposition, DeliveryTransitionContext,
-        NonClaudeOutboundDeliveryWriter, PostSendNotificationExecutor,
-        emit_delivery_plan_transitions, execute_delivery_plan,
+        NonClaudeOutboundDeliveryWriter, emit_delivery_plan_transitions, execute_delivery_plan,
     };
     use crate::delivery_plan::{
         DeliveryPlan, DeliveryPlanDisposition, DeliveryPlanKind, DeliveryTarget, LogicalMessage,
@@ -495,7 +477,7 @@ mod tests {
     };
     use crate::protocol::{NotificationEvent, NotificationKind};
     use crate::schema::{AtmMessageId, MessageEnvelope};
-    use crate::send::{ResolvedRecipient, WarningEntry};
+    use crate::send::ResolvedRecipient;
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::{AgentName, IsoTimestamp, TeamName};
 
@@ -524,14 +506,9 @@ mod tests {
         }
     }
 
-    impl PostSendNotificationExecutor for NoopRuntime {
-        fn deliver_notifications(
-            &self,
-            _warnings: &mut Vec<WarningEntry>,
-            _recipient: &ResolvedRecipient,
-            _recipient_pane_id: Option<&str>,
-            _notifications: &[NotificationTarget],
-        ) {
+    impl crate::boundary::NotificationSink for NoopRuntime {
+        fn deliver(&self, _event: NotificationEvent) -> Result<(), AtmError> {
+            Ok(())
         }
     }
 
@@ -697,38 +674,18 @@ mod tests {
         }
     }
 
-    impl PostSendNotificationExecutor for RecordingRuntime {
-        fn deliver_notifications(
-            &self,
-            warnings: &mut Vec<WarningEntry>,
-            recipient: &ResolvedRecipient,
-            recipient_pane_id: Option<&str>,
-            notifications: &[NotificationTarget],
-        ) {
-            for notification in notifications {
-                let event = super::notification_event_from_target(
-                    recipient,
-                    recipient_pane_id,
-                    notification,
-                );
-                if let Some(message) = self.notification_error_message {
-                    let error = AtmError::daemon_unavailable(message).with_recovery(
-                        "Restore the notification boundary before retrying retained-runtime delivery.",
-                    );
-                    warnings.push(WarningEntry::new(
-                        format!(
-                            "warning: notification delivery failed for {}@{}: {error}",
-                            recipient.agent, recipient.team
-                        ),
-                        error.recovery.clone(),
-                    ));
-                    continue;
-                }
-                self.notification_events
-                    .lock()
-                    .expect("notification events")
-                    .push(event);
+    impl crate::boundary::NotificationSink for RecordingRuntime {
+        fn deliver(&self, event: NotificationEvent) -> Result<(), AtmError> {
+            if let Some(message) = self.notification_error_message {
+                return Err(AtmError::daemon_unavailable(message).with_recovery(
+                    "Restore the notification boundary before retrying retained-runtime delivery.",
+                ));
             }
+            self.notification_events
+                .lock()
+                .expect("notification events")
+                .push(event);
+            Ok(())
         }
     }
 

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -112,6 +112,16 @@ impl TestRuntime {
 
 impl crate::boundary::sealed::Sealed for TestRuntime {}
 
+impl crate::boundary::NotificationSink for TestRuntime {
+    fn deliver(&self, event: NotificationEvent) -> Result<(), AtmError> {
+        self.notification_events
+            .lock()
+            .expect("notification events lock")
+            .push(event);
+        Ok(())
+    }
+}
+
 impl RetainedServiceRuntime for TestRuntime {
     fn load_config(&self, _current_dir: &Path) -> Result<Option<AtmConfig>, AtmError> {
         Ok(None)
@@ -218,14 +228,6 @@ impl RetainedServiceRuntime for TestRuntime {
                 recipient_pane_id: recipient.recipient_pane_id.clone(),
                 messages: messages.to_vec(),
             });
-        Ok(())
-    }
-
-    fn deliver_notification_event(&self, event: NotificationEvent) -> Result<(), AtmError> {
-        self.notification_events
-            .lock()
-            .expect("notification events lock")
-            .push(event);
         Ok(())
     }
 

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -24,7 +24,7 @@ pub(crate) struct RetainedMailboxTimeoutPolicy {
     pub(crate) workflow_lock_timeout: Duration,
 }
 
-pub(crate) trait RetainedServiceRuntime {
+pub(crate) trait RetainedServiceRuntime: crate::boundary::NotificationSink {
     fn load_config(&self, current_dir: &Path) -> Result<Option<AtmConfig>, AtmError>;
     fn load_team_config(&self, team_dir: &Path) -> Result<TeamConfig, AtmError>;
     fn team_dir(&self, home_dir: &Path, team: &TeamName) -> Result<PathBuf, AtmError>;
@@ -74,7 +74,6 @@ pub(crate) trait RetainedServiceRuntime {
         recipient: &DeliveryRecipientSnapshot,
         messages: &[MessageEnvelope],
     ) -> Result<(), AtmError>;
-    fn deliver_notification_event(&self, event: NotificationEvent) -> Result<(), AtmError>;
     fn load_roster_member(
         &self,
         team: &TeamName,
@@ -143,6 +142,12 @@ impl fmt::Debug for LocalServiceRuntime {
 }
 
 impl crate::boundary::sealed::Sealed for LocalServiceRuntime {}
+
+impl crate::boundary::NotificationSink for LocalServiceRuntime {
+    fn deliver(&self, event: NotificationEvent) -> Result<(), AtmError> {
+        self.notification_sink.deliver(event)
+    }
+}
 
 #[derive(Debug, Clone, Copy, Default)]
 /// Production fallback boundary used when the daemon runtime is not composing
@@ -354,10 +359,6 @@ impl RetainedServiceRuntime for LocalServiceRuntime {
             .map(|_| ())
     }
 
-    fn deliver_notification_event(&self, event: NotificationEvent) -> Result<(), AtmError> {
-        self.notification_sink.deliver(event)
-    }
-
     fn commit_workflow_state<T, I, F>(
         &self,
         home_dir: &Path,
@@ -471,7 +472,6 @@ mod tests {
         RetainedServiceRuntime,
     };
     use crate::boundary;
-    use crate::delivery_execution::PostSendNotificationExecutor;
     use crate::error_codes::AtmErrorCode;
     use crate::protocol::{NotificationEvent, NotificationKind};
     use crate::schema::MessageEnvelope;
@@ -789,8 +789,7 @@ mod tests {
             agent: Some("recipient".parse::<AgentName>().expect("agent")),
         };
 
-        runtime
-            .deliver_notification_event(event.clone())
+        crate::boundary::NotificationSink::deliver(&runtime, event.clone())
             .expect("direct sink delivery");
 
         let direct_events = read_notification_events(&notification_path);
@@ -798,7 +797,7 @@ mod tests {
         assert_eq!(direct_events[0].detail, "runtime-direct");
 
         let mut warnings = Vec::new();
-        PostSendNotificationExecutor::deliver_notifications(
+        crate::delivery_execution::deliver_notifications(
             &runtime,
             &mut warnings,
             &crate::send::ResolvedRecipient {

--- a/docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md
+++ b/docs/adr/ADR-013-unified-delivery-plan-and-state-machine-ownership.md
@@ -11,6 +11,10 @@ Closeout note:
 - `Y.12` closed the recovered Claude logical-message-set contract
 - `Y.13` closed the production `NotificationSink` boundary bypass and narrowed
   retained-runtime assembly to one approved delivery-boundary constructor
+- `Y.15` re-proved the production `NotificationSink` boundary invariant on the
+  final accepted `Phase Y` candidate line at `ad61b3dd`, preserving
+  `NotificationSink::deliver(...)` as the only approved notification side
+  effect on the live send/ack path
 
 ## Context
 

--- a/docs/phase-Y/issues.md
+++ b/docs/phase-Y/issues.md
@@ -60,6 +60,17 @@ These items block `Phase Y` from landing on `develop`.
        `NotificationSink::deliver(...)`
      - no production-path direct `maybe_run_post_send_hook(...)` bypass may
        remain
+   - closure status:
+     - closed by `Y.15` on
+       `feature/pYd-s15-production-notification-boundary-closure`
+     - accepted proof consists of:
+       - `rg -n "maybe_run_post_send_hook" crates/atm-core/src` returning no
+         matches
+       - surviving `Y.13` boundary tests passing on the accepted candidate
+         line:
+         - `delivery_notifications_use_notification_sink_boundary`
+         - `notification_sink_failure_is_explicit_in_delivery_warnings`
+         - `notification_sink_backpressure_does_not_reopen_hook_helper_bypass`
 
 3. Daemon retained-runtime composition must install the live
    `NotificationSink`.

--- a/docs/phase-Yd/readiness.md
+++ b/docs/phase-Yd/readiness.md
@@ -12,7 +12,7 @@ record explicitly says the line is ready.
 | Sprint | Closure Result | Date | Candidate Commit | Notes |
 | --- | --- | --- | --- | --- |
 | `Y.14` | `PENDING` | `TBD` | `TBD` | recovered Claude logical-message-set closure on final accepted candidate line |
-| `Y.15` | `PASS` | `2026-05-19` | `feature/pYd-s15-production-notification-boundary-closure HEAD` | production `NotificationSink` boundary closure on final accepted candidate line; surviving `Y.13` boundary tests passed and helper-bypass grep is clean |
+| `Y.15` | `PASS` | `2026-05-19` | `ad61b3dd` | production `NotificationSink` boundary closure on final accepted candidate line; surviving `Y.13` boundary tests passed and helper-bypass grep is clean |
 | `Y.16` | `PENDING` | `TBD` | `TBD` | retained-runtime composition installs live production `NotificationSink` |
 | `Y.17` | `PENDING` | `TBD` | `TBD` | accepted merge candidate includes required end-of-phase fix line and passes validation |
 | `Y.18` | `PENDING` | `TBD` | `TBD` | thin liveness closure or explicit reclassification with final develop-gate result |

--- a/docs/phase-Yd/readiness.md
+++ b/docs/phase-Yd/readiness.md
@@ -12,7 +12,7 @@ record explicitly says the line is ready.
 | Sprint | Closure Result | Date | Candidate Commit | Notes |
 | --- | --- | --- | --- | --- |
 | `Y.14` | `PENDING` | `TBD` | `TBD` | recovered Claude logical-message-set closure on final accepted candidate line |
-| `Y.15` | `PENDING` | `TBD` | `TBD` | production `NotificationSink` boundary closure on final accepted candidate line |
+| `Y.15` | `PASS` | `2026-05-19` | `feature/pYd-s15-production-notification-boundary-closure HEAD` | production `NotificationSink` boundary closure on final accepted candidate line; surviving `Y.13` boundary tests passed and helper-bypass grep is clean |
 | `Y.16` | `PENDING` | `TBD` | `TBD` | retained-runtime composition installs live production `NotificationSink` |
 | `Y.17` | `PENDING` | `TBD` | `TBD` | accepted merge candidate includes required end-of-phase fix line and passes validation |
 | `Y.18` | `PENDING` | `TBD` | `TBD` | thin liveness closure or explicit reclassification with final develop-gate result |
@@ -38,6 +38,8 @@ this table.
 
 - the production send/ack notification path executes through
   `NotificationSink::deliver(...)`
+- the accepted candidate line contains no production-path
+  `maybe_run_post_send_hook(...)` bypass
 
 `Y.16` must prove that:
 

--- a/docs/phase-Yd/sprint-Y15.md
+++ b/docs/phase-Yd/sprint-Y15.md
@@ -1,7 +1,7 @@
 ---
 id: Y.15
 title: Production Notification Boundary Closure
-status: planned
+status: complete
 branch: feature/pYd-s15-production-notification-boundary-closure
 worktree: ../atm-core-worktrees/feature/pYd-s15-production-notification-boundary-closure
 target: integrate/phase-Y
@@ -48,6 +48,8 @@ target: integrate/phase-Y
   direct helper bypass
 - the blocker inventory and readiness record explicitly record the `Y.15`
   closure result
+- surviving `Y.13` boundary tests continue to prove the accepted candidate
+  line does not reopen the helper-bypass path
 
 ## Relationship To Phase Yc
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3653,6 +3653,10 @@ Acceptance / Phase Z Smoke Gate:
 Status summary:
 - `Phase Yc` captured the two original runtime blockers reopened by the focused
   production-readiness review.
+- `Y.15` is now closed on
+  `feature/pYd-s15-production-notification-boundary-closure`; the surviving
+  notification boundary proof now lives on the final accepted `Phase Y`
+  candidate line instead of only on the focused `Yc` line.
 - before `integrate/phase-Y` lands on `develop`, the broader `Phase Y`
   blocker set must be documented explicitly and closed on a final
   develop-gate line.


### PR DESCRIPTION
## Summary

- Closes Y.15 re-proof: production send/ack notification execution routes through `NotificationSink::deliver(...)`, no `maybe_run_post_send_hook` production-path calls remain
- Named Y.13 boundary tests survive and pass on final candidate line
- Updates `docs/phase-Y/issues.md`, `docs/phase-Yd/readiness.md`, `docs/phase-Yd/sprint-Y15.md`

## Acceptance Criteria

- `rg -rn 'maybe_run_post_send_hook' crates/atm-core/src/` returns no matches ✅
- Named tests `delivery_notifications_use_notification_sink_boundary`, `notification_sink_failure_is_explicit_in_delivery_warnings`, `notification_sink_backpressure_does_not_reopen_hook_helper_bypass` pass ✅
- `docs/phase-Yd/readiness.md` updated with Y.15 closure result ✅
- cargo fmt + lint + clippy + git diff --check all clean ✅

## Test plan

- [ ] quality-mgr QA-1 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)