### PR TITLE
Add GraftPostSendPort governance and fix AD.8 readiness evidence

### DIFF
--- a/boundaries/atm-core/graft-post-send-port.toml
+++ b/boundaries/atm-core/graft-post-send-port.toml
@@ -1,0 +1,46 @@
+boundary_id = "BOUNDARY-GraftPostSendPort"
+owner_package = "atm-core"
+owner_crate_path = "atm_core"
+name = "GraftPostSendPort"
+
+[public]
+trait = "GraftPostSendPort"
+notes = "sealed graft-backed post-send advisory handoff contract landed in Phase AD AD.8; the accepted out-of-owner implementation lives in atm-daemon advisory runtime glue"
+
+[implementation]
+visibility = "trait_only"
+constructor = "none"
+
+[composition]
+roots = []
+
+[ownership]
+io_owns = ["graft_post_send_advisory_delivery"]
+io_forbidden = ["sqlite", "process_spawn", "tmux_nudge_delivery"]
+
+[dependencies]
+allowed_dependents = ["atm-daemon", "atm-runtime"]
+allowed_dependencies = []
+forbidden_edges = ["atm-core -> atm-daemon", "atm-core -> atm-storage-rusqlite"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = ["std::process::Command", "NotificationSink::deliver", "append_compat_inbox_message"]
+
+[contracts]
+request_types = ["PostSendHookEvent"]
+response_types = ["typed graft post-send delivery success"]
+error_types = ["AtmError"]
+notes = ["sender-visible warning construction remains at the send/ack call site; this port only owns one graft-backed delivery attempt"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["std::process::Command"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-GRAFT-POST-SEND-PORT-REFERENCES"]
+review_gates = ["no_process_spawn_substitution", "no_notification_sink_substitution"]
+
+[status]
+state = "active"
+notes = ["Phase AD AD.8 established the canonical graft-backed post-send delivery port.", "The accepted out-of-owner implementation is atm_daemon::advisory_runtime::AdvisoryRuntime."]

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -359,6 +359,27 @@ Notes:
 - this boundary must not become a logical-message-delivery, persistence, or
   generic notification-planning seam.
 
+## GraftPostSendPort
+
+Canonical machine-readable boundary source:
+- [../../boundaries/atm-core/graft-post-send-port.toml](../../boundaries/atm-core/graft-post-send-port.toml)
+
+
+Purpose:
+- Owns the one accepted graft-backed advisory handoff for post-send events
+  after `atm-core` has already decided that recipient-side graft emission is
+  required.
+
+Notes:
+- This stays narrower than `PostSendHookEmitter`:
+  - `atm-core` still decides whether graft-backed post-send applies
+  - `atm-core` still logs failures and constructs sender-visible warnings
+  - the port only attempts the graft-side advisory delivery
+- the accepted out-of-owner implementation is
+  `atm_daemon::advisory_runtime::AdvisoryRuntime`.
+- this boundary must not expand into generic notification routing, mailbox
+  compatibility append, tmux delivery, or local process spawning.
+
 ## NotificationSink
 
 Canonical machine-readable boundary source:

--- a/docs/plans/phase-AD/readiness.md
+++ b/docs/plans/phase-AD/readiness.md
@@ -30,16 +30,14 @@ Record the accepted closure state for Phase AD:
 
 ## Evidence
 
-- `reports/smoke/smoke.md`
-  - normal Phase AD smoke evidence for caller-context, doctor, and local
-    post-send lanes
-- `reports/smoke/smoke-thorough.md`
-  - thorough Phase AD smoke evidence for cross-repo sender-home and graft
-    emission lanes
-- `boundaries/atm-core/post-send-hook-emitter.toml`
-  - authoritative boundary record for `PostSendHookEmitter`
-- `docs/atm-core/boundaries.md`
-  - inventory entry for `PostSendHookEmitter`
+| Sprint / Gate | Evidence | Meaning |
+| --- | --- | --- |
+| general smoke | `reports/smoke/smoke.md` | normal Phase AD smoke evidence for caller-context, doctor, and local post-send lanes |
+| general smoke | `reports/smoke/smoke-thorough.md` | thorough Phase AD smoke evidence for cross-repo sender-home and graft emission lanes |
+| `AD.6` governance | `boundaries/atm-core/post-send-hook-emitter.toml` | authoritative boundary record for `PostSendHookEmitter` |
+| `AD.6` governance | `docs/atm-core/boundaries.md` | inventory entry for `PostSendHookEmitter` |
+| `AD.8` governance | `boundaries/atm-core/graft-post-send-port.toml` | authoritative boundary record for `GraftPostSendPort` |
+| `AD.8` governance | `docs/atm-core/boundaries.md` | inventory entry for `GraftPostSendPort` and its allowlisted daemon implementation |
 
 ## Phase Exit Criteria
 
@@ -59,6 +57,8 @@ Phase AD is not ready until all of the following are true:
   post-send config lookup ownership
 - graft-backed post-send behavior is mediated only by the graft port / emitter
   seam
+- `GraftPostSendPort` governance exists in both the machine-readable boundary
+  record and the boundary inventory
 - no accepted Phase AD gate depends on daemon ambient identity, queued
   notification-runtime behavior, or historical Claude mailbox append logic
 
@@ -72,4 +72,5 @@ Phase AD is not ready until all of the following are true:
   validation commands pass
 - notes: readiness remains fail-closed because the retained validation suite
   now checks the Phase AD readiness record, every AD sprint status, the
-  `PostSendHookEmitter` boundary inventory, and the boundary TOML state
+  `PostSendHookEmitter` / `GraftPostSendPort` boundary inventories, and both
+  boundary TOML states

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -585,12 +585,20 @@ def validate_phase_ad_readiness(root: Path, findings: list[Finding]) -> None:
     readiness_path = root / "docs" / "plans" / "phase-AD" / "readiness.md"
     smoke_normal = root / "reports" / "smoke" / "smoke.md"
     smoke_thorough = root / "reports" / "smoke" / "smoke-thorough.md"
-    boundary_toml = root / "boundaries" / "atm-core" / "post-send-hook-emitter.toml"
+    post_send_boundary_toml = root / "boundaries" / "atm-core" / "post-send-hook-emitter.toml"
+    graft_boundary_toml = root / "boundaries" / "atm-core" / "graft-post-send-port.toml"
     boundary_inventory = root / "docs" / "atm-core" / "boundaries.md"
 
     missing = [
         path
-        for path in (readiness_path, smoke_normal, smoke_thorough, boundary_toml, boundary_inventory)
+        for path in (
+            readiness_path,
+            smoke_normal,
+            smoke_thorough,
+            post_send_boundary_toml,
+            graft_boundary_toml,
+            boundary_inventory,
+        )
         if not path.exists()
     ]
     if missing:
@@ -635,6 +643,15 @@ def validate_phase_ad_readiness(root: Path, findings: list[Finding]) -> None:
                 detail="docs/atm-core/boundaries.md does not contain the PostSendHookEmitter heading",
             )
         )
+    if "## GraftPostSendPort" not in boundary_text:
+        findings.append(
+            Finding(
+                check="phase-ad-readiness",
+                severity="error",
+                summary="GraftPostSendPort boundary inventory entry is missing",
+                detail="docs/atm-core/boundaries.md does not contain the GraftPostSendPort heading",
+            )
+        )
 
     expected_sprint_statuses = {
         "AD.1": "complete",
@@ -662,14 +679,29 @@ def validate_phase_ad_readiness(root: Path, findings: list[Finding]) -> None:
                 )
             )
 
-    boundary_state = tomllib.loads(boundary_toml.read_text(encoding="utf-8")).get("status", {}).get("state")
-    if boundary_state != "active":
+    post_send_boundary_state = tomllib.loads(post_send_boundary_toml.read_text(encoding="utf-8")).get(
+        "status", {}
+    ).get("state")
+    if post_send_boundary_state != "active":
         findings.append(
             Finding(
                 check="phase-ad-readiness",
                 severity="error",
                 summary="PostSendHookEmitter boundary state does not match the readiness contract",
-                detail=f"boundaries/atm-core/post-send-hook-emitter.toml has state={boundary_state!r}; expected 'active'",
+                detail=f"boundaries/atm-core/post-send-hook-emitter.toml has state={post_send_boundary_state!r}; expected 'active'",
+            )
+        )
+
+    graft_boundary_state = tomllib.loads(graft_boundary_toml.read_text(encoding="utf-8")).get("status", {}).get(
+        "state"
+    )
+    if graft_boundary_state != "active":
+        findings.append(
+            Finding(
+                check="phase-ad-readiness",
+                severity="error",
+                summary="GraftPostSendPort boundary state does not match the readiness contract",
+                detail=f"boundaries/atm-core/graft-post-send-port.toml has state={graft_boundary_state!r}; expected 'active'",
             )
         )
 


### PR DESCRIPTION
## Summary
- add the missing GraftPostSendPort boundary TOML under boundaries/atm-core
- add the matching docs/atm-core boundary inventory entry
- harden the Phase AD readiness gate so it checks graft boundary presence/state and update readiness evidence to cite the real AD.8 governance files

## Validation
- python3 scripts/validate_release.py phase-ad-readiness
- python3 .just/lint_boundaries.py
- git diff --check
- just test
- cargo clippy --workspace --all-targets -- -D warnings
- python3 .just/run_lint.py all