### PR TITLE
feat(publish): PI.2 publisher prompt release-branch discipline

### DIFF
--- a/.claude/agents/publisher.md
+++ b/.claude/agents/publisher.md
@@ -179,7 +179,7 @@ After the release workflow completes and the GitHub Release is created, publishe
 updates the release body with the provided notes:
 
 ```bash
-gh release edit v{VERSION} --notes "$(cat /tmp/release-notes.md)"
+gh release edit v{VERSION} --notes "$(cat release/release-notes.md)"
 ```
 
 ---

--- a/.claude/agents/publisher.md
+++ b/.claude/agents/publisher.md
@@ -13,18 +13,24 @@ Homebrew, and `winget`.
 
 Publisher owns release execution discipline. Follow the documented release flow
 exactly as written. Do not invent alternate publish paths.
+Publisher must minimize the number of release-window PRs by finding and fixing
+the full blocker set in one preflight pass rather than one blocker per cycle.
 
 ## Hard Rules
 - Release tags are created **only** by the release workflow.
 - Never manually push `v*` tags from a local machine.
 - Never request tag deletion, retagging, or tag mutation as a recovery path.
-- `develop` must already be merged into `main` before release starts.
-- Always run the preflight workflow before the release workflow.
+- Publisher may be launched from either `develop` or `main`, but actual release
+  execution always converges on a short-lived `release/vX.Y.Z` branch cut from
+  `main`.
+- Always run `just validate` before the release workflow.
 - Follow the standard release flow in order. Do not skip or reorder gates.
 - If any gate or prerequisite fails, stop and report to `team-lead` before
   making corrective changes.
 - Never bump the workspace version except when a sprint explicitly delivers that
   version increment or when `team-lead` approves a failed-release recovery bump.
+- Routine missing release inputs are not user blockers. Request them from
+  `team-lead` immediately instead of escalating to the user.
 
 > [!CAUTION]
 > If you are about to run `git tag`, `git push --tags`, or `git push origin v*`,
@@ -36,10 +42,12 @@ exactly as written. Do not invent alternate publish paths.
 - Artifact manifest SSoT: `release/publish-artifacts.toml`
 - Preflight workflow: `.github/workflows/release-preflight.yml`
 - Release workflow: `.github/workflows/release.yml`
+- Canonical local preflight: `just validate`
 - Gate script: `scripts/release_gate.sh`
 - Manifest helper: `scripts/release_artifacts.py`
 - Release inventory schema: `docs/release-inventory-schema.json`
 - Tag policy: `docs/release-tag-protection.md`
+- Release notes template: `release/RELEASE-NOTES-TEMPLATE.md`
 - `winget` setup note: `docs/WINGET_SETUP.md`
 - Homebrew tap: `randlee/homebrew-tap`
 - Formula files: `Formula/agent-team-mail.rb`, `Formula/atm.rb`
@@ -87,6 +95,35 @@ out of date for this repo.
 
 ---
 
+## Entry Modes
+
+Publisher supports two valid launch modes:
+
+### Launch From `develop`
+- verify the intended release change list is on `develop`
+- create or validate the `develop -> main` release PR
+- demand current release notes / change list from `team-lead` if missing
+- run `just validate`
+- after gates pass and the PR is green, shepherd merge to `main`
+- cut a short-lived `release/vX.Y.Z` branch from `main`
+- any release fixes required after that point land on `release/vX.Y.Z`, not on
+  `develop` and not directly on `main`
+- run release workflows from `release/vX.Y.Z`
+
+### Launch From `main`
+- verify the intended release change list is already on `main`
+- demand current release notes / change list from `team-lead` if missing
+- run `just validate`
+- cut a short-lived `release/vX.Y.Z` branch from `main`
+- any release fixes required after that point land on `release/vX.Y.Z`, not
+  directly on `main`
+- dispatch the release workflows from `release/vX.Y.Z`
+
+In both modes, publisher coordinates with `team-lead`. Do not ask the user for
+routine release inputs.
+
+---
+
 ## Pre-Release Validation (automated CI gates)
 
 Three automated checks run in CI on every PR and catch common release mistakes
@@ -126,7 +163,7 @@ already confirmed — do not re-run them manually.
 
 ## Release Notes Requirement
 
-**Before merging `develop` → `main`, `team-lead` must provide completed release notes.**
+**Before cutting `release/vX.Y.Z`, `team-lead` must provide completed release notes.**
 
 The template is at `release/RELEASE-NOTES-TEMPLATE.md`. If team-lead has not
 provided filled release notes by Step 3, publisher must request them:
@@ -136,7 +173,7 @@ ATM to team-lead: "Please provide completed release notes
 (release/RELEASE-NOTES-TEMPLATE.md) before I proceed with the merge."
 ```
 
-Do not merge `develop` → `main` until release notes are received.
+Do not cut `release/vX.Y.Z` until release notes are received.
 
 After the release workflow completes and the GitHub Release is created, publisher
 updates the release body with the provided notes:
@@ -148,32 +185,50 @@ gh release edit v{VERSION} --notes "$(cat /tmp/release-notes.md)"
 ---
 
 ## Standard Release Flow
-1. **Step 0 — Tag gate (must pass before any PR/workflow action):**
-   - Determine release version from `develop` (version already in source).
+1. Determine launch mode:
+   - `develop` mode: publisher owns the release PR and merge shepherding to
+     `main`
+   - `main` mode: publisher verifies the intended release content is already on
+     `main`
+2. Demand current release notes / change list from `team-lead` immediately if
+   they are missing or stale.
+3. Run `just validate`. Any failure is a hard stop that must be reported to
+   `team-lead`.
+4. In `develop` mode, merge `develop` → `main` only after `just validate`
+   passes and the release PR is green.
+5. Cut `release/vX.Y.Z` from `main` and keep all release-window fixes on that
+   branch. Do not fix release blockers directly on `develop` or `main`.
+6. **Step 0 — Tag gate (must pass before any workflow action):**
+   - Determine release version from `release/vX.Y.Z` (version already in source).
    - Check: `git ls-remote --tags origin "refs/tags/v<version>"`.
    - If the tag already exists on remote, STOP and report to `team-lead`.
-2. Verify version bump already exists on `develop` (workspace + all crate
+7. Verify version bump already exists on `release/vX.Y.Z` (workspace + all crate
    `Cargo.toml` files). If missing, stop and report.
-3. Create PR `develop` → `main`.
-4. While waiting for PR CI, run the **Inline Pre-Publish Audit** directly —
+8. While waiting for CI, run the **Inline Pre-Publish Audit** directly —
    no sub-agents spawned.
-5. Run **Release Preflight** workflow via `workflow_dispatch` with:
+9. Run **Release Preflight** workflow via `workflow_dispatch` with:
    - `version=<X.Y.Z or vX.Y.Z>`
    - `run_by_agent=publisher`
-6. Monitor in parallel:
-   - PR CI: `atm gh monitor pr <PR_NUMBER>` — reports merge_conflict, CI pass/fail
+10. Monitor in parallel:
+   - PR CI (if a release PR or release-fix PR is open): `atm gh monitor pr <PR_NUMBER>` — reports merge_conflict, CI pass/fail
    - Preflight: `atm gh monitor run <run-id>` (fallback: `gh run watch --exit-status <run-id>`)
    - If `atm gh monitor pr` returns `merge_conflict`, stop and report to `team-lead`.
-7. If the inline audit or preflight finds gaps, report to `team-lead` and pause.
-8. Proceed only after `team-lead` confirms mitigations are complete and PR is green.
-9. Merge `develop` → `main`.
-10. Run **Release** workflow via `workflow_dispatch` with version input.
-11. Workflow runs gate, creates tag from `origin/main`, builds assets, publishes
-    crates (idempotent — skips already-published versions), runs post-publish
-    verification.
-12. Verify Homebrew formulas (`agent-team-mail.rb` and `atm.rb`) were updated in
+11. If the inline audit or preflight finds gaps, report the full blocker set to
+    `team-lead`, batch the required fixes onto the current `release/vX.Y.Z`
+    branch, and avoid one-blocker-per-PR churn.
+12. Proceed only after `team-lead` confirms mitigations are complete and the
+    release branch is the accepted source.
+13. Run **Release** workflow via `workflow_dispatch` with version input.
+14. Workflow runs gate, creates tag from the accepted `release/vX.Y.Z` head,
+    builds assets, publishes crates (idempotent — skips already-published
+    versions), runs post-publish verification.
+15. Verify Homebrew formulas (`agent-team-mail.rb` and `atm.rb`) were updated in
     `randlee/homebrew-tap`. If automation did not update them, report to `team-lead`.
-13. Verify all retained channels, then report to `team-lead`.
+16. Verify all retained channels, then report to `team-lead`.
+17. After `release/vX.Y.Z` merges back to `main`, verify whether a `main ->
+    develop` reconciliation PR already exists. If it does not, create it
+    immediately so release-window commits and version updates flow back to
+    `develop`.
 
 ---
 
@@ -222,7 +277,7 @@ python3 -c "
 import json, re
 with open('Cargo.toml') as f:
     content = f.read()
-ws_version = re.search(r'version\s*=\s*\"([^\"]+)\"', content).group(1)
+ws_version = re.search(r'version\\s*=\\s*\"([^\"]+)\"', content).group(1)
 with open('release/release-inventory.json') as f:
     inv = json.load(f)
 inv_version = inv.get('releaseVersion', '')
@@ -270,7 +325,9 @@ Any failure in Steps A–F is a release blocker. Report to `team-lead` immediate
 ---
 
 ## Preflight Expectations
-`Release Preflight` is the mandatory release gate. It must validate:
+`Release Preflight` is the mandatory release gate. The canonical local
+equivalent is `just validate`. It must validate:
+- `just lint`
 - release manifest coverage
 - preflight modes
 - publish ordering
@@ -278,6 +335,12 @@ Any failure in Steps A–F is a release blocker. Report to `team-lead` immediate
 - release inventory generation
 - workspace version alignment
 - crate-level dependency-aware preflight checks
+- release notes template / support-file existence
+- required retained release binaries (`atm`, `atm-daemon`)
+
+Preflight is expected to return the full blocker set in one pass. Publisher
+should batch fixes and avoid one-blocker-per-PR churn whenever the defects are
+mechanical and known up front.
 
 If preflight fails, publisher does not improvise a workaround. Report the
 failing gate to `team-lead`.
@@ -327,11 +390,14 @@ current version has failed**.
 If the release workflow fails **after** the tag has been created but **before**
 anything is published to crates.io or GitHub Releases:
 
-1. **Do NOT fix the workflow on main and re-run.** Merging a hotfix to main moves
-   HEAD past the tag, causing the gate to reject the tag/main mismatch.
-2. **Bump the patch version** on develop (e.g., 0.29.0 → 0.29.1), merge the
-   workflow fix into develop, and start a fresh release cycle. This avoids tag
-   conflicts entirely.
+1. **Do NOT fix the workflow on main and re-run.** Merge the release-window fix
+   onto `release/vX.Y.Z`, re-run preflight there, and either complete the
+   current release or bump from the release branch if the version must be
+   abandoned.
+2. **Bump the patch version** only when the current version really must be
+   abandoned (for example, the tag already exists and the attempted release can
+   no longer be completed safely). Use `release/vX.Y.Z` as the recovery branch
+   and start a fresh release cycle from the replacement version.
 3. Only bump **minor** version if team-lead explicitly requests it. Default to
    **patch** for workflow-only fixes.
 4. If the tag was created but nothing was published, the stuck tag is harmless —
@@ -342,12 +408,43 @@ and bump forward.
 
 ---
 
+## Release Failure Ratchet
+
+If publisher encounters a release-time failure that reasonably should have been
+caught by `just validate` / preflight, publisher must immediately file a GitHub
+issue describing:
+- the exact failing workflow step / command
+- why current preflight missed it
+- the concrete validation, prompt, or workflow improvement required so it does
+  not recur
+
+Do not treat avoidable release failures as one-off incidents. Every missed
+failure must become a tracked improvement.
+
+---
+
 ## Communication
 - Receive release tasks from `team-lead`.
 - Follow ATM team messaging protocol: immediate acknowledgement → execute →
   completion summary → receiver acknowledgement.
 - Send stage updates when preflight completes, release completes, or a blocker
   appears.
+- Every status report must include a `STATE:` block with:
+  - current `origin/main` SHA
+  - current release branch SHA
+  - target release version/tag
+  - open release-related PRs
+  - latest preflight run ID + conclusion
+  - latest release run ID + conclusion
+- Ask `team-lead`, not the user, for:
+  - release notes / changelist completion
+  - missing release PR coordination
+  - missing branch ownership / merge sequencing
+  - routine release-window follow-through
+- Escalate to the user only for real policy ambiguity. Example:
+  - a dependency such as `sc-lint-attributes` unexpectedly becomes part of the
+    production publish surface and there is no accepted decision on whether that
+    expansion is allowed
 
 ---
 
@@ -371,6 +468,20 @@ Report must include:
 - post-publish verification summary
 - waiver summary (if any)
 - residual risks/issues
+
+`winget` handoff details should be concrete. If automation cannot complete the
+submission and manual follow-through is required, publisher should record the
+`komac` path explicitly, for example:
+
+```bash
+komac update randlee.agent-team-mail \
+  --version <X.Y.Z> \
+  --urls <github-release-asset-url> \
+  --submit
+```
+
+If the first submission still requires manual Store-side approval or repo
+bootstrapping, record that as handoff status, not as a failed release workflow.
 
 ---
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3937,3 +3937,12 @@ Acceptance / Phase Entry Gate:
   on the accepted `integrate/phase-Z` line
 - the final `Z.4` release verdict must not close until `Z.23` and `Z.24` also
   close on the accepted `integrate/phase-Z` line
+
+Publishing improvements implementation:
+
+- `PI.2`
+  - branch: `feature/pPI-s2-publisher-prompt`
+  - artifacts:
+    - `.claude/agents/publisher.md`
+    - `docs/publishing-improvements/plan.md`
+    - `docs/project-plan.md`

--- a/docs/publishing-improvements/plan.md
+++ b/docs/publishing-improvements/plan.md
@@ -1,7 +1,7 @@
 ---
 status: complete
-branch: feature/publishing-improvements
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/publishing-improvements
+branch: feature/pPI-s2-publisher-prompt
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pPI-s2-publisher-prompt
 ---
 
 # Publishing Improvements Plan

--- a/docs/publishing-improvements/plan.md
+++ b/docs/publishing-improvements/plan.md
@@ -1,0 +1,299 @@
+---
+status: complete
+branch: feature/publishing-improvements
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/publishing-improvements
+---
+
+# Publishing Improvements Plan
+
+## Goal
+
+Make publisher-driven releases predictable, low-churn, and self-contained:
+
+- publisher may start from `develop` or `main`
+- release execution always converges onto a short-lived `release/vX.Y.Z` branch
+  cut from `main`
+- the canonical preflight is `just validate`
+- all known publish failures must be caught before the release workflow starts
+- routine missing inputs come from `team-lead`, not from the user
+- any publish-time failure that should have been preflighted becomes an
+  automatic GitHub issue so the same surprise does not recur
+
+## Governing Decisions
+
+### Release source model
+
+- `develop` remains an allowed launch point only for publisher to shepherd the
+  release PR into `main`
+- `main` remains the source branch for cutting the release line
+- actual release execution happens from `release/vX.Y.Z`
+- any release-window fixes happen on `release/vX.Y.Z`, not directly on `main`
+  and not on `develop`
+- after the release branch merges to `main`, publisher must immediately ensure
+  the resulting release commits flow back into `develop` via a `main ->
+  develop` reconciliation PR if one is not already open
+
+### Canonical preflight
+
+- `just validate` is the single local command that represents release
+  preflight
+- phase-ending review should require `just validate` whenever a phase changes
+  publishable crates, release workflows, release manifests, version SSOT,
+  release notes templates, or other release-surface inputs; that gate blocks
+  merge into `develop`, not just the later publish attempt
+- release-preflight CI should use the same validation logic, not a different
+  handwritten checklist
+
+### No-surprises policy
+
+- every known publish failure class must be represented in preflight
+- publisher should get the full blocker set in one pass
+- publisher should batch mechanical fixes and avoid one-blocker-per-PR churn
+
+### Escalation policy
+
+- publisher requests routine missing inputs from `team-lead`
+- publisher does not ask the user for ordinary release coordination details
+- user escalation is reserved for real policy ambiguity only
+
+### Failure ratchet
+
+- if a publish-time failure should have been caught by preflight, publisher
+  must file a GitHub issue immediately with exact failure details and the
+  missing gate
+
+## Current Status Audit
+
+### `GH #376` items
+
+- add `just lint` to preflight:
+  - `PLANNED TO LAND AS PART OF just validate`
+- add manifest / preflight-check / publish-order validation:
+  - `ALREADY PRESENT`
+- add `cargo package -p agent-team-mail-core --locked`:
+  - `ALREADY PRESENT` in workflow, but not yet unified under `just validate`
+- add archive membership verification for `atm` + `atm-daemon`:
+  - `MISSING` before this branch
+- aggregate all blockers into one preflight result set:
+  - `MISSING`; current release validation flow does not yet require a single
+    `release-findings.json` artifact with all blockers collected before exit
+- check Cargo.lock drift against `origin/main`:
+  - `MISSING` as an explicit release-window gate
+- check dependency currency and file stale-version issues automatically:
+  - `MISSING`; this was only a follow-on idea before publisher review
+- treat failures as hard stops:
+  - `PARTIAL`; prompt already stops on gate failures, but the full local gate
+    was missing
+
+### `GH #380` items
+
+- lineage gate friction:
+  - `RESOLVED` in current [scripts/release_gate.sh](/Users/randlee/Documents/github/atm-core-worktrees/feature/publishing-improvements/scripts/release_gate.sh)
+    because the old `develop ⊂ main` enforcement is already gone
+- publish from `main`, not from live `develop` ancestry:
+  - `NOT FULLY DOCUMENTED` before this branch
+- Cargo.lock drift / dependency bump policy:
+  - `PARTIAL`; lock/version checks exist, but the publisher prompt still needed
+    stronger release-window guidance
+- parallel comprehensive preflight:
+  - `PARTIAL`; workflow had many checks, but no canonical `just validate`
+    contract
+- stale state communication:
+  - `MISSING`; no structured `STATE:` block requirement
+- release notes template / source of truth:
+  - `MISSING`; the prompt referenced a template that was absent
+- winget bootstrap handling:
+  - `PARTIAL`; docs existed, but prompt handling was too thin
+- develop fast-forward / divergence semantics:
+  - `SUPERSEDED` by the release-branch model in this plan
+- post-release `main -> develop` reconciliation after release-branch merges:
+  - `MISSING` as an explicit publisher-owned operational step
+- publishability / surface-expansion escalation example:
+  - `MISSING`; the prompt did not yet include a concrete example such as
+    `sc-lint-attributes` unexpectedly becoming a production publish blocker
+
+## Sprint Breakdown
+
+### Sprint PI.1 — Canonical Validation Infrastructure
+
+Goal:
+- create the single authoritative preflight command and align repo-owned
+  release metadata around it
+
+Deliverables:
+- `Justfile`
+  - add `just validate`
+- `scripts/validate_release.py`
+  - canonical local preflight runner
+  - collect all blockers and emit `release-findings.json`
+  - exit non-zero only after the full blocker set is recorded
+- `scripts/release_artifacts.py`
+  - release-binary validation helper(s)
+- `release/publish-artifacts.toml`
+  - retained release-binary SSOT includes both `atm` and `atm-daemon`
+- `release/RELEASE-NOTES-TEMPLATE.md`
+  - real file exists in repo
+- `.github/workflows/release-preflight.yml`
+  - canonical validation suite invoked from CI
+- `.github/workflows/release.yml`
+  - release packaging driven from manifest release binaries, with archive
+    membership verification
+- release validation logic
+  - explicit `Cargo.lock` drift check against `origin/main`
+  - dependency version-currency check using `cargo search`, gated by env var so
+    CI can suppress issue-spam while local or release contexts can file issues
+
+Acceptance:
+- `just validate` runs the full local retained release preflight
+- `just validate` includes:
+  - `just lint`
+  - manifest coverage / preflight-mode / publish-order checks
+  - publish-surface package / dry-run checks
+  - release support-file checks
+  - release inventory generation/shape check
+  - retained release-binary validation
+- `just validate` emits `release-findings.json` and does not stop at the first
+  blocker
+- `just validate` checks whether `Cargo.lock` drifted from `origin/main` during
+  the release window
+- `just validate` includes a version-currency check path, env-gated for CI
+  noise control and capable of auto-filing a GitHub issue on stale results
+- release manifest declares both `atm` and `atm-daemon`
+- release archives are built from the manifest binary list and verified for
+  expected membership
+- dependency version-pin × publish-flag mismatches are explicitly covered by the
+  combined manifest validation plus package / dry-run checks; `cargo publish
+  --dry-run` alone is not treated as sufficient proof
+
+### Sprint PI.2 — Publisher Prompt and Release-Branch Discipline
+
+Goal:
+- make publisher operationally self-sufficient and remove user babysitting from
+  routine release work
+
+Deliverables:
+- `.claude/agents/publisher.md`
+  - explicit `develop` and `main` launch modes
+  - release execution converges on `release/vX.Y.Z`
+  - any release-window fixes land on `release/vX.Y.Z`, regardless of launch
+    mode
+  - routine missing inputs sourced from `team-lead`
+  - `just validate` mandated before release workflow execution
+  - structured `STATE:` status report format
+  - explicit instruction to batch blocker fixes rather than serial PR churn
+  - explicit post-release `main -> develop` reconciliation step after the
+    release branch merges back to `main`
+  - concrete winget handoff mechanics, including `komac` CLI steps and the
+    expectation that a first-time manual Store handoff is not itself a workflow
+    failure
+  - concrete user-escalation examples, including the publishability /
+    surface-expansion case where a dependency such as `sc-lint-attributes`
+    becomes production-facing unexpectedly
+
+Acceptance:
+- publisher no longer relies on `develop` ancestry as the live release gate
+- publisher documents that all release-window fixes happen on `release/vX.Y.Z`
+- publisher documents the exact `main -> develop` reconciliation step required
+  after release-branch merges so version-bump commits are not stranded on
+  `main`
+- publisher asks `team-lead`, not the user, for release notes / changelist /
+  missing coordination inputs
+- publisher status reports include a structured `STATE:` block
+- publisher documents the expected winget / `komac` handoff path and treats a
+  first-time manual handoff as operational follow-through, not as a workflow
+  failure
+
+Operational detail:
+- after merge of `release/vX.Y.Z -> main`, publisher must:
+  - verify whether a `main -> develop` PR already exists
+  - create it immediately if missing
+  - route any missing changelist or release-note follow-through to `team-lead`
+- winget handoff text in the prompt should include the expected `komac` CLI
+  path, for example:
+  - `komac update <package-id> --version <X.Y.Z> --urls <artifact-url> ...`
+  - if the first submission still requires manual Store-side approval or repo
+    bootstrapping, publisher records that as handoff status, not as a failed
+    release workflow
+
+### Sprint PI.3 — Failure Ratchet and Remaining Process Hardening
+
+Goal:
+- ensure every future release surprise turns into a tracked preflight or prompt
+  improvement
+
+Deliverables:
+- `.claude/agents/publisher.md`
+  - automatic GitHub issue requirement for any publish-time failure that should
+    have been caught by preflight
+- `docs/publishing-improvements/plan.md`
+  - closure proof matrix mapping every known `v1.2.0` incident category to the
+    preflight or prompt control that prevents recurrence
+- follow-on automation/documentation plan for:
+  - release incident reporting templates if needed
+
+Publisher review checkpoint:
+- publisher must sign off on:
+  - whether `just validate` covers all failure classes encountered in the last
+    release
+  - whether any remaining late-release surprises still lack a gate
+  - whether the `STATE:` block and release-branch workflow are operationally
+    sufficient
+
+Acceptance:
+- publisher prompt requires issue filing for missed preflight failures
+- the plan contains a closure proof matrix for `v1.2.0` incident categories and
+  confirms the intended preflight coverage for each
+- remaining non-blocking release-process gaps are enumerated explicitly, not
+  left implicit
+
+## Coverage Notes
+
+### Dependency version-pin × publish-flag cross-check
+
+- this plan treats the cross-check as the combined responsibility of:
+  - manifest/version SSOT validation
+  - publish-surface manifest validation
+  - `cargo package --locked`
+  - `cargo publish --dry-run` where applicable
+- `cargo publish --dry-run` by itself is not enough to prove internal
+  path-version correctness or publish-surface completeness
+
+### User escalation examples
+
+- ordinary missing inputs are not user blockers:
+  - release notes not refreshed
+  - changelist not refreshed
+  - missing `main -> develop` reconciliation PR
+  - missing release-branch follow-through
+- true escalation examples are policy decisions:
+  - a publishability / surface-expansion change such as
+    `sc-lint-attributes` unexpectedly becoming a production dependency in a
+    publishable crate
+  - a disputed decision about whether a crate must ship publicly or may remain
+    internal
+
+### `v1.2.0` closure proof matrix
+
+| Incident category | Required preflight / prompt control |
+|---|---|
+| internal dev-dependency version-pin leakage (`atm-runtime-test-support`) | `just lint` plus manifest/version SSOT validation plus `cargo package --locked` |
+| publish-surface manifest drift or wrong publish order | `validate-manifest`, `validate-preflight-checks`, `validate-publish-order` inside `just validate` |
+| release archives missing `atm-daemon` | manifest-declared release binaries plus archive membership verification inside `just validate` |
+| `Cargo.lock` drift or silent release-window dependency bump | explicit `Cargo.lock` drift check against `origin/main` in `just validate` |
+| stale dependency currency discovered late | env-gated version-currency check plus auto-filed GitHub issue when stale |
+| publisher discovers blockers serially and opens multiple PRs | `release-findings.json` aggregation requirement so preflight returns the full blocker set in one pass |
+| release notes template / changelist source missing | release support-file checks plus publisher requirement to obtain missing inputs from `team-lead` |
+| winget handoff confusion or first-submission bootstrap surprise | explicit `komac` handoff steps in prompt plus non-failure status treatment for manual Store follow-through |
+| publishability / surface-expansion ambiguity (for example `sc-lint-attributes`) | publisher prompt escalation example routes the policy question to `team-lead` / user instead of treating it as a mechanical blocker |
+| post-release divergence between `main` and `develop` | explicit publisher-owned `main -> develop` reconciliation step after release-branch merge |
+
+## Planning Branch Scope
+
+This branch is planning-only.
+
+Allowed closeout artifacts on this branch:
+- `docs/publishing-improvements/plan.md`
+- `docs/project-plan.md`
+
+Everything else described in `PI.1` through `PI.3` is implementation work for
+later sprint branches after publisher reviews the plan.


### PR DESCRIPTION
## Summary
- Overhauls `.claude/agents/publisher.md` per Sprint PI.2 of the publishing-improvements plan
- Adds explicit `develop`/`main` launch modes, `release/vX.Y.Z` convergence requirement, release-window-fix-on-release-branch-only policy, team-lead sourcing for missing inputs, `just validate` mandate, `STATE:` block format, batch-fix requirement, `main→develop` reconciliation step, `komac` winget handoff steps, and user-escalation examples
- Sprint doc: `docs/publishing-improvements/plan.md` (on `feature/publishing-improvements`)

## Test plan
- [ ] `.claude/agents/publisher.md` exists and contains all 9 required changes from PI.2 acceptance criteria
- [ ] Explicit `develop` and `main` launch modes documented
- [ ] `release/vX.Y.Z` convergence requirement documented
- [ ] Release-window fixes land on `release/vX.Y.Z` not `main` or `develop`
- [ ] Routine missing inputs sourced from `team-lead`, not user
- [ ] `just validate` mandated before release execution
- [ ] `STATE:` block format specified
- [ ] Batch-fix requirement documented (no serial PR churn)
- [ ] `main→develop` reconciliation step after release-branch merges to `main`
- [ ] `komac` CLI winget handoff steps included; first-time manual handoff treated as operational, not failure
- [ ] User-escalation examples include publishability/surface-expansion case

🤖 Generated with [Claude Code](https://claude.com/claude-code)