### PR TITLE
release: gate publish metadata in preflight (fixes #435)

### DIFF
--- a/.just/tests/test_release_artifacts.py
+++ b/.just/tests/test_release_artifacts.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "release_artifacts.py"
+
+
+class ReleaseArtifactsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def write_workspace(self, *, crate_package_block: str) -> tuple[Path, Path]:
+        workspace_toml = self.root / "Cargo.toml"
+        manifest_toml = self.root / "release" / "publish-artifacts.toml"
+        crate_toml = self.root / "crates" / "demo-crate" / "Cargo.toml"
+
+        manifest_toml.parent.mkdir(parents=True, exist_ok=True)
+        crate_toml.parent.mkdir(parents=True, exist_ok=True)
+
+        workspace_toml.write_text(
+            textwrap.dedent(
+                """
+                [workspace]
+                members = ["crates/demo-crate"]
+                resolver = "2"
+
+                [workspace.package]
+                version = "1.2.3"
+                edition = "2024"
+                rust-version = "1.94.1"
+                description = "Workspace inherited description."
+                license = "MIT OR Apache-2.0"
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        manifest_toml.write_text(
+            textwrap.dedent(
+                """
+                schema_version = 1
+
+                [[crates]]
+                artifact = "demo-crate"
+                package = "demo-crate"
+                cargo_toml = "crates/demo-crate/Cargo.toml"
+                required = true
+                publish = true
+                publish_order = 1
+                preflight_check = "full"
+                wait_after_publish_seconds = 0
+                verify_install = false
+
+                [[release_binaries]]
+                name = "atm"
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        crate_toml.write_text(
+            textwrap.dedent(crate_package_block).strip() + "\n",
+            encoding="utf-8",
+        )
+        return workspace_toml, manifest_toml
+
+    def run_validate_manifest(self, *, workspace_toml: Path, manifest_toml: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "validate-manifest",
+                "--manifest",
+                str(manifest_toml),
+                "--workspace-toml",
+                str(workspace_toml),
+            ],
+            cwd=self.root,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+    def test_validate_manifest_accepts_workspace_inherited_publish_metadata(self) -> None:
+        workspace_toml, manifest_toml = self.write_workspace(
+            crate_package_block="""
+            [package]
+            name = "demo-crate"
+            version.workspace = true
+            edition.workspace = true
+            rust-version.workspace = true
+            description.workspace = true
+            license.workspace = true
+            """
+        )
+
+        completed = self.run_validate_manifest(workspace_toml=workspace_toml, manifest_toml=manifest_toml)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("ok: all publishable workspace crates are present in the manifest", completed.stdout)
+        self.assertIn("ok: all publishable manifest crates define required publish metadata", completed.stdout)
+
+    def test_validate_manifest_rejects_missing_publish_metadata(self) -> None:
+        workspace_toml, manifest_toml = self.write_workspace(
+            crate_package_block="""
+            [package]
+            name = "demo-crate"
+            version.workspace = true
+            edition.workspace = true
+            rust-version.workspace = true
+            """
+        )
+
+        completed = self.run_validate_manifest(workspace_toml=workspace_toml, manifest_toml=manifest_toml)
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("publish metadata violation(s):", completed.stdout)
+        self.assertIn(
+            "demo-crate: missing required publish metadata field(s): description, license or license-file",
+            completed.stdout,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -210,10 +210,53 @@ def crate_is_publishable(crate_toml: Path) -> bool:
     return True
 
 
+def workspace_package_defaults(workspace_toml: Path) -> dict:
+    data = tomllib.loads(workspace_toml.read_text(encoding="utf-8"))
+    package = data.get("workspace", {}).get("package", {})
+    if not isinstance(package, dict):
+        return {}
+    return package
+
+
+def package_field_value(
+    package: dict,
+    field: str,
+    *,
+    workspace_defaults: dict,
+) -> str | None:
+    value = package.get(field)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, dict) and value.get("workspace") is True:
+        inherited = workspace_defaults.get(field)
+        if isinstance(inherited, str) and inherited.strip():
+            return inherited.strip()
+    return None
+
+
+def missing_publish_metadata_fields(crate_toml: Path, workspace_defaults: dict) -> list[str]:
+    data = tomllib.loads(crate_toml.read_text(encoding="utf-8"))
+    package = data.get("package", {})
+    if not isinstance(package, dict):
+        return ["package"]
+
+    missing: list[str] = []
+    if package_field_value(package, "description", workspace_defaults=workspace_defaults) is None:
+        missing.append("description")
+
+    license_value = package_field_value(package, "license", workspace_defaults=workspace_defaults)
+    license_file_value = package_field_value(package, "license-file", workspace_defaults=workspace_defaults)
+    if license_value is None and license_file_value is None:
+        missing.append("license or license-file")
+    return missing
+
+
 def validate_manifest(args: argparse.Namespace) -> int:
-    manifest_packages = {crate["package"] for crate in load_manifest(Path(args.manifest))["crates"]}
+    manifest = load_manifest(Path(args.manifest))
+    manifest_packages = {crate["package"] for crate in manifest["crates"]}
     workspace_toml = Path(args.workspace_toml)
     workspace_root = workspace_toml.parent
+    workspace_defaults = workspace_package_defaults(workspace_toml)
     missing = []
     for member in workspace_members(workspace_toml):
         crate_toml = workspace_root / member / "Cargo.toml"
@@ -226,7 +269,25 @@ def validate_manifest(args: argparse.Namespace) -> int:
     if missing:
         print(f"\n{len(missing)} publishable crate(s) missing from manifest.", file=sys.stderr)
         return 1
+
+    metadata_errors = []
+    for crate in manifest["crates"]:
+        if not crate["publish"]:
+            continue
+        crate_toml = workspace_root / crate["cargo_toml"]
+        missing_fields = missing_publish_metadata_fields(crate_toml, workspace_defaults)
+        if missing_fields:
+            metadata_errors.append(
+                f"{crate['package']}: missing required publish metadata field(s): {', '.join(missing_fields)}"
+            )
+    if metadata_errors:
+        print("publish metadata violation(s):")
+        for error in metadata_errors:
+            print(f"  - {error}")
+        return 1
+
     print("ok: all publishable workspace crates are present in the manifest")
+    print("ok: all publishable manifest crates define required publish metadata")
     return 0
 
 


### PR DESCRIPTION
## Summary
- Adds a preflight gate in `scripts/release_artifacts.py`'s `validate-manifest` command that fails when any publishable crate is missing `description` or `license`/`license-file` (workspace-inherited metadata via `description.workspace = true` / `license.workspace = true` counts as satisfying the check).
- Follows up on the v1.2.2 release recovery, where `atm-storage-claude` was missing `description` and only got a one-off symptomatic fix (commit `68cfc35c`) — this closes the actual gap by catching the next missing-metadata crate in preflight instead of at crates.io publish time.

## Test plan
- [x] `python3 .just/tests/test_release_artifacts.py` — PASS (workspace-inherited metadata accepted, missing metadata rejected with per-crate error)
- [x] `python3 scripts/release_artifacts.py validate-manifest --manifest release/publish-artifacts.toml --workspace-toml Cargo.toml` — PASS against current repo state
- [x] `just lint` — PASS
- [x] `just validate` — PASS
- [x] `git diff --check` — clean

Fixes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)