### PR TITLE
Show message id in post-send nudges

### DIFF
--- a/scripts/atm-nudge.py
+++ b/scripts/atm-nudge.py
@@ -318,6 +318,12 @@ def build_message(team: str, payload: dict[str, object] | None = None) -> str:
     payload = payload or {}
     is_ack = payload.get("is_ack") is True
     message_id = str(payload.get("message_id", "")).strip()
+    description = ""
+    for key in ("description", "summary"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            description = value.strip()
+            break
     if is_ack:
         acknowledgement = (
             f"message {message_id} acknowledged"
@@ -333,9 +339,17 @@ def build_message(team: str, payload: dict[str, object] | None = None) -> str:
             f'<console announce="concise" pause="false"/></atm>'
         )
 
+    message_context = (
+        f"<action>message {message_id} received</action>" if message_id else ""
+    )
+    description_context = (
+        f"<action>description: {description}</action>" if description else ""
+    )
     return (
         f"<atm><action>read atm --team {team}</action>"
         f"<action>ack the message</action>"
+        f"{message_context}"
+        f"{description_context}"
         f"<action>execute the assigned task</action>"
         f'<when idle="immediate" busy="after-current-task"/>'
         f'<console announce="concise" pause="false"/></atm>'

--- a/scripts/atm-nudge.py
+++ b/scripts/atm-nudge.py
@@ -330,9 +330,13 @@ def build_message(team: str, payload: dict[str, object] | None = None) -> str:
             if message_id
             else "message acknowledged"
         )
+        message_context = (
+            f"<message-id>{message_id}</message-id>" if message_id else ""
+        )
         return (
             f"<atm><action>read atm --team {team}</action>"
             f"<action>ack the message</action>"
+            f"{message_context}"
             f"<action>{acknowledgement}</action>"
             f"<action>complete associated work immediately</action>"
             f'<when idle="immediate" busy="complete tasks based on established priority"/>'
@@ -340,10 +344,10 @@ def build_message(team: str, payload: dict[str, object] | None = None) -> str:
         )
 
     message_context = (
-        f"<action>message {message_id} received</action>" if message_id else ""
+        f"<message-id>{message_id}</message-id>" if message_id else ""
     )
     description_context = (
-        f"<action>description: {description}</action>" if description else ""
+        f"<description>{description}</description>" if description else ""
     )
     return (
         f"<atm><action>read atm --team {team}</action>"

--- a/scripts/test_atm_nudge.py
+++ b/scripts/test_atm_nudge.py
@@ -357,6 +357,26 @@ class TestBuildMessage(unittest.TestCase):
         self.assertIn(f"read atm --team {TEST_TEAM}", message)
         self.assertIn("execute the assigned task", message)
         self.assertIn('busy="after-current-task"', message)
+        self.assertNotIn("message ", message)
+
+    def test_send_message_includes_message_id_when_present(self):
+        message = _MOD.build_message(
+            TEST_TEAM,
+            {"message_id": "01JSENDTEST0000000000000000"},
+        )
+        self.assertIn("message 01JSENDTEST0000000000000000 received", message)
+        self.assertIn("execute the assigned task", message)
+
+    def test_send_message_includes_description_when_present(self):
+        message = _MOD.build_message(
+            TEST_TEAM,
+            {
+                "message_id": "01JSENDTEST0000000000000000",
+                "summary": "review failing smoke lane",
+            },
+        )
+        self.assertIn("message 01JSENDTEST0000000000000000 received", message)
+        self.assertIn("description: review failing smoke lane", message)
 
     def test_ack_message_requests_immediate_work_with_message_context(self):
         message = _MOD.build_message(

--- a/scripts/test_atm_nudge.py
+++ b/scripts/test_atm_nudge.py
@@ -364,7 +364,7 @@ class TestBuildMessage(unittest.TestCase):
             TEST_TEAM,
             {"message_id": "01JSENDTEST0000000000000000"},
         )
-        self.assertIn("message 01JSENDTEST0000000000000000 received", message)
+        self.assertIn("<message-id>01JSENDTEST0000000000000000</message-id>", message)
         self.assertIn("execute the assigned task", message)
 
     def test_send_message_includes_description_when_present(self):
@@ -375,8 +375,8 @@ class TestBuildMessage(unittest.TestCase):
                 "summary": "review failing smoke lane",
             },
         )
-        self.assertIn("message 01JSENDTEST0000000000000000 received", message)
-        self.assertIn("description: review failing smoke lane", message)
+        self.assertIn("<message-id>01JSENDTEST0000000000000000</message-id>", message)
+        self.assertIn("<description>review failing smoke lane</description>", message)
 
     def test_ack_message_requests_immediate_work_with_message_context(self):
         message = _MOD.build_message(
@@ -384,6 +384,7 @@ class TestBuildMessage(unittest.TestCase):
             {"is_ack": True, "message_id": "01JACKTEST00000000000000000"},
         )
         self.assertIn(f"read atm --team {TEST_TEAM}", message)
+        self.assertIn("<message-id>01JACKTEST00000000000000000</message-id>", message)
         self.assertIn("message 01JACKTEST00000000000000000 acknowledged", message)
         self.assertIn("complete associated work immediately", message)
         self.assertIn(


### PR DESCRIPTION
## Summary
- include the ATM message id in normal post-send nudge text
- render an optional summary/description field when future hook payloads provide one
- add unit coverage for the new nudge text contract

## Testing
- python3 -m unittest scripts/test_atm_nudge.py