### PR TITLE
fix: close accept-loop/per-connection dispatch-panic reap race in atm-daemon

### DIFF
--- a/crates/atm-daemon/src/active_connection_registry.rs
+++ b/crates/atm-daemon/src/active_connection_registry.rs
@@ -18,6 +18,24 @@ impl std::fmt::Debug for TrackedDispatchHandle {
     }
 }
 
+/// Controls whether reaping a panicked dispatch worker escalates as an error.
+///
+/// Two independent call sites race to reap the same tracked dispatch handles: the
+/// accept-loop's opportunistic bookkeeping reap, and the per-connection worker's own
+/// post-response reap. Whichever wins observes the panic; the other never sees it again,
+/// since the handle has already been removed from the tracked list. Escalating
+/// unconditionally would make a single dispatcher panic non-deterministically fatal or
+/// benign depending on which caller happened to win that race.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DispatchPanicHandling {
+    /// Log the panic and continue; used by opportunistic bookkeeping reaps where a single
+    /// panicked worker must not be treated as a fatal accept-loop or connection error.
+    LogAndContinue,
+    /// Propagate the panic as an error; used by the deliberate shutdown drain, where a
+    /// wedged or panicked worker blocking graceful shutdown is worth surfacing.
+    Escalate,
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct ActiveConnectionRegistry {
     // These counters are updated from independent accept, connection, and dispatch threads, so
@@ -98,7 +116,32 @@ impl ActiveConnectionRegistry {
         Ok(())
     }
 
+    /// Reaps completed dispatch workers without escalating a panicked worker as an error.
+    ///
+    /// This is the opportunistic bookkeeping reap used by the accept loop between
+    /// iterations, and by the per-connection worker after writing its response. Both call
+    /// sites race each other to reap the same shared handles, so treating a panic here as
+    /// fatal would non-deterministically escalate a single-request panic into tearing down
+    /// the whole daemon runtime depending on which caller wins the race. A panicked dispatch
+    /// worker is logged and otherwise ignored; it has already been removed from the tracked
+    /// handle list and cannot be reaped again.
     pub(crate) fn reap_finished_dispatches(&self) -> Result<(), AtmError> {
+        self.reap_finished_dispatches_with(DispatchPanicHandling::LogAndContinue)
+    }
+
+    /// Reaps completed dispatch workers, escalating a panicked worker as an error.
+    ///
+    /// This is used by the deliberate shutdown drain (via [`Self::join_tracked_dispatches`]),
+    /// where a wedged or panicked worker blocking graceful shutdown is legitimately worth
+    /// surfacing to the caller.
+    fn reap_finished_dispatches_escalating(&self) -> Result<(), AtmError> {
+        self.reap_finished_dispatches_with(DispatchPanicHandling::Escalate)
+    }
+
+    fn reap_finished_dispatches_with(
+        &self,
+        panic_handling: DispatchPanicHandling,
+    ) -> Result<(), AtmError> {
         let finished = {
             let mut handles = self.lock_dispatch_handles()?;
             let mut pending = Vec::with_capacity(handles.len());
@@ -117,13 +160,26 @@ impl ActiveConnectionRegistry {
             finished
         };
         for handle in finished {
-            join_dispatch_handle(handle)?;
+            if let Err(error) = join_dispatch_handle(handle) {
+                match panic_handling {
+                    DispatchPanicHandling::Escalate => return Err(error),
+                    DispatchPanicHandling::LogAndContinue => {
+                        tracing::warn!(
+                            subsystem = "active_connection_registry",
+                            action = "reap_finished_dispatches",
+                            outcome = "panic_recovered",
+                            %error,
+                            "dispatch worker panicked before completing; opportunistic reap continuing without escalating"
+                        );
+                    }
+                }
+            }
         }
         Ok(())
     }
 
     pub(crate) fn join_tracked_dispatches(&self, timeout: Duration) -> Result<(), AtmError> {
-        self.reap_finished_dispatches()?;
+        self.reap_finished_dispatches_escalating()?;
         let handles = {
             let mut handles = self.lock_dispatch_handles()?;
             std::mem::take(&mut *handles)
@@ -214,5 +270,86 @@ fn join_dispatch_handle_with_timeout(
                 "Restart the daemon; a request worker outlived the bounded shutdown window.",
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pushes a dispatch handle whose worker thread panics immediately, then blocks until
+    /// the panic has fully unwound so `completion_rx` deterministically observes
+    /// `Disconnected` before the caller reaps it.
+    ///
+    /// This deliberately does not synchronize on [`ActiveConnectionRegistry::active_work_items`]:
+    /// the worker only increments that counter after it starts running, so polling it from
+    /// the caller races the thread scheduler (the caller can observe zero active work items
+    /// before the worker has even registered, let alone panicked). Instead, a dedicated
+    /// one-shot channel is dropped last during unwinding (after `completion_tx`), so
+    /// observing it disconnect proves `completion_tx` has already been dropped too.
+    fn push_panicking_dispatch_handle(registry: &Arc<ActiveConnectionRegistry>) {
+        let dispatch_registry = Arc::clone(registry);
+        let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
+        let (unwound_tx, unwound_rx) = std::sync::mpsc::sync_channel::<()>(1);
+        let join_handle = std::thread::Builder::new()
+            .name("reap-panic-test-dispatch".to_string())
+            .spawn(move || {
+                // Declared first so it drops last during unwinding (locals drop in
+                // reverse declaration order), after `_completion_tx` below.
+                let _unwound_tx = unwound_tx;
+                let _dispatch_work = dispatch_registry.register_dispatch_work();
+                let _completion_tx = completion_tx;
+                panic!("intentional dispatch worker panic for reap test");
+            })
+            .expect("spawn panicking dispatch worker");
+        registry
+            .push_dispatch_handle(
+                TrackedDispatchHandle {
+                    completion_rx,
+                    join_handle,
+                },
+                1,
+            )
+            .expect("push dispatch handle");
+        match unwound_rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                panic!("panicking dispatch worker did not unwind within 5s");
+            }
+        }
+    }
+
+    #[test]
+    fn reap_finished_dispatches_logs_and_continues_after_panic() {
+        let registry = Arc::new(ActiveConnectionRegistry::default());
+        push_panicking_dispatch_handle(&registry);
+
+        registry
+            .reap_finished_dispatches()
+            .expect("opportunistic reap must not escalate a dispatch worker panic");
+        assert_eq!(
+            registry
+                .lock_dispatch_handles()
+                .expect("lock dispatch handles")
+                .len(),
+            0,
+            "the panicked handle should have been removed from the tracked list"
+        );
+    }
+
+    #[test]
+    fn join_tracked_dispatches_escalates_after_panic() {
+        let registry = Arc::new(ActiveConnectionRegistry::default());
+        push_panicking_dispatch_handle(&registry);
+
+        let error = registry
+            .join_tracked_dispatches(Duration::from_secs(5))
+            .expect_err(
+                "the deliberate shutdown drain must surface a panicked dispatch worker as fatal",
+            );
+        assert!(
+            error.message.contains("daemon dispatch thread panicked"),
+            "unexpected error: {error:?}"
+        );
     }
 }

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -1208,6 +1208,19 @@ mod tests {
         assert!(matches!(response, ResponseEnvelope::Error(_)));
 
         lifecycle.set_terminate_for_test(true);
+        // Two independent call sites race to reap the same panicked dispatch-worker
+        // JoinHandle: the per-connection reap in `handle_connection`, and the opportunistic
+        // accept-loop reap in `prepare_accept_iteration` (which always runs on the very
+        // iteration that observes the termination signal, before the loop breaks). Both are
+        // now non-escalating on a dispatch-worker panic (see
+        // `ActiveConnectionRegistry::reap_finished_dispatches`), so by the time the shutdown
+        // drain's own escalating reap (`join_tracked_dispatches`) runs, the panicked handle
+        // has always already been removed from the tracked list. The serve result is
+        // therefore deterministically non-fatal for this single-request-panic scenario,
+        // regardless of which opportunistic reap wins the race; only a panic first
+        // discovered during the deliberate shutdown drain is escalated as fatal (covered by
+        // `drain_active_connections_for_shutdown_surfaces_dispatch_panic_as_fatal` and
+        // `active_connection_registry::tests::join_tracked_dispatches_escalates_after_panic`).
         serve_result_rx
             .recv_timeout(Duration::from_secs(15))
             .expect("recv serve result")
@@ -1263,6 +1276,47 @@ mod tests {
         );
         let _ = release_tx.send(());
         drop(active_connection);
+    }
+
+    #[test]
+    fn drain_active_connections_for_shutdown_surfaces_dispatch_panic_as_fatal() {
+        // The opportunistic accept-loop and per-connection reaps treat a panicked dispatch
+        // worker as non-fatal (see `active_connection_registry::tests::
+        // reap_finished_dispatches_logs_and_continues_after_panic`). The deliberate shutdown
+        // drain must still surface a panic discovered while it is joining tracked dispatch
+        // workers, since a wedged/panicked worker blocking graceful shutdown is legitimately
+        // worth surfacing to the caller.
+        let registry = Arc::new(ActiveConnectionRegistry::default());
+        let dispatch_registry = Arc::clone(&registry);
+        let (completion_tx, completion_rx) = mpsc::sync_channel(1);
+        let join_handle = std::thread::spawn(move || {
+            let _dispatch = dispatch_registry.register_dispatch_work();
+            let _completion_tx = completion_tx;
+            panic!("intentional dispatch worker panic for shutdown drain test");
+        });
+        registry
+            .push_dispatch_handle(
+                TrackedDispatchHandle {
+                    completion_rx,
+                    join_handle,
+                },
+                1,
+            )
+            .expect("dispatch handle push");
+        let force_shutdown = AtomicBool::new(false);
+        let error = drain_active_connections_for_shutdown(
+            registry.as_ref(),
+            &force_shutdown,
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            Instant::now(),
+            TRACKED_DISPATCH_JOIN_DEADLINE,
+        )
+        .expect_err("a dispatch worker panic discovered during the shutdown drain must be fatal");
+        assert!(
+            error.message.contains("daemon dispatch thread panicked"),
+            "unexpected error: {error:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Root-caused via quality-mgr → flaky-test-qa: two independent call sites (`prepare_accept_iteration` in the accept loop, and the per-connection reap in `handle_connection`) raced to reap the same panicked dispatch-worker `JoinHandle` through the shared `ActiveConnectionRegistry::reap_finished_dispatches`, and treated the identical panic differently — one downgraded it to a warning, the other escalated it to a fatal `serve()` error, depending on which won the race.
- Fix splits `reap_finished_dispatches` into a non-escalating variant (used by both opportunistic racing call sites — panic is logged and swallowed, loop continues) and an escalating variant `reap_finished_dispatches_escalating` (used only by the deliberate shutdown-drain path `join_tracked_dispatches`, where a wedged/panicked worker blocking graceful shutdown is still legitimately fatal).
- This closes PR #442's flaky CI failure on `local_ipc_transport::tests::panic_in_dispatch_still_cleans_up_socket_path_on_shutdown` (ubuntu-latest only), which was a genuine race, not CI flakiness.

## Test plan
- [x] `cargo build -p atm-daemon`
- [x] `cargo clippy -p atm-daemon --all-targets -- -D warnings`
- [x] `cargo test -p atm-daemon` (115 lib + 8 bin tests)
- [x] 20x loop of the previously-flaky test — 20/20 pass
- [x] New coverage: `active_connection_registry::tests::reap_finished_dispatches_logs_and_continues_after_panic`, `join_tracked_dispatches_escalates_after_panic`, `local_ipc_transport::tests::drain_active_connections_for_shutdown_surfaces_dispatch_panic_as_fatal` — all pass, repeat-looped 20-30x

🤖 Generated with [Claude Code](https://claude.com/claude-code)