### PR TITLE
chore: remove obsolete atm config identity

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -1,6 +1,5 @@
 [atm]
 default_team = "atm-dev"
-identity = "team-lead"
 
 [atm.idle_notify]
 recipient = "team-lead"
@@ -64,5 +63,4 @@ tmux_pane_id = "%2"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
-
 


### PR DESCRIPTION
## Summary
- remove obsolete `[atm].identity` from `.atm.toml`
- keep ATM identity sourced from environment only

## Verification
- `atm doctor --json` from the worktree now reports `warning_count: 0`
- previous `ATM_WARNING_IDENTITY_DRIFT` finding is eliminated