### PR TITLE
fix: restore windows daemon parity

### DIFF
--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.2.0
+PackageVersion: 1.2.1
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.2.0/atm_1.2.0_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.2.1/atm_1.2.1_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.2.0
+ManifestVersion: 1.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "signal-hook",
  "tempfile",
  "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,6 @@ dependencies = [
  "signal-hook",
  "tempfile",
  "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "atm-runtime-test-support",
  "chrono",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-team-mail-core",
  "arc-swap",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-client",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-team-mail-core",
  "fs2",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-bootstrap",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-team-mail-core",
  "atm-rusqlite",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "atm-rusqlite"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime-test-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/README.md
+++ b/README.md
@@ -224,8 +224,21 @@ Useful docs in this repo:
 
 ## Development
 
+Windows first-run prerequisites on a new machine:
+- install Rust `1.94.1` with the MSVC toolchain
+- install Visual Studio C++ build tools
+- install `just` (`winget install Casey.Just`)
+- ensure `python` resolves on `PATH` for repo scripts and helpers
+
 ```bash
 cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
+```
+
+Windows CI parity command:
+
+```powershell
+$env:ATM_TEST_RECV_TIMEOUT_SECS="60"
+cargo test --workspace --verbose
 ```

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -35,7 +35,7 @@ sc-observability-types.workspace = true
 sc-lint-attributes = { path = "../sc-lint-attributes", version = "0.1.0" }
 
 [dev-dependencies]
-atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.2.0" }
+atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.2.1" }
 serial_test = "3"
 tempfile = "3"
 

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -10,6 +10,6 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.0" }
-atm-rusqlite = { path = "../atm-rusqlite", version = "1.2.0" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.1" }
+atm-rusqlite = { path = "../atm-rusqlite", version = "1.2.1" }

--- a/crates/atm-daemon-client/Cargo.toml
+++ b/crates/atm-daemon-client/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1" }
 fs2 = "0.4"
 interprocess = "2.4.2"
 tracing = "0.1"

--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -361,7 +361,10 @@ pub fn exchange(
     Ok(response)
 }
 
-fn apply_local_ipc_deadline(result: std::io::Result<()>, message: &'static str) -> Result<(), AtmError> {
+fn apply_local_ipc_deadline(
+    result: std::io::Result<()>,
+    message: &'static str,
+) -> Result<(), AtmError> {
     match result {
         Ok(()) => Ok(()),
         #[cfg(windows)]
@@ -1036,6 +1039,10 @@ mod tests {
         .expect_err("non-unsupported timeout errors should remain failures");
 
         assert_eq!(result.code, AtmErrorCode::DaemonUnavailable);
-        assert!(result.message.contains("failed to configure daemon local IPC write timeout"));
+        assert!(
+            result
+                .message
+                .contains("failed to configure daemon local IPC write timeout")
+        );
     }
 }

--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -22,6 +22,15 @@ use std::sync::Mutex;
 pub const AUTO_START_PUBLISH_TIMEOUT: Duration = Duration::from_secs(10);
 pub const HOST_RUNTIME_LAUNCH_LOCK_FILE: &str = "launch.lock";
 const LOCAL_IPC_CONNECT_DEADLINE: Duration = Duration::from_millis(250);
+#[cfg(windows)]
+const LOCAL_IPC_READ_HELPER_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[cfg_attr(not(windows), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalIpcDeadlineSupport {
+    Applied,
+    Unsupported,
+}
 
 #[derive(Debug, Clone)]
 pub struct DaemonLocalIpcEndpoint(PathBuf);
@@ -321,11 +330,11 @@ pub fn exchange(
     request_deadline: Duration,
 ) -> Result<ResponseEnvelope, AtmError> {
     let mut stream = try_connect(endpoint)?;
-    apply_local_ipc_deadline(
+    let _send_deadline_support = apply_local_ipc_deadline(
         stream.set_send_timeout(Some(request_deadline)),
         "failed to configure daemon local IPC write timeout",
     )?;
-    apply_local_ipc_deadline(
+    let recv_deadline_support = apply_local_ipc_deadline(
         stream.set_recv_timeout(Some(request_deadline)),
         "failed to configure daemon local IPC read timeout",
     )?;
@@ -335,19 +344,8 @@ pub fn exchange(
     stream.flush().map_err(|source| {
         AtmError::daemon_unavailable("failed to flush daemon request frame").with_source(source)
     })?;
-    let response_frame = atm_core::protocol::read_frame(
-        &mut stream,
-        "failed to read daemon response frame",
-        "daemon response frame exceeded the maximum supported size",
-    )?
-    .ok_or_else(|| {
-        AtmError::daemon_unavailable(
-            "daemon closed the local IPC connection before returning a response frame",
-        )
-        .with_recovery(
-            "Retry the request after atm-daemon reaches serving state and inspect daemon logs if the problem persists.",
-        )
-    })?;
+    let response_frame =
+        read_response_frame_with_deadline(stream, request_deadline, recv_deadline_support)?;
     let (response_id, response) = atm_core::protocol::response_from_frame_payload(response_frame)?;
     if response_id != request_id {
         return Err(AtmError::daemon_unavailable(format!(
@@ -361,14 +359,96 @@ pub fn exchange(
     Ok(response)
 }
 
+fn read_response_frame_with_deadline(
+    mut stream: LocalSocketStream,
+    request_deadline: Duration,
+    recv_deadline_support: LocalIpcDeadlineSupport,
+) -> Result<atm_core::protocol::FramePayload, AtmError> {
+    #[cfg(windows)]
+    if recv_deadline_support == LocalIpcDeadlineSupport::Unsupported {
+        return read_response_frame_with_helper(stream, request_deadline);
+    }
+    #[cfg(not(windows))]
+    let _ = (request_deadline, recv_deadline_support);
+
+    read_response_frame(&mut stream)
+}
+
+#[cfg(windows)]
+fn read_response_frame_with_helper(
+    mut stream: LocalSocketStream,
+    request_deadline: Duration,
+) -> Result<atm_core::protocol::FramePayload, AtmError> {
+    let (result_tx, result_rx) = mpsc::sync_channel(1);
+    thread::Builder::new()
+        .name("local-ipc-response-read-helper".to_string())
+        .spawn(move || {
+            let result = read_response_frame(&mut stream);
+            let _ = result_tx.send(result);
+        })
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to spawn daemon local IPC read helper")
+                .with_recovery(
+                    "Retry the request after the same-host daemon read helper can be created again.",
+                )
+                .with_source(source)
+        })?;
+
+    let started = Instant::now();
+    loop {
+        let remaining = request_deadline.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            return Err(AtmError::daemon_unavailable(
+                "timed out reading daemon response frame",
+            )
+            .with_recovery(
+                "Retry the request after atm-daemon reaches serving state. If the same-host read path remains stuck, inspect daemon and local IPC health before retrying again.",
+            ));
+        }
+        let poll = std::cmp::min(remaining, LOCAL_IPC_READ_HELPER_POLL_INTERVAL);
+        match result_rx.recv_timeout(poll) {
+            Ok(result) => return result,
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(AtmError::daemon_unavailable(
+                    "daemon local IPC read helper disconnected unexpectedly",
+                )
+                .with_recovery(
+                    "Retry the request after the same-host daemon read helper can be created again.",
+                ));
+            }
+        }
+    }
+}
+
+fn read_response_frame(
+    stream: &mut LocalSocketStream,
+) -> Result<atm_core::protocol::FramePayload, AtmError> {
+    atm_core::protocol::read_frame(
+        stream,
+        "failed to read daemon response frame",
+        "daemon response frame exceeded the maximum supported size",
+    )?
+    .ok_or_else(|| {
+        AtmError::daemon_unavailable(
+            "daemon closed the local IPC connection before returning a response frame",
+        )
+        .with_recovery(
+            "Retry the request after atm-daemon reaches serving state and inspect daemon logs if the problem persists.",
+        )
+    })
+}
+
 fn apply_local_ipc_deadline(
     result: std::io::Result<()>,
     message: &'static str,
-) -> Result<(), AtmError> {
+) -> Result<LocalIpcDeadlineSupport, AtmError> {
     match result {
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(LocalIpcDeadlineSupport::Applied),
         #[cfg(windows)]
-        Err(source) if source.kind() == std::io::ErrorKind::Unsupported => Ok(()),
+        Err(source) if source.kind() == std::io::ErrorKind::Unsupported => {
+            Ok(LocalIpcDeadlineSupport::Unsupported)
+        }
         Err(source) => Err(AtmError::daemon_unavailable(message).with_source(source)),
     }
 }

--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -361,15 +361,13 @@ pub fn exchange(
 
 fn read_response_frame_with_deadline(
     mut stream: LocalSocketStream,
-    request_deadline: Duration,
-    recv_deadline_support: LocalIpcDeadlineSupport,
+    _request_deadline: Duration,
+    _recv_deadline_support: LocalIpcDeadlineSupport,
 ) -> Result<atm_core::protocol::FramePayload, AtmError> {
     #[cfg(windows)]
-    if recv_deadline_support == LocalIpcDeadlineSupport::Unsupported {
-        return read_response_frame_with_helper(stream, request_deadline);
+    if _recv_deadline_support == LocalIpcDeadlineSupport::Unsupported {
+        return read_response_frame_with_helper(stream, _request_deadline);
     }
-    #[cfg(not(windows))]
-    let _ = (request_deadline, recv_deadline_support);
 
     read_response_frame(&mut stream)
 }
@@ -384,7 +382,11 @@ fn read_response_frame_with_helper(
         .name("local-ipc-response-read-helper".to_string())
         .spawn(move || {
             let result = read_response_frame(&mut stream);
-            let _ = result_tx.send(result);
+            if result_tx.send(result).is_err() {
+                tracing::debug!(
+                    "daemon local IPC response-read helper dropped its result because the caller timed out first"
+                );
+            }
         })
         .map_err(|source| {
             AtmError::daemon_unavailable("failed to spawn daemon local IPC read helper")

--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -321,18 +321,14 @@ pub fn exchange(
     request_deadline: Duration,
 ) -> Result<ResponseEnvelope, AtmError> {
     let mut stream = try_connect(endpoint)?;
-    stream
-        .set_send_timeout(Some(request_deadline))
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to configure daemon local IPC write timeout")
-                .with_source(source)
-        })?;
-    stream
-        .set_recv_timeout(Some(request_deadline))
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to configure daemon local IPC read timeout")
-                .with_source(source)
-        })?;
+    apply_local_ipc_deadline(
+        stream.set_send_timeout(Some(request_deadline)),
+        "failed to configure daemon local IPC write timeout",
+    )?;
+    apply_local_ipc_deadline(
+        stream.set_recv_timeout(Some(request_deadline)),
+        "failed to configure daemon local IPC read timeout",
+    )?;
     let request_id = atm_core::protocol::next_request_id();
     let frame = atm_core::protocol::request_to_frame_payload(request_id, request)?;
     atm_core::protocol::write_frame(&mut stream, &frame, "failed to write daemon request frame")?;
@@ -363,6 +359,15 @@ pub fn exchange(
         ));
     }
     Ok(response)
+}
+
+fn apply_local_ipc_deadline(result: std::io::Result<()>, message: &'static str) -> Result<(), AtmError> {
+    match result {
+        Ok(()) => Ok(()),
+        #[cfg(windows)]
+        Err(source) if source.kind() == std::io::ErrorKind::Unsupported => Ok(()),
+        Err(source) => Err(AtmError::daemon_unavailable(message).with_source(source)),
+    }
 }
 
 pub fn unexpected_response(command: &str, response: ResponseEnvelope) -> AtmError {
@@ -782,6 +787,7 @@ pub fn is_launch_gate_contention_error(error: &std::io::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
@@ -800,7 +806,7 @@ mod tests {
 
     use super::{
         BootstrapTraceability, DaemonBinaryPath, DaemonLocalIpcEndpoint, DaemonSupervisor,
-        HOST_RUNTIME_LAUNCH_LOCK_FILE, LaunchGateGuard,
+        HOST_RUNTIME_LAUNCH_LOCK_FILE, LaunchGateGuard, apply_local_ipc_deadline,
     };
 
     #[derive(Debug, Default)]
@@ -989,5 +995,47 @@ mod tests {
 
         let error = LaunchGateGuard::rejected_error(&endpoint);
         assert_eq!(error.code, AtmErrorCode::DaemonLaunchGateRejected);
+    }
+
+    #[test]
+    fn local_ipc_deadline_handles_unsupported_timeout_per_platform_contract() {
+        let result = apply_local_ipc_deadline(
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "named pipes do not support I/O timeouts",
+            )),
+            "failed to configure daemon local IPC write timeout",
+        );
+
+        #[cfg(windows)]
+        assert!(result.is_ok());
+
+        #[cfg(not(windows))]
+        {
+            let error = result.expect_err(
+                "non-Windows local IPC transports should keep unsupported deadline setup as an error",
+            );
+            assert_eq!(error.code, AtmErrorCode::DaemonUnavailable);
+            assert!(
+                error
+                    .message
+                    .contains("failed to configure daemon local IPC write timeout")
+            );
+        }
+    }
+
+    #[test]
+    fn local_ipc_deadline_preserves_non_unsupported_errors() {
+        let result = apply_local_ipc_deadline(
+            Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "synthetic local IPC failure",
+            )),
+            "failed to configure daemon local IPC write timeout",
+        )
+        .expect_err("non-unsupported timeout errors should remain failures");
+
+        assert_eq!(result.code, AtmErrorCode::DaemonUnavailable);
+        assert!(result.message.contains("failed to configure daemon local IPC write timeout"));
     }
 }

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0" }
-atm-rusqlite = { path = "../atm-rusqlite", version = "1.2.0" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1" }
+atm-rusqlite = { path = "../atm-rusqlite", version = "1.2.1" }
 arc-swap.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 fs2 = "0.4"
@@ -28,8 +28,8 @@ signal-hook = "0.3"
 signal-hook = "0.3"
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0", features = ["test-utils"] }
-atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.2.0" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1", features = ["test-utils"] }
+atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.2.1" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -26,7 +26,6 @@ signal-hook = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 signal-hook = "0.3"
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_IO"] }
 
 [dev-dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1", features = ["test-utils"] }

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -26,6 +26,7 @@ signal-hook = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 signal-hook = "0.3"
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_IO"] }
 
 [dev-dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1", features = ["test-utils"] }

--- a/crates/atm-daemon/src/host_ownership.rs
+++ b/crates/atm-daemon/src/host_ownership.rs
@@ -46,7 +46,7 @@ impl std::fmt::Display for OwnerToken {
 
 #[cfg(test)]
 // Tests inject one stale-recovery rendezvous at a time, so the hook state stays behind a
-// process-local mutex instead of raw statics that would race under parallel execution.
+// process-local mutex instead of raw static items that would race under parallel execution.
 static STALE_RECOVERY_OBSERVED_SIGNAL: std::sync::Mutex<Option<StaleRecoverySignal>> =
     std::sync::Mutex::new(None);
 

--- a/crates/atm-daemon/src/host_ownership.rs
+++ b/crates/atm-daemon/src/host_ownership.rs
@@ -24,7 +24,29 @@ struct StaleRecoverySignal {
     continue_rx: std::sync::mpsc::Receiver<()>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OwnerToken(String);
+
+impl OwnerToken {
+    fn from_record(record: impl Into<String>) -> Self {
+        Self(record.into())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for OwnerToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 #[cfg(test)]
+// Tests inject one stale-recovery rendezvous at a time, so the hook state stays behind a
+// process-local mutex instead of raw statics that would race under parallel execution.
 static STALE_RECOVERY_OBSERVED_SIGNAL: std::sync::Mutex<Option<StaleRecoverySignal>> =
     std::sync::Mutex::new(None);
 
@@ -192,12 +214,22 @@ fn open_lock_file(lock_path: &Path) -> Result<File, AtmError> {
 fn recover_stale_owner_lock(
     lock_path: &Path,
     stale_pid: u32,
-    stale_token: &str,
+    stale_token: &OwnerToken,
 ) -> Result<File, AtmError> {
-    for _ in 0..STALE_OWNER_RECOVERY_RETRY_ATTEMPTS {
+    for attempt in 0..STALE_OWNER_RECOVERY_RETRY_ATTEMPTS {
         // This retry is only used on stale-owner recovery, not the hot path.
         // OS file-lock APIs do not expose a release notification, so bounded
         // polling is required here and is capped at 3 x 25ms = 75ms total.
+        tracing::debug!(
+            subsystem = "host_ownership",
+            action = "recover_stale_owner_wait",
+            attempt = attempt + 1,
+            attempts = STALE_OWNER_RECOVERY_RETRY_ATTEMPTS,
+            retry_interval_ms = OWNER_RECOVERY_RETRY_INTERVAL.as_millis() as u64,
+            stale_pid,
+            lock_path = %lock_path.display(),
+            "waiting before retrying stale host-runtime owner recovery"
+        );
         thread::sleep(OWNER_RECOVERY_RETRY_INTERVAL);
         let retry_file = open_lock_file(lock_path)?;
         match retry_file.try_lock_exclusive() {
@@ -233,11 +265,17 @@ fn recover_stale_owner_lock(
 fn recorded_owner_identity(
     lock_file: &File,
     lock_path: &Path,
-) -> Result<Option<(u32, String)>, AtmError> {
+) -> Result<Option<(u32, OwnerToken)>, AtmError> {
     match read_owner_record_from_handle(lock_file) {
         Ok(identity) => Ok(identity),
+        #[cfg(windows)]
         Err(error) if is_owner_lock_contention_error(&error) => {
             read_owner_record_from_shadow_path(lock_path)
+        }
+        #[cfg(not(windows))]
+        Err(error) if is_owner_lock_contention_error(&error) => {
+            let _ = error;
+            Ok(read_owner_record_from_shadow_path(lock_path))
         }
         Err(source) => Err(
             AtmError::daemon_unavailable("failed to read daemon ownership record")
@@ -248,7 +286,7 @@ fn recorded_owner_identity(
 
 fn read_owner_record_from_handle(
     lock_file: &File,
-) -> Result<Option<(u32, String)>, std::io::Error> {
+) -> Result<Option<(u32, OwnerToken)>, std::io::Error> {
     let mut clone = lock_file
         .try_clone()
         .map_err(|source| std::io::Error::new(source.kind(), source.to_string()))?;
@@ -258,14 +296,14 @@ fn read_owner_record_from_handle(
     Ok(parse_owner_record(&record))
 }
 
-fn parse_owner_record(record: &str) -> Option<(u32, String)> {
+fn parse_owner_record(record: &str) -> Option<(u32, OwnerToken)> {
     let trimmed = record.trim();
     if trimmed.is_empty() {
         return None;
     }
     let (pid, token) = trimmed.split_once(':').unwrap_or((trimmed, ""));
     let pid = pid.parse::<u32>().ok()?;
-    Some((pid, token.to_string()))
+    Some((pid, OwnerToken::from_record(token)))
 }
 
 #[cfg(windows)]
@@ -279,14 +317,14 @@ fn owner_record_shadow_path(lock_path: &Path) -> PathBuf {
 }
 
 #[cfg(not(windows))]
-fn read_owner_record_from_shadow_path(
-    _lock_path: &Path,
-) -> Result<Option<(u32, String)>, AtmError> {
-    Ok(None)
+fn read_owner_record_from_shadow_path(_lock_path: &Path) -> Option<(u32, OwnerToken)> {
+    None
 }
 
 #[cfg(windows)]
-fn read_owner_record_from_shadow_path(lock_path: &Path) -> Result<Option<(u32, String)>, AtmError> {
+fn read_owner_record_from_shadow_path(
+    lock_path: &Path,
+) -> Result<Option<(u32, OwnerToken)>, AtmError> {
     let shadow_path = owner_record_shadow_path(lock_path);
     let record = match fs::read_to_string(&shadow_path) {
         Ok(record) => record,
@@ -313,9 +351,40 @@ fn sync_owner_record_shadow(lock_path: &Path, record: &str) -> Result<(), AtmErr
     #[cfg(windows)]
     {
         let shadow_path = owner_record_shadow_path(lock_path);
-        fs::write(&shadow_path, record).map_err(|source| {
+        let temp_path = shadow_path.with_file_name(format!(
+            ".{}.tmp.{}.shadow",
+            shadow_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("owner.lock.meta"),
+            std::process::id(),
+        ));
+        {
+            let mut file = File::create(&temp_path).map_err(|source| {
+                AtmError::daemon_unavailable(format!(
+                    "failed to create daemon ownership shadow temp record at {}",
+                    temp_path.display()
+                ))
+                .with_source(source)
+            })?;
+            file.write_all(record.as_bytes()).map_err(|source| {
+                AtmError::daemon_unavailable(format!(
+                    "failed to write daemon ownership shadow temp record at {}",
+                    temp_path.display()
+                ))
+                .with_source(source)
+            })?;
+            file.sync_all().map_err(|source| {
+                AtmError::daemon_unavailable(format!(
+                    "failed to sync daemon ownership shadow temp record at {}",
+                    temp_path.display()
+                ))
+                .with_source(source)
+            })?;
+        }
+        fs::rename(&temp_path, &shadow_path).map_err(|source| {
             AtmError::daemon_unavailable(format!(
-                "failed to write daemon ownership shadow record at {}",
+                "failed to replace daemon ownership shadow record at {}",
                 shadow_path.display()
             ))
             .with_source(source)
@@ -325,14 +394,17 @@ fn sync_owner_record_shadow(lock_path: &Path, record: &str) -> Result<(), AtmErr
 
 #[cfg_attr(windows, allow(dead_code))]
 fn write_owner_record(lock_file: &mut File, lock_path: &Path) -> Result<(), AtmError> {
-    let token = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to derive daemon ownership token")
-                .with_source(source)
-        })?
-        .as_nanos();
-    let record = format!("{}:{token:x}\n", std::process::id());
+    let token = OwnerToken::from_record(format!(
+        "{:x}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|source| {
+                AtmError::daemon_unavailable("failed to derive daemon ownership token")
+                    .with_source(source)
+            })?
+            .as_nanos()
+    ));
+    let record = format!("{}:{token}\n", std::process::id());
     lock_file.set_len(0).map_err(|source| {
         AtmError::daemon_unavailable("failed to reset daemon ownership metadata")
             .with_source(source)
@@ -353,10 +425,10 @@ fn owner_record_matches(
     lock_file: &File,
     lock_path: &Path,
     expected_pid: u32,
-    expected_token: &str,
+    expected_token: &OwnerToken,
 ) -> Result<bool, AtmError> {
     Ok(match recorded_owner_identity(lock_file, lock_path)? {
-        Some((pid, token)) => pid == expected_pid && token == expected_token,
+        Some((pid, token)) => pid == expected_pid && token == *expected_token,
         None => false,
     })
 }
@@ -387,14 +459,14 @@ fn clear_owner_record(lock_file: &mut File, lock_path: &Path) -> Result<(), AtmE
 #[cfg(test)]
 pub(crate) fn recorded_owner_identity_for_guard_for_test(
     guard: &HostOwnershipGuard,
-) -> Result<Option<(u32, String)>, AtmError> {
+) -> Result<Option<(u32, OwnerToken)>, AtmError> {
     recorded_owner_identity(&guard.lock_file, &guard.lock_path)
 }
 
 #[cfg(test)]
 pub(crate) fn recorded_owner_identity_at_path_for_test(
     lock_path: &Path,
-) -> Result<Option<(u32, String)>, AtmError> {
+) -> Result<Option<(u32, OwnerToken)>, AtmError> {
     let file = open_lock_file(lock_path)?;
     recorded_owner_identity(&file, lock_path)
 }

--- a/crates/atm-daemon/src/host_ownership.rs
+++ b/crates/atm-daemon/src/host_ownership.rs
@@ -1,6 +1,6 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -38,6 +38,7 @@ pub(crate) struct HostOwnershipAdapter {
 #[derive(Debug)]
 pub(crate) struct HostOwnershipGuard {
     lock_file: File,
+    lock_path: PathBuf,
 }
 
 #[cfg_attr(windows, allow(dead_code))]
@@ -77,7 +78,7 @@ impl HostOwnershipAdapter {
                 let mut recovered = false;
                 // ADR-002 uses launch.lock for single-launch admission and owner.lock for the
                 // actual serving owner so only one daemon can transition into serving state.
-                if let Some((pid, token)) = recorded_owner_identity(&lock_file)?
+                if let Some((pid, token)) = recorded_owner_identity(&lock_file, &lock_path)?
                     && !atm_core::process::process_is_alive(pid)
                 {
                     #[cfg(test)]
@@ -120,13 +121,16 @@ impl HostOwnershipAdapter {
                 .with_source(source));
             }
         }
-        write_owner_record(&mut lock_file)?;
+        write_owner_record(&mut lock_file, &lock_path)?;
         self.observability.emit_or_warn(
             "acquire_owner_lock",
             "ok",
             "daemon acquired the host-runtime owner lock",
         );
-        Ok(HostOwnershipGuard { lock_file })
+        Ok(HostOwnershipGuard {
+            lock_file,
+            lock_path,
+        })
     }
 }
 
@@ -152,7 +156,7 @@ fn is_owner_lock_contention_error(error: &std::io::Error) -> bool {
 #[cfg_attr(windows, allow(dead_code))]
 impl Drop for HostOwnershipGuard {
     fn drop(&mut self) {
-        let _ = clear_owner_record(&mut self.lock_file);
+        let _ = clear_owner_record(&mut self.lock_file, &self.lock_path);
         let _ = self.lock_file.unlock();
     }
 }
@@ -198,13 +202,13 @@ fn recover_stale_owner_lock(
         let retry_file = open_lock_file(lock_path)?;
         match retry_file.try_lock_exclusive() {
             Ok(()) => {
-                if owner_record_matches(&retry_file, stale_pid, stale_token)? {
+                if owner_record_matches(&retry_file, lock_path, stale_pid, stale_token)? {
                     return Ok(retry_file);
                 }
                 return Err(owner_token_mismatch_error(lock_path, stale_pid));
             }
             Err(source) if is_owner_lock_contention_error(&source) => {
-                if !owner_record_matches(&retry_file, stale_pid, stale_token)? {
+                if !owner_record_matches(&retry_file, lock_path, stale_pid, stale_token)? {
                     return Err(owner_token_mismatch_error(lock_path, stale_pid));
                 }
                 continue;
@@ -226,31 +230,99 @@ fn recover_stale_owner_lock(
     )))
 }
 
-fn recorded_owner_identity(lock_file: &File) -> Result<Option<(u32, String)>, AtmError> {
+fn recorded_owner_identity(
+    lock_file: &File,
+    lock_path: &Path,
+) -> Result<Option<(u32, String)>, AtmError> {
+    match read_owner_record_from_handle(lock_file) {
+        Ok(identity) => Ok(identity),
+        Err(error) if is_owner_lock_contention_error(&error) => {
+            read_owner_record_from_shadow_path(lock_path)
+        }
+        Err(source) => Err(
+            AtmError::daemon_unavailable("failed to read daemon ownership record")
+                .with_source(source),
+        ),
+    }
+}
+
+fn read_owner_record_from_handle(lock_file: &File) -> Result<Option<(u32, String)>, std::io::Error> {
     let mut clone = lock_file.try_clone().map_err(|source| {
-        AtmError::daemon_unavailable("failed to clone daemon ownership record handle")
-            .with_source(source)
+        std::io::Error::new(source.kind(), source.to_string())
     })?;
-    clone.seek(SeekFrom::Start(0)).map_err(|source| {
-        AtmError::daemon_unavailable("failed to seek daemon ownership record").with_source(source)
-    })?;
+    clone.seek(SeekFrom::Start(0))?;
     let mut record = String::new();
-    clone.read_to_string(&mut record).map_err(|source| {
-        AtmError::daemon_unavailable("failed to read daemon ownership record").with_source(source)
-    })?;
+    clone.read_to_string(&mut record)?;
+    Ok(parse_owner_record(&record))
+}
+
+fn parse_owner_record(record: &str) -> Option<(u32, String)> {
     let trimmed = record.trim();
     if trimmed.is_empty() {
-        return Ok(None);
+        return None;
     }
     let (pid, token) = trimmed.split_once(':').unwrap_or((trimmed, ""));
-    let Some(pid) = pid.parse::<u32>().ok() else {
-        return Ok(None);
+    let pid = pid.parse::<u32>().ok()?;
+    Some((pid, token.to_string()))
+}
+
+#[cfg(windows)]
+fn owner_record_shadow_path(lock_path: &Path) -> PathBuf {
+    let mut name = lock_path
+        .file_name()
+        .map(|value| value.to_os_string())
+        .unwrap_or_else(|| "owner.lock".into());
+    name.push(".meta");
+    lock_path.with_file_name(name)
+}
+
+#[cfg(not(windows))]
+fn read_owner_record_from_shadow_path(_lock_path: &Path) -> Result<Option<(u32, String)>, AtmError> {
+    Ok(None)
+}
+
+#[cfg(windows)]
+fn read_owner_record_from_shadow_path(lock_path: &Path) -> Result<Option<(u32, String)>, AtmError> {
+    let shadow_path = owner_record_shadow_path(lock_path);
+    let record = match fs::read_to_string(&shadow_path) {
+        Ok(record) => record,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(
+                AtmError::daemon_unavailable(format!(
+                    "failed to read daemon ownership shadow record at {}",
+                    shadow_path.display()
+                ))
+                .with_source(source),
+            );
+        }
     };
-    Ok(Some((pid, token.to_string())))
+    Ok(parse_owner_record(&record))
+}
+
+fn sync_owner_record_shadow(lock_path: &Path, record: &str) -> Result<(), AtmError> {
+    #[cfg(not(windows))]
+    {
+        let _ = lock_path;
+        let _ = record;
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    {
+        let shadow_path = owner_record_shadow_path(lock_path);
+        fs::write(&shadow_path, record).map_err(|source| {
+            AtmError::daemon_unavailable(format!(
+                "failed to write daemon ownership shadow record at {}",
+                shadow_path.display()
+            ))
+            .with_source(source)
+        })
+    }
 }
 
 #[cfg_attr(windows, allow(dead_code))]
-fn write_owner_record(lock_file: &mut File) -> Result<(), AtmError> {
+fn write_owner_record(lock_file: &mut File, lock_path: &Path) -> Result<(), AtmError> {
     let token = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|source| {
@@ -258,27 +330,30 @@ fn write_owner_record(lock_file: &mut File) -> Result<(), AtmError> {
                 .with_source(source)
         })?
         .as_nanos();
+    let record = format!("{}:{token:x}\n", std::process::id());
     lock_file.set_len(0).map_err(|source| {
         AtmError::daemon_unavailable("failed to reset daemon ownership metadata")
             .with_source(source)
     })?;
-    writeln!(lock_file, "{}:{token:x}", std::process::id()).map_err(|source| {
+    write!(lock_file, "{record}").map_err(|source| {
         AtmError::daemon_unavailable("failed to write daemon ownership metadata")
             .with_source(source)
     })?;
     lock_file.sync_all().map_err(|source| {
         AtmError::daemon_unavailable("failed to sync daemon ownership metadata").with_source(source)
     })?;
+    sync_owner_record_shadow(lock_path, &record)?;
     Ok(())
 }
 
 #[cfg_attr(windows, allow(dead_code))]
 fn owner_record_matches(
     lock_file: &File,
+    lock_path: &Path,
     expected_pid: u32,
     expected_token: &str,
 ) -> Result<bool, AtmError> {
-    Ok(match recorded_owner_identity(lock_file)? {
+    Ok(match recorded_owner_identity(lock_file, lock_path)? {
         Some((pid, token)) => pid == expected_pid && token == expected_token,
         None => false,
     })
@@ -294,7 +369,7 @@ fn owner_token_mismatch_error(lock_path: &Path, stale_pid: u32) -> AtmError {
 }
 
 #[cfg_attr(windows, allow(dead_code))]
-fn clear_owner_record(lock_file: &mut File) -> Result<(), AtmError> {
+fn clear_owner_record(lock_file: &mut File, lock_path: &Path) -> Result<(), AtmError> {
     lock_file.set_len(0).map_err(|source| {
         AtmError::daemon_unavailable("failed to clear daemon ownership metadata")
             .with_source(source)
@@ -303,7 +378,23 @@ fn clear_owner_record(lock_file: &mut File) -> Result<(), AtmError> {
         AtmError::daemon_unavailable("failed to sync cleared daemon ownership metadata")
             .with_source(source)
     })?;
+    sync_owner_record_shadow(lock_path, "")?;
     Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn recorded_owner_identity_for_guard_for_test(
+    guard: &HostOwnershipGuard,
+) -> Result<Option<(u32, String)>, AtmError> {
+    recorded_owner_identity(&guard.lock_file, &guard.lock_path)
+}
+
+#[cfg(test)]
+pub(crate) fn recorded_owner_identity_at_path_for_test(
+    lock_path: &Path,
+) -> Result<Option<(u32, String)>, AtmError> {
+    let file = open_lock_file(lock_path)?;
+    recorded_owner_identity(&file, lock_path)
 }
 
 #[cfg(test)]

--- a/crates/atm-daemon/src/host_ownership.rs
+++ b/crates/atm-daemon/src/host_ownership.rs
@@ -246,10 +246,12 @@ fn recorded_owner_identity(
     }
 }
 
-fn read_owner_record_from_handle(lock_file: &File) -> Result<Option<(u32, String)>, std::io::Error> {
-    let mut clone = lock_file.try_clone().map_err(|source| {
-        std::io::Error::new(source.kind(), source.to_string())
-    })?;
+fn read_owner_record_from_handle(
+    lock_file: &File,
+) -> Result<Option<(u32, String)>, std::io::Error> {
+    let mut clone = lock_file
+        .try_clone()
+        .map_err(|source| std::io::Error::new(source.kind(), source.to_string()))?;
     clone.seek(SeekFrom::Start(0))?;
     let mut record = String::new();
     clone.read_to_string(&mut record)?;
@@ -277,7 +279,9 @@ fn owner_record_shadow_path(lock_path: &Path) -> PathBuf {
 }
 
 #[cfg(not(windows))]
-fn read_owner_record_from_shadow_path(_lock_path: &Path) -> Result<Option<(u32, String)>, AtmError> {
+fn read_owner_record_from_shadow_path(
+    _lock_path: &Path,
+) -> Result<Option<(u32, String)>, AtmError> {
     Ok(None)
 }
 
@@ -288,13 +292,11 @@ fn read_owner_record_from_shadow_path(lock_path: &Path) -> Result<Option<(u32, S
         Ok(record) => record,
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(source) => {
-            return Err(
-                AtmError::daemon_unavailable(format!(
-                    "failed to read daemon ownership shadow record at {}",
-                    shadow_path.display()
-                ))
-                .with_source(source),
-            );
+            return Err(AtmError::daemon_unavailable(format!(
+                "failed to read daemon ownership shadow record at {}",
+                shadow_path.display()
+            ))
+            .with_source(source));
         }
     };
     Ok(parse_owner_record(&record))

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -11,6 +11,9 @@ use interprocess::local_socket::traits::Stream;
 
 use crate::active_connection_registry::{ActiveConnectionRegistry, TrackedDispatchHandle};
 
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+
 #[cfg(test)]
 use super::PreparedRuntimeServer;
 use super::{MAX_CONCURRENT_CONNECTIONS, REQUEST_DEADLINE, write_shutdown_response};
@@ -26,6 +29,19 @@ enum RequestExecutionRisk {
     SideEffecting,
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeadlineSupport {
+    Applied,
+    Unsupported,
+}
+
+enum ReadRequestFrameOutcome {
+    EndOfStream,
+    Frame(atm_core::protocol::FramePayload),
+    TimedOut,
+}
+
 pub(super) fn handle_connection(
     mut stream: LocalSocketStream,
     dispatcher: Arc<dyn RequestDispatcher + Send + Sync>,
@@ -36,10 +52,22 @@ pub(super) fn handle_connection(
     if force_shutdown.load(Ordering::SeqCst) {
         return write_shutdown_response(&mut stream, &codec).map(|_| ());
     }
-    configure_request_deadlines(&stream)?;
+    let read_deadline_support = configure_request_deadlines(&stream)?;
+    let _read_deadline_guard = RequestReadDeadlineGuard::arm(&stream, read_deadline_support)?;
 
-    let Some(frame) = read_request_frame(&mut stream)? else {
-        return Ok(());
+    let frame = match read_request_frame(&mut stream)? {
+        ReadRequestFrameOutcome::EndOfStream => return Ok(()),
+        ReadRequestFrameOutcome::Frame(frame) => frame,
+        ReadRequestFrameOutcome::TimedOut => {
+            tracing::warn!(
+                subsystem = "local_ipc",
+                action = "request_read",
+                outcome = "deadline_exceeded",
+                deadline_ms = REQUEST_DEADLINE.as_millis() as u64,
+                "daemon local IPC request read exceeded the runtime deadline; closing the stalled connection"
+            );
+            return Ok(());
+        }
     };
     tracing::debug!(
         max_daemon_frame_bytes = atm_core::protocol::MAX_DAEMON_FRAME_BYTES,
@@ -63,25 +91,31 @@ pub(super) fn handle_connection(
     Ok(())
 }
 
-fn configure_request_deadlines(stream: &LocalSocketStream) -> Result<(), AtmError> {
-    apply_deadline(
+fn configure_request_deadlines(stream: &LocalSocketStream) -> Result<DeadlineSupport, AtmError> {
+    let read_deadline_support = apply_optional_deadline(
         stream.set_recv_timeout(Some(REQUEST_DEADLINE)),
         "failed to apply daemon request read deadline",
     )?;
-    apply_deadline(
+    apply_optional_deadline(
         stream.set_send_timeout(Some(REQUEST_DEADLINE)),
         "failed to apply daemon response write deadline",
-    )
+    )?;
+    Ok(read_deadline_support)
 }
 
-fn read_request_frame(
-    stream: &mut LocalSocketStream,
-) -> Result<Option<atm_core::protocol::FramePayload>, AtmError> {
-    atm_core::protocol::read_frame(
+fn read_request_frame(stream: &mut LocalSocketStream) -> Result<ReadRequestFrameOutcome, AtmError> {
+    match atm_core::protocol::read_frame(
         stream,
         "failed to read daemon request frame",
         "daemon request frame exceeded the maximum supported size",
-    )
+    ) {
+        Ok(Some(frame)) => Ok(ReadRequestFrameOutcome::Frame(frame)),
+        Ok(None) => Ok(ReadRequestFrameOutcome::EndOfStream),
+        Err(error) if is_windows_named_pipe_deadline_abort(&error) => {
+            Ok(ReadRequestFrameOutcome::TimedOut)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn dispatch_advisory_stream(
@@ -92,7 +126,7 @@ fn dispatch_advisory_stream(
     request_id: RequestId,
     request: atm_core::AdvisoryStreamRequest,
 ) -> Result<(), AtmError> {
-    apply_deadline(
+    apply_deadline_contract(
         stream.set_send_timeout(Some(REQUEST_DEADLINE)),
         "failed to apply daemon advisory-stream write deadline",
     )?;
@@ -105,17 +139,153 @@ fn dispatch_advisory_stream(
     dispatcher.dispatch_advisory_stream(request, &mut sink)
 }
 
-fn apply_deadline(result: std::io::Result<()>, message: &'static str) -> Result<(), AtmError> {
+fn apply_deadline_contract(
+    result: std::io::Result<()>,
+    message: &'static str,
+) -> Result<(), AtmError> {
+    match apply_optional_deadline(result, message)? {
+        DeadlineSupport::Applied | DeadlineSupport::Unsupported => Ok(()),
+    }
+}
+
+fn apply_optional_deadline(
+    result: std::io::Result<()>,
+    message: &'static str,
+) -> Result<DeadlineSupport, AtmError> {
     match result {
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(DeadlineSupport::Applied),
         #[cfg(windows)]
-        Err(source) if source.kind() == std::io::ErrorKind::Unsupported => Ok(()),
+        Err(source) if source.kind() == std::io::ErrorKind::Unsupported => {
+            Ok(DeadlineSupport::Unsupported)
+        }
         Err(source) => Err(AtmError::daemon_unavailable(message)
             .with_recovery(
                 "Restart the daemon; the same-host request socket could not apply its bounded deadline.",
             )
             .with_source(source)),
     }
+}
+
+struct RequestReadDeadlineGuard {
+    #[cfg(windows)]
+    watchdog: Option<std::thread::JoinHandle<()>>,
+    #[cfg(windows)]
+    cancel_tx: Option<std::sync::mpsc::Sender<()>>,
+}
+
+impl RequestReadDeadlineGuard {
+    fn arm(
+        stream: &LocalSocketStream,
+        read_deadline_support: DeadlineSupport,
+    ) -> Result<Self, AtmError> {
+        #[cfg(not(windows))]
+        {
+            let _ = stream;
+            let _ = read_deadline_support;
+            Ok(Self {})
+        }
+
+        #[cfg(windows)]
+        {
+            if read_deadline_support != DeadlineSupport::Unsupported {
+                return Ok(Self {
+                    watchdog: None,
+                    cancel_tx: None,
+                });
+            }
+
+            let handle = stream.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE;
+            let (cancel_tx, cancel_rx) = std::sync::mpsc::channel();
+            let watchdog = std::thread::Builder::new()
+                .name("local-ipc-read-watchdog".to_string())
+                .spawn(move || match cancel_rx.recv_timeout(REQUEST_DEADLINE) {
+                    Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {}
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                        if let Err(error) = cancel_windows_named_pipe_io(handle) {
+                            tracing::warn!(
+                                %error,
+                                subsystem = "local_ipc",
+                                action = "request_read_watchdog_cancel",
+                                deadline_ms = REQUEST_DEADLINE.as_millis() as u64,
+                                "failed to cancel a stalled Windows named-pipe request read after the bounded runtime deadline"
+                            );
+                        }
+                    }
+                })
+                .map_err(|source| {
+                    AtmError::daemon_unavailable(
+                        "failed to spawn Windows named-pipe request read watchdog",
+                    )
+                    .with_recovery(
+                        "Restart the daemon; the same-host Windows request watchdog could not be created.",
+                    )
+                    .with_source(source)
+                })?;
+            Ok(Self {
+                watchdog: Some(watchdog),
+                cancel_tx: Some(cancel_tx),
+            })
+        }
+    }
+}
+
+impl Drop for RequestReadDeadlineGuard {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        {
+            if let Some(cancel_tx) = self.cancel_tx.take() {
+                let _ = cancel_tx.send(());
+            }
+            if let Some(watchdog) = self.watchdog.take()
+                && watchdog.join().is_err()
+            {
+                tracing::warn!(
+                    subsystem = "local_ipc",
+                    action = "request_read_watchdog_join",
+                    "Windows named-pipe request read watchdog panicked during teardown"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+fn cancel_windows_named_pipe_io(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+) -> std::io::Result<()> {
+    use std::ptr;
+
+    use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
+    use windows_sys::Win32::System::IO::CancelIoEx;
+
+    let cancelled = unsafe { CancelIoEx(handle, ptr::null_mut()) };
+    if cancelled != 0 {
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(ERROR_NOT_FOUND as i32) {
+        return Ok(());
+    }
+    Err(error)
+}
+
+#[cfg(not(windows))]
+fn is_windows_named_pipe_deadline_abort(_error: &AtmError) -> bool {
+    false
+}
+
+#[cfg(windows)]
+fn is_windows_named_pipe_deadline_abort(error: &AtmError) -> bool {
+    use windows_sys::Win32::Foundation::ERROR_OPERATION_ABORTED;
+
+    error
+        .source
+        .as_ref()
+        .and_then(|source| source.downcast_ref::<std::io::Error>())
+        .is_some_and(|source| {
+            source.kind() == std::io::ErrorKind::Interrupted
+                || source.raw_os_error() == Some(ERROR_OPERATION_ABORTED as i32)
+        })
 }
 
 fn dispatch_request(

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -11,9 +11,6 @@ use interprocess::local_socket::traits::Stream;
 
 use crate::active_connection_registry::{ActiveConnectionRegistry, TrackedDispatchHandle};
 
-#[cfg(windows)]
-use std::os::windows::io::AsRawHandle;
-
 #[cfg(test)]
 use super::PreparedRuntimeServer;
 use super::{MAX_CONCURRENT_CONNECTIONS, REQUEST_DEADLINE, write_shutdown_response};
@@ -36,9 +33,17 @@ enum DeadlineSupport {
     Unsupported,
 }
 
-enum ReadRequestFrameOutcome {
+#[cfg(windows)]
+const WINDOWS_READ_HELPER_POLL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(100);
+
+enum ReadRequestFrameResult {
     EndOfStream,
-    Frame(atm_core::protocol::FramePayload),
+    Frame {
+        stream: LocalSocketStream,
+        frame: atm_core::protocol::FramePayload,
+    },
+    #[cfg(windows)]
     TimedOut,
 }
 
@@ -53,12 +58,32 @@ pub(super) fn handle_connection(
         return write_shutdown_response(&mut stream, &codec).map(|_| ());
     }
     let read_deadline_support = configure_request_deadlines(&stream)?;
-    let _read_deadline_guard = RequestReadDeadlineGuard::arm(&stream, read_deadline_support)?;
 
-    let frame = match read_request_frame(&mut stream)? {
-        ReadRequestFrameOutcome::EndOfStream => return Ok(()),
-        ReadRequestFrameOutcome::Frame(frame) => frame,
-        ReadRequestFrameOutcome::TimedOut => {
+    let frame = match read_request_frame_with_deadline(
+        stream,
+        force_shutdown,
+        read_deadline_support,
+    )? {
+        ReadRequestFrameResult::EndOfStream => return Ok(()),
+        ReadRequestFrameResult::Frame {
+            stream: resumed_stream,
+            frame,
+        } => {
+            stream = resumed_stream;
+            frame
+        }
+        #[cfg(windows)]
+        ReadRequestFrameResult::TimedOut if force_shutdown.load(Ordering::SeqCst) => {
+            tracing::info!(
+                subsystem = "local_ipc",
+                action = "request_read",
+                outcome = "forced_shutdown",
+                "daemon forced shutdown interrupted a Windows same-host request read before a complete frame arrived"
+            );
+            return Ok(());
+        }
+        #[cfg(windows)]
+        ReadRequestFrameResult::TimedOut => {
             tracing::warn!(
                 subsystem = "local_ipc",
                 action = "request_read",
@@ -91,6 +116,80 @@ pub(super) fn handle_connection(
     Ok(())
 }
 
+fn read_request_frame_with_deadline(
+    mut stream: LocalSocketStream,
+    force_shutdown: &AtomicBool,
+    read_deadline_support: DeadlineSupport,
+) -> Result<ReadRequestFrameResult, AtmError> {
+    #[cfg(windows)]
+    if read_deadline_support == DeadlineSupport::Unsupported {
+        return read_request_frame_with_helper(stream, force_shutdown);
+    }
+    #[cfg(not(windows))]
+    let _ = (force_shutdown, read_deadline_support);
+
+    match read_request_frame(&mut stream)? {
+        None => Ok(ReadRequestFrameResult::EndOfStream),
+        Some(frame) => Ok(ReadRequestFrameResult::Frame { stream, frame }),
+    }
+}
+
+#[cfg(windows)]
+fn read_request_frame_with_helper(
+    mut stream: LocalSocketStream,
+    force_shutdown: &AtomicBool,
+) -> Result<ReadRequestFrameResult, AtmError> {
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("local-ipc-read-helper".to_string())
+        .spawn(move || {
+            let result = read_request_frame(&mut stream);
+            let _ = result_tx.send((stream, result));
+        })
+        .map_err(|source| {
+            AtmError::daemon_unavailable("failed to spawn Windows named-pipe request read helper")
+                .with_recovery(
+                    "Restart the daemon; the same-host Windows request read helper could not be created.",
+                )
+                .with_source(source)
+        })?;
+
+    let started = std::time::Instant::now();
+    loop {
+        let remaining = REQUEST_DEADLINE.saturating_sub(started.elapsed());
+        if remaining.is_zero() || force_shutdown.load(Ordering::SeqCst) {
+            return Ok(ReadRequestFrameResult::TimedOut);
+        }
+        let poll = std::cmp::min(remaining, WINDOWS_READ_HELPER_POLL_INTERVAL);
+        match result_rx.recv_timeout(poll) {
+            Ok((stream, Ok(Some(frame)))) => {
+                return Ok(ReadRequestFrameResult::Frame { stream, frame });
+            }
+            Ok((_, Ok(None))) => return Ok(ReadRequestFrameResult::EndOfStream),
+            Ok((_, Err(error))) => return Err(error),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(AtmError::daemon_unavailable(
+                    "Windows named-pipe request read helper disconnected unexpectedly",
+                )
+                .with_recovery(
+                    "Restart the daemon; the same-host Windows request read helper stopped before it could return a frame result.",
+                ));
+            }
+        }
+    }
+}
+
+fn read_request_frame(
+    stream: &mut LocalSocketStream,
+) -> Result<Option<atm_core::protocol::FramePayload>, AtmError> {
+    atm_core::protocol::read_frame(
+        stream,
+        "failed to read daemon request frame",
+        "daemon request frame exceeded the maximum supported size",
+    )
+}
+
 fn configure_request_deadlines(stream: &LocalSocketStream) -> Result<DeadlineSupport, AtmError> {
     let read_deadline_support = apply_optional_deadline(
         stream.set_recv_timeout(Some(REQUEST_DEADLINE)),
@@ -101,21 +200,6 @@ fn configure_request_deadlines(stream: &LocalSocketStream) -> Result<DeadlineSup
         "failed to apply daemon response write deadline",
     )?;
     Ok(read_deadline_support)
-}
-
-fn read_request_frame(stream: &mut LocalSocketStream) -> Result<ReadRequestFrameOutcome, AtmError> {
-    match atm_core::protocol::read_frame(
-        stream,
-        "failed to read daemon request frame",
-        "daemon request frame exceeded the maximum supported size",
-    ) {
-        Ok(Some(frame)) => Ok(ReadRequestFrameOutcome::Frame(frame)),
-        Ok(None) => Ok(ReadRequestFrameOutcome::EndOfStream),
-        Err(error) if is_windows_named_pipe_deadline_abort(&error) => {
-            Ok(ReadRequestFrameOutcome::TimedOut)
-        }
-        Err(error) => Err(error),
-    }
 }
 
 fn dispatch_advisory_stream(
@@ -164,128 +248,6 @@ fn apply_optional_deadline(
             )
             .with_source(source)),
     }
-}
-
-struct RequestReadDeadlineGuard {
-    #[cfg(windows)]
-    watchdog: Option<std::thread::JoinHandle<()>>,
-    #[cfg(windows)]
-    cancel_tx: Option<std::sync::mpsc::Sender<()>>,
-}
-
-impl RequestReadDeadlineGuard {
-    fn arm(
-        stream: &LocalSocketStream,
-        read_deadline_support: DeadlineSupport,
-    ) -> Result<Self, AtmError> {
-        #[cfg(not(windows))]
-        {
-            let _ = stream;
-            let _ = read_deadline_support;
-            Ok(Self {})
-        }
-
-        #[cfg(windows)]
-        {
-            if read_deadline_support != DeadlineSupport::Unsupported {
-                return Ok(Self {
-                    watchdog: None,
-                    cancel_tx: None,
-                });
-            }
-
-            let handle = stream.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE;
-            let (cancel_tx, cancel_rx) = std::sync::mpsc::channel();
-            let watchdog = std::thread::Builder::new()
-                .name("local-ipc-read-watchdog".to_string())
-                .spawn(move || match cancel_rx.recv_timeout(REQUEST_DEADLINE) {
-                    Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {}
-                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                        if let Err(error) = cancel_windows_named_pipe_io(handle) {
-                            tracing::warn!(
-                                %error,
-                                subsystem = "local_ipc",
-                                action = "request_read_watchdog_cancel",
-                                deadline_ms = REQUEST_DEADLINE.as_millis() as u64,
-                                "failed to cancel a stalled Windows named-pipe request read after the bounded runtime deadline"
-                            );
-                        }
-                    }
-                })
-                .map_err(|source| {
-                    AtmError::daemon_unavailable(
-                        "failed to spawn Windows named-pipe request read watchdog",
-                    )
-                    .with_recovery(
-                        "Restart the daemon; the same-host Windows request watchdog could not be created.",
-                    )
-                    .with_source(source)
-                })?;
-            Ok(Self {
-                watchdog: Some(watchdog),
-                cancel_tx: Some(cancel_tx),
-            })
-        }
-    }
-}
-
-impl Drop for RequestReadDeadlineGuard {
-    fn drop(&mut self) {
-        #[cfg(windows)]
-        {
-            if let Some(cancel_tx) = self.cancel_tx.take() {
-                let _ = cancel_tx.send(());
-            }
-            if let Some(watchdog) = self.watchdog.take()
-                && watchdog.join().is_err()
-            {
-                tracing::warn!(
-                    subsystem = "local_ipc",
-                    action = "request_read_watchdog_join",
-                    "Windows named-pipe request read watchdog panicked during teardown"
-                );
-            }
-        }
-    }
-}
-
-#[cfg(windows)]
-fn cancel_windows_named_pipe_io(
-    handle: windows_sys::Win32::Foundation::HANDLE,
-) -> std::io::Result<()> {
-    use std::ptr;
-
-    use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
-    use windows_sys::Win32::System::IO::CancelIoEx;
-
-    let cancelled = unsafe { CancelIoEx(handle, ptr::null_mut()) };
-    if cancelled != 0 {
-        return Ok(());
-    }
-    let error = std::io::Error::last_os_error();
-    if error.raw_os_error() == Some(ERROR_NOT_FOUND as i32) {
-        return Ok(());
-    }
-    Err(error)
-}
-
-#[cfg(not(windows))]
-fn is_windows_named_pipe_deadline_abort(_error: &AtmError) -> bool {
-    false
-}
-
-#[cfg(windows)]
-fn is_windows_named_pipe_deadline_abort(error: &AtmError) -> bool {
-    use windows_sys::Win32::Foundation::ERROR_OPERATION_ABORTED;
-
-    error
-        .source
-        .as_ref()
-        .and_then(|source| source.downcast_ref::<std::io::Error>())
-        .is_some_and(|source| {
-            source.kind() == std::io::ErrorKind::Interrupted
-                || source.raw_os_error() == Some(ERROR_OPERATION_ABORTED as i32)
-        })
 }
 
 fn dispatch_request(

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -64,24 +64,8 @@ pub(super) fn handle_connection(
 }
 
 fn configure_request_deadlines(stream: &LocalSocketStream) -> Result<(), AtmError> {
-    stream
-        .set_recv_timeout(Some(REQUEST_DEADLINE))
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to apply daemon request read deadline")
-                .with_recovery(
-                    "Restart the daemon; the same-host request socket could not apply its bounded read deadline.",
-                )
-                .with_source(source)
-        })?;
-    stream
-        .set_send_timeout(Some(REQUEST_DEADLINE))
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to apply daemon response write deadline")
-                .with_recovery(
-                    "Restart the daemon; the same-host request socket could not apply its bounded write deadline.",
-                )
-                .with_source(source)
-        })
+    apply_deadline(stream.set_recv_timeout(Some(REQUEST_DEADLINE)), "failed to apply daemon request read deadline")?;
+    apply_deadline(stream.set_send_timeout(Some(REQUEST_DEADLINE)), "failed to apply daemon response write deadline")
 }
 
 fn read_request_frame(
@@ -102,13 +86,10 @@ fn dispatch_advisory_stream(
     request_id: RequestId,
     request: atm_core::AdvisoryStreamRequest,
 ) -> Result<(), AtmError> {
-    stream.set_send_timeout(Some(REQUEST_DEADLINE)).map_err(|source| {
-        AtmError::daemon_unavailable("failed to apply daemon advisory-stream write deadline")
-            .with_recovery(
-                "Restart the daemon; the same-host advisory stream socket could not apply its bounded write deadline.",
-            )
-            .with_source(source)
-    })?;
+    apply_deadline(
+        stream.set_send_timeout(Some(REQUEST_DEADLINE)),
+        "failed to apply daemon advisory-stream write deadline",
+    )?;
     let mut sink = LocalIpcAdvisoryStreamSink {
         stream,
         codec,
@@ -116,6 +97,19 @@ fn dispatch_advisory_stream(
         force_shutdown,
     };
     dispatcher.dispatch_advisory_stream(request, &mut sink)
+}
+
+fn apply_deadline(result: std::io::Result<()>, message: &'static str) -> Result<(), AtmError> {
+    match result {
+        Ok(()) => Ok(()),
+        #[cfg(windows)]
+        Err(source) if source.kind() == std::io::ErrorKind::Unsupported => Ok(()),
+        Err(source) => Err(AtmError::daemon_unavailable(message)
+            .with_recovery(
+                "Restart the daemon; the same-host request socket could not apply its bounded deadline.",
+            )
+            .with_source(source)),
+    }
 }
 
 fn dispatch_request(

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -64,8 +64,14 @@ pub(super) fn handle_connection(
 }
 
 fn configure_request_deadlines(stream: &LocalSocketStream) -> Result<(), AtmError> {
-    apply_deadline(stream.set_recv_timeout(Some(REQUEST_DEADLINE)), "failed to apply daemon request read deadline")?;
-    apply_deadline(stream.set_send_timeout(Some(REQUEST_DEADLINE)), "failed to apply daemon response write deadline")
+    apply_deadline(
+        stream.set_recv_timeout(Some(REQUEST_DEADLINE)),
+        "failed to apply daemon request read deadline",
+    )?;
+    apply_deadline(
+        stream.set_send_timeout(Some(REQUEST_DEADLINE)),
+        "failed to apply daemon response write deadline",
+    )
 }
 
 fn read_request_frame(

--- a/crates/atm-daemon/src/local_ipc_wake.rs
+++ b/crates/atm-daemon/src/local_ipc_wake.rs
@@ -9,6 +9,12 @@ use interprocess::local_socket::prelude::*;
 const LISTENER_WAKE_CONNECT_DEADLINE: Duration = Duration::from_millis(250);
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeadlineSupport {
+    Applied,
+    Unsupported,
+}
+
 pub(crate) fn schedule_delayed_listener_wake(
     endpoint_path: PathBuf,
     delay: Duration,
@@ -78,29 +84,16 @@ pub(crate) fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {
             ));
         }
     };
-    if let Err(source) = stream.set_send_timeout(Some(REQUEST_DEADLINE)) {
-        #[cfg(not(windows))]
-        {
-            return Err(
-                AtmError::daemon_unavailable("failed to apply daemon listener wake timeout")
-                    .with_recovery(
-                        "Restart the daemon; the shutdown wake connection could not apply its bounded send deadline.",
-                    )
-                    .with_source(source),
-            );
-        }
-        #[cfg(windows)]
-        {
-            if source.kind() != std::io::ErrorKind::Unsupported {
-                return Err(
-                    AtmError::daemon_unavailable("failed to apply daemon listener wake timeout")
-                        .with_recovery(
-                            "Restart the daemon; the shutdown wake connection could not apply its bounded send deadline.",
-                        )
-                        .with_source(source),
-                );
-            }
-        }
+    let send_deadline_support = apply_listener_wake_deadline(
+        stream.set_send_timeout(Some(REQUEST_DEADLINE)),
+        "failed to apply daemon listener wake timeout",
+    )?;
+    if send_deadline_support == DeadlineSupport::Unsupported {
+        // The wake path only needs the connect itself to unblock accept(). On Windows named
+        // pipes, explicit flush can block until the peer drains the send buffer, so once the
+        // timeout API is reported as unsupported we drop the empty wake connection immediately
+        // instead of reintroducing an unbounded wait while shutting the daemon down.
+        return Ok(());
     }
     stream.flush().map_err(|source| {
         AtmError::daemon_unavailable("failed to flush daemon listener wake signal")
@@ -110,4 +103,22 @@ pub(crate) fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {
             .with_source(source)
     })?;
     Ok(())
+}
+
+fn apply_listener_wake_deadline(
+    result: std::io::Result<()>,
+    message: &'static str,
+) -> Result<DeadlineSupport, AtmError> {
+    match result {
+        Ok(()) => Ok(DeadlineSupport::Applied),
+        #[cfg(windows)]
+        Err(source) if source.kind() == std::io::ErrorKind::Unsupported => {
+            Ok(DeadlineSupport::Unsupported)
+        }
+        Err(source) => Err(AtmError::daemon_unavailable(message)
+            .with_recovery(
+                "Restart the daemon; the shutdown wake connection could not apply its bounded send deadline.",
+            )
+            .with_source(source)),
+    }
 }

--- a/crates/atm-daemon/src/local_ipc_wake.rs
+++ b/crates/atm-daemon/src/local_ipc_wake.rs
@@ -78,15 +78,30 @@ pub(crate) fn wake_listener(endpoint_path: &Path) -> Result<(), AtmError> {
             ));
         }
     };
-    stream
-        .set_send_timeout(Some(REQUEST_DEADLINE))
-        .map_err(|source| {
-            AtmError::daemon_unavailable("failed to apply daemon listener wake timeout")
-                .with_recovery(
-                    "Restart the daemon; the shutdown wake connection could not apply its bounded send deadline.",
-                )
-                .with_source(source)
-        })?;
+    if let Err(source) = stream.set_send_timeout(Some(REQUEST_DEADLINE)) {
+        #[cfg(not(windows))]
+        {
+            return Err(
+                AtmError::daemon_unavailable("failed to apply daemon listener wake timeout")
+                    .with_recovery(
+                        "Restart the daemon; the shutdown wake connection could not apply its bounded send deadline.",
+                    )
+                    .with_source(source),
+            );
+        }
+        #[cfg(windows)]
+        {
+            if source.kind() != std::io::ErrorKind::Unsupported {
+                return Err(
+                    AtmError::daemon_unavailable("failed to apply daemon listener wake timeout")
+                        .with_recovery(
+                            "Restart the daemon; the shutdown wake connection could not apply its bounded send deadline.",
+                        )
+                        .with_source(source),
+                );
+            }
+        }
+    }
     stream.flush().map_err(|source| {
         AtmError::daemon_unavailable("failed to flush daemon listener wake signal")
             .with_recovery(

--- a/crates/atm-daemon/src/test_support.rs
+++ b/crates/atm-daemon/src/test_support.rs
@@ -11,6 +11,10 @@ use crate::lifecycle_control::LifecycleControlSourceAdapter;
 
 const TEST_LOCAL_IPC_CONNECT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
 const TEST_LOCAL_IPC_REQUEST_DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
+const TEST_LOCAL_IPC_CONNECT_RETRY_INITIAL_DELAY: std::time::Duration =
+    std::time::Duration::from_millis(1);
+const TEST_LOCAL_IPC_CONNECT_RETRY_MAX_DELAY: std::time::Duration =
+    std::time::Duration::from_millis(25);
 
 pub(crate) struct LifecycleFlagResetGuard {
     lifecycle: LifecycleControlSourceAdapter,
@@ -107,6 +111,7 @@ pub(crate) fn connect_daemon_local_ipc_until_ready(
         .into_owned();
     let deadline = std::time::Instant::now() + TEST_LOCAL_IPC_CONNECT_DEADLINE;
     let mut attempts = 0usize;
+    let mut retry_delay = TEST_LOCAL_IPC_CONNECT_RETRY_INITIAL_DELAY;
     let mut last_error = None;
     while std::time::Instant::now() < deadline {
         match connect_local_ipc_with_timeout(ipc_name.clone(), TEST_LOCAL_IPC_CONNECT_DEADLINE) {
@@ -116,7 +121,11 @@ pub(crate) fn connect_daemon_local_ipc_until_ready(
                 last_error = Some(error);
                 // The ready signal is the structural synchronization point; this retry only
                 // covers the residual OS socket publication race after readiness.
-                std::thread::sleep(std::time::Duration::from_millis(1));
+                std::thread::sleep(retry_delay);
+                retry_delay = std::cmp::min(
+                    retry_delay.saturating_mul(2),
+                    TEST_LOCAL_IPC_CONNECT_RETRY_MAX_DELAY,
+                );
             }
         }
     }
@@ -153,22 +162,24 @@ pub(crate) fn connect_local_ipc_with_timeout(
 }
 
 pub(crate) fn configure_test_local_ipc_timeouts(stream: &LocalSocketStream) {
-    if let Err(error) = stream.set_send_timeout(Some(TEST_LOCAL_IPC_REQUEST_DEADLINE)) {
+    apply_test_deadline(
+        stream.set_send_timeout(Some(TEST_LOCAL_IPC_REQUEST_DEADLINE)),
+        "set send timeout",
+    );
+    apply_test_deadline(
+        stream.set_recv_timeout(Some(TEST_LOCAL_IPC_REQUEST_DEADLINE)),
+        "set recv timeout",
+    );
+}
+
+fn apply_test_deadline(result: std::io::Result<()>, context: &str) {
+    if let Err(error) = result {
         #[cfg(windows)]
         {
             if error.kind() == std::io::ErrorKind::Unsupported {
                 return;
             }
         }
-        panic!("set send timeout: {error}");
-    }
-    if let Err(error) = stream.set_recv_timeout(Some(TEST_LOCAL_IPC_REQUEST_DEADLINE)) {
-        #[cfg(windows)]
-        {
-            if error.kind() == std::io::ErrorKind::Unsupported {
-                return;
-            }
-        }
-        panic!("set recv timeout: {error}");
+        panic!("{context}: {error}");
     }
 }

--- a/crates/atm-daemon/src/test_support.rs
+++ b/crates/atm-daemon/src/test_support.rs
@@ -3,10 +3,14 @@ use atm_core::doctor::{DoctorEnvironmentVisibility, DoctorReport, DoctorStatus, 
 use atm_core::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
 use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
 
+use interprocess::local_socket::Name as LocalSocketName;
 use interprocess::local_socket::Stream as LocalSocketStream;
 use interprocess::local_socket::traits::Stream as _;
 
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
+
+const TEST_LOCAL_IPC_CONNECT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
+const TEST_LOCAL_IPC_REQUEST_DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
 
 pub(crate) struct LifecycleFlagResetGuard {
     lifecycle: LifecycleControlSourceAdapter,
@@ -98,13 +102,14 @@ pub(crate) fn connect_daemon_local_ipc_until_ready(
             panic!("daemon local ipc ready signal sender dropped before readiness")
         }
     }
-    let ipc_name =
-        atm_core::protocol::daemon_local_ipc_name_from_path(endpoint_path).expect("ipc name");
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let ipc_name = atm_core::protocol::daemon_local_ipc_name_from_path(endpoint_path)
+        .expect("ipc name")
+        .into_owned();
+    let deadline = std::time::Instant::now() + TEST_LOCAL_IPC_CONNECT_DEADLINE;
     let mut attempts = 0usize;
     let mut last_error = None;
     while std::time::Instant::now() < deadline {
-        match LocalSocketStream::connect(ipc_name.clone()) {
+        match connect_local_ipc_with_timeout(ipc_name.clone(), TEST_LOCAL_IPC_CONNECT_DEADLINE) {
             Ok(stream) => return stream,
             Err(error) => {
                 attempts += 1;
@@ -121,4 +126,49 @@ pub(crate) fn connect_daemon_local_ipc_until_ready(
             .map(|error| error.to_string())
             .unwrap_or_else(|| "unknown connect error".to_string())
     )
+}
+
+pub(crate) fn connect_local_ipc_with_timeout(
+    ipc_name: LocalSocketName<'static>,
+    timeout: std::time::Duration,
+) -> std::io::Result<LocalSocketStream> {
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("test-local-ipc-connect".to_string())
+        .spawn(move || {
+            let _ = result_tx.send(LocalSocketStream::connect(ipc_name));
+        })
+        .expect("spawn bounded local IPC connect helper");
+    match result_rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "bounded local IPC connect timed out",
+        )),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::new(
+            std::io::ErrorKind::ConnectionAborted,
+            "bounded local IPC connect worker disconnected",
+        )),
+    }
+}
+
+pub(crate) fn configure_test_local_ipc_timeouts(stream: &LocalSocketStream) {
+    if let Err(error) = stream.set_send_timeout(Some(TEST_LOCAL_IPC_REQUEST_DEADLINE)) {
+        #[cfg(windows)]
+        {
+            if error.kind() == std::io::ErrorKind::Unsupported {
+                return;
+            }
+        }
+        panic!("set send timeout: {error}");
+    }
+    if let Err(error) = stream.set_recv_timeout(Some(TEST_LOCAL_IPC_REQUEST_DEADLINE)) {
+        #[cfg(windows)]
+        {
+            if error.kind() == std::io::ErrorKind::Unsupported {
+                return;
+            }
+        }
+        panic!("set recv timeout: {error}");
+    }
 }

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -30,9 +30,6 @@ use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_runtime_test_support::SQLITE_RUNTIME_PATH_ENV;
 use atm_runtime_test_support::install_sqlite_retained_runtime_factory;
 use atm_rusqlite::assemble_boundary;
-#[cfg(windows)]
-use interprocess::local_socket::Stream as LocalSocketStream;
-use interprocess::local_socket::traits::Stream as _;
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -40,7 +37,10 @@ use std::sync::mpsc;
 use std::time::Duration;
 use tempfile::TempDir;
 
-use crate::test_support::connect_daemon_local_ipc_until_ready;
+use crate::test_support::{
+    configure_test_local_ipc_timeouts, connect_daemon_local_ipc_until_ready,
+    connect_local_ipc_with_timeout,
+};
 
 const TEST_TEAM: &str = "test-team";
 fn test_team() -> &'static TeamName {
@@ -121,12 +121,7 @@ fn local_ipc_runtime_round_trips_doctor_requests_on_shared_transport() {
     });
 
     let mut stream = connect_daemon_local_ipc_until_ready(&socket_path, ready_rx);
-    stream
-        .set_send_timeout(Some(Duration::from_secs(5)))
-        .expect("set send timeout");
-    stream
-        .set_recv_timeout(Some(Duration::from_secs(5)))
-        .expect("set recv timeout");
+    configure_test_local_ipc_timeouts(&stream);
     let request = RequestEnvelope::Doctor(DoctorQuery {
         home_dir: tempdir.path().join("home"),
         current_dir: tempdir.path().join("cwd"),
@@ -170,6 +165,10 @@ fn compose_runtime_start_writes_retained_log_and_reports_healthy_observability()
     let _env = EnvGuard::set_many([
         ("ATM_HOME", Some(atm_home.to_str().expect("utf8 atm home"))),
         (
+            "ATM_CONFIG_HOME",
+            Some(tempdir.path().to_str().expect("utf8 config home")),
+        ),
+        (
             SQLITE_RUNTIME_PATH_ENV,
             Some(db_path.to_str().expect("utf8 sqlite db path")),
         ),
@@ -199,12 +198,7 @@ fn compose_runtime_start_writes_retained_log_and_reports_healthy_observability()
     });
 
     let mut stream = connect_daemon_local_ipc_until_ready(&socket_path, ready_rx);
-    stream
-        .set_send_timeout(Some(Duration::from_secs(5)))
-        .expect("set send timeout");
-    stream
-        .set_recv_timeout(Some(Duration::from_secs(5)))
-        .expect("set recv timeout");
+    configure_test_local_ipc_timeouts(&stream);
     let request = RequestEnvelope::Doctor(DoctorQuery {
         home_dir: atm_home.clone(),
         current_dir: atm_home.clone(),
@@ -249,6 +243,17 @@ fn compose_runtime_start_writes_retained_log_and_reports_healthy_observability()
 #[serial_test::serial(env)]
 fn windows_local_ipc_runtime_terminate_finishes_within_deadline() {
     let tempdir = TempDir::new().expect("tempdir");
+    let atm_home = tempdir.path().join("atm-home");
+    std::fs::create_dir_all(&atm_home).expect("atm home dir");
+    let _env = EnvGuard::set_many([
+        ("ATM_HOME", Some(atm_home.to_str().expect("utf8 atm home"))),
+        (
+            "ATM_CONFIG_HOME",
+            Some(tempdir.path().to_str().expect("utf8 config home")),
+        ),
+        ("HOME", Some(tempdir.path().to_str().expect("utf8 home"))),
+        ("USERPROFILE", None),
+    ]);
     let socket_path = tempdir.path().join("daemon.sock");
     let server_transport = LocalIpcServerTransportAdapter::new();
     let runtime = server_transport
@@ -296,7 +301,7 @@ fn windows_local_ipc_runtime_terminate_finishes_within_deadline() {
         .expect("serve runtime result");
     join.join().expect("join serve thread");
     assert!(
-        LocalSocketStream::connect(local_ipc_name).is_err(),
+        connect_local_ipc_with_timeout(local_ipc_name, Duration::from_millis(250)).is_err(),
         "windows same-host runtime should reject new local IPC connections after shutdown",
     );
 }
@@ -364,6 +369,10 @@ fn production_runtime_installs_daemon_notification_sink() {
 
     let _env = EnvGuard::set_many([
         ("ATM_HOME", Some(atm_home.to_str().expect("utf8 atm home"))),
+        (
+            "ATM_CONFIG_HOME",
+            Some(tempdir.path().to_str().expect("utf8 config home")),
+        ),
         ("HOME", Some(tempdir.path().to_str().expect("utf8 home"))),
         ("USERPROFILE", None),
     ]);

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -293,7 +293,9 @@ fn windows_local_ipc_runtime_terminate_finishes_within_deadline() {
     let local_ipc_name =
         atm_core::protocol::daemon_local_ipc_name_from_path(&tempdir.path().join("daemon.sock"))
             .expect("ipc name");
-    ready_rx.recv().expect("daemon ready");
+    ready_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("daemon ready within deadline");
     lifecycle.set_terminate_for_test(true);
 
     serve_result_rx

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -37,9 +37,10 @@ use std::sync::mpsc;
 use std::time::Duration;
 use tempfile::TempDir;
 
+#[cfg(windows)]
+use crate::test_support::connect_local_ipc_with_timeout;
 use crate::test_support::{
     configure_test_local_ipc_timeouts, connect_daemon_local_ipc_until_ready,
-    connect_local_ipc_with_timeout,
 };
 
 const TEST_TEAM: &str = "test-team";

--- a/crates/atm-daemon/src/tests_host_ownership.rs
+++ b/crates/atm-daemon/src/tests_host_ownership.rs
@@ -8,7 +8,8 @@ use tempfile::TempDir;
 
 use crate::host_ownership::{
     HOST_RUNTIME_OWNER_LOCK_FILE, HostOwnershipAdapter, clear_stale_recovery_signal_for_test,
-    install_stale_recovery_signal_for_test,
+    install_stale_recovery_signal_for_test, recorded_owner_identity_at_path_for_test,
+    recorded_owner_identity_for_guard_for_test,
 };
 
 struct StaleRecoverySignalGuard;
@@ -23,6 +24,26 @@ impl StaleRecoverySignalGuard {
 impl Drop for StaleRecoverySignalGuard {
     fn drop(&mut self) {
         clear_stale_recovery_signal_for_test();
+    }
+}
+
+fn write_stale_owner_record(
+    lock_path: &std::path::Path,
+    file: &mut std::fs::File,
+    token: &str,
+) {
+    writeln!(file, "{}:{token}", u32::MAX).expect("write owner");
+    file.sync_all().expect("sync owner");
+    #[cfg(windows)]
+    {
+        let shadow_path = lock_path.with_file_name(format!(
+            "{}.meta",
+            lock_path
+                .file_name()
+                .expect("lock file name")
+                .to_string_lossy()
+        ));
+        std::fs::write(&shadow_path, format!("{}:{token}\n", u32::MAX)).expect("write owner shadow");
     }
 }
 
@@ -85,8 +106,7 @@ fn singleton_guard_reports_stale_owner_record_failure() {
         .open(&lock_path)
         .expect("open lock file");
     fs2::FileExt::try_lock_exclusive(&file).expect("lock file");
-    writeln!(&mut file, "{}:deadbeef", u32::MAX).expect("write owner");
-    file.sync_all().expect("sync owner");
+    write_stale_owner_record(&lock_path, &mut file, "deadbeef");
 
     let error = HostOwnershipAdapter::acquire_at(lock_path).expect_err("stale");
     assert_eq!(error.code, AtmErrorCode::DaemonStaleOwnerRecoveryFailed);
@@ -111,8 +131,7 @@ fn singleton_guard_recovers_stale_owner_once_lock_is_released() {
         .open(&lock_path)
         .expect("open lock file");
     fs2::FileExt::try_lock_exclusive(&file).expect("lock file");
-    writeln!(&mut file, "{}:deadbeef", u32::MAX).expect("write owner");
-    file.sync_all().expect("sync owner");
+    write_stale_owner_record(&lock_path, &mut file, "deadbeef");
     drop(file);
 
     let guard =
@@ -139,8 +158,7 @@ fn singleton_guard_rejects_stale_recovery_when_owner_token_changes() {
         .open(&lock_path)
         .expect("open lock file");
     fs2::FileExt::try_lock_exclusive(&file).expect("lock file");
-    writeln!(&mut file, "{}:token-a", u32::MAX).expect("write owner");
-    file.sync_all().expect("sync owner");
+    write_stale_owner_record(&lock_path, &mut file, "token-a");
 
     let (ready_tx, ready_rx) = mpsc::sync_channel(1);
     let (continue_tx, continue_rx) = mpsc::sync_channel(0);
@@ -152,8 +170,7 @@ fn singleton_guard_rejects_stale_recovery_when_owner_token_changes() {
         .expect("stale recovery hook did not fire within 5s");
     file.set_len(0).expect("clear record");
     file.seek(SeekFrom::Start(0)).expect("rewind");
-    writeln!(&mut file, "{}:token-b", u32::MAX).expect("rewrite owner");
-    file.sync_all().expect("resync owner");
+    write_stale_owner_record(&lock_path, &mut file, "token-b");
     drop(file);
     continue_tx
         .send(())
@@ -172,19 +189,17 @@ fn host_ownership_record_uses_pid_and_token_while_held_and_clears_on_release() {
     );
     let guard = HostOwnershipAdapter::acquire_at(lock_path.clone()).expect("acquire");
 
-    let record = std::fs::read_to_string(&lock_path).expect("read record");
-    let trimmed = record.trim();
-    // The singleton tests intentionally read the same owner.lock metadata that
-    // ADR-002 documents for the launch.lock -> owner.lock handoff.
-    let (pid, token) = trimmed.split_once(':').expect("pid:token");
-    assert_eq!(pid, std::process::id().to_string());
+    let (pid, token) = recorded_owner_identity_for_guard_for_test(&guard)
+        .expect("read owner record while held")
+        .expect("pid:token");
+    assert_eq!(pid, std::process::id());
     assert!(!token.is_empty(), "token should not be empty");
 
     drop(guard);
 
-    let cleared = std::fs::read_to_string(&lock_path).expect("read cleared record");
-    assert!(
-        cleared.trim().is_empty(),
+    assert_eq!(
+        recorded_owner_identity_at_path_for_test(&lock_path).expect("read cleared record"),
+        None,
         "record should be cleared on drop"
     );
 }

--- a/crates/atm-daemon/src/tests_host_ownership.rs
+++ b/crates/atm-daemon/src/tests_host_ownership.rs
@@ -27,6 +27,30 @@ impl Drop for StaleRecoverySignalGuard {
     }
 }
 
+fn join_with_timeout<T: Send + 'static>(
+    join: std::thread::JoinHandle<T>,
+    timeout: Duration,
+    context: &str,
+) -> T {
+    let (result_tx, result_rx) = mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("test-bounded-join".to_string())
+        .spawn(move || {
+            let _ = result_tx.send(join.join());
+        })
+        .expect("spawn bounded join helper");
+    match result_rx.recv_timeout(timeout) {
+        Ok(Ok(result)) => result,
+        Ok(Err(_)) => panic!("{context}: worker panicked"),
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!("{context}: join did not complete within {timeout:?}")
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("{context}: join helper disconnected before returning")
+        }
+    }
+}
+
 fn write_stale_owner_record(_lock_path: &std::path::Path, file: &mut std::fs::File, token: &str) {
     writeln!(file, "{}:{token}", u32::MAX).expect("write owner");
     file.sync_all().expect("sync owner");
@@ -173,7 +197,8 @@ fn singleton_guard_rejects_stale_recovery_when_owner_token_changes() {
         .send(())
         .expect("resume stale owner recovery after rewriting the token");
 
-    let error = join.join().expect("join").expect_err("token mismatch");
+    let error = join_with_timeout(join, Duration::from_secs(15), "stale owner recovery join")
+        .expect_err("token mismatch");
     assert_eq!(error.code, AtmErrorCode::DaemonStaleOwnerRecoveryFailed);
 }
 

--- a/crates/atm-daemon/src/tests_host_ownership.rs
+++ b/crates/atm-daemon/src/tests_host_ownership.rs
@@ -27,23 +27,20 @@ impl Drop for StaleRecoverySignalGuard {
     }
 }
 
-fn write_stale_owner_record(
-    lock_path: &std::path::Path,
-    file: &mut std::fs::File,
-    token: &str,
-) {
+fn write_stale_owner_record(_lock_path: &std::path::Path, file: &mut std::fs::File, token: &str) {
     writeln!(file, "{}:{token}", u32::MAX).expect("write owner");
     file.sync_all().expect("sync owner");
     #[cfg(windows)]
     {
-        let shadow_path = lock_path.with_file_name(format!(
+        let shadow_path = _lock_path.with_file_name(format!(
             "{}.meta",
-            lock_path
+            _lock_path
                 .file_name()
                 .expect("lock file name")
                 .to_string_lossy()
         ));
-        std::fs::write(&shadow_path, format!("{}:{token}\n", u32::MAX)).expect("write owner shadow");
+        std::fs::write(&shadow_path, format!("{}:{token}\n", u32::MAX))
+            .expect("write owner shadow");
     }
 }
 

--- a/crates/atm-graft/Cargo.toml
+++ b/crates/atm-graft/Cargo.toml
@@ -10,14 +10,14 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.2.0" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.0" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1" }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.2.1" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.1" }
 interprocess = "2.4.2"
 serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1", features = ["test-utils"] }
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-runtime-test-support/Cargo.toml
+++ b/crates/atm-runtime-test-support/Cargo.toml
@@ -13,5 +13,5 @@ homepage.workspace = true
 name = "atm_runtime_test_support"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0", features = ["test-utils"] }
-atm-rusqlite = { path = "../atm-rusqlite", version = "1.2.0" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1", features = ["test-utils"] }
+atm-rusqlite = { path = "../atm-rusqlite", version = "1.2.1" }

--- a/crates/atm-rusqlite/Cargo.toml
+++ b/crates/atm-rusqlite/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 name = "atm_rusqlite"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1" }
 serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
@@ -30,4 +30,4 @@ tempfile = "3"
 serde = { version = "1.0.140", features = ["derive"] }
 serde_json = "1.0.140"
 serial_test = "3"
-atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.2.0" }
+atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.2.1" }

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -22,9 +22,9 @@ path = "src/main.rs"
 fault-injection = ["sc-observability/fault-injection"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.2.0" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.0" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1" }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.2.1" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.1" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -38,8 +38,8 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.0", features = ["test-utils"] }
-atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.2.0" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1", features = ["test-utils"] }
+atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.2.1" }
 sc-observability = { version = "1.1.0", features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -41,6 +41,43 @@ Mechanical-enforcement rule:
 - if a prohibited pattern is cheap and deterministic to detect, it belongs in
   `just lint` rather than review-only guidance
 
+## Windows Same-Host Runtime Contracts
+
+### Host-Ownership Sidecar Recovery
+
+Windows host-ownership recovery uses a same-directory sidecar shadow file:
+- lock file: `owner.lock`
+- shadow file: `owner.lock.meta`
+
+Required behavior:
+- write the canonical `pid:token` owner record to the locked file
+- mirror the same record to `owner.lock.meta` with temp-file-plus-rename replacement
+- when reading the locked file fails with a Windows lock/sharing violation during stale-owner
+  recovery, fall back to `owner.lock.meta`
+- reject recovery if the pid/token changes between the first stale-owner observation and the
+  eventual retry lock acquisition
+
+This sidecar is a recovery aid only. It does not replace the locked file as the source of truth
+while the lock handle remains readable.
+
+### `ErrorKind::Unsupported` Is Not a Timeout Exemption
+
+Windows named pipes report `ErrorKind::Unsupported` for `set_recv_timeout()` and
+`set_send_timeout()`. Code may tolerate that result only when it immediately installs a bounded
+fallback contract.
+
+Required fallback shapes:
+- request reads: watchdog or equivalent cancellation path that actively breaks the blocked read at
+  the documented deadline
+- shutdown wake connections: no unbounded `flush()`/drain after the `Unsupported` bypass; the wake
+  path must still return within the same bounded deadline
+- shutdown drain: unsupported socket deadlines must not leave `active_connections` pinned past the
+  forced-cancel window
+
+Forbidden shape:
+- swallowing `ErrorKind::Unsupported` and then proceeding to an unbounded read, write, flush, or
+  shutdown wait
+
 ## Home Directory Resolution
 
 **Problem**: `dirs::home_dir()` on Windows uses the Windows API (`SHGetKnownFolderPath`), which ignores both `HOME` and `USERPROFILE` environment variables. Tests that only redirect `HOME` do not relocate the canonical `~/.claude` config root on Windows.

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -84,6 +84,13 @@ Use this procedure on a fresh Windows checkout of `feature/windows-test-parity`.
 machine should treat Git as the handoff channel: pull this branch first, then run the steps below
 from Windows PowerShell in the repository root.
 
+Observed result on the first Windows machine for this branch:
+- `PASS` after pulling `feature/windows-test-parity` and running the same-host daemon smoke flow
+- verified outcomes: `doctor --json` reached ready, the named pipe was published, `send` succeeded,
+  and `read --all --json` returned the delivered body
+- one environment caveat: stale local daemon/test processes can hold the host owner lock and must
+  be cleared before rerunning the smoke
+
 1. Prerequisites
    - Install the Rust MSVC toolchain (`rustup default stable-x86_64-pc-windows-msvc` or equivalent).
    - Clone `atm-core`, then pull the branch under test:
@@ -108,18 +115,19 @@ from Windows PowerShell in the repository root.
    $env:ATM_DAEMON_SOCKET = "\\.\pipe\atm-win-smoke"
    ```
 
-3. Build the release binaries
+3. Build the workspace
    ```powershell
-   cargo build --release -p atm-daemon -p atm-daemon-client
+   just build
    ```
    Pass indicator:
-   - `target\release\atm-daemon.exe` and `target\release\atm.exe` exist
+   - workspace build exits zero
+   - `target\debug\atm-daemon.exe` and `target\debug\atm.exe` exist
    Fail indicator:
-   - cargo exits non-zero or the release binaries are missing
+   - `just build` exits non-zero or the binaries are missing
 
 4. Run `atm doctor` and confirm the daemon reaches ready state
    ```powershell
-   $Doctor = .\target\release\atm.exe doctor --json | ConvertFrom-Json
+   $Doctor = .\target\debug\atm.exe doctor --json | ConvertFrom-Json
    $Doctor.summary.status
    $Doctor.runtime_status.readiness
    ```
@@ -141,8 +149,8 @@ from Windows PowerShell in the repository root.
 
 6. Confirm the daemon accepts a connection and a round-trip mailbox operation
    ```powershell
-   .\target\release\atm.exe send smoke-user "windows smoke hello" --json
-   .\target\release\atm.exe read --all --json
+   .\target\debug\atm.exe send smoke-user "windows smoke hello" --json
+   .\target\debug\atm.exe read --all --json
    ```
    Pass indicator:
    - `send` returns a normal sent result

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -103,7 +103,7 @@ Deferred analyzer families:
 
 ## Clippy Compliance
 
-CI runs Rust 1.93 clippy with `-D warnings`. Local toolchains may be older and miss lints.
+CI runs Rust 1.94.1 clippy with `-D warnings`. Local toolchains may be older and miss lints.
 
 ### Known Strict Lints
 

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -67,8 +67,8 @@ Windows named pipes report `ErrorKind::Unsupported` for `set_recv_timeout()` and
 fallback contract.
 
 Required fallback shapes:
-- request reads: watchdog or equivalent cancellation path that actively breaks the blocked read at
-  the documented deadline
+- request reads: a watchdog or equivalent bounded fallback that prevents blocked Windows
+  named-pipe reads from pinning the connection slot or shutdown drain past the documented deadline
 - shutdown wake connections: no unbounded `flush()`/drain after the `Unsupported` bypass; the wake
   path must still return within the same bounded deadline
 - shutdown drain: unsupported socket deadlines must not leave `active_connections` pinned past the

--- a/docs/cross-platform-guidelines.md
+++ b/docs/cross-platform-guidelines.md
@@ -78,6 +78,79 @@ Forbidden shape:
 - swallowing `ErrorKind::Unsupported` and then proceeding to an unbounded read, write, flush, or
   shutdown wait
 
+## Windows Smoke Test
+
+Use this procedure on a fresh Windows checkout of `feature/windows-test-parity`. The Windows
+machine should treat Git as the handoff channel: pull this branch first, then run the steps below
+from Windows PowerShell in the repository root.
+
+1. Prerequisites
+   - Install the Rust MSVC toolchain (`rustup default stable-x86_64-pc-windows-msvc` or equivalent).
+   - Clone `atm-core`, then pull the branch under test:
+   ```powershell
+   git fetch origin
+   git switch feature/windows-test-parity
+   git pull --ff-only origin feature/windows-test-parity
+   ```
+
+2. Create a disposable ATM environment
+   ```powershell
+   $SmokeRoot = Join-Path $env:TEMP "atm-win-smoke"
+   Remove-Item $SmokeRoot -Recurse -Force -ErrorAction SilentlyContinue
+   New-Item -ItemType Directory -Force -Path $SmokeRoot | Out-Null
+   New-Item -ItemType Directory -Force -Path (Join-Path $SmokeRoot ".claude\\teams\\smoke-team\\inboxes") | Out-Null
+   Set-Content -Path (Join-Path $SmokeRoot ".claude\\teams\\smoke-team\\config.json") -Value '{"members":[{"name":"smoke-user"}]}'
+   Set-Content -Path (Join-Path (Get-Location) ".atm.toml") -Value "[atm]`ndefault_team = `"smoke-team`"`n"
+   $env:ATM_HOME = $SmokeRoot
+   $env:ATM_CONFIG_HOME = $SmokeRoot
+   $env:ATM_TEAM = "smoke-team"
+   $env:ATM_IDENTITY = "smoke-user"
+   $env:ATM_DAEMON_SOCKET = "\\.\pipe\atm-win-smoke"
+   ```
+
+3. Build the release binaries
+   ```powershell
+   cargo build --release -p atm-daemon -p atm-daemon-client
+   ```
+   Pass indicator:
+   - `target\release\atm-daemon.exe` and `target\release\atm.exe` exist
+   Fail indicator:
+   - cargo exits non-zero or the release binaries are missing
+
+4. Run `atm doctor` and confirm the daemon reaches ready state
+   ```powershell
+   $Doctor = .\target\release\atm.exe doctor --json | ConvertFrom-Json
+   $Doctor.summary.status
+   $Doctor.runtime_status.readiness
+   ```
+   Pass indicator:
+   - `summary.status` is `healthy` or `warning`
+   - `runtime_status.readiness` is `ready`
+   Fail indicator:
+   - `doctor` exits non-zero
+   - `runtime_status.readiness` is absent or not `ready`
+
+5. Verify the named-pipe IPC endpoint is published
+   ```powershell
+   Get-ChildItem \\.\pipe\ | Where-Object { $_.Name -eq "atm-win-smoke" }
+   ```
+   Pass indicator:
+   - the command returns one pipe entry named `atm-win-smoke`
+   Fail indicator:
+   - no matching pipe appears after the `doctor` step
+
+6. Confirm the daemon accepts a connection and a round-trip mailbox operation
+   ```powershell
+   .\target\release\atm.exe send smoke-user "windows smoke hello" --json
+   .\target\release\atm.exe read --all --json
+   ```
+   Pass indicator:
+   - `send` returns a normal sent result
+   - `read --all --json` includes the `windows smoke hello` body for `smoke-user@smoke-team`
+   Fail indicator:
+   - `send` reports daemon unavailable / connection refused
+   - `read` does not show the just-sent message
+
 ## Home Directory Resolution
 
 **Problem**: `dirs::home_dir()` on Windows uses the Windows API (`SHGetKnownFolderPath`), which ignores both `HOME` and `USERPROFILE` environment variables. Tests that only redirect `HOME` do not relocate the canonical `~/.claude` config root on Windows.


### PR DESCRIPTION
## Summary
- fix Windows host-ownership lock recovery by mirroring owner metadata through a sidecar record when the locked file cannot be read
- make daemon runtime, daemon tests, and daemon client tolerate Windows named-pipe timeout APIs that return `ErrorKind::Unsupported`
- update Windows contributor docs and cross-platform guidance to reflect the validated toolchain and smoke/test commands

## Verification
- cargo test -p atm-daemon --verbose
- cargo test -p atm-daemon-client --verbose
- $env:ATM_TEST_RECV_TIMEOUT_SECS='60'; cargo test --workspace --verbose
- cargo build --release -p agent-team-mail -p atm-daemon -p atm-daemon-client
- disposable Windows release smoke subset: `atm doctor --json`, `list --json`, `clear --json`, `send ... --json`, `read --all --json`

## Issues
- closes #384
- closes #385
- closes #386
