### PR TITLE
Retire Claude compatibility delivery executor

### DIFF
--- a/boundaries/atm-core/claude-compatibility-mailbox-writer.toml
+++ b/boundaries/atm-core/claude-compatibility-mailbox-writer.toml
@@ -1,0 +1,45 @@
+boundary_id = "BOUNDARY-ClaudeCompatibilityMailboxWriter"
+owner_package = "atm-core"
+owner_crate_path = "atm_core"
+name = "ClaudeCompatibilityMailboxWriter"
+
+[public]
+trait = "ClaudeCompatibilityMailboxWriter"
+notes = "Historical boundary record only. Phase AD AD.3 removed the accepted executor seam that appended directly into Claude compatibility inbox files during send/ack delivery."
+
+[implementation]
+visibility = "trait_only"
+constructor = "none"
+
+[composition]
+roots = []
+
+[ownership]
+io_owns = ["historical_claude_compatibility_inbox_append"]
+io_forbidden = ["sqlite", "socket_io", "process_spawn"]
+
+[dependencies]
+allowed_dependents = ["atm-daemon", "atm-runtime"]
+allowed_dependencies = []
+forbidden_edges = ["atm-core -> atm-daemon", "atm-core -> atm-storage-rusqlite"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = ["ClaudeCompatibilityMailboxWriter", "execute_claude_delivery", "append_compat_inbox_message", "append_compat_inbox_message_set"]
+
+[contracts]
+request_types = ["historical logical message append requests"]
+response_types = ["compatibility inbox append results"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = ["execute_claude_delivery"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-CLAUDE-COMPATIBILITY-MAILBOX-WRITER-REFERENCES"]
+review_gates = ["no_direct_claude_compat_delivery_executor"]
+
+[status]
+state = "retired"
+notes = ["Phase AD AD.3 deleted the accepted Claude-compatibility delivery executor and its retained-runtime append seam.", "Explicit inbox rebuild/export helpers remain separate repair-only compatibility support and are not part of the live send or ack delivery path."]

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -678,9 +678,7 @@ mod tests {
         AckReplyStateMachine, FinalizeAckContextOwned, PersistedAckReply, ReplyTarget,
         canonical_sender_identity, finalize_ack_outcome, resolve_reply_target,
     };
-    use crate::boundary::{
-        self, MessageKey, NonClaudeOutboundDeliveryRequest, ProjectionAppendMode,
-    };
+    use crate::boundary::{self, MessageKey, NonClaudeOutboundDeliveryRequest};
     use crate::delivery_plan::{DeliveryPlanDisposition, DeliveryTarget};
     use crate::observability::NullObservability;
     use crate::roles::ROLE_TEAM_LEAD;
@@ -824,23 +822,6 @@ mod tests {
             unreachable!("ack writer-path test should not rebuild compatibility inboxes")
         }
 
-        fn append_compat_inbox_message(
-            &self,
-            _inbox_path: &Path,
-            _message: &InboxMessage,
-        ) -> Result<(), crate::error::AtmError> {
-            panic!("ack writer-path test should not use the retired Claude inbox append path")
-        }
-
-        fn append_compat_inbox_message_set(
-            &self,
-            _inbox_path: &Path,
-            _mode: ProjectionAppendMode,
-            _messages: &[InboxMessage],
-        ) -> Result<(), crate::error::AtmError> {
-            panic!("ack writer-path test should use the single-message Claude inbox writer path")
-        }
-
         fn deliver_non_claude_payloads(
             &self,
             recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
@@ -957,25 +938,6 @@ mod tests {
             _agent: &AgentName,
         ) -> Result<(), crate::error::AtmError> {
             unreachable!("ack roster-gate tests do not rebuild compatibility inboxes")
-        }
-
-        fn append_compat_inbox_message(
-            &self,
-            _inbox_path: &Path,
-            _message: &InboxMessage,
-        ) -> Result<(), crate::error::AtmError> {
-            unreachable!(
-                "ack roster-gate tests should not use the retired Claude inbox append path"
-            )
-        }
-
-        fn append_compat_inbox_message_set(
-            &self,
-            _inbox_path: &Path,
-            _mode: ProjectionAppendMode,
-            _messages: &[InboxMessage],
-        ) -> Result<(), crate::error::AtmError> {
-            unreachable!("ack roster-gate tests do not append compatibility inbox message sets")
         }
 
         fn deliver_non_claude_payloads(
@@ -1194,12 +1156,10 @@ mod tests {
         assert_eq!(plan.messages[0].envelope, original);
         assert_eq!(plan.messages[1].envelope, companion);
         assert_eq!(plan.warnings.len(), 1);
-        match plan.delivery_target {
-            DeliveryTarget::NonClaude { .. } => {}
-            DeliveryTarget::ClaudeCode { .. } => {
-                panic!("expected non-Claude target for retired Claude harness path")
-            }
-        }
+        assert!(matches!(
+            plan.delivery_target,
+            DeliveryTarget::NonClaude { .. }
+        ));
     }
 
     #[test]

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -334,7 +334,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{ClearQuery, clear_mail_with_runtime_impl};
-    use crate::boundary::{self, ProjectionAppendMode, RosterHarness, RosterMemberKind};
+    use crate::boundary::{self, RosterHarness, RosterMemberKind};
     use crate::error::AtmError;
     use crate::observability::NullObservability;
     use crate::schema::InboxMessage;
@@ -437,23 +437,6 @@ mod tests {
             _agent: &AgentName,
         ) -> Result<(), AtmError> {
             unreachable!("clear roster-truth tests do not rebuild projections")
-        }
-
-        fn append_compat_inbox_message(
-            &self,
-            _inbox_path: &Path,
-            _message: &InboxMessage,
-        ) -> Result<(), AtmError> {
-            unreachable!("clear roster-truth tests do not append compat inbox messages")
-        }
-
-        fn append_compat_inbox_message_set(
-            &self,
-            _inbox_path: &Path,
-            _mode: ProjectionAppendMode,
-            _messages: &[InboxMessage],
-        ) -> Result<(), AtmError> {
-            unreachable!("clear roster-truth tests do not append compat inbox message sets")
         }
 
         fn deliver_non_claude_payloads(

--- a/crates/atm-core/src/delivery_execution.rs
+++ b/crates/atm-core/src/delivery_execution.rs
@@ -1,15 +1,11 @@
-use std::path::Path;
-
-use crate::boundary::ProjectionAppendMode;
 use crate::config::AtmConfig;
-use crate::delivery_plan::{DeliveryPlan, DeliveryPlanDisposition, DeliveryTarget, LogicalMessage};
+use crate::delivery_plan::{DeliveryPlan, DeliveryPlanDisposition, LogicalMessage};
 use crate::delivery_policy::{
-    DeliveryEventFamily, DeliveryHarnessPath, claude_append_failure_transition_names,
-    persisted_success_transition_names, sqlite_failure_transition_names,
+    DeliveryEventFamily, persisted_success_transition_names, sqlite_failure_transition_names,
 };
 use crate::error::AtmError;
 use crate::observability::ObservabilityPort;
-use crate::schema::{AtmMessageId, InboxMessage};
+use crate::schema::AtmMessageId;
 use crate::send::WarningEntry;
 use crate::service_runtime::RetainedServiceRuntime;
 use crate::types::{AgentName, TaskId, TeamName};
@@ -17,7 +13,6 @@ use crate::types::{AgentName, TaskId, TeamName};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DeliveryExecutionDisposition {
     Delivered,
-    AppendDegraded,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,56 +37,6 @@ pub(crate) struct DeliveryTransitionContext<'a> {
     pub(crate) sender: &'a AgentName,
     pub(crate) message_id: AtmMessageId,
     pub(crate) task_id: Option<TaskId>,
-}
-
-pub(crate) trait ClaudeCompatibilityMailboxWriter: crate::boundary::sealed::Sealed {
-    fn append_claude_inbox_message(
-        &self,
-        inbox_path: &Path,
-        recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-        message: &InboxMessage,
-    ) -> Result<(), AtmError>;
-    fn append_claude_message_set(
-        &self,
-        inbox_path: &Path,
-        recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-        disposition: DeliveryPlanDisposition,
-        messages: &[LogicalMessage],
-    ) -> Result<(), AtmError>;
-}
-
-impl<T> ClaudeCompatibilityMailboxWriter for T
-where
-    T: RetainedServiceRuntime + crate::boundary::sealed::Sealed + ?Sized,
-{
-    fn append_claude_inbox_message(
-        &self,
-        inbox_path: &Path,
-        _recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-        message: &InboxMessage,
-    ) -> Result<(), AtmError> {
-        self.append_compat_inbox_message(inbox_path, message)
-    }
-
-    fn append_claude_message_set(
-        &self,
-        inbox_path: &Path,
-        _recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-        disposition: DeliveryPlanDisposition,
-        messages: &[LogicalMessage],
-    ) -> Result<(), AtmError> {
-        let mode = claude_compatibility_delivery_mode_for_disposition(disposition);
-        // The retained runtime boundary still accepts owned envelopes, so this
-        // delivery seam must clone until the boundary contract is widened.
-        self.append_compat_inbox_message_set(
-            inbox_path,
-            mode,
-            &messages
-                .iter()
-                .map(|message| message.envelope.clone())
-                .collect::<Vec<_>>(),
-        )
-    }
 }
 
 pub(crate) trait NonClaudeOutboundDeliveryWriter: crate::boundary::sealed::Sealed {
@@ -127,109 +72,31 @@ where
 
 pub(crate) fn execute_delivery_plan<R>(
     runtime: &R,
-    config: Option<&AtmConfig>,
+    _config: Option<&AtmConfig>,
     plan: &DeliveryPlan,
 ) -> Result<DeliveryExecutionResult, AtmError>
 where
-    R: ClaudeCompatibilityMailboxWriter + NonClaudeOutboundDeliveryWriter,
+    R: NonClaudeOutboundDeliveryWriter,
 {
-    execute_messages(
-        runtime,
-        config,
-        ExecutionView {
-            disposition: plan.disposition,
-            delivery_target: &plan.delivery_target,
-            messages: &plan.messages,
-        },
-    )
+    let crate::delivery_plan::DeliveryTarget::NonClaude { recipient } = &plan.delivery_target;
+    runtime.deliver_non_claude_payloads(recipient, &plan.messages)?;
+    Ok(DeliveryExecutionResult::delivered())
 }
 
 pub(crate) use execute_delivery_plan as execute_reply_delivery_plan;
-
-struct ExecutionView<'a> {
-    disposition: DeliveryPlanDisposition,
-    delivery_target: &'a DeliveryTarget,
-    messages: &'a [LogicalMessage],
-}
-
-fn execute_messages<R>(
-    runtime: &R,
-    _config: Option<&AtmConfig>,
-    view: ExecutionView<'_>,
-) -> Result<DeliveryExecutionResult, AtmError>
-where
-    R: ClaudeCompatibilityMailboxWriter + NonClaudeOutboundDeliveryWriter,
-{
-    validate_delivery_target(view.delivery_target)?;
-    let mut result = DeliveryExecutionResult::delivered();
-
-    match view.delivery_target {
-        DeliveryTarget::ClaudeCode {
-            inbox_path,
-            recipient: snapshot,
-        } => execute_claude_delivery(
-            runtime,
-            view.disposition,
-            inbox_path,
-            snapshot,
-            view.messages,
-            &mut result,
-        )?,
-        DeliveryTarget::NonClaude { recipient } => {
-            runtime.deliver_non_claude_payloads(recipient, view.messages)?;
-        }
-    }
-
-    Ok(result)
-}
 
 pub(crate) fn emit_delivery_plan_transitions(
     observability: &dyn ObservabilityPort,
     context: DeliveryTransitionContext<'_>,
     plan: &DeliveryPlan,
-    execution: &DeliveryExecutionResult,
+    _execution: &DeliveryExecutionResult,
 ) -> Result<(), AtmError> {
-    emit_plan_transitions(
-        observability,
-        context,
-        plan.disposition,
-        plan.delivery_target.harness_path(),
-        execution.disposition,
-    )
-}
-
-pub(crate) use emit_delivery_plan_transitions as emit_reply_delivery_plan_transitions;
-
-fn emit_plan_transitions(
-    observability: &dyn ObservabilityPort,
-    context: DeliveryTransitionContext<'_>,
-    disposition: DeliveryPlanDisposition,
-    harness: DeliveryHarnessPath,
-    execution_disposition: DeliveryExecutionDisposition,
-) -> Result<(), AtmError> {
-    let transitions = match (disposition, execution_disposition, harness) {
-        (DeliveryPlanDisposition::SqliteFailedRecovered, _, harness) => {
-            sqlite_failure_transition_names(harness).to_vec()
+    let transitions = match plan.disposition {
+        DeliveryPlanDisposition::SqliteFailedRecovered => {
+            sqlite_failure_transition_names(plan.delivery_target.harness_path()).to_vec()
         }
-        (
-            DeliveryPlanDisposition::Persisted,
-            DeliveryExecutionDisposition::AppendDegraded,
-            DeliveryHarnessPath::ClaudeCode,
-        ) => claude_append_failure_transition_names().to_vec(),
-        (
-            DeliveryPlanDisposition::Persisted,
-            DeliveryExecutionDisposition::AppendDegraded,
-            DeliveryHarnessPath::NonClaude,
-        ) => {
-            return Err(AtmError::validation(
-                "append-degraded delivery is unsupported for DeliveryHarnessPath::NonClaude",
-            )
-            .with_recovery(
-                "Route non-Claude delivery through the state-machine-owned non-Claude outbound path instead of attempting Claude compatibility append semantics.",
-            ));
-        }
-        (_, DeliveryExecutionDisposition::Delivered, harness) => {
-            persisted_success_transition_names(context.family, harness)
+        DeliveryPlanDisposition::Persisted => {
+            persisted_success_transition_names(context.family, plan.delivery_target.harness_path())
         }
     };
     for transition in transitions {
@@ -251,114 +118,15 @@ fn emit_plan_transitions(
     Ok(())
 }
 
-fn validate_delivery_target(target: &DeliveryTarget) -> Result<(), AtmError> {
-    match (target, target.recipient_snapshot().harness) {
-        (DeliveryTarget::ClaudeCode { .. }, DeliveryHarnessPath::ClaudeCode)
-        | (DeliveryTarget::NonClaude { .. }, _) => Ok(()),
-        (DeliveryTarget::ClaudeCode { recipient, .. }, DeliveryHarnessPath::NonClaude) => {
-            Err(AtmError::validation(format!(
-                "unsupported delivery plan target: ClaudeCode target for non-Claude harness {}@{}",
-                recipient.agent, recipient.team
-            ))
-            .with_recovery(
-                "Build the delivery plan through the state machine so non-Claude recipients stay on the non-Claude outbound path.",
-            ))
-        }
-    }
-}
-
-fn execute_claude_delivery<R: ClaudeCompatibilityMailboxWriter + ?Sized>(
-    runtime: &R,
-    disposition: DeliveryPlanDisposition,
-    inbox_path: &Path,
-    recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-    messages: &[LogicalMessage],
-    result: &mut DeliveryExecutionResult,
-) -> Result<(), AtmError> {
-    match disposition {
-        DeliveryPlanDisposition::SqliteFailedRecovered => {
-            runtime.append_claude_message_set(inbox_path, recipient, disposition, messages)?;
-            Ok(())
-        }
-        DeliveryPlanDisposition::Persisted => {
-            execute_persisted_claude_delivery(runtime, inbox_path, recipient, messages, result);
-            Ok(())
-        }
-    }
-}
-
-fn execute_persisted_claude_delivery<R: ClaudeCompatibilityMailboxWriter + ?Sized>(
-    runtime: &R,
-    inbox_path: &Path,
-    recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-    messages: &[LogicalMessage],
-    result: &mut DeliveryExecutionResult,
-) {
-    for (index, message) in messages.iter().enumerate() {
-        let envelope = &message.envelope;
-        if let Err(error) = runtime.append_claude_inbox_message(inbox_path, recipient, envelope) {
-            result.disposition = DeliveryExecutionDisposition::AppendDegraded;
-            result.warnings.push(build_append_warning(
-                DeliveryPlanDisposition::Persisted,
-                recipient,
-                index,
-                error,
-            ));
-        }
-    }
-}
-
-fn claude_compatibility_delivery_mode_for_disposition(
-    disposition: DeliveryPlanDisposition,
-) -> ProjectionAppendMode {
-    debug_assert_eq!(
-        disposition,
-        DeliveryPlanDisposition::SqliteFailedRecovered,
-        "recovered Claude message-set seam only accepts SqliteFailedRecovered plans",
-    );
-    ProjectionAppendMode::RecoveredLogicalMessageSet
-}
-
-fn build_append_warning(
-    disposition: DeliveryPlanDisposition,
-    recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-    index: usize,
-    error: AtmError,
-) -> WarningEntry {
-    let ordinal = index + 1;
-    let (message, recovery) = if disposition == DeliveryPlanDisposition::Persisted {
-        (
-            format!(
-                "warning: compatibility append degraded for {}@{} message[{ordinal}]: {error}",
-                recipient.agent, recipient.team
-            ),
-            Some(
-                "SQLite persistence succeeded. Post-send-hook fallback remains available for notification degradation.",
-            ),
-        )
-    } else {
-        (
-            format!(
-                "degraded Claude Code delivery append failed for {}@{} message[{ordinal}] after SQLite failure: {error}",
-                recipient.agent, recipient.team
-            ),
-            Some(
-                "ATM still executed the shared notification path, but degraded delivery is incomplete and the Claude Code compatibility surface must be repaired immediately.",
-            ),
-        )
-    };
-    WarningEntry::new(message, recovery)
-}
+pub(crate) use emit_delivery_plan_transitions as emit_reply_delivery_plan_transitions;
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
-
     use serde_json::Map;
 
     use super::{
-        ClaudeCompatibilityMailboxWriter, DeliveryExecutionDisposition, DeliveryTransitionContext,
-        NonClaudeOutboundDeliveryWriter, emit_delivery_plan_transitions, execute_delivery_plan,
+        DeliveryExecutionDisposition, DeliveryTransitionContext, NonClaudeOutboundDeliveryWriter,
+        emit_delivery_plan_transitions, execute_delivery_plan,
     };
     use crate::delivery_plan::{
         DeliveryPlan, DeliveryPlanDisposition, DeliveryPlanKind, DeliveryTarget, LogicalMessage,
@@ -380,27 +148,6 @@ mod tests {
 
     impl crate::boundary::sealed::Sealed for NoopRuntime {}
 
-    impl ClaudeCompatibilityMailboxWriter for NoopRuntime {
-        fn append_claude_inbox_message(
-            &self,
-            _inbox_path: &Path,
-            _recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-            _message: &InboxMessage,
-        ) -> Result<(), AtmError> {
-            Ok(())
-        }
-
-        fn append_claude_message_set(
-            &self,
-            _inbox_path: &Path,
-            _recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-            _disposition: DeliveryPlanDisposition,
-            _messages: &[LogicalMessage],
-        ) -> Result<(), AtmError> {
-            Ok(())
-        }
-    }
-
     impl NonClaudeOutboundDeliveryWriter for NoopRuntime {
         fn deliver_non_claude_payloads(
             &self,
@@ -411,8 +158,6 @@ mod tests {
         }
     }
 
-    // Mutex required: observability captures may be mutated from multiple test
-    // threads when delivery execution is exercised under concurrent send flows.
     #[derive(Default)]
     struct RecordingObservability {
         events: std::sync::Mutex<Vec<CommandEvent>>,
@@ -477,87 +222,21 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingRuntime {
-        // The execution-path tests mutate these fields from trait-method calls
-        // on `&self`, so the test double needs interior mutability to record
-        // side effects without changing the production executor signatures.
-        single_append_texts: std::sync::Mutex<Vec<String>>,
-        message_set_texts: std::sync::Mutex<Vec<Vec<String>>>,
-        fail_message_set: bool,
-        fail_single_append_indexes: Vec<usize>,
-        single_append_calls: std::sync::Mutex<usize>,
-    }
-
-    impl RecordingRuntime {
-        fn with_message_set_failure() -> Self {
-            Self {
-                fail_message_set: true,
-                ..Self::default()
-            }
-        }
-
-        fn with_single_append_failures(indexes: &[usize]) -> Self {
-            Self {
-                fail_single_append_indexes: indexes.to_vec(),
-                ..Self::default()
-            }
-        }
+        delivered_texts: std::sync::Mutex<Vec<String>>,
     }
 
     impl crate::boundary::sealed::Sealed for RecordingRuntime {}
-
-    impl ClaudeCompatibilityMailboxWriter for RecordingRuntime {
-        fn append_claude_inbox_message(
-            &self,
-            _inbox_path: &Path,
-            _recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-            message: &InboxMessage,
-        ) -> Result<(), AtmError> {
-            let mut call_count = self.single_append_calls.lock().expect("call count");
-            let current_index = *call_count;
-            *call_count += 1;
-
-            if self.fail_single_append_indexes.contains(&current_index) {
-                return Err(AtmError::mailbox_write(format!(
-                    "single append failure for message[{}]",
-                    current_index + 1
-                )));
-            }
-
-            self.single_append_texts
-                .lock()
-                .expect("single appends")
-                .push(message.text.clone());
-            Ok(())
-        }
-
-        fn append_claude_message_set(
-            &self,
-            _inbox_path: &Path,
-            _recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-            _disposition: DeliveryPlanDisposition,
-            messages: &[LogicalMessage],
-        ) -> Result<(), AtmError> {
-            self.message_set_texts.lock().expect("message sets").push(
-                messages
-                    .iter()
-                    .map(|message| message.envelope.text.clone())
-                    .collect(),
-            );
-            if self.fail_message_set {
-                return Err(AtmError::mailbox_write(
-                    "recovered Claude logical message set export failed",
-                ));
-            }
-            Ok(())
-        }
-    }
 
     impl NonClaudeOutboundDeliveryWriter for RecordingRuntime {
         fn deliver_non_claude_payloads(
             &self,
             _recipient: &crate::delivery_policy::DeliveryRecipientSnapshot,
-            _messages: &[LogicalMessage],
+            messages: &[LogicalMessage],
         ) -> Result<(), AtmError> {
+            self.delivered_texts
+                .lock()
+                .expect("deliveries")
+                .extend(messages.iter().map(|message| message.envelope.text.clone()));
             Ok(())
         }
     }
@@ -592,34 +271,6 @@ mod tests {
     }
 
     #[test]
-    fn execute_delivery_plan_rejects_claude_target_for_non_claude_harness() {
-        let runtime = NoopRuntime;
-        let message = logical_message();
-        let plan = DeliveryPlan::new(
-            DeliveryPlanKind::Send,
-            DeliveryPlanDisposition::Persisted,
-            DeliveryTarget::ClaudeCode {
-                inbox_path: PathBuf::from("recipient.jsonl"),
-                recipient: recipient_snapshot(DeliveryHarnessPath::NonClaude),
-            },
-            ResolvedRecipient {
-                agent: AgentName::from_validated("recipient"),
-                team: TeamName::from_validated(TEST_TEAM),
-            },
-            vec![message],
-            Vec::new(),
-        );
-
-        let error = execute_delivery_plan(&runtime, None, &plan).expect_err("fail closed");
-        assert!(error.is_validation());
-        assert!(
-            error
-                .message
-                .contains("ClaudeCode target for non-Claude harness")
-        );
-    }
-
-    #[test]
     fn execute_delivery_plan_allows_non_claude_target_for_claude_harness() {
         let runtime = NoopRuntime;
         let message = logical_message();
@@ -643,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn emit_delivery_plan_transitions_rejects_non_claude_append_degraded_state() {
+    fn emit_delivery_plan_transitions_use_non_claude_path_for_persisted_delivery() {
         let observability = RecordingObservability::default();
         let message = logical_message();
         let message_id = message.message_id();
@@ -661,109 +312,27 @@ mod tests {
             Vec::new(),
         );
 
-        let error = emit_delivery_plan_transitions(
+        emit_delivery_plan_transitions(
             &observability,
             transition_context(message_id),
             &plan,
-            &super::DeliveryExecutionResult {
-                disposition: DeliveryExecutionDisposition::AppendDegraded,
-                warnings: Vec::new(),
-            },
+            &super::DeliveryExecutionResult::delivered(),
         )
-        .expect_err("reject impossible append-degraded non-claude transition");
-        assert!(error.is_validation());
-        assert!(
-            error
-                .message
-                .contains("unsupported for DeliveryHarnessPath::NonClaude")
-        );
+        .expect("persisted transitions");
+        let events = observability.events.lock().expect("events");
+        assert!(events.iter().any(|event| {
+            event.command == "delivery_policy"
+                && event.outcome.as_str() == "delivery_policy.new_message.non_claude_original"
+        }));
     }
 
     #[test]
-    fn emit_reply_delivery_plan_transitions_rejects_non_claude_append_degraded_state() {
-        let observability = RecordingObservability::default();
-        let message = logical_message();
-        let message_id = message.message_id();
+    fn execute_delivery_plan_routes_recovered_message_sets_through_non_claude_outbound() {
+        let runtime = RecordingRuntime::default();
         let plan = DeliveryPlan::new(
-            DeliveryPlanKind::Reply,
-            DeliveryPlanDisposition::Persisted,
+            DeliveryPlanKind::Send,
+            DeliveryPlanDisposition::SqliteFailedRecovered,
             DeliveryTarget::NonClaude {
-                recipient: recipient_snapshot(DeliveryHarnessPath::NonClaude),
-            },
-            ResolvedRecipient {
-                agent: AgentName::from_validated("recipient"),
-                team: TeamName::from_validated(TEST_TEAM),
-            },
-            vec![message],
-            Vec::new(),
-        );
-
-        let error = super::emit_reply_delivery_plan_transitions(
-            &observability,
-            transition_context(message_id),
-            &plan,
-            &super::DeliveryExecutionResult {
-                disposition: DeliveryExecutionDisposition::AppendDegraded,
-                warnings: Vec::new(),
-            },
-        )
-        .expect_err("reject impossible append-degraded non-claude reply transition");
-        assert!(error.is_validation());
-        assert!(
-            error
-                .message
-                .contains("unsupported for DeliveryHarnessPath::NonClaude")
-        );
-    }
-
-    #[test]
-    fn sqlite_failure_for_claude_requires_full_logical_message_set_delivery() {
-        let runtime = RecordingRuntime::with_message_set_failure();
-        let plan = DeliveryPlan::new(
-            DeliveryPlanKind::Send,
-            DeliveryPlanDisposition::SqliteFailedRecovered,
-            DeliveryTarget::ClaudeCode {
-                inbox_path: PathBuf::from("recipient.jsonl"),
-                recipient: recipient_snapshot(DeliveryHarnessPath::ClaudeCode),
-            },
-            ResolvedRecipient {
-                agent: AgentName::from_validated("recipient"),
-                team: TeamName::from_validated(TEST_TEAM),
-            },
-            vec![
-                logical_message_with_text("message[1]"),
-                logical_message_with_text("message[2]"),
-            ],
-            Vec::new(),
-        );
-
-        let error = execute_delivery_plan(&runtime, None, &plan).expect_err("hard failure");
-        assert!(error.message.contains("logical message set export failed"));
-        assert_eq!(
-            runtime
-                .message_set_texts
-                .lock()
-                .expect("message sets")
-                .len(),
-            1
-        );
-        assert!(
-            runtime
-                .single_append_texts
-                .lock()
-                .expect("single appends")
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn sqlite_failure_for_claude_does_not_emit_message1_without_message2() {
-        let runtime = RecordingRuntime::with_message_set_failure();
-        let plan = DeliveryPlan::new(
-            DeliveryPlanKind::Send,
-            DeliveryPlanDisposition::SqliteFailedRecovered,
-            DeliveryTarget::ClaudeCode {
-                inbox_path: PathBuf::from("recipient.jsonl"),
                 recipient: recipient_snapshot(DeliveryHarnessPath::ClaudeCode),
             },
             ResolvedRecipient {
@@ -777,64 +346,15 @@ mod tests {
             Vec::new(),
         );
 
-        let _ = execute_delivery_plan(&runtime, None, &plan).expect_err("hard failure");
+        let result = execute_delivery_plan(&runtime, None, &plan).expect("delivery");
+        assert_eq!(result.disposition, DeliveryExecutionDisposition::Delivered);
+        assert!(result.warnings.is_empty());
         assert_eq!(
-            *runtime.message_set_texts.lock().expect("message sets"),
-            vec![vec![
+            *runtime.delivered_texts.lock().expect("deliveries"),
+            vec![
                 "original message".to_string(),
                 "companion error".to_string()
-            ]]
-        );
-        assert!(
-            runtime
-                .single_append_texts
-                .lock()
-                .expect("single appends")
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn persisted_claude_append_degradation_remains_explicit_and_warning_typed() {
-        let runtime = RecordingRuntime::with_single_append_failures(&[0]);
-        let plan = DeliveryPlan::new(
-            DeliveryPlanKind::Send,
-            DeliveryPlanDisposition::Persisted,
-            DeliveryTarget::ClaudeCode {
-                inbox_path: PathBuf::from("recipient.jsonl"),
-                recipient: recipient_snapshot(DeliveryHarnessPath::ClaudeCode),
-            },
-            ResolvedRecipient {
-                agent: AgentName::from_validated("recipient"),
-                team: TeamName::from_validated(TEST_TEAM),
-            },
-            vec![
-                logical_message_with_text("persisted first"),
-                logical_message_with_text("persisted second"),
-            ],
-            Vec::new(),
-        );
-
-        let result = execute_delivery_plan(&runtime, None, &plan).expect("append degraded");
-        assert_eq!(
-            result.disposition,
-            DeliveryExecutionDisposition::AppendDegraded
-        );
-        assert_eq!(result.warnings.len(), 1);
-        assert!(
-            result.warnings[0]
-                .message
-                .contains("warning: compatibility append degraded")
-        );
-        assert_eq!(
-            result.warnings[0].recovery.as_deref(),
-            Some(
-                "SQLite persistence succeeded. Post-send-hook fallback remains available for notification degradation."
-            )
-        );
-        assert_eq!(
-            *runtime.single_append_texts.lock().expect("single appends"),
-            vec!["persisted second".to_string()]
+            ]
         );
     }
 }

--- a/crates/atm-core/src/delivery_plan.rs
+++ b/crates/atm-core/src/delivery_plan.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::delivery_policy::DeliveryRecipientSnapshot;
 use crate::schema::{AtmMessageId, InboxMessage};
@@ -101,14 +101,6 @@ pub(crate) fn delivery_target_for_snapshot(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DeliveryTarget {
-    #[allow(
-        dead_code,
-        reason = "Phase AD obsolete: historical Claude mailbox compatibility only."
-    )]
-    ClaudeCode {
-        inbox_path: PathBuf,
-        recipient: DeliveryRecipientSnapshot,
-    },
     NonClaude {
         recipient: DeliveryRecipientSnapshot,
     },
@@ -117,18 +109,7 @@ pub(crate) enum DeliveryTarget {
 impl DeliveryTarget {
     pub(crate) fn harness_path(&self) -> crate::delivery_policy::DeliveryHarnessPath {
         match self {
-            Self::ClaudeCode { .. } => crate::delivery_policy::DeliveryHarnessPath::ClaudeCode,
             Self::NonClaude { .. } => crate::delivery_policy::DeliveryHarnessPath::NonClaude,
-        }
-    }
-
-    #[allow(
-        dead_code,
-        reason = "Phase AD obsolete: historical Claude mailbox compatibility only."
-    )]
-    pub(crate) fn recipient_snapshot(&self) -> &DeliveryRecipientSnapshot {
-        match self {
-            Self::ClaudeCode { recipient, .. } | Self::NonClaude { recipient } => recipient,
         }
     }
 }

--- a/crates/atm-core/src/delivery_policy.rs
+++ b/crates/atm-core/src/delivery_policy.rs
@@ -516,6 +516,7 @@ pub(crate) fn sqlite_failure_transition_names(
     new_message_sqlite_failure_transitions(harness)
 }
 
+#[cfg(test)]
 pub(crate) fn claude_append_failure_transition_names() -> &'static [&'static str] {
     &[
         "delivery_policy.new_message.received",
@@ -659,23 +660,6 @@ mod tests {
             _inbox_path: &Path,
             _team: &TeamName,
             _agent: &AgentName,
-        ) -> Result<(), AtmError> {
-            Ok(())
-        }
-
-        fn append_compat_inbox_message(
-            &self,
-            _inbox_path: &Path,
-            _message: &crate::schema::InboxMessage,
-        ) -> Result<(), AtmError> {
-            Ok(())
-        }
-
-        fn append_compat_inbox_message_set(
-            &self,
-            _inbox_path: &Path,
-            _mode: crate::boundary::ProjectionAppendMode,
-            _messages: &[crate::schema::InboxMessage],
         ) -> Result<(), AtmError> {
             Ok(())
         }

--- a/crates/atm-core/src/list.rs
+++ b/crates/atm-core/src/list.rs
@@ -263,7 +263,7 @@ mod tests {
     use super::{
         ListQuery, apply_list_filters, list_mail_with_runtime_impl, logical_current_messages,
     };
-    use crate::boundary::{self, ProjectionAppendMode, RosterHarness, RosterMemberKind};
+    use crate::boundary::{self, RosterHarness, RosterMemberKind};
     use crate::error::AtmError;
     use crate::observability::NullObservability;
     use crate::read::ClassifiedMessage;
@@ -415,23 +415,6 @@ mod tests {
             _agent: &AgentName,
         ) -> Result<(), AtmError> {
             unreachable!("list roster-truth tests do not rebuild projections")
-        }
-
-        fn append_compat_inbox_message(
-            &self,
-            _inbox_path: &Path,
-            _message: &InboxMessage,
-        ) -> Result<(), AtmError> {
-            unreachable!("list roster-truth tests do not append compat inbox messages")
-        }
-
-        fn append_compat_inbox_message_set(
-            &self,
-            _inbox_path: &Path,
-            _mode: ProjectionAppendMode,
-            _messages: &[InboxMessage],
-        ) -> Result<(), AtmError> {
-            unreachable!("list roster-truth tests do not append compat inbox message sets")
         }
 
         fn deliver_non_claude_payloads(

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -750,7 +750,7 @@ mod tests {
         BucketCounts, ClassifiedMessage, ReadQuery, metadata_selection,
         read_mail_with_runtime_impl, state,
     };
-    use crate::boundary::{self, ProjectionAppendMode, RosterHarness, RosterMemberKind};
+    use crate::boundary::{self, RosterHarness, RosterMemberKind};
     use crate::mailbox::source::SourceFile;
     use crate::mailbox::source::SourcedMessage;
     use crate::mailbox::surface::dedupe_message_id_surface;
@@ -1113,23 +1113,6 @@ mod tests {
             _agent: &AgentName,
         ) -> Result<(), crate::error::AtmError> {
             unreachable!("read roster-truth tests do not rebuild projections")
-        }
-
-        fn append_compat_inbox_message(
-            &self,
-            _inbox_path: &Path,
-            _message: &InboxMessage,
-        ) -> Result<(), crate::error::AtmError> {
-            unreachable!("read roster-truth tests do not append compat inbox messages")
-        }
-
-        fn append_compat_inbox_message_set(
-            &self,
-            _inbox_path: &Path,
-            _mode: ProjectionAppendMode,
-            _messages: &[InboxMessage],
-        ) -> Result<(), crate::error::AtmError> {
-            unreachable!("read roster-truth tests do not append compat inbox message sets")
         }
 
         fn deliver_non_claude_payloads(

--- a/crates/atm-core/src/send/graft_warning_tests.rs
+++ b/crates/atm-core/src/send/graft_warning_tests.rs
@@ -74,7 +74,7 @@ fn load_send_alert_state_parse_errors_are_config_errors() {
 #[test]
 #[serial_test::serial(env)]
 fn send_non_claude_success_delivers_original_via_outbound_boundary() {
-    let runtime = TestRuntime::new(None, None, DeliveryHarnessPath::NonClaude);
+    let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
     let graft_port = RecordingGraftPort::default();
     let tempdir = tempdir().expect("tempdir");
     let home_dir = tempdir.path().join("home");
@@ -129,7 +129,7 @@ fn send_non_claude_success_delivers_original_via_outbound_boundary() {
 #[test]
 #[serial_test::serial(env)]
 fn send_non_claude_warns_when_graft_post_send_delivery_fails() {
-    let runtime = TestRuntime::new(None, None, DeliveryHarnessPath::NonClaude);
+    let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
     let graft_port = FailingGraftPort {
         events: Mutex::new(Vec::new()),
     };

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -862,8 +862,8 @@ mod tests {
         sender_config_root,
     };
     use crate::boundary::{
-        GraftPostSendPort, PostSendHookEmitter, PostSendHookEvent, ProjectionAppendMode,
-        RosterEntry, RosterHarness, RosterMemberKind,
+        GraftPostSendPort, PostSendHookEmitter, PostSendHookEvent, RosterEntry, RosterHarness,
+        RosterMemberKind,
     };
     use crate::config::AtmConfig;
     use crate::config::types::HookRecipient;
@@ -949,23 +949,6 @@ mod tests {
             _agent: &AgentName,
         ) -> Result<(), AtmError> {
             unreachable!("config lookup test does not rebuild projections")
-        }
-
-        fn append_compat_inbox_message(
-            &self,
-            _inbox_path: &Path,
-            _message: &InboxMessage,
-        ) -> Result<(), AtmError> {
-            unreachable!("config lookup test does not append messages")
-        }
-
-        fn append_compat_inbox_message_set(
-            &self,
-            _inbox_path: &Path,
-            _mode: ProjectionAppendMode,
-            _messages: &[InboxMessage],
-        ) -> Result<(), AtmError> {
-            unreachable!("config lookup test does not append message sets")
         }
 
         fn deliver_non_claude_payloads(

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -13,8 +13,7 @@ use super::{
 };
 use crate::boundary::{
     MailMessageState, MailStoreMailboxMetadataRow, Message, MessageKey,
-    NonClaudeOutboundDeliveryRequest, ProjectionAppendMode, RosterEntry, RosterHarness,
-    RosterMemberKind,
+    NonClaudeOutboundDeliveryRequest, RosterEntry, RosterHarness, RosterMemberKind,
 };
 use crate::config::AtmConfig;
 use crate::delivery_execution::{DeliveryExecutionDisposition, execute_delivery_plan};
@@ -100,7 +99,6 @@ fn assert_recovered_payload_texts(
 
 pub(super) struct TestRuntime {
     commit_error_message: Option<&'static str>,
-    append_error_message: Option<&'static str>,
     recipient_harness: DeliveryHarnessPath,
     claude_roster_members: Vec<AgentName>,
     roster_member_missing: bool,
@@ -111,12 +109,10 @@ pub(super) struct TestRuntime {
 impl TestRuntime {
     pub(super) fn new(
         commit_error_message: Option<&'static str>,
-        append_error_message: Option<&'static str>,
         recipient_harness: DeliveryHarnessPath,
     ) -> Self {
         Self {
             commit_error_message,
-            append_error_message,
             recipient_harness,
             claude_roster_members: vec![AgentName::from_validated("recipient")],
             roster_member_missing: false,
@@ -184,37 +180,6 @@ impl RetainedServiceRuntime for TestRuntime {
         _team: &TeamName,
         _agent: &AgentName,
     ) -> Result<(), AtmError> {
-        Ok(())
-    }
-
-    fn append_compat_inbox_message(
-        &self,
-        _inbox_path: &Path,
-        message: &InboxMessage,
-    ) -> Result<(), AtmError> {
-        if let Some(message) = self.append_error_message {
-            return Err(AtmError::mailbox_write(message));
-        }
-        self.appended_messages
-            .lock()
-            .expect("append captures lock")
-            .push(message.clone());
-        Ok(())
-    }
-
-    fn append_compat_inbox_message_set(
-        &self,
-        _inbox_path: &Path,
-        _mode: ProjectionAppendMode,
-        messages: &[InboxMessage],
-    ) -> Result<(), AtmError> {
-        if let Some(message) = self.append_error_message {
-            return Err(AtmError::mailbox_write(message));
-        }
-        self.appended_messages
-            .lock()
-            .expect("append captures lock")
-            .extend(messages.iter().cloned());
         Ok(())
     }
 
@@ -406,13 +371,13 @@ pub(super) fn send_request(home_dir: &Path) -> SendRequest {
 }
 
 fn send_runtime_with_missing_claude_member() -> TestRuntime {
-    let mut runtime = TestRuntime::new(None, None, DeliveryHarnessPath::ClaudeCode);
+    let mut runtime = TestRuntime::new(None, DeliveryHarnessPath::ClaudeCode);
     runtime.claude_roster_members.clear();
     runtime
 }
 
 fn send_runtime_with_missing_atm_roster_member() -> TestRuntime {
-    let mut runtime = TestRuntime::new(None, None, DeliveryHarnessPath::ClaudeCode);
+    let mut runtime = TestRuntime::new(None, DeliveryHarnessPath::ClaudeCode);
     runtime.roster_member_missing = true;
     runtime
 }
@@ -455,11 +420,7 @@ impl ObservabilityPort for RecordingObservability {
 #[test]
 fn sqlite_failure_for_claude_preserves_original_and_companion_error_payloads() {
     let outbound = outbound_message();
-    let runtime = TestRuntime::new(
-        Some("sqlite write failed"),
-        None,
-        DeliveryHarnessPath::ClaudeCode,
-    );
+    let runtime = TestRuntime::new(Some("sqlite write failed"), DeliveryHarnessPath::ClaudeCode);
     let tempdir = tempdir().expect("tempdir");
     let inbox_path = tempdir.path().join("recipient.jsonl");
 
@@ -489,11 +450,7 @@ fn sqlite_failure_for_claude_preserves_original_and_companion_error_payloads() {
 #[test]
 fn sqlite_failure_for_non_claude_preserves_original_and_companion_payloads() {
     let outbound = outbound_message();
-    let runtime = TestRuntime::new(
-        Some("sqlite write failed"),
-        None,
-        DeliveryHarnessPath::NonClaude,
-    );
+    let runtime = TestRuntime::new(Some("sqlite write failed"), DeliveryHarnessPath::NonClaude);
     let tempdir = tempdir().expect("tempdir");
     let inbox_path = tempdir.path().join("recipient.jsonl");
 
@@ -522,7 +479,7 @@ fn sqlite_failure_for_non_claude_preserves_original_and_companion_payloads() {
 #[test]
 #[serial_test::serial(env)]
 fn claude_harness_delivery_no_longer_has_append_degradation_path() {
-    let runtime = TestRuntime::new(None, Some("append failed"), DeliveryHarnessPath::ClaudeCode);
+    let runtime = TestRuntime::new(None, DeliveryHarnessPath::ClaudeCode);
     let tempdir = tempdir().expect("tempdir");
     let context = SendExecutionContext {
         command_config: None,
@@ -610,11 +567,7 @@ fn named_plan_builder_proves_payload_equality_across_harnesses() {
 #[test]
 #[serial_test::serial(env)]
 fn recovered_claude_harness_sqlite_failure_routes_via_non_claude_outbound() {
-    let runtime = TestRuntime::new(
-        Some("sqlite write failed"),
-        Some("append failed"),
-        DeliveryHarnessPath::ClaudeCode,
-    );
+    let runtime = TestRuntime::new(Some("sqlite write failed"), DeliveryHarnessPath::ClaudeCode);
     let observability = RecordingObservability::default();
     let tempdir = tempdir().expect("tempdir");
     let home_dir = tempdir.path().join("home");
@@ -723,11 +676,7 @@ fn assert_non_claude_sqlite_failure_observability(observability: &RecordingObser
 #[test]
 #[serial_test::serial(env)]
 fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_boundary() {
-    let runtime = TestRuntime::new(
-        Some("sqlite write failed"),
-        None,
-        DeliveryHarnessPath::NonClaude,
-    );
+    let runtime = TestRuntime::new(Some("sqlite write failed"), DeliveryHarnessPath::NonClaude);
     let observability = RecordingObservability::default();
     let tempdir = tempdir().expect("tempdir");
     let home_dir = tempdir.path().join("home");
@@ -751,7 +700,7 @@ fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_bound
 #[test]
 #[serial_test::serial(env)]
 fn send_claude_harness_success_delivers_original_via_outbound_boundary() {
-    let runtime = TestRuntime::new(None, None, DeliveryHarnessPath::ClaudeCode);
+    let runtime = TestRuntime::new(None, DeliveryHarnessPath::ClaudeCode);
     let observability = RecordingObservability::default();
     let tempdir = tempdir().expect("tempdir");
     let home_dir = tempdir.path().join("home");

--- a/crates/atm-core/src/service_runtime.rs
+++ b/crates/atm-core/src/service_runtime.rs
@@ -9,7 +9,6 @@ use std::time::Duration;
 
 use atm_storage::{MessageStore as SharedMessageStore, RosterStore as SharedRosterStore};
 
-use crate::boundary::ProjectionAppendMode;
 use crate::config::{self, AtmConfig};
 use crate::delivery_policy::DeliveryRecipientSnapshot;
 use crate::error::AtmError;
@@ -60,25 +59,6 @@ pub(crate) trait RetainedServiceRuntime: crate::boundary::sealed::Sealed {
         inbox_path: &Path,
         team: &TeamName,
         agent: &AgentName,
-    ) -> Result<(), AtmError>;
-    #[allow(
-        dead_code,
-        reason = "Phase AD obsolete: historical Claude mailbox compatibility only."
-    )]
-    fn append_compat_inbox_message(
-        &self,
-        inbox_path: &Path,
-        message: &InboxMessage,
-    ) -> Result<(), AtmError>;
-    #[allow(
-        dead_code,
-        reason = "Phase AD obsolete: historical Claude mailbox compatibility only."
-    )]
-    fn append_compat_inbox_message_set(
-        &self,
-        inbox_path: &Path,
-        mode: ProjectionAppendMode,
-        messages: &[InboxMessage],
     ) -> Result<(), AtmError>;
     fn deliver_non_claude_payloads(
         &self,
@@ -329,45 +309,6 @@ impl RetainedServiceRuntime for LocalServiceRuntime {
         crate::mailbox::export_compat_mailbox_projection(inbox_path, &messages)
     }
 
-    fn append_compat_inbox_message(
-        &self,
-        inbox_path: &Path,
-        message: &InboxMessage,
-    ) -> Result<(), AtmError> {
-        crate::mailbox::store::append_compat_mailbox_message(inbox_path, message).map_err(|error| {
-            if current_claude_inbox_requires_repair(inbox_path).unwrap_or(false) {
-                AtmError::validation(format!(
-                    "compatibility inbox {} is malformed or unsupported for the primary Claude delivery path",
-                    inbox_path.display()
-                ))
-                .with_recovery(
-                    "Run the explicit repair/rebuild inbox projection path before retrying normal Claude compatibility delivery; healthy current Claude inbox files should not require this path.",
-                )
-                .with_source(error)
-            } else {
-                error
-            }
-        })
-    }
-
-    fn append_compat_inbox_message_set(
-        &self,
-        inbox_path: &Path,
-        mode: ProjectionAppendMode,
-        messages: &[InboxMessage],
-    ) -> Result<(), AtmError> {
-        match mode {
-            ProjectionAppendMode::RecoveredLogicalMessageSet => {
-                let export_policy = crate::mailbox::store::export_policy_for_path(inbox_path)?;
-                crate::mailbox::store::append_compat_mailbox_message_set(
-                    inbox_path,
-                    export_policy,
-                    messages,
-                )
-            }
-        }
-    }
-
     fn load_roster_member(
         &self,
         team: &TeamName,
@@ -464,21 +405,6 @@ fn load_store_backed_mailbox_projection(
         messages.push(record.envelope);
     }
     Ok(messages)
-}
-
-#[allow(
-    dead_code,
-    reason = "Phase AD obsolete: historical Claude mailbox compatibility only."
-)]
-fn current_claude_inbox_requires_repair(path: &Path) -> Result<bool, AtmError> {
-    if !path.exists()
-        || crate::mailbox::store::inbox_file_format(path)
-            != crate::mailbox::store::InboxFileFormat::ClaudeJsonArray
-    {
-        return Ok(false);
-    }
-
-    Ok(crate::mailbox::load_compat_mailbox_messages_strict(path).is_err())
 }
 
 #[cfg(test)]
@@ -591,63 +517,6 @@ mod tests {
             .lines()
             .map(|line| serde_json::from_str(line).expect("notification event"))
             .collect()
-    }
-
-    #[test]
-    fn append_compat_inbox_message_accepts_current_claude_json_array_mailbox() {
-        let tempdir = tempdir().expect("tempdir");
-        let inbox_path = tempdir.path().join("recipient.json");
-        let first = message();
-        let second = message();
-        std::fs::write(
-            &inbox_path,
-            format!(
-                "{}\n",
-                serde_json::to_string_pretty(&vec![first.clone()]).expect("mailbox array")
-            ),
-        )
-        .expect("write mailbox");
-
-        let runtime = LocalServiceRuntime::new_with_delivery_boundaries(
-            Arc::new(NoopMessageStore),
-            Arc::new(NoopRosterStore),
-            Arc::new(LocalFileNonClaudeOutbound::new()),
-        );
-
-        runtime
-            .append_compat_inbox_message(&inbox_path, &second)
-            .expect("current Claude array path should succeed");
-
-        let raw = std::fs::read_to_string(&inbox_path).expect("mailbox contents");
-        let encoded: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("json array");
-        assert_eq!(encoded.len(), 2);
-        assert_eq!(encoded[0]["text"], serde_json::Value::String(first.text));
-        assert_eq!(encoded[1]["text"], serde_json::Value::String(second.text));
-    }
-
-    #[test]
-    fn append_compat_inbox_message_rejects_malformed_current_claude_json_array_mailbox() {
-        let tempdir = tempdir().expect("tempdir");
-        let inbox_path = tempdir.path().join("recipient.json");
-        std::fs::write(&inbox_path, "[{ not-json }\n").expect("write malformed mailbox");
-
-        let runtime = LocalServiceRuntime::new_with_delivery_boundaries(
-            Arc::new(NoopMessageStore),
-            Arc::new(NoopRosterStore),
-            Arc::new(LocalFileNonClaudeOutbound::new()),
-        );
-
-        let error = runtime
-            .append_compat_inbox_message(&inbox_path, &message())
-            .expect_err("malformed Claude array path must fail closed");
-        assert_eq!(error.code, AtmErrorCode::MessageValidationFailed);
-        assert!(
-            error
-                .recovery
-                .iter()
-                .any(|recovery| recovery.contains("explicit repair/rebuild inbox projection path")),
-            "unexpected recovery: {error:?}"
-        );
     }
 
     #[test]

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -376,7 +376,7 @@ Notes:
   - durable message persistence succeeds first
   - recipient-specific post-send emission happens directly through the accepted
     post-send emitter seam
-- retained notification logging, when enabled, appends directly to the
+  - retained notification logging, when enabled, appends directly to the
     notification log with no `NotificationSink` substitution
 - Non-Claude outbound payload delivery still uses the dedicated
   `NonClaudeOutbound` boundary rather than any notification surface.

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -376,10 +376,36 @@ Notes:
   - durable message persistence succeeds first
   - recipient-specific post-send emission happens directly through the accepted
     post-send emitter seam
-  - retained notification logging, when enabled, appends directly to the
+- retained notification logging, when enabled, appends directly to the
     notification log with no `NotificationSink` substitution
 - Non-Claude outbound payload delivery still uses the dedicated
   `NonClaudeOutbound` boundary rather than any notification surface.
+
+## ClaudeCompatibilityMailboxWriter
+
+Canonical machine-readable boundary source:
+- [../../boundaries/atm-core/claude-compatibility-mailbox-writer.toml](../../boundaries/atm-core/claude-compatibility-mailbox-writer.toml)
+
+Historical status:
+- retired from the accepted runtime by `AD.3`
+- any surviving references are historical boundary records only
+
+Purpose:
+- Historical boundary record only. Phase `AD.3` retired the
+  `ClaudeCompatibilityMailboxWriter` executor seam from the accepted send/ack
+  runtime.
+
+Notes:
+- The retired boundary remains documented only so historical plan/ADR
+  references still resolve.
+- The deleted seam previously owned:
+  - `execute_claude_delivery(...)`
+  - direct `append_claude_inbox_message(...)` / recovered message-set append
+    execution
+- Accepted send/ack delivery now routes through the retained
+  `NonClaudeOutbound` seam only.
+- Repair-only inbox rebuild/export support remains outside the live send/ack
+  executor and must not be treated as a surviving delivery boundary.
 
 ## NonClaudeOutbound
 


### PR DESCRIPTION
## Summary
- delete the dead Claude compatibility delivery executor and retained-runtime append seam from the live send/ack path
- keep repaired inbox projection support separate as an explicit rebuild-only path
- add a retired boundary record for the removed ClaudeCompatibilityMailboxWriter seam

## Validation
- just test
- cargo clippy --workspace --all-targets -- -D warnings
- python3 .just/run_lint.py all
- git diff --check