### PR TITLE
Plan: Phase AA doctor/schema hardening (AA.8–AA.11)

### DIFF
--- a/docs/phase-AA/issues.md
+++ b/docs/phase-AA/issues.md
@@ -17,8 +17,9 @@ AA.0 freezes this inventory as the starting point for the execution line.
 | `AA-ISSUE-004` | `closed` | repository enforcement currently trusts boundary TOML as final authority without an independent guard for policy widening. | `AA.5` |
 | `AA-ISSUE-005` | `open` | the repo still misclassifies the current array-backed Claude Code inbox file shape as legacy in runtime/docs/smoke wording even though real `team-lead -> quality-mgr` traffic uses that current Claude path. | `AA.8` and `AA.9` |
 | `AA-ISSUE-006` | `open` | schema docs, Pydantic models, and live historical samples are not frozen together as one current Claude Code inbox contract. | `AA.8` |
-| `AA-ISSUE-007` | `open` | active docs/tests still promise support for historical ATM-owned inbox JSON variants that are not intended to remain supported in 1.2. | `AA.10` |
+| `AA-ISSUE-007` | `open` | active docs/tests still present historical ATM-owned inbox JSON variants too broadly; 1.2 must stop treating them as the primary contract while still accepting legal additive derivatives on read. | `AA.10` |
 | `AA-ISSUE-008` | `open` | pre-production SQLite identity compatibility scaffolding such as `legacy_message_id` remains on the active runtime line despite no accepted production need. | `AA.11` |
+| `AA-ISSUE-009` | `open` | one malformed Claude inbox fragment can still hide unrelated valid messages or surface an opaque parser failure instead of a degraded salvage result. | `AA.12` |
 
 ## Inventory Rules
 

--- a/docs/phase-AA/issues.md
+++ b/docs/phase-AA/issues.md
@@ -15,6 +15,10 @@ AA.0 freezes this inventory as the starting point for the execution line.
 | `AA-ISSUE-002` | `closed` | daemon runtime health currently owns SQLite-specific readiness and status fields. | `AA.3` |
 | `AA-ISSUE-003` | `closed` | daemon still carries SQLite observability, replay-store, and test-support leakage. | `AA.4` |
 | `AA-ISSUE-004` | `closed` | repository enforcement currently trusts boundary TOML as final authority without an independent guard for policy widening. | `AA.5` |
+| `AA-ISSUE-005` | `open` | the repo still misclassifies the current array-backed Claude Code inbox file shape as legacy in runtime/docs/smoke wording even though real `team-lead -> quality-mgr` traffic uses that current Claude path. | `AA.8` and `AA.9` |
+| `AA-ISSUE-006` | `open` | schema docs, Pydantic models, and live historical samples are not frozen together as one current Claude Code inbox contract. | `AA.8` |
+| `AA-ISSUE-007` | `open` | active docs/tests still promise support for historical ATM-owned inbox JSON variants that are not intended to remain supported in 1.2. | `AA.10` |
+| `AA-ISSUE-008` | `open` | pre-production SQLite identity compatibility scaffolding such as `legacy_message_id` remains on the active runtime line despite no accepted production need. | `AA.11` |
 
 ## Inventory Rules
 
@@ -22,4 +26,6 @@ AA.0 freezes this inventory as the starting point for the execution line.
   planning scope.
 - A finding may move to `closed` only when the owning sprint closes and the
   readiness record references the accepted closure evidence.
+- Smoke QA follow-up findings stay out of Phase AA planning scope until
+  `team-lead` routes the concrete finding ids / verdict summary into this file.
 - This file is the authoritative issues inventory for Phase AA.

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -54,8 +54,8 @@ Authoritative supporting inventory:
   Claude inbox file shape as legacy or degraded-only behavior
 - no active 1.2 documentation or runtime path presents historical ATM-owned
   inbox JSON schema variants such as top-level ATM fields or `metadata.atm.*`
-  as the primary or forward-write contract, while legal additive derivatives
-  remain accepted on read
+  as the primary or forward-write contract, while legal ATM 1.1 additive
+  derivatives still parse successfully on read
 - one malformed shared-inbox fragment cannot hide unrelated valid messages when
   the valid messages are still segmentable from the same Claude inbox file
 - no active 1.2 runtime path depends on pre-production SQLite compatibility

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -22,8 +22,9 @@ Authoritative supporting inventory:
 | `AA.7` | `complete` | `feature/pAA-s7-atm-architecture-crate` | `../atm-core-worktrees/feature/pAA-s7-atm-architecture-crate` | Rust boundary enforcement crate lands, Python boundary scripts are removed, and `cargo test -p atm-architecture` becomes the sole code-driven boundary guard |
 | `AA.8` | `planned` | `feature/pAA-s8-claude-schema-contract` | `../atm-core-worktrees/feature/pAA-s8-claude-schema-contract` | current Claude Code inbox schema is frozen from real `team-lead -> quality-mgr` samples and all docs/models stop calling the current array-backed inbox shape legacy |
 | `AA.9` | `planned` | `feature/pAA-s9-claude-inbox-primary-path` | `../atm-core-worktrees/feature/pAA-s9-claude-inbox-primary-path` | the normal retained append path treats the current Claude inbox file shape as supported primary behavior rather than degraded legacy behavior |
-| `AA.10` | `planned` | `feature/pAA-s10-remove-historical-atm-json` | `../atm-core-worktrees/feature/pAA-s10-remove-historical-atm-json` | historical ATM-owned JSON schema variants are removed from the active 1.2 contract and no live doc/runtime path promises their support |
+| `AA.10` | `planned` | `feature/pAA-s10-remove-historical-atm-json` | `../atm-core-worktrees/feature/pAA-s10-remove-historical-atm-json` | historical ATM-owned JSON schema variants stop being the active 1.2 contract while legal ATM additive derivatives remain accepted on read |
 | `AA.11` | `planned` | `feature/pAA-s11-delete-sqlite-legacy-compat` | `../atm-core-worktrees/feature/pAA-s11-delete-sqlite-legacy-compat` | pre-production SQLite compatibility scaffolding such as `legacy_message_id` support is removed from the active 1.2 runtime line unless explicitly reapproved |
+| `AA.12` | `planned` | `feature/pAA-s12-malformed-claude-inbox-recovery` | `../atm-core-worktrees/feature/pAA-s12-malformed-claude-inbox-recovery` | malformed Claude inbox content degrades and salvages recoverable messages instead of aborting the entire inbox surface where segmented valid records still exist |
 
 ## Phase Exit Criteria
 
@@ -51,9 +52,12 @@ Authoritative supporting inventory:
   `team-lead -> quality-mgr` samples
 - the normal retained runtime path does not classify the current array-backed
   Claude inbox file shape as legacy or degraded-only behavior
-- no active 1.2 documentation or runtime path promises support for historical
-  ATM-owned inbox JSON schema variants such as top-level ATM fields or
-  `metadata.atm.*`
+- no active 1.2 documentation or runtime path presents historical ATM-owned
+  inbox JSON schema variants such as top-level ATM fields or `metadata.atm.*`
+  as the primary or forward-write contract, while legal additive derivatives
+  remain accepted on read
+- one malformed shared-inbox fragment cannot hide unrelated valid messages when
+  the valid messages are still segmentable from the same Claude inbox file
 - no active 1.2 runtime path depends on pre-production SQLite compatibility
   scaffolding such as `legacy_message_id`, unless an explicit exception is
   recorded in this readiness file

--- a/docs/phase-AA/readiness.md
+++ b/docs/phase-AA/readiness.md
@@ -20,6 +20,10 @@ Authoritative supporting inventory:
 | `AA.5` | `complete` | `feature/pAA-s5-boundary-relock-and-permanent-enforcement` | `../atm-core-worktrees/feature/pAA-s5-boundary-relock-and-permanent-enforcement` | daemon-to-SQLite edge is forbidden again, all boundary TOMLs agree on that policy, and a second enforcement layer exists beyond TOML lint |
 | `AA.6` | `complete` | `feature/pAA-s6-obs-upgrade` | `../atm-core-worktrees/feature/pAA-s6-obs-upgrade` | ATM builds and validates on `sc-observability` / `sc-observability-types` `1.2.0` with the queue-backed logger API, retained-log policy field migration, and updated health projection |
 | `AA.7` | `complete` | `feature/pAA-s7-atm-architecture-crate` | `../atm-core-worktrees/feature/pAA-s7-atm-architecture-crate` | Rust boundary enforcement crate lands, Python boundary scripts are removed, and `cargo test -p atm-architecture` becomes the sole code-driven boundary guard |
+| `AA.8` | `planned` | `feature/pAA-s8-claude-schema-contract` | `../atm-core-worktrees/feature/pAA-s8-claude-schema-contract` | current Claude Code inbox schema is frozen from real `team-lead -> quality-mgr` samples and all docs/models stop calling the current array-backed inbox shape legacy |
+| `AA.9` | `planned` | `feature/pAA-s9-claude-inbox-primary-path` | `../atm-core-worktrees/feature/pAA-s9-claude-inbox-primary-path` | the normal retained append path treats the current Claude inbox file shape as supported primary behavior rather than degraded legacy behavior |
+| `AA.10` | `planned` | `feature/pAA-s10-remove-historical-atm-json` | `../atm-core-worktrees/feature/pAA-s10-remove-historical-atm-json` | historical ATM-owned JSON schema variants are removed from the active 1.2 contract and no live doc/runtime path promises their support |
+| `AA.11` | `planned` | `feature/pAA-s11-delete-sqlite-legacy-compat` | `../atm-core-worktrees/feature/pAA-s11-delete-sqlite-legacy-compat` | pre-production SQLite compatibility scaffolding such as `legacy_message_id` support is removed from the active 1.2 runtime line unless explicitly reapproved |
 
 ## Phase Exit Criteria
 
@@ -42,5 +46,16 @@ Authoritative supporting inventory:
 - ATM has completed the `sc-observability` / `sc-observability-types` `1.2.0`
   upgrade and no remaining migration blocker from the deprecated
   `Logger::emit()` path or the old retained-log policy field surface remains
+- the current Claude Code inbox JSON schema is the explicitly documented
+  primary shared inbox contract and is proven against real fixture-backed
+  `team-lead -> quality-mgr` samples
+- the normal retained runtime path does not classify the current array-backed
+  Claude inbox file shape as legacy or degraded-only behavior
+- no active 1.2 documentation or runtime path promises support for historical
+  ATM-owned inbox JSON schema variants such as top-level ATM fields or
+  `metadata.atm.*`
+- no active 1.2 runtime path depends on pre-production SQLite compatibility
+  scaffolding such as `legacy_message_id`, unless an explicit exception is
+  recorded in this readiness file
 - `docs/phase-AA/issues.md` has no open issue whose planned closure sprint is
   still incomplete

--- a/docs/phase-AA/sprint-AA10.md
+++ b/docs/phase-AA/sprint-AA10.md
@@ -14,7 +14,9 @@ estimated_scope: medium
 
 Stop treating historical ATM-authored inbox JSON extensions as the primary or
 forward-write contract for 1.2 while preserving read compatibility for legal
-Claude-schema derivatives produced by ATM 1.1.
+Claude-schema derivatives produced by ATM 1.1, the historical ATM producer
+that wrote Claude-envelope messages plus additive ATM-owned fields such as
+`metadata.atm.*`.
 
 ## Scope Summary
 
@@ -78,8 +80,10 @@ salvage policy is not part of this sprint and is planned separately in
     they contain additive ATM metadata
   - those derivatives are not described as the primary or forward-write
     contract
-  - any truly obsolete/non-derivative repair or import path is explicitly named
-    and does not leak into normal send/read/runtime behavior
+  - retirement behavior is explicit for truly obsolete/non-derivative inputs:
+    they are either ignored safely, rejected with a structured error, or
+    routed to a named repair/import-only admin path, and none of those paths
+    leak into normal send/read/runtime behavior
 
 - The repo no longer ships a “legacy ATM message schema” doc/model as if that
   were the accepted primary 1.2 shared inbox contract.
@@ -93,7 +97,8 @@ schema removal is its own risk surface and belongs in `AA.11`.
 
 - `docs/phase-AA/sprint-AA10.md` exists with the planned branch/worktree
 - `docs/phase-AA/readiness.md` is updated consistently with the accepted AA.10
-  closure state
+  closure state, including the retained rule that legal ATM 1.1 additive
+  derivatives still parse successfully on read
 - `docs/legacy-atm-message-schema.md` is retained only as a read-compatibility
   contract for legal additive derivatives or is clearly retired in favor of an
   equivalent read-compatibility contract with no wording that implies

--- a/docs/phase-AA/sprint-AA10.md
+++ b/docs/phase-AA/sprint-AA10.md
@@ -49,6 +49,12 @@ through a named admin path, but do not treat them as supported live schema.
 - The repo no longer presents historical ATM JSON variants as supported active
   shared inbox schema for 1.2.
 
+- ATM 1.1 messages that extend the Claude Code schema by adding metadata fields
+  such as `metadata.atm.*` MUST parse successfully. The read path silently
+  ignores unknown or ATM-owned additive fields. Removing live-contract status
+  means no new code depends on those fields; it does not mean reading them
+  fails.
+
 - The removal set is explicit and authoritative:
   - historical top-level ATM fields such as `message_id`, `source_team`,
     `pendingAckAt`, `acknowledgedAt`, and `acknowledgesMessageId`
@@ -82,6 +88,9 @@ schema removal is its own risk surface and belongs in `AA.11`.
   the active test gate
 - no requirements/architecture/Phase AA doc still promises normal read-path
   support for historical ATM top-level JSON or `metadata.atm.*`
+- schema-derivative messages (ATM 1.1 format = Claude Code schema + metadata
+  extension fields) parse without error; tests explicitly assert non-failure
+  for these inputs
 - the active tests validate the current Claude contract and the chosen fail
   behavior for obsolete ATM-authored JSON
 
@@ -90,6 +99,9 @@ schema removal is its own risk surface and belongs in `AA.11`.
 - `python3 -m unittest tools.schema_models.test_schema_models`
 - `cargo test -p agent-team-mail-core`
 - `git diff --check`
+- tests include at least one schema-derivative fixture (ATM 1.1 payload with
+  Claude schema fields plus `metadata.atm` additions) that asserts parse
+  success and field-ignore behavior
 
 ## Required Document Updates
 

--- a/docs/phase-AA/sprint-AA10.md
+++ b/docs/phase-AA/sprint-AA10.md
@@ -1,0 +1,112 @@
+# AA.10 Remove Historical ATM JSON Compatibility From 1.2
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.10
+worktree: ../atm-core-worktrees/feature/pAA-s10-remove-historical-atm-json
+branch: feature/pAA-s10-remove-historical-atm-json
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Remove support promises for historical ATM-owned inbox JSON schema variants so
+ATM 1.2 supports only the current legal Claude Code inbox schema on the
+Claude-to-Claude shared inbox path.
+
+## Scope Summary
+
+This sprint is the JSON compatibility removal line. It deletes the repo-owned
+contract that still promises read support for historical ATM top-level inbox
+fields and `metadata.atm` machine-state shapes, and it replaces that promise
+with explicit 1.2 behavior for obsolete inputs: ignore, reject, or repair
+through a named admin path, but do not treat them as supported live schema.
+
+## Governing Sources
+
+- `docs/claude-code-message-schema.md`
+- `docs/atm-message-schema.md`
+- `docs/legacy-atm-message-schema.md`
+- `tools/schema_models/atm_message_schema.py`
+- `tools/schema_models/legacy_atm_message_schema.py`
+- `tools/schema_models/test_schema_models.py`
+
+## Prerequisites
+
+- `AA.8`
+- `AA.9`
+
+## Out Of Scope
+
+- no SQLite durable-schema removal
+- no change to Claude-owned message semantics
+- no silent extension of the supported 1.2 schema surface
+
+## Deliverables
+
+- The repo no longer presents historical ATM JSON variants as supported active
+  shared inbox schema for 1.2.
+
+- The removal set is explicit and authoritative:
+  - historical top-level ATM fields such as `message_id`, `source_team`,
+    `pendingAckAt`, `acknowledgedAt`, and `acknowledgesMessageId`
+  - historical alert-only top-level fields such as `atmAlertKind` and
+    `missingConfigPath`
+  - `metadata.atm.*` as an active shared inbox contract
+
+- The docs, schema models, and tests agree on 1.2 behavior for obsolete JSON:
+  - current Claude schema is supported
+  - obsolete ATM-authored JSON is not treated as a supported live contract
+  - any remaining repair or import path is explicitly named and does not leak
+    into normal send/read/runtime behavior
+
+- The repo no longer ships a “legacy ATM message schema” doc/model as if that
+  were part of the accepted 1.2 shared inbox contract.
+
+## Split Recommendation
+
+Keep this sprint focused on JSON-schema support removal. SQLite historical
+schema removal is its own risk surface and belongs in `AA.11`.
+
+## Acceptance Criteria
+
+- `docs/phase-AA/sprint-AA10.md` exists with the planned branch/worktree
+- `docs/legacy-atm-message-schema.md` is removed or clearly retired from the
+  active 1.2 contract with no remaining source-of-truth references that imply
+  live support
+- `tools/schema_models/legacy_atm_message_schema.py` is removed or retired from
+  the active test gate
+- no requirements/architecture/Phase AA doc still promises normal read-path
+  support for historical ATM top-level JSON or `metadata.atm.*`
+- the active tests validate the current Claude contract and the chosen fail
+  behavior for obsolete ATM-authored JSON
+
+## Required Validation
+
+- `python3 -m unittest tools.schema_models.test_schema_models`
+- `cargo test -p agent-team-mail-core`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/phase-AA/sprint-AA10.md`
+- `docs/phase-AA/readiness.md`
+- `docs/phase-AA/issues.md`
+- `docs/plan-phase-AA.md`
+- `docs/project-plan.md`
+- `docs/claude-code-message-schema.md`
+- `docs/atm-message-schema.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+
+## Risks And Watchouts
+
+- if this sprint leaves documentation and tests half-migrated, QA will read one
+  contract while runtime enforces another
+- if obsolete ATM-authored JSON remains silently accepted without an explicit
+  policy, operators will not know whether they are on supported or unsupported
+  1.2 behavior

--- a/docs/phase-AA/sprint-AA10.md
+++ b/docs/phase-AA/sprint-AA10.md
@@ -12,17 +12,21 @@ estimated_scope: medium
 
 ## Goal
 
-Remove support promises for historical ATM-owned inbox JSON schema variants so
-ATM 1.2 supports only the current legal Claude Code inbox schema on the
-Claude-to-Claude shared inbox path.
+Stop treating historical ATM-authored inbox JSON extensions as the primary or
+forward-write contract for 1.2 while preserving read compatibility for legal
+Claude-schema derivatives produced by ATM 1.1.
 
 ## Scope Summary
 
-This sprint is the JSON compatibility removal line. It deletes the repo-owned
-contract that still promises read support for historical ATM top-level inbox
-fields and `metadata.atm` machine-state shapes, and it replaces that promise
-with explicit 1.2 behavior for obsolete inputs: ignore, reject, or repair
-through a named admin path, but do not treat them as supported live schema.
+This sprint is the JSON contract-tightening line. It removes the repo-owned
+claim that historical ATM top-level inbox fields and `metadata.atm`
+machine-state shapes are the active primary shared-inbox contract for 1.2, but
+it does not make legal Claude-schema derivatives invalid on read. Historical
+ATM-authored additive fields remain read-compatible when they extend the legal
+Claude envelope; ATM ignores or strips the ATM-owned machine metadata rather
+than failing schema validation for those derivative shapes. Malformed-record
+salvage policy is not part of this sprint and is planned separately in
+`AA.12`.
 
 ## Governing Sources
 
@@ -43,11 +47,12 @@ through a named admin path, but do not treat them as supported live schema.
 - no SQLite durable-schema removal
 - no change to Claude-owned message semantics
 - no silent extension of the supported 1.2 schema surface
+- no malformed-record salvage/recovery behavior changes
 
 ## Deliverables
 
-- The repo no longer presents historical ATM JSON variants as supported active
-  shared inbox schema for 1.2.
+- The repo no longer presents historical ATM JSON variants as the supported
+  active primary shared inbox schema for 1.2.
 
 - ATM 1.1 messages that extend the Claude Code schema by adding metadata fields
   such as `metadata.atm.*` MUST parse successfully. The read path silently
@@ -55,21 +60,29 @@ through a named admin path, but do not treat them as supported live schema.
   means no new code depends on those fields; it does not mean reading them
   fails.
 
-- The removal set is explicit and authoritative:
-  - historical top-level ATM fields such as `message_id`, `source_team`,
-    `pendingAckAt`, `acknowledgedAt`, and `acknowledgesMessageId`
+- The contract split is explicit and authoritative:
+  - current Claude Code-native inbox schema is the primary shared inbox
+    contract
+  - historical ATM additive fields such as `message_id`, `source_team`,
+    `pendingAckAt`, `acknowledgedAt`, and `acknowledgesMessageId` are
+    read-compatible derivative fields, not the forward-write contract
   - historical alert-only top-level fields such as `atmAlertKind` and
-    `missingConfigPath`
-  - `metadata.atm.*` as an active shared inbox contract
+    `missingConfigPath` remain read-compatible only as additive derivatives
+  - `metadata.atm.*` is not the active primary contract, but inbox records that
+    carry it still validate as legal additive derivatives and are ignored or
+    stripped by the read path rather than rejected as invalid schema
 
-- The docs, schema models, and tests agree on 1.2 behavior for obsolete JSON:
+- The docs, schema models, and tests agree on 1.2 behavior for derivative JSON:
   - current Claude schema is supported
-  - obsolete ATM-authored JSON is not treated as a supported live contract
-  - any remaining repair or import path is explicitly named and does not leak
-    into normal send/read/runtime behavior
+  - legal ATM-authored schema derivatives do not fail validation solely because
+    they contain additive ATM metadata
+  - those derivatives are not described as the primary or forward-write
+    contract
+  - any truly obsolete/non-derivative repair or import path is explicitly named
+    and does not leak into normal send/read/runtime behavior
 
 - The repo no longer ships a “legacy ATM message schema” doc/model as if that
-  were part of the accepted 1.2 shared inbox contract.
+  were the accepted primary 1.2 shared inbox contract.
 
 ## Split Recommendation
 
@@ -81,18 +94,24 @@ schema removal is its own risk surface and belongs in `AA.11`.
 - `docs/phase-AA/sprint-AA10.md` exists with the planned branch/worktree
 - `docs/phase-AA/readiness.md` is updated consistently with the accepted AA.10
   closure state
-- `docs/legacy-atm-message-schema.md` is removed or clearly retired from the
-  active 1.2 contract with no remaining source-of-truth references that imply
-  live support
-- `tools/schema_models/legacy_atm_message_schema.py` is removed or retired from
-  the active test gate
-- no requirements/architecture/Phase AA doc still promises normal read-path
-  support for historical ATM top-level JSON or `metadata.atm.*`
+- `docs/legacy-atm-message-schema.md` is retained only as a read-compatibility
+  contract for legal additive derivatives or is clearly retired in favor of an
+  equivalent read-compatibility contract with no wording that implies
+  primary/write ownership
+- `tools/schema_models/legacy_atm_message_schema.py` and/or the active schema
+  test gate continue validating legal additive derivative shapes on read
+- no requirements/architecture/Phase AA doc still promises that historical ATM
+  top-level JSON or `metadata.atm.*` are the primary or forward-write 1.2
+  contract
 - schema-derivative messages (ATM 1.1 format = Claude Code schema + metadata
   extension fields) parse without error; tests explicitly assert non-failure
   for these inputs
-- the active tests validate the current Claude contract and the chosen fail
-  behavior for obsolete ATM-authored JSON
+- the active tests validate:
+  - the current Claude contract
+  - top-level ATM additive derivative shapes
+  - `metadata.atm.*` additive derivative shapes
+  - derivative-schema validation does not fail solely because of tolerated ATM
+    additive metadata
 
 ## Required Validation
 
@@ -119,8 +138,8 @@ schema removal is its own risk surface and belongs in `AA.11`.
 
 ## Risks And Watchouts
 
-- if this sprint leaves documentation and tests half-migrated, QA will read one
-  contract while runtime enforces another
-- if obsolete ATM-authored JSON remains silently accepted without an explicit
-  policy, operators will not know whether they are on supported or unsupported
-  1.2 behavior
+- if this sprint confuses “not the primary contract” with “invalid on read,”
+  it will break legal ATM 1.1 Claude-schema derivatives that must remain
+  accepted
+- if documentation and tests are half-migrated, QA will read one contract while
+  runtime enforces another

--- a/docs/phase-AA/sprint-AA10.md
+++ b/docs/phase-AA/sprint-AA10.md
@@ -73,6 +73,8 @@ schema removal is its own risk surface and belongs in `AA.11`.
 ## Acceptance Criteria
 
 - `docs/phase-AA/sprint-AA10.md` exists with the planned branch/worktree
+- `docs/phase-AA/readiness.md` is updated consistently with the accepted AA.10
+  closure state
 - `docs/legacy-atm-message-schema.md` is removed or clearly retired from the
   active 1.2 contract with no remaining source-of-truth references that imply
   live support

--- a/docs/phase-AA/sprint-AA11.md
+++ b/docs/phase-AA/sprint-AA11.md
@@ -1,0 +1,97 @@
+# AA.11 Delete Pre-Production SQLite Compatibility Scaffolding
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.11
+worktree: ../atm-core-worktrees/feature/pAA-s11-delete-sqlite-legacy-compat
+branch: feature/pAA-s11-delete-sqlite-legacy-compat
+status: planned
+estimated_scope: small
+```
+
+## Goal
+
+Remove SQLite compatibility scaffolding for abandoned pre-production schema
+shapes that ATM 1.2 no longer intends to support.
+
+## Scope Summary
+
+This sprint is the SQLite cleanup complement to `AA.10`. The work is to delete
+the historical `legacy_message_id` migration support and any related docs/tests
+that still treat pre-production SQLite schema drift as supported 1.2 behavior,
+unless a narrower user-approved compatibility exception is recorded first.
+
+## Governing Sources
+
+- `crates/atm-rusqlite/src/lib.rs`
+- `docs/phase-U/removal-inventory.md`
+- `docs/phase-Z/smoke-findings-ledger.md`
+- `docs/adr/ADR-012-one-message-identity.md`
+
+## Prerequisites
+
+- `AA.10`
+
+## Out Of Scope
+
+- no current Claude inbox schema changes
+- no daemon/runtime boundary changes beyond deleting obsolete SQLite
+  compatibility paths
+- no support restoration for historical mail DB shapes that never shipped as
+  accepted production state
+
+## Deliverables
+
+- The `legacy_message_id` compatibility path is either deleted or moved behind
+  an explicitly documented non-default repair/import seam that is outside normal
+  1.2 runtime behavior.
+
+- The active 1.2 SQLite bootstrap/migration contract is restated clearly:
+  - what exact schema versions/shapes are supported
+  - what is no longer supported
+  - what repair path, if any, exists for abandoned pre-production DBs
+
+- Tests and docs no longer claim that pre-production `legacy_message_id`
+  identity shapes are part of normal runtime support.
+
+## Split Recommendation
+
+Keep this sprint small and mechanical. If deleting the compatibility code
+reveals a broader durable-store redesign need, stop and plan that separately.
+
+## Acceptance Criteria
+
+- `docs/phase-AA/sprint-AA11.md` exists with the planned branch/worktree
+- no normal 1.2 runtime path depends on `legacy_message_id` support
+- docs and tests no longer describe abandoned pre-production SQLite identity
+  shapes as supported active behavior
+- any remaining exceptional repair path is explicit and not silently exercised
+  during normal bootstrap
+
+## Required Validation
+
+- `cargo test -p atm-rusqlite`
+- `cargo test --workspace`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/phase-AA/sprint-AA11.md`
+- `docs/phase-AA/readiness.md`
+- `docs/phase-AA/issues.md`
+- `docs/plan-phase-AA.md`
+- `docs/project-plan.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/adr/ADR-012-one-message-identity.md`
+- `docs/phase-U/removal-inventory.md`
+
+## Risks And Watchouts
+
+- if this sprint deletes compatibility code without restating the supported 1.2
+  SQLite baseline, operators and QA will not know what database states are in
+  scope
+- if pre-production repair logic remains silently reachable from normal
+  bootstrap, the repo will still be carrying an undeclared compatibility
+  contract

--- a/docs/phase-AA/sprint-AA11.md
+++ b/docs/phase-AA/sprint-AA11.md
@@ -26,7 +26,7 @@ unless a narrower user-approved compatibility exception is recorded first.
 
 - `crates/atm-rusqlite/src/lib.rs`
 - `docs/phase-U/removal-inventory.md`
-- `docs/phase-Z/smoke-findings-ledger.md`
+- `docs/phase-Z/smoke-findings-review.md`
 - `docs/adr/ADR-012-one-message-identity.md`
 
 ## Prerequisites
@@ -55,6 +55,11 @@ unless a narrower user-approved compatibility exception is recorded first.
 - Tests and docs no longer claim that pre-production `legacy_message_id`
   identity shapes are part of normal runtime support.
 
+- The retained `Phase U` removal inventory reference is justified directly in
+  the sprint outputs as the canonical cross-phase ledger for deleting
+  superseded storage/runtime scaffolding rather than treating it as a stray
+  historical artifact mention.
+
 ## Split Recommendation
 
 Keep this sprint small and mechanical. If deleting the compatibility code
@@ -63,6 +68,8 @@ reveals a broader durable-store redesign need, stop and plan that separately.
 ## Acceptance Criteria
 
 - `docs/phase-AA/sprint-AA11.md` exists with the planned branch/worktree
+- `docs/phase-AA/readiness.md` is updated consistently with the accepted AA.11
+  closure state
 - no normal 1.2 runtime path depends on `legacy_message_id` support
 - docs and tests no longer describe abandoned pre-production SQLite identity
   shapes as supported active behavior

--- a/docs/phase-AA/sprint-AA12.md
+++ b/docs/phase-AA/sprint-AA12.md
@@ -101,6 +101,8 @@ salvages around malformed input that is outside that legal contract.
   those valid messages are still segmentable
 - malformed ATM-owned metadata on an otherwise valid Claude message does not
   drop that message
+- malformed-salvageable reads return a degraded/error variant, do not panic,
+  and do not corrupt the underlying inbox file
 - the read path emits explicit degraded warnings/sentinels for salvageable bad
   fragments instead of a generic opaque parse failure
 - any remaining terminal-failure cases are enumerated in docs and backed by

--- a/docs/phase-AA/sprint-AA12.md
+++ b/docs/phase-AA/sprint-AA12.md
@@ -1,0 +1,139 @@
+# AA.12 Malformed Claude Inbox Recovery Hardening
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.12
+worktree: ../atm-core-worktrees/feature/pAA-s12-malformed-claude-inbox-recovery
+branch: feature/pAA-s12-malformed-claude-inbox-recovery
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Make the Claude inbox read path fail-soft: preserve every recoverable message,
+emit explicit degraded warnings for malformed fragments, and avoid dropping an
+entire sprint conversation because one producer wrote bad JSON.
+
+## Scope Summary
+
+This sprint is the malformed-ingress recovery line. It does not widen the
+legal schema contract beyond what `AA.8` and `AA.10` freeze. Instead, it
+defines how ATM reads the inbox when the file or one record is malformed,
+truncated, or mixed good/bad. The required behavior is best-effort salvage with
+traceable degraded output, not an all-or-nothing parser failure, unless the
+root document is genuinely unreadable end-to-end.
+
+## Governing Sources
+
+- `docs/claude-code-message-schema.md`
+- `docs/atm-message-schema.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `crates/atm-core/src/mailbox/store.rs`
+- `crates/atm-core/src/service_runtime.rs`
+- `tools/schema_models/test_schema_models.py`
+
+## Prerequisites
+
+- `AA.9`
+- `AA.10`
+
+## Out Of Scope
+
+- no expansion of the legal Claude inbox schema
+- no reapproval of historical ATM-owned fields beyond the derivative support
+  explicitly frozen in `AA.10`
+- no SQLite durable-schema work
+
+## Deliverables
+
+- The repo has one explicit malformed-ingress policy for Claude inbox reads:
+  - legal current-schema records parse normally
+  - legal derivative-schema records tolerated by `AA.10` still parse normally
+  - malformed-but-localized records degrade to a readable sentinel/warning
+    result without hiding unrelated valid messages in the same inbox
+  - only root-level unreadable content that cannot be segmented or salvaged may
+    fail the whole read with a structured error
+
+- The read-path contract is spelled out with a code-shaped outcome surface, or
+  an equivalent accepted API, so implementation choice is not left open:
+
+  ```rust
+  enum InboxReadItem {
+      Message(ClaudeCodeInboxMessage),
+      Degraded {
+          summary: String,
+          warning: String,
+          raw_fragment: Option<String>,
+      },
+  }
+  ```
+
+- The docs and tests define which corruption classes are expected to salvage:
+  - malformed ATM metadata on an otherwise valid message
+  - one malformed message object adjacent to valid message objects
+  - truncated tail after at least one valid earlier message
+  - unknown additive metadata on otherwise valid Claude messages
+
+- The docs and tests define which corruption classes remain terminal:
+  - unreadable root content with no segmentable message objects
+  - invalid root shape that cannot be interpreted as any supported inbox
+    collection surface
+
+- An ADR is added or updated if the chosen fail-soft policy changes the
+  repository-wide shared-inbox boundary contract rather than only
+  implementation details. If no existing ADR can absorb that decision, create
+  `docs/adr/ADR-017-claude-inbox-fail-soft-read-policy.md` and register it in
+  `docs/adr/INDEX.md`.
+
+## Split Recommendation
+
+Keep malformed-ingress recovery separate from schema-contract support removal.
+`AA.10` decides what is legal on read; `AA.12` decides how aggressively ATM
+salvages around malformed input that is outside that legal contract.
+
+## Acceptance Criteria
+
+- `docs/phase-AA/sprint-AA12.md` exists with the planned branch/worktree
+- one malformed shared-inbox fragment cannot hide unrelated valid messages when
+  those valid messages are still segmentable
+- malformed ATM-owned metadata on an otherwise valid Claude message does not
+  drop that message
+- the read path emits explicit degraded warnings/sentinels for salvageable bad
+  fragments instead of a generic opaque parse failure
+- any remaining terminal-failure cases are enumerated in docs and backed by
+  tests
+- if the malformed-recovery policy is architectural, a new or updated ADR is
+  linked from the sprint outputs
+
+## Required Validation
+
+- `python3 -m unittest tools.schema_models.test_schema_models`
+- `cargo test -p agent-team-mail-core`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/phase-AA/sprint-AA12.md`
+- `docs/phase-AA/readiness.md`
+- `docs/phase-AA/issues.md`
+- `docs/plan-phase-AA.md`
+- `docs/project-plan.md`
+- `docs/claude-code-message-schema.md`
+- `docs/atm-message-schema.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/adr/ADR-017-claude-inbox-fail-soft-read-policy.md` if a new ADR is
+  required
+- `docs/adr/INDEX.md`
+
+## Risks And Watchouts
+
+- if this sprint silently widens the legal schema instead of only hardening the
+  recovery path, `AA.10` will be undermined
+- if “best effort” is left undefined, one implementation may salvage messages
+  while another still aborts the whole inbox
+- if degraded warnings are not explicit and testable, operators will not know
+  whether a message was missing, malformed, or fully consumed

--- a/docs/phase-AA/sprint-AA7.md
+++ b/docs/phase-AA/sprint-AA7.md
@@ -1,0 +1,119 @@
+# AA.7 Rust Boundary Enforcement Crate
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.7
+worktree: ../atm-core-worktrees/feature/pAA-s7-atm-architecture-crate
+branch: feature/pAA-s7-atm-architecture-crate
+status: complete
+estimated_scope: medium
+```
+
+## Goal
+
+Make the repository-owned Rust boundary crate the visible, required
+second-layer architecture guard for the daemon-to-SQLite relock line.
+
+## Scope Summary
+
+This sprint is the code-driven enforcement closeout for the `AA.5` boundary
+relock. It lands the Rust guard as a first-class workspace crate, removes the
+superseded Python boundary scripts, and makes the required merge gate obvious
+in normal Rust validation flow.
+
+## Governing Sources
+
+- `docs/plan-phase-AA.md`
+- `docs/phase-AA/readiness.md`
+- `docs/phase-AA/issues.md`
+- `docs/architecture.md`
+- `docs/testing-guidelines.md`
+- `.claude/agents/boundary-guard.md`
+
+## Prerequisites
+
+- `AA.5`
+
+## Out Of Scope
+
+- no new daemon/runtime behavior
+- no additional SQLite-boundary redesign beyond the already accepted relock
+- no reintroduction of Python as a code-driven architecture guard
+
+## Deliverables
+
+- `crates/atm-architecture/` exists as a test-only workspace crate and is the
+  canonical code-driven boundary guard.
+
+- The required forbidden-edge coverage is present for every currently accepted
+  Phase AA boundary rule:
+
+  ```rust
+  // Representative guard surface. The exact implementation may differ,
+  // but the crate must fail closed when any listed edge is relaxed.
+  const FORBIDDEN_EDGES: &[(&str, &str)] = &[
+      ("atm-daemon", "atm-rusqlite"),
+      ("atm", "atm-rusqlite"),
+      ("atm-runtime", "atm-daemon"),
+      ("atm-graft", "atm-rusqlite"),
+  ];
+  ```
+
+- The deleted Python scripts are not part of the active code-driven guard
+  surface anymore.
+
+- The docs and review workflow say the same thing:
+  - `cargo test --package atm-architecture` is the required code-driven guard
+  - `.claude/agents/boundary-guard.md` is the required review-layer guard
+
+- A synthetic relaxation fixture exists and proves that removing a forbidden
+  edge or weakening a boundary TOML causes the Rust guard to fail.
+
+## Implementation Summary
+
+- `crates/atm-architecture/` landed and now owns the workspace-visible
+  forbidden-edge tests.
+- The now-superseded Python boundary scripts were deleted.
+- The sprint/readiness/project-plan docs were corrected so the Rust crate is
+  the active enforcement layer.
+
+## Split Recommendation
+
+Keep this sprint limited to enforcement visibility and guard ownership. Do not
+mix it with follow-on schema-contract, inbox-runtime, or SQLite-removal work.
+
+## Acceptance Criteria
+
+- `docs/phase-AA/sprint-AA7.md` exists with the correct `branch`, `worktree`,
+  and `status: complete`
+- `crates/atm-architecture/` is present in the workspace and is named in the
+  project-plan crate inventory
+- `cargo test --package atm-architecture` is the named required merge gate
+- the deleted Python boundary scripts are not described as the active
+  code-driven enforcement layer anywhere in Phase AA docs
+- a synthetic boundary-relaxation fixture proves the Rust guard fails closed
+
+## Required Validation
+
+- `cargo test --package atm-architecture`
+- `cargo test --workspace`
+- `python3 .just/run_lint.py all`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/phase-AA/sprint-AA7.md`
+- `docs/phase-AA/readiness.md`
+- `docs/plan-phase-AA.md`
+- `docs/project-plan.md`
+- `docs/architecture.md`
+- `docs/testing-guidelines.md`
+- `.claude/agents/boundary-guard.md`
+
+## Risks And Watchouts
+
+- if the Rust guard becomes optional or hidden behind a non-default review
+  path, policy widening can drift back into routine branch churn
+- if sprint docs still describe deleted Python scripts as active, QA will read
+  the wrong enforcement model from the source of truth

--- a/docs/phase-AA/sprint-AA8.md
+++ b/docs/phase-AA/sprint-AA8.md
@@ -1,0 +1,123 @@
+# AA.8 Claude Code Inbox Schema Contract Alignment
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.8
+worktree: ../atm-core-worktrees/feature/pAA-s8-claude-schema-contract
+branch: feature/pAA-s8-claude-schema-contract
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Freeze the current Claude Code inbox JSON contract as the primary shared inbox
+surface and align ATM’s docs, schema models, and fixture-backed tests to that
+contract.
+
+## Scope Summary
+
+This sprint is schema-contract and documentation alignment only. It does not
+change the runtime append implementation yet. The work is to prove exactly what
+the legal Claude inbox message schema is, compare that contract to real
+`team-lead -> quality-mgr` traffic, and remove wording that incorrectly treats
+the current Claude inbox file shape as legacy.
+
+## Governing Sources
+
+- `docs/claude-code-message-schema.md`
+- `docs/atm-message-schema.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `tools/schema_models/claude_code_message_schema.py`
+- `tools/schema_models/test_schema_models.py`
+
+## Prerequisites
+
+- `AA.7`
+
+## Out Of Scope
+
+- no runtime append-path behavior changes
+- no SQLite schema removal
+- no continued promise of historical ATM 1.1 JSON support beyond what this
+  sprint explicitly freezes as current contract or hands to `AA.10`
+
+## Deliverables
+
+- The current Claude Code inbox envelope is frozen in the docs and model as the
+  primary shared inbox contract:
+
+  ```json
+  {
+    "from": "team-lead",
+    "text": "message body or encoded task payload",
+    "timestamp": "2026-06-06T23:23:32.085Z",
+    "read": true,
+    "summary": "optional summary",
+    "color": "optional Claude-owned producer field"
+  }
+  ```
+
+- Real historical `team-lead -> quality-mgr` message samples are redacted into
+  fixture coverage, and the fixtures are validated against the current Pydantic
+  model.
+
+- The docs explicitly distinguish three categories:
+  1. current Claude Code-native envelope
+  2. tolerated unknown additive fields on that envelope
+  3. historical ATM-owned additive fields that are not part of the current
+     Claude contract and are queued for `AA.10`
+
+- Any sentence that classifies the current array-backed Claude inbox file shape
+  itself as legacy is corrected or removed.
+
+- The schema enforcement tests prove the current contract against at least:
+  - native Claude envelope
+  - current real-world `team-lead -> quality-mgr` samples
+  - any still-documented ATM additive shape that remains temporarily accepted
+
+## Split Recommendation
+
+Keep this sprint limited to contract discovery, wording correction, and
+fixture-backed model alignment. Runtime behavior changes belong in `AA.9`.
+
+## Acceptance Criteria
+
+- `docs/phase-AA/sprint-AA8.md` exists with the planned branch/worktree
+- `docs/claude-code-message-schema.md` defines the current shared inbox
+  contract clearly enough that `req-qa` can enumerate the legal envelope
+  directly from the sprint outputs
+- `tools/schema_models/claude_code_message_schema.py` matches the current
+  contract
+- real `team-lead -> quality-mgr` fixture samples validate against the model
+- no Phase AA or schema-ownership doc still calls the current array-backed
+  Claude inbox file shape “legacy”
+- any remaining historical ATM JSON support is called out explicitly as
+  follow-on removal scope for `AA.10`, not as the current Claude contract
+
+## Required Validation
+
+- `python3 -m unittest tools.schema_models.test_schema_models`
+- `git diff --check`
+- `rg -n "legacy array inbox|array-backed inbox" docs tools crates scripts`
+
+## Required Document Updates
+
+- `docs/phase-AA/sprint-AA8.md`
+- `docs/phase-AA/readiness.md`
+- `docs/phase-AA/issues.md`
+- `docs/plan-phase-AA.md`
+- `docs/project-plan.md`
+- `docs/claude-code-message-schema.md`
+- `docs/atm-message-schema.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+
+## Risks And Watchouts
+
+- if this sprint stops at prose and does not add real fixture-backed validation,
+  the schema can drift again without anyone noticing
+- if the sprint silently treats historical ATM additive fields as current
+  Claude contract, `AA.10` will start from a false baseline

--- a/docs/phase-AA/sprint-AA8.md
+++ b/docs/phase-AA/sprint-AA8.md
@@ -86,6 +86,8 @@ fixture-backed model alignment. Runtime behavior changes belong in `AA.9`.
 ## Acceptance Criteria
 
 - `docs/phase-AA/sprint-AA8.md` exists with the planned branch/worktree
+- `docs/phase-AA/readiness.md` is updated consistently with the accepted AA.8
+  closure state
 - `docs/claude-code-message-schema.md` defines the current shared inbox
   contract clearly enough that `req-qa` can enumerate the legal envelope
   directly from the sprint outputs

--- a/docs/phase-AA/sprint-AA9.md
+++ b/docs/phase-AA/sprint-AA9.md
@@ -1,0 +1,107 @@
+# AA.9 Current Claude Inbox Primary-Path Repair
+
+```yaml
+plan_type: sprint_plan
+phase: AA
+sprint: AA.9
+worktree: ../atm-core-worktrees/feature/pAA-s9-claude-inbox-primary-path
+branch: feature/pAA-s9-claude-inbox-primary-path
+status: planned
+estimated_scope: medium
+```
+
+## Goal
+
+Make the current Claude Code inbox JSON file shape the working primary ATM
+compatibility path instead of treating it as a degraded or legacy fallback.
+
+## Scope Summary
+
+This sprint is runtime-behavior repair. It closes the gap where ATM’s retained
+append path treats any inbox file that begins with `[` as a “legacy array
+inbox,” even though the current Claude Code inbox files are array-backed JSON
+mailboxes. The deliverable is a normal append path that works on the current
+Claude mailbox shape and reserves repair/rebuild only for malformed or truly
+unsupported inbox state.
+
+## Governing Sources
+
+- `docs/claude-code-message-schema.md`
+- `docs/atm-message-schema.md`
+- `crates/atm-core/src/service_runtime.rs`
+- `crates/atm-core/src/mailbox/store.rs`
+- `scripts/claude_inbox_send.py`
+- `reports/smoke/smoke-thorough.md`
+
+## Prerequisites
+
+- `AA.8`
+
+## Out Of Scope
+
+- no removal of historical ATM JSON compatibility promises
+- no SQLite schema-removal work
+- no broad resend/replay redesign unrelated to the Claude inbox primary path
+
+## Deliverables
+
+- The normal retained append path recognizes the current Claude inbox file
+  shape as supported, not legacy.
+
+- The current guard in `service_runtime.rs` is replaced with one that
+  distinguishes:
+  - current supported Claude array-backed inbox JSON
+  - current supported JSONL append surface, if retained intentionally
+  - malformed or unsupported mailbox content that really must fail closed
+
+- The repair/rebuild seam remains explicit, but it is no longer the expected
+  path for a healthy current Claude inbox file.
+
+- Smoke/report wording is corrected so a healthy send to a current Claude inbox
+  does not claim success only after a “legacy array inbox projection failed.”
+
+- The retained runtime tests and smoke coverage prove the supported path using
+  the current Claude mailbox shape.
+
+## Split Recommendation
+
+Do not mix runtime primary-path repair with historical-schema deletion. Once
+the current path is fixed, historical JSON removal belongs in `AA.10`.
+
+## Acceptance Criteria
+
+- `docs/phase-AA/sprint-AA9.md` exists with the planned branch/worktree
+- `compat_inbox_uses_legacy_array_format(...)` no longer classifies the current
+  Claude array-backed inbox file by its leading `[` alone
+- ATM can append or otherwise write through the normal primary path to the
+  current Claude inbox file shape without surfacing a degraded “legacy array
+  inbox” warning
+- the retained repair/rebuild seam is reserved for malformed or explicitly
+  unsupported mailbox state, not healthy current Claude inbox files
+- smoke/report wording is consistent with the repaired primary path
+
+## Required Validation
+
+- `cargo test -p agent-team-mail-core`
+- `python3 scripts/smoke/run.py thorough --write-artifacts`
+- `git diff --check`
+
+## Required Document Updates
+
+- `docs/phase-AA/sprint-AA9.md`
+- `docs/phase-AA/readiness.md`
+- `docs/phase-AA/issues.md`
+- `docs/plan-phase-AA.md`
+- `docs/project-plan.md`
+- `docs/claude-code-message-schema.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `reports/smoke/smoke-thorough.md` if this sprint uses a checked-in regenerated
+  artifact or wording fixture
+
+## Risks And Watchouts
+
+- if the fix remains heuristic and still keys on file prefix rather than legal
+  Claude mailbox shape, the same bug will reappear under another name
+- if the runtime still treats the Claude path as degraded-only, operators will
+  keep seeing false warnings on the primary inbox surface

--- a/docs/phase-AA/sprint-AA9.md
+++ b/docs/phase-AA/sprint-AA9.md
@@ -30,7 +30,7 @@ unsupported inbox state.
 - `docs/atm-message-schema.md`
 - `crates/atm-core/src/service_runtime.rs`
 - `crates/atm-core/src/mailbox/store.rs`
-- `scripts/claude_inbox_send.py`
+- `scripts/smoke/run.py`
 - `reports/smoke/smoke-thorough.md`
 
 ## Prerequisites
@@ -71,6 +71,8 @@ the current path is fixed, historical JSON removal belongs in `AA.10`.
 ## Acceptance Criteria
 
 - `docs/phase-AA/sprint-AA9.md` exists with the planned branch/worktree
+- `docs/phase-AA/readiness.md` is updated consistently with the accepted AA.9
+  closure state
 - `compat_inbox_uses_legacy_array_format(...)` no longer classifies the current
   Claude array-backed inbox file by its leading `[` alone
 - ATM can append or otherwise write through the normal primary path to the

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -67,6 +67,12 @@ That invariant no longer holds. Once the boundary widened, daemon code started
 to accumulate concrete adapter knowledge instead of staying a thin router.
 `Phase AA` is not feature expansion; it is architectural damage removal.
 
+The `AA.8` through `AA.10` Claude inbox schema repairs remain inside `Phase AA`
+because `team-lead` explicitly rerouted the smoke-fix closeout into the
+`plan/phase-AA-doctor-hardening` sprint line instead of a separate follow-on
+phase, treating the current Claude inbox contract and append-path drift as part
+of the same daemon/runtime hardening closure.
+
 ## Target Architecture
 
 ### `atm-runtime` becomes the concrete composition root
@@ -260,6 +266,18 @@ Execution branch:
 
 Execution worktree:
 - `../atm-core-worktrees/feature/pAA-s3-direct-doctor-and-runtime-health-split`
+
+### AA.8 Through AA.10 Claude Inbox Hardening Dependency Chain
+
+The Claude inbox repair line is intentionally sequential:
+
+- `AA.8` freezes the current legal Claude inbox contract from real samples and
+  corrects docs/models/tests.
+- `AA.9` then repairs the retained runtime so that frozen current contract is
+  the supported primary path rather than a degraded fallback.
+- `AA.10` only then removes historical ATM-authored JSON compatibility from the
+  active 1.2 contract, after the current supported path is both documented and
+  working.
 
 ### AA.4 Delete Remaining Daemon SQLite Leaks
 

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -377,6 +377,9 @@ Purpose:
   legacy-only input
 - reserve repair/rebuild for malformed or truly unsupported mailbox content
 
+Depends on:
+- `AA.8` (schema contract must be frozen first)
+
 Execution branch:
 - `feature/pAA-s9-claude-inbox-primary-path`
 
@@ -391,6 +394,9 @@ Purpose:
   active 1.2 schema
 - make current Claude Code inbox JSON the only accepted shared inbox contract
   unless a narrower exception is reapproved explicitly
+
+Depends on:
+- `AA.9` (primary path must be proven before compatibility removal)
 
 Execution branch:
 - `feature/pAA-s10-remove-historical-atm-json`

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -389,11 +389,13 @@ Execution worktree:
 ### AA.10 Remove Historical ATM JSON Compatibility From 1.2
 
 Purpose:
-- remove support promises for historical ATM-owned inbox JSON schema variants
-- stop treating top-level ATM machine fields and `metadata.atm.*` as supported
-  active 1.2 schema
-- make current Claude Code inbox JSON the only accepted shared inbox contract
-  unless a narrower exception is reapproved explicitly
+- remove primary-contract support promises for historical ATM-owned inbox JSON
+  schema variants
+- stop treating top-level ATM machine fields and `metadata.atm.*` as the
+  active or forward-write 1.2 schema
+- preserve read compatibility for legal ATM additive derivatives that extend
+  the current Claude Code envelope
+- leave malformed-ingress salvage policy to `AA.12`
 
 Depends on:
 - `AA.9` (primary path must be proven before compatibility removal)
@@ -417,6 +419,22 @@ Execution branch:
 
 Execution worktree:
 - `../atm-core-worktrees/feature/pAA-s11-delete-sqlite-legacy-compat`
+
+### AA.12 Malformed Claude Inbox Recovery Hardening
+
+Purpose:
+- define the fail-soft malformed-ingress policy for Claude inbox reads
+- salvage recoverable valid messages even when adjacent fragments are malformed
+- emit explicit degraded warnings/sentinels instead of dropping the whole inbox
+  surface when best-effort recovery is possible
+- add or update an ADR if the recovery contract changes the accepted
+  repository-wide shared-inbox boundary policy
+
+Execution branch:
+- `feature/pAA-s12-malformed-claude-inbox-recovery`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s12-malformed-claude-inbox-recovery`
 
 ## Out Of Scope
 

--- a/docs/plan-phase-AA.md
+++ b/docs/plan-phase-AA.md
@@ -316,6 +316,84 @@ Execution branch:
 Execution worktree:
 - `../atm-core-worktrees/feature/pAA-s6-obs-upgrade`
 
+### AA.7 Rust Boundary Enforcement Crate
+
+Status:
+- complete on `feature/pAA-s7-atm-architecture-crate`
+- `crates/atm-architecture/` is now the visible code-driven boundary guard
+- the superseded Python boundary scripts were removed from the active line
+
+Purpose:
+- make the second architecture-enforcement layer visible in the workspace
+- replace the deleted Python boundary scripts with the Rust crate as the
+  required code-driven guard
+- freeze `cargo test --package atm-architecture` as the merge-gate command
+
+Execution branch:
+- `feature/pAA-s7-atm-architecture-crate`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s7-atm-architecture-crate`
+
+### AA.8 Claude Code Inbox Schema Contract Alignment
+
+Purpose:
+- freeze the current Claude Code inbox JSON schema from real
+  `team-lead -> quality-mgr` samples
+- align docs, schema models, and tests to that current contract
+- remove wording that misclassifies the current array-backed Claude inbox file
+  shape as legacy
+
+Execution branch:
+- `feature/pAA-s8-claude-schema-contract`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s8-claude-schema-contract`
+
+### AA.9 Current Claude Inbox Primary-Path Repair
+
+Purpose:
+- make the current Claude inbox JSON file shape the supported primary ATM
+  compatibility path
+- stop treating the current array-backed Claude mailbox file as degraded
+  legacy-only input
+- reserve repair/rebuild for malformed or truly unsupported mailbox content
+
+Execution branch:
+- `feature/pAA-s9-claude-inbox-primary-path`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s9-claude-inbox-primary-path`
+
+### AA.10 Remove Historical ATM JSON Compatibility From 1.2
+
+Purpose:
+- remove support promises for historical ATM-owned inbox JSON schema variants
+- stop treating top-level ATM machine fields and `metadata.atm.*` as supported
+  active 1.2 schema
+- make current Claude Code inbox JSON the only accepted shared inbox contract
+  unless a narrower exception is reapproved explicitly
+
+Execution branch:
+- `feature/pAA-s10-remove-historical-atm-json`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s10-remove-historical-atm-json`
+
+### AA.11 Delete Pre-Production SQLite Compatibility Scaffolding
+
+Purpose:
+- remove abandoned pre-production SQLite compatibility scaffolding such as
+  `legacy_message_id`
+- restate the supported 1.2 SQLite bootstrap/migration baseline cleanly
+- keep unsupported historical database shapes out of the active runtime line
+
+Execution branch:
+- `feature/pAA-s11-delete-sqlite-legacy-compat`
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAA-s11-delete-sqlite-legacy-compat`
+
 ## Out Of Scope
 
 `Phase AA` does not:
@@ -329,6 +407,11 @@ Execution worktree:
 The scoped `sc-observability` / `sc-observability-types` `1.2.0` dependency
 upgrade in `AA.6` is in scope for this phase as closeout work required to
 finish the daemon/runtime simplification line cleanly.
+
+Smoke QA follow-up note:
+- if `team-lead` routes concrete smoke QA findings that widen the accepted
+  Phase AA scope beyond `AA.11`, add a new numbered sprint rather than
+  overloading the schema/runtime/removal sprints above
 
 ## Exit Criteria
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -230,11 +230,14 @@ Status summary:
 - `AA.9` will repair the retained runtime so the current Claude inbox JSON file
   shape is the working primary compatibility path rather than a degraded
   legacy-only path.
-- `AA.10` will remove historical ATM-owned inbox JSON schema support from the
-  active 1.2 contract, including top-level ATM machine fields and
-  `metadata.atm.*` compatibility promises.
+- `AA.10` will remove historical ATM-owned inbox JSON from the active primary
+  1.2 contract while preserving read compatibility for legal additive
+  derivatives such as tolerated top-level ATM fields and `metadata.atm.*`.
 - `AA.11` will delete pre-production SQLite compatibility scaffolding such as
   `legacy_message_id` unless an explicit user-approved exception survives.
+- `AA.12` will harden malformed Claude inbox recovery so one bad fragment does
+  not hide recoverable valid messages, and it will record an ADR if the
+  fail-soft policy changes the shared-inbox boundary contract.
 
 Goal:
 - move concrete SQLite/runtime assembly to `atm-runtime`
@@ -265,6 +268,7 @@ Sprint line:
 - `AA.9` `feature/pAA-s9-claude-inbox-primary-path`
 - `AA.10` `feature/pAA-s10-remove-historical-atm-json`
 - `AA.11` `feature/pAA-s11-delete-sqlite-legacy-compat`
+- `AA.12` `feature/pAA-s12-malformed-claude-inbox-recovery`
 
 Acceptance:
 - Phase AA exit criteria are satisfied only through

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -222,6 +222,17 @@ Status summary:
   architecture gate by landing `crates/atm-architecture/`, removing the
   superseded Python boundary scripts, and making `cargo test -p atm-architecture`
   the sole code-driven boundary-enforcement check. Status: `complete`.
+- `AA.8` will freeze the current Claude Code inbox JSON contract from real
+  `team-lead -> quality-mgr` samples and correct any docs/models/tests that
+  still classify that current array-backed inbox shape as legacy.
+- `AA.9` will repair the retained runtime so the current Claude inbox JSON file
+  shape is the working primary compatibility path rather than a degraded
+  legacy-only path.
+- `AA.10` will remove historical ATM-owned inbox JSON schema support from the
+  active 1.2 contract, including top-level ATM machine fields and
+  `metadata.atm.*` compatibility promises.
+- `AA.11` will delete pre-production SQLite compatibility scaffolding such as
+  `legacy_message_id` unless an explicit user-approved exception survives.
 
 Goal:
 - move concrete SQLite/runtime assembly to `atm-runtime`
@@ -248,6 +259,10 @@ Sprint line:
 - `AA.5` `feature/pAA-s5-boundary-relock-and-permanent-enforcement`
 - `AA.6` `feature/pAA-s6-obs-upgrade`
 - `AA.7` `feature/pAA-s7-atm-architecture-crate`
+- `AA.8` `feature/pAA-s8-claude-schema-contract`
+- `AA.9` `feature/pAA-s9-claude-inbox-primary-path`
+- `AA.10` `feature/pAA-s10-remove-historical-atm-json`
+- `AA.11` `feature/pAA-s11-delete-sqlite-legacy-compat`
 
 Acceptance:
 - Phase AA exit criteria are satisfied only through

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -206,6 +206,8 @@ Status summary:
   production SQLite/runtime assembly out of daemon production composition, and
   froze the target runtime boundary while the SQLite TOML relock remains
   deferred to `AA.5`.
+- `AA.3` completed the direct-local doctor split and daemon runtime-health
+  simplification so store diagnostics no longer require daemon-only routing.
 - `AA.4` removes the remaining daemon-side SQLite leak paths by deleting the
   daemon-private SQLite observability adapter, deleting direct daemon test
   boundary assembly calls, and relying on `atm-core` / `atm-runtime` replay


### PR DESCRIPTION
## Summary

Phase AA planning consolidation: formalized sprints AA.8–AA.11 integrating deferred smoke-test findings into proper sprint scopes and deliverables.

- **AA.8**: Claude Code inbox schema contract alignment (freeze current contract, align docs/models/tests, document primary shared inbox surface)
- **AA.9**: Claude inbox primary path (repair runtime so current Claude inbox JSON shape is working primary, not degraded-legacy path)
- **AA.10**: Historical ATM JSON compatibility removal (remove ATM-owned inbox JSON schema support from active contract)
- **AA.11**: SQLite compatibility scaffolding removal (delete pre-production compatibility like legacy_message_id)

## Changes

- Added docs/phase-AA/sprint-AA7.md through sprint-AA11.md with full planning scope
- Updated docs/phase-AA/readiness.md, docs/phase-AA/issues.md
- Updated docs/plan-phase-AA.md and docs/project-plan.md with sprint details
- All sprints organized with deliverables, prerequisites, governing sources

## Plan QA

Reviewers: req-qa, arch-qa
Worktree: /Users/randlee/Documents/github/atm-core-worktrees/plan/phase-AA-doctor-hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)