### PR TITLE
AD.13: ULID Message Identity Reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
  "tempfile",
  "toml",
  "tracing",
- "uuid",
+ "ulid",
  "windows-sys 0.59.0",
 ]
 
@@ -116,9 +116,9 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -216,7 +216,6 @@ dependencies = [
  "serde_json",
  "toml",
  "ulid",
- "uuid",
 ]
 
 [[package]]
@@ -240,33 +239,33 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -297,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -313,9 +312,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -383,7 +382,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -498,15 +496,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -520,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -564,21 +560,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -608,11 +596,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -621,12 +610,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -662,15 +645,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "nu-ansi-term"
@@ -683,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -759,16 +742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -945,25 +918,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -1007,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1029,24 +987,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1064,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1096,9 +1053,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -1108,9 +1065,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1124,7 +1081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1161,12 +1118,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1176,15 +1132,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1306,28 +1262,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
-dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "valuable"
@@ -1343,27 +1281,18 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1374,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1384,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1397,45 +1326,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1637,112 +1532,24 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ serde_json = "1.0"
 anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-uuid = { version = "1", features = ["serde", "v4"] }
 cargo_metadata = "0.23"
 sc-observability = "1.2.0"
 sc-observability-types = "1.2.0"
 arc-swap = "1.7"
+ulid = { version = "1.2.1", features = ["serde"] }

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -28,11 +28,11 @@ interprocess = "2.4.2"
 libc = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"
-uuid.workspace = true
 fs2 = "0.4"
 same-file = "1"
 sc-observability-types.workspace = true
 parking_lot = "0.12"
+ulid.workspace = true
 
 [dev-dependencies]
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }

--- a/crates/atm-core/src/mailbox/mod.rs
+++ b/crates/atm-core/src/mailbox/mod.rs
@@ -390,7 +390,7 @@ fn sanitize_message_id(value: &mut Value, path: &Path, line_number: usize) {
             mailbox_path = %path.display(),
             line = line_number,
             field = "message_id",
-            expected_format = "ULID or UUID wire string",
+            expected_format = "ULID string",
             raw_value = %raw_message_id,
             "treating malformed ATM-owned field as absent during mailbox read"
         );
@@ -580,9 +580,8 @@ mod tests {
 
     use chrono::{TimeZone, Utc};
     use tempfile::TempDir;
-    use uuid::Uuid;
 
-    use crate::schema::InboxMessage;
+    use crate::schema::{AtmMessageId, InboxMessage};
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::{AgentName, IsoTimestamp, TeamName};
 
@@ -596,7 +595,7 @@ mod tests {
     fn append_message_persists_one_jsonl_record() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("append-message.jsonl");
-        let envelope = sample_message(Uuid::new_v4(), "first");
+        let envelope = sample_message(AtmMessageId::new(), "first");
 
         append_message(&path, &envelope).expect("append");
 
@@ -613,7 +612,7 @@ mod tests {
     fn append_message_keeps_approved_machine_fields_top_level() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("append-message-top-level.jsonl");
-        let envelope = sample_message(Uuid::new_v4(), "first");
+        let envelope = sample_message(AtmMessageId::new(), "first");
 
         append_message(&path, &envelope).expect("append");
 
@@ -629,13 +628,13 @@ mod tests {
     fn locked_read_modify_write_reads_mutates_and_rewrites_under_lock() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("locked-rmw.json");
-        let first = sample_message(Uuid::new_v4(), "first");
+        let first = sample_message(AtmMessageId::new(), "first");
         append_message(&path, &first).expect("seed");
 
         locked_read_modify_write(&path, lock::DEFAULT_LOCK_TIMEOUT, |messages| {
             assert_eq!(messages.len(), 1);
             messages[0].read = true;
-            messages.push(sample_message(Uuid::new_v4(), "second"));
+            messages.push(sample_message(AtmMessageId::new(), "second"));
             Ok(())
         })
         .expect("locked read modify write");
@@ -652,7 +651,7 @@ mod tests {
         let path = tempdir.path().join("append-removes-lock.jsonl");
 
         assert!(!lock::sentinel_path(&path).exists());
-        append_message(&path, &sample_message(Uuid::new_v4(), "first")).expect("append");
+        append_message(&path, &sample_message(AtmMessageId::new(), "first")).expect("append");
 
         assert!(!lock::sentinel_path(&path).exists());
     }
@@ -663,7 +662,7 @@ mod tests {
         let path = tempdir.path().join("append-cleans-stale-lock.jsonl");
         fs::write(lock::sentinel_path(&path), u32::MAX.to_string()).expect("stale lock");
 
-        append_message(&path, &sample_message(Uuid::new_v4(), "first")).expect("append");
+        append_message(&path, &sample_message(AtmMessageId::new(), "first")).expect("append");
 
         assert!(lock::sentinel_path(&path).exists());
     }
@@ -672,8 +671,8 @@ mod tests {
     fn load_compat_mailbox_messages_skips_malformed_lines() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("skip-malformed.jsonl");
-        let valid =
-            serde_json::to_string(&sample_message(Uuid::new_v4(), "valid")).expect("valid json");
+        let valid = serde_json::to_string(&sample_message(AtmMessageId::new(), "valid"))
+            .expect("valid json");
         fs::write(&path, format!("{valid}\n{{not-json}}\n")).expect("write");
 
         let messages = load_compat_mailbox_messages(&path).expect("read");
@@ -685,8 +684,8 @@ mod tests {
     fn load_compat_mailbox_items_reports_malformed_jsonl_lines_without_hiding_valid_messages() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("jsonl-degraded-items.jsonl");
-        let valid =
-            serde_json::to_string(&sample_message(Uuid::new_v4(), "valid")).expect("valid json");
+        let valid = serde_json::to_string(&sample_message(AtmMessageId::new(), "valid"))
+            .expect("valid json");
         fs::write(&path, format!("{valid}\n{{not-json}}\n")).expect("write");
 
         let items = load_compat_mailbox_items(&path).expect("read items");
@@ -704,8 +703,8 @@ mod tests {
     fn read_messages_jsonl_format_still_works() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("jsonl-ingress-still-works.jsonl");
-        let first = sample_message(Uuid::new_v4(), "first");
-        let second = sample_message(Uuid::new_v4(), "second");
+        let first = sample_message(AtmMessageId::new(), "first");
+        let second = sample_message(AtmMessageId::new(), "second");
         let contents = format!(
             "{}\n{}\n",
             serde_json::to_string(&first).expect("json"),
@@ -721,8 +720,8 @@ mod tests {
     fn append_message_appends_after_existing_jsonl_record() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("jsonl-appends-second-record.jsonl");
-        let first = sample_message(Uuid::new_v4(), "first");
-        let second = sample_message(Uuid::new_v4(), "second");
+        let first = sample_message(AtmMessageId::new(), "first");
+        let second = sample_message(AtmMessageId::new(), "second");
         fs::write(
             &path,
             format!("{}\n", serde_json::to_string(&first).expect("json line")),
@@ -766,7 +765,7 @@ mod tests {
     fn load_compat_mailbox_messages_preserves_duplicate_message_ids_for_surface_canonicalization() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("dedupe.jsonl");
-        let message_id = Uuid::new_v4();
+        let message_id = AtmMessageId::new();
         let first = sample_message(message_id, "first");
         let mut second = sample_message(message_id, "second");
         second.timestamp = IsoTimestamp::from_datetime(
@@ -835,7 +834,7 @@ mod tests {
     fn load_compat_mailbox_messages_supports_json_array_mailboxes_with_atm_fields() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("array-with-atm-fields.json");
-        let message = sample_message(Uuid::new_v4(), "array with id");
+        let message = sample_message(AtmMessageId::new(), "array with id");
         fs::write(
             &path,
             serde_json::to_vec(&vec![message.clone()]).expect("json"),
@@ -850,8 +849,10 @@ mod tests {
     fn load_compat_mailbox_items_salvages_valid_messages_around_malformed_array_fragment() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("array-salvage-middle.json");
-        let first = serde_json::to_string(&sample_message(Uuid::new_v4(), "first")).expect("json");
-        let third = serde_json::to_string(&sample_message(Uuid::new_v4(), "third")).expect("json");
+        let first =
+            serde_json::to_string(&sample_message(AtmMessageId::new(), "first")).expect("json");
+        let third =
+            serde_json::to_string(&sample_message(AtmMessageId::new(), "third")).expect("json");
         fs::write(&path, format!("[{first}, {{not-json}}, {third}]")).expect("write");
 
         let items = load_compat_mailbox_items(&path).expect("read items");
@@ -875,7 +876,8 @@ mod tests {
     fn load_compat_mailbox_items_salvages_valid_messages_before_truncated_array_tail() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir.path().join("array-salvage-tail.json");
-        let first = serde_json::to_string(&sample_message(Uuid::new_v4(), "first")).expect("json");
+        let first =
+            serde_json::to_string(&sample_message(AtmMessageId::new(), "first")).expect("json");
         fs::write(&path, format!("[{first}, {{\"from\":\"broken\"")).expect("write");
 
         let items = load_compat_mailbox_items(&path).expect("read items");
@@ -908,7 +910,7 @@ mod tests {
             "timestamp": "2026-03-30T00:00:00Z",
             "read": false,
             "summary": "hello",
-            "message_id": "11111111-1111-4111-8111-111111111111",
+            "message_id": "01KRFK5QTF2R6NRS3Q0F8Z9K0S",
             "source_team": TEST_TEAM,
             "pendingAckAt": "2026-03-30T00:00:01Z",
             "taskId": "TASK-123"
@@ -972,7 +974,7 @@ mod tests {
             let path = path.clone();
             let barrier = Arc::clone(&barrier);
             handles.push(thread::spawn(move || {
-                let envelope = sample_message(Uuid::new_v4(), body);
+                let envelope = sample_message(AtmMessageId::new(), body);
                 barrier.wait();
                 append_message(&path, &envelope).expect("append");
             }));
@@ -989,9 +991,7 @@ mod tests {
         assert!(messages.iter().any(|message| message.text == "second"));
     }
 
-    fn sample_message(message_id: Uuid, body: &str) -> InboxMessage {
-        let atm_message_id = crate::schema::AtmMessageId::from(message_id);
-
+    fn sample_message(message_id: AtmMessageId, body: &str) -> InboxMessage {
         InboxMessage {
             from: TEST_SENDER.parse::<AgentName>().expect("agent"),
             text: body.into(),
@@ -1003,7 +1003,7 @@ mod tests {
             read: false,
             source_team: Some(TEST_TEAM.parse::<TeamName>().expect("team")),
             summary: None,
-            message_id: Some(atm_message_id),
+            message_id: Some(message_id),
             pending_ack_at: None,
             acknowledged_at: None,
             acknowledges_message_id: None,

--- a/crates/atm-core/src/persistence.rs
+++ b/crates/atm-core/src/persistence.rs
@@ -1,9 +1,9 @@
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use ulid::Ulid;
 
 use crate::error::{AtmError, AtmErrorKind};
-use uuid::Uuid;
 
 /// Atomically replace one shared mutable ATM-owned state file.
 ///
@@ -92,7 +92,7 @@ fn temp_path_for_atomic_write(path: &Path, label: &str) -> PathBuf {
             .and_then(|name| name.to_str())
             .unwrap_or(label),
         std::process::id(),
-        Uuid::new_v4()
+        Ulid::new()
     ))
 }
 

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -83,7 +83,7 @@ impl ReadQuery {
                     value.parse::<AtmMessageId>().map_err(|source| {
                         AtmError::validation(format!("invalid message id: {value}"))
                             .with_recovery(
-                                "Provide a valid UUID-formatted --message-id before retrying `atm read`.",
+                                "Provide a valid ULID-formatted --message-id before retrying `atm read`.",
                             )
                             .with_source(source)
                     })

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -261,30 +261,10 @@ mod tests {
     }
 
     #[test]
-    fn atm_message_id_parses_from_uuid_wire_string() {
-        let parsed: AtmMessageId = "11111111-1111-4111-8111-111111111111"
-            .parse()
-            .expect("parse uuid wire id");
-        assert_eq!(
-            parsed.into_uuid_wire().to_string(),
-            "11111111-1111-4111-8111-111111111111"
-        );
-    }
-
-    #[test]
     fn atm_message_id_parses_from_ulid_string() {
         let (message_id, _) = AtmMessageId::new_with_timestamp();
         let parsed: AtmMessageId = message_id.to_string().parse().expect("parse atm id");
         assert_eq!(parsed, message_id);
-    }
-
-    #[test]
-    fn atm_message_id_uuid_wire_round_trip_preserves_identity() {
-        let message_id: AtmMessageId = "01KRFK5QTF2R6NRS3Q0F8Z9K0S".parse().expect("parse atm id");
-
-        let round_trip = AtmMessageId::from_uuid_wire(message_id.into_uuid_wire());
-
-        assert_eq!(round_trip, message_id);
     }
 
     #[test]
@@ -479,10 +459,7 @@ mod tests {
             json!(format!("atm read --message-id {message_id}"))
         );
         assert_eq!(encoded["summary"], json!("oversized"));
-        assert_eq!(
-            encoded["message_id"],
-            json!(message_id.into_uuid_wire().to_string())
-        );
+        assert_eq!(encoded["message_id"], json!(message_id.to_string()));
     }
 
     #[test]

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -27,7 +27,6 @@ use chrono::Utc;
 #[cfg(unix)]
 use fs2::FileExt;
 use tempfile::TempDir;
-use uuid::Uuid;
 
 // Test-side ceiling guard only; production lock timeout defaults to 5s per
 // architecture §18.3.
@@ -141,7 +140,7 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
         &[read_message(
             SECONDARY_AGENT,
             "clearable history entry",
-            AtmMessageId::from(Uuid::new_v4()),
+            AtmMessageId::new(),
         )],
     );
     let barrier = Arc::new(Barrier::new(3));
@@ -195,7 +194,7 @@ fn concurrent_send_with_ack_and_clear_completes_without_deadlock_or_data_loss() 
     );
     drop(clear_fixture);
     let ack_fixture = Fixture::new();
-    let pending_message_id = AtmMessageId::from(Uuid::new_v4());
+    let pending_message_id = AtmMessageId::new();
     ack_fixture.write_primary_inbox(
         PRIMARY_AGENT,
         &[pending_ack_message(
@@ -529,7 +528,7 @@ fn multi_source_read_and_clear_complete_without_deadlock() {
         &[unread_message(
             TEAM_LEAD,
             "primary unread",
-            AtmMessageId::from(Uuid::new_v4()),
+            AtmMessageId::new(),
         )],
     );
     fixture.write_origin_inbox(
@@ -538,7 +537,7 @@ fn multi_source_read_and_clear_complete_without_deadlock() {
         &[unread_message(
             SECONDARY_AGENT,
             "origin unread b",
-            AtmMessageId::from(Uuid::new_v4()),
+            AtmMessageId::new(),
         )],
     );
     fixture.write_origin_inbox(
@@ -547,7 +546,7 @@ fn multi_source_read_and_clear_complete_without_deadlock() {
         &[read_message(
             SECONDARY_AGENT,
             "origin read a",
-            AtmMessageId::from(Uuid::new_v4()),
+            AtmMessageId::new(),
         )],
     );
 
@@ -635,7 +634,7 @@ fn clear_dry_run_does_not_wait_on_mailbox_lock() {
         &[unread_message(
             TEAM_LEAD,
             "read without lock",
-            AtmMessageId::from(Uuid::new_v4()),
+            AtmMessageId::new(),
         )],
     );
     let lock_path = sentinel_path(&fixture.primary_inbox_path(PRIMARY_AGENT));
@@ -673,7 +672,7 @@ fn read_store_backed_display_mutation_ignores_mailbox_file_lock() {
         &[unread_message(
             TEAM_LEAD,
             "needs mark-read",
-            AtmMessageId::from(Uuid::new_v4()),
+            AtmMessageId::new(),
         )],
     );
     let mutation_lock_path = sentinel_path(&mutation_fixture.primary_inbox_path(PRIMARY_AGENT));
@@ -697,11 +696,7 @@ fn read_store_backed_display_mutation_ignores_mailbox_file_lock() {
     let no_mutation_fixture = Fixture::new();
     no_mutation_fixture.write_primary_inbox(
         PRIMARY_AGENT,
-        &[read_message(
-            TEAM_LEAD,
-            "already read",
-            AtmMessageId::from(Uuid::new_v4()),
-        )],
+        &[read_message(TEAM_LEAD, "already read", AtmMessageId::new())],
     );
     let no_mutation_lock_path =
         sentinel_path(&no_mutation_fixture.primary_inbox_path(PRIMARY_AGENT));
@@ -814,7 +809,7 @@ fn clear_ignores_synthetic_source_discovery_fault_in_store_only_mode() {
         &[read_message(
             SECONDARY_AGENT,
             "origin read a",
-            AtmMessageId::from(Uuid::new_v4()),
+            AtmMessageId::new(),
         )],
     );
     let before_primary = fs::read_to_string(fixture.primary_inbox_path(PRIMARY_AGENT))

--- a/crates/atm-storage-rusqlite/src/writer/ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/ops.rs
@@ -309,20 +309,14 @@ impl<'a> StorageEnvelope<'a> {
             read: envelope.read,
             source_team: &envelope.source_team,
             summary: &envelope.summary,
-            message_id: envelope
-                .message_id
-                .as_ref()
-                .map(|value| value.into_uuid_wire().to_string()),
+            message_id: envelope.message_id.as_ref().map(ToString::to_string),
             pending_ack_at: envelope.pending_ack_at,
             acknowledged_at: envelope.acknowledged_at,
             acknowledges_message_id: envelope
                 .acknowledges_message_id
                 .as_ref()
-                .map(|value| value.into_uuid_wire().to_string()),
-            parent_message_id: envelope
-                .parent_message_id
-                .as_ref()
-                .map(|value| value.into_uuid_wire().to_string()),
+                .map(ToString::to_string),
+            parent_message_id: envelope.parent_message_id.as_ref().map(ToString::to_string),
             thread_mode: &envelope.thread_mode,
             expires_at: envelope.expires_at,
             task_id: &envelope.task_id,

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -14,5 +14,4 @@ serde.workspace = true
 serde_json.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"
-ulid = { version = "1.2.1", features = ["serde"] }
-uuid.workspace = true
+ulid.workspace = true

--- a/crates/atm-storage/src/schema/inbox_message.rs
+++ b/crates/atm-storage/src/schema/inbox_message.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::fmt;
 use ulid::Ulid;
-use uuid::Uuid;
 
 use crate::types::{AgentName, IsoTimestamp, TaskId, TeamName};
 
@@ -25,14 +24,6 @@ pub struct AtmMessageId(Ulid);
 impl AtmMessageId {
     pub fn new() -> Self {
         Self(Ulid::new())
-    }
-
-    pub fn from_uuid_wire(value: Uuid) -> Self {
-        Self(Ulid::from_bytes(value.into_bytes()))
-    }
-
-    pub fn into_uuid_wire(self) -> Uuid {
-        Uuid::from_bytes(self.0.to_bytes())
     }
 
     pub fn into_ulid(self) -> Ulid {
@@ -63,21 +54,9 @@ impl From<Ulid> for AtmMessageId {
     }
 }
 
-impl From<Uuid> for AtmMessageId {
-    fn from(value: Uuid) -> Self {
-        Self::from_uuid_wire(value)
-    }
-}
-
 impl From<AtmMessageId> for Ulid {
     fn from(value: AtmMessageId) -> Self {
         value.0
-    }
-}
-
-impl From<AtmMessageId> for Uuid {
-    fn from(value: AtmMessageId) -> Self {
-        value.into_uuid_wire()
     }
 }
 
@@ -87,7 +66,6 @@ impl std::str::FromStr for AtmMessageId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ulid::from_string(s)
             .map(Self)
-            .or_else(|_| Uuid::parse_str(s).map(Self::from_uuid_wire))
             .map_err(|error| AtmMessageIdParseError(error.to_string()))
     }
 }
@@ -95,57 +73,6 @@ impl std::str::FromStr for AtmMessageId {
 impl fmt::Display for AtmMessageId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-mod atm_message_id_uuid_wire {
-    use super::AtmMessageId;
-    use serde::{Deserialize, Deserializer, Serializer};
-    use uuid::Uuid;
-
-    pub fn serialize<S>(value: &AtmMessageId, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&value.into_uuid_wire().to_string())
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<AtmMessageId, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let raw = String::deserialize(deserializer)?;
-        Uuid::parse_str(&raw)
-            .map(AtmMessageId::from_uuid_wire)
-            .map_err(serde::de::Error::custom)
-    }
-}
-
-mod option_atm_message_id_uuid_wire {
-    use super::AtmMessageId;
-    use serde::{Deserialize, Deserializer, Serializer};
-    use uuid::Uuid;
-
-    pub fn serialize<S>(value: &Option<AtmMessageId>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match value {
-            Some(value) => serializer.serialize_some(&value.into_uuid_wire().to_string()),
-            None => serializer.serialize_none(),
-        }
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<AtmMessageId>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Option::<String>::deserialize(deserializer)?
-            .map(|raw| {
-                let uuid = Uuid::parse_str(&raw).map_err(serde::de::Error::custom)?;
-                Ok(AtmMessageId::from_uuid_wire(uuid))
-            })
-            .transpose()
     }
 }
 
@@ -218,7 +145,6 @@ pub struct MessageEnvelope {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[serde(with = "option_atm_message_id_uuid_wire")]
     pub message_id: Option<AtmMessageId>,
     #[serde(rename = "pendingAckAt", skip_serializing_if = "Option::is_none")]
     pub pending_ack_at: Option<IsoTimestamp>,
@@ -229,14 +155,12 @@ pub struct MessageEnvelope {
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    #[serde(with = "option_atm_message_id_uuid_wire")]
     pub acknowledges_message_id: Option<AtmMessageId>,
     #[serde(
         rename = "parentMessageId",
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    #[serde(with = "option_atm_message_id_uuid_wire")]
     pub parent_message_id: Option<AtmMessageId>,
     #[serde(rename = "threadMode", skip_serializing_if = "Option::is_none")]
     pub thread_mode: Option<ThreadMode>,
@@ -250,7 +174,6 @@ pub struct MessageEnvelope {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PendingAck {
-    #[serde(with = "atm_message_id_uuid_wire")]
     pub message_id: AtmMessageId,
     pub from: AgentName,
     pub acked: bool,

--- a/crates/atm/src/commands/ack.rs
+++ b/crates/atm/src/commands/ack.rs
@@ -74,7 +74,7 @@ mod tests {
 
     use super::AckCommand;
 
-    const VALID_MESSAGE_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+    const VALID_MESSAGE_ID: &str = "01KRFK5QTF2R6NRS3Q0F8Z9K0S";
 
     fn test_paths() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
         let tempdir = TempDir::new().expect("tempdir");

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -211,7 +211,7 @@ mod tests {
         command.target = Some("recipient-a@test-team".to_string());
         command.team = Some("override-team".to_string());
         command.actor = Some(ROLE_TEAM_LEAD.to_string());
-        command.message_id = Some("550e8400-e29b-41d4-a716-446655440000".to_string());
+        command.message_id = Some("01KRFK5QTF2R6NRS3Q0F8Z9K0S".to_string());
         command.no_since_last_seen = true;
         command.no_mark = true;
         command.no_update_seen = true;

--- a/crates/atm/src/observability.rs
+++ b/crates/atm/src/observability.rs
@@ -267,7 +267,7 @@ mod tests {
                 .expect("concrete adapter");
 
         observability
-            .emit(event(Some("550e8400-e29b-41d4-a716-446655440000")))
+            .emit(event(Some("01KRFK5QTF2R6NRS3Q0F8Z9K0S")))
             .expect("emit backlog");
 
         let health = observability.health().expect("health");
@@ -298,7 +298,7 @@ mod tests {
                 .expect("concrete adapter");
 
         observability
-            .emit(event(Some("550e8400-e29b-41d4-a716-446655440000")))
+            .emit(event(Some("01KRFK5QTF2R6NRS3Q0F8Z9K0S")))
             .expect("emit backlog");
 
         let initial = observability
@@ -338,10 +338,10 @@ mod tests {
             })
             .expect("follow");
         observability
-            .emit(event(Some("550e8400-e29b-41d4-a716-446655440001")))
+            .emit(event(Some("01KRFK5QTF2R6NRS3Q0F8Z9K0T")))
             .expect("emit followed");
 
-        let followed_message_id = "550e8400-e29b-41d4-a716-446655440001"
+        let followed_message_id = "01KRFK5QTF2R6NRS3Q0F8Z9K0T"
             .parse::<atm_core::schema::AtmMessageId>()
             .expect("message id")
             .to_string();

--- a/docs/adr/ADR-012-one-message-identity.md
+++ b/docs/adr/ADR-012-one-message-identity.md
@@ -65,3 +65,8 @@ Implementation status:
 - No `legacy_message_id` code paths remain under `crates/atm-rusqlite/`; any
   surviving `legacy_*` references are historical planning or removal-ledger
   context only.
+- `AD.13` closes the retained UUID-compatibility consequence on
+  `feature/pAD-s13-ulid-message-identity-reset`.
+- The accepted ATM line no longer depends on the `uuid` crate, no retained
+  `AtmMessageId` path accepts or emits UUID-form message ids, and retained
+  schemas/tooling document ULID-only ATM message identity.

--- a/docs/adr/ADR-012-one-message-identity.md
+++ b/docs/adr/ADR-012-one-message-identity.md
@@ -21,7 +21,7 @@ ATM had accumulated multiple message-identity representations:
 
 That shape created duplicated storage, ambiguous query paths, and confusing
 ownership. Phase U resolves that by keeping one logical ATM identity and
-treating Claude's UUID form as boundary encoding only.
+eliminating the retired alternate-id compatibility cast.
 
 ## Decision
 
@@ -29,23 +29,20 @@ ATM keeps one logical message identity: `AtmMessageId`.
 
 Rules:
 - `AtmMessageId` is the only ATM-owned message identity in code.
-- Claude Code `message_id` is the UUID wire encoding of that same identity at
-  the shared inbox boundary.
-- ATM may cast UUID wire values into `AtmMessageId` on ingest and cast
-  `AtmMessageId` back into UUID wire form on export.
+- ATM renders `AtmMessageId` as canonical ULID text anywhere it serializes or
+  accepts a message identity.
 - ATM must not persist or query a second ATM-owned message-id field for the
   same logical message.
 - `metadata.atm.messageId` is removed from the design and implementation.
 - `LegacyMessageId` and `legacy_*` naming are removed from the active identity
   model. Remaining references may survive only as historical planning or
   removal-ledger context, not as runtime compatibility.
-- CLI and service addressing may accept either ULID text or UUID wire text, but
-  both resolve to the same `AtmMessageId`.
+- CLI and service addressing accept only ULID text for `AtmMessageId`.
 
 SQLite consequence:
 - if SQLite stores a durable `message_id` field, that field stores the same
-  logical identity in compatibility UUID wire form only; it is not a second
-  ATM-owned identity.
+  logical identity in canonical ULID text only; it is not a second ATM-owned
+  identity.
 
 ## Consequences
 
@@ -59,8 +56,6 @@ Required implementation consequences:
   sidecar keys as a read-compatibility shim only; all new writes use `atm:`,
   and the shim can be removed once older workflow-state files no longer need
   to be read in place
-- Claude compatibility ingest/export remains supported through the approved
-  UUID-wire boundary cast
 - future ATM features must use `AtmMessageId` as the only ATM-owned message
   identity
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2387,7 +2387,7 @@ Phase O adds three architecture-level hardening decisions:
      eviction
 
 3. **Atomic writes must use collision-proof temp names**
-   - temp files for atomic replacement must use UUID-based suffixes instead of
+   - temp files for atomic replacement must use ULID-based suffixes instead of
      timestamp-only suffixes
    - this keeps same-process rapid writes to the same target path from
      colliding on the temp-file name while preserving the target basename for

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -102,8 +102,8 @@ Consequences:
 - Thin extensions expose a smaller public surface.
 - Task-state rules still remain explicit in store and workflow boundaries.
 - The reply emitted by that workflow must hardcode `requires_ack = false`.
-- Shared core request and query surfaces must resolve both ULID text and UUID
-  wire text to the same `AtmMessageId`.
+- Shared core request and query surfaces must resolve only canonical ULID text
+  to `AtmMessageId`.
 - Send-shaped request data may carry `parentMessageId` and `threadMode` when
   the caller is creating a successor-thread message.
 - Update/correction threads are modeled as one linear successor chain whose

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -132,6 +132,8 @@ The governing rules are:
 - backend interoperability does not require multiple live concrete backends on
   the accepted line; it requires that the shared contract stays future-backend
   ready without another architectural rewrite
+- `AD.17` owns re-enabling the Windows `atm-daemon` CI lane on the accepted
+  line and must not close while that lane remains disabled, cancelled, or red
 - any new sealed `atm-core` boundary trait introduced in this phase must land
   with a matching `boundaries/atm-core/*.toml` governance record and a
   `docs/atm-core/boundaries.md` inventory entry before implementation

--- a/docs/plans/phase-AD/sprint-AD17.md
+++ b/docs/plans/phase-AD/sprint-AD17.md
@@ -1,0 +1,141 @@
+---
+id: AD.17
+title: Boundary Reset Verification Closeout
+status: planned
+branch: feature/pAD-s17-boundary-reset-verification-closeout
+worktree: ../atm-core-worktrees/feature/pAD-s17-boundary-reset-verification-closeout
+target: integrate/phase-AD
+---
+
+# Sprint AD.17 — Boundary Reset Verification Closeout
+
+## Goal
+
+- prove the graft boundary reset on the accepted line and close the added
+  `AD.12` through `AD.20` corrective scope
+
+## Hard Dependencies
+
+- `AD.13` complete
+- `AD.14` complete
+- `AD.15` complete
+- `AD.16` complete
+- `AD.18` complete
+- `AD.19` complete
+- `AD.20` complete
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- `.triage/phase-T/findings/FTQ-001.ttl`
+- `.triage/phase-T/findings/FTQ-003.ttl`
+- `.triage/phase-T/findings/FTQ-T7-002.ttl`
+
+## Exact Targets
+
+- `.github/workflows/ci.yml`
+- `README.md`
+- `crates/atm-daemon/src/tests.rs`
+- `crates/atm-daemon/src/lifecycle_control.rs`
+- `crates/atm-daemon/src/local_ipc_transport.rs`
+- `crates/atm-daemon/src/local_ipc_transport/request_worker.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `scripts/smoke/run.py`
+- `scripts/smoke/run_thorough.py`
+- `scripts/smoke/run_thorough_graft.py`
+- `reports/smoke/`
+- `docs/plans/phase-AD/`
+- readiness/project-plan docs touched by final verdict
+
+## Interfaces To Verify
+
+The accepted verification target after this sprint is:
+
+- retained ATM message identity is ULID-only on the accepted line
+- daemon local IPC remains framed unary request/response for retained ATM
+  command paths
+- the GitHub Actions `CI` workflow restores Windows `atm-daemon` coverage in
+  the `Test (windows-latest)` job by running the `Run atm-daemon tests` step
+  on Windows rather than leaving that step disabled behind
+  `if: runner.os != 'Windows'`
+- post-send emission still happens after persistence through the accepted
+  `PostSendHookEmitter` seam
+- raw CLI runtime-root selection stays host-home-based rather than
+  invocation-directory-based across sibling worktrees
+- `atm read` mutation output remains self-consistent after durable read-state
+  changes
+- metadata-backed `--contains` selection still honors full durable message body
+  matches
+- graft-backed receiver behavior is verified without reintroducing shared
+  advisory session protocol families
+
+## Paths To Delete
+
+- any smoke or regression test that still expects daemon-owned graft advisory
+  register/unregister/fetch/drain/stream packet families
+- any smoke or readiness step that treats a dedicated advisory-stream daemon
+  socket as release-required architecture
+
+## Deliverables
+
+- smoke evidence proving the ULID-only message identity line holds after the
+  boundary reset
+- smoke evidence proving local tmux post-send still works after the boundary
+  reset
+- smoke evidence proving graft-backed post-send still works after the boundary
+  reset
+- regression evidence proving the local IPC receive loop no longer hangs on the
+  deleted graft stream path
+- restored Windows `atm-daemon` CI coverage on the accepted line, with the
+  `CI` workflow's `Test (windows-latest)` job executing the `Run atm-daemon
+  tests` step against the repaired local-IPC path instead of leaving Windows
+  daemon validation disabled
+- regression evidence proving raw CLI sibling-worktree invocation does not
+  switch stores or message-id formats
+- regression evidence proving read-state mutation returns the mutated message
+  plus post-mutation counts
+- regression evidence proving `atm read --contains` finds summary-only and
+  body-only matches correctly on the accepted metadata path
+- release-surface docs no longer describe the accepted ATM line as daemon-free
+  or UUID-message-id based
+- final readiness verdict for the `AD.12` through `AD.20` corrective line
+
+## This Sprint Does Not Close
+
+- unrelated cross-host feature work outside the reset scope
+
+## Acceptance Criteria
+
+- smoke artifacts prove retained ATM message ids remain ULID-only on the
+  accepted line
+- smoke artifacts prove the corrected post-send path still works for local
+  tmux-backed recipients
+- smoke artifacts prove the corrected graft-backed lane works without shared
+  advisory session packet families
+- targeted Windows/local-IPC regression coverage proves the removed stream path
+  no longer blocks command completion
+- `.github/workflows/ci.yml` restores Windows `atm-daemon` coverage in the
+  `CI` workflow's `Test (windows-latest)` job, and the `Run atm-daemon tests`
+  step is green on the accepted line
+- `AD.17` does not close while the restored Windows `atm-daemon` lane remains
+  disabled, cancelled, or red
+- targeted raw multi-worktree CLI regression coverage proves wrappers are not
+  a release requirement
+- targeted read-mutation regression coverage proves returned payload/counts
+  correspond to the same post-mutation durable state
+- targeted contains-filter regression coverage proves metadata-backed read/list
+  selection still honors full-body matches
+- `README.md` matches the accepted daemon-backed, ULID-only retained ATM line
+- readiness artifacts record `Phase AD` as closed only if the original
+  `AD.1` through `AD.11` gates and the added `AD.12` through `AD.20` reset
+  gates all pass on the accepted line
+
+## Required Validation
+
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 .just/run_lint.py all`
+- `just smoke normal`
+- `just smoke thorough`
+- targeted Windows/local-IPC regression coverage for the former advisory-stream lane
+- GitHub CI with `.github/workflows/ci.yml` restored so the `CI` workflow's
+  `Test (windows-latest)` job runs the `Run atm-daemon tests` step and that
+  step finishes green
+- `git diff --check`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1529,7 +1529,7 @@ JSON output must include:
 - `team`
 - `agent`
 - `message_id`
-- `reply_message_id` (Uuid of the reply message sent)
+- `reply_message_id` (ULID of the reply message sent)
 - `reply_text` (String body of the reply message sent)
 - `task_id` (optional String, present when the source message has `taskId`)
 - `reply_target`
@@ -2055,8 +2055,7 @@ For ATM-authored messages:
 - ATM machine-readable identity is mandatory
 - ATM uses one logical message identity and exports it through `message_id` on
   the shared compatibility surface
-- ATM service addressing may accept either ULID text or UUID-wire text, but
-  both must resolve to the same logical identity
+- ATM service addressing accepts only ULID text for `message_id`
 - thread/update metadata uses `parentMessageId` plus `threadMode`
 - time-bounded ephemeral retention uses SQLite-owned `expires_at`
 - ATM-authored machine identifiers must not be null or blank

--- a/tools/schema_models/atm_message_schema.py
+++ b/tools/schema_models/atm_message_schema.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Literal
-from uuid import UUID
+from typing import Annotated, Literal
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, StringConstraints
 
 from .claude_code_message_schema import ClaudeCodeInboxMessage
+
+UlidString = Annotated[
+    str,
+    StringConstraints(pattern=r"^[0-7][0-9A-HJKMNP-TV-Z]{25}$"),
+]
 
 
 class AtmInboxMessage(ClaudeCodeInboxMessage):
@@ -19,8 +23,8 @@ class AtmInboxMessage(ClaudeCodeInboxMessage):
 
     model_config = ConfigDict(extra="allow")
 
-    message_id: UUID | None = None
-    parentMessageId: UUID | None = None
+    message_id: UlidString | None = None
+    parentMessageId: UlidString | None = None
     threadMode: Literal["add-details", "supersede"] | None = None
     taskId: str | None = None
 

--- a/tools/schema_models/test_schema_models.py
+++ b/tools/schema_models/test_schema_models.py
@@ -114,13 +114,10 @@ class SchemaModelTests(unittest.TestCase):
                 "timestamp": "2026-04-04T18:49:59.525805+00:00",
                 "read": True,
                 "summary": "ping",
-                "message_id": "81286baa-e783-4f0c-bfea-82d070750fae",
+                "message_id": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
             }
         )
-        self.assertEqual(
-            str(message.message_id),
-            "81286baa-e783-4f0c-bfea-82d070750fae",
-        )
+        self.assertEqual(message.message_id, "01JQYVB6W51Q2E7E6T3Y4Q9N2M")
 
     def test_atm_superset_named_thread_fields_validate(self) -> None:
         """Write-path: approved immutable compatibility fields stay typed explicitly."""
@@ -132,15 +129,12 @@ class SchemaModelTests(unittest.TestCase):
                 "timestamp": "2026-04-04T18:49:59.525805+00:00",
                 "read": True,
                 "summary": "thread update",
-                "parentMessageId": "81286baa-e783-4f0c-bfea-82d070750fae",
+                "parentMessageId": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
                 "threadMode": "add-details",
                 "taskId": "TASK-123",
             }
         )
-        self.assertEqual(
-            str(message.parentMessageId),
-            "81286baa-e783-4f0c-bfea-82d070750fae",
-        )
+        self.assertEqual(message.parentMessageId, "01JQYVB6W51Q2E7E6T3Y4Q9N2M")
         self.assertEqual(message.threadMode, "add-details")
         self.assertEqual(message.taskId, "TASK-123")
 
@@ -154,7 +148,7 @@ class SchemaModelTests(unittest.TestCase):
                 "timestamp": "2026-04-04T18:49:59.525805+00:00",
                 "read": False,
                 "summary": "ATM warning",
-                "message_id": "81286baa-e783-4f0c-bfea-82d070750fae",
+                "message_id": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
                 "atmAlertKind": "missing_team_config",
                 "missingConfigPath": os.path.join(
                     self._temp_home.name,
@@ -224,8 +218,8 @@ class SchemaModelTests(unittest.TestCase):
         self.assertIsNone(current_model.threadMode)
         self.assertIsNone(current_model.taskId)
 
-    def test_legacy_top_level_message_id_rejects_ulid(self) -> None:
-        """Write-path: current top-level message_id stays typed as the UUID wire form."""
+    def test_top_level_message_id_rejects_uuid(self) -> None:
+        """Write-path: current top-level message_id is ULID-only."""
 
         with self.assertRaises(Exception):
             AtmInboxMessage.model_validate(
@@ -234,7 +228,7 @@ class SchemaModelTests(unittest.TestCase):
                     "text": "ping",
                     "timestamp": "2026-04-04T18:49:59.525805+00:00",
                     "read": True,
-                    "message_id": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
+                    "message_id": "81286baa-e783-4f0c-bfea-82d070750fae",
                 }
             )
 
@@ -257,14 +251,14 @@ class SchemaModelTests(unittest.TestCase):
             "timestamp": "2026-04-04T18:49:59.525805+00:00",
             "read": True,
             "summary": "ping",
-            "message_id": "01JQYVB6W51Q2E7E6T3Y4Q9N2M",
+            "message_id": "81286baa-e783-4f0c-bfea-82d070750fae",
         }
 
         warnings: list[str] = []
 
         try:
             AtmInboxMessage.model_validate(raw_message)
-            self.fail("write-path validator should reject ULID in legacy top-level message_id")
+            self.fail("write-path validator should reject legacy alternate-id text")
         except Exception as exc:
             warnings.append(f"format warning: {exc}")
 


### PR DESCRIPTION
## Summary
- Removes all retained UUID usage from the accepted ATM code path; message identity, schema/tooling, and uniqueness helpers are now ULID-only
- Includes AD.17 Windows-CI-closeout doc sync merge-forward carried on this worktree (5e30c20f)

Sprint doc: docs/plans/phase-AD/sprint-AD13.md

## Test plan
- [x] cargo test --workspace
- [x] cargo clippy --workspace -- -D warnings
- [x] python3 .just/run_lint.py all
- [x] git diff --check