### PR TITLE
Refine plan-hardening reviewer flow

### DIFF
--- a/.claude/agents/critical-plan-reviewer.md
+++ b/.claude/agents/critical-plan-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: critical-plan-reviewer
-version: 0.1.0
+version: 0.2.0
 description: Performs a hostile late-stage review of hardened plans for architecture mistakes, weak boundaries, false closure, and cross-document ambiguity.
 tools: Glob, Grep, LS, Read, BashOutput
 model: sonnet
@@ -27,18 +27,18 @@ Always read:
 
 ## Input Contract
 
-The assignment must contain:
+The assignment must contain a fenced JSON input payload. Inside it:
 - related planning docs describing the hardened plan state
-- a required fenced JSON handoff from sprint-scope hardening
+- a required JSON handoff from sprint-scope hardening
 - context fields `source_of_truth`, `references`, `worktree_path`, and
   `branch`
 - current round metadata: `reviewed_commit`, `previous_reviewed_commit`, and
   `findings_hash`
 
-Reject the task if the fenced JSON handoff from sprint-scope hardening is
-missing or malformed.
+Reject the task if the JSON handoff from sprint-scope hardening is missing or
+malformed.
 
-Expected previous-step fenced JSON:
+Expected previous-step JSON:
 
 ```json
 {
@@ -185,8 +185,7 @@ Gate policy:
 - `FAIL` if any `Blocking` or any `Important` finding exists
 - `PASS` only when `100%` of entries in `sprint_scores` have
   `blocking_count = 0` and `important_count = 0`
-- `FAIL` if the sprint-scope-hardening fenced JSON handoff is missing or
-  malformed
+- `FAIL` if the sprint-scope-hardening JSON handoff is missing or malformed
 - `FAIL` if architecture or boundary commitments are not explicit enough to
   prevent obvious implementation drift
 - `PASS` only when architecture, boundary ownership, and closure language are

--- a/.claude/agents/plan-scope-reviewer.md
+++ b/.claude/agents/plan-scope-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: plan-scope-reviewer
-version: 0.1.0
+version: 0.2.0
 description: Reviews sprint shape, deliverable ownership, early split decisions, and direct sprint-doc consumability before hardening fixes.
 tools: Glob, Grep, LS, Read, BashOutput
 model: sonnet
@@ -27,18 +27,18 @@ Always read:
 
 ## Input Contract
 
-The assignment must contain:
+The assignment must contain a fenced JSON input payload. Inside it:
 - related planning docs that describe the current plan state
-- a required fenced JSON handoff from the initial arch-ctm guidelines pass
+- a required JSON handoff from the initial arch-ctm guidelines pass
 - context fields `source_of_truth`, `references`, `worktree_path`, and
   `branch`
 - current round metadata: `reviewed_commit`, `previous_reviewed_commit`, and
   `findings_hash`
 
-Reject the task if the fenced JSON handoff from the initial arch-ctm
-guidelines pass is missing or malformed.
+Reject the task if the JSON handoff from the initial arch-ctm guidelines pass
+is missing or malformed.
 
-Expected previous-step fenced JSON:
+Expected previous-step JSON:
 
 ```json
 {
@@ -187,8 +187,8 @@ Gate policy:
 - `FAIL` if any `Blocking` or any `Important` finding exists
 - `PASS` only when `100%` of entries in `sprint_scores` have
   `blocking_count = 0` and `important_count = 0`
-- `FAIL` if the fenced JSON handoff from the initial arch-ctm guidelines pass
-  is missing or malformed
+- `FAIL` if the JSON handoff from the initial arch-ctm guidelines pass is
+  missing or malformed
 - `FAIL` if a sprint doc is not directly consumable without duplicated scope
   transport
 - `PASS` only when sprint splitting, authoritative checklist shape, and

--- a/.claude/skills/plan-hardening/01-plan-scope-review.xml.j2
+++ b/.claude/skills/plan-hardening/01-plan-scope-review.xml.j2
@@ -1,6 +1,6 @@
 ---
 name: 01-plan-scope-review-task
-version: 2.0.0
+version: 2.1.0
 description: team-lead assignment template for the initial arch-ctm guidelines pass before background scope review.
 format: xml
 required_variables:
@@ -69,31 +69,17 @@ required_variables:
     team-lead directly. If team-lead does not concede, escalate to the user.
     Do not normalize the new scope into the plan without user approval.
 
-    Return fenced JSON to `team-lead` when this pass is complete. `team-lead`
-    will launch `plan-scope-reviewer` with that JSON.
+    Return JSON to `team-lead` when this pass is complete. `team-lead` will
+    launch `plan-scope-reviewer` with that JSON.
 
-    If `team-lead` later sends back fenced JSON findings and `sprint_scores`
-    from
-    `plan-scope-reviewer`, fix those findings and return updated fenced JSON.
-    Continue until `team-lead` reports that `plan-scope-reviewer` returned
-    `PASS`.
+    If `team-lead` later sends back reviewer findings JSON and
+    `sprint_scores` from `plan-scope-reviewer`, fix those findings and return
+    updated JSON. `team-lead` decides whether to relaunch review or advance.
 
-    Expected output shape:
-    ```json
-    {
-      "status": "PASS | FAIL",
-      "mode": "plan-hardening-guidelines-pass",
-      "round_id": "{{ round_id }}",
-      "round_index": {{ round_index }},
-      "reviewed_commit": "<commit-sha>",
-      "previous_reviewed_commit": "{{ previous_reviewed_commit | default('') }}",
-      "iterations": 0,
-      "docs_modified": [],
-      "docs_created": [],
-      "ready_for_next_step": true,
-      "errors": []
-    }
-    ```
+    Return one JSON object with:
+    `status`, `mode`, `round_id`, `round_index`, `reviewed_commit`,
+    `previous_reviewed_commit`, `iterations`, `docs_modified`,
+    `docs_created`, `ready_for_next_step`, and `errors`.
   </plan-hardening>
 
   <workflow>
@@ -103,7 +89,7 @@ required_variables:
     <step id="d">As soon as the guidelines pass is complete and the branch is pushable, commit and push immediately. Send branch name and commit hash right away so scope review can begin in parallel.</step>
     <step id="e">After the push report, run the required validation.</step>
     <step id="f">When validation completes, send a second report with PASS or FAIL, concrete failure details if any, and whether follow-up fixes are required.</step>
-    <step id="g">Return fenced JSON only after the current pass converges. If `reviewer-findings-json` is present, treat it as the current correction target from `plan-scope-reviewer` and return updated fenced JSON to `team-lead`.</step>
+    <step id="g">Return JSON only after the current pass converges. If `reviewer-findings-json` is present, treat it as the current correction target from `plan-scope-reviewer` and return updated JSON to `team-lead`.</step>
     <step id="h">After the validation report, read ATM again for follow-up work.</step>
   </workflow>
 </atm-task>

--- a/.claude/skills/plan-hardening/02-sprint-scope-hardening.xml.j2
+++ b/.claude/skills/plan-hardening/02-sprint-scope-hardening.xml.j2
@@ -1,6 +1,6 @@
 ---
 name: 02-sprint-scope-hardening-task
-version: 2.0.0
+version: 2.1.0
 description: team-lead assignment template for sprint-scope and deliverable hardening before implementation.
 format: xml
 required_variables:
@@ -49,40 +49,12 @@ required_variables:
 {% endif %}
 
   <required-input>
-    The following fenced JSON handoff from `plan-scope-reviewer` is required
-    input. Reject the task if it is missing or malformed.
-
-    Expected shape:
-    ```json
-    {
-      "status": "PASS | FAIL",
-      "mode": "plan-scope-review",
-      "reviewer": "plan-scope-reviewer",
-      "round_id": "STEP1-R1",
-      "round_index": 1,
-      "reviewed_commit": "abc1234",
-      "previous_reviewed_commit": "",
-      "findings_hash": "stable-round-fingerprint",
-      "scope": {
-        "phase": "string or null",
-        "sprint": "string or null"
-      },
-      "sprint_scores": [
-        {
-          "sprint": "X.12",
-          "status": "PASS | FAIL",
-          "blocking_count": 0,
-          "important_count": 0,
-          "minor_count": 0
-        }
-      ],
-      "docs_read": [],
-      "findings": [],
-      "minor_wording": [],
-      "ready_for_next_step": true,
-      "errors": []
-    }
-    ```
+    The following review JSON from `plan-scope-reviewer` is required input.
+    Reject the task if it is missing or malformed. It must include:
+    `status`, `mode`, `reviewer`, `round_id`, `round_index`,
+    `reviewed_commit`, `previous_reviewed_commit`, `findings_hash`,
+    `sprint_scores`, `findings`, `minor_wording`, `ready_for_next_step`, and
+    `errors`.
 <![CDATA[
 {{ previous_step_json }}
 ]]>
@@ -260,45 +232,30 @@ required_variables:
       Continue until audit-phase produces zero findings.
     </repeat>
 
-    Return fenced JSON to `team-lead` when this pass completes.
+    Return JSON to `team-lead` when this pass completes.
 
-    If `team-lead` later sends back fenced JSON findings and `sprint_scores` from
-    `critical-plan-reviewer`, fix those findings and return updated fenced
-    JSON. Continue until `team-lead` reports that
-    `critical-plan-reviewer` returned `PASS`.
+    If `team-lead` later sends back reviewer findings JSON and
+    `sprint_scores` from `critical-plan-reviewer`, fix those findings and
+    return updated JSON. `team-lead` decides whether to relaunch review or
+    advance.
 
     <exit-criterion>
-      Output fenced JSON only when audit-phase produces zero findings:
-
-      ```json
-      {
-        "status": "PASS | FAIL",
-        "mode": "plan-hardening-sprint-scope",
-        "round_id": "{{ round_id }}",
-        "round_index": {{ round_index }},
-        "reviewed_commit": "<commit-sha>",
-        "previous_reviewed_commit": "{{ previous_reviewed_commit | default('') }}",
-        "iterations": 0,
-        "findings_resolved": 0,
-        "final_finding_count": 0,
-        "sprint_splits_added": 0,
-        "docs_modified": [],
-        "docs_created": [],
-        "ready_for_next_step": true,
-        "errors": []
-      }
-      ```
+      Output JSON only when audit-phase produces zero findings. Include:
+      `status`, `mode`, `round_id`, `round_index`, `reviewed_commit`,
+      `previous_reviewed_commit`, `iterations`, `findings_resolved`,
+      `final_finding_count`, `sprint_splits_added`, `docs_modified`,
+      `docs_created`, `ready_for_next_step`, and `errors`.
     </exit-criterion>
   </plan-hardening>
 
   <workflow>
-    <step id="a">ACK this message immediately. In the ACK, include a brief outline of the plan/work you understand to be in scope. If the required fenced JSON handoff from `plan-scope-reviewer` is missing or malformed, reject the task immediately. If the task includes questions-or-concerns, address them explicitly in the same ACK before starting work. If the task appears to materially change the user-discussed deliverable scope, the ACK must push back explicitly and state that hardening is blocked pending user discussion. Team-lead should review that ACK and outline first, then discuss any scope concerns with the user after the ACK is received. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
+    <step id="a">ACK this message immediately. In the ACK, include a brief outline of the plan/work you understand to be in scope. If the required review JSON from `plan-scope-reviewer` is missing or malformed, reject the task immediately. If the task includes questions-or-concerns, address them explicitly in the same ACK before starting work. If the task appears to materially change the user-discussed deliverable scope, the ACK must push back explicitly and state that hardening is blocked pending user discussion. Team-lead should review that ACK and outline first, then discuss any scope concerns with the user after the ACK is received. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
     <step id="b">Immediately after ACK, begin executing the task in the same work session.</step>
     <step id="c">Before editing, update the worktree from the target branch and include prior fixes already merged to that target.</step>
     <step id="d">As soon as the hardening changes are complete and the branch is pushable, commit and push immediately. Send branch name and commit hash right away so team-lead can prepare the critical review step.</step>
     <step id="e">After the push report, run the required validation. Do not wait for PR creation before starting validation.</step>
     <step id="f">When validation completes, send a second report with PASS or FAIL, concrete failure details if any, and whether follow-up fixes are required.</step>
-    <step id="g">After the current hardening pass converges, ensure all document updates are staged, committed, and pushed. Return fenced JSON only. If `reviewer-findings-json` is present, treat it as the current correction target from `critical-plan-reviewer` and return updated fenced JSON to `team-lead`.</step>
+    <step id="g">After the current hardening pass converges, ensure all document updates are staged, committed, and pushed. Return JSON only. If `reviewer-findings-json` is present, treat it as the current correction target from `critical-plan-reviewer` and return updated JSON to `team-lead`.</step>
     <step id="h">Team-lead must not route the plan to QA or implementation from this pass alone. `critical-plan-reviewer` must run after this pass, and `03-consistency-hardening.xml.j2` must run after that.</step>
     <step id="i">After the validation report, read ATM again for follow-up work.</step>
   </workflow>

--- a/.claude/skills/plan-hardening/03-consistency-hardening.xml.j2
+++ b/.claude/skills/plan-hardening/03-consistency-hardening.xml.j2
@@ -1,6 +1,6 @@
 ---
 name: 03-consistency-hardening-task
-version: 1.0.0
+version: 1.1.0
 description: team-lead assignment template for cross-document consistency and ambiguity hardening after critical plan review.
 format: xml
 required_variables:
@@ -49,40 +49,12 @@ required_variables:
 {% endif %}
 
   <required-input>
-    The following fenced JSON handoff from `critical-plan-reviewer` is
-    required input. Reject the task if it is missing or malformed.
-
-    Expected shape:
-    ```json
-    {
-      "status": "PASS | FAIL",
-      "mode": "critical-plan-review",
-      "reviewer": "critical-plan-reviewer",
-      "round_id": "STEP3-R1",
-      "round_index": 1,
-      "reviewed_commit": "abc1234",
-      "previous_reviewed_commit": "",
-      "findings_hash": "stable-round-fingerprint",
-      "scope": {
-        "phase": "string or null",
-        "sprint": "string or null"
-      },
-      "sprint_scores": [
-        {
-          "sprint": "X.12",
-          "status": "PASS | FAIL",
-          "blocking_count": 0,
-          "important_count": 0,
-          "minor_count": 0
-        }
-      ],
-      "docs_read": [],
-      "findings": [],
-      "minor_wording": [],
-      "ready_for_next_step": true,
-      "errors": []
-    }
-    ```
+    The following review JSON from `critical-plan-reviewer` is required
+    input. Reject the task if it is missing or malformed. It must include:
+    `status`, `mode`, `reviewer`, `round_id`, `round_index`,
+    `reviewed_commit`, `previous_reviewed_commit`, `findings_hash`,
+    `sprint_scores`, `findings`, `minor_wording`, `ready_for_next_step`, and
+    `errors`.
 <![CDATA[
 {{ previous_step_json }}
 ]]>
@@ -207,41 +179,27 @@ required_variables:
       Continue until audit-phase produces zero findings.
     </repeat>
 
-    Return fenced JSON to `team-lead` when this pass completes. `team-lead`
-    will hand the plan off to the codex-orchestration plan-QA flow via
+    Return JSON to `team-lead` when this pass completes. `team-lead` will hand
+    the plan off to the codex-orchestration plan-QA flow via
     `quality-mgr`.
 
     <exit-criterion>
-      Output fenced JSON only when audit-phase produces zero findings:
-
-      ```json
-      {
-        "status": "PASS | FAIL",
-        "mode": "plan-hardening-consistency",
-        "round_id": "{{ round_id }}",
-        "round_index": {{ round_index }},
-        "reviewed_commit": "<commit-sha>",
-        "previous_reviewed_commit": "{{ previous_reviewed_commit | default('') }}",
-        "iterations": 0,
-        "findings_resolved": 0,
-        "final_finding_count": 0,
-        "docs_modified": [],
-        "docs_created": [],
-        "ready_for_next_step": true,
-        "errors": []
-      }
-      ```
+      Output JSON only when audit-phase produces zero findings. Include:
+      `status`, `mode`, `round_id`, `round_index`, `reviewed_commit`,
+      `previous_reviewed_commit`, `iterations`, `findings_resolved`,
+      `final_finding_count`, `docs_modified`, `docs_created`,
+      `ready_for_next_step`, and `errors`.
     </exit-criterion>
   </plan-hardening-consistency>
 
   <workflow>
-    <step id="a">ACK this message immediately. In the ACK, include a brief outline of the plan/work you understand to be in scope. If the required fenced JSON handoff from `critical-plan-reviewer` is missing or malformed, reject the task immediately. If the task includes questions-or-concerns, address them explicitly in the same ACK before starting work. If the task appears to materially change the user-discussed deliverable scope, the ACK must push back explicitly and state that consistency hardening is blocked pending user discussion. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
+    <step id="a">ACK this message immediately. In the ACK, include a brief outline of the plan/work you understand to be in scope. If the required review JSON from `critical-plan-reviewer` is missing or malformed, reject the task immediately. If the task includes questions-or-concerns, address them explicitly in the same ACK before starting work. If the task appears to materially change the user-discussed deliverable scope, the ACK must push back explicitly and state that consistency hardening is blocked pending user discussion. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
     <step id="b">Immediately after ACK, begin executing the task in the same work session.</step>
     <step id="c">Before editing, update the worktree from the target branch and include prior fixes already merged to that target.</step>
     <step id="d">As soon as the hardening changes are complete and the branch is pushable, commit and push immediately. Send branch name and commit hash right away so team-lead critical review can begin in parallel.</step>
     <step id="e">After the push report, run the required validation. Do not wait for PR creation before starting validation.</step>
     <step id="f">When validation completes, send a second report with PASS or FAIL, concrete failure details if any, and whether follow-up fixes are required.</step>
-    <step id="g">After the hardening loop converges, ensure all document updates are staged, committed, and pushed. Return fenced JSON only. The next step after this pass is codex-orchestration plan QA through `quality-mgr`, not another local plan-hardening review loop.</step>
+    <step id="g">After the hardening loop converges, ensure all document updates are staged, committed, and pushed. Return JSON only. The next step after this pass is codex-orchestration plan QA through `quality-mgr`, not another local plan-hardening review loop.</step>
     <step id="h">After the validation report, read ATM again for follow-up work.</step>
   </workflow>
 </atm-task>

--- a/.claude/skills/plan-hardening/SKILL.md
+++ b/.claude/skills/plan-hardening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-hardening
-version: 1.5.0
+version: 1.6.0
 description: >
   Team-lead drives plan hardening after the current plan state already exists
   in repo docs.
@@ -45,11 +45,11 @@ Always use:
 
 | # | Route to | Input required | Output expected | Read before executing |
 |---|----------|----------------|-----------------|-----------------------|
-| 1 | `arch-ctm` | vars file | `step-1` fenced JSON | `steps/step-1.md` |
+| 1 | `arch-ctm` | vars file | `step-1` JSON | `steps/step-1.md` |
 | 2 | `plan-scope-reviewer` (background) | context + `step-1` JSON | `step-2` fenced JSON | `steps/step-2.md` |
-| 3 | `arch-ctm` | `step-2` JSON | `step-3` fenced JSON | `steps/step-3.md` |
+| 3 | `arch-ctm` | `step-2` JSON | `step-3` JSON | `steps/step-3.md` |
 | 4 | `critical-plan-reviewer` (background) | context + `step-3` JSON | `step-4` fenced JSON | `steps/step-4.md` |
-| 5 | `arch-ctm` | `step-4` JSON | `step-5` fenced JSON | `steps/step-5.md` |
+| 5 | `arch-ctm` | `step-4` JSON | `step-5` JSON | `steps/step-5.md` |
 | 6 | `quality-mgr` | `step-5` JSON + QA vars file | codex-orchestration plan-QA handoff | `steps/step-6.md` |
 
 ## Round Tracking
@@ -83,17 +83,20 @@ Cycle-cap behavior:
 - no reviewer findings may be accepted as-is or bypass the plan-editing agent
 - if a reviewer returns `FAIL` on the final allowed reviewer cycle, `team-lead`
   must still send those findings to `arch-ctm` for one final correction pass
-- after that final correction pass, if no reviewer cycles remain, stop the
-  hardening run as `cap-exhausted / not converged` and report status plainly
+- after that final correction pass, if no reviewer cycles remain, do not
+  launch that reviewer again in the current hardening run; advance directly to
+  the next phase with the updated plan-editing output
 - do not ask the user how to proceed, do not offer multiple-choice options,
   and do not invent an "accept and proceed" path
 
 ## Hard Stops
 
 - `team-lead` only checks the top-level `status` and expected `mode` fields on
-  each fenced JSON response before advancing
-- every step after step 1 must receive the previous step's fenced JSON
-- missing or malformed fenced JSON is a hard stop
+  each response before advancing
+- reviewer steps require fenced JSON; plan-editing and QA-handoff steps use
+  plain JSON
+- every step after step 1 must receive the previous step response JSON
+- missing or malformed required JSON is a hard stop
 - a reviewer rerun is valid only when either `reviewed_commit` changed or
   `findings_hash` changed
 - if the same reviewer returns the same `reviewed_commit` and the same
@@ -103,10 +106,9 @@ Cycle-cap behavior:
 - remaining in-scope work without sprint ownership is a hard stop
 - if a sprint cannot credibly land its committed deliverables at a
   production-ready level, split it before implementation
-- if a reviewer loop reaches its configured cap without converging, stop after
-  routing the last findings to `arch-ctm` and report `cap-exhausted / not
-  converged`; do not continue launching background reviewers and do not ask
-  the user for a decision mid-loop
+- if a reviewer loop reaches its configured cap, stop launching that reviewer
+  after routing the last findings to `arch-ctm`; then continue with the next
+  hardening phase without asking the user for a mid-loop decision
 
 ## Render
 

--- a/.claude/skills/plan-hardening/examples/plan-hardening-rounds.example.md
+++ b/.claude/skills/plan-hardening/examples/plan-hardening-rounds.example.md
@@ -11,7 +11,7 @@ Cap behavior reminder:
   JSON overrides it explicitly
 - every reviewer `FAIL` must still be routed to `arch-ctm`
 - if the final allowed reviewer cycle still returns `FAIL`, route that finding
-  set to `arch-ctm`, complete the correction pass, then stop and report
-  `cap-exhausted / not converged`
+  set to `arch-ctm`, complete the correction pass, then advance to the next
+  hardening phase without launching that reviewer again
 - do not offer `accept and proceed`
 - do not ask the user for a branching decision mid-loop

--- a/.claude/skills/plan-hardening/steps/step-1.md
+++ b/.claude/skills/plan-hardening/steps/step-1.md
@@ -32,23 +32,23 @@ atm send arch-ctm --stdin < /tmp/step-1-message.xml
 
 **3. Check the response**
 
-Read the `arch-ctm` response and confirm it contains fenced JSON.
+Read the `arch-ctm` response and confirm it contains JSON.
 The expected output shape is specified inside `01-plan-scope-review.xml.j2`.
-Do not proceed to Step 2 until that fenced JSON is present and well formed.
+Do not proceed to Step 2 until that JSON is present and well formed.
 If the response is incomplete or malformed, send a correction request to
 `arch-ctm` immediately.
-Save the extracted fenced JSON to `/tmp/step-1.json`.
+Save the extracted JSON to `/tmp/step-1.json`.
 
 **4. Route by status**
 
 - `PASS` -> proceed to Step 2
 - `FAIL` -> re-render and re-send Step 1 to `arch-ctm`
-- if `arch-ctm` ACKs but returns no new fenced JSON, increment `round_index`,
+- if `arch-ctm` ACKs but returns no new JSON, increment `round_index`,
   update `round_id`, refresh `replay_nonce` with the current UTC timestamp,
   and re-render Step 1 before re-sending
 
 ## Hard stops
 
 - worktree does not exist: create it before running this step
-- fenced JSON is missing or malformed: do not advance; send a correction
+- JSON is missing or malformed: do not advance; send a correction
   request immediately and identify the missing or malformed fields explicitly

--- a/.claude/skills/plan-hardening/steps/step-2.md
+++ b/.claude/skills/plan-hardening/steps/step-2.md
@@ -15,7 +15,7 @@ Pass a fenced JSON input that includes:
 - `branch`
 - `review_cycle_limit`
 - `review_cycle_index`
-- `step-1` fenced JSON
+- `step-1` JSON
 
 Set `run_in_background: true`.
 
@@ -68,7 +68,7 @@ Save the extracted fenced JSON to `/tmp/step-2.json`.
   `reviewer_findings_json` contains the Step 2 fenced JSON, then re-run Step 1
 - every Step 2 `FAIL` must be routed to Step 1; there is no accept-and-proceed
   path
-- after Step 1 returns updated fenced JSON, update:
+- after Step 1 returns updated JSON, update:
   - `previous_reviewed_commit`
   - `reviewed_commit`
   - `findings_hash`
@@ -80,8 +80,8 @@ Save the extracted fenced JSON to `/tmp/step-2.json`.
     `plan-scope-reviewer` agent when possible
   - if the just-completed reviewer response used cycle index equal to
     `plan_scope_review_cycle_limit`, do not launch another background review;
-    stop the hardening run after the Step 1 correction pass and report
-    `cap-exhausted / not converged`
+    complete the Step 1 correction pass, record the capped review state, and
+    proceed directly to Step 3
 - if the next Step 2 response repeats the same `reviewed_commit` and the same
   `findings_hash`, classify it as a stale replay and do not open a new Step 1
   round
@@ -106,12 +106,12 @@ Update the round table after every Step 2 response:
 
 ## Hard stops
 
-- `step-1` fenced JSON from the Step 1 response is missing or malformed: do
+- `step-1` JSON from the Step 1 response is missing or malformed: do
   not advance; send a correction request immediately and identify the missing
   or malformed fields explicitly
 - reviewer launch input is missing `source_of_truth`, `references`,
   `worktree_path`, `branch`, `review_cycle_limit`, `review_cycle_index`, or
-  `step-1` fenced JSON: do not advance; correct the launch payload immediately
+  `step-1` JSON: do not advance; correct the launch payload immediately
 - reviewer output is missing or malformed: do not advance; send a correction
   request immediately and identify the missing or malformed fields explicitly
 - reviewer output repeats the same `reviewed_commit` and the same
@@ -120,4 +120,4 @@ Update the round table after every Step 2 response:
 - reviewer has reached `plan_scope_review_cycle_limit` without converging: do
   not launch another reviewer cycle, do not ask the user what to do, and do
   not accept the findings silently; finish the Step 1 correction pass and
-  report `cap-exhausted / not converged`
+  continue to Step 3

--- a/.claude/skills/plan-hardening/steps/step-3.md
+++ b/.claude/skills/plan-hardening/steps/step-3.md
@@ -12,7 +12,7 @@ sc-compose render \
   --output /tmp/step-3-message.xml
 ```
 
-The vars file or rendered task must include `step-2` fenced JSON as the
+The vars file or rendered task must include `step-2` reviewer JSON as the
 required input payload.
 It must also carry current round metadata:
 - `round_id`
@@ -30,13 +30,13 @@ atm send arch-ctm --stdin < /tmp/step-3-message.xml
 
 **3. Check the response**
 
-Read the `arch-ctm` response and confirm it contains fenced JSON.
+Read the `arch-ctm` response and confirm it contains JSON.
 The expected output shape is specified inside
 `02-sprint-scope-hardening.xml.j2`.
-Do not proceed to Step 4 until that fenced JSON is present and well formed.
+Do not proceed to Step 4 until that JSON is present and well formed.
 If the response is incomplete or malformed, send a correction request to
 `arch-ctm` immediately.
-Save the extracted fenced JSON to `/tmp/step-3.json`.
+Save the extracted JSON to `/tmp/step-3.json`.
 
 **4. Route by status**
 
@@ -54,8 +54,8 @@ Maintain the round table after every Step 3 / Step 4 loop:
 
 ## Hard stops
 
-- `step-2` fenced JSON from the Step 2 response is missing or malformed: do
+- `step-2` reviewer JSON from the Step 2 response is missing or malformed: do
   not advance; send a correction request immediately and identify the missing
   or malformed fields explicitly
-- fenced JSON is missing or malformed: do not advance; send a correction
+- JSON is missing or malformed: do not advance; send a correction
   request immediately and identify the missing or malformed fields explicitly

--- a/.claude/skills/plan-hardening/steps/step-4.md
+++ b/.claude/skills/plan-hardening/steps/step-4.md
@@ -15,7 +15,7 @@ Pass a fenced JSON input that includes:
 - `branch`
 - `review_cycle_limit`
 - `review_cycle_index`
-- `step-3` fenced JSON
+- `step-3` JSON
 
 Set `run_in_background: true`.
 
@@ -68,7 +68,7 @@ Save the extracted fenced JSON to `/tmp/step-4.json`.
   `reviewer_findings_json` contains the Step 4 fenced JSON, then re-run Step 3
 - every Step 4 `FAIL` must be routed to Step 3; there is no accept-and-proceed
   path
-- after Step 3 returns updated fenced JSON, update:
+- after Step 3 returns updated JSON, update:
   - `previous_reviewed_commit`
   - `reviewed_commit`
   - `findings_hash`
@@ -80,8 +80,8 @@ Save the extracted fenced JSON to `/tmp/step-4.json`.
     `critical-plan-reviewer` agent when possible
   - if the just-completed reviewer response used cycle index equal to
     `critical_review_cycle_limit`, do not launch another background review;
-    stop the hardening run after the Step 3 correction pass and report
-    `cap-exhausted / not converged`
+    complete the Step 3 correction pass, record the capped review state, and
+    proceed directly to Step 5
 - the reviewer must return all remaining `Blocking` and `Important` findings
   in one pass; newly surfaced findings after a previous round are acceptable
   only if the plan changed between rounds
@@ -114,12 +114,12 @@ Update the round table after every Step 4 response:
 
 ## Hard stops
 
-- `step-3` fenced JSON from the Step 3 response is missing or malformed: do
+- `step-3` JSON from the Step 3 response is missing or malformed: do
   not advance; send a correction request immediately and identify the missing
   or malformed fields explicitly
 - reviewer launch input is missing `source_of_truth`, `references`,
   `worktree_path`, `branch`, `review_cycle_limit`, `review_cycle_index`, or
-  `step-3` fenced JSON: do not advance; correct the launch payload immediately
+  `step-3` JSON: do not advance; correct the launch payload immediately
 - reviewer output is missing or malformed: do not advance; send a correction
   request immediately and identify the missing or malformed fields explicitly
 - reviewer output repeats the same `reviewed_commit` and the same
@@ -127,5 +127,5 @@ Update the round table after every Step 4 response:
   review cycle only after the plan state changes
 - reviewer has reached `critical_review_cycle_limit` without converging: do not
   launch another reviewer cycle, do not ask the user what to do, and do not
-  accept the findings silently; finish the Step 3 correction pass and report
-  `cap-exhausted / not converged`
+  accept the findings silently; finish the Step 3 correction pass and continue
+  to Step 5

--- a/.claude/skills/plan-hardening/steps/step-5.md
+++ b/.claude/skills/plan-hardening/steps/step-5.md
@@ -12,7 +12,7 @@ sc-compose render \
   --output /tmp/step-5-message.xml
 ```
 
-The vars file or rendered task must include `step-4` fenced JSON as the
+The vars file or rendered task must include `step-4` reviewer JSON as the
 required input payload.
 It must also carry current round metadata:
 - `round_id`
@@ -30,13 +30,13 @@ atm send arch-ctm --stdin < /tmp/step-5-message.xml
 
 **3. Check the response**
 
-Read the `arch-ctm` response and confirm it contains fenced JSON.
+Read the `arch-ctm` response and confirm it contains JSON.
 The expected output shape is specified inside
 `03-consistency-hardening.xml.j2`.
-Do not proceed to Step 6 until that fenced JSON is present and well formed.
+Do not proceed to Step 6 until that JSON is present and well formed.
 If the response is incomplete or malformed, send a correction request to
 `arch-ctm` immediately.
-Save the extracted fenced JSON to `/tmp/step-5.json`.
+Save the extracted JSON to `/tmp/step-5.json`.
 
 **4. Route by status**
 
@@ -46,15 +46,11 @@ Save the extracted fenced JSON to `/tmp/step-5.json`.
   being replayed, increment `round_index`, update `round_id`, refresh
   `replay_nonce` with the current UTC timestamp, and re-render before
   re-sending
-- if Step 5 returns `FAIL` three times without converging, stop and report
-  `cap-exhausted / not converged`; do not ask the user what to do mid-loop
 
 ## Hard stops
 
-- `step-4` fenced JSON from the Step 4 response is missing or malformed: do
+- `step-4` reviewer JSON from the Step 4 response is missing or malformed: do
   not advance; send a correction request immediately and identify the missing
   or malformed fields explicitly
-- fenced JSON is missing or malformed: do not advance; send a correction
+- JSON is missing or malformed: do not advance; send a correction
   request immediately and identify the missing or malformed fields explicitly
-- Step 5 has returned `FAIL` three times without converging: do not advance;
-  stop and report `cap-exhausted / not converged` without prompting the user

--- a/.claude/skills/plan-hardening/steps/step-6.md
+++ b/.claude/skills/plan-hardening/steps/step-6.md
@@ -13,7 +13,7 @@ sc-compose render \
 ```
 
 The vars file or rendered task must include the QA assignment fields required
-by `qa-template.xml.j2`, and it must use `step-5` fenced JSON to populate the
+by `qa-template.xml.j2`, and it must use `step-5` JSON to populate the
 QA scope. Use `review_mode: "plan"`.
 
 Expected `/tmp/plan-hardening-qa-vars.json` shape:
@@ -43,15 +43,15 @@ Expected `/tmp/plan-hardening-qa-vars.json` shape:
 ```
 
 Populate `sprint_doc` and `review_targets` by listing the phase plan and every
-sprint doc in the current plan state. Use `step-5` fenced JSON only to confirm
+sprint doc in the current plan state. Use `step-5` JSON only to confirm
 that the expected files were modified or created. Do not invent QA scope from
 memory.
 
 **2. Send to `quality-mgr`**
 
-Use the SendMessage tool to send the rendered XML content from
-`/tmp/step-6-message.xml` to the named teammate `quality-mgr`.
-Do not use `atm send` for this step.
+```bash
+atm send quality-mgr --stdin < /tmp/step-6-message.xml
+```
 
 **3. Handoff**
 
@@ -64,6 +64,6 @@ and recheck loops.
 
 - `/tmp/plan-hardening-qa-vars.json` is missing required QA assignment fields:
   do not advance; correct the QA vars file immediately
-- `step-5` fenced JSON from the Step 5 response is missing or malformed: do
+- `step-5` JSON from the Step 5 response is missing or malformed: do
   not advance; send a correction request immediately and identify the missing
   or malformed fields explicitly


### PR DESCRIPTION
## Summary
- remove the reviewer-cap dead-end so capped plan-scope and critical-plan review loops flow through one final `arch-ctm` fix pass and then advance to the next phase
- limit fenced JSON guidance to the background reviewer boundary and switch named-teammate handoffs to plain JSON
- update the `quality-mgr` handoff to use `atm send` instead of the no-longer-supported `SendMessage`

## Testing
- `git diff --check`
