### PR TITLE
Release v1.2.3 (recovery)

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -39,9 +39,35 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+          components: clippy, rustfmt
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
 
       - name: Install just
         uses: taiki-e/install-action@just
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
+
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@cargo-shear
+
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@cargo-binstall
+
+      - name: Install cargo-modules
+        run: cargo binstall cargo-modules --no-confirm
+
+      - name: Install codespell
+        run: python -m pip install codespell
 
       - name: Normalize version input
         id: meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,25 +178,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t full_checks < <(
+          while IFS= read -r crate; do
+            [[ -n "$crate" ]] || continue
+            cargo package -p "$crate" --locked
+          done < <(
             python3 scripts/release_artifacts.py list-preflight \
               --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
               --mode full
           )
-          for crate in "${full_checks[@]}"; do
-            [[ -n "$crate" ]] || continue
-            cargo package -p "$crate" --locked
-          done
 
-          mapfile -t locked_checks < <(
+          while IFS= read -r crate; do
+            [[ -n "$crate" ]] || continue
+            cargo check -p "$crate" --locked
+          done < <(
             python3 scripts/release_artifacts.py list-preflight \
               --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
               --mode locked
           )
-          for crate in "${locked_checks[@]}"; do
-            [[ -n "$crate" ]] || continue
-            cargo check -p "$crate" --locked
-          done
 
   publish-crates:
     needs: [gate-and-tag, prepare-release-inventory, pre-publish-audit]
@@ -292,7 +290,11 @@ jobs:
           VERSION='${{ needs.gate-and-tag.outputs.release_version }}'
           ARCHIVE="atm_${VERSION}_${{ matrix.target }}.tar.gz"
           cd target/${{ matrix.target }}/release
-          mapfile -t bins < <(python3 ../../../scripts/release_artifacts.py list-release-binaries --manifest ../../../release/publish-artifacts.toml)
+          bins=()
+          while IFS= read -r bin; do
+            [[ -n "$bin" ]] || continue
+            bins+=("$bin")
+          done < <(python3 ../../../scripts/release_artifacts.py list-release-binaries --manifest ../../../release/publish-artifacts.toml)
           tar czf "../../../${ARCHIVE}" "${bins[@]}"
           cd ../../..
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.2.2
+PackageVersion: 1.2.3
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.2.2/atm_1.2.2_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.2.3/atm_1.2.3_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.2.2
+ManifestVersion: 1.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.2.3
+
+- recover the interrupted `v1.2.2` publish by cutting a clean `release/v1.2.3`
+  line from the immutable `3075384e` tag point rather than mutating the
+  partial `v1.2.2` release in place
+- add the missing `description` metadata to `atm-storage-claude` so crates.io
+  accepts the crate during ordered publish
+- replace bash-4-only `mapfile` usage in `release.yml` with bash-3.2-compatible
+  loops so the macOS archive jobs package release binaries successfully
+
 ## 1.2.2
 
 - converge the Phase AC storage layer on the `atm-storage` contract and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "atm-runtime-test-support",
  "atm-storage",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "cargo_metadata",
  "serde",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "agent-team-mail-core",
  "arc-swap",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-client",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "chrono",
  "serde",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-claude"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "atm-storage",
  "serde",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "atm-storage",
  "chrono",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "atm-storage",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.2"
+version = "1.2.3"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -20,7 +20,7 @@ name = "atm_core"
 test-utils = []
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.2.2" }
+atm-storage = { path = "../atm-storage", version = "1.2.3" }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -10,5 +10,5 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2" }
-atm-runtime = { path = "../atm-runtime", version = "1.2.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
+atm-runtime = { path = "../atm-runtime", version = "1.2.3" }

--- a/crates/atm-daemon-client/Cargo.toml
+++ b/crates/atm-daemon-client/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2" }
-atm-storage = { path = "../atm-storage", version = "1.2.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
+atm-storage = { path = "../atm-storage", version = "1.2.3" }
 bytes = "1"
 fs2 = "0.4"
 interprocess = "2.4.2"
@@ -20,5 +20,5 @@ serde_json = { workspace = true }
 tracing = "0.1"
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
 tempfile = "3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -10,10 +10,10 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2" }
-atm-runtime = { path = "../atm-runtime", version = "1.2.2" }
-atm-storage = { path = "../atm-storage", version = "1.2.2" }
-atm-storage-claude = { path = "../atm-storage-claude", version = "1.2.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
+atm-runtime = { path = "../atm-runtime", version = "1.2.3" }
+atm-storage = { path = "../atm-storage", version = "1.2.3" }
+atm-storage-claude = { path = "../atm-storage-claude", version = "1.2.3" }
 arc-swap.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 fs2 = "0.4"
@@ -30,8 +30,8 @@ signal-hook = "0.3"
 signal-hook = "0.3"
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2", features = ["test-utils"] }
-atm-runtime = { path = "../atm-runtime", version = "1.2.2", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3", features = ["test-utils"] }
+atm-runtime = { path = "../atm-runtime", version = "1.2.3", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"

--- a/crates/atm-graft/Cargo.toml
+++ b/crates/atm-graft/Cargo.toml
@@ -10,13 +10,13 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.3" }
 interprocess = "2.4.2"
 serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3", features = ["test-utils"] }
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-runtime-test-support/Cargo.toml
+++ b/crates/atm-runtime-test-support/Cargo.toml
@@ -14,6 +14,6 @@ publish = false
 name = "atm_runtime_test_support"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2", features = ["test-utils"] }
-atm-runtime = { path = "../atm-runtime", version = "1.2.2" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.2.2", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3", features = ["test-utils"] }
+atm-runtime = { path = "../atm-runtime", version = "1.2.3" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.2.3", features = ["test-support"] }

--- a/crates/atm-runtime/Cargo.toml
+++ b/crates/atm-runtime/Cargo.toml
@@ -16,7 +16,7 @@ name = "atm_runtime"
 test-utils = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2" }
-atm-storage = { path = "../atm-storage", version = "1.2.2" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.2.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
+atm-storage = { path = "../atm-storage", version = "1.2.3" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.2.3" }
 serde_json.workspace = true

--- a/crates/atm-storage-claude/Cargo.toml
+++ b/crates/atm-storage-claude/Cargo.toml
@@ -4,12 +4,13 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+description = "Claude-compatible mailbox and roster storage backend for atm-storage."
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.2.2" }
+atm-storage = { path = "../atm-storage", version = "1.2.3" }
 serde.workspace = true
 serde_json.workspace = true
 toml = "0.8"

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -16,7 +16,7 @@ name = "atm_storage_rusqlite"
 test-support = []
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.2.2" }
+atm-storage = { path = "../atm-storage", version = "1.2.3" }
 serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm-storage-sqlserver-proof/Cargo.toml
+++ b/crates/atm-storage-sqlserver-proof/Cargo.toml
@@ -14,4 +14,4 @@ publish = false
 name = "atm_storage_sqlserver_proof"
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.2.2" }
+atm-storage = { path = "../atm-storage", version = "1.2.3" }

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -22,10 +22,10 @@ path = "src/main.rs"
 fault-injection = ["sc-observability/fault-injection"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.2.2" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.2" }
-atm-runtime = { path = "../atm-runtime", version = "1.2.2" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.2.3" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.3" }
+atm-runtime = { path = "../atm-runtime", version = "1.2.3" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -39,7 +39,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.2", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"

--- a/release/release-notes.md
+++ b/release/release-notes.md
@@ -1,17 +1,24 @@
 # Release Notes
 
 ## Summary
-- version: 1.2.2
+- version: 1.2.3
 - release date: 2026-07-02
 - release owner: publisher (ATM release execution)
 
-This release rolls up two development phases (AA and AC), the release-readiness
-consolidation (PR #425), and the release-branch reconciliation that re-applied
-main's v1.2.0 publish-surface hotfixes on top of the develop content. It covers
-the un-shipped 1.2.1 line (Phase AA) and the current 1.2.2 line (Phase AC +
-release readiness) in a single release.
+This recovery release preserves the Phase AA, Phase AC, and release-readiness
+content already assembled for `v1.2.2`, but cuts a new immutable tag after two
+publish-blocking defects were discovered mid-release. `v1.2.2` remains as the
+partial, abandoned attempt; `v1.2.3` is the clean tag+publish line.
 
 ## Included Changes
+
+### 1.2.3 — Recovery patch release
+- Add the missing `description` metadata to `atm-storage-claude` so crates.io
+  accepts the crate during ordered publish.
+- Replace bash-4-only `mapfile` usage in `release.yml` with bash-3.2-compatible
+  loops so macOS packaging works on GitHub-hosted runners.
+- Preserve the immutable `v1.2.2` tag and recover with a new `release/v1.2.3`
+  branch/tag instead of mutating the failed release attempt.
 
 ### 1.2.2 — Phase AC + release readiness
 - Converge the storage layer on the `atm-storage` contract and canonical types,
@@ -65,22 +72,22 @@ release readiness) in a single release.
   `x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, and
   `x86_64-pc-windows-msvc`, with checksums.
 - Homebrew: tap `randlee/homebrew-tap`, formulas `agent-team-mail.rb` and
-  `atm.rb` updated to 1.2.2.
-- winget: package `randlee.agent-team-mail` at 1.2.2. Microsoft review normally
+  `atm.rb` updated to 1.2.3.
+- winget: package `randlee.agent-team-mail` at 1.2.3. Microsoft review normally
   delays public `winget install` visibility by 1–2 days; submission success is
   the immediate release signal.
 
 ## Known Issues / Waivers
 - None. No verification waivers are required for this release.
 - Note (non-blocking): a standalone local `cargo publish -p agent-team-mail-core
-  --locked --dry-run` fails to resolve `atm-storage v1.2.2` because that new
+  --locked --dry-run` fails to resolve `atm-storage v1.2.3` because that new
   crate is not yet on crates.io outside the ordered release run. This is an
   ordering artifact, not a defect — the release workflow publishes `atm-storage`
   first, and CI preflight runs the full package check only on the leaf crate.
 
 ## Follow-Up
 - After the GitHub Release is created, attach these notes to the release body.
-- After `release/v1.2.2` merges back to `main`, ensure a `main -> develop`
+- After `release/v1.2.3` merges back to `main`, ensure a `main -> develop`
   reconciliation PR exists so the publish-surface hotfixes and version updates
   flow back to `develop`.
 - Confirm `winget` public visibility 1–2 days post-submission.


### PR DESCRIPTION
## Release v1.2.3 — recovery patch release

Recovery release after the v1.2.2 Release workflow failed mid-publish (partial). v1.2.2 is abandoned in place (tag left untouched; `atm-storage`, `agent-team-mail-core`, `atm-storage-rusqlite` remain published at 1.2.2). This branch is cut from release/v1.2.2 @ 3075384e with the two publish blockers fixed and versions bumped to 1.2.3.

### Fixes
- **crates.io publish blocker:** add missing `description` to `crates/atm-storage-claude/Cargo.toml` (crates.io rejected 1.2.2 with `400: missing metadata fields: description`). Ref #435.
- **macOS release build:** replace `mapfile` (Bash 4+) in `release.yml` with Bash-3.2-compatible read loops (macOS runners ship Bash 3.2; `mapfile: command not found`). Ref #436.
- Version bump 1.2.2 → 1.2.3 (workspace + internal path-dep pins), CHANGELOG `## 1.2.3`, release notes, winget metadata.

### Verification
- `just validate` → PASS (21/21 lint; manifest/publish-surface/inventory/cargo-lock-drift/dependency-currency ok; 0 non-pass)
- version alignment clean (no lingering 1.2.2 pins); `atm-storage-claude` has description + license; no `mapfile` in release.yml; CHANGELOG/notes at 1.2.3
- Preflight will re-run post-merge (the standalone-branch preflight only blocked on expected Cargo.lock drift vs main, resolved once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)