### PR TITLE
AA.6 sc-observability 1.2.0 Upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,21 +884,22 @@ dependencies = [
 
 [[package]]
 name = "sc-observability"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e885e135bd6d6330b18528f3d25b812c354ffde1fc7bca49de56cf90dbbf61f"
+checksum = "2055d92ac115dce2a139b182f9f7c716351a4f93c4449f9693a2a3c4493b345d"
 dependencies = [
  "sc-observability-types",
  "serde",
  "serde_json",
+ "thiserror",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "sc-observability-types"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b43c59f93ca2bf8416d5e0c12b2fcb6de58913543aa4c0b62cddbb9e25b430"
+checksum = "b3ddd83dc10e65f4fda4c8b392fb9cfb520c4007c5ee5d0cde3af75c463b98ab"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,6 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 uuid = { version = "1", features = ["serde", "v4"] }
 cargo_metadata = "0.23"
-sc-observability = "1.1.0"
-sc-observability-types = "1.1.0"
+sc-observability = "1.2.0"
+sc-observability-types = "1.2.0"
 arc-swap = "1.7"

--- a/crates/atm-daemon/bin_support/daemon_observability.rs
+++ b/crates/atm-daemon/bin_support/daemon_observability.rs
@@ -17,6 +17,7 @@ use atm_daemon::DaemonSubsystem;
 use atm_daemon::{DaemonEvent, TeamScope};
 #[cfg(test)]
 use sc_observability::{JsonlFileSink, LoggerBuilder, RetentionPolicy, RotationPolicy, SinkRegistration};
+use sc_observability_types::DiagnosticInfo;
 
 type ActionName = sc_observability_types::ActionName;
 type CorrelationId = sc_observability_types::CorrelationId;
@@ -39,7 +40,7 @@ const RETAINED_LOG_RETENTION_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60
 const RETAINED_LOG_MAINTENANCE_CADENCE: Duration = Duration::from_secs(60);
 // Allow one bounded maintenance join during shutdown without turning routine
 // daemon stop into a long blocking operation.
-const RETAINED_LOG_MAINTENANCE_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
+const RETAINED_LOG_WRITER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 #[cfg(test)]
 const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAINED_SINK_FAULT";
 
@@ -203,13 +204,10 @@ impl DaemonObservability {
             ));
         };
         match lifecycle {
-            LoggerLifecycle::Running(logger_runtime) => logger_runtime.emit(event).map_err(|source| {
-                let code = sc_observability_types::DiagnosticInfo::diagnostic(&source)
-                    .code
-                    .as_str()
-                    .to_string();
+            LoggerLifecycle::Running(logger_runtime) => logger_runtime.log(event).map_err(|source| {
+                let code = log_error_code(&source);
                 AtmError::observability_emit(format!(
-                    "shared daemon observability emit failed ({code})"
+                    "shared daemon observability log admission failed ({code})"
                 ))
                 .with_source(source)
             }),
@@ -236,13 +234,7 @@ impl DaemonObservability {
                     )
                     .with_source(source)
                 })?;
-                let stopped = logger_runtime.shutdown().map_err(|source| {
-                    AtmError::observability_health(format!(
-                        "failed to stop retained observability maintenance for {}",
-                        self.active_log_path.display()
-                    ))
-                    .with_source(source)
-                })?;
+                let stopped = logger_runtime.shutdown();
                 *logger = Some(LoggerLifecycle::Stopped(stopped));
                 Ok(())
             }
@@ -382,8 +374,8 @@ impl ObservabilityPort for DaemonObservability {
             });
         };
         let report = lifecycle.health();
-        let diagnostic = report.last_error.map(map_diagnostic_summary);
-        let detail = build_observability_detail(diagnostic.as_ref(), report.maintenance.as_ref());
+        let diagnostic = report.last_error.clone().map(map_diagnostic_summary);
+        let detail = build_observability_detail(&report, diagnostic.as_ref());
         Ok(AtmObservabilityHealth {
             active_log_path: Some(self.active_log_path.clone()),
             logging_state: map_logging_state(report.state),
@@ -467,19 +459,26 @@ impl DaemonObservability {
             ));
         };
         match lifecycle {
-            LoggerLifecycle::Running(logger_runtime) => logger_runtime.emit(event).map_err(|source| {
-                let code = sc_observability_types::DiagnosticInfo::diagnostic(&source)
-                    .code
-                    .as_str()
-                    .to_string();
+            LoggerLifecycle::Running(logger_runtime) => logger_runtime.log(event).map_err(|source| {
+                let code = log_error_code(&source);
                 AtmError::observability_emit(format!(
-                    "shared daemon observability emit failed ({code})"
+                    "shared daemon observability log admission failed ({code})"
                 ))
                 .with_source(source)
             }),
             LoggerLifecycle::Stopped(_) => Err(AtmError::observability_emit(
                 "shared daemon observability emit attempted after the retained logger shut down",
             )),
+        }
+    }
+}
+
+fn log_error_code(source: &sc_observability::LogError) -> &str {
+    match source {
+        sc_observability::LogError::InvalidEvent(error) => error.diagnostic().code.as_str(),
+        sc_observability::LogError::WriterDegraded(context)
+        | sc_observability::LogError::ShutdownTimedOut(context) => {
+            context.diagnostic().code.as_str()
         }
     }
 }
@@ -596,22 +595,30 @@ fn retained_log_policy(rotation_max_bytes: u64) -> sc_observability::RetainedLog
         maintenance_cadence: sc_observability::MaintenanceCadence::new(
             RETAINED_LOG_MAINTENANCE_CADENCE,
         ),
-        maintenance_join_timeout: sc_observability::MaintenanceJoinTimeout::new(
-            RETAINED_LOG_MAINTENANCE_JOIN_TIMEOUT,
+        writer_shutdown_timeout: sc_observability::WriterShutdownTimeout::new(
+            RETAINED_LOG_WRITER_SHUTDOWN_TIMEOUT,
         ),
         maintenance_max_work_per_pass: Some(RETAINED_LOG_ROTATION_MAX_FILES),
     }
 }
 
 fn build_observability_detail(
+    report: &sc_observability_types::LoggingHealthReport,
     diagnostic: Option<&AtmObservabilityDiagnostic>,
-    maintenance: Option<&sc_observability_types::MaintenanceHealthReport>,
 ) -> Option<String> {
     let mut parts = Vec::new();
     if let Some(diagnostic) = diagnostic {
         parts.push(diagnostic.message.clone());
     }
-    if let Some(maintenance) = maintenance {
+    parts.push(format!(
+        "writer_state={} queue_depth={} queue_capacity={} queue_high_water_mark={} queue_full_drops_total={}",
+        writer_state_label(report.writer_state),
+        report.queue_depth,
+        report.queue_capacity,
+        report.queue_high_water_mark,
+        report.queue_full_drops_total,
+    ));
+    if let Some(maintenance) = &report.maintenance {
         let last_pass = maintenance
             .last_pass_at
             .map(|timestamp| timestamp.into_inner().to_string())
@@ -628,6 +635,14 @@ fn build_observability_detail(
         parts.push(summary);
     }
     (!parts.is_empty()).then(|| parts.join(" | "))
+}
+
+fn writer_state_label(state: sc_observability_types::WriterState) -> &'static str {
+    match state {
+        sc_observability_types::WriterState::Running => "running",
+        sc_observability_types::WriterState::Degraded => "degraded",
+        sc_observability_types::WriterState::Stopped => "stopped",
+    }
 }
 
 #[cfg(test)]
@@ -1098,7 +1113,7 @@ mod tests {
             rotation_max_files: sc_observability_types::FileCount::from_usize(5),
             retention_max_age: sc_observability::RetentionMaxAge::from_duration(Duration::from_millis(1)),
             maintenance_cadence: sc_observability::MaintenanceCadence::new(Duration::from_millis(10)),
-            maintenance_join_timeout: sc_observability::MaintenanceJoinTimeout::new(Duration::from_secs(1)),
+            writer_shutdown_timeout: sc_observability::WriterShutdownTimeout::new(Duration::from_secs(1)),
             maintenance_max_work_per_pass: Some(5),
         };
         let observability =

--- a/crates/atm-daemon/bin_support/daemon_observability.rs
+++ b/crates/atm-daemon/bin_support/daemon_observability.rs
@@ -39,7 +39,9 @@ const RETAINED_LOG_ROTATION_MAX_FILES: usize = 5;
 const RETAINED_LOG_RETENTION_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 const RETAINED_LOG_MAINTENANCE_CADENCE: Duration = Duration::from_secs(60);
 // Allow one bounded maintenance join during shutdown without turning routine
-// daemon stop into a long blocking operation.
+// daemon stop into a long blocking operation. This stays below the outer 2s
+// graceful drain budget so retained-log shutdown cannot consume the entire
+// daemon stop window by itself.
 const RETAINED_LOG_WRITER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 #[cfg(test)]
 const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAINED_SINK_FAULT";
@@ -218,27 +220,99 @@ impl DaemonObservability {
     }
 
     pub(crate) fn best_effort_flush_blocking(&self) -> Result<(), AtmError> {
-        let mut logger = self.logger.lock().map_err(|_| {
-            AtmError::observability_health(
-                "failed to finalize daemon observability because the logger lock was poisoned",
-            )
-        })?;
-        let Some(lifecycle) = logger.take() else {
+        let lifecycle = {
+            let mut logger = self.logger.lock().map_err(|_| {
+                AtmError::observability_health(
+                    "failed to finalize daemon observability because the logger lock was poisoned",
+                )
+            })?;
+            logger.take()
+        };
+        let Some(lifecycle) = lifecycle else {
             return Ok(());
         };
         match lifecycle {
             LoggerLifecycle::Running(logger_runtime) => {
-                logger_runtime.flush().map_err(|source| {
+                // Remove the shared logger slot before the blocking
+                // flush/shutdown sequence so concurrent emitters fail closed
+                // instead of waiting on the same mutex during shutdown.
+                let flush_result = logger_runtime.flush().map_err(|source| {
                     AtmError::observability_health(
                         "failed to flush retained observability sink during daemon shutdown",
                     )
                     .with_source(source)
-                })?;
-                let stopped = logger_runtime.shutdown();
-                *logger = Some(LoggerLifecycle::Stopped(stopped));
-                Ok(())
+                });
+                match flush_result {
+                    Ok(()) => {
+                        let stopped = logger_runtime.shutdown();
+                        let mut logger = self.logger.lock().map_err(|_| {
+                            AtmError::observability_health(
+                                "failed to record daemon observability shutdown state because the logger lock was poisoned",
+                            )
+                        })?;
+                        *logger = Some(LoggerLifecycle::Stopped(stopped));
+                        Ok(())
+                    }
+                    Err(error) => {
+                        let mut logger = self.logger.lock().map_err(|_| {
+                            AtmError::observability_health(
+                                "failed to restore daemon observability state after a flush error because the logger lock was poisoned",
+                            )
+                        })?;
+                        *logger = Some(LoggerLifecycle::Running(logger_runtime));
+                        Err(error)
+                    }
+                }
             }
             LoggerLifecycle::Stopped(logger_runtime) => {
+                let mut logger = self.logger.lock().map_err(|_| {
+                    AtmError::observability_health(
+                        "failed to record daemon observability shutdown state because the logger lock was poisoned",
+                    )
+                })?;
+                *logger = Some(LoggerLifecycle::Stopped(logger_runtime));
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn best_effort_preflush_blocking(&self) -> Result<(), AtmError> {
+        let lifecycle = {
+            let mut logger = self.logger.lock().map_err(|_| {
+                AtmError::observability_health(
+                    "failed to preflush daemon observability because the logger lock was poisoned",
+                )
+            })?;
+            logger.take()
+        };
+        let Some(lifecycle) = lifecycle else {
+            return Ok(());
+        };
+        match lifecycle {
+            LoggerLifecycle::Running(logger_runtime) => {
+                // Drain queued work before the final shutdown event is emitted,
+                // but release the mutex first so the blocking flush path cannot
+                // deadlock with a concurrent logger admission attempt.
+                let flush_result = logger_runtime.flush().map_err(|source| {
+                    AtmError::observability_health(
+                        "failed to preflush retained observability sink before daemon shutdown completion",
+                    )
+                    .with_source(source)
+                });
+                let mut logger = self.logger.lock().map_err(|_| {
+                    AtmError::observability_health(
+                        "failed to restore daemon observability state after preflush because the logger lock was poisoned",
+                    )
+                })?;
+                *logger = Some(LoggerLifecycle::Running(logger_runtime));
+                flush_result
+            }
+            LoggerLifecycle::Stopped(logger_runtime) => {
+                let mut logger = self.logger.lock().map_err(|_| {
+                    AtmError::observability_health(
+                        "failed to restore daemon observability state after preflush because the logger lock was poisoned",
+                    )
+                })?;
                 *logger = Some(LoggerLifecycle::Stopped(logger_runtime));
                 Ok(())
             }
@@ -388,6 +462,10 @@ impl ObservabilityPort for DaemonObservability {
 }
 
 impl atm_daemon::DaemonRuntimeObservability for DaemonObservability {
+    fn best_effort_preflush_blocking(&self) -> Result<(), AtmError> {
+        Self::best_effort_preflush_blocking(self)
+    }
+
     fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
         Self::emit_daemon_event(self, event)
     }
@@ -698,6 +776,8 @@ fn observability_test_event(
 }
 
 fn logger_level_override() -> Result<Option<SharedLevelFilter>, AtmError> {
+    // The daemon latches ATM_LOG during bootstrap; changing the environment
+    // later does not reconfigure the live retained logger.
     let Some(raw_value) = std::env::var(ATM_LOG_LEVEL_ENV)
         .ok()
         .map(|value| value.trim().to_string())

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -488,6 +488,10 @@ impl RuntimeComposition {
                 Ok(()) => Err(force_error),
             };
         }
+        // Preflush any queued retained-log work before emitting the terminal
+        // shutdown event so the final status update does not race older queue
+        // entries during shutdown.
+        self.request_dispatcher.preflush_observability_shutdown();
         match result.as_ref() {
             Ok(()) => {
                 self.composition_observability.emit_or_warn(

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -478,6 +478,10 @@ impl RuntimeComposition {
                 Ok(()) => Err(force_error),
             };
         }
+        // Drain any earlier retained-log backlog before the terminal shutdown
+        // event is admitted so the final event does not compete with stale
+        // queue pressure during the last bounded flush.
+        self.request_dispatcher.preflush_observability_shutdown();
         match result.as_ref() {
             Ok(()) => {
                 self.composition_observability.emit_or_warn(

--- a/crates/atm-daemon/src/daemon_runtime_observability.rs
+++ b/crates/atm-daemon/src/daemon_runtime_observability.rs
@@ -144,6 +144,10 @@ pub trait DaemonRuntimeObservability:
     ) -> Result<(), AtmError>;
 
     /// Attempt one best-effort synchronous flush during daemon shutdown.
+    fn best_effort_preflush_blocking(&self) -> Result<(), AtmError>;
+
+    /// Attempt one best-effort synchronous flush + shutdown during daemon
+    /// shutdown finalization.
     fn best_effort_flush_blocking(&self) -> Result<(), AtmError>;
 }
 

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -517,6 +517,15 @@ impl DaemonRequestDispatcher {
         );
     }
 
+    pub(crate) fn preflush_observability_shutdown(&self) {
+        let observability = self.observability.clone();
+        Self::run_bounded_shutdown_step(
+            "observability_preflush",
+            SHUTDOWN_OBSERVABILITY_FLUSH_DEADLINE,
+            move || observability.best_effort_preflush_blocking(),
+        );
+    }
+
     fn record_heartbeat(
         &self,
         request: TeamMemberHeartbeatRequest,

--- a/crates/atm-daemon/src/test_observability.rs
+++ b/crates/atm-daemon/src/test_observability.rs
@@ -180,6 +180,10 @@ impl ObservabilityPort for TestDaemonObservability {
 }
 
 impl DaemonRuntimeObservability for TestDaemonObservability {
+    fn best_effort_preflush_blocking(&self) -> Result<(), AtmError> {
+        self.best_effort_flush_blocking()
+    }
+
     fn emit_daemon_event(&self, event: DaemonEvent) -> Result<(), AtmError> {
         self.append_message(format!(
             "{{\"subsystem\":\"{}\",\"action\":\"{}\",\"outcome\":\"{}\",\"message\":\"{}\"}}",

--- a/crates/atm-runtime/src/composition.rs
+++ b/crates/atm-runtime/src/composition.rs
@@ -56,6 +56,9 @@ impl boundary::sealed::Sealed for RuntimeConfigDoctor {}
 
 impl ConfigDoctor for RuntimeConfigDoctor {
     fn inspect_config(&self) -> Result<ConfigDoctorReport, AtmError> {
+        // This doctor path is diagnostic-only: it validates the currently
+        // reachable config snapshot for reporting, but it does not mutate or
+        // pre-stage daemon startup state on behalf of the runtime.
         let current_dir = std::env::current_dir().map_err(|source| {
             AtmError::config("failed to resolve current directory for config doctor")
                 .with_recovery(

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -30,8 +30,8 @@ anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 interprocess = "2.4.2"
-sc-observability = "1.2.0"
-sc-observability-types = "1.2.0"
+sc-observability.workspace = true
+sc-observability-types.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 time = "0.3"
@@ -41,6 +41,6 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.2.1" }
-sc-observability = { version = "1.2.0", features = ["fault-injection"] }
+sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -30,8 +30,8 @@ anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 interprocess = "2.4.2"
-sc-observability = "1.1.0"
-sc-observability-types = "1.1.0"
+sc-observability = "1.2.0"
+sc-observability-types = "1.2.0"
 serde.workspace = true
 serde_json.workspace = true
 time = "0.3"
@@ -41,6 +41,6 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.1", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support", version = "1.2.1" }
-sc-observability = { version = "1.1.0", features = ["fault-injection"] }
+sc-observability = { version = "1.2.0", features = ["fault-injection"] }
 serial_test = "3"
 tempfile = "3"

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -432,6 +432,9 @@ impl atm_core::boundary::sealed::Sealed for ScObservabilityAdapter {}
 
 impl ObservabilityPort for ScObservabilityAdapter {
     fn emit(&self, event: CommandEvent) -> Result<(), AtmError> {
+        // The CLI is a short-lived synchronous caller, so per-command flush is
+        // the explicit durability barrier here. Do not reuse this adapter as a
+        // daemon or async runtime logger without revisiting that contract.
         let event = map_command_event(&self.service_name, &self.target_category, event)?;
         self.logger.log(event).map_err(map_log_error)?;
         self.logger.flush().map_err(map_flush_error)

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -433,11 +433,8 @@ impl atm_core::boundary::sealed::Sealed for ScObservabilityAdapter {}
 impl ObservabilityPort for ScObservabilityAdapter {
     fn emit(&self, event: CommandEvent) -> Result<(), AtmError> {
         let event = map_command_event(&self.service_name, &self.target_category, event)?;
-        self.logger.emit(event).map_err(|source| {
-            let code = source.diagnostic().code.as_str().to_string();
-            AtmError::observability_emit(format!("shared observability emit failed ({code})"))
-                .with_source(source)
-        })
+        self.logger.log(event).map_err(map_log_error)?;
+        self.logger.flush().map_err(map_flush_error)
     }
 
     fn query(&self, req: AtmLogQuery) -> Result<AtmLogSnapshot, AtmError> {
@@ -472,29 +469,10 @@ impl ObservabilityPort for ScObservabilityAdapter {
             .and_then(|query| query.last_error.clone().map(map_diagnostic_summary));
         let diagnostic = report
             .last_error
+            .clone()
             .map(map_diagnostic_summary)
             .or(query_diagnostic);
-        let detail = diagnostic
-            .as_ref()
-            .map(|diagnostic| diagnostic.message.clone())
-            .or_else(|| {
-                report.maintenance.as_ref().map(|maintenance| {
-                    format!(
-                        "maintenance state={} rotated_files_total={} pruned_files_total={} last_pass_at={}",
-                        match maintenance.state {
-                            sc_observability_types::MaintenanceWorkerState::Running => "running",
-                            sc_observability_types::MaintenanceWorkerState::Degraded => "degraded",
-                            sc_observability_types::MaintenanceWorkerState::Stopped => "stopped",
-                        },
-                        maintenance.rotated_files_total,
-                        maintenance.pruned_files_total,
-                        maintenance
-                            .last_pass_at
-                            .map(|timestamp| timestamp.into_inner().to_string())
-                            .unwrap_or_else(|| "never".to_string())
-                    )
-                })
-            });
+        let detail = Some(build_logging_health_detail(&report, diagnostic.as_ref()));
         Ok(AtmObservabilityHealth {
             active_log_path: Some(self.active_log_path.clone()),
             logging_state: map_logging_state(report.state),
@@ -503,6 +481,75 @@ impl ObservabilityPort for ScObservabilityAdapter {
             diagnostic,
             detail,
         })
+    }
+}
+
+fn map_log_error(source: sc_observability::LogError) -> AtmError {
+    let code = match &source {
+        sc_observability::LogError::InvalidEvent(error) => error.diagnostic().code.as_str(),
+        sc_observability::LogError::WriterDegraded(context)
+        | sc_observability::LogError::ShutdownTimedOut(context) => {
+            context.diagnostic().code.as_str()
+        }
+    };
+    AtmError::observability_emit(format!(
+        "shared observability log admission failed ({code})"
+    ))
+    .with_source(source)
+}
+
+fn map_flush_error(source: sc_observability_types::FlushError) -> AtmError {
+    let code = source.diagnostic().code.as_str();
+    AtmError::observability_emit(format!(
+        "shared observability durability flush failed ({code})"
+    ))
+    .with_source(source)
+}
+
+fn build_logging_health_detail(
+    report: &sc_observability_types::LoggingHealthReport,
+    diagnostic: Option<&AtmObservabilityDiagnostic>,
+) -> String {
+    let mut parts = Vec::new();
+    if let Some(diagnostic) = diagnostic {
+        parts.push(diagnostic.message.clone());
+    }
+    parts.push(format!(
+        "writer_state={} queue_depth={} queue_capacity={} queue_high_water_mark={} queue_full_drops_total={}",
+        writer_state_label(report.writer_state),
+        report.queue_depth,
+        report.queue_capacity,
+        report.queue_high_water_mark,
+        report.queue_full_drops_total,
+    ));
+    if let Some(maintenance) = &report.maintenance {
+        parts.push(format!(
+            "maintenance state={} rotated_files_total={} pruned_files_total={} last_pass_at={}",
+            maintenance_state_label(maintenance.state),
+            maintenance.rotated_files_total,
+            maintenance.pruned_files_total,
+            maintenance
+                .last_pass_at
+                .map(|timestamp| timestamp.into_inner().to_string())
+                .unwrap_or_else(|| "never".to_string())
+        ));
+    }
+    parts.join(" | ")
+}
+
+fn writer_state_label(state: sc_observability_types::WriterState) -> &'static str {
+    match state {
+        sc_observability_types::WriterState::Running => "running",
+        sc_observability_types::WriterState::Degraded => "degraded",
+        sc_observability_types::WriterState::Stopped => "stopped",
+    }
+}
+
+fn maintenance_state_label(state: sc_observability_types::MaintenanceWorkerState) -> &'static str {
+    match state {
+        sc_observability_types::MaintenanceWorkerState::Running => "running",
+        sc_observability_types::MaintenanceWorkerState::Degraded => "degraded",
+        sc_observability_types::MaintenanceWorkerState::Stopped => "stopped",
     }
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1473,6 +1473,11 @@ Initial-release boundary rulings:
   - `Unavailable`
 - public ATM observability projections must not expose raw
   `serde_json::Value` / `Map<String, Value>` directly
+- the concrete `sc-observability` adapter is queue-backed as of Phase `AA.6`;
+  ATM uses `Logger::log()` for blocking admission, treats `flush()` /
+  `shutdown()` as the only durability barriers, and projects queue/writer/
+  maintenance state through ATM-owned health detail rather than leaking raw
+  shared types across the public boundary
 
 ### 14.2 Shared Crate Usage Rules
 

--- a/docs/atm-core/design/sc-observability-integration.md
+++ b/docs/atm-core/design/sc-observability-integration.md
@@ -216,7 +216,8 @@ routing.
 
 Required mapping rules:
 
-- ATM command events emit through `Logger::emit(...)`
+- ATM command events use queue-backed logger admission through `Logger::log()`
+  or `Logger::try_log()` at the concrete adapter layer
 - ATM command events use shared `LogEvent` fields for:
   - `service = "atm"`
   - `target` for ATM subsystem grouping
@@ -234,6 +235,9 @@ Required mapping rules:
   line-by-line ATM parsing
 - `atm doctor` must project shared `LoggingHealthReport` and
   `QueryHealthReport` into ATM findings
+- ATM-owned health detail must intentionally summarize the shared queue depth,
+  queue high-water mark, queue-full drops, writer state, and maintenance state
+  rather than silently discarding the additional `1.2.0` logger runtime data
 
 ## 8. Sink Policy
 

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -18,7 +18,7 @@ Authoritative supporting inventory:
 | `AA.3` | `complete` | `feature/pAA-s3-direct-doctor-and-runtime-health-split` | `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split` | `atm doctor` regains direct local store diagnostics; daemon aggregates injected subsystem reports plus daemon-owned runtime state without backend-specific diagnosis logic |
 | `AA.4` | `complete` | `feature/pAA-s4-delete-daemon-sqlite-leaks` | `../atm-core-worktrees/feature/pAA-s4-delete-daemon-sqlite-leaks` | remaining SQLite observability, replay, and test-support leaks are removed from `atm-daemon` |
 | `AA.5` | `complete` | `feature/pAA-s5-boundary-relock-and-permanent-enforcement` | `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement` | daemon-to-SQLite edge is forbidden again, all boundary TOMLs agree on that policy, and a second enforcement layer exists beyond TOML lint |
-| `AA.6` | `planned` | `feature/pAA-s6-obs-upgrade` | `../atm-core-worktrees/feature/pAA-s6-obs-upgrade` | ATM builds and validates on `sc-observability` / `sc-observability-types` `1.2.0` with the queue-backed logger API, retained-log policy field migration, and updated health projection |
+| `AA.6` | `complete` | `feature/pAA-s6-obs-upgrade` | `../atm-core-worktrees/feature/pAA-s6-obs-upgrade` | ATM builds and validates on `sc-observability` / `sc-observability-types` `1.2.0` with the queue-backed logger API, retained-log policy field migration, and updated health projection |
 
 ## Phase Exit Criteria
 

--- a/docs/phase-AA/sprint-AA6.md
+++ b/docs/phase-AA/sprint-AA6.md
@@ -6,7 +6,7 @@ phase: AA
 sprint: AA.6
 worktree: ../atm-core-worktrees/feature/pAA-s6-obs-upgrade
 branch: feature/pAA-s6-obs-upgrade
-status: planned
+status: complete
 estimated_scope: medium
 ```
 
@@ -135,6 +135,23 @@ The `1.2.0` migration surface is frozen now:
   6. `LoggingHealthReport` queue/writer/maintenance projection review
   7. `RetainedLogPolicy.writer_shutdown_timeout` and typed policy wrappers
 
+## Implementation Summary
+
+- Workspace `sc-observability` and `sc-observability-types` pins now target
+  `1.2.0`.
+- The concrete CLI and daemon adapters now use `Logger::log()` for blocking
+  queue admission instead of the deprecated `Logger::emit()` compatibility
+  path.
+- Daemon retained-log shutdown keeps `flush()` as the explicit durability
+  barrier and preserves `Logger<Stopped>` health inspection after shutdown.
+- ATM retained-log policy code now uses
+  `RetainedLogPolicy.writer_shutdown_timeout` and the typed
+  `ByteCount` / `FileCount` / `RetentionMaxAge` / `MaintenanceCadence` /
+  `WriterShutdownTimeout` wrappers.
+- CLI and daemon observability detail strings now intentionally project
+  queue-depth, queue-capacity, queue high-water mark, queue-full drops, writer
+  state, and retained-log maintenance state into ATM-owned health output.
+
 ## Split Recommendation
 
 Keep this sprint strictly scoped to the `1.2.0` upgrade. Do not mix in
@@ -142,7 +159,7 @@ unrelated observability refactors or feature work once the migration compiles.
 
 ## Acceptance Criteria
 
-- `docs/phase-AA/sprint-AA6.md` exists with `status: planned`,
+- `docs/phase-AA/sprint-AA6.md` exists with `status: complete`,
   `branch: feature/pAA-s6-obs-upgrade`, and a populated `worktree:`
 - the sprint doc enumerates every `sc-observability` `1.2.0` migration item
   currently required by ATM:

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -295,6 +295,12 @@ Execution worktree:
 
 ### AA.6 `sc-observability` 1.2.0 Upgrade
 
+Status:
+- complete on `feature/pAA-s6-obs-upgrade`
+- the concrete CLI and daemon adapters now use queue-backed `Logger::log()`
+  admission, the retained-log policy uses `writer_shutdown_timeout`, and ATM
+  health projection surfaces queue/writer/maintenance state intentionally
+
 Purpose:
 - upgrade `sc-observability` / `sc-observability-types` from `1.1.0` to
   `1.2.0`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -212,6 +212,10 @@ Status summary:
 - `AA.5` relocks the daemon-to-SQLite edge in the runtime and SQLite boundary
   TOMLs, adds the independent `check-boundary-guard.py` review guard, and
   freezes boundary-policy widening as an explicit architecture change.
+- `AA.6` completes the scoped `sc-observability` `1.2.0` migration by moving
+  the concrete adapters to queue-backed `Logger::log()` admission, renaming
+  the retained-log shutdown policy field to `writer_shutdown_timeout`, and
+  projecting queue/writer/maintenance health detail intentionally.
 
 Goal:
 - move concrete SQLite/runtime assembly to `atm-runtime`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2047,12 +2047,20 @@ Required retained-log maintenance behavior:
   handoff on the synchronous path; it must not reopen, append, flush, rotate,
   or prune retained files inline before returning control to the active daemon
   request/lifecycle path
+- blocking retained-log admission must use the queue-backed
+  `sc-observability` logger admission path (`Logger::log()`); any future
+  non-blocking admission path must use `Logger::try_log()` and handle explicit
+  queue-full degradation
+- `flush()` / `shutdown()` are the only durability barriers for retained-log
+  writes; queue admission alone must not be treated as immediate persistence
 - retained-log file append, rotation, and pruning must run on background
   maintenance machinery instead
 - if retained-log maintenance falls behind, ATM must degrade explicitly with
   structured diagnostics rather than silently blocking the daemon success path
 - retained-log pruning must use a bounded work budget per maintenance tick and
   must not rely on an unbounded wall-clock scan
+- the retained-log shutdown threshold is configured through
+  `RetainedLogPolicy.writer_shutdown_timeout`
 - actor identity when known
 - target identity when known
 - task id when known


### PR DESCRIPTION
## Summary
- Bump sc-observability and sc-observability-types to 1.2.0
- Migrate emit() to log()/try_log(); add flush()/shutdown() durability barriers
- Update RetainedLogPolicy typed wrappers; replace maintenance_join_timeout with writer_shutdown_timeout
- Handle Logger<Stopped> shutdown typestate; update LoggingHealthReport projection

## Sprint
docs/phase-AA/sprint-AA6.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)