### PR TITLE
feat(phase-AA): AA.0 daemon architecture restatement and state-machine inventory

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,11 +102,12 @@ Phase-AA simplification note:
 
 ## 2. Crate Boundaries
 
-The post-Q product runtime is implemented by four crates:
+The post-Q product runtime is implemented by five crates:
 
 - `atm-core`
 - `atm`
 - `atm-daemon`
+- `atm-runtime`
 - `atm-rusqlite`
 
 Product-level boundary rules:
@@ -114,13 +115,17 @@ Product-level boundary rules:
 - `atm-core` owns ATM business logic and the strict I/O boundaries that the current SQLite/daemon architecture
   routes through a daemon runtime.
 - `atm` owns CLI parsing, dispatch, rendering, and bootstrap.
-- `atm-daemon` owns runtime composition, transport adapters, singleton
-  enforcement, and live-status runtime state.
+- `atm-daemon` owns transport adapters, singleton enforcement, live-status
+  runtime state, and daemon-owned runtime projection.
+- `atm-runtime` owns concrete runtime/store composition and concrete
+  doctor/runtime assembly that must stay out of `atm-daemon`.
 - `atm-rusqlite` owns the first concrete SQLite implementation of the durable
   store boundaries.
 - `atm-core` must not own clap or terminal-formatting concerns.
 - `atm` must not own mailbox, workflow, log-query, or doctor business logic.
 - `atm-daemon` must not become a second business-logic crate.
+- `atm-runtime` must remain a thin composition crate rather than a second
+  daemon or workflow host.
 - `atm-rusqlite` must not absorb workflow or command logic; it implements store
   contracts only.
 - crate-local boundary records in `docs/<crate>/boundaries.md` are the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,10 @@ Phase-AA simplification note:
   `atm-daemon`
 - the daemon remains in the product, but as a thin router rather than a
   concrete storage/runtime host
+- subsystem-specific diagnosis belongs behind subsystem-owned diagnostic traits
+  instead of daemon-local backend-aware helpers
+- top-level doctor code may aggregate subsystem reports and daemon-owned
+  runtime state, but must not reimplement backend-specific diagnosis logic
 
 ## 2. Crate Boundaries
 

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -97,6 +97,10 @@ Phase-AA target direction:
 - SQLite-specific composition, observability, replay, and direct store-health
   logic are removed from this crate
 - daemon health becomes daemon-owned runtime projection only
+- subsystem-owned diagnostic traits perform backend-specific investigation
+- daemon doctor code aggregates subsystem reports and daemon-owned runtime
+  state only, and may compare reports for drift without reimplementing backend
+  diagnosis
 
 Phase R redesign notes:
 - `atm-daemon` remains runtime-oriented, not business-logic-oriented
@@ -136,6 +140,7 @@ Current retained ATM surfaces outside the daemon request/response packet family:
 - `atm-daemon` must not reimplement `atm-core` business logic.
 - `atm-daemon` must not access SQLite except through the `atm-core` store
   boundary.
+- `atm-daemon` must not own concrete SQLite semantics.
 - `atm-daemon` must not parse or write inbox JSONL except through the
   `atm-core` ingress/export boundaries.
 - write-affecting daemon mail events must route through one central
@@ -150,6 +155,11 @@ Current retained ATM surfaces outside the daemon request/response packet family:
 - daemon runtime-health/status assembly must discover teams and members only
   through the installed `RosterStore`; `ATM_HOME/.claude/teams` is a config
   ingress surface, not a runtime-truth discovery path
+- deep backend-specific diagnosis belongs to subsystem-owned doctor traits
+  rather than daemon-local logic
+- daemon doctor aggregation may combine subsystem reports with daemon-owned
+  runtime state and compare those reports for drift, but it must not inspect
+  SQLite internals directly
 - read-mostly daemon runtime-health/status projection must publish immutable
   snapshots to readers rather than coordinating ordinary reads through one
   daemon-shared mutable cache lock

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -30,6 +30,7 @@ adr_id: ADR-ATM-DAEMON-001
 crate: atm-daemon
 title: Daemon is the current runtime composition root
 status: accepted
+superseded_by: ADR-ATM-RUNTIME-001
 date: 2026-05-03
 deciders:
   - team-lead
@@ -101,6 +102,12 @@ Phase-AA target direction:
 - daemon doctor code aggregates subsystem reports and daemon-owned runtime
   state only, and may compare reports for drift without reimplementing backend
   diagnosis
+- in the steady-state `Phase AA` ownership split, `atm-daemon` owns only:
+  1. transport admission and endpoint publication
+  2. lifecycle / singleton ownership and bounded shutdown
+  3. request validation and frame-contract enforcement
+  4. request dispatch through injected service/runtime ports
+  5. typed daemon error/report projection for daemon-owned runtime state
 
 Phase R redesign notes:
 - `atm-daemon` remains runtime-oriented, not business-logic-oriented
@@ -391,9 +398,9 @@ Lifecycle state model:
   - `Stopped`
 - the authoritative transition document is
   [`./startup-state-machine.md`](./startup-state-machine.md)
-- the implementation may use typestate or one internal state enum, but the
-  legal lifecycle transitions must remain explicit rather than inferred from
-  loosely-coupled booleans
+- the implementation must use typestate as the governing lifecycle contract;
+  helper enums may exist internally, but they must remain subordinate to the
+  typestate boundary and must not replace the explicit legal transitions
 - accepted transition graph:
   - `Starting -> Running`
   - `Starting -> Stopped` on failed startup/rollback
@@ -458,10 +465,12 @@ The final daemon observability contract is defined in
 
 Required architectural decisions:
 - the injected daemon observability trait remains object-safe and sealed
-- the daemon lifecycle stays modeled as an explicit runtime state machine
-  rather than a typestate API in Phase V
+- the daemon lifecycle stays modeled as an explicit typestate-backed runtime
+  state machine; helper enums may not replace the typestate contract
 - `LaunchGateGuard` remains a launch/admission coordination primitive, not a
-  typestate token
+  lifecycle typestate token, but it still carries one type-level invariant:
+  a live guard proves launch admission is held for the current startup handoff
+  and cannot coexist with the post-admission running token
 - daemon event payloads use typed semantic identifiers:
   - `DaemonSubsystem` enum
   - `AtmMessageId`
@@ -610,9 +619,11 @@ Required shutdown sequence:
 4. cancel remaining inflight work at the force-cancel deadline
 5. checkpoint SQLite WAL
 6. flush observability sinks on a best-effort basis
-7. clear or invalidate current owner metadata while `owner.lock` is still held
-8. release the live exclusive ownership lock
-9. remove the same-host listener artifact if the local-IPC adapter requires a
+7. request stop for the lifecycle wake worker, unregister active hooks, and
+   join the worker within the documented `1s` bound
+8. clear or invalidate current owner metadata while `owner.lock` is still held
+9. release the live exclusive ownership lock
+10. remove the same-host listener artifact if the local-IPC adapter requires a
    removable endpoint artifact on that operating system
 
 Force-cancel rule:
@@ -636,6 +647,8 @@ Exit-code expectations tied to these SLOs:
 - singleton or stale-owner admission failures exit `64` and must not hot-loop
   restart
 - lifecycle-wedge detection exits `71`
+- degraded shutdown after force-cancel or helper-lane timeout emits
+  `DaemonShutdownDegraded` and exits `72`
 
 Required deadlines:
 - normal drain deadline: `5s`
@@ -697,7 +710,7 @@ Required saturation behavior:
   in Phase R the transport remains single-request-per-connection, so the
   in-flight count is structurally `1` until framed multiplexing exists
 - ingest queue full: fail the enqueue with structured degradation/health
-  reporting; no silent drop
+  reporting through `DaemonIngestQueueSaturated`; no silent drop
 - retry queue full: fail remote send attempt rather than enqueueing unbounded
 - watch subscription cap exceeded: reject the new subscription with typed
   over-capacity failure rather than retaining unbounded watcher state
@@ -759,6 +772,11 @@ Required timeout defaults:
 - reconcile runtime drain during runtime teardown: `2s` max
 - watch runtime drain during runtime teardown: `2s` max
 - retained-log flush and sync during runtime teardown: `2s` best-effort max
+- configurable timeout or retry-budget overrides may raise these defaults, but
+  they must not violate the floor contract:
+  - global minimum timeout floor: `250ms`
+  - same-host request and daemon-health minimum floor: `1s`
+  - `daemon.remote_retry_budget` accepted range: `1s..=300s`
 
 Shutdown sub-deadline rationale:
 - these per-component bounds sit under the existing daemon shutdown ceilings so
@@ -793,6 +811,21 @@ Doctor health contract distinction:
   them through the documented request boundary
 - `atm doctor` must report both dimensions explicitly rather than treating
   process existence as equivalent to request-serving readiness
+- interim `AA.0` to `AA.2` runtime snapshot stub:
+  - minimum daemon-owned fields:
+    - `liveness`
+    - `readiness`
+    - `owner_pid`
+    - `degraded_ingest`
+    - `active_count`
+    - `idle_count`
+    - `offline_count`
+    - `unknown_count`
+  - transitional pre-`AA.3` fields still present until the delete sprint lands:
+    - `sqlite_ready`
+    - `sqlite_detail`
+  - this interim stub is valid only through the `AA.0` to `AA.2` window and
+    must not be treated as the post-`AA.3` daemon-runtime DTO
 - Phase AA supersession note:
   - `AA.3` deletes `sqlite_ready`, `sqlite_detail`, and the SQLite-backed
     continuity wording from the daemon-owned runtime snapshot

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -29,7 +29,7 @@ This crate remains part of the current workspace.
 adr_id: ADR-ATM-DAEMON-001
 crate: atm-daemon
 title: Daemon is the current runtime composition root
-status: accepted
+status: superseded
 superseded_by: ADR-ATM-RUNTIME-001
 date: 2026-05-03
 deciders:

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -52,6 +52,10 @@ Phase-AA target direction:
   SQLite health probing move out of this crate
 - daemon-owned doctor reporting is reduced to daemon-owned runtime state rather
   than direct store readiness checks
+- each subsystem owns its own backend-specific diagnosis behind a subsystem
+  doctor trait
+- daemon doctor code aggregates subsystem reports and daemon-owned runtime
+  state only; it must not reimplement backend-specific diagnosis
 
 Current request/response packet families owned by the daemon transport line:
 - send compose

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -30,8 +30,7 @@ The canonical daemon/client recovery text rule set lives in:
 - singleton daemon startup and host ownership
 - same-host daemon API transport
 - cross-host daemon-to-daemon transport
-- runtime composition of `atm-core` service boundaries
-- runtime composition of the current concrete adapter set used in production
+- daemon-private orchestration around injected `atm-core` service boundaries
 - live agent status cache
 - runtime watch/reconcile loop if enabled
 - daemon-side `sc-observability` emission
@@ -103,8 +102,10 @@ Initial crate requirement IDs:
   requirement `#1` and is not subordinate to convenience test or tooling
   flows. Satisfies the runtime ownership aspects of:
   `REQ-CORE-DAEMON-001`, `REQ-CORE-QA-RUNTIME-001`.
-- `REQ-DAEMON-RUNTIME-002` `atm-daemon` owns runtime composition only and must
-  remain a thin wrapper over `atm-core` service boundaries. Satisfies:
+- `REQ-DAEMON-RUNTIME-002` `atm-daemon` owns runtime orchestration around
+  injected `atm-core` service boundaries only and must remain a thin wrapper
+  over those boundaries. Concrete runtime/store assembly moves to
+  `atm-runtime` in `AA.2`. Satisfies:
   `REQ-CORE-DAEMON-002`, `REQ-CORE-BOUNDARY-001`.
 - `REQ-DAEMON-RUNTIME-003` `atm-daemon` owns graceful shutdown sequencing for
   the singleton runtime. Satisfies:
@@ -202,9 +203,20 @@ Initial crate requirement IDs:
   depend on one daemon-shared mutable cache lock for ordinary reads. Satisfies:
   `REQ-CORE-DOCTOR-002`, `REQ-DAEMON-STATUS-001`.
 - `REQ-DAEMON-CONFIG-001` `atm-daemon` owns daemon config validation at startup
-  and on lifecycle-control-triggered reload or rescan. Invalid config must
-  produce a typed failure or bounded reload rejection rather than a silent
-  degraded state. Satisfies:
+  and on lifecycle-control-triggered reload or rescan. The minimum daemon-owned
+  config inventory includes:
+  - same-host endpoint contract inputs
+  - remote peer transport endpoint and credential inputs
+  - timeout and retry-budget inputs
+  - queue/cap inputs
+  - lifecycle-control / watch / reconcile enablement inputs
+  - retained-log / observability sink inputs
+  Invalid config must produce a typed failure or bounded reload rejection
+  rather than a silent degraded state. Startup-fatal or reload-fatal validation
+  applies to ownership, transport, replay-store, timeout-floor, retry-budget,
+  and cap violations; warning-only handling is allowed only for optional
+  observability sinks or optional background-lane features when the daemon
+  keeps one documented degraded fallback path. Satisfies:
   `REQ-CORE-CONFIG-001`, `REQ-CORE-CONFIG-003`, `REQ-DAEMON-SIGNAL-001`.
 - `REQ-DAEMON-TEST-001` `atm-daemon` must not define the core test strategy.
   Core correctness must remain testable without daemon process spawning.
@@ -241,7 +253,15 @@ Initial crate requirement IDs:
   meaning. Satisfies:
   `REQ-CORE-BOUNDARY-001`, `REQ-CORE-OBS-001`.
 - `REQ-DAEMON-HEALTH-001` `atm-daemon` owns the daemon health interface
-  consumed by `atm doctor`. Satisfies:
+  consumed by `atm doctor`. The minimum daemon-owned field inventory is:
+  - liveness
+  - readiness
+  - owner pid when known
+  - active / idle / offline / unknown counts
+  - daemon-owned degraded-runtime findings
+  During `AA.0` through `AA.2`, the health contract may still carry the
+  transitional SQLite readiness fields documented in the daemon architecture,
+  but those fields are explicitly removed in `AA.3`. Satisfies:
   `REQ-CORE-DOCTOR-002`.
 - `REQ-DAEMON-SIGNAL-001` `atm-daemon` owns runtime-control installation and
   handling for daemon lifecycle transitions. Unix may satisfy this through
@@ -286,6 +306,7 @@ The `atm-daemon` crate docs must remain aligned with:
 - [`../requirements.md`](../requirements.md)
 - [`../architecture.md`](../architecture.md)
 - [`../project-plan.md`](../project-plan.md)
+- [`../plan-phase-AA.md`](../plan-phase-AA.md)
 - [`../plan-phase-R.md`](../plan-phase-R.md)
 - [`../plan-phase-S.md`](../plan-phase-S.md)
 - [`../plan-phase-U.md`](../plan-phase-U.md)
@@ -455,6 +476,11 @@ Required runtime rules:
   - authoritative timeout budget references:
     [`../architecture.md §21.6.4`](../architecture.md) and
     [`architecture.md §3.4`](./architecture.md)
+  - configured values may raise the documented defaults, but they must not
+    drop below the daemon timeout floor of `250ms`; same-host request and
+    daemon-health deadlines must not drop below `1s`
+  - `daemon.remote_retry_budget` is configurable only in the inclusive range
+    `1s..=300s`; out-of-range values are startup-fatal and reload-fatal
 - runtime queues and handles must obey one documented concrete cap policy
 - resource-cap matrix:
   - max concurrent accepted connections: `64`
@@ -490,6 +516,8 @@ Required runtime rules:
   retaining unbounded watcher state
 - notification runtime must reject or degrade delivery beyond the bounded queue
   cap rather than silently buffering unbounded work
+- ingest saturation emits `DaemonIngestQueueSaturated` and the matching health
+  finding rather than silently dropping or only incrementing a counter
 - notification runtime producer paths must publish only lifecycle/degraded
   checks plus bounded command-channel submission; callers must not mutate queue
   state or persistence sequencing directly
@@ -501,9 +529,14 @@ Required runtime rules:
   the daemon must reject the update unless the explicit admin takeover path
   documented in `docs/team-member-state.md` is active
 - accepted pid changes must update daemon memory and emit `AgentPidChanged`
+- the semantic pid newtype closure for daemon-owned runtime state is assigned
+  to `AA.3`, which already owns the runtime-health and doctor DTO rewrite
 - crash recovery must preserve the ordering rule `SQLite commit -> export`
   and any retry/re-export state needed after daemon crash must be durable rather
   than RAM-only
+- replay-store unavailability after startup must fail closed for new replay
+  work, emit typed degraded retry findings, and require operator restart or
+  bounded runtime reload rather than silently bypassing replay durability
 - daemon code must not bypass `atm-core` subsystem boundaries
 - the current Phase R baseline keeps `atm-daemon` as the runtime composition
   root for production runtime wiring unless a later ADR extracts a separate

--- a/docs/phase-AA/daemon-sqlite-leak-ledger.md
+++ b/docs/phase-AA/daemon-sqlite-leak-ledger.md
@@ -12,13 +12,13 @@ than rediscovering ownership.
 | --- | --- | --- |
 | `crates/atm-daemon/src/sqlite_observability.rs` | daemon-owned SQLite observability adapter | `delete` |
 | `crates/atm-daemon/src/runtime_health_test_support.rs` | daemon-local SQLite test assembly | `delete` |
-| `crates/atm-daemon/src/lib.rs` | `SqliteRemoteReplayStore`, `RemoteReplayStateRecord` re-export, direct SQLite observability type use | `rewrite` to remove replay wrapper and all direct `atm_rusqlite` types |
-| `crates/atm-daemon/src/composition.rs` | `SqliteBoundaryAssembly::new*`, SQLite observability injection, concrete production boundary construction | `move` concrete assembly to `atm-runtime`; `rewrite` daemon composition to injected ports only |
-| `crates/atm-daemon/src/runtime_health.rs` | direct `SqliteBoundaryAssembly`, direct roster-store use, WAL checkpoint call, SQLite readiness probing | `rewrite` to injected subsystem reports plus daemon-owned runtime state only |
-| `crates/atm-daemon/src/runtime_status_cache.rs` | `sqlite_ready`, `sqlite_detail`, `mark_sqlite_unavailable*` | `delete` SQLite-named fields/helpers; keep only daemon runtime fields |
-| `crates/atm-daemon/src/peer_transport.rs` | daemon-owned replay DTO/trait coupled to SQLite-owned record type | `rewrite` to storage-neutral replay DTO/trait owned outside daemon and `atm-rusqlite` |
-| `crates/atm-daemon/src/tests.rs` | direct `assemble_boundary(...)` use | `rewrite` to composition/subsystem fixtures; no daemon-local SQLite assembly |
-| `crates/atm-daemon/src/tests_advisory.rs` | direct `assemble_boundary(...)` use | `rewrite` to composition/subsystem fixtures; no daemon-local SQLite assembly |
+| `crates/atm-daemon/src/lib.rs` | `SqliteRemoteReplayStore`, `RemoteReplayStateRecord` re-export, direct SQLite observability type use | `keep-and-rewrite` to remove the replay wrapper and all direct `atm_rusqlite` types while preserving the daemon entry surface |
+| `crates/atm-daemon/src/composition.rs` | `SqliteBoundaryAssembly::new*`, SQLite observability injection, concrete production boundary construction | `move` concrete assembly to `atm-runtime`; keep daemon composition storage-neutral |
+| `crates/atm-daemon/src/runtime_health.rs` | direct `SqliteBoundaryAssembly`, direct roster-store use, WAL checkpoint call, SQLite readiness probing | `keep-and-rewrite` to injected subsystem reports plus daemon-owned runtime state only |
+| `crates/atm-daemon/src/runtime_status_cache.rs` | `sqlite_ready`, `sqlite_detail`, `mark_sqlite_unavailable*` | `keep-and-rewrite` to daemon runtime fields only, with SQLite-named status removed |
+| `crates/atm-daemon/src/peer_transport.rs` | daemon-owned replay DTO/trait coupled to SQLite-owned record type | `keep-and-rewrite` to a storage-neutral replay DTO/trait owned outside daemon and `atm-rusqlite` |
+| `crates/atm-daemon/src/tests.rs` | direct `assemble_boundary(...)` use | `keep-and-rewrite` to composition/subsystem fixtures with no daemon-local SQLite assembly |
+| `crates/atm-daemon/src/tests_advisory.rs` | direct `assemble_boundary(...)` use | `keep-and-rewrite` to composition/subsystem fixtures with no daemon-local SQLite assembly |
 
 ## Concrete Type Decisions
 

--- a/docs/phase-AA/daemon-sqlite-leak-ledger.md
+++ b/docs/phase-AA/daemon-sqlite-leak-ledger.md
@@ -53,6 +53,18 @@ Phase AA decision:
 - deep health belongs to subsystem doctor traits
 - daemon aggregates subsystem reports and daemon-owned runtime state only
 
+## WAL Checkpoint Ownership Record
+
+Frozen references that must leave daemon-owned SQLite control flow by `AA.3`:
+- `docs/atm-daemon/architecture.md §3.1.2` step `5` documents the current
+  graceful-shutdown WAL checkpoint step; the daemon-side implementation leak is
+  the direct checkpoint call in `crates/atm-daemon/src/runtime_health.rs`, and
+  the Phase AA decision remains `keep-and-rewrite` until that call is removed
+- `docs/atm-daemon/architecture.md §3.6` documents the crash-recovery rule that
+  graceful-shutdown WAL checkpoint is best-effort only; this is a retained
+  contract reference, not permission for daemon-owned SQLite control flow after
+  `AA.3`
+
 ## Review Rule
 
 If implementation work proposes:

--- a/docs/phase-AA/daemon-state-machines.md
+++ b/docs/phase-AA/daemon-state-machines.md
@@ -33,7 +33,11 @@ Owned concerns:
 Primary files:
 - `crates/atm-daemon/src/local_ipc_transport.rs`
 - `crates/atm-daemon/src/local_ipc_transport/request_worker.rs`
-- dispatch portions of `crates/atm-daemon/src/runtime_health.rs`
+- temporary pre-`AA.3` dispatch portions of
+  `crates/atm-daemon/src/runtime_health.rs`
+  - this file is still listed below as a target violation because its current
+    SQLite-aware health logic exceeds the desired machine boundary and must be
+    deleted or split during the Phase AA line
 
 ### 3. Session / Connection Lifecycle
 

--- a/docs/phase-AA/issues.md
+++ b/docs/phase-AA/issues.md
@@ -5,6 +5,8 @@
 Track the known Phase AA issue set so planning, QA, and phase closeout use one
 authoritative inventory rather than ad hoc reviewer memory.
 
+AA.0 freezes this inventory as the starting point for the execution line.
+
 ## Open Architectural Issues
 
 | ID | Status | Summary | Planned Closure |

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -12,7 +12,7 @@ Authoritative supporting inventory:
 
 | Sprint | Status | Branch | Worktree | Closure Gate |
 | --- | --- | --- | --- | --- |
-| `AA.0` | `planned` | `feature/pAA-s0-daemon-architecture-restatement` | `../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement` | daemon role, doctor aggregation model, and state-machine inventory documented and accepted |
+| `AA.0` | `complete` | `feature/pAA-s0-daemon-architecture-restatement` | `../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement` | daemon role, doctor aggregation model, and state-machine inventory documented and accepted |
 | `AA.1` | `planned` | `feature/pAA-s1-subsystem-doctor-traits` | `../atm-core-worktrees/feature/pAA-s1-subsystem-doctor-traits` | subsystem-owned capability/doctor traits and shared diagnostic DTOs land in the governing docs and code |
 | `AA.2` | `planned` | `feature/pAA-s2-atm-runtime-composition-transfer` | `../atm-core-worktrees/feature/pAA-s2-atm-runtime-composition-transfer` | `atm-runtime` owns concrete SQLite/runtime assembly; `atm-daemon` stops constructing SQLite boundaries; target-state runtime boundary is frozen even though SQLite TOML relock waits for `AA.5` |
 | `AA.3` | `planned` | `feature/pAA-s3-direct-doctor-and-runtime-health-split` | `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split` | `atm doctor` regains direct local store diagnostics; daemon aggregates injected subsystem reports plus daemon-owned runtime state without backend-specific diagnosis logic |

--- a/docs/phase-AA/sprint-AA0.md
+++ b/docs/phase-AA/sprint-AA0.md
@@ -6,7 +6,7 @@ phase: AA
 sprint: AA.0
 worktree: ../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement
 branch: feature/pAA-s0-daemon-architecture-restatement
-status: planned
+status: complete
 estimated_scope: medium
 ```
 

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -53,6 +53,8 @@ Current violated state that `Phase AA` must delete:
 Authoritative planning support artifacts:
 - `docs/phase-AA/readiness.md`
 - `docs/phase-AA/issues.md`
+- `docs/phase-AA/daemon-state-machines.md`
+- `docs/phase-AA/daemon-sqlite-leak-ledger.md`
 - `.claude/agents/boundary-guard.md`
 
 ## Why Phase AA Exists

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -196,6 +196,9 @@ Status summary:
 - The authoritative plan is [`docs/plan-phase-AA.md`](./plan-phase-AA.md).
 - The authoritative closure checklist is
   [`docs/phase-AA/readiness.md`](./phase-AA/readiness.md).
+- `AA.0` completed the daemon-role restatement, top-level state-machine
+  inventory, and daemon-side SQLite leak ledger that later AA sprints must
+  follow.
 
 Goal:
 - move concrete SQLite/runtime assembly to `atm-runtime`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -27,6 +27,9 @@ Phase-AA simplification direction:
 - the daemon must not know that the current durable adapter is SQLite
 - direct local diagnostics such as store-openability and baseline SQLite
   health may be answered without routing through the daemon
+- each subsystem owns its own diagnostic trait and backend-specific diagnosis
+- top-level doctor code aggregates subsystem findings and daemon-owned runtime
+  state, but must not reimplement backend-specific diagnosis logic
 
 The retained product surface is:
 - `atm send`


### PR DESCRIPTION
## Summary
- Daemon thin-router role restated in governing docs (architecture.md, requirements.md)
- `docs/phase-AA/daemon-state-machines.md` — ≤5 top-level machines documented
- `docs/phase-AA/daemon-sqlite-leak-ledger.md` — every daemon-side SQLite touch classified (delete/move/keep-and-rewrite)
- `docs/phase-AA/readiness.md` — AA sprint line + phase exit criteria recorded
- `docs/phase-AA/issues.md` — Phase AA issues inventory

## Sprint
Phase AA sprint AA.0 — docs-only sprint establishing daemon architecture baseline.

Sprint doc: `docs/phase-AA/sprint-AA0.md`