### PR TITLE
Plan AC.8: thin-client bootstrap dependency relock

### DIFF
--- a/docs/atm-graft/architecture.md
+++ b/docs/atm-graft/architecture.md
@@ -18,6 +18,10 @@ the pre-daemon workspace.
   in-process so ATM nudges can be injected without terminal automation layers.
 - `atm-graft` depends on `atm-core` semantic types, request/result contracts,
   config semantics, and error vocabulary.
+- `atm-graft` may depend on a shared thin-client same-host bootstrap seam for
+  canonical endpoint resolution, daemon-binary resolution, probe, and
+  supervised auto-start convenience, but it must not depend on runtime/storage
+  composition crates to obtain that behavior.
 - `atm-graft` must not depend on `atm-daemon` as a Rust crate; it talks to the
   daemon over the documented same-host protocol only.
 - `atm-graft` must not depend on `atm-rusqlite`; direct store access is outside
@@ -73,6 +77,10 @@ Architectural rules:
 - first-party Rust host agents must not invent a parallel transport or
   alternate daemon contract outside the `atm-core` client models consumed by
   `atm-graft`
+- first-party Rust host agents may expose a standard convenience `connect()`
+  path that resolves ATM environment/config inputs and starts the daemon when
+  launch conditions are met, but that path must remain a thin-client wrapper
+  over the shared bootstrap seam rather than a second composition root
 - all structs, enums, and traits needed by `atm-graft` must live in
   `atm-core`, even when the daemon is the concrete runtime peer
 - concrete socket/runtime code may remain outside `atm-core`, but it must bind
@@ -103,6 +111,10 @@ Boundary correction note:
   is not part of the target architecture
 - follow-up refactor work must keep daemon-owned protocol and runtime naming
   generic so `atm-graft` is only an external client crate
+- version skew between `atm-graft` and the primary `atm` install is acceptable
+  as long as both sides remain compatible with the documented same-host RPC
+  surface; `atm-graft` must not rely on lockstep crate-version equality as an
+  architectural requirement
 
 Rust boundary rules:
 - semantic request / response / event types must not remain raw
@@ -122,6 +134,11 @@ Architectural rules:
 - if `.atm.toml` is absent, `atm-graft` remains inert
 - runtime identity comes from `ATM_IDENTITY`; graft mode does not add a second
   identity-resolution scheme
+- if graft mode is active and identity/team resolution succeeds, the standard
+  convenience connection path may resolve the canonical same-host daemon
+  endpoint and attempt supervised daemon auto-start; the presence of
+  `.atm.toml`, `ATM_IDENTITY`, and `ATM_TEAM` is a valid launch precondition,
+  not a reason to forbid daemon startup
 - optional graft-specific config remains ATM-owned config semantics rather than
   host-private settings
 - the initial graft config surface must stay small:
@@ -132,6 +149,10 @@ Architectural consequence:
   `atm-graft` activation logic can be implemented cleanly
 - the concrete `atm-graft` crate consumes the public `atm_core::load_atm_config`
   helper rather than reparsing `.atm.toml` privately
+- the standard convenience path must collect those ATM-owned inputs and pass
+  them into a shared thin-client bootstrap helper seam rather than binding
+  `atm-graft` directly to `atm-daemon-bootstrap`, `atm-runtime`, or concrete
+  storage backends
 
 ## 2.5 Graft Session
 

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -32,6 +32,7 @@ product requirements without re-owning `atm-core` service semantics,
 - direct inbox JSONL parsing or writes
 - direct ownership of ATM semantic types that already belong to `atm-core`
 - forced interruption of a running tool call inside the host executable
+- runtime/storage composition ownership
 
 ## 3. Requirement Namespace
 
@@ -98,6 +99,10 @@ Required rules:
   `atm_core::load_atm_config`; it must not privately reparse `.atm.toml`
 - if graft mode is active, runtime identity comes from `ATM_IDENTITY`; graft
   mode must not invent a separate identity source
+- if graft mode is active, `ATM_IDENTITY` and `ATM_TEAM` resolve successfully,
+  and the standard same-host daemon endpoint can be derived from ATM-owned
+  config/environment inputs, `atm-graft` may attempt the standard supervised
+  daemon auto-start path instead of requiring the daemon to be pre-running
 - graft mode is enabled by default when active and may be disabled only by
   explicit config or runtime opt-out
 - `atm-graft` must use the same-host daemon API for:
@@ -109,6 +114,8 @@ Required rules:
   - optional runtime heartbeat / activity reporting when the host enables it
 - `atm-graft` must not bypass the daemon by talking directly to SQLite or inbox
   JSONL
+- `atm-graft` must not obtain same-host daemon bootstrap convenience by taking
+  a compile-time dependency on runtime/storage composition crates
 - pending nudge state must remain daemon-owned so embedded and CLI/hook-based
   consumers observe one queue
 - the host-facing nudge payload is structured and must contain at least:
@@ -147,6 +154,16 @@ Required rules:
   - typed shared DTOs for registration, unregistration, and nudge delivery
   - no graft-specific public trait family unless the shared boundary proves
     insufficient
+- the standard convenience `GraftClient::connect()` path must reuse the same
+  thin-client same-host bootstrap helper seam used by the CLI rather than
+  inventing a graft-private bootstrap path
+- the thin-client bootstrap helper seam may resolve the canonical same-host
+  endpoint, daemon binary, and supervised auto-start behavior, but it must not
+  introduce a transitive dependency on `atm-runtime`,
+  `atm-storage-rusqlite`, or other concrete storage backends
+- `atm-graft` compatibility with the primary `atm` install is defined by the
+  documented same-host RPC surface, not by a requirement that both crates ship
+  in lockstep versions
 - any hook-facing command that renders insertion-ready nudge text belongs on
   the `atm` CLI surface and must call the same daemon API used by `atm-graft`,
   but it is not a production substitute for embedded-mode automatic injection
@@ -214,6 +231,11 @@ Scope-simplification rule for the first implementation pass:
     unregistration, and typed nudge fetch/drain requests
   - the concrete exported types include `GraftClient` and `GraftSession`
   - `atm-graft` does not take a Rust dependency on `atm-daemon`
+  - the standard convenience connection path uses the shared thin-client
+    bootstrap seam instead of a graft-private runtime/storage composition path
+  - `cargo tree -p atm-graft -e normal --prefix none` does not pull
+    `atm-runtime` or `atm-storage-rusqlite` solely to support same-host daemon
+    bootstrap convenience
 - `REQ-GRAFT-NOTIFY-001`
 - daemon-originated nudge receipt is automatic in embedded mode
 - daemon-owned advisory-stream delivery plus companion drain/fetch or

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -89,6 +89,8 @@ Consequences:
 - CLI runtime wiring stays thin.
 - Thin extension crates can mirror the same client shape without importing CLI
   internals.
+- Thin extension crates can also version-skew from the primary `atm` install as
+  long as they remain compatible with the documented same-host RPC surface.
 
 Alternatives considered:
 - Let CLI call daemon internals directly.
@@ -134,6 +136,13 @@ Follow-up work:
   effect of transport object construction
 - the client-side launch path must acquire the documented pre-spawn launch gate
   before daemon fork/exec
+- the CLI standard same-host bootstrap path must be the canonical thin-client
+  convenience wrapper for endpoint resolution, daemon-binary resolution, probe,
+  and supervised auto-start; other first-party thin clients may mirror that
+  path, but they must not depend on CLI internals to do so
+- the canonical thin-client bootstrap seam must stay free of runtime/storage
+  composition ownership so convenience auto-start never forces `atm-runtime` or
+  concrete backend crates into thin-client dependency graphs
 - `atm` must preserve typed runtime error identity until the rendering
   boundary instead of collapsing failures into panic/unwrap control flow
 

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -37,6 +37,8 @@ The canonical daemon packet contract lives in:
 - singleton daemon lifecycle
 - direct SQLite access
 - direct inbox JSONL parsing or writes
+- the requirement that all first-party thin clients ship at the exact same
+  crate version
 
 ## 3. Requirement Namespace
 
@@ -196,6 +198,17 @@ Required Phase R rules:
   - attempt the one documented daemon auto-start path
   - retry connection once
   - fail clearly with recovery guidance rather than silently bypassing the daemon
+- the documented daemon auto-start path is also the canonical first-party
+  thin-client convenience path:
+  - it may be reused by crates such as `atm-graft`
+  - it resolves ATM-owned environment/config inputs into the canonical
+    same-host endpoint and daemon binary
+  - it is allowed to start the daemon when launch conditions are met
+  - it must not require a compile-time dependency on `atm-runtime`,
+    `atm-storage-rusqlite`, or other concrete backend composition crates
+- compatibility between first-party thin clients and the primary `atm` install
+  is governed by the documented same-host RPC surface rather than lockstep
+  crate-version equality
 - `atm doctor` remains a CLI command, but its production runtime checks may
   query daemon state through the runtime boundary
 - CLI runtime failures must preserve typed error identity until the rendering

--- a/docs/plans/phase-AB/plan-phase-AB.md
+++ b/docs/plans/phase-AB/plan-phase-AB.md
@@ -38,6 +38,8 @@ outside the same-host daemon and release-signoff line:
 `Phase AB` does not begin until:
 
 - `Phase Z` remains closed with the release-ready verdict already recorded
+- the accepted `develop` baseline includes the `AC.8` thin-client bootstrap
+  dependency relock
 - the accepted `develop` baseline passes the same-host workspace test suite on:
   - Windows
   - macOS

--- a/docs/plans/phase-AC/issues.md
+++ b/docs/plans/phase-AC/issues.md
@@ -32,6 +32,7 @@ The authoritative design reset is:
 | `AC-ISSUE-004` | `closed` | the concrete SQLite backend had become the implicit home of business logic, causing backend-specific seams and logic leakage upward; `AC.6` completed the cleanup by removing the last `atm-storage`-level SQLite observability leakage and leaving that surface owned by `atm-storage-rusqlite`. | `AC.3`, `AC.4`, and `AC.6` |
 | `AC-ISSUE-005` | `closed` | notifications are not frozen as a separate post-commit trait, which leaves write and event semantics underspecified across backends. | `AC.1` and `AC.3` |
 | `AC-ISSUE-006` | `closed` | the current crate graph did not keep future SQL Server support easy because backend crates orbited `atm-core` too closely; Phase `AC` now proves peer backends can target `atm-storage` directly, including the compile-only SQL Server proof crate with no `atm-core` edge. | `AC.3` and `AC.7` |
+| `AC-ISSUE-007` | `open` | `atm-graft` still carries an unconditional compile-time dependency on `atm-daemon-bootstrap`, which leaks `atm-runtime` and `atm-storage-rusqlite` into a thin client even though same-host daemon auto-start should remain only a thin-client convenience path. | `AC.8` |
 
 ## Inventory Rules
 

--- a/docs/plans/phase-AC/plan-phase-AC.md
+++ b/docs/plans/phase-AC/plan-phase-AC.md
@@ -1,6 +1,6 @@
 ---
 title: Phase AC Plan
-status: complete
+status: active
 branch: plan/phase-AC
 worktree: ../atm-core-worktrees/plan/phase-AC
 ---
@@ -32,6 +32,17 @@ The required end state is:
 - the SQLite backend implements the same contract with richer capabilities layered separately
 - RPC carries canonical domain bodies under one generic envelope instead of per-message transport clones
 - `atm-core` depends on storage semantics, not concrete backend details
+
+Post-closeout follow-on note:
+
+- `AC.0` through `AC.7` closed the storage-contract reset line, but `Phase AC`
+  is reopened for one pre-`AB` crate-boundary follow-on sprint
+- `AC.8` owns a thin-client dependency relock: remove the unconditional
+  `atm-graft -> atm-daemon-bootstrap` compile-time edge while preserving the
+  standard same-host convenience bootstrap path for thin clients
+- this follow-on does not reopen the storage-contract design; it extends the
+  crate-graph cleanup line because the current `atm-graft` dependency path
+  still leaks runtime/storage implementation choices into a thin client
 
 ## Design Rules
 
@@ -335,6 +346,29 @@ Completion note:
   `crates/atm-storage-sqlserver-proof` compiles against `atm-storage` without
   an `atm-core` edge
 
+### AC.8 Thin-Client Same-Host Bootstrap Dependency Relock
+
+Purpose:
+
+- remove the unconditional `atm-graft -> atm-daemon-bootstrap` compile-time
+  edge
+- preserve the standard same-host thin-client convenience path, including
+  daemon auto-start when launch conditions are met
+- move canonical same-host endpoint and daemon-binary resolution onto the
+  thin-client bootstrap seam so `atm` and `atm-graft` use the same shared path
+  without pulling runtime or concrete storage backend crates
+- keep the RPC surface unchanged so a future `atm-graft` build does not have
+  to version-lock to the primary `atm` install beyond RPC compatibility
+
+Execution branch:
+- `feature/pAC-s8-thin-client-bootstrap-dependency-relock`
+
+Current status:
+- planned
+
+Execution worktree:
+- `../atm-core-worktrees/feature/pAC-s8-thin-client-bootstrap-dependency-relock`
+
 ## Immediate Planning Outputs
 
 Phase `AC` planning is not complete until these artifacts exist and agree:
@@ -350,6 +384,7 @@ Phase `AC` planning is not complete until these artifacts exist and agree:
 - `docs/plans/phase-AC/sprint-AC5.md`
 - `docs/plans/phase-AC/sprint-AC6.md`
 - `docs/plans/phase-AC/sprint-AC7.md`
+- `docs/plans/phase-AC/sprint-AC8.md`
 - `docs/plans/phase-AC/storage-surface-inventory.md`
 - `docs/plans/phase-AC/type-convergence-map.md`
 - `docs/plans/phase-AC/type-ledger.md`
@@ -375,6 +410,10 @@ Phase `AC` is not complete until:
 - the resulting storage contract is explicitly documented as suitable for a future `atm-storage-sqlserver` implementation
 - speculative task-store code is not treated as an approved compatibility line
   inside the shared storage contract
+- `atm-graft` keeps the shared same-host autostart convenience path without a
+  direct dependency on `atm-daemon-bootstrap`
+- `atm-graft` does not transitively pull runtime or concrete storage backend
+  crates solely to participate in same-host daemon bootstrap
 
 Phase `AC` closeout evidence now includes:
 

--- a/docs/plans/phase-AC/readiness.md
+++ b/docs/plans/phase-AC/readiness.md
@@ -9,6 +9,10 @@ Track accepted closure for the storage-contract reset line that restores:
 - interchangeable storage backends
 - Claude storage as a first-class backend
 
+Phase `AC` reopened for the planned `AC.8` follow-on because the thin-client
+crate graph still contains one pre-`AB` dependency leak that is in-scope for
+the Phase AC boundary-cleanup line.
+
 Authoritative supporting inventory:
 - `docs/plans/phase-AC/issues.md`
 
@@ -24,6 +28,7 @@ Authoritative supporting inventory:
 | `AC.5` | `complete` | `feature/pAC-s5-rpc-envelope-and-domain-type-unification` | `../atm-core-worktrees/feature/pAC-s5-rpc-envelope-and-domain-type-unification` | `atm-daemon-client` owns `RpcEnvelope`, same-host clients exchange that generic wrapper, canonical message/roster bodies are encoded through `atm-storage`, and no new transport-local message/roster clones were introduced in the cutover |
 | `AC.6` | `complete` | `feature/pAC-s6-cleanup-and-deletion-closeout` | `../atm-core-worktrees/feature/pAC-s6-cleanup-and-deletion-closeout` | speculative task-store contract surfaces and their runtime/daemon bridge usage are deleted, stale Claude source/projection wrapper families are removed from the shared/public seam, daemon consumers use canonical `atm-storage-claude::compat` paths, and SQLite observability is removed from `atm-storage` and owned by `atm-storage-rusqlite` |
 | `AC.7` | `complete` | `feature/pAC-s7-sqlserver-readiness-proof` | `../atm-core-worktrees/feature/pAC-s7-sqlserver-readiness-proof` | the post-`AC.6` contract is explicitly proven backend-neutral, `atm-storage-sqlserver-proof` compiles against `atm-storage` with no `atm-core` dependency, and the remaining SQL Server work is backend implementation scope only |
+| `AC.8` | `planned` | `feature/pAC-s8-thin-client-bootstrap-dependency-relock` | `../atm-core-worktrees/feature/pAC-s8-thin-client-bootstrap-dependency-relock` | `atm-daemon-client` owns the standard same-host endpoint/binary resolution helpers used by thin clients, `atm-graft` no longer depends on `atm-daemon-bootstrap`, and the convenience autostart path still runs through `DaemonSupervisor` without a runtime/storage backend leak |
 
 ## Phase Exit Criteria
 
@@ -48,3 +53,5 @@ Phase `AC` is not complete until all of the following are true:
 - `docs/plans/phase-AC/sqlserver-readiness-proof.md` proves future SQL Server
   work can implement the existing contract without another architecture reset
 - `docs/plans/phase-AC/issues.md` has no open issue whose owning sprint is still incomplete
+- thin clients retain the standard same-host daemon auto-start convenience path
+  without linking `atm-daemon-bootstrap` into `atm-graft`

--- a/docs/plans/phase-AC/sprint-AC8.md
+++ b/docs/plans/phase-AC/sprint-AC8.md
@@ -1,0 +1,177 @@
+# AC.8 Thin-Client Same-Host Bootstrap Dependency Relock
+
+```yaml
+plan_type: sprint_plan
+phase: AC
+sprint: AC.8
+worktree: ../atm-core-worktrees/feature/pAC-s8-thin-client-bootstrap-dependency-relock
+branch: feature/pAC-s8-thin-client-bootstrap-dependency-relock
+status: planned
+estimated_scope: small
+```
+
+## Goal
+
+Remove the unconditional `atm-graft -> atm-daemon-bootstrap` compile-time edge
+while preserving the standard same-host thin-client convenience path:
+
+- resolve the canonical daemon endpoint and daemon binary from the normal ATM
+  environment/config path
+- auto-start the daemon when launch conditions are met
+- keep the RPC surface unchanged
+
+## Scope Summary
+
+This sprint is a narrow structural extraction. It does not redesign daemon
+policy, graft session lifecycle, or the RPC contract.
+
+Production-ready commitment:
+- every listed deliverable must land with the real dependency leak removed and
+  with the standard convenience autostart behavior still intact for thin
+  clients
+
+Primary closure rule:
+- `AC.8` closes only when `atm-graft` no longer links `atm-daemon-bootstrap`
+  transitively, yet both `atm` and `atm-graft` still use the same thin-client
+  same-host bootstrap helper seam
+
+## Bootstrap Seam Contract
+
+`AC.8` must land one explicit shared thin-client helper seam in
+`crates/atm-daemon-client/src/lib.rs`:
+
+```rust
+pub fn resolve_daemon_local_ipc_endpoint() -> Result<DaemonLocalIpcEndpoint, AtmError>;
+pub fn resolve_daemon_bin(current_host_label: &str) -> Result<DaemonBinaryPath, AtmError>;
+```
+
+Required `AC.8` consumer call sites:
+
+- `crates/atm/src/composition.rs`
+- `crates/atm-graft/src/lib.rs`
+
+Required `AC.8` behavior at those call sites:
+
+- both clients resolve the canonical same-host endpoint through
+  `resolve_daemon_local_ipc_endpoint()`
+- both clients resolve the daemon binary through
+  `resolve_daemon_bin(current_host_label)`
+- both clients construct `DaemonSupervisor` from those resolved values
+- both clients keep the supervised convenience auto-start path
+- neither client depends on `atm-daemon-bootstrap` to reach that path
+
+Compatibility-shim rule:
+
+- `AC.8` does not use a compatibility-shim closure mode
+- helper ownership and thin-client call-site migration close in the same sprint
+- `atm` and `atm-graft` must import the shared seam directly from
+  `atm-daemon-client`
+
+## Governing Sources
+
+- `docs/plans/phase-AC/plan-phase-AC.md`
+- `docs/plans/phase-AC/readiness.md`
+- `docs/plans/phase-AC/issues.md`
+- `docs/atm-graft/architecture.md`
+- `docs/atm-graft/boundaries.md`
+- `docs/atm-daemon-client/boundaries.md`
+- `boundaries/atm-graft/shared-client-consumer.toml`
+- `boundaries/atm-daemon-client/daemon-bootstrap.toml`
+
+## Prerequisites
+
+- accepted post-`AC.7` baseline on `develop`
+
+## Out Of Scope
+
+- no RPC envelope changes
+- no daemon/runtime/storage backend redesign
+- no removal of convenience autostart from `atm` or `atm-graft`
+- no version-lock requirement between `atm-graft` and the primary `atm`
+  install beyond RPC compatibility
+- no broader `atm-graft` API redesign beyond the helper-seam migration and
+  dependency relock documented here
+
+## Deliverables
+
+- `atm-daemon-client` owns the standard same-host daemon endpoint and daemon
+  binary resolution helpers used by thin clients
+- `atm` and `atm-graft` both consume those shared thin-client helpers for the
+  convenience bootstrap path
+- `crates/atm-graft/Cargo.toml` no longer depends on `atm-daemon-bootstrap`
+- `atm-graft` no longer transitively pulls `atm-runtime`,
+  `atm-storage-rusqlite`, `rusqlite`, or `libsqlite3-sys`
+- the endpoint/bin helper ownership no longer remains in
+  `atm-daemon-bootstrap`
+
+## Acceptance Criteria
+
+- `cargo tree -p atm-graft -e normal --prefix none` does not include
+  `atm-daemon-bootstrap`
+- `cargo tree -p atm-graft -e normal --prefix none` does not include
+  `atm-runtime`
+- `cargo tree -p atm-graft -e normal --prefix none` does not include
+  `atm-storage-rusqlite`
+- `cargo tree -p atm-graft -e normal --prefix none` does not include
+  `rusqlite`
+- `cargo tree -p atm-graft -e normal --prefix none` does not include
+  `libsqlite3-sys`
+- `GraftClient::connect()` still resolves the standard same-host daemon
+  endpoint/binary and still attempts daemon auto-start through
+  `DaemonSupervisor`
+- CLI bootstrap still uses the same shared thin-client helper seam
+- `crates/atm/src/composition.rs` and `crates/atm-graft/src/lib.rs` both call
+  the shared `atm-daemon-client` helper seam rather than
+  `atm-daemon-bootstrap`
+- `atm-daemon-bootstrap` no longer owns the endpoint/bin helper seam
+- the RPC surface exposed by `atm-daemon-client` and consumed by `atm-graft`
+  remains unchanged
+
+## Required Validation
+
+- `cargo test -p atm-daemon-client`
+- `cargo test -p atm-graft`
+- `cargo test -p atm`
+- `cargo tree -p atm-graft -e normal --prefix none`
+- `cargo tree -p atm-daemon-client -e normal --prefix none`
+- `python3 .just/lint_boundaries.py`
+- `git diff --check`
+- `rg -n "resolve_daemon_local_ipc_endpoint|resolve_daemon_bin" crates/atm-daemon-client/src/lib.rs`
+- `rg -n "atm_daemon_client::.*resolve_daemon|resolve_daemon_local_ipc_endpoint|resolve_daemon_bin" crates/atm/src/composition.rs crates/atm-graft/src/lib.rs`
+- `! rg -n "atm_daemon_bootstrap::.*resolve_daemon|resolve_daemon_local_ipc_endpoint|resolve_daemon_bin" crates/atm/src/composition.rs crates/atm-graft/src/lib.rs`
+- `! rg -n "pub fn resolve_daemon_local_ipc_endpoint|pub fn resolve_daemon_bin" crates/atm-daemon-bootstrap/src/lib.rs`
+- `! rg -n "atm-daemon-bootstrap" crates/atm-graft/Cargo.toml`
+- `! cargo tree -p atm-graft -e normal --prefix none | rg "rusqlite|libsqlite3-sys"`
+
+## Required Document Updates
+
+- `docs/plans/phase-AC/sprint-AC8.md`
+- `docs/plans/phase-AC/plan-phase-AC.md`
+- `docs/plans/phase-AC/readiness.md`
+- `docs/plans/phase-AC/issues.md`
+- `boundaries/atm-daemon-client/daemon-bootstrap.toml`
+- `docs/atm-daemon-client/boundaries.md`
+- `docs/atm-graft/architecture.md`
+- `docs/atm-graft/requirements.md`
+- `docs/atm/architecture.md`
+- `docs/atm/requirements.md`
+
+## Risks And Watchouts
+
+- moving the helper seam must not reintroduce runtime/storage knowledge into
+  thin clients
+- preserving convenience autostart must not be mistaken for restoring a daemon
+  composition dependency
+- if `atm-daemon-client` depends on `atm-core` for canonical ATM
+  environment/endpoint resolution, that new edge must stay free of
+  `atm-runtime` and concrete storage backend leakage
+- the sprint must not claim closure by leaving the helper seam effectively
+  owned by `atm-daemon-bootstrap` under a renamed or delegated path
+
+## Review Notes
+
+- `AC.8` is a post-closeout follow-on sprint on the completed `Phase AC`
+  crate-graph cleanup line
+- this sprint exists because thin-client bootstrap convenience is acceptable,
+  but the prior `atm-graft -> atm-daemon-bootstrap -> atm-runtime ->
+  atm-storage-rusqlite` edge violates the intended thin-client boundary

--- a/docs/plans/phase-AC/sprint-AC8.md
+++ b/docs/plans/phase-AC/sprint-AC8.md
@@ -98,6 +98,10 @@ Compatibility-shim rule:
   binary resolution helpers used by thin clients
 - `atm` and `atm-graft` both consume those shared thin-client helpers for the
   convenience bootstrap path
+- `boundaries/atm-daemon-client/daemon-bootstrap.toml` and
+  `boundaries/atm-graft/shared-client-consumer.toml` are updated to encode the
+  relocked thin-client ownership and dependency rules enforced by
+  `python3 .just/lint_boundaries.py`
 - `crates/atm-graft/Cargo.toml` no longer depends on `atm-daemon-bootstrap`
 - `atm-graft` no longer transitively pulls `atm-runtime`,
   `atm-storage-rusqlite`, `rusqlite`, or `libsqlite3-sys`
@@ -126,6 +130,9 @@ Compatibility-shim rule:
 - `atm-daemon-bootstrap` no longer owns the endpoint/bin helper seam
 - the RPC surface exposed by `atm-daemon-client` and consumed by `atm-graft`
   remains unchanged
+- the machine-readable boundary records for the shared thin-client consumer and
+  daemon-bootstrap seam pass `python3 .just/lint_boundaries.py` with the
+  relocked dependency policy encoded directly in the TOMLs
 
 ## Required Validation
 
@@ -150,7 +157,9 @@ Compatibility-shim rule:
 - `docs/plans/phase-AC/readiness.md`
 - `docs/plans/phase-AC/issues.md`
 - `boundaries/atm-daemon-client/daemon-bootstrap.toml`
+- `boundaries/atm-graft/shared-client-consumer.toml`
 - `docs/atm-daemon-client/boundaries.md`
+- `docs/atm-graft/boundaries.md`
 - `docs/atm-graft/architecture.md`
 - `docs/atm-graft/requirements.md`
 - `docs/atm/architecture.md`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -124,6 +124,7 @@ Status:
   - `crates/atm-core`
   - `crates/atm`
   - `crates/atm-daemon`
+  - `crates/atm-daemon-bootstrap`
   - `crates/atm-daemon-client`
   - `crates/atm-graft`
   - `crates/atm-runtime`
@@ -155,6 +156,7 @@ The abandoned early SQLite/daemon target implementation was split across:
 - `crates/atm-core`
 - `crates/atm`
 - `crates/atm-daemon`
+- `crates/atm-daemon-bootstrap`
 - `crates/atm-daemon-client`
 - `crates/atm-graft`
 - `crates/atm-rusqlite`
@@ -329,12 +331,20 @@ Sprint line:
 - `AC.5` `feature/pAC-s5-rpc-envelope-and-domain-type-unification` `complete`
 - `AC.6` `feature/pAC-s6-cleanup-and-deletion-closeout` `complete`
 - `AC.7` `feature/pAC-s7-sqlserver-readiness-proof` `complete`
+- `AC.8` `feature/pAC-s8-thin-client-bootstrap-dependency-relock` `planned`
 
 Completion note:
 - `AC.7` proves SQL Server readiness from the real post-`AC.6` contract,
   lands `crates/atm-storage-sqlserver-proof` as a compile-only backend proof,
   and closes the final backend-interchangeability issue without another storage
   reset.
+
+AC.8 follow-on note:
+- `AC.8` is the thin-client dependency relock follow-on that removes the
+  unconditional `atm-graft -> atm-daemon-bootstrap` compile-time edge while
+  preserving the standard same-host daemon auto-start convenience path through
+  shared `atm-daemon-client` helpers and machine-readable boundary-policy
+  enforcement.
 
 AC.6 closeout:
 - deleted the speculative `TaskStore` family from `atm-core` and removed the


### PR DESCRIPTION
## Summary
- Plans AC.8: closes the atm-graft crate-boundary leak (`atm-graft -> atm-daemon-bootstrap -> atm-runtime -> atm-storage-rusqlite -> libsqlite3-sys`) surfaced during dependency analysis on `plan/atm-grate-dependency-analysis` (GH #426).
- Hardens sprint/phase docs plus atm/atm-graft architecture and requirements docs against `sprint-planning-guidelines.md`: one closure mode, explicit seam signatures/call sites, fail-closed validation gates, anti-drift docs.
- No code changes — planning/docs only.

## Test plan
- [ ] quality-mgr plan review (requested)
- [ ] User review of open design question: should `GraftClient::connect()` keep implicit auto-start semantics by default once helpers move below the leak, or should host code opt in explicitly via a separate constructor/helper?