### PR TITLE
feat(publish): PI.1 canonical validation infrastructure

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -56,119 +56,24 @@ jobs:
           echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
           echo "release_version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Verify release manifest and helper files exist
+      - name: Run canonical retained release validation suite
+        id: validate
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
-          test -f "${RELEASE_ARTIFACT_MANIFEST}"
-          test -f scripts/release_gate.sh
-          test -f scripts/release_artifacts.py
-          test -f docs/release-inventory-schema.json
+          python3 scripts/validate_release.py all \
+            --version '${{ steps.meta.outputs.release_version }}' \
+            --findings release-findings.json
 
-      - name: Validate manifest coverage, preflight modes, and publish ordering
+      - name: Upload release findings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-findings
+          path: release-findings.json
+
+      - name: Fail if canonical validation failed
+        if: steps.validate.outcome != 'success'
         shell: bash
-        run: |
-          set -euo pipefail
-          python3 scripts/release_artifacts.py validate-manifest \
-            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
-            --workspace-toml Cargo.toml
-          python3 scripts/release_artifacts.py validate-preflight-checks \
-            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
-            --workspace-toml Cargo.toml
-          python3 scripts/release_artifacts.py validate-publish-order \
-            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
-            --workspace-toml Cargo.toml
-
-      - name: Preflight guard — fail if release version already exists on crates.io
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 scripts/release_artifacts.py check-version-unpublished \
-            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
-            --version '${{ steps.meta.outputs.release_version }}'
-
-      - name: Generate preflight release inventory
-        shell: bash
-        run: |
-          set -euo pipefail
-          version='${{ steps.meta.outputs.release_version }}'
-          tag='${{ steps.meta.outputs.release_tag }}'
-          commit="$(git rev-parse HEAD)"
-          generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          source_ref="${GITHUB_REF:-refs/heads/develop}"
-          mkdir -p release
-          python3 scripts/release_artifacts.py emit-inventory \
-            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
-            --version "$version" \
-            --tag "$tag" \
-            --commit "$commit" \
-            --source-ref "$source_ref" \
-            --generated-at "$generated_at" \
-            --output release/release-inventory.json
-
-      - name: Validate inventory shape
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import json
-          from pathlib import Path
-
-          inventory = json.loads(Path("release/release-inventory.json").read_text(encoding="utf-8"))
-          required_top = ["releaseVersion", "releaseTag", "releaseCommit", "generatedAt", "items"]
-          for field in required_top:
-              if field not in inventory:
-                  raise SystemExit(f"inventory missing required field: {field}")
-          items = inventory.get("items", [])
-          if not isinstance(items, list) or not items:
-              raise SystemExit("inventory.items must be a non-empty list")
-          for idx, item in enumerate(items):
-              for field in ["artifact", "version", "sourceRef", "publishTarget", "verifyCommands", "required"]:
-                  if field not in item:
-                      raise SystemExit(f"inventory.items[{idx}] missing {field}")
-          print("release inventory validation passed")
-          PY
-
-      - name: Validate workspace and crate versions match preflight version
-        shell: bash
-        run: |
-          set -euo pipefail
-          VERSION='${{ steps.meta.outputs.release_version }}'
-          python3 - <<'PY' "$VERSION"
-          import sys
-          import tomllib
-          from pathlib import Path
-
-          version = sys.argv[1]
-          root = Path(".")
-          root_toml = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
-          workspace_version = root_toml.get("workspace", {}).get("package", {}).get("version")
-          if workspace_version != version:
-              raise SystemExit(f"workspace version mismatch: expected {version}, got {workspace_version}")
-          print("workspace version validated")
-          PY
-
-      - name: Run dependency-aware preflight crate checks
-        shell: bash
-        run: |
-          set -euo pipefail
-          mapfile -t full_checks < <(
-            python3 scripts/release_artifacts.py list-preflight \
-              --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
-              --mode full
-          )
-          for crate in "${full_checks[@]}"; do
-            [[ -n "$crate" ]] || continue
-            cargo package -p "$crate" --locked --no-verify
-            cargo publish --dry-run -p "$crate" --locked --no-verify
-          done
-
-          mapfile -t locked_checks < <(
-            python3 scripts/release_artifacts.py list-preflight \
-              --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
-              --mode locked
-          )
-          for crate in "${locked_checks[@]}"; do
-            [[ -n "$crate" ]] || continue
-            cargo check -p "$crate" --locked
-          done
+        run: exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,17 +49,17 @@ jobs:
         run: |
           set -euo pipefail
           tag='${{ steps.meta.outputs.release_tag }}'
-          main_sha="$(git rev-parse origin/main)"
+          release_sha="$(git rev-parse HEAD)"
           remote_tag_sha="$(git ls-remote --tags origin "refs/tags/${tag}" | awk '{print $1}' || true)"
           if [[ -n "$remote_tag_sha" ]]; then
-            if [[ "$remote_tag_sha" == "$main_sha" ]]; then
-              echo "Tag ${tag} already exists and points to origin/main (${main_sha}), skipping creation"
+            if [[ "$remote_tag_sha" == "$release_sha" ]]; then
+              echo "Tag ${tag} already exists and points to the release ref (${release_sha}), skipping creation"
               exit 0
             fi
-            echo "Tag ${tag} exists but points to ${remote_tag_sha}, not origin/main (${main_sha})" >&2
+            echo "Tag ${tag} exists but points to ${remote_tag_sha}, not the release ref (${release_sha})" >&2
             exit 1
           fi
-          git tag "$tag" origin/main
+          git tag "$tag" HEAD
           git push origin "$tag"
 
   prepare-release-inventory:
@@ -292,7 +292,8 @@ jobs:
           VERSION='${{ needs.gate-and-tag.outputs.release_version }}'
           ARCHIVE="atm_${VERSION}_${{ matrix.target }}.tar.gz"
           cd target/${{ matrix.target }}/release
-          tar czf "../../../${ARCHIVE}" atm
+          mapfile -t bins < <(python3 ../../../scripts/release_artifacts.py list-release-binaries --manifest ../../../release/publish-artifacts.toml)
+          tar czf "../../../${ARCHIVE}" "${bins[@]}"
           cd ../../..
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
@@ -302,8 +303,21 @@ jobs:
         run: |
           $VERSION = '${{ needs.gate-and-tag.outputs.release_version }}'
           $ARCHIVE = "atm_${VERSION}_${{ matrix.target }}.zip"
-          Compress-Archive -Path "target/${{ matrix.target }}/release/atm.exe" -DestinationPath $ARCHIVE
+          $bins = python3 scripts/release_artifacts.py list-release-binaries --manifest release/publish-artifacts.toml
+          $paths = @()
+          foreach ($bin in $bins) {
+            $paths += "target/${{ matrix.target }}/release/$bin.exe"
+          }
+          Compress-Archive -Path $paths -DestinationPath $ARCHIVE
           echo "ARCHIVE=$ARCHIVE" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Verify archive membership
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/verify_release_archive.py \
+            --manifest release/publish-artifacts.toml \
+            --archive "${ARCHIVE}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.just/print_help.py
+++ b/.just/print_help.py
@@ -15,6 +15,7 @@ SECTIONS = (
             ("version", "Show current workspace version state."),
             ("version latest", "Show recommended direct dependency upgrades."),
             ("ci", "Run the local CI-equivalent command set."),
+            ("validate", "Run the full retained release validation suite."),
         ),
     ),
     (
@@ -54,6 +55,18 @@ SECTIONS = (
             ("lint spell", "Run the spelling/content check."),
             ("lint daemon-singleton", "Run the daemon singleton/no-spawn test gate."),
             ("lint pytests", "Run the Python lint-tool unit tests."),
+        ),
+    ),
+    (
+        "Validate",
+        (
+            ("validate", "Run the full retained release preflight suite."),
+            ("validate lint", "Run only the lint portion of release validation."),
+            ("validate support-files", "Check required release support files."),
+            ("validate manifest", "Run manifest / preflight-mode / publish-order checks."),
+            ("validate publish-surface", "Run package / dry-run / unpublished-version checks."),
+            ("validate release-binaries", "Check required release binaries in the manifest."),
+            ("validate inventory", "Generate and validate a temporary release inventory."),
         ),
     ),
     (

--- a/Justfile
+++ b/Justfile
@@ -141,6 +141,10 @@ clean:
 lint target='all':
     {{python_cmd}} .just/run_lint.py {{target}}
 
+# Run the retained release validation / preflight suite.
+validate target='all':
+    {{python_cmd}} scripts/validate_release.py {{target}}
+
 # Run the Phase Z smoke harness.
 smoke level='normal':
     {{python_cmd}} scripts/smoke/run.py {{level}} --write-artifacts

--- a/crates/atm-runtime-test-support/Cargo.toml
+++ b/crates/atm-runtime-test-support/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 description = "SQLite-backed retained-runtime test support for ATM workspace crates."
 repository.workspace = true
 homepage.workspace = true
+publish = false
 
 [lib]
 name = "atm_runtime_test_support"

--- a/crates/sc-lint-attributes/Cargo.toml
+++ b/crates/sc-lint-attributes/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 description = "Source-level declarative attributes for sc-lint analyzers."
 repository.workspace = true
 homepage.workspace = true
+publish = false
 
 [lib]
 proc-macro = true

--- a/crates/sc-lint-boundary/Cargo.toml
+++ b/crates/sc-lint-boundary/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 description = "AST-sensitive Rust boundary analyzer."
 repository.workspace = true
 homepage.workspace = true
+publish = false
 
 [[bin]]
 name = "sc-lint-boundary"

--- a/crates/sc-lint-directives/Cargo.toml
+++ b/crates/sc-lint-directives/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 description = "Shared directive parsing for sc-lint proc-macro and analyzer crates."
 repository.workspace = true
 homepage.workspace = true
+publish = false
 
 [lib]
 name = "sc_lint_directives"

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3945,3 +3945,8 @@ Implementation Branches:
 | Sprint | Status | Branch | Artifacts |
 | --- | --- | --- | --- |
 | `PI.1` | `complete` | `feature/pPI-s1-validation-infra` | `Justfile`, `.just/print_help.py`, `scripts/validate_release.py`, `scripts/verify_release_archive.py`, `scripts/release_artifacts.py`, `release/publish-artifacts.toml`, `release/RELEASE-NOTES-TEMPLATE.md`, `.github/workflows/release-preflight.yml`, `.github/workflows/release.yml` |
+| `PI.2` | `in_progress` | `feature/pPI-s2-publisher-prompt` | `.claude/agents/publisher.md`, `docs/publishing-improvements/plan.md` |
+| `PI.3` | `planned` | `TBD` | `.claude/agents/publisher.md`, `docs/publishing-improvements/plan.md` |
+
+Authoritative sprint plan:
+- `docs/publishing-improvements/plan.md`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3937,3 +3937,11 @@ Acceptance / Phase Entry Gate:
   on the accepted `integrate/phase-Z` line
 - the final `Z.4` release verdict must not close until `Z.23` and `Z.24` also
   close on the accepted `integrate/phase-Z` line
+
+## Publishing Improvements
+
+Implementation Branches:
+
+| Sprint | Status | Branch | Artifacts |
+| --- | --- | --- | --- |
+| `PI.1` | `complete` | `feature/pPI-s1-validation-infra` | `Justfile`, `.just/print_help.py`, `scripts/validate_release.py`, `scripts/verify_release_archive.py`, `scripts/release_artifacts.py`, `release/publish-artifacts.toml`, `release/RELEASE-NOTES-TEMPLATE.md`, `.github/workflows/release-preflight.yml`, `.github/workflows/release.yml` |

--- a/docs/publishing-improvements/plan.md
+++ b/docs/publishing-improvements/plan.md
@@ -1,7 +1,7 @@
 ---
 status: complete
-branch: feature/publishing-improvements
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/publishing-improvements
+branch: feature/pPI-s1-validation-infra
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pPI-s1-validation-infra
 ---
 
 # Publishing Improvements Plan

--- a/docs/publishing-improvements/plan.md
+++ b/docs/publishing-improvements/plan.md
@@ -1,0 +1,299 @@
+---
+status: complete
+branch: feature/publishing-improvements
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/publishing-improvements
+---
+
+# Publishing Improvements Plan
+
+## Goal
+
+Make publisher-driven releases predictable, low-churn, and self-contained:
+
+- publisher may start from `develop` or `main`
+- release execution always converges onto a short-lived `release/vX.Y.Z` branch
+  cut from `main`
+- the canonical preflight is `just validate`
+- all known publish failures must be caught before the release workflow starts
+- routine missing inputs come from `team-lead`, not from the user
+- any publish-time failure that should have been preflighted becomes an
+  automatic GitHub issue so the same surprise does not recur
+
+## Governing Decisions
+
+### Release source model
+
+- `develop` remains an allowed launch point only for publisher to shepherd the
+  release PR into `main`
+- `main` remains the source branch for cutting the release line
+- actual release execution happens from `release/vX.Y.Z`
+- any release-window fixes happen on `release/vX.Y.Z`, not directly on `main`
+  and not on `develop`
+- after the release branch merges to `main`, publisher must immediately ensure
+  the resulting release commits flow back into `develop` via a `main ->
+  develop` reconciliation PR if one is not already open
+
+### Canonical preflight
+
+- `just validate` is the single local command that represents release
+  preflight
+- phase-ending review should require `just validate` whenever a phase changes
+  publishable crates, release workflows, release manifests, version SSOT,
+  release notes templates, or other release-surface inputs; that gate blocks
+  merge into `develop`, not just the later publish attempt
+- release-preflight CI should use the same validation logic, not a different
+  handwritten checklist
+
+### No-surprises policy
+
+- every known publish failure class must be represented in preflight
+- publisher should get the full blocker set in one pass
+- publisher should batch mechanical fixes and avoid one-blocker-per-PR churn
+
+### Escalation policy
+
+- publisher requests routine missing inputs from `team-lead`
+- publisher does not ask the user for ordinary release coordination details
+- user escalation is reserved for real policy ambiguity only
+
+### Failure ratchet
+
+- if a publish-time failure should have been caught by preflight, publisher
+  must file a GitHub issue immediately with exact failure details and the
+  missing gate
+
+## Current Status Audit
+
+### `GH #376` items
+
+- add `just lint` to preflight:
+  - `PLANNED TO LAND AS PART OF just validate`
+- add manifest / preflight-check / publish-order validation:
+  - `ALREADY PRESENT`
+- add `cargo package -p agent-team-mail-core --locked`:
+  - `ALREADY PRESENT` in workflow, but not yet unified under `just validate`
+- add archive membership verification for `atm` + `atm-daemon`:
+  - `MISSING` before this branch
+- aggregate all blockers into one preflight result set:
+  - `MISSING`; current release validation flow does not yet require a single
+    `release-findings.json` artifact with all blockers collected before exit
+- check Cargo.lock drift against `origin/main`:
+  - `MISSING` as an explicit release-window gate
+- check dependency currency and file stale-version issues automatically:
+  - `MISSING`; this was only a follow-on idea before publisher review
+- treat failures as hard stops:
+  - `PARTIAL`; prompt already stops on gate failures, but the full local gate
+    was missing
+
+### `GH #380` items
+
+- lineage gate friction:
+  - `RESOLVED` in current [scripts/release_gate.sh](/Users/randlee/Documents/github/atm-core-worktrees/feature/publishing-improvements/scripts/release_gate.sh)
+    because the old `develop ⊂ main` enforcement is already gone
+- publish from `main`, not from live `develop` ancestry:
+  - `NOT FULLY DOCUMENTED` before this branch
+- Cargo.lock drift / dependency bump policy:
+  - `PARTIAL`; lock/version checks exist, but the publisher prompt still needed
+    stronger release-window guidance
+- parallel comprehensive preflight:
+  - `PARTIAL`; workflow had many checks, but no canonical `just validate`
+    contract
+- stale state communication:
+  - `MISSING`; no structured `STATE:` block requirement
+- release notes template / source of truth:
+  - `MISSING`; the prompt referenced a template that was absent
+- winget bootstrap handling:
+  - `PARTIAL`; docs existed, but prompt handling was too thin
+- develop fast-forward / divergence semantics:
+  - `SUPERSEDED` by the release-branch model in this plan
+- post-release `main -> develop` reconciliation after release-branch merges:
+  - `MISSING` as an explicit publisher-owned operational step
+- publishability / surface-expansion escalation example:
+  - `MISSING`; the prompt did not yet include a concrete example such as
+    `sc-lint-attributes` unexpectedly becoming a production publish blocker
+
+## Sprint Breakdown
+
+### Sprint PI.1 — Canonical Validation Infrastructure
+
+Goal:
+- create the single authoritative preflight command and align repo-owned
+  release metadata around it
+
+Deliverables:
+- `Justfile`
+  - add `just validate`
+- `scripts/validate_release.py`
+  - canonical local preflight runner
+  - collect all blockers and emit `release-findings.json`
+  - exit non-zero only after the full blocker set is recorded
+- `scripts/release_artifacts.py`
+  - release-binary validation helper(s)
+- `release/publish-artifacts.toml`
+  - retained release-binary SSOT includes both `atm` and `atm-daemon`
+- `release/RELEASE-NOTES-TEMPLATE.md`
+  - real file exists in repo
+- `.github/workflows/release-preflight.yml`
+  - canonical validation suite invoked from CI
+- `.github/workflows/release.yml`
+  - release packaging driven from manifest release binaries, with archive
+    membership verification
+- release validation logic
+  - explicit `Cargo.lock` drift check against `origin/main`
+  - dependency version-currency check using `cargo search`, gated by env var so
+    CI can suppress issue-spam while local or release contexts can file issues
+
+Acceptance:
+- `just validate` runs the full local retained release preflight
+- `just validate` includes:
+  - `just lint`
+  - manifest coverage / preflight-mode / publish-order checks
+  - publish-surface package / dry-run checks
+  - release support-file checks
+  - release inventory generation/shape check
+  - retained release-binary validation
+- `just validate` emits `release-findings.json` and does not stop at the first
+  blocker
+- `just validate` checks whether `Cargo.lock` drifted from `origin/main` during
+  the release window
+- `just validate` includes a version-currency check path, env-gated for CI
+  noise control and capable of auto-filing a GitHub issue on stale results
+- release manifest declares both `atm` and `atm-daemon`
+- release archives are built from the manifest binary list and verified for
+  expected membership
+- dependency version-pin × publish-flag mismatches are explicitly covered by the
+  combined manifest validation plus package / dry-run checks; `cargo publish
+  --dry-run` alone is not treated as sufficient proof
+
+### Sprint PI.2 — Publisher Prompt and Release-Branch Discipline
+
+Goal:
+- make publisher operationally self-sufficient and remove user babysitting from
+  routine release work
+
+Deliverables:
+- `.claude/agents/publisher.md`
+  - explicit `develop` and `main` launch modes
+  - release execution converges on `release/vX.Y.Z`
+  - any release-window fixes land on `release/vX.Y.Z`, regardless of launch
+    mode
+  - routine missing inputs sourced from `team-lead`
+  - `just validate` mandated before release workflow execution
+  - structured `STATE:` status report format
+  - explicit instruction to batch blocker fixes rather than serial PR churn
+  - explicit post-release `main -> develop` reconciliation step after the
+    release branch merges back to `main`
+  - concrete winget handoff mechanics, including `komac` CLI steps and the
+    expectation that a first-time manual Store handoff is not itself a workflow
+    failure
+  - concrete user-escalation examples, including the publishability /
+    surface-expansion case where a dependency such as `sc-lint-attributes`
+    becomes production-facing unexpectedly
+
+Acceptance:
+- publisher no longer relies on `develop` ancestry as the live release gate
+- publisher documents that all release-window fixes happen on `release/vX.Y.Z`
+- publisher documents the exact `main -> develop` reconciliation step required
+  after release-branch merges so version-bump commits are not stranded on
+  `main`
+- publisher asks `team-lead`, not the user, for release notes / changelist /
+  missing coordination inputs
+- publisher status reports include a structured `STATE:` block
+- publisher documents the expected winget / `komac` handoff path and treats a
+  first-time manual handoff as operational follow-through, not as a workflow
+  failure
+
+Operational detail:
+- after merge of `release/vX.Y.Z -> main`, publisher must:
+  - verify whether a `main -> develop` PR already exists
+  - create it immediately if missing
+  - route any missing changelist or release-note follow-through to `team-lead`
+- winget handoff text in the prompt should include the expected `komac` CLI
+  path, for example:
+  - `komac update <package-id> --version <X.Y.Z> --urls <artifact-url> ...`
+  - if the first submission still requires manual Store-side approval or repo
+    bootstrapping, publisher records that as handoff status, not as a failed
+    release workflow
+
+### Sprint PI.3 — Failure Ratchet and Remaining Process Hardening
+
+Goal:
+- ensure every future release surprise turns into a tracked preflight or prompt
+  improvement
+
+Deliverables:
+- `.claude/agents/publisher.md`
+  - automatic GitHub issue requirement for any publish-time failure that should
+    have been caught by preflight
+- `docs/publishing-improvements/plan.md`
+  - closure proof matrix mapping every known `v1.2.0` incident category to the
+    preflight or prompt control that prevents recurrence
+- follow-on automation/documentation plan for:
+  - release incident reporting templates if needed
+
+Publisher review checkpoint:
+- publisher must sign off on:
+  - whether `just validate` covers all failure classes encountered in the last
+    release
+  - whether any remaining late-release surprises still lack a gate
+  - whether the `STATE:` block and release-branch workflow are operationally
+    sufficient
+
+Acceptance:
+- publisher prompt requires issue filing for missed preflight failures
+- the plan contains a closure proof matrix for `v1.2.0` incident categories and
+  confirms the intended preflight coverage for each
+- remaining non-blocking release-process gaps are enumerated explicitly, not
+  left implicit
+
+## Coverage Notes
+
+### Dependency version-pin × publish-flag cross-check
+
+- this plan treats the cross-check as the combined responsibility of:
+  - manifest/version SSOT validation
+  - publish-surface manifest validation
+  - `cargo package --locked`
+  - `cargo publish --dry-run` where applicable
+- `cargo publish --dry-run` by itself is not enough to prove internal
+  path-version correctness or publish-surface completeness
+
+### User escalation examples
+
+- ordinary missing inputs are not user blockers:
+  - release notes not refreshed
+  - changelist not refreshed
+  - missing `main -> develop` reconciliation PR
+  - missing release-branch follow-through
+- true escalation examples are policy decisions:
+  - a publishability / surface-expansion change such as
+    `sc-lint-attributes` unexpectedly becoming a production dependency in a
+    publishable crate
+  - a disputed decision about whether a crate must ship publicly or may remain
+    internal
+
+### `v1.2.0` closure proof matrix
+
+| Incident category | Required preflight / prompt control |
+|---|---|
+| internal dev-dependency version-pin leakage (`atm-runtime-test-support`) | `just lint` plus manifest/version SSOT validation plus `cargo package --locked` |
+| publish-surface manifest drift or wrong publish order | `validate-manifest`, `validate-preflight-checks`, `validate-publish-order` inside `just validate` |
+| release archives missing `atm-daemon` | manifest-declared release binaries plus archive membership verification inside `just validate` |
+| `Cargo.lock` drift or silent release-window dependency bump | explicit `Cargo.lock` drift check against `origin/main` in `just validate` |
+| stale dependency currency discovered late | env-gated version-currency check plus auto-filed GitHub issue when stale |
+| publisher discovers blockers serially and opens multiple PRs | `release-findings.json` aggregation requirement so preflight returns the full blocker set in one pass |
+| release notes template / changelist source missing | release support-file checks plus publisher requirement to obtain missing inputs from `team-lead` |
+| winget handoff confusion or first-submission bootstrap surprise | explicit `komac` handoff steps in prompt plus non-failure status treatment for manual Store follow-through |
+| publishability / surface-expansion ambiguity (for example `sc-lint-attributes`) | publisher prompt escalation example routes the policy question to `team-lead` / user instead of treating it as a mechanical blocker |
+| post-release divergence between `main` and `develop` | explicit publisher-owned `main -> develop` reconciliation step after release-branch merge |
+
+## Planning Branch Scope
+
+This branch is planning-only.
+
+Allowed closeout artifacts on this branch:
+- `docs/publishing-improvements/plan.md`
+- `docs/project-plan.md`
+
+Everything else described in `PI.1` through `PI.3` is implementation work for
+later sprint branches after publisher reviews the plan.

--- a/release/RELEASE-NOTES-TEMPLATE.md
+++ b/release/RELEASE-NOTES-TEMPLATE.md
@@ -1,0 +1,24 @@
+# Release Notes
+
+## Summary
+- version:
+- release date:
+- release owner:
+
+## Included Changes
+- 
+
+## Operator / User Impact
+- 
+
+## Packaging / Distribution Notes
+- crates.io:
+- GitHub Releases:
+- Homebrew:
+- winget:
+
+## Known Issues / Waivers
+- 
+
+## Follow-Up
+- 

--- a/release/publish-artifacts.toml
+++ b/release/publish-artifacts.toml
@@ -7,8 +7,63 @@ cargo_toml = "crates/atm-core/Cargo.toml"
 required = true
 publish = true
 publish_order = 1
-preflight_check = "full"
+preflight_check = "locked"
 wait_after_publish_seconds = 60
+verify_install = false
+
+[[crates]]
+artifact = "atm-rusqlite"
+package = "atm-rusqlite"
+cargo_toml = "crates/atm-rusqlite/Cargo.toml"
+required = true
+publish = true
+publish_order = 2
+preflight_check = "locked"
+wait_after_publish_seconds = 30
+verify_install = false
+
+[[crates]]
+artifact = "atm-daemon-client"
+package = "atm-daemon-client"
+cargo_toml = "crates/atm-daemon-client/Cargo.toml"
+required = true
+publish = true
+publish_order = 3
+preflight_check = "locked"
+wait_after_publish_seconds = 30
+verify_install = false
+
+[[crates]]
+artifact = "atm-daemon-bootstrap"
+package = "atm-daemon-bootstrap"
+cargo_toml = "crates/atm-daemon-bootstrap/Cargo.toml"
+required = true
+publish = true
+publish_order = 4
+preflight_check = "locked"
+wait_after_publish_seconds = 30
+verify_install = false
+
+[[crates]]
+artifact = "atm-daemon"
+package = "atm-daemon"
+cargo_toml = "crates/atm-daemon/Cargo.toml"
+required = true
+publish = true
+publish_order = 5
+preflight_check = "locked"
+wait_after_publish_seconds = 30
+verify_install = false
+
+[[crates]]
+artifact = "atm-graft"
+package = "atm-graft"
+cargo_toml = "crates/atm-graft/Cargo.toml"
+required = false
+publish = true
+publish_order = 6
+preflight_check = "locked"
+wait_after_publish_seconds = 30
 verify_install = false
 
 [[crates]]
@@ -17,10 +72,13 @@ package = "agent-team-mail"
 cargo_toml = "crates/atm/Cargo.toml"
 required = true
 publish = true
-publish_order = 2
+publish_order = 7
 preflight_check = "locked"
 wait_after_publish_seconds = 0
 verify_install = true
 
 [[release_binaries]]
 name = "atm"
+
+[[release_binaries]]
+name = "atm-daemon"

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -159,6 +159,18 @@ def list_release_binaries(args: argparse.Namespace) -> int:
     return 0
 
 
+def validate_release_binaries(args: argparse.Namespace) -> int:
+    binaries = {entry["name"] for entry in load_manifest(Path(args.manifest))["release_binaries"]}
+    missing = [name for name in args.required if name not in binaries]
+    if missing:
+        print("missing required release binaries:")
+        for name in missing:
+            print(f"  - {name}")
+        return 1
+    print("ok: required release binaries are present in the manifest")
+    return 0
+
+
 def cargo_build_bin_args(args: argparse.Namespace) -> int:
     print(" ".join(f'--bin {entry["name"]}' for entry in load_manifest(Path(args.manifest))["release_binaries"]))
     return 0
@@ -385,6 +397,11 @@ def build_parser() -> argparse.ArgumentParser:
     list_bins = subparsers.add_parser("list-release-binaries")
     list_bins.add_argument("--manifest", required=True)
     list_bins.set_defaults(func=list_release_binaries)
+
+    validate_bins = subparsers.add_parser("validate-release-binaries")
+    validate_bins.add_argument("--manifest", required=True)
+    validate_bins.add_argument("--required", action="append", default=[])
+    validate_bins.set_defaults(func=validate_release_binaries)
 
     build_bins = subparsers.add_parser("cargo-build-bin-args")
     build_bins.add_argument("--manifest", required=True)

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+from dataclasses import asdict
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+
+
+REQUIRED_RELEASE_FILES = (
+    "release/publish-artifacts.toml",
+    "scripts/release_gate.sh",
+    "scripts/release_artifacts.py",
+    "docs/release-inventory-schema.json",
+    "release/RELEASE-NOTES-TEMPLATE.md",
+)
+REQUIRED_RELEASE_BINARIES = ("atm", "atm-daemon")
+INVENTORY_REQUIRED_TOP = ("releaseVersion", "releaseTag", "releaseCommit", "generatedAt", "items")
+INVENTORY_REQUIRED_ITEM = ("artifact", "version", "sourceRef", "publishTarget", "verifyCommands", "required")
+CHECK_DEP_CURRENCY_ENV = "ATMD_CHECK_DEP_CURRENCY"
+GITHUB_ISSUE_ENV = "ATMD_GH_AUTOFIX_ISSUES"
+
+
+@dataclass
+class Finding:
+    check: str
+    severity: str
+    summary: str
+    detail: str = ""
+    command: list[str] | None = None
+    exit_code: int | None = None
+
+    @property
+    def blocks(self) -> bool:
+        return self.severity == "error"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def workspace_version(root: Path) -> str:
+    cargo = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+    version = cargo.get("workspace", {}).get("package", {}).get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise SystemExit("workspace.package.version missing from Cargo.toml")
+    return version
+
+
+def current_ref(root: Path) -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if completed.returncode != 0:
+        return "UNKNOWN"
+    return completed.stdout.strip() or "UNKNOWN"
+
+
+def run_capture(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def append_completed_findings(
+    findings: list[Finding],
+    check: str,
+    completed: subprocess.CompletedProcess[str],
+    success_summary: str,
+    failure_summary: str,
+) -> None:
+    if completed.returncode == 0:
+        if completed.stdout.strip():
+            sys.stdout.write(completed.stdout)
+        if completed.stderr.strip():
+            sys.stderr.write(completed.stderr)
+        return
+    if completed.stdout.strip():
+        sys.stdout.write(completed.stdout)
+    if completed.stderr.strip():
+        sys.stderr.write(completed.stderr)
+    findings.append(
+        Finding(
+            check=check,
+            severity="error",
+            summary=failure_summary,
+            detail=(completed.stderr or completed.stdout).strip(),
+            command=completed.args if isinstance(completed.args, list) else None,
+            exit_code=completed.returncode,
+        )
+    )
+
+
+def validate_support_files(root: Path, findings: list[Finding]) -> None:
+    missing = [path for path in REQUIRED_RELEASE_FILES if not (root / path).exists()]
+    if missing:
+        findings.append(
+            Finding(
+                check="support-files",
+                severity="error",
+                summary="missing required release support files",
+                detail=", ".join(missing),
+            )
+        )
+
+
+def validate_lint(root: Path, findings: list[Finding]) -> None:
+    completed = run_capture(["python3", ".just/run_lint.py", "all"], cwd=root)
+    append_completed_findings(
+        findings,
+        "lint",
+        completed,
+        "lint passed",
+        "just lint failed",
+    )
+
+
+def validate_manifest(root: Path, findings: list[Finding]) -> None:
+    commands = (
+        (
+            "manifest-coverage",
+            [
+                "python3",
+                "scripts/release_artifacts.py",
+                "validate-manifest",
+                "--manifest",
+                "release/publish-artifacts.toml",
+                "--workspace-toml",
+                "Cargo.toml",
+            ],
+            "manifest coverage validation failed",
+        ),
+        (
+            "preflight-modes",
+            [
+                "python3",
+                "scripts/release_artifacts.py",
+                "validate-preflight-checks",
+                "--manifest",
+                "release/publish-artifacts.toml",
+                "--workspace-toml",
+                "Cargo.toml",
+            ],
+            "preflight mode validation failed",
+        ),
+        (
+            "publish-order",
+            [
+                "python3",
+                "scripts/release_artifacts.py",
+                "validate-publish-order",
+                "--manifest",
+                "release/publish-artifacts.toml",
+                "--workspace-toml",
+                "Cargo.toml",
+            ],
+            "publish-order validation failed",
+        ),
+    )
+    for check, cmd, summary in commands:
+        completed = run_capture(cmd, cwd=root)
+        append_completed_findings(findings, check, completed, f"{check} passed", summary)
+
+
+def validate_release_binaries(root: Path, findings: list[Finding]) -> None:
+    completed = run_capture(
+        [
+            "python3",
+            "scripts/release_artifacts.py",
+            "validate-release-binaries",
+            "--manifest",
+            "release/publish-artifacts.toml",
+            "--required",
+            "atm",
+            "--required",
+            "atm-daemon",
+        ],
+        cwd=root,
+    )
+    append_completed_findings(
+        findings,
+        "release-binaries",
+        completed,
+        "required release binaries validated",
+        "required release binaries missing from manifest",
+    )
+
+
+def validate_publish_surface(
+    root: Path,
+    version: str,
+    findings: list[Finding],
+    *,
+    enforce_release_version: bool,
+) -> None:
+    if enforce_release_version:
+        unpublished = run_capture(
+            [
+                "python3",
+                "scripts/release_artifacts.py",
+                "check-version-unpublished",
+                "--manifest",
+                "release/publish-artifacts.toml",
+                "--version",
+                version,
+            ],
+            cwd=root,
+        )
+        append_completed_findings(
+            findings,
+            "publish-version-unpublished",
+            unpublished,
+            "release version is unpublished",
+            "release version already published",
+        )
+    else:
+        findings.append(
+            Finding(
+                check="publish-version-unpublished",
+                severity="warning",
+                summary="release version publication check skipped outside explicit release-candidate mode",
+            )
+        )
+
+    modes = {
+        "full": [
+            "python3",
+            "scripts/release_artifacts.py",
+            "list-preflight",
+            "--manifest",
+            "release/publish-artifacts.toml",
+            "--mode",
+            "full",
+        ],
+        "locked": [
+            "python3",
+            "scripts/release_artifacts.py",
+            "list-preflight",
+            "--manifest",
+            "release/publish-artifacts.toml",
+            "--mode",
+            "locked",
+        ],
+    }
+    crates_by_mode: dict[str, list[str]] = {}
+    for mode, cmd in modes.items():
+        completed = run_capture(cmd, cwd=root)
+        if completed.returncode != 0:
+            append_completed_findings(
+                findings,
+                f"publish-surface-{mode}-list",
+                completed,
+                f"{mode} preflight list generated",
+                f"{mode} preflight list generation failed",
+            )
+            crates_by_mode[mode] = []
+            continue
+        crates_by_mode[mode] = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+
+    for crate in crates_by_mode.get("full", []):
+        for cmd, check_name, summary in (
+            (
+                ["cargo", "package", "-p", crate, "--locked", "--no-verify"],
+                f"cargo-package-{crate}",
+                f"`cargo package` failed for {crate}",
+            ),
+            (
+                ["cargo", "publish", "--dry-run", "-p", crate, "--locked", "--no-verify"],
+                f"cargo-publish-dry-run-{crate}",
+                f"`cargo publish --dry-run` failed for {crate}",
+            ),
+        ):
+            completed = run_capture(cmd, cwd=root)
+            append_completed_findings(findings, check_name, completed, f"{check_name} passed", summary)
+
+    for crate in crates_by_mode.get("locked", []):
+        completed = run_capture(["cargo", "check", "-p", crate, "--locked"], cwd=root)
+        append_completed_findings(
+            findings,
+            f"cargo-check-{crate}",
+            completed,
+            f"cargo check passed for {crate}",
+            f"`cargo check --locked` failed for {crate}",
+        )
+
+
+def validate_inventory(root: Path, version: str, findings: list[Finding]) -> None:
+    tag = f"v{version}"
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+    with tempfile.TemporaryDirectory(prefix="atm-release-inventory-") as tmpdir:
+        output = Path(tmpdir) / "release-inventory.json"
+        completed = run_capture(
+            [
+                "python3",
+                "scripts/release_artifacts.py",
+                "emit-inventory",
+                "--manifest",
+                "release/publish-artifacts.toml",
+                "--version",
+                version,
+                "--tag",
+                tag,
+                "--commit",
+                commit,
+                "--source-ref",
+                f"refs/heads/{current_ref(root)}",
+                "--generated-at",
+                utc_now(),
+                "--output",
+                str(output),
+            ],
+            cwd=root,
+        )
+        if completed.returncode != 0:
+            append_completed_findings(
+                findings,
+                "inventory-generate",
+                completed,
+                "release inventory generated",
+                "release inventory generation failed",
+            )
+            return
+        inventory = json.loads(output.read_text(encoding="utf-8"))
+
+    missing_top = [field for field in INVENTORY_REQUIRED_TOP if field not in inventory]
+    if missing_top:
+        findings.append(
+            Finding(
+                check="inventory-shape",
+                severity="error",
+                summary="inventory missing required top-level fields",
+                detail=", ".join(missing_top),
+            )
+        )
+        return
+    items = inventory.get("items", [])
+    if not isinstance(items, list) or not items:
+        findings.append(
+            Finding(
+                check="inventory-shape",
+                severity="error",
+                summary="inventory.items must be a non-empty list",
+            )
+        )
+        return
+    item_errors: list[str] = []
+    for idx, item in enumerate(items):
+        if not isinstance(item, dict):
+            item_errors.append(f"items[{idx}] must be an object")
+            continue
+        for field in INVENTORY_REQUIRED_ITEM:
+            if field not in item:
+                item_errors.append(f"items[{idx}] missing {field}")
+    if item_errors:
+        findings.append(
+            Finding(
+                check="inventory-shape",
+                severity="error",
+                summary="inventory shape validation failed",
+                detail="; ".join(item_errors),
+            )
+        )
+
+
+def validate_cargo_lock_drift(root: Path, findings: list[Finding], *, enforce_release_window: bool) -> None:
+    if not enforce_release_window:
+        findings.append(
+            Finding(
+                check="cargo-lock-drift",
+                severity="warning",
+                summary="Cargo.lock drift check skipped outside explicit release-candidate mode",
+            )
+        )
+        return
+    verify_ref = run_capture(["git", "rev-parse", "--verify", "origin/main"], cwd=root)
+    if verify_ref.returncode != 0:
+        append_completed_findings(
+            findings,
+            "cargo-lock-origin-main",
+            verify_ref,
+            "origin/main available",
+            "origin/main is not available for Cargo.lock drift comparison",
+        )
+        return
+    completed = run_capture(["git", "diff", "--name-only", "origin/main", "--", "Cargo.lock"], cwd=root)
+    if completed.returncode != 0:
+        append_completed_findings(
+            findings,
+            "cargo-lock-drift",
+            completed,
+            "Cargo.lock drift check passed",
+            "Cargo.lock drift check failed",
+        )
+        return
+    if completed.stdout.strip():
+        findings.append(
+            Finding(
+                check="cargo-lock-drift",
+                severity="error",
+                summary="Cargo.lock drift detected against origin/main",
+                detail=completed.stdout.strip(),
+                command=["git", "diff", "--name-only", "origin/main", "--", "Cargo.lock"],
+            )
+        )
+
+
+def workspace_package_names(root: Path) -> set[str]:
+    cargo = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+    members = cargo.get("workspace", {}).get("members", [])
+    names: set[str] = set()
+    for member in members:
+        manifest = root / member / "Cargo.toml"
+        if not manifest.exists():
+            continue
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+        name = data.get("package", {}).get("name")
+        if isinstance(name, str) and name:
+            names.add(name)
+    return names
+
+
+def direct_registry_dependencies(root: Path) -> dict[str, str]:
+    internal = workspace_package_names(root)
+    manifests = [root / "Cargo.toml"]
+    cargo = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+    for member in cargo.get("workspace", {}).get("members", []):
+        manifest = root / member / "Cargo.toml"
+        if manifest.exists():
+            manifests.append(manifest)
+
+    deps: dict[str, str] = {}
+
+    def collect_from_table(table: object) -> None:
+        if not isinstance(table, dict):
+            return
+        for dep_name, spec in table.items():
+            if dep_name in internal:
+                continue
+            package_name = dep_name
+            version: str | None = None
+            if isinstance(spec, str):
+                version = spec
+            elif isinstance(spec, dict):
+                if spec.get("workspace") is True or "path" in spec:
+                    continue
+                package_name = str(spec.get("package", dep_name))
+                if package_name in internal:
+                    continue
+                raw = spec.get("version")
+                if isinstance(raw, str):
+                    version = raw
+            if isinstance(version, str) and version.strip():
+                deps.setdefault(package_name, version.strip())
+
+    for manifest in manifests:
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+        collect_from_table(data.get("dependencies"))
+        collect_from_table(data.get("build-dependencies"))
+        for target_data in data.get("target", {}).values():
+            if isinstance(target_data, dict):
+                collect_from_table(target_data.get("dependencies"))
+                collect_from_table(target_data.get("build-dependencies"))
+    return deps
+
+
+def latest_registry_version(root: Path, crate: str) -> str | None:
+    completed = run_capture(["cargo", "search", crate, "--limit", "1"], cwd=root)
+    if completed.returncode != 0:
+        return None
+    pattern = re.compile(rf"^{re.escape(crate)} = \"([^\"]+)\"")
+    for line in completed.stdout.splitlines():
+        match = pattern.match(line.strip())
+        if match:
+            return match.group(1)
+    return None
+
+
+def maybe_file_dep_currency_issue(root: Path, stale: list[tuple[str, str, str]]) -> None:
+    if os.environ.get(GITHUB_ISSUE_ENV) != "1":
+        return
+    if not stale:
+        return
+    completed = run_capture(["gh", "--version"], cwd=root)
+    if completed.returncode != 0:
+        return
+    title = f"Release preflight stale dependency findings on {current_ref(root)}"
+    body_lines = [
+        "Publisher preflight found stale direct dependencies that should be reviewed:",
+        "",
+    ]
+    for dep, current, latest in stale:
+        body_lines.append(f"- `{dep}` current `{current}` latest `{latest}`")
+    body_lines.extend(
+        [
+            "",
+            f"Detected by `scripts/validate_release.py` with `{CHECK_DEP_CURRENCY_ENV}=1`.",
+        ]
+    )
+    run_capture(["gh", "issue", "create", "--title", title, "--body", "\n".join(body_lines)], cwd=root)
+
+
+def validate_dependency_currency(root: Path, findings: list[Finding]) -> None:
+    if os.environ.get(CHECK_DEP_CURRENCY_ENV) != "1":
+        findings.append(
+            Finding(
+                check="dependency-currency",
+                severity="warning",
+                summary=f"dependency currency check skipped; set {CHECK_DEP_CURRENCY_ENV}=1 to enable it",
+            )
+        )
+        return
+
+    stale: list[tuple[str, str, str]] = []
+    unresolved: list[str] = []
+    for dep, current in sorted(direct_registry_dependencies(root).items()):
+        latest = latest_registry_version(root, dep)
+        if latest is None:
+            unresolved.append(dep)
+            continue
+        if latest != current:
+            stale.append((dep, current, latest))
+
+    if unresolved:
+        findings.append(
+            Finding(
+                check="dependency-currency",
+                severity="warning",
+                summary="dependency currency check could not resolve some crates via cargo search",
+                detail=", ".join(unresolved),
+            )
+        )
+    if stale:
+        detail = "; ".join(f"{dep}: current {current}, latest {latest}" for dep, current, latest in stale)
+        findings.append(
+            Finding(
+                check="dependency-currency",
+                severity="warning",
+                summary="stale direct dependency versions detected",
+                detail=detail,
+            )
+        )
+        maybe_file_dep_currency_issue(root, stale)
+
+
+def write_findings(root: Path, version: str, findings_path: Path, findings: list[Finding]) -> None:
+    payload = {
+        "generatedAt": utc_now(),
+        "branch": current_ref(root),
+        "version": version,
+        "status": "fail" if any(f.blocks for f in findings) else "pass",
+        "findings": [asdict(f) | {"blocks": f.blocks} for f in findings],
+    }
+    findings_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the retained release validation suite")
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default="all",
+        choices=(
+            "all",
+            "lint",
+            "support-files",
+            "manifest",
+            "publish-surface",
+            "release-binaries",
+            "inventory",
+            "cargo-lock-drift",
+            "dependency-currency",
+        ),
+    )
+    parser.add_argument("--version", help="Release version to validate; defaults to workspace.package.version")
+    parser.add_argument("--findings", default="release-findings.json", help="Path to findings JSON output")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = repo_root()
+    explicit_version = args.version is not None
+    version = args.version or workspace_version(root)
+    if version != workspace_version(root):
+        raise SystemExit(
+            f"release version mismatch: expected workspace version {workspace_version(root)}, got {version}"
+        )
+
+    findings: list[Finding] = []
+    actions = {
+        "support-files": lambda: validate_support_files(root, findings),
+        "lint": lambda: validate_lint(root, findings),
+        "manifest": lambda: validate_manifest(root, findings),
+        "publish-surface": lambda: validate_publish_surface(
+            root,
+            version,
+            findings,
+            enforce_release_version=explicit_version,
+        ),
+        "release-binaries": lambda: validate_release_binaries(root, findings),
+        "inventory": lambda: validate_inventory(root, version, findings),
+        "cargo-lock-drift": lambda: validate_cargo_lock_drift(
+            root,
+            findings,
+            enforce_release_window=explicit_version,
+        ),
+        "dependency-currency": lambda: validate_dependency_currency(root, findings),
+    }
+
+    if args.target == "all":
+        for target in (
+            "support-files",
+            "lint",
+            "manifest",
+            "publish-surface",
+            "release-binaries",
+            "inventory",
+            "cargo-lock-drift",
+            "dependency-currency",
+        ):
+            print(f"== validate {target} ==")
+            actions[target]()
+    else:
+        actions[args.target]()
+
+    findings_path = root / args.findings
+    write_findings(root, version, findings_path, findings)
+    print(f"wrote findings: {findings_path}")
+
+    blockers = [finding for finding in findings if finding.blocks]
+    if blockers:
+        print("release validation blockers:")
+        for finding in blockers:
+            print(f"- [{finding.check}] {finding.summary}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -129,7 +129,7 @@ def validate_support_files(root: Path, findings: list[Finding]) -> None:
 
 
 def validate_lint(root: Path, findings: list[Finding]) -> None:
-    completed = run_capture(["python3", ".just/run_lint.py", "all"], cwd=root)
+    completed = run_capture(["just", "lint"], cwd=root)
     append_completed_findings(
         findings,
         "lint",
@@ -310,7 +310,17 @@ def validate_publish_surface(
 
 def validate_inventory(root: Path, version: str, findings: list[Finding]) -> None:
     tag = f"v{version}"
-    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+    commit_result = run_capture(["git", "rev-parse", "HEAD"], cwd=root)
+    if commit_result.returncode != 0:
+        append_completed_findings(
+            findings,
+            "inventory-commit",
+            commit_result,
+            "release commit resolved",
+            "release commit resolution failed",
+        )
+        return
+    commit = commit_result.stdout.strip()
     with tempfile.TemporaryDirectory(prefix="atm-release-inventory-") as tmpdir:
         output = Path(tmpdir) / "release-inventory.json"
         completed = run_capture(
@@ -631,25 +641,26 @@ def main(argv: list[str] | None = None) -> int:
         "dependency-currency": lambda: validate_dependency_currency(root, findings),
     }
 
-    if args.target == "all":
-        for target in (
-            "support-files",
-            "lint",
-            "manifest",
-            "publish-surface",
-            "release-binaries",
-            "inventory",
-            "cargo-lock-drift",
-            "dependency-currency",
-        ):
-            print(f"== validate {target} ==")
-            actions[target]()
-    else:
-        actions[args.target]()
-
     findings_path = root / args.findings
-    write_findings(root, version, findings_path, findings)
-    print(f"wrote findings: {findings_path}")
+    try:
+        if args.target == "all":
+            for target in (
+                "support-files",
+                "lint",
+                "manifest",
+                "publish-surface",
+                "release-binaries",
+                "inventory",
+                "cargo-lock-drift",
+                "dependency-currency",
+            ):
+                print(f"== validate {target} ==")
+                actions[target]()
+        else:
+            actions[args.target]()
+    finally:
+        write_findings(root, version, findings_path, findings)
+        print(f"wrote findings: {findings_path}")
 
     blockers = [finding for finding in findings if finding.blocks]
     if blockers:

--- a/scripts/verify_release_archive.py
+++ b/scripts/verify_release_archive.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+def expected_members(manifest_path: Path, windows: bool) -> set[str]:
+    import tomllib
+
+    data = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    binaries = data.get("release_binaries", [])
+    names = {entry["name"] for entry in binaries}
+    return {f"{name}.exe" if windows else name for name in names}
+
+
+def archive_members(archive_path: Path) -> set[str]:
+    if archive_path.suffix == ".zip":
+        with zipfile.ZipFile(archive_path) as archive:
+            return {Path(name).name for name in archive.namelist() if not name.endswith("/")}
+    if archive_path.suffixes[-2:] == [".tar", ".gz"]:
+        with tarfile.open(archive_path, "r:gz") as archive:
+            return {Path(member.name).name for member in archive.getmembers() if member.isfile()}
+    raise SystemExit(f"unsupported archive type: {archive_path}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify release archive membership against the manifest")
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--archive", required=True)
+    args = parser.parse_args()
+
+    archive_path = Path(args.archive)
+    windows = archive_path.suffix == ".zip"
+    expected = expected_members(Path(args.manifest), windows)
+    actual = archive_members(archive_path)
+    missing = sorted(expected - actual)
+    if missing:
+        raise SystemExit(
+            f"{archive_path.name} missing expected members: {', '.join(missing)}; actual members: {', '.join(sorted(actual))}"
+        )
+    print(f"ok: {archive_path.name} contains expected members: {', '.join(sorted(expected))}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `just validate` as the single canonical local release preflight command
- `scripts/validate_release.py` collects ALL blockers before exit, emits `release-findings.json` (fail-aggregating, not exit-on-first)
- `scripts/release_artifacts.py` provides archive membership verification for `atm` and `atm-daemon`
- `release/publish-artifacts.toml` carries both `atm` and `atm-daemon` binaries plus 7 publishable crates
- `release/RELEASE-NOTES-TEMPLATE.md` committed as real file
- `.github/workflows/release-preflight.yml` and `release.yml` updated for manifest-driven packaging and archive verification
- Cargo.lock drift check vs `origin/main` (release-candidate-gated via `--version`)
- Env-gated version-currency check (`ATMD_CHECK_DEP_CURRENCY=1`)

## Sprint

PI.1 — Canonical Validation Infrastructure  
Sprint doc: `docs/publishing-improvements/plan.md`  
Branch: `feature/pPI-s1-validation-infra` @ `7ee89368`

## Test plan

- [ ] `just validate` runs end-to-end and emits `release-findings.json`
- [ ] `just validate` collects all blockers (no early exit on first failure)
- [ ] `release/publish-artifacts.toml` includes both `atm` and `atm-daemon`
- [ ] `release/RELEASE-NOTES-TEMPLATE.md` exists as committed file
- [ ] CI release-preflight workflow invokes same validation logic
- [ ] All PI.1 acceptance criteria verified by req-qa

🤖 Generated with [Claude Code](https://claude.com/claude-code)