### PR TITLE
docs: rename cross-host smoke planning to phase AB

### DIFF
--- a/docs/phase-AB/README.md
+++ b/docs/phase-AB/README.md
@@ -1,0 +1,17 @@
+# Phase AB
+
+Phase `AB` owns Windows/macOS cross-host ATM smoke testing after the completed
+same-host release-readiness line in `Phase Z`.
+
+Planning source of truth:
+- [`../plan-phase-AB.md`](../plan-phase-AB.md)
+
+Expected planning artifacts:
+- `cross-host-smoke-checklist.md`
+- `cross-host-findings-ledger.md`
+- `readiness.md`
+- `sprint-AB1.md`
+- `sprint-AB2.md`
+- `sprint-AB3.md`
+- `sprint-AB4.md`
+- `sprint-AB5.md`

--- a/docs/plan-phase-AB.md
+++ b/docs/plan-phase-AB.md
@@ -1,0 +1,220 @@
+# Phase AB Plan
+
+## Goal
+
+Validate cross-host ATM messaging between Windows and macOS on real binaries
+after the Phase Z single-host release-readiness line is complete.
+
+Phase `AB` owns executable cross-host smoke coverage that was intentionally left
+outside the same-host daemon and release-signoff line:
+
+- Windows <-> macOS daemon/bootstrap interoperability on disposable state
+- peer transport bring-up across hosts
+- durable send/read/ack behavior across hosts
+- degraded notification behavior after durable cross-host delivery
+- retry-visible observability during cross-host interruption and restart
+- copied-state revalidation only after the clean-room lane passes
+
+## Baseline
+
+- planning branch: `plan/phase-AB`
+- follow-up planning branch for post-`AB.1` fixes, if needed:
+  - `plan/phase-AB-fix-planning`
+- prerequisite accepted line:
+  - `Phase Z` complete on `develop`
+  - Windows same-host build/test parity restored on the accepted baseline
+- execution integration branch:
+  - `integrate/phase-AB`
+
+## Phase Entry Criteria
+
+`Phase AB` does not begin until:
+
+- `Phase Z` remains closed with the release-ready verdict already recorded
+- the accepted `develop` baseline passes the same-host workspace test suite on:
+  - Windows
+  - macOS
+- the Windows release-binary daemon client path is proven healthy for:
+  - `doctor --json`
+  - `list --json`
+  - `clear --json`
+  - `send --json`
+  - `read --all --json`
+- both participating hosts can run disposable ATM homes/config roots without
+  touching live host state
+- the operator has confirmed any host firewall / local-network prompts before
+  the active smoke pass begins
+
+## Scope Rules
+
+Phase `AB` is a smoke and interoperability line, not a new transport-design
+phase.
+
+Phase `AB` may:
+
+- add smoke fixtures, checklists, reports, and targeted cross-host bug fixes
+- harden existing cross-host delivery/bootstrap code when the bug is required to
+  make the smoke matrix pass
+- add explicit operator guidance for cross-host setup and recovery
+
+Phase `AB` must not:
+
+- redesign the peer transport contract without a separate ADR/planning line
+- absorb unrelated same-host daemon refactors
+- use live host state as the first validation lane
+- treat notification-only degradation as a durable-delivery failure
+
+## Validation Lanes
+
+### Lane A: Disposable Clean-Room Cross-Host Smoke
+
+Purpose:
+
+- prove the full Windows/macOS cross-host flow on synthetic state only
+- keep failures attributable to config/bootstrap/transport/runtime boundaries
+
+Required shape:
+
+- one disposable `ATM_HOME` per host
+- one disposable `ATM_CONFIG_HOME` per host
+- explicit `ATM_LOG_DIR` per host
+- explicit cross-host transport configuration per host
+- no reads or writes against live `~/.claude` or `~/.atm`
+
+### Lane B: Copied-State Cross-Host Revalidation
+
+Purpose:
+
+- prove cross-host delivery on a disposable copy of realistic retained state
+
+Entry condition:
+
+- Lane A must already pass end to end
+
+Required shape:
+
+- disposable copy of each host's ATM/Claude state
+- no writes against live host-scoped state
+- exact capture of any repair/setup step needed before send/read/ack succeeds
+
+## Sprint Sequence
+
+### AB.1 Cross-Host Harness And Clean-Room Baseline
+
+Purpose:
+
+- freeze the Windows/macOS host-pair smoke checklist
+- define disposable env/bootstrap rules for both hosts
+- prove same-host release commands on both hosts under disposable state before
+  any cross-host send is attempted
+
+Execution branch:
+- `feature/pAB-s1-cross-host-harness-and-clean-room-baseline`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAB-s1-cross-host-harness-and-clean-room-baseline`
+
+### AB.2 One-Way Cross-Host Delivery
+
+Purpose:
+
+- prove Windows -> macOS durable delivery on the disposable lane
+- prove macOS -> Windows durable delivery on the disposable lane
+- record exact transport/bootstrap evidence in retained logs on both hosts
+
+Execution branch:
+- `feature/pAB-s2-one-way-cross-host-delivery`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAB-s2-one-way-cross-host-delivery`
+
+### AB.3 Cross-Host Ack Round-Trip
+
+Purpose:
+
+- prove `--requires-ack` send plus reply-state mutation across hosts
+- validate receiver read and sender reply visibility on the disposable lane
+
+Execution branch:
+- `feature/pAB-s3-cross-host-ack-round-trip`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAB-s3-cross-host-ack-round-trip`
+
+### AB.4 Degraded Notification And Retry-Visible Recovery
+
+Purpose:
+
+- prove durable cross-host delivery still succeeds when notification/hook paths
+  degrade
+- prove retry-visible observability during daemon restart or temporary peer
+  unavailability
+
+Execution branch:
+- `feature/pAB-s4-degraded-notification-and-retry-visible-recovery`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAB-s4-degraded-notification-and-retry-visible-recovery`
+
+### AB.5 Copied-State Revalidation And Readiness Closeout
+
+Purpose:
+
+- rerun the approved subset on disposable copied state from both hosts
+- capture any remaining operator setup or repair guidance
+- record the phase readiness verdict
+
+Execution branch:
+- `feature/pAB-s5-copied-state-revalidation-and-readiness-closeout`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAB-s5-copied-state-revalidation-and-readiness-closeout`
+
+## Required Smoke Coverage
+
+The frozen `AB.1` checklist must include at least:
+
+- release-binary `doctor` on Windows and macOS individually
+- Windows -> macOS send
+- macOS -> Windows send
+- cross-host `read` on the receiving side
+- cross-host `ack` back to the original sender
+- one degraded-notification case after durable cross-host send succeeds
+- one retry-visible interruption/recovery case
+- one copied-state lane after clean-room success
+
+## Required Evidence Per Row
+
+Every smoke row must capture:
+
+- host pair and sender/receiver direction
+- exact disposable env/config inputs
+- command transcript on both hosts
+- sender JSON result
+- receiver read/ack JSON result
+- `doctor --json` for the active daemon host when relevant
+- `log snapshot --json` from both hosts when the row exercises daemon-backed
+  behavior
+
+## Immediate Planning Outputs
+
+- `docs/plan-phase-AB.md`
+- `docs/phase-AB/cross-host-smoke-checklist.md`
+- `docs/phase-AB/cross-host-findings-ledger.md`
+- `docs/phase-AB/readiness.md`
+- `docs/phase-AB/sprint-AB1.md`
+- `docs/phase-AB/sprint-AB2.md`
+- `docs/phase-AB/sprint-AB3.md`
+- `docs/phase-AB/sprint-AB4.md`
+- `docs/phase-AB/sprint-AB5.md`
+
+## Acceptance / Phase Entry Gate
+
+- `Phase Z` must remain closed and accepted on `develop`
+- `AB.1` must freeze the authoritative Windows/macOS checklist before later
+  smoke/fix sprints widen execution
+- `AB.5` must not begin until `AB.2` through `AB.4` are complete on the
+  accepted `integrate/phase-AB` line
+- the phase closeout verdict must remain `FAIL` until both:
+  - disposable clean-room cross-host smoke passes
+  - copied-state cross-host revalidation passes

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -3937,3 +3937,57 @@ Acceptance / Phase Entry Gate:
   on the accepted `integrate/phase-Z` line
 - the final `Z.4` release verdict must not close until `Z.23` and `Z.24` also
   close on the accepted `integrate/phase-Z` line
+
+## 37. Phase AB Windows/macOS Cross-Host Smoke
+
+Status summary:
+- `Phase Z` is complete and remains the accepted same-host release-readiness
+  line on `develop`.
+- Windows same-host build/test and release-binary daemon parity have been
+  restored on the post-`Z` baseline.
+- cross-host messaging between Windows and macOS has not yet been validated in
+  one authoritative executable smoke phase.
+- `Phase AB` is the next planning line and is not yet started.
+
+Planning branch:
+- `plan/phase-AB`
+
+Future integration branch:
+- `integrate/phase-AB`
+
+Goal:
+- validate Windows <-> macOS cross-host ATM messaging on real binaries
+- keep clean-room disposable state as the first validation lane
+- prove durable send/read/ack, degraded notification visibility, and
+  retry-visible recovery across hosts
+- revalidate on copied state only after the disposable lane passes
+
+Execution shape:
+- `AB.1` cross-host harness and clean-room baseline
+  - branch: `feature/pAB-s1-cross-host-harness-and-clean-room-baseline`
+- `AB.2` one-way cross-host delivery
+  - branch: `feature/pAB-s2-one-way-cross-host-delivery`
+- `AB.3` cross-host ack round-trip
+  - branch: `feature/pAB-s3-cross-host-ack-round-trip`
+- `AB.4` degraded notification and retry-visible recovery
+  - branch: `feature/pAB-s4-degraded-notification-and-retry-visible-recovery`
+- `AB.5` copied-state revalidation and readiness closeout
+  - branch: `feature/pAB-s5-copied-state-revalidation-and-readiness-closeout`
+
+Immediate planning outputs:
+- `docs/plan-phase-AB.md`
+- `docs/phase-AB/cross-host-smoke-checklist.md`
+- `docs/phase-AB/cross-host-findings-ledger.md`
+- `docs/phase-AB/readiness.md`
+- `docs/phase-AB/sprint-AB1.md`
+- `docs/phase-AB/sprint-AB2.md`
+- `docs/phase-AB/sprint-AB3.md`
+- `docs/phase-AB/sprint-AB4.md`
+- `docs/phase-AB/sprint-AB5.md`
+
+Acceptance / Phase Entry Gate:
+- `Phase Z` must remain closed on `develop`
+- the clean-room disposable host-pair lane must pass before copied-state
+  validation begins
+- the phase does not close until both disposable and copied-state cross-host
+  smoke lanes pass with retained evidence


### PR DESCRIPTION
## Summary
- rename the Windows/macOS cross-host smoke planning line from Phase AA to Phase AB
- rename the planning artifacts and references under docs/
- keep the existing local worktree/branch flow while correcting the plan label

## Testing
- not run (docs-only change)
