### PR TITLE
phase-y: close Y.16 retained-runtime composition

### DIFF
--- a/boundaries/atm-daemon/daemon-notification-sink.toml
+++ b/boundaries/atm-daemon/daemon-notification-sink.toml
@@ -8,7 +8,7 @@ trait = "NotificationSink"
 
 [implementation]
 type = "DaemonNotificationSink"
-module = "atm_daemon::notification_runtime"
+module = "atm_daemon::boundary_adapters"
 visibility = "pub(crate)"
 constructor = "pub(crate)"
 

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -136,3 +136,5 @@ pub use service_runtime::{
 };
 #[doc(hidden)]
 pub use service_runtime_store::install_default_runtime_factory;
+#[doc(hidden)]
+pub use service_runtime_store::install_default_runtime_instance;

--- a/crates/atm-core/src/service_runtime_store.rs
+++ b/crates/atm-core/src/service_runtime_store.rs
@@ -8,16 +8,26 @@ use crate::types::{AgentName, TeamName};
 
 type DefaultRuntimeFactory = fn() -> Result<LocalServiceRuntime, AtmError>;
 
-static DEFAULT_RUNTIME_FACTORY: OnceLock<DefaultRuntimeFactory> = OnceLock::new();
+#[derive(Clone)]
+enum DefaultRuntimeProvider {
+    Factory(DefaultRuntimeFactory),
+    Instance(LocalServiceRuntime),
+}
+
+static DEFAULT_RUNTIME_PROVIDER: OnceLock<DefaultRuntimeProvider> = OnceLock::new();
 
 pub fn install_default_runtime_factory(factory: DefaultRuntimeFactory) {
-    let _ = DEFAULT_RUNTIME_FACTORY.set(factory);
+    let _ = DEFAULT_RUNTIME_PROVIDER.set(DefaultRuntimeProvider::Factory(factory));
+}
+
+pub fn install_default_runtime_instance(runtime: LocalServiceRuntime) {
+    let _ = DEFAULT_RUNTIME_PROVIDER.set(DefaultRuntimeProvider::Instance(runtime));
 }
 
 pub(crate) fn default_runtime() -> Result<LocalServiceRuntime, AtmError> {
-    DEFAULT_RUNTIME_FACTORY
+    DEFAULT_RUNTIME_PROVIDER
         .get()
-        .copied()
+        .cloned()
         .ok_or_else(|| {
             AtmError::daemon_unavailable(
                 "sqlite-backed retained runtime is unavailable because no default runtime factory is installed",
@@ -25,8 +35,11 @@ pub(crate) fn default_runtime() -> Result<LocalServiceRuntime, AtmError> {
             .with_recovery(
                 "Start the daemon-backed ATM runtime or install the sqlite default runtime factory before retrying this command.",
             )
-        })?
-        ()
+        })
+        .and_then(|provider| match provider {
+            DefaultRuntimeProvider::Factory(factory) => factory(),
+            DefaultRuntimeProvider::Instance(runtime) => Ok(runtime),
+        })
 }
 
 pub(crate) trait RetainedMailboxRuntime {

--- a/crates/atm-daemon/src/boundary_adapters.rs
+++ b/crates/atm-daemon/src/boundary_adapters.rs
@@ -31,10 +31,8 @@ impl std::fmt::Debug for DaemonNotificationSink {
 }
 
 impl DaemonNotificationSink {
-    pub(crate) fn new_with_observability(observability: SubsystemObservability) -> Self {
-        Self {
-            runtime: NotificationRuntime::new_with_observability(observability),
-        }
+    pub(crate) fn new(runtime: NotificationRuntime) -> Self {
+        Self { runtime }
     }
 
     #[cfg(test)]

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -22,6 +22,9 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
+#[cfg(test)]
+use crate::notification_runtime::NotificationRuntime;
+
 const BACKGROUND_LANE_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -162,10 +165,55 @@ impl RuntimeComposition {
         )
     }
 
+    #[cfg(test)]
     fn new_with_replay_store_path(
         home_dir: AtmHomeDir,
         replay_store_path: PathBuf,
         observability: Arc<dyn DaemonRuntimeObservability>,
+    ) -> Result<Self, AtmError> {
+        let composition_observability =
+            SubsystemObservability::new(DaemonSubsystem::Composition, Arc::clone(&observability));
+        let notification_sink = DaemonNotificationSink::new(
+            NotificationRuntime::new_with_observability(SubsystemObservability::new(
+                DaemonSubsystem::NotificationRuntime,
+                Arc::clone(&observability),
+            )),
+        );
+        let sqlite_observability: Arc<dyn atm_rusqlite::SqliteObservability> =
+            Arc::new(DaemonSqliteObservability::new(
+                Arc::clone(&observability),
+                RuntimeStatusCache::new_with_observability(SubsystemObservability::new(
+                    DaemonSubsystem::RuntimeStatusCache,
+                    Arc::clone(&observability),
+                )),
+            ));
+        let production_boundary = SqliteBoundaryAssembly::new_with_observability(
+            replay_store_path.clone(),
+            Arc::clone(&sqlite_observability),
+        )
+        .map_err(|error| replay_store_assembly_failed(error, &composition_observability))?;
+        let production_runtime = build_production_runtime(
+            production_boundary.mail_store_arc(),
+            production_boundary.task_store_arc(),
+            production_boundary.roster_store_arc(),
+            Arc::new(DaemonNonClaudeOutbound::new()),
+            Arc::new(notification_sink.clone()),
+        );
+        Self::new_with_replay_store_path_and_runtime(
+            home_dir,
+            replay_store_path,
+            observability,
+            production_runtime,
+            notification_sink,
+        )
+    }
+
+    fn new_with_replay_store_path_and_runtime(
+        home_dir: AtmHomeDir,
+        replay_store_path: PathBuf,
+        observability: Arc<dyn DaemonRuntimeObservability>,
+        production_runtime: atm_core::LocalServiceRuntime,
+        notification_sink: DaemonNotificationSink,
     ) -> Result<Self, AtmError> {
         let config_ingress = DaemonConfigIngress::new();
         let composition_observability =
@@ -177,11 +225,6 @@ impl RuntimeComposition {
         let sqlite_observability: Arc<dyn atm_rusqlite::SqliteObservability> = Arc::new(
             DaemonSqliteObservability::new(Arc::clone(&observability), status_cache.clone()),
         );
-        let notification_sink =
-            DaemonNotificationSink::new_with_observability(SubsystemObservability::new(
-                DaemonSubsystem::NotificationRuntime,
-                Arc::clone(&observability),
-            ));
         let watch_event_source = FileWatchEventSource::new_with_observability(
             SubsystemObservability::new(DaemonSubsystem::WatchRuntime, Arc::clone(&observability)),
         );
@@ -198,8 +241,6 @@ impl RuntimeComposition {
             Arc::clone(&sqlite_observability),
         )
         .map_err(|error| replay_store_assembly_failed(error, &composition_observability))?;
-        let production_runtime =
-            build_production_runtime(&production_boundary, Arc::new(notification_sink.clone()));
         atm_core::install_default_runtime_instance(production_runtime.clone());
         let server_transport = build_server_transport(&observability);
         let request_dispatcher =
@@ -583,14 +624,17 @@ impl RuntimeComposition {
 }
 
 pub(crate) fn build_production_runtime(
-    sqlite_boundary: &SqliteBoundaryAssembly,
+    mail_store: Arc<dyn atm_core::boundary::MailStore + Send + Sync>,
+    task_store: Arc<dyn atm_core::boundary::TaskStore + Send + Sync>,
+    roster_store: Arc<dyn atm_core::boundary::RosterStore + Send + Sync>,
+    non_claude_outbound: Arc<dyn atm_core::boundary::NonClaudeOutbound + Send + Sync>,
     notification_sink: Arc<dyn atm_core::boundary::NotificationSink + Send + Sync>,
 ) -> atm_core::LocalServiceRuntime {
     atm_core::LocalServiceRuntime::new_with_delivery_boundaries(
-        sqlite_boundary.mail_store_arc(),
-        sqlite_boundary.task_store_arc(),
-        sqlite_boundary.roster_store_arc(),
-        Arc::new(DaemonNonClaudeOutbound::new()),
+        mail_store,
+        task_store,
+        roster_store,
+        non_claude_outbound,
         notification_sink,
     )
 }
@@ -811,16 +855,30 @@ pub(crate) fn compose_runtime(
 ) -> Result<RuntimeComposition, AtmError> {
     let home_dir = AtmHomeDir::resolve()?;
     validate_runtime_home_dir(home_dir.as_path())?;
-    let runtime = RuntimeComposition::new_with_replay_store_path(
+    let replay_store_path = atm_core::home::host_mail_db_path()?;
+    let notification_sink = DaemonNotificationSink::new(
+        crate::notification_runtime::NotificationRuntime::new_with_observability(
+            SubsystemObservability::new(
+                DaemonSubsystem::NotificationRuntime,
+                Arc::clone(&observability),
+            ),
+        ),
+    );
+    let production_boundary = SqliteBoundaryAssembly::new(replay_store_path.clone())?;
+    let production_runtime = build_production_runtime(
+        production_boundary.mail_store_arc(),
+        production_boundary.task_store_arc(),
+        production_boundary.roster_store_arc(),
+        Arc::new(DaemonNonClaudeOutbound::new()),
+        Arc::new(notification_sink.clone()),
+    );
+    RuntimeComposition::new_with_replay_store_path_and_runtime(
         home_dir,
-        atm_core::home::host_mail_db_path()?,
+        replay_store_path,
         observability,
-    )?;
-    // The composition root owns retained-runtime installation for the live
-    // daemon path; keeping the assembled production runtime here prevents
-    // runtime-health from silently becoming the de facto owner again.
-    let _retained_runtime = &runtime._production_runtime;
-    Ok(runtime)
+        production_runtime,
+        notification_sink,
+    )
 }
 
 #[cfg(test)]

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -5,6 +5,7 @@ use crate::boundary_adapters::{
 use crate::daemon_runtime_observability::{DaemonRuntimeObservability, SubsystemObservability};
 use crate::host_ownership::HostOwnershipAdapter;
 use crate::local_ipc_transport::{PreparedRuntimeServer, RuntimeServeHooks, SocketEndpointGuard};
+use crate::non_claude_outbound_runtime::DaemonNonClaudeOutbound;
 use crate::runtime_health::DaemonRequestDispatcher;
 use crate::runtime_health::{DaemonStatusSource, RuntimeStatusCache};
 use crate::sqlite_observability::DaemonSqliteObservability;
@@ -14,6 +15,7 @@ use crate::{
 };
 use atm_core::boundary::{ConfigIngress, ConfigLoadRequest, RequestDispatcher};
 use atm_core::error::AtmError;
+use atm_rusqlite::SqliteBoundaryAssembly;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -136,6 +138,7 @@ pub(crate) struct RuntimeComposition {
     server_transport: LocalIpcServerTransportAdapter,
     request_dispatcher: Arc<DaemonRequestDispatcher>,
     composition_observability: SubsystemObservability,
+    _production_runtime: atm_core::LocalServiceRuntime,
     _notification_sink: DaemonNotificationSink,
     _status_source: DaemonStatusSource,
     _watch_event_source: FileWatchEventSource,
@@ -165,6 +168,8 @@ impl RuntimeComposition {
         observability: Arc<dyn DaemonRuntimeObservability>,
     ) -> Result<Self, AtmError> {
         let config_ingress = DaemonConfigIngress::new();
+        let composition_observability =
+            SubsystemObservability::new(DaemonSubsystem::Composition, Arc::clone(&observability));
         let status_cache = RuntimeStatusCache::new_with_observability(SubsystemObservability::new(
             DaemonSubsystem::RuntimeStatusCache,
             Arc::clone(&observability),
@@ -181,22 +186,24 @@ impl RuntimeComposition {
             SubsystemObservability::new(DaemonSubsystem::WatchRuntime, Arc::clone(&observability)),
         );
         let inbox_ingress = DaemonInboxIngress::new();
-        let composition_observability =
-            SubsystemObservability::new(DaemonSubsystem::Composition, Arc::clone(&observability));
         let peer_transport_config =
             load_peer_transport_config(&config_ingress, &composition_observability)?;
-        let server_transport = build_server_transport(&observability);
-        let request_dispatcher = build_request_dispatcher(
-            home_dir,
-            &status_cache,
-            &observability,
-            Arc::clone(&sqlite_observability),
-        );
         let replay_store = sqlite_remote_replay_store_from_path_with_observability(
-            replay_store_path,
+            replay_store_path.clone(),
             Arc::clone(&sqlite_observability),
         )
         .map_err(|error| replay_store_assembly_failed(error, &composition_observability))?;
+        let production_boundary = SqliteBoundaryAssembly::new_with_observability(
+            replay_store_path.clone(),
+            Arc::clone(&sqlite_observability),
+        )
+        .map_err(|error| replay_store_assembly_failed(error, &composition_observability))?;
+        let production_runtime =
+            build_production_runtime(&production_boundary, Arc::new(notification_sink.clone()));
+        atm_core::install_default_runtime_instance(production_runtime.clone());
+        let server_transport = build_server_transport(&observability);
+        let request_dispatcher =
+            build_request_dispatcher(home_dir, &status_cache, &observability, production_boundary);
         Ok(Self {
             lifecycle: Arc::new(RuntimeLifecycle::new()),
             _host_ownership_adapter: HostOwnershipAdapter::new_with_observability(
@@ -209,6 +216,7 @@ impl RuntimeComposition {
             server_transport,
             request_dispatcher,
             composition_observability,
+            _production_runtime: production_runtime,
             _notification_sink: notification_sink.clone(),
             _status_source: DaemonStatusSource::new(status_cache),
             _watch_event_source: watch_event_source.clone(),
@@ -574,6 +582,19 @@ impl RuntimeComposition {
     }
 }
 
+pub(crate) fn build_production_runtime(
+    sqlite_boundary: &SqliteBoundaryAssembly,
+    notification_sink: Arc<dyn atm_core::boundary::NotificationSink + Send + Sync>,
+) -> atm_core::LocalServiceRuntime {
+    atm_core::LocalServiceRuntime::new_with_delivery_boundaries(
+        sqlite_boundary.mail_store_arc(),
+        sqlite_boundary.task_store_arc(),
+        sqlite_boundary.roster_store_arc(),
+        Arc::new(DaemonNonClaudeOutbound::new()),
+        notification_sink,
+    )
+}
+
 fn replay_store_assembly_failed(
     error: AtmError,
     observability: &SubsystemObservability,
@@ -640,13 +661,13 @@ fn build_request_dispatcher(
     home_dir: AtmHomeDir,
     status_cache: &RuntimeStatusCache,
     observability: &Arc<dyn DaemonRuntimeObservability>,
-    sqlite_observability: Arc<dyn atm_rusqlite::SqliteObservability>,
+    sqlite_boundary: SqliteBoundaryAssembly,
 ) -> Arc<DaemonRequestDispatcher> {
     Arc::new(DaemonRequestDispatcher::new(
         home_dir,
         status_cache.clone(),
         Arc::clone(observability),
-        sqlite_observability,
+        sqlite_boundary,
     ))
 }
 
@@ -790,11 +811,16 @@ pub(crate) fn compose_runtime(
 ) -> Result<RuntimeComposition, AtmError> {
     let home_dir = AtmHomeDir::resolve()?;
     validate_runtime_home_dir(home_dir.as_path())?;
-    RuntimeComposition::new_with_replay_store_path(
+    let runtime = RuntimeComposition::new_with_replay_store_path(
         home_dir,
         atm_core::home::host_mail_db_path()?,
         observability,
-    )
+    )?;
+    // The composition root owns retained-runtime installation for the live
+    // daemon path; keeping the assembled production runtime here prevents
+    // runtime-health from silently becoming the de facto owner again.
+    let _retained_runtime = &runtime._production_runtime;
+    Ok(runtime)
 }
 
 #[cfg(test)]

--- a/crates/atm-daemon/src/daemon_observability.rs
+++ b/crates/atm-daemon/src/daemon_observability.rs
@@ -1,8 +1,1 @@
-// Keep the implementation in bin_support/, but make the dependency ownership
-// explicit in the in-tree shim so cargo-shear can see the package-level use.
-use sc_observability as _;
-
-#[cfg(test)]
-const _: Option<fn(sc_observability::Logger)> = None;
-
 include!("../bin_support/daemon_observability.rs");

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -103,10 +103,6 @@ impl AtmHomeDir {
         &self.0
     }
 
-    pub(crate) fn into_inner(self) -> PathBuf {
-        self.0
-    }
-
     #[cfg(test)]
     pub(crate) fn from_path_for_test(path: PathBuf) -> Self {
         Self(path)

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
 
 use atm_core::error::AtmError;
+use sc_observability as _;
 
 mod daemon_observability;
 
 use daemon_observability::DaemonObservability;
+
+const _: Option<fn(sc_observability::Logger)> = None;
 
 fn main() {
     let exit_code = match run() {

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -27,18 +27,13 @@ use atm_core::{
     read::read_mail,
     send::send_mail,
 };
-use atm_rusqlite::{
-    SqliteBoundaryAssembly, SqliteObservability, assemble_default_boundary,
-    assemble_default_boundary_with_observability,
-};
+use atm_rusqlite::SqliteBoundaryAssembly;
 
 use crate::AtmHomeDir;
 use crate::advisory_runtime::AdvisoryRuntime;
-use crate::boundary_adapters::DaemonNotificationSink;
 use crate::daemon_runtime_observability::{
     DaemonRuntimeObservability, DaemonSubsystem, SubsystemObservability,
 };
-use crate::non_claude_outbound_runtime::DaemonNonClaudeOutbound;
 #[cfg(test)]
 pub(crate) use crate::runtime_status_cache::MAX_STATUS_CACHE_ENTRIES;
 pub(crate) use crate::runtime_status_cache::RuntimeStatusCache;
@@ -55,15 +50,6 @@ const MAX_SHUTDOWN_FINALIZER_THREADS: usize = 16;
 // to recover and join those retained workers later.
 static SHUTDOWN_FINALIZER_THREADS: std::sync::Mutex<Vec<std::thread::JoinHandle<()>>> =
     std::sync::Mutex::new(Vec::new());
-#[cfg_attr(
-    test,
-    allow(
-        dead_code,
-        reason = "Production retained-runtime installation is compiled out in daemon lib tests."
-    )
-)]
-static INSTALL_DAEMON_RUNTIME_FACTORY: std::sync::Once = std::sync::Once::new();
-
 pub(crate) struct DaemonRequestDispatcher {
     // Invariant: this is the validated ATM_HOME root for the running daemon,
     // not an arbitrary workspace path.
@@ -315,10 +301,8 @@ impl DaemonRequestDispatcher {
         home_dir: AtmHomeDir,
         status_cache: RuntimeStatusCache,
         observability: Arc<dyn DaemonRuntimeObservability>,
-        sqlite_observability: Arc<dyn SqliteObservability>,
+        sqlite_boundary: SqliteBoundaryAssembly,
     ) -> Self {
-        #[cfg(not(test))]
-        install_daemon_runtime_factory();
         let home_dir = home_dir.into_inner();
         let advisory_runtime_observability = SubsystemObservability::new(
             DaemonSubsystem::AdvisoryRuntime,
@@ -326,93 +310,35 @@ impl DaemonRequestDispatcher {
         );
         let runtime_health_observability =
             SubsystemObservability::new(DaemonSubsystem::RuntimeHealth, Arc::clone(&observability));
-        let sqlite_boundary =
-            match assemble_default_boundary_with_observability(sqlite_observability) {
-                Ok(boundary) => {
-                    if let Err(error) =
-                        build_runtime_status_cache_state(None, boundary.roster_store())
-                            .and_then(|state| status_cache.replace_state(state))
-                    {
-                        tracing::warn!(
-                            subsystem = "runtime_health",
-                            action = "sqlite_cache_hydration",
-                            outcome = "degraded",
-                            %error,
-                            "failed to hydrate runtime status cache from sqlite roster state"
-                        );
-                        runtime_health_observability.emit_or_warn(
-                            "sqlite_cache_hydration",
-                            "degraded",
-                            "failed to hydrate runtime status cache from sqlite roster state",
-                        );
-                        status_cache.mark_sqlite_unavailable();
-                    }
-                    Some(boundary)
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        subsystem = "runtime_health",
-                        action = "sqlite_boundary_assembly",
-                        outcome = "failed",
-                        %error,
-                        "failed to assemble default sqlite boundary for daemon runtime health"
-                    );
-                    runtime_health_observability.emit_or_warn(
-                        "sqlite_boundary_assembly",
-                        "failed",
-                        "failed to assemble sqlite boundary for daemon runtime health",
-                    );
-                    status_cache.mark_sqlite_unavailable();
-                    None
-                }
-            };
+        if let Err(error) = build_runtime_status_cache_state(None, sqlite_boundary.roster_store())
+            .and_then(|state| status_cache.replace_state(state))
+        {
+            tracing::warn!(
+                subsystem = "runtime_health",
+                action = "sqlite_cache_hydration",
+                outcome = "degraded",
+                %error,
+                "failed to hydrate runtime status cache from sqlite roster state"
+            );
+            runtime_health_observability.emit_or_warn(
+                "sqlite_cache_hydration",
+                "degraded",
+                "failed to hydrate runtime status cache from sqlite roster state",
+            );
+            status_cache.mark_sqlite_unavailable();
+        }
         Self {
             home_dir: home_dir.clone(),
             observability: Arc::clone(&observability),
             advisory_runtime_observability: advisory_runtime_observability.clone(),
             runtime_health_observability: runtime_health_observability.clone(),
             status_cache,
-            sqlite_boundary,
+            sqlite_boundary: Some(sqlite_boundary),
             advisory_runtime: AdvisoryRuntime::new_with_observability(
                 advisory_runtime_observability,
             ),
         }
     }
-}
-
-#[cfg_attr(
-    test,
-    allow(
-        dead_code,
-        reason = "Production retained-runtime installation is compiled out in daemon lib tests."
-    )
-)]
-fn install_daemon_runtime_factory() {
-    INSTALL_DAEMON_RUNTIME_FACTORY.call_once(|| {
-        atm_core::install_default_runtime_factory(daemon_local_runtime);
-    });
-}
-
-#[cfg_attr(
-    test,
-    allow(
-        dead_code,
-        reason = "Production retained-runtime installation is compiled out in daemon lib tests."
-    )
-)]
-fn daemon_local_runtime() -> Result<atm_core::LocalServiceRuntime, AtmError> {
-    let assembly = assemble_default_boundary()?;
-    let notification_sink = DaemonNotificationSink::new_with_observability(
-        SubsystemObservability::disabled(DaemonSubsystem::NotificationRuntime),
-    );
-    notification_sink.start()?;
-    Ok(atm_core::LocalServiceRuntime::new_with_delivery_boundaries(
-        assembly.mail_store_arc(),
-        assembly.task_store_arc(),
-        assembly.roster_store_arc(),
-        Arc::new(DaemonNonClaudeOutbound::new()),
-        Arc::new(notification_sink),
-    ))
 }
 
 fn with_shutdown_finalizer_registry<R>(

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -53,7 +52,7 @@ static SHUTDOWN_FINALIZER_THREADS: std::sync::Mutex<Vec<std::thread::JoinHandle<
 pub(crate) struct DaemonRequestDispatcher {
     // Invariant: this is the validated ATM_HOME root for the running daemon,
     // not an arbitrary workspace path.
-    home_dir: PathBuf,
+    home_dir: AtmHomeDir,
     observability: Arc<dyn DaemonRuntimeObservability>,
     advisory_runtime_observability: SubsystemObservability,
     runtime_health_observability: SubsystemObservability,
@@ -65,7 +64,7 @@ pub(crate) struct DaemonRequestDispatcher {
 impl std::fmt::Debug for DaemonRequestDispatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DaemonRequestDispatcher")
-            .field("home_dir", &self.home_dir)
+            .field("home_dir", &self.home_dir.as_path())
             .field("status_cache", &self.status_cache)
             .field("sqlite_boundary_present", &self.sqlite_boundary.is_some())
             .field("advisory_runtime", &"AdvisoryRuntime")
@@ -303,7 +302,6 @@ impl DaemonRequestDispatcher {
         observability: Arc<dyn DaemonRuntimeObservability>,
         sqlite_boundary: SqliteBoundaryAssembly,
     ) -> Self {
-        let home_dir = home_dir.into_inner();
         let advisory_runtime_observability = SubsystemObservability::new(
             DaemonSubsystem::AdvisoryRuntime,
             Arc::clone(&observability),
@@ -328,7 +326,7 @@ impl DaemonRequestDispatcher {
             status_cache.mark_sqlite_unavailable();
         }
         Self {
-            home_dir: home_dir.clone(),
+            home_dir,
             observability: Arc::clone(&observability),
             advisory_runtime_observability: advisory_runtime_observability.clone(),
             runtime_health_observability: runtime_health_observability.clone(),

--- a/crates/atm-daemon/src/runtime_health_test_support.rs
+++ b/crates/atm-daemon/src/runtime_health_test_support.rs
@@ -59,7 +59,7 @@ impl DaemonRequestDispatcher {
             Arc::clone(&runtime_observability),
         );
         Self {
-            home_dir: home_dir.clone(),
+            home_dir: crate::AtmHomeDir::from_path_for_test(home_dir.clone()),
             observability: runtime_observability,
             advisory_runtime_observability: advisory_runtime_observability.clone(),
             runtime_health_observability,

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -5,8 +5,11 @@ use super::{
     LocalIpcServerTransportAdapter,
     boundary_adapters::DaemonNotificationSink,
     composition::build_production_runtime,
+    daemon_runtime_observability::SubsystemObservability,
     lifecycle_control::LifecycleControlSourceAdapter,
     local_ipc_transport::RuntimeServeHooks,
+    non_claude_outbound_runtime::DaemonNonClaudeOutbound,
+    notification_runtime::NotificationRuntime,
     test_support::{DoctorOnlyDispatcher, LifecycleFlagResetGuard},
 };
 use atm_core::boundary::RequestDispatcher;
@@ -375,17 +378,32 @@ fn production_runtime_installs_daemon_notification_sink() {
     let workspace_dir = tempdir.path().join("workspace");
     let atm_home = tempdir.path().join("atm-home");
     let db_path = tempdir.path().join("mail.db");
-    let notification_path = tempdir.path().join("notifications.jsonl");
     std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
     std::fs::create_dir_all(&atm_home).expect("atm home dir");
     write_workspace_config(&workspace_dir);
     install_test_roster(&db_path, &[ROLE_TEAM_LEAD, "qa-a"]);
     write_team_config(&atm_home, &[ROLE_TEAM_LEAD, "qa-a"]);
 
-    let sink = DaemonNotificationSink::new_for_test_with_path(notification_path.clone(), 8);
+    let _env = EnvGuard::set_many([
+        ("ATM_HOME", Some(atm_home.to_str().expect("utf8 atm home"))),
+        ("HOME", Some(tempdir.path().to_str().expect("utf8 home"))),
+        ("USERPROFILE", None),
+    ]);
+    let notification_path = atm_core::home::host_runtime_dir()
+        .expect("host runtime dir")
+        .join("notifications.jsonl");
+    let sink = DaemonNotificationSink::new(NotificationRuntime::new_with_observability(
+        SubsystemObservability::disabled(crate::DaemonSubsystem::NotificationRuntime),
+    ));
     sink.start().expect("start notification sink");
     let assembly = assemble_boundary(&db_path).expect("sqlite boundary");
-    let runtime = build_production_runtime(&assembly, Arc::new(sink.clone()));
+    let runtime = build_production_runtime(
+        assembly.mail_store_arc(),
+        assembly.task_store_arc(),
+        assembly.roster_store_arc(),
+        Arc::new(DaemonNonClaudeOutbound::new()),
+        Arc::new(sink.clone()),
+    );
 
     let request = SendRequest::new(
         atm_home.clone(),

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -3,6 +3,8 @@ use super::runtime_health::{
 };
 use super::{
     LocalIpcServerTransportAdapter,
+    boundary_adapters::DaemonNotificationSink,
+    composition::build_production_runtime,
     lifecycle_control::LifecycleControlSourceAdapter,
     local_ipc_transport::RuntimeServeHooks,
     test_support::{DoctorOnlyDispatcher, LifecycleFlagResetGuard},
@@ -18,6 +20,7 @@ use atm_core::protocol::{
     RuntimeReadinessState, TeamMemberHeartbeatRequest,
 };
 use atm_core::schema::{AgentMember, TeamConfig};
+use atm_core::send::{SendMessageSource, SendRequest, send_mail_with_runtime};
 use atm_core::test_support::EnvGuard;
 use atm_core::test_support::ROLE_TEAM_LEAD;
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
@@ -356,6 +359,57 @@ fn write_team_config(home_dir: &std::path::Path, members: &[&str]) {
         serde_json::to_vec(&config).expect("team config"),
     )
     .expect("write team config");
+}
+
+fn write_workspace_config(workspace_dir: &std::path::Path) {
+    std::fs::write(workspace_dir.join(".atm.toml"), "[atm]\n").expect("workspace config");
+}
+
+fn read_notification_output(path: &std::path::Path) -> String {
+    std::fs::read_to_string(path).expect("notification output")
+}
+
+#[test]
+fn production_runtime_installs_daemon_notification_sink() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let workspace_dir = tempdir.path().join("workspace");
+    let atm_home = tempdir.path().join("atm-home");
+    let db_path = tempdir.path().join("mail.db");
+    let notification_path = tempdir.path().join("notifications.jsonl");
+    std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+    std::fs::create_dir_all(&atm_home).expect("atm home dir");
+    write_workspace_config(&workspace_dir);
+    install_test_roster(&db_path, &[ROLE_TEAM_LEAD, "qa-a"]);
+    write_team_config(&atm_home, &[ROLE_TEAM_LEAD, "qa-a"]);
+
+    let sink = DaemonNotificationSink::new_for_test_with_path(notification_path.clone(), 8);
+    sink.start().expect("start notification sink");
+    let assembly = assemble_boundary(&db_path).expect("sqlite boundary");
+    let runtime = build_production_runtime(&assembly, Arc::new(sink.clone()));
+
+    let request = SendRequest::new(
+        atm_home.clone(),
+        workspace_dir.clone(),
+        Some(ROLE_TEAM_LEAD),
+        "qa-a@test-team",
+        Some(TEST_TEAM),
+        SendMessageSource::Inline("boundary install proof".to_string()),
+        None,
+        false,
+        None,
+        false,
+    )
+    .expect("send request");
+    let observability = atm_core::observability::NullObservability;
+
+    send_mail_with_runtime(request, &observability, &runtime).expect("send mail");
+    sink.shutdown().expect("shutdown notification sink");
+
+    let output = read_notification_output(&notification_path);
+    assert!(
+        output.contains("\"kind\":\"delivery\""),
+        "expected delivery notification output, got: {output}"
+    );
 }
 
 #[test]

--- a/docs/phase-Y/issues.md
+++ b/docs/phase-Y/issues.md
@@ -70,6 +70,13 @@ These items block `Phase Y` from landing on `develop`.
    - closure requirement:
      - the live retained runtime used by the daemon must construct and install
        the daemon-owned `NotificationSink`
+   - closure evidence:
+     - `Y.16` moves retained-runtime installation ownership into
+       `atm_daemon::composition::compose_runtime`
+     - the production retained runtime is built through
+       `build_production_runtime(...)`
+     - named proof test:
+       - `production_runtime_installs_daemon_notification_sink`
 
 4. The final accepted `Phase Y` line must be lint-clean, test-clean, and
    phase-end-review clean on the candidate merge line.

--- a/docs/phase-Y/issues.md
+++ b/docs/phase-Y/issues.md
@@ -63,6 +63,8 @@ These items block `Phase Y` from landing on `develop`.
 
 3. Daemon retained-runtime composition must install the live
    `NotificationSink`.
+   - status:
+     - `CLOSED: Y.16`
    - issue class:
      - production composition
    - historical owner:

--- a/docs/phase-Yd/readiness.md
+++ b/docs/phase-Yd/readiness.md
@@ -13,7 +13,7 @@ record explicitly says the line is ready.
 | --- | --- | --- | --- | --- |
 | `Y.14` | `PENDING` | `TBD` | `TBD` | recovered Claude logical-message-set closure on final accepted candidate line |
 | `Y.15` | `PENDING` | `TBD` | `TBD` | production `NotificationSink` boundary closure on final accepted candidate line |
-| `Y.16` | `PENDING` | `TBD` | `TBD` | retained-runtime composition installs live production `NotificationSink` |
+| `Y.16` | `PASS` | `2026-05-20` | `feature/pYd-s16-retained-runtime-composition-closure HEAD` | retained-runtime composition owns production runtime installation, installs the live daemon `NotificationSink`, and passes `production_runtime_installs_daemon_notification_sink` |
 | `Y.17` | `PENDING` | `TBD` | `TBD` | accepted merge candidate includes required end-of-phase fix line and passes validation |
 | `Y.18` | `PENDING` | `TBD` | `TBD` | thin liveness closure or explicit reclassification with final develop-gate result |
 

--- a/docs/phase-Yd/sprint-Y16.md
+++ b/docs/phase-Yd/sprint-Y16.md
@@ -1,7 +1,7 @@
 ---
 id: Y.16
 title: Retained-Runtime Composition Closure
-status: planned
+status: complete
 branch: feature/pYd-s16-retained-runtime-composition-closure
 worktree: ../atm-core-worktrees/feature/pYd-s16-retained-runtime-composition-closure
 target: integrate/phase-Y


### PR DESCRIPTION
## Summary
- `compose_runtime` now assembles and installs the production retained runtime with the live `DaemonNotificationSink`
- `runtime_health` consumes the preassembled sqlite boundary instead of owning the factory install
- Named proof test `production_runtime_installs_daemon_notification_sink` added
- `docs/phase-Y/issues.md`, `docs/phase-Yd/readiness.md`, `docs/phase-Yd/sprint-Y16.md` updated with Y.16 closure

## Test plan
- [ ] `rg -n "DaemonNotificationSink::new" crates/atm-daemon/src/composition.rs` ≥1 match
- [ ] `rg -n "compose_runtime|build_production_runtime" crates/atm-daemon/src/composition.rs` shows compose_runtime calling build_production_runtime
- [ ] `cargo test --workspace production_runtime_installs_daemon_notification_sink` passes
- [ ] `cargo test --workspace` passes (324+ tests)
- [ ] `cargo fmt --all` + `cargo clippy --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)