### PR TITLE
docs: sync phase-AD plan doc changes to develop

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -27,14 +27,17 @@ approval_policy = "on-failure"
 
 [startup.team-lead]
 all = ["Read /codex-orchestration SKILL.md and /triaging-findings SKILL.md",
-       "Use atm_send for all messages to arch-ctm or quality-mgr" ]
+       "Use atm_send or atm_ack for all messages to arch-ctm or quality-mgr",
+       "Use atm_read to read messages from team-members" ]
 
 [startup.arch-ctm]
-all = ["Use atm_send for all messages to team-lead or quality-mgr"]
+all = ["Use atm_send or atm_ack for all messages to team-lead or quality-mgr",
+       "Use atm_read to read messages from team-members" ]
 
 [startup.quality-mgr]
 all = ["read .claude/agents/quality-mgr.md for directive",
-       "Use atm_send for all messages to team-lead or arch-ctm" ]
+       "Use atm_send or atm_ack for all messages to team-lead or arch-ctm",
+       "Use atm_read to read messages from team-members" ]
 
 # ── rmux: tmux session launcher ──────────────────────────────────────
 [rmux]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -638,15 +638,18 @@ ATM must distinguish canonical routing identity from the Claude-facing sender
 projection.
 
 Architectural rules:
-- caller-owned command identity resolves from explicit CLI override when the
-  command supports it, otherwise from invoking-shell `ATM_IDENTITY`, not
-  repo-local `[atm].identity`
-- caller-owned commands must resolve identity at the CLI boundary before any
-  daemon dispatch
-- daemon-backed caller-owned request DTOs must carry resolved caller identity
-  as required request data
+- commands that require caller identity/team resolve them according to the
+  matrix in `docs/requirements.md` §4.1, never from repo-local
+  `[atm].identity` / `[atm].default_team`
+- caller-context-owned commands must resolve required context at the CLI
+  boundary before any daemon dispatch
+- daemon-backed caller-owned request DTOs must carry required resolved caller
+  context as request data
 - the daemon must execute caller-owned commands against declared request
-  identity only and must never substitute daemon ambient `ATM_IDENTITY`
+  caller context only and must never substitute daemon ambient
+  `ATM_IDENTITY` / `ATM_TEAM`
+- `atm doctor` is diagnostic and remains outside the mandatory caller-context
+  path
 - ATM-owned aliases are input shorthands that resolve to canonical member names
 - same-team messages keep current canonical sender projection behavior
 - cross-team messages may project an alias-friendly sender in the persisted
@@ -704,6 +707,9 @@ ATM config and team-launch config are distinct concerns:
 - ATM-owned config uses the `[atm]` section of `.atm.toml`
 - launcher-owned sections such as `[rmux]` and future `[scmux]` remain outside
   the `atm-core` runtime config boundary and are ignored by ATM
+- `[atm].default_team` remains a config/bootstrap default only for flows that
+  explicitly consume ATM config defaults; it is not a runtime caller-team
+  fallback for commands governed by the caller-context matrix
 - `[atm].team_members` is the ATM-owned baseline roster for doctor/orchestration
   checks
 - `[atm].aliases` is the ATM-owned shorthand map for canonical agent names
@@ -737,10 +743,11 @@ Diagnostics for team config failures must preserve:
 It is no longer part of runtime sender or actor resolution.
 
 Current runtime contract:
-- caller-owned command identity resolves from explicit CLI override when
-  supported, then invoking-shell `ATM_IDENTITY`
-- if no caller-owned command identity source is available, the CLI fails with
-  `ATM_IDENTITY_UNAVAILABLE` before daemon dispatch
+- caller-context-owned commands resolve required caller identity/team according
+  to the matrix in `docs/requirements.md` §4.1
+- if required caller context is unavailable, the CLI fails before daemon
+  dispatch
+- `atm doctor` remains the explicit identity-free, optional-team exception
 - `[atm].identity` is ignored for runtime resolution even when still present in
   `.atm.toml`
 
@@ -1371,10 +1378,11 @@ Shared `sc-observability` should own record storage, filtering, and follow mecha
 
 The doctor pipeline stages are:
 1. resolve config and environment overrides
-2. resolve effective team and identity inputs
+2. resolve optional diagnostic team scope and inspect caller-context visibility
 3. inspect ATM config for obsolete fields such as `[atm].identity`
 4. verify local team/mailbox/config paths
-5. verify caller identity inputs and `ATM_IDENTITY` visibility
+5. verify caller-context visibility and invalid override situations without
+   making caller identity/team mandatory
 6. compare baseline `[atm].team_members` against `config.json.members`
 7. verify observability initialization and health
 8. verify observability query readiness for `atm log`
@@ -1474,18 +1482,26 @@ Supported structured hook-result levels remain:
 - `warn`
 - `error`
 
-### 13.2 Identity Resolution
+### 13.2 Caller Context Resolution
 
-Caller-owned command identity is not guessed.
+Caller-owned command context is not guessed.
+
+The authoritative command-by-command caller-context matrix lives in
+`docs/requirements.md` §4.1.
 
 The accepted command contract is:
-- the CLI resolves caller identity from explicit override when supported, or
-  from invoking-shell `ATM_IDENTITY`
-- if caller identity is unavailable, the CLI fails before daemon dispatch
-- downstream caller-owned request DTOs carry resolved caller identity as a
-  required field
-- the daemon never treats hook files, repo-local config, or daemon ambient
-  `ATM_IDENTITY` as fallback caller identity
+- commands that require caller identity resolve it from explicit override when
+  supported, otherwise from invoking-shell `ATM_IDENTITY`
+- commands that require caller team resolve it from explicit override when
+  supported, otherwise from invoking-shell `ATM_TEAM`
+- if required caller context is unavailable, the CLI fails before daemon
+  dispatch or retained command execution
+- downstream caller-owned request DTOs carry required resolved caller context
+  as request data
+- the daemon never treats hook files, repo-local config, roster state, or
+  daemon ambient `ATM_IDENTITY` / `ATM_TEAM` as fallback caller context
+- `atm doctor` is the explicit exception and may run without caller identity
+  or caller team while still honoring optional `--team` diagnostic scoping
 
 An obsolete `[atm].identity` field may be diagnosed by doctor, but it must not
 control sender/actor resolution.

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -452,7 +452,10 @@ Required config rules:
   `.atm.toml`
 - `atm-core` ignores launcher-owned sections such as `[rmux]` and future
   `[scmux]`
-- `[atm].default_team` remains the shared team default
+- `[atm].default_team` remains the shared config default for ATM-owned
+  config/bootstrap flows that explicitly consume config defaults; it is not a
+  runtime caller-team fallback for commands governed by the caller-context
+  matrix
 - `[atm].team_members` defines the baseline team roster that should always be
   present in `config.json`
 - `[atm].aliases` may define ATM-owned shorthand names for canonical agent
@@ -466,18 +469,28 @@ Required config rules:
 - `[atm].identity` is obsolete and must not participate in runtime identity
   resolution; doctor should report it as configuration drift when present
 
-Required identity rules:
-- runtime identity for caller-owned commands must come from explicit command
-  override when supported or invoking-shell `ATM_IDENTITY`
-- if no valid runtime identity exists where a command requires one, the command
-  must fail with a structured recovery-oriented error rather than inventing a
-  normal sender identity
-- caller-owned command entry points must reject unresolved identity before
-  daemon dispatch
-- downstream caller-owned request DTOs must carry resolved caller identity as a
-  required field
-- `atm-core` must not treat hook files, repo-local config, or daemon ambient
-  `ATM_IDENTITY` as fallback caller identity
+Required caller-context rules:
+- the authoritative command-by-command caller-context matrix is
+  `docs/requirements.md` §4.1
+- `atm-core` must implement that matrix exactly; crate-local code must not
+  widen accepted caller identity/team sources beyond the product matrix
+- where a command requires caller identity, runtime identity must come from the
+  documented explicit command override when supported or invoking-shell
+  `ATM_IDENTITY`
+- where a command requires caller team, runtime team must come from the
+  documented explicit command override when supported or invoking-shell
+  `ATM_TEAM`
+- if no valid required caller context exists, the command must fail with a
+  structured recovery-oriented error rather than inventing a normal sender
+  identity or caller team
+- caller-context-owned command entry points must reject unresolved context
+  before daemon dispatch
+- downstream caller-owned request DTOs must carry resolved required caller
+  context as required fields
+- `atm-core` must not treat hook files, repo-local config, roster state, or
+  daemon ambient `ATM_IDENTITY` / `ATM_TEAM` as fallback caller context
+- `atm doctor` is the explicit exception: it remains identity-free and
+  optional-team, while still inspecting caller-context visibility
 - aliases are input shorthand only until ATM resolves them to canonical member
   names
 - recipient aliases must resolve before membership validation, self-send

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -216,3 +216,7 @@ Required Phase R rules:
   query daemon state through the runtime boundary
 - CLI runtime failures must preserve typed error identity until the rendering
   boundary instead of collapsing into ad hoc panic/unwrap behavior
+- CLI-owned caller-context parsing and precedence must follow the authoritative
+  matrix in `docs/requirements.md` §4.1 exactly, including the `atm doctor`
+  exception and the rule that explicit CLI override wins over env when both are
+  present

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -12,7 +12,9 @@ worktree: /Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-AD
 Restore the original ATM runtime model for caller context, send, read, and post-send
 nudge behavior:
 
-- every ATM command runs with a known caller identity and caller team
+- every retained ATM command that requires caller context runs with a known
+  caller identity and caller team, while `atm doctor` remains the explicit
+  identity-free, optional-team diagnostic exception
 - `atm send` persists the message to the database
 - if the recipient exposes a post-send hook capability, ATM fires it
 - post-send emission failure is logged and surfaced as a sender-visible warning
@@ -56,22 +58,24 @@ Phase `AD` is corrective simplification, not a feature-expansion line.
 
 The governing rules are:
 
-- caller identity and caller team are mandatory for every retained ATM command
-  that touches ATM state or routing
-- the accepted command inventory for this rule is:
+- caller identity and caller team are mandatory only for retained ATM commands
+  that require caller-owned state or routing context
+- the accepted mandatory caller-context inventory for this rule is:
   - `send`
   - `read`
   - `ack`
   - `list`
   - `clear`
   - `log`
-  - `doctor`
   - `members`
   - `teams`
   - `teams add-member`
   - `teams update-member`
   - `teams backup`
   - `teams restore`
+- `atm doctor` is diagnostic-only and must not require caller identity; its
+  `--team` override remains optional diagnostic scope, not mandatory caller
+  context
 - caller identity and caller team must be resolved together by one shared
   CLI-owned caller-context resolver; retained ATM commands must not each parse
   `ATM_IDENTITY`, `ATM_TEAM`, or repo config independently
@@ -84,8 +88,8 @@ The governing rules are:
 - repo-local `[atm].default_team`, obsolete `[atm].identity`, hook files, and
   daemon ambient environment must never be used to guess missing caller
   context
-- if caller identity or caller team is unresolved at the CLI boundary, the CLI
-  must fail the command and must not contact the daemon
+- if caller identity or caller team is unresolved for a command that requires
+  caller context, the CLI must fail the command and must not contact the daemon
 - every downstream request DTO for caller-owned daemon-backed commands must
   carry resolved caller identity and resolved caller team as required fields,
   never optional fields
@@ -139,6 +143,8 @@ Phase `AD` may:
 - make local retained command entry points consume the same shared
   caller-context resolver rather than carrying duplicate command-specific
   fallback logic
+- preserve diagnostic commands that do not need caller identity; `doctor`
+  remains identity-free with optional team scoping
 - simplify the post-send nudge path to one post-commit emission seam
 - add or tighten trait contracts for local tmux-backed and graft-backed
   post-send emission
@@ -209,6 +215,10 @@ Required runtime meaning:
   - CLI fails locally if caller identity or caller team is unavailable
   - daemon receives caller identity and caller team as required request data
   - daemon never substitutes its own ambient identity or team
+- doctor:
+  - CLI does not require caller identity
+  - CLI accepts optional `--team` diagnostic scope
+  - daemon/local doctor paths must not invent or require caller identity
 - send:
   - persist
   - if recipient has post-send hook capability, call `emit(...)`
@@ -292,11 +302,12 @@ Phase `AD` orchestration rule:
 Phase `AD` closes only when:
 
 - bare daemon-backed ATM commands honor the invoking shell identity correctly
-- bare retained ATM commands honor the invoking shell identity and team
-  correctly
-- retained ATM commands fail before command execution or daemon dispatch when
-  neither explicit override nor invoking-shell `ATM_IDENTITY` / `ATM_TEAM` is
-  present
+- retained ATM commands that require caller context honor the invoking shell
+  identity and team correctly
+- retained ATM commands that require caller context fail before command
+  execution or daemon dispatch when neither explicit override nor
+  invoking-shell `ATM_IDENTITY` / `ATM_TEAM` is present
+- `atm doctor` runs without caller identity and accepts optional team scoping
 - daemon-backed caller-owned request shapes carry caller identity and caller
   team as required data rather than relying on daemon ambient identity/team
 - repo config no longer carries obsolete `[atm].identity`

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -221,6 +221,17 @@ Phase `AD` executes the deletion line first so new emitter work does not get
 implemented on top of retired Claude JSON, reconcile, or notification
 infrastructure.
 
+Phase `AD` orchestration rule:
+
+- `Phase AD` is a strict merge-forward line
+- each implementation sprint branch/worktree must be created from the current
+  accepted tip of the immediately preceding `AD` sprint
+- sprint branches must merge forward numerically:
+  - `AD.1 -> AD.2 -> AD.3 -> AD.4 -> AD.5 -> AD.6 -> AD.7 -> AD.8 -> AD.9 -> AD.10 -> AD.11`
+- accepted execution for this phase is immediate-predecessor merge-forward
+  only; do not run pairwise cross-merges between unrelated `AD` sprint
+  branches
+
 1. [AD.1 Caller Identity Ownership Restore](./sprint-AD1.md)
 2. [AD.2 Obsolete Config Identity Removal And Doctor Contract Repair](./sprint-AD2.md)
 3. [AD.3 Claude Backend And Inbox Nudge Retirement](./sprint-AD3.md)

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -1,17 +1,18 @@
 ---
 title: Phase AD Plan
 status: active
-branch: plan/post-send-hook-fix
-worktree: /Users/randlee/Documents/github/atm-core-worktrees/plan/post-send-hook-fix
+branch: integrate/phase-AD
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/integrate/phase-AD
 ---
 
 # Phase AD Plan
 
 ## Goal
 
-Restore the original ATM runtime model for identity, send, read, and post-send
+Restore the original ATM runtime model for caller context, send, read, and post-send
 nudge behavior:
 
+- every ATM command runs with a known caller identity and caller team
 - `atm send` persists the message to the database
 - if the recipient exposes a post-send hook capability, ATM fires it
 - post-send emission failure is logged and surfaced as a sender-visible warning
@@ -21,6 +22,9 @@ Phase `AD` exists because the current accepted line has drifted away from that
 model in several release-blocking ways:
 
 - bare ATM commands in an `arch-ctm` session can resolve as `team-lead`
+- bare ATM commands can also resolve or persist under the wrong team when
+  caller team falls back from repo-local/default config instead of the
+  invoking shell or explicit command-line context
 - `.atm.toml` still configures `[[atm.post_send_hooks]]`, but the live daemon
   path can complete a send with no nudge and no warning
 - the current post-send path is obscured by generic delivery/notification
@@ -36,6 +40,9 @@ model in several release-blocking ways:
 
 - `ATM_IDENTITY=arch-ctm` was present in the active shell, but bare ATM
   commands still resolved as `team-lead` until `--as arch-ctm` was forced
+- bare `atm read` on the accepted `1.2.3` release could still resolve as
+  `team-lead@atm-dev` even when `ATM_IDENTITY` and `ATM_TEAM` were unset,
+  proving that both caller identity and caller team can be guessed today
 - `.atm.toml` currently contains a `team-lead` post-send hook rule, but a live
   send produced neither the expected nudge nor a sender-visible warning
 - `atm doctor --team atm-dev` currently reports
@@ -49,17 +56,42 @@ Phase `AD` is corrective simplification, not a feature-expansion line.
 
 The governing rules are:
 
-- caller identity is mandatory for every caller-owned ATM command before any
-  daemon dispatch occurs
+- caller identity and caller team are mandatory for every retained ATM command
+  that touches ATM state or routing
+- the accepted command inventory for this rule is:
+  - `send`
+  - `read`
+  - `ack`
+  - `list`
+  - `clear`
+  - `log`
+  - `doctor`
+  - `members`
+  - `teams`
+  - `teams add-member`
+  - `teams update-member`
+  - `teams backup`
+  - `teams restore`
+- caller identity and caller team must be resolved together by one shared
+  CLI-owned caller-context resolver; retained ATM commands must not each parse
+  `ATM_IDENTITY`, `ATM_TEAM`, or repo config independently
 - the only accepted caller-identity sources at the CLI boundary are an explicit
-  command-line override or `ATM_IDENTITY` from the invoking shell
-- if caller identity is unresolved at the CLI boundary, the CLI must fail the
-  command and must not contact the daemon
-- every downstream request DTO for caller-owned commands must carry resolved
-  caller identity as a required field, never an optional field
+  command-line override when the command supports it or `ATM_IDENTITY` from
+  the invoking shell
+- the only accepted caller-team sources at the CLI boundary are an explicit
+  command-line override when the command supports it or `ATM_TEAM` from the
+  invoking shell
+- repo-local `[atm].default_team`, obsolete `[atm].identity`, hook files, and
+  daemon ambient environment must never be used to guess missing caller
+  context
+- if caller identity or caller team is unresolved at the CLI boundary, the CLI
+  must fail the command and must not contact the daemon
+- every downstream request DTO for caller-owned daemon-backed commands must
+  carry resolved caller identity and resolved caller team as required fields,
+  never optional fields
 - the daemon must execute caller-owned commands against declared request
-  identity only and must never consult daemon ambient `ATM_IDENTITY` to fill a
-  missing caller identity
+  identity and team only and must never consult daemon ambient
+  `ATM_IDENTITY` or `ATM_TEAM` to fill missing caller context
 - message persistence is the send success boundary
 - post-send behavior is a post-commit side effect only
 - post-send behavior is event-driven; it is not planned through a generic
@@ -101,9 +133,12 @@ The governing rules are:
 
 Phase `AD` may:
 
-- fix caller identity ownership on daemon-backed ATM commands
-- make caller identity transport explicit and required for daemon-backed
-  caller-owned commands
+- fix caller context ownership on the full retained ATM command surface
+- make caller identity and caller team transport explicit and required for
+  daemon-backed caller-owned commands
+- make local retained command entry points consume the same shared
+  caller-context resolver rather than carrying duplicate command-specific
+  fallback logic
 - simplify the post-send nudge path to one post-commit emission seam
 - add or tighten trait contracts for local tmux-backed and graft-backed
   post-send emission
@@ -169,9 +204,11 @@ Required runtime meaning:
 - caller-owned commands:
   - CLI resolves caller identity from explicit override or invoking-shell
     `ATM_IDENTITY`
-  - CLI fails locally if caller identity is unavailable
-  - daemon receives caller identity as required request data
-  - daemon never substitutes its own ambient identity
+  - CLI resolves caller team from explicit override or invoking-shell
+    `ATM_TEAM`
+  - CLI fails locally if caller identity or caller team is unavailable
+  - daemon receives caller identity and caller team as required request data
+  - daemon never substitutes its own ambient identity or team
 - send:
   - persist
   - if recipient has post-send hook capability, call `emit(...)`
@@ -238,7 +275,7 @@ Phase `AD` orchestration rule:
 - do not stop downstream development waiting for prior sprint QA to pass
 - do not run pairwise cross-merges between unrelated `AD` sprint branches
 
-1. [AD.1 Caller Identity Ownership Restore](./sprint-AD1.md)
+1. [AD.1 Caller Context Ownership Restore](./sprint-AD1.md)
 2. [AD.2 Obsolete Config Identity Removal And Doctor Contract Repair](./sprint-AD2.md)
 3. [AD.3 Claude Backend And Inbox Nudge Retirement](./sprint-AD3.md)
 4. [AD.4 Reconcile Runtime Removal](./sprint-AD4.md)
@@ -255,10 +292,13 @@ Phase `AD` orchestration rule:
 Phase `AD` closes only when:
 
 - bare daemon-backed ATM commands honor the invoking shell identity correctly
-- caller-owned commands fail before daemon dispatch when neither explicit
-  override nor invoking-shell `ATM_IDENTITY` is present
-- daemon-backed caller-owned request shapes carry caller identity as required
-  data rather than relying on daemon ambient identity
+- bare retained ATM commands honor the invoking shell identity and team
+  correctly
+- retained ATM commands fail before command execution or daemon dispatch when
+  neither explicit override nor invoking-shell `ATM_IDENTITY` / `ATM_TEAM` is
+  present
+- daemon-backed caller-owned request shapes carry caller identity and caller
+  team as required data rather than relying on daemon ambient identity/team
 - repo config no longer carries obsolete `[atm].identity`
 - post-send configured recipients either receive an emitted nudge or return a
   sender-visible warning
@@ -282,3 +322,5 @@ Phase `AD` closes only when:
 - any remaining drift category not validated on entry is surfaced with accurate
   diagnostics
 - smoke and doctor coverage prove the repaired behavior on the accepted line
+- command-matrix coverage proves the repaired caller-context behavior on the
+  full retained ATM command surface

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -223,6 +223,10 @@ Required runtime meaning:
   - persist
   - if recipient has post-send hook capability, call `emit(...)`
   - if `emit(...)` fails, log it and append a sender-visible warning
+  - `AD.6` owns the stable post-send emission failure warning/error code used
+    by both local-tmux and graft emitters; earlier sprints may reference the
+    warning behavior, but they must not invent competing codes for the same
+    failure class
 - read:
   - load from durable state only
 

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -226,6 +226,10 @@ Phase `AD` orchestration rule:
 - `Phase AD` is a strict merge-forward line
 - each implementation sprint branch/worktree must be created from the current
   accepted tip of the immediately preceding `AD` sprint
+- before development starts on a sprint, that sprint worktree must merge the
+  immediately preceding accepted `AD` sprint
+- before a sprint starts any QA-findings fix pass, that sprint worktree must
+  merge the latest tip of the immediately preceding accepted `AD` sprint again
 - sprint branches must merge forward numerically:
   - `AD.1 -> AD.2 -> AD.3 -> AD.4 -> AD.5 -> AD.6 -> AD.7 -> AD.8 -> AD.9 -> AD.10 -> AD.11`
 - accepted execution for this phase is immediate-predecessor merge-forward

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -224,17 +224,19 @@ infrastructure.
 Phase `AD` orchestration rule:
 
 - `Phase AD` is a strict merge-forward line
-- each implementation sprint branch/worktree must be created from the current
-  accepted tip of the immediately preceding `AD` sprint
-- before development starts on a sprint, that sprint worktree must merge the
-  immediately preceding accepted `AD` sprint
-- before a sprint starts any QA-findings fix pass, that sprint worktree must
-  merge the latest tip of the immediately preceding accepted `AD` sprint again
+- Phase `AD` sprints execute back-to-back without stopping for QA or waiting
+  for all prior branches to be green
+- quality review trails implementation and must not be used to pause
+  downstream sprint development
+- before starting work on a sprint branch/worktree, merge forward from the
+  latest preceding sprint branch chain already in flight
+- if multiple predecessor sprint branches exist in front of the current
+  sprint, merge the full predecessor chain before starting new work on the
+  current sprint
 - sprint branches must merge forward numerically:
   - `AD.1 -> AD.2 -> AD.3 -> AD.4 -> AD.5 -> AD.6 -> AD.7 -> AD.8 -> AD.9 -> AD.10 -> AD.11`
-- accepted execution for this phase is immediate-predecessor merge-forward
-  only; do not run pairwise cross-merges between unrelated `AD` sprint
-  branches
+- do not stop downstream development waiting for prior sprint QA to pass
+- do not run pairwise cross-merges between unrelated `AD` sprint branches
 
 1. [AD.1 Caller Identity Ownership Restore](./sprint-AD1.md)
 2. [AD.2 Obsolete Config Identity Removal And Doctor Contract Repair](./sprint-AD2.md)

--- a/docs/plans/phase-AD/sprint-AD1.md
+++ b/docs/plans/phase-AD/sprint-AD1.md
@@ -79,11 +79,19 @@ pub(crate) struct CallerContext {
     pub caller_team: TeamName,
 }
 
+pub(crate) struct CallerIdentityOverride<'a>(pub &'a str);
+pub(crate) struct CallerTeamOverride<'a>(pub &'a str);
+
 pub(crate) struct CallerContextOverrides<'a> {
-    pub identity_override: Option<&'a str>,
-    pub team_override: Option<&'a str>,
+    pub identity_override: Option<CallerIdentityOverride<'a>>,
+    pub team_override: Option<CallerTeamOverride<'a>>,
 }
 ```
+
+- the lightweight override wrappers above are required even though this is a
+  transient CLI-owned struct; caller identity and caller team must not share a
+  bare `Option<&str>` shape that makes the two override roles interchangeable
+  in implementation notes or downstream review
 
 - define one exported retained-command entry helper in that module:
 
@@ -99,7 +107,9 @@ pub(crate) fn resolve_cli_caller_context(
   - caller team: explicit command override if present, else invoking-shell
     `ATM_TEAM`, else `CallerTeamUnresolved`
 - `resolve_cli_caller_context(...)` must parse both values into
-  `AgentName` / `TeamName` before returning
+  `AgentName` / `TeamName` before returning; malformed explicit/env values must
+  fail with stable parse-oriented caller-context errors rather than reusing the
+  unresolved/missing-context contract
 - `resolve_cli_caller_context(...)` must not:
   - read `.atm.toml`
   - read repo-local default-team config
@@ -192,6 +202,10 @@ pub(crate) fn resolve_cli_caller_context(
 - request decode/dispatch must reject missing caller-context fields before
   command execution; downstream `Option<AgentName>` / `Option<TeamName>` caller
   fields are not allowed on retained daemon-backed commands after this sprint
+- daemon-side decode/dispatch rejection is a separate failure class from
+  CLI-side caller-context resolution failure; the sprint must document both
+  paths explicitly rather than treating daemon validation as implied by the CLI
+  contract
 - local-only retained commands do not need to invent daemon DTOs, but they do
   need to receive a resolved `CallerContext` at CLI entry and fail closed when
   resolution fails
@@ -268,6 +282,35 @@ fn resolve_cli_caller_context(
   - recovery: set `ATM_TEAM` in the invoking shell or pass the explicit
     `--team` override the command supports
   - daemon contact: forbidden
+- `CallerIdentityInvalid` / `ATM_IDENTITY_INVALID`
+  - cause: a caller-context-owned command received a caller-identity override
+    or invoking-shell `ATM_IDENTITY` value that could not be parsed into
+    `AgentName`
+  - emitted by: `resolve_cli_caller_context(...)`
+  - caller surface: command failure before daemon dispatch
+  - recovery: pass a syntactically valid caller identity through `--from` /
+    `--as` or repair the invoking-shell `ATM_IDENTITY`
+  - daemon contact: forbidden
+- `CallerTeamInvalid` / `ATM_TEAM_INVALID`
+  - cause: a caller-context-owned command received a caller-team override or
+    invoking-shell `ATM_TEAM` value that could not be parsed into `TeamName`
+  - emitted by: `resolve_cli_caller_context(...)`
+  - caller surface: command failure before retained execution or daemon
+    dispatch
+  - recovery: pass a syntactically valid caller team through `--team` or
+    repair the invoking-shell `ATM_TEAM`
+  - daemon contact: forbidden
+- `CallerContextRequestInvalid` / `ATM_CALLER_CONTEXT_REQUEST_INVALID`
+  - cause: a daemon-backed request reached decode/dispatch with missing,
+    malformed, or otherwise invalid required `caller_identity` /
+    `caller_team` fields despite the CLI contract
+  - emitted by: daemon request decode/dispatch validation before retained
+    command execution
+  - caller surface: hard failure on the daemon-routed path; request is rejected
+    instead of being repaired from daemon ambient state
+  - recovery: repair the CLI/request-builder path so it always sends validated
+    caller-context fields that match the `AD.1` request shape
+  - daemon contact: already occurred; command execution remains forbidden
 
 ## Obsolescence Instructions
 
@@ -349,8 +392,14 @@ fn resolve_cli_caller_context(
   - env identity/team works when override is absent
   - missing identity fails with `CallerIdentityUnresolved`
   - missing team fails with `CallerTeamUnresolved`
-  - invalid explicit identity/team fails during parsing
-  - invalid env identity/team fails during parsing
+  - invalid explicit identity fails with `CallerIdentityInvalid`
+  - invalid explicit team fails with `CallerTeamInvalid`
+  - invalid env identity fails with `CallerIdentityInvalid`
+  - invalid env team fails with `CallerTeamInvalid`
+- targeted daemon request decode/dispatch tests proving malformed or missing
+  `caller_identity` / `caller_team` fields fail with
+  `CallerContextRequestInvalid` instead of falling back to daemon ambient
+  state
 - targeted command-entry tests proving no retained command reads caller context
   from repo-local `.atm.toml`, roster state, or daemon ambient state
 - `cargo test --workspace`

--- a/docs/plans/phase-AD/sprint-AD1.md
+++ b/docs/plans/phase-AD/sprint-AD1.md
@@ -53,7 +53,6 @@ target: integrate/phase-AD
   - `ReadQuery`
   - `ListQuery`
   - `ClearQuery`
-  - `DoctorQuery`
 - update daemon dispatch/request decode so caller-owned requests fail closed if
   the required caller-context fields are absent or invalid
 - update command-entry helpers so command-line overrides win over
@@ -62,6 +61,9 @@ target: integrate/phase-AD
 - update retained non-daemon and local-only command entry points (`log`,
   `teams`, `members`, and their subcommands) so they use the same
   caller-context rule even when they do not dispatch through the daemon
+- preserve `doctor` as a diagnostic command that does not require caller
+  identity; optional team scoping remains separate from caller-context
+  enforcement
 
 ## Exact Implementation Shape
 
@@ -127,10 +129,9 @@ pub(crate) fn resolve_cli_caller_context(
   - caller identity override source: `ClearCommand.actor_override` (`--as`)
   - caller team override source: `ClearCommand.team`
 - `atm doctor`
-  - caller identity override source: none; invoking-shell `ATM_IDENTITY` is
-    mandatory
-  - caller team override source: `DoctorCommand.team` when present, else
-    invoking-shell `ATM_TEAM`
+  - caller identity override source: none; caller identity is not required
+  - caller team override source: `DoctorCommand.team` when present; otherwise
+    diagnostic scope remains unset
 - `atm log`
   - caller identity override source: none; invoking-shell `ATM_IDENTITY` is
     mandatory
@@ -172,9 +173,10 @@ pub(crate) fn resolve_cli_caller_context(
   business logic
 - `members` / `teams` / `log` must fail closed at CLI entry when caller
   identity or caller team is missing; they must not remain "special cases"
-- `doctor` must enforce caller identity/team before both:
-  - the direct local fallback path
-  - the daemon-routed path
+- `doctor` must remain outside the shared caller-context failure path:
+  - no caller-identity requirement on the direct local path
+  - no caller-identity requirement on the daemon-routed path
+  - optional `--team` continues to scope diagnostics when supplied
 - no command may silently substitute a target team, repo-local default team, or
   roster-derived team as caller team
 
@@ -187,7 +189,6 @@ pub(crate) fn resolve_cli_caller_context(
   - `ReadQuery`
   - `ListQuery`
   - `ClearQuery`
-  - `DoctorQuery`
 - request decode/dispatch must reject missing caller-context fields before
   command execution; downstream `Option<AgentName>` / `Option<TeamName>` caller
   fields are not allowed on retained daemon-backed commands after this sprint
@@ -206,13 +207,14 @@ pub(crate) fn resolve_cli_caller_context(
 - unresolved caller identity or caller team fails at the CLI boundary before
   daemon dispatch or retained command execution
 - every retained ATM command that already exists before AD.9 uses the shared
-  caller-context resolver rather than per-command fallback logic
+  caller-context resolver rather than per-command fallback logic, except
+  `doctor`, which remains identity-free by design
 
 ## Required Work
 
 - add `caller_context.rs` as the only retained-command env-resolution module
-- wire `send`, `read`, `ack`, `list`, `clear`, `log`, `doctor`, `members`,
-  `teams`, `teams add-member`, `teams backup`, and `teams restore` through
+- wire `send`, `read`, `ack`, `list`, `clear`, `log`, `members`, `teams`,
+  `teams add-member`, `teams backup`, and `teams restore` through
   `resolve_cli_caller_context(...)`
 - thread resolved caller identity/team into daemon-backed request DTOs and
   fail closed before daemon dispatch when resolution fails
@@ -220,6 +222,8 @@ pub(crate) fn resolve_cli_caller_context(
   repo config, roster state, or daemon ambient env supply caller context
 - delete or obsolete every production caller-context fallback outside
   `caller_context.rs`
+- keep `doctor` out of the caller-context resolver and document/test that it
+  runs without caller identity while still honoring optional `--team`
 
 ## Explicit Code Samples
 
@@ -248,7 +252,7 @@ fn resolve_cli_caller_context(
 ## Error Contract
 
 - `CallerIdentityUnresolved` / `ATM_IDENTITY_UNAVAILABLE`
-  - cause: a caller-owned command reached the CLI boundary with neither an
+  - cause: a caller-context-owned command reached the CLI boundary with neither an
     explicit caller override nor invoking-shell `ATM_IDENTITY`
   - emitted by: `resolve_cli_caller_context(...)`
   - sender surface: command failure before daemon dispatch
@@ -290,34 +294,56 @@ fn resolve_cli_caller_context(
 - `ATM_IDENTITY=arch-ctm ATM_TEAM=atm-dev atm ack ...` replies as
   `arch-ctm@atm-dev`
 - `ATM_IDENTITY=arch-ctm ATM_TEAM=atm-dev atm list ...`,
-  `atm clear ...`, `atm log ...`, `atm doctor ...`, `atm members ...`,
+  `atm clear ...`, `atm log ...`, `atm members ...`,
   `atm teams ...`, `atm teams add-member ...`, `atm teams backup ...`, and
   `atm teams restore ...` all execute against `arch-ctm@atm-dev` caller
   context rather than guessed fallback context
+- `atm doctor ...` runs without requiring `ATM_IDENTITY`
+- `atm doctor --team atm-dev ...` scopes diagnostics to the supplied team, but
+  bare `atm doctor ...` still works when `ATM_TEAM` is unset
 - explicit `--as` / `--from` / `--team` continues to override invoking-shell
   `ATM_IDENTITY` / `ATM_TEAM`
 - if neither explicit override nor invoking-shell `ATM_IDENTITY` /
-  `ATM_TEAM` is present, retained ATM commands fail locally and do not
-  dispatch to the daemon
+  `ATM_TEAM` is present, caller-context-owned retained ATM commands fail
+  locally and do not dispatch to the daemon
 - no validated reproduction remains where a bare `arch-ctm` command resolves
   as `team-lead@atm-dev`
 
 ## Required Validation
 
-- targeted command tests for bare-env, explicit-override, and missing-context
-  paths across:
+- targeted command tests for env-only success across:
   - `send`
   - `read`
   - `ack`
   - `list`
   - `clear`
   - `log`
-  - `doctor`
   - `members`
   - `teams`
   - `teams add-member`
   - `teams backup`
   - `teams restore`
+- targeted command tests for CLI-only caller-context success across commands
+  that expose both caller-identity and caller-team override surfaces:
+  - `send`
+  - `read`
+  - `ack`
+  - `list`
+  - `clear`
+- targeted precedence tests proving explicit CLI caller-context overrides win
+  over env across:
+  - `send`
+  - `read`
+  - `ack`
+  - `list`
+  - `clear`
+- targeted missing-context failure tests across caller-context-owned commands:
+  - missing identity failure
+  - missing team failure
+- targeted doctor tests proving:
+  - `atm doctor` succeeds without `ATM_IDENTITY`
+  - `atm doctor` succeeds without `ATM_TEAM`
+  - `atm doctor --team <team>` still scopes diagnostics when supplied
 - targeted unit coverage for `resolve_cli_caller_context(...)` itself:
   - explicit identity/team override wins over env
   - env identity/team works when override is absent

--- a/docs/plans/phase-AD/sprint-AD1.md
+++ b/docs/plans/phase-AD/sprint-AD1.md
@@ -1,17 +1,18 @@
 ---
 id: AD.1
-title: Caller Identity Ownership Restore
+title: Caller Context Ownership Restore
 status: planned
-branch: feature/pAD-s1-caller-identity-ownership-restore
-worktree: ../atm-core-worktrees/feature/pAD-s1-caller-identity-ownership-restore
+branch: feature/pAD-s1-caller-context-ownership-restore
+worktree: ../atm-core-worktrees/feature/pAD-s1-caller-context-ownership-restore
 target: integrate/phase-AD
 ---
 
-# Sprint AD.1 — Caller Identity Ownership Restore
+# Sprint AD.1 — Caller Context Ownership Restore
 
 ## Goal
 
-- restore correct caller identity ownership on daemon-backed ATM commands
+- restore correct caller identity and caller team ownership on the ATM command
+  surface
 
 ## Hard Dependencies
 
@@ -26,64 +27,221 @@ target: integrate/phase-AD
 
 - `crates/atm/src/commands/`
 - `crates/atm/src/composition.rs`
+- `crates/atm/src/observability.rs`
 - `crates/atm-core/src/identity/`
 - `crates/atm-core/src/protocol.rs`
 - `crates/atm-core/src/send/`
 - `crates/atm-core/src/read/`
 - `crates/atm-core/src/ack/`
+- `crates/atm-core/src/list.rs`
+- `crates/atm-core/src/clear/`
+- `crates/atm-core/src/doctor/`
+- `crates/atm-core/src/team_admin.rs`
 - `docs/plans/phase-AD/`
 
 ## Interfaces To Add Or Modify
 
-- add one CLI-owned caller-identity resolver used by caller-owned commands
-- add required `caller_identity: AgentName` fields to caller-owned request DTOs
-  that cross the CLI/daemon boundary:
+- add one CLI-owned caller-context resolver used by retained ATM commands
+- add one shared override-normalization path so retained ATM commands consume
+  caller identity and caller team through the same code rather than parsing
+  `ATM_IDENTITY`, `ATM_TEAM`, or repo config independently
+- add required `caller_identity: AgentName` and
+  `caller_team: TeamName` fields to caller-owned request DTOs that cross the
+  CLI/daemon boundary:
   - `SendRequest`
   - `AckRequest`
   - `ReadQuery`
   - `ListQuery`
   - `ClearQuery`
+  - `DoctorQuery`
 - update daemon dispatch/request decode so caller-owned requests fail closed if
-  the required caller-identity field is absent or invalid
-- update command-entry helpers so `--from` / `--as` override
-  invoking-shell `ATM_IDENTITY`, but no other fallback is allowed
+  the required caller-context fields are absent or invalid
+- update command-entry helpers so command-line overrides win over
+  invoking-shell `ATM_IDENTITY` / `ATM_TEAM`, but no other fallback is
+  allowed
+- update retained non-daemon and local-only command entry points (`log`,
+  `teams`, `members`, and their subcommands) so they use the same
+  caller-context rule even when they do not dispatch through the daemon
+
+## Exact Implementation Shape
+
+- add `crates/atm/src/commands/caller_context.rs`
+- move retained command caller-context ownership into that module; do not
+  duplicate env parsing in `send.rs`, `read.rs`, `ack.rs`, `list.rs`,
+  `clear.rs`, `log.rs`, `doctor.rs`, `members.rs`, or `teams.rs`
+- define these exact core helper types in the new module:
+
+```rust
+pub(crate) struct CallerContext {
+    pub caller_identity: AgentName,
+    pub caller_team: TeamName,
+}
+
+pub(crate) struct CallerContextOverrides<'a> {
+    pub identity_override: Option<&'a str>,
+    pub team_override: Option<&'a str>,
+}
+```
+
+- define one exported retained-command entry helper in that module:
+
+```rust
+pub(crate) fn resolve_cli_caller_context(
+    overrides: CallerContextOverrides<'_>,
+) -> Result<CallerContext, AtmError>
+```
+
+- `resolve_cli_caller_context(...)` must implement this exact precedence:
+  - caller identity: explicit command override if present, else invoking-shell
+    `ATM_IDENTITY`, else `CallerIdentityUnresolved`
+  - caller team: explicit command override if present, else invoking-shell
+    `ATM_TEAM`, else `CallerTeamUnresolved`
+- `resolve_cli_caller_context(...)` must parse both values into
+  `AgentName` / `TeamName` before returning
+- `resolve_cli_caller_context(...)` must not:
+  - read `.atm.toml`
+  - read repo-local default-team config
+  - inspect daemon state
+  - inspect roster state
+  - consult `ATM_IDENTITY` / `ATM_TEAM` from any process other than the
+    invoking CLI process
+- retained ATM commands must not call `std::env::var("ATM_IDENTITY")`,
+  `std::env::var("ATM_TEAM")`, or equivalent env helpers outside
+  `caller_context.rs`
+
+## Per-Command Override Mapping
+
+- `atm send`
+  - caller identity override source: `SendCommand.from`
+  - caller team override source: `SendCommand.team`
+- `atm read`
+  - caller identity override source: `ReadCommand.actor` (`--as`)
+  - caller team override source: `ReadCommand.team`
+- `atm ack`
+  - caller identity override source: `AckCommand.actor` (`--as`)
+  - caller team override source: `AckCommand.team`
+- `atm list`
+  - caller identity override source: `ListCommand.actor` (`--as`)
+  - caller team override source: `ListCommand.team`
+- `atm clear`
+  - caller identity override source: `ClearCommand.actor_override` (`--as`)
+  - caller team override source: `ClearCommand.team`
+- `atm doctor`
+  - caller identity override source: none; invoking-shell `ATM_IDENTITY` is
+    mandatory
+  - caller team override source: `DoctorCommand.team` when present, else
+    invoking-shell `ATM_TEAM`
+- `atm log`
+  - caller identity override source: none; invoking-shell `ATM_IDENTITY` is
+    mandatory
+  - caller team override source: none; invoking-shell `ATM_TEAM` is mandatory
+- `atm members`
+  - caller identity override source: none; invoking-shell `ATM_IDENTITY` is
+    mandatory
+  - caller team override source: `MembersCommand.team` when present, else
+    invoking-shell `ATM_TEAM`
+- `atm teams`
+  - caller identity override source: none; invoking-shell `ATM_IDENTITY` is
+    mandatory
+  - caller team override source: invoking-shell `ATM_TEAM`
+- `atm teams add-member`
+  - caller identity override source: none; invoking-shell `ATM_IDENTITY` is
+    mandatory
+  - caller team override source: invoking-shell `ATM_TEAM`
+  - note: positional `team` is the target roster team, not caller team, and
+    must not be reused as caller context
+- `atm teams backup`
+  - caller identity override source: none; invoking-shell `ATM_IDENTITY` is
+    mandatory
+  - caller team override source: invoking-shell `ATM_TEAM`
+  - note: positional `team` is the backup target, not caller team
+- `atm teams restore`
+  - caller identity override source: none; invoking-shell `ATM_IDENTITY` is
+    mandatory
+  - caller team override source: invoking-shell `ATM_TEAM`
+  - note: positional `team` is the restore target, not caller team
+
+## Wiring Rules
+
+- every retained ATM command `run(...)` method must resolve caller context once
+  at command entry before composing any request/query or touching the daemon
+- daemon-backed commands must thread the resolved `CallerContext` into the
+  request/query builder and then into the `atm-core` request DTO
+- local-only commands must still call `resolve_cli_caller_context(...)` even if
+  the downstream retained operation does not currently need caller identity for
+  business logic
+- `members` / `teams` / `log` must fail closed at CLI entry when caller
+  identity or caller team is missing; they must not remain "special cases"
+- `doctor` must enforce caller identity/team before both:
+  - the direct local fallback path
+  - the daemon-routed path
+- no command may silently substitute a target team, repo-local default team, or
+  roster-derived team as caller team
+
+## DTO And Entry-Point Changes
+
+- add `caller_identity: AgentName` and `caller_team: TeamName` as required
+  fields on these daemon-crossing shapes:
+  - `SendRequest`
+  - `AckRequest`
+  - `ReadQuery`
+  - `ListQuery`
+  - `ClearQuery`
+  - `DoctorQuery`
+- request decode/dispatch must reject missing caller-context fields before
+  command execution; downstream `Option<AgentName>` / `Option<TeamName>` caller
+  fields are not allowed on retained daemon-backed commands after this sprint
+- local-only retained commands do not need to invent daemon DTOs, but they do
+  need to receive a resolved `CallerContext` at CLI entry and fail closed when
+  resolution fails
 
 ## Deliverables
 
-- bare ATM commands in an `arch-ctm` shell no longer resolve as `team-lead`
-- daemon-backed request envelopes carry required caller identity fields
-- explicit overrides still win over invoking-shell `ATM_IDENTITY`
-- unresolved caller identity fails at the CLI boundary before daemon dispatch
+- bare ATM commands in an `arch-ctm` shell no longer resolve as
+  `team-lead@atm-dev`
+- daemon-backed request envelopes carry required caller identity and caller
+  team fields
+- explicit overrides still win over invoking-shell `ATM_IDENTITY` /
+  `ATM_TEAM`
+- unresolved caller identity or caller team fails at the CLI boundary before
+  daemon dispatch or retained command execution
+- every retained ATM command that already exists before AD.9 uses the shared
+  caller-context resolver rather than per-command fallback logic
 
 ## Required Work
 
-- define the one accepted identity ownership rule for daemon-backed commands
-- make caller identity mandatory for every caller-owned daemon request shape;
-  downstream identity must never be optional
-- make bare `send`, `read`, `ack`, and any other actor-scoped commands honor
-  invoking-shell `ATM_IDENTITY` without requiring `--as` or `--from`
-- make CLI command entry points reject caller-owned commands when neither an
-  explicit override nor invoking-shell `ATM_IDENTITY` is available
-- remove any remaining reliance on daemon-process ambient identity for caller
-  resolution
+- add `caller_context.rs` as the only retained-command env-resolution module
+- wire `send`, `read`, `ack`, `list`, `clear`, `log`, `doctor`, `members`,
+  `teams`, `teams add-member`, `teams backup`, and `teams restore` through
+  `resolve_cli_caller_context(...)`
+- thread resolved caller identity/team into daemon-backed request DTOs and
+  fail closed before daemon dispatch when resolution fails
+- fail closed at CLI entry for local-only retained commands instead of letting
+  repo config, roster state, or daemon ambient env supply caller context
+- delete or obsolete every production caller-context fallback outside
+  `caller_context.rs`
 
 ## Explicit Code Samples
 
 ```rust
 pub struct SendRequest {
     pub caller_identity: AgentName,
+    pub caller_team: TeamName,
     // existing send fields...
 }
 
 pub struct ReadQuery {
     pub caller_identity: AgentName,
+    pub caller_team: TeamName,
     // existing read fields...
 }
 ```
 
 ```rust
-fn resolve_cli_caller_identity(...) -> Result<AgentName, AtmError> {
-    // explicit override when supported, otherwise invoking-shell ATM_IDENTITY
+fn resolve_cli_caller_context(
+    overrides: CallerContextOverrides<'_>,
+) -> Result<CallerContext, AtmError> {
+    // one shared retained-command entry path; all ATM commands call this
 }
 ```
 
@@ -92,40 +250,83 @@ fn resolve_cli_caller_identity(...) -> Result<AgentName, AtmError> {
 - `CallerIdentityUnresolved` / `ATM_IDENTITY_UNAVAILABLE`
   - cause: a caller-owned command reached the CLI boundary with neither an
     explicit caller override nor invoking-shell `ATM_IDENTITY`
-  - emitted by: `resolve_cli_caller_identity(...)`
+  - emitted by: `resolve_cli_caller_context(...)`
   - sender surface: command failure before daemon dispatch
   - recovery: set `ATM_IDENTITY` in the invoking shell or pass the explicit
     `--as` / `--from` override the command supports
   - daemon contact: forbidden
+- `CallerTeamUnresolved` / `ATM_TEAM_UNAVAILABLE`
+  - cause: a retained ATM command reached command entry with neither an
+    explicit team override nor invoking-shell `ATM_TEAM`
+  - emitted by: `resolve_cli_caller_context(...)`
+  - caller surface: command failure before retained execution or daemon
+    dispatch
+  - recovery: set `ATM_TEAM` in the invoking shell or pass the explicit
+    `--team` override the command supports
+  - daemon contact: forbidden
 
 ## Obsolescence Instructions
 
-- any caller-owned identity helper that falls back to hook files or daemon
-  ambient environment becomes obsolete in this sprint
+- any caller-context helper that falls back to hook files, repo config, or
+  daemon ambient environment becomes obsolete in this sprint
 - if a legacy helper cannot be deleted immediately, mark it as
-  `Phase AD obsolete: caller-owned identity fallback forbidden`, remove all
+  `Phase AD obsolete: caller-owned context fallback forbidden`, remove all
   production call sites, and forbid new call sites while AD remains open
 
 ## This Sprint Does Not Close
 
+- caller-context coverage for `atm teams update-member`; that command is added
+  in `AD.9` and closes there using the same shared resolver
 - obsolete config identity removal
 - post-send nudge simplification
 - roster drift repair
 
 ## Acceptance Criteria
 
-- `ATM_IDENTITY=arch-ctm atm read --team atm-dev` reads `arch-ctm` state
-- `ATM_IDENTITY=arch-ctm atm send --team atm-dev ...` sends as `arch-ctm`
-- explicit `--as` / `--from` continues to override invoking-shell
-  `ATM_IDENTITY`
-- if neither explicit override nor invoking-shell `ATM_IDENTITY` is present,
-  caller-owned commands fail locally and do not dispatch to the daemon
-- no validated reproduction remains where a bare `arch-ctm` command resolves as
-  `team-lead`
+- `ATM_IDENTITY=arch-ctm ATM_TEAM=atm-dev atm read ...` reads
+  `arch-ctm@atm-dev` state
+- `ATM_IDENTITY=arch-ctm ATM_TEAM=atm-dev atm send ...` sends as
+  `arch-ctm@atm-dev`
+- `ATM_IDENTITY=arch-ctm ATM_TEAM=atm-dev atm ack ...` replies as
+  `arch-ctm@atm-dev`
+- `ATM_IDENTITY=arch-ctm ATM_TEAM=atm-dev atm list ...`,
+  `atm clear ...`, `atm log ...`, `atm doctor ...`, `atm members ...`,
+  `atm teams ...`, `atm teams add-member ...`, `atm teams backup ...`, and
+  `atm teams restore ...` all execute against `arch-ctm@atm-dev` caller
+  context rather than guessed fallback context
+- explicit `--as` / `--from` / `--team` continues to override invoking-shell
+  `ATM_IDENTITY` / `ATM_TEAM`
+- if neither explicit override nor invoking-shell `ATM_IDENTITY` /
+  `ATM_TEAM` is present, retained ATM commands fail locally and do not
+  dispatch to the daemon
+- no validated reproduction remains where a bare `arch-ctm` command resolves
+  as `team-lead@atm-dev`
 
 ## Required Validation
 
-- targeted command tests for bare and explicit identity paths
+- targeted command tests for bare-env, explicit-override, and missing-context
+  paths across:
+  - `send`
+  - `read`
+  - `ack`
+  - `list`
+  - `clear`
+  - `log`
+  - `doctor`
+  - `members`
+  - `teams`
+  - `teams add-member`
+  - `teams backup`
+  - `teams restore`
+- targeted unit coverage for `resolve_cli_caller_context(...)` itself:
+  - explicit identity/team override wins over env
+  - env identity/team works when override is absent
+  - missing identity fails with `CallerIdentityUnresolved`
+  - missing team fails with `CallerTeamUnresolved`
+  - invalid explicit identity/team fails during parsing
+  - invalid env identity/team fails during parsing
+- targeted command-entry tests proving no retained command reads caller context
+  from repo-local `.atm.toml`, roster state, or daemon ambient state
 - `cargo test --workspace`
 - `cargo clippy --workspace -- -D warnings`
 - `python3 .just/run_lint.py all`

--- a/docs/plans/phase-AD/sprint-AD11.md
+++ b/docs/plans/phase-AD/sprint-AD11.md
@@ -37,6 +37,8 @@ target: integrate/phase-AD
   - caller-owned identity success with invoking-shell `ATM_IDENTITY`
   - caller-owned missing-identity failure before daemon dispatch
   - local tmux post-send emission
+  - cross-team, cross-repo local post-send emission from a sender working in a
+    different repository with a different durable `home_dir`
   - graft advisory post-send emission
   - sender-visible warning behavior on forced emission failure
 - add final report artifacts that map each AD closure claim to concrete smoke
@@ -57,6 +59,8 @@ target: integrate/phase-AD
   missing
 - smoke evidence proving configured post-send emission either succeeds or warns
 - smoke evidence proving local tmux recipients on the accepted line
+- smoke evidence proving sender repository/home-dir differences do not change
+  post-send emission behavior
 - smoke evidence proving graft-backed recipients on the accepted line
 - recorded readiness verdict for `Phase AD`
 
@@ -65,6 +69,8 @@ target: integrate/phase-AD
 - prove bare `send`/`read`/`ack` caller identity on the accepted baseline
 - prove caller-owned commands reject missing identity before daemon dispatch
 - prove local tmux-backed post-send emission
+- prove `atm send` from another team/repository with a different sender
+  `home_dir` still fires the same recipient post-send behavior
 - prove graft-backed post-send emission
 - prove sender-visible warning behavior on forced emission failure
 - update readiness artifacts with final AD closure state
@@ -82,6 +88,9 @@ target: integrate/phase-AD
   identity plus local-emitter lane
 - smoke artifacts prove missing-identity caller commands fail locally before
   daemon dispatch
+- smoke artifacts prove that sending from another team/repository with a
+  different sender `home_dir` does not change whether local post-send
+  emission is attempted
 - `just smoke thorough` passes and its report artifacts prove the repaired
   graft-backed lane
 - smoke artifacts record sender-visible warning behavior on forced emission

--- a/docs/plans/phase-AD/sprint-AD11.md
+++ b/docs/plans/phase-AD/sprint-AD11.md
@@ -34,8 +34,25 @@ target: integrate/phase-AD
 ## Added Or Modified Artifacts
 
 - modify smoke runners so they prove:
-  - caller-owned identity success with invoking-shell `ATM_IDENTITY`
-  - caller-owned missing-identity failure before daemon dispatch
+  - caller-context success with invoking-shell `ATM_IDENTITY` plus `ATM_TEAM`
+  - caller-context failure when either `ATM_IDENTITY` or `ATM_TEAM` is
+    missing
+  - explicit override success when env caller context is absent but the
+    command-line override surface is present
+  - command-matrix coverage for the retained ATM command inventory:
+    - `send`
+    - `read`
+    - `ack`
+    - `list`
+    - `clear`
+    - `log`
+    - `doctor`
+    - `members`
+    - `teams`
+    - `teams add-member`
+    - `teams update-member`
+    - `teams backup`
+    - `teams restore`
   - local tmux post-send emission
   - cross-team, cross-repo local post-send emission from a sender working in a
     different repository with a different durable `home_dir`
@@ -54,9 +71,13 @@ target: integrate/phase-AD
 
 ## Deliverables
 
-- smoke evidence proving bare identity commands work correctly
-- smoke evidence proving caller-owned commands fail locally when identity is
-  missing
+- smoke evidence proving bare caller-context commands work correctly
+- smoke evidence proving retained ATM commands fail locally when caller
+  identity or caller team is missing
+- smoke evidence proving explicit override paths still work when env caller
+  context is absent
+- smoke evidence proving the retained ATM command matrix stays on the declared
+  caller context instead of guessed fallback context
 - smoke evidence proving configured post-send emission either succeeds or warns
 - smoke evidence proving local tmux recipients on the accepted line
 - smoke evidence proving sender repository/home-dir differences do not change
@@ -66,8 +87,15 @@ target: integrate/phase-AD
 
 ## Required Work
 
-- prove bare `send`/`read`/`ack` caller identity on the accepted baseline
-- prove caller-owned commands reject missing identity before daemon dispatch
+- prove bare `send`, `read`, `ack`, `list`, `clear`, `log`, `doctor`,
+  `members`, `teams`, `teams add-member`, `teams update-member`,
+  `teams backup`, and `teams restore` all execute on the declared caller
+  context on the accepted baseline
+- prove retained ATM commands reject missing identity before retained
+  execution or daemon dispatch
+- prove retained ATM commands reject missing team before retained execution or
+  daemon dispatch
+- prove explicit override paths still work when env caller context is absent
 - prove local tmux-backed post-send emission
 - prove `atm send` from another team/repository with a different sender
   `home_dir` still fires the same recipient post-send behavior
@@ -85,9 +113,28 @@ target: integrate/phase-AD
 ## Acceptance Criteria
 
 - `just smoke normal` passes and its report artifacts prove the repaired local
-  identity plus local-emitter lane
+  caller-context plus local-emitter lane
 - smoke artifacts prove missing-identity caller commands fail locally before
-  daemon dispatch
+  retained execution or daemon dispatch
+- smoke artifacts prove missing-team caller commands fail locally before
+  retained execution or daemon dispatch
+- smoke artifacts prove explicit override paths still work when env caller
+  context is absent
+- smoke artifacts or targeted CLI-matrix artifacts prove the retained ATM
+  command inventory executes against the declared caller context:
+  - `send`
+  - `read`
+  - `ack`
+  - `list`
+  - `clear`
+  - `log`
+  - `doctor`
+  - `members`
+  - `teams`
+  - `teams add-member`
+  - `teams update-member`
+  - `teams backup`
+  - `teams restore`
 - smoke artifacts prove that sending from another team/repository with a
   different sender `home_dir` does not change whether local post-send
   emission is attempted
@@ -108,6 +155,7 @@ target: integrate/phase-AD
 - `python3 .just/run_lint.py all`
 - `just smoke normal`
 - `just smoke thorough`
+- targeted CLI integration coverage for the retained ATM command matrix
 - `just validate all`
 - boundary governance check for `PostSendHookEmitter`
 - `git diff --check`

--- a/docs/plans/phase-AD/sprint-AD11.md
+++ b/docs/plans/phase-AD/sprint-AD11.md
@@ -34,11 +34,15 @@ target: integrate/phase-AD
 ## Added Or Modified Artifacts
 
 - modify smoke runners so they prove:
-  - caller-context success with invoking-shell `ATM_IDENTITY` plus `ATM_TEAM`
-  - caller-context failure when either `ATM_IDENTITY` or `ATM_TEAM` is
+  - env-only caller-context success for commands that require invoking-shell
+    `ATM_IDENTITY` plus `ATM_TEAM`
+  - caller-context failure for commands that require it when either
+    `ATM_IDENTITY` or `ATM_TEAM` is
     missing
-  - explicit override success when env caller context is absent but the
-    command-line override surface is present
+  - CLI-only caller-context success when env caller context is absent but the
+    command-line override surface is present on commands that support it
+  - explicit CLI override wins over env when both are present on commands that
+    support override surfaces
   - command-matrix coverage for the retained ATM command inventory:
     - `send`
     - `read`
@@ -46,13 +50,16 @@ target: integrate/phase-AD
     - `list`
     - `clear`
     - `log`
-    - `doctor`
     - `members`
     - `teams`
     - `teams add-member`
     - `teams update-member`
     - `teams backup`
     - `teams restore`
+  - diagnostic coverage for `doctor`:
+    - succeeds without caller identity
+    - succeeds without caller team
+    - still honors optional `--team` scoping
   - local tmux post-send emission
   - cross-team, cross-repo local post-send emission from a sender working in a
     different repository with a different durable `home_dir`
@@ -72,12 +79,16 @@ target: integrate/phase-AD
 ## Deliverables
 
 - smoke evidence proving bare caller-context commands work correctly
-- smoke evidence proving retained ATM commands fail locally when caller
-  identity or caller team is missing
-- smoke evidence proving explicit override paths still work when env caller
-  context is absent
+- smoke evidence proving caller-context-owned retained ATM commands fail
+  locally when caller identity or caller team is missing
+- smoke evidence proving CLI-only caller-context paths still work when env
+  caller context is absent on commands that support overrides
+- smoke evidence proving explicit CLI caller-context overrides win over env on
+  commands that support both
 - smoke evidence proving the retained ATM command matrix stays on the declared
   caller context instead of guessed fallback context
+- smoke evidence proving `doctor` remains identity-free and optional-team
+  diagnostics continue to work
 - smoke evidence proving configured post-send emission either succeeds or warns
 - smoke evidence proving local tmux recipients on the accepted line
 - smoke evidence proving sender repository/home-dir differences do not change
@@ -87,15 +98,19 @@ target: integrate/phase-AD
 
 ## Required Work
 
-- prove bare `send`, `read`, `ack`, `list`, `clear`, `log`, `doctor`,
+- prove bare `send`, `read`, `ack`, `list`, `clear`, `log`,
   `members`, `teams`, `teams add-member`, `teams update-member`,
   `teams backup`, and `teams restore` all execute on the declared caller
   context on the accepted baseline
-- prove retained ATM commands reject missing identity before retained
+- prove `atm doctor` runs without caller identity and without caller team,
+  while still honoring optional `--team` scoping
+- prove caller-context-owned retained ATM commands reject missing identity before retained
   execution or daemon dispatch
-- prove retained ATM commands reject missing team before retained execution or
+- prove caller-context-owned retained ATM commands reject missing team before retained execution or
   daemon dispatch
-- prove explicit override paths still work when env caller context is absent
+- prove CLI-only caller-context paths still work when env caller context is absent
+- prove explicit CLI caller-context overrides win over env when both are
+  present
 - prove local tmux-backed post-send emission
 - prove `atm send` from another team/repository with a different sender
   `home_dir` still fires the same recipient post-send behavior
@@ -114,12 +129,14 @@ target: integrate/phase-AD
 
 - `just smoke normal` passes and its report artifacts prove the repaired local
   caller-context plus local-emitter lane
-- smoke artifacts prove missing-identity caller commands fail locally before
+- smoke artifacts prove missing-identity caller-context-owned commands fail locally before
   retained execution or daemon dispatch
-- smoke artifacts prove missing-team caller commands fail locally before
+- smoke artifacts prove missing-team caller-context-owned commands fail locally before
   retained execution or daemon dispatch
-- smoke artifacts prove explicit override paths still work when env caller
-  context is absent
+- smoke artifacts prove CLI-only caller-context paths still work when env
+  caller context is absent on commands that support overrides
+- smoke artifacts prove explicit CLI caller-context overrides win over env on
+  commands that support both
 - smoke artifacts or targeted CLI-matrix artifacts prove the retained ATM
   command inventory executes against the declared caller context:
   - `send`
@@ -128,13 +145,14 @@ target: integrate/phase-AD
   - `list`
   - `clear`
   - `log`
-  - `doctor`
   - `members`
   - `teams`
   - `teams add-member`
   - `teams update-member`
   - `teams backup`
   - `teams restore`
+- smoke artifacts prove `atm doctor` does not require `ATM_IDENTITY`,
+  does not require `ATM_TEAM`, and still honors optional `--team` scoping
 - smoke artifacts prove that sending from another team/repository with a
   different sender `home_dir` does not change whether local post-send
   emission is attempted

--- a/docs/plans/phase-AD/sprint-AD9.md
+++ b/docs/plans/phase-AD/sprint-AD9.md
@@ -36,11 +36,13 @@ target: integrate/phase-AD
 ## Interfaces To Add Or Modify
 
 ```rust
+pub struct MemberName(pub AgentName);
+
 pub struct UpdateMemberRequest {
     pub caller_identity: AgentName,
     pub caller_team: TeamName,
     pub team: TeamName,
-    pub member: AgentName,
+    pub member: MemberName,
     pub home_dir: Option<PathBuf>,
     pub harness: Option<RosterHarness>,
     pub agent_type: Option<AgentType>,
@@ -66,6 +68,9 @@ pub struct UpdateMemberCommand {
 }
 ```
 
+- `MemberName` is the target-roster-member semantic type for this sprint; it
+  must stay distinct from `caller_identity: AgentName` so the CLI repair path
+  cannot confuse the acting member with the row being updated
 - add `atm teams update-member` as the accepted CLI mutation path for existing
   roster metadata
 - keep `atm teams add-member` as create-only behavior; it must not become the
@@ -131,9 +136,59 @@ pub struct UpdateMemberCommand {
 
 - `MemberAlreadyExists` / `ATM_MEMBER_ALREADY_EXISTS`
   - cause: `atm teams add-member` targets a member row that already exists
+  - emitted by: `atm teams add-member` duplicate-member validation before any
+    roster mutation is attempted
   - caller surface: command failure with no roster mutation
   - recovery: use `atm teams update-member` for metadata repair on existing
     members instead of retrying `add-member`
+  - daemon contact: forbidden for the retained local CLI path; no mutation is
+    dispatched after duplicate detection
+- `MemberNotFound` / `ATM_MEMBER_NOT_FOUND`
+  - cause: `atm teams update-member` targets a member row that does not exist
+    on the canonical SQLite-backed roster for the requested team
+  - emitted by: `atm teams update-member` target-member lookup before any
+    roster mutation is attempted
+  - caller surface: command failure with no roster mutation
+  - recovery: confirm the target team/member pair, create the member through
+    `atm teams add-member` if the row is genuinely missing, or retry
+    `atm teams update-member` against an existing row
+  - daemon contact: forbidden for the retained local CLI path; no mutation is
+    dispatched after missing-member detection
+- `CallerIdentityUnresolved` / `ATM_IDENTITY_UNAVAILABLE`
+  - cause: `atm teams update-member` reached CLI entry with neither an
+    explicit caller-identity override surface nor invoking-shell
+    `ATM_IDENTITY`
+  - emitted by: shared `resolve_cli_caller_context(...)` before update-member
+    request construction
+  - caller surface: command failure with no roster mutation
+  - recovery: set invoking-shell `ATM_IDENTITY` before running
+    `atm teams update-member`
+  - daemon contact: forbidden
+- `CallerTeamUnresolved` / `ATM_TEAM_UNAVAILABLE`
+  - cause: `atm teams update-member` reached CLI entry with no valid
+    invoking-shell `ATM_TEAM`; the positional target `team` argument does not
+    satisfy caller-team resolution
+  - emitted by: shared `resolve_cli_caller_context(...)` before update-member
+    request construction
+  - caller surface: command failure with no roster mutation
+  - recovery: set invoking-shell `ATM_TEAM` before running
+    `atm teams update-member`
+  - daemon contact: forbidden
+- `CallerIdentityInvalid` / `ATM_IDENTITY_INVALID`
+  - cause: invoking-shell `ATM_IDENTITY` or any retained caller-identity
+    override shape reused by `atm teams update-member` could not be parsed into
+    a valid `AgentName`
+  - emitted by: shared `resolve_cli_caller_context(...)`
+  - caller surface: command failure with no roster mutation
+  - recovery: repair the caller identity value before retrying the command
+  - daemon contact: forbidden
+- `CallerTeamInvalid` / `ATM_TEAM_INVALID`
+  - cause: invoking-shell `ATM_TEAM` could not be parsed into a valid
+    `TeamName` for `atm teams update-member`
+  - emitted by: shared `resolve_cli_caller_context(...)`
+  - caller surface: command failure with no roster mutation
+  - recovery: repair the caller team value before retrying the command
+  - daemon contact: forbidden
 
 ## This Sprint Does Not Close
 
@@ -170,6 +225,8 @@ pub struct UpdateMemberCommand {
   - success with invoking-shell `ATM_IDENTITY` plus `ATM_TEAM`
   - missing-identity local failure
   - missing-team local failure
+  - invalid-identity local failure
+  - invalid-team local failure
   - proof that positional target `team` does not satisfy caller-team
     resolution
 - `cargo test --workspace`

--- a/docs/plans/phase-AD/sprint-AD9.md
+++ b/docs/plans/phase-AD/sprint-AD9.md
@@ -28,6 +28,7 @@ target: integrate/phase-AD
 - `crates/atm-core/src/team_admin.rs`
 - `crates/atm-core/src/boundary/store.rs`
 - `crates/atm-core/src/schema/agent_member.rs`
+- `crates/atm/src/commands/caller_context.rs`
 - `crates/atm/src/commands/teams.rs`
 - `crates/atm/src/commands/members.rs`
 - team startup / rmux / pane metadata guidance touched by pane repair
@@ -36,6 +37,8 @@ target: integrate/phase-AD
 
 ```rust
 pub struct UpdateMemberRequest {
+    pub caller_identity: AgentName,
+    pub caller_team: TeamName,
     pub team: TeamName,
     pub member: AgentName,
     pub home_dir: Option<PathBuf>,
@@ -46,10 +49,29 @@ pub struct UpdateMemberRequest {
 }
 ```
 
+```rust
+pub struct UpdateMemberCommand {
+    team: String,
+    member: String,
+    #[arg(long)]
+    home_dir: Option<PathBuf>,
+    #[arg(long)]
+    harness: Option<String>,
+    #[arg(long)]
+    agent_type: Option<String>,
+    #[arg(long)]
+    model: Option<String>,
+    #[arg(long = "pane-id")]
+    pane_id: Option<String>,
+}
+```
+
 - add `atm teams update-member` as the accepted CLI mutation path for existing
   roster metadata
 - keep `atm teams add-member` as create-only behavior; it must not become the
   repair/update path for existing members
+- make `atm teams update-member` consume the same shared
+  `resolve_cli_caller_context(...)` path introduced in `AD.1`
 - modify the accepted CLI repair path so existing roster metadata can be set
   and repaired through ATM-owned commands against SQLite roster truth:
   - `home_dir`
@@ -76,6 +98,9 @@ pub struct UpdateMemberRequest {
 
 - existing member metadata is updateable from the CLI through one accepted
   mutation path
+- `atm teams update-member` enforces caller identity and caller team through
+  the same shared CLI-owned resolver used by the rest of the retained ATM
+  command surface
 - durable member `home_dir` is stored on the canonical SQL-backed roster row
 - authoritative pane metadata is restored for active team members in the
   existing SQLite roster rows
@@ -93,6 +118,12 @@ pub struct UpdateMemberRequest {
   - `model`
   - `harness`
   - `agent_type`
+- wire `atm teams update-member` through `resolve_cli_caller_context(...)`
+  instead of parsing `ATM_IDENTITY` / `ATM_TEAM` separately or reusing target
+  team as caller team
+- require invoking-shell caller identity and caller team at CLI entry for
+  `atm teams update-member`; the positional `team` argument remains the target
+  roster team only
 - remove lingering `.atm.toml` assumptions around active pane-id authority
 - update operator guidance for restoring pane truth when drift occurs
 
@@ -119,6 +150,11 @@ pub struct UpdateMemberRequest {
   `arch-ctm` is repaired on the accepted baseline
 - operators can update existing member metadata through `atm teams
   update-member`
+- `atm teams update-member` fails locally when caller identity or caller team
+  is unavailable instead of guessing from repo config, roster state, or daemon
+  ambient environment
+- `atm teams update-member` uses invoking-shell `ATM_TEAM` as caller team and
+  does not reinterpret the positional target `team` argument as caller context
 - `atm teams add-member` remains create-only and rejects attempts to use it as
   an update path for existing members
 - `atm teams update-member` accepts durable `home_dir` repair for existing
@@ -130,6 +166,12 @@ pub struct UpdateMemberRequest {
 ## Required Validation
 
 - targeted doctor/roster/pane-cli tests
+- targeted `teams update-member` caller-context tests:
+  - success with invoking-shell `ATM_IDENTITY` plus `ATM_TEAM`
+  - missing-identity local failure
+  - missing-team local failure
+  - proof that positional target `team` does not satisfy caller-team
+    resolution
 - `cargo test --workspace`
 - `python3 .just/run_lint.py all`
 - `git diff --check`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -605,26 +605,40 @@ Configuration resolution order:
 5. defaults
 
 Required config fields:
-- default team
+- default team for config/bootstrap flows that explicitly consume ATM config
+  defaults; it is not a runtime caller-team fallback for commands governed by
+  the caller-context matrix
 
 Supported optional config fields:
 - `[atm].team_members`
 - `[atm].aliases`
 - `[[atm.post_send_hooks]]`
 
-Runtime identity rules:
+Runtime caller-context rules:
 - repo-local `.atm.toml` `[atm].identity` is not a valid runtime identity
   fallback for the retained multi-agent ATM model
+- repo-local `.atm.toml` `[atm].default_team` is not a valid runtime caller
+  team fallback for commands that require caller context
+- the authoritative command-by-command caller-context matrix is
+  `docs/requirements.md` §4.1
 - runtime identity must come from:
   - explicit command override when supported
   - `ATM_IDENTITY`
+- runtime caller team for commands that require it must come from:
+  - explicit command override when supported
+  - `ATM_TEAM`
 - caller-owned CLI commands must resolve identity before daemon dispatch; if no
   valid identity exists, the CLI must fail locally and must not contact the
   daemon
+- caller-owned CLI commands must resolve required caller team before daemon
+  dispatch; if no valid required caller team exists, the CLI must fail locally
+  and must not contact the daemon
 - daemon-backed caller-owned request DTOs must carry resolved caller identity
   as required request data
-- the daemon must not consult hook files, repo-local config, or daemon ambient
-  `ATM_IDENTITY` to fill a missing caller identity
+- daemon-backed caller-owned request DTOs must carry resolved caller team as
+  required request data when the command requires caller team
+- the daemon must not consult hook files, repo-local config, roster state, or
+  daemon ambient `ATM_IDENTITY` / `ATM_TEAM` to fill missing caller context
 - an obsolete config `[atm].identity` field may remain temporarily for
   migration, but ATM must ignore it for runtime identity resolution and
   `atm doctor` must flag it for removal
@@ -731,31 +745,64 @@ Historical note:
 - `OBS-GAP-1` is complete as a historical planning artifact and does not remain
   the gating item for retained observability delivery
 
-## 4. Identity Resolution
+## 4. Caller Context Resolution
 
 Product requirement ID:
-- `REQ-P-IDENTITY-001` Identity resolution must follow the documented command
-  precedence rules.
+- `REQ-P-IDENTITY-001` Caller-context resolution must follow the documented
+  command precedence rules.
 
 Satisfied by:
-- `REQ-CORE-CONFIG-001` for identity resolution policy
+- `REQ-CORE-CONFIG-001` for caller-context resolution policy
 
-### 4.1 Send Identity Resolution Order
+Caller context means:
 
-1. `--from`
-2. `ATM_IDENTITY`
+- caller identity when the command needs caller identity
+- caller team when the command needs caller team
 
-### 4.2 Read Identity Resolution Order
+Global caller-context rules:
 
-1. `--as`
-2. `ATM_IDENTITY`
+- repo-local `.atm.toml` `[atm].identity` is not valid runtime caller identity
+- repo-local `.atm.toml` `[atm].default_team` is not valid runtime caller team
+  for commands that require explicit caller context
+- daemon ambient `ATM_IDENTITY` / `ATM_TEAM` are not valid fallback sources
+- roster state, hook files, and target-address fields are not valid caller
+  context sources
+- if caller context is required and cannot be resolved from the documented
+  sources, the CLI must fail locally before daemon dispatch or retained
+  command execution
+- when both an explicit CLI caller-context override and invoking-shell env are
+  present, the explicit CLI override wins
+- `atm doctor` is diagnostic and is the explicit exception: it may run without
+  caller identity and without caller team
 
-### 4.3 Doctor Identity Resolution
+### 4.1 Caller-Context Matrix
 
-`atm doctor` is diagnostic and may run without resolved caller identity. It may
-inspect `ATM_IDENTITY` visibility and explicit-override behavior, but it must
-not treat hook files, repo-local config identity, or daemon ambient identity as
-command identity.
+| Command | Caller identity required | Caller identity may come from | Caller team required | Caller team may come from | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `atm send` | Yes | `--from`, else `ATM_IDENTITY` | Yes | `--team`, else `ATM_TEAM` | target recipient/team are not caller context |
+| `atm read` | Yes | `--as`, else `ATM_IDENTITY` | Yes | `--team`, else `ATM_TEAM` | `--from` is a sender filter, not caller identity |
+| `atm ack` | Yes | `--as`, else `ATM_IDENTITY` | Yes | `--team`, else `ATM_TEAM` | reply target metadata is not caller context |
+| `atm list` | Yes | `--as`, else `ATM_IDENTITY` | Yes | `--team`, else `ATM_TEAM` | `--from` is a sender filter, not caller identity |
+| `atm clear` | Yes | `--as`, else `ATM_IDENTITY` | Yes | `--team`, else `ATM_TEAM` | target inbox/member selection is not caller context |
+| `atm log` | Yes | `ATM_IDENTITY` | Yes | `ATM_TEAM` | no explicit caller override surface |
+| `atm members` | Yes | `ATM_IDENTITY` | Yes | `--team`, else `ATM_TEAM` | `--team` scopes the roster being inspected and may also satisfy caller-team requirement |
+| `atm teams` | Yes | `ATM_IDENTITY` | Yes | `ATM_TEAM` | no explicit override surface |
+| `atm teams add-member` | Yes | `ATM_IDENTITY` | Yes | `ATM_TEAM` | positional `team` is the target roster team, not caller team |
+| `atm teams update-member` | Yes | `ATM_IDENTITY` | Yes | `ATM_TEAM` | positional `team` is the target roster team, not caller team |
+| `atm teams backup` | Yes | `ATM_IDENTITY` | Yes | `ATM_TEAM` | positional `team` is the backup target, not caller team |
+| `atm teams restore` | Yes | `ATM_IDENTITY` | Yes | `ATM_TEAM` | positional `team` is the restore target, not caller team |
+| `atm doctor` | No | not required | No | optional `--team` only | diagnostic scope is optional; `ATM_IDENTITY` / `ATM_TEAM` visibility may be reported but are not required inputs |
+
+### 4.2 Command-Specific Notes
+
+- `--from` on `send` is caller identity override
+- `--from` on `read` / `list` is a sender filter only
+- `--as` changes caller identity only; it does not change target matching
+- any command without an explicit caller override surface must rely on the
+  invoking shell when caller context is required
+- `atm doctor` may inspect `ATM_IDENTITY` visibility and team override
+  behavior, but it must not treat hook files, repo-local config identity/team,
+  or daemon ambient identity/team as command caller context
 
 If command identity cannot be determined where required, the CLI must fail with
 a structured recovery-oriented error before daemon dispatch. An obsolete config
@@ -1660,7 +1707,7 @@ Phase-AA target direction:
 The initial doctor implementation must cover:
 - config file discovery and parse health
 - effective team resolution
-- caller identity inputs and failure contract
+- caller identity/team visibility and optional diagnostic scope behavior
 - obsolete `[atm].identity` configuration drift detection
 - daemon control-socket existence and reachability
 - singleton daemon ownership health
@@ -1679,6 +1726,15 @@ The initial doctor implementation must cover:
 - `sc-observability` initialization health
 - active shared log path visibility
 - `sc-observability` query-health readiness for `atm log`
+
+Caller-context behavior for `atm doctor`:
+
+- `atm doctor` must not require `ATM_IDENTITY`
+- `atm doctor` must not require `ATM_TEAM`
+- `atm doctor --team <name>` may narrow diagnostic scope when supplied
+- `atm doctor` may report caller-context visibility and invalid override
+  situations diagnostically, but it must not fail solely because caller
+  identity/team are absent
 
 ### 11.4 Output Contract
 


### PR DESCRIPTION
## Summary
- `docs/plans/phase-AD/plan-phase-AD.md` and `sprint-AD11.md` gained an orchestration rule (strict merge-forward, no pairwise cross-merges, no QA-wait) and expanded AD.11 cross-repo/home_dir smoke scope on `integrate/phase-AD`, but these commits never made it to `develop` — only the integration branch.
- Cherry-picked the 3 docs-only commits from `integrate/phase-AD` in original order: `355ebe6f`, `ea951eb3`, `de4376a2`.
- Docs-only, no code changes, no conflicts on cherry-pick.

## Test plan
- [x] Cherry-pick applied cleanly with no conflicts
- N/A — docs-only change, no build/test required