### PR TITLE
Phase AD PM: retire dead compat-mailbox append helpers

### DIFF
--- a/crates/atm-core/src/mailbox/atomic.rs
+++ b/crates/atm-core/src/mailbox/atomic.rs
@@ -62,6 +62,13 @@ where
     )
 }
 
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "JSONL append helper remains test-only after compat retirement"
+    )
+)]
 pub fn append_message(
     path: &Path,
     message: &InboxMessage,

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -1,10 +1,5 @@
 //! Mailbox read/write helpers, compatibility parsing, and lock-scoped mutation.
 
-#![allow(
-    dead_code,
-    reason = "AC.2 retains internal compatibility readers and salvage helpers while Claude storage ownership finishes moving below the trait line."
-)]
-
 pub(crate) mod atomic;
 pub(crate) mod hash;
 pub(crate) mod lock;
@@ -18,10 +13,7 @@ use std::path::Path;
 use tracing::warn;
 
 use crate::error::{AtmError, AtmErrorCode, AtmErrorKind};
-use crate::mailbox::source::SourceFile;
 use crate::schema::{AtmMessageId, InboxMessage};
-use crate::types::{AgentName, TeamName};
-
 const MAX_MAILBOX_READ_BYTES: u64 = 10 * 1024 * 1024;
 const DEGRADED_RAW_FRAGMENT_MAX_CHARS: usize = 512;
 
@@ -70,8 +62,7 @@ pub fn append_message(path: &Path, envelope: &InboxMessage) -> Result<(), AtmErr
 /// Lock, load, mutate, and atomically rewrite one mailbox file.
 ///
 /// Production mutation paths use equivalent lock coverage through
-/// `workflow::commit_workflow_state()` plus
-/// `mailbox::store::write_compat_source_projections()`.
+/// `workflow::commit_workflow_state()`.
 /// This helper stays test-only so unit tests can exercise the shared mailbox
 /// lock contract directly without the workflow/state sidecars required in
 /// production commands.
@@ -177,6 +168,13 @@ pub(crate) fn load_compat_mailbox_items(path: &Path) -> Result<Vec<InboxReadItem
     parse_mailbox_contents(&raw, path)
 }
 
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "strict mailbox compatibility reads remain test-only"
+    )
+)]
 pub(crate) fn load_compat_mailbox_messages_strict(
     path: &Path,
 ) -> Result<Vec<InboxMessage>, AtmError> {
@@ -222,20 +220,6 @@ pub(crate) fn load_compat_mailbox_messages_strict(
     parse_mailbox_contents_strict(&raw, path)
 }
 
-pub(crate) fn import_source_projections(
-    home_dir: &Path,
-    team: &TeamName,
-    agent: &AgentName,
-) -> Result<Vec<SourceFile>, AtmError> {
-    store::load_source_projections(home_dir, team, agent)
-}
-
-pub(crate) fn export_compat_source_projections(
-    source_files: &[SourceFile],
-) -> Result<(), AtmError> {
-    store::write_compat_source_projections(source_files)
-}
-
 pub(crate) fn export_compat_mailbox_projection(
     path: &Path,
     messages: &[InboxMessage],
@@ -252,6 +236,13 @@ fn parse_mailbox_contents(raw: &str, path: &Path) -> Result<Vec<InboxReadItem>, 
     }
 }
 
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "strict mailbox compatibility reads remain test-only"
+    )
+)]
 fn parse_mailbox_contents_strict(raw: &str, path: &Path) -> Result<Vec<InboxMessage>, AtmError> {
     match raw.chars().find(|ch| !ch.is_whitespace()) {
         None => Ok(Vec::new()),
@@ -277,6 +268,13 @@ fn parse_mailbox_array(raw: &str, path: &Path) -> Result<Vec<InboxReadItem>, Atm
     }
 }
 
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "strict mailbox compatibility reads remain test-only"
+    )
+)]
 fn parse_mailbox_array_strict(raw: &str, path: &Path) -> Result<Vec<InboxMessage>, AtmError> {
     let records = serde_json::from_str::<Vec<Value>>(raw).map_err(|error| {
         AtmError::new(

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -35,11 +35,8 @@ pub(crate) enum InboxReadItem {
     },
 }
 
-/// Append one message through the shared inbox compatibility writer.
+/// Append one message through the surviving mailbox projection rules.
 ///
-/// Production send flows use the same compatibility writer through the
-/// retained runtime boundary. Current Claude `.json` inboxes rewrite the array
-/// projection atomically; `.jsonl` compatibility files remain append-only.
 /// This helper stays test-only because production callers must also coordinate
 /// workflow persistence and delivery policy routing.
 ///
@@ -53,7 +50,21 @@ pub(crate) enum InboxReadItem {
 /// cannot be loaded, locked, or atomically replaced.
 #[cfg(test)]
 pub fn append_message(path: &Path, envelope: &InboxMessage) -> Result<(), AtmError> {
-    store::append_compat_mailbox_message(path, envelope)
+    let export_policy = store::export_policy_for_path(path)?;
+    if store::inbox_file_format(path) == store::InboxFileFormat::ClaudeJsonArray {
+        let existing_messages = if path.exists() {
+            load_compat_mailbox_messages_strict(path)?
+        } else {
+            Vec::new()
+        };
+        return atomic::write_message_iter(
+            path,
+            existing_messages.iter().chain(std::iter::once(envelope)),
+            export_policy,
+        );
+    }
+
+    atomic::append_message(path, envelope, export_policy)
 }
 
 /// Lock, load, mutate, and atomically rewrite one mailbox file.

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -1,16 +1,20 @@
 //! Mailbox owner-layer write boundaries for the Claude-owned inbox surface.
 
-use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::config;
 use crate::error::AtmError;
 use crate::mailbox::atomic;
-use crate::mailbox::source::{SourceFile, discover_source_paths, load_source_files};
 use crate::schema::InboxMessage;
 use crate::schema::inbox_message::SharedAppendPolicy;
-use crate::types::{AgentName, TeamName};
 
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "mailbox format detection remains test-only after compat retirement"
+    )
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InboxFileFormat {
     ClaudeJsonArray,
@@ -42,27 +46,6 @@ fn write_compat_mailbox_projection_with_policy(
     atomic::write_messages(path, messages, export_policy)
 }
 
-/// Write one already-loaded multi-source compatibility inbox projection set.
-pub(crate) fn write_compat_source_projections(source_files: &[SourceFile]) -> Result<(), AtmError> {
-    let mut export_policy_by_dir = BTreeMap::<PathBuf, SharedAppendPolicy>::new();
-    for source in source_files {
-        let config_dir = source
-            .path
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .to_path_buf();
-        let export_policy = if let Some(policy) = export_policy_by_dir.get(&config_dir).copied() {
-            policy
-        } else {
-            let policy = export_policy_for_path(&source.path)?;
-            export_policy_by_dir.insert(config_dir, policy);
-            policy
-        };
-        write_compat_mailbox_projection_with_policy(&source.path, &source.messages, export_policy)?;
-    }
-    Ok(())
-}
-
 pub(crate) fn export_policy_for_path(path: &Path) -> Result<SharedAppendPolicy, AtmError> {
     let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
     let atm_authored_body_export_max_bytes = config::load_config(config_dir)?
@@ -73,6 +56,13 @@ pub(crate) fn export_policy_for_path(path: &Path) -> Result<SharedAppendPolicy, 
     })
 }
 
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "mailbox format detection remains test-only after compat retirement"
+    )
+)]
 pub(crate) fn inbox_file_format(path: &Path) -> InboxFileFormat {
     path.extension()
         .and_then(|value| value.to_str())
@@ -88,23 +78,12 @@ pub(crate) fn inbox_file_format(path: &Path) -> InboxFileFormat {
         .unwrap_or(InboxFileFormat::Other)
 }
 
-/// Load the current inbox projection set without mailbox locks.
-pub(crate) fn load_source_projections(
-    home_dir: &Path,
-    team: &TeamName,
-    agent: &AgentName,
-) -> Result<Vec<SourceFile>, AtmError> {
-    let source_paths = discover_source_paths(home_dir, team, agent)?;
-    load_source_files(&source_paths)
-}
-
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
 
-    use super::{write_compat_mailbox_projection, write_compat_source_projections};
+    use super::write_compat_mailbox_projection;
     use crate::mailbox::load_compat_mailbox_messages;
-    use crate::mailbox::source::SourceFile;
     use crate::schema::{AtmMessageId, InboxMessage};
     use crate::test_support::{TEST_QA, TEST_SENDER};
     use crate::types::{AgentName, IsoTimestamp};
@@ -168,73 +147,6 @@ mod tests {
             encoded[0]["summary"],
             serde_json::Value::String("stub summary".into())
         );
-    }
-
-    #[test]
-    fn write_compat_source_projections_commits_each_source_path() {
-        let tempdir = tempdir().expect("tempdir");
-        let left_path = tempdir.path().join(format!("{TEST_SENDER}.json"));
-        let right_path = tempdir.path().join(format!("{TEST_QA}.json"));
-        let left_messages = vec![sample_message(TEST_SENDER, "left message")];
-        let right_messages = vec![
-            sample_message(TEST_SENDER, "right first"),
-            sample_message(TEST_QA, "right second"),
-        ];
-
-        write_compat_source_projections(&[
-            SourceFile {
-                path: left_path.clone(),
-                messages: left_messages.clone(),
-            },
-            SourceFile {
-                path: right_path.clone(),
-                messages: right_messages.clone(),
-            },
-        ])
-        .expect("commit source files");
-
-        let left = load_compat_mailbox_messages(&left_path).expect("left inbox");
-        let right = load_compat_mailbox_messages(&right_path).expect("right inbox");
-        assert_eq!(left.len(), left_messages.len());
-        assert_eq!(right.len(), right_messages.len());
-        assert_eq!(left[0].text, left_messages[0].text);
-        assert_eq!(right[0].text, right_messages[0].text);
-        assert_eq!(right[1].text, right_messages[1].text);
-        assert!(left.iter().all(|message| message.source_team.is_none()));
-        assert!(right.iter().all(|message| message.source_team.is_none()));
-    }
-
-    #[test]
-    fn write_compat_source_projections_stops_after_first_write_error() {
-        let tempdir = tempdir().expect("tempdir");
-        let first_path = tempdir.path().join("first.json");
-        let invalid_path = tempdir.path().to_path_buf();
-        let later_path = tempdir.path().join("later.json");
-
-        let error = write_compat_source_projections(&[
-            SourceFile {
-                path: first_path.clone(),
-                messages: vec![sample_message(TEST_SENDER, "first")],
-            },
-            SourceFile {
-                path: invalid_path,
-                messages: vec![sample_message(TEST_QA, "broken")],
-            },
-            SourceFile {
-                path: later_path.clone(),
-                messages: vec![sample_message(TEST_SENDER, "later")],
-            },
-        ])
-        .expect_err("write failure");
-
-        assert!(error.is_mailbox_write());
-        assert_eq!(
-            load_compat_mailbox_messages(&first_path)
-                .expect("first inbox")
-                .len(),
-            1
-        );
-        assert!(!later_path.exists());
     }
 
     fn sample_message(from: &str, text: &str) -> InboxMessage {

--- a/crates/atm-core/src/mailbox/store.rs
+++ b/crates/atm-core/src/mailbox/store.rs
@@ -1,10 +1,5 @@
 //! Mailbox owner-layer write boundaries for the Claude-owned inbox surface.
 
-#![allow(
-    dead_code,
-    reason = "Phase AD obsolete: retained only for historical Claude compatibility projection paths until the later deletion sprint removes the remaining helpers."
-)]
-
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -15,10 +10,6 @@ use crate::mailbox::source::{SourceFile, discover_source_paths, load_source_file
 use crate::schema::InboxMessage;
 use crate::schema::inbox_message::SharedAppendPolicy;
 use crate::types::{AgentName, TeamName};
-
-const MAX_RECOVERED_MESSAGE_SET_COUNT: usize = 2;
-const MAX_RECOVERED_MESSAGE_SET_BYTES: usize = 1024 * 1024;
-const MAX_COMPAT_MAILBOX_FILE_BYTES: u64 = 8 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InboxFileFormat {
@@ -40,45 +31,6 @@ pub(crate) fn write_compat_mailbox_projection(
 ) -> Result<(), AtmError> {
     let export_policy = export_policy_for_path(path)?;
     write_compat_mailbox_projection_with_policy(path, messages, export_policy)
-}
-
-pub(crate) fn append_compat_mailbox_message(
-    path: &Path,
-    message: &InboxMessage,
-) -> Result<(), AtmError> {
-    let export_policy = export_policy_for_path(path)?;
-    if inbox_file_format(path) == InboxFileFormat::ClaudeJsonArray {
-        let existing_messages = if path.exists() {
-            crate::mailbox::load_compat_mailbox_messages_strict(path)?
-        } else {
-            Vec::new()
-        };
-        return atomic::write_message_iter(
-            path,
-            existing_messages.iter().chain(std::iter::once(message)),
-            export_policy,
-        );
-    }
-
-    atomic::append_message(path, message, export_policy)
-}
-
-/// Recovered-delivery only — atomically materializes one logical message set
-/// after loading the existing compatibility inbox projection.
-pub(crate) fn append_compat_mailbox_message_set(
-    path: &Path,
-    export_policy: SharedAppendPolicy,
-    messages: &[InboxMessage],
-) -> Result<(), AtmError> {
-    validate_recovered_message_set(messages)?;
-    validate_compat_mailbox_file_size(path)?;
-    let mut existing_messages = if path.exists() {
-        crate::mailbox::load_compat_mailbox_messages_strict(path)?
-    } else {
-        Vec::new()
-    };
-    existing_messages.extend(messages.iter().cloned());
-    write_compat_mailbox_projection_with_policy(path, &existing_messages, export_policy)
 }
 
 /// Repair/rebuild only — not reachable from normal runtime send or ack paths.
@@ -136,56 +88,6 @@ pub(crate) fn inbox_file_format(path: &Path) -> InboxFileFormat {
         .unwrap_or(InboxFileFormat::Other)
 }
 
-fn validate_recovered_message_set(messages: &[InboxMessage]) -> Result<(), AtmError> {
-    if messages.len() > MAX_RECOVERED_MESSAGE_SET_COUNT {
-        return Err(AtmError::new_with_code(
-            crate::error_codes::AtmErrorCode::MailboxRecoveredMessageSetTooLarge,
-            crate::error::AtmErrorKind::Validation,
-            format!(
-                "recovered Claude logical message set exceeded {MAX_RECOVERED_MESSAGE_SET_COUNT} messages"
-            ),
-        )
-        .with_recovery(
-            "Keep recovered Claude compatibility delivery to the original message plus one optional companion error message before retrying.",
-        ));
-    }
-
-    let encoded = serde_json::to_vec(messages).map_err(|error| {
-        AtmError::mailbox_write("failed to measure recovered Claude logical message set size")
-            .with_source(error)
-    })?;
-    if encoded.len() > MAX_RECOVERED_MESSAGE_SET_BYTES {
-        return Err(AtmError::new_with_code(
-            crate::error_codes::AtmErrorCode::MailboxRecoveredMessageSetTooLarge,
-            crate::error::AtmErrorKind::Validation,
-            format!(
-                "recovered Claude logical message set exceeded {MAX_RECOVERED_MESSAGE_SET_BYTES} bytes"
-            ),
-        )
-        .with_recovery(
-            "Reduce the recovered Claude message bodies or attachments before retrying compatibility export.",
-        ));
-    }
-
-    Ok(())
-}
-
-fn validate_compat_mailbox_file_size(path: &Path) -> Result<(), AtmError> {
-    let Ok(metadata) = std::fs::metadata(path) else {
-        return Ok(());
-    };
-    if metadata.len() > MAX_COMPAT_MAILBOX_FILE_BYTES {
-        return Err(AtmError::mailbox_read(format!(
-            "compatibility inbox {} exceeded the {MAX_COMPAT_MAILBOX_FILE_BYTES}-byte recovered export ceiling",
-            path.display()
-        ))
-        .with_recovery(
-            "Run the explicit repair/rebuild inbox projection path or reduce retained inbox size before retrying recovered Claude compatibility delivery.",
-        ));
-    }
-    Ok(())
-}
-
 /// Load the current inbox projection set without mailbox locks.
 pub(crate) fn load_source_projections(
     home_dir: &Path,
@@ -200,13 +102,9 @@ pub(crate) fn load_source_projections(
 mod tests {
     use tempfile::tempdir;
 
-    use super::{
-        append_compat_mailbox_message, append_compat_mailbox_message_set,
-        write_compat_mailbox_projection, write_compat_source_projections,
-    };
+    use super::{write_compat_mailbox_projection, write_compat_source_projections};
     use crate::mailbox::load_compat_mailbox_messages;
     use crate::mailbox::source::SourceFile;
-    use crate::schema::inbox_message::SharedAppendPolicy;
     use crate::schema::{AtmMessageId, InboxMessage};
     use crate::test_support::{TEST_QA, TEST_SENDER};
     use crate::types::{AgentName, IsoTimestamp};
@@ -270,130 +168,6 @@ mod tests {
             encoded[0]["summary"],
             serde_json::Value::String("stub summary".into())
         );
-    }
-
-    #[test]
-    fn append_compat_mailbox_message_writes_jsonl_records() {
-        let tempdir = tempdir().expect("tempdir");
-        let path = tempdir.path().join(format!("{TEST_SENDER}.jsonl"));
-        let first = sample_message(TEST_SENDER, "first line");
-        let second = sample_message(TEST_QA, "second line");
-
-        append_compat_mailbox_message(&path, &first).expect("append first");
-        append_compat_mailbox_message(&path, &second).expect("append second");
-
-        let raw = std::fs::read_to_string(&path).expect("mailbox contents");
-        assert_eq!(raw.lines().count(), 2);
-        let read_back = load_compat_mailbox_messages(&path).expect("read mailbox");
-        assert_eq!(read_back.len(), 2);
-        assert_eq!(read_back[0].text, first.text);
-        assert_eq!(read_back[1].text, second.text);
-    }
-
-    #[test]
-    fn append_compat_mailbox_message_creates_current_claude_json_array_mailbox() {
-        let tempdir = tempdir().expect("tempdir");
-        let path = tempdir.path().join(format!("{TEST_SENDER}.json"));
-        let first = sample_message(TEST_SENDER, "first array entry");
-
-        append_compat_mailbox_message(&path, &first).expect("append first");
-
-        let raw = std::fs::read_to_string(&path).expect("mailbox contents");
-        let encoded: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("json array");
-        assert_eq!(encoded.len(), 1);
-        assert_eq!(
-            encoded[0]["text"],
-            serde_json::Value::String(first.text.clone())
-        );
-        let read_back = load_compat_mailbox_messages(&path).expect("read mailbox");
-        assert_eq!(read_back.len(), 1);
-        assert_eq!(read_back[0].text, first.text);
-    }
-
-    #[test]
-    fn append_compat_mailbox_message_rewrites_current_claude_json_array_mailbox() {
-        let tempdir = tempdir().expect("tempdir");
-        let path = tempdir.path().join(format!("{TEST_SENDER}.json"));
-        let first = sample_message(TEST_SENDER, "first array entry");
-        let second = sample_message(TEST_QA, "second array entry");
-
-        write_compat_mailbox_projection(&path, std::slice::from_ref(&first))
-            .expect("seed array mailbox");
-        append_compat_mailbox_message(&path, &second).expect("append second");
-
-        let raw = std::fs::read_to_string(&path).expect("mailbox contents");
-        let encoded: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("json array");
-        assert_eq!(encoded.len(), 2);
-        let read_back = load_compat_mailbox_messages(&path).expect("read mailbox");
-        assert_eq!(read_back.len(), 2);
-        assert_eq!(read_back[0].text, first.text);
-        assert_eq!(read_back[1].text, second.text);
-    }
-
-    #[test]
-    fn append_compat_mailbox_message_exports_retrieval_stub_when_config_cap_is_zero() {
-        let tempdir = tempdir().expect("tempdir");
-        std::fs::write(
-            tempdir.path().join(".atm.toml"),
-            "[atm]\nclaude_jsonl_body_export_max_bytes = 0\n",
-        )
-        .expect("config");
-        let path = tempdir.path().join(format!("{TEST_SENDER}.jsonl"));
-        let mut message = sample_message(TEST_SENDER, "full body retained elsewhere");
-        let message_id = message.message_id.expect("message id");
-        message.summary = Some("stub summary".to_string());
-
-        append_compat_mailbox_message(&path, &message).expect("append message");
-
-        let raw = std::fs::read_to_string(&path).expect("mailbox contents");
-        let first_line = raw.lines().next().expect("jsonl record");
-        let encoded: serde_json::Value = serde_json::from_str(first_line).expect("json object");
-        assert_eq!(
-            encoded["text"],
-            serde_json::Value::String(format!("atm read --message-id {message_id}"))
-        );
-        assert_eq!(
-            encoded["summary"],
-            serde_json::Value::String("stub summary".into())
-        );
-    }
-
-    #[test]
-    fn append_compat_mailbox_message_set_appends_existing_messages_atomically() {
-        let tempdir = tempdir().expect("tempdir");
-        let path = tempdir.path().join(format!("{TEST_SENDER}.jsonl"));
-        let existing = sample_message(TEST_SENDER, "existing");
-        let appended = [
-            sample_message(TEST_QA, "new first"),
-            sample_message(TEST_SENDER, "new second"),
-        ];
-        let export_policy = SharedAppendPolicy::default();
-
-        append_compat_mailbox_message(&path, &existing).expect("seed existing");
-        append_compat_mailbox_message_set(&path, export_policy, &appended).expect("append set");
-
-        let read_back = load_compat_mailbox_messages(&path).expect("read mailbox");
-        assert_eq!(read_back.len(), 3);
-        assert_eq!(read_back[0].text, existing.text);
-        assert_eq!(read_back[1].text, appended[0].text);
-        assert_eq!(read_back[2].text, appended[1].text);
-    }
-
-    #[test]
-    fn append_compat_mailbox_message_set_rejects_more_than_two_messages() {
-        let tempdir = tempdir().expect("tempdir");
-        let path = tempdir.path().join(format!("{TEST_SENDER}.jsonl"));
-        let appended = [
-            sample_message(TEST_QA, "new first"),
-            sample_message(TEST_SENDER, "new second"),
-            sample_message(TEST_QA, "new third"),
-        ];
-
-        let error =
-            append_compat_mailbox_message_set(&path, SharedAppendPolicy::default(), &appended)
-                .expect_err("reject oversized recovered message set");
-        assert!(error.is_validation());
-        assert!(error.message.contains("exceeded 2 messages"));
     }
 
     #[test]

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -156,7 +156,6 @@ const fn error_kind_for_code(code: AtmErrorCode) -> AtmErrorKind {
         | AtmErrorCode::PostSendAdvisoryDeliveryFailed => AtmErrorKind::DaemonUnavailable,
         AtmErrorCode::ObservabilityBootstrapFailed => AtmErrorKind::ObservabilityBootstrap,
         AtmErrorCode::MessageValidationFailed
-        | AtmErrorCode::MailboxRecoveredMessageSetTooLarge
         | AtmErrorCode::HelpTopicNotFound
         | AtmErrorCode::AckInvalidState
         | AtmErrorCode::ClearInvalidState

--- a/crates/atm-storage/src/error_codes.rs
+++ b/crates/atm-storage/src/error_codes.rs
@@ -46,7 +46,6 @@ pub enum AtmErrorCode {
     TeamNotFound,
     AgentNotFound,
     MailboxReadFailed,
-    MailboxRecoveredMessageSetTooLarge,
     MailboxWriteFailed,
     MailboxLockFailed,
     MailboxLockReadOnlyFilesystem,
@@ -154,9 +153,6 @@ impl AtmErrorCode {
     fn mailbox_or_validation_str(self) -> Option<&'static str> {
         Some(match self {
             Self::MailboxReadFailed => "ATM_MAILBOX_READ_FAILED",
-            Self::MailboxRecoveredMessageSetTooLarge => {
-                "ATM_MAILBOX_RECOVERED_MESSAGE_SET_TOO_LARGE"
-            }
             Self::MailboxWriteFailed => "ATM_MAILBOX_WRITE_FAILED",
             Self::MailboxLockFailed => "ATM_MAILBOX_LOCK_FAILED",
             Self::MailboxLockReadOnlyFilesystem => "ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM",
@@ -278,9 +274,6 @@ fn parse_daemon_or_address_code(value: &str) -> Option<AtmErrorCode> {
 fn parse_mailbox_or_validation_code(value: &str) -> Option<AtmErrorCode> {
     Some(match value {
         "ATM_MAILBOX_READ_FAILED" => AtmErrorCode::MailboxReadFailed,
-        "ATM_MAILBOX_RECOVERED_MESSAGE_SET_TOO_LARGE" => {
-            AtmErrorCode::MailboxRecoveredMessageSetTooLarge
-        }
         "ATM_MAILBOX_WRITE_FAILED" => AtmErrorCode::MailboxWriteFailed,
         "ATM_MAILBOX_LOCK_FAILED" => AtmErrorCode::MailboxLockFailed,
         "ATM_MAILBOX_LOCK_READ_ONLY_FILESYSTEM" => AtmErrorCode::MailboxLockReadOnlyFilesystem,

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -89,7 +89,6 @@ fn exit_code_for_atm_error(error: &AtmError) -> i32 {
         | AtmErrorCode::AgentNotFound
         | AtmErrorCode::MessageValidationFailed
         | AtmErrorCode::CallerContextRequestInvalid
-        | AtmErrorCode::MailboxRecoveredMessageSetTooLarge
         | AtmErrorCode::AckInvalidState
         | AtmErrorCode::ClearInvalidState
         | AtmErrorCode::HelpTopicNotFound


### PR DESCRIPTION
## Summary
- Follow-up postmortem cleanup (ARCH-AD-PM-003): removes dead `append_compat_mailbox_message`/`append_compat_mailbox_message_set` helpers from `crates/atm-core/src/mailbox/store.rs`, drops the obsolete module-level `dead_code` suppression, deletes tests that only exercised the retired seam, and keeps mailbox test seeding local to `crates/atm-core/src/mailbox/mod.rs` instead of retaining the retired compatibility boundary API.
- Branch previously merged once as PR #467 (retiring the executor path); this is a new commit (a7215062) landed on the same branch after that merge, requiring a fresh PR.

## Test plan
- [x] git diff --check
- [x] python3 .just/run_lint.py all
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] just test