### PR TITLE
AD.21: Built-in post-send nudge hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,6 @@ version = "1.2.3"
 dependencies = [
  "agent-team-mail-core",
  "arc-swap",
- "atm-graft",
  "atm-runtime",
  "atm-runtime-test-support",
  "atm-storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
 name = "atm-storage-rusqlite"
 version = "1.2.3"
 dependencies = [
+ "agent-team-mail-core",
  "atm-storage",
  "chrono",
  "rusqlite",

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -671,6 +671,7 @@ fn canonical_sender_identity(message: &InboxMessage) -> AgentName {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
     use std::time::Duration;
@@ -707,40 +708,33 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
-    struct RecordingGraftPort {
-        events: Mutex<Vec<crate::boundary::PostSendHookEvent>>,
-        fail: bool,
-    }
-
-    impl RecordingGraftPort {
-        fn failing() -> Self {
-            Self {
-                events: Mutex::new(Vec::new()),
-                fail: true,
-            }
-        }
-    }
-
-    impl crate::boundary::sealed::Sealed for RecordingGraftPort {}
-
-    impl crate::boundary::GraftPostSendPort for RecordingGraftPort {
-        fn deliver_post_send(
-            &self,
-            event: &crate::boundary::PostSendHookEvent,
-        ) -> Result<(), crate::error::AtmError> {
-            self.events
-                .lock()
-                .expect("graft events lock")
-                .push(event.clone());
-            if self.fail {
-                return Err(crate::error::AtmError::new_with_code(
-                    crate::error_codes::AtmErrorCode::PostSendGraftUnavailable,
-                    crate::error::AtmErrorKind::DaemonUnavailable,
-                    "simulated graft delivery failure",
-                ));
-            }
-            Ok(())
+    fn write_atm_nudge_shim(path: &Path, capture_path: &Path, exit_code: i32) {
+        #[cfg(windows)]
+        fs::write(
+            path,
+            format!(
+                "@echo off\r\n> \"{}\" echo %1^|%ATM_INTERNAL_NUDGE_SINK%^|%ATM_POST_SEND%\r\nexit /b {}\r\n",
+                capture_path.display(),
+                exit_code
+            ),
+        )
+        .expect("write atm shim");
+        #[cfg(not(windows))]
+        fs::write(
+            path,
+            format!(
+                "#!/bin/sh\nprintf '%s|%s|%s\\n' \"$1\" \"$ATM_INTERNAL_NUDGE_SINK\" \"$ATM_POST_SEND\" > \"{}\"\nexit {}\n",
+                capture_path.display(),
+                exit_code
+            ),
+        )
+        .expect("write atm shim");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(path).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(path, perms).expect("chmod");
         }
     }
 
@@ -1243,11 +1237,6 @@ mod tests {
     fn ack_reply_graft_post_send_dispatches_to_graft_port() {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let home_dir = tempdir.path().join("home");
-        let _env = EnvGuard::set_many([
-            ("HOME", Some(home_dir.to_str().expect("utf8 home"))),
-            ("USERPROFILE", None),
-            ("ATM_LOG_DIR", None),
-        ]);
         let team = TEST_TEAM.parse::<TeamName>().expect("team");
         let agent = ROLE_TEAM_LEAD.parse::<AgentName>().expect("agent");
         let reply_message_id = AtmMessageId::new();
@@ -1296,12 +1285,24 @@ mod tests {
         let runtime = AckRuntime {
             outbound_deliveries: Mutex::new(Vec::new()),
         };
-        let graft_port = RecordingGraftPort::default();
+        let capture_path = tempdir.path().join("ack-nudge.txt");
+        #[cfg(windows)]
+        let atm_path = tempdir.path().join("atm.cmd");
+        #[cfg(not(windows))]
+        let atm_path = tempdir.path().join("atm");
+        write_atm_nudge_shim(&atm_path, &capture_path, 0);
+        let atm_bin = atm_path.display().to_string();
+        let _env = EnvGuard::set_many([
+            ("HOME", Some(home_dir.to_str().expect("utf8 home"))),
+            ("USERPROFILE", None),
+            ("ATM_LOG_DIR", None),
+            ("ATM_TEST_ATM_BIN", Some(atm_bin.as_str())),
+        ]);
 
         let outcome = finalize_ack_outcome(
             &runtime,
             &NullObservability,
-            Some(&graft_port),
+            None,
             FinalizeAckContextOwned {
                 actor: "sender".parse::<AgentName>().expect("agent"),
                 team,
@@ -1316,16 +1317,19 @@ mod tests {
         .expect("finalize ack outcome");
 
         assert_eq!(outcome.reply_message_id, reply_message_id);
-        let events = graft_port.events.lock().expect("graft events lock");
-        assert_eq!(events.len(), 1);
-        assert!(events[0].is_ack);
-        assert_eq!(events[0].recipient.as_str(), ROLE_TEAM_LEAD);
-        assert_eq!(events[0].recipient_team.as_str(), TEST_TEAM);
+        assert!(outcome.warnings.is_empty());
+        let captured = fs::read_to_string(&capture_path).expect("capture");
+        assert!(captured.contains("internal-nudge"));
+        assert!(captured.contains("|graft|"));
+        assert!(captured.contains("\"is_ack\":true"));
+        assert!(captured.contains(format!("\"recipient\":\"{ROLE_TEAM_LEAD}\"").as_str()));
     }
 
     #[test]
+    #[serial_test::serial(env)]
     fn finalize_ack_outcome_warns_when_graft_post_send_delivery_fails() {
         let tempdir = tempfile::tempdir().expect("tempdir");
+        let home_dir = tempdir.path().join("home");
         let team = TEST_TEAM.parse::<TeamName>().expect("team");
         let agent = ROLE_TEAM_LEAD.parse::<AgentName>().expect("agent");
         let reply_message_id = AtmMessageId::new();
@@ -1374,12 +1378,24 @@ mod tests {
         let runtime = AckRuntime {
             outbound_deliveries: Mutex::new(Vec::new()),
         };
-        let graft_port = RecordingGraftPort::failing();
+        let capture_path = tempdir.path().join("ack-nudge.txt");
+        #[cfg(windows)]
+        let atm_path = tempdir.path().join("atm.cmd");
+        #[cfg(not(windows))]
+        let atm_path = tempdir.path().join("atm");
+        write_atm_nudge_shim(&atm_path, &capture_path, 7);
+        let atm_bin = atm_path.display().to_string();
+        let _env = EnvGuard::set_many([
+            ("HOME", Some(home_dir.to_str().expect("utf8 home"))),
+            ("USERPROFILE", None),
+            ("ATM_LOG_DIR", None),
+            ("ATM_TEST_ATM_BIN", Some(atm_bin.as_str())),
+        ]);
 
         let outcome = finalize_ack_outcome(
             &runtime,
             &NullObservability,
-            Some(&graft_port),
+            None,
             FinalizeAckContextOwned {
                 actor: "sender".parse::<AgentName>().expect("agent"),
                 team,
@@ -1399,15 +1415,6 @@ mod tests {
             outcome.warnings[0]
                 .message
                 .contains("warning: post-send emission failed")
-        );
-        assert!(
-            outcome.warnings[0]
-                .message
-                .contains("ATM_POST_SEND_GRAFT_UNAVAILABLE")
-        );
-        assert_eq!(
-            graft_port.events.lock().expect("graft events lock").len(),
-            1
         );
     }
 

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -4,7 +4,7 @@ use crate::error::AtmError;
 use crate::protocol::{FramePayload, RequestEnvelope, RequestId, ResponseEnvelope};
 pub use crate::protocol::{NotificationEvent, RuntimeStatusSnapshot};
 use crate::schema::AtmMessageId;
-use crate::types::{AgentName, PaneId, TaskId, TeamName};
+use crate::types::{AgentName, IsoTimestamp, PaneId, TaskId, TeamName};
 pub use atm_storage::contract::{AckTransition, Message, MessageKey, TaskState};
 
 /// Workspace-convention seal only; not compiler-enforced outside this crate.
@@ -115,11 +115,45 @@ pub struct PostSendHookEvent {
     pub recipient: AgentName,
     pub recipient_team: TeamName,
     pub message_id: AtmMessageId,
-    pub message: String,
+    pub description: String,
     pub requires_ack: bool,
     pub is_ack: bool,
     pub task_id: Option<TaskId>,
     pub recipient_pane_id: Option<PaneId>,
+}
+
+#[derive(
+    Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum BuiltInNudgeTemplateKind {
+    Delivery,
+    DeliveryAck,
+    DeliveryTask,
+    DeliveryTaskAck,
+    Acknowledge,
+    AcknowledgeTask,
+}
+
+impl BuiltInNudgeTemplateKind {
+    pub fn from_post_send_event(event: &PostSendHookEvent) -> Self {
+        match (event.is_ack, event.task_id.is_some(), event.requires_ack) {
+            (true, true, _) => Self::AcknowledgeTask,
+            (true, false, _) => Self::Acknowledge,
+            (false, true, true) => Self::DeliveryTaskAck,
+            (false, true, false) => Self::DeliveryTask,
+            (false, false, true) => Self::DeliveryAck,
+            (false, false, false) => Self::Delivery,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct TeamNudgeTemplateOverrideRow {
+    pub team_name: TeamName,
+    pub kind: BuiltInNudgeTemplateKind,
+    pub template_body: String,
+    pub updated_at: IsoTimestamp,
 }
 
 /// BOUNDARY-PostSendHookEmitter — see docs/atm-core/boundaries.md.

--- a/crates/atm-core/src/boundary/store.rs
+++ b/crates/atm-core/src/boundary/store.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::mail::DoctorFinding;
+use super::{BuiltInNudgeTemplateKind, TeamNudgeTemplateOverrideRow};
 use super::{ReplaySource, sealed};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -229,6 +230,19 @@ pub trait ConfigDoctor: sealed::Sealed + Send + Sync {
     /// Returns `AtmError` when config diagnostics cannot be collected or
     /// summarized into the shared doctor report shape.
     fn inspect_config(&self) -> Result<ConfigDoctorReport, AtmError>;
+}
+
+/// BOUNDARY-NudgeTemplateOverrideStore — see docs/atm-core/boundaries.md.
+pub trait NudgeTemplateOverrideStore: sealed::Sealed + Send + Sync {
+    /// # Errors
+    ///
+    /// Returns `AtmError` when the storage-neutral lookup for one team-scoped
+    /// built-in nudge template override row cannot complete.
+    fn load_template_override(
+        &self,
+        team: &TeamName,
+        kind: BuiltInNudgeTemplateKind,
+    ) -> Result<Option<TeamNudgeTemplateOverrideRow>, AtmError>;
 }
 
 /// BOUNDARY-NonClaudeOutbound — see docs/atm-core/boundaries.md.

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -92,16 +92,17 @@ pub(crate) mod workflow;
 
 #[allow(deprecated)]
 pub use boundary::{
-    AckTransition, AtmProtocol, ClientTransport, ConfigDoctor, ConfigDoctorReport, ConfigIngress,
-    ConfigLoadRequest, ConfigLoadResponse, DoctorFinding, LoadMailMessageStateRequest,
-    LoadMailMessageStateResponse, MailMessageState, MailStore, MailStoreDoctor,
-    MailStoreDoctorReport, MailStoreHealthSnapshot, MailStoreIngestReplayState,
+    AckTransition, AtmProtocol, BuiltInNudgeTemplateKind, ClientTransport, ConfigDoctor,
+    ConfigDoctorReport, ConfigIngress, ConfigLoadRequest, ConfigLoadResponse, DoctorFinding,
+    LoadMailMessageStateRequest, LoadMailMessageStateResponse, MailMessageState, MailStore,
+    MailStoreDoctor, MailStoreDoctorReport, MailStoreHealthSnapshot, MailStoreIngestReplayState,
     MailStoreMailboxMetadataCounts, MailStoreMailboxMetadataRow, Message, MessageFingerprint,
-    MessageKey, NotificationEvent, PostSendHookEmitter, PostSendHookEvent, RemoteReplayStateRecord,
-    RemoteReplayStore, RequestDispatcher, RosterEntry, RosterHarness, RosterMemberKind,
-    RosterStore, RosterStoreDoctor, RosterStoreDoctorReport, RosterStoreHealthSnapshot,
-    RuntimeStatusSnapshot, RuntimeStorageFinalizer, ServerTransport, StatusSource, TaskState,
-    UpsertMailMessageStateRequest, UpsertMailMessageStateResponse,
+    MessageKey, NotificationEvent, NudgeTemplateOverrideStore, PostSendHookEmitter,
+    PostSendHookEvent, RemoteReplayStateRecord, RemoteReplayStore, RequestDispatcher, RosterEntry,
+    RosterHarness, RosterMemberKind, RosterStore, RosterStoreDoctor, RosterStoreDoctorReport,
+    RosterStoreHealthSnapshot, RuntimeStatusSnapshot, RuntimeStorageFinalizer, ServerTransport,
+    StatusSource, TaskState, TeamNudgeTemplateOverrideRow, UpsertMailMessageStateRequest,
+    UpsertMailMessageStateResponse,
 };
 pub use config::AtmConfig;
 pub use config::load_config as load_atm_config;

--- a/crates/atm-core/src/send/graft_warning_tests.rs
+++ b/crates/atm-core/src/send/graft_warning_tests.rs
@@ -35,14 +35,20 @@ pub(super) fn write_atm_nudge_shim(
         ),
     )
     .expect("write atm shim");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(path).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(path, perms).expect("chmod");
-    }
+    set_executable_permissions(path);
 }
+
+#[cfg(unix)]
+fn set_executable_permissions(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut perms = fs::metadata(path).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod");
+}
+
+#[cfg(not(unix))]
+fn set_executable_permissions(_path: &std::path::Path) {}
 
 #[test]
 fn load_send_alert_state_parse_errors_are_config_errors() {

--- a/crates/atm-core/src/send/graft_warning_tests.rs
+++ b/crates/atm-core/src/send/graft_warning_tests.rs
@@ -1,60 +1,46 @@
-use std::sync::Mutex;
-
 use std::fs;
 
 use tempfile::tempdir;
 
-use super::tests::{TestRuntime, install_home_env, send_request};
-use crate::boundary::GraftPostSendPort;
+use super::tests::{TestRuntime, install_home_env_with_atm_bin, send_request};
 use crate::delivery_policy::DeliveryHarnessPath;
-use crate::error::{AtmError, AtmErrorKind};
-use crate::error_codes::AtmErrorCode;
 use crate::observability::NullObservability;
 use crate::protocol::NotificationKind;
 use crate::send::SendCommandOutcome;
 use crate::test_support::TEST_SENDER;
 use crate::types::TeamName;
 
-#[derive(Default)]
-struct RecordingGraftPort {
-    events: Mutex<Vec<crate::boundary::PostSendHookEvent>>,
-}
-
-impl crate::boundary::sealed::Sealed for RecordingGraftPort {}
-
-impl GraftPostSendPort for RecordingGraftPort {
-    fn deliver_post_send(
-        &self,
-        event: &crate::boundary::PostSendHookEvent,
-    ) -> Result<(), AtmError> {
-        self.events
-            .lock()
-            .expect("graft events lock")
-            .push(event.clone());
-        Ok(())
-    }
-}
-
-struct FailingGraftPort {
-    events: Mutex<Vec<crate::boundary::PostSendHookEvent>>,
-}
-
-impl crate::boundary::sealed::Sealed for FailingGraftPort {}
-
-impl GraftPostSendPort for FailingGraftPort {
-    fn deliver_post_send(
-        &self,
-        event: &crate::boundary::PostSendHookEvent,
-    ) -> Result<(), AtmError> {
-        self.events
-            .lock()
-            .expect("graft events lock")
-            .push(event.clone());
-        Err(AtmError::new_with_code(
-            AtmErrorCode::PostSendGraftUnavailable,
-            AtmErrorKind::DaemonUnavailable,
-            "simulated graft delivery failure",
-        ))
+pub(super) fn write_atm_nudge_shim(
+    path: &std::path::Path,
+    capture_path: &std::path::Path,
+    exit_code: i32,
+) {
+    #[cfg(windows)]
+    fs::write(
+        path,
+        format!(
+            "@echo off\r\n> \"{}\" echo %1^|%ATM_INTERNAL_NUDGE_SINK%^|%ATM_POST_SEND%\r\nexit /b {}\r\n",
+            capture_path.display(),
+            exit_code
+        ),
+    )
+    .expect("write atm shim");
+    #[cfg(not(windows))]
+    fs::write(
+        path,
+        format!(
+            "#!/bin/sh\nprintf '%s|%s|%s\\n' \"$1\" \"$ATM_INTERNAL_NUDGE_SINK\" \"$ATM_POST_SEND\" > \"{}\"\nexit {}\n",
+            capture_path.display(),
+            exit_code
+        ),
+    )
+    .expect("write atm shim");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod");
     }
 }
 
@@ -75,16 +61,22 @@ fn load_send_alert_state_parse_errors_are_config_errors() {
 #[serial_test::serial(env)]
 fn send_non_claude_success_delivers_original_via_outbound_boundary() {
     let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
-    let graft_port = RecordingGraftPort::default();
     let tempdir = tempdir().expect("tempdir");
     let home_dir = tempdir.path().join("home");
-    let _env = install_home_env(&home_dir);
+    let capture_path = tempdir.path().join("graft-nudge.txt");
+    #[cfg(windows)]
+    let atm_path = tempdir.path().join("atm.cmd");
+    #[cfg(not(windows))]
+    let atm_path = tempdir.path().join("atm");
+    write_atm_nudge_shim(&atm_path, &capture_path, 0);
+    let atm_bin = atm_path.display().to_string();
+    let _env = install_home_env_with_atm_bin(&home_dir, atm_bin.as_str());
 
     let outcome = super::send_mail_with_runtime_impl(
         send_request(tempdir.path()),
         &NullObservability,
         &runtime,
-        Some(&graft_port),
+        None,
     )
     .expect("send outcome");
 
@@ -118,52 +110,42 @@ fn send_non_claude_success_delivers_original_via_outbound_boundary() {
         events[0].team.as_ref().map(TeamName::as_str),
         Some("test-team")
     );
-    let graft_events = graft_port.events.lock().expect("graft events lock");
-    assert_eq!(graft_events.len(), 1);
-    assert_eq!(graft_events[0].sender.as_str(), TEST_SENDER);
-    assert_eq!(graft_events[0].recipient.as_str(), "recipient");
-    assert_eq!(graft_events[0].recipient_team.as_str(), "test-team");
-    assert_eq!(graft_events[0].message, "hello");
+    let captured = fs::read_to_string(&capture_path).expect("capture");
+    assert!(captured.contains("internal-nudge"));
+    assert!(captured.contains("|graft|"));
+    assert!(captured.contains(format!("\"sender\":\"{TEST_SENDER}\"").as_str()));
+    assert!(captured.contains("\"description\":\"hello\""));
 }
 
 #[test]
 #[serial_test::serial(env)]
 fn send_non_claude_warns_when_graft_post_send_delivery_fails() {
     let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
-    let graft_port = FailingGraftPort {
-        events: Mutex::new(Vec::new()),
-    };
     let tempdir = tempdir().expect("tempdir");
     let home_dir = tempdir.path().join("home");
-    let _env = install_home_env(&home_dir);
+    let capture_path = tempdir.path().join("graft-nudge.txt");
+    #[cfg(windows)]
+    let atm_path = tempdir.path().join("atm.cmd");
+    #[cfg(not(windows))]
+    let atm_path = tempdir.path().join("atm");
+    write_atm_nudge_shim(&atm_path, &capture_path, 7);
+    let atm_bin = atm_path.display().to_string();
+    let _env = install_home_env_with_atm_bin(&home_dir, atm_bin.as_str());
 
     let outcome = super::send_mail_with_runtime_impl(
         send_request(tempdir.path()),
         &NullObservability,
         &runtime,
-        Some(&graft_port),
+        None,
     )
     .expect("send outcome");
 
     assert_eq!(outcome.outcome, SendCommandOutcome::Sent);
     assert_eq!(outcome.warnings.len(), 1);
-    assert_eq!(
-        outcome.warnings[0].code,
-        Some(AtmErrorCode::PostSendGraftUnavailable)
-    );
     assert!(
         outcome.warnings[0]
             .message
             .contains("warning: post-send emission failed")
-    );
-    assert!(
-        outcome.warnings[0]
-            .message
-            .contains("ATM_POST_SEND_GRAFT_UNAVAILABLE")
-    );
-    assert_eq!(
-        graft_port.events.lock().expect("graft events lock").len(),
-        1
     );
     let notification_path =
         crate::home::host_runtime_dir_from_home(&home_dir).join("notifications.jsonl");

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -15,10 +15,10 @@ use tracing::Level;
 use tracing::{debug, error, info, warn};
 
 use super::{POST_SEND_HOOK_TIMEOUT, ResolvedRecipient, WarningEntry, qualified_sender_identity};
-use crate::boundary::{GraftPostSendPort, PostSendHookEmitter, PostSendHookEvent};
+use crate::boundary::PostSendHookEvent;
 use crate::config::types::HookRecipient;
 use crate::config::{self, AtmConfig};
-use crate::error::{AtmError, AtmErrorKind};
+use crate::error::AtmError;
 use crate::error_codes::AtmErrorCode;
 use crate::protocol::{NotificationEvent, NotificationKind};
 use crate::schema::compatible_home_dir;
@@ -27,8 +27,8 @@ use crate::types::{AgentName, TeamName};
 
 const POST_SEND_HOOK_MAX_STDOUT_BYTES: usize = 8 * 1024;
 const POST_SEND_HOOK_STDOUT_JOIN_TIMEOUT: Duration = Duration::from_millis(500);
-#[cfg(test)]
-const TMUX_PROGRAM_ENV: &str = "ATM_TEST_TMUX_BIN";
+const ATM_PROGRAM_ENV: &str = "ATM_TEST_ATM_BIN";
+const INTERNAL_NUDGE_SINK_ENV: &str = "ATM_INTERNAL_NUDGE_SINK";
 
 #[derive(Debug, Deserialize)]
 struct PostSendHookResult {
@@ -47,6 +47,21 @@ enum PostSendHookResultLevel {
     Error,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuiltInNudgeSinkTarget {
+    Tmux,
+    Graft,
+}
+
+impl BuiltInNudgeSinkTarget {
+    fn env_value(self) -> &'static str {
+        match self {
+            Self::Tmux => "tmux",
+            Self::Graft => "graft",
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 struct HookCancellationToken(Arc<AtomicBool>);
 
@@ -60,94 +75,14 @@ impl HookCancellationToken {
     }
 }
 
-pub(crate) struct ConfiguredPostSendHookEmitter<'a> {
-    config: &'a AtmConfig,
-}
-
-impl<'a> ConfiguredPostSendHookEmitter<'a> {
-    pub(crate) fn new(config: &'a AtmConfig) -> Self {
-        Self { config }
-    }
-}
-
-impl crate::boundary::sealed::Sealed for ConfiguredPostSendHookEmitter<'_> {}
-
-impl PostSendHookEmitter for ConfiguredPostSendHookEmitter<'_> {
-    fn emit(&self, event: &PostSendHookEvent) -> Result<(), AtmError> {
-        let mut warnings = Vec::new();
-        run_post_send_hooks_for_cli(&mut warnings, self.config, event);
-        warnings_to_result(&warnings)
-    }
-}
-
-pub(crate) struct LocalTmuxPostSendEmitter;
-
-impl crate::boundary::sealed::Sealed for LocalTmuxPostSendEmitter {}
-
-impl PostSendHookEmitter for LocalTmuxPostSendEmitter {
-    fn emit(&self, event: &PostSendHookEvent) -> Result<(), AtmError> {
-        let Some(pane_id) = event.recipient_pane_id.as_ref() else {
-            let error = AtmError::new_with_code(
-                AtmErrorCode::PostSendPaneMissing,
-                AtmErrorKind::Validation,
-                format!(
-                    "recipient {}@{} has tmux-backed post-send capability but no pane id",
-                    event.recipient, event.recipient_team
-                ),
-            )
-            .with_recovery(format!(
-                "Repair the roster row with `atm teams update-member --team {} --member {} --tmux-pane-id <pane>`.",
-                event.recipient_team, event.recipient
-            ));
-            warn!(
-                code = %AtmErrorCode::PostSendPaneMissing,
-                sender = %event.sender,
-                recipient = %event.recipient,
-                recipient_team = %event.recipient_team,
-                message_id = %event.message_id,
-                "local tmux post-send emission is missing authoritative pane metadata"
-            );
-            return Err(error);
-        };
-
-        let message = super::hook_tmux::tmux_nudge_message(&event.recipient_team);
-        super::hook_tmux::run_tmux_send_keys(pane_id, &message, event)?;
-        super::hook_tmux::run_tmux_send_enter(pane_id, event)?;
-        Ok(())
-    }
-}
-
-pub(crate) struct GraftPostSendEmitter<'a> {
-    port: &'a dyn GraftPostSendPort,
-}
-
-impl<'a> GraftPostSendEmitter<'a> {
-    pub(crate) fn new(port: &'a dyn GraftPostSendPort) -> Self {
-        Self { port }
-    }
-}
-
-impl crate::boundary::sealed::Sealed for GraftPostSendEmitter<'_> {}
-
-impl PostSendHookEmitter for GraftPostSendEmitter<'_> {
-    fn emit(&self, event: &PostSendHookEvent) -> Result<(), AtmError> {
-        self.port.deliver_post_send(event)
-    }
-}
-
 pub(crate) fn emit_post_send_effects(
     warnings: &mut Vec<WarningEntry>,
     config: Option<&AtmConfig>,
-    graft_port: Option<&dyn GraftPostSendPort>,
+    _graft_port: Option<&dyn crate::boundary::GraftPostSendPort>,
     recipient: &ResolvedRecipient,
     delivery_snapshot: &crate::delivery_policy::DeliveryRecipientSnapshot,
     messages: &[crate::delivery_plan::LogicalMessage],
 ) {
-    let hook_emitter = config.map(ConfiguredPostSendHookEmitter::new);
-    let graft_emitter = graft_port.map(GraftPostSendEmitter::new);
-    let tmux_emitter = delivery_snapshot
-        .local_tmux_post_send
-        .then_some(LocalTmuxPostSendEmitter);
     for message in messages {
         let event = post_send_event_from_message(
             recipient,
@@ -155,34 +90,24 @@ pub(crate) fn emit_post_send_effects(
             delivery_snapshot.recipient_pane_id.as_ref(),
         );
         let mut emitted = false;
-        if let Some(emitter) = tmux_emitter.as_ref() {
-            match emitter.emit(&event) {
+        let hook_matched = config.is_some_and(|loaded| {
+            let mut hook_warnings = Vec::new();
+            let matched = run_post_send_hooks_for_cli(&mut hook_warnings, loaded, &event);
+            if !hook_warnings.is_empty() {
+                warnings.extend(hook_warnings);
+            } else if matched {
+                emitted = true;
+            }
+            matched
+        });
+        if !hook_matched && let Some(target) = built_in_nudge_sink_target(delivery_snapshot) {
+            match emit_built_in_nudge(&event, target) {
                 Ok(()) => emitted = true,
                 Err(error) => warnings.push(post_send_warning(
                     "post-send emission failed",
                     &event,
                     &error,
                 )),
-            }
-        }
-        if delivery_snapshot.graft_post_send
-            && let Some(emitter) = graft_emitter.as_ref()
-        {
-            match emitter.emit(&event) {
-                Ok(()) => emitted = true,
-                Err(error) => warnings.push(post_send_warning(
-                    "post-send emission failed",
-                    &event,
-                    &error,
-                )),
-            }
-        }
-        if let Some(emitter) = hook_emitter.as_ref() {
-            match emitter.emit(&event) {
-                Ok(()) => emitted = true,
-                Err(error) => {
-                    warnings.push(post_send_warning("post-send hook failed", &event, &error))
-                }
             }
         }
         if emitted && let Err(error) = append_notification_log(&notification_event(&event)) {
@@ -219,7 +144,7 @@ fn run_post_send_hooks_for_cli(
     warnings: &mut Vec<WarningEntry>,
     config: &AtmConfig,
     event: &PostSendHookEvent,
-) {
+) -> bool {
     // This helper is intentionally synchronous and may block the caller thread
     // for up to POST_SEND_HOOK_TIMEOUT while supervising one child process.
     // Keep it on the CLI path; do not call it from an async runtime thread.
@@ -236,12 +161,174 @@ fn run_post_send_hooks_for_cli(
             recipient_team = %event.recipient_team,
             "post-send hook had no matching recipient rules"
         );
-        return;
+        return false;
     }
 
     for rule in matching_rules {
         execute_post_send_hook(warnings, config, rule, event);
     }
+    true
+}
+
+fn built_in_nudge_sink_target(
+    delivery_snapshot: &crate::delivery_policy::DeliveryRecipientSnapshot,
+) -> Option<BuiltInNudgeSinkTarget> {
+    if delivery_snapshot.local_tmux_post_send {
+        Some(BuiltInNudgeSinkTarget::Tmux)
+    } else if delivery_snapshot.graft_post_send {
+        Some(BuiltInNudgeSinkTarget::Graft)
+    } else {
+        None
+    }
+}
+
+fn emit_built_in_nudge(
+    event: &PostSendHookEvent,
+    sink_target: BuiltInNudgeSinkTarget,
+) -> Result<(), AtmError> {
+    let command_path = atm_command_path()?;
+    let payload = post_send_hook_payload(event).to_string();
+    let mut command = Command::new(&command_path);
+    command
+        .arg("internal-nudge")
+        .env("ATM_POST_SEND", payload)
+        .env(INTERNAL_NUDGE_SINK_ENV, sink_target.env_value())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = command.spawn().map_err(|source| {
+        AtmError::daemon_unavailable(format!(
+            "failed to start built-in post-send nudge command {}: {source}",
+            command_path.display()
+        ))
+        .with_recovery(
+            "Ensure the installed `atm` binary is executable and on disk before retrying post-send delivery.",
+        )
+        .with_source(source)
+    })?;
+    let started_at = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => return Ok(()),
+            Ok(Some(status)) => {
+                let error = match sink_target {
+                    BuiltInNudgeSinkTarget::Tmux => AtmError::new_with_code(
+                        AtmErrorCode::PostSendTmuxSendFailed,
+                        crate::error::AtmErrorKind::DaemonUnavailable,
+                        format!(
+                            "built-in tmux post-send nudge exited unsuccessfully with status {status}"
+                        ),
+                    )
+                    .with_recovery(
+                        "Inspect the built-in tmux nudge path and the recipient pane state before retrying post-send delivery.",
+                    ),
+                    BuiltInNudgeSinkTarget::Graft => AtmError::new_with_code(
+                        AtmErrorCode::PostSendGraftUnavailable,
+                        crate::error::AtmErrorKind::DaemonUnavailable,
+                        format!(
+                            "built-in graft post-send nudge exited unsuccessfully with status {status}"
+                        ),
+                    )
+                    .with_recovery(
+                        "Ensure the recipient graft receiver is listening and retry once the built-in graft nudge path is healthy.",
+                    ),
+                };
+                return Err(error);
+            }
+            Ok(None) if started_at.elapsed() < POST_SEND_HOOK_TIMEOUT => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) => {
+                terminate_post_send_hook_process(&mut child, &command_path);
+                return Err(AtmError::daemon_unavailable(format!(
+                    "built-in post-send nudge command timed out after {}s",
+                    POST_SEND_HOOK_TIMEOUT.as_secs()
+                ))
+                .with_recovery(
+                    "Fix the built-in `atm internal-nudge` path so it exits promptly after one nudge delivery attempt.",
+                ));
+            }
+            Err(source) => {
+                terminate_post_send_hook_process(&mut child, &command_path);
+                return Err(AtmError::daemon_unavailable(
+                    "failed while waiting for built-in post-send nudge command",
+                )
+                .with_recovery(
+                    "Inspect the built-in `atm internal-nudge` process lifecycle and retry once the local process environment is healthy.",
+                )
+                .with_source(source));
+            }
+        }
+    }
+}
+
+fn atm_command_path() -> Result<PathBuf, AtmError> {
+    if let Some(path) = std::env::var_os(ATM_PROGRAM_ENV).filter(|value| !value.is_empty()) {
+        return Ok(path.into());
+    }
+
+    let current_exe = std::env::current_exe().map_err(|source| {
+        AtmError::daemon_unavailable("failed to resolve the running ATM process executable")
+            .with_recovery(
+                "Run ATM from an installed binary path or repair the current process environment before retrying built-in post-send delivery.",
+            )
+            .with_source(source)
+    })?;
+    if is_atm_binary_path(&current_exe) {
+        return Ok(current_exe);
+    }
+
+    for candidate in atm_binary_candidates(&current_exe) {
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(AtmError::daemon_unavailable(format!(
+        "failed to resolve the companion `atm` CLI binary for built-in post-send delivery from {}",
+        current_exe.display()
+    ))
+    .with_recovery(
+        "Install `atm` alongside the running ATM binary, or set ATM_TEST_ATM_BIN to an explicit `atm` path before retrying built-in post-send delivery.",
+    ))
+}
+
+fn atm_binary_candidates(current_exe: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(parent) = current_exe.parent() {
+        candidates.push(parent.join(atm_binary_leaf()));
+        if parent.file_name().is_some_and(|name| name == "deps")
+            && let Some(grandparent) = parent.parent()
+        {
+            candidates.push(grandparent.join(atm_binary_leaf()));
+        }
+    }
+    candidates
+}
+
+fn atm_binary_leaf() -> &'static str {
+    #[cfg(windows)]
+    {
+        "atm.exe"
+    }
+    #[cfg(not(windows))]
+    {
+        "atm"
+    }
+}
+
+fn is_atm_binary_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            #[cfg(windows)]
+            {
+                name.eq_ignore_ascii_case("atm.exe")
+            }
+            #[cfg(not(windows))]
+            {
+                name == "atm"
+            }
+        })
 }
 
 fn execute_post_send_hook(
@@ -337,6 +424,8 @@ fn post_send_hook_payload(event: &PostSendHookEvent) -> Value {
         "recipient": event.recipient.as_str(),
         "team": event.recipient_team.as_str(),
         "message_id": event.message_id.to_string(),
+        "description": event.description,
+        "message": event.description,
         "requires_ack": event.requires_ack,
         "is_ack": event.is_ack,
     });
@@ -566,6 +655,7 @@ fn notification_event(event: &PostSendHookEvent) -> NotificationEvent {
             "sender": event.sender.as_str(),
             "sender_team": event.sender_team.as_str(),
             "message_id": event.message_id.to_string(),
+            "description": event.description,
             "requires_ack": event.requires_ack,
             "is_ack": event.is_ack,
             "task_id": event.task_id.as_ref().map(ToString::to_string),
@@ -592,7 +682,7 @@ fn post_send_event_from_message(
         recipient: recipient.agent.clone(),
         recipient_team: recipient.team.clone(),
         message_id: message.message_id(),
-        message: message
+        description: message
             .envelope
             .summary
             .clone()
@@ -607,30 +697,6 @@ fn post_send_event_from_message(
 
 fn sender_config_root(metadata: &serde_json::Map<String, Value>) -> Option<PathBuf> {
     compatible_home_dir(metadata).map(Into::into)
-}
-
-fn warnings_to_result(warnings: &[WarningEntry]) -> Result<(), AtmError> {
-    if warnings.is_empty() {
-        return Ok(());
-    }
-
-    let message = warnings
-        .iter()
-        .map(|warning| warning.message.as_str())
-        .collect::<Vec<_>>()
-        .join(" ");
-    let mut error = AtmError::new_with_code(
-        AtmErrorCode::WarningHookExecutionFailed,
-        AtmErrorKind::Internal,
-        message,
-    );
-    for recovery in warnings
-        .iter()
-        .filter_map(|warning| warning.recovery.as_deref())
-    {
-        error = error.with_recovery(recovery.to_string());
-    }
-    Err(error)
 }
 
 fn post_send_warning(prefix: &str, event: &PostSendHookEvent, error: &AtmError) -> WarningEntry {
@@ -857,27 +923,23 @@ fn hook_result_log_level(level: PostSendHookResultLevel) -> Level {
 mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use serde_json::{Map, json};
     use tempfile::tempdir;
     use tracing::Level;
 
     use super::{
-        GraftPostSendEmitter, HookCancellationToken, LocalTmuxPostSendEmitter,
-        POST_SEND_HOOK_MAX_STDOUT_BYTES, PostSendHookResultLevel, TMUX_PROGRAM_ENV,
+        ATM_PROGRAM_ENV, BuiltInNudgeSinkTarget, HookCancellationToken,
+        POST_SEND_HOOK_MAX_STDOUT_BYTES, PostSendHookResultLevel, emit_built_in_nudge,
         finish_abandoned_post_send_hook_stdout_capture, hook_matches_recipient,
         hook_result_log_level, load_post_send_config_for_sender, parse_post_send_hook_result,
         sender_config_root,
     };
-    use crate::boundary::{
-        GraftPostSendPort, PostSendHookEmitter, PostSendHookEvent, RosterEntry, RosterHarness,
-        RosterMemberKind,
-    };
+    use crate::boundary::{PostSendHookEvent, RosterEntry, RosterHarness, RosterMemberKind};
     use crate::config::AtmConfig;
     use crate::config::types::HookRecipient;
     use crate::error::AtmError;
-    use crate::error_codes::AtmErrorCode;
     use crate::roles::ROLE_TEAM_LEAD;
     #[allow(
         deprecated,
@@ -885,7 +947,6 @@ mod tests {
     )]
     use crate::schema::agent_member::LEGACY_CWD_METADATA_KEY;
     use crate::schema::{HOME_DIR_METADATA_KEY, InboxMessage, TeamConfig};
-    use crate::send::hook_tmux::tmux_nudge_message;
     use crate::service_runtime::{RetainedMailboxTimeoutPolicy, RetainedServiceRuntime};
     use crate::test_support::{EnvGuard, TEST_SENDER};
     use crate::types::{AgentName, IsoTimestamp, PaneId, TeamName};
@@ -994,27 +1055,6 @@ mod tests {
             F: FnOnce(&mut WorkflowStateFile) -> Result<(T, bool), AtmError>,
         {
             unreachable!("config lookup test does not commit workflow state")
-        }
-    }
-
-    #[derive(Default)]
-    struct RecordingGraftPort {
-        delivered: std::sync::Mutex<Vec<PostSendHookEvent>>,
-        fail_message: Option<String>,
-    }
-
-    impl crate::boundary::sealed::Sealed for RecordingGraftPort {}
-
-    impl GraftPostSendPort for RecordingGraftPort {
-        fn deliver_post_send(&self, event: &PostSendHookEvent) -> Result<(), AtmError> {
-            if let Some(message) = &self.fail_message {
-                return Err(AtmError::daemon_unavailable(message.clone()));
-            }
-            self.delivered
-                .lock()
-                .expect("graft deliveries")
-                .push(event.clone());
-            Ok(())
         }
     }
 
@@ -1155,7 +1195,7 @@ mod tests {
             recipient: AgentName::from_validated("recipient"),
             recipient_team: TeamName::from_validated("test-team"),
             message_id: crate::schema::AtmMessageId::new(),
-            message: "hello".to_string(),
+            description: "hello".to_string(),
             requires_ack: false,
             is_ack: false,
             task_id: None,
@@ -1164,130 +1204,82 @@ mod tests {
     }
 
     #[test]
-    fn local_tmux_post_send_emitter_requires_authoritative_pane_id() {
-        let emitter = LocalTmuxPostSendEmitter;
-        let error = emitter
-            .emit(&tmux_event(None))
-            .expect_err("missing pane must fail");
-
-        assert_eq!(error.code, AtmErrorCode::PostSendPaneMissing);
-        assert!(error.message.contains("no pane id"));
-    }
-
-    #[test]
     #[serial_test::serial(env)]
-    fn local_tmux_post_send_emitter_uses_authoritative_pane_id() {
+    fn built_in_nudge_fallback_invokes_hidden_cli_with_sink_and_payload() {
         let tempdir = tempdir().expect("tempdir");
-        let tmux_log = tempdir.path().join("tmux.log");
+        let capture_path = tempdir.path().join("capture.txt");
         #[cfg(windows)]
-        let tmux_path = tempdir.path().join("tmux.cmd");
+        let atm_path = tempdir.path().join("atm.cmd");
         #[cfg(not(windows))]
-        let tmux_path = tempdir.path().join("tmux");
+        let atm_path = tempdir.path().join("atm");
         #[cfg(windows)]
         fs::write(
-            &tmux_path,
-            "@echo off\r\n>> \"%ATM_TEST_TMUX_LOG%\" echo %*\r\nexit /b 0\r\n",
+            &atm_path,
+            "@echo off\r\n> \"%ATM_TEST_CAPTURE%\" echo %1|%ATM_INTERNAL_NUDGE_SINK%|%ATM_POST_SEND%\r\nexit /b 0\r\n",
         )
-        .expect("write tmux shim");
+        .expect("write atm shim");
         #[cfg(not(windows))]
         fs::write(
-            &tmux_path,
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"$ATM_TEST_TMUX_LOG\"\nexit 0\n",
+            &atm_path,
+            "#!/bin/sh\nprintf '%s|%s|%s\\n' \"$1\" \"$ATM_INTERNAL_NUDGE_SINK\" \"$ATM_POST_SEND\" > \"$ATM_TEST_CAPTURE\"\nexit 0\n",
         )
-        .expect("write tmux shim");
+        .expect("write atm shim");
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&tmux_path).expect("metadata").permissions();
+            let mut perms = fs::metadata(&atm_path).expect("metadata").permissions();
             perms.set_mode(0o755);
-            fs::set_permissions(&tmux_path, perms).expect("chmod");
+            fs::set_permissions(&atm_path, perms).expect("chmod");
         }
 
-        let tmux_log = tmux_log.to_str().expect("utf8 tmux log").to_owned();
-        let tmux_bin = tmux_path.to_str().expect("utf8 tmux path").to_owned();
+        let capture_value = capture_path.display().to_string();
+        let atm_bin = atm_path.display().to_string();
         let _env = EnvGuard::set_many([
-            (TMUX_PROGRAM_ENV, Some(tmux_bin.as_str())),
-            ("ATM_TEST_TMUX_LOG", Some(tmux_log.as_str())),
+            (ATM_PROGRAM_ENV, Some(atm_bin.as_str())),
+            ("ATM_TEST_CAPTURE", Some(capture_value.as_str())),
         ]);
 
-        let result =
-            LocalTmuxPostSendEmitter.emit(&tmux_event(Some(PaneId::from_cli("%9").expect("pane"))));
+        emit_built_in_nudge(
+            &tmux_event(Some(PaneId::from_cli("%9").expect("pane"))),
+            BuiltInNudgeSinkTarget::Tmux,
+        )
+        .expect("fallback emit");
 
-        result.expect("tmux send");
-        let logged = fs::read_to_string(&tmux_log).expect("tmux log");
-        assert!(logged.contains("send-keys"));
-        assert!(logged.contains("%9"));
-        assert!(logged.contains(&tmux_nudge_message(&TeamName::from_validated("test-team"))));
-        assert!(logged.contains("Enter"));
+        let captured = fs::read_to_string(&capture_path).expect("capture");
+        assert!(captured.contains("internal-nudge"));
+        assert!(captured.contains("|tmux|"));
+        assert!(captured.contains("\"description\":\"hello\""));
     }
 
     #[test]
     #[serial_test::serial(env)]
-    fn local_tmux_post_send_emitter_times_out_hung_tmux() {
+    fn built_in_nudge_fallback_surfaces_nonzero_exit() {
         let tempdir = tempdir().expect("tempdir");
         #[cfg(windows)]
-        let tmux_path = tempdir.path().join("tmux.cmd");
+        let atm_path = tempdir.path().join("atm.cmd");
         #[cfg(not(windows))]
-        let tmux_path = tempdir.path().join("tmux");
+        let atm_path = tempdir.path().join("atm");
         #[cfg(windows)]
-        fs::write(
-            &tmux_path,
-            "@echo off\r\nsetlocal EnableDelayedExpansion\r\nfor /f \"tokens=1-4 delims=:.\" %%a in (\"%time%\") do (\r\n  set /a start=%%a*3600+%%b*60+%%c\r\n)\r\n:loop\r\nfor /f \"tokens=1-4 delims=:.\" %%a in (\"%time%\") do (\r\n  set /a now=%%a*3600+%%b*60+%%c\r\n)\r\nif !now! lss !start! set /a now+=86400\r\nset /a elapsed=now-start\r\nif !elapsed! lss 30 goto loop\r\nexit /b 0\r\n",
-        )
-        .expect("write tmux shim");
+        fs::write(&atm_path, "@echo off\r\nexit /b 7\r\n").expect("write atm shim");
         #[cfg(not(windows))]
-        fs::write(
-            &tmux_path,
-            "#!/usr/bin/env python3\nimport time\ntime.sleep(30)\n",
-        )
-        .expect("write tmux shim");
+        fs::write(&atm_path, "#!/bin/sh\nexit 7\n").expect("write atm shim");
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&tmux_path).expect("metadata").permissions();
+            let mut perms = fs::metadata(&atm_path).expect("metadata").permissions();
             perms.set_mode(0o755);
-            fs::set_permissions(&tmux_path, perms).expect("chmod");
+            fs::set_permissions(&atm_path, perms).expect("chmod");
         }
 
-        let tmux_bin = tmux_path.to_str().expect("utf8 tmux path").to_owned();
-        let _env = EnvGuard::set_many([(TMUX_PROGRAM_ENV, Some(tmux_bin.as_str()))]);
+        let atm_bin = atm_path.display().to_string();
+        let _env = EnvGuard::set_many([(ATM_PROGRAM_ENV, Some(atm_bin.as_str()))]);
 
-        let started_at = Instant::now();
-        let error = LocalTmuxPostSendEmitter
-            .emit(&tmux_event(Some(PaneId::from_cli("%9").expect("pane"))))
-            .expect_err("hung tmux must time out");
+        let error = emit_built_in_nudge(
+            &tmux_event(Some(PaneId::from_cli("%9").expect("pane"))),
+            BuiltInNudgeSinkTarget::Graft,
+        )
+        .expect_err("nonzero exit must fail");
 
-        assert!(started_at.elapsed() < Duration::from_secs(8));
-        assert_eq!(error.code, AtmErrorCode::PostSendTmuxSendFailed);
-        assert!(error.message.contains("timed out"));
-    }
-
-    #[test]
-    fn graft_post_send_emitter_delegates_to_graft_port() {
-        let port = RecordingGraftPort::default();
-        let event = tmux_event(Some(PaneId::from_cli("%9").expect("pane")));
-
-        GraftPostSendEmitter::new(&port)
-            .emit(&event)
-            .expect("graft send");
-
-        let delivered = port.delivered.lock().expect("graft deliveries");
-        assert_eq!(delivered.len(), 1);
-        assert_eq!(delivered[0], event);
-    }
-
-    #[test]
-    fn graft_post_send_emitter_surfaces_port_failure() {
-        let port = RecordingGraftPort {
-            delivered: std::sync::Mutex::new(Vec::new()),
-            fail_message: Some("synthetic graft failure".to_string()),
-        };
-
-        let error = GraftPostSendEmitter::new(&port)
-            .emit(&tmux_event(Some(PaneId::from_cli("%9").expect("pane"))))
-            .expect_err("graft failure");
-
-        assert_eq!(error.code, AtmErrorCode::DaemonUnavailable);
-        assert!(error.message.contains("synthetic graft failure"));
+        assert!(error.message.contains("exited unsuccessfully"));
     }
 }

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -1215,7 +1215,7 @@ mod tests {
         #[cfg(windows)]
         fs::write(
             &atm_path,
-            "@echo off\r\n> \"%ATM_TEST_CAPTURE%\" echo %1|%ATM_INTERNAL_NUDGE_SINK%|%ATM_POST_SEND%\r\nexit /b 0\r\n",
+            "@echo off\r\n> \"%ATM_TEST_CAPTURE%\" echo %1^|%ATM_INTERNAL_NUDGE_SINK%^|%ATM_POST_SEND%\r\nexit /b 0\r\n",
         )
         .expect("write atm shim");
         #[cfg(not(windows))]

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -459,7 +459,13 @@ fn post_send_messages_from_persistence(
     persistence: &DeliveryPersistenceResult,
     requires_ack: bool,
 ) -> Result<Vec<crate::delivery_plan::LogicalMessage>, AtmError> {
-    logical_messages_from_persistence(persistence, requires_ack, false).map_err(|error| {
+    crate::delivery_plan::LogicalMessage::new(
+        persistence.original_message.clone(),
+        requires_ack,
+        false,
+    )
+    .map(|message| vec![message])
+    .map_err(|error| {
         AtmError::mailbox_write(error.to_string()).with_recovery(
             "Repair the persisted delivery record shape before retrying post-send emission.",
         )

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -81,6 +81,15 @@ pub(super) fn install_home_env(home_dir: &Path) -> EnvGuard {
     ])
 }
 
+pub(super) fn install_home_env_with_atm_bin(home_dir: &Path, atm_bin: &str) -> EnvGuard {
+    EnvGuard::set_many([
+        ("HOME", Some(home_dir.to_str().expect("utf8 home"))),
+        ("USERPROFILE", None),
+        ("ATM_LOG_DIR", None),
+        ("ATM_TEST_ATM_BIN", Some(atm_bin)),
+    ])
+}
+
 fn assert_recovered_payload_texts(
     original: &InboxMessage,
     companion: &InboxMessage,
@@ -639,7 +648,14 @@ fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_bound
     let observability = RecordingObservability::default();
     let tempdir = tempdir().expect("tempdir");
     let home_dir = tempdir.path().join("home");
-    let _env = install_home_env(&home_dir);
+    let capture_path = tempdir.path().join("graft-nudge.txt");
+    #[cfg(windows)]
+    let atm_path = tempdir.path().join("atm.cmd");
+    #[cfg(not(windows))]
+    let atm_path = tempdir.path().join("atm");
+    super::graft_warning_tests::write_atm_nudge_shim(&atm_path, &capture_path, 0);
+    let atm_bin = atm_path.display().to_string();
+    let _env = install_home_env_with_atm_bin(&home_dir, atm_bin.as_str());
 
     let outcome = super::send_mail_with_runtime_impl(
         send_request(tempdir.path()),
@@ -652,8 +668,14 @@ fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_bound
     assert_eq!(outcome.outcome, SendCommandOutcome::Sent);
     assert_eq!(outcome.warnings.len(), 1);
     assert_non_claude_sqlite_failure_delivery(&runtime);
-    assert_notification_log_absent(&home_dir);
+    let events = read_notification_events(&home_dir);
+    assert_eq!(events.len(), 1);
     assert_non_claude_sqlite_failure_observability(&observability);
+    let captured = fs::read_to_string(&capture_path).expect("capture");
+    assert!(captured.contains("internal-nudge"));
+    assert!(captured.contains("|graft|"));
+    assert!(captured.contains(format!("\"sender\":\"{TEST_SENDER}\"").as_str()));
+    assert!(!captured.contains("\"sender\":\"atm-system\""));
 }
 
 #[test]

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -29,3 +29,18 @@ pub fn with_default_roster_store<T>(
 ) -> Result<T, AtmError> {
     atm_runtime::with_default_roster_store(f)
 }
+
+/// Open the default SQLite boundary and expose only the approved built-in
+/// nudge-template override lookup seam.
+///
+/// # Errors
+///
+/// Returns [`AtmError`] when the default SQLite-backed retained runtime cannot
+/// assemble its canonical override-store boundary state.
+pub fn with_default_nudge_template_override_store<T>(
+    f: impl FnOnce(
+        &(dyn atm_core::boundary::NudgeTemplateOverrideStore + Send + Sync),
+    ) -> Result<T, AtmError>,
+) -> Result<T, AtmError> {
+    atm_runtime::with_default_nudge_template_override_store(f)
+}

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -29,7 +29,6 @@ signal-hook = "0.3"
 signal-hook = "0.3"
 
 [dev-dependencies]
-atm-graft = { path = "../atm-graft", version = "1.2.3" }
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3", features = ["test-utils"] }
 atm-runtime = { path = "../atm-runtime", version = "1.2.3", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -1,23 +1,23 @@
 use atm_core::ack::AckRequest;
 use atm_core::boundary::{ReplaySource, RequestDispatcher, RosterHarness};
 use atm_core::error_codes::AtmErrorCode;
+use atm_core::graft::{
+    GraftPostSendRequest, GraftPostSendResponse, graft_receiver_socket_path_from_home,
+    read_graft_post_send_message, write_graft_post_send_message,
+};
 use atm_core::protocol::{
     RequestEnvelope, ResponseEnvelope, SendRequestEnvelope, SendResponseEnvelope,
 };
 use atm_core::schema::{AgentMember, TeamConfig};
 use atm_core::send::{SendMessageSource, SendRequest};
 use atm_core::test_support::{EnvGuard, ROLE_TEAM_LEAD};
-use atm_core::types::TeamName;
-use atm_graft::{
-    GraftClient, GraftSession, GraftSessionOptions, GraftSessionState, HostNudgeInjector,
-};
+use atm_core::types::{AgentName, TeamName};
 use atm_runtime_test_support::open_sqlite_boundary;
+use interprocess::local_socket::ListenerOptions;
+use interprocess::local_socket::traits::Listener as _;
 use tempfile::TempDir;
 
-use crate::LocalIpcServerTransportAdapter;
-use crate::lifecycle_control::LifecycleControlSourceAdapter;
 use crate::runtime_health::{DaemonRequestDispatcher, RuntimeStatusCache};
-use crate::test_support::LifecycleFlagResetGuard;
 
 const TEST_TEAM: &str = "test-team";
 
@@ -114,89 +114,6 @@ fn write_graft_enabled_config(workspace_dir: &std::path::Path) {
     .expect("write graft config");
 }
 
-struct RunningDispatcherServer {
-    lifecycle: LifecycleControlSourceAdapter,
-    _reset: LifecycleFlagResetGuard,
-    join: std::thread::JoinHandle<()>,
-    result_rx: std::sync::mpsc::Receiver<Result<(), atm_core::error::AtmError>>,
-}
-
-impl RunningDispatcherServer {
-    fn stop(self) {
-        self.lifecycle.set_terminate_for_test(true);
-        self.result_rx
-            .recv_timeout(std::time::Duration::from_secs(15))
-            .expect("recv serve result")
-            .expect("serve runtime result");
-        self.join.join().expect("join serve thread");
-    }
-}
-
-fn spawn_dispatcher_server(
-    socket_path: std::path::PathBuf,
-    dispatcher: DaemonRequestDispatcher,
-) -> (RunningDispatcherServer, std::sync::mpsc::Receiver<()>) {
-    let server_transport = LocalIpcServerTransportAdapter::new();
-    let mut runtime = server_transport
-        .prepare_runtime_at_socket_path(socket_path)
-        .expect("prepare runtime");
-    let endpoint_guard = runtime.take_endpoint_guard().expect("take endpoint guard");
-    let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
-    let reset = LifecycleFlagResetGuard::install(lifecycle.clone());
-    let dispatcher: std::sync::Arc<dyn RequestDispatcher + Send + Sync> =
-        std::sync::Arc::new(dispatcher);
-    let (serve_result_tx, serve_result_rx) = std::sync::mpsc::channel();
-    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
-    let join = std::thread::spawn(move || {
-        let result = runtime.serve_with_runtime_hooks(
-            dispatcher,
-            crate::local_ipc_transport::RuntimeServeHooks {
-                endpoint_guard,
-                graceful_drain_deadline: std::time::Duration::from_millis(500),
-                force_cancel_deadline: std::time::Duration::from_secs(2),
-                begin_shutdown: || Ok(()),
-                reload_runtime_view: || Ok(()),
-                finalize_shutdown: || {},
-                publish_ready: move || {
-                    ready_tx.send(()).map_err(|_| {
-                        atm_core::error::AtmError::daemon_unavailable(
-                            "graft warning test failed to observe the daemon ready signal",
-                        )
-                        .with_recovery(
-                            "Rerun the graft warning test after restoring the bounded ready-signal handshake.",
-                        )
-                    })
-                },
-            },
-        );
-        serve_result_tx.send(result).expect("send serve result");
-    });
-    (
-        RunningDispatcherServer {
-            lifecycle,
-            _reset: reset,
-            join,
-            result_rx: serve_result_rx,
-        },
-        ready_rx,
-    )
-}
-
-#[derive(Debug, Default)]
-struct RecordingInjector {
-    nudges: std::sync::Mutex<Vec<atm_core::boundary::PostSendHookEvent>>,
-}
-
-impl HostNudgeInjector for RecordingInjector {
-    fn inject_nudge(
-        &self,
-        nudge: atm_core::boundary::PostSendHookEvent,
-    ) -> Result<(), atm_core::error::AtmError> {
-        self.nudges.lock().expect("nudges lock").push(nudge);
-        Ok(())
-    }
-}
-
 #[test]
 #[serial_test::serial(env)]
 fn dispatcher_send_surfaces_typed_warning_when_graft_receiver_path_is_unavailable() {
@@ -289,42 +206,52 @@ fn dispatcher_ack_surfaces_typed_warning_when_graft_reply_target_is_unavailable(
 fn dispatcher_send_delivers_direct_graft_nudge_without_warning() {
     let (_tempdir, atm_home, workspace_dir, dispatcher) = graft_warning_dispatcher();
     write_graft_enabled_config(&workspace_dir);
-    let socket_path = atm_home.join(".atm").join("daemon").join("atm-daemon.sock");
+    let recipient_team = TEST_TEAM.parse::<TeamName>().expect("team");
+    let recipient_agent = "qa-a".parse::<AgentName>().expect("agent");
+    let receiver_path =
+        graft_receiver_socket_path_from_home(&atm_home, &recipient_team, &recipient_agent);
+    if let Some(parent) = receiver_path.parent() {
+        std::fs::create_dir_all(parent).expect("receiver dir");
+    }
+    #[cfg(unix)]
+    if receiver_path.exists() {
+        std::fs::remove_file(&receiver_path).expect("remove stale receiver");
+    }
+    let receiver_name =
+        atm_core::protocol::daemon_local_ipc_name_from_path(&receiver_path).expect("receiver name");
+    let listener = ListenerOptions::new()
+        .name(receiver_name)
+        .create_sync()
+        .expect("bind fake graft receiver");
+    let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+    let receiver_thread = std::thread::spawn(move || {
+        let mut stream = listener.accept().expect("accept graft receiver");
+        let request: GraftPostSendRequest = read_graft_post_send_message(
+            &mut stream,
+            "failed to read graft post-send request",
+            "graft post-send request exceeded the bounded payload cap",
+        )
+        .expect("read graft request");
+        event_tx
+            .send(request.event.clone())
+            .expect("send captured event");
+        write_graft_post_send_message(
+            &mut stream,
+            &GraftPostSendResponse::Delivered,
+            "failed to write graft post-send response",
+            "graft post-send response exceeded the bounded payload cap",
+        )
+        .expect("write graft response");
+        use std::io::Write as _;
+        stream.flush().expect("flush graft response");
+    });
     let _env = EnvGuard::set_many([
         ("ATM_HOME", Some(atm_home.to_str().expect("utf8 atm home"))),
-        (
-            "ATM_DAEMON_SOCKET",
-            Some(socket_path.to_str().expect("utf8 socket path")),
-        ),
-        ("ATM_TEAM", Some(TEST_TEAM)),
-        ("ATM_IDENTITY", Some("qa-a")),
         ("HOME", Some(atm_home.to_str().expect("utf8 home"))),
         ("USERPROFILE", None),
     ]);
-    let (server, ready_rx) = spawn_dispatcher_server(socket_path, dispatcher);
-    ready_rx
-        .recv_timeout(std::time::Duration::from_secs(5))
-        .expect("daemon ready");
-
-    let client = GraftClient::connect().expect("connect graft client");
-    let injector = std::sync::Arc::new(RecordingInjector::default());
-    let session = GraftSession::activate(
-        client,
-        GraftSessionOptions::for_current_process(
-            workspace_dir.clone(),
-            TEST_TEAM.parse().expect("team"),
-            "qa-a".parse().expect("agent"),
-        ),
-        injector.clone() as std::sync::Arc<dyn HostNudgeInjector>,
-    )
-    .expect("activate graft session");
-    assert_eq!(
-        session.snapshot().expect("snapshot").state,
-        GraftSessionState::Listening
-    );
-
-    let response = session
-        .send(
+    let response = dispatcher
+        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
             SendRequest::new(
                 atm_home,
                 workspace_dir,
@@ -338,16 +265,19 @@ fn dispatcher_send_delivers_direct_graft_nudge_without_warning() {
                 false,
             )
             .expect("send request"),
-        )
+        )))
         .expect("send response");
+    let response = match response {
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => outcome,
+        other => panic!("expected send response, got {other:?}"),
+    };
 
     assert!(response.warnings.is_empty());
-    let nudges = injector.nudges.lock().expect("nudges lock");
-    assert_eq!(nudges.len(), 1);
-    assert_eq!(nudges[0].recipient.as_str(), "qa-a");
-    assert_eq!(nudges[0].recipient_team.as_str(), TEST_TEAM);
-    assert_eq!(nudges[0].message, "hello graft");
-
-    drop(session);
-    server.stop();
+    let nudge = event_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("receive graft nudge");
+    assert_eq!(nudge.recipient.as_str(), "qa-a");
+    assert_eq!(nudge.recipient_team.as_str(), TEST_TEAM);
+    assert_eq!(nudge.description, "hello graft");
+    receiver_thread.join().expect("join fake graft receiver");
 }

--- a/crates/atm-graft/examples/smoke_same_host.rs
+++ b/crates/atm-graft/examples/smoke_same_host.rs
@@ -158,14 +158,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         .into());
     }
     if !nudge
-        .message
+        .description
         .as_str()
         .contains(&args.expected_nudge_substring)
     {
         return Err(io::Error::other(format!(
-            "expected nudge message to contain {:?}, found {:?}",
+            "expected nudge description to contain {:?}, found {:?}",
             args.expected_nudge_substring,
-            nudge.message.as_str()
+            nudge.description.as_str()
         ))
         .into());
     }
@@ -243,7 +243,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 "recipient": nudge.recipient.to_string(),
                 "recipient_team": nudge.recipient_team.to_string(),
                 "message_id": nudge.message_id.to_string(),
-                "message": nudge.message,
+                "description": nudge.description,
                 "requires_ack": nudge.requires_ack,
                 "is_ack": nudge.is_ack,
                 "task_id": nudge.task_id.map(|task_id| task_id.to_string()),

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -27,6 +27,7 @@ use atm_daemon_client::{
     resolve_daemon_bin, resolve_daemon_local_ipc_endpoint,
 };
 
+mod nudge_sink;
 mod runtime;
 mod transport;
 

--- a/crates/atm-graft/src/nudge_sink.rs
+++ b/crates/atm-graft/src/nudge_sink.rs
@@ -1,0 +1,125 @@
+use std::sync::{Arc, RwLock};
+
+use atm_core::boundary::PostSendHookEvent;
+use atm_core::protocol::ProtocolErrorEnvelope;
+
+use crate::runtime::read_snapshot;
+use crate::{GraftObservability, HostNudgeInjector, SessionSnapshot};
+
+pub(crate) struct GraftNudgeSink<'a> {
+    pub(crate) injector: &'a dyn HostNudgeInjector,
+    pub(crate) snapshot: &'a Arc<RwLock<SessionSnapshot>>,
+    pub(crate) observability: &'a dyn GraftObservability,
+}
+
+impl GraftNudgeSink<'_> {
+    pub(crate) fn deliver(&self, event: PostSendHookEvent) -> Result<(), ProtocolErrorEnvelope> {
+        match self.injector.inject_nudge(event.clone()) {
+            Ok(()) => {
+                if let Ok(snapshot) = read_snapshot(self.snapshot) {
+                    self.observability.nudge_delivered(&snapshot, &event);
+                }
+                Ok(())
+            }
+            Err(error) => {
+                if let Ok(snapshot) = read_snapshot(self.snapshot) {
+                    self.observability
+                        .session_error(&snapshot, "inject_nudge", &error);
+                }
+                Err(ProtocolErrorEnvelope::from_error(&error))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex, RwLock};
+
+    use atm_core::boundary::PostSendHookEvent;
+    use atm_core::error::{AtmError, AtmErrorKind};
+
+    use super::GraftNudgeSink;
+    use crate::{GraftObservability, GraftSessionState, HostNudgeInjector, SessionSnapshot};
+
+    #[derive(Default)]
+    struct RecordingInjector {
+        events: Mutex<Vec<PostSendHookEvent>>,
+    }
+
+    impl HostNudgeInjector for RecordingInjector {
+        fn inject_nudge(&self, nudge: PostSendHookEvent) -> Result<(), AtmError> {
+            self.events.lock().expect("events").push(nudge);
+            Ok(())
+        }
+    }
+
+    struct FailingInjector;
+
+    impl HostNudgeInjector for FailingInjector {
+        fn inject_nudge(&self, _nudge: PostSendHookEvent) -> Result<(), AtmError> {
+            Err(AtmError::new(
+                AtmErrorKind::DaemonUnavailable,
+                "synthetic graft receiver unavailable",
+            ))
+        }
+    }
+
+    #[derive(Default)]
+    struct NoopObservability;
+
+    impl GraftObservability for NoopObservability {}
+
+    fn request_event() -> PostSendHookEvent {
+        PostSendHookEvent {
+            sender: "team-lead".parse().expect("sender"),
+            sender_team: "atm-dev".parse().expect("team"),
+            recipient: "arch-ctm".parse().expect("recipient"),
+            recipient_team: "atm-dev".parse().expect("team"),
+            message_id: "01KX1TEST00000000000000000".parse().expect("message id"),
+            description: "review failing smoke lane".to_string(),
+            requires_ack: false,
+            is_ack: false,
+            task_id: None,
+            recipient_pane_id: None,
+        }
+    }
+
+    fn snapshot() -> Arc<RwLock<SessionSnapshot>> {
+        Arc::new(RwLock::new(SessionSnapshot {
+            team: "atm-dev".parse().expect("team"),
+            agent: "arch-ctm".parse().expect("agent"),
+            state: GraftSessionState::Listening,
+        }))
+    }
+
+    #[test]
+    fn graft_nudge_sink_delivers_to_host_injector() {
+        let injector = RecordingInjector::default();
+        let sink = GraftNudgeSink {
+            injector: &injector,
+            snapshot: &snapshot(),
+            observability: &NoopObservability,
+        };
+
+        sink.deliver(request_event()).expect("delivery");
+
+        assert_eq!(injector.events.lock().expect("events").len(), 1);
+    }
+
+    #[test]
+    fn graft_nudge_sink_returns_typed_error_envelope() {
+        let sink = GraftNudgeSink {
+            injector: &FailingInjector,
+            snapshot: &snapshot(),
+            observability: &NoopObservability,
+        };
+
+        let error = sink.deliver(request_event()).expect_err("typed error");
+        assert!(
+            error
+                .message
+                .contains("synthetic graft receiver unavailable")
+        );
+    }
+}

--- a/crates/atm-graft/src/nudge_sink.rs
+++ b/crates/atm-graft/src/nudge_sink.rs
@@ -38,6 +38,7 @@ mod tests {
 
     use atm_core::boundary::PostSendHookEvent;
     use atm_core::error::{AtmError, AtmErrorKind};
+    use atm_core::test_support::{TEST_ARCH_CTM, TEST_LEAD, TEST_TEAM};
 
     use super::GraftNudgeSink;
     use crate::{GraftObservability, GraftSessionState, HostNudgeInjector, SessionSnapshot};
@@ -72,10 +73,10 @@ mod tests {
 
     fn request_event() -> PostSendHookEvent {
         PostSendHookEvent {
-            sender: "team-lead".parse().expect("sender"),
-            sender_team: "atm-dev".parse().expect("team"),
-            recipient: "arch-ctm".parse().expect("recipient"),
-            recipient_team: "atm-dev".parse().expect("team"),
+            sender: TEST_LEAD.parse().expect("sender"),
+            sender_team: TEST_TEAM.parse().expect("team"),
+            recipient: TEST_ARCH_CTM.parse().expect("recipient"),
+            recipient_team: TEST_TEAM.parse().expect("team"),
             message_id: "01KX1TEST00000000000000000".parse().expect("message id"),
             description: "review failing smoke lane".to_string(),
             requires_ack: false,
@@ -87,8 +88,8 @@ mod tests {
 
     fn snapshot() -> Arc<RwLock<SessionSnapshot>> {
         Arc::new(RwLock::new(SessionSnapshot {
-            team: "atm-dev".parse().expect("team"),
-            agent: "arch-ctm".parse().expect("agent"),
+            team: TEST_TEAM.parse().expect("team"),
+            agent: TEST_ARCH_CTM.parse().expect("agent"),
             state: GraftSessionState::Listening,
         }))
     }

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -11,12 +11,12 @@ use atm_core::graft::{
     GraftPostSendRequest, GraftPostSendResponse, read_graft_post_send_message,
     write_graft_post_send_message,
 };
-use atm_core::protocol::ProtocolErrorEnvelope;
 use interprocess::local_socket::prelude::*;
 use interprocess::local_socket::{
     Listener as LocalSocketListener, ListenerOptions, Stream as LocalSocketStream,
 };
 
+use crate::nudge_sink::GraftNudgeSink;
 use crate::{
     GraftObservability, GraftSessionState, HostNudgeInjector, RECEIVE_LOOP_JOIN_DEADLINE,
     SessionSnapshot,
@@ -42,6 +42,12 @@ struct InjectRequest {
 
 struct BoundedHostNudgeInjector {
     request_tx: SyncSender<InjectRequest>,
+}
+
+impl crate::HostNudgeInjector for BoundedHostNudgeInjector {
+    fn inject_nudge(&self, nudge: PostSendHookEvent) -> Result<(), AtmError> {
+        Self::inject_nudge(self, nudge)
+    }
 }
 
 impl BoundedHostNudgeInjector {
@@ -390,19 +396,15 @@ fn handle_graft_receiver_connection(
         "graft post-send request exceeded the bounded payload cap",
     )?;
     let event = request.event;
-    let response = match injector.inject_nudge(event.clone()) {
-        Ok(()) => {
-            let snapshot = read_snapshot(&ctx.snapshot)?;
-            ctx.observability.nudge_delivered(&snapshot, &event);
-            GraftPostSendResponse::Delivered
-        }
-        Err(error) => {
-            if let Ok(snapshot) = read_snapshot(&ctx.snapshot) {
-                ctx.observability
-                    .session_error(&snapshot, "inject_nudge", &error);
-            }
-            GraftPostSendResponse::Error(ProtocolErrorEnvelope::from_error(&error))
-        }
+    let response = match (GraftNudgeSink {
+        injector,
+        snapshot: &ctx.snapshot,
+        observability: ctx.observability.as_ref(),
+    })
+    .deliver(event)
+    {
+        Ok(()) => GraftPostSendResponse::Delivered,
+        Err(error) => GraftPostSendResponse::Error(error),
     };
     write_graft_post_send_message(
         stream,
@@ -561,7 +563,7 @@ mod tests {
             recipient: AgentName::from_validated(TEST_QA),
             recipient_team: TeamName::from_validated(TEST_TEAM),
             message_id: AtmMessageId::new(),
-            message: "review failing smoke lane".to_string(),
+            description: "review failing smoke lane".to_string(),
             requires_ack: false,
             is_ack: false,
             task_id: None,

--- a/crates/atm-runtime/src/composition.rs
+++ b/crates/atm-runtime/src/composition.rs
@@ -197,3 +197,22 @@ pub fn with_default_roster_store<T>(
         (Err(error), Err(_)) => Err(error),
     }
 }
+
+pub fn with_default_nudge_template_override_store<T>(
+    f: impl FnOnce(&(dyn boundary::NudgeTemplateOverrideStore + Send + Sync)) -> Result<T, AtmError>,
+) -> Result<T, AtmError> {
+    let sqlite_backend = Arc::new(SqliteStorageBackend::new_with_observability(
+        host_mail_db_path()?,
+        RuntimeSqliteObservability::disabled(),
+    )?);
+    let override_store = sqlite_backend.nudge_template_override_store();
+    let result = f(override_store.as_ref());
+    let finalize_result =
+        SqliteRuntimeStorageFinalizer::new(sqlite_backend).finalize_storage_shutdown();
+    match (result, finalize_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), Ok(())) => Err(error),
+        (Err(error), Err(_)) => Err(error),
+    }
+}

--- a/crates/atm-runtime/src/lib.rs
+++ b/crates/atm-runtime/src/lib.rs
@@ -13,7 +13,7 @@ mod sqlite_observability;
 
 pub use composition::{
     RuntimeAssembly, RuntimeAssemblyInputs, assemble_default_runtime, assemble_sqlite_runtime,
-    default_local_runtime, with_default_roster_store,
+    default_local_runtime, with_default_nudge_template_override_store, with_default_roster_store,
 };
 #[cfg(any(test, feature = "test-utils"))]
 pub use replay_store::sqlite_remote_replay_store_for_test;

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -16,6 +16,7 @@ name = "atm_storage_rusqlite"
 test-support = []
 
 [dependencies]
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
 atm-storage = { path = "../atm-storage", version = "1.2.3" }
 serde_json.workspace = true
 serde.workspace = true

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -8,6 +8,7 @@
 //! message and roster contracts.
 
 mod mailbox_metadata;
+mod nudge_template_override_store;
 mod observability;
 mod roster_store;
 mod shared_db;
@@ -175,6 +176,11 @@ struct SqliteMessageStore {
 
 #[derive(Debug)]
 struct SqliteRosterStore {
+    db: Arc<SharedDb>,
+}
+
+#[derive(Debug)]
+struct SqliteNudgeTemplateOverrideStore {
     db: Arc<SharedDb>,
 }
 
@@ -436,6 +442,7 @@ impl MessageStore for SqliteMessageStore {
 pub struct SqliteStorageBackend {
     message_store: Arc<SqliteMessageStore>,
     roster_store: Arc<SqliteRosterStore>,
+    nudge_template_override_store: Arc<SqliteNudgeTemplateOverrideStore>,
 }
 
 impl SqliteStorageBackend {
@@ -450,7 +457,8 @@ impl SqliteStorageBackend {
         let db = Arc::new(SharedDb::open_with_observability(path, observability)?);
         Ok(Self {
             message_store: Arc::new(SqliteMessageStore::new(Arc::clone(&db))),
-            roster_store: Arc::new(SqliteRosterStore::new(db)),
+            roster_store: Arc::new(SqliteRosterStore::new(Arc::clone(&db))),
+            nudge_template_override_store: Arc::new(SqliteNudgeTemplateOverrideStore::new(db)),
         })
     }
 
@@ -459,7 +467,8 @@ impl SqliteStorageBackend {
         let db = Arc::new(SharedDb::open_in_memory_for_test()?);
         Ok(Self {
             message_store: Arc::new(SqliteMessageStore::new(Arc::clone(&db))),
-            roster_store: Arc::new(SqliteRosterStore::new(db)),
+            roster_store: Arc::new(SqliteRosterStore::new(Arc::clone(&db))),
+            nudge_template_override_store: Arc::new(SqliteNudgeTemplateOverrideStore::new(db)),
         })
     }
 
@@ -499,6 +508,12 @@ impl SqliteStorageBackend {
 
     pub fn roster_store(&self) -> Arc<dyn RosterStore + Send + Sync> {
         self.roster_store.clone()
+    }
+
+    pub fn nudge_template_override_store(
+        &self,
+    ) -> Arc<dyn atm_core::boundary::NudgeTemplateOverrideStore + Send + Sync> {
+        self.nudge_template_override_store.clone()
     }
 
     pub fn replace_roster(

--- a/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
+++ b/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
@@ -1,0 +1,135 @@
+use super::SqliteNudgeTemplateOverrideStore;
+use crate::shared_db::SharedDb;
+use atm_core::boundary::{
+    BuiltInNudgeTemplateKind, NudgeTemplateOverrideStore, TeamNudgeTemplateOverrideRow,
+};
+use atm_core::error::AtmError;
+use atm_core::types::{IsoTimestamp, TeamName};
+use rusqlite::{OptionalExtension, params};
+use std::sync::Arc;
+
+impl SqliteNudgeTemplateOverrideStore {
+    pub(crate) fn new(db: Arc<SharedDb>) -> Self {
+        Self { db }
+    }
+}
+
+impl atm_core::boundary::sealed::Sealed for SqliteNudgeTemplateOverrideStore {}
+
+impl NudgeTemplateOverrideStore for SqliteNudgeTemplateOverrideStore {
+    fn load_template_override(
+        &self,
+        team: &TeamName,
+        kind: BuiltInNudgeTemplateKind,
+    ) -> Result<Option<TeamNudgeTemplateOverrideRow>, AtmError> {
+        self.db.with_connection(|connection| {
+            connection
+                .query_row(
+                    "SELECT template_body, updated_at
+                     FROM team_nudge_template_overrides
+                     WHERE team_name = ?1 AND template_kind = ?2;",
+                    params![team.as_str(), template_kind_value(kind)],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()
+                .map_err(|error| {
+                    self.db
+                        .error("failed to load team nudge template override row", error)
+                })?
+                .map(|(template_body, updated_at)| {
+                    Ok(TeamNudgeTemplateOverrideRow {
+                        team_name: team.clone(),
+                        kind,
+                        template_body,
+                        updated_at: parse_updated_at(updated_at)?,
+                    })
+                })
+                .transpose()
+        })
+    }
+}
+
+fn template_kind_value(kind: BuiltInNudgeTemplateKind) -> &'static str {
+    match kind {
+        BuiltInNudgeTemplateKind::Delivery => "delivery",
+        BuiltInNudgeTemplateKind::DeliveryAck => "delivery_ack",
+        BuiltInNudgeTemplateKind::DeliveryTask => "delivery_task",
+        BuiltInNudgeTemplateKind::DeliveryTaskAck => "delivery_task_ack",
+        BuiltInNudgeTemplateKind::Acknowledge => "acknowledge",
+        BuiltInNudgeTemplateKind::AcknowledgeTask => "acknowledge_task",
+    }
+}
+
+fn parse_updated_at(raw: String) -> Result<IsoTimestamp, AtmError> {
+    raw.parse::<chrono::DateTime<chrono::Utc>>()
+        .map(IsoTimestamp::from_datetime)
+        .map_err(|error| {
+            AtmError::validation(format!(
+                "failed to parse team_nudge_template_overrides.updated_at `{raw}`: {error}"
+            ))
+            .with_recovery(
+                "Repair the malformed team_nudge_template_overrides.updated_at row before retrying the override lookup.",
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::template_kind_value;
+    use atm_core::boundary::BuiltInNudgeTemplateKind;
+
+    #[test]
+    fn sqlite_override_store_loads_saved_override_row() {
+        let backend = crate::SqliteStorageBackend::in_memory_for_test().expect("backend");
+        backend
+            .message_store
+            .db
+            .with_connection(|connection| {
+                connection
+                    .execute(
+                        "INSERT INTO team_nudge_template_overrides(
+                            team_name, template_kind, template_body, updated_at
+                         ) VALUES (?1, ?2, ?3, ?4);",
+                        rusqlite::params![
+                            "test-team",
+                            template_kind_value(BuiltInNudgeTemplateKind::DeliveryAck),
+                            "<atm/>",
+                            chrono::Utc::now().to_rfc3339(),
+                        ],
+                    )
+                    .map_err(|error| {
+                        backend.message_store.db.error("insert override row", error)
+                    })?;
+                Ok(())
+            })
+            .expect("insert");
+
+        let row = backend
+            .nudge_template_override_store()
+            .load_template_override(
+                &"test-team".parse().expect("team"),
+                BuiltInNudgeTemplateKind::DeliveryAck,
+            )
+            .expect("lookup")
+            .expect("row");
+
+        assert_eq!(row.team_name.as_str(), "test-team");
+        assert_eq!(row.kind, BuiltInNudgeTemplateKind::DeliveryAck);
+        assert_eq!(row.template_body, "<atm/>");
+    }
+
+    #[test]
+    fn sqlite_override_store_returns_none_for_missing_row() {
+        let backend = crate::SqliteStorageBackend::in_memory_for_test().expect("backend");
+
+        let row = backend
+            .nudge_template_override_store()
+            .load_template_override(
+                &"test-team".parse().expect("team"),
+                BuiltInNudgeTemplateKind::Delivery,
+            )
+            .expect("lookup");
+
+        assert!(row.is_none());
+    }
+}

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -87,6 +87,22 @@ CREATE TABLE IF NOT EXISTS team_roster (
     PRIMARY KEY (team_name, agent_name)
 );
 
+CREATE TABLE IF NOT EXISTS team_nudge_template_overrides (
+    team_name TEXT NOT NULL,
+    template_kind TEXT NOT NULL
+        CHECK(template_kind IN (
+            'delivery',
+            'delivery_ack',
+            'delivery_task',
+            'delivery_task_ack',
+            'acknowledge',
+            'acknowledge_task'
+        )),
+    template_body TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (team_name, template_kind)
+);
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mail_messages_single_successor
     ON mail_messages(team, agent, parent_message_id)
     WHERE parent_message_id IS NOT NULL;
@@ -109,6 +125,9 @@ CREATE INDEX IF NOT EXISTS idx_daemon_remote_replay_mailbox
 
 CREATE INDEX IF NOT EXISTS idx_team_roster_team_name
     ON team_roster(team_name);
+
+CREATE INDEX IF NOT EXISTS idx_team_nudge_template_overrides_team_name
+    ON team_nudge_template_overrides(team_name);
 "#;
 // `team_roster` is the single canonical durable roster truth. Runtime pid
 // continuity is transient daemon-owned state and must not be persisted here.

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -1,0 +1,631 @@
+use std::collections::BTreeMap;
+use std::io::Write as _;
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use atm_core::boundary::{
+    BuiltInNudgeTemplateKind, PostSendHookEvent, TeamNudgeTemplateOverrideRow,
+};
+use atm_core::error::{AtmError, AtmErrorKind};
+use atm_core::error_codes::AtmErrorCode;
+use atm_core::graft::{
+    GraftPostSendRequest, GraftPostSendResponse, graft_receiver_socket_path_from_home,
+    read_graft_post_send_message, write_graft_post_send_message,
+};
+use atm_core::home;
+use atm_daemon_bootstrap::with_default_nudge_template_override_store;
+use clap::Args;
+use interprocess::local_socket::Stream as LocalSocketStream;
+use interprocess::local_socket::traits::Stream as _;
+
+use crate::observability::CliObservability;
+
+const ATM_POST_SEND_ENV: &str = "ATM_POST_SEND";
+const INTERNAL_NUDGE_SINK_ENV: &str = "ATM_INTERNAL_NUDGE_SINK";
+const TMUX_DOUBLE_ENTER_DELAY: Duration = Duration::from_millis(275);
+const TMUX_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const TMUX_PROGRAM_ENV: &str = "ATM_TEST_TMUX_BIN";
+
+#[derive(Debug, Args)]
+#[command(hide = true)]
+pub struct InternalNudgeCommand;
+
+impl InternalNudgeCommand {
+    pub fn run(self, _observability: &CliObservability) -> Result<()> {
+        let input = InternalNudgeInput::from_env()?;
+        let kind = BuiltInNudgeTemplateKind::from_post_send_event(&input.event);
+        let template = load_override_body(&input.event.recipient_team, kind)?
+            .unwrap_or_else(|| default_template(kind).to_string());
+        let rendered = render_template(&template, &input.render_values())?;
+        match input.sink_target {
+            NudgeSinkTarget::Tmux => TmuxNudgeSink.deliver(&input.event, &rendered)?,
+            NudgeSinkTarget::Graft => GraftNudgeSink.deliver(&input.event)?,
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NudgeSinkTarget {
+    Tmux,
+    Graft,
+}
+
+impl NudgeSinkTarget {
+    fn from_env() -> Result<Self> {
+        match std::env::var(INTERNAL_NUDGE_SINK_ENV).as_deref() {
+            Ok("tmux") => Ok(Self::Tmux),
+            Ok("graft") => Ok(Self::Graft),
+            Ok(other) => Err(AtmError::validation(format!(
+                "unsupported built-in nudge sink target `{other}`"
+            ))
+            .with_recovery(
+                "Set ATM_INTERNAL_NUDGE_SINK to `tmux` or `graft` before retrying the built-in post-send path.",
+            )
+            .into()),
+            Err(_) => Err(AtmError::validation(
+                "missing ATM_INTERNAL_NUDGE_SINK for built-in post-send nudge",
+            )
+            .with_recovery(
+                "Populate ATM_INTERNAL_NUDGE_SINK before invoking `atm internal-nudge`.",
+            )
+            .into()),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RawInternalNudgePayload {
+    from: String,
+    sender: String,
+    recipient: String,
+    team: String,
+    message_id: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    message: String,
+    requires_ack: bool,
+    is_ack: bool,
+    #[serde(default)]
+    task_id: Option<String>,
+    #[serde(default)]
+    recipient_pane_id: Option<String>,
+}
+
+#[derive(Debug)]
+struct InternalNudgeInput {
+    from: String,
+    event: PostSendHookEvent,
+    sink_target: NudgeSinkTarget,
+}
+
+impl InternalNudgeInput {
+    fn from_env() -> Result<Self> {
+        let raw_payload = std::env::var(ATM_POST_SEND_ENV).map_err(|_| {
+            AtmError::validation("missing ATM_POST_SEND payload for built-in post-send nudge")
+                .with_recovery(
+                    "Populate ATM_POST_SEND before invoking the built-in `atm internal-nudge` path.",
+                )
+        })?;
+        let payload: RawInternalNudgePayload =
+            serde_json::from_str(&raw_payload).map_err(|source| {
+                AtmError::validation("failed to decode ATM_POST_SEND payload for built-in nudge")
+                    .with_recovery(
+                        "Repair the ATM_POST_SEND JSON payload before retrying the built-in post-send path.",
+                    )
+                    .with_source(source)
+            })?;
+        let description = if payload.description.trim().is_empty() {
+            payload.message.clone()
+        } else {
+            payload.description.clone()
+        };
+        Ok(Self {
+            from: payload.from,
+            event: PostSendHookEvent {
+                sender: payload.sender.parse()?,
+                sender_team: payload.team.parse()?,
+                recipient: payload.recipient.parse()?,
+                recipient_team: payload.team.parse()?,
+                message_id: payload.message_id.parse()?,
+                description,
+                requires_ack: payload.requires_ack,
+                is_ack: payload.is_ack,
+                task_id: payload
+                    .task_id
+                    .filter(|value| !value.trim().is_empty())
+                    .map(|value| value.parse())
+                    .transpose()?,
+                recipient_pane_id: payload
+                    .recipient_pane_id
+                    .filter(|value| !value.trim().is_empty())
+                    .as_deref()
+                    .map(atm_core::types::PaneId::from_cli)
+                    .transpose()?,
+            },
+            sink_target: NudgeSinkTarget::from_env()?,
+        })
+    }
+
+    fn render_values(&self) -> BTreeMap<&'static str, String> {
+        BTreeMap::from([
+            ("from", self.from.clone()),
+            ("team", self.event.recipient_team.to_string()),
+            ("message_id", self.event.message_id.to_string()),
+            ("description", self.event.description.clone()),
+            (
+                "task_id",
+                self.event
+                    .task_id
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+            ),
+        ])
+    }
+}
+
+fn load_override_body(
+    team: &atm_core::types::TeamName,
+    kind: BuiltInNudgeTemplateKind,
+) -> Result<Option<String>> {
+    with_default_nudge_template_override_store(|store| {
+        Ok(store
+            .load_template_override(team, kind)?
+            .map(|row: TeamNudgeTemplateOverrideRow| row.template_body))
+    })
+    .map_err(Into::into)
+}
+
+fn default_template(kind: BuiltInNudgeTemplateKind) -> &'static str {
+    match kind {
+        BuiltInNudgeTemplateKind::Delivery => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <description>{{description}}</description>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        }
+        BuiltInNudgeTemplateKind::DeliveryAck => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <action>ack the message</action>\n  <description>{{description}}</description>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        }
+        BuiltInNudgeTemplateKind::DeliveryTask => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <task id=\"{{task_id}}\">{{description}}</task>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        }
+        BuiltInNudgeTemplateKind::DeliveryTaskAck => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <action>ack the message</action>\n  <task id=\"{{task_id}}\">{{description}}</task>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        }
+        BuiltInNudgeTemplateKind::Acknowledge => {
+            "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\"/>"
+        }
+        BuiltInNudgeTemplateKind::AcknowledgeTask => {
+            "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\" task-id=\"{{task_id}}\"/>"
+        }
+    }
+}
+
+fn render_template(template: &str, values: &BTreeMap<&'static str, String>) -> Result<String> {
+    if template.contains("{%") || template.contains("%}") {
+        return Err(AtmError::validation(
+            "built-in nudge templates do not support Jinja or conditional blocks",
+        )
+        .with_recovery(
+            "Use only the documented placeholder tokens in the stored template body before retrying built-in nudge rendering.",
+        )
+        .into());
+    }
+    let mut output = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("{{") {
+        output.push_str(&rest[..start]);
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find("}}") else {
+            return Err(AtmError::validation("unterminated built-in nudge placeholder")
+                .with_recovery(
+                    "Close every built-in nudge placeholder with `}}` before retrying template rendering.",
+                )
+                .into());
+        };
+        let key = after_start[..end].trim();
+        let Some(value) = values.get(key) else {
+            return Err(AtmError::validation(format!(
+                "unsupported built-in nudge placeholder `{{{{{key}}}}}`"
+            ))
+            .with_recovery(
+                "Use only {{from}}, {{team}}, {{message_id}}, {{description}}, and {{task_id}} in built-in nudge templates.",
+            )
+            .into());
+        };
+        output.push_str(value);
+        rest = &after_start[end + 2..];
+    }
+    output.push_str(rest);
+    Ok(output)
+}
+
+struct TmuxNudgeSink;
+
+impl TmuxNudgeSink {
+    fn deliver(&self, event: &PostSendHookEvent, rendered: &str) -> Result<()> {
+        let pane_id = event.recipient_pane_id.as_ref().ok_or_else(|| {
+            AtmError::new_with_code(
+                AtmErrorCode::PostSendPaneMissing,
+                AtmErrorKind::Validation,
+                format!(
+                    "recipient {}@{} has tmux-backed post-send capability but no pane id",
+                    event.recipient, event.recipient_team
+                ),
+            )
+            .with_recovery(format!(
+                "Repair the roster row with `atm teams update-member --team {} --member {} --pane-id <pane>`.",
+                event.recipient_team, event.recipient
+            ))
+        })?;
+        run_tmux_command(
+            {
+                let mut command = tmux_command();
+                command.args(["send-keys", "-t", pane_id.as_str(), "-l", rendered]);
+                command
+            },
+            "send literal nudge",
+        )?;
+        run_tmux_command(
+            {
+                let mut command = tmux_command();
+                command.args(["send-keys", "-t", pane_id.as_str(), "Enter"]);
+                command
+            },
+            "send first Enter to nudge pane",
+        )?;
+        thread::sleep(TMUX_DOUBLE_ENTER_DELAY);
+        run_tmux_command(
+            {
+                let mut command = tmux_command();
+                command.args(["send-keys", "-t", pane_id.as_str(), "Enter"]);
+                command
+            },
+            "send second Enter to nudge pane",
+        )?;
+        Ok(())
+    }
+}
+
+struct GraftNudgeSink;
+
+impl GraftNudgeSink {
+    fn deliver(&self, event: &PostSendHookEvent) -> Result<()> {
+        let home_dir = home::atm_home()?;
+        let endpoint_path = graft_receiver_socket_path_from_home(
+            &home_dir,
+            &event.recipient_team,
+            &event.recipient,
+        );
+        let endpoint_name = atm_core::protocol::daemon_local_ipc_name_from_path(&endpoint_path)?;
+        let mut stream = LocalSocketStream::connect(endpoint_name).map_err(|source| {
+            AtmError::new_with_code(
+                AtmErrorCode::PostSendGraftUnavailable,
+                AtmErrorKind::DaemonUnavailable,
+                format!(
+                    "failed to connect to graft nudge receiver for {}@{}",
+                    event.recipient, event.recipient_team
+                ),
+            )
+            .with_recovery(
+                "Start or repair the graft-backed receiver before retrying post-send delivery.",
+            )
+            .with_source(source)
+        })?;
+        let request = GraftPostSendRequest {
+            event: event.clone(),
+        };
+        write_graft_post_send_message(
+            &mut stream,
+            &request,
+            "failed to write graft post-send request",
+            "graft post-send request exceeded the bounded payload cap",
+        )?;
+        let response: GraftPostSendResponse = read_graft_post_send_message(
+            &mut stream,
+            "failed to read graft post-send response",
+            "graft post-send response exceeded the bounded payload cap",
+        )?;
+        stream.flush().map_err(|source| {
+            AtmError::new_with_code(
+                AtmErrorCode::PostSendGraftUnavailable,
+                AtmErrorKind::DaemonUnavailable,
+                "failed to flush graft post-send request",
+            )
+            .with_recovery(
+                "Repair the graft-backed receiver socket before retrying post-send delivery.",
+            )
+            .with_source(source)
+        })?;
+        match response {
+            GraftPostSendResponse::Delivered => Ok(()),
+            GraftPostSendResponse::Error(error) => Err(error.into_atm_error().into()),
+        }
+    }
+}
+
+fn tmux_command() -> Command {
+    #[cfg(test)]
+    if let Some(program) = std::env::var_os(TMUX_PROGRAM_ENV).filter(|value| !value.is_empty()) {
+        return Command::new(program);
+    }
+    Command::new("tmux")
+}
+
+fn run_tmux_command(mut command: Command, action: &'static str) -> Result<()> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let child = command.spawn().map_err(|source| {
+        AtmError::new_with_code(
+            AtmErrorCode::PostSendTmuxSendFailed,
+            AtmErrorKind::DaemonUnavailable,
+            format!("failed to start tmux while trying to {action}: {source}"),
+        )
+        .with_recovery("Repair the local tmux installation before retrying post-send delivery.")
+        .with_source(source)
+    })?;
+    let output = wait_for_tmux_output(child, action)?;
+    ensure_tmux_success(output, action).map_err(Into::into)
+}
+
+fn wait_for_tmux_output(mut child: Child, action: &'static str) -> Result<Output> {
+    let started_at = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                return child.wait_with_output().map_err(|source| {
+                    AtmError::new_with_code(
+                        AtmErrorCode::PostSendTmuxSendFailed,
+                        AtmErrorKind::DaemonUnavailable,
+                        format!("failed to collect tmux output while trying to {action}: {source}"),
+                    )
+                    .with_recovery(
+                        "Repair the local tmux installation before retrying post-send delivery.",
+                    )
+                    .with_source(source)
+                    .into()
+                });
+            }
+            Ok(None) if started_at.elapsed() < TMUX_SEND_TIMEOUT => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(AtmError::new_with_code(
+                    AtmErrorCode::PostSendTmuxSendFailed,
+                    AtmErrorKind::Timeout,
+                    format!(
+                        "tmux {action} timed out after {}s",
+                        TMUX_SEND_TIMEOUT.as_secs()
+                    ),
+                )
+                .with_recovery(
+                    "Repair the local tmux installation or pane state before retrying post-send delivery.",
+                )
+                .into());
+            }
+            Err(source) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(AtmError::new_with_code(
+                    AtmErrorCode::PostSendTmuxSendFailed,
+                    AtmErrorKind::DaemonUnavailable,
+                    format!("failed while waiting for tmux {action}: {source}"),
+                )
+                .with_recovery(
+                    "Repair the local tmux installation before retrying post-send delivery.",
+                )
+                .with_source(source)
+                .into());
+            }
+        }
+    }
+}
+
+fn ensure_tmux_success(output: Output, action: &'static str) -> Result<(), AtmError> {
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let detail = if stderr.is_empty() {
+        format!("tmux exited unsuccessfully while trying to {action}")
+    } else {
+        format!("tmux exited unsuccessfully while trying to {action}: {stderr}")
+    };
+    Err(AtmError::new_with_code(
+        AtmErrorCode::PostSendTmuxSendFailed,
+        AtmErrorKind::DaemonUnavailable,
+        detail,
+    )
+    .with_recovery("Repair the local tmux installation before retrying post-send delivery."))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::Duration;
+
+    use atm_core::boundary::{BuiltInNudgeTemplateKind, PostSendHookEvent};
+    use atm_core::test_support::EnvGuard;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    use super::{
+        ATM_POST_SEND_ENV, INTERNAL_NUDGE_SINK_ENV, InternalNudgeInput, NudgeSinkTarget,
+        TMUX_DOUBLE_ENTER_DELAY, TMUX_PROGRAM_ENV, default_template, render_template,
+    };
+
+    fn base_event() -> PostSendHookEvent {
+        PostSendHookEvent {
+            sender: "team-lead".parse().expect("sender"),
+            sender_team: "atm-dev".parse().expect("team"),
+            recipient: "arch-ctm".parse().expect("recipient"),
+            recipient_team: "atm-dev".parse().expect("team"),
+            message_id: "01KX1TEST00000000000000000".parse().expect("message id"),
+            description: "review failing smoke lane".to_string(),
+            requires_ack: false,
+            is_ack: false,
+            task_id: None,
+            recipient_pane_id: Some(atm_core::types::PaneId::from_cli("%9").expect("pane")),
+        }
+    }
+
+    #[test]
+    fn built_in_templates_keep_ack_payloads_compact() {
+        assert_eq!(
+            default_template(BuiltInNudgeTemplateKind::Acknowledge),
+            "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\"/>"
+        );
+        assert_eq!(
+            default_template(BuiltInNudgeTemplateKind::AcknowledgeTask),
+            "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\" task-id=\"{{task_id}}\"/>"
+        );
+    }
+
+    #[test]
+    fn built_in_template_kind_selection_covers_six_paths() {
+        let mut event = base_event();
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::Delivery
+        );
+        event.requires_ack = true;
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::DeliveryAck
+        );
+        event.requires_ack = false;
+        event.task_id = Some("AD.21".parse().expect("task"));
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::DeliveryTask
+        );
+        event.requires_ack = true;
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::DeliveryTaskAck
+        );
+        event.is_ack = true;
+        event.requires_ack = false;
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::AcknowledgeTask
+        );
+        event.task_id = None;
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::Acknowledge
+        );
+    }
+
+    #[test]
+    fn render_template_replaces_only_supported_placeholders() {
+        let rendered = render_template(
+            "<atm from=\"{{from}}\" task-id=\"{{task_id}}\">{{description}}</atm>",
+            &InternalNudgeInput {
+                from: "team-lead@atm-dev".to_string(),
+                event: base_event(),
+                sink_target: NudgeSinkTarget::Tmux,
+            }
+            .render_values(),
+        )
+        .expect("render");
+        assert!(rendered.contains("team-lead@atm-dev"));
+        assert!(rendered.contains("review failing smoke lane"));
+        assert!(rendered.contains("task-id=\"\""));
+    }
+
+    #[test]
+    fn render_template_rejects_unknown_placeholder() {
+        let error = render_template(
+            "<atm>{{unknown}}</atm>",
+            &InternalNudgeInput {
+                from: "team-lead@atm-dev".to_string(),
+                event: base_event(),
+                sink_target: NudgeSinkTarget::Tmux,
+            }
+            .render_values(),
+        )
+        .expect_err("unknown placeholder");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported built-in nudge placeholder")
+        );
+    }
+
+    #[test]
+    #[serial(env)]
+    fn internal_nudge_input_reads_post_send_env() {
+        let payload = serde_json::json!({
+            "from": "team-lead@atm-dev",
+            "sender": "team-lead",
+            "recipient": "arch-ctm",
+            "team": "atm-dev",
+            "message_id": "01KX1TEST00000000000000000",
+            "description": "review failing smoke lane",
+            "message": "review failing smoke lane",
+            "requires_ack": true,
+            "is_ack": false,
+            "task_id": "AD.21",
+            "recipient_pane_id": "%9"
+        });
+        let payload_value = payload.to_string();
+        let _env = EnvGuard::set_many([
+            (ATM_POST_SEND_ENV, Some(payload_value.as_str())),
+            (INTERNAL_NUDGE_SINK_ENV, Some("tmux")),
+        ]);
+
+        let input = InternalNudgeInput::from_env().expect("input");
+
+        assert_eq!(input.from, "team-lead@atm-dev");
+        assert_eq!(input.sink_target, NudgeSinkTarget::Tmux);
+        assert_eq!(input.event.task_id.expect("task").as_str(), "AD.21");
+    }
+
+    #[test]
+    #[serial(env)]
+    fn tmux_sink_uses_double_enter_sequence() {
+        let tempdir = tempdir().expect("tempdir");
+        let tmux_log = tempdir.path().join("tmux.log");
+        #[cfg(windows)]
+        let tmux_path = tempdir.path().join("tmux.cmd");
+        #[cfg(not(windows))]
+        let tmux_path = tempdir.path().join("tmux");
+        #[cfg(windows)]
+        fs::write(
+            &tmux_path,
+            "@echo off\r\n>> \"%ATM_TEST_TMUX_LOG%\" echo %*\r\nexit /b 0\r\n",
+        )
+        .expect("write tmux shim");
+        #[cfg(not(windows))]
+        fs::write(
+            &tmux_path,
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"$ATM_TEST_TMUX_LOG\"\nexit 0\n",
+        )
+        .expect("write tmux shim");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&tmux_path).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&tmux_path, perms).expect("chmod");
+        }
+
+        let tmux_log_value = tmux_log.display().to_string();
+        let tmux_bin_value = tmux_path.display().to_string();
+        let _env = EnvGuard::set_many([
+            (TMUX_PROGRAM_ENV, Some(tmux_bin_value.as_str())),
+            ("ATM_TEST_TMUX_LOG", Some(tmux_log_value.as_str())),
+        ]);
+        super::TmuxNudgeSink
+            .deliver(&base_event(), "<atm/>")
+            .expect("deliver");
+        let logged = fs::read_to_string(&tmux_log).expect("tmux log");
+        assert_eq!(logged.matches("Enter").count(), 2);
+        assert!(TMUX_DOUBLE_ENTER_DELAY >= Duration::from_millis(250));
+    }
+}

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -449,7 +449,7 @@ mod tests {
     use std::time::Duration;
 
     use atm_core::boundary::{BuiltInNudgeTemplateKind, PostSendHookEvent};
-    use atm_core::test_support::EnvGuard;
+    use atm_core::test_support::{EnvGuard, TEST_ARCH_CTM, TEST_LEAD, TEST_TEAM};
     use serial_test::serial;
     use tempfile::tempdir;
 
@@ -460,10 +460,10 @@ mod tests {
 
     fn base_event() -> PostSendHookEvent {
         PostSendHookEvent {
-            sender: "team-lead".parse().expect("sender"),
-            sender_team: "atm-dev".parse().expect("team"),
-            recipient: "arch-ctm".parse().expect("recipient"),
-            recipient_team: "atm-dev".parse().expect("team"),
+            sender: TEST_LEAD.parse().expect("sender"),
+            sender_team: TEST_TEAM.parse().expect("team"),
+            recipient: TEST_ARCH_CTM.parse().expect("recipient"),
+            recipient_team: TEST_TEAM.parse().expect("team"),
             message_id: "01KX1TEST00000000000000000".parse().expect("message id"),
             description: "review failing smoke lane".to_string(),
             requires_ack: false,
@@ -543,7 +543,7 @@ mod tests {
         let error = render_template(
             "<atm>{{unknown}}</atm>",
             &InternalNudgeInput {
-                from: "team-lead@atm-dev".to_string(),
+                from: format!("{TEST_LEAD}@{TEST_TEAM}"),
                 event: base_event(),
                 sink_target: NudgeSinkTarget::Tmux,
             }
@@ -561,10 +561,10 @@ mod tests {
     #[serial(env)]
     fn internal_nudge_input_reads_post_send_env() {
         let payload = serde_json::json!({
-            "from": "team-lead@atm-dev",
-            "sender": "team-lead",
-            "recipient": "arch-ctm",
-            "team": "atm-dev",
+            "from": format!("{TEST_LEAD}@{TEST_TEAM}"),
+            "sender": TEST_LEAD,
+            "recipient": TEST_ARCH_CTM,
+            "team": TEST_TEAM,
             "message_id": "01KX1TEST00000000000000000",
             "description": "review failing smoke lane",
             "message": "review failing smoke lane",
@@ -581,7 +581,7 @@ mod tests {
 
         let input = InternalNudgeInput::from_env().expect("input");
 
-        assert_eq!(input.from, "team-lead@atm-dev");
+        assert_eq!(input.from, format!("{TEST_LEAD}@{TEST_TEAM}"));
         assert_eq!(input.sink_target, NudgeSinkTarget::Tmux);
         assert_eq!(input.event.task_id.expect("task").as_str(), "AD.21");
     }

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod caller_context;
 pub mod clear;
 pub mod doctor;
 pub mod help;
+pub(crate) mod internal_nudge;
 pub mod list;
 pub mod log;
 pub mod members;
@@ -19,6 +20,7 @@ pub use ack::AckCommand;
 pub use clear::ClearCommand;
 pub use doctor::DoctorCommand;
 pub use help::HelpCommand;
+pub(crate) use internal_nudge::InternalNudgeCommand;
 pub use list::ListCommand;
 pub use log::LogCommand;
 pub use members::MembersCommand;
@@ -70,6 +72,8 @@ enum Command {
     Log(LogCommand),
     Doctor(DoctorCommand),
     Help(HelpCommand),
+    #[command(hide = true)]
+    InternalNudge(InternalNudgeCommand),
     Teams(TeamsCommand),
     Members(MembersCommand),
 }
@@ -85,6 +89,7 @@ impl Command {
             Self::Log(command) => command.run(observability),
             Self::Doctor(command) => command.run(observability),
             Self::Help(command) => command.run(observability),
+            Self::InternalNudge(command) => command.run(observability),
             Self::Teams(command) => command.run(observability),
             Self::Members(command) => command.run(observability),
         }


### PR DESCRIPTION
Implements AD.21 per docs/plans/phase-AD/sprint-AD21.md.

Commit: 14d348eb

## Summary
- Built-in post-send nudge templates (6 kinds: Delivery/DeliveryAck/DeliveryTask/DeliveryTaskAck/Acknowledge/AcknowledgeTask), direct-substitution renderer
- NudgeTemplateOverrideStore sealed trait boundary upstream of PostSendHookEmitter and atm internal-nudge
- team_nudge_template_overrides table via atm-storage-rusqlite additive migration
- Precedence: external hook > team override row > built-in default
- Empty-string override => nudge skipped entirely (no blank-body send), with regression coverage

QA-1 dispatch to follow.