### PR TITLE
Z.1 Smoke Bring-Up — daemon + SQLite mail-SSOT smoke pass

### DIFF
--- a/docs/phase-Z/readiness.md
+++ b/docs/phase-Z/readiness.md
@@ -42,7 +42,7 @@ The final release verdict must remain `PENDING` until:
 
 | Sprint | Accepted Commit | Verdict | Current Status | Notes |
 | --- | --- | --- | --- | --- |
-| Z.1 | `PENDING` | `PENDING` | `not started` | smoke checklist and findings ledger not yet frozen |
+| Z.1 | `PENDING` | `FAIL` | `complete` | smoke checklist frozen; two blocking findings promoted to `Z.2` |
 | Z.2 | `PENDING` | `PENDING` | `not started` | awaits `Z.1` closure |
 | Z.3 | `PENDING` | `PENDING` | `not started` | awaits `Z.2` closure |
 | Z.4 | `PENDING` | `PENDING` | `not started` | awaits `Z.3` closure |

--- a/docs/phase-Z/readiness.md
+++ b/docs/phase-Z/readiness.md
@@ -42,7 +42,7 @@ The final release verdict must remain `PENDING` until:
 
 | Sprint | Accepted Commit | Verdict | Current Status | Notes |
 | --- | --- | --- | --- | --- |
-| Z.1 | `PENDING` | `FAIL` | `complete` | smoke checklist frozen; two blocking findings promoted to `Z.2` |
+| Z.1 | `0ed9031a` | `FAIL` | `complete` | smoke checklist frozen; two blocking findings promoted to `Z.2` |
 | Z.2 | `PENDING` | `PENDING` | `not started` | awaits `Z.1` closure |
 | Z.3 | `PENDING` | `PENDING` | `not started` | awaits `Z.2` closure |
 | Z.4 | `PENDING` | `PENDING` | `not started` | awaits `Z.3` closure |

--- a/docs/phase-Z/readiness.md
+++ b/docs/phase-Z/readiness.md
@@ -42,7 +42,7 @@ The final release verdict must remain `PENDING` until:
 
 | Sprint | Accepted Commit | Verdict | Current Status | Notes |
 | --- | --- | --- | --- | --- |
-| Z.1 | `0ed9031a` | `FAIL` | `complete` | smoke checklist frozen; two blocking findings promoted to `Z.2` |
+| Z.1 | `70f4fa7f` | `FAIL` | `complete` | smoke checklist frozen; two blocking findings promoted to `Z.2`; cargo test --workspace PASS (CI: macOS/Ubuntu/Windows); git diff --check PASS (CI: Format check) |
 | Z.2 | `PENDING` | `PENDING` | `not started` | awaits `Z.1` closure |
 | Z.3 | `PENDING` | `PENDING` | `not started` | awaits `Z.2` closure |
 | Z.4 | `PENDING` | `PENDING` | `not started` | awaits `Z.3` closure |

--- a/docs/phase-Z/smoke-checklist.md
+++ b/docs/phase-Z/smoke-checklist.md
@@ -50,8 +50,8 @@ The frozen checklist must include at least:
   - disposable `.atm.toml` with `default_team = "z1-team"`
   - disposable `config.json` roster for `z1-team`
 - cloned real-state lane:
-  - disposable copy of `~/.claude/teams/atm-dev` at `<disposable-copy-of-~/.claude/teams/atm-dev>`
-  - disposable copy of `~/.atm/db/mail.db` at `<disposable-copy-of-~/.atm/db/mail.db>`
+  - disposable copy of `~/.claude/teams/atm-dev` at `/tmp/z1-smoke-atm-dev`
+  - disposable copy of `~/.atm/db/mail.db` at `/tmp/z1-smoke-mail.db`
   - no writes against the live host-scoped ATM state
 
 ## Frozen Z.1 Results
@@ -59,7 +59,7 @@ The frozen checklist must include at least:
 | flow_id | operator_flow | command_or_entrypoint | expected_result | recovery_or_corner_case | z1_verdict | z2_revalidation_verdict | notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `Z1-001` | Build the approved smoke baseline | `cargo build --release -p agent-team-mail -p atm-daemon` | release CLI and daemon binaries build successfully on `integrate/phase-Z` baseline | baseline build proof | `PASS` | `PENDING` | `target/release/atm` and `target/release/atm-daemon` built successfully before the smoke pass. |
-| `Z1-002` | Bring up daemon/runtime on a clean-room baseline | `HOME=<tmp> ATM_HOME=<tmp> ATM_TEAM=z1-team ATM_IDENTITY=z1-operator target/release/atm doctor --json` | daemon auto-start succeeds and `doctor` reports ready runtime state | daemon startup / readiness failure or degraded-start behavior | `PASS` | `PENDING` | Clean-room `doctor` succeeded and reported ready runtime state with bootstrap trace and retained observability paths. |
+| `Z1-002` | Bring up daemon/runtime on a clean-room baseline | `HOME=/tmp/z1-smoke-home ATM_HOME=/tmp/z1-smoke-atm ATM_TEAM=z1-team ATM_IDENTITY=z1-operator target/release/atm doctor --json` | daemon auto-start succeeds and `doctor` reports ready runtime state | daemon startup / readiness failure or degraded-start behavior | `PASS` | `PENDING` | Clean-room `doctor` succeeded and reported ready runtime state with bootstrap trace and retained observability paths. |
 | `Z1-003` | Inspect retained local roster surface on a clean-room baseline | `target/release/atm teams --json` and `target/release/atm members --json` in the clean-room environment | retained team and member inspection commands succeed against the frozen team config | retained CLI command coverage | `PASS` | `PENDING` | `teams --json` and `members --json` succeeded against disposable `z1-team` config state. |
 | `Z1-004` | Exercise empty-mailbox retained CLI surface on a clean-room baseline | `target/release/atm list --json`, `read --all --json`, `clear --json`, `log snapshot --json` in the clean-room environment | retained CLI mailbox/log commands succeed on an empty durable-state baseline | retained CLI command coverage | `PASS` | `PENDING` | `list`, `read`, `clear`, and `log snapshot` all succeeded on the disposable empty-store baseline. |
 | `Z1-005` | Send the first message to a config-defined recipient on a clean-room baseline | `target/release/atm send z1-recipient \"hello z1\" --requires-ack --json` | config-defined roster member resolves to a delivery harness and the message persists/delivers successfully | notification delivery failure or degraded-notification behavior | `FAIL` | `PENDING` | Send failed closed with `failed to resolve roster-backed delivery harness for z1-recipient@z1-team`; fresh `config.json` membership alone did not seed the SQLite roster store. |

--- a/docs/phase-Z/smoke-checklist.md
+++ b/docs/phase-Z/smoke-checklist.md
@@ -40,3 +40,29 @@ The frozen checklist must include at least:
 - rerun without widening or narrowing in `Z.2`
 - any proposed scope change after `Z.1` freeze must be documented as a separate
   plan correction, not silently edited into the active checklist
+
+## Frozen Baseline Under Test
+
+- release binaries built from `feature/pZ-s1-smoke-bring-up`
+- clean-room bring-up lane:
+  - disposable `HOME` + `ATM_HOME`
+  - disposable `.atm.toml` with `default_team = "z1-team"`
+  - disposable `config.json` roster for `z1-team`
+- cloned real-state lane:
+  - disposable copy of `~/.claude/teams/atm-dev`
+  - disposable copy of `~/.atm/db/mail.db`
+  - no writes against the live host-scoped ATM state
+
+## Frozen Z.1 Results
+
+| flow_id | operator_flow | command_or_entrypoint | expected_result | recovery_or_corner_case | z1_verdict | z2_revalidation_verdict | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Z1-001` | Build the approved smoke baseline | `cargo build --release -p agent-team-mail -p atm-daemon` | release CLI and daemon binaries build successfully on `integrate/phase-Z` baseline | baseline build proof | `PASS` | `PENDING` | `target/release/atm` and `target/release/atm-daemon` built successfully before the smoke pass. |
+| `Z1-002` | Bring up daemon/runtime on a clean-room baseline | `HOME=<tmp> ATM_HOME=<tmp> ATM_TEAM=z1-team ATM_IDENTITY=z1-operator target/release/atm doctor --json` | daemon auto-start succeeds and `doctor` reports ready runtime state | daemon startup / readiness failure or degraded-start behavior | `PASS` | `PENDING` | Clean-room `doctor` succeeded and reported ready runtime state with bootstrap trace and retained observability paths. |
+| `Z1-003` | Inspect retained local roster surface on a clean-room baseline | `target/release/atm teams --json` and `target/release/atm members --json` in the clean-room environment | retained team and member inspection commands succeed against the frozen team config | retained CLI command coverage | `PASS` | `PENDING` | `teams --json` and `members --json` succeeded against disposable `z1-team` config state. |
+| `Z1-004` | Exercise empty-mailbox retained CLI surface on a clean-room baseline | `target/release/atm list --json`, `read --all --json`, `clear --json`, `log snapshot --json` in the clean-room environment | retained CLI mailbox/log commands succeed on an empty durable-state baseline | retained CLI command coverage | `PASS` | `PENDING` | `list`, `read`, `clear`, and `log snapshot` all succeeded on the disposable empty-store baseline. |
+| `Z1-005` | Send the first message to a config-defined recipient on a clean-room baseline | `target/release/atm send z1-recipient \"hello z1\" --requires-ack --json` | config-defined roster member resolves to a delivery harness and the message persists/delivers successfully | notification delivery failure or degraded-notification behavior | `FAIL` | `PENDING` | Send failed closed with `failed to resolve roster-backed delivery harness for z1-recipient@z1-team`; fresh `config.json` membership alone did not seed the SQLite roster store. |
+| `Z1-006` | Exercise degraded notification after a successful durable send | same clean-room send lane with a failing `[[atm.post_send_hooks]]` rule for `z1-recipient` | durable send succeeds and degraded notification is surfaced as a warning/evidence artifact when the post-send hook fails | notification delivery failure or degraded-notification behavior | `FAIL` | `PENDING` | This row was blocked by `Z1-005`: the send path never reached notification/post-send-hook execution because roster-backed harness resolution failed first. |
+| `Z1-007` | Verify retained CLI validation and recovery guidance | `ATM_IDENTITY=z1-recipient target/release/atm ack \"\" \"ack from z1\" --json` in the clean-room environment | command fails with actionable validation/recovery guidance rather than silent misuse | retained CLI command error reporting and operator recovery guidance | `PASS` | `PENDING` | Invalid `ack` invocation failed with explicit validation behavior instead of mutating state silently. |
+| `Z1-008` | Bring up the current real-state durable baseline without touching live host data | cloned `atm-dev` state under disposable `HOME`/`ATM_HOME`; run `target/release/atm doctor --json`, `list --json`, `send ... --json`, `read --all --json` | daemon starts, publishes IPC, and serves daemon-backed retained commands on a copied current-state baseline | daemon startup / readiness failure or degraded-start behavior | `FAIL` | `PENDING` | Every daemon-backed command failed: first `failed to initialize sqlite schema`, then `failed to connect to daemon local IPC endpoint ... after auto-start`. Direct `target/release/atm-daemon` startup reproduced the same schema-init failure. |
+| `Z1-009` | Exercise reconcile/runtime retry-visible smoke coverage | daemon-backed send/read lifecycle on either the clean-room or cloned real-state lane | retry-visible daemon/runtime behavior is observable while the durable send/read path succeeds | reconcile interruption, shutdown, or retry-visible behavior | `FAIL` | `PENDING` | No `Z.1` lane reached a successful daemon-backed durable send/read cycle once reconcile/runtime ownership mattered: the clean-room lane stopped at roster-harness resolution, and the copied real-state lane stopped at SQLite schema initialization. |

--- a/docs/phase-Z/smoke-checklist.md
+++ b/docs/phase-Z/smoke-checklist.md
@@ -43,14 +43,15 @@ The frozen checklist must include at least:
 
 ## Frozen Baseline Under Test
 
-- release binaries built from `feature/pZ-s1-smoke-bring-up`
+- release binaries: `target/release/atm` and `target/release/atm-daemon` built from `feature/pZ-s1-smoke-bring-up`
 - clean-room bring-up lane:
-  - disposable `HOME` + `ATM_HOME`
+  - `HOME=/tmp/z1-smoke-home`, `ATM_HOME=/tmp/z1-smoke-atm`
+  - `ATM_TEAM=z1-team`, `ATM_IDENTITY=z1-operator`
   - disposable `.atm.toml` with `default_team = "z1-team"`
   - disposable `config.json` roster for `z1-team`
 - cloned real-state lane:
-  - disposable copy of `~/.claude/teams/atm-dev`
-  - disposable copy of `~/.atm/db/mail.db`
+  - disposable copy of `~/.claude/teams/atm-dev` at `<disposable-copy-of-~/.claude/teams/atm-dev>`
+  - disposable copy of `~/.atm/db/mail.db` at `<disposable-copy-of-~/.atm/db/mail.db>`
   - no writes against the live host-scoped ATM state
 
 ## Frozen Z.1 Results

--- a/docs/phase-Z/smoke-findings-ledger.md
+++ b/docs/phase-Z/smoke-findings-ledger.md
@@ -28,3 +28,10 @@ Each finding entry must record:
 - newly discovered issues found during `Z.2` that are out of scope for the
   frozen `Z.1` handoff must be recorded here using `status: out_of_scope`
   rather than fixed in the `Z.2` sprint
+
+## Z.1 Findings
+
+| finding_id | discovered_in | linked_flow_id | summary | severity | fix_owner | status | z2_disposition | revalidation_result | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `Z1-F001` | `Z.1` | `Z1-005` | Fresh team config membership is not sufficient to resolve a roster-backed delivery harness, so the first clean-room `atm send` fails closed instead of delivering to a config-defined recipient. | `blocking` | `arch-ctm` | `open` | `PENDING` | `PENDING` | Reproduced in a disposable `HOME` + `ATM_HOME` environment with a valid `z1-team/config.json` member list. The command failed with `failed to resolve roster-backed delivery harness for z1-recipient@z1-team`. `Z1-006` remained blocked by this root cause. |
+| `Z1-F002` | `Z.1` | `Z1-008` | Current-state `mail.db` cannot pass current SQLite schema initialization, so daemon auto-start never publishes IPC and daemon-backed retained commands fail on the copied real-state baseline. | `blocking` | `arch-ctm` | `open` | `PENDING` | `PENDING` | Reproduced on a disposable copy of `~/.claude/teams/atm-dev` plus `~/.atm/db/mail.db` with no live-state writes. `atm doctor`, `list`, `send`, `read`, and direct `atm-daemon` startup all failed with `failed to initialize sqlite schema`; the copied DB still exposes `mail_messages.legacy_message_id` and does not expose `mail_messages.message_id`, which is consistent with the failing current migration batch. |

--- a/docs/phase-Z/sprint-Z1.md
+++ b/docs/phase-Z/sprint-Z1.md
@@ -53,6 +53,7 @@ the first full feature-by-feature smoke pass before broader team dogfood.
 - real-binary bring-up evidence for the daemon baseline under test
 - `docs/phase-Z/smoke-findings-ledger.md` containing only validated `Z.1`
   findings promoted to `Z.2`
+- `docs/phase-Z/readiness.md` Z.1 row updated with smoke verdict and commit
 
 ## Required Work
 

--- a/docs/phase-Z/sprint-Z1.md
+++ b/docs/phase-Z/sprint-Z1.md
@@ -1,7 +1,7 @@
 ---
 id: Z.1
 title: Smoke Bring-Up
-status: planned
+status: complete
 branch: feature/pZ-s1-smoke-bring-up
 worktree: ../atm-core-worktrees/feature/pZ-s1-smoke-bring-up
 target: integrate/phase-Z
@@ -15,7 +15,7 @@ phase: Z
 sprint: Z.1
 worktree: ../atm-core-worktrees/feature/pZ-s1-smoke-bring-up
 branch: feature/pZ-s1-smoke-bring-up
-status: planned
+status: complete
 estimated_scope: large
 ```
 


### PR DESCRIPTION
## Summary

- Built release binaries from `feature/pZ-s1-smoke-bring-up` baseline
- Ran full feature-by-feature smoke pass across 9 flows
- Froze `docs/phase-Z/smoke-checklist.md` with Z.1 verdicts
- Recorded 2 blocking findings in `docs/phase-Z/smoke-findings-ledger.md` for Z.2

## Smoke Results (Z.1)

| flow_id | flow | verdict |
|---------|------|---------|
| Z1-001 | Release build | PASS |
| Z1-002 | Daemon bring-up (clean-room) | PASS |
| Z1-003 | teams/members CLI | PASS |
| Z1-004 | Empty-mailbox CLI | PASS |
| Z1-005 | First send (clean-room) | FAIL |
| Z1-006 | Degraded notification | FAIL (blocked by Z1-005) |
| Z1-007 | CLI error reporting | PASS |
| Z1-008 | Real-state daemon bring-up | FAIL |
| Z1-009 | Reconcile/retry smoke | FAIL (no lane reached daemon-backed cycle) |

## Findings for Z.2

- **Z1-F001** (blocking): Fresh team config membership does not seed roster-backed delivery harness — `atm send` fails closed on clean-room baseline
- **Z1-F002** (blocking): Current-state `mail.db` fails SQLite schema init (`legacy_message_id` vs `message_id` migration) — daemon never publishes IPC on real-state baseline

## Artifacts

- `docs/phase-Z/smoke-checklist.md` — frozen Z.1 matrix
- `docs/phase-Z/smoke-findings-ledger.md` — authoritative Z.2 handoff ledger
- `docs/phase-Z/sprint-Z1.md` — status updated
- `docs/phase-Z/readiness.md` — updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)