### PR TITLE
docs: plan phase AA — daemon SQLite boundary removal

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,15 @@ Phase-S portability note:
   contract
 - Phase S planning is tracked in [`docs/plan-phase-S.md`](./plan-phase-S.md)
 
+Phase-AA simplification note:
+- the current daemon composition root and daemon-routed doctor model are not
+  the intended steady-state architecture
+- Phase AA moves concrete SQLite construction into a dedicated `atm-runtime`
+  crate and removes adapter-specific health/observability ownership from
+  `atm-daemon`
+- the daemon remains in the product, but as a thin router rather than a
+  concrete storage/runtime host
+
 ## 2. Crate Boundaries
 
 The post-Q product runtime is implemented by four crates:
@@ -183,6 +192,11 @@ Current Phase R boundary direction:
   - `atm` is the CLI client composition root
   - `atm-daemon` is the runtime composition root
   - a separate composition crate remains out of scope unless an ADR opens it
+- Phase AA target ownership:
+  - `atm` remains the CLI composition root
+  - `atm-runtime` becomes the concrete runtime/store composition root
+  - `atm-daemon` consumes storage-neutral runtime inputs and stops
+    constructing SQLite-backed adapters directly
 
 Current Phase R lint partition direction:
 - extend the existing `sc-portability` analyzer for reusable platform-gating
@@ -2829,6 +2843,15 @@ Architectural rules:
   - aggregate active/idle/offline/unknown member counts
 - CLI code must not inspect private daemon state directly to synthesize health
   answers
+
+Phase AA target doctor split:
+- daemon health remains a separate explicit request/response boundary for
+  daemon-owned runtime state
+- direct local doctor checks that only require config or store access do not
+  need daemon routing
+- SQLite/store readiness is therefore expected to move out of daemon-owned
+  health collection and into the direct local diagnostics path or the
+  `atm-runtime` composition layer
 
 ### 21.6.4 Shutdown, Signals, Timeouts, And Resource Caps
 

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -70,6 +70,13 @@ Follow-up work:
 - Keep adapter assembly in daemon-owned composition code only.
 - Revisit only if a later ADR extracts a dedicated composition crate.
 
+Phase-AA supersession note:
+- this ADR records the current merged ownership shape only
+- `Phase AA` intentionally supersedes it by moving concrete runtime/store
+  composition into a dedicated `atm-runtime` crate
+- after `Phase AA`, `atm-daemon` is no longer a legal home for SQLite adapter
+  construction
+
 ## 2. Responsibilities
 
 The `atm-daemon` crate is responsible for:
@@ -84,6 +91,12 @@ The `atm-daemon` crate is responsible for:
 - daemon health/status query surface for `atm doctor`
 
 The `atm-daemon` crate must remain thin.
+
+Phase-AA target direction:
+- the daemon remains transport/lifecycle-owned
+- SQLite-specific composition, observability, replay, and direct store-health
+  logic are removed from this crate
+- daemon health becomes daemon-owned runtime projection only
 
 Phase R redesign notes:
 - `atm-daemon` remains runtime-oriented, not business-logic-oriented

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -46,6 +46,13 @@ The canonical daemon/client recovery text rule set lives in:
 - direct ownership of SQLite semantics beyond using the `atm-core` store
   boundary
 
+Phase-AA target direction:
+- `atm-daemon` stops being the concrete SQLite composition owner
+- SQLite construction, SQLite-specific observability injection, and direct
+  SQLite health probing move out of this crate
+- daemon-owned doctor reporting is reduced to daemon-owned runtime state rather
+  than direct store readiness checks
+
 Current request/response packet families owned by the daemon transport line:
 - send compose
 - send acknowledge

--- a/docs/atm-rusqlite/requirements.md
+++ b/docs/atm-rusqlite/requirements.md
@@ -98,6 +98,11 @@ Required rules:
   and store boundaries
 - the current runtime composition owner may depend on this crate in order to
   assemble production adapters, but thin callers and extension crates must not
+- Phase-AA target direction:
+  - the long-term concrete composition owner is `atm-runtime`, not
+    `atm-daemon`
+  - daemon crates must not retain direct SQLite assembly dependencies after
+    the Phase AA simplification line closes
 - schema bootstrap must be deterministic and idempotent
 - schema bootstrap must run once per database root before normal store
   operations, not on every connection acquisition

--- a/docs/phase-AA/daemon-sqlite-leak-ledger.md
+++ b/docs/phase-AA/daemon-sqlite-leak-ledger.md
@@ -1,0 +1,64 @@
+# Phase AA Daemon SQLite Leak Ledger
+
+## Purpose
+
+Freeze the exact daemon-side SQLite leak inventory and the Phase AA repair
+decision now, so later sprints perform mechanical deletion or movement rather
+than rediscovering ownership.
+
+## Frozen Leak Decisions
+
+| File | Current leak | Phase AA decision |
+| --- | --- | --- |
+| `crates/atm-daemon/src/sqlite_observability.rs` | daemon-owned SQLite observability adapter | `delete` |
+| `crates/atm-daemon/src/runtime_health_test_support.rs` | daemon-local SQLite test assembly | `delete` |
+| `crates/atm-daemon/src/lib.rs` | `SqliteRemoteReplayStore`, `RemoteReplayStateRecord` re-export, direct SQLite observability type use | `rewrite` to remove replay wrapper and all direct `atm_rusqlite` types |
+| `crates/atm-daemon/src/composition.rs` | `SqliteBoundaryAssembly::new*`, SQLite observability injection, concrete production boundary construction | `move` concrete assembly to `atm-runtime`; `rewrite` daemon composition to injected ports only |
+| `crates/atm-daemon/src/runtime_health.rs` | direct `SqliteBoundaryAssembly`, direct roster-store use, WAL checkpoint call, SQLite readiness probing | `rewrite` to injected subsystem reports plus daemon-owned runtime state only |
+| `crates/atm-daemon/src/runtime_status_cache.rs` | `sqlite_ready`, `sqlite_detail`, `mark_sqlite_unavailable*` | `delete` SQLite-named fields/helpers; keep only daemon runtime fields |
+| `crates/atm-daemon/src/peer_transport.rs` | daemon-owned replay DTO/trait coupled to SQLite-owned record type | `rewrite` to storage-neutral replay DTO/trait owned outside daemon and `atm-rusqlite` |
+| `crates/atm-daemon/src/tests.rs` | direct `assemble_boundary(...)` use | `rewrite` to composition/subsystem fixtures; no daemon-local SQLite assembly |
+| `crates/atm-daemon/src/tests_advisory.rs` | direct `assemble_boundary(...)` use | `rewrite` to composition/subsystem fixtures; no daemon-local SQLite assembly |
+
+## Concrete Type Decisions
+
+### `SqliteBoundaryAssembly`
+
+Current location of daemon use:
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/lib.rs`
+
+Phase AA decision:
+- no production use remains in `atm-daemon`
+- concrete construction moves to `atm-runtime`
+
+### `RemoteReplayStateRecord`
+
+Current location:
+- `crates/atm-rusqlite/src/boundary_assembly.rs`
+- re-exported from `crates/atm-daemon/src/lib.rs`
+
+Phase AA decision:
+- move to a storage-neutral boundary owned outside both `atm-daemon` and
+  `atm-rusqlite`, expected in `atm-core`
+
+### Store/roster health
+
+Current location of daemon probing:
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+
+Phase AA decision:
+- deep health belongs to subsystem doctor traits
+- daemon aggregates subsystem reports and daemon-owned runtime state only
+
+## Review Rule
+
+If implementation work proposes:
+- “keep this SQLite helper in the daemon for convenience”
+- “re-export this SQLite type from daemon temporarily”
+- “leave sqlite_ready in runtime status for now”
+
+the proposal is out of plan and should be rejected unless the Phase AA docs are
+first updated with explicit user-approved justification.

--- a/docs/phase-AA/daemon-state-machines.md
+++ b/docs/phase-AA/daemon-state-machines.md
@@ -1,0 +1,99 @@
+# Phase AA Daemon State-Machine Inventory
+
+## Purpose
+
+Freeze the small auditable daemon-machine target before code deletion begins.
+
+Phase AA target:
+- no more than `5` top-level daemon state machines
+- no backend-specific SQLite control flow in the daemon
+
+## Target Machine Set
+
+### 1. Bootstrap / Singleton Ownership
+
+Owned concerns:
+- launch gate
+- host ownership acquisition
+- transition into serving or clean failure
+
+Primary files:
+- `crates/atm-daemon/src/host_ownership.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+- bootstrap portions of `crates/atm-daemon/src/composition.rs`
+
+### 2. Request Receipt / Validation / Dispatch / Reply
+
+Owned concerns:
+- local IPC request acceptance
+- request decoding
+- dispatch to injected runtime/service ports
+- bounded reply / error return
+
+Primary files:
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/local_ipc_transport/request_worker.rs`
+- dispatch portions of `crates/atm-daemon/src/runtime_health.rs`
+
+### 3. Session / Connection Lifecycle
+
+Owned concerns:
+- active connection registration
+- session open / active / draining / close
+- advisory session registration lifecycle
+
+Primary files:
+- `crates/atm-daemon/src/active_connection_registry.rs`
+- `crates/atm-daemon/src/local_ipc_connection.rs`
+- `crates/atm-daemon/src/advisory_runtime.rs`
+
+### 4. Graceful Shutdown / Drain
+
+Owned concerns:
+- runtime stop transition
+- bounded drain
+- shutdown beacon / finalizer ownership
+
+Primary files:
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/shutdown_beacon.rs`
+
+### 5. Advisory Stream Lifecycle
+
+Owned concerns:
+- one live stream per active session if that surface survives
+- register / drain / close
+
+Primary files:
+- `crates/atm-daemon/src/advisory_runtime.rs`
+
+## Current Modules That Violate The Target
+
+These modules or function families are not part of the desired thin-router
+machine set and must be removed, moved outward, or reduced to injected trait
+calls:
+
+- `crates/atm-daemon/src/sqlite_observability.rs`
+  - backend-specific observability logic
+- `crates/atm-daemon/src/runtime_health.rs`
+  - direct SQLite health / roster access
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+  - SQLite-named readiness fields and helpers
+- `crates/atm-daemon/src/lib.rs`
+  - daemon-owned SQLite replay wrapper
+- `crates/atm-daemon/src/composition.rs`
+  - concrete SQLite construction
+- `crates/atm-daemon/src/runtime_health_test_support.rs`
+  - daemon-local SQLite test assembly
+
+## Review Rule
+
+Any daemon code path that introduces:
+- `SqliteBoundaryAssembly`
+- `SqliteObservability`
+- direct `atm_rusqlite::*` references
+- backend-specific health or replay semantics
+
+must be treated as outside the target machine inventory unless explicitly moved
+behind an injected storage-neutral trait.

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -1,0 +1,34 @@
+# Phase AA Readiness
+
+## Goal
+
+Track the accepted closure state for the daemon simplification line that
+removes concrete SQLite knowledge from `atm-daemon`.
+
+## Sprint Status
+
+| Sprint | Status | Branch | Worktree | Closure Gate |
+| --- | --- | --- | --- | --- |
+| `AA.0` | `planned` | `feature/pAA-s0-daemon-architecture-restatement` | `../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement` | daemon role, doctor aggregation model, and state-machine inventory documented and accepted |
+| `AA.1` | `planned` | `feature/pAA-s1-subsystem-doctor-traits` | `../atm-core-worktrees/feature/pAA-s1-subsystem-doctor-traits` | subsystem-owned capability/doctor traits and shared diagnostic DTOs land in the governing docs and code |
+| `AA.2` | `planned` | `feature/pAA-s2-atm-runtime-composition-transfer` | `../atm-core-worktrees/feature/pAA-s2-atm-runtime-composition-transfer` | `atm-runtime` owns concrete SQLite/runtime assembly; `atm-daemon` stops constructing SQLite boundaries |
+| `AA.3` | `planned` | `feature/pAA-s3-direct-doctor-and-runtime-health-split` | `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split` | `atm doctor` regains direct local store diagnostics; daemon aggregates injected subsystem reports plus daemon-owned runtime state without backend-specific diagnosis logic |
+| `AA.4` | `planned` | `feature/pAA-s4-delete-daemon-sqlite-leaks` | `../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks` | remaining SQLite observability, replay, and test-support leaks are removed from `atm-daemon` |
+| `AA.5` | `planned` | `feature/pAA-s5-boundary-relock-and-permanent-enforcement` | `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement` | daemon-to-SQLite edge is forbidden again and a second enforcement layer exists beyond TOML lint |
+
+## Phase Exit Criteria
+
+`Phase AA` is not complete until all of the following are true:
+
+- `crates/atm-daemon/Cargo.toml` has no direct `atm-rusqlite` dependency
+- no `atm_rusqlite::*` references remain in daemon production code
+- direct local store diagnostics exist behind subsystem-owned doctor traits
+- storage behavior is expressed through small behavior-named capability traits,
+  not backend-shaped interfaces
+- daemon doctor aggregation does not inspect SQLite internals directly and only
+  compares subsystem reports at the aggregate level
+- the boundary TOMLs forbid the daemon-to-SQLite edge again
+- a repository-enforced dependency-boundary test or equivalent guard fails
+  whenever that edge reappears
+- a `boundary-guard` QA agent reviews both plans and phase-ending reviews
+  and flags boundary-policy widening before closure

--- a/docs/phase-AA/sprint-AA0.md
+++ b/docs/phase-AA/sprint-AA0.md
@@ -1,0 +1,135 @@
+# AA.0 Daemon Architecture Restatement And State-Machine Inventory
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.0
+worktree: ../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement
+branch: feature/pAA-s0-daemon-architecture-restatement
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Freeze the intended daemon design before code deletion begins: thin router,
+subsystem-owned diagnostics, direct local doctor path where possible, and a
+small auditable daemon state-machine inventory.
+
+## Scope Summary
+
+This sprint is documentation-first. It does not remove the SQLite dependency
+yet. It makes the target architecture explicit enough that later sprints can
+delete code instead of arguing about ownership.
+
+## Governing Requirements
+
+- `REQ-P-PRODUCT-001`
+- `REQ-P-DOCTOR-001`
+- `REQ-CORE-BOUNDARY-001`
+- `REQ-DAEMON-RUNTIME-002`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+- `docs/atm-daemon/architecture.md` ADR `ADR-ATM-DAEMON-001` as the current
+  state to be superseded by Phase `AA`
+
+## Governing Boundaries
+
+- `boundaries/atm-rusqlite/sqlite-boundary-assembly.toml`
+- `boundaries/atm-rusqlite/mail-store-sqlite.toml`
+- `boundaries/atm-rusqlite/roster-store-sqlite.toml`
+- `boundaries/atm-core/runtime-factory.toml`
+
+## Prerequisites
+
+- current daemon/SQLite leak inventory is frozen
+- user-approved Phase `AA` target architecture is recorded
+
+## Hard Dependencies
+
+- none
+
+## Non-Goals
+
+- no code movement yet
+- no partial boundary rollback without the full inventory
+
+## Sub-Tasks
+
+- Restate the daemon role in requirements and architecture docs as:
+  transport, lifecycle, routing, bounded dispatch, and minor error handling
+  only.
+  Development work: update product and crate-local docs.
+  Required tests: none beyond document validation.
+  Required doc or boundary updates: requirements, architecture, daemon
+  architecture, and the new Phase AA readiness record.
+
+- Record the subsystem-doctor pattern as a hard rule:
+  each subsystem diagnoses itself through a trait; top-level doctor code only
+  aggregates subsystem results.
+  Development work: document the trait/aggregation rule and where those traits
+  live.
+  Required tests: none yet.
+  Required doc or boundary updates: requirements and architecture docs.
+
+- Produce the daemon state-machine inventory with a hard target of five or
+  fewer top-level machines.
+  Development work: write the inventory and flag every daemon function family
+  that violates it.
+  Required tests: none yet.
+  Required doc or boundary updates: `docs/phase-AA/*` and daemon architecture.
+
+- Freeze the concrete leak ledger up front.
+  Development work: record the exact current daemon-side SQLite leak files and
+  classify them now as delete / move / keep-and-rewrite so later sprints are
+  mechanical. The initial frozen file set is:
+  - `crates/atm-daemon/src/lib.rs`
+  - `crates/atm-daemon/src/composition.rs`
+  - `crates/atm-daemon/src/runtime_health.rs`
+  - `crates/atm-daemon/src/runtime_status_cache.rs`
+  - `crates/atm-daemon/src/sqlite_observability.rs`
+  - `crates/atm-daemon/src/runtime_health_test_support.rs`
+  - `crates/atm-daemon/src/tests.rs`
+  - `crates/atm-daemon/src/tests_advisory.rs`
+  Required tests: none yet.
+  Required doc or boundary updates:
+  - `docs/phase-AA/daemon-state-machines.md`
+  - `docs/phase-AA/daemon-sqlite-leak-ledger.md`
+
+## Split Recommendation
+
+Keep this sprint documentation-only. If daemon code edits begin before the
+state-machine and doctor-ownership rules are accepted, later deletion sprints
+will reintroduce ambiguity.
+
+## Acceptance Criteria
+
+- the daemon role is documented as thin and storage-agnostic
+- the subsystem-doctor aggregation rule is explicit
+- the daemon state-machine inventory exists and caps top-level machines at five
+- the leak ledger exists and classifies every current daemon-side SQLite touch
+  point as delete / move / keep-and-rewrite
+- the Phase AA readiness record exists
+
+## Required Validation
+
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/plan-phase-AA.md`
+- `docs/project-plan.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+- `docs/phase-AA/readiness.md`
+- `docs/phase-AA/daemon-state-machines.md`
+- `docs/phase-AA/daemon-sqlite-leak-ledger.md`
+
+## Risks And Watchouts
+
+- if this sprint leaves “doctor may do either thing” ambiguity, later sprints
+  will accrete more special cases instead of deleting them

--- a/docs/phase-AA/sprint-AA1.md
+++ b/docs/phase-AA/sprint-AA1.md
@@ -1,0 +1,140 @@
+# AA.1 Subsystem Doctor Traits And Shared Diagnostic Contracts
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.1
+worktree: ../atm-core-worktrees/feature/pAA-s1-subsystem-doctor-traits
+branch: feature/pAA-s1-subsystem-doctor-traits
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Define the storage-facing capability traits, subsystem doctor traits, and
+shared diagnostic DTOs so every subsystem can report its own health without
+the daemon or CLI reimplementing subsystem logic.
+
+## Scope Summary
+
+This sprint introduces the architectural contract that later code-removal
+sprints use: `atm-core` keeps `MailStore` / `TaskStore` / `RosterStore` as the
+primary storage-neutral capability boundaries, adds doctor traits beside them,
+allows backend implementations such as SQLite and Claude JSON to satisfy the
+same trait family, and makes `atm-daemon` consume injected traits rather than
+peeking into SQLite internals.
+
+## Governing Requirements
+
+- `REQ-P-DOCTOR-001`
+- `REQ-CORE-DOCTOR-001`
+- `REQ-CORE-BOUNDARY-001`
+- `REQ-RUSQLITE-STORE-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+
+## Governing Boundaries
+
+- `docs/atm-core/boundaries.md`
+- `docs/atm-rusqlite/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
+
+## Prerequisites
+
+- `AA.0`
+
+## Hard Dependencies
+
+- accepted shared diagnostic DTO shape
+
+## Non-Goals
+
+- no concrete runtime composition transfer yet
+- no boundary relock yet
+
+## Sub-Tasks
+
+- Freeze the capability-trait reuse decision.
+  Development work: keep `MailStore`, `TaskStore`, and `RosterStore` as the
+  storage-neutral read/write capability surfaces for Phase AA; do not add a
+  parallel `MessageReader` / `MessageWriter` / `RosterReader` / `RosterWriter`
+  hierarchy in this phase.
+  Required tests: compile/build validation for unchanged callers.
+  Required doc or boundary updates: `atm-core` requirements and architecture.
+
+- Add doctor traits beside the existing capability boundaries.
+  Development work: define `MailStoreDoctor` beside
+  `crates/atm-core/src/boundary/mail.rs`, define `RosterStoreDoctor` beside
+  `crates/atm-core/src/boundary/store.rs`, and define `ConfigDoctor` beside
+  the config ingress boundary so deep backend/config investigation logic lives
+  with the owning subsystem.
+  Required tests: trait/object-safety and DTO unit coverage.
+  Required doc or boundary updates: `atm-core` requirements, architecture, and
+  boundaries.
+
+- Define the store doctor contract for `atm-rusqlite`.
+  Development work: document and implement the trait that reports store path,
+  openability, migration/bootstrap readiness, and bounded storage findings.
+  Required tests: in-process SQLite doctor tests.
+  Required doc or boundary updates: `atm-rusqlite` requirements/architecture.
+
+- Define daemon-owned runtime doctor aggregation.
+  Development work: document that daemon doctor code aggregates injected
+  subsystem reports plus daemon-only runtime state, may compare subsystem
+  outputs for drift, and does not inspect SQLite directly.
+  Required tests: aggregation-only unit coverage.
+  Required doc or boundary updates: `atm-daemon` requirements/architecture.
+
+- Define the backend-agnostic implementation rule.
+  Development work: document that behavior traits are backend-neutral and may
+  be implemented by both SQLite-backed and Claude-JSON-backed subsystems,
+  without exposing one giant `Storage` god-interface. The Phase AA decision is
+  that Claude JSON may implement the same `MailStore` / `RosterStore` plus
+  doctor traits later; AA does not require that implementation to land now.
+  Required tests: none beyond doc and trait-surface validation.
+  Required doc or boundary updates: `requirements.md`, `architecture.md`, and
+  `atm-core` docs.
+
+## Split Recommendation
+
+Keep the trait and DTO line separate from the composition transfer. This sprint
+must settle the contracts before any crate starts moving code across them.
+
+## Acceptance Criteria
+
+- `MailStore`, `TaskStore`, and `RosterStore` are explicitly retained as the
+  Phase AA storage-neutral capability surfaces
+- `MailStoreDoctor`, `RosterStoreDoctor`, and `ConfigDoctor` are defined in
+  `atm-core`
+- `atm-rusqlite` has a documented store doctor contract
+- the docs explicitly allow both SQLite-backed and Claude-JSON-backed
+  implementations behind the same behavior-named traits
+- daemon doctor aggregation is explicitly aggregate-only
+- no new daemon-local SQLite helper is introduced while landing the traits
+
+## Required Validation
+
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-rusqlite/requirements.md`
+- `docs/atm-rusqlite/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+
+## Risks And Watchouts
+
+- if AA creates a second parallel read/write trait hierarchy on top of
+  `MailStore` / `TaskStore` / `RosterStore`, the phase will widen churn instead
+  of making the later deletion sprints mechanical

--- a/docs/phase-AA/sprint-AA2.md
+++ b/docs/phase-AA/sprint-AA2.md
@@ -1,0 +1,138 @@
+# AA.2 `atm-runtime` Skeleton And Concrete Composition Transfer
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.2
+worktree: ../atm-core-worktrees/feature/pAA-s2-atm-runtime-composition-transfer
+branch: feature/pAA-s2-atm-runtime-composition-transfer
+status: planned
+estimated_scope: large
+```
+
+## Goal
+
+Introduce `atm-runtime` and move all concrete SQLite/runtime assembly out of
+`atm-daemon`.
+
+## Scope Summary
+
+This sprint creates the dedicated composition crate that replaces the daemon as
+the legal home for `SqliteBoundaryAssembly`, SQLite observability injection,
+and concrete production runtime/store wiring behind the `atm-core`
+capability-trait family.
+
+The concrete transfer decisions are frozen now:
+- move `SqliteBoundaryAssembly::new*` calls out of
+  `crates/atm-daemon/src/composition.rs`
+- move `SqliteRemoteReplayStore` out of
+  `crates/atm-daemon/src/lib.rs`
+- move `RemoteReplayStateRecord` out of `atm-rusqlite` and into a
+  storage-neutral `atm-core` boundary surface
+- move `RemoteReplayStore` out of `crates/atm-daemon/src/peer_transport.rs`
+  and onto a storage-neutral boundary surface that `atm-runtime` can
+  implement without depending on `atm-daemon`
+
+## Governing Requirements
+
+- `REQ-CORE-BOUNDARY-001`
+- `REQ-DAEMON-RUNTIME-002`
+- `REQ-RUSQLITE-STORE-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+- supersedes the current daemon composition assumption in
+  `docs/atm-daemon/architecture.md`
+
+## Governing Boundaries
+
+- `boundaries/atm-core/runtime-factory.toml`
+- `boundaries/atm-rusqlite/sqlite-boundary-assembly.toml`
+- `boundaries/atm-rusqlite/shared-db.toml`
+
+## Prerequisites
+
+- `AA.1`
+
+## Hard Dependencies
+
+- accepted `atm-runtime` crate ownership model
+
+## Non-Goals
+
+- final boundary relock
+- final doctor split
+
+## Sub-Tasks
+
+- Add `crates/atm-runtime`.
+  Development work: introduce the crate, manifests, and composition entrypoints
+  that can build production runtime inputs from concrete adapters. The expected
+  new files are:
+  - `crates/atm-runtime/src/lib.rs`
+  - `crates/atm-runtime/src/composition.rs`
+  - `crates/atm-runtime/src/replay_store.rs`
+  Required tests: compile/build coverage and narrow integration coverage.
+  Required doc or boundary updates: project plan, crate docs, boundaries.
+
+- Move SQLite boundary assembly into `atm-runtime`.
+  Development work: relocate `SqliteBoundaryAssembly` construction and
+  observability injection out of daemon composition. The concrete daemon edits
+  are:
+  - delete `SqliteBoundaryAssembly` construction from
+    `crates/atm-daemon/src/composition.rs`
+  - replace the direct `sqlite_boundary` construction path with an injected
+    runtime bundle from `atm-runtime`
+  Required tests: runtime composition tests proving `atm-daemon` consumes
+  injected ports only.
+  Required doc or boundary updates: daemon/runtime/rusqlite architecture docs.
+
+- Change `atm-daemon` to consume storage-neutral runtime inputs.
+  Development work: delete direct construction from daemon composition and make
+  daemon startup take injected ports/factories only, expressed through
+  `MailStore`, `TaskStore`, `RosterStore`, and the new doctor traits from
+  `AA.1`.
+  Required tests: daemon startup and request-dispatch regression coverage.
+  Required doc or boundary updates: daemon boundaries and architecture docs.
+
+## Split Recommendation
+
+Do not combine doctor behavior changes into this sprint. This sprint is only
+about composition ownership transfer.
+
+## Acceptance Criteria
+
+- `atm-runtime` exists and owns concrete production assembly
+- `atm-daemon` no longer constructs `SqliteBoundaryAssembly`
+- `RemoteReplayStateRecord` and `RemoteReplayStore` no longer originate in
+  daemon-private or SQLite-private modules
+- daemon composition consumes storage-neutral injected inputs
+- daemon composition depends on `MailStore` / `TaskStore` / `RosterStore` plus
+  doctor traits rather than backend identity
+- direct daemon-to-SQLite assembly imports are removed from production
+  composition code
+
+## Required Validation
+
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `Cargo.toml`
+- `docs/project-plan.md`
+- `docs/plan-phase-AA.md`
+- `docs/architecture.md`
+- `docs/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-rusqlite/requirements.md`
+
+## Risks And Watchouts
+
+- the crate move must not just relocate daemon-shaped assumptions into
+  `atm-runtime`; the new crate is composition-only

--- a/docs/phase-AA/sprint-AA3.md
+++ b/docs/phase-AA/sprint-AA3.md
@@ -1,0 +1,137 @@
+# AA.3 Direct Doctor Path And Runtime Health Simplification
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.3
+worktree: ../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split
+branch: feature/pAA-s3-direct-doctor-and-runtime-health-split
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Move store diagnostics into the store subsystem, restore a direct CLI doctor
+path for local diagnostics, and strip SQLite-specific health logic out of the
+daemon.
+
+## Scope Summary
+
+This sprint applies the doctor-trait model: `atm-rusqlite` diagnoses itself,
+the CLI can query it directly, and daemon health becomes aggregation of
+daemon-owned runtime state plus injected subsystem reports, including
+cross-subsystem drift comparison where that comparison is not backend-specific.
+
+The concrete simplification decisions are frozen now:
+- remove `sqlite_boundary: Option<SqliteBoundaryAssembly>` from
+  `crates/atm-daemon/src/runtime_health.rs`
+- replace direct roster access there with injected `RosterStore`
+- remove daemon-owned WAL checkpoint calls from `runtime_health.rs`
+- remove `sqlite_ready` / `sqlite_detail` from
+  `crates/atm-daemon/src/runtime_status_cache.rs` and from
+  `crates/atm-core/src/protocol.rs::RuntimeStatusSnapshot`
+- report store health through subsystem doctor results, not daemon cache fields
+- keep daemon runtime health free to aggregate subsystem doctor reports, but do
+  not let it perform backend-specific investigation logic itself
+
+## Governing Requirements
+
+- `REQ-P-DOCTOR-001`
+- `REQ-CORE-DOCTOR-001`
+- `REQ-DAEMON-HEALTH-001`
+- `REQ-RUSQLITE-STORE-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+- `docs/adr/ADR-014-runtime-health-projection-and-liveness-signal-ownership.md`
+
+## Governing Boundaries
+
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
+- `docs/atm-rusqlite/boundaries.md`
+
+## Prerequisites
+
+- `AA.1`
+- `AA.2`
+
+## Hard Dependencies
+
+- shared doctor traits from `AA.1`
+
+## Non-Goals
+
+- boundary relock
+- full replay leak cleanup
+
+## Sub-Tasks
+
+- Implement `atm-rusqlite` store-doctor logic.
+  Development work: move SQLite readiness/openability/migration health into
+  the store subsystem and expose it only through the doctor trait. This
+  includes the current direct SQLite readiness concerns presently projected
+  through daemon runtime status.
+  Required tests: in-process store doctor tests.
+  Required doc or boundary updates: `atm-rusqlite` docs.
+
+- Restore a direct CLI doctor path for local diagnostics.
+  Development work: make CLI doctor query local config/store diagnostics
+  directly when daemon-owned runtime state is not required. The concrete core
+  target is `crates/atm-core/src/doctor/mod.rs`, which should become an
+  aggregator/orchestrator over `ConfigDoctor`, `MailStoreDoctor`, and
+  `RosterStoreDoctor` instead of burying backend-specific logic inline.
+  Required tests: doctor CLI regression coverage with and without a live
+  daemon.
+  Required doc or boundary updates: product requirements and architecture.
+
+- Simplify daemon runtime health to daemon-owned projection only.
+  Development work: remove direct SQLite roster/store health probing from
+  `runtime_health.rs`, convert `reload_runtime_view(...)` and
+  `record_heartbeat(...)` to injected `RosterStore`, and delete
+  `mark_sqlite_unavailable*`-style daemon cache semantics. The precise cache
+  decision is:
+  - `RuntimeStatusSnapshot` keeps daemon runtime liveness/readiness/member
+    counts
+  - `RuntimeStatusSnapshot` stops carrying `sqlite_ready` and `sqlite_detail`
+  - any store-specific detail appears only in subsystem doctor reports
+  Required tests: runtime-health projection tests.
+  Required doc or boundary updates: daemon requirements/architecture.
+
+## Split Recommendation
+
+Keep doctor behavior and runtime-health simplification together; they are the
+same seam from opposite sides.
+
+## Acceptance Criteria
+
+- store diagnostics are owned by `atm-rusqlite`
+- CLI doctor can answer direct local store/config checks without daemon routing
+- daemon runtime health no longer owns SQLite-specific probing or SQLite-named
+  runtime cache fields
+- daemon doctor aggregation may include injected store/config subsystem reports
+  but does not deeply analyze SQLite internals and only performs
+  cross-subsystem comparison at the report level
+
+## Required Validation
+
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+- `docs/atm-rusqlite/requirements.md`
+
+## Risks And Watchouts
+
+- do not let “optional daemon fast path” turn back into “daemon owns the only
+  doctor implementation”

--- a/docs/phase-AA/sprint-AA4.md
+++ b/docs/phase-AA/sprint-AA4.md
@@ -1,0 +1,126 @@
+# AA.4 Delete Remaining Daemon SQLite Leaks
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.4
+worktree: ../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks
+branch: feature/pAA-s4-delete-daemon-sqlite-leaks
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Delete the remaining daemon-side SQLite observability, replay-store, and test
+support leakage after composition and doctor behavior have moved out.
+
+## Scope Summary
+
+This sprint is deletion-heavy. It removes code that exists only because the
+boundary was broken and should not be re-homed inside the daemon.
+
+The concrete delete/move decisions are frozen now:
+- delete `crates/atm-daemon/src/sqlite_observability.rs`
+- delete `crates/atm-daemon/src/runtime_health_test_support.rs`
+- delete `mod sqlite_observability;` from `crates/atm-daemon/src/lib.rs`
+- delete `SqliteRemoteReplayStore` from `crates/atm-daemon/src/lib.rs`
+- delete `use atm_rusqlite::SqliteBoundaryAssembly;` and the
+  `RemoteReplayStateRecord` re-export from `crates/atm-daemon/src/lib.rs`
+- delete direct `atm_rusqlite::assemble_boundary*` test use from:
+  - `crates/atm-daemon/src/tests.rs`
+  - `crates/atm-daemon/src/tests_advisory.rs`
+- delete `mark_sqlite_unavailable(...)` and
+  `mark_sqlite_unavailable_with_detail(...)` from
+  `crates/atm-daemon/src/runtime_status_cache.rs`
+- keep `crates/atm-daemon/src/peer_transport.rs`, but rewrite it to consume
+  storage-neutral replay DTOs/traits that no longer originate in `atm-rusqlite`
+
+## Governing Requirements
+
+- `REQ-CORE-BOUNDARY-001`
+- `REQ-DAEMON-RUNTIME-002`
+- `REQ-DAEMON-OBS-003`
+- `REQ-RUSQLITE-STORE-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+
+## Governing Boundaries
+
+- `docs/atm-daemon/boundaries.md`
+- `docs/atm-rusqlite/boundaries.md`
+
+## Prerequisites
+
+- `AA.2`
+- `AA.3`
+
+## Hard Dependencies
+
+- `atm-runtime` owns composition
+- store doctor trait owns store diagnostics
+
+## Non-Goals
+
+- final boundary relock
+- permanent enforcement guardrails
+
+## Sub-Tasks
+
+- Delete daemon-owned SQLite observability glue.
+  Development work: remove `sqlite_observability.rs` and route SQLite
+  observability injection entirely through `atm-runtime` / `atm-rusqlite`.
+  Required tests: retained observability regression coverage.
+  Required doc or boundary updates: daemon/rusqlite architecture docs.
+
+- Delete daemon-owned SQLite test support.
+  Development work: remove `runtime_health_test_support.rs` and any daemon test
+  setup that assembles SQLite directly. Replace daemon-local assembly with
+  runtime-owned or subsystem-owned fixtures.
+  Required tests: replace with subsystem or composition-level tests.
+  Required doc or boundary updates: testing docs if test ownership changes.
+
+- Remove replay/store type leakage from daemon public/internal seams.
+  Development work: eliminate `SqliteRemoteReplayStore`,
+  `RemoteReplayStateRecord` re-exports, and any daemon-local SQLite replay
+  wrappers. The exact destination decision is:
+  - storage-neutral replay DTO/trait live outside `atm-daemon` and
+    `atm-rusqlite`, under `atm-core`
+  - concrete SQLite replay implementation lives in `atm-runtime`
+  Required tests: peer transport / replay regression coverage.
+  Required doc or boundary updates: daemon boundaries if trait ownership moves.
+
+## Split Recommendation
+
+Keep this sprint deletion-first. If a leaked helper is not required by the
+simple router model, remove it instead of preserving compatibility for it.
+
+## Acceptance Criteria
+
+- daemon production code contains no SQLite observability glue
+- daemon test support no longer assembles SQLite directly
+- daemon replay/store seams no longer expose SQLite-owned record types
+- `runtime_status_cache.rs` contains no SQLite-named degradation helpers
+- the remaining daemon code is materially smaller and simpler
+
+## Required Validation
+
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/atm-daemon/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-rusqlite/requirements.md`
+- `docs/project-plan.md`
+
+## Risks And Watchouts
+
+- replay helpers are easy to preserve by habit; if they still mention SQLite in
+  the daemon, this sprint did not actually close

--- a/docs/phase-AA/sprint-AA5.md
+++ b/docs/phase-AA/sprint-AA5.md
@@ -1,0 +1,163 @@
+# AA.5 Boundary Relock And Permanent Enforcement
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.5
+worktree: ../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement
+branch: feature/pAA-s5-boundary-relock-and-permanent-enforcement
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Re-establish the daemon-to-SQLite boundary and add a second enforcement layer
+so widening the boundary cannot hide behind TOML-only changes again. This
+includes the dedicated `boundary-guard` QA agent for plan review and
+phase-ending review.
+
+## Scope Summary
+
+This sprint is the final closure gate. It restores the forbidden edge and adds
+permanent protection beyond the existing boundary TOMLs and lint rules, both in
+code and in review workflow.
+
+## Governing Requirements
+
+- `REQ-CORE-BOUNDARY-001`
+- `REQ-DAEMON-RUNTIME-002`
+- `REQ-RUSQLITE-STORE-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+
+## Governing Boundaries
+
+- `boundaries/atm-rusqlite/sqlite-boundary-assembly.toml`
+- `boundaries/atm-rusqlite/mail-store-sqlite.toml`
+- `boundaries/atm-rusqlite/roster-store-sqlite.toml`
+- `boundaries/atm-rusqlite/task-store-sqlite.toml`
+
+## Prerequisites
+
+- `AA.2`
+- `AA.3`
+- `AA.4`
+
+## Hard Dependencies
+
+- daemon production code is already free of direct SQLite coupling
+
+## Non-Goals
+
+- no new subsystem behavior
+- no broad release-surface redesign beyond the corrected boundary
+
+## Sub-Tasks
+
+- Relock the TOML boundaries.
+  Development work: remove `atm-daemon` from SQLite boundary allowlists,
+  restore explicit forbidden edges, and close any visibility widened only to
+  permit daemon-side SQLite assembly.
+  Required tests: `just lint boundaries` or equivalent must fail if the edge
+  returns.
+  Required doc or boundary updates: boundary TOMLs and crate-local boundaries
+  docs.
+
+- Add a second architecture enforcement layer.
+  Development work: add a repository-owned guard at
+  `scripts/check-boundary-guard.py` plus a self-test at
+  `scripts/test_boundary_guard.py`, modeled on the Ironclaw-style
+  dependency-boundary check, so crate-edge regressions fail even if TOML
+  policy is edited incorrectly. The script must inspect the workspace graph and
+  fail if `atm-daemon -> atm-rusqlite` reappears or if forbidden edge
+  removals / allowed dependent expansions are present in the changed boundary
+  TOMLs without an explicit approval artifact.
+  Required tests:
+  - `python3 scripts/check-boundary-guard.py --base-ref <target>`
+  - `python3 -m unittest scripts.test_boundary_guard`
+  Required doc or boundary updates: testing docs, project plan, and Phase AA
+  readiness record.
+
+- Add governance for boundary-policy changes.
+  Development work: make widening `allowed_dependents`, removing forbidden
+  edges, or widening adapter visibility an explicit reviewed architecture
+  change rather than ordinary lint data churn.
+  Required tests: CI guard or repo-local lint for boundary-policy drift.
+  Required doc or boundary updates: project plan and architecture docs.
+
+- Add the `boundary-guard` QA agent.
+  Development work: define and wire a dedicated QA/review agent named
+  `boundary-guard` that examines
+  planning PRs and phase-ending review packets for boundary loosening. The
+  agent must treat any of the following TOML field changes as a relaxation
+  requiring explicit architectural justification:
+
+  | Field | Relaxation direction |
+  |---|---|
+  | `allowed_dependents` | any addition |
+  | `forbidden_edges` | any removal |
+  | `visibility` | any promotion toward public |
+  | `constructor` | any promotion toward public |
+  | `forbidden_test_bypasses` | any removal |
+  | `forbidden` | any removal |
+
+  The agent fires at two named points in the plan workflow: (1) after
+  critical-plan-reviewer and before team-lead approval on any plan branch
+  that modifies a boundary TOML, and (2) as a required reviewer in every
+  phase-ending review packet.
+  Required tests: a synthetic boundary-TOML relaxation fixture that the agent
+  must catch, unconditionally, as a required self-test; prove the review
+  workflow requires this agent at both named trigger points.
+  Required doc or boundary updates: review workflow docs, project plan,
+  readiness record, and any team/QA protocol docs that assign the new review
+  responsibility.
+
+## Split Recommendation
+
+This must remain the final sprint. Relocking the boundary before the daemon is
+actually clean will either fail immediately or produce more policy cheating.
+
+## Acceptance Criteria
+
+- `atm-daemon` is forbidden again as a dependent of SQLite assembly/store
+  boundaries
+- a second architecture-enforcement layer exists beyond the TOML lint
+- boundary-policy widening is treated as an architecture change, not routine
+  config churn
+- `boundary-guard` exists, fires at the two named workflow
+  trigger points (post-critical-plan-review and phase-ending review), and a
+  finding at BLOCKING severity prevents the plan branch or phase PR from
+  merging
+- the daemon-to-SQLite edge fails both the TOML-based guard and the
+  code-driven architecture guard if reintroduced
+
+## Required Validation
+
+- `just lint boundaries`
+- `python3 scripts/check-boundary-guard.py --base-ref <target>`
+- `python3 -m unittest scripts.test_boundary_guard`
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/phase-AA/readiness.md`
+- `docs/project-plan.md`
+- `docs/plan-phase-AA.md`
+- `docs/architecture.md`
+- `docs/atm-daemon/boundaries.md`
+- `docs/atm-rusqlite/boundaries.md`
+- CI / testing documentation for the second enforcement layer
+- review workflow / QA protocol documentation for the new boundary-enforcement
+  agent
+
+## Risks And Watchouts
+
+- if this sprint ships without the second enforcement layer, the repo is still
+  trusting boundary TOML as the final authority
+- if the QA agent is advisory-only instead of required, boundary-policy drift
+  can still be normalized during planning or phase closeout

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -1,0 +1,314 @@
+# Phase AA Plan
+
+## Goal
+
+Remove every concrete SQLite reference from `atm-daemon` and restore the
+daemon to the original simple role:
+
+- singleton host/runtime ownership
+- transport routing
+- bounded request dispatch
+- minor runtime error handling
+
+`Phase AA` exists because the current daemon line drifted across the storage
+boundary and accumulated SQLite-aware composition, health, observability, and
+test support that do not belong in a thin router.
+
+The required end state is:
+
+- concrete SQLite construction moves to a dedicated `atm-runtime` composition
+  crate
+- existing storage-facing capability traits live in `atm-core` and remain
+  backend-neutral:
+  - `MailStore`
+  - `TaskStore`
+  - `RosterStore`
+- Phase AA adds subsystem doctor traits beside those boundaries instead of
+  introducing a second parallel storage trait family
+- `atm-daemon` knows only storage-neutral `atm-core` ports
+- `atm doctor` regains a direct local diagnostics path that can inspect
+  SQLite/store health without requiring daemon routing
+- daemon-routed doctor data remains optional and additive, used only for
+  daemon-only runtime state or for faster asynchronous answers when the daemon
+  is already live
+
+## Baseline
+
+Planning branch:
+- `plan/remove-sqlite-from-daemon`
+
+Planning worktree:
+- `../atm-core-worktrees/plan/remove-sqlite-from-daemon`
+
+Expected execution integration branch:
+- `integrate/phase-AA`
+
+Current violated state that `Phase AA` must delete:
+- `atm-daemon` directly depends on `atm-rusqlite`
+- daemon composition constructs `SqliteBoundaryAssembly`
+- daemon runtime-health code reads SQLite-backed roster state directly
+- daemon owns SQLite-specific observability glue
+- daemon test support composes SQLite assemblies directly
+
+## Why Phase AA Exists
+
+The daemon was intended to be simple and storage-agnostic. The boundary was
+created specifically so the daemon would never know that the first storage
+adapter is SQLite.
+
+That invariant no longer holds. Once the boundary widened, daemon code started
+to accumulate concrete adapter knowledge instead of staying a thin router.
+`Phase AA` is not feature expansion; it is architectural damage removal.
+
+## Target Architecture
+
+### `atm-runtime` becomes the concrete composition root
+
+`Phase AA` introduces a dedicated `atm-runtime` crate.
+
+`atm-runtime` owns:
+- construction of `SqliteBoundaryAssembly`
+- injection of SQLite-specific observability into `atm-rusqlite`
+- assembly of the concrete production `MailStore`, `RosterStore`, and replay
+  store implementations
+- any direct local doctor helper that must inspect the installed storage
+  adapter
+- installation of the active capability-trait implementations used by the CLI
+  and daemon
+
+`atm-runtime` does not own:
+- CLI parsing/rendering
+- daemon transport
+- workflow/state-machine business logic
+
+### `atm-daemon` becomes a thin router again
+
+After `Phase AA`, `atm-daemon` owns only:
+- singleton startup / shutdown
+- local and remote transport hosting
+- request validation and routing
+- bounded dispatch / reply handling
+- daemon-only runtime state that truly cannot be answered outside the daemon
+
+`atm-daemon` must not own:
+- SQLite construction
+- SQLite observability adapters
+- SQLite health probing
+- SQLite replay-store implementations
+- SQLite-specific test helpers
+- backend identity branching such as "if SQLite then ..."
+
+### Storage capability traits replace backend-shaped seams
+
+`Phase AA` should not replace SQLite-specific code with one giant generic
+`Storage` trait. The Phase AA implementation decision is:
+
+- keep the existing storage-neutral `atm-core` boundaries as the primary
+  storage capability surfaces:
+  - `MailStore`
+  - `TaskStore`
+  - `RosterStore`
+- add subsystem doctor traits beside those boundaries rather than introducing a
+  second parallel read/write trait hierarchy in the same phase
+- if a narrower reader/writer split is still desirable after the daemon is
+  clean, it becomes a later simplification line rather than extra churn inside
+  Phase AA
+
+Rules:
+- traits are named for the behavior they expose, not for backend identity
+- traits stay small and composable
+- daemon and CLI depend only on the capabilities they actually need
+- backend implementations may satisfy multiple traits, but callers should not
+  receive a giant god-interface just because one backend can do many things
+- both SQLite-backed and Claude-JSON-backed implementations are allowed to
+  satisfy the same capability family
+- `Phase AA` reuses `MailStore` / `TaskStore` / `RosterStore` as the primary
+  storage-neutral capability surfaces and does not create parallel
+  `MessageReader` / `MessageWriter` / `RosterReader` / `RosterWriter` traits
+  in the same phase
+
+### `atm doctor` becomes direct-first, daemon-optional
+
+The baseline `atm doctor` path should be local and direct:
+- config discovery
+- team/identity resolution
+- direct store-path / SQLite health
+- roster/store consistency checks that do not require a running daemon
+
+The daemon path is additive:
+- singleton owner state
+- live in-memory daemon status cache
+- active background worker state
+- degraded runtime conditions that exist only while the daemon is live
+- cross-subsystem drift findings such as SQLite roster vs `config.json` roster
+  mismatch
+
+The routing rule is therefore:
+- if a check can be answered directly from local config/store state, the CLI
+  may query it directly
+- the daemon is used only when daemon-owned runtime state is required or when
+  an already-live daemon can answer faster/asynchronously
+
+The diagnostic ownership rule is:
+- deep investigation belongs to the implementing subsystem
+- aggregation and cross-subsystem comparison belong to the caller
+- the daemon may compare subsystem reports, but it must not reimplement
+  backend-specific diagnosis logic
+- config diagnostics follow the same rule: backend-specific `config.json`
+  investigation belongs behind a config doctor trait rather than ad hoc logic
+  buried in daemon code
+- daemon runtime snapshots remain daemon-owned; backend-specific store health
+  leaves the runtime snapshot and appears only through subsystem doctor reports
+
+## Simplicity Contract
+
+The daemon must remain auditable through a very small state-machine set.
+
+`Phase AA` closure requires an explicit daemon state-machine inventory with no
+more than five top-level machines:
+
+1. bootstrap / singleton ownership
+2. request receipt / validation / dispatch / reply
+3. session / connection lifecycle
+4. graceful shutdown / drain
+5. advisory-stream lifecycle, if it remains daemon-owned
+
+Any SQLite-specific control flow that creates additional daemon machines is a
+violation and should be deleted or moved out of the crate.
+
+## Phase Entry Criteria
+
+`Phase AA` begins only when:
+- the boundary audit is frozen with the direct daemon-side SQLite leak list
+- the user-approved target architecture is recorded in requirements and
+  architecture docs
+- the new `atm-runtime` crate is accepted as the concrete composition home
+- boundary TOML changes are treated as architecture changes rather than
+  routine lint data edits
+
+## Sprint Sequence
+
+### AA.0 Boundary Freeze And Audit Ledger
+
+Purpose:
+- freeze the exact daemon-side SQLite leak inventory
+- revert boundary TOMLs so `atm-daemon` is no longer an allowed dependent of
+  the SQLite assembly/store boundaries
+- document the small allowed post-AA daemon state-machine inventory
+
+Execution branch:
+- `feature/pAA-s0-daemon-architecture-restatement`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement`
+
+### AA.1 Subsystem Doctor Traits And Shared Diagnostic Contracts
+
+Purpose:
+- define subsystem-owned capability and doctor traits in `atm-core`
+- make `atm-rusqlite` the owner of store diagnostics
+- allow backend implementations such as SQLite and Claude JSON to satisfy the
+  same behavior-named trait family
+- make daemon doctor an aggregation surface rather than a subsystem analyzer
+
+Execution branch:
+- `feature/pAA-s1-subsystem-doctor-traits`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s1-subsystem-doctor-traits`
+
+### AA.2 `atm-runtime` Skeleton And Composition Transfer
+
+Purpose:
+- add `crates/atm-runtime`
+- move concrete SQLite construction and production runtime wiring there
+- make `atm-daemon` receive only storage-neutral runtime inputs
+
+Execution branch:
+- `feature/pAA-s2-atm-runtime-composition-transfer`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s2-atm-runtime-composition-transfer`
+
+### AA.3 Direct Doctor Path And Runtime Health Simplification
+
+Purpose:
+- restore a direct local doctor path for config/store checks
+- keep daemon health as an additive runtime subreport rather than the only
+  doctor path
+- remove daemon-owned SQLite health probing
+
+Execution branch:
+- `feature/pAA-s3-direct-doctor-and-runtime-health-split`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split`
+
+### AA.4 Delete Remaining Daemon SQLite Leaks
+
+Purpose:
+- move SQLite observability injection to `atm-runtime` / `atm-rusqlite`
+- move or delete daemon-local SQLite replay/store wrappers
+- delete daemon-private SQLite test support
+
+Execution branch:
+- `feature/pAA-s4-delete-daemon-sqlite-leaks`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks`
+
+### AA.5 Boundary Relock And Permanent Enforcement
+
+Purpose:
+- relock the `atm-daemon` / `atm-rusqlite` boundary in code and TOML
+- add a second architecture-enforcement layer beyond the TOML lint rules
+- treat boundary-policy widening as an explicit architecture change
+- add a `boundary-guard` QA agent that reviews plans and phase-ending
+  reviews for any boundary loosening before closure
+
+Execution branch:
+- `feature/pAA-s5-boundary-relock-and-permanent-enforcement`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement`
+
+## Non-Goals
+
+`Phase AA` does not:
+- redesign ATM business logic
+- replace SQLite with a second adapter in the same phase
+- expand the daemon packet surface
+- introduce new product features unrelated to removing SQLite knowledge from
+  the daemon
+- preserve daemon-local helper code solely because it already exists
+
+## Exit Criteria
+
+`Phase AA` closes only when all of the following are true:
+
+- `crates/atm-daemon` has no direct dependency on `atm-rusqlite`
+- daemon source contains no direct `atm_rusqlite::*` references
+- SQLite observability is injected into SQLite-owned code outside the daemon
+- local `atm doctor` can report direct config/store health without requiring
+  daemon routing
+- daemon health reporting aggregates injected subsystem reports plus
+  daemon-owned runtime state without backend-specific diagnosis logic
+- the boundary TOMLs forbid the daemon-to-SQLite edge again
+- a `boundary-guard` QA agent exists and is part of plan review plus
+  phase-ending review for boundary-widening detection
+- the daemon state-machine inventory is explicitly documented and stays within
+  the Phase AA simplicity contract
+
+## Planning Consequences
+
+The cheapest correct implementation path is deletion-first, not compatibility-
+preserving refactor-first.
+
+If a daemon-side SQLite-aware behavior is not essential to:
+- transport
+- routing
+- lifecycle
+- bounded request handling
+
+then `Phase AA` should prefer deleting it over inventing a new daemon-local
+abstraction for it.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -60,6 +60,16 @@ Phase-S planning note:
   - `S.9` host-scoped retained logging defaults, including watcher/reconcile
     exclusion for `~/.atm/logs/`
 
+Phase-AA simplification note:
+- after the retained daemon/SQLite line proved the transport split, the daemon
+  accumulated concrete SQLite composition and health/observability ownership
+  that violated the intended boundary
+- the corrective planning line is Phase AA, tracked in
+  [`docs/plan-phase-AA.md`](./plan-phase-AA.md)
+- Phase AA restores the original daemon role as a thin router by moving
+  concrete SQLite construction to a dedicated `atm-runtime` crate and
+  restoring a direct local doctor/store-health path
+
 Phase R execution entry:
 - Wave 1 deliverable: the new Phase R skeleton
   - new crates
@@ -94,6 +104,9 @@ Status:
   source-of-truth and daemon-boundary redesign.
 - Phase R is the merged daemon baseline.
 - Phase S is the active planning line for Windows-complete daemon parity.
+- Phase AA is the architectural simplification planning line for removing
+  SQLite references from `atm-daemon` and moving concrete runtime assembly out
+  to `atm-runtime`.
 - the current merged workspace contains:
   - `crates/atm-core`
   - `crates/atm`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -20,6 +20,14 @@ mail routing, native agent notification, and cross-host transport need one
 coordinating process, while ATM command behavior remains the user-facing
 surface.
 
+Phase-AA simplification direction:
+- the daemon remains part of the product, but it must return to the original
+  thin-router role
+- concrete SQLite construction moves to a dedicated `atm-runtime` crate
+- the daemon must not know that the current durable adapter is SQLite
+- direct local diagnostics such as store-openability and baseline SQLite
+  health may be answered without routing through the daemon
+
 The retained product surface is:
 - `atm send`
 - `atm list`
@@ -1563,6 +1571,14 @@ Run local ATM diagnostics for the retained ATM runtime.
 `atm doctor` remains a local diagnostics command, but in the current SQLite/daemon architecture
 architecture it must also report daemon/runtime availability because normal ATM
 mail behavior depends on the singleton daemon being present.
+
+Phase-AA target direction:
+- `atm doctor` keeps daemon/runtime reporting, but daemon routing is not the
+  only legal path for diagnostics
+- checks that are inherently local and store-backed may run directly from the
+  CLI
+- daemon-routed doctor data is additive and exists for daemon-owned runtime
+  state or faster asynchronous answers when the daemon is already live
 
 ### 11.2 Supported Flags
 


### PR DESCRIPTION
## Summary

- Phase AA planning docs: daemon SQLite boundary removal sprint plan
- Adds `docs/plan-phase-AA.md`, sprint docs AA0–AA5, state machines, readiness doc, and leak ledger
- Updates `docs/architecture.md`, `docs/atm-daemon/architecture.md`, `docs/atm-daemon/requirements.md`, `docs/atm-rusqlite/requirements.md`
- Documents the authorized coupling (commit 34467437) and the phased plan to remove it post-v1.2.0

## Test plan

- [ ] Docs-only branch — no code changes
- [ ] `docs/plan-phase-AA.md` present with full sprint breakdown
- [ ] Sprint docs AA0–AA5 present under `docs/phase-AA/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)