### PR TITLE
docs: plan phase AA daemon SQLite boundary removal

### DIFF
--- a/.claude/agents/boundary-guard.md
+++ b/.claude/agents/boundary-guard.md
@@ -1,0 +1,54 @@
+---
+name: boundary-guard
+version: 0.1.0
+description: Reviews boundary TOML and crate-edge changes for policy relaxations or forbidden dependency reintroduction before plan approval and phase closeout.
+tools: Glob, Grep, LS, Read, BashOutput
+model: sonnet
+color: red
+---
+
+You are the boundary-guard review agent for the `atm-core` repository.
+
+Your mission is to detect boundary-policy widening and forbidden dependency
+reintroduction, especially `atm-daemon -> atm-rusqlite`, before those changes
+can pass plan review or phase-ending review.
+
+Output fenced JSON findings only; do not send ATM messages directly.
+
+## Required Reference
+
+Always read:
+- `.claude/skills/plan-hardening/sprint-planning-guidelines.md`
+- `docs/phase-AA/sprint-AA5.md`
+
+## Required Checks
+
+At minimum, detect:
+- any addition to `allowed_dependents`
+- any removal from `forbidden_edges`
+- any promotion of `visibility` toward public
+- any promotion of `constructor` toward public
+- any removal from `forbidden_test_bypasses`
+- any removal from `forbidden`
+- any direct `atm-daemon -> atm-rusqlite` dependency edge in code or manifests
+
+## Output Contract
+
+Return fenced JSON only.
+
+```json
+{
+  "status": "PASS | FAIL",
+  "mode": "boundary-guard-review",
+  "reviewer": "boundary-guard",
+  "findings": [
+    {
+      "severity": "Blocking | Important | Minor",
+      "category": "POLICY-RELAXATION | FORBIDDEN-EDGE | VISIBILITY-WIDENING | TEST-BYPASS-REMOVAL",
+      "target_refs": ["path:line"],
+      "issue": "clear statement of the boundary problem",
+      "required_correction": "specific corrective action"
+    }
+  ]
+}
+```

--- a/.claude/agents/boundary-guard.md
+++ b/.claude/agents/boundary-guard.md
@@ -32,6 +32,22 @@ At minimum, detect:
 - any removal from `forbidden`
 - any direct `atm-daemon -> atm-rusqlite` dependency edge in code or manifests
 
+## Mandatory Trigger Points
+
+`boundary-guard` must run at these points:
+1. after `critical-plan-reviewer` and before `team-lead` approval on any plan
+   branch that modifies a boundary TOML
+2. as a required reviewer in every phase-ending review packet
+
+## Blocking Posture
+
+`boundary-guard` is mandatory, not advisory.
+
+- any `Blocking` finding stops merge on plan branches that modify boundary
+  TOMLs
+- any `Blocking` finding stops merge on phase-ending review branches
+- `Minor` findings remain advisory only
+
 ## Output Contract
 
 Return fenced JSON only.

--- a/.claude/agents/registry.yaml
+++ b/.claude/agents/registry.yaml
@@ -17,6 +17,9 @@ agents:
   critical-plan-reviewer:
     version: 0.1.0
     path: .claude/agents/critical-plan-reviewer.md
+  boundary-guard:
+    version: 0.1.0
+    path: .claude/agents/boundary-guard.md
   flaky-test-qa:
     version: 0.1.0
     path: .claude/agents/flaky-test-qa.md

--- a/boundaries/atm-runtime/runtime-composition.toml
+++ b/boundaries/atm-runtime/runtime-composition.toml
@@ -4,24 +4,26 @@ owner_crate_path = "atm_runtime"
 name = "RuntimeComposition"
 
 [public]
-trait = null
+facade = "RuntimeComposition"
 notes = "Phase AA concrete composition seam that assembles storage-neutral runtime inputs for atm and atm-daemon"
 
 [implementation]
-visibility = "crate_only"
-constructor = "crate_only"
+type = "RuntimeComposition"
+module = "atm_runtime"
+visibility = "pub(crate)"
+constructor = "pub(crate)"
 
 [composition]
-roots = ["atm-runtime"]
+roots = ["atm_runtime::composition"]
 
 [ownership]
 io_owns = ["runtime_dependency_assembly", "config_doctor_assembly", "replay_store_assembly"]
 io_forbidden = ["daemon_transport", "daemon_lifecycle", "direct_socket_io"]
 
 [dependencies]
-allowed_dependents = ["atm", "atm-daemon"]
+allowed_dependents = ["atm", "atm-daemon", "atm-runtime"]
 allowed_dependencies = ["atm-core", "atm-rusqlite"]
-forbidden_edges = ["atm-daemon -> atm-rusqlite", "atm -> atm-rusqlite", "atm-runtime -> atm-daemon"]
+forbidden_edges = ["atm -> atm-rusqlite", "atm-runtime -> atm-daemon"]
 
 [references]
 scope = "outside_owner_crate"
@@ -34,7 +36,7 @@ error_types = ["AtmError"]
 
 [testing]
 allowed_test_double_paths = []
-forbidden_test_bypasses = ["direct sqlite assembly inside atm-daemon"]
+forbidden_test_bypasses = ["RuntimeComposition"]
 
 [enforcement]
 lint_rules = ["SCB-RUNTIME-001", "SCB-RUNTIME-002"]
@@ -42,4 +44,4 @@ review_gates = ["no_direct_backend_leakage", "no_runtime_to_daemon_backedge"]
 
 [status]
 state = "planned"
-notes = ["introduced by Phase AA to freeze the atm-runtime ownership boundary before implementation", "daemon startup remains fail-closed on any RuntimeBundle assembly failure"]
+notes = ["introduced by Phase AA to freeze the atm-runtime ownership boundary before implementation", "daemon startup remains fail-closed on any RuntimeBundle assembly failure", "the daemon-to-sqlite edge remains governed by the existing rusqlite boundary TOMLs until AA.5 relocks them; this record does not fail that edge during the AA.2-AA.4 transition window"]

--- a/boundaries/atm-runtime/runtime-composition.toml
+++ b/boundaries/atm-runtime/runtime-composition.toml
@@ -1,0 +1,45 @@
+boundary_id = "BOUNDARY-AtmRuntime-Composition"
+owner_package = "atm-runtime"
+owner_crate_path = "atm_runtime"
+name = "RuntimeComposition"
+
+[public]
+trait = null
+notes = "Phase AA concrete composition seam that assembles storage-neutral runtime inputs for atm and atm-daemon"
+
+[implementation]
+visibility = "crate_only"
+constructor = "crate_only"
+
+[composition]
+roots = ["atm-runtime"]
+
+[ownership]
+io_owns = ["runtime_dependency_assembly", "config_doctor_assembly", "replay_store_assembly"]
+io_forbidden = ["daemon_transport", "daemon_lifecycle", "direct_socket_io"]
+
+[dependencies]
+allowed_dependents = ["atm", "atm-daemon"]
+allowed_dependencies = ["atm-core", "atm-rusqlite"]
+forbidden_edges = ["atm-daemon -> atm-rusqlite", "atm -> atm-rusqlite", "atm-runtime -> atm-daemon"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = []
+
+[contracts]
+request_types = ["runtime bootstrap/config inputs"]
+response_types = ["RuntimeBundle", "doctor assembly handles"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["direct sqlite assembly inside atm-daemon"]
+
+[enforcement]
+lint_rules = ["SCB-RUNTIME-001", "SCB-RUNTIME-002"]
+review_gates = ["no_direct_backend_leakage", "no_runtime_to_daemon_backedge"]
+
+[status]
+state = "planned"
+notes = ["introduced by Phase AA to freeze the atm-runtime ownership boundary before implementation", "daemon startup remains fail-closed on any RuntimeBundle assembly failure"]

--- a/boundaries/atm-rusqlite/mail-store-sqlite.toml
+++ b/boundaries/atm-rusqlite/mail-store-sqlite.toml
@@ -69,4 +69,5 @@ state = "active"
 notes = [
   "crate-root implementation remains temporary; module split is still deferred",
   "assembled through atm_rusqlite::SqliteBoundaryAssembly",
+  "transition note: atm-daemon remains in allowed_dependents through the AA.2-AA.4 window; runtime-composition.toml governs the target end-state while AA.5 relocks the sqlite boundary TOMLs",
 ]

--- a/boundaries/atm-rusqlite/roster-store-sqlite.toml
+++ b/boundaries/atm-rusqlite/roster-store-sqlite.toml
@@ -71,4 +71,5 @@ notes = [
   "the canonical table is explicit member rows; daemon-owned pid continuity is not persisted here",
   "crate-root implementation remains temporary; module split is still deferred",
   "assembled through atm_rusqlite::SqliteBoundaryAssembly",
+  "transition note: atm-daemon remains in allowed_dependents through the AA.2-AA.4 window; runtime-composition.toml governs the target end-state while AA.5 relocks the sqlite boundary TOMLs",
 ]

--- a/boundaries/atm-rusqlite/shared-db.toml
+++ b/boundaries/atm-rusqlite/shared-db.toml
@@ -69,4 +69,5 @@ state = "unix_implemented_windows_pending"
 notes = [
   "crate-private state-root surface must remain review-visible because it owns sqlite bootstrap and transaction policy",
   "shared database root is host-scoped under the ADR-005 durable-state model",
+  "transition note: atm-daemon remains in allowed_dependents through the AA.2-AA.4 window; runtime-composition.toml governs the target end-state while AA.5 relocks the sqlite boundary TOMLs",
 ]

--- a/boundaries/atm-rusqlite/sqlite-boundary-assembly.toml
+++ b/boundaries/atm-rusqlite/sqlite-boundary-assembly.toml
@@ -67,4 +67,5 @@ state = "active"
 notes = [
   "hosts the shared assembly seam for mail, task, and roster adapters over one sqlite root",
   "daemon runtime may use the public assembly seam for roster truth and SQLite readiness checks",
+  "transition note: atm-daemon remains in allowed_dependents through the AA.2-AA.4 window; runtime-composition.toml governs the target end-state while AA.5 relocks the sqlite boundary TOMLs",
 ]

--- a/boundaries/atm-rusqlite/task-store-sqlite.toml
+++ b/boundaries/atm-rusqlite/task-store-sqlite.toml
@@ -70,4 +70,5 @@ notes = [
   "ack-related task transitions still resolve through send-shape workflows, not a separate public ack API",
   "crate-root implementation remains temporary; module split is still deferred",
   "assembled through atm_rusqlite::SqliteBoundaryAssembly",
+  "transition note: atm-daemon remains in allowed_dependents through the AA.2-AA.4 window; runtime-composition.toml governs the target end-state while AA.5 relocks the sqlite boundary TOMLs",
 ]

--- a/docs/adr/ADR-ATM-RUNTIME-001.md
+++ b/docs/adr/ADR-ATM-RUNTIME-001.md
@@ -1,0 +1,62 @@
+# ADR-ATM-RUNTIME-001 — `atm-runtime` As Concrete Composition Root
+
+```yaml
+adr_id: ADR-ATM-RUNTIME-001
+crate: atm-runtime
+title: atm-runtime as concrete composition root
+status: proposed
+date: 2026-05-30
+deciders:
+  - team-lead
+  - arch-ctm
+tags:
+  - runtime
+  - composition
+  - boundaries
+related_boundaries:
+  - BOUNDARY-RuntimeFactory
+  - BOUNDARY-AtmRuntime-Composition
+code_references:
+  - docs/phase-AA/sprint-AA2.md
+  - docs/phase-AA/sprint-AA3.md
+  - docs/atm-runtime/architecture.md
+```
+
+## Context
+
+`atm-daemon` drifted into direct SQLite-aware composition, health probing,
+observability wiring, and replay-store ownership. The daemon is intended to be
+a thin router and must not know the concrete storage backend.
+
+Phase AA introduces a new crate to own the concrete runtime/store composition
+work that currently lives in the wrong place.
+
+## Decision
+
+Introduce `atm-runtime` as the concrete composition root.
+
+`atm-runtime` owns:
+- `SqliteBoundaryAssembly` construction
+- concrete store/replay assembly
+- concrete `ConfigDoctor` assembly
+- `RuntimeBundle` assembly for CLI and daemon callers
+
+`atm-runtime` does not own:
+- daemon transport
+- daemon lifecycle
+- CLI rendering
+- backend-specific SQLite logic that belongs inside `atm-rusqlite`
+
+## Alternatives Considered
+
+- keep concrete composition in `atm-daemon`
+- move the composition burden directly into `atm`
+- let `atm` and `atm-daemon` each assemble SQLite independently
+
+## Consequences
+
+- `atm-daemon` can become storage-agnostic again
+- the direct CLI doctor path can depend on `atm-runtime` without taking a
+  direct dependency on `atm-rusqlite`
+- the new crate requires explicit boundary governance so its dependency edges
+  do not become another silent leak point

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -24,6 +24,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 
 ## Extracted Crate-Local ADRs
 
+- [ADR-ATM-RUNTIME-001 — `atm-runtime` As Concrete Composition Root](./ADR-ATM-RUNTIME-001.md)
 - [ADR-ATM-RUSQLITE-002 — Single In-Process SQLite Write Worker](./ADR-ATM-RUSQLITE-002.md)
 
 ## Embedded Crate-Local ADR Records

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,15 @@ Phase-S portability note:
   contract
 - Phase S planning is tracked in [`docs/plan-phase-S.md`](./plan-phase-S.md)
 
+Phase-AA simplification note:
+- the current daemon composition root and daemon-routed doctor model are not
+  the intended steady-state architecture
+- Phase AA moves concrete SQLite construction into a dedicated `atm-runtime`
+  crate and removes adapter-specific health/observability ownership from
+  `atm-daemon`
+- the daemon remains in the product, but as a thin router rather than a
+  concrete storage/runtime host
+
 ## 2. Crate Boundaries
 
 The post-Q product runtime is implemented by four crates:
@@ -183,6 +192,11 @@ Current Phase R boundary direction:
   - `atm` is the CLI client composition root
   - `atm-daemon` is the runtime composition root
   - a separate composition crate remains out of scope unless an ADR opens it
+- Phase AA target ownership:
+  - `atm` remains the CLI composition root
+  - `atm-runtime` becomes the concrete runtime/store composition root
+  - `atm-daemon` consumes storage-neutral runtime inputs and stops
+    constructing SQLite-backed adapters directly
 
 Current Phase R lint partition direction:
 - extend the existing `sc-portability` analyzer for reusable platform-gating
@@ -2829,6 +2843,15 @@ Architectural rules:
   - aggregate active/idle/offline/unknown member counts
 - CLI code must not inspect private daemon state directly to synthesize health
   answers
+
+Phase AA target doctor split:
+- daemon health remains a separate explicit request/response boundary for
+  daemon-owned runtime state
+- direct local doctor checks that only require config or store access do not
+  need daemon routing
+- SQLite/store readiness is therefore expected to move out of daemon-owned
+  health collection and into the direct local diagnostics path or the
+  `atm-runtime` composition layer
 
 ### 21.6.4 Shutdown, Signals, Timeouts, And Resource Caps
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,7 @@ moved into:
 - [`docs/atm/architecture.md`](./atm/architecture.md)
 - [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
 - [`docs/atm-daemon/architecture.md`](./atm-daemon/architecture.md)
+- [`docs/atm-runtime/architecture.md`](./atm-runtime/architecture.md)
 - [`docs/atm-rusqlite/architecture.md`](./atm-rusqlite/architecture.md)
 
 Phase-Q supersession note:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2849,9 +2849,11 @@ Phase AA target doctor split:
   daemon-owned runtime state
 - direct local doctor checks that only require config or store access do not
   need daemon routing
-- SQLite/store readiness is therefore expected to move out of daemon-owned
-  health collection and into the direct local diagnostics path or the
-  `atm-runtime` composition layer
+- SQLite/store readiness will be removed from daemon-owned health collection in
+  `AA.3`, with `sqlite_ready` and `sqlite_detail` deleted per
+  `docs/phase-AA/sprint-AA3.md`
+- store readiness then lives in direct local diagnostics or other subsystem
+  doctor reports assembled above the backend, not in the daemon runtime DTO
 
 ### 21.6.4 Shutdown, Signals, Timeouts, And Resource Caps
 

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -783,6 +783,16 @@ Doctor health contract distinction:
   them through the documented request boundary
 - `atm doctor` must report both dimensions explicitly rather than treating
   process existence as equivalent to request-serving readiness
+- Phase AA supersession note:
+  - `AA.3` deletes `sqlite_ready`, `sqlite_detail`, and the SQLite-backed
+    continuity wording from the daemon-owned runtime snapshot
+  - after `AA.3`, `RuntimeStatusSnapshot` carries only daemon-owned runtime
+    state and no store-specific readiness fields
+  - SQLite/store readiness moves to subsystem doctor reports and does not
+    remain part of the daemon runtime DTO
+  - `docs/phase-AA/sprint-AA3.md` is the frozen source of truth for the
+    post-AA runtime snapshot shape, and this section must be updated during
+    that sprint to match the final implementation
 - readiness states are:
   - `ready` when the daemon owns the runtime, SQLite-backed continuity is
     available, ingest is healthy, and no active identity-conflict path exists

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -793,18 +793,17 @@ Doctor health contract distinction:
   - `docs/phase-AA/sprint-AA3.md` is the frozen source of truth for the
     post-AA runtime snapshot shape, and this section must be updated during
     that sprint to match the final implementation
-- readiness states are:
-  - `ready` when the daemon owns the runtime, SQLite-backed continuity is
-    available, ingest is healthy, and no active identity-conflict path exists
-  - `degraded` when the daemon is still running but SQLite continuity, ingest,
-    or identity-conflict handling is impaired
-  - `unavailable` when the daemon still owns the runtime but every tracked
-    member has transitioned fully offline
-- the runtime health snapshot projected into `atm doctor` must also carry:
-  - singleton-owner pid when known
-  - SQLite-ready state
-  - degraded-ingest state
-  - aggregate active/idle/offline/unknown member counts
+- pre-AA historical baseline only, superseded by the frozen `AA.3` delete
+  list:
+  - readiness states previously treated SQLite continuity as part of daemon
+    readiness
+  - the runtime health snapshot previously carried:
+    - singleton-owner pid when known
+    - SQLite-ready state
+    - degraded-ingest state
+    - aggregate active/idle/offline/unknown member counts
+  - this historical baseline is retained only to explain the pre-AA daemon
+    shape and must not be treated as the post-AA runtime-health contract
 
 ## 3.6 Crash Recovery
 

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -70,6 +70,13 @@ Follow-up work:
 - Keep adapter assembly in daemon-owned composition code only.
 - Revisit only if a later ADR extracts a dedicated composition crate.
 
+Phase-AA supersession note:
+- this ADR records the current merged ownership shape only
+- `Phase AA` intentionally supersedes it by moving concrete runtime/store
+  composition into a dedicated `atm-runtime` crate
+- after `Phase AA`, `atm-daemon` is no longer a legal home for SQLite adapter
+  construction
+
 ## 2. Responsibilities
 
 The `atm-daemon` crate is responsible for:
@@ -84,6 +91,12 @@ The `atm-daemon` crate is responsible for:
 - daemon health/status query surface for `atm doctor`
 
 The `atm-daemon` crate must remain thin.
+
+Phase-AA target direction:
+- the daemon remains transport/lifecycle-owned
+- SQLite-specific composition, observability, replay, and direct store-health
+  logic are removed from this crate
+- daemon health becomes daemon-owned runtime projection only
 
 Phase R redesign notes:
 - `atm-daemon` remains runtime-oriented, not business-logic-oriented

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -46,6 +46,13 @@ The canonical daemon/client recovery text rule set lives in:
 - direct ownership of SQLite semantics beyond using the `atm-core` store
   boundary
 
+Phase-AA target direction:
+- `atm-daemon` stops being the concrete SQLite composition owner
+- SQLite construction, SQLite-specific observability injection, and direct
+  SQLite health probing move out of this crate
+- daemon-owned doctor reporting is reduced to daemon-owned runtime state rather
+  than direct store readiness checks
+
 Current request/response packet families owned by the daemon transport line:
 - send compose
 - send acknowledge

--- a/docs/atm-runtime/architecture.md
+++ b/docs/atm-runtime/architecture.md
@@ -16,6 +16,8 @@ It sits between:
 - installation of the active `MailStore`, `TaskStore`, and `RosterStore`
   implementations
 - installation of subsystem doctor implementations
+- the concrete `ConfigDoctor` implementation and its direct local doctor-path
+  assembly
 - installation of the active `RemoteReplayStore`
 - SQLite-specific observability injection into SQLite-owned code
 
@@ -45,7 +47,16 @@ pub struct RuntimeBundle {
 `atm-daemon` must consume only this kind of injected storage-neutral bundle and
 must not construct `SqliteBoundaryAssembly` directly.
 
+The direct CLI doctor path is allowed to depend on `atm-runtime` for this
+bundle/doctor assembly. It must not depend directly on `atm-rusqlite`.
+
 ## Boundary Rule
 
 `atm-runtime` is the legal Phase AA location for concrete SQLite assembly.
 That authorization does not extend to `atm-daemon`.
+
+## Startup Rule
+
+Any `RuntimeBundle` assembly failure is fail-closed. The daemon must not enter
+serving state if any required runtime component, including replay-store
+construction, fails.

--- a/docs/atm-runtime/architecture.md
+++ b/docs/atm-runtime/architecture.md
@@ -1,0 +1,51 @@
+# `atm-runtime` Architecture
+
+## Role
+
+`atm-runtime` is the concrete composition root introduced by `Phase AA`.
+
+It sits between:
+- storage-neutral interfaces in `atm-core`
+- backend implementation crates such as `atm-rusqlite`
+- top-level callers such as the CLI and `atm-daemon`
+
+## Ownership
+
+`atm-runtime` owns:
+- concrete production assembly of runtime/store dependencies
+- installation of the active `MailStore`, `TaskStore`, and `RosterStore`
+  implementations
+- installation of subsystem doctor implementations
+- installation of the active `RemoteReplayStore`
+- SQLite-specific observability injection into SQLite-owned code
+
+`atm-runtime` does not own:
+- daemon request routing
+- daemon lifecycle control
+- CLI command rendering
+- backend-specific store logic that belongs inside `atm-rusqlite`
+
+## Required Seam
+
+The minimum Phase AA seam is a storage-neutral runtime bundle:
+
+```rust
+pub struct RuntimeBundle {
+    pub mail_store: Arc<dyn MailStore>,
+    pub task_store: Arc<dyn TaskStore>,
+    pub roster_store: Arc<dyn RosterStore>,
+    pub mail_store_doctor: Arc<dyn MailStoreDoctor>,
+    pub task_store_doctor: Arc<dyn TaskStoreDoctor>,
+    pub roster_store_doctor: Arc<dyn RosterStoreDoctor>,
+    pub config_doctor: Arc<dyn ConfigDoctor>,
+    pub remote_replay_store: Arc<dyn RemoteReplayStore>,
+}
+```
+
+`atm-daemon` must consume only this kind of injected storage-neutral bundle and
+must not construct `SqliteBoundaryAssembly` directly.
+
+## Boundary Rule
+
+`atm-runtime` is the legal Phase AA location for concrete SQLite assembly.
+That authorization does not extend to `atm-daemon`.

--- a/docs/atm-runtime/boundaries.md
+++ b/docs/atm-runtime/boundaries.md
@@ -27,3 +27,11 @@ Notes:
 - `atm-runtime` is composition-only
 - direct local `ConfigDoctor` ownership lives here
 - daemon startup remains fail-closed on any `RuntimeBundle` construction error
+- transition rule for `AA.2` through `AA.4`:
+  - this boundary record freezes the intended end-state edges early so code and
+    sprint scope can be built toward them
+  - the existing `atm-rusqlite` boundary TOMLs remain the authoritative lint
+    policy until `AA.5` relocks those files to remove `atm-daemon` from their
+    allowlists
+  - `AA.5` is the sprint that makes every machine-readable boundary record
+    agree again on the forbidden `atm-daemon -> atm-rusqlite` edge

--- a/docs/atm-runtime/boundaries.md
+++ b/docs/atm-runtime/boundaries.md
@@ -1,0 +1,29 @@
+# `atm-runtime` Boundary Inventory
+
+Canonical machine-readable boundary source:
+- [../../boundaries/atm-runtime/runtime-composition.toml](../../boundaries/atm-runtime/runtime-composition.toml)
+
+## RuntimeComposition
+
+Purpose:
+- own concrete runtime/store composition for the CLI direct-doctor path and
+  daemon startup without letting either caller depend directly on
+  `atm-rusqlite`
+
+Allowed dependents:
+- `atm`
+- `atm-daemon`
+
+Allowed dependencies:
+- `atm-core`
+- `atm-rusqlite`
+
+Forbidden edges:
+- `atm-daemon -> atm-rusqlite`
+- `atm -> atm-rusqlite`
+- `atm-runtime -> atm-daemon`
+
+Notes:
+- `atm-runtime` is composition-only
+- direct local `ConfigDoctor` ownership lives here
+- daemon startup remains fail-closed on any `RuntimeBundle` construction error

--- a/docs/atm-runtime/requirements.md
+++ b/docs/atm-runtime/requirements.md
@@ -1,0 +1,37 @@
+# `atm-runtime` Requirements
+
+## Goal
+
+Define the concrete composition-root requirements for the `atm-runtime` crate
+introduced by `Phase AA`.
+
+## Scope
+
+`atm-runtime` exists only to own concrete runtime/store assembly that must not
+live in `atm-daemon`.
+
+## Requirements
+
+- `atm-runtime` must be the only legal home for concrete production assembly
+  of SQLite-backed runtime/store components after `AA.2`.
+- `atm-runtime` must construct and inject:
+  - `SqliteBoundaryAssembly`
+  - SQLite-backed `MailStore`
+  - SQLite-backed `TaskStore`
+  - SQLite-backed `RosterStore`
+  - SQLite-backed `RemoteReplayStore`
+- `atm-runtime` must expose storage-neutral runtime inputs to callers through
+  the `atm-core` trait surfaces frozen by `Phase AA`.
+- `atm-runtime` must not own:
+  - CLI parsing/rendering
+  - daemon transport
+  - daemon lifecycle state machines
+  - backend-specific logic that belongs inside `atm-rusqlite`
+- `atm-runtime` must remain composition-only. If logic is not composition, it
+  belongs in another crate.
+
+## Doctor Ownership Rule
+
+- `atm-runtime` may wire together subsystem doctors for caller use.
+- `atm-runtime` must not become a second implementation home for deep
+  SQLite-specific diagnosis; that remains inside `atm-rusqlite`.

--- a/docs/atm-runtime/requirements.md
+++ b/docs/atm-runtime/requirements.md
@@ -22,6 +22,18 @@ live in `atm-daemon`.
   - SQLite-backed `RemoteReplayStore`
 - `atm-runtime` must expose storage-neutral runtime inputs to callers through
   the `atm-core` trait surfaces frozen by `Phase AA`.
+- `atm-runtime` must own the concrete `ConfigDoctor` implementation used by
+  the direct local doctor path.
+- `atm-runtime` must support an `atm -> atm-runtime` dependency edge for the
+  direct local doctor path while forbidding any direct `atm -> atm-rusqlite`
+  dependency.
+- `atm-runtime` must support an `atm-daemon -> atm-runtime` dependency edge
+  for runtime bundle assembly while preserving the forbidden
+  `atm-daemon -> atm-rusqlite` edge.
+- `atm-runtime` must fail closed during `RuntimeBundle` assembly. If any
+  component cannot be constructed, including the replay-store component needed
+  by `REQ-DAEMON-RUNTIME-005`, daemon startup must fail before entering
+  serving state.
 - `atm-runtime` must not own:
   - CLI parsing/rendering
   - daemon transport

--- a/docs/atm-rusqlite/requirements.md
+++ b/docs/atm-rusqlite/requirements.md
@@ -98,6 +98,11 @@ Required rules:
   and store boundaries
 - the current runtime composition owner may depend on this crate in order to
   assemble production adapters, but thin callers and extension crates must not
+- Phase-AA target direction:
+  - the long-term concrete composition owner is `atm-runtime`, not
+    `atm-daemon`
+  - daemon crates must not retain direct SQLite assembly dependencies after
+    the Phase AA simplification line closes
 - schema bootstrap must be deterministic and idempotent
 - schema bootstrap must run once per database root before normal store
   operations, not on every connection acquisition

--- a/docs/phase-AA/daemon-sqlite-leak-ledger.md
+++ b/docs/phase-AA/daemon-sqlite-leak-ledger.md
@@ -1,0 +1,64 @@
+# Phase AA Daemon SQLite Leak Ledger
+
+## Purpose
+
+Freeze the exact daemon-side SQLite leak inventory and the Phase AA repair
+decision now, so later sprints perform mechanical deletion or movement rather
+than rediscovering ownership.
+
+## Frozen Leak Decisions
+
+| File | Current leak | Phase AA decision |
+| --- | --- | --- |
+| `crates/atm-daemon/src/sqlite_observability.rs` | daemon-owned SQLite observability adapter | `delete` |
+| `crates/atm-daemon/src/runtime_health_test_support.rs` | daemon-local SQLite test assembly | `delete` |
+| `crates/atm-daemon/src/lib.rs` | `SqliteRemoteReplayStore`, `RemoteReplayStateRecord` re-export, direct SQLite observability type use | `rewrite` to remove replay wrapper and all direct `atm_rusqlite` types |
+| `crates/atm-daemon/src/composition.rs` | `SqliteBoundaryAssembly::new*`, SQLite observability injection, concrete production boundary construction | `move` concrete assembly to `atm-runtime`; `rewrite` daemon composition to injected ports only |
+| `crates/atm-daemon/src/runtime_health.rs` | direct `SqliteBoundaryAssembly`, direct roster-store use, WAL checkpoint call, SQLite readiness probing | `rewrite` to injected subsystem reports plus daemon-owned runtime state only |
+| `crates/atm-daemon/src/runtime_status_cache.rs` | `sqlite_ready`, `sqlite_detail`, `mark_sqlite_unavailable*` | `delete` SQLite-named fields/helpers; keep only daemon runtime fields |
+| `crates/atm-daemon/src/peer_transport.rs` | daemon-owned replay DTO/trait coupled to SQLite-owned record type | `rewrite` to storage-neutral replay DTO/trait owned outside daemon and `atm-rusqlite` |
+| `crates/atm-daemon/src/tests.rs` | direct `assemble_boundary(...)` use | `rewrite` to composition/subsystem fixtures; no daemon-local SQLite assembly |
+| `crates/atm-daemon/src/tests_advisory.rs` | direct `assemble_boundary(...)` use | `rewrite` to composition/subsystem fixtures; no daemon-local SQLite assembly |
+
+## Concrete Type Decisions
+
+### `SqliteBoundaryAssembly`
+
+Current location of daemon use:
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/lib.rs`
+
+Phase AA decision:
+- no production use remains in `atm-daemon`
+- concrete construction moves to `atm-runtime`
+
+### `RemoteReplayStateRecord`
+
+Current location:
+- `crates/atm-rusqlite/src/boundary_assembly.rs`
+- re-exported from `crates/atm-daemon/src/lib.rs`
+
+Phase AA decision:
+- move to a storage-neutral boundary owned outside both `atm-daemon` and
+  `atm-rusqlite`, expected in `atm-core`
+
+### Store/roster health
+
+Current location of daemon probing:
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+
+Phase AA decision:
+- deep health belongs to subsystem doctor traits
+- daemon aggregates subsystem reports and daemon-owned runtime state only
+
+## Review Rule
+
+If implementation work proposes:
+- “keep this SQLite helper in the daemon for convenience”
+- “re-export this SQLite type from daemon temporarily”
+- “leave sqlite_ready in runtime status for now”
+
+the proposal is out of plan and should be rejected unless the Phase AA docs are
+first updated with explicit user-approved justification.

--- a/docs/phase-AA/daemon-state-machines.md
+++ b/docs/phase-AA/daemon-state-machines.md
@@ -1,0 +1,99 @@
+# Phase AA Daemon State-Machine Inventory
+
+## Purpose
+
+Freeze the small auditable daemon-machine target before code deletion begins.
+
+Phase AA target:
+- no more than `5` top-level daemon state machines
+- no backend-specific SQLite control flow in the daemon
+
+## Target Machine Set
+
+### 1. Bootstrap / Singleton Ownership
+
+Owned concerns:
+- launch gate
+- host ownership acquisition
+- transition into serving or clean failure
+
+Primary files:
+- `crates/atm-daemon/src/host_ownership.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+- bootstrap portions of `crates/atm-daemon/src/composition.rs`
+
+### 2. Request Receipt / Validation / Dispatch / Reply
+
+Owned concerns:
+- local IPC request acceptance
+- request decoding
+- dispatch to injected runtime/service ports
+- bounded reply / error return
+
+Primary files:
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/local_ipc_transport/request_worker.rs`
+- dispatch portions of `crates/atm-daemon/src/runtime_health.rs`
+
+### 3. Session / Connection Lifecycle
+
+Owned concerns:
+- active connection registration
+- session open / active / draining / close
+- advisory session registration lifecycle
+
+Primary files:
+- `crates/atm-daemon/src/active_connection_registry.rs`
+- `crates/atm-daemon/src/local_ipc_connection.rs`
+- `crates/atm-daemon/src/advisory_runtime.rs`
+
+### 4. Graceful Shutdown / Drain
+
+Owned concerns:
+- runtime stop transition
+- bounded drain
+- shutdown beacon / finalizer ownership
+
+Primary files:
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/shutdown_beacon.rs`
+
+### 5. Advisory Stream Lifecycle
+
+Owned concerns:
+- one live stream per active session if that surface survives
+- register / drain / close
+
+Primary files:
+- `crates/atm-daemon/src/advisory_runtime.rs`
+
+## Current Modules That Violate The Target
+
+These modules or function families are not part of the desired thin-router
+machine set and must be removed, moved outward, or reduced to injected trait
+calls:
+
+- `crates/atm-daemon/src/sqlite_observability.rs`
+  - backend-specific observability logic
+- `crates/atm-daemon/src/runtime_health.rs`
+  - direct SQLite health / roster access
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+  - SQLite-named readiness fields and helpers
+- `crates/atm-daemon/src/lib.rs`
+  - daemon-owned SQLite replay wrapper
+- `crates/atm-daemon/src/composition.rs`
+  - concrete SQLite construction
+- `crates/atm-daemon/src/runtime_health_test_support.rs`
+  - daemon-local SQLite test assembly
+
+## Review Rule
+
+Any daemon code path that introduces:
+- `SqliteBoundaryAssembly`
+- `SqliteObservability`
+- direct `atm_rusqlite::*` references
+- backend-specific health or replay semantics
+
+must be treated as outside the target machine inventory unless explicitly moved
+behind an injected storage-neutral trait.

--- a/docs/phase-AA/issues.md
+++ b/docs/phase-AA/issues.md
@@ -1,0 +1,23 @@
+# Phase AA Issues Inventory
+
+## Goal
+
+Track the known Phase AA issue set so planning, QA, and phase closeout use one
+authoritative inventory rather than ad hoc reviewer memory.
+
+## Open Architectural Issues
+
+| ID | Status | Summary | Planned Closure |
+| --- | --- | --- | --- |
+| `AA-ISSUE-001` | `planned` | `atm-daemon` currently carries a direct `atm-rusqlite` dependency and concrete SQLite references. | `AA.2` through `AA.5` |
+| `AA-ISSUE-002` | `planned` | daemon runtime health currently owns SQLite-specific readiness and status fields. | `AA.3` |
+| `AA-ISSUE-003` | `planned` | daemon still carries SQLite observability, replay-store, and test-support leakage. | `AA.4` |
+| `AA-ISSUE-004` | `planned` | repository enforcement currently trusts boundary TOML as final authority without an independent guard for policy widening. | `AA.5` |
+
+## Inventory Rules
+
+- New Phase AA findings must be added here before they are considered accepted
+  planning scope.
+- A finding may move to `closed` only when the owning sprint closes and the
+  readiness record references the accepted closure evidence.
+- This file is the authoritative issues inventory for Phase AA.

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -5,6 +5,9 @@
 Track the accepted closure state for the daemon simplification line that
 removes concrete SQLite knowledge from `atm-daemon`.
 
+Authoritative supporting inventory:
+- `docs/phase-AA/issues.md`
+
 ## Sprint Status
 
 | Sprint | Status | Branch | Worktree | Closure Gate |
@@ -32,3 +35,5 @@ removes concrete SQLite knowledge from `atm-daemon`.
   whenever that edge reappears
 - a `boundary-guard` QA agent reviews both plans and phase-ending reviews
   and flags boundary-policy widening before closure
+- `docs/phase-AA/issues.md` has no open issue whose planned closure sprint is
+  still incomplete

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -14,10 +14,10 @@ Authoritative supporting inventory:
 | --- | --- | --- | --- | --- |
 | `AA.0` | `planned` | `feature/pAA-s0-daemon-architecture-restatement` | `../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement` | daemon role, doctor aggregation model, and state-machine inventory documented and accepted |
 | `AA.1` | `planned` | `feature/pAA-s1-subsystem-doctor-traits` | `../atm-core-worktrees/feature/pAA-s1-subsystem-doctor-traits` | subsystem-owned capability/doctor traits and shared diagnostic DTOs land in the governing docs and code |
-| `AA.2` | `planned` | `feature/pAA-s2-atm-runtime-composition-transfer` | `../atm-core-worktrees/feature/pAA-s2-atm-runtime-composition-transfer` | `atm-runtime` owns concrete SQLite/runtime assembly; `atm-daemon` stops constructing SQLite boundaries |
+| `AA.2` | `planned` | `feature/pAA-s2-atm-runtime-composition-transfer` | `../atm-core-worktrees/feature/pAA-s2-atm-runtime-composition-transfer` | `atm-runtime` owns concrete SQLite/runtime assembly; `atm-daemon` stops constructing SQLite boundaries; target-state runtime boundary is frozen even though SQLite TOML relock waits for `AA.5` |
 | `AA.3` | `planned` | `feature/pAA-s3-direct-doctor-and-runtime-health-split` | `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split` | `atm doctor` regains direct local store diagnostics; daemon aggregates injected subsystem reports plus daemon-owned runtime state without backend-specific diagnosis logic |
 | `AA.4` | `planned` | `feature/pAA-s4-delete-daemon-sqlite-leaks` | `../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks` | remaining SQLite observability, replay, and test-support leaks are removed from `atm-daemon` |
-| `AA.5` | `planned` | `feature/pAA-s5-boundary-relock-and-permanent-enforcement` | `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement` | daemon-to-SQLite edge is forbidden again and a second enforcement layer exists beyond TOML lint |
+| `AA.5` | `planned` | `feature/pAA-s5-boundary-relock-and-permanent-enforcement` | `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement` | daemon-to-SQLite edge is forbidden again, all boundary TOMLs agree on that policy, and a second enforcement layer exists beyond TOML lint |
 
 ## Phase Exit Criteria
 

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -18,6 +18,7 @@ Authoritative supporting inventory:
 | `AA.3` | `planned` | `feature/pAA-s3-direct-doctor-and-runtime-health-split` | `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split` | `atm doctor` regains direct local store diagnostics; daemon aggregates injected subsystem reports plus daemon-owned runtime state without backend-specific diagnosis logic |
 | `AA.4` | `planned` | `feature/pAA-s4-delete-daemon-sqlite-leaks` | `../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks` | remaining SQLite observability, replay, and test-support leaks are removed from `atm-daemon` |
 | `AA.5` | `planned` | `feature/pAA-s5-boundary-relock-and-permanent-enforcement` | `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement` | daemon-to-SQLite edge is forbidden again, all boundary TOMLs agree on that policy, and a second enforcement layer exists beyond TOML lint |
+| `AA.6` | `planned` | `feature/pAA-s6-obs-upgrade` | `../atm-core-worktrees/feature/pAA-s6-obs-upgrade` | ATM builds and validates on `sc-observability` / `sc-observability-types` `1.2.0` with the queue-backed logger API, retained-log policy field migration, and updated health projection |
 
 ## Phase Exit Criteria
 
@@ -35,5 +36,8 @@ Authoritative supporting inventory:
   whenever that edge reappears
 - a `boundary-guard` QA agent reviews both plans and phase-ending reviews
   and flags boundary-policy widening before closure
+- ATM has completed the `sc-observability` / `sc-observability-types` `1.2.0`
+  upgrade and no remaining migration blocker from the deprecated
+  `Logger::emit()` path or the old retained-log policy field surface remains
 - `docs/phase-AA/issues.md` has no open issue whose planned closure sprint is
   still incomplete

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -1,0 +1,34 @@
+# Phase AA Readiness
+
+## Goal
+
+Track the accepted closure state for the daemon simplification line that
+removes concrete SQLite knowledge from `atm-daemon`.
+
+## Sprint Status
+
+| Sprint | Status | Branch | Worktree | Closure Gate |
+| --- | --- | --- | --- | --- |
+| `AA.0` | `planned` | `feature/pAA-s0-daemon-architecture-restatement` | `../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement` | daemon role, doctor aggregation model, and state-machine inventory documented and accepted |
+| `AA.1` | `planned` | `feature/pAA-s1-subsystem-doctor-traits` | `../atm-core-worktrees/feature/pAA-s1-subsystem-doctor-traits` | subsystem-owned capability/doctor traits and shared diagnostic DTOs land in the governing docs and code |
+| `AA.2` | `planned` | `feature/pAA-s2-atm-runtime-composition-transfer` | `../atm-core-worktrees/feature/pAA-s2-atm-runtime-composition-transfer` | `atm-runtime` owns concrete SQLite/runtime assembly; `atm-daemon` stops constructing SQLite boundaries |
+| `AA.3` | `planned` | `feature/pAA-s3-direct-doctor-and-runtime-health-split` | `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split` | `atm doctor` regains direct local store diagnostics; daemon aggregates injected subsystem reports plus daemon-owned runtime state without backend-specific diagnosis logic |
+| `AA.4` | `planned` | `feature/pAA-s4-delete-daemon-sqlite-leaks` | `../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks` | remaining SQLite observability, replay, and test-support leaks are removed from `atm-daemon` |
+| `AA.5` | `planned` | `feature/pAA-s5-boundary-relock-and-permanent-enforcement` | `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement` | daemon-to-SQLite edge is forbidden again and a second enforcement layer exists beyond TOML lint |
+
+## Phase Exit Criteria
+
+`Phase AA` is not complete until all of the following are true:
+
+- `crates/atm-daemon/Cargo.toml` has no direct `atm-rusqlite` dependency
+- no `atm_rusqlite::*` references remain in daemon production code
+- direct local store diagnostics exist behind subsystem-owned doctor traits
+- storage behavior is expressed through small behavior-named capability traits,
+  not backend-shaped interfaces
+- daemon doctor aggregation does not inspect SQLite internals directly and only
+  compares subsystem reports at the aggregate level
+- the boundary TOMLs forbid the daemon-to-SQLite edge again
+- a repository-enforced dependency-boundary test or equivalent guard fails
+  whenever that edge reappears
+- a `boundary-guard` QA agent reviews both plans and phase-ending reviews
+  and flags boundary-policy widening before closure

--- a/docs/phase-AA/sprint-AA0.md
+++ b/docs/phase-AA/sprint-AA0.md
@@ -96,6 +96,10 @@ delete code instead of arguing about ownership.
 - `docs/phase-AA/readiness.md` exists and records the AA sprint line plus
   phase exit criteria.
 
+- `docs/phase-AA/issues.md` exists and is the authoritative Phase AA issues
+  inventory for architectural findings that remain open across multiple
+  sprints.
+
 ## Split Recommendation
 
 Keep this sprint documentation-only. If daemon code edits begin before the
@@ -126,6 +130,7 @@ will reintroduce ambiguity.
 - `docs/atm-daemon/requirements.md`
 - `docs/atm-daemon/architecture.md`
 - `docs/phase-AA/readiness.md`
+- `docs/phase-AA/issues.md`
 - `docs/phase-AA/daemon-state-machines.md`
 - `docs/phase-AA/daemon-sqlite-leak-ledger.md`
 

--- a/docs/phase-AA/sprint-AA0.md
+++ b/docs/phase-AA/sprint-AA0.md
@@ -51,40 +51,39 @@ delete code instead of arguing about ownership.
 
 - none
 
-## Non-Goals
+## Out Of Scope
 
-- no code movement yet
-- no partial boundary rollback without the full inventory
+- code movement into `atm-runtime`
+- trait introduction beyond documenting the ownership rule
+- partial boundary rollback without a frozen leak ledger
 
-## Sub-Tasks
+## Deliverables
 
-- Restate the daemon role in requirements and architecture docs as:
-  transport, lifecycle, routing, bounded dispatch, and minor error handling
-  only.
-  Development work: update product and crate-local docs.
-  Required tests: none beyond document validation.
-  Required doc or boundary updates: requirements, architecture, daemon
-  architecture, and the new Phase AA readiness record.
+- A daemon-role restatement lands in the governing docs and says explicitly
+  that `atm-daemon` owns only:
+  - transport
+  - lifecycle
+  - request validation/routing
+  - bounded dispatch/reply
+  - minor runtime error handling
+  and does not own concrete SQLite semantics.
 
-- Record the subsystem-doctor pattern as a hard rule:
-  each subsystem diagnoses itself through a trait; top-level doctor code only
-  aggregates subsystem results.
-  Development work: document the trait/aggregation rule and where those traits
-  live.
-  Required tests: none yet.
-  Required doc or boundary updates: requirements and architecture docs.
+- A subsystem-doctor ownership rule lands in the governing docs and says
+  explicitly:
+  - each subsystem diagnoses itself through a trait it owns
+  - top-level doctor code aggregates subsystem reports
+  - top-level doctor code may compare subsystem reports for drift
+  - top-level doctor code must not reimplement backend-specific diagnosis
 
-- Produce the daemon state-machine inventory with a hard target of five or
-  fewer top-level machines.
-  Development work: write the inventory and flag every daemon function family
-  that violates it.
-  Required tests: none yet.
-  Required doc or boundary updates: `docs/phase-AA/*` and daemon architecture.
+- `docs/phase-AA/daemon-state-machines.md` exists and freezes the target
+  top-level daemon machine inventory at five or fewer machines.
 
-- Freeze the concrete leak ledger up front.
-  Development work: record the exact current daemon-side SQLite leak files and
-  classify them now as delete / move / keep-and-rewrite so later sprints are
-  mechanical. The initial frozen file set is:
+- `docs/phase-AA/daemon-sqlite-leak-ledger.md` exists and classifies every
+  current daemon-side SQLite leak as one of:
+  - `delete`
+  - `move`
+  - `keep-and-rewrite`
+  The minimum frozen file set is:
   - `crates/atm-daemon/src/lib.rs`
   - `crates/atm-daemon/src/composition.rs`
   - `crates/atm-daemon/src/runtime_health.rs`
@@ -93,10 +92,9 @@ delete code instead of arguing about ownership.
   - `crates/atm-daemon/src/runtime_health_test_support.rs`
   - `crates/atm-daemon/src/tests.rs`
   - `crates/atm-daemon/src/tests_advisory.rs`
-  Required tests: none yet.
-  Required doc or boundary updates:
-  - `docs/phase-AA/daemon-state-machines.md`
-  - `docs/phase-AA/daemon-sqlite-leak-ledger.md`
+
+- `docs/phase-AA/readiness.md` exists and records the AA sprint line plus
+  phase exit criteria.
 
 ## Split Recommendation
 
@@ -112,6 +110,8 @@ will reintroduce ambiguity.
 - the leak ledger exists and classifies every current daemon-side SQLite touch
   point as delete / move / keep-and-rewrite
 - the Phase AA readiness record exists
+- no implementation work is required to infer the intended daemon role or the
+  leak inventory after reading this sprint doc and its listed artifacts
 
 ## Required Validation
 

--- a/docs/phase-AA/sprint-AA0.md
+++ b/docs/phase-AA/sprint-AA0.md
@@ -1,0 +1,135 @@
+# AA.0 Daemon Architecture Restatement And State-Machine Inventory
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.0
+worktree: ../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement
+branch: feature/pAA-s0-daemon-architecture-restatement
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Freeze the intended daemon design before code deletion begins: thin router,
+subsystem-owned diagnostics, direct local doctor path where possible, and a
+small auditable daemon state-machine inventory.
+
+## Scope Summary
+
+This sprint is documentation-first. It does not remove the SQLite dependency
+yet. It makes the target architecture explicit enough that later sprints can
+delete code instead of arguing about ownership.
+
+## Governing Requirements
+
+- `REQ-P-PRODUCT-001`
+- `REQ-P-DOCTOR-001`
+- `REQ-CORE-BOUNDARY-001`
+- `REQ-DAEMON-RUNTIME-002`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+- `docs/atm-daemon/architecture.md` ADR `ADR-ATM-DAEMON-001` as the current
+  state to be superseded by Phase `AA`
+
+## Governing Boundaries
+
+- `boundaries/atm-rusqlite/sqlite-boundary-assembly.toml`
+- `boundaries/atm-rusqlite/mail-store-sqlite.toml`
+- `boundaries/atm-rusqlite/roster-store-sqlite.toml`
+- `boundaries/atm-core/runtime-factory.toml`
+
+## Prerequisites
+
+- current daemon/SQLite leak inventory is frozen
+- user-approved Phase `AA` target architecture is recorded
+
+## Hard Dependencies
+
+- none
+
+## Non-Goals
+
+- no code movement yet
+- no partial boundary rollback without the full inventory
+
+## Sub-Tasks
+
+- Restate the daemon role in requirements and architecture docs as:
+  transport, lifecycle, routing, bounded dispatch, and minor error handling
+  only.
+  Development work: update product and crate-local docs.
+  Required tests: none beyond document validation.
+  Required doc or boundary updates: requirements, architecture, daemon
+  architecture, and the new Phase AA readiness record.
+
+- Record the subsystem-doctor pattern as a hard rule:
+  each subsystem diagnoses itself through a trait; top-level doctor code only
+  aggregates subsystem results.
+  Development work: document the trait/aggregation rule and where those traits
+  live.
+  Required tests: none yet.
+  Required doc or boundary updates: requirements and architecture docs.
+
+- Produce the daemon state-machine inventory with a hard target of five or
+  fewer top-level machines.
+  Development work: write the inventory and flag every daemon function family
+  that violates it.
+  Required tests: none yet.
+  Required doc or boundary updates: `docs/phase-AA/*` and daemon architecture.
+
+- Freeze the concrete leak ledger up front.
+  Development work: record the exact current daemon-side SQLite leak files and
+  classify them now as delete / move / keep-and-rewrite so later sprints are
+  mechanical. The initial frozen file set is:
+  - `crates/atm-daemon/src/lib.rs`
+  - `crates/atm-daemon/src/composition.rs`
+  - `crates/atm-daemon/src/runtime_health.rs`
+  - `crates/atm-daemon/src/runtime_status_cache.rs`
+  - `crates/atm-daemon/src/sqlite_observability.rs`
+  - `crates/atm-daemon/src/runtime_health_test_support.rs`
+  - `crates/atm-daemon/src/tests.rs`
+  - `crates/atm-daemon/src/tests_advisory.rs`
+  Required tests: none yet.
+  Required doc or boundary updates:
+  - `docs/phase-AA/daemon-state-machines.md`
+  - `docs/phase-AA/daemon-sqlite-leak-ledger.md`
+
+## Split Recommendation
+
+Keep this sprint documentation-only. If daemon code edits begin before the
+state-machine and doctor-ownership rules are accepted, later deletion sprints
+will reintroduce ambiguity.
+
+## Acceptance Criteria
+
+- the daemon role is documented as thin and storage-agnostic
+- the subsystem-doctor aggregation rule is explicit
+- the daemon state-machine inventory exists and caps top-level machines at five
+- the leak ledger exists and classifies every current daemon-side SQLite touch
+  point as delete / move / keep-and-rewrite
+- the Phase AA readiness record exists
+
+## Required Validation
+
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/plan-phase-AA.md`
+- `docs/project-plan.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+- `docs/phase-AA/readiness.md`
+- `docs/phase-AA/daemon-state-machines.md`
+- `docs/phase-AA/daemon-sqlite-leak-ledger.md`
+
+## Risks And Watchouts
+
+- if this sprint leaves “doctor may do either thing” ambiguity, later sprints
+  will accrete more special cases instead of deleting them

--- a/docs/phase-AA/sprint-AA1.md
+++ b/docs/phase-AA/sprint-AA1.md
@@ -50,53 +50,70 @@ peeking into SQLite internals.
 
 - accepted shared diagnostic DTO shape
 
-## Non-Goals
+## Out Of Scope
 
-- no concrete runtime composition transfer yet
-- no boundary relock yet
+- concrete runtime composition transfer
+- daemon code deletion
+- boundary relock
 
-## Sub-Tasks
+## Deliverables
 
-- Freeze the capability-trait reuse decision.
-  Development work: keep `MailStore`, `TaskStore`, and `RosterStore` as the
-  storage-neutral read/write capability surfaces for Phase AA; do not add a
-  parallel `MessageReader` / `MessageWriter` / `RosterReader` / `RosterWriter`
-  hierarchy in this phase.
-  Required tests: compile/build validation for unchanged callers.
-  Required doc or boundary updates: `atm-core` requirements and architecture.
+- The Phase AA trait-family reuse decision is frozen in the docs:
+  - `MailStore`
+  - `TaskStore`
+  - `RosterStore`
+  remain the primary storage-neutral capability traits.
+  This sprint must not introduce a second parallel
+  `MessageReader` / `MessageWriter` / `RosterReader` / `RosterWriter`
+  hierarchy.
 
-- Add doctor traits beside the existing capability boundaries.
-  Development work: define `MailStoreDoctor` beside
-  `crates/atm-core/src/boundary/mail.rs`, define `RosterStoreDoctor` beside
-  `crates/atm-core/src/boundary/store.rs`, and define `ConfigDoctor` beside
-  the config ingress boundary so deep backend/config investigation logic lives
-  with the owning subsystem.
-  Required tests: trait/object-safety and DTO unit coverage.
-  Required doc or boundary updates: `atm-core` requirements, architecture, and
-  boundaries.
+- The doctor traits are defined beside the existing capability boundaries in
+  `atm-core`. The intended shape is frozen now:
 
-- Define the store doctor contract for `atm-rusqlite`.
-  Development work: document and implement the trait that reports store path,
-  openability, migration/bootstrap readiness, and bounded storage findings.
-  Required tests: in-process SQLite doctor tests.
-  Required doc or boundary updates: `atm-rusqlite` requirements/architecture.
+  ```rust
+  pub trait MailStoreDoctor: Send + Sync {
+      fn inspect_mail_store(&self) -> Result<MailStoreDoctorReport, AtmError>;
+  }
 
-- Define daemon-owned runtime doctor aggregation.
-  Development work: document that daemon doctor code aggregates injected
-  subsystem reports plus daemon-only runtime state, may compare subsystem
-  outputs for drift, and does not inspect SQLite directly.
-  Required tests: aggregation-only unit coverage.
-  Required doc or boundary updates: `atm-daemon` requirements/architecture.
+  pub trait RosterStoreDoctor: Send + Sync {
+      fn inspect_roster_store(&self) -> Result<RosterStoreDoctorReport, AtmError>;
+  }
 
-- Define the backend-agnostic implementation rule.
-  Development work: document that behavior traits are backend-neutral and may
-  be implemented by both SQLite-backed and Claude-JSON-backed subsystems,
-  without exposing one giant `Storage` god-interface. The Phase AA decision is
-  that Claude JSON may implement the same `MailStore` / `RosterStore` plus
-  doctor traits later; AA does not require that implementation to land now.
-  Required tests: none beyond doc and trait-surface validation.
-  Required doc or boundary updates: `requirements.md`, `architecture.md`, and
-  `atm-core` docs.
+  pub trait ConfigDoctor: Send + Sync {
+      fn inspect_config(&self) -> Result<ConfigDoctorReport, AtmError>;
+  }
+  ```
+
+- The shared report DTO direction is frozen now: subsystem reports are
+  normalized enough for aggregation but still allow backend-specific findings.
+  The minimum DTO shape is:
+
+  ```rust
+  pub struct DoctorFinding {
+      pub code: &'static str,
+      pub severity: DoctorSeverity,
+      pub summary: String,
+      pub detail: Option<String>,
+  }
+  ```
+
+- `atm-rusqlite` owns store health through the doctor traits. The minimum
+  store-doctor responsibilities are frozen:
+  - path resolution
+  - openability
+  - schema/bootstrap/migration readiness
+  - bounded store findings
+
+- Daemon doctor aggregation is documented as aggregate-only. The minimum
+  ownership rule is frozen:
+  - daemon doctor may aggregate `ConfigDoctor`, `MailStoreDoctor`, and
+    `RosterStoreDoctor` reports plus daemon-owned runtime state
+  - daemon doctor may compare subsystem reports for drift
+  - daemon doctor must not inspect SQLite internals directly
+
+- The backend-agnostic rule is frozen: SQLite-backed and Claude-JSON-backed
+  implementations may satisfy the same behavior-named trait family later, but
+  this sprint does not require the Claude JSON implementation to land.
 
 ## Split Recommendation
 
@@ -109,6 +126,8 @@ must settle the contracts before any crate starts moving code across them.
   Phase AA storage-neutral capability surfaces
 - `MailStoreDoctor`, `RosterStoreDoctor`, and `ConfigDoctor` are defined in
   `atm-core`
+- the sprint docs include explicit trait signatures and a minimum report DTO
+  shape, so implementation does not have to invent the contract later
 - `atm-rusqlite` has a documented store doctor contract
 - the docs explicitly allow both SQLite-backed and Claude-JSON-backed
   implementations behind the same behavior-named traits

--- a/docs/phase-AA/sprint-AA1.md
+++ b/docs/phase-AA/sprint-AA1.md
@@ -1,0 +1,140 @@
+# AA.1 Subsystem Doctor Traits And Shared Diagnostic Contracts
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.1
+worktree: ../atm-core-worktrees/feature/pAA-s1-subsystem-doctor-traits
+branch: feature/pAA-s1-subsystem-doctor-traits
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Define the storage-facing capability traits, subsystem doctor traits, and
+shared diagnostic DTOs so every subsystem can report its own health without
+the daemon or CLI reimplementing subsystem logic.
+
+## Scope Summary
+
+This sprint introduces the architectural contract that later code-removal
+sprints use: `atm-core` keeps `MailStore` / `TaskStore` / `RosterStore` as the
+primary storage-neutral capability boundaries, adds doctor traits beside them,
+allows backend implementations such as SQLite and Claude JSON to satisfy the
+same trait family, and makes `atm-daemon` consume injected traits rather than
+peeking into SQLite internals.
+
+## Governing Requirements
+
+- `REQ-P-DOCTOR-001`
+- `REQ-CORE-DOCTOR-001`
+- `REQ-CORE-BOUNDARY-001`
+- `REQ-RUSQLITE-STORE-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+
+## Governing Boundaries
+
+- `docs/atm-core/boundaries.md`
+- `docs/atm-rusqlite/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
+
+## Prerequisites
+
+- `AA.0`
+
+## Hard Dependencies
+
+- accepted shared diagnostic DTO shape
+
+## Non-Goals
+
+- no concrete runtime composition transfer yet
+- no boundary relock yet
+
+## Sub-Tasks
+
+- Freeze the capability-trait reuse decision.
+  Development work: keep `MailStore`, `TaskStore`, and `RosterStore` as the
+  storage-neutral read/write capability surfaces for Phase AA; do not add a
+  parallel `MessageReader` / `MessageWriter` / `RosterReader` / `RosterWriter`
+  hierarchy in this phase.
+  Required tests: compile/build validation for unchanged callers.
+  Required doc or boundary updates: `atm-core` requirements and architecture.
+
+- Add doctor traits beside the existing capability boundaries.
+  Development work: define `MailStoreDoctor` beside
+  `crates/atm-core/src/boundary/mail.rs`, define `RosterStoreDoctor` beside
+  `crates/atm-core/src/boundary/store.rs`, and define `ConfigDoctor` beside
+  the config ingress boundary so deep backend/config investigation logic lives
+  with the owning subsystem.
+  Required tests: trait/object-safety and DTO unit coverage.
+  Required doc or boundary updates: `atm-core` requirements, architecture, and
+  boundaries.
+
+- Define the store doctor contract for `atm-rusqlite`.
+  Development work: document and implement the trait that reports store path,
+  openability, migration/bootstrap readiness, and bounded storage findings.
+  Required tests: in-process SQLite doctor tests.
+  Required doc or boundary updates: `atm-rusqlite` requirements/architecture.
+
+- Define daemon-owned runtime doctor aggregation.
+  Development work: document that daemon doctor code aggregates injected
+  subsystem reports plus daemon-only runtime state, may compare subsystem
+  outputs for drift, and does not inspect SQLite directly.
+  Required tests: aggregation-only unit coverage.
+  Required doc or boundary updates: `atm-daemon` requirements/architecture.
+
+- Define the backend-agnostic implementation rule.
+  Development work: document that behavior traits are backend-neutral and may
+  be implemented by both SQLite-backed and Claude-JSON-backed subsystems,
+  without exposing one giant `Storage` god-interface. The Phase AA decision is
+  that Claude JSON may implement the same `MailStore` / `RosterStore` plus
+  doctor traits later; AA does not require that implementation to land now.
+  Required tests: none beyond doc and trait-surface validation.
+  Required doc or boundary updates: `requirements.md`, `architecture.md`, and
+  `atm-core` docs.
+
+## Split Recommendation
+
+Keep the trait and DTO line separate from the composition transfer. This sprint
+must settle the contracts before any crate starts moving code across them.
+
+## Acceptance Criteria
+
+- `MailStore`, `TaskStore`, and `RosterStore` are explicitly retained as the
+  Phase AA storage-neutral capability surfaces
+- `MailStoreDoctor`, `RosterStoreDoctor`, and `ConfigDoctor` are defined in
+  `atm-core`
+- `atm-rusqlite` has a documented store doctor contract
+- the docs explicitly allow both SQLite-backed and Claude-JSON-backed
+  implementations behind the same behavior-named traits
+- daemon doctor aggregation is explicitly aggregate-only
+- no new daemon-local SQLite helper is introduced while landing the traits
+
+## Required Validation
+
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-rusqlite/requirements.md`
+- `docs/atm-rusqlite/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+
+## Risks And Watchouts
+
+- if AA creates a second parallel read/write trait hierarchy on top of
+  `MailStore` / `TaskStore` / `RosterStore`, the phase will widen churn instead
+  of making the later deletion sprints mechanical

--- a/docs/phase-AA/sprint-AA1.md
+++ b/docs/phase-AA/sprint-AA1.md
@@ -75,6 +75,10 @@ peeking into SQLite internals.
       fn inspect_mail_store(&self) -> Result<MailStoreDoctorReport, AtmError>;
   }
 
+  pub trait TaskStoreDoctor: Send + Sync {
+      fn inspect_task_store(&self) -> Result<TaskStoreDoctorReport, AtmError>;
+  }
+
   pub trait RosterStoreDoctor: Send + Sync {
       fn inspect_roster_store(&self) -> Result<RosterStoreDoctorReport, AtmError>;
   }
@@ -95,6 +99,22 @@ peeking into SQLite internals.
       pub summary: String,
       pub detail: Option<String>,
   }
+
+  pub struct MailStoreDoctorReport {
+      pub findings: Vec<DoctorFinding>,
+  }
+
+  pub struct TaskStoreDoctorReport {
+      pub findings: Vec<DoctorFinding>,
+  }
+
+  pub struct RosterStoreDoctorReport {
+      pub findings: Vec<DoctorFinding>,
+  }
+
+  pub struct ConfigDoctorReport {
+      pub findings: Vec<DoctorFinding>,
+  }
   ```
 
 - `atm-rusqlite` owns store health through the doctor traits. The minimum
@@ -103,11 +123,13 @@ peeking into SQLite internals.
   - openability
   - schema/bootstrap/migration readiness
   - bounded store findings
+  - bounded task-store findings when `TaskStore` is backed by the same store
 
 - Daemon doctor aggregation is documented as aggregate-only. The minimum
   ownership rule is frozen:
-  - daemon doctor may aggregate `ConfigDoctor`, `MailStoreDoctor`, and
-    `RosterStoreDoctor` reports plus daemon-owned runtime state
+  - daemon doctor may aggregate `ConfigDoctor`, `MailStoreDoctor`,
+    `TaskStoreDoctor`, and `RosterStoreDoctor` reports plus daemon-owned
+    runtime state
   - daemon doctor may compare subsystem reports for drift
   - daemon doctor must not inspect SQLite internals directly
 
@@ -124,10 +146,11 @@ must settle the contracts before any crate starts moving code across them.
 
 - `MailStore`, `TaskStore`, and `RosterStore` are explicitly retained as the
   Phase AA storage-neutral capability surfaces
-- `MailStoreDoctor`, `RosterStoreDoctor`, and `ConfigDoctor` are defined in
-  `atm-core`
+- `MailStoreDoctor`, `TaskStoreDoctor`, `RosterStoreDoctor`, and
+  `ConfigDoctor` are defined in `atm-core`
 - the sprint docs include explicit trait signatures and a minimum report DTO
-  shape, so implementation does not have to invent the contract later
+  shape, including the minimum subsystem report structs, so implementation
+  does not have to invent the contract later
 - `atm-rusqlite` has a documented store doctor contract
 - the docs explicitly allow both SQLite-backed and Claude-JSON-backed
   implementations behind the same behavior-named traits

--- a/docs/phase-AA/sprint-AA2.md
+++ b/docs/phase-AA/sprint-AA2.md
@@ -59,42 +59,63 @@ The concrete transfer decisions are frozen now:
 
 - accepted `atm-runtime` crate ownership model
 
-## Non-Goals
+## Out Of Scope
 
 - final boundary relock
 - final doctor split
 
-## Sub-Tasks
+## Deliverables
 
-- Add `crates/atm-runtime`.
-  Development work: introduce the crate, manifests, and composition entrypoints
-  that can build production runtime inputs from concrete adapters. The expected
-  new files are:
+- `crates/atm-runtime` exists and is the only legal Phase AA home for
+  concrete production runtime/store assembly. The expected minimum file set is:
   - `crates/atm-runtime/src/lib.rs`
   - `crates/atm-runtime/src/composition.rs`
   - `crates/atm-runtime/src/replay_store.rs`
-  Required tests: compile/build coverage and narrow integration coverage.
-  Required doc or boundary updates: project plan, crate docs, boundaries.
 
-- Move SQLite boundary assembly into `atm-runtime`.
-  Development work: relocate `SqliteBoundaryAssembly` construction and
-  observability injection out of daemon composition. The concrete daemon edits
-  are:
-  - delete `SqliteBoundaryAssembly` construction from
+- The minimum runtime bundle contract is frozen in this sprint doc so daemon
+  startup does not invent its own seam:
+
+  ```rust
+  pub struct RuntimeBundle {
+      pub mail_store: Arc<dyn MailStore>,
+      pub task_store: Arc<dyn TaskStore>,
+      pub roster_store: Arc<dyn RosterStore>,
+      pub mail_store_doctor: Arc<dyn MailStoreDoctor>,
+      pub roster_store_doctor: Arc<dyn RosterStoreDoctor>,
+      pub config_doctor: Arc<dyn ConfigDoctor>,
+      pub remote_replay_store: Arc<dyn RemoteReplayStore>,
+  }
+  ```
+
+- Concrete SQLite boundary assembly moves into `atm-runtime`. The frozen move
+  list is:
+  - move `SqliteBoundaryAssembly::new*` calls out of
     `crates/atm-daemon/src/composition.rs`
-  - replace the direct `sqlite_boundary` construction path with an injected
-    runtime bundle from `atm-runtime`
-  Required tests: runtime composition tests proving `atm-daemon` consumes
-  injected ports only.
-  Required doc or boundary updates: daemon/runtime/rusqlite architecture docs.
+  - move SQLite observability injection out of daemon composition
+  - replace the direct daemon `sqlite_boundary` construction path with an
+    injected `RuntimeBundle`
 
-- Change `atm-daemon` to consume storage-neutral runtime inputs.
-  Development work: delete direct construction from daemon composition and make
-  daemon startup take injected ports/factories only, expressed through
-  `MailStore`, `TaskStore`, `RosterStore`, and the new doctor traits from
-  `AA.1`.
-  Required tests: daemon startup and request-dispatch regression coverage.
-  Required doc or boundary updates: daemon boundaries and architecture docs.
+- Replay ownership is moved out of daemon-private and SQLite-private seams.
+  The frozen shape is:
+
+  ```rust
+  pub struct RemoteReplayStateRecord {
+      pub request_id: String,
+      pub created_at: DateTime<Utc>,
+      pub payload: Vec<u8>,
+  }
+
+  pub trait RemoteReplayStore: Send + Sync {
+      fn enqueue(&self, record: RemoteReplayStateRecord) -> Result<(), AtmError>;
+      fn load_all(&self) -> Result<Vec<RemoteReplayStateRecord>, AtmError>;
+      fn delete(&self, request_id: &str) -> Result<(), AtmError>;
+      fn purge_expired(&self) -> Result<(), AtmError>;
+  }
+  ```
+
+- `atm-daemon` startup consumes only injected storage-neutral runtime inputs
+  expressed through `MailStore`, `TaskStore`, `RosterStore`, the doctor
+  traits from `AA.1`, and `RemoteReplayStore`.
 
 ## Split Recommendation
 
@@ -107,6 +128,8 @@ about composition ownership transfer.
 - `atm-daemon` no longer constructs `SqliteBoundaryAssembly`
 - `RemoteReplayStateRecord` and `RemoteReplayStore` no longer originate in
   daemon-private or SQLite-private modules
+- the sprint doc contains the minimum `RuntimeBundle` and replay contract
+  shapes, so implementation does not have to invent them during the move
 - daemon composition consumes storage-neutral injected inputs
 - daemon composition depends on `MailStore` / `TaskStore` / `RosterStore` plus
   doctor traits rather than backend identity

--- a/docs/phase-AA/sprint-AA2.md
+++ b/docs/phase-AA/sprint-AA2.md
@@ -81,6 +81,7 @@ The concrete transfer decisions are frozen now:
       pub task_store: Arc<dyn TaskStore>,
       pub roster_store: Arc<dyn RosterStore>,
       pub mail_store_doctor: Arc<dyn MailStoreDoctor>,
+      pub task_store_doctor: Arc<dyn TaskStoreDoctor>,
       pub roster_store_doctor: Arc<dyn RosterStoreDoctor>,
       pub config_doctor: Arc<dyn ConfigDoctor>,
       pub remote_replay_store: Arc<dyn RemoteReplayStore>,
@@ -151,6 +152,8 @@ about composition ownership transfer.
 - `docs/requirements.md`
 - `docs/atm-core/architecture.md`
 - `docs/atm-core/boundaries.md`
+- `docs/atm-runtime/architecture.md`
+- `docs/atm-runtime/requirements.md`
 - `docs/atm-daemon/architecture.md`
 - `docs/atm-daemon/requirements.md`
 - `docs/atm-rusqlite/requirements.md`

--- a/docs/phase-AA/sprint-AA2.md
+++ b/docs/phase-AA/sprint-AA2.md
@@ -37,17 +37,20 @@ The concrete transfer decisions are frozen now:
 
 - `REQ-CORE-BOUNDARY-001`
 - `REQ-DAEMON-RUNTIME-002`
+- `REQ-DAEMON-RUNTIME-005`
 - `REQ-RUSQLITE-STORE-001`
 
 ## Governing ADRs
 
 - `docs/adr/ADR-001-sealed-trait-pattern.md`
+- `docs/adr/ADR-ATM-RUNTIME-001.md`
 - supersedes the current daemon composition assumption in
   `docs/atm-daemon/architecture.md`
 
 ## Governing Boundaries
 
 - `boundaries/atm-core/runtime-factory.toml`
+- `boundaries/atm-runtime/runtime-composition.toml`
 - `boundaries/atm-rusqlite/sqlite-boundary-assembly.toml`
 - `boundaries/atm-rusqlite/shared-db.toml`
 
@@ -72,6 +75,21 @@ The concrete transfer decisions are frozen now:
   - `crates/atm-runtime/src/composition.rs`
   - `crates/atm-runtime/src/replay_store.rs`
 
+- `atm-runtime` dependency ownership is frozen through a machine-readable
+  boundary record:
+  - `boundaries/atm-runtime/runtime-composition.toml`
+  The minimum rule set is:
+  - allowed dependents:
+    - `atm`
+    - `atm-daemon`
+  - allowed dependencies:
+    - `atm-core`
+    - `atm-rusqlite`
+  - forbidden edges:
+    - `atm-daemon -> atm-rusqlite`
+    - `atm -> atm-rusqlite`
+    - `atm-runtime -> atm-daemon`
+
 - The minimum runtime bundle contract is frozen in this sprint doc so daemon
   startup does not invent its own seam:
 
@@ -87,6 +105,13 @@ The concrete transfer decisions are frozen now:
       pub remote_replay_store: Arc<dyn RemoteReplayStore>,
   }
   ```
+
+- RuntimeBundle assembly remains fail-closed. The frozen startup rule is:
+  - if any RuntimeBundle component cannot be constructed, including
+    `remote_replay_store`, daemon startup must fail before entering serving
+    state
+  - this preserves the `REQ-DAEMON-RUNTIME-005` replay-resume invariant
+  - the property must remain testable through the existing in-process harness
 
 - Concrete SQLite boundary assembly moves into `atm-runtime`. The frozen move
   list is:
@@ -126,6 +151,8 @@ about composition ownership transfer.
 ## Acceptance Criteria
 
 - `atm-runtime` exists and owns concrete production assembly
+- `boundaries/atm-runtime/runtime-composition.toml` exists and records the
+  allowed and forbidden dependency edges for the new crate
 - `atm-daemon` no longer constructs `SqliteBoundaryAssembly`
 - `RemoteReplayStateRecord` and `RemoteReplayStore` no longer originate in
   daemon-private or SQLite-private modules
@@ -136,6 +163,9 @@ about composition ownership transfer.
   doctor traits rather than backend identity
 - direct daemon-to-SQLite assembly imports are removed from production
   composition code
+- daemon startup remains fail-closed when any RuntimeBundle component cannot be
+  assembled, including the replay-store component required by
+  `REQ-DAEMON-RUNTIME-005`
 
 ## Required Validation
 
@@ -153,7 +183,9 @@ about composition ownership transfer.
 - `docs/atm-core/architecture.md`
 - `docs/atm-core/boundaries.md`
 - `docs/atm-runtime/architecture.md`
+- `docs/atm-runtime/boundaries.md`
 - `docs/atm-runtime/requirements.md`
+- `docs/adr/ADR-ATM-RUNTIME-001.md`
 - `docs/atm-daemon/architecture.md`
 - `docs/atm-daemon/requirements.md`
 - `docs/atm-rusqlite/requirements.md`

--- a/docs/phase-AA/sprint-AA2.md
+++ b/docs/phase-AA/sprint-AA2.md
@@ -61,6 +61,7 @@ The concrete transfer decisions are frozen now:
 ## Hard Dependencies
 
 - accepted `atm-runtime` crate ownership model
+- `ADR-ATM-RUNTIME-001` must be accepted before this sprint begins
 
 ## Out Of Scope
 

--- a/docs/phase-AA/sprint-AA2.md
+++ b/docs/phase-AA/sprint-AA2.md
@@ -90,6 +90,17 @@ The concrete transfer decisions are frozen now:
     - `atm -> atm-rusqlite`
     - `atm-runtime -> atm-daemon`
 
+- The `AA.2` to `AA.4` boundary-governance window is frozen explicitly:
+  - `boundaries/atm-runtime/runtime-composition.toml` defines the intended
+    post-AA end-state edges immediately so composition work cannot drift
+  - the existing `atm-rusqlite` boundary TOMLs remain the authoritative
+    `just lint boundaries` policy until `AA.5` relocks them
+  - `AA.2`, `AA.3`, and `AA.4` must not widen any SQLite boundary allowlist to
+    match temporary implementation convenience
+  - `AA.5` is the sprint that removes `atm-daemon` from the SQLite boundary
+    allowlists and makes all machine-readable boundary records agree on the
+    forbidden edge again
+
 - The minimum runtime bundle contract is frozen in this sprint doc so daemon
   startup does not invent its own seam:
 
@@ -153,6 +164,10 @@ about composition ownership transfer.
 - `atm-runtime` exists and owns concrete production assembly
 - `boundaries/atm-runtime/runtime-composition.toml` exists and records the
   allowed and forbidden dependency edges for the new crate
+- the sprint doc explicitly defines the `AA.2` through `AA.4` transition
+  policy: `runtime-composition.toml` freezes the target end-state edges while
+  the existing `atm-rusqlite` TOMLs remain the authoritative lint inputs until
+  `AA.5` relocks them
 - `atm-daemon` no longer constructs `SqliteBoundaryAssembly`
 - `RemoteReplayStateRecord` and `RemoteReplayStore` no longer originate in
   daemon-private or SQLite-private modules

--- a/docs/phase-AA/sprint-AA2.md
+++ b/docs/phase-AA/sprint-AA2.md
@@ -1,0 +1,138 @@
+# AA.2 `atm-runtime` Skeleton And Concrete Composition Transfer
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.2
+worktree: ../atm-core-worktrees/feature/pAA-s2-atm-runtime-composition-transfer
+branch: feature/pAA-s2-atm-runtime-composition-transfer
+status: planned
+estimated_scope: large
+```
+
+## Goal
+
+Introduce `atm-runtime` and move all concrete SQLite/runtime assembly out of
+`atm-daemon`.
+
+## Scope Summary
+
+This sprint creates the dedicated composition crate that replaces the daemon as
+the legal home for `SqliteBoundaryAssembly`, SQLite observability injection,
+and concrete production runtime/store wiring behind the `atm-core`
+capability-trait family.
+
+The concrete transfer decisions are frozen now:
+- move `SqliteBoundaryAssembly::new*` calls out of
+  `crates/atm-daemon/src/composition.rs`
+- move `SqliteRemoteReplayStore` out of
+  `crates/atm-daemon/src/lib.rs`
+- move `RemoteReplayStateRecord` out of `atm-rusqlite` and into a
+  storage-neutral `atm-core` boundary surface
+- move `RemoteReplayStore` out of `crates/atm-daemon/src/peer_transport.rs`
+  and onto a storage-neutral boundary surface that `atm-runtime` can
+  implement without depending on `atm-daemon`
+
+## Governing Requirements
+
+- `REQ-CORE-BOUNDARY-001`
+- `REQ-DAEMON-RUNTIME-002`
+- `REQ-RUSQLITE-STORE-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+- supersedes the current daemon composition assumption in
+  `docs/atm-daemon/architecture.md`
+
+## Governing Boundaries
+
+- `boundaries/atm-core/runtime-factory.toml`
+- `boundaries/atm-rusqlite/sqlite-boundary-assembly.toml`
+- `boundaries/atm-rusqlite/shared-db.toml`
+
+## Prerequisites
+
+- `AA.1`
+
+## Hard Dependencies
+
+- accepted `atm-runtime` crate ownership model
+
+## Non-Goals
+
+- final boundary relock
+- final doctor split
+
+## Sub-Tasks
+
+- Add `crates/atm-runtime`.
+  Development work: introduce the crate, manifests, and composition entrypoints
+  that can build production runtime inputs from concrete adapters. The expected
+  new files are:
+  - `crates/atm-runtime/src/lib.rs`
+  - `crates/atm-runtime/src/composition.rs`
+  - `crates/atm-runtime/src/replay_store.rs`
+  Required tests: compile/build coverage and narrow integration coverage.
+  Required doc or boundary updates: project plan, crate docs, boundaries.
+
+- Move SQLite boundary assembly into `atm-runtime`.
+  Development work: relocate `SqliteBoundaryAssembly` construction and
+  observability injection out of daemon composition. The concrete daemon edits
+  are:
+  - delete `SqliteBoundaryAssembly` construction from
+    `crates/atm-daemon/src/composition.rs`
+  - replace the direct `sqlite_boundary` construction path with an injected
+    runtime bundle from `atm-runtime`
+  Required tests: runtime composition tests proving `atm-daemon` consumes
+  injected ports only.
+  Required doc or boundary updates: daemon/runtime/rusqlite architecture docs.
+
+- Change `atm-daemon` to consume storage-neutral runtime inputs.
+  Development work: delete direct construction from daemon composition and make
+  daemon startup take injected ports/factories only, expressed through
+  `MailStore`, `TaskStore`, `RosterStore`, and the new doctor traits from
+  `AA.1`.
+  Required tests: daemon startup and request-dispatch regression coverage.
+  Required doc or boundary updates: daemon boundaries and architecture docs.
+
+## Split Recommendation
+
+Do not combine doctor behavior changes into this sprint. This sprint is only
+about composition ownership transfer.
+
+## Acceptance Criteria
+
+- `atm-runtime` exists and owns concrete production assembly
+- `atm-daemon` no longer constructs `SqliteBoundaryAssembly`
+- `RemoteReplayStateRecord` and `RemoteReplayStore` no longer originate in
+  daemon-private or SQLite-private modules
+- daemon composition consumes storage-neutral injected inputs
+- daemon composition depends on `MailStore` / `TaskStore` / `RosterStore` plus
+  doctor traits rather than backend identity
+- direct daemon-to-SQLite assembly imports are removed from production
+  composition code
+
+## Required Validation
+
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `Cargo.toml`
+- `docs/project-plan.md`
+- `docs/plan-phase-AA.md`
+- `docs/architecture.md`
+- `docs/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-rusqlite/requirements.md`
+
+## Risks And Watchouts
+
+- the crate move must not just relocate daemon-shaped assumptions into
+  `atm-runtime`; the new crate is composition-only

--- a/docs/phase-AA/sprint-AA3.md
+++ b/docs/phase-AA/sprint-AA3.md
@@ -53,6 +53,7 @@ The concrete simplification decisions are frozen now:
 - `docs/atm-core/boundaries.md`
 - `docs/atm-daemon/boundaries.md`
 - `docs/atm-rusqlite/boundaries.md`
+- `boundaries/atm-runtime/runtime-composition.toml`
 
 ## Prerequisites
 
@@ -179,3 +180,6 @@ same seam from opposite sides.
 
 - do not let “optional daemon fast path” turn back into “daemon owns the only
   doctor implementation”
+- `AA.3` must update `docs/atm-daemon/architecture.md` and
+  `docs/architecture.md` so their runtime-health contract no longer claims
+  daemon-owned `sqlite_ready` / `sqlite_detail` fields once this sprint lands

--- a/docs/phase-AA/sprint-AA3.md
+++ b/docs/phase-AA/sprint-AA3.md
@@ -84,9 +84,14 @@ The concrete simplification decisions are frozen now:
   pub struct DoctorReport {
       pub config: ConfigDoctorReport,
       pub mail_store: MailStoreDoctorReport,
+      pub task_store: TaskStoreDoctorReport,
       pub roster_store: RosterStoreDoctorReport,
       pub daemon_runtime: Option<DaemonRuntimeDoctorReport>,
       pub drift_findings: Vec<DoctorFinding>,
+  }
+
+  pub struct DaemonRuntimeDoctorReport {
+      pub findings: Vec<DoctorFinding>,
   }
   ```
 

--- a/docs/phase-AA/sprint-AA3.md
+++ b/docs/phase-AA/sprint-AA3.md
@@ -24,6 +24,7 @@ daemon-owned runtime state plus injected subsystem reports, including
 cross-subsystem drift comparison where that comparison is not backend-specific.
 
 The concrete simplification decisions are frozen now:
+- the concrete `ConfigDoctor` implementation lives in `atm-runtime`
 - remove `sqlite_boundary: Option<SqliteBoundaryAssembly>` from
   `crates/atm-daemon/src/runtime_health.rs`
 - replace direct roster access there with injected `RosterStore`
@@ -76,6 +77,13 @@ The concrete simplification decisions are frozen now:
   - bounded store findings
   - any SQLite-specific detail that does not belong in daemon runtime state
 
+- `atm-runtime` owns the concrete `ConfigDoctor` implementation and the direct
+  local doctor-path assembly used by the CLI. The frozen ownership rule is:
+  - `ConfigDoctor` trait stays in `atm-core`
+  - concrete `ConfigDoctor` implementation lives in `atm-runtime`
+  - backend-specific `config.json` investigation does not live in
+    `atm-daemon`
+
 - `atm-core/src/doctor/mod.rs` becomes an explicit aggregator/orchestrator over
   subsystem doctors rather than a backend-specific implementation surface.
   The minimum aggregate shape is frozen:
@@ -96,7 +104,11 @@ The concrete simplification decisions are frozen now:
   ```
 
 - The direct CLI doctor path is restored for local diagnostics that do not
-  require daemon-owned runtime state.
+  require daemon-owned runtime state. The frozen dependency-edge decision is:
+  - the `atm` crate depends on `atm-runtime` for direct local doctor-path
+    assembly
+  - `atm` must not depend directly on `atm-rusqlite`
+  - direct local doctor wiring must remain outside `atm-daemon`
 
 - `RuntimeStatusSnapshot` is simplified to daemon-owned runtime state only.
   The frozen delete list is:
@@ -131,7 +143,11 @@ same seam from opposite sides.
 ## Acceptance Criteria
 
 - store diagnostics are owned by `atm-rusqlite`
+- the owning crate for the concrete `ConfigDoctor` implementation is named
+  explicitly as `atm-runtime`
 - CLI doctor can answer direct local store/config checks without daemon routing
+- the `atm -> atm-runtime` dependency edge is frozen explicitly as the direct
+  local doctor-path seam, and no direct `atm -> atm-rusqlite` edge is allowed
 - daemon runtime health no longer owns SQLite-specific probing or SQLite-named
   runtime cache fields
 - the sprint doc freezes the aggregate doctor DTO and the reduced runtime
@@ -154,6 +170,9 @@ same seam from opposite sides.
 - `docs/atm-core/boundaries.md`
 - `docs/atm-daemon/requirements.md`
 - `docs/atm-daemon/architecture.md`
+- `docs/atm-runtime/architecture.md`
+- `docs/atm-runtime/requirements.md`
+- `docs/atm-runtime/boundaries.md`
 - `docs/atm-rusqlite/requirements.md`
 
 ## Risks And Watchouts

--- a/docs/phase-AA/sprint-AA3.md
+++ b/docs/phase-AA/sprint-AA3.md
@@ -1,0 +1,137 @@
+# AA.3 Direct Doctor Path And Runtime Health Simplification
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.3
+worktree: ../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split
+branch: feature/pAA-s3-direct-doctor-and-runtime-health-split
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Move store diagnostics into the store subsystem, restore a direct CLI doctor
+path for local diagnostics, and strip SQLite-specific health logic out of the
+daemon.
+
+## Scope Summary
+
+This sprint applies the doctor-trait model: `atm-rusqlite` diagnoses itself,
+the CLI can query it directly, and daemon health becomes aggregation of
+daemon-owned runtime state plus injected subsystem reports, including
+cross-subsystem drift comparison where that comparison is not backend-specific.
+
+The concrete simplification decisions are frozen now:
+- remove `sqlite_boundary: Option<SqliteBoundaryAssembly>` from
+  `crates/atm-daemon/src/runtime_health.rs`
+- replace direct roster access there with injected `RosterStore`
+- remove daemon-owned WAL checkpoint calls from `runtime_health.rs`
+- remove `sqlite_ready` / `sqlite_detail` from
+  `crates/atm-daemon/src/runtime_status_cache.rs` and from
+  `crates/atm-core/src/protocol.rs::RuntimeStatusSnapshot`
+- report store health through subsystem doctor results, not daemon cache fields
+- keep daemon runtime health free to aggregate subsystem doctor reports, but do
+  not let it perform backend-specific investigation logic itself
+
+## Governing Requirements
+
+- `REQ-P-DOCTOR-001`
+- `REQ-CORE-DOCTOR-001`
+- `REQ-DAEMON-HEALTH-001`
+- `REQ-RUSQLITE-STORE-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+- `docs/adr/ADR-014-runtime-health-projection-and-liveness-signal-ownership.md`
+
+## Governing Boundaries
+
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
+- `docs/atm-rusqlite/boundaries.md`
+
+## Prerequisites
+
+- `AA.1`
+- `AA.2`
+
+## Hard Dependencies
+
+- shared doctor traits from `AA.1`
+
+## Non-Goals
+
+- boundary relock
+- full replay leak cleanup
+
+## Sub-Tasks
+
+- Implement `atm-rusqlite` store-doctor logic.
+  Development work: move SQLite readiness/openability/migration health into
+  the store subsystem and expose it only through the doctor trait. This
+  includes the current direct SQLite readiness concerns presently projected
+  through daemon runtime status.
+  Required tests: in-process store doctor tests.
+  Required doc or boundary updates: `atm-rusqlite` docs.
+
+- Restore a direct CLI doctor path for local diagnostics.
+  Development work: make CLI doctor query local config/store diagnostics
+  directly when daemon-owned runtime state is not required. The concrete core
+  target is `crates/atm-core/src/doctor/mod.rs`, which should become an
+  aggregator/orchestrator over `ConfigDoctor`, `MailStoreDoctor`, and
+  `RosterStoreDoctor` instead of burying backend-specific logic inline.
+  Required tests: doctor CLI regression coverage with and without a live
+  daemon.
+  Required doc or boundary updates: product requirements and architecture.
+
+- Simplify daemon runtime health to daemon-owned projection only.
+  Development work: remove direct SQLite roster/store health probing from
+  `runtime_health.rs`, convert `reload_runtime_view(...)` and
+  `record_heartbeat(...)` to injected `RosterStore`, and delete
+  `mark_sqlite_unavailable*`-style daemon cache semantics. The precise cache
+  decision is:
+  - `RuntimeStatusSnapshot` keeps daemon runtime liveness/readiness/member
+    counts
+  - `RuntimeStatusSnapshot` stops carrying `sqlite_ready` and `sqlite_detail`
+  - any store-specific detail appears only in subsystem doctor reports
+  Required tests: runtime-health projection tests.
+  Required doc or boundary updates: daemon requirements/architecture.
+
+## Split Recommendation
+
+Keep doctor behavior and runtime-health simplification together; they are the
+same seam from opposite sides.
+
+## Acceptance Criteria
+
+- store diagnostics are owned by `atm-rusqlite`
+- CLI doctor can answer direct local store/config checks without daemon routing
+- daemon runtime health no longer owns SQLite-specific probing or SQLite-named
+  runtime cache fields
+- daemon doctor aggregation may include injected store/config subsystem reports
+  but does not deeply analyze SQLite internals and only performs
+  cross-subsystem comparison at the report level
+
+## Required Validation
+
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-daemon/architecture.md`
+- `docs/atm-rusqlite/requirements.md`
+
+## Risks And Watchouts
+
+- do not let “optional daemon fast path” turn back into “daemon owns the only
+  doctor implementation”

--- a/docs/phase-AA/sprint-AA3.md
+++ b/docs/phase-AA/sprint-AA3.md
@@ -62,43 +62,61 @@ The concrete simplification decisions are frozen now:
 
 - shared doctor traits from `AA.1`
 
-## Non-Goals
+## Out Of Scope
 
 - boundary relock
 - full replay leak cleanup
 
-## Sub-Tasks
+## Deliverables
 
-- Implement `atm-rusqlite` store-doctor logic.
-  Development work: move SQLite readiness/openability/migration health into
-  the store subsystem and expose it only through the doctor trait. This
-  includes the current direct SQLite readiness concerns presently projected
-  through daemon runtime status.
-  Required tests: in-process store doctor tests.
-  Required doc or boundary updates: `atm-rusqlite` docs.
+- `atm-rusqlite` owns store diagnostics through the doctor traits. The frozen
+  doctor responsibility list is:
+  - SQLite openability
+  - schema/bootstrap/migration readiness
+  - bounded store findings
+  - any SQLite-specific detail that does not belong in daemon runtime state
 
-- Restore a direct CLI doctor path for local diagnostics.
-  Development work: make CLI doctor query local config/store diagnostics
-  directly when daemon-owned runtime state is not required. The concrete core
-  target is `crates/atm-core/src/doctor/mod.rs`, which should become an
-  aggregator/orchestrator over `ConfigDoctor`, `MailStoreDoctor`, and
-  `RosterStoreDoctor` instead of burying backend-specific logic inline.
-  Required tests: doctor CLI regression coverage with and without a live
-  daemon.
-  Required doc or boundary updates: product requirements and architecture.
+- `atm-core/src/doctor/mod.rs` becomes an explicit aggregator/orchestrator over
+  subsystem doctors rather than a backend-specific implementation surface.
+  The minimum aggregate shape is frozen:
 
-- Simplify daemon runtime health to daemon-owned projection only.
-  Development work: remove direct SQLite roster/store health probing from
-  `runtime_health.rs`, convert `reload_runtime_view(...)` and
-  `record_heartbeat(...)` to injected `RosterStore`, and delete
-  `mark_sqlite_unavailable*`-style daemon cache semantics. The precise cache
-  decision is:
-  - `RuntimeStatusSnapshot` keeps daemon runtime liveness/readiness/member
-    counts
-  - `RuntimeStatusSnapshot` stops carrying `sqlite_ready` and `sqlite_detail`
-  - any store-specific detail appears only in subsystem doctor reports
-  Required tests: runtime-health projection tests.
-  Required doc or boundary updates: daemon requirements/architecture.
+  ```rust
+  pub struct DoctorReport {
+      pub config: ConfigDoctorReport,
+      pub mail_store: MailStoreDoctorReport,
+      pub roster_store: RosterStoreDoctorReport,
+      pub daemon_runtime: Option<DaemonRuntimeDoctorReport>,
+      pub drift_findings: Vec<DoctorFinding>,
+  }
+  ```
+
+- The direct CLI doctor path is restored for local diagnostics that do not
+  require daemon-owned runtime state.
+
+- `RuntimeStatusSnapshot` is simplified to daemon-owned runtime state only.
+  The frozen delete list is:
+  - remove `sqlite_boundary: Option<SqliteBoundaryAssembly>` from
+    `crates/atm-daemon/src/runtime_health.rs`
+  - remove direct roster-store hydration through SQLite from
+    `runtime_health.rs`
+  - remove daemon-owned WAL checkpoint calls from `runtime_health.rs`
+  - remove `sqlite_ready`
+  - remove `sqlite_detail`
+  - remove `mark_sqlite_unavailable(...)`
+  - remove `mark_sqlite_unavailable_with_detail(...)`
+
+- The minimum post-AA runtime snapshot direction is frozen:
+
+  ```rust
+  pub struct RuntimeStatusSnapshot {
+      pub daemon_ready: bool,
+      pub active_connections: u64,
+      pub active_advisory_sessions: u64,
+      pub live_member_count: u64,
+      // no sqlite_ready
+      // no sqlite_detail
+  }
+  ```
 
 ## Split Recommendation
 
@@ -111,6 +129,8 @@ same seam from opposite sides.
 - CLI doctor can answer direct local store/config checks without daemon routing
 - daemon runtime health no longer owns SQLite-specific probing or SQLite-named
   runtime cache fields
+- the sprint doc freezes the aggregate doctor DTO and the reduced runtime
+  snapshot shape so later code work is mechanical
 - daemon doctor aggregation may include injected store/config subsystem reports
   but does not deeply analyze SQLite internals and only performs
   cross-subsystem comparison at the report level

--- a/docs/phase-AA/sprint-AA4.md
+++ b/docs/phase-AA/sprint-AA4.md
@@ -51,6 +51,7 @@ The concrete delete/move decisions are frozen now:
 
 - `docs/atm-daemon/boundaries.md`
 - `docs/atm-rusqlite/boundaries.md`
+- `boundaries/atm-runtime/runtime-composition.toml`
 
 ## Prerequisites
 

--- a/docs/phase-AA/sprint-AA4.md
+++ b/docs/phase-AA/sprint-AA4.md
@@ -1,0 +1,126 @@
+# AA.4 Delete Remaining Daemon SQLite Leaks
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.4
+worktree: ../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks
+branch: feature/pAA-s4-delete-daemon-sqlite-leaks
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Delete the remaining daemon-side SQLite observability, replay-store, and test
+support leakage after composition and doctor behavior have moved out.
+
+## Scope Summary
+
+This sprint is deletion-heavy. It removes code that exists only because the
+boundary was broken and should not be re-homed inside the daemon.
+
+The concrete delete/move decisions are frozen now:
+- delete `crates/atm-daemon/src/sqlite_observability.rs`
+- delete `crates/atm-daemon/src/runtime_health_test_support.rs`
+- delete `mod sqlite_observability;` from `crates/atm-daemon/src/lib.rs`
+- delete `SqliteRemoteReplayStore` from `crates/atm-daemon/src/lib.rs`
+- delete `use atm_rusqlite::SqliteBoundaryAssembly;` and the
+  `RemoteReplayStateRecord` re-export from `crates/atm-daemon/src/lib.rs`
+- delete direct `atm_rusqlite::assemble_boundary*` test use from:
+  - `crates/atm-daemon/src/tests.rs`
+  - `crates/atm-daemon/src/tests_advisory.rs`
+- delete `mark_sqlite_unavailable(...)` and
+  `mark_sqlite_unavailable_with_detail(...)` from
+  `crates/atm-daemon/src/runtime_status_cache.rs`
+- keep `crates/atm-daemon/src/peer_transport.rs`, but rewrite it to consume
+  storage-neutral replay DTOs/traits that no longer originate in `atm-rusqlite`
+
+## Governing Requirements
+
+- `REQ-CORE-BOUNDARY-001`
+- `REQ-DAEMON-RUNTIME-002`
+- `REQ-DAEMON-OBS-003`
+- `REQ-RUSQLITE-STORE-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+
+## Governing Boundaries
+
+- `docs/atm-daemon/boundaries.md`
+- `docs/atm-rusqlite/boundaries.md`
+
+## Prerequisites
+
+- `AA.2`
+- `AA.3`
+
+## Hard Dependencies
+
+- `atm-runtime` owns composition
+- store doctor trait owns store diagnostics
+
+## Non-Goals
+
+- final boundary relock
+- permanent enforcement guardrails
+
+## Sub-Tasks
+
+- Delete daemon-owned SQLite observability glue.
+  Development work: remove `sqlite_observability.rs` and route SQLite
+  observability injection entirely through `atm-runtime` / `atm-rusqlite`.
+  Required tests: retained observability regression coverage.
+  Required doc or boundary updates: daemon/rusqlite architecture docs.
+
+- Delete daemon-owned SQLite test support.
+  Development work: remove `runtime_health_test_support.rs` and any daemon test
+  setup that assembles SQLite directly. Replace daemon-local assembly with
+  runtime-owned or subsystem-owned fixtures.
+  Required tests: replace with subsystem or composition-level tests.
+  Required doc or boundary updates: testing docs if test ownership changes.
+
+- Remove replay/store type leakage from daemon public/internal seams.
+  Development work: eliminate `SqliteRemoteReplayStore`,
+  `RemoteReplayStateRecord` re-exports, and any daemon-local SQLite replay
+  wrappers. The exact destination decision is:
+  - storage-neutral replay DTO/trait live outside `atm-daemon` and
+    `atm-rusqlite`, under `atm-core`
+  - concrete SQLite replay implementation lives in `atm-runtime`
+  Required tests: peer transport / replay regression coverage.
+  Required doc or boundary updates: daemon boundaries if trait ownership moves.
+
+## Split Recommendation
+
+Keep this sprint deletion-first. If a leaked helper is not required by the
+simple router model, remove it instead of preserving compatibility for it.
+
+## Acceptance Criteria
+
+- daemon production code contains no SQLite observability glue
+- daemon test support no longer assembles SQLite directly
+- daemon replay/store seams no longer expose SQLite-owned record types
+- `runtime_status_cache.rs` contains no SQLite-named degradation helpers
+- the remaining daemon code is materially smaller and simpler
+
+## Required Validation
+
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/atm-daemon/architecture.md`
+- `docs/atm-daemon/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/atm-core/boundaries.md`
+- `docs/atm-rusqlite/requirements.md`
+- `docs/project-plan.md`
+
+## Risks And Watchouts
+
+- replay helpers are easy to preserve by habit; if they still mention SQLite in
+  the daemon, this sprint did not actually close

--- a/docs/phase-AA/sprint-AA4.md
+++ b/docs/phase-AA/sprint-AA4.md
@@ -62,35 +62,44 @@ The concrete delete/move decisions are frozen now:
 - `atm-runtime` owns composition
 - store doctor trait owns store diagnostics
 
-## Non-Goals
+## Out Of Scope
 
 - final boundary relock
 - permanent enforcement guardrails
 
-## Sub-Tasks
+## Paths To Delete
 
-- Delete daemon-owned SQLite observability glue.
-  Development work: remove `sqlite_observability.rs` and route SQLite
-  observability injection entirely through `atm-runtime` / `atm-rusqlite`.
-  Required tests: retained observability regression coverage.
-  Required doc or boundary updates: daemon/rusqlite architecture docs.
+- `crates/atm-daemon/src/sqlite_observability.rs`
+- `crates/atm-daemon/src/runtime_health_test_support.rs`
+- `mod sqlite_observability;` from `crates/atm-daemon/src/lib.rs`
+- `SqliteRemoteReplayStore` from `crates/atm-daemon/src/lib.rs`
+- `use atm_rusqlite::SqliteBoundaryAssembly;` from
+  `crates/atm-daemon/src/lib.rs`
+- `RemoteReplayStateRecord` re-export from `crates/atm-daemon/src/lib.rs`
+- direct `atm_rusqlite::assemble_boundary*` test use from:
+  - `crates/atm-daemon/src/tests.rs`
+  - `crates/atm-daemon/src/tests_advisory.rs`
+- `mark_sqlite_unavailable(...)` from
+  `crates/atm-daemon/src/runtime_status_cache.rs`
+- `mark_sqlite_unavailable_with_detail(...)` from
+  `crates/atm-daemon/src/runtime_status_cache.rs`
 
-- Delete daemon-owned SQLite test support.
-  Development work: remove `runtime_health_test_support.rs` and any daemon test
-  setup that assembles SQLite directly. Replace daemon-local assembly with
-  runtime-owned or subsystem-owned fixtures.
-  Required tests: replace with subsystem or composition-level tests.
-  Required doc or boundary updates: testing docs if test ownership changes.
+## Deliverables
 
-- Remove replay/store type leakage from daemon public/internal seams.
-  Development work: eliminate `SqliteRemoteReplayStore`,
-  `RemoteReplayStateRecord` re-exports, and any daemon-local SQLite replay
-  wrappers. The exact destination decision is:
-  - storage-neutral replay DTO/trait live outside `atm-daemon` and
-    `atm-rusqlite`, under `atm-core`
-  - concrete SQLite replay implementation lives in `atm-runtime`
-  Required tests: peer transport / replay regression coverage.
-  Required doc or boundary updates: daemon boundaries if trait ownership moves.
+- All paths in `Paths To Delete` are removed.
+
+- SQLite observability injection is fully outside the daemon and lives only in
+  `atm-runtime` / `atm-rusqlite`.
+
+- Daemon test support no longer assembles SQLite directly. Any remaining test
+  fixture ownership is moved to subsystem or composition layers.
+
+- Replay/store leakage is removed from daemon seams. The frozen ownership
+  decision is:
+  - storage-neutral replay DTO/trait live under `atm-core`
+  - concrete SQLite replay implementation lives under `atm-runtime`
+  - `crates/atm-daemon/src/peer_transport.rs` remains, but consumes only the
+    storage-neutral replay seam
 
 ## Split Recommendation
 
@@ -103,6 +112,8 @@ simple router model, remove it instead of preserving compatibility for it.
 - daemon test support no longer assembles SQLite directly
 - daemon replay/store seams no longer expose SQLite-owned record types
 - `runtime_status_cache.rs` contains no SQLite-named degradation helpers
+- every path listed under `Paths To Delete` is either removed or replaced by a
+  storage-neutral seam explicitly frozen in earlier AA sprints
 - the remaining daemon code is materially smaller and simpler
 
 ## Required Validation

--- a/docs/phase-AA/sprint-AA5.md
+++ b/docs/phase-AA/sprint-AA5.md
@@ -50,50 +50,46 @@ code and in review workflow.
 
 - daemon production code is already free of direct SQLite coupling
 
-## Non-Goals
+## Out Of Scope
 
 - no new subsystem behavior
 - no broad release-surface redesign beyond the corrected boundary
 
-## Sub-Tasks
+## Deliverables
 
-- Relock the TOML boundaries.
-  Development work: remove `atm-daemon` from SQLite boundary allowlists,
-  restore explicit forbidden edges, and close any visibility widened only to
-  permit daemon-side SQLite assembly.
-  Required tests: `just lint boundaries` or equivalent must fail if the edge
-  returns.
-  Required doc or boundary updates: boundary TOMLs and crate-local boundaries
-  docs.
+- The SQLite boundary TOMLs are relocked. The minimum closure set is:
+  - remove `atm-daemon` from SQLite boundary allowlists
+  - restore explicit forbidden edges
+  - restore any visibility/constructor privacy that was widened only to permit
+    daemon-side SQLite assembly
 
-- Add a second architecture enforcement layer.
-  Development work: add a repository-owned guard at
-  `scripts/check-boundary-guard.py` plus a self-test at
-  `scripts/test_boundary_guard.py`, modeled on the Ironclaw-style
-  dependency-boundary check, so crate-edge regressions fail even if TOML
-  policy is edited incorrectly. The script must inspect the workspace graph and
-  fail if `atm-daemon -> atm-rusqlite` reappears or if forbidden edge
-  removals / allowed dependent expansions are present in the changed boundary
-  TOMLs without an explicit approval artifact.
-  Required tests:
-  - `python3 scripts/check-boundary-guard.py --base-ref <target>`
-  - `python3 -m unittest scripts.test_boundary_guard`
-  Required doc or boundary updates: testing docs, project plan, and Phase AA
-  readiness record.
+- A second repository-owned architecture guard exists. The minimum executable
+  surface is frozen now:
+  - `scripts/check-boundary-guard.py`
+  - `scripts/test_boundary_guard.py`
 
-- Add governance for boundary-policy changes.
-  Development work: make widening `allowed_dependents`, removing forbidden
-  edges, or widening adapter visibility an explicit reviewed architecture
-  change rather than ordinary lint data churn.
-  Required tests: CI guard or repo-local lint for boundary-policy drift.
-  Required doc or boundary updates: project plan and architecture docs.
+- The second guard enforces both code-edge and policy-edge checks. The minimum
+  machine-checked contract is frozen now:
 
-- Add the `boundary-guard` QA agent.
-  Development work: define and wire a dedicated QA/review agent named
-  `boundary-guard` that examines
-  planning PRs and phase-ending review packets for boundary loosening. The
-  agent must treat any of the following TOML field changes as a relaxation
-  requiring explicit architectural justification:
+  ```json
+  {
+    "status": "PASS | FAIL",
+    "forbidden_edges": ["atm-daemon -> atm-rusqlite"],
+    "policy_relaxations": [
+      {
+        "field": "allowed_dependents",
+        "change": "added atm-daemon",
+        "requires_approval": true
+      }
+    ]
+  }
+  ```
+
+- Boundary-policy widening is explicitly documented as an architecture change,
+  not routine lint-data churn.
+
+- The `boundary-guard` QA agent is defined as a required review participant.
+  The exact relaxation table is frozen:
 
   | Field | Relaxation direction |
   |---|---|
@@ -104,16 +100,13 @@ code and in review workflow.
   | `forbidden_test_bypasses` | any removal |
   | `forbidden` | any removal |
 
-  The agent fires at two named points in the plan workflow: (1) after
-  critical-plan-reviewer and before team-lead approval on any plan branch
-  that modifies a boundary TOML, and (2) as a required reviewer in every
-  phase-ending review packet.
-  Required tests: a synthetic boundary-TOML relaxation fixture that the agent
-  must catch, unconditionally, as a required self-test; prove the review
-  workflow requires this agent at both named trigger points.
-  Required doc or boundary updates: review workflow docs, project plan,
-  readiness record, and any team/QA protocol docs that assign the new review
-  responsibility.
+- The `boundary-guard` workflow trigger points are frozen:
+  1. after `critical-plan-reviewer` and before `team-lead` approval on any
+     plan branch that modifies a boundary TOML
+  2. as a required reviewer in every phase-ending review packet
+
+- A synthetic boundary-relaxation fixture exists and is required self-test
+  coverage for the second guard.
 
 ## Split Recommendation
 
@@ -127,10 +120,11 @@ actually clean will either fail immediately or produce more policy cheating.
 - a second architecture-enforcement layer exists beyond the TOML lint
 - boundary-policy widening is treated as an architecture change, not routine
   config churn
-- `boundary-guard` exists, fires at the two named workflow
-  trigger points (post-critical-plan-review and phase-ending review), and a
-  finding at BLOCKING severity prevents the plan branch or phase PR from
-  merging
+- `boundary-guard` exists, fires at the two named workflow trigger points, and
+  the sprint docs explicitly state whether blocking findings are required to
+  stop merge
+- the sprint docs include the exact relaxation table and a machine-checkable
+  output shape for the second guard
 - the daemon-to-SQLite edge fails both the TOML-based guard and the
   code-driven architecture guard if reintroduced
 

--- a/docs/phase-AA/sprint-AA5.md
+++ b/docs/phase-AA/sprint-AA5.md
@@ -150,6 +150,9 @@ actually clean will either fail immediately or produce more policy cheating.
 
 ## Required Validation
 
+- `scripts/check-boundary-guard.py` and `scripts/test_boundary_guard.py` are
+  AA.5 deliverables; run these checks at end-of-sprint after implementation
+  lands
 - `just lint boundaries`
 - `python3 scripts/check-boundary-guard.py --base-ref origin/integrate/phase-AA`
 - `python3 -m unittest scripts.test_boundary_guard`

--- a/docs/phase-AA/sprint-AA5.md
+++ b/docs/phase-AA/sprint-AA5.md
@@ -1,0 +1,163 @@
+# AA.5 Boundary Relock And Permanent Enforcement
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.5
+worktree: ../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement
+branch: feature/pAA-s5-boundary-relock-and-permanent-enforcement
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Re-establish the daemon-to-SQLite boundary and add a second enforcement layer
+so widening the boundary cannot hide behind TOML-only changes again. This
+includes the dedicated `boundary-guard` QA agent for plan review and
+phase-ending review.
+
+## Scope Summary
+
+This sprint is the final closure gate. It restores the forbidden edge and adds
+permanent protection beyond the existing boundary TOMLs and lint rules, both in
+code and in review workflow.
+
+## Governing Requirements
+
+- `REQ-CORE-BOUNDARY-001`
+- `REQ-DAEMON-RUNTIME-002`
+- `REQ-RUSQLITE-STORE-001`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+
+## Governing Boundaries
+
+- `boundaries/atm-rusqlite/sqlite-boundary-assembly.toml`
+- `boundaries/atm-rusqlite/mail-store-sqlite.toml`
+- `boundaries/atm-rusqlite/roster-store-sqlite.toml`
+- `boundaries/atm-rusqlite/task-store-sqlite.toml`
+
+## Prerequisites
+
+- `AA.2`
+- `AA.3`
+- `AA.4`
+
+## Hard Dependencies
+
+- daemon production code is already free of direct SQLite coupling
+
+## Non-Goals
+
+- no new subsystem behavior
+- no broad release-surface redesign beyond the corrected boundary
+
+## Sub-Tasks
+
+- Relock the TOML boundaries.
+  Development work: remove `atm-daemon` from SQLite boundary allowlists,
+  restore explicit forbidden edges, and close any visibility widened only to
+  permit daemon-side SQLite assembly.
+  Required tests: `just lint boundaries` or equivalent must fail if the edge
+  returns.
+  Required doc or boundary updates: boundary TOMLs and crate-local boundaries
+  docs.
+
+- Add a second architecture enforcement layer.
+  Development work: add a repository-owned guard at
+  `scripts/check-boundary-guard.py` plus a self-test at
+  `scripts/test_boundary_guard.py`, modeled on the Ironclaw-style
+  dependency-boundary check, so crate-edge regressions fail even if TOML
+  policy is edited incorrectly. The script must inspect the workspace graph and
+  fail if `atm-daemon -> atm-rusqlite` reappears or if forbidden edge
+  removals / allowed dependent expansions are present in the changed boundary
+  TOMLs without an explicit approval artifact.
+  Required tests:
+  - `python3 scripts/check-boundary-guard.py --base-ref <target>`
+  - `python3 -m unittest scripts.test_boundary_guard`
+  Required doc or boundary updates: testing docs, project plan, and Phase AA
+  readiness record.
+
+- Add governance for boundary-policy changes.
+  Development work: make widening `allowed_dependents`, removing forbidden
+  edges, or widening adapter visibility an explicit reviewed architecture
+  change rather than ordinary lint data churn.
+  Required tests: CI guard or repo-local lint for boundary-policy drift.
+  Required doc or boundary updates: project plan and architecture docs.
+
+- Add the `boundary-guard` QA agent.
+  Development work: define and wire a dedicated QA/review agent named
+  `boundary-guard` that examines
+  planning PRs and phase-ending review packets for boundary loosening. The
+  agent must treat any of the following TOML field changes as a relaxation
+  requiring explicit architectural justification:
+
+  | Field | Relaxation direction |
+  |---|---|
+  | `allowed_dependents` | any addition |
+  | `forbidden_edges` | any removal |
+  | `visibility` | any promotion toward public |
+  | `constructor` | any promotion toward public |
+  | `forbidden_test_bypasses` | any removal |
+  | `forbidden` | any removal |
+
+  The agent fires at two named points in the plan workflow: (1) after
+  critical-plan-reviewer and before team-lead approval on any plan branch
+  that modifies a boundary TOML, and (2) as a required reviewer in every
+  phase-ending review packet.
+  Required tests: a synthetic boundary-TOML relaxation fixture that the agent
+  must catch, unconditionally, as a required self-test; prove the review
+  workflow requires this agent at both named trigger points.
+  Required doc or boundary updates: review workflow docs, project plan,
+  readiness record, and any team/QA protocol docs that assign the new review
+  responsibility.
+
+## Split Recommendation
+
+This must remain the final sprint. Relocking the boundary before the daemon is
+actually clean will either fail immediately or produce more policy cheating.
+
+## Acceptance Criteria
+
+- `atm-daemon` is forbidden again as a dependent of SQLite assembly/store
+  boundaries
+- a second architecture-enforcement layer exists beyond the TOML lint
+- boundary-policy widening is treated as an architecture change, not routine
+  config churn
+- `boundary-guard` exists, fires at the two named workflow
+  trigger points (post-critical-plan-review and phase-ending review), and a
+  finding at BLOCKING severity prevents the plan branch or phase PR from
+  merging
+- the daemon-to-SQLite edge fails both the TOML-based guard and the
+  code-driven architecture guard if reintroduced
+
+## Required Validation
+
+- `just lint boundaries`
+- `python3 scripts/check-boundary-guard.py --base-ref <target>`
+- `python3 -m unittest scripts.test_boundary_guard`
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/phase-AA/readiness.md`
+- `docs/project-plan.md`
+- `docs/plan-phase-AA.md`
+- `docs/architecture.md`
+- `docs/atm-daemon/boundaries.md`
+- `docs/atm-rusqlite/boundaries.md`
+- CI / testing documentation for the second enforcement layer
+- review workflow / QA protocol documentation for the new boundary-enforcement
+  agent
+
+## Risks And Watchouts
+
+- if this sprint ships without the second enforcement layer, the repo is still
+  trusting boundary TOML as the final authority
+- if the QA agent is advisory-only instead of required, boundary-policy drift
+  can still be normalized during planning or phase closeout

--- a/docs/phase-AA/sprint-AA5.md
+++ b/docs/phase-AA/sprint-AA5.md
@@ -35,6 +35,7 @@ code and in review workflow.
 
 ## Governing Boundaries
 
+- `boundaries/atm-runtime/runtime-composition.toml`
 - `boundaries/atm-rusqlite/sqlite-boundary-assembly.toml`
 - `boundaries/atm-rusqlite/mail-store-sqlite.toml`
 - `boundaries/atm-rusqlite/roster-store-sqlite.toml`
@@ -62,6 +63,10 @@ code and in review workflow.
   - restore explicit forbidden edges
   - restore any visibility/constructor privacy that was widened only to permit
     daemon-side SQLite assembly
+  - make the SQLite boundary TOMLs agree with
+    `boundaries/atm-runtime/runtime-composition.toml` on the forbidden
+    `atm-daemon -> atm-rusqlite` edge so no policy contradiction remains after
+    relock
 
 - A second repository-owned architecture guard exists. The minimum executable
   surface is frozen now:
@@ -88,6 +93,10 @@ code and in review workflow.
 
 - Boundary-policy widening is explicitly documented as an architecture change,
   not routine lint-data churn.
+- The temporary `AA.2` through `AA.4` transition rule is closed, meaning there
+  is no longer a split between target-state boundary policy in
+  `runtime-composition.toml` and authoritative lint policy in the SQLite
+  boundary TOMLs.
 
 - The `boundary-guard` QA agent is defined as a required review participant.
   The exact relaxation table is frozen:
@@ -125,6 +134,8 @@ actually clean will either fail immediately or produce more policy cheating.
 
 - `atm-daemon` is forbidden again as a dependent of SQLite assembly/store
   boundaries
+- `boundaries/atm-runtime/runtime-composition.toml` and the SQLite boundary
+  TOMLs agree on the same forbidden daemon-to-SQLite edge after relock
 - a second architecture-enforcement layer exists beyond the TOML lint
 - boundary-policy widening is treated as an architecture change, not routine
   config churn

--- a/docs/phase-AA/sprint-AA5.md
+++ b/docs/phase-AA/sprint-AA5.md
@@ -149,6 +149,7 @@ actually clean will either fail immediately or produce more policy cheating.
 ## Required Document Updates
 
 - `docs/phase-AA/readiness.md`
+- `docs/phase-AA/issues.md`
 - `docs/project-plan.md`
 - `docs/plan-phase-AA.md`
 - `docs/architecture.md`

--- a/docs/phase-AA/sprint-AA5.md
+++ b/docs/phase-AA/sprint-AA5.md
@@ -67,6 +67,7 @@ code and in review workflow.
   surface is frozen now:
   - `scripts/check-boundary-guard.py`
   - `scripts/test_boundary_guard.py`
+  - `.claude/agents/boundary-guard.md`
 
 - The second guard enforces both code-edge and policy-edge checks. The minimum
   machine-checked contract is frozen now:
@@ -105,6 +106,13 @@ code and in review workflow.
      plan branch that modifies a boundary TOML
   2. as a required reviewer in every phase-ending review packet
 
+- The `boundary-guard` blocking posture is frozen:
+  - any `Blocking` severity finding from `.claude/agents/boundary-guard.md`
+    stops merge on plan branches that modify boundary TOMLs
+  - any `Blocking` severity finding from `.claude/agents/boundary-guard.md`
+    stops merge on phase-ending review branches
+  - `Minor` findings remain advisory only
+
 - A synthetic boundary-relaxation fixture exists and is required self-test
   coverage for the second guard.
 
@@ -120,9 +128,10 @@ actually clean will either fail immediately or produce more policy cheating.
 - a second architecture-enforcement layer exists beyond the TOML lint
 - boundary-policy widening is treated as an architecture change, not routine
   config churn
-- `boundary-guard` exists, fires at the two named workflow trigger points, and
-  the sprint docs explicitly state whether blocking findings are required to
-  stop merge
+- `.claude/agents/boundary-guard.md` exists, `boundary-guard` fires at the two
+  named workflow trigger points, and `Blocking` findings are required to stop
+  merge on both plan branches touching boundary TOMLs and phase-ending review
+  branches
 - the sprint docs include the exact relaxation table and a machine-checkable
   output shape for the second guard
 - the daemon-to-SQLite edge fails both the TOML-based guard and the
@@ -131,7 +140,7 @@ actually clean will either fail immediately or produce more policy cheating.
 ## Required Validation
 
 - `just lint boundaries`
-- `python3 scripts/check-boundary-guard.py --base-ref <target>`
+- `python3 scripts/check-boundary-guard.py --base-ref origin/integrate/phase-AA`
 - `python3 -m unittest scripts.test_boundary_guard`
 - `cargo test --workspace`
 - `python3 .just/run_lint.py all`

--- a/docs/phase-AA/sprint-AA6.md
+++ b/docs/phase-AA/sprint-AA6.md
@@ -1,0 +1,177 @@
+# AA.6 `sc-observability` 1.2.0 Upgrade
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.6
+worktree: ../atm-core-worktrees/feature/pAA-s6-obs-upgrade
+branch: feature/pAA-s6-obs-upgrade
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Upgrade ATM from `sc-observability` / `sc-observability-types` `1.1.0` to
+`1.2.0` and absorb the public logging/runtime API changes without regressing
+CLI or daemon observability behavior.
+
+## Scope Summary
+
+This sprint is an explicit dependency-upgrade line after the daemon/SQLite
+boundary repair. It is not a general observability redesign. The work is to
+migrate ATM to the `1.2.0` public surface that now uses queue-backed logger
+admission, stopped-logger typestate, and the renamed retained-log shutdown
+policy.
+
+The `1.2.0` migration surface is frozen now:
+- `Logger::emit()` is deprecated; ATM must migrate to `Logger::log()` or
+  `Logger::try_log()` at the concrete `sc-observability` adapter layer rather
+  than carrying the deprecated compatibility path forward indefinitely
+- queue admission is no longer sink durability; ATM must make
+  `flush()` / `shutdown()` the explicit durability/lifecycle barriers where
+  it currently relies on immediate retained-log visibility
+- the queue-backed APIs use `LogError` / `TryLogError` rather than the older
+  synchronous `emit()` error surface; ATM must update its `AtmError`
+  observability mapping accordingly
+- logger shutdown returns `Logger<Stopped>`; daemon retained-log shutdown
+  wrappers must preserve stopped-logger health inspection across the new
+  typestate API
+- `LoggingHealthReport` now exposes queue/writer/maintenance state; ATM doctor
+  and observability presentation must project the additional health data
+- `RetainedLogPolicy` now uses typed policy fields and renames the shutdown
+  timeout field to `writer_shutdown_timeout`; ATM code still carrying
+  `maintenance_join_timeout` must be migrated
+
+## Governing Requirements
+
+- `REQ-P-OBS-001`
+- `REQ-P-OBS-004`
+- `REQ-ATM-OBS-001`
+- `REQ-CORE-OBS-001`
+- `REQ-CORE-DOCTOR-001`
+- `REQ-DAEMON-OBS-002`
+- `REQ-DAEMON-OBS-003`
+
+## Governing ADRs
+
+- `docs/adr/ADR-001-sealed-trait-pattern.md`
+
+## Governing Boundaries
+
+- `docs/atm-core/boundaries.md`
+- `docs/atm-daemon/boundaries.md`
+- `docs/atm-runtime/boundaries.md`
+
+## Prerequisites
+
+- `AA.5`
+
+## Hard Dependencies
+
+- the `AA.5` boundary relock is complete, so the upgrade does not have to
+  preserve daemon-local SQLite seams that the earlier sprints are deleting
+
+## Out Of Scope
+
+- no new observability product features
+- no new daemon/storage boundary decisions
+- no retry/replay redesign unrelated to the `sc-observability` API change
+
+## Deliverables
+
+- Workspace dependency versions are bumped to `1.2.0` where ATM currently pins
+  `sc-observability` and `sc-observability-types`.
+
+- The concrete `sc-observability` adapter call sites are migrated off the
+  deprecated compatibility path. The minimum migration set is frozen now:
+  - `crates/atm/src/main.rs`
+  - `crates/atm-daemon/bin_support/daemon_observability.rs`
+  - any surviving direct adapter-layer logger call site after `AA.4`
+
+- Queue-admission vs durability semantics are made explicit. The migration rule
+  is frozen now:
+  - `log()` or `try_log()` is used for queue admission
+  - `flush()` or `shutdown()` is the only durability barrier
+  - ATM lifecycle code must not assume queue admission implies immediate
+    retained-log persistence
+
+- The retained-log policy/config migration is frozen now. The minimum required
+  code updates are:
+  - replace `maintenance_join_timeout` with `writer_shutdown_timeout`
+  - replace old raw policy-field shapes with the `1.2.0` typed wrappers:
+    - `ByteCount`
+    - `FileCount`
+    - `RetentionMaxAge`
+    - `MaintenanceCadence`
+    - `WriterShutdownTimeout`
+  The known affected ATM source is:
+  - `crates/atm-daemon/bin_support/daemon_observability.rs`
+  - any retained-log policy helper that still uses the old field name or shape
+
+- ATM health/report projection is updated for the `1.2.0` logger runtime.
+  The minimum presentation-review surface is frozen now:
+  - `crates/atm/src/main.rs`
+  - `crates/atm/src/output.rs`
+  - `crates/atm-core/src/doctor/mod.rs`
+  - `crates/atm-daemon/bin_support/daemon_observability.rs`
+  The goal is not to expose every new raw field, but ATM must compile cleanly
+  and intentionally decide which queue/writer/maintenance details are surfaced
+  in doctor and retained-log health reports.
+
+- The `1.2.0` breaking/migration items are documented in the sprint itself so
+  implementation is mechanical:
+  1. deprecated `Logger::emit()` compatibility path
+  2. queue-backed admission via `log()` / `try_log()`
+  3. durability boundary moves to `flush()` / `shutdown()`
+  4. `LogError` / `TryLogError` mapping updates
+  5. `Logger<Stopped>` shutdown typestate handling
+  6. `LoggingHealthReport` queue/writer/maintenance projection review
+  7. `RetainedLogPolicy.writer_shutdown_timeout` and typed policy wrappers
+
+## Split Recommendation
+
+Keep this sprint strictly scoped to the `1.2.0` upgrade. Do not mix in
+unrelated observability refactors or feature work once the migration compiles.
+
+## Acceptance Criteria
+
+- `docs/phase-AA/sprint-AA6.md` exists with `status: planned`,
+  `branch: feature/pAA-s6-obs-upgrade`, and a populated `worktree:`
+- the sprint doc enumerates every `sc-observability` `1.2.0` migration item
+  currently required by ATM:
+  - deprecated `emit()` path
+  - `log()` / `try_log()` queue-admission APIs
+  - explicit durability barriers
+  - `LogError` / `TryLogError`
+  - `Logger<Stopped>` shutdown typestate
+  - `LoggingHealthReport` queue/writer/maintenance projection review
+  - `writer_shutdown_timeout` and typed retained-log policy field migration
+- `docs/plan-phase-AA.md` contains an `AA.6` section after `AA.5`
+- `docs/project-plan.md` includes the `AA.6` sprint entry before closeout
+
+## Required Validation
+
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/phase-AA/sprint-AA6.md`
+- `docs/phase-AA/readiness.md`
+- `docs/plan-phase-AA.md`
+- `docs/project-plan.md`
+- `docs/architecture.md`
+- `docs/requirements.md`
+- `docs/atm-core/design/sc-observability-integration.md`
+
+## Risks And Watchouts
+
+- if ATM upgrades the version pins without replacing the old retained-log
+  policy field names, the build will fail on the logger config seam
+- if ATM keeps using the deprecated `emit()` path indefinitely, the repo will
+  carry forward the old synchronous mental model even though the logger runtime
+  is queue-backed
+- if doctor/health output ignores the new queue/writer state entirely, ATM may
+  compile but lose meaningful operator signal during retained-log degradation

--- a/docs/phase-AA/sprint-AA6.md
+++ b/docs/phase-AA/sprint-AA6.md
@@ -71,6 +71,8 @@ The `1.2.0` migration surface is frozen now:
 
 - the `AA.5` boundary relock is complete, so the upgrade does not have to
   preserve daemon-local SQLite seams that the earlier sprints are deleting
+- `docs/atm-runtime/boundaries.md` is created by `AA.2` and must exist before
+  this sprint begins
 
 ## Out Of Scope
 
@@ -87,6 +89,10 @@ The `1.2.0` migration surface is frozen now:
   deprecated compatibility path. The minimum migration set is frozen now:
   - `crates/atm/src/main.rs`
   - `crates/atm-daemon/bin_support/daemon_observability.rs`
+  - if `AA.4` moves the concrete `sc-observability` composition into
+    `atm-runtime`, the migration target shifts from daemon bin-support code to
+    the `atm-runtime` adapter/composition path that owns logger assembly after
+    that move
   - any surviving direct adapter-layer logger call site after `AA.4`
 
 - Queue-admission vs durability semantics are made explicit. The migration rule
@@ -149,6 +155,13 @@ unrelated observability refactors or feature work once the migration compiles.
   - `writer_shutdown_timeout` and typed retained-log policy field migration
 - `docs/plan-phase-AA.md` contains an `AA.6` section after `AA.5`
 - `docs/project-plan.md` includes the `AA.6` sprint entry before closeout
+- `docs/architecture.md` is either updated by this sprint or removed from
+  Required Document Updates if no `AA.6` migration detail lands there
+- `docs/requirements.md` is either updated by this sprint or removed from
+  Required Document Updates if no `AA.6` requirement text lands there
+- `docs/atm-core/design/sc-observability-integration.md` is either updated by
+  this sprint or removed from Required Document Updates if no migration detail
+  lands there
 
 ## Required Validation
 

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -50,6 +50,11 @@ Current violated state that `Phase AA` must delete:
 - daemon owns SQLite-specific observability glue
 - daemon test support composes SQLite assemblies directly
 
+Authoritative planning support artifacts:
+- `docs/phase-AA/readiness.md`
+- `docs/phase-AA/issues.md`
+- `.claude/agents/boundary-guard.md`
+
 ## Why Phase AA Exists
 
 The daemon was intended to be simple and storage-agnostic. The boundary was

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -230,6 +230,8 @@ Purpose:
 - add `crates/atm-runtime`
 - move concrete SQLite construction and production runtime wiring there
 - make `atm-daemon` receive only storage-neutral runtime inputs
+- freeze the end-state runtime boundary early in
+  `runtime-composition.toml` while leaving the SQLite TOML relock to `AA.5`
 
 Execution branch:
 - `feature/pAA-s2-atm-runtime-composition-transfer`
@@ -272,6 +274,8 @@ Purpose:
 - treat boundary-policy widening as an explicit architecture change
 - add a `boundary-guard` QA agent that reviews plans and phase-ending
   reviews for any boundary loosening before closure
+- close the temporary `AA.2` to `AA.4` transition window by making the
+  SQLite boundary TOMLs agree with `runtime-composition.toml`
 
 Execution branch:
 - `feature/pAA-s5-boundary-relock-and-permanent-enforcement`

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -1,0 +1,314 @@
+# Phase AA Plan
+
+## Goal
+
+Remove every concrete SQLite reference from `atm-daemon` and restore the
+daemon to the original simple role:
+
+- singleton host/runtime ownership
+- transport routing
+- bounded request dispatch
+- minor runtime error handling
+
+`Phase AA` exists because the current daemon line drifted across the storage
+boundary and accumulated SQLite-aware composition, health, observability, and
+test support that do not belong in a thin router.
+
+The required end state is:
+
+- concrete SQLite construction moves to a dedicated `atm-runtime` composition
+  crate
+- existing storage-facing capability traits live in `atm-core` and remain
+  backend-neutral:
+  - `MailStore`
+  - `TaskStore`
+  - `RosterStore`
+- Phase AA adds subsystem doctor traits beside those boundaries instead of
+  introducing a second parallel storage trait family
+- `atm-daemon` knows only storage-neutral `atm-core` ports
+- `atm doctor` regains a direct local diagnostics path that can inspect
+  SQLite/store health without requiring daemon routing
+- daemon-routed doctor data remains optional and additive, used only for
+  daemon-only runtime state or for faster asynchronous answers when the daemon
+  is already live
+
+## Baseline
+
+Planning branch:
+- `plan/remove-sqlite-from-daemon`
+
+Planning worktree:
+- `../atm-core-worktrees/plan/remove-sqlite-from-daemon`
+
+Expected execution integration branch:
+- `integrate/phase-AA`
+
+Current violated state that `Phase AA` must delete:
+- `atm-daemon` directly depends on `atm-rusqlite`
+- daemon composition constructs `SqliteBoundaryAssembly`
+- daemon runtime-health code reads SQLite-backed roster state directly
+- daemon owns SQLite-specific observability glue
+- daemon test support composes SQLite assemblies directly
+
+## Why Phase AA Exists
+
+The daemon was intended to be simple and storage-agnostic. The boundary was
+created specifically so the daemon would never know that the first storage
+adapter is SQLite.
+
+That invariant no longer holds. Once the boundary widened, daemon code started
+to accumulate concrete adapter knowledge instead of staying a thin router.
+`Phase AA` is not feature expansion; it is architectural damage removal.
+
+## Target Architecture
+
+### `atm-runtime` becomes the concrete composition root
+
+`Phase AA` introduces a dedicated `atm-runtime` crate.
+
+`atm-runtime` owns:
+- construction of `SqliteBoundaryAssembly`
+- injection of SQLite-specific observability into `atm-rusqlite`
+- assembly of the concrete production `MailStore`, `RosterStore`, and replay
+  store implementations
+- any direct local doctor helper that must inspect the installed storage
+  adapter
+- installation of the active capability-trait implementations used by the CLI
+  and daemon
+
+`atm-runtime` does not own:
+- CLI parsing/rendering
+- daemon transport
+- workflow/state-machine business logic
+
+### `atm-daemon` becomes a thin router again
+
+After `Phase AA`, `atm-daemon` owns only:
+- singleton startup / shutdown
+- local and remote transport hosting
+- request validation and routing
+- bounded dispatch / reply handling
+- daemon-only runtime state that truly cannot be answered outside the daemon
+
+`atm-daemon` must not own:
+- SQLite construction
+- SQLite observability adapters
+- SQLite health probing
+- SQLite replay-store implementations
+- SQLite-specific test helpers
+- backend identity branching such as "if SQLite then ..."
+
+### Storage capability traits replace backend-shaped seams
+
+`Phase AA` should not replace SQLite-specific code with one giant generic
+`Storage` trait. The Phase AA implementation decision is:
+
+- keep the existing storage-neutral `atm-core` boundaries as the primary
+  storage capability surfaces:
+  - `MailStore`
+  - `TaskStore`
+  - `RosterStore`
+- add subsystem doctor traits beside those boundaries rather than introducing a
+  second parallel read/write trait hierarchy in the same phase
+- if a narrower reader/writer split is still desirable after the daemon is
+  clean, it becomes a later simplification line rather than extra churn inside
+  Phase AA
+
+Rules:
+- traits are named for the behavior they expose, not for backend identity
+- traits stay small and composable
+- daemon and CLI depend only on the capabilities they actually need
+- backend implementations may satisfy multiple traits, but callers should not
+  receive a giant god-interface just because one backend can do many things
+- both SQLite-backed and Claude-JSON-backed implementations are allowed to
+  satisfy the same capability family
+- `Phase AA` reuses `MailStore` / `TaskStore` / `RosterStore` as the primary
+  storage-neutral capability surfaces and does not create parallel
+  `MessageReader` / `MessageWriter` / `RosterReader` / `RosterWriter` traits
+  in the same phase
+
+### `atm doctor` becomes direct-first, daemon-optional
+
+The baseline `atm doctor` path should be local and direct:
+- config discovery
+- team/identity resolution
+- direct store-path / SQLite health
+- roster/store consistency checks that do not require a running daemon
+
+The daemon path is additive:
+- singleton owner state
+- live in-memory daemon status cache
+- active background worker state
+- degraded runtime conditions that exist only while the daemon is live
+- cross-subsystem drift findings such as SQLite roster vs `config.json` roster
+  mismatch
+
+The routing rule is therefore:
+- if a check can be answered directly from local config/store state, the CLI
+  may query it directly
+- the daemon is used only when daemon-owned runtime state is required or when
+  an already-live daemon can answer faster/asynchronously
+
+The diagnostic ownership rule is:
+- deep investigation belongs to the implementing subsystem
+- aggregation and cross-subsystem comparison belong to the caller
+- the daemon may compare subsystem reports, but it must not reimplement
+  backend-specific diagnosis logic
+- config diagnostics follow the same rule: backend-specific `config.json`
+  investigation belongs behind a config doctor trait rather than ad hoc logic
+  buried in daemon code
+- daemon runtime snapshots remain daemon-owned; backend-specific store health
+  leaves the runtime snapshot and appears only through subsystem doctor reports
+
+## Simplicity Contract
+
+The daemon must remain auditable through a very small state-machine set.
+
+`Phase AA` closure requires an explicit daemon state-machine inventory with no
+more than five top-level machines:
+
+1. bootstrap / singleton ownership
+2. request receipt / validation / dispatch / reply
+3. session / connection lifecycle
+4. graceful shutdown / drain
+5. advisory-stream lifecycle, if it remains daemon-owned
+
+Any SQLite-specific control flow that creates additional daemon machines is a
+violation and should be deleted or moved out of the crate.
+
+## Phase Entry Criteria
+
+`Phase AA` begins only when:
+- the boundary audit is frozen with the direct daemon-side SQLite leak list
+- the user-approved target architecture is recorded in requirements and
+  architecture docs
+- the new `atm-runtime` crate is accepted as the concrete composition home
+- boundary TOML changes are treated as architecture changes rather than
+  routine lint data edits
+
+## Sprint Sequence
+
+### AA.0 Boundary Freeze And Audit Ledger
+
+Purpose:
+- freeze the exact daemon-side SQLite leak inventory
+- revert boundary TOMLs so `atm-daemon` is no longer an allowed dependent of
+  the SQLite assembly/store boundaries
+- document the small allowed post-AA daemon state-machine inventory
+
+Execution branch:
+- `feature/pAA-s0-daemon-architecture-restatement`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement`
+
+### AA.1 Subsystem Doctor Traits And Shared Diagnostic Contracts
+
+Purpose:
+- define subsystem-owned capability and doctor traits in `atm-core`
+- make `atm-rusqlite` the owner of store diagnostics
+- allow backend implementations such as SQLite and Claude JSON to satisfy the
+  same behavior-named trait family
+- make daemon doctor an aggregation surface rather than a subsystem analyzer
+
+Execution branch:
+- `feature/pAA-s1-subsystem-doctor-traits`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s1-subsystem-doctor-traits`
+
+### AA.2 `atm-runtime` Skeleton And Composition Transfer
+
+Purpose:
+- add `crates/atm-runtime`
+- move concrete SQLite construction and production runtime wiring there
+- make `atm-daemon` receive only storage-neutral runtime inputs
+
+Execution branch:
+- `feature/pAA-s2-atm-runtime-composition-transfer`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s2-atm-runtime-composition-transfer`
+
+### AA.3 Direct Doctor Path And Runtime Health Simplification
+
+Purpose:
+- restore a direct local doctor path for config/store checks
+- keep daemon health as an additive runtime subreport rather than the only
+  doctor path
+- remove daemon-owned SQLite health probing
+
+Execution branch:
+- `feature/pAA-s3-direct-doctor-and-runtime-health-split`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split`
+
+### AA.4 Delete Remaining Daemon SQLite Leaks
+
+Purpose:
+- move SQLite observability injection to `atm-runtime` / `atm-rusqlite`
+- move or delete daemon-local SQLite replay/store wrappers
+- delete daemon-private SQLite test support
+
+Execution branch:
+- `feature/pAA-s4-delete-daemon-sqlite-leaks`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks`
+
+### AA.5 Boundary Relock And Permanent Enforcement
+
+Purpose:
+- relock the `atm-daemon` / `atm-rusqlite` boundary in code and TOML
+- add a second architecture-enforcement layer beyond the TOML lint rules
+- treat boundary-policy widening as an explicit architecture change
+- add a `boundary-guard` QA agent that reviews plans and phase-ending
+  reviews for any boundary loosening before closure
+
+Execution branch:
+- `feature/pAA-s5-boundary-relock-and-permanent-enforcement`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement`
+
+## Non-Goals
+
+`Phase AA` does not:
+- redesign ATM business logic
+- replace SQLite with a second adapter in the same phase
+- expand the daemon packet surface
+- introduce new product features unrelated to removing SQLite knowledge from
+  the daemon
+- preserve daemon-local helper code solely because it already exists
+
+## Exit Criteria
+
+`Phase AA` closes only when all of the following are true:
+
+- `crates/atm-daemon` has no direct dependency on `atm-rusqlite`
+- daemon source contains no direct `atm_rusqlite::*` references
+- SQLite observability is injected into SQLite-owned code outside the daemon
+- local `atm doctor` can report direct config/store health without requiring
+  daemon routing
+- daemon health reporting aggregates injected subsystem reports plus
+  daemon-owned runtime state without backend-specific diagnosis logic
+- the boundary TOMLs forbid the daemon-to-SQLite edge again
+- a `boundary-guard` QA agent exists and is part of plan review plus
+  phase-ending review for boundary-widening detection
+- the daemon state-machine inventory is explicitly documented and stays within
+  the Phase AA simplicity contract
+
+## Planning Consequences
+
+The cheapest correct implementation path is deletion-first, not compatibility-
+preserving refactor-first.
+
+If a daemon-side SQLite-aware behavior is not essential to:
+- transport
+- routing
+- lifecycle
+- bounded request handling
+
+then `Phase AA` should prefer deleting it over inventing a new daemon-local
+abstraction for it.

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -283,6 +283,23 @@ Execution branch:
 Execution worktree:
 - `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement`
 
+### AA.6 `sc-observability` 1.2.0 Upgrade
+
+Purpose:
+- upgrade `sc-observability` / `sc-observability-types` from `1.1.0` to
+  `1.2.0`
+- migrate ATM off the deprecated `Logger::emit()` compatibility path
+- absorb the queue-backed logger runtime API changes without regressing CLI or
+  daemon observability behavior
+- migrate retained-log policy code to the `1.2.0` field/type surface,
+  including `writer_shutdown_timeout`
+
+Execution branch:
+- `feature/pAA-s6-obs-upgrade`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s6-obs-upgrade`
+
 ## Out Of Scope
 
 `Phase AA` does not:

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -188,13 +188,15 @@ violation and should be deleted or moved out of the crate.
 
 ## Sprint Sequence
 
-### AA.0 Boundary Freeze And Audit Ledger
+### AA.0 Daemon Architecture Restatement And State-Machine Inventory
 
 Purpose:
 - freeze the exact daemon-side SQLite leak inventory
-- revert boundary TOMLs so `atm-daemon` is no longer an allowed dependent of
-  the SQLite assembly/store boundaries
+- restate the intended thin-daemon role in the governing docs before code
+  deletion begins
 - document the small allowed post-AA daemon state-machine inventory
+- freeze the delete / move / keep-and-rewrite classifications that later
+  sprints must follow
 
 Execution branch:
 - `feature/pAA-s0-daemon-architecture-restatement`
@@ -272,7 +274,7 @@ Execution branch:
 Execution worktree:
 - `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement`
 
-## Non-Goals
+## Out Of Scope
 
 `Phase AA` does not:
 - redesign ATM business logic

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -310,6 +310,10 @@ Execution worktree:
   the daemon
 - preserve daemon-local helper code solely because it already exists
 
+The scoped `sc-observability` / `sc-observability-types` `1.2.0` dependency
+upgrade in `AA.6` is in scope for this phase as closeout work required to
+finish the daemon/runtime simplification line cleanly.
+
 ## Exit Criteria
 
 Authoritative Phase `AA` exit criteria live only in

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -286,20 +286,12 @@ Execution worktree:
 
 ## Exit Criteria
 
-`Phase AA` closes only when all of the following are true:
+Authoritative Phase `AA` exit criteria live only in
+`docs/phase-AA/readiness.md`.
 
-- `crates/atm-daemon` has no direct dependency on `atm-rusqlite`
-- daemon source contains no direct `atm_rusqlite::*` references
-- SQLite observability is injected into SQLite-owned code outside the daemon
-- local `atm doctor` can report direct config/store health without requiring
-  daemon routing
-- daemon health reporting aggregates injected subsystem reports plus
-  daemon-owned runtime state without backend-specific diagnosis logic
-- the boundary TOMLs forbid the daemon-to-SQLite edge again
-- a `boundary-guard` QA agent exists and is part of plan review plus
-  phase-ending review for boundary-widening detection
-- the daemon state-machine inventory is explicitly documented and stays within
-  the Phase AA simplicity contract
+This overview intentionally does not restate the closure checklist. Any
+Phase `AA` closeout review must use `readiness.md` as the sole source of truth
+for final branch/phase exit gates.
 
 ## Planning Consequences
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -113,6 +113,7 @@ Status:
   - `crates/atm-daemon`
   - `crates/atm-daemon-client`
   - `crates/atm-graft`
+  - `crates/atm-runtime`
   - `crates/atm-rusqlite`
   - `crates/sc-lint-*` support crates
 
@@ -173,6 +174,32 @@ Phase R sequencing rule:
   - feature behavior
 
 ## 4. Work Sequence
+
+### Phase AA: Remove SQLite From Daemon [PLANNED]
+
+Status summary:
+- Phase AA is the active simplification planning line for restoring
+  `atm-daemon` to a thin-router role.
+- The authoritative plan is [`docs/plan-phase-AA.md`](./plan-phase-AA.md).
+- The authoritative closure checklist is
+  [`docs/phase-AA/readiness.md`](./phase-AA/readiness.md).
+
+Goal:
+- move concrete SQLite/runtime assembly to `atm-runtime`
+- remove daemon-owned SQLite diagnostics, observability glue, and replay/store
+  leakage
+- relock the daemon-to-SQLite boundary with a permanent second enforcement
+  layer
+
+Deliverables:
+- `crates/atm-runtime` as the concrete composition root
+- subsystem doctor trait model and direct local doctor path
+- deletion of remaining daemon-side SQLite leaks
+- `boundary-guard` and relocked machine-readable boundary policy
+
+Acceptance:
+- Phase AA exit criteria are satisfied only through
+  `docs/phase-AA/readiness.md`
 
 ### Phase 0: Document Lock [COMPLETE]
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -204,7 +204,7 @@ Sprint line:
 - `AA.2` `feature/pAA-s2-atm-runtime-composition-transfer`
 - `AA.3` `feature/pAA-s3-direct-doctor-and-runtime-health-split`
 - `AA.4` `feature/pAA-s4-delete-daemon-sqlite-leaks`
-- `AA.5` `feature/pAA-s5-boundary-relock-and-guard`
+- `AA.5` `feature/pAA-s5-boundary-relock-and-permanent-enforcement`
 
 Acceptance:
 - Phase AA exit criteria are satisfied only through

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -197,6 +197,9 @@ Deliverables:
 - subsystem doctor trait model and direct local doctor path
 - deletion of remaining daemon-side SQLite leaks
 - `boundary-guard` and relocked machine-readable boundary policy
+- `sc-observability` / `sc-observability-types` upgraded to `1.2.0` with the
+  queue-backed logger API, retained-log policy field migration, and updated
+  health projection
 
 Sprint line:
 - `AA.0` `feature/pAA-s0-daemon-architecture-restatement`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -205,6 +205,7 @@ Sprint line:
 - `AA.3` `feature/pAA-s3-direct-doctor-and-runtime-health-split`
 - `AA.4` `feature/pAA-s4-delete-daemon-sqlite-leaks`
 - `AA.5` `feature/pAA-s5-boundary-relock-and-permanent-enforcement`
+- `AA.6` `feature/pAA-s6-obs-upgrade`
 
 Acceptance:
 - Phase AA exit criteria are satisfied only through

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -180,6 +180,7 @@ Phase R sequencing rule:
 Status summary:
 - Phase AA is the active simplification planning line for restoring
   `atm-daemon` to a thin-router role.
+- Integration Branch: `integrate/phase-AA`
 - The authoritative plan is [`docs/plan-phase-AA.md`](./plan-phase-AA.md).
 - The authoritative closure checklist is
   [`docs/phase-AA/readiness.md`](./phase-AA/readiness.md).
@@ -196,6 +197,14 @@ Deliverables:
 - subsystem doctor trait model and direct local doctor path
 - deletion of remaining daemon-side SQLite leaks
 - `boundary-guard` and relocked machine-readable boundary policy
+
+Sprint line:
+- `AA.0` `feature/pAA-s0-daemon-architecture-restatement`
+- `AA.1` `feature/pAA-s1-subsystem-doctor-traits`
+- `AA.2` `feature/pAA-s2-atm-runtime-composition-transfer`
+- `AA.3` `feature/pAA-s3-direct-doctor-and-runtime-health-split`
+- `AA.4` `feature/pAA-s4-delete-daemon-sqlite-leaks`
+- `AA.5` `feature/pAA-s5-boundary-relock-and-guard`
 
 Acceptance:
 - Phase AA exit criteria are satisfied only through

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -60,6 +60,16 @@ Phase-S planning note:
   - `S.9` host-scoped retained logging defaults, including watcher/reconcile
     exclusion for `~/.atm/logs/`
 
+Phase-AA simplification note:
+- after the retained daemon/SQLite line proved the transport split, the daemon
+  accumulated concrete SQLite composition and health/observability ownership
+  that violated the intended boundary
+- the corrective planning line is Phase AA, tracked in
+  [`docs/plan-phase-AA.md`](./plan-phase-AA.md)
+- Phase AA restores the original daemon role as a thin router by moving
+  concrete SQLite construction to a dedicated `atm-runtime` crate and
+  restoring a direct local doctor/store-health path
+
 Phase R execution entry:
 - Wave 1 deliverable: the new Phase R skeleton
   - new crates
@@ -94,6 +104,9 @@ Status:
   source-of-truth and daemon-boundary redesign.
 - Phase R is the merged daemon baseline.
 - Phase S is the active planning line for Windows-complete daemon parity.
+- Phase AA is the architectural simplification planning line for removing
+  SQLite references from `atm-daemon` and moving concrete runtime assembly out
+  to `atm-runtime`.
 - the current merged workspace contains:
   - `crates/atm-core`
   - `crates/atm`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -20,6 +20,14 @@ mail routing, native agent notification, and cross-host transport need one
 coordinating process, while ATM command behavior remains the user-facing
 surface.
 
+Phase-AA simplification direction:
+- the daemon remains part of the product, but it must return to the original
+  thin-router role
+- concrete SQLite construction moves to a dedicated `atm-runtime` crate
+- the daemon must not know that the current durable adapter is SQLite
+- direct local diagnostics such as store-openability and baseline SQLite
+  health may be answered without routing through the daemon
+
 The retained product surface is:
 - `atm send`
 - `atm list`
@@ -1563,6 +1571,14 @@ Run local ATM diagnostics for the retained ATM runtime.
 `atm doctor` remains a local diagnostics command, but in the current SQLite/daemon architecture
 architecture it must also report daemon/runtime availability because normal ATM
 mail behavior depends on the singleton daemon being present.
+
+Phase-AA target direction:
+- `atm doctor` keeps daemon/runtime reporting, but daemon routing is not the
+  only legal path for diagnostics
+- checks that are inherently local and store-backed may run directly from the
+  CLI
+- daemon-routed doctor data is additive and exists for daemon-owned runtime
+  state or faster asynchronous answers when the daemon is already live
 
 ### 11.2 Supported Flags
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -81,10 +81,13 @@ Crate-local ownership docs live under:
 - [`docs/atm-core/architecture.md`](./atm-core/architecture.md)
 - [`docs/atm-daemon/requirements.md`](./atm-daemon/requirements.md)
 - [`docs/atm-daemon/architecture.md`](./atm-daemon/architecture.md)
+- [`docs/atm-runtime/requirements.md`](./atm-runtime/requirements.md)
+- [`docs/atm-runtime/architecture.md`](./atm-runtime/architecture.md)
 - [`docs/atm-rusqlite/requirements.md`](./atm-rusqlite/requirements.md)
 - [`docs/atm-rusqlite/architecture.md`](./atm-rusqlite/architecture.md)
 - [`docs/atm-core/boundaries.md`](./atm-core/boundaries.md)
 - [`docs/atm-daemon/boundaries.md`](./atm-daemon/boundaries.md)
+- [`docs/atm-runtime/boundaries.md`](./atm-runtime/boundaries.md)
 - [`docs/atm-rusqlite/boundaries.md`](./atm-rusqlite/boundaries.md)
 - [`docs/atm/boundaries.md`](./atm/boundaries.md)
 


### PR DESCRIPTION
## Summary
- add Phase AA overview and readiness plan for removing daemon SQLite coupling
- define sprints AA0-AA5, including state-machine documentation, subsystem doctor traits, runtime composition transfer, daemon leak deletion, and boundary relock
- add daemon state-machine inventory and SQLite leak ledger
- include boundary-guard QA planning for permanent boundary enforcement

## Validation
- git diff --check