### PR TITLE
ci: disable Gemini auto-dispatch on PR open

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -54,7 +54,7 @@ env = { ATM_IDENTITY = "team-lead", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_
 [[rmux.windows.panes]]
 name = "arch-ctm"
 tmux_pane_id = "%1"
-command = "codex -c features.codex_hooks=true --yolo"
+command = "codex -c features.hooks=true --yolo"
 env = { ATM_IDENTITY = "arch-ctm", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
 
 [[rmux.windows.panes]]
@@ -63,4 +63,3 @@ tmux_pane_id = "%2"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
-

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -7,9 +7,6 @@ on:
   pull_request_review:
     types:
       - 'submitted'
-  pull_request:
-    types:
-      - 'opened'
   issues:
     types:
       - 'opened'
@@ -43,14 +40,10 @@ jobs:
           env | grep '^DEBUG_'
 
   dispatch:
-    # For PRs: only if not from a fork
     # For issues: only on open/reopen
     # For comments: only if user types @gemini-cli and is OWNER/MEMBER/COLLABORATOR
     if: |-
       (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.fork == false
-      ) || (
         github.event_name == 'issues' &&
         contains(fromJSON('["opened", "reopened"]'), github.event.action)
       ) || (
@@ -93,9 +86,7 @@ jobs:
             const request = process.env.REQUEST;
             core.setOutput('request', request);
 
-            if (eventType === 'pull_request.opened') {
-              core.setOutput('command', 'review');
-            } else if (['issues.opened', 'issues.reopened'].includes(eventType)) {
+            if (['issues.opened', 'issues.reopened'].includes(eventType)) {
               core.setOutput('command', 'triage');
             } else if (request.startsWith("@gemini-cli /review")) {
               core.setOutput('command', 'review');


### PR DESCRIPTION
## Summary
- `gemini-dispatch.yml` auto-routed every same-repo PR (`opened`, non-fork) into `gemini-review.yml`
- No `GEMINI_API_KEY`/`GOOGLE_API_KEY` secret or Vertex AI workload-identity vars are configured on this repo
- Result: every PR install-and-hangs on the Gemini CLI extension's unanswerable interactive trust prompt, burning a full 7-minute CI slot until timeout/cancellation on every PR (confirmed via run logs)
- Removed the `pull_request: opened` trigger and its dispatch branch/extract_command case; manual `@gemini-cli /review` comments and the `issues` opened/reopened triage trigger are untouched

## Test plan
- [x] YAML re-parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Open this PR and confirm Gemini Dispatch does not fire automatically
- [ ] Confirm `@gemini-cli /review` comment trigger still works if/when Gemini credentials are configured later