### PR TITLE
AA.5 Boundary Relock And Permanent Enforcement

### DIFF
--- a/.claude/agents/boundary-guard.md
+++ b/.claude/agents/boundary-guard.md
@@ -1,6 +1,6 @@
 ---
 name: boundary-guard
-version: 0.1.0
+version: 0.2.0
 description: Reviews boundary TOML and crate-edge changes for policy relaxations or forbidden dependency reintroduction before plan approval and phase closeout.
 tools: Glob, Grep, LS, Read, BashOutput
 model: sonnet
@@ -31,6 +31,11 @@ At minimum, detect:
 - any removal from `forbidden_test_bypasses`
 - any removal from `forbidden`
 - any direct `atm-daemon -> atm-rusqlite` dependency edge in code or manifests
+- any mismatch between `runtime-composition.toml` and the SQLite boundary TOMLs
+  on the forbidden `atm-daemon -> atm-rusqlite` edge
+
+Run `python3 scripts/check-boundary-guard.py --base-ref <review-base-ref>` as
+the first machine check and treat any non-zero result as a blocking failure.
 
 ## Mandatory Trigger Points
 
@@ -57,6 +62,7 @@ Return fenced JSON only.
   "status": "PASS | FAIL",
   "mode": "boundary-guard-review",
   "reviewer": "boundary-guard",
+  "guard_script": "python3 scripts/check-boundary-guard.py --base-ref <review-base-ref>",
   "findings": [
     {
       "severity": "Blocking | Important | Minor",

--- a/.claude/agents/registry.yaml
+++ b/.claude/agents/registry.yaml
@@ -18,7 +18,7 @@ agents:
     version: 0.1.0
     path: .claude/agents/critical-plan-reviewer.md
   boundary-guard:
-    version: 0.1.0
+    version: 0.2.0
     path: .claude/agents/boundary-guard.md
   flaky-test-qa:
     version: 0.1.0

--- a/boundaries/atm-runtime/runtime-composition.toml
+++ b/boundaries/atm-runtime/runtime-composition.toml
@@ -26,7 +26,11 @@ io_forbidden = ["daemon_transport", "daemon_lifecycle", "direct_socket_io"]
 [dependencies]
 allowed_dependents = ["atm", "atm-daemon", "atm-daemon-bootstrap"]
 allowed_dependencies = ["atm-core", "atm-rusqlite"]
-forbidden_edges = ["atm -> atm-rusqlite", "atm-runtime -> atm-daemon"]
+forbidden_edges = [
+  "atm -> atm-rusqlite",
+  "atm-daemon -> atm-rusqlite",
+  "atm-runtime -> atm-daemon",
+]
 
 [references]
 scope = "outside_owner_crate"
@@ -50,5 +54,5 @@ state = "concrete_landed"
 notes = [
   "implemented by AA.2 as the concrete runtime/store composition root for atm and atm-daemon",
   "daemon startup remains fail-closed on any RuntimeBundle assembly failure",
-  "the daemon-to-sqlite edge remains governed by the existing rusqlite boundary TOMLs until AA.5 relocks them; this record freezes the target end-state during the AA.2-AA.4 transition window",
+  "AA.5 relocks the sqlite boundary TOMLs so this record and the sqlite boundary records now agree on the forbidden atm-daemon -> atm-rusqlite edge",
 ]

--- a/boundaries/atm-rusqlite/mail-store-sqlite.toml
+++ b/boundaries/atm-rusqlite/mail-store-sqlite.toml
@@ -26,13 +26,14 @@ io_forbidden = [
 ]
 
 [dependencies]
-allowed_dependents = ["atm-daemon", "atm-daemon-bootstrap", "atm-runtime", "atm-runtime-test-support"]
+allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime", "atm-runtime-test-support"]
 allowed_dependencies = [
   "atm-core",
   "rusqlite",
 ]
 forbidden_edges = [
   "atm -> atm-rusqlite",
+  "atm-daemon -> atm-rusqlite",
   "atm-graft -> atm-rusqlite",
 ]
 
@@ -69,5 +70,5 @@ state = "active"
 notes = [
   "crate-root implementation remains temporary; module split is still deferred",
   "assembled through atm_rusqlite::SqliteBoundaryAssembly",
-  "transition note: atm-daemon remains in allowed_dependents through the AA.2-AA.4 window; runtime-composition.toml governs the target end-state while AA.5 relocks the sqlite boundary TOMLs",
+  "AA.5 relocks this store boundary so daemon callers must reach it only through atm-runtime-owned composition",
 ]

--- a/boundaries/atm-rusqlite/roster-store-sqlite.toml
+++ b/boundaries/atm-rusqlite/roster-store-sqlite.toml
@@ -26,13 +26,14 @@ io_forbidden = [
 ]
 
 [dependencies]
-allowed_dependents = ["atm-daemon", "atm-daemon-bootstrap", "atm-runtime", "atm-runtime-test-support"]
+allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime", "atm-runtime-test-support"]
 allowed_dependencies = [
   "atm-core",
   "rusqlite",
 ]
 forbidden_edges = [
   "atm -> atm-rusqlite",
+  "atm-daemon -> atm-rusqlite",
   "atm-graft -> atm-rusqlite",
 ]
 
@@ -71,5 +72,5 @@ notes = [
   "the canonical table is explicit member rows; daemon-owned pid continuity is not persisted here",
   "crate-root implementation remains temporary; module split is still deferred",
   "assembled through atm_rusqlite::SqliteBoundaryAssembly",
-  "transition note: atm-daemon remains in allowed_dependents through the AA.2-AA.4 window; runtime-composition.toml governs the target end-state while AA.5 relocks the sqlite boundary TOMLs",
+  "AA.5 relocks this store boundary so daemon callers must reach roster truth only through atm-runtime-owned composition",
 ]

--- a/boundaries/atm-rusqlite/shared-db.toml
+++ b/boundaries/atm-rusqlite/shared-db.toml
@@ -27,13 +27,14 @@ io_forbidden = [
 ]
 
 [dependencies]
-allowed_dependents = ["atm-daemon", "atm-daemon-bootstrap", "atm-runtime", "atm-runtime-test-support"]
+allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime", "atm-runtime-test-support"]
 allowed_dependencies = [
   "atm-core",
   "rusqlite",
 ]
 forbidden_edges = [
   "atm -> atm-rusqlite",
+  "atm-daemon -> atm-rusqlite",
   "atm-graft -> atm-rusqlite",
 ]
 
@@ -69,5 +70,5 @@ state = "unix_implemented_windows_pending"
 notes = [
   "crate-private state-root surface must remain review-visible because it owns sqlite bootstrap and transaction policy",
   "shared database root is host-scoped under the ADR-005 durable-state model",
-  "transition note: atm-daemon remains in allowed_dependents through the AA.2-AA.4 window; runtime-composition.toml governs the target end-state while AA.5 relocks the sqlite boundary TOMLs",
+  "AA.5 relocks this state-root boundary so daemon callers must reach sqlite bootstrap and transaction policy only through atm-runtime-owned composition",
 ]

--- a/boundaries/atm-rusqlite/sqlite-boundary-assembly.toml
+++ b/boundaries/atm-rusqlite/sqlite-boundary-assembly.toml
@@ -29,13 +29,14 @@ io_forbidden = [
 ]
 
 [dependencies]
-allowed_dependents = ["atm-daemon", "atm-daemon-bootstrap", "atm-runtime", "atm-runtime-test-support"]
+allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime", "atm-runtime-test-support"]
 allowed_dependencies = [
   "atm-core",
   "rusqlite",
 ]
 forbidden_edges = [
   "atm -> atm-rusqlite",
+  "atm-daemon -> atm-rusqlite",
   "atm-graft -> atm-rusqlite",
 ]
 
@@ -66,6 +67,6 @@ review_gates = [
 state = "active"
 notes = [
   "hosts the shared assembly seam for mail, task, and roster adapters over one sqlite root",
-  "daemon runtime may use the public assembly seam for roster truth and SQLite readiness checks",
-  "transition note: atm-daemon remains in allowed_dependents through the AA.2-AA.4 window; runtime-composition.toml governs the target end-state while AA.5 relocks the sqlite boundary TOMLs",
+  "daemon runtime reaches the public assembly seam only through atm-runtime-owned composition",
+  "AA.5 relocks this boundary so the sqlite assembly record again forbids the daemon-to-sqlite edge directly",
 ]

--- a/boundaries/atm-rusqlite/task-store-sqlite.toml
+++ b/boundaries/atm-rusqlite/task-store-sqlite.toml
@@ -26,13 +26,14 @@ io_forbidden = [
 ]
 
 [dependencies]
-allowed_dependents = ["atm-daemon", "atm-daemon-bootstrap", "atm-runtime", "atm-runtime-test-support"]
+allowed_dependents = ["atm-daemon-bootstrap", "atm-runtime", "atm-runtime-test-support"]
 allowed_dependencies = [
   "atm-core",
   "rusqlite",
 ]
 forbidden_edges = [
   "atm -> atm-rusqlite",
+  "atm-daemon -> atm-rusqlite",
   "atm-graft -> atm-rusqlite",
 ]
 
@@ -70,5 +71,5 @@ notes = [
   "ack-related task transitions still resolve through send-shape workflows, not a separate public ack API",
   "crate-root implementation remains temporary; module split is still deferred",
   "assembled through atm_rusqlite::SqliteBoundaryAssembly",
-  "transition note: atm-daemon remains in allowed_dependents through the AA.2-AA.4 window; runtime-composition.toml governs the target end-state while AA.5 relocks the sqlite boundary TOMLs",
+  "AA.5 relocks this store boundary so daemon callers must reach task persistence only through atm-runtime-owned composition",
 ]

--- a/crates/atm-runtime/src/replay_store.rs
+++ b/crates/atm-runtime/src/replay_store.rs
@@ -1,10 +1,14 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use atm_core::boundary::{self, MessageKey, RemoteReplayStateRecord};
 use atm_core::error::AtmError;
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
-use atm_rusqlite::{NullSqliteObservability, SqliteBoundaryAssembly};
+use atm_rusqlite::SqliteBoundaryAssembly;
+
+#[cfg(any(test, feature = "test-utils"))]
+use std::path::PathBuf;
+#[cfg(any(test, feature = "test-utils"))]
+use atm_rusqlite::NullSqliteObservability;
 
 #[derive(Debug, Clone)]
 pub(crate) struct SqliteRemoteReplayStore {

--- a/crates/atm-runtime/src/replay_store.rs
+++ b/crates/atm-runtime/src/replay_store.rs
@@ -6,9 +6,9 @@ use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_rusqlite::SqliteBoundaryAssembly;
 
 #[cfg(any(test, feature = "test-utils"))]
-use std::path::PathBuf;
-#[cfg(any(test, feature = "test-utils"))]
 use atm_rusqlite::NullSqliteObservability;
+#[cfg(any(test, feature = "test-utils"))]
+use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub(crate) struct SqliteRemoteReplayStore {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,10 @@ Phase-AA simplification note:
   storage-neutral capability traits
 - backend-specific implementations such as SQLite-backed and Claude-JSON-backed
   adapters are allowed to satisfy that same behavior-named trait family
+- `AA.5` relocks the daemon-to-SQLite edge in both the runtime-composition and
+  SQLite boundary records and adds an independent boundary-guard review script
+  so policy widening is treated as an architecture change rather than routine
+  lint-data churn
 
 ## 2. Crate Boundaries
 
@@ -210,6 +214,9 @@ Current Phase R boundary direction:
   - `atm-runtime` becomes the concrete runtime/store composition root
   - `atm-daemon` consumes storage-neutral runtime inputs and stops
     constructing SQLite-backed adapters directly in production composition
+  - relocked boundary records forbid a direct `atm-daemon -> atm-rusqlite`
+    edge; any reintroduction must fail both TOML policy checks and the
+    boundary-guard review script
 
 Current Phase R lint partition direction:
 - extend the existing `sc-portability` analyzer for reusable platform-gating

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -7,6 +7,10 @@ Current design assumption:
 - `atm-daemon` is the production runtime composition root
 - `allowed_dependents: []` means no external crate should depend on these
   daemon-private concrete adapters
+- after `AA.5`, `atm-daemon` reaches SQLite-backed stores only through
+  `atm-runtime`; a direct `atm-daemon -> atm-rusqlite` dependency is a
+  boundary violation guarded by both the boundary TOMLs and
+  `scripts/check-boundary-guard.py`
 - Runtime test doubles now exist for the watch/reconcile/notifier lanes so
   boundary tests can exercise the daemon-owned runtimes without bypassing the
   declared contracts.

--- a/docs/atm-rusqlite/boundaries.md
+++ b/docs/atm-rusqlite/boundaries.md
@@ -9,6 +9,9 @@ Current design assumption:
 - runtime composition must go through `atm-core` boundary traits/facades
 - client crates such as `atm`, `atm-graft`, and future harness-specific clients
   must not depend on this crate directly
+- after `AA.5`, `atm-daemon` is forbidden again as a direct dependent of the
+  SQLite assembly, store, and shared-db state-root records; daemon callers
+  reach SQLite only through `atm-runtime`
 
 Canonical machine-readable boundary sources:
 - [`boundaries/atm-rusqlite/mail-store-sqlite.toml`](../../boundaries/atm-rusqlite/mail-store-sqlite.toml)
@@ -28,6 +31,11 @@ review:
 
 These are not public boundary traits, but they are important private
 implementation surfaces for review.
+
+AA.5 relock note:
+- `python3 scripts/check-boundary-guard.py --base-ref <review-base-ref>` is the
+  second enforcement layer that detects policy widening and any reintroduced
+  `atm-daemon -> atm-rusqlite` code edge before review closure
 
 ## SqliteBoundaryAssembly
 

--- a/docs/phase-AA/issues.md
+++ b/docs/phase-AA/issues.md
@@ -11,10 +11,10 @@ AA.0 freezes this inventory as the starting point for the execution line.
 
 | ID | Status | Summary | Planned Closure |
 | --- | --- | --- | --- |
-| `AA-ISSUE-001` | `planned` | `atm-daemon` currently carries a direct `atm-rusqlite` dependency and concrete SQLite references. | `AA.2` through `AA.5` |
-| `AA-ISSUE-002` | `planned` | daemon runtime health currently owns SQLite-specific readiness and status fields. | `AA.3` |
-| `AA-ISSUE-003` | `planned` | daemon still carries SQLite observability, replay-store, and test-support leakage. | `AA.4` |
-| `AA-ISSUE-004` | `planned` | repository enforcement currently trusts boundary TOML as final authority without an independent guard for policy widening. | `AA.5` |
+| `AA-ISSUE-001` | `closed` | `atm-daemon` currently carries a direct `atm-rusqlite` dependency and concrete SQLite references. | `AA.2` through `AA.5` |
+| `AA-ISSUE-002` | `closed` | daemon runtime health currently owns SQLite-specific readiness and status fields. | `AA.3` |
+| `AA-ISSUE-003` | `closed` | daemon still carries SQLite observability, replay-store, and test-support leakage. | `AA.4` |
+| `AA-ISSUE-004` | `closed` | repository enforcement currently trusts boundary TOML as final authority without an independent guard for policy widening. | `AA.5` |
 
 ## Inventory Rules
 

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -15,9 +15,9 @@ Authoritative supporting inventory:
 | `AA.0` | `complete` | `feature/pAA-s0-daemon-architecture-restatement` | `../atm-core-worktrees/feature/pAA-s0-daemon-architecture-restatement` | daemon role, doctor aggregation model, and state-machine inventory documented and accepted |
 | `AA.1` | `complete` | `feature/pAA-s1-subsystem-doctor-traits` | `../atm-core-worktrees/feature/pAA-s1-subsystem-doctor-traits` | subsystem-owned capability/doctor traits and shared diagnostic DTOs land in the governing docs and code |
 | `AA.2` | `complete` | `feature/pAA-s2-atm-runtime-composition-transfer` | `../atm-core-worktrees/feature/pAA-s2-atm-runtime-composition-transfer` | `atm-runtime` owns concrete SQLite/runtime assembly; `atm-daemon` stops constructing SQLite boundaries in production; target-state runtime boundary is frozen even though SQLite TOML relock waits for `AA.5` |
-| `AA.3` | `planned` | `feature/pAA-s3-direct-doctor-and-runtime-health-split` | `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split` | `atm doctor` regains direct local store diagnostics; daemon aggregates injected subsystem reports plus daemon-owned runtime state without backend-specific diagnosis logic |
-| `AA.4` | `planned` | `feature/pAA-s4-delete-daemon-sqlite-leaks` | `../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks` | remaining SQLite observability, replay, and test-support leaks are removed from `atm-daemon` |
-| `AA.5` | `planned` | `feature/pAA-s5-boundary-relock-and-permanent-enforcement` | `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement` | daemon-to-SQLite edge is forbidden again, all boundary TOMLs agree on that policy, and a second enforcement layer exists beyond TOML lint |
+| `AA.3` | `complete` | `feature/pAA-s3-direct-doctor-and-runtime-health-split` | `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split` | `atm doctor` regains direct local store diagnostics; daemon aggregates injected subsystem reports plus daemon-owned runtime state without backend-specific diagnosis logic |
+| `AA.4` | `complete` | `feature/pAA-s4-delete-daemon-sqlite-leaks` | `../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks` | remaining SQLite observability, replay, and test-support leaks are removed from `atm-daemon` |
+| `AA.5` | `complete` | `feature/pAA-s5-boundary-relock-and-permanent-enforcement` | `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement` | daemon-to-SQLite edge is forbidden again, all boundary TOMLs agree on that policy, and a second enforcement layer exists beyond TOML lint |
 | `AA.6` | `planned` | `feature/pAA-s6-obs-upgrade` | `../atm-core-worktrees/feature/pAA-s6-obs-upgrade` | ATM builds and validates on `sc-observability` / `sc-observability-types` `1.2.0` with the queue-backed logger API, retained-log policy field migration, and updated health projection |
 
 ## Phase Exit Criteria
@@ -34,6 +34,8 @@ Authoritative supporting inventory:
 - the boundary TOMLs forbid the daemon-to-SQLite edge again
 - a repository-enforced dependency-boundary test or equivalent guard fails
   whenever that edge reappears
+- `python3 scripts/check-boundary-guard.py --base-ref <review-base-ref>` is
+  the required second guard for review-time policy widening detection
 - a `boundary-guard` QA agent reviews both plans and phase-ending reviews
   and flags boundary-policy widening before closure
 - ATM has completed the `sc-observability` / `sc-observability-types` `1.2.0`

--- a/docs/phase-AA/sprint-AA5.md
+++ b/docs/phase-AA/sprint-AA5.md
@@ -6,7 +6,7 @@ phase: AA
 sprint: AA.5
 worktree: ../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement
 branch: feature/pAA-s5-boundary-relock-and-permanent-enforcement
-status: planned
+status: complete
 estimated_scope: medium
 ```
 
@@ -40,6 +40,7 @@ code and in review workflow.
 - `boundaries/atm-rusqlite/mail-store-sqlite.toml`
 - `boundaries/atm-rusqlite/roster-store-sqlite.toml`
 - `boundaries/atm-rusqlite/task-store-sqlite.toml`
+- `boundaries/atm-rusqlite/shared-db.toml`
 
 ## Prerequisites
 
@@ -63,6 +64,8 @@ code and in review workflow.
   - restore explicit forbidden edges
   - restore any visibility/constructor privacy that was widened only to permit
     daemon-side SQLite assembly
+  - include the crate-private `SharedDbStateRoot` record in the relock so no
+    daemon allowlist survives on a SQLite state-root seam
   - make the SQLite boundary TOMLs agree with
     `boundaries/atm-runtime/runtime-composition.toml` on the forbidden
     `atm-daemon -> atm-rusqlite` edge so no policy contradiction remains after
@@ -86,6 +89,13 @@ code and in review workflow.
         "field": "allowed_dependents",
         "change": "added atm-daemon",
         "requires_approval": true
+      }
+    ],
+    "violations": [
+      {
+        "category": "FORBIDDEN-EDGE | POLICY-RELAXATION",
+        "detail": "clear statement of the boundary problem",
+        "ref": "path:line"
       }
     ]
   }

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -284,6 +284,8 @@ Purpose:
   reviews for any boundary loosening before closure
 - close the temporary `AA.2` to `AA.4` transition window by making the
   SQLite boundary TOMLs agree with `runtime-composition.toml`
+- include the `SharedDbStateRoot` record in that relock so no daemon allowlist
+  survives on a crate-private SQLite state-root seam
 
 Execution branch:
 - `feature/pAA-s5-boundary-relock-and-permanent-enforcement`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -209,6 +209,9 @@ Status summary:
   daemon-private SQLite observability adapter, deleting direct daemon test
   boundary assembly calls, and relying on `atm-core` / `atm-runtime` replay
   seams instead of a direct `atm-daemon -> atm-rusqlite` dependency.
+- `AA.5` relocks the daemon-to-SQLite edge in the runtime and SQLite boundary
+  TOMLs, adds the independent `check-boundary-guard.py` review guard, and
+  freezes boundary-policy widening as an explicit architecture change.
 
 Goal:
 - move concrete SQLite/runtime assembly to `atm-runtime`

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -231,6 +231,23 @@ Required behavior:
 Existing generic tools such as `clippy` are not sufficient on their own for
 this repository-specific architectural rule.
 
+### Boundary Policy Relock Reviews
+
+Phase AA adds a second enforcement layer for boundary-policy widening:
+
+- `python3 scripts/check-boundary-guard.py --base-ref <review-base-ref>`
+- `python3 -m unittest scripts.test_boundary_guard`
+
+Rules:
+
+- the boundary-guard script is required on plan branches that modify boundary
+  TOMLs
+- the boundary-guard script is required on phase-ending review branches
+- any `FAIL` result is merge-blocking for those review flows
+- this guard remains separate from ordinary `just lint` because it compares the
+  current branch against an explicit review base ref and treats policy widening
+  as an architecture change rather than routine lint churn
+
 ## 7. Quality Bar
 
 A test architecture is acceptable only if it increases confidence in the

--- a/scripts/check-boundary-guard.py
+++ b/scripts/check-boundary-guard.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""CLI wrapper for the boundary-guard repository check."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.check_boundary_guard import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_boundary_guard.py
+++ b/scripts/check_boundary_guard.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Independent guard for boundary-policy relaxations and daemon->sqlite drift."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+FORBIDDEN_EDGE = "atm-daemon -> atm-rusqlite"
+RUNTIME_COMPOSITION = Path("boundaries/atm-runtime/runtime-composition.toml")
+SQLITE_BOUNDARY_FILES = [
+    Path("boundaries/atm-rusqlite/sqlite-boundary-assembly.toml"),
+    Path("boundaries/atm-rusqlite/mail-store-sqlite.toml"),
+    Path("boundaries/atm-rusqlite/roster-store-sqlite.toml"),
+    Path("boundaries/atm-rusqlite/task-store-sqlite.toml"),
+    Path("boundaries/atm-rusqlite/shared-db.toml"),
+]
+ALL_GUARDED_BOUNDARY_FILES = [RUNTIME_COMPOSITION, *SQLITE_BOUNDARY_FILES]
+VISIBILITY_ORDER = {
+    "private": 0,
+    "pub(crate)": 1,
+    "crate": 1,
+    "public": 2,
+}
+
+
+def _read_toml(path: Path) -> dict:
+    return tomllib.loads(path.read_text())
+
+
+def _find_line(path: Path, needle: str) -> str:
+    try:
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            if needle in line:
+                return f"{path.as_posix()}:{number}"
+    except FileNotFoundError:
+        pass
+    return path.as_posix()
+
+
+def _as_list(doc: dict, *keys: str) -> list[str]:
+    current = doc
+    for key in keys:
+        if not isinstance(current, dict):
+            return []
+        current = current.get(key, [])
+    return list(current) if isinstance(current, list) else []
+
+
+def _as_string(doc: dict, *keys: str) -> str | None:
+    current = doc
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current if isinstance(current, str) else None
+
+
+def _removed(base_values: list[str], current_values: list[str]) -> list[str]:
+    return sorted(set(base_values) - set(current_values))
+
+
+def _added(base_values: list[str], current_values: list[str]) -> list[str]:
+    return sorted(set(current_values) - set(base_values))
+
+
+def compare_boundary_policy(path: Path, base_doc: dict, current_doc: dict) -> list[dict]:
+    relaxations: list[dict] = []
+    if path not in ALL_GUARDED_BOUNDARY_FILES:
+        return relaxations
+
+    allowed_additions = _added(
+        _as_list(base_doc, "dependencies", "allowed_dependents"),
+        _as_list(current_doc, "dependencies", "allowed_dependents"),
+    )
+    daemon_additions = [value for value in allowed_additions if value == "atm-daemon"]
+    if daemon_additions:
+        relaxations.append(
+            {
+                "file": path.as_posix(),
+                "field": "allowed_dependents",
+                "change": f"added {', '.join(daemon_additions)}",
+                "requires_approval": True,
+            }
+        )
+
+    forbidden_removals = _removed(
+        _as_list(base_doc, "dependencies", "forbidden_edges"),
+        _as_list(current_doc, "dependencies", "forbidden_edges"),
+    )
+    daemon_edge_removals = [value for value in forbidden_removals if value == FORBIDDEN_EDGE]
+    if daemon_edge_removals:
+        relaxations.append(
+            {
+                "file": path.as_posix(),
+                "field": "forbidden_edges",
+                "change": f"removed {', '.join(daemon_edge_removals)}",
+                "requires_approval": True,
+            }
+        )
+
+    if path in SQLITE_BOUNDARY_FILES:
+        for field in ("visibility", "constructor"):
+            base_value = _as_string(base_doc, "implementation", field)
+            current_value = _as_string(current_doc, "implementation", field)
+            if (
+                base_value in VISIBILITY_ORDER
+                and current_value in VISIBILITY_ORDER
+                and VISIBILITY_ORDER[current_value] > VISIBILITY_ORDER[base_value]
+            ):
+                relaxations.append(
+                    {
+                        "file": path.as_posix(),
+                        "field": field,
+                        "change": f"{base_value} -> {current_value}",
+                        "requires_approval": True,
+                    }
+                )
+
+        for field, key_path in (
+            ("forbidden_test_bypasses", ("testing", "forbidden_test_bypasses")),
+            ("forbidden", ("references", "forbidden")),
+        ):
+            removals = _removed(_as_list(base_doc, *key_path), _as_list(current_doc, *key_path))
+            if removals:
+                relaxations.append(
+                    {
+                        "file": path.as_posix(),
+                        "field": field,
+                        "change": f"removed {', '.join(removals)}",
+                        "requires_approval": True,
+                    }
+                )
+
+    return relaxations
+
+
+def _git_stdout(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def changed_boundary_files(repo_root: Path, base_ref: str) -> list[Path]:
+    output = _git_stdout(repo_root, "diff", "--name-only", "--diff-filter=ACMR", base_ref, "--", "boundaries")
+    files = [Path(line.strip()) for line in output.splitlines() if line.strip().endswith(".toml")]
+    return sorted(files)
+
+
+def load_base_toml(repo_root: Path, base_ref: str, relative_path: Path) -> dict | None:
+    result = subprocess.run(
+        ["git", "show", f"{base_ref}:{relative_path.as_posix()}"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    return tomllib.loads(result.stdout.decode())
+
+
+def detect_policy_relaxations(repo_root: Path, base_ref: str) -> list[dict]:
+    relaxations: list[dict] = []
+    for relative_path in changed_boundary_files(repo_root, base_ref):
+        current_path = repo_root / relative_path
+        if not current_path.exists():
+            continue
+        base_doc = load_base_toml(repo_root, base_ref, relative_path)
+        if base_doc is None:
+            continue
+        current_doc = _read_toml(current_path)
+        relaxations.extend(compare_boundary_policy(relative_path, base_doc, current_doc))
+    return relaxations
+
+
+def check_required_boundary_policy(repo_root: Path) -> list[dict]:
+    violations: list[dict] = []
+
+    runtime_doc = _read_toml(repo_root / RUNTIME_COMPOSITION)
+    runtime_edges = set(_as_list(runtime_doc, "dependencies", "forbidden_edges"))
+    if FORBIDDEN_EDGE not in runtime_edges:
+        violations.append(
+            {
+                "category": "FORBIDDEN-EDGE",
+                "detail": "runtime-composition.toml must forbid atm-daemon -> atm-rusqlite",
+                "ref": _find_line(repo_root / RUNTIME_COMPOSITION, "forbidden_edges"),
+            }
+        )
+
+    for relative_path in SQLITE_BOUNDARY_FILES:
+        doc = _read_toml(repo_root / relative_path)
+        allowed_dependents = set(_as_list(doc, "dependencies", "allowed_dependents"))
+        forbidden_edges = set(_as_list(doc, "dependencies", "forbidden_edges"))
+        if "atm-daemon" in allowed_dependents:
+            violations.append(
+                {
+                    "category": "POLICY-RELAXATION",
+                    "detail": "sqlite boundary still lists atm-daemon as an allowed dependent",
+                    "ref": _find_line(repo_root / relative_path, "allowed_dependents"),
+                }
+            )
+        if FORBIDDEN_EDGE not in forbidden_edges:
+            violations.append(
+                {
+                    "category": "FORBIDDEN-EDGE",
+                    "detail": "sqlite boundary must forbid atm-daemon -> atm-rusqlite",
+                    "ref": _find_line(repo_root / relative_path, "forbidden_edges"),
+                }
+            )
+
+    return violations
+
+
+def _dependency_section_violations(doc: dict, cargo_path: Path, section_name: str, table: dict | None) -> list[dict]:
+    if not isinstance(table, dict) or "atm-rusqlite" not in table:
+        return []
+    return [
+        {
+            "category": "FORBIDDEN-EDGE",
+            "detail": f"crates/atm-daemon/Cargo.toml must not declare atm-rusqlite in {section_name}",
+            "ref": _find_line(cargo_path, "atm-rusqlite"),
+        }
+    ]
+
+
+def check_forbidden_code_edge(repo_root: Path) -> list[dict]:
+    violations: list[dict] = []
+    cargo_path = repo_root / "crates/atm-daemon/Cargo.toml"
+    cargo_doc = _read_toml(cargo_path)
+
+    for section_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+        violations.extend(
+            _dependency_section_violations(cargo_doc, cargo_path, section_name, cargo_doc.get(section_name))
+        )
+
+    for target_name, target_table in cargo_doc.get("target", {}).items():
+        if not isinstance(target_table, dict):
+            continue
+        for section_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+            full_section = f"target.{target_name}.{section_name}"
+            violations.extend(
+                _dependency_section_violations(
+                    cargo_doc,
+                    cargo_path,
+                    full_section,
+                    target_table.get(section_name),
+                )
+            )
+
+    daemon_src = repo_root / "crates/atm-daemon/src"
+    for path in sorted(daemon_src.rglob("*.rs")):
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            if "atm_rusqlite" in line:
+                violations.append(
+                    {
+                        "category": "FORBIDDEN-EDGE",
+                        "detail": "daemon source must not reference atm_rusqlite directly",
+                        "ref": f"{path.as_posix()}:{number}",
+                    }
+                )
+
+    return violations
+
+
+def build_report(repo_root: Path, base_ref: str) -> dict:
+    policy_relaxations = detect_policy_relaxations(repo_root, base_ref)
+    violations = [
+        *check_required_boundary_policy(repo_root),
+        *check_forbidden_code_edge(repo_root),
+    ]
+    return {
+        "status": "FAIL" if policy_relaxations or violations else "PASS",
+        "forbidden_edges": [FORBIDDEN_EDGE],
+        "policy_relaxations": policy_relaxations,
+        "violations": violations,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--base-ref", default="HEAD~1")
+    parser.add_argument("--pretty", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_report(args.repo_root.resolve(), args.base_ref)
+    json.dump(report, sys.stdout, indent=2 if args.pretty else None)
+    sys.stdout.write("\n")
+    return 0 if report["status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_boundary_guard.py
+++ b/scripts/check_boundary_guard.py
@@ -15,8 +15,11 @@ RUNTIME_COMPOSITION = Path("boundaries/atm-runtime/runtime-composition.toml")
 SQLITE_BOUNDARY_FILES = [
     Path("boundaries/atm-rusqlite/sqlite-boundary-assembly.toml"),
     Path("boundaries/atm-rusqlite/mail-store-sqlite.toml"),
+    Path("boundaries/atm-rusqlite/mail-store-doctor-sqlite.toml"),
     Path("boundaries/atm-rusqlite/roster-store-sqlite.toml"),
+    Path("boundaries/atm-rusqlite/roster-store-doctor-sqlite.toml"),
     Path("boundaries/atm-rusqlite/task-store-sqlite.toml"),
+    Path("boundaries/atm-rusqlite/task-store-doctor-sqlite.toml"),
     Path("boundaries/atm-rusqlite/shared-db.toml"),
 ]
 ALL_GUARDED_BOUNDARY_FILES = [RUNTIME_COMPOSITION, *SQLITE_BOUNDARY_FILES]

--- a/scripts/test_boundary_guard.py
+++ b/scripts/test_boundary_guard.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_boundary_guard as guard
+
+
+RUNTIME_DOC = """
+[dependencies]
+allowed_dependents = ["atm", "atm-daemon", "atm-daemon-bootstrap"]
+forbidden_edges = ["atm -> atm-rusqlite", "atm-daemon -> atm-rusqlite", "atm-runtime -> atm-daemon"]
+
+[implementation]
+visibility = "public"
+constructor = "public"
+
+[references]
+forbidden = []
+
+[testing]
+forbidden_test_bypasses = []
+"""
+
+SQLITE_DOC = """
+[dependencies]
+allowed_dependents = ["atm-runtime", "atm-daemon-bootstrap", "atm-runtime-test-support"]
+forbidden_edges = ["atm -> atm-rusqlite", "atm-daemon -> atm-rusqlite", "atm-graft -> atm-rusqlite"]
+
+[implementation]
+visibility = "private"
+constructor = "private"
+
+[references]
+forbidden = ["rusqlite::Connection"]
+
+[testing]
+forbidden_test_bypasses = ["rusqlite::Connection"]
+"""
+
+
+class BoundaryGuardTests(unittest.TestCase):
+    def _write_repo(self, root: Path) -> None:
+        (root / "boundaries/atm-runtime").mkdir(parents=True, exist_ok=True)
+        (root / "boundaries/atm-rusqlite").mkdir(parents=True, exist_ok=True)
+        (root / "crates/atm-daemon/src").mkdir(parents=True, exist_ok=True)
+        (root / "crates/atm-daemon").mkdir(parents=True, exist_ok=True)
+        (root / "boundaries/atm-runtime/runtime-composition.toml").write_text(RUNTIME_DOC)
+        for relative_path in guard.SQLITE_BOUNDARY_FILES:
+            (root / relative_path).write_text(SQLITE_DOC)
+        (root / "crates/atm-daemon/Cargo.toml").write_text(
+            "[package]\nname='atm-daemon'\nversion='1.2.1'\n\n[dependencies]\natm-core={ path='../atm-core' }\n"
+        )
+        (root / "crates/atm-daemon/src/lib.rs").write_text("pub fn daemon() {}\n")
+
+    def test_compare_boundary_policy_detects_relaxations(self) -> None:
+        base_doc = {
+            "dependencies": {
+                "allowed_dependents": ["atm-runtime"],
+                "forbidden_edges": ["atm-daemon -> atm-rusqlite", "atm -> atm-rusqlite"],
+            },
+            "implementation": {"visibility": "private", "constructor": "private"},
+            "testing": {"forbidden_test_bypasses": ["rusqlite::Connection"]},
+            "references": {"forbidden": ["SharedDb"]},
+        }
+        current_doc = {
+            "dependencies": {
+                "allowed_dependents": ["atm-runtime", "atm-daemon"],
+                "forbidden_edges": ["atm -> atm-rusqlite"],
+            },
+            "implementation": {"visibility": "public", "constructor": "public"},
+            "testing": {"forbidden_test_bypasses": []},
+            "references": {"forbidden": []},
+        }
+        relaxations = guard.compare_boundary_policy(
+            Path("boundaries/atm-rusqlite/sqlite-boundary-assembly.toml"),
+            base_doc,
+            current_doc,
+        )
+        fields = {item["field"] for item in relaxations}
+        self.assertEqual(
+            fields,
+            {
+                "allowed_dependents",
+                "forbidden_edges",
+                "visibility",
+                "constructor",
+                "forbidden_test_bypasses",
+                "forbidden",
+            },
+        )
+
+    def test_required_policy_rejects_lingering_daemon_allowlist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._write_repo(root)
+            sqlite_path = root / guard.SQLITE_BOUNDARY_FILES[0]
+            sqlite_path.write_text(SQLITE_DOC.replace('"atm-runtime", ', '"atm-daemon", "atm-runtime", ', 1))
+            violations = guard.check_required_boundary_policy(root)
+            self.assertTrue(any("allowed dependent" in item["detail"] for item in violations))
+
+    def test_required_policy_rejects_missing_forbidden_edge(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._write_repo(root)
+            runtime_path = root / guard.RUNTIME_COMPOSITION
+            runtime_path.write_text(RUNTIME_DOC.replace('"atm-daemon -> atm-rusqlite", ', "", 1))
+            violations = guard.check_required_boundary_policy(root)
+            self.assertTrue(any("runtime-composition.toml" in item["detail"] for item in violations))
+
+    def test_code_edge_rejects_manifest_and_source_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._write_repo(root)
+            (root / "crates/atm-daemon/Cargo.toml").write_text(
+                "[package]\nname='atm-daemon'\nversion='1.2.1'\n\n[dependencies]\natm-rusqlite={ path='../atm-rusqlite' }\n"
+            )
+            (root / "crates/atm-daemon/src/lib.rs").write_text("use atm_rusqlite::SqliteBoundaryAssembly;\n")
+            violations = guard.check_forbidden_code_edge(root)
+            self.assertTrue(any("Cargo.toml" in item["detail"] for item in violations))
+            self.assertTrue(any("source" in item["detail"] for item in violations))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Remove atm-daemon from SQLite boundary allowlists
- Restore forbidden atm-daemon->atm-rusqlite edges in all SQLite boundary TOMLs
- Create scripts/check-boundary-guard.py, scripts/test_boundary_guard.py, .claude/agents/boundary-guard.md

## Sprint
docs/phase-AA/sprint-AA5.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)