### PR TITLE
feat(pYe-s21): Reconcile Runtime Actor Foundation

### DIFF
--- a/crates/atm-daemon/src/reconcile_runtime.rs
+++ b/crates/atm-daemon/src/reconcile_runtime.rs
@@ -31,15 +31,14 @@ pub(crate) struct ReconcileRuntime {
     inner: Arc<ReconcileRuntimeInner>,
 }
 
-type ReconcileExecutor =
-    Arc<
-        dyn Fn(
-                &ReconcileRequest,
-                &mut NotificationFingerprintRegistry,
-            ) -> Result<ReconcileResult, AtmError>
-            + Send
-            + Sync,
-    >;
+type ReconcileExecutor = Arc<
+    dyn Fn(
+            &ReconcileRequest,
+            &mut NotificationFingerprintRegistry,
+        ) -> Result<ReconcileResult, AtmError>
+        + Send
+        + Sync,
+>;
 
 struct ReconcileRuntimeInner {
     state: Mutex<ReconcileState>,
@@ -411,10 +410,9 @@ impl ReconcileRuntime {
     ) -> Result<(), AtmError> {
         let command_tx = {
             let state = self.inner.state.lock().map_err(|_| {
-                AtmError::daemon_unavailable("reconcile runtime state lock poisoned")
-                    .with_recovery(
-                        "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
-                    )
+                AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
+                    "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
+                )
             })?;
             self.validate_reconcile_runtime_state(&state, request_team, request_agent)?;
             let slot = self.inner.command_tx.lock().map_err(|_| {
@@ -713,7 +711,11 @@ fn should_emit_reconcile_notification(
     let is_new_key = !notification_fingerprints.entries.contains_key(&key);
     if is_new_key && notification_fingerprints.entries.len() >= MAX_RECONCILE_FINGERPRINT_KEYS {
         while let Some(evicted_key) = notification_fingerprints.order.pop_front() {
-            if notification_fingerprints.entries.remove(&evicted_key).is_some() {
+            if notification_fingerprints
+                .entries
+                .remove(&evicted_key)
+                .is_some()
+            {
                 tracing::warn!(
                     subsystem = "reconcile",
                     action = "fingerprint_evict",
@@ -764,24 +766,22 @@ fn reconcile_worker_loop(
             };
 
         for pending_request in pending {
-            let outcome = match (inner.executor)(
-                &pending_request.request,
-                &mut notification_fingerprints,
-            ) {
-                Ok(result) => Ok(result),
-                Err(error) => {
-                    tracing::warn!(
-                        subsystem = "reconcile",
-                        action = "executor",
-                        outcome = "failed",
-                        team = %pending_request.request.team,
-                        agent = %pending_request.request.agent,
-                        %error,
-                        "reconcile runtime executor failed"
-                    );
-                    Err(error)
-                }
-            };
+            let outcome =
+                match (inner.executor)(&pending_request.request, &mut notification_fingerprints) {
+                    Ok(result) => Ok(result),
+                    Err(error) => {
+                        tracing::warn!(
+                            subsystem = "reconcile",
+                            action = "executor",
+                            outcome = "failed",
+                            team = %pending_request.request.team,
+                            agent = %pending_request.request.agent,
+                            %error,
+                            "reconcile runtime executor failed"
+                        );
+                        Err(error)
+                    }
+                };
             if record_reconcile_outcome(pending_request, outcome).is_none() {
                 return;
             }
@@ -842,18 +842,14 @@ impl ReconcileRuntimeInner {
     }
 }
 
-fn handle_reconcile_command(
-    inner: &ReconcileRuntimeInner,
-    command: ReconcileCommand,
-) -> bool {
+fn handle_reconcile_command(inner: &ReconcileRuntimeInner, command: ReconcileCommand) -> bool {
     match command {
         ReconcileCommand::Reconcile { request, reply_tx } => {
             let mut state = match inner.state.lock() {
                 Ok(state) => state,
                 Err(_) => return false,
             };
-            state.worker_state.pending_epoch =
-                state.worker_state.pending_epoch.saturating_add(1);
+            state.worker_state.pending_epoch = state.worker_state.pending_epoch.saturating_add(1);
             let key = ReconcileKey::from_request(&request);
             if let Some(pending) = state.worker_state.pending.get_mut(&key) {
                 pending.request = request;
@@ -1439,7 +1435,8 @@ mod tests {
             .reconcile(first_request)
             .expect("reconcile after eviction");
 
-        let (entry_count, order_count) = runtime.notification_fingerprint_registry_counts_for_test();
+        let (entry_count, order_count) =
+            runtime.notification_fingerprint_registry_counts_for_test();
         assert_eq!(entry_count, MAX_RECONCILE_FINGERPRINT_KEYS);
         assert_eq!(order_count, MAX_RECONCILE_FINGERPRINT_KEYS);
 

--- a/crates/atm-daemon/src/reconcile_runtime.rs
+++ b/crates/atm-daemon/src/reconcile_runtime.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use crate::worker_support::JoinHandleOwner;
 use crate::{DaemonSubsystem, SubsystemObservability};
 
 const DEFAULT_RECONCILE_DEBOUNCE: Duration = Duration::from_millis(25);
@@ -34,8 +35,9 @@ type ReconcileExecutor =
 
 struct ReconcileRuntimeInner {
     // Worker thread, reconcile callers, and shutdown path all access state
-    // concurrently; Mutex+Condvar guards the lifecycle and pending/completed
-    // reconcile registries.
+    // concurrently; Mutex+Condvar still guards lifecycle and pending
+    // coalescing state in Y.21 while the actor command/reply contract is
+    // frozen ahead of the Y.22 production cutover.
     state: Mutex<ReconcileState>,
     wake: Condvar,
     #[cfg(test)]
@@ -43,13 +45,13 @@ struct ReconcileRuntimeInner {
     debounce: Duration,
     executor: ReconcileExecutor,
     observability: SubsystemObservability,
+    worker: Arc<JoinHandleOwner>,
     #[cfg_attr(not(test), allow(dead_code))]
     // Lock ordering invariant: if code ever needs both runtime state and this
     // fingerprint registry, it must drop `state` before locking the registry
-    // mutex. The registry is ancillary reconcile-emission state and must never
-    // nest inside the primary runtime lifecycle lock.
-    // Mutex required because reconcile worker and callers both mutate
-    // fingerprint dedupe state across requests and shutdown.
+    // mutex. The registry remains an ancillary side registry in Y.21 and must
+    // never nest inside the primary runtime lifecycle lock. Y.22 owns the
+    // final move into worker-owned reconcile state.
     notification_fingerprints: Arc<Mutex<NotificationFingerprintRegistry>>,
 }
 
@@ -57,50 +59,40 @@ struct ReconcileRuntimeInner {
 struct ReconcileState {
     started: bool,
     shutdown: bool,
-    worker: Option<JoinHandle<()>>,
-    next_waiter_id: u64,
-    pending_epoch: u64,
-    pending: HashMap<ReconcileKey, PendingReconcile>,
-    pending_order: VecDeque<ReconcileKey>,
-    active_waiters: HashSet<u64>,
-    completed: HashMap<u64, ReconcileOutcome>,
+    worker_state: ReconcileWorkerState,
 }
 
 impl ReconcileState {
-    fn release_waiter(&mut self, waiter_id: u64) {
-        self.active_waiters.remove(&waiter_id);
-        self.completed.remove(&waiter_id);
-        for pending in self.pending.values_mut() {
-            pending.waiters.retain(|candidate| *candidate != waiter_id);
-        }
-        self.pending
-            .retain(|_, pending| !pending.waiters.is_empty());
-        self.pending_order
-            .retain(|key| self.pending.contains_key(key));
-    }
-
     #[cfg(test)]
     fn counts(&self) -> (usize, usize, usize) {
         (
-            self.pending.len(),
-            self.pending_order.len(),
-            self.completed.len(),
+            self.worker_state.pending.len(),
+            self.worker_state.pending_order.len(),
+            0,
         )
     }
 
-    #[cfg(test)]
     fn waiter_count(&self) -> usize {
-        self.pending
+        self.worker_state
+            .pending
             .values()
-            .map(|pending| pending.waiters.len())
+            .map(|pending| pending.replies.len())
             .sum()
     }
 }
 
-#[derive(Clone)]
-enum ReconcileOutcome {
-    Success(ReconcileResult),
-    Failure(ReconcileFailureSnapshot),
+#[derive(Default)]
+struct ReconcileWorkerState {
+    pending_epoch: u64,
+    pending: HashMap<ReconcileKey, PendingReconcile>,
+    pending_order: VecDeque<ReconcileKey>,
+}
+
+pub(crate) enum ReconcileCommand {
+    Reconcile {
+        request: ReconcileRequest,
+        reply_tx: mpsc::SyncSender<Result<ReconcileResult, AtmError>>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -112,7 +104,35 @@ struct ReconcileKey {
 
 struct PendingReconcile {
     request: ReconcileRequest,
-    waiters: Vec<u64>,
+    replies: Vec<mpsc::SyncSender<Result<ReconcileResult, AtmError>>>,
+}
+
+#[derive(Clone)]
+struct ReconcileReplyErrorSnapshot {
+    code: atm_core::error_codes::AtmErrorCode,
+    message: String,
+    recovery: Option<String>,
+}
+
+impl From<&AtmError> for ReconcileReplyErrorSnapshot {
+    fn from(error: &AtmError) -> Self {
+        Self {
+            code: error.code,
+            message: error.message.clone(),
+            recovery: error.recovery.clone(),
+        }
+    }
+}
+
+impl ReconcileReplyErrorSnapshot {
+    fn into_error(self) -> AtmError {
+        ProtocolErrorEnvelope {
+            code: self.code,
+            message: self.message,
+            recovery: self.recovery,
+        }
+        .into_atm_error()
+    }
 }
 
 #[derive(Default)]
@@ -122,34 +142,6 @@ struct NotificationFingerprintRegistry {
     // genuinely new fingerprint appears.
     entries: HashMap<ReconcileKey, HashSet<String>>,
     order: VecDeque<ReconcileKey>,
-}
-
-#[derive(Clone)]
-struct ReconcileFailureSnapshot {
-    code: atm_core::error_codes::AtmErrorCode,
-    message: String,
-    recovery: Option<String>,
-}
-
-impl From<AtmError> for ReconcileFailureSnapshot {
-    fn from(error: AtmError) -> Self {
-        Self {
-            code: error.code,
-            message: error.message,
-            recovery: error.recovery,
-        }
-    }
-}
-
-impl ReconcileFailureSnapshot {
-    fn to_error(&self) -> AtmError {
-        ProtocolErrorEnvelope {
-            code: self.code,
-            message: self.message.clone(),
-            recovery: self.recovery.clone(),
-        }
-        .into_atm_error()
-    }
 }
 
 impl ReconcileKey {
@@ -246,6 +238,7 @@ impl ReconcileRuntime {
                 debounce,
                 executor,
                 observability,
+                worker: Arc::new(JoinHandleOwner::default()),
                 notification_fingerprints,
             }),
         }
@@ -289,7 +282,9 @@ impl ReconcileRuntime {
                 );
             }
         };
-        state.worker = Some(handle);
+        self.inner.worker.install(handle).inspect_err(|_| {
+            state.shutdown = true;
+        })?;
         self.inner
             .observability
             .emit_or_warn("start", "ok", "reconcile runtime worker started");
@@ -304,8 +299,9 @@ impl ReconcileRuntime {
                 )
             })?;
             state.shutdown = true;
+            state.worker_state = ReconcileWorkerState::default();
             self.inner.wake.notify_all();
-            state.worker.take()
+            self.inner.worker.take()?
         };
         if let Some(handle) = handle {
             let worker_thread_id = handle.thread().id();
@@ -394,44 +390,51 @@ impl ReconcileRuntime {
     pub(crate) fn reconcile(&self, request: ReconcileRequest) -> Result<ReconcileResult, AtmError> {
         let request_team = request.team.clone();
         let request_agent = request.agent.clone();
-        let waiter_id = self.enqueue_reconcile_request(&request, &request_team, &request_agent)?;
-        self.wait_for_reconcile_result(waiter_id, &request_team, &request_agent)
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        self.enqueue_reconcile_command(
+            ReconcileCommand::Reconcile { request, reply_tx },
+            &request_team,
+            &request_agent,
+        )?;
+        self.wait_for_reconcile_result(reply_rx, &request_team, &request_agent)
     }
 
-    fn enqueue_reconcile_request(
+    fn enqueue_reconcile_command(
         &self,
-        request: &ReconcileRequest,
+        command: ReconcileCommand,
         request_team: &atm_core::types::TeamName,
         request_agent: &atm_core::types::AgentName,
-    ) -> Result<u64, AtmError> {
+    ) -> Result<(), AtmError> {
         let mut state = self.inner.state.lock().map_err(|_| {
             AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
                 "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
             )
         })?;
         self.validate_reconcile_runtime_state(&state, request_team, request_agent)?;
-        let waiter_id = state.next_waiter_id;
-        state.next_waiter_id += 1;
-        state.active_waiters.insert(waiter_id);
-        state.pending_epoch = state.pending_epoch.saturating_add(1);
-        let key = ReconcileKey::from_request(request);
-        if let Some(pending) = state.pending.get_mut(&key) {
-            pending.request = request.clone();
-            pending.waiters.push(waiter_id);
-        } else {
-            state.pending_order.push_back(key.clone());
-            state.pending.insert(
-                key,
-                PendingReconcile {
-                    request: request.clone(),
-                    waiters: vec![waiter_id],
-                },
-            );
+        match command {
+            ReconcileCommand::Reconcile { request, reply_tx } => {
+                state.worker_state.pending_epoch =
+                    state.worker_state.pending_epoch.saturating_add(1);
+                let key = ReconcileKey::from_request(&request);
+                if let Some(pending) = state.worker_state.pending.get_mut(&key) {
+                    pending.request = request;
+                    pending.replies.push(reply_tx);
+                } else {
+                    state.worker_state.pending_order.push_back(key.clone());
+                    state.worker_state.pending.insert(
+                        key,
+                        PendingReconcile {
+                            request,
+                            replies: vec![reply_tx],
+                        },
+                    );
+                }
+            }
         }
         self.inner.wake.notify_one();
         #[cfg(test)]
         self.inner.pending_changed.notify_all();
-        Ok(waiter_id)
+        Ok(())
     }
 
     fn validate_reconcile_runtime_state(
@@ -456,7 +459,7 @@ impl ReconcileRuntime {
                 request_agent,
             ));
         }
-        if state.active_waiters.len() >= MAX_RECONCILE_WAITERS {
+        if state.waiter_count() >= MAX_RECONCILE_WAITERS {
             return Err(self
                 .reconcile_unavailable_error(
                     "rejected",
@@ -473,52 +476,24 @@ impl ReconcileRuntime {
 
     fn wait_for_reconcile_result(
         &self,
-        waiter_id: u64,
+        reply_rx: mpsc::Receiver<Result<ReconcileResult, AtmError>>,
         request_team: &atm_core::types::TeamName,
         request_agent: &atm_core::types::AgentName,
     ) -> Result<ReconcileResult, AtmError> {
-        let mut state = self.inner.state.lock().map_err(|_| {
-            AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
-                "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
-            )
-        })?;
-        loop {
-            if state.shutdown {
-                state.release_waiter(waiter_id);
-                return Err(self.reconcile_unavailable_error(
-                    "degraded",
-                    "reconcile runtime shut down before completion",
-                    request_team,
-                    request_agent,
-                ));
-            }
-            if let Some(outcome) = state.completed.remove(&waiter_id) {
-                state.active_waiters.remove(&waiter_id);
-                return match outcome {
-                    ReconcileOutcome::Success(result) => Ok(result),
-                    ReconcileOutcome::Failure(failure) => Err(failure.to_error()),
-                };
-            }
-            let wait = self
-                .inner
-                .wake
-                .wait_timeout(state, DEFAULT_RECONCILE_COMPLETION_TIMEOUT)
-                .map_err(|_| {
-                    AtmError::daemon_unavailable("reconcile runtime state lock poisoned")
-                        .with_recovery(
-                            "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
-                        )
-                })?;
-            state = wait.0;
-            if wait.1.timed_out() {
-                state.release_waiter(waiter_id);
-                return Err(self.reconcile_unavailable_error(
-                    "degraded",
-                    "reconcile runtime timed out waiting for background completion",
-                    request_team,
-                    request_agent,
-                ));
-            }
+        match reply_rx.recv_timeout(DEFAULT_RECONCILE_COMPLETION_TIMEOUT) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(self.reconcile_unavailable_error(
+                "degraded",
+                "reconcile runtime timed out waiting for background completion",
+                request_team,
+                request_agent,
+            )),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(self.reconcile_unavailable_error(
+                "degraded",
+                "reconcile runtime shut down before completion",
+                request_team,
+                request_agent,
+            )),
         }
     }
 
@@ -564,7 +539,7 @@ impl ReconcileRuntime {
     ) -> bool {
         let deadline = std::time::Instant::now() + timeout;
         let mut state = self.inner.state.lock().expect("state lock");
-        while state.pending.len() < minimum_pending {
+        while state.worker_state.pending.len() < minimum_pending {
             let now = std::time::Instant::now();
             if now >= deadline {
                 return false;
@@ -576,7 +551,7 @@ impl ReconcileRuntime {
                 .expect("pending change wait");
             state = wait.0;
             if wait.1.timed_out() {
-                return state.pending.len() >= minimum_pending;
+                return state.worker_state.pending.len() >= minimum_pending;
             }
         }
         true
@@ -613,6 +588,7 @@ impl ReconcileRuntime {
         let deadline = std::time::Instant::now() + timeout;
         let mut state = self.inner.state.lock().expect("state lock");
         while !state
+            .worker_state
             .pending
             .values()
             .any(|pending| pending.request.agent.as_str() == agent)
@@ -629,6 +605,7 @@ impl ReconcileRuntime {
             state = wait.0;
             if wait.1.timed_out() {
                 return state
+                    .worker_state
                     .pending
                     .values()
                     .any(|pending| pending.request.agent.as_str() == agent);
@@ -722,7 +699,7 @@ fn reconcile_worker_loop(inner: Arc<ReconcileRuntimeInner>) {
 
         for pending_request in pending {
             let outcome = match (inner.executor)(&pending_request.request) {
-                Ok(result) => ReconcileOutcome::Success(result),
+                Ok(result) => Ok(result),
                 Err(error) => {
                     tracing::warn!(
                         subsystem = "reconcile",
@@ -733,7 +710,7 @@ fn reconcile_worker_loop(inner: Arc<ReconcileRuntimeInner>) {
                         %error,
                         "reconcile runtime executor failed"
                     );
-                    ReconcileOutcome::Failure(error.into())
+                    Err(error)
                 }
             };
             if record_reconcile_outcome(inner.as_ref(), pending_request, outcome).is_none() {
@@ -782,7 +759,7 @@ fn wait_for_reconcile_join(
 
 fn take_pending_reconcile_batch(inner: &ReconcileRuntimeInner) -> Option<Vec<PendingReconcile>> {
     let mut state = inner.state.lock().ok()?;
-    while state.pending.is_empty() && !state.shutdown {
+    while state.worker_state.pending.is_empty() && !state.shutdown {
         let wait = inner
             .wake
             .wait_timeout(state, DEFAULT_RECONCILE_IDLE_INTERVAL)
@@ -799,7 +776,7 @@ fn debounce_pending_reconcile_batch(
     inner: &ReconcileRuntimeInner,
     mut state: std::sync::MutexGuard<'_, ReconcileState>,
 ) -> Option<Vec<PendingReconcile>> {
-    let mut debounce_epoch = state.pending_epoch;
+    let mut debounce_epoch = state.worker_state.pending_epoch;
     let mut debounce_extensions = 0u32;
     loop {
         let wait = inner.wake.wait_timeout(state, inner.debounce).ok()?;
@@ -807,8 +784,8 @@ fn debounce_pending_reconcile_batch(
         if state.shutdown {
             return None;
         }
-        if state.pending_epoch != debounce_epoch {
-            debounce_epoch = state.pending_epoch;
+        if state.worker_state.pending_epoch != debounce_epoch {
+            debounce_epoch = state.worker_state.pending_epoch;
             debounce_extensions = debounce_extensions.saturating_add(1);
             if debounce_extensions >= MAX_RECONCILE_DEBOUNCE_EXTENSIONS {
                 break;
@@ -826,10 +803,10 @@ fn debounce_pending_reconcile_batch(
 }
 
 fn drain_pending_reconcile_batch(state: &mut ReconcileState) -> Vec<PendingReconcile> {
-    let pending_order = std::mem::take(&mut state.pending_order);
+    let pending_order = std::mem::take(&mut state.worker_state.pending_order);
     let mut drained = Vec::with_capacity(pending_order.len());
     for key in pending_order {
-        if let Some(pending) = state.pending.remove(&key) {
+        if let Some(pending) = state.worker_state.pending.remove(&key) {
             drained.push(pending);
         }
     }
@@ -837,25 +814,30 @@ fn drain_pending_reconcile_batch(state: &mut ReconcileState) -> Vec<PendingRecon
 }
 
 fn record_reconcile_outcome(
-    inner: &ReconcileRuntimeInner,
+    _inner: &ReconcileRuntimeInner,
     pending_request: PendingReconcile,
-    outcome: ReconcileOutcome,
+    outcome: Result<ReconcileResult, AtmError>,
 ) -> Option<()> {
-    let mut state = inner.state.lock().ok()?;
-    for waiter in pending_request.waiters {
-        if state.active_waiters.contains(&waiter) {
-            state.completed.insert(waiter, outcome.clone());
-        }
+    for reply in pending_request.replies {
+        let _ = reply.send(clone_reconcile_outcome(&outcome));
     }
-    inner.wake.notify_all();
     Some(())
+}
+
+fn clone_reconcile_outcome(
+    outcome: &Result<ReconcileResult, AtmError>,
+) -> Result<ReconcileResult, AtmError> {
+    match outcome {
+        Ok(result) => Ok(result.clone()),
+        Err(error) => Err(ReconcileReplyErrorSnapshot::from(error).into_error()),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_RECONCILE_FINGERPRINT_KEYS, MAX_RECONCILE_FINGERPRINTS_PER_KEY, ReconcileKey,
-        ReconcileRuntime,
+        MAX_RECONCILE_DEBOUNCE_EXTENSIONS, MAX_RECONCILE_FINGERPRINT_KEYS,
+        MAX_RECONCILE_FINGERPRINTS_PER_KEY, ReconcileKey, ReconcileRuntime,
     };
     use atm_core::boundary::{
         self, InboxIngress, InboxIngressDiagnosticsRequest, InboxIngressDiagnosticsResponse,
@@ -899,7 +881,7 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_runtime_coalesces_duplicate_requests() {
+    fn reconcile_runtime_actor_coalesces_identical_requests_into_one_worker_run() {
         let calls = Arc::new(Mutex::new(0usize));
         let runtime = ReconcileRuntime::new_for_test(
             Arc::new({
@@ -937,6 +919,100 @@ mod tests {
         assert_eq!(first.join().expect("join").observed_paths, 2);
         assert_eq!(second.join().expect("join").imported_sources, 1);
         assert_eq!(*calls.lock().expect("calls"), 1);
+        runtime.shutdown().expect("shutdown");
+    }
+
+    #[test]
+    fn reconcile_runtime_actor_fans_one_result_to_all_waiters_for_a_key() {
+        let calls = Arc::new(Mutex::new(0usize));
+        let runtime = ReconcileRuntime::new_for_test(
+            Arc::new({
+                let calls = Arc::clone(&calls);
+                move |_| {
+                    *calls.lock().expect("calls") += 1;
+                    Ok(ReconcileResult {
+                        observed_paths: 7,
+                        imported_sources: 3,
+                    })
+                }
+            }),
+            Duration::from_millis(200),
+        );
+        runtime.start().expect("start");
+
+        let request = request();
+        let runtime_a = runtime.clone();
+        let runtime_b = runtime.clone();
+        let request_a = request.clone();
+        let request_b = request;
+        let first = std::thread::spawn(move || runtime_a.reconcile(request_a).expect("first"));
+        assert!(
+            runtime.wait_for_pending_count_for_test(1, Duration::from_secs(1)),
+            "first reconcile request never entered the pending queue"
+        );
+        let second = std::thread::spawn(move || runtime_b.reconcile(request_b).expect("second"));
+        assert!(
+            runtime.wait_for_pending_waiter_count_for_test(2, Duration::from_secs(1)),
+            "duplicate reconcile requests never shared one worker-owned pending reply fanout"
+        );
+
+        let first_result = first.join().expect("join");
+        let second_result = second.join().expect("join");
+        assert_eq!(first_result, second_result);
+        assert_eq!(first_result.observed_paths, 7);
+        assert_eq!(first_result.imported_sources, 3);
+        assert_eq!(*calls.lock().expect("calls"), 1);
+        runtime.shutdown().expect("shutdown");
+    }
+
+    #[test]
+    fn reconcile_runtime_actor_preserves_bounded_debounce_extensions() {
+        let calls = Arc::new(Mutex::new(0usize));
+        let runtime = ReconcileRuntime::new_for_test(
+            Arc::new({
+                let calls = Arc::clone(&calls);
+                move |_| {
+                    *calls.lock().expect("calls") += 1;
+                    Ok(ReconcileResult {
+                        observed_paths: 1,
+                        imported_sources: 1,
+                    })
+                }
+            }),
+            Duration::from_millis(25),
+        );
+        runtime.start().expect("start");
+
+        let request = request();
+        let started = std::time::Instant::now();
+        let mut joins = Vec::new();
+        joins.push({
+            let runtime = runtime.clone();
+            let request = request.clone();
+            std::thread::spawn(move || runtime.reconcile(request).expect("first"))
+        });
+        assert!(
+            runtime.wait_for_pending_count_for_test(1, Duration::from_secs(1)),
+            "first reconcile request never entered the pending queue"
+        );
+        for _ in 0..=MAX_RECONCILE_DEBOUNCE_EXTENSIONS {
+            let runtime = runtime.clone();
+            let request = request.clone();
+            joins.push(std::thread::spawn(move || {
+                runtime.reconcile(request).expect("duplicate")
+            }));
+        }
+
+        for join in joins {
+            let result = join.join().expect("join");
+            assert_eq!(result.observed_paths, 1);
+            assert_eq!(result.imported_sources, 1);
+        }
+        assert_eq!(*calls.lock().expect("calls"), 1);
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "bounded debounce extensions never converged to one worker run"
+        );
         runtime.shutdown().expect("shutdown");
     }
 

--- a/crates/atm-daemon/src/reconcile_runtime.rs
+++ b/crates/atm-daemon/src/reconcile_runtime.rs
@@ -6,7 +6,9 @@ use atm_core::error::AtmError;
 use atm_core::protocol::{NotificationEvent, NotificationKind, ProtocolErrorEnvelope};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
-use std::sync::{Arc, Condvar, Mutex, mpsc};
+#[cfg(test)]
+use std::sync::Condvar;
+use std::sync::{Arc, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -15,7 +17,6 @@ use crate::{DaemonSubsystem, SubsystemObservability};
 
 const DEFAULT_RECONCILE_DEBOUNCE: Duration = Duration::from_millis(25);
 const DEFAULT_RECONCILE_COMPLETION_TIMEOUT: Duration = Duration::from_secs(5);
-const DEFAULT_RECONCILE_IDLE_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_RECONCILE_DEBOUNCE_EXTENSIONS: u32 = 8;
 const MAX_RECONCILE_FINGERPRINT_KEYS: usize = 1024;
 const MAX_RECONCILE_FINGERPRINTS_PER_KEY: usize = 256;
@@ -31,28 +32,24 @@ pub(crate) struct ReconcileRuntime {
 }
 
 type ReconcileExecutor =
-    Arc<dyn Fn(&ReconcileRequest) -> Result<ReconcileResult, AtmError> + Send + Sync>;
+    Arc<
+        dyn Fn(
+                &ReconcileRequest,
+                &mut NotificationFingerprintRegistry,
+            ) -> Result<ReconcileResult, AtmError>
+            + Send
+            + Sync,
+    >;
 
 struct ReconcileRuntimeInner {
-    // Worker thread, reconcile callers, and shutdown path all access state
-    // concurrently; Mutex+Condvar still guards lifecycle and pending
-    // coalescing state in Y.21 while the actor command/reply contract is
-    // frozen ahead of the Y.22 production cutover.
     state: Mutex<ReconcileState>,
-    wake: Condvar,
+    command_tx: Mutex<Option<mpsc::SyncSender<ReconcileCommand>>>,
     #[cfg(test)]
     pending_changed: Condvar,
     debounce: Duration,
     executor: ReconcileExecutor,
     observability: SubsystemObservability,
     worker: Arc<JoinHandleOwner>,
-    #[cfg_attr(not(test), allow(dead_code))]
-    // Lock ordering invariant: if code ever needs both runtime state and this
-    // fingerprint registry, it must drop `state` before locking the registry
-    // mutex. The registry remains an ancillary side registry in Y.21 and must
-    // never nest inside the primary runtime lifecycle lock. Y.22 owns the
-    // final move into worker-owned reconcile state.
-    notification_fingerprints: Arc<Mutex<NotificationFingerprintRegistry>>,
 }
 
 #[derive(Default)]
@@ -86,6 +83,7 @@ struct ReconcileWorkerState {
     pending_epoch: u64,
     pending: HashMap<ReconcileKey, PendingReconcile>,
     pending_order: VecDeque<ReconcileKey>,
+    notification_fingerprints: NotificationFingerprintRegistry,
 }
 
 pub(crate) enum ReconcileCommand {
@@ -93,6 +91,7 @@ pub(crate) enum ReconcileCommand {
         request: ReconcileRequest,
         reply_tx: mpsc::SyncSender<Result<ReconcileResult, AtmError>>,
     },
+    Shutdown,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -136,7 +135,7 @@ impl ReconcileReplyErrorSnapshot {
 }
 
 #[derive(Default)]
-struct NotificationFingerprintRegistry {
+pub(crate) struct NotificationFingerprintRegistry {
     // Each key retains the distinct fingerprint strings already emitted for one
     // reconcile target so duplicate inbox projections do not re-notify until a
     // genuinely new fingerprint appears.
@@ -175,14 +174,8 @@ impl ReconcileRuntime {
         notification_sink: Arc<dyn NotificationSink + Send + Sync>,
         observability: SubsystemObservability,
     ) -> Self {
-        // Fingerprints must survive across executor invocations so duplicate
-        // reconcile cycles can compare the newest inbox projection with the
-        // previous one before deciding whether to emit a notification.
-        let notification_fingerprints =
-            Arc::new(Mutex::new(NotificationFingerprintRegistry::default()));
-        let notification_fingerprints_for_executor = Arc::clone(&notification_fingerprints);
         Self::new_with_executor(
-            Arc::new(move |request| {
+            Arc::new(move |request, notification_fingerprints| {
                 let batch = watch_source.poll(WatchSubscriptionRequest {
                     home_dir: request.home_dir.clone(),
                     team: request.team.clone(),
@@ -199,7 +192,7 @@ impl ReconcileRuntime {
                     request,
                     &import,
                     inbox_ingress.as_ref(),
-                    notification_fingerprints_for_executor.as_ref(),
+                    notification_fingerprints,
                 )? {
                     notification_sink.deliver(NotificationEvent {
                         kind: NotificationKind::ReconcileComplete,
@@ -218,7 +211,6 @@ impl ReconcileRuntime {
                 })
             }),
             DEFAULT_RECONCILE_DEBOUNCE,
-            notification_fingerprints,
             observability,
         )
     }
@@ -226,25 +218,24 @@ impl ReconcileRuntime {
     fn new_with_executor(
         executor: ReconcileExecutor,
         debounce: Duration,
-        notification_fingerprints: Arc<Mutex<NotificationFingerprintRegistry>>,
         observability: SubsystemObservability,
     ) -> Self {
         Self {
             inner: Arc::new(ReconcileRuntimeInner {
                 state: Mutex::new(ReconcileState::default()),
-                wake: Condvar::new(),
+                command_tx: Mutex::new(None),
                 #[cfg(test)]
                 pending_changed: Condvar::new(),
                 debounce,
                 executor,
                 observability,
                 worker: Arc::new(JoinHandleOwner::default()),
-                notification_fingerprints,
             }),
         }
     }
 
     pub(crate) fn start(&self) -> Result<(), AtmError> {
+        let (command_tx, command_rx) = mpsc::sync_channel(MAX_RECONCILE_WAITERS);
         let mut state = self.inner.state.lock().map_err(|_| {
             AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
                 "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
@@ -255,13 +246,16 @@ impl ReconcileRuntime {
         }
         state.started = true;
         state.shutdown = false;
+        state.worker_state = ReconcileWorkerState::default();
         drop(state);
+        self.install_command_tx(command_tx)?;
 
         let inner = Arc::clone(&self.inner);
         let handle = thread::Builder::new()
             .name("atm-daemon-reconcile".to_string())
-            .spawn(move || reconcile_worker_loop(inner))
+            .spawn(move || reconcile_worker_loop(inner, command_rx))
             .map_err(|source| {
+                let _ = self.take_command_tx();
                 self.inner.observability.emit_or_warn(
                     "start",
                     "failed",
@@ -273,6 +267,7 @@ impl ReconcileRuntime {
         let mut state = match self.inner.state.lock() {
             Ok(state) => state,
             Err(_) => {
+                let _ = self.take_command_tx();
                 let _ = handle.join();
                 return Err(
                     AtmError::daemon_unavailable("reconcile runtime state lock poisoned")
@@ -283,6 +278,7 @@ impl ReconcileRuntime {
             }
         };
         self.inner.worker.install(handle).inspect_err(|_| {
+            let _ = self.take_command_tx();
             state.shutdown = true;
         })?;
         self.inner
@@ -292,21 +288,29 @@ impl ReconcileRuntime {
     }
 
     pub(crate) fn shutdown(&self) -> Result<(), AtmError> {
-        let handle = {
+        let command_tx = {
             let mut state = self.inner.state.lock().map_err(|_| {
                 AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
                     "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
                 )
             })?;
             state.shutdown = true;
-            state.worker_state = ReconcileWorkerState::default();
-            self.inner.wake.notify_all();
-            self.inner.worker.take()?
+            self.take_command_tx()?
         };
+        if let Some(command_tx) = command_tx {
+            let _ = command_tx.send(ReconcileCommand::Shutdown);
+        }
+        let handle = self.inner.worker.take()?;
         if let Some(handle) = handle {
             let worker_thread_id = handle.thread().id();
             let (result_rx, join_helper) = spawn_reconcile_join_helper(handle)?;
             self.complete_reconcile_shutdown(result_rx, join_helper, worker_thread_id)?;
+        }
+        if let Ok(mut state) = self.inner.state.lock() {
+            state.started = false;
+            state.worker_state = ReconcileWorkerState::default();
+            #[cfg(test)]
+            self.inner.pending_changed.notify_all();
         }
         Ok(())
     }
@@ -405,36 +409,56 @@ impl ReconcileRuntime {
         request_team: &atm_core::types::TeamName,
         request_agent: &atm_core::types::AgentName,
     ) -> Result<(), AtmError> {
-        let mut state = self.inner.state.lock().map_err(|_| {
-            AtmError::daemon_unavailable("reconcile runtime state lock poisoned").with_recovery(
-                "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
+        let command_tx = {
+            let state = self.inner.state.lock().map_err(|_| {
+                AtmError::daemon_unavailable("reconcile runtime state lock poisoned")
+                    .with_recovery(
+                        "Restart the daemon; reconcile lifecycle state can no longer be trusted.",
+                    )
+            })?;
+            self.validate_reconcile_runtime_state(&state, request_team, request_agent)?;
+            let slot = self.inner.command_tx.lock().map_err(|_| {
+                AtmError::daemon_unavailable("reconcile runtime command sender lock poisoned")
+                    .with_recovery(
+                        "Restart atm-daemon; reconcile command-lane ownership can no longer be trusted.",
+                    )
+            })?;
+            slot.clone().ok_or_else(|| {
+                self.reconcile_unavailable_error(
+                    "rejected",
+                    "reconcile runtime command lane is unavailable",
+                    request_team,
+                    request_agent,
+                )
+            })?
+        };
+        command_tx.send(command).map_err(|_| {
+            self.reconcile_unavailable_error(
+                "degraded",
+                "reconcile runtime command lane is unavailable",
+                request_team,
+                request_agent,
             )
         })?;
-        self.validate_reconcile_runtime_state(&state, request_team, request_agent)?;
-        match command {
-            ReconcileCommand::Reconcile { request, reply_tx } => {
-                state.worker_state.pending_epoch =
-                    state.worker_state.pending_epoch.saturating_add(1);
-                let key = ReconcileKey::from_request(&request);
-                if let Some(pending) = state.worker_state.pending.get_mut(&key) {
-                    pending.request = request;
-                    pending.replies.push(reply_tx);
-                } else {
-                    state.worker_state.pending_order.push_back(key.clone());
-                    state.worker_state.pending.insert(
-                        key,
-                        PendingReconcile {
-                            request,
-                            replies: vec![reply_tx],
-                        },
-                    );
-                }
-            }
-        }
-        self.inner.wake.notify_one();
-        #[cfg(test)]
-        self.inner.pending_changed.notify_all();
         Ok(())
+    }
+
+    fn install_command_tx(
+        &self,
+        command_tx: mpsc::SyncSender<ReconcileCommand>,
+    ) -> Result<(), AtmError> {
+        let mut slot = self.inner.command_tx.lock().map_err(|_| {
+            AtmError::daemon_unavailable("reconcile runtime command sender lock poisoned")
+                .with_recovery(
+                    "Restart atm-daemon; reconcile command-lane ownership can no longer be trusted.",
+                )
+        })?;
+        *slot = Some(command_tx);
+        Ok(())
+    }
+
+    fn take_command_tx(&self) -> Result<Option<mpsc::SyncSender<ReconcileCommand>>, AtmError> {
+        self.inner.take_command_tx()
     }
 
     fn validate_reconcile_runtime_state(
@@ -521,7 +545,6 @@ impl ReconcileRuntime {
         Self::new_with_executor(
             executor,
             debounce,
-            Arc::new(Mutex::new(NotificationFingerprintRegistry::default())),
             SubsystemObservability::disabled(DaemonSubsystem::ReconcileRuntime),
         )
     }
@@ -613,13 +636,37 @@ impl ReconcileRuntime {
         }
         true
     }
+
+    #[cfg(test)]
+    pub(crate) fn notification_fingerprint_registry_counts_for_test(&self) -> (usize, usize) {
+        let state = self.inner.state.lock().expect("state lock");
+        (
+            state.worker_state.notification_fingerprints.entries.len(),
+            state.worker_state.notification_fingerprints.order.len(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn notification_fingerprint_count_for_key_for_test(
+        &self,
+        request: &ReconcileRequest,
+    ) -> usize {
+        let state = self.inner.state.lock().expect("state lock");
+        state
+            .worker_state
+            .notification_fingerprints
+            .entries
+            .get(&ReconcileKey::from_request(request))
+            .expect("entry")
+            .len()
+    }
 }
 
 fn should_emit_reconcile_notification(
     request: &ReconcileRequest,
     import: &atm_core::boundary::InboxIngressImportResponse,
     inbox_ingress: &dyn InboxIngress,
-    notification_fingerprints: &Mutex<NotificationFingerprintRegistry>,
+    notification_fingerprints: &mut NotificationFingerprintRegistry,
 ) -> Result<bool, AtmError> {
     let mut current_fingerprints = HashSet::new();
     for source in &import.source_files {
@@ -658,18 +705,15 @@ fn should_emit_reconcile_notification(
             "reconcile notification fingerprint set exceeded the per-key bounded cap; truncating deterministically"
         );
     }
-    let mut fingerprints = notification_fingerprints.lock().map_err(|_| {
-        AtmError::daemon_unavailable("reconcile notification fingerprint state lock poisoned")
-    })?;
-    let changed = fingerprints
+    let changed = notification_fingerprints
         .entries
         .get(&key)
         .map(|previous| previous != &current_fingerprints)
         .unwrap_or(true);
-    let is_new_key = !fingerprints.entries.contains_key(&key);
-    if is_new_key && fingerprints.entries.len() >= MAX_RECONCILE_FINGERPRINT_KEYS {
-        while let Some(evicted_key) = fingerprints.order.pop_front() {
-            if fingerprints.entries.remove(&evicted_key).is_some() {
+    let is_new_key = !notification_fingerprints.entries.contains_key(&key);
+    if is_new_key && notification_fingerprints.entries.len() >= MAX_RECONCILE_FINGERPRINT_KEYS {
+        while let Some(evicted_key) = notification_fingerprints.order.pop_front() {
+            if notification_fingerprints.entries.remove(&evicted_key).is_some() {
                 tracing::warn!(
                     subsystem = "reconcile",
                     action = "fingerprint_evict",
@@ -684,21 +728,46 @@ fn should_emit_reconcile_notification(
         }
     }
     if is_new_key {
-        fingerprints.order.push_back(key.clone());
+        notification_fingerprints.order.push_back(key.clone());
     }
-    fingerprints.entries.insert(key, current_fingerprints);
+    notification_fingerprints
+        .entries
+        .insert(key, current_fingerprints);
     Ok(changed)
 }
 
-fn reconcile_worker_loop(inner: Arc<ReconcileRuntimeInner>) {
+fn reconcile_worker_loop(
+    inner: Arc<ReconcileRuntimeInner>,
+    command_rx: mpsc::Receiver<ReconcileCommand>,
+) {
     loop {
-        let pending = match take_pending_reconcile_batch(inner.as_ref()) {
-            Some(pending) => pending,
-            None => return,
+        let command = match command_rx.recv() {
+            Ok(command) => command,
+            Err(_) => {
+                clear_pending_reconcile_state(inner.as_ref());
+                return;
+            }
         };
+        if !handle_reconcile_command(inner.as_ref(), command) {
+            clear_pending_reconcile_state(inner.as_ref());
+            return;
+        }
+        if !debounce_reconcile_command_batch(inner.as_ref(), &command_rx) {
+            clear_pending_reconcile_state(inner.as_ref());
+            return;
+        }
+
+        let (pending, mut notification_fingerprints) =
+            match take_pending_reconcile_batch(inner.as_ref()) {
+                Some(pending) => pending,
+                None => return,
+            };
 
         for pending_request in pending {
-            let outcome = match (inner.executor)(&pending_request.request) {
+            let outcome = match (inner.executor)(
+                &pending_request.request,
+                &mut notification_fingerprints,
+            ) {
                 Ok(result) => Ok(result),
                 Err(error) => {
                     tracing::warn!(
@@ -713,9 +782,13 @@ fn reconcile_worker_loop(inner: Arc<ReconcileRuntimeInner>) {
                     Err(error)
                 }
             };
-            if record_reconcile_outcome(inner.as_ref(), pending_request, outcome).is_none() {
+            if record_reconcile_outcome(pending_request, outcome).is_none() {
                 return;
             }
+        }
+
+        if restore_notification_fingerprints(inner.as_ref(), notification_fingerprints).is_none() {
+            return;
         }
     }
 }
@@ -757,49 +830,106 @@ fn wait_for_reconcile_join(
         })
 }
 
-fn take_pending_reconcile_batch(inner: &ReconcileRuntimeInner) -> Option<Vec<PendingReconcile>> {
-    let mut state = inner.state.lock().ok()?;
-    while state.worker_state.pending.is_empty() && !state.shutdown {
-        let wait = inner
-            .wake
-            .wait_timeout(state, DEFAULT_RECONCILE_IDLE_INTERVAL)
-            .ok()?;
-        state = wait.0;
+impl ReconcileRuntimeInner {
+    fn take_command_tx(&self) -> Result<Option<mpsc::SyncSender<ReconcileCommand>>, AtmError> {
+        let mut slot = self.command_tx.lock().map_err(|_| {
+            AtmError::daemon_unavailable("reconcile runtime command sender lock poisoned")
+                .with_recovery(
+                    "Restart atm-daemon; reconcile command-lane ownership can no longer be trusted.",
+                )
+        })?;
+        Ok(slot.take())
     }
-    if state.shutdown {
-        return None;
-    }
-    debounce_pending_reconcile_batch(inner, state)
 }
 
-fn debounce_pending_reconcile_batch(
+fn handle_reconcile_command(
     inner: &ReconcileRuntimeInner,
-    mut state: std::sync::MutexGuard<'_, ReconcileState>,
-) -> Option<Vec<PendingReconcile>> {
-    let mut debounce_epoch = state.worker_state.pending_epoch;
+    command: ReconcileCommand,
+) -> bool {
+    match command {
+        ReconcileCommand::Reconcile { request, reply_tx } => {
+            let mut state = match inner.state.lock() {
+                Ok(state) => state,
+                Err(_) => return false,
+            };
+            state.worker_state.pending_epoch =
+                state.worker_state.pending_epoch.saturating_add(1);
+            let key = ReconcileKey::from_request(&request);
+            if let Some(pending) = state.worker_state.pending.get_mut(&key) {
+                pending.request = request;
+                pending.replies.push(reply_tx);
+            } else {
+                state.worker_state.pending_order.push_back(key.clone());
+                state.worker_state.pending.insert(
+                    key,
+                    PendingReconcile {
+                        request,
+                        replies: vec![reply_tx],
+                    },
+                );
+            }
+            #[cfg(test)]
+            inner.pending_changed.notify_all();
+            true
+        }
+        ReconcileCommand::Shutdown => false,
+    }
+}
+
+fn debounce_reconcile_command_batch(
+    inner: &ReconcileRuntimeInner,
+    command_rx: &mpsc::Receiver<ReconcileCommand>,
+) -> bool {
     let mut debounce_extensions = 0u32;
     loop {
-        let wait = inner.wake.wait_timeout(state, inner.debounce).ok()?;
-        state = wait.0;
-        if state.shutdown {
-            return None;
-        }
-        if state.worker_state.pending_epoch != debounce_epoch {
-            debounce_epoch = state.worker_state.pending_epoch;
-            debounce_extensions = debounce_extensions.saturating_add(1);
-            if debounce_extensions >= MAX_RECONCILE_DEBOUNCE_EXTENSIONS {
-                break;
+        match command_rx.recv_timeout(inner.debounce) {
+            Ok(command) => {
+                if !handle_reconcile_command(inner, command) {
+                    return false;
+                }
+                debounce_extensions = debounce_extensions.saturating_add(1);
+                if debounce_extensions >= MAX_RECONCILE_DEBOUNCE_EXTENSIONS {
+                    while let Ok(command) = command_rx.try_recv() {
+                        if !handle_reconcile_command(inner, command) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
             }
-            continue;
-        }
-        if wait.1.timed_out() {
-            break;
+            Err(mpsc::RecvTimeoutError::Timeout) => return true,
+            Err(mpsc::RecvTimeoutError::Disconnected) => return false,
         }
     }
+}
+
+fn clear_pending_reconcile_state(inner: &ReconcileRuntimeInner) {
+    if let Ok(mut state) = inner.state.lock() {
+        state.worker_state = ReconcileWorkerState::default();
+        #[cfg(test)]
+        inner.pending_changed.notify_all();
+    }
+}
+
+fn take_pending_reconcile_batch(
+    inner: &ReconcileRuntimeInner,
+) -> Option<(Vec<PendingReconcile>, NotificationFingerprintRegistry)> {
+    let mut state = inner.state.lock().ok()?;
     let drained = drain_pending_reconcile_batch(&mut state);
+    let notification_fingerprints =
+        std::mem::take(&mut state.worker_state.notification_fingerprints);
     #[cfg(test)]
     inner.pending_changed.notify_all();
-    Some(drained)
+    Some((drained, notification_fingerprints))
+}
+
+fn restore_notification_fingerprints(
+    inner: &ReconcileRuntimeInner,
+    notification_fingerprints: NotificationFingerprintRegistry,
+) -> Option<()> {
+    let mut state = inner.state.lock().ok()?;
+    state.worker_state.notification_fingerprints = notification_fingerprints;
+    Some(())
 }
 
 fn drain_pending_reconcile_batch(state: &mut ReconcileState) -> Vec<PendingReconcile> {
@@ -814,7 +944,6 @@ fn drain_pending_reconcile_batch(state: &mut ReconcileState) -> Vec<PendingRecon
 }
 
 fn record_reconcile_outcome(
-    _inner: &ReconcileRuntimeInner,
     pending_request: PendingReconcile,
     outcome: Result<ReconcileResult, AtmError>,
 ) -> Option<()> {
@@ -837,7 +966,7 @@ fn clone_reconcile_outcome(
 mod tests {
     use super::{
         MAX_RECONCILE_DEBOUNCE_EXTENSIONS, MAX_RECONCILE_FINGERPRINT_KEYS,
-        MAX_RECONCILE_FINGERPRINTS_PER_KEY, ReconcileKey, ReconcileRuntime,
+        MAX_RECONCILE_FINGERPRINTS_PER_KEY, ReconcileRuntime,
     };
     use atm_core::boundary::{
         self, InboxIngress, InboxIngressDiagnosticsRequest, InboxIngressDiagnosticsResponse,
@@ -886,7 +1015,7 @@ mod tests {
         let runtime = ReconcileRuntime::new_for_test(
             Arc::new({
                 let calls = Arc::clone(&calls);
-                move |_| {
+                move |_, _| {
                     *calls.lock().expect("calls") += 1;
                     Ok(ReconcileResult {
                         observed_paths: 2,
@@ -928,7 +1057,7 @@ mod tests {
         let runtime = ReconcileRuntime::new_for_test(
             Arc::new({
                 let calls = Arc::clone(&calls);
-                move |_| {
+                move |_, _| {
                     *calls.lock().expect("calls") += 1;
                     Ok(ReconcileResult {
                         observed_paths: 7,
@@ -971,7 +1100,7 @@ mod tests {
         let runtime = ReconcileRuntime::new_for_test(
             Arc::new({
                 let calls = Arc::clone(&calls);
-                move |_| {
+                move |_, _| {
                     *calls.lock().expect("calls") += 1;
                     Ok(ReconcileResult {
                         observed_paths: 1,
@@ -1019,7 +1148,7 @@ mod tests {
     #[test]
     fn reconcile_runtime_cleans_up_pending_waiters_during_shutdown() {
         let runtime = ReconcileRuntime::new_for_test(
-            Arc::new(|_| {
+            Arc::new(|_, _| {
                 Ok(ReconcileResult {
                     observed_paths: 1,
                     imported_sources: 1,
@@ -1048,7 +1177,7 @@ mod tests {
     #[test]
     fn reconcile_runtime_returns_executor_failures() {
         let runtime = ReconcileRuntime::new_for_test(
-            Arc::new(|_| {
+            Arc::new(|_, _| {
                 Err(atm_core::error::AtmError::daemon_unavailable(
                     "reconcile failed",
                 ))
@@ -1071,7 +1200,7 @@ mod tests {
                 let order = Arc::clone(&order);
                 let started_tx = started_tx.clone();
                 let release = Arc::clone(&release);
-                move |request| {
+                move |request, _| {
                     order
                         .lock()
                         .expect("order")
@@ -1310,14 +1439,9 @@ mod tests {
             .reconcile(first_request)
             .expect("reconcile after eviction");
 
-        let fingerprints = runtime
-            .inner
-            .notification_fingerprints
-            .lock()
-            .expect("fingerprints");
-        assert_eq!(fingerprints.entries.len(), MAX_RECONCILE_FINGERPRINT_KEYS);
-        assert_eq!(fingerprints.order.len(), MAX_RECONCILE_FINGERPRINT_KEYS);
-        drop(fingerprints);
+        let (entry_count, order_count) = runtime.notification_fingerprint_registry_counts_for_test();
+        assert_eq!(entry_count, MAX_RECONCILE_FINGERPRINT_KEYS);
+        assert_eq!(order_count, MAX_RECONCILE_FINGERPRINT_KEYS);
 
         let delivered = delivered.lock().expect("delivered");
         assert_eq!(delivered.len(), MAX_RECONCILE_FINGERPRINT_KEYS + 2);
@@ -1344,20 +1468,10 @@ mod tests {
         let request = request();
         runtime.reconcile(request.clone()).expect("reconcile");
 
-        let fingerprints = runtime
-            .inner
-            .notification_fingerprints
-            .lock()
-            .expect("fingerprints");
         assert_eq!(
-            fingerprints
-                .entries
-                .get(&ReconcileKey::from_request(&request))
-                .expect("entry")
-                .len(),
+            runtime.notification_fingerprint_count_for_key_for_test(&request),
             MAX_RECONCILE_FINGERPRINTS_PER_KEY
         );
-        drop(fingerprints);
 
         runtime.shutdown().expect("shutdown");
     }
@@ -1369,7 +1483,7 @@ mod tests {
         let runtime = ReconcileRuntime::new_for_test(
             Arc::new({
                 let release = Arc::clone(&release);
-                move |_| {
+                move |_, _| {
                     started_tx.send(()).expect("started");
                     let (released, wake) = &*release;
                     let mut released = released.lock().expect("released");

--- a/crates/atm-daemon/src/worker_support.rs
+++ b/crates/atm-daemon/src/worker_support.rs
@@ -4,6 +4,9 @@ use std::thread::JoinHandle;
 
 #[derive(Debug, Default)]
 pub(crate) struct JoinHandleOwner {
+    // Narrow RBP-006 exception: this mutex owns only the install-once /
+    // take-once handoff for one worker JoinHandle and must not expand into
+    // general runtime coordination or request-state ownership.
     join_handle: Mutex<Option<JoinHandle<()>>>,
 }
 

--- a/docs/adr/ADR-015-daemon-runtime-snapshot-and-worker-ownership.md
+++ b/docs/adr/ADR-015-daemon-runtime-snapshot-and-worker-ownership.md
@@ -112,7 +112,8 @@ reader/writer lock tuning.
   - `NotificationRuntime` -> bounded command channel + immutable runtime-status
     publication + worker-owned persistence state
 - `Y.21`:
-  - `ReconcileRuntime` actor contract and reply-path foundation
+  - `ReconcileRuntime` actor contract and reply-path foundation, including
+    shared `JoinHandleOwner` reuse and per-request reply fanout
 - `Y.22`:
   - `ReconcileRuntime` actor cutover and deletion of the shared-state runtime
     path

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -143,6 +143,10 @@ Current retained ATM surfaces outside the daemon request/response packet family:
 - daemon worker lanes with active queue/debounce/completion state must use one
   worker-owned command-channel or actor ownership model rather than exposing
   shared mutable coordination locks to callers
+  - `Y.21` freezes the reconcile lane on the command-in / reply-out actor
+    contract and shared `JoinHandleOwner` lifecycle helper
+  - `Y.22` owns deletion of the remaining production shared-state reconcile
+    runtime path
 - `atm-daemon` owns runtime implementations of one shared ATM protocol with
   multiple transport implementations:
   - cross-platform local IPC for same-host daemon access

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -662,7 +662,7 @@ Required caps:
 - live status-cache cap: `4096` entries
 - reconcile notification fingerprint registry cap: `1024` keys
 - watch subscription cap: `256` active subscriptions
-- notification work queue depth: `256`
+- notification work queue depth: `64`
 
 Required saturation behavior:
 - connection cap exceeded: reject new accepts with a typed over-capacity error
@@ -806,4 +806,4 @@ Initial use cases:
 - remote daemon-to-daemon protocol structure
 - runtime watch/reconcile orchestration
 - queued notifier/runtime delivery structure
-  - bounded at `256` in-memory events with typed backpressure on overflow
+  - bounded at `64` in-memory events with typed backpressure on overflow

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -262,6 +262,9 @@ Notes:
 - Phase `Ye` target design is one worker-owned actor lane with bounded command
   input plus per-request reply routing; pending/completed/debounce state must
   not remain daemon-shared mutex state at closure.
+- `Y.21` closes the command/reply contract, reply fanout, and shared
+  `JoinHandleOwner` lifecycle helper; `Y.22` closes deletion of the remaining
+  production shared-state runtime path and final fingerprint-registry cutover.
 - Runtime lifecycle ownership stays above this boundary:
   - `start()` and `shutdown()` are composition-root responsibilities
   - callers outside `RuntimeComposition` must use

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -122,6 +122,10 @@ Initial crate requirement IDs:
   `NotificationRuntime` closes this rule in `Y.20` by using one bounded
   `sync_channel` handoff, immutable runtime-status publication, and a
   worker-owned persistence/drain lane.
+  `ReconcileRuntime` closes the contract/fanout half of this rule in `Y.21`
+  by freezing the command-in / reply-out actor contract and shared
+  `JoinHandleOwner` lifecycle helper ahead of the final `Y.22` production
+  cutover.
 - `REQ-DAEMON-TRANSPORT-001` `atm-daemon` owns one protocol with two
   production transport implementations plus one test transport:
   - one cross-platform local IPC contract for same-host

--- a/docs/phase-Ye/sprint-Y21.md
+++ b/docs/phase-Ye/sprint-Y21.md
@@ -1,7 +1,7 @@
 ---
 id: Y.21
 title: Reconcile Runtime Actor Foundation
-status: planned
+status: complete
 branch: feature/pYe-s21-reconcile-runtime-actor-foundation
 worktree: ../atm-core-worktrees/feature/pYe-s21-reconcile-runtime-actor-foundation
 target: integrate/phase-Y
@@ -59,7 +59,6 @@ ADR-015 ownership in this sprint:
 
 - `crates/atm-daemon/src/worker_support.rs`
 - `crates/atm-daemon/src/reconcile_runtime.rs`
-- `crates/atm-daemon/src/composition.rs`
 - `docs/adr/ADR-015-daemon-runtime-snapshot-and-worker-ownership.md`
 - `docs/atm-daemon/requirements.md`
 - `docs/atm-daemon/architecture.md`
@@ -136,6 +135,8 @@ impl ReconcileRuntime {
   types
 - debounce, coalescing, and reply fanout are modeled as worker-owned state
   rather than daemon-shared lock state
+- `JoinHandleOwner` is reused from `crates/atm-daemon/src/worker_support.rs`
+  rather than redefined inside the reconcile lane
 - daemon requirements and architecture docs explicitly state that reconcile is
   a worker-owned actor boundary
 - `ADR-015` is updated to name reconcile as an actor/channel lane


### PR DESCRIPTION
## Sprint Y.21 — Reconcile Runtime Actor Foundation

Freezes the reconcile actor command/reply contract; moves authoritative reconcile ownership to worker-owned actor state without claiming final shared-state cutover.

## Deliverables
- ReconcileCommand + ReconcileWorkerState defined with explicit types
- Debounce, coalescing, and reply fanout modeled as worker-owned state
- JoinHandleOwner reused from worker_support.rs (NOT redefined in reconcile_runtime.rs)
- ADR-015 updated to name reconcile as actor/channel lane
- Daemon requirements and architecture docs updated
- Sprint Y.21 acceptance tests passing

## Acceptance Tests
- `reconcile_runtime_actor_coalesces_identical_requests_into_one_worker_run`
- `reconcile_runtime_actor_fans_one_result_to_all_waiters_for_a_key`
- `reconcile_runtime_actor_preserves_bounded_debounce_extensions`

**Sprint doc**: docs/phase-Ye/sprint-Y21.md
**Commit**: f9d8d0cc

🤖 Generated with [Claude Code](https://claude.com/claude-code)