### PR TITLE
chore: add arch-ctm idle notify config

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -2,6 +2,12 @@
 default_team = "atm-dev"
 identity = "team-lead"
 
+[atm.idle_notify]
+recipient = "team-lead"
+
+[atm.idle_notify.agent.arch-ctm]
+seconds = 60
+
 [[atm.post_send_hooks]]
 recipient = "arch-ctm"
 command = ["scripts/atm-nudge.py", "arch-ctm"]


### PR DESCRIPTION
## Summary
- add repo-local ATM idle notify recipient config
- add arch-ctm-specific idle threshold of 60 seconds

## Validation
- python3 tomllib parse of .atm.toml
- git diff --check
