### PR TITLE
AD.22: built-in nudge hardening part 2 (roster-backed pane routing)

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -7,18 +7,6 @@ recipient = "team-lead"
 [atm.idle_notify.agent.arch-ctm]
 seconds = 60
 
-[[atm.post_send_hooks]]
-recipient = "arch-ctm"
-command = ["scripts/atm-nudge.sh", "arch-ctm"]
-
-[[atm.post_send_hooks]]
-recipient = "quality-mgr"
-command = ["scripts/atm-nudge.sh", "quality-mgr"]
-
-[[atm.post_send_hooks]]
-recipient = "team-lead"
-command = ["scripts/atm-nudge.sh", "team-lead"]
-
 [plugins.atm-agent-mcp]
 codex_bin = "codex"
 identity = "arch-ctm"
@@ -49,20 +37,17 @@ layout = "even-horizontal"
 
 [[rmux.windows.panes]]
 name = "team-lead"
-tmux_pane_id = "%0"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "team-lead", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
 
 [[rmux.windows.panes]]
 name = "arch-ctm"
-tmux_pane_id = "%1"
 command = "codex -c features.hooks=true --yolo"
 env = { ATM_IDENTITY = "arch-ctm", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
 
 [[rmux.windows.panes]]
 name = "quality-mgr"
-tmux_pane_id = "%2"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,6 @@ version = "1.2.3"
 dependencies = [
  "agent-team-mail-core",
  "arc-swap",
- "atm-graft",
  "atm-runtime",
  "atm-runtime-test-support",
  "atm-storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
 name = "atm-storage-rusqlite"
 version = "1.2.3"
 dependencies = [
+ "agent-team-mail-core",
  "atm-storage",
  "chrono",
  "rusqlite",

--- a/README.md
+++ b/README.md
@@ -155,7 +155,12 @@ surface and uses the accepted daemon/SQLite runtime for retained mail state.
 
 ## Post-Send Hook
 
-`atm send` can run an optional post-send hook configured in `.atm.toml`:
+ATM ships one default post-send path for successful `atm send` and `atm ack`:
+the built-in `atm internal-nudge` command. Most teams do not need any
+`.atm.toml` hook configuration.
+
+Use `[[atm.post_send_hooks]]` only for an explicit local override or
+compatibility helper:
 
 ```toml
 [[atm.post_send_hooks]]
@@ -168,6 +173,8 @@ command = ["scripts/atm-nudge.sh", "arch-ctm"]
 ```
 
 Behavior:
+- If no matching external rule is configured, ATM falls back to the shipped
+  built-in `atm internal-nudge` path.
 - Each `[[atm.post_send_hooks]]` rule binds one `recipient` and one `command`.
 - `recipient` matches either one exact member name or `*` for all recipients.
 - Multiple matching rules all run, in config order.
@@ -180,6 +187,9 @@ Behavior:
 - Hook stderr is suppressed. Hook stdout may optionally return one JSON object with `level`, `message`, and optional `fields` for ATM to log.
 - For troubleshooting hook diagnostics, combine `--stderr-logs` with `ATM_LOG=debug` to surface debug-level hook results on stderr.
 - If the hook exits non-zero, fails to start, or times out, `atm send` still succeeds and prints a warning.
+
+Repo-local `scripts/atm-nudge.sh` / `scripts/atm-nudge.py` remain
+compatibility-only helpers. They are not the shipped default.
 
 Example `ATM_POST_SEND` payload:
 

--- a/boundaries/atm-core/nudge-template-override-store.toml
+++ b/boundaries/atm-core/nudge-template-override-store.toml
@@ -42,5 +42,5 @@ lint_rules = ["LINT-BOUNDARY-NUDGE-TEMPLATE-OVERRIDE-STORE-REFERENCES"]
 review_gates = ["no_cli_sqlite_lookup", "no_emitter_side_lookup"]
 
 [status]
-state = "planned"
-notes = ["AD.21 introduces the contract so team-scoped built-in override lookup resolves upstream of PostSendHookEmitter.", "atm-storage-rusqlite is the first concrete storage implementation site for the accepted host-scoped override rows."]
+state = "concrete_landed"
+notes = ["AD.21 landed the contract so team-scoped built-in override lookup resolves upstream of PostSendHookEmitter.", "atm-storage-rusqlite is the first concrete storage implementation site for the accepted host-scoped override rows, including the write path consumed by `atm teams set-nudge-template`."]

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -671,6 +671,7 @@ fn canonical_sender_identity(message: &InboxMessage) -> AgentName {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
     use std::time::Duration;
@@ -707,40 +708,33 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
-    struct RecordingGraftPort {
-        events: Mutex<Vec<crate::boundary::PostSendHookEvent>>,
-        fail: bool,
-    }
-
-    impl RecordingGraftPort {
-        fn failing() -> Self {
-            Self {
-                events: Mutex::new(Vec::new()),
-                fail: true,
-            }
-        }
-    }
-
-    impl crate::boundary::sealed::Sealed for RecordingGraftPort {}
-
-    impl crate::boundary::GraftPostSendPort for RecordingGraftPort {
-        fn deliver_post_send(
-            &self,
-            event: &crate::boundary::PostSendHookEvent,
-        ) -> Result<(), crate::error::AtmError> {
-            self.events
-                .lock()
-                .expect("graft events lock")
-                .push(event.clone());
-            if self.fail {
-                return Err(crate::error::AtmError::new_with_code(
-                    crate::error_codes::AtmErrorCode::PostSendGraftUnavailable,
-                    crate::error::AtmErrorKind::DaemonUnavailable,
-                    "simulated graft delivery failure",
-                ));
-            }
-            Ok(())
+    fn write_atm_nudge_shim(path: &Path, capture_path: &Path, exit_code: i32) {
+        #[cfg(windows)]
+        fs::write(
+            path,
+            format!(
+                "@echo off\r\n> \"{}\" echo %1^|%ATM_INTERNAL_NUDGE_SINK%^|%ATM_POST_SEND%\r\nexit /b {}\r\n",
+                capture_path.display(),
+                exit_code
+            ),
+        )
+        .expect("write atm shim");
+        #[cfg(not(windows))]
+        fs::write(
+            path,
+            format!(
+                "#!/bin/sh\nprintf '%s|%s|%s\\n' \"$1\" \"$ATM_INTERNAL_NUDGE_SINK\" \"$ATM_POST_SEND\" > \"{}\"\nexit {}\n",
+                capture_path.display(),
+                exit_code
+            ),
+        )
+        .expect("write atm shim");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(path).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(path, perms).expect("chmod");
         }
     }
 
@@ -1243,11 +1237,6 @@ mod tests {
     fn ack_reply_graft_post_send_dispatches_to_graft_port() {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let home_dir = tempdir.path().join("home");
-        let _env = EnvGuard::set_many([
-            ("HOME", Some(home_dir.to_str().expect("utf8 home"))),
-            ("USERPROFILE", None),
-            ("ATM_LOG_DIR", None),
-        ]);
         let team = TEST_TEAM.parse::<TeamName>().expect("team");
         let agent = ROLE_TEAM_LEAD.parse::<AgentName>().expect("agent");
         let reply_message_id = AtmMessageId::new();
@@ -1296,12 +1285,24 @@ mod tests {
         let runtime = AckRuntime {
             outbound_deliveries: Mutex::new(Vec::new()),
         };
-        let graft_port = RecordingGraftPort::default();
+        let capture_path = tempdir.path().join("ack-nudge.txt");
+        #[cfg(windows)]
+        let atm_path = tempdir.path().join("atm.cmd");
+        #[cfg(not(windows))]
+        let atm_path = tempdir.path().join("atm");
+        write_atm_nudge_shim(&atm_path, &capture_path, 0);
+        let atm_bin = atm_path.display().to_string();
+        let _env = EnvGuard::set_many([
+            ("HOME", Some(home_dir.to_str().expect("utf8 home"))),
+            ("USERPROFILE", None),
+            ("ATM_LOG_DIR", None),
+            ("ATM_TEST_ATM_BIN", Some(atm_bin.as_str())),
+        ]);
 
         let outcome = finalize_ack_outcome(
             &runtime,
             &NullObservability,
-            Some(&graft_port),
+            None,
             FinalizeAckContextOwned {
                 actor: "sender".parse::<AgentName>().expect("agent"),
                 team,
@@ -1316,16 +1317,19 @@ mod tests {
         .expect("finalize ack outcome");
 
         assert_eq!(outcome.reply_message_id, reply_message_id);
-        let events = graft_port.events.lock().expect("graft events lock");
-        assert_eq!(events.len(), 1);
-        assert!(events[0].is_ack);
-        assert_eq!(events[0].recipient.as_str(), ROLE_TEAM_LEAD);
-        assert_eq!(events[0].recipient_team.as_str(), TEST_TEAM);
+        assert!(outcome.warnings.is_empty());
+        let captured = fs::read_to_string(&capture_path).expect("capture");
+        assert!(captured.contains("internal-nudge"));
+        assert!(captured.contains("|graft|"));
+        assert!(captured.contains("\"is_ack\":true"));
+        assert!(captured.contains(format!("\"recipient\":\"{ROLE_TEAM_LEAD}\"").as_str()));
     }
 
     #[test]
+    #[serial_test::serial(env)]
     fn finalize_ack_outcome_warns_when_graft_post_send_delivery_fails() {
         let tempdir = tempfile::tempdir().expect("tempdir");
+        let home_dir = tempdir.path().join("home");
         let team = TEST_TEAM.parse::<TeamName>().expect("team");
         let agent = ROLE_TEAM_LEAD.parse::<AgentName>().expect("agent");
         let reply_message_id = AtmMessageId::new();
@@ -1374,12 +1378,24 @@ mod tests {
         let runtime = AckRuntime {
             outbound_deliveries: Mutex::new(Vec::new()),
         };
-        let graft_port = RecordingGraftPort::failing();
+        let capture_path = tempdir.path().join("ack-nudge.txt");
+        #[cfg(windows)]
+        let atm_path = tempdir.path().join("atm.cmd");
+        #[cfg(not(windows))]
+        let atm_path = tempdir.path().join("atm");
+        write_atm_nudge_shim(&atm_path, &capture_path, 7);
+        let atm_bin = atm_path.display().to_string();
+        let _env = EnvGuard::set_many([
+            ("HOME", Some(home_dir.to_str().expect("utf8 home"))),
+            ("USERPROFILE", None),
+            ("ATM_LOG_DIR", None),
+            ("ATM_TEST_ATM_BIN", Some(atm_bin.as_str())),
+        ]);
 
         let outcome = finalize_ack_outcome(
             &runtime,
             &NullObservability,
-            Some(&graft_port),
+            None,
             FinalizeAckContextOwned {
                 actor: "sender".parse::<AgentName>().expect("agent"),
                 team,
@@ -1399,15 +1415,6 @@ mod tests {
             outcome.warnings[0]
                 .message
                 .contains("warning: post-send emission failed")
-        );
-        assert!(
-            outcome.warnings[0]
-                .message
-                .contains("ATM_POST_SEND_GRAFT_UNAVAILABLE")
-        );
-        assert_eq!(
-            graft_port.events.lock().expect("graft events lock").len(),
-            1
         );
     }
 

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -4,7 +4,7 @@ use crate::error::AtmError;
 use crate::protocol::{FramePayload, RequestEnvelope, RequestId, ResponseEnvelope};
 pub use crate::protocol::{NotificationEvent, RuntimeStatusSnapshot};
 use crate::schema::AtmMessageId;
-use crate::types::{AgentName, PaneId, TaskId, TeamName};
+use crate::types::{AgentName, IsoTimestamp, PaneId, TaskId, TeamName};
 pub use atm_storage::contract::{AckTransition, Message, MessageKey, TaskState};
 
 /// Workspace-convention seal only; not compiler-enforced outside this crate.
@@ -115,11 +115,45 @@ pub struct PostSendHookEvent {
     pub recipient: AgentName,
     pub recipient_team: TeamName,
     pub message_id: AtmMessageId,
-    pub message: String,
+    pub description: String,
     pub requires_ack: bool,
     pub is_ack: bool,
     pub task_id: Option<TaskId>,
     pub recipient_pane_id: Option<PaneId>,
+}
+
+#[derive(
+    Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum BuiltInNudgeTemplateKind {
+    Delivery,
+    DeliveryAck,
+    DeliveryTask,
+    DeliveryTaskAck,
+    Acknowledge,
+    AcknowledgeTask,
+}
+
+impl BuiltInNudgeTemplateKind {
+    pub fn from_post_send_event(event: &PostSendHookEvent) -> Self {
+        match (event.is_ack, event.task_id.is_some(), event.requires_ack) {
+            (true, true, _) => Self::AcknowledgeTask,
+            (true, false, _) => Self::Acknowledge,
+            (false, true, true) => Self::DeliveryTaskAck,
+            (false, true, false) => Self::DeliveryTask,
+            (false, false, true) => Self::DeliveryAck,
+            (false, false, false) => Self::Delivery,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct TeamNudgeTemplateOverrideRow {
+    pub team_name: TeamName,
+    pub kind: BuiltInNudgeTemplateKind,
+    pub template_body: String,
+    pub updated_at: IsoTimestamp,
 }
 
 /// BOUNDARY-PostSendHookEmitter — see docs/atm-core/boundaries.md.

--- a/crates/atm-core/src/boundary/mod.rs
+++ b/crates/atm-core/src/boundary/mod.rs
@@ -136,6 +136,17 @@ pub enum BuiltInNudgeTemplateKind {
 }
 
 impl BuiltInNudgeTemplateKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Delivery => "delivery",
+            Self::DeliveryAck => "delivery_ack",
+            Self::DeliveryTask => "delivery_task",
+            Self::DeliveryTaskAck => "delivery_task_ack",
+            Self::Acknowledge => "acknowledge",
+            Self::AcknowledgeTask => "acknowledge_task",
+        }
+    }
+
     pub fn from_post_send_event(event: &PostSendHookEvent) -> Self {
         match (event.is_ack, event.task_id.is_some(), event.requires_ack) {
             (true, true, _) => Self::AcknowledgeTask,
@@ -144,6 +155,33 @@ impl BuiltInNudgeTemplateKind {
             (false, true, false) => Self::DeliveryTask,
             (false, false, true) => Self::DeliveryAck,
             (false, false, false) => Self::Delivery,
+        }
+    }
+}
+
+impl std::fmt::Display for BuiltInNudgeTemplateKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for BuiltInNudgeTemplateKind {
+    type Err = crate::error::AtmError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "delivery" => Ok(Self::Delivery),
+            "delivery_ack" => Ok(Self::DeliveryAck),
+            "delivery_task" => Ok(Self::DeliveryTask),
+            "delivery_task_ack" => Ok(Self::DeliveryTaskAck),
+            "acknowledge" => Ok(Self::Acknowledge),
+            "acknowledge_task" => Ok(Self::AcknowledgeTask),
+            other => Err(crate::error::AtmError::validation(format!(
+                "unsupported built-in nudge template kind `{other}`"
+            ))
+            .with_recovery(
+                "Use one of delivery, delivery_ack, delivery_task, delivery_task_ack, acknowledge, or acknowledge_task.",
+            )),
         }
     }
 }

--- a/crates/atm-core/src/boundary/store.rs
+++ b/crates/atm-core/src/boundary/store.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::mail::DoctorFinding;
+use super::{BuiltInNudgeTemplateKind, TeamNudgeTemplateOverrideRow};
 use super::{ReplaySource, sealed};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -229,6 +230,19 @@ pub trait ConfigDoctor: sealed::Sealed + Send + Sync {
     /// Returns `AtmError` when config diagnostics cannot be collected or
     /// summarized into the shared doctor report shape.
     fn inspect_config(&self) -> Result<ConfigDoctorReport, AtmError>;
+}
+
+/// BOUNDARY-NudgeTemplateOverrideStore — see docs/atm-core/boundaries.md.
+pub trait NudgeTemplateOverrideStore: sealed::Sealed + Send + Sync {
+    /// # Errors
+    ///
+    /// Returns `AtmError` when the storage-neutral lookup for one team-scoped
+    /// built-in nudge template override row cannot complete.
+    fn load_template_override(
+        &self,
+        team: &TeamName,
+        kind: BuiltInNudgeTemplateKind,
+    ) -> Result<Option<TeamNudgeTemplateOverrideRow>, AtmError>;
 }
 
 /// BOUNDARY-NonClaudeOutbound — see docs/atm-core/boundaries.md.

--- a/crates/atm-core/src/boundary/store.rs
+++ b/crates/atm-core/src/boundary/store.rs
@@ -243,6 +243,17 @@ pub trait NudgeTemplateOverrideStore: sealed::Sealed + Send + Sync {
         team: &TeamName,
         kind: BuiltInNudgeTemplateKind,
     ) -> Result<Option<TeamNudgeTemplateOverrideRow>, AtmError>;
+
+    /// # Errors
+    ///
+    /// Returns `AtmError` when the storage-neutral upsert for one team-scoped
+    /// built-in nudge template override row cannot complete.
+    fn save_template_override(
+        &self,
+        team: &TeamName,
+        kind: BuiltInNudgeTemplateKind,
+        template_body: &str,
+    ) -> Result<TeamNudgeTemplateOverrideRow, AtmError>;
 }
 
 /// BOUNDARY-NonClaudeOutbound — see docs/atm-core/boundaries.md.
@@ -263,9 +274,11 @@ mod tests {
 
     struct WitnessRosterStoreDoctor;
     struct WitnessConfigDoctor;
+    struct WitnessNudgeTemplateOverrideStore;
 
     impl sealed::Sealed for WitnessRosterStoreDoctor {}
     impl sealed::Sealed for WitnessConfigDoctor {}
+    impl sealed::Sealed for WitnessNudgeTemplateOverrideStore {}
 
     impl RosterStoreDoctor for WitnessRosterStoreDoctor {
         fn inspect_roster_store(&self) -> Result<RosterStoreDoctorReport, AtmError> {
@@ -276,6 +289,30 @@ mod tests {
     impl ConfigDoctor for WitnessConfigDoctor {
         fn inspect_config(&self) -> Result<ConfigDoctorReport, AtmError> {
             Ok(ConfigDoctorReport::default())
+        }
+    }
+
+    impl NudgeTemplateOverrideStore for WitnessNudgeTemplateOverrideStore {
+        fn load_template_override(
+            &self,
+            _team: &TeamName,
+            _kind: BuiltInNudgeTemplateKind,
+        ) -> Result<Option<TeamNudgeTemplateOverrideRow>, AtmError> {
+            Ok(None)
+        }
+
+        fn save_template_override(
+            &self,
+            team: &TeamName,
+            kind: BuiltInNudgeTemplateKind,
+            template_body: &str,
+        ) -> Result<TeamNudgeTemplateOverrideRow, AtmError> {
+            Ok(TeamNudgeTemplateOverrideRow {
+                team_name: team.clone(),
+                kind,
+                template_body: template_body.to_string(),
+                updated_at: crate::types::IsoTimestamp::now(),
+            })
         }
     }
 
@@ -292,6 +329,14 @@ mod tests {
         fn assert_object_safe(_doctor: &dyn ConfigDoctor) {}
 
         let witness = WitnessConfigDoctor;
+        assert_object_safe(&witness);
+    }
+
+    #[test]
+    fn nudge_template_override_store_trait_is_object_safe_and_compiles() {
+        fn assert_object_safe(_store: &dyn NudgeTemplateOverrideStore) {}
+
+        let witness = WitnessNudgeTemplateOverrideStore;
         assert_object_safe(&witness);
     }
 }

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -92,16 +92,17 @@ pub(crate) mod workflow;
 
 #[allow(deprecated)]
 pub use boundary::{
-    AckTransition, AtmProtocol, ClientTransport, ConfigDoctor, ConfigDoctorReport, ConfigIngress,
-    ConfigLoadRequest, ConfigLoadResponse, DoctorFinding, LoadMailMessageStateRequest,
-    LoadMailMessageStateResponse, MailMessageState, MailStore, MailStoreDoctor,
-    MailStoreDoctorReport, MailStoreHealthSnapshot, MailStoreIngestReplayState,
+    AckTransition, AtmProtocol, BuiltInNudgeTemplateKind, ClientTransport, ConfigDoctor,
+    ConfigDoctorReport, ConfigIngress, ConfigLoadRequest, ConfigLoadResponse, DoctorFinding,
+    LoadMailMessageStateRequest, LoadMailMessageStateResponse, MailMessageState, MailStore,
+    MailStoreDoctor, MailStoreDoctorReport, MailStoreHealthSnapshot, MailStoreIngestReplayState,
     MailStoreMailboxMetadataCounts, MailStoreMailboxMetadataRow, Message, MessageFingerprint,
-    MessageKey, NotificationEvent, PostSendHookEmitter, PostSendHookEvent, RemoteReplayStateRecord,
-    RemoteReplayStore, RequestDispatcher, RosterEntry, RosterHarness, RosterMemberKind,
-    RosterStore, RosterStoreDoctor, RosterStoreDoctorReport, RosterStoreHealthSnapshot,
-    RuntimeStatusSnapshot, RuntimeStorageFinalizer, ServerTransport, StatusSource, TaskState,
-    UpsertMailMessageStateRequest, UpsertMailMessageStateResponse,
+    MessageKey, NotificationEvent, NudgeTemplateOverrideStore, PostSendHookEmitter,
+    PostSendHookEvent, RemoteReplayStateRecord, RemoteReplayStore, RequestDispatcher, RosterEntry,
+    RosterHarness, RosterMemberKind, RosterStore, RosterStoreDoctor, RosterStoreDoctorReport,
+    RosterStoreHealthSnapshot, RuntimeStatusSnapshot, RuntimeStorageFinalizer, ServerTransport,
+    StatusSource, TaskState, TeamNudgeTemplateOverrideRow, UpsertMailMessageStateRequest,
+    UpsertMailMessageStateResponse,
 };
 pub use config::AtmConfig;
 pub use config::load_config as load_atm_config;

--- a/crates/atm-core/src/send/graft_warning_tests.rs
+++ b/crates/atm-core/src/send/graft_warning_tests.rs
@@ -35,14 +35,20 @@ pub(super) fn write_atm_nudge_shim(
         ),
     )
     .expect("write atm shim");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(path).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(path, perms).expect("chmod");
-    }
+    set_executable_permissions(path);
 }
+
+#[cfg(unix)]
+fn set_executable_permissions(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut perms = fs::metadata(path).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod");
+}
+
+#[cfg(not(unix))]
+fn set_executable_permissions(_path: &std::path::Path) {}
 
 #[test]
 fn load_send_alert_state_parse_errors_are_config_errors() {

--- a/crates/atm-core/src/send/graft_warning_tests.rs
+++ b/crates/atm-core/src/send/graft_warning_tests.rs
@@ -1,60 +1,46 @@
-use std::sync::Mutex;
-
 use std::fs;
 
 use tempfile::tempdir;
 
-use super::tests::{TestRuntime, install_home_env, send_request};
-use crate::boundary::GraftPostSendPort;
+use super::tests::{TestRuntime, install_home_env_with_atm_bin, send_request};
 use crate::delivery_policy::DeliveryHarnessPath;
-use crate::error::{AtmError, AtmErrorKind};
-use crate::error_codes::AtmErrorCode;
 use crate::observability::NullObservability;
 use crate::protocol::NotificationKind;
 use crate::send::SendCommandOutcome;
 use crate::test_support::TEST_SENDER;
 use crate::types::TeamName;
 
-#[derive(Default)]
-struct RecordingGraftPort {
-    events: Mutex<Vec<crate::boundary::PostSendHookEvent>>,
-}
-
-impl crate::boundary::sealed::Sealed for RecordingGraftPort {}
-
-impl GraftPostSendPort for RecordingGraftPort {
-    fn deliver_post_send(
-        &self,
-        event: &crate::boundary::PostSendHookEvent,
-    ) -> Result<(), AtmError> {
-        self.events
-            .lock()
-            .expect("graft events lock")
-            .push(event.clone());
-        Ok(())
-    }
-}
-
-struct FailingGraftPort {
-    events: Mutex<Vec<crate::boundary::PostSendHookEvent>>,
-}
-
-impl crate::boundary::sealed::Sealed for FailingGraftPort {}
-
-impl GraftPostSendPort for FailingGraftPort {
-    fn deliver_post_send(
-        &self,
-        event: &crate::boundary::PostSendHookEvent,
-    ) -> Result<(), AtmError> {
-        self.events
-            .lock()
-            .expect("graft events lock")
-            .push(event.clone());
-        Err(AtmError::new_with_code(
-            AtmErrorCode::PostSendGraftUnavailable,
-            AtmErrorKind::DaemonUnavailable,
-            "simulated graft delivery failure",
-        ))
+pub(super) fn write_atm_nudge_shim(
+    path: &std::path::Path,
+    capture_path: &std::path::Path,
+    exit_code: i32,
+) {
+    #[cfg(windows)]
+    fs::write(
+        path,
+        format!(
+            "@echo off\r\n> \"{}\" echo %1^|%ATM_INTERNAL_NUDGE_SINK%^|%ATM_POST_SEND%\r\nexit /b {}\r\n",
+            capture_path.display(),
+            exit_code
+        ),
+    )
+    .expect("write atm shim");
+    #[cfg(not(windows))]
+    fs::write(
+        path,
+        format!(
+            "#!/bin/sh\nprintf '%s|%s|%s\\n' \"$1\" \"$ATM_INTERNAL_NUDGE_SINK\" \"$ATM_POST_SEND\" > \"{}\"\nexit {}\n",
+            capture_path.display(),
+            exit_code
+        ),
+    )
+    .expect("write atm shim");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod");
     }
 }
 
@@ -75,16 +61,22 @@ fn load_send_alert_state_parse_errors_are_config_errors() {
 #[serial_test::serial(env)]
 fn send_non_claude_success_delivers_original_via_outbound_boundary() {
     let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
-    let graft_port = RecordingGraftPort::default();
     let tempdir = tempdir().expect("tempdir");
     let home_dir = tempdir.path().join("home");
-    let _env = install_home_env(&home_dir);
+    let capture_path = tempdir.path().join("graft-nudge.txt");
+    #[cfg(windows)]
+    let atm_path = tempdir.path().join("atm.cmd");
+    #[cfg(not(windows))]
+    let atm_path = tempdir.path().join("atm");
+    write_atm_nudge_shim(&atm_path, &capture_path, 0);
+    let atm_bin = atm_path.display().to_string();
+    let _env = install_home_env_with_atm_bin(&home_dir, atm_bin.as_str());
 
     let outcome = super::send_mail_with_runtime_impl(
         send_request(tempdir.path()),
         &NullObservability,
         &runtime,
-        Some(&graft_port),
+        None,
     )
     .expect("send outcome");
 
@@ -118,52 +110,42 @@ fn send_non_claude_success_delivers_original_via_outbound_boundary() {
         events[0].team.as_ref().map(TeamName::as_str),
         Some("test-team")
     );
-    let graft_events = graft_port.events.lock().expect("graft events lock");
-    assert_eq!(graft_events.len(), 1);
-    assert_eq!(graft_events[0].sender.as_str(), TEST_SENDER);
-    assert_eq!(graft_events[0].recipient.as_str(), "recipient");
-    assert_eq!(graft_events[0].recipient_team.as_str(), "test-team");
-    assert_eq!(graft_events[0].message, "hello");
+    let captured = fs::read_to_string(&capture_path).expect("capture");
+    assert!(captured.contains("internal-nudge"));
+    assert!(captured.contains("|graft|"));
+    assert!(captured.contains(format!("\"sender\":\"{TEST_SENDER}\"").as_str()));
+    assert!(captured.contains("\"description\":\"hello\""));
 }
 
 #[test]
 #[serial_test::serial(env)]
 fn send_non_claude_warns_when_graft_post_send_delivery_fails() {
     let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
-    let graft_port = FailingGraftPort {
-        events: Mutex::new(Vec::new()),
-    };
     let tempdir = tempdir().expect("tempdir");
     let home_dir = tempdir.path().join("home");
-    let _env = install_home_env(&home_dir);
+    let capture_path = tempdir.path().join("graft-nudge.txt");
+    #[cfg(windows)]
+    let atm_path = tempdir.path().join("atm.cmd");
+    #[cfg(not(windows))]
+    let atm_path = tempdir.path().join("atm");
+    write_atm_nudge_shim(&atm_path, &capture_path, 7);
+    let atm_bin = atm_path.display().to_string();
+    let _env = install_home_env_with_atm_bin(&home_dir, atm_bin.as_str());
 
     let outcome = super::send_mail_with_runtime_impl(
         send_request(tempdir.path()),
         &NullObservability,
         &runtime,
-        Some(&graft_port),
+        None,
     )
     .expect("send outcome");
 
     assert_eq!(outcome.outcome, SendCommandOutcome::Sent);
     assert_eq!(outcome.warnings.len(), 1);
-    assert_eq!(
-        outcome.warnings[0].code,
-        Some(AtmErrorCode::PostSendGraftUnavailable)
-    );
     assert!(
         outcome.warnings[0]
             .message
             .contains("warning: post-send emission failed")
-    );
-    assert!(
-        outcome.warnings[0]
-            .message
-            .contains("ATM_POST_SEND_GRAFT_UNAVAILABLE")
-    );
-    assert_eq!(
-        graft_port.events.lock().expect("graft events lock").len(),
-        1
     );
     let notification_path =
         crate::home::host_runtime_dir_from_home(&home_dir).join("notifications.jsonl");

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -15,10 +15,10 @@ use tracing::Level;
 use tracing::{debug, error, info, warn};
 
 use super::{POST_SEND_HOOK_TIMEOUT, ResolvedRecipient, WarningEntry, qualified_sender_identity};
-use crate::boundary::{GraftPostSendPort, PostSendHookEmitter, PostSendHookEvent};
+use crate::boundary::PostSendHookEvent;
 use crate::config::types::HookRecipient;
 use crate::config::{self, AtmConfig};
-use crate::error::{AtmError, AtmErrorKind};
+use crate::error::AtmError;
 use crate::error_codes::AtmErrorCode;
 use crate::protocol::{NotificationEvent, NotificationKind};
 use crate::schema::compatible_home_dir;
@@ -27,8 +27,8 @@ use crate::types::{AgentName, TeamName};
 
 const POST_SEND_HOOK_MAX_STDOUT_BYTES: usize = 8 * 1024;
 const POST_SEND_HOOK_STDOUT_JOIN_TIMEOUT: Duration = Duration::from_millis(500);
-#[cfg(test)]
-const TMUX_PROGRAM_ENV: &str = "ATM_TEST_TMUX_BIN";
+const ATM_PROGRAM_ENV: &str = "ATM_TEST_ATM_BIN";
+const INTERNAL_NUDGE_SINK_ENV: &str = "ATM_INTERNAL_NUDGE_SINK";
 
 #[derive(Debug, Deserialize)]
 struct PostSendHookResult {
@@ -47,6 +47,21 @@ enum PostSendHookResultLevel {
     Error,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuiltInNudgeSinkTarget {
+    Tmux,
+    Graft,
+}
+
+impl BuiltInNudgeSinkTarget {
+    fn env_value(self) -> &'static str {
+        match self {
+            Self::Tmux => "tmux",
+            Self::Graft => "graft",
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 struct HookCancellationToken(Arc<AtomicBool>);
 
@@ -60,94 +75,14 @@ impl HookCancellationToken {
     }
 }
 
-pub(crate) struct ConfiguredPostSendHookEmitter<'a> {
-    config: &'a AtmConfig,
-}
-
-impl<'a> ConfiguredPostSendHookEmitter<'a> {
-    pub(crate) fn new(config: &'a AtmConfig) -> Self {
-        Self { config }
-    }
-}
-
-impl crate::boundary::sealed::Sealed for ConfiguredPostSendHookEmitter<'_> {}
-
-impl PostSendHookEmitter for ConfiguredPostSendHookEmitter<'_> {
-    fn emit(&self, event: &PostSendHookEvent) -> Result<(), AtmError> {
-        let mut warnings = Vec::new();
-        run_post_send_hooks_for_cli(&mut warnings, self.config, event);
-        warnings_to_result(&warnings)
-    }
-}
-
-pub(crate) struct LocalTmuxPostSendEmitter;
-
-impl crate::boundary::sealed::Sealed for LocalTmuxPostSendEmitter {}
-
-impl PostSendHookEmitter for LocalTmuxPostSendEmitter {
-    fn emit(&self, event: &PostSendHookEvent) -> Result<(), AtmError> {
-        let Some(pane_id) = event.recipient_pane_id.as_ref() else {
-            let error = AtmError::new_with_code(
-                AtmErrorCode::PostSendPaneMissing,
-                AtmErrorKind::Validation,
-                format!(
-                    "recipient {}@{} has tmux-backed post-send capability but no pane id",
-                    event.recipient, event.recipient_team
-                ),
-            )
-            .with_recovery(format!(
-                "Repair the roster row with `atm teams update-member --team {} --member {} --tmux-pane-id <pane>`.",
-                event.recipient_team, event.recipient
-            ));
-            warn!(
-                code = %AtmErrorCode::PostSendPaneMissing,
-                sender = %event.sender,
-                recipient = %event.recipient,
-                recipient_team = %event.recipient_team,
-                message_id = %event.message_id,
-                "local tmux post-send emission is missing authoritative pane metadata"
-            );
-            return Err(error);
-        };
-
-        let message = super::hook_tmux::tmux_nudge_message(&event.recipient_team);
-        super::hook_tmux::run_tmux_send_keys(pane_id, &message, event)?;
-        super::hook_tmux::run_tmux_send_enter(pane_id, event)?;
-        Ok(())
-    }
-}
-
-pub(crate) struct GraftPostSendEmitter<'a> {
-    port: &'a dyn GraftPostSendPort,
-}
-
-impl<'a> GraftPostSendEmitter<'a> {
-    pub(crate) fn new(port: &'a dyn GraftPostSendPort) -> Self {
-        Self { port }
-    }
-}
-
-impl crate::boundary::sealed::Sealed for GraftPostSendEmitter<'_> {}
-
-impl PostSendHookEmitter for GraftPostSendEmitter<'_> {
-    fn emit(&self, event: &PostSendHookEvent) -> Result<(), AtmError> {
-        self.port.deliver_post_send(event)
-    }
-}
-
 pub(crate) fn emit_post_send_effects(
     warnings: &mut Vec<WarningEntry>,
     config: Option<&AtmConfig>,
-    graft_port: Option<&dyn GraftPostSendPort>,
+    _graft_port: Option<&dyn crate::boundary::GraftPostSendPort>,
     recipient: &ResolvedRecipient,
     delivery_snapshot: &crate::delivery_policy::DeliveryRecipientSnapshot,
     messages: &[crate::delivery_plan::LogicalMessage],
 ) {
-    let hook_emitter = config.map(ConfiguredPostSendHookEmitter::new);
-    let graft_emitter = graft_port.map(GraftPostSendEmitter::new);
-    let tmux_emitter = delivery_snapshot
-        .local_tmux_post_send
-        .then_some(LocalTmuxPostSendEmitter);
     for message in messages {
         let event = post_send_event_from_message(
             recipient,
@@ -155,34 +90,24 @@ pub(crate) fn emit_post_send_effects(
             delivery_snapshot.recipient_pane_id.as_ref(),
         );
         let mut emitted = false;
-        if let Some(emitter) = tmux_emitter.as_ref() {
-            match emitter.emit(&event) {
+        let hook_matched = config.is_some_and(|loaded| {
+            let mut hook_warnings = Vec::new();
+            let matched = run_post_send_hooks_for_cli(&mut hook_warnings, loaded, &event);
+            if !hook_warnings.is_empty() {
+                warnings.extend(hook_warnings);
+            } else if matched {
+                emitted = true;
+            }
+            matched
+        });
+        if !hook_matched && let Some(target) = built_in_nudge_sink_target(delivery_snapshot) {
+            match emit_built_in_nudge(&event, target) {
                 Ok(()) => emitted = true,
                 Err(error) => warnings.push(post_send_warning(
                     "post-send emission failed",
                     &event,
                     &error,
                 )),
-            }
-        }
-        if delivery_snapshot.graft_post_send
-            && let Some(emitter) = graft_emitter.as_ref()
-        {
-            match emitter.emit(&event) {
-                Ok(()) => emitted = true,
-                Err(error) => warnings.push(post_send_warning(
-                    "post-send emission failed",
-                    &event,
-                    &error,
-                )),
-            }
-        }
-        if let Some(emitter) = hook_emitter.as_ref() {
-            match emitter.emit(&event) {
-                Ok(()) => emitted = true,
-                Err(error) => {
-                    warnings.push(post_send_warning("post-send hook failed", &event, &error))
-                }
             }
         }
         if emitted && let Err(error) = append_notification_log(&notification_event(&event)) {
@@ -219,7 +144,7 @@ fn run_post_send_hooks_for_cli(
     warnings: &mut Vec<WarningEntry>,
     config: &AtmConfig,
     event: &PostSendHookEvent,
-) {
+) -> bool {
     // This helper is intentionally synchronous and may block the caller thread
     // for up to POST_SEND_HOOK_TIMEOUT while supervising one child process.
     // Keep it on the CLI path; do not call it from an async runtime thread.
@@ -236,12 +161,174 @@ fn run_post_send_hooks_for_cli(
             recipient_team = %event.recipient_team,
             "post-send hook had no matching recipient rules"
         );
-        return;
+        return false;
     }
 
     for rule in matching_rules {
         execute_post_send_hook(warnings, config, rule, event);
     }
+    true
+}
+
+fn built_in_nudge_sink_target(
+    delivery_snapshot: &crate::delivery_policy::DeliveryRecipientSnapshot,
+) -> Option<BuiltInNudgeSinkTarget> {
+    if delivery_snapshot.local_tmux_post_send {
+        Some(BuiltInNudgeSinkTarget::Tmux)
+    } else if delivery_snapshot.graft_post_send {
+        Some(BuiltInNudgeSinkTarget::Graft)
+    } else {
+        None
+    }
+}
+
+fn emit_built_in_nudge(
+    event: &PostSendHookEvent,
+    sink_target: BuiltInNudgeSinkTarget,
+) -> Result<(), AtmError> {
+    let command_path = atm_command_path()?;
+    let payload = post_send_hook_payload(event).to_string();
+    let mut command = Command::new(&command_path);
+    command
+        .arg("internal-nudge")
+        .env("ATM_POST_SEND", payload)
+        .env(INTERNAL_NUDGE_SINK_ENV, sink_target.env_value())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = command.spawn().map_err(|source| {
+        AtmError::daemon_unavailable(format!(
+            "failed to start built-in post-send nudge command {}: {source}",
+            command_path.display()
+        ))
+        .with_recovery(
+            "Ensure the installed `atm` binary is executable and on disk before retrying post-send delivery.",
+        )
+        .with_source(source)
+    })?;
+    let started_at = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => return Ok(()),
+            Ok(Some(status)) => {
+                let error = match sink_target {
+                    BuiltInNudgeSinkTarget::Tmux => AtmError::new_with_code(
+                        AtmErrorCode::PostSendTmuxSendFailed,
+                        crate::error::AtmErrorKind::DaemonUnavailable,
+                        format!(
+                            "built-in tmux post-send nudge exited unsuccessfully with status {status}"
+                        ),
+                    )
+                    .with_recovery(
+                        "Inspect the built-in tmux nudge path and the recipient pane state before retrying post-send delivery.",
+                    ),
+                    BuiltInNudgeSinkTarget::Graft => AtmError::new_with_code(
+                        AtmErrorCode::PostSendGraftUnavailable,
+                        crate::error::AtmErrorKind::DaemonUnavailable,
+                        format!(
+                            "built-in graft post-send nudge exited unsuccessfully with status {status}"
+                        ),
+                    )
+                    .with_recovery(
+                        "Ensure the recipient graft receiver is listening and retry once the built-in graft nudge path is healthy.",
+                    ),
+                };
+                return Err(error);
+            }
+            Ok(None) if started_at.elapsed() < POST_SEND_HOOK_TIMEOUT => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) => {
+                terminate_post_send_hook_process(&mut child, &command_path);
+                return Err(AtmError::daemon_unavailable(format!(
+                    "built-in post-send nudge command timed out after {}s",
+                    POST_SEND_HOOK_TIMEOUT.as_secs()
+                ))
+                .with_recovery(
+                    "Fix the built-in `atm internal-nudge` path so it exits promptly after one nudge delivery attempt.",
+                ));
+            }
+            Err(source) => {
+                terminate_post_send_hook_process(&mut child, &command_path);
+                return Err(AtmError::daemon_unavailable(
+                    "failed while waiting for built-in post-send nudge command",
+                )
+                .with_recovery(
+                    "Inspect the built-in `atm internal-nudge` process lifecycle and retry once the local process environment is healthy.",
+                )
+                .with_source(source));
+            }
+        }
+    }
+}
+
+fn atm_command_path() -> Result<PathBuf, AtmError> {
+    if let Some(path) = std::env::var_os(ATM_PROGRAM_ENV).filter(|value| !value.is_empty()) {
+        return Ok(path.into());
+    }
+
+    let current_exe = std::env::current_exe().map_err(|source| {
+        AtmError::daemon_unavailable("failed to resolve the running ATM process executable")
+            .with_recovery(
+                "Run ATM from an installed binary path or repair the current process environment before retrying built-in post-send delivery.",
+            )
+            .with_source(source)
+    })?;
+    if is_atm_binary_path(&current_exe) {
+        return Ok(current_exe);
+    }
+
+    for candidate in atm_binary_candidates(&current_exe) {
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(AtmError::daemon_unavailable(format!(
+        "failed to resolve the companion `atm` CLI binary for built-in post-send delivery from {}",
+        current_exe.display()
+    ))
+    .with_recovery(
+        "Install `atm` alongside the running ATM binary, or set ATM_TEST_ATM_BIN to an explicit `atm` path before retrying built-in post-send delivery.",
+    ))
+}
+
+fn atm_binary_candidates(current_exe: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(parent) = current_exe.parent() {
+        candidates.push(parent.join(atm_binary_leaf()));
+        if parent.file_name().is_some_and(|name| name == "deps")
+            && let Some(grandparent) = parent.parent()
+        {
+            candidates.push(grandparent.join(atm_binary_leaf()));
+        }
+    }
+    candidates
+}
+
+fn atm_binary_leaf() -> &'static str {
+    #[cfg(windows)]
+    {
+        "atm.exe"
+    }
+    #[cfg(not(windows))]
+    {
+        "atm"
+    }
+}
+
+fn is_atm_binary_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            #[cfg(windows)]
+            {
+                name.eq_ignore_ascii_case("atm.exe")
+            }
+            #[cfg(not(windows))]
+            {
+                name == "atm"
+            }
+        })
 }
 
 fn execute_post_send_hook(
@@ -337,6 +424,8 @@ fn post_send_hook_payload(event: &PostSendHookEvent) -> Value {
         "recipient": event.recipient.as_str(),
         "team": event.recipient_team.as_str(),
         "message_id": event.message_id.to_string(),
+        "description": event.description,
+        "message": event.description,
         "requires_ack": event.requires_ack,
         "is_ack": event.is_ack,
     });
@@ -566,6 +655,7 @@ fn notification_event(event: &PostSendHookEvent) -> NotificationEvent {
             "sender": event.sender.as_str(),
             "sender_team": event.sender_team.as_str(),
             "message_id": event.message_id.to_string(),
+            "description": event.description,
             "requires_ack": event.requires_ack,
             "is_ack": event.is_ack,
             "task_id": event.task_id.as_ref().map(ToString::to_string),
@@ -592,7 +682,7 @@ fn post_send_event_from_message(
         recipient: recipient.agent.clone(),
         recipient_team: recipient.team.clone(),
         message_id: message.message_id(),
-        message: message
+        description: message
             .envelope
             .summary
             .clone()
@@ -607,30 +697,6 @@ fn post_send_event_from_message(
 
 fn sender_config_root(metadata: &serde_json::Map<String, Value>) -> Option<PathBuf> {
     compatible_home_dir(metadata).map(Into::into)
-}
-
-fn warnings_to_result(warnings: &[WarningEntry]) -> Result<(), AtmError> {
-    if warnings.is_empty() {
-        return Ok(());
-    }
-
-    let message = warnings
-        .iter()
-        .map(|warning| warning.message.as_str())
-        .collect::<Vec<_>>()
-        .join(" ");
-    let mut error = AtmError::new_with_code(
-        AtmErrorCode::WarningHookExecutionFailed,
-        AtmErrorKind::Internal,
-        message,
-    );
-    for recovery in warnings
-        .iter()
-        .filter_map(|warning| warning.recovery.as_deref())
-    {
-        error = error.with_recovery(recovery.to_string());
-    }
-    Err(error)
 }
 
 fn post_send_warning(prefix: &str, event: &PostSendHookEvent, error: &AtmError) -> WarningEntry {
@@ -857,27 +923,23 @@ fn hook_result_log_level(level: PostSendHookResultLevel) -> Level {
 mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use serde_json::{Map, json};
     use tempfile::tempdir;
     use tracing::Level;
 
     use super::{
-        GraftPostSendEmitter, HookCancellationToken, LocalTmuxPostSendEmitter,
-        POST_SEND_HOOK_MAX_STDOUT_BYTES, PostSendHookResultLevel, TMUX_PROGRAM_ENV,
+        ATM_PROGRAM_ENV, BuiltInNudgeSinkTarget, HookCancellationToken,
+        POST_SEND_HOOK_MAX_STDOUT_BYTES, PostSendHookResultLevel, emit_built_in_nudge,
         finish_abandoned_post_send_hook_stdout_capture, hook_matches_recipient,
         hook_result_log_level, load_post_send_config_for_sender, parse_post_send_hook_result,
         sender_config_root,
     };
-    use crate::boundary::{
-        GraftPostSendPort, PostSendHookEmitter, PostSendHookEvent, RosterEntry, RosterHarness,
-        RosterMemberKind,
-    };
+    use crate::boundary::{PostSendHookEvent, RosterEntry, RosterHarness, RosterMemberKind};
     use crate::config::AtmConfig;
     use crate::config::types::HookRecipient;
     use crate::error::AtmError;
-    use crate::error_codes::AtmErrorCode;
     use crate::roles::ROLE_TEAM_LEAD;
     #[allow(
         deprecated,
@@ -885,7 +947,6 @@ mod tests {
     )]
     use crate::schema::agent_member::LEGACY_CWD_METADATA_KEY;
     use crate::schema::{HOME_DIR_METADATA_KEY, InboxMessage, TeamConfig};
-    use crate::send::hook_tmux::tmux_nudge_message;
     use crate::service_runtime::{RetainedMailboxTimeoutPolicy, RetainedServiceRuntime};
     use crate::test_support::{EnvGuard, TEST_SENDER};
     use crate::types::{AgentName, IsoTimestamp, PaneId, TeamName};
@@ -994,27 +1055,6 @@ mod tests {
             F: FnOnce(&mut WorkflowStateFile) -> Result<(T, bool), AtmError>,
         {
             unreachable!("config lookup test does not commit workflow state")
-        }
-    }
-
-    #[derive(Default)]
-    struct RecordingGraftPort {
-        delivered: std::sync::Mutex<Vec<PostSendHookEvent>>,
-        fail_message: Option<String>,
-    }
-
-    impl crate::boundary::sealed::Sealed for RecordingGraftPort {}
-
-    impl GraftPostSendPort for RecordingGraftPort {
-        fn deliver_post_send(&self, event: &PostSendHookEvent) -> Result<(), AtmError> {
-            if let Some(message) = &self.fail_message {
-                return Err(AtmError::daemon_unavailable(message.clone()));
-            }
-            self.delivered
-                .lock()
-                .expect("graft deliveries")
-                .push(event.clone());
-            Ok(())
         }
     }
 
@@ -1155,7 +1195,7 @@ mod tests {
             recipient: AgentName::from_validated("recipient"),
             recipient_team: TeamName::from_validated("test-team"),
             message_id: crate::schema::AtmMessageId::new(),
-            message: "hello".to_string(),
+            description: "hello".to_string(),
             requires_ack: false,
             is_ack: false,
             task_id: None,
@@ -1164,130 +1204,82 @@ mod tests {
     }
 
     #[test]
-    fn local_tmux_post_send_emitter_requires_authoritative_pane_id() {
-        let emitter = LocalTmuxPostSendEmitter;
-        let error = emitter
-            .emit(&tmux_event(None))
-            .expect_err("missing pane must fail");
-
-        assert_eq!(error.code, AtmErrorCode::PostSendPaneMissing);
-        assert!(error.message.contains("no pane id"));
-    }
-
-    #[test]
     #[serial_test::serial(env)]
-    fn local_tmux_post_send_emitter_uses_authoritative_pane_id() {
+    fn built_in_nudge_fallback_invokes_hidden_cli_with_sink_and_payload() {
         let tempdir = tempdir().expect("tempdir");
-        let tmux_log = tempdir.path().join("tmux.log");
+        let capture_path = tempdir.path().join("capture.txt");
         #[cfg(windows)]
-        let tmux_path = tempdir.path().join("tmux.cmd");
+        let atm_path = tempdir.path().join("atm.cmd");
         #[cfg(not(windows))]
-        let tmux_path = tempdir.path().join("tmux");
+        let atm_path = tempdir.path().join("atm");
         #[cfg(windows)]
         fs::write(
-            &tmux_path,
-            "@echo off\r\n>> \"%ATM_TEST_TMUX_LOG%\" echo %*\r\nexit /b 0\r\n",
+            &atm_path,
+            "@echo off\r\n> \"%ATM_TEST_CAPTURE%\" echo %1|%ATM_INTERNAL_NUDGE_SINK%|%ATM_POST_SEND%\r\nexit /b 0\r\n",
         )
-        .expect("write tmux shim");
+        .expect("write atm shim");
         #[cfg(not(windows))]
         fs::write(
-            &tmux_path,
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"$ATM_TEST_TMUX_LOG\"\nexit 0\n",
+            &atm_path,
+            "#!/bin/sh\nprintf '%s|%s|%s\\n' \"$1\" \"$ATM_INTERNAL_NUDGE_SINK\" \"$ATM_POST_SEND\" > \"$ATM_TEST_CAPTURE\"\nexit 0\n",
         )
-        .expect("write tmux shim");
+        .expect("write atm shim");
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&tmux_path).expect("metadata").permissions();
+            let mut perms = fs::metadata(&atm_path).expect("metadata").permissions();
             perms.set_mode(0o755);
-            fs::set_permissions(&tmux_path, perms).expect("chmod");
+            fs::set_permissions(&atm_path, perms).expect("chmod");
         }
 
-        let tmux_log = tmux_log.to_str().expect("utf8 tmux log").to_owned();
-        let tmux_bin = tmux_path.to_str().expect("utf8 tmux path").to_owned();
+        let capture_value = capture_path.display().to_string();
+        let atm_bin = atm_path.display().to_string();
         let _env = EnvGuard::set_many([
-            (TMUX_PROGRAM_ENV, Some(tmux_bin.as_str())),
-            ("ATM_TEST_TMUX_LOG", Some(tmux_log.as_str())),
+            (ATM_PROGRAM_ENV, Some(atm_bin.as_str())),
+            ("ATM_TEST_CAPTURE", Some(capture_value.as_str())),
         ]);
 
-        let result =
-            LocalTmuxPostSendEmitter.emit(&tmux_event(Some(PaneId::from_cli("%9").expect("pane"))));
+        emit_built_in_nudge(
+            &tmux_event(Some(PaneId::from_cli("%9").expect("pane"))),
+            BuiltInNudgeSinkTarget::Tmux,
+        )
+        .expect("fallback emit");
 
-        result.expect("tmux send");
-        let logged = fs::read_to_string(&tmux_log).expect("tmux log");
-        assert!(logged.contains("send-keys"));
-        assert!(logged.contains("%9"));
-        assert!(logged.contains(&tmux_nudge_message(&TeamName::from_validated("test-team"))));
-        assert!(logged.contains("Enter"));
+        let captured = fs::read_to_string(&capture_path).expect("capture");
+        assert!(captured.contains("internal-nudge"));
+        assert!(captured.contains("|tmux|"));
+        assert!(captured.contains("\"description\":\"hello\""));
     }
 
     #[test]
     #[serial_test::serial(env)]
-    fn local_tmux_post_send_emitter_times_out_hung_tmux() {
+    fn built_in_nudge_fallback_surfaces_nonzero_exit() {
         let tempdir = tempdir().expect("tempdir");
         #[cfg(windows)]
-        let tmux_path = tempdir.path().join("tmux.cmd");
+        let atm_path = tempdir.path().join("atm.cmd");
         #[cfg(not(windows))]
-        let tmux_path = tempdir.path().join("tmux");
+        let atm_path = tempdir.path().join("atm");
         #[cfg(windows)]
-        fs::write(
-            &tmux_path,
-            "@echo off\r\nsetlocal EnableDelayedExpansion\r\nfor /f \"tokens=1-4 delims=:.\" %%a in (\"%time%\") do (\r\n  set /a start=%%a*3600+%%b*60+%%c\r\n)\r\n:loop\r\nfor /f \"tokens=1-4 delims=:.\" %%a in (\"%time%\") do (\r\n  set /a now=%%a*3600+%%b*60+%%c\r\n)\r\nif !now! lss !start! set /a now+=86400\r\nset /a elapsed=now-start\r\nif !elapsed! lss 30 goto loop\r\nexit /b 0\r\n",
-        )
-        .expect("write tmux shim");
+        fs::write(&atm_path, "@echo off\r\nexit /b 7\r\n").expect("write atm shim");
         #[cfg(not(windows))]
-        fs::write(
-            &tmux_path,
-            "#!/usr/bin/env python3\nimport time\ntime.sleep(30)\n",
-        )
-        .expect("write tmux shim");
+        fs::write(&atm_path, "#!/bin/sh\nexit 7\n").expect("write atm shim");
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&tmux_path).expect("metadata").permissions();
+            let mut perms = fs::metadata(&atm_path).expect("metadata").permissions();
             perms.set_mode(0o755);
-            fs::set_permissions(&tmux_path, perms).expect("chmod");
+            fs::set_permissions(&atm_path, perms).expect("chmod");
         }
 
-        let tmux_bin = tmux_path.to_str().expect("utf8 tmux path").to_owned();
-        let _env = EnvGuard::set_many([(TMUX_PROGRAM_ENV, Some(tmux_bin.as_str()))]);
+        let atm_bin = atm_path.display().to_string();
+        let _env = EnvGuard::set_many([(ATM_PROGRAM_ENV, Some(atm_bin.as_str()))]);
 
-        let started_at = Instant::now();
-        let error = LocalTmuxPostSendEmitter
-            .emit(&tmux_event(Some(PaneId::from_cli("%9").expect("pane"))))
-            .expect_err("hung tmux must time out");
+        let error = emit_built_in_nudge(
+            &tmux_event(Some(PaneId::from_cli("%9").expect("pane"))),
+            BuiltInNudgeSinkTarget::Graft,
+        )
+        .expect_err("nonzero exit must fail");
 
-        assert!(started_at.elapsed() < Duration::from_secs(8));
-        assert_eq!(error.code, AtmErrorCode::PostSendTmuxSendFailed);
-        assert!(error.message.contains("timed out"));
-    }
-
-    #[test]
-    fn graft_post_send_emitter_delegates_to_graft_port() {
-        let port = RecordingGraftPort::default();
-        let event = tmux_event(Some(PaneId::from_cli("%9").expect("pane")));
-
-        GraftPostSendEmitter::new(&port)
-            .emit(&event)
-            .expect("graft send");
-
-        let delivered = port.delivered.lock().expect("graft deliveries");
-        assert_eq!(delivered.len(), 1);
-        assert_eq!(delivered[0], event);
-    }
-
-    #[test]
-    fn graft_post_send_emitter_surfaces_port_failure() {
-        let port = RecordingGraftPort {
-            delivered: std::sync::Mutex::new(Vec::new()),
-            fail_message: Some("synthetic graft failure".to_string()),
-        };
-
-        let error = GraftPostSendEmitter::new(&port)
-            .emit(&tmux_event(Some(PaneId::from_cli("%9").expect("pane"))))
-            .expect_err("graft failure");
-
-        assert_eq!(error.code, AtmErrorCode::DaemonUnavailable);
-        assert!(error.message.contains("synthetic graft failure"));
+        assert!(error.message.contains("exited unsuccessfully"));
     }
 }

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -1243,7 +1243,7 @@ mod tests {
         #[cfg(windows)]
         fs::write(
             &atm_path,
-            "@echo off\r\n> \"%ATM_TEST_CAPTURE%\" echo %1|%ATM_INTERNAL_NUDGE_SINK%|%ATM_POST_SEND%\r\nexit /b 0\r\n",
+            "@echo off\r\nsetlocal EnableDelayedExpansion\r\n> \"%ATM_TEST_CAPTURE%\" echo %1^|!ATM_INTERNAL_NUDGE_SINK!^|!ATM_POST_SEND!\r\nexit /b 0\r\n",
         )
         .expect("write atm shim");
         #[cfg(not(windows))]
@@ -1328,7 +1328,7 @@ mod tests {
         #[cfg(windows)]
         fs::write(
             &hook_path,
-            "@echo off\r\n> \"%ATM_TEST_HOOK_CAPTURE%\" echo %ATM_POST_SEND%\r\nexit /b 0\r\n",
+            "@echo off\r\nsetlocal EnableDelayedExpansion\r\n> \"%ATM_TEST_HOOK_CAPTURE%\" echo !ATM_POST_SEND!\r\nexit /b 0\r\n",
         )
         .expect("write hook shim");
         #[cfg(not(windows))]
@@ -1369,6 +1369,7 @@ mod tests {
                 Some(built_in_capture_value.as_str()),
             ),
             ("ATM_HOME", tempdir.path().to_str()),
+            ("ATM_CONFIG_HOME", tempdir.path().to_str()),
             ("HOME", tempdir.path().to_str()),
             (ATM_PROGRAM_ENV, Some(atm_bin.as_str())),
         ]);

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -932,13 +932,15 @@ mod tests {
     use super::{
         ATM_PROGRAM_ENV, BuiltInNudgeSinkTarget, HookCancellationToken,
         POST_SEND_HOOK_MAX_STDOUT_BYTES, PostSendHookResultLevel, emit_built_in_nudge,
-        finish_abandoned_post_send_hook_stdout_capture, hook_matches_recipient,
-        hook_result_log_level, load_post_send_config_for_sender, parse_post_send_hook_result,
-        sender_config_root,
+        emit_post_send_effects, finish_abandoned_post_send_hook_stdout_capture,
+        hook_matches_recipient, hook_result_log_level, load_post_send_config_for_sender,
+        parse_post_send_hook_result, sender_config_root,
     };
     use crate::boundary::{PostSendHookEvent, RosterEntry, RosterHarness, RosterMemberKind};
     use crate::config::AtmConfig;
-    use crate::config::types::HookRecipient;
+    use crate::config::types::{HookRecipient, PostSendHookRule};
+    use crate::delivery_plan::LogicalMessage;
+    use crate::delivery_policy::{DeliveryHarnessPath, DeliveryRecipientSnapshot};
     use crate::error::AtmError;
     use crate::roles::ROLE_TEAM_LEAD;
     #[allow(
@@ -946,7 +948,8 @@ mod tests {
         reason = "Phase AD obsolete: derived compatibility field only. Hook tests intentionally exercise the retained legacy cwd compatibility seam."
     )]
     use crate::schema::agent_member::LEGACY_CWD_METADATA_KEY;
-    use crate::schema::{HOME_DIR_METADATA_KEY, InboxMessage, TeamConfig};
+    use crate::schema::{AtmMessageId, HOME_DIR_METADATA_KEY, InboxMessage, TeamConfig};
+    use crate::send::ResolvedRecipient;
     use crate::service_runtime::{RetainedMailboxTimeoutPolicy, RetainedServiceRuntime};
     use crate::test_support::{EnvGuard, TEST_SENDER};
     use crate::types::{AgentName, IsoTimestamp, PaneId, TeamName};
@@ -1203,6 +1206,31 @@ mod tests {
         }
     }
 
+    fn logical_message(text: &str) -> LogicalMessage {
+        LogicalMessage::new(
+            InboxMessage {
+                from: AgentName::from_validated(TEST_SENDER),
+                text: text.to_string(),
+                timestamp: IsoTimestamp::now(),
+                read: false,
+                source_team: Some(TeamName::from_validated("test-team")),
+                summary: Some(text.to_string()),
+                message_id: Some(AtmMessageId::new()),
+                pending_ack_at: None,
+                acknowledged_at: None,
+                acknowledges_message_id: None,
+                parent_message_id: None,
+                thread_mode: None,
+                expires_at: None,
+                task_id: None,
+                extra: Map::new(),
+            },
+            false,
+            false,
+        )
+        .expect("logical message")
+    }
+
     #[test]
     #[serial_test::serial(env)]
     fn built_in_nudge_fallback_invokes_hidden_cli_with_sink_and_payload() {
@@ -1281,5 +1309,104 @@ mod tests {
         .expect_err("nonzero exit must fail");
 
         assert!(error.message.contains("exited unsuccessfully"));
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn external_post_send_hook_takes_precedence_over_built_in_nudge() {
+        let tempdir = tempdir().expect("tempdir");
+        let hook_capture = tempdir.path().join("hook-capture.txt");
+        let built_in_capture = tempdir.path().join("built-in-capture.txt");
+        #[cfg(windows)]
+        let hook_path = tempdir.path().join("hook.cmd");
+        #[cfg(not(windows))]
+        let hook_path = tempdir.path().join("hook");
+        #[cfg(windows)]
+        let atm_path = tempdir.path().join("atm.cmd");
+        #[cfg(not(windows))]
+        let atm_path = tempdir.path().join("atm");
+        #[cfg(windows)]
+        fs::write(
+            &hook_path,
+            "@echo off\r\n> \"%ATM_TEST_HOOK_CAPTURE%\" echo %ATM_POST_SEND%\r\nexit /b 0\r\n",
+        )
+        .expect("write hook shim");
+        #[cfg(not(windows))]
+        fs::write(
+            &hook_path,
+            "#!/bin/sh\nprintf '%s\\n' \"$ATM_POST_SEND\" > \"$ATM_TEST_HOOK_CAPTURE\"\nexit 0\n",
+        )
+        .expect("write hook shim");
+        #[cfg(windows)]
+        fs::write(
+            &atm_path,
+            "@echo off\r\n> \"%ATM_TEST_BUILT_IN_CAPTURE%\" echo invoked\r\nexit /b 0\r\n",
+        )
+        .expect("write atm shim");
+        #[cfg(not(windows))]
+        fs::write(
+            &atm_path,
+            "#!/bin/sh\nprintf 'invoked\\n' > \"$ATM_TEST_BUILT_IN_CAPTURE\"\nexit 0\n",
+        )
+        .expect("write atm shim");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for path in [&hook_path, &atm_path] {
+                let mut perms = fs::metadata(path).expect("metadata").permissions();
+                perms.set_mode(0o755);
+                fs::set_permissions(path, perms).expect("chmod");
+            }
+        }
+
+        let hook_capture_value = hook_capture.display().to_string();
+        let built_in_capture_value = built_in_capture.display().to_string();
+        let atm_bin = atm_path.display().to_string();
+        let _env = EnvGuard::set_many([
+            ("ATM_TEST_HOOK_CAPTURE", Some(hook_capture_value.as_str())),
+            (
+                "ATM_TEST_BUILT_IN_CAPTURE",
+                Some(built_in_capture_value.as_str()),
+            ),
+            ("ATM_HOME", tempdir.path().to_str()),
+            ("HOME", tempdir.path().to_str()),
+            (ATM_PROGRAM_ENV, Some(atm_bin.as_str())),
+        ]);
+
+        let config = AtmConfig {
+            config_root: tempdir.path().to_path_buf(),
+            post_send_hooks: vec![PostSendHookRule {
+                recipient: HookRecipient::Named("recipient".parse().expect("recipient")),
+                command: vec![hook_path.display().to_string()],
+            }],
+            ..Default::default()
+        };
+        let recipient = ResolvedRecipient {
+            agent: AgentName::from_validated("recipient"),
+            team: TeamName::from_validated("test-team"),
+        };
+        let snapshot = DeliveryRecipientSnapshot {
+            agent: recipient.agent.clone(),
+            team: recipient.team.clone(),
+            harness: DeliveryHarnessPath::ClaudeCode,
+            recipient_pane_id: Some(PaneId::from_cli("%9").expect("pane")),
+            local_tmux_post_send: true,
+            graft_post_send: false,
+            roster_backed: true,
+        };
+        let mut warnings = Vec::new();
+
+        emit_post_send_effects(
+            &mut warnings,
+            Some(&config),
+            None,
+            &recipient,
+            &snapshot,
+            &[logical_message("hello")],
+        );
+
+        let captured = fs::read_to_string(&hook_capture).expect("hook capture");
+        assert!(captured.contains("\"description\":\"hello\""));
+        assert!(!built_in_capture.exists());
     }
 }

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -459,7 +459,13 @@ fn post_send_messages_from_persistence(
     persistence: &DeliveryPersistenceResult,
     requires_ack: bool,
 ) -> Result<Vec<crate::delivery_plan::LogicalMessage>, AtmError> {
-    logical_messages_from_persistence(persistence, requires_ack, false).map_err(|error| {
+    crate::delivery_plan::LogicalMessage::new(
+        persistence.original_message.clone(),
+        requires_ack,
+        false,
+    )
+    .map(|message| vec![message])
+    .map_err(|error| {
         AtmError::mailbox_write(error.to_string()).with_recovery(
             "Repair the persisted delivery record shape before retrying post-send emission.",
         )

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -81,6 +81,15 @@ pub(super) fn install_home_env(home_dir: &Path) -> EnvGuard {
     ])
 }
 
+pub(super) fn install_home_env_with_atm_bin(home_dir: &Path, atm_bin: &str) -> EnvGuard {
+    EnvGuard::set_many([
+        ("HOME", Some(home_dir.to_str().expect("utf8 home"))),
+        ("USERPROFILE", None),
+        ("ATM_LOG_DIR", None),
+        ("ATM_TEST_ATM_BIN", Some(atm_bin)),
+    ])
+}
+
 fn assert_recovered_payload_texts(
     original: &InboxMessage,
     companion: &InboxMessage,
@@ -639,7 +648,14 @@ fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_bound
     let observability = RecordingObservability::default();
     let tempdir = tempdir().expect("tempdir");
     let home_dir = tempdir.path().join("home");
-    let _env = install_home_env(&home_dir);
+    let capture_path = tempdir.path().join("graft-nudge.txt");
+    #[cfg(windows)]
+    let atm_path = tempdir.path().join("atm.cmd");
+    #[cfg(not(windows))]
+    let atm_path = tempdir.path().join("atm");
+    super::graft_warning_tests::write_atm_nudge_shim(&atm_path, &capture_path, 0);
+    let atm_bin = atm_path.display().to_string();
+    let _env = install_home_env_with_atm_bin(&home_dir, atm_bin.as_str());
 
     let outcome = super::send_mail_with_runtime_impl(
         send_request(tempdir.path()),
@@ -652,8 +668,14 @@ fn send_non_claude_sqlite_failure_delivers_original_and_error_via_outbound_bound
     assert_eq!(outcome.outcome, SendCommandOutcome::Sent);
     assert_eq!(outcome.warnings.len(), 1);
     assert_non_claude_sqlite_failure_delivery(&runtime);
-    assert_notification_log_absent(&home_dir);
+    let events = read_notification_events(&home_dir);
+    assert_eq!(events.len(), 1);
     assert_non_claude_sqlite_failure_observability(&observability);
+    let captured = fs::read_to_string(&capture_path).expect("capture");
+    assert!(captured.contains("internal-nudge"));
+    assert!(captured.contains("|graft|"));
+    assert!(captured.contains(format!("\"sender\":\"{TEST_SENDER}\"").as_str()));
+    assert!(!captured.contains("\"sender\":\"atm-system\""));
 }
 
 #[test]

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -8,7 +8,9 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::boundary::{RosterEntry, RosterStore};
+use crate::boundary::{
+    BuiltInNudgeTemplateKind, NudgeTemplateOverrideStore, RosterEntry, RosterStore,
+};
 use crate::error::AtmError;
 use crate::schema::HomeDirPath;
 use crate::types::{AgentName, ModelName, PaneId, TeamName};
@@ -153,6 +155,41 @@ pub enum RestoreResult {
     Applied(RestoreOutcome),
 }
 
+/// Parameters for setting one team-scoped built-in nudge template override.
+#[derive(Debug, Clone)]
+pub struct SetNudgeTemplateOverrideRequest {
+    pub caller_team: TeamName,
+    pub team: TeamName,
+    pub kind: BuiltInNudgeTemplateKind,
+    pub template_body: String,
+}
+
+impl SetNudgeTemplateOverrideRequest {
+    pub fn new(
+        caller_team: TeamName,
+        team: &str,
+        kind: &str,
+        template_body: String,
+    ) -> Result<Self, AtmError> {
+        Ok(Self {
+            caller_team,
+            team: team.parse()?,
+            kind: kind.parse()?,
+            template_body,
+        })
+    }
+}
+
+/// Result of setting one team-scoped built-in nudge template override.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SetNudgeTemplateOverrideOutcome {
+    pub action: &'static str,
+    pub team: TeamName,
+    pub kind: BuiltInNudgeTemplateKind,
+    pub template_body: String,
+    pub updated_at: crate::types::IsoTimestamp,
+}
+
 /// List teams currently discoverable under ATM home.
 ///
 /// # Errors
@@ -235,6 +272,40 @@ pub fn restore_team_with_roster_store(
     restore::restore_team_with_roster_store(roster_store, request)
 }
 
+/// Save one team-scoped built-in nudge template override.
+///
+/// # Errors
+///
+/// Returns [`AtmError`] when caller-team validation fails or the override row
+/// cannot be persisted through the shared override-store boundary.
+pub fn set_nudge_template_override_with_store(
+    override_store: &(dyn NudgeTemplateOverrideStore + Send + Sync),
+    request: SetNudgeTemplateOverrideRequest,
+) -> Result<SetNudgeTemplateOverrideOutcome, AtmError> {
+    if request.caller_team != request.team {
+        return Err(AtmError::validation(format!(
+            "caller team '{}' does not match nudge-template target team '{}'",
+            request.caller_team, request.team
+        ))
+        .with_recovery(
+            "Run `atm teams set-nudge-template` from the same ATM team that owns the target override row.",
+        ));
+    }
+
+    let row = override_store.save_template_override(
+        &request.team,
+        request.kind,
+        &request.template_body,
+    )?;
+    Ok(SetNudgeTemplateOverrideOutcome {
+        action: "set-nudge-template",
+        team: row.team_name,
+        kind: row.kind,
+        template_body: row.template_body,
+        updated_at: row.updated_at,
+    })
+}
+
 pub(crate) fn ordered_roster_member_summaries(
     records: &[RosterEntry],
     caller_identity: Option<&AgentName>,
@@ -254,13 +325,15 @@ mod tests {
 
     use super::{
         AddMemberRequest, BackupRequest, MemberName, MembersQuery, RestoreRequest,
-        UpdateMemberRequest, add_member_with_roster_store, backup_team_with_roster_store,
-        list_members_with_roster_store, list_teams_with_roster_store,
+        SetNudgeTemplateOverrideRequest, UpdateMemberRequest, add_member_with_roster_store,
+        backup_team_with_roster_store, list_members_with_roster_store,
+        list_teams_with_roster_store, set_nudge_template_override_with_store,
         update_member_with_roster_store,
     };
     use crate::boundary::{
-        self, ReplaySource, RosterEntry, RosterHarness, RosterMemberKind, RosterStore,
-        RosterStoreHealthSnapshot,
+        self, BuiltInNudgeTemplateKind, NudgeTemplateOverrideStore, ReplaySource, RosterEntry,
+        RosterHarness, RosterMemberKind, RosterStore, RosterStoreHealthSnapshot,
+        TeamNudgeTemplateOverrideRow,
     };
     use crate::error_codes::AtmErrorCode;
     use crate::schema::{HOME_DIR_METADATA_KEY, TeamConfig};
@@ -278,6 +351,11 @@ mod tests {
         teams: Mutex<BTreeMap<TeamName, Vec<RosterEntry>>>,
     }
 
+    #[derive(Default)]
+    struct RecordingNudgeTemplateOverrideStore {
+        rows: Mutex<BTreeMap<(TeamName, BuiltInNudgeTemplateKind), TeamNudgeTemplateOverrideRow>>,
+    }
+
     impl RecordingRosterStore {
         fn seed_team(&self, team: &str, members: Vec<RosterEntry>) {
             self.teams
@@ -288,6 +366,7 @@ mod tests {
     }
 
     impl boundary::sealed::Sealed for RecordingRosterStore {}
+    impl boundary::sealed::Sealed for RecordingNudgeTemplateOverrideStore {}
 
     impl RosterStore for RecordingRosterStore {
         fn replace_roster(
@@ -358,6 +437,40 @@ mod tests {
                 stale: false,
                 refreshed_at: None,
             })
+        }
+    }
+
+    impl NudgeTemplateOverrideStore for RecordingNudgeTemplateOverrideStore {
+        fn load_template_override(
+            &self,
+            team: &TeamName,
+            kind: BuiltInNudgeTemplateKind,
+        ) -> Result<Option<TeamNudgeTemplateOverrideRow>, crate::error::AtmError> {
+            Ok(self
+                .rows
+                .lock()
+                .expect("override store lock")
+                .get(&(team.clone(), kind))
+                .cloned())
+        }
+
+        fn save_template_override(
+            &self,
+            team: &TeamName,
+            kind: BuiltInNudgeTemplateKind,
+            template_body: &str,
+        ) -> Result<TeamNudgeTemplateOverrideRow, crate::error::AtmError> {
+            let row = TeamNudgeTemplateOverrideRow {
+                team_name: team.clone(),
+                kind,
+                template_body: template_body.to_string(),
+                updated_at: crate::types::IsoTimestamp::now(),
+            };
+            self.rows
+                .lock()
+                .expect("override store lock")
+                .insert((team.clone(), kind), row.clone());
+            Ok(row)
         }
     }
 
@@ -876,6 +989,73 @@ mod tests {
         .expect("parse snapshot");
         assert_eq!(snapshot["team"], serde_json::json!(TEST_TEAM));
         assert_eq!(snapshot["members"].as_array().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn set_nudge_template_override_rejects_invalid_kind() {
+        let error = SetNudgeTemplateOverrideRequest::new(
+            TEST_TEAM.parse().expect("caller team"),
+            TEST_TEAM,
+            "not-a-kind",
+            "<atm/>".to_string(),
+        )
+        .expect_err("invalid kind");
+
+        assert_eq!(error.code, AtmErrorCode::MessageValidationFailed);
+        assert!(
+            error
+                .message
+                .contains("unsupported built-in nudge template kind")
+        );
+    }
+
+    #[test]
+    fn set_nudge_template_override_rejects_caller_team_mismatch() {
+        let override_store = RecordingNudgeTemplateOverrideStore::default();
+        let error = set_nudge_template_override_with_store(
+            &override_store,
+            SetNudgeTemplateOverrideRequest::new(
+                "other-team".parse().expect("caller team"),
+                TEST_TEAM,
+                "delivery_ack",
+                "<atm/>".to_string(),
+            )
+            .expect("request"),
+        )
+        .expect_err("caller mismatch");
+
+        assert_eq!(error.code, AtmErrorCode::MessageValidationFailed);
+        assert!(error.message.contains("caller team"));
+    }
+
+    #[test]
+    fn set_nudge_template_override_saves_row_through_boundary() {
+        let override_store = RecordingNudgeTemplateOverrideStore::default();
+        let outcome = set_nudge_template_override_with_store(
+            &override_store,
+            SetNudgeTemplateOverrideRequest::new(
+                TEST_TEAM.parse().expect("caller team"),
+                TEST_TEAM,
+                "delivery_ack",
+                "<atm/>".to_string(),
+            )
+            .expect("request"),
+        )
+        .expect("save");
+
+        assert_eq!(outcome.action, "set-nudge-template");
+        assert_eq!(outcome.team.as_str(), TEST_TEAM);
+        assert_eq!(outcome.kind, BuiltInNudgeTemplateKind::DeliveryAck);
+        assert_eq!(outcome.template_body, "<atm/>");
+
+        let saved = override_store
+            .load_template_override(
+                &TEST_TEAM.parse().expect("team"),
+                BuiltInNudgeTemplateKind::DeliveryAck,
+            )
+            .expect("load")
+            .expect("saved row");
+        assert_eq!(saved.template_body, "<atm/>");
     }
 
     #[test]

--- a/crates/atm-daemon-bootstrap/src/lib.rs
+++ b/crates/atm-daemon-bootstrap/src/lib.rs
@@ -29,3 +29,18 @@ pub fn with_default_roster_store<T>(
 ) -> Result<T, AtmError> {
     atm_runtime::with_default_roster_store(f)
 }
+
+/// Open the default SQLite boundary and expose only the approved built-in
+/// nudge-template override lookup seam.
+///
+/// # Errors
+///
+/// Returns [`AtmError`] when the default SQLite-backed retained runtime cannot
+/// assemble its canonical override-store boundary state.
+pub fn with_default_nudge_template_override_store<T>(
+    f: impl FnOnce(
+        &(dyn atm_core::boundary::NudgeTemplateOverrideStore + Send + Sync),
+    ) -> Result<T, AtmError>,
+) -> Result<T, AtmError> {
+    atm_runtime::with_default_nudge_template_override_store(f)
+}

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -29,7 +29,6 @@ signal-hook = "0.3"
 signal-hook = "0.3"
 
 [dev-dependencies]
-atm-graft = { path = "../atm-graft", version = "1.2.3" }
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3", features = ["test-utils"] }
 atm-runtime = { path = "../atm-runtime", version = "1.2.3", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -160,7 +160,7 @@ fn dispatcher_ack_surfaces_typed_warning_when_graft_reply_target_is_unavailable(
                 atm_home.clone(),
                 workspace_dir.clone(),
                 "qa-a".parse().expect("caller"),
-                "team-lead@test-team",
+                &format!("{ROLE_TEAM_LEAD}@{TEST_TEAM}"),
                 TEST_TEAM.parse().expect("team"),
                 SendMessageSource::Inline("please ack".to_string()),
                 None,

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -1,23 +1,23 @@
 use atm_core::ack::AckRequest;
 use atm_core::boundary::{ReplaySource, RequestDispatcher, RosterHarness};
 use atm_core::error_codes::AtmErrorCode;
+use atm_core::graft::{
+    GraftPostSendRequest, GraftPostSendResponse, graft_receiver_socket_path_from_home,
+    read_graft_post_send_message, write_graft_post_send_message,
+};
 use atm_core::protocol::{
     RequestEnvelope, ResponseEnvelope, SendRequestEnvelope, SendResponseEnvelope,
 };
 use atm_core::schema::{AgentMember, TeamConfig};
 use atm_core::send::{SendMessageSource, SendRequest};
 use atm_core::test_support::{EnvGuard, ROLE_TEAM_LEAD};
-use atm_core::types::TeamName;
-use atm_graft::{
-    GraftClient, GraftSession, GraftSessionOptions, GraftSessionState, HostNudgeInjector,
-};
+use atm_core::types::{AgentName, TeamName};
 use atm_runtime_test_support::open_sqlite_boundary;
+use interprocess::local_socket::ListenerOptions;
+use interprocess::local_socket::traits::Listener as _;
 use tempfile::TempDir;
 
-use crate::LocalIpcServerTransportAdapter;
-use crate::lifecycle_control::LifecycleControlSourceAdapter;
 use crate::runtime_health::{DaemonRequestDispatcher, RuntimeStatusCache};
-use crate::test_support::LifecycleFlagResetGuard;
 
 const TEST_TEAM: &str = "test-team";
 
@@ -114,89 +114,6 @@ fn write_graft_enabled_config(workspace_dir: &std::path::Path) {
     .expect("write graft config");
 }
 
-struct RunningDispatcherServer {
-    lifecycle: LifecycleControlSourceAdapter,
-    _reset: LifecycleFlagResetGuard,
-    join: std::thread::JoinHandle<()>,
-    result_rx: std::sync::mpsc::Receiver<Result<(), atm_core::error::AtmError>>,
-}
-
-impl RunningDispatcherServer {
-    fn stop(self) {
-        self.lifecycle.set_terminate_for_test(true);
-        self.result_rx
-            .recv_timeout(std::time::Duration::from_secs(15))
-            .expect("recv serve result")
-            .expect("serve runtime result");
-        self.join.join().expect("join serve thread");
-    }
-}
-
-fn spawn_dispatcher_server(
-    socket_path: std::path::PathBuf,
-    dispatcher: DaemonRequestDispatcher,
-) -> (RunningDispatcherServer, std::sync::mpsc::Receiver<()>) {
-    let server_transport = LocalIpcServerTransportAdapter::new();
-    let mut runtime = server_transport
-        .prepare_runtime_at_socket_path(socket_path)
-        .expect("prepare runtime");
-    let endpoint_guard = runtime.take_endpoint_guard().expect("take endpoint guard");
-    let lifecycle = LifecycleControlSourceAdapter::install().expect("install lifecycle");
-    let reset = LifecycleFlagResetGuard::install(lifecycle.clone());
-    let dispatcher: std::sync::Arc<dyn RequestDispatcher + Send + Sync> =
-        std::sync::Arc::new(dispatcher);
-    let (serve_result_tx, serve_result_rx) = std::sync::mpsc::channel();
-    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
-    let join = std::thread::spawn(move || {
-        let result = runtime.serve_with_runtime_hooks(
-            dispatcher,
-            crate::local_ipc_transport::RuntimeServeHooks {
-                endpoint_guard,
-                graceful_drain_deadline: std::time::Duration::from_millis(500),
-                force_cancel_deadline: std::time::Duration::from_secs(2),
-                begin_shutdown: || Ok(()),
-                reload_runtime_view: || Ok(()),
-                finalize_shutdown: || {},
-                publish_ready: move || {
-                    ready_tx.send(()).map_err(|_| {
-                        atm_core::error::AtmError::daemon_unavailable(
-                            "graft warning test failed to observe the daemon ready signal",
-                        )
-                        .with_recovery(
-                            "Rerun the graft warning test after restoring the bounded ready-signal handshake.",
-                        )
-                    })
-                },
-            },
-        );
-        serve_result_tx.send(result).expect("send serve result");
-    });
-    (
-        RunningDispatcherServer {
-            lifecycle,
-            _reset: reset,
-            join,
-            result_rx: serve_result_rx,
-        },
-        ready_rx,
-    )
-}
-
-#[derive(Debug, Default)]
-struct RecordingInjector {
-    nudges: std::sync::Mutex<Vec<atm_core::boundary::PostSendHookEvent>>,
-}
-
-impl HostNudgeInjector for RecordingInjector {
-    fn inject_nudge(
-        &self,
-        nudge: atm_core::boundary::PostSendHookEvent,
-    ) -> Result<(), atm_core::error::AtmError> {
-        self.nudges.lock().expect("nudges lock").push(nudge);
-        Ok(())
-    }
-}
-
 #[test]
 #[serial_test::serial(env)]
 fn dispatcher_send_surfaces_typed_warning_when_graft_receiver_path_is_unavailable() {
@@ -289,42 +206,52 @@ fn dispatcher_ack_surfaces_typed_warning_when_graft_reply_target_is_unavailable(
 fn dispatcher_send_delivers_direct_graft_nudge_without_warning() {
     let (_tempdir, atm_home, workspace_dir, dispatcher) = graft_warning_dispatcher();
     write_graft_enabled_config(&workspace_dir);
-    let socket_path = atm_home.join(".atm").join("daemon").join("atm-daemon.sock");
+    let recipient_team = TEST_TEAM.parse::<TeamName>().expect("team");
+    let recipient_agent = "qa-a".parse::<AgentName>().expect("agent");
+    let receiver_path =
+        graft_receiver_socket_path_from_home(&atm_home, &recipient_team, &recipient_agent);
+    if let Some(parent) = receiver_path.parent() {
+        std::fs::create_dir_all(parent).expect("receiver dir");
+    }
+    #[cfg(unix)]
+    if receiver_path.exists() {
+        std::fs::remove_file(&receiver_path).expect("remove stale receiver");
+    }
+    let receiver_name =
+        atm_core::protocol::daemon_local_ipc_name_from_path(&receiver_path).expect("receiver name");
+    let listener = ListenerOptions::new()
+        .name(receiver_name)
+        .create_sync()
+        .expect("bind fake graft receiver");
+    let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+    let receiver_thread = std::thread::spawn(move || {
+        let mut stream = listener.accept().expect("accept graft receiver");
+        let request: GraftPostSendRequest = read_graft_post_send_message(
+            &mut stream,
+            "failed to read graft post-send request",
+            "graft post-send request exceeded the bounded payload cap",
+        )
+        .expect("read graft request");
+        event_tx
+            .send(request.event.clone())
+            .expect("send captured event");
+        write_graft_post_send_message(
+            &mut stream,
+            &GraftPostSendResponse::Delivered,
+            "failed to write graft post-send response",
+            "graft post-send response exceeded the bounded payload cap",
+        )
+        .expect("write graft response");
+        use std::io::Write as _;
+        stream.flush().expect("flush graft response");
+    });
     let _env = EnvGuard::set_many([
         ("ATM_HOME", Some(atm_home.to_str().expect("utf8 atm home"))),
-        (
-            "ATM_DAEMON_SOCKET",
-            Some(socket_path.to_str().expect("utf8 socket path")),
-        ),
-        ("ATM_TEAM", Some(TEST_TEAM)),
-        ("ATM_IDENTITY", Some("qa-a")),
         ("HOME", Some(atm_home.to_str().expect("utf8 home"))),
         ("USERPROFILE", None),
     ]);
-    let (server, ready_rx) = spawn_dispatcher_server(socket_path, dispatcher);
-    ready_rx
-        .recv_timeout(std::time::Duration::from_secs(5))
-        .expect("daemon ready");
-
-    let client = GraftClient::connect().expect("connect graft client");
-    let injector = std::sync::Arc::new(RecordingInjector::default());
-    let session = GraftSession::activate(
-        client,
-        GraftSessionOptions::for_current_process(
-            workspace_dir.clone(),
-            TEST_TEAM.parse().expect("team"),
-            "qa-a".parse().expect("agent"),
-        ),
-        injector.clone() as std::sync::Arc<dyn HostNudgeInjector>,
-    )
-    .expect("activate graft session");
-    assert_eq!(
-        session.snapshot().expect("snapshot").state,
-        GraftSessionState::Listening
-    );
-
-    let response = session
-        .send(
+    let response = dispatcher
+        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
             SendRequest::new(
                 atm_home,
                 workspace_dir,
@@ -338,16 +265,19 @@ fn dispatcher_send_delivers_direct_graft_nudge_without_warning() {
                 false,
             )
             .expect("send request"),
-        )
+        )))
         .expect("send response");
+    let response = match response {
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => outcome,
+        other => panic!("expected send response, got {other:?}"),
+    };
 
     assert!(response.warnings.is_empty());
-    let nudges = injector.nudges.lock().expect("nudges lock");
-    assert_eq!(nudges.len(), 1);
-    assert_eq!(nudges[0].recipient.as_str(), "qa-a");
-    assert_eq!(nudges[0].recipient_team.as_str(), TEST_TEAM);
-    assert_eq!(nudges[0].message, "hello graft");
-
-    drop(session);
-    server.stop();
+    let nudge = event_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("receive graft nudge");
+    assert_eq!(nudge.recipient.as_str(), "qa-a");
+    assert_eq!(nudge.recipient_team.as_str(), TEST_TEAM);
+    assert_eq!(nudge.description, "hello graft");
+    receiver_thread.join().expect("join fake graft receiver");
 }

--- a/crates/atm-graft/examples/smoke_same_host.rs
+++ b/crates/atm-graft/examples/smoke_same_host.rs
@@ -158,14 +158,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         .into());
     }
     if !nudge
-        .message
+        .description
         .as_str()
         .contains(&args.expected_nudge_substring)
     {
         return Err(io::Error::other(format!(
-            "expected nudge message to contain {:?}, found {:?}",
+            "expected nudge description to contain {:?}, found {:?}",
             args.expected_nudge_substring,
-            nudge.message.as_str()
+            nudge.description.as_str()
         ))
         .into());
     }
@@ -243,7 +243,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 "recipient": nudge.recipient.to_string(),
                 "recipient_team": nudge.recipient_team.to_string(),
                 "message_id": nudge.message_id.to_string(),
-                "message": nudge.message,
+                "description": nudge.description,
                 "requires_ack": nudge.requires_ack,
                 "is_ack": nudge.is_ack,
                 "task_id": nudge.task_id.map(|task_id| task_id.to_string()),

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -27,6 +27,7 @@ use atm_daemon_client::{
     resolve_daemon_bin, resolve_daemon_local_ipc_endpoint,
 };
 
+mod nudge_sink;
 mod runtime;
 mod transport;
 

--- a/crates/atm-graft/src/nudge_sink.rs
+++ b/crates/atm-graft/src/nudge_sink.rs
@@ -1,0 +1,125 @@
+use std::sync::{Arc, RwLock};
+
+use atm_core::boundary::PostSendHookEvent;
+use atm_core::protocol::ProtocolErrorEnvelope;
+
+use crate::runtime::read_snapshot;
+use crate::{GraftObservability, HostNudgeInjector, SessionSnapshot};
+
+pub(crate) struct GraftNudgeSink<'a> {
+    pub(crate) injector: &'a dyn HostNudgeInjector,
+    pub(crate) snapshot: &'a Arc<RwLock<SessionSnapshot>>,
+    pub(crate) observability: &'a dyn GraftObservability,
+}
+
+impl GraftNudgeSink<'_> {
+    pub(crate) fn deliver(&self, event: PostSendHookEvent) -> Result<(), ProtocolErrorEnvelope> {
+        match self.injector.inject_nudge(event.clone()) {
+            Ok(()) => {
+                if let Ok(snapshot) = read_snapshot(self.snapshot) {
+                    self.observability.nudge_delivered(&snapshot, &event);
+                }
+                Ok(())
+            }
+            Err(error) => {
+                if let Ok(snapshot) = read_snapshot(self.snapshot) {
+                    self.observability
+                        .session_error(&snapshot, "inject_nudge", &error);
+                }
+                Err(ProtocolErrorEnvelope::from_error(&error))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex, RwLock};
+
+    use atm_core::boundary::PostSendHookEvent;
+    use atm_core::error::{AtmError, AtmErrorKind};
+
+    use super::GraftNudgeSink;
+    use crate::{GraftObservability, GraftSessionState, HostNudgeInjector, SessionSnapshot};
+
+    #[derive(Default)]
+    struct RecordingInjector {
+        events: Mutex<Vec<PostSendHookEvent>>,
+    }
+
+    impl HostNudgeInjector for RecordingInjector {
+        fn inject_nudge(&self, nudge: PostSendHookEvent) -> Result<(), AtmError> {
+            self.events.lock().expect("events").push(nudge);
+            Ok(())
+        }
+    }
+
+    struct FailingInjector;
+
+    impl HostNudgeInjector for FailingInjector {
+        fn inject_nudge(&self, _nudge: PostSendHookEvent) -> Result<(), AtmError> {
+            Err(AtmError::new(
+                AtmErrorKind::DaemonUnavailable,
+                "synthetic graft receiver unavailable",
+            ))
+        }
+    }
+
+    #[derive(Default)]
+    struct NoopObservability;
+
+    impl GraftObservability for NoopObservability {}
+
+    fn request_event() -> PostSendHookEvent {
+        PostSendHookEvent {
+            sender: "team-lead".parse().expect("sender"),
+            sender_team: "atm-dev".parse().expect("team"),
+            recipient: "arch-ctm".parse().expect("recipient"),
+            recipient_team: "atm-dev".parse().expect("team"),
+            message_id: "01KX1TEST00000000000000000".parse().expect("message id"),
+            description: "review failing smoke lane".to_string(),
+            requires_ack: false,
+            is_ack: false,
+            task_id: None,
+            recipient_pane_id: None,
+        }
+    }
+
+    fn snapshot() -> Arc<RwLock<SessionSnapshot>> {
+        Arc::new(RwLock::new(SessionSnapshot {
+            team: "atm-dev".parse().expect("team"),
+            agent: "arch-ctm".parse().expect("agent"),
+            state: GraftSessionState::Listening,
+        }))
+    }
+
+    #[test]
+    fn graft_nudge_sink_delivers_to_host_injector() {
+        let injector = RecordingInjector::default();
+        let sink = GraftNudgeSink {
+            injector: &injector,
+            snapshot: &snapshot(),
+            observability: &NoopObservability,
+        };
+
+        sink.deliver(request_event()).expect("delivery");
+
+        assert_eq!(injector.events.lock().expect("events").len(), 1);
+    }
+
+    #[test]
+    fn graft_nudge_sink_returns_typed_error_envelope() {
+        let sink = GraftNudgeSink {
+            injector: &FailingInjector,
+            snapshot: &snapshot(),
+            observability: &NoopObservability,
+        };
+
+        let error = sink.deliver(request_event()).expect_err("typed error");
+        assert!(
+            error
+                .message
+                .contains("synthetic graft receiver unavailable")
+        );
+    }
+}

--- a/crates/atm-graft/src/nudge_sink.rs
+++ b/crates/atm-graft/src/nudge_sink.rs
@@ -38,6 +38,7 @@ mod tests {
 
     use atm_core::boundary::PostSendHookEvent;
     use atm_core::error::{AtmError, AtmErrorKind};
+    use atm_core::test_support::{TEST_ARCH_CTM, TEST_LEAD, TEST_TEAM};
 
     use super::GraftNudgeSink;
     use crate::{GraftObservability, GraftSessionState, HostNudgeInjector, SessionSnapshot};
@@ -72,10 +73,10 @@ mod tests {
 
     fn request_event() -> PostSendHookEvent {
         PostSendHookEvent {
-            sender: "team-lead".parse().expect("sender"),
-            sender_team: "atm-dev".parse().expect("team"),
-            recipient: "arch-ctm".parse().expect("recipient"),
-            recipient_team: "atm-dev".parse().expect("team"),
+            sender: TEST_LEAD.parse().expect("sender"),
+            sender_team: TEST_TEAM.parse().expect("team"),
+            recipient: TEST_ARCH_CTM.parse().expect("recipient"),
+            recipient_team: TEST_TEAM.parse().expect("team"),
             message_id: "01KX1TEST00000000000000000".parse().expect("message id"),
             description: "review failing smoke lane".to_string(),
             requires_ack: false,
@@ -87,8 +88,8 @@ mod tests {
 
     fn snapshot() -> Arc<RwLock<SessionSnapshot>> {
         Arc::new(RwLock::new(SessionSnapshot {
-            team: "atm-dev".parse().expect("team"),
-            agent: "arch-ctm".parse().expect("agent"),
+            team: TEST_TEAM.parse().expect("team"),
+            agent: TEST_ARCH_CTM.parse().expect("agent"),
             state: GraftSessionState::Listening,
         }))
     }

--- a/crates/atm-graft/src/runtime.rs
+++ b/crates/atm-graft/src/runtime.rs
@@ -11,12 +11,12 @@ use atm_core::graft::{
     GraftPostSendRequest, GraftPostSendResponse, read_graft_post_send_message,
     write_graft_post_send_message,
 };
-use atm_core::protocol::ProtocolErrorEnvelope;
 use interprocess::local_socket::prelude::*;
 use interprocess::local_socket::{
     Listener as LocalSocketListener, ListenerOptions, Stream as LocalSocketStream,
 };
 
+use crate::nudge_sink::GraftNudgeSink;
 use crate::{
     GraftObservability, GraftSessionState, HostNudgeInjector, RECEIVE_LOOP_JOIN_DEADLINE,
     SessionSnapshot,
@@ -42,6 +42,12 @@ struct InjectRequest {
 
 struct BoundedHostNudgeInjector {
     request_tx: SyncSender<InjectRequest>,
+}
+
+impl crate::HostNudgeInjector for BoundedHostNudgeInjector {
+    fn inject_nudge(&self, nudge: PostSendHookEvent) -> Result<(), AtmError> {
+        Self::inject_nudge(self, nudge)
+    }
 }
 
 impl BoundedHostNudgeInjector {
@@ -390,19 +396,15 @@ fn handle_graft_receiver_connection(
         "graft post-send request exceeded the bounded payload cap",
     )?;
     let event = request.event;
-    let response = match injector.inject_nudge(event.clone()) {
-        Ok(()) => {
-            let snapshot = read_snapshot(&ctx.snapshot)?;
-            ctx.observability.nudge_delivered(&snapshot, &event);
-            GraftPostSendResponse::Delivered
-        }
-        Err(error) => {
-            if let Ok(snapshot) = read_snapshot(&ctx.snapshot) {
-                ctx.observability
-                    .session_error(&snapshot, "inject_nudge", &error);
-            }
-            GraftPostSendResponse::Error(ProtocolErrorEnvelope::from_error(&error))
-        }
+    let response = match (GraftNudgeSink {
+        injector,
+        snapshot: &ctx.snapshot,
+        observability: ctx.observability.as_ref(),
+    })
+    .deliver(event)
+    {
+        Ok(()) => GraftPostSendResponse::Delivered,
+        Err(error) => GraftPostSendResponse::Error(error),
     };
     write_graft_post_send_message(
         stream,
@@ -561,7 +563,7 @@ mod tests {
             recipient: AgentName::from_validated(TEST_QA),
             recipient_team: TeamName::from_validated(TEST_TEAM),
             message_id: AtmMessageId::new(),
-            message: "review failing smoke lane".to_string(),
+            description: "review failing smoke lane".to_string(),
             requires_ack: false,
             is_ack: false,
             task_id: None,

--- a/crates/atm-runtime/src/composition.rs
+++ b/crates/atm-runtime/src/composition.rs
@@ -197,3 +197,22 @@ pub fn with_default_roster_store<T>(
         (Err(error), Err(_)) => Err(error),
     }
 }
+
+pub fn with_default_nudge_template_override_store<T>(
+    f: impl FnOnce(&(dyn boundary::NudgeTemplateOverrideStore + Send + Sync)) -> Result<T, AtmError>,
+) -> Result<T, AtmError> {
+    let sqlite_backend = Arc::new(SqliteStorageBackend::new_with_observability(
+        host_mail_db_path()?,
+        RuntimeSqliteObservability::disabled(),
+    )?);
+    let override_store = sqlite_backend.nudge_template_override_store();
+    let result = f(override_store.as_ref());
+    let finalize_result =
+        SqliteRuntimeStorageFinalizer::new(sqlite_backend).finalize_storage_shutdown();
+    match (result, finalize_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), Ok(())) => Err(error),
+        (Err(error), Err(_)) => Err(error),
+    }
+}

--- a/crates/atm-runtime/src/lib.rs
+++ b/crates/atm-runtime/src/lib.rs
@@ -13,7 +13,7 @@ mod sqlite_observability;
 
 pub use composition::{
     RuntimeAssembly, RuntimeAssemblyInputs, assemble_default_runtime, assemble_sqlite_runtime,
-    default_local_runtime, with_default_roster_store,
+    default_local_runtime, with_default_nudge_template_override_store, with_default_roster_store,
 };
 #[cfg(any(test, feature = "test-utils"))]
 pub use replay_store::sqlite_remote_replay_store_for_test;

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -16,6 +16,7 @@ name = "atm_storage_rusqlite"
 test-support = []
 
 [dependencies]
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
 atm-storage = { path = "../atm-storage", version = "1.2.3" }
 serde_json.workspace = true
 serde.workspace = true

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -8,6 +8,7 @@
 //! message and roster contracts.
 
 mod mailbox_metadata;
+mod nudge_template_override_store;
 mod observability;
 mod roster_store;
 mod shared_db;
@@ -175,6 +176,11 @@ struct SqliteMessageStore {
 
 #[derive(Debug)]
 struct SqliteRosterStore {
+    db: Arc<SharedDb>,
+}
+
+#[derive(Debug)]
+struct SqliteNudgeTemplateOverrideStore {
     db: Arc<SharedDb>,
 }
 
@@ -436,6 +442,7 @@ impl MessageStore for SqliteMessageStore {
 pub struct SqliteStorageBackend {
     message_store: Arc<SqliteMessageStore>,
     roster_store: Arc<SqliteRosterStore>,
+    nudge_template_override_store: Arc<SqliteNudgeTemplateOverrideStore>,
 }
 
 impl SqliteStorageBackend {
@@ -450,7 +457,8 @@ impl SqliteStorageBackend {
         let db = Arc::new(SharedDb::open_with_observability(path, observability)?);
         Ok(Self {
             message_store: Arc::new(SqliteMessageStore::new(Arc::clone(&db))),
-            roster_store: Arc::new(SqliteRosterStore::new(db)),
+            roster_store: Arc::new(SqliteRosterStore::new(Arc::clone(&db))),
+            nudge_template_override_store: Arc::new(SqliteNudgeTemplateOverrideStore::new(db)),
         })
     }
 
@@ -459,7 +467,8 @@ impl SqliteStorageBackend {
         let db = Arc::new(SharedDb::open_in_memory_for_test()?);
         Ok(Self {
             message_store: Arc::new(SqliteMessageStore::new(Arc::clone(&db))),
-            roster_store: Arc::new(SqliteRosterStore::new(db)),
+            roster_store: Arc::new(SqliteRosterStore::new(Arc::clone(&db))),
+            nudge_template_override_store: Arc::new(SqliteNudgeTemplateOverrideStore::new(db)),
         })
     }
 
@@ -499,6 +508,12 @@ impl SqliteStorageBackend {
 
     pub fn roster_store(&self) -> Arc<dyn RosterStore + Send + Sync> {
         self.roster_store.clone()
+    }
+
+    pub fn nudge_template_override_store(
+        &self,
+    ) -> Arc<dyn atm_core::boundary::NudgeTemplateOverrideStore + Send + Sync> {
+        self.nudge_template_override_store.clone()
     }
 
     pub fn replace_roster(

--- a/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
+++ b/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
@@ -47,17 +47,47 @@ impl NudgeTemplateOverrideStore for SqliteNudgeTemplateOverrideStore {
                 .transpose()
         })
     }
+
+    fn save_template_override(
+        &self,
+        team: &TeamName,
+        kind: BuiltInNudgeTemplateKind,
+        template_body: &str,
+    ) -> Result<TeamNudgeTemplateOverrideRow, AtmError> {
+        let updated_at = IsoTimestamp::now();
+        let updated_at_raw = updated_at.into_inner().to_rfc3339();
+        self.db.with_connection(|connection| {
+            connection
+                .execute(
+                    "INSERT INTO team_nudge_template_overrides(
+                        team_name, template_kind, template_body, updated_at
+                     ) VALUES (?1, ?2, ?3, ?4)
+                     ON CONFLICT(team_name, template_kind) DO UPDATE SET
+                        template_body = excluded.template_body,
+                        updated_at = excluded.updated_at;",
+                    params![
+                        team.as_str(),
+                        template_kind_value(kind),
+                        template_body,
+                        &updated_at_raw,
+                    ],
+                )
+                .map_err(|error| {
+                    self.db
+                        .error("failed to save team nudge template override row", error)
+                })?;
+            Ok(TeamNudgeTemplateOverrideRow {
+                team_name: team.clone(),
+                kind,
+                template_body: template_body.to_string(),
+                updated_at: parse_updated_at(updated_at_raw.clone())?,
+            })
+        })
+    }
 }
 
 fn template_kind_value(kind: BuiltInNudgeTemplateKind) -> &'static str {
-    match kind {
-        BuiltInNudgeTemplateKind::Delivery => "delivery",
-        BuiltInNudgeTemplateKind::DeliveryAck => "delivery_ack",
-        BuiltInNudgeTemplateKind::DeliveryTask => "delivery_task",
-        BuiltInNudgeTemplateKind::DeliveryTaskAck => "delivery_task_ack",
-        BuiltInNudgeTemplateKind::Acknowledge => "acknowledge",
-        BuiltInNudgeTemplateKind::AcknowledgeTask => "acknowledge_task",
-    }
+    kind.as_str()
 }
 
 fn parse_updated_at(raw: String) -> Result<IsoTimestamp, AtmError> {
@@ -75,34 +105,19 @@ fn parse_updated_at(raw: String) -> Result<IsoTimestamp, AtmError> {
 
 #[cfg(test)]
 mod tests {
-    use super::template_kind_value;
     use atm_core::boundary::BuiltInNudgeTemplateKind;
 
     #[test]
-    fn sqlite_override_store_loads_saved_override_row() {
+    fn sqlite_override_store_saves_and_loads_override_row() {
         let backend = crate::SqliteStorageBackend::in_memory_for_test().expect("backend");
-        backend
-            .message_store
-            .db
-            .with_connection(|connection| {
-                connection
-                    .execute(
-                        "INSERT INTO team_nudge_template_overrides(
-                            team_name, template_kind, template_body, updated_at
-                         ) VALUES (?1, ?2, ?3, ?4);",
-                        rusqlite::params![
-                            "test-team",
-                            template_kind_value(BuiltInNudgeTemplateKind::DeliveryAck),
-                            "<atm/>",
-                            chrono::Utc::now().to_rfc3339(),
-                        ],
-                    )
-                    .map_err(|error| {
-                        backend.message_store.db.error("insert override row", error)
-                    })?;
-                Ok(())
-            })
-            .expect("insert");
+        let saved = backend
+            .nudge_template_override_store()
+            .save_template_override(
+                &"test-team".parse().expect("team"),
+                BuiltInNudgeTemplateKind::DeliveryAck,
+                "<atm/>",
+            )
+            .expect("save");
 
         let row = backend
             .nudge_template_override_store()
@@ -116,6 +131,9 @@ mod tests {
         assert_eq!(row.team_name.as_str(), "test-team");
         assert_eq!(row.kind, BuiltInNudgeTemplateKind::DeliveryAck);
         assert_eq!(row.template_body, "<atm/>");
+        assert_eq!(saved.team_name, row.team_name);
+        assert_eq!(saved.kind, row.kind);
+        assert_eq!(saved.template_body, row.template_body);
     }
 
     #[test]

--- a/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
+++ b/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
@@ -28,7 +28,7 @@ impl NudgeTemplateOverrideStore for SqliteNudgeTemplateOverrideStore {
                     "SELECT template_body, updated_at
                      FROM team_nudge_template_overrides
                      WHERE team_name = ?1 AND template_kind = ?2;",
-                    params![team.as_str(), template_kind_value(kind)],
+                    params![team.as_str(), kind.as_str()],
                     |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
                 )
                 .optional()
@@ -55,22 +55,17 @@ impl NudgeTemplateOverrideStore for SqliteNudgeTemplateOverrideStore {
         template_body: &str,
     ) -> Result<TeamNudgeTemplateOverrideRow, AtmError> {
         let updated_at = IsoTimestamp::now();
-        let updated_at_raw = updated_at.into_inner().to_rfc3339();
+        let updated_at_raw = updated_at.to_string();
         self.db.with_connection(|connection| {
             connection
                 .execute(
                     "INSERT INTO team_nudge_template_overrides(
                         team_name, template_kind, template_body, updated_at
                      ) VALUES (?1, ?2, ?3, ?4)
-                     ON CONFLICT(team_name, template_kind) DO UPDATE SET
+                    ON CONFLICT(team_name, template_kind) DO UPDATE SET
                         template_body = excluded.template_body,
                         updated_at = excluded.updated_at;",
-                    params![
-                        team.as_str(),
-                        template_kind_value(kind),
-                        template_body,
-                        &updated_at_raw,
-                    ],
+                    params![team.as_str(), kind.as_str(), template_body, &updated_at_raw,],
                 )
                 .map_err(|error| {
                     self.db
@@ -80,14 +75,10 @@ impl NudgeTemplateOverrideStore for SqliteNudgeTemplateOverrideStore {
                 team_name: team.clone(),
                 kind,
                 template_body: template_body.to_string(),
-                updated_at: parse_updated_at(updated_at_raw.clone())?,
+                updated_at,
             })
         })
     }
-}
-
-fn template_kind_value(kind: BuiltInNudgeTemplateKind) -> &'static str {
-    kind.as_str()
 }
 
 fn parse_updated_at(raw: String) -> Result<IsoTimestamp, AtmError> {

--- a/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
+++ b/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
@@ -1,0 +1,135 @@
+use super::SqliteNudgeTemplateOverrideStore;
+use crate::shared_db::SharedDb;
+use atm_core::boundary::{
+    BuiltInNudgeTemplateKind, NudgeTemplateOverrideStore, TeamNudgeTemplateOverrideRow,
+};
+use atm_core::error::AtmError;
+use atm_core::types::{IsoTimestamp, TeamName};
+use rusqlite::{OptionalExtension, params};
+use std::sync::Arc;
+
+impl SqliteNudgeTemplateOverrideStore {
+    pub(crate) fn new(db: Arc<SharedDb>) -> Self {
+        Self { db }
+    }
+}
+
+impl atm_core::boundary::sealed::Sealed for SqliteNudgeTemplateOverrideStore {}
+
+impl NudgeTemplateOverrideStore for SqliteNudgeTemplateOverrideStore {
+    fn load_template_override(
+        &self,
+        team: &TeamName,
+        kind: BuiltInNudgeTemplateKind,
+    ) -> Result<Option<TeamNudgeTemplateOverrideRow>, AtmError> {
+        self.db.with_connection(|connection| {
+            connection
+                .query_row(
+                    "SELECT template_body, updated_at
+                     FROM team_nudge_template_overrides
+                     WHERE team_name = ?1 AND template_kind = ?2;",
+                    params![team.as_str(), template_kind_value(kind)],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()
+                .map_err(|error| {
+                    self.db
+                        .error("failed to load team nudge template override row", error)
+                })?
+                .map(|(template_body, updated_at)| {
+                    Ok(TeamNudgeTemplateOverrideRow {
+                        team_name: team.clone(),
+                        kind,
+                        template_body,
+                        updated_at: parse_updated_at(updated_at)?,
+                    })
+                })
+                .transpose()
+        })
+    }
+}
+
+fn template_kind_value(kind: BuiltInNudgeTemplateKind) -> &'static str {
+    match kind {
+        BuiltInNudgeTemplateKind::Delivery => "delivery",
+        BuiltInNudgeTemplateKind::DeliveryAck => "delivery_ack",
+        BuiltInNudgeTemplateKind::DeliveryTask => "delivery_task",
+        BuiltInNudgeTemplateKind::DeliveryTaskAck => "delivery_task_ack",
+        BuiltInNudgeTemplateKind::Acknowledge => "acknowledge",
+        BuiltInNudgeTemplateKind::AcknowledgeTask => "acknowledge_task",
+    }
+}
+
+fn parse_updated_at(raw: String) -> Result<IsoTimestamp, AtmError> {
+    raw.parse::<chrono::DateTime<chrono::Utc>>()
+        .map(IsoTimestamp::from_datetime)
+        .map_err(|error| {
+            AtmError::validation(format!(
+                "failed to parse team_nudge_template_overrides.updated_at `{raw}`: {error}"
+            ))
+            .with_recovery(
+                "Repair the malformed team_nudge_template_overrides.updated_at row before retrying the override lookup.",
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::template_kind_value;
+    use atm_core::boundary::BuiltInNudgeTemplateKind;
+
+    #[test]
+    fn sqlite_override_store_loads_saved_override_row() {
+        let backend = crate::SqliteStorageBackend::in_memory_for_test().expect("backend");
+        backend
+            .message_store
+            .db
+            .with_connection(|connection| {
+                connection
+                    .execute(
+                        "INSERT INTO team_nudge_template_overrides(
+                            team_name, template_kind, template_body, updated_at
+                         ) VALUES (?1, ?2, ?3, ?4);",
+                        rusqlite::params![
+                            "test-team",
+                            template_kind_value(BuiltInNudgeTemplateKind::DeliveryAck),
+                            "<atm/>",
+                            chrono::Utc::now().to_rfc3339(),
+                        ],
+                    )
+                    .map_err(|error| {
+                        backend.message_store.db.error("insert override row", error)
+                    })?;
+                Ok(())
+            })
+            .expect("insert");
+
+        let row = backend
+            .nudge_template_override_store()
+            .load_template_override(
+                &"test-team".parse().expect("team"),
+                BuiltInNudgeTemplateKind::DeliveryAck,
+            )
+            .expect("lookup")
+            .expect("row");
+
+        assert_eq!(row.team_name.as_str(), "test-team");
+        assert_eq!(row.kind, BuiltInNudgeTemplateKind::DeliveryAck);
+        assert_eq!(row.template_body, "<atm/>");
+    }
+
+    #[test]
+    fn sqlite_override_store_returns_none_for_missing_row() {
+        let backend = crate::SqliteStorageBackend::in_memory_for_test().expect("backend");
+
+        let row = backend
+            .nudge_template_override_store()
+            .load_template_override(
+                &"test-team".parse().expect("team"),
+                BuiltInNudgeTemplateKind::Delivery,
+            )
+            .expect("lookup");
+
+        assert!(row.is_none());
+    }
+}

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -87,6 +87,22 @@ CREATE TABLE IF NOT EXISTS team_roster (
     PRIMARY KEY (team_name, agent_name)
 );
 
+CREATE TABLE IF NOT EXISTS team_nudge_template_overrides (
+    team_name TEXT NOT NULL,
+    template_kind TEXT NOT NULL
+        CHECK(template_kind IN (
+            'delivery',
+            'delivery_ack',
+            'delivery_task',
+            'delivery_task_ack',
+            'acknowledge',
+            'acknowledge_task'
+        )),
+    template_body TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (team_name, template_kind)
+);
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mail_messages_single_successor
     ON mail_messages(team, agent, parent_message_id)
     WHERE parent_message_id IS NOT NULL;
@@ -109,6 +125,9 @@ CREATE INDEX IF NOT EXISTS idx_daemon_remote_replay_mailbox
 
 CREATE INDEX IF NOT EXISTS idx_team_roster_team_name
     ON team_roster(team_name);
+
+CREATE INDEX IF NOT EXISTS idx_team_nudge_template_overrides_team_name
+    ON team_nudge_template_overrides(team_name);
 "#;
 // `team_roster` is the single canonical durable roster truth. Runtime pid
 // continuity is transient daemon-owned state and must not be persisted here.

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -1,0 +1,631 @@
+use std::collections::BTreeMap;
+use std::io::Write as _;
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use atm_core::boundary::{
+    BuiltInNudgeTemplateKind, PostSendHookEvent, TeamNudgeTemplateOverrideRow,
+};
+use atm_core::error::{AtmError, AtmErrorKind};
+use atm_core::error_codes::AtmErrorCode;
+use atm_core::graft::{
+    GraftPostSendRequest, GraftPostSendResponse, graft_receiver_socket_path_from_home,
+    read_graft_post_send_message, write_graft_post_send_message,
+};
+use atm_core::home;
+use atm_daemon_bootstrap::with_default_nudge_template_override_store;
+use clap::Args;
+use interprocess::local_socket::Stream as LocalSocketStream;
+use interprocess::local_socket::traits::Stream as _;
+
+use crate::observability::CliObservability;
+
+const ATM_POST_SEND_ENV: &str = "ATM_POST_SEND";
+const INTERNAL_NUDGE_SINK_ENV: &str = "ATM_INTERNAL_NUDGE_SINK";
+const TMUX_DOUBLE_ENTER_DELAY: Duration = Duration::from_millis(275);
+const TMUX_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const TMUX_PROGRAM_ENV: &str = "ATM_TEST_TMUX_BIN";
+
+#[derive(Debug, Args)]
+#[command(hide = true)]
+pub struct InternalNudgeCommand;
+
+impl InternalNudgeCommand {
+    pub fn run(self, _observability: &CliObservability) -> Result<()> {
+        let input = InternalNudgeInput::from_env()?;
+        let kind = BuiltInNudgeTemplateKind::from_post_send_event(&input.event);
+        let template = load_override_body(&input.event.recipient_team, kind)?
+            .unwrap_or_else(|| default_template(kind).to_string());
+        let rendered = render_template(&template, &input.render_values())?;
+        match input.sink_target {
+            NudgeSinkTarget::Tmux => TmuxNudgeSink.deliver(&input.event, &rendered)?,
+            NudgeSinkTarget::Graft => GraftNudgeSink.deliver(&input.event)?,
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NudgeSinkTarget {
+    Tmux,
+    Graft,
+}
+
+impl NudgeSinkTarget {
+    fn from_env() -> Result<Self> {
+        match std::env::var(INTERNAL_NUDGE_SINK_ENV).as_deref() {
+            Ok("tmux") => Ok(Self::Tmux),
+            Ok("graft") => Ok(Self::Graft),
+            Ok(other) => Err(AtmError::validation(format!(
+                "unsupported built-in nudge sink target `{other}`"
+            ))
+            .with_recovery(
+                "Set ATM_INTERNAL_NUDGE_SINK to `tmux` or `graft` before retrying the built-in post-send path.",
+            )
+            .into()),
+            Err(_) => Err(AtmError::validation(
+                "missing ATM_INTERNAL_NUDGE_SINK for built-in post-send nudge",
+            )
+            .with_recovery(
+                "Populate ATM_INTERNAL_NUDGE_SINK before invoking `atm internal-nudge`.",
+            )
+            .into()),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RawInternalNudgePayload {
+    from: String,
+    sender: String,
+    recipient: String,
+    team: String,
+    message_id: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    message: String,
+    requires_ack: bool,
+    is_ack: bool,
+    #[serde(default)]
+    task_id: Option<String>,
+    #[serde(default)]
+    recipient_pane_id: Option<String>,
+}
+
+#[derive(Debug)]
+struct InternalNudgeInput {
+    from: String,
+    event: PostSendHookEvent,
+    sink_target: NudgeSinkTarget,
+}
+
+impl InternalNudgeInput {
+    fn from_env() -> Result<Self> {
+        let raw_payload = std::env::var(ATM_POST_SEND_ENV).map_err(|_| {
+            AtmError::validation("missing ATM_POST_SEND payload for built-in post-send nudge")
+                .with_recovery(
+                    "Populate ATM_POST_SEND before invoking the built-in `atm internal-nudge` path.",
+                )
+        })?;
+        let payload: RawInternalNudgePayload =
+            serde_json::from_str(&raw_payload).map_err(|source| {
+                AtmError::validation("failed to decode ATM_POST_SEND payload for built-in nudge")
+                    .with_recovery(
+                        "Repair the ATM_POST_SEND JSON payload before retrying the built-in post-send path.",
+                    )
+                    .with_source(source)
+            })?;
+        let description = if payload.description.trim().is_empty() {
+            payload.message.clone()
+        } else {
+            payload.description.clone()
+        };
+        Ok(Self {
+            from: payload.from,
+            event: PostSendHookEvent {
+                sender: payload.sender.parse()?,
+                sender_team: payload.team.parse()?,
+                recipient: payload.recipient.parse()?,
+                recipient_team: payload.team.parse()?,
+                message_id: payload.message_id.parse()?,
+                description,
+                requires_ack: payload.requires_ack,
+                is_ack: payload.is_ack,
+                task_id: payload
+                    .task_id
+                    .filter(|value| !value.trim().is_empty())
+                    .map(|value| value.parse())
+                    .transpose()?,
+                recipient_pane_id: payload
+                    .recipient_pane_id
+                    .filter(|value| !value.trim().is_empty())
+                    .as_deref()
+                    .map(atm_core::types::PaneId::from_cli)
+                    .transpose()?,
+            },
+            sink_target: NudgeSinkTarget::from_env()?,
+        })
+    }
+
+    fn render_values(&self) -> BTreeMap<&'static str, String> {
+        BTreeMap::from([
+            ("from", self.from.clone()),
+            ("team", self.event.recipient_team.to_string()),
+            ("message_id", self.event.message_id.to_string()),
+            ("description", self.event.description.clone()),
+            (
+                "task_id",
+                self.event
+                    .task_id
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+            ),
+        ])
+    }
+}
+
+fn load_override_body(
+    team: &atm_core::types::TeamName,
+    kind: BuiltInNudgeTemplateKind,
+) -> Result<Option<String>> {
+    with_default_nudge_template_override_store(|store| {
+        Ok(store
+            .load_template_override(team, kind)?
+            .map(|row: TeamNudgeTemplateOverrideRow| row.template_body))
+    })
+    .map_err(Into::into)
+}
+
+fn default_template(kind: BuiltInNudgeTemplateKind) -> &'static str {
+    match kind {
+        BuiltInNudgeTemplateKind::Delivery => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <description>{{description}}</description>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        }
+        BuiltInNudgeTemplateKind::DeliveryAck => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <action>ack the message</action>\n  <description>{{description}}</description>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        }
+        BuiltInNudgeTemplateKind::DeliveryTask => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <task id=\"{{task_id}}\">{{description}}</task>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        }
+        BuiltInNudgeTemplateKind::DeliveryTaskAck => {
+            "<atm from=\"{{from}}\" message-id=\"{{message_id}}\">\n  <action>read atm --team {{team}}</action>\n  <action>ack the message</action>\n  <task id=\"{{task_id}}\">{{description}}</task>\n  <action>execute the assigned task</action>\n  <when idle=\"immediate\" busy=\"after-current-task\"/>\n  <console announce=\"concise\" pause=\"false\"/>\n</atm>"
+        }
+        BuiltInNudgeTemplateKind::Acknowledge => {
+            "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\"/>"
+        }
+        BuiltInNudgeTemplateKind::AcknowledgeTask => {
+            "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\" task-id=\"{{task_id}}\"/>"
+        }
+    }
+}
+
+fn render_template(template: &str, values: &BTreeMap<&'static str, String>) -> Result<String> {
+    if template.contains("{%") || template.contains("%}") {
+        return Err(AtmError::validation(
+            "built-in nudge templates do not support Jinja or conditional blocks",
+        )
+        .with_recovery(
+            "Use only the documented placeholder tokens in the stored template body before retrying built-in nudge rendering.",
+        )
+        .into());
+    }
+    let mut output = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("{{") {
+        output.push_str(&rest[..start]);
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find("}}") else {
+            return Err(AtmError::validation("unterminated built-in nudge placeholder")
+                .with_recovery(
+                    "Close every built-in nudge placeholder with `}}` before retrying template rendering.",
+                )
+                .into());
+        };
+        let key = after_start[..end].trim();
+        let Some(value) = values.get(key) else {
+            return Err(AtmError::validation(format!(
+                "unsupported built-in nudge placeholder `{{{{{key}}}}}`"
+            ))
+            .with_recovery(
+                "Use only {{from}}, {{team}}, {{message_id}}, {{description}}, and {{task_id}} in built-in nudge templates.",
+            )
+            .into());
+        };
+        output.push_str(value);
+        rest = &after_start[end + 2..];
+    }
+    output.push_str(rest);
+    Ok(output)
+}
+
+struct TmuxNudgeSink;
+
+impl TmuxNudgeSink {
+    fn deliver(&self, event: &PostSendHookEvent, rendered: &str) -> Result<()> {
+        let pane_id = event.recipient_pane_id.as_ref().ok_or_else(|| {
+            AtmError::new_with_code(
+                AtmErrorCode::PostSendPaneMissing,
+                AtmErrorKind::Validation,
+                format!(
+                    "recipient {}@{} has tmux-backed post-send capability but no pane id",
+                    event.recipient, event.recipient_team
+                ),
+            )
+            .with_recovery(format!(
+                "Repair the roster row with `atm teams update-member --team {} --member {} --pane-id <pane>`.",
+                event.recipient_team, event.recipient
+            ))
+        })?;
+        run_tmux_command(
+            {
+                let mut command = tmux_command();
+                command.args(["send-keys", "-t", pane_id.as_str(), "-l", rendered]);
+                command
+            },
+            "send literal nudge",
+        )?;
+        run_tmux_command(
+            {
+                let mut command = tmux_command();
+                command.args(["send-keys", "-t", pane_id.as_str(), "Enter"]);
+                command
+            },
+            "send first Enter to nudge pane",
+        )?;
+        thread::sleep(TMUX_DOUBLE_ENTER_DELAY);
+        run_tmux_command(
+            {
+                let mut command = tmux_command();
+                command.args(["send-keys", "-t", pane_id.as_str(), "Enter"]);
+                command
+            },
+            "send second Enter to nudge pane",
+        )?;
+        Ok(())
+    }
+}
+
+struct GraftNudgeSink;
+
+impl GraftNudgeSink {
+    fn deliver(&self, event: &PostSendHookEvent) -> Result<()> {
+        let home_dir = home::atm_home()?;
+        let endpoint_path = graft_receiver_socket_path_from_home(
+            &home_dir,
+            &event.recipient_team,
+            &event.recipient,
+        );
+        let endpoint_name = atm_core::protocol::daemon_local_ipc_name_from_path(&endpoint_path)?;
+        let mut stream = LocalSocketStream::connect(endpoint_name).map_err(|source| {
+            AtmError::new_with_code(
+                AtmErrorCode::PostSendGraftUnavailable,
+                AtmErrorKind::DaemonUnavailable,
+                format!(
+                    "failed to connect to graft nudge receiver for {}@{}",
+                    event.recipient, event.recipient_team
+                ),
+            )
+            .with_recovery(
+                "Start or repair the graft-backed receiver before retrying post-send delivery.",
+            )
+            .with_source(source)
+        })?;
+        let request = GraftPostSendRequest {
+            event: event.clone(),
+        };
+        write_graft_post_send_message(
+            &mut stream,
+            &request,
+            "failed to write graft post-send request",
+            "graft post-send request exceeded the bounded payload cap",
+        )?;
+        let response: GraftPostSendResponse = read_graft_post_send_message(
+            &mut stream,
+            "failed to read graft post-send response",
+            "graft post-send response exceeded the bounded payload cap",
+        )?;
+        stream.flush().map_err(|source| {
+            AtmError::new_with_code(
+                AtmErrorCode::PostSendGraftUnavailable,
+                AtmErrorKind::DaemonUnavailable,
+                "failed to flush graft post-send request",
+            )
+            .with_recovery(
+                "Repair the graft-backed receiver socket before retrying post-send delivery.",
+            )
+            .with_source(source)
+        })?;
+        match response {
+            GraftPostSendResponse::Delivered => Ok(()),
+            GraftPostSendResponse::Error(error) => Err(error.into_atm_error().into()),
+        }
+    }
+}
+
+fn tmux_command() -> Command {
+    #[cfg(test)]
+    if let Some(program) = std::env::var_os(TMUX_PROGRAM_ENV).filter(|value| !value.is_empty()) {
+        return Command::new(program);
+    }
+    Command::new("tmux")
+}
+
+fn run_tmux_command(mut command: Command, action: &'static str) -> Result<()> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let child = command.spawn().map_err(|source| {
+        AtmError::new_with_code(
+            AtmErrorCode::PostSendTmuxSendFailed,
+            AtmErrorKind::DaemonUnavailable,
+            format!("failed to start tmux while trying to {action}: {source}"),
+        )
+        .with_recovery("Repair the local tmux installation before retrying post-send delivery.")
+        .with_source(source)
+    })?;
+    let output = wait_for_tmux_output(child, action)?;
+    ensure_tmux_success(output, action).map_err(Into::into)
+}
+
+fn wait_for_tmux_output(mut child: Child, action: &'static str) -> Result<Output> {
+    let started_at = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                return child.wait_with_output().map_err(|source| {
+                    AtmError::new_with_code(
+                        AtmErrorCode::PostSendTmuxSendFailed,
+                        AtmErrorKind::DaemonUnavailable,
+                        format!("failed to collect tmux output while trying to {action}: {source}"),
+                    )
+                    .with_recovery(
+                        "Repair the local tmux installation before retrying post-send delivery.",
+                    )
+                    .with_source(source)
+                    .into()
+                });
+            }
+            Ok(None) if started_at.elapsed() < TMUX_SEND_TIMEOUT => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(AtmError::new_with_code(
+                    AtmErrorCode::PostSendTmuxSendFailed,
+                    AtmErrorKind::Timeout,
+                    format!(
+                        "tmux {action} timed out after {}s",
+                        TMUX_SEND_TIMEOUT.as_secs()
+                    ),
+                )
+                .with_recovery(
+                    "Repair the local tmux installation or pane state before retrying post-send delivery.",
+                )
+                .into());
+            }
+            Err(source) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(AtmError::new_with_code(
+                    AtmErrorCode::PostSendTmuxSendFailed,
+                    AtmErrorKind::DaemonUnavailable,
+                    format!("failed while waiting for tmux {action}: {source}"),
+                )
+                .with_recovery(
+                    "Repair the local tmux installation before retrying post-send delivery.",
+                )
+                .with_source(source)
+                .into());
+            }
+        }
+    }
+}
+
+fn ensure_tmux_success(output: Output, action: &'static str) -> Result<(), AtmError> {
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let detail = if stderr.is_empty() {
+        format!("tmux exited unsuccessfully while trying to {action}")
+    } else {
+        format!("tmux exited unsuccessfully while trying to {action}: {stderr}")
+    };
+    Err(AtmError::new_with_code(
+        AtmErrorCode::PostSendTmuxSendFailed,
+        AtmErrorKind::DaemonUnavailable,
+        detail,
+    )
+    .with_recovery("Repair the local tmux installation before retrying post-send delivery."))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::Duration;
+
+    use atm_core::boundary::{BuiltInNudgeTemplateKind, PostSendHookEvent};
+    use atm_core::test_support::EnvGuard;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    use super::{
+        ATM_POST_SEND_ENV, INTERNAL_NUDGE_SINK_ENV, InternalNudgeInput, NudgeSinkTarget,
+        TMUX_DOUBLE_ENTER_DELAY, TMUX_PROGRAM_ENV, default_template, render_template,
+    };
+
+    fn base_event() -> PostSendHookEvent {
+        PostSendHookEvent {
+            sender: "team-lead".parse().expect("sender"),
+            sender_team: "atm-dev".parse().expect("team"),
+            recipient: "arch-ctm".parse().expect("recipient"),
+            recipient_team: "atm-dev".parse().expect("team"),
+            message_id: "01KX1TEST00000000000000000".parse().expect("message id"),
+            description: "review failing smoke lane".to_string(),
+            requires_ack: false,
+            is_ack: false,
+            task_id: None,
+            recipient_pane_id: Some(atm_core::types::PaneId::from_cli("%9").expect("pane")),
+        }
+    }
+
+    #[test]
+    fn built_in_templates_keep_ack_payloads_compact() {
+        assert_eq!(
+            default_template(BuiltInNudgeTemplateKind::Acknowledge),
+            "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\"/>"
+        );
+        assert_eq!(
+            default_template(BuiltInNudgeTemplateKind::AcknowledgeTask),
+            "<atm kind=\"ack\" from=\"{{from}}\" message-id=\"{{message_id}}\" task-id=\"{{task_id}}\"/>"
+        );
+    }
+
+    #[test]
+    fn built_in_template_kind_selection_covers_six_paths() {
+        let mut event = base_event();
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::Delivery
+        );
+        event.requires_ack = true;
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::DeliveryAck
+        );
+        event.requires_ack = false;
+        event.task_id = Some("AD.21".parse().expect("task"));
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::DeliveryTask
+        );
+        event.requires_ack = true;
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::DeliveryTaskAck
+        );
+        event.is_ack = true;
+        event.requires_ack = false;
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::AcknowledgeTask
+        );
+        event.task_id = None;
+        assert_eq!(
+            BuiltInNudgeTemplateKind::from_post_send_event(&event),
+            BuiltInNudgeTemplateKind::Acknowledge
+        );
+    }
+
+    #[test]
+    fn render_template_replaces_only_supported_placeholders() {
+        let rendered = render_template(
+            "<atm from=\"{{from}}\" task-id=\"{{task_id}}\">{{description}}</atm>",
+            &InternalNudgeInput {
+                from: "team-lead@atm-dev".to_string(),
+                event: base_event(),
+                sink_target: NudgeSinkTarget::Tmux,
+            }
+            .render_values(),
+        )
+        .expect("render");
+        assert!(rendered.contains("team-lead@atm-dev"));
+        assert!(rendered.contains("review failing smoke lane"));
+        assert!(rendered.contains("task-id=\"\""));
+    }
+
+    #[test]
+    fn render_template_rejects_unknown_placeholder() {
+        let error = render_template(
+            "<atm>{{unknown}}</atm>",
+            &InternalNudgeInput {
+                from: "team-lead@atm-dev".to_string(),
+                event: base_event(),
+                sink_target: NudgeSinkTarget::Tmux,
+            }
+            .render_values(),
+        )
+        .expect_err("unknown placeholder");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported built-in nudge placeholder")
+        );
+    }
+
+    #[test]
+    #[serial(env)]
+    fn internal_nudge_input_reads_post_send_env() {
+        let payload = serde_json::json!({
+            "from": "team-lead@atm-dev",
+            "sender": "team-lead",
+            "recipient": "arch-ctm",
+            "team": "atm-dev",
+            "message_id": "01KX1TEST00000000000000000",
+            "description": "review failing smoke lane",
+            "message": "review failing smoke lane",
+            "requires_ack": true,
+            "is_ack": false,
+            "task_id": "AD.21",
+            "recipient_pane_id": "%9"
+        });
+        let payload_value = payload.to_string();
+        let _env = EnvGuard::set_many([
+            (ATM_POST_SEND_ENV, Some(payload_value.as_str())),
+            (INTERNAL_NUDGE_SINK_ENV, Some("tmux")),
+        ]);
+
+        let input = InternalNudgeInput::from_env().expect("input");
+
+        assert_eq!(input.from, "team-lead@atm-dev");
+        assert_eq!(input.sink_target, NudgeSinkTarget::Tmux);
+        assert_eq!(input.event.task_id.expect("task").as_str(), "AD.21");
+    }
+
+    #[test]
+    #[serial(env)]
+    fn tmux_sink_uses_double_enter_sequence() {
+        let tempdir = tempdir().expect("tempdir");
+        let tmux_log = tempdir.path().join("tmux.log");
+        #[cfg(windows)]
+        let tmux_path = tempdir.path().join("tmux.cmd");
+        #[cfg(not(windows))]
+        let tmux_path = tempdir.path().join("tmux");
+        #[cfg(windows)]
+        fs::write(
+            &tmux_path,
+            "@echo off\r\n>> \"%ATM_TEST_TMUX_LOG%\" echo %*\r\nexit /b 0\r\n",
+        )
+        .expect("write tmux shim");
+        #[cfg(not(windows))]
+        fs::write(
+            &tmux_path,
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"$ATM_TEST_TMUX_LOG\"\nexit 0\n",
+        )
+        .expect("write tmux shim");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&tmux_path).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&tmux_path, perms).expect("chmod");
+        }
+
+        let tmux_log_value = tmux_log.display().to_string();
+        let tmux_bin_value = tmux_path.display().to_string();
+        let _env = EnvGuard::set_many([
+            (TMUX_PROGRAM_ENV, Some(tmux_bin_value.as_str())),
+            ("ATM_TEST_TMUX_LOG", Some(tmux_log_value.as_str())),
+        ]);
+        super::TmuxNudgeSink
+            .deliver(&base_event(), "<atm/>")
+            .expect("deliver");
+        let logged = fs::read_to_string(&tmux_log).expect("tmux log");
+        assert_eq!(logged.matches("Enter").count(), 2);
+        assert!(TMUX_DOUBLE_ENTER_DELAY >= Duration::from_millis(250));
+    }
+}

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -449,7 +449,7 @@ mod tests {
     use std::time::Duration;
 
     use atm_core::boundary::{BuiltInNudgeTemplateKind, PostSendHookEvent};
-    use atm_core::test_support::EnvGuard;
+    use atm_core::test_support::{EnvGuard, TEST_ARCH_CTM, TEST_LEAD, TEST_TEAM};
     use serial_test::serial;
     use tempfile::tempdir;
 
@@ -460,10 +460,10 @@ mod tests {
 
     fn base_event() -> PostSendHookEvent {
         PostSendHookEvent {
-            sender: "team-lead".parse().expect("sender"),
-            sender_team: "atm-dev".parse().expect("team"),
-            recipient: "arch-ctm".parse().expect("recipient"),
-            recipient_team: "atm-dev".parse().expect("team"),
+            sender: TEST_LEAD.parse().expect("sender"),
+            sender_team: TEST_TEAM.parse().expect("team"),
+            recipient: TEST_ARCH_CTM.parse().expect("recipient"),
+            recipient_team: TEST_TEAM.parse().expect("team"),
             message_id: "01KX1TEST00000000000000000".parse().expect("message id"),
             description: "review failing smoke lane".to_string(),
             requires_ack: false,
@@ -543,7 +543,7 @@ mod tests {
         let error = render_template(
             "<atm>{{unknown}}</atm>",
             &InternalNudgeInput {
-                from: "team-lead@atm-dev".to_string(),
+                from: format!("{TEST_LEAD}@{TEST_TEAM}"),
                 event: base_event(),
                 sink_target: NudgeSinkTarget::Tmux,
             }
@@ -561,10 +561,10 @@ mod tests {
     #[serial(env)]
     fn internal_nudge_input_reads_post_send_env() {
         let payload = serde_json::json!({
-            "from": "team-lead@atm-dev",
-            "sender": "team-lead",
-            "recipient": "arch-ctm",
-            "team": "atm-dev",
+            "from": format!("{TEST_LEAD}@{TEST_TEAM}"),
+            "sender": TEST_LEAD,
+            "recipient": TEST_ARCH_CTM,
+            "team": TEST_TEAM,
             "message_id": "01KX1TEST00000000000000000",
             "description": "review failing smoke lane",
             "message": "review failing smoke lane",
@@ -581,7 +581,7 @@ mod tests {
 
         let input = InternalNudgeInput::from_env().expect("input");
 
-        assert_eq!(input.from, "team-lead@atm-dev");
+        assert_eq!(input.from, format!("{TEST_LEAD}@{TEST_TEAM}"));
         assert_eq!(input.sink_target, NudgeSinkTarget::Tmux);
         assert_eq!(input.event.task_id.expect("task").as_str(), "AD.21");
     }

--- a/crates/atm/src/commands/internal_nudge.rs
+++ b/crates/atm/src/commands/internal_nudge.rs
@@ -37,8 +37,9 @@ impl InternalNudgeCommand {
     pub fn run(self, _observability: &CliObservability) -> Result<()> {
         let input = InternalNudgeInput::from_env()?;
         let kind = BuiltInNudgeTemplateKind::from_post_send_event(&input.event);
-        let template = load_override_body(&input.event.recipient_team, kind)?
-            .unwrap_or_else(|| default_template(kind).to_string());
+        let Some(template) = resolve_template_body(&input.event.recipient_team, kind)? else {
+            return Ok(());
+        };
         let rendered = render_template(&template, &input.render_values())?;
         match input.sink_target {
             NudgeSinkTarget::Tmux => TmuxNudgeSink.deliver(&input.event, &rendered)?,
@@ -179,6 +180,17 @@ fn load_override_body(
             .map(|row: TeamNudgeTemplateOverrideRow| row.template_body))
     })
     .map_err(Into::into)
+}
+
+fn resolve_template_body(
+    team: &atm_core::types::TeamName,
+    kind: BuiltInNudgeTemplateKind,
+) -> Result<Option<String>> {
+    match load_override_body(team, kind)? {
+        Some(template) if template.is_empty() => Ok(None),
+        Some(template) => Ok(Some(template)),
+        None => Ok(Some(default_template(kind).to_string())),
+    }
 }
 
 fn default_template(kind: BuiltInNudgeTemplateKind) -> &'static str {
@@ -456,6 +468,7 @@ mod tests {
     use super::{
         ATM_POST_SEND_ENV, INTERNAL_NUDGE_SINK_ENV, InternalNudgeInput, NudgeSinkTarget,
         TMUX_DOUBLE_ENTER_DELAY, TMUX_PROGRAM_ENV, default_template, render_template,
+        resolve_template_body,
     };
 
     fn base_event() -> PostSendHookEvent {
@@ -526,14 +539,14 @@ mod tests {
         let rendered = render_template(
             "<atm from=\"{{from}}\" task-id=\"{{task_id}}\">{{description}}</atm>",
             &InternalNudgeInput {
-                from: "team-lead@atm-dev".to_string(),
+                from: format!("{TEST_LEAD}@{TEST_TEAM}"),
                 event: base_event(),
                 sink_target: NudgeSinkTarget::Tmux,
             }
             .render_values(),
         )
         .expect("render");
-        assert!(rendered.contains("team-lead@atm-dev"));
+        assert!(rendered.contains(&format!("{TEST_LEAD}@{TEST_TEAM}")));
         assert!(rendered.contains("review failing smoke lane"));
         assert!(rendered.contains("task-id=\"\""));
     }
@@ -627,5 +640,62 @@ mod tests {
         let logged = fs::read_to_string(&tmux_log).expect("tmux log");
         assert_eq!(logged.matches("Enter").count(), 2);
         assert!(TMUX_DOUBLE_ENTER_DELAY >= Duration::from_millis(250));
+    }
+
+    #[test]
+    #[serial(env)]
+    fn empty_override_body_skips_built_in_nudge_delivery() {
+        let tempdir = tempdir().expect("tempdir");
+        let home_dir = tempdir.path().join("home");
+        fs::create_dir_all(&home_dir).expect("home");
+        let team = TEST_TEAM.parse().expect("team");
+        let _env = EnvGuard::set_many([
+            ("ATM_HOME", Some(home_dir.to_str().expect("utf8"))),
+            ("HOME", Some(home_dir.to_str().expect("utf8"))),
+        ]);
+
+        atm_daemon_bootstrap::with_default_nudge_template_override_store(|override_store| {
+            override_store.save_template_override(&team, BuiltInNudgeTemplateKind::Delivery, "")?;
+            Ok(())
+        })
+        .expect("save override");
+
+        let template =
+            resolve_template_body(&team, BuiltInNudgeTemplateKind::Delivery).expect("resolve");
+        assert!(template.is_none());
+    }
+
+    #[test]
+    #[serial(env)]
+    fn override_row_only_applies_to_selected_template_kind() {
+        let tempdir = tempdir().expect("tempdir");
+        let home_dir = tempdir.path().join("home");
+        fs::create_dir_all(&home_dir).expect("home");
+        let team = TEST_TEAM.parse().expect("team");
+        let _env = EnvGuard::set_many([
+            ("ATM_HOME", Some(home_dir.to_str().expect("utf8"))),
+            ("HOME", Some(home_dir.to_str().expect("utf8"))),
+        ]);
+
+        atm_daemon_bootstrap::with_default_nudge_template_override_store(|override_store| {
+            override_store.save_template_override(
+                &team,
+                BuiltInNudgeTemplateKind::DeliveryAck,
+                "<atm kind=\"override\"/>",
+            )?;
+            Ok(())
+        })
+        .expect("save override");
+
+        let overridden = resolve_template_body(&team, BuiltInNudgeTemplateKind::DeliveryAck)
+            .expect("resolve ack override");
+        let fallback = resolve_template_body(&team, BuiltInNudgeTemplateKind::Delivery)
+            .expect("resolve delivery fallback");
+
+        assert_eq!(overridden.as_deref(), Some("<atm kind=\"override\"/>"));
+        assert_eq!(
+            fallback.as_deref(),
+            Some(default_template(BuiltInNudgeTemplateKind::Delivery))
+        );
     }
 }

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod caller_context;
 pub mod clear;
 pub mod doctor;
 pub mod help;
+pub(crate) mod internal_nudge;
 pub mod list;
 pub mod log;
 pub mod members;
@@ -19,6 +20,7 @@ pub use ack::AckCommand;
 pub use clear::ClearCommand;
 pub use doctor::DoctorCommand;
 pub use help::HelpCommand;
+pub(crate) use internal_nudge::InternalNudgeCommand;
 pub use list::ListCommand;
 pub use log::LogCommand;
 pub use members::MembersCommand;
@@ -70,6 +72,8 @@ enum Command {
     Log(LogCommand),
     Doctor(DoctorCommand),
     Help(HelpCommand),
+    #[command(hide = true)]
+    InternalNudge(InternalNudgeCommand),
     Teams(TeamsCommand),
     Members(MembersCommand),
 }
@@ -85,6 +89,7 @@ impl Command {
             Self::Log(command) => command.run(observability),
             Self::Doctor(command) => command.run(observability),
             Self::Help(command) => command.run(observability),
+            Self::InternalNudge(command) => command.run(observability),
             Self::Teams(command) => command.run(observability),
             Self::Members(command) => command.run(observability),
         }

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -8,8 +8,10 @@ use std::path::PathBuf;
 use anyhow::Result;
 use atm_core::home;
 use atm_core::team_admin::{
-    self, AddMemberRequest, BackupRequest, RestoreRequest, RestoreResult, UpdateMemberRequest,
+    self, AddMemberRequest, BackupRequest, RestoreRequest, RestoreResult,
+    SetNudgeTemplateOverrideRequest, UpdateMemberRequest,
 };
+use atm_daemon_bootstrap::with_default_nudge_template_override_store;
 use clap::{Args, Subcommand};
 
 use crate::commands::caller_context::{
@@ -33,6 +35,7 @@ pub struct TeamsCommand {
 enum TeamsSubcommand {
     AddMember(AddMemberCommand),
     UpdateMember(UpdateMemberCommand),
+    SetNudgeTemplate(SetNudgeTemplateCommand),
     Backup(BackupCommand),
     Restore(RestoreCommand),
 }
@@ -89,6 +92,18 @@ struct UpdateMemberCommand {
 }
 
 #[derive(Debug, Args)]
+struct SetNudgeTemplateCommand {
+    team: String,
+    kind: String,
+
+    #[arg(long = "template-body")]
+    template_body: String,
+
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
 struct BackupCommand {
     team: String,
 
@@ -127,6 +142,7 @@ impl TeamsCommand {
             }
             Some(TeamsSubcommand::AddMember(command)) => command.run(home_dir),
             Some(TeamsSubcommand::UpdateMember(command)) => command.run(home_dir, caller_context),
+            Some(TeamsSubcommand::SetNudgeTemplate(command)) => command.run(caller_context),
             Some(TeamsSubcommand::Backup(command)) => command.run(home_dir),
             Some(TeamsSubcommand::Restore(command)) => command.run(home_dir),
         }
@@ -181,6 +197,30 @@ impl BackupCommand {
 
     fn build_request(self, home_dir: PathBuf) -> Result<BackupRequest> {
         BackupRequest::new(home_dir, &self.team).map_err(Into::into)
+    }
+}
+
+impl SetNudgeTemplateCommand {
+    fn run(self, caller_context: CallerContext) -> Result<()> {
+        let json = self.json;
+        let request = self.build_request(caller_context)?;
+        let outcome = with_default_nudge_template_override_store(|override_store| {
+            team_admin::set_nudge_template_override_with_store(override_store, request)
+        })?;
+        output::print_set_nudge_template_override_result(&outcome, json)
+    }
+
+    fn build_request(
+        self,
+        caller_context: CallerContext,
+    ) -> Result<SetNudgeTemplateOverrideRequest> {
+        SetNudgeTemplateOverrideRequest::new(
+            caller_context.caller_team,
+            &self.team,
+            &self.kind,
+            self.template_body,
+        )
+        .map_err(Into::into)
     }
 }
 
@@ -243,7 +283,8 @@ mod tests {
 
     use super::TeamsCommand;
     use super::{
-        AddMemberCommand, BackupCommand, RestoreCommand, TeamsSubcommand, UpdateMemberCommand,
+        AddMemberCommand, BackupCommand, RestoreCommand, SetNudgeTemplateCommand, TeamsSubcommand,
+        UpdateMemberCommand,
     };
     use crate::commands::caller_context::CallerContext;
     use crate::observability::CliObservability;
@@ -282,6 +323,18 @@ mod tests {
                 agent_type: Some("worker".to_string()),
                 model: Some("gpt-5".to_string()),
                 pane_id: Some("%19".to_string()),
+                json,
+            })),
+            json: false,
+        }
+    }
+
+    fn set_nudge_template_command(json: bool, template_body: &str) -> TeamsCommand {
+        TeamsCommand {
+            command: Some(TeamsSubcommand::SetNudgeTemplate(SetNudgeTemplateCommand {
+                team: TEST_TEAM.to_string(),
+                kind: "delivery_ack".to_string(),
+                template_body: template_body.to_string(),
                 json,
             })),
             json: false,
@@ -420,6 +473,26 @@ mod tests {
 
         let atm_error = error.downcast_ref::<AtmError>().expect("AtmError");
         assert_eq!(atm_error.code, AtmErrorCode::AddressParseFailed);
+    }
+
+    #[test]
+    fn set_nudge_template_build_request_rejects_invalid_kind_before_core() {
+        let command = SetNudgeTemplateCommand {
+            team: TEST_TEAM.to_string(),
+            kind: "not-a-kind".to_string(),
+            template_body: "<atm/>".to_string(),
+            json: false,
+        };
+
+        let error = command
+            .build_request(CallerContext {
+                caller_identity: TEST_SENDER.parse().expect("caller"),
+                caller_team: TEST_TEAM.parse().expect("team"),
+            })
+            .expect_err("invalid kind");
+
+        let atm_error = error.downcast_ref::<AtmError>().expect("AtmError");
+        assert_eq!(atm_error.code, AtmErrorCode::MessageValidationFailed);
     }
 
     #[test]
@@ -633,6 +706,30 @@ mod tests {
                 },
             )
             .expect("update-member run");
+        });
+    }
+
+    #[test]
+    #[serial(env)]
+    fn set_nudge_template_executes_through_shared_override_boundary() {
+        let fixture = Fixture::new();
+
+        fixture.with_env_and_cwd(|| {
+            set_nudge_template_command(true, "<atm/>")
+                .run(&CliObservability::fallback())
+                .expect("set-nudge-template run");
+
+            let saved = atm_daemon_bootstrap::with_default_nudge_template_override_store(
+                |override_store| {
+                    override_store.load_template_override(
+                        &TEST_TEAM.parse().expect("team"),
+                        "delivery_ack".parse().expect("kind"),
+                    )
+                },
+            )
+            .expect("load override")
+            .expect("saved row");
+            assert_eq!(saved.template_body, "<atm/>");
         });
     }
 

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -12,8 +12,8 @@ use atm_core::protocol::{RuntimeLivenessState, RuntimeReadinessState, RuntimeSta
 use atm_core::read::ReadOutcome;
 use atm_core::send::SendOutcome;
 use atm_core::team_admin::{
-    AddMemberOutcome, BackupOutcome, MembersList, RestoreOutcome, RestorePlan, TeamsList,
-    UpdateMemberOutcome,
+    AddMemberOutcome, BackupOutcome, MembersList, RestoreOutcome, RestorePlan,
+    SetNudgeTemplateOverrideOutcome, TeamsList, UpdateMemberOutcome,
 };
 
 /// Print one send result in human-readable or JSON form.
@@ -444,6 +444,22 @@ pub fn print_update_member_result(outcome: &UpdateMemberOutcome, json: bool) -> 
         println!("{}", serde_json::to_string_pretty(outcome)?);
     } else {
         println!("Updated member {} in {}", outcome.member, outcome.team);
+    }
+    Ok(())
+}
+
+/// Print one set-nudge-template result in human-readable or JSON form.
+pub fn print_set_nudge_template_override_result(
+    outcome: &SetNudgeTemplateOverrideOutcome,
+    json: bool,
+) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+    } else {
+        println!(
+            "Set nudge template override {} for {} at {}",
+            outcome.kind, outcome.team, outcome.updated_at
+        );
     }
     Ok(())
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1508,6 +1508,9 @@ Current runtime hook-note:
 - the shipped built-in `atm internal-nudge` path must consume this same payload
   contract so ATM does not carry separate external-hook and built-in nudge
   event shapes
+- retained compatibility helpers must treat committed `.atm.toml` pane ids as
+  non-authoritative and use roster/payload pane truth or explicit `--pane`
+  only
 
 Supported structured hook-result levels remain:
 - `debug`

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -454,6 +454,9 @@ Identity-specific policy:
 - after roster migration, the send path should populate
   `ATM_POST_SEND.recipient_pane_id` from the authoritative roster/store record
   so hook scripts do not need to rediscover pane mappings from file state
+- committed `.atm.toml` pane ids are not live routing truth; any retained
+  compatibility helper must consume authoritative roster/payload pane metadata
+  or an explicit operator-provided pane id
 - the reserved diagnostic sender `atm-identity-missing@<team>` is for
   ATM-generated repair/diagnostic notices only
 - doctor should compare the live `config.json` roster against canonical ATM

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -541,6 +541,9 @@ Required caller-context rules:
 - once roster truth is stored in SQLite, `atm-core` must source
   `recipient_pane_id` from the authoritative roster/store boundary rather than
   forcing hooks to rediscover it from local files
+- repo-tracked `.atm.toml` is dogfood/bootstrap config only; it must not carry
+  live post-send pane-routing authority through committed
+  `[[rmux.windows.panes]].tmux_pane_id` values
 - `atm-core` owns canonical post-send event construction, but it must not own
   built-in XML template storage, placeholder substitution policy, or sink-local
   transport behavior

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -29,8 +29,9 @@ model in several release-blocking ways:
   invoking shell or explicit command-line context
 - historical Claude/compatibility UUID message-id support still remains in the
   shared identity model even though the accepted runtime is now ULID-only
-- `.atm.toml` still configures `[[atm.post_send_hooks]]`, but the live daemon
-  path can complete a send with no nudge and no warning
+- the accepted `1.2.3` release entered Phase `AD` with repo-local
+  `[[atm.post_send_hooks]]` dogfood config, but the live daemon path could
+  still complete a send with no nudge and no warning
 - the current post-send path is obscured by generic delivery/notification
   machinery instead of one direct post-commit emission path
 - graft-specific session, queue, and stream concepts have leaked into
@@ -61,8 +62,9 @@ model in several release-blocking ways:
 - bare `atm read` on the accepted `1.2.3` release could still resolve as
   `team-lead@atm-dev` even when `ATM_IDENTITY` and `ATM_TEAM` were unset,
   proving that both caller identity and caller team can be guessed today
-- `.atm.toml` currently contains a `team-lead` post-send hook rule, but a live
-  send produced neither the expected nudge nor a sender-visible warning
+- the accepted `1.2.3` dogfood repo config contained a `team-lead`
+  post-send hook rule, but a live send produced neither the expected nudge nor
+  a sender-visible warning
 - `atm doctor --team atm-dev` currently reports
   `ATM_WARNING_IDENTITY_DRIFT`
 - current doctor output shows blank `tmux_pane_id` values in roster state for
@@ -180,6 +182,9 @@ The governing rules are:
 - active `tmux_pane_id` already exists in SQLite roster state and must remain
   authoritative there rather than drifting back to repo config assumptions
 - pane metadata must be settable and repairable from the CLI
+- repo-tracked `.atm.toml` is not a live pane-routing authority; committed
+  dogfood config must not carry `[[atm.post_send_hooks]]` defaults or
+  `[[rmux.windows.panes]].tmux_pane_id` values as production routing truth
 - `ReconcileRuntime` and the watched-source daemon lane are not part of the
   accepted Claude Code runtime and must be removed
 - daemon notification delivery is not a protected subsystem; if notification
@@ -257,6 +262,8 @@ Phase `AD` may:
   `live_cwd`, and log-only startup `launch_cwd` remain
 - remove committed pane-id routing state from repo config and keep live pane
   routing in SQLite roster state plus CLI repair/update flows only
+- keep repo-local troubleshooting helpers roster-backed or explicit-override
+  only; they must not revive `.atm.toml` pane discovery as a production seam
 - add smoke and doctor coverage required to keep these regressions closed
 
 Phase `AD` must not:

--- a/docs/plans/phase-AD/sprint-AD22.md
+++ b/docs/plans/phase-AD/sprint-AD22.md
@@ -2,8 +2,8 @@
 id: AD.22
 title: Nudge Routing State Ownership And Dogfood Transition Cleanup
 status: planned
-branch: feature/pAD-s22-nudge-routing-state-and-dogfood-transition-cleanup
-worktree: ../atm-core-worktrees/feature/pAD-s22-nudge-routing-state-and-dogfood-transition-cleanup
+branch: feature/pAD-s22-built-in-nudge-hardening-part2
+worktree: ../atm-core-worktrees/feature/pAD-s22-built-in-nudge-hardening-part2
 target: integrate/phase-AD
 ---
 
@@ -25,9 +25,7 @@ target: integrate/phase-AD
 - `.atm.toml`
 - `scripts/atm-nudge.py`
 - `scripts/atm-nudge.sh`
-- `scripts/atm-nudge-xml-1.py`
-- `crates/atm-core/src/team_admin.rs`
-- `crates/atm/src/commands/teams.rs`
+- `scripts/test_atm_nudge.py`
 - `docs/requirements.md`
 - `docs/architecture.md`
 - `docs/atm-core/requirements.md`
@@ -62,6 +60,9 @@ with these invariants:
   update path for pane routing
 - repo-local scripts may exist only as explicit compatibility tools or explicit
   local overrides; they are not the default shipped nudge implementation
+- compatibility helpers that survive must resolve pane routing from canonical
+  roster state or explicit `--pane` only; they must not rediscover live pane
+  ids from committed repo config
 
 ## Paths To Delete
 
@@ -81,6 +82,8 @@ with these invariants:
   marked explicit local override path
 - repo-local nudge scripts are either deleted or marked compatibility-only with
   no ambiguity that they are not the default shipped path
+- retained compatibility helpers render the same six accepted XML forms as the
+  built-in path when they are used explicitly
 - if any residual graft-facing nudge docs remain after `AD.21`, this sprint
   closes them without reopening sink-private receiver behavior
 
@@ -100,6 +103,8 @@ with these invariants:
 - any retained repo-local script clearly states compatibility-only or
   override-only status and no accepted doc treats it as the default installed
   path
+- targeted regression coverage proves `scripts/atm-nudge.py` resolves panes
+  from canonical roster state only unless the operator passes `--pane`
 - `atm teams add-member` / `update-member` docs remain the explicit pane repair
   and update workflow
 

--- a/docs/plans/phase-AD/sprint-AD22.md
+++ b/docs/plans/phase-AD/sprint-AD22.md
@@ -40,15 +40,21 @@ target: integrate/phase-AD
 
 ## Interfaces To Add Or Modify
 
-The accepted pane-routing ownership rule after this sprint is:
+The accepted pane-routing ownership rule after this sprint is carried by the
+existing canonical roster row plus the retained `atm members --json`
+projection; this sprint does not introduce a new Rust coordinator struct just
+to restate that invariant.
 
-```rust
-pub struct RosterMemberNudgeTarget {
-    pub recipient: AgentName,
-    pub recipient_team: TeamName,
-    pub recipient_pane_id: Option<PaneId>,
-}
-```
+Accepted seam:
+
+- canonical roster/store truth keeps `recipient_pane_id` on `RosterEntry`
+- retained local team projection in `crates/atm-core/src/team_admin.rs`
+  exposes that same value through `MemberSummary.tmux_pane_id`
+- `crates/atm/src/commands/teams.rs` continues to surface the same roster
+  projection to CLI JSON consumers such as `scripts/atm-nudge.py`
+- compatibility helpers may consume only that canonical roster projection or
+  an explicit `--pane`; they may not rediscover live pane ids from committed
+  `.atm.toml`
 
 with these invariants:
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -487,6 +487,8 @@ The rewrite is ready when:
   testing
 - `ATM_POST_SEND.recipient_pane_id` is sourced from SQLite roster truth when
   known
+- repo-tracked dogfood config does not carry live `[[atm.post_send_hooks]]`
+  defaults or committed `tmux_pane_id` routing truth
 - retained command behavior is preserved, and any current-runtime shape changes
   are intentionally documented
 - task-linked mail remains pending until acknowledged

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3598,11 +3598,14 @@ mail correctness.
     silently change whether post-send emission is attempted
   - hook configuration lookup must follow the sender's canonical roster
     `home_dir` metadata
-  - authoritative `recipient_pane_id`, when known, must come from canonical ATM
-    roster state rather than from rediscovering live pane routing through local
-    mailbox files
-  - live pane routing for built-in tmux nudge must not depend on committed
-    `.atm.toml` `tmux_pane_id` values
+- authoritative `recipient_pane_id`, when known, must come from canonical ATM
+  roster state rather than from rediscovering live pane routing through local
+  mailbox files
+- live pane routing for built-in tmux nudge must not depend on committed
+  `.atm.toml` `tmux_pane_id` values
+- retained repo-local compatibility helpers may use only authoritative
+  `recipient_pane_id` payload/roster data or an explicit operator-provided
+  `--pane`; they must not revive committed `.atm.toml` pane lookup
 
 - `REQ-CORE-COMPAT-005` `NotificationSink`, queued notifier runtimes, and
   typed delivery-plan execution are not the governing send-path contract.

--- a/scripts/atm-nudge.py
+++ b/scripts/atm-nudge.py
@@ -12,10 +12,8 @@ Legacy helper: nudge a named agent's tmux pane after successful send.
 
 Normal mode:
   atm-nudge.py <recipient>
-  Resolves the target pane from canonical ATM roster state first via
-  `atm members --team <team> --json`. If that lookup cannot produce a usable
-  pane id, the script falls back to the repo-local `.atm.toml` pane mapping as
-  a last-resort compatibility seam.
+  Resolves the target pane from canonical ATM roster state via
+  `atm members --team <team> --json`.
 
 Override mode:
   atm-nudge.py --pane <id> <recipient> [<message>]
@@ -46,12 +44,9 @@ except ModuleNotFoundError:
 CODEX_DEFAULT_PANE = "%1"
 LOG_FILE = str(Path(tempfile.gettempdir()) / "atm-nudge.log")
 
-ERR_FILE_MISSING = "file_missing"
 ERR_NOT_FOUND = "not_found"
 ERR_EMPTY_PANE = "empty_pane"
 ERR_PARSE_ERROR = "parse_error"
-ERR_NO_TOMLLIB = "no_tomllib"
-ERR_AMBIGUOUS = "ambiguous_match"
 ERR_INVALID_STRUCTURE = "invalid_structure"
 ERR_COMMAND_FAILED = "command_failed"
 
@@ -147,20 +142,6 @@ def resolve_team() -> str:
     return env_team or "atm-dev"
 
 
-def _normalize_team(candidate: object) -> str | None:
-    if not isinstance(candidate, str):
-        return None
-    value = candidate.strip()
-    return value or None
-
-
-def _pane_team(pane: dict[str, object]) -> str | None:
-    env = pane.get("env")
-    if not isinstance(env, dict):
-        return None
-    return _normalize_team(env.get("ATM_TEAM"))
-
-
 def read_pane_from_roster(
     recipient: str,
     team: str,
@@ -244,103 +225,6 @@ def read_pane_from_roster(
     return PaneLookup(pane_id, None, None, source)
 
 
-def read_pane_from_toml(recipient: str, team: str) -> PaneLookup:
-    """Read a legacy fallback pane from the repo-local .atm.toml."""
-    # Phase AD obsolete fallback: live production post-send routing must use
-    # authoritative roster / ATM_POST_SEND pane data rather than `.atm.toml`.
-    if tomllib is None:
-        return PaneLookup(
-            None,
-            ERR_NO_TOMLLIB,
-            "tomllib not available (install tomli for Python < 3.11)",
-        )
-
-    toml_path = discover_atm_toml()
-    if toml_path is None:
-        return PaneLookup(
-            None,
-            ERR_FILE_MISSING,
-            ".atm.toml not found in any parent directory",
-        )
-
-    try:
-        with toml_path.open("rb") as handle:
-            config = tomllib.load(handle)
-    except Exception as exc:
-        return PaneLookup(
-            None,
-            ERR_PARSE_ERROR,
-            f"Cannot parse {toml_path}: {exc}",
-            str(toml_path),
-        )
-
-    windows = config.get("rmux", {}).get("windows", [])
-    if not isinstance(windows, list):
-        return PaneLookup(
-            None,
-            ERR_INVALID_STRUCTURE,
-            f"{toml_path} has invalid rmux.windows structure",
-            str(toml_path),
-        )
-
-    matches: list[dict[str, object]] = []
-    team_matches: list[dict[str, object]] = []
-
-    for window in windows:
-        if not isinstance(window, dict):
-            continue
-        panes = window.get("panes", [])
-        if not isinstance(panes, list):
-            continue
-        for pane in panes:
-            if not isinstance(pane, dict):
-                continue
-            if pane.get("name") != recipient:
-                continue
-            matches.append(pane)
-            if _pane_team(pane) == team:
-                team_matches.append(pane)
-
-    if not matches:
-        return PaneLookup(
-            None,
-            ERR_NOT_FOUND,
-            f"'{recipient}' not found in {toml_path} [[rmux.windows.panes]]",
-            str(toml_path),
-        )
-
-    if not team_matches and len(matches) == 1:
-        team_matches = matches
-
-    if not team_matches:
-        return PaneLookup(
-            None,
-            ERR_NOT_FOUND,
-            f"'{recipient}' found in {toml_path}, but no pane is tagged with ATM_TEAM='{team}'",
-            str(toml_path),
-        )
-
-    if len(team_matches) > 1:
-        panes = ", ".join(str(pane.get("tmux_pane_id", "")).strip() or "<empty>" for pane in team_matches)
-        return PaneLookup(
-            None,
-            ERR_AMBIGUOUS,
-            f"Multiple panes match '{recipient}@{team}' in {toml_path}: {panes}",
-            str(toml_path),
-        )
-
-    pane_id = str(team_matches[0].get("tmux_pane_id", "")).strip()
-    if not pane_id:
-        return PaneLookup(
-            None,
-            ERR_EMPTY_PANE,
-            f"'{recipient}@{team}' found in {toml_path} but tmux_pane_id is empty",
-            str(toml_path),
-        )
-
-    return PaneLookup(pane_id, None, None, str(toml_path))
-
-
 def nudge_pane(pane_id: str, recipient: str, message: str) -> None:
     """Send a message to a tmux pane after validating all inputs."""
     if not isinstance(pane_id, str) or not pane_id.strip():
@@ -357,47 +241,47 @@ def nudge_pane(pane_id: str, recipient: str, message: str) -> None:
 
 def build_message(team: str, payload: dict[str, object] | None = None) -> str:
     payload = payload or {}
+    from_value = str(payload.get("from", "")).strip()
     is_ack = payload.get("is_ack") is True
     message_id = str(payload.get("message_id", "")).strip()
+    task_id = str(payload.get("task_id", "")).strip()
+    requires_ack = payload.get("requires_ack") is True
     description = ""
     for key in ("description", "summary"):
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
             description = value.strip()
             break
+    base_attrs: list[str] = []
+    if from_value:
+        base_attrs.append(f'from="{from_value}"')
+    if message_id:
+        base_attrs.append(f'message-id="{message_id}"')
+    base = "<atm" + (f" {' '.join(base_attrs)}" if base_attrs else "")
     if is_ack:
-        acknowledgement = (
-            f"message {message_id} acknowledged"
-            if message_id
-            else "message acknowledged"
-        )
-        message_context = (
-            f"<message-id>{message_id}</message-id>" if message_id else ""
-        )
-        return (
-            f"<atm><action>read atm --team {team}</action>"
-            f"<action>ack the message</action>"
-            f"{message_context}"
-            f"<action>{acknowledgement}</action>"
-            f"<action>complete associated work immediately</action>"
-            f'<when idle="immediate" busy="complete tasks based on established priority"/>'
-            f'<console announce="concise" pause="false"/></atm>'
-        )
+        if task_id:
+            return f'{base} kind="ack" task-id="{task_id}"/>'
+        return f'{base} kind="ack"/>'
 
-    message_context = (
-        f"<message-id>{message_id}</message-id>" if message_id else ""
-    )
-    description_context = (
-        f"<description>{description}</description>" if description else ""
+    body = [f"{base}>", f"<action>read atm --team {team}</action>"]
+    if requires_ack:
+        body.append("<action>ack the message</action>")
+    if task_id:
+        body.append(f"<task id=\"{task_id}\">{description}</task>")
+    elif description:
+        body.append(f"<description>{description}</description>")
+    else:
+        body.append("<description></description>")
+    body.extend(
+        [
+            "<action>execute the assigned task</action>",
+            '<when idle="immediate" busy="after-current-task"/>',
+            '<console announce="concise" pause="false"/>',
+            "</atm>",
+        ]
     )
     return (
-        f"<atm><action>read atm --team {team}</action>"
-        f"<action>ack the message</action>"
-        f"{message_context}"
-        f"{description_context}"
-        f"<action>execute the assigned task</action>"
-        f'<when idle="immediate" busy="after-current-task"/>'
-        f'<console announce="concise" pause="false"/></atm>'
+        "".join(body)
     )
 
 
@@ -427,12 +311,8 @@ def build_error_payload(
     team: str,
     message: str,
     roster: PaneLookup,
-    toml: PaneLookup,
 ) -> dict[str, object]:
-    recommended_pane = toml.pane_id or CODEX_DEFAULT_PANE
-    recommended_source = ".atm.toml fallback" if toml.pane_id else "default"
-    discovered_toml = discover_atm_toml()
-    toml_path = toml.source_path or (str(discovered_toml) if discovered_toml else None)
+    recommended_pane = CODEX_DEFAULT_PANE
     nudge_command = build_nudge_command(recommended_pane, recipient, message)
     try:
         cwd = os.getcwd()
@@ -441,13 +321,13 @@ def build_error_payload(
 
     call_to_action = [
         "STOP: the ATM message was NOT delivered automatically.",
-        f"Run nudge_command NOW to deliver the message manually using suggested pane {recommended_pane} from {recommended_source}.",
+        f"Run nudge_command NOW to deliver the message manually using suggested pane {recommended_pane}.",
         "VERIFY the pane id before running it; the suggested pane may be stale or incorrect.",
-        "THEN fix the configuration in fix[] so future sends work automatically.",
+        "THEN repair canonical ATM roster state so future sends work automatically.",
     ]
 
     fix: list[str] = []
-    pane_hint = toml.pane_id or "<pane>"
+    pane_hint = recommended_pane
     fix.append(
         f"Repair canonical ATM roster pane metadata with `atm teams update-member {team} {recipient} --pane-id {pane_hint}`."
     )
@@ -472,26 +352,15 @@ def build_error_payload(
             "Investigate the `atm members --json` response shape; the canonical ATM roster output was not in the expected format."
         )
 
-    if toml.error_code in {ERR_FILE_MISSING, ERR_PARSE_ERROR, ERR_INVALID_STRUCTURE}:
-        fix.append("Fix or restore the repo-local .atm.toml so the compatibility fallback can resolve a pane if roster lookup fails again.")
-    elif toml.error_code == ERR_NOT_FOUND:
-        fix.append(f"Add [[rmux.windows.panes]] name='{recipient}' with env.ATM_TEAM='{team}' and a tmux_pane_id in .atm.toml as a last-resort fallback.")
-    elif toml.error_code == ERR_EMPTY_PANE:
-        fix.append(f"Set tmux_pane_id for '{recipient}@{team}' in .atm.toml if the fallback mapping should remain available.")
-    elif toml.error_code == ERR_AMBIGUOUS:
-        fix.append(f"Make the .atm.toml fallback mapping for '{recipient}@{team}' unique so the hook can select exactly one pane.")
-    elif toml.error_code == ERR_NO_TOMLLIB:
-        fix.append("Install tomli (Python < 3.11) or run the hook under Python 3.11+.")
-
     if not fix:
-        fix.append("Review canonical ATM roster state and the repo-local .atm.toml fallback before retrying the nudge.")
+        fix.append("Review canonical ATM roster state before retrying the nudge.")
 
     return {
         "status": "error",
-        "error_code": roster.error_code or toml.error_code or "nudge_resolution_failed",
+        "error_code": roster.error_code or "nudge_resolution_failed",
         "recipient": recipient,
         "team": team,
-        "detail": roster.error_msg or toml.error_msg or "Unable to resolve pane from canonical ATM roster state or .atm.toml fallback",
+        "detail": roster.error_msg or "Unable to resolve pane from canonical ATM roster state",
         "call_to_action": call_to_action,
         "nudge_command": nudge_command,
         "fix": fix,
@@ -506,79 +375,10 @@ def build_error_payload(
         "pane_resolution": {
             "authoritative_source": "atm roster",
             "recommended_pane": recommended_pane,
-            "recommended_pane_source": recommended_source,
+            "recommended_pane_source": "manual default",
             "roster_lookup": roster.source_path,
             "roster_error_code": roster.error_code,
             "roster_error": roster.error_msg,
-            "toml_path": toml_path,
-            "toml_error_code": toml.error_code,
-            "toml_error": toml.error_msg,
-        },
-    }
-
-
-def build_warning_payload(
-    *,
-    recipient: str,
-    team: str,
-    message: str,
-    roster: PaneLookup,
-    delivered_pane: str,
-    toml: PaneLookup,
-) -> dict[str, object]:
-    try:
-        cwd = os.getcwd()
-    except Exception:
-        cwd = None
-    detail = (
-        f"Nudge sent to pane {delivered_pane} from .atm.toml fallback for "
-        f"'{recipient}@{team}' because canonical ATM roster lookup did not yield a usable pane"
-    )
-    fix = [
-        f"Repair canonical ATM roster pane metadata with `atm teams update-member {team} {recipient} --pane-id {delivered_pane}`."
-    ]
-    if roster.error_code == ERR_COMMAND_FAILED:
-        fix.append(
-            f"Make sure `atm members --team {team} --json` succeeds from the hook environment and preserves ATM_IDENTITY/ATM_TEAM."
-        )
-    elif roster.error_code == ERR_NOT_FOUND:
-        fix.append(f"Add or restore '{recipient}@{team}' in canonical ATM roster state.")
-    elif roster.error_code == ERR_EMPTY_PANE:
-        fix.append(f"Set tmux_pane_id for '{recipient}@{team}' in canonical ATM roster state.")
-    elif roster.error_code == ERR_PARSE_ERROR:
-        fix.append("Investigate the `atm members --json` response; the hook could not parse canonical ATM roster output.")
-    elif roster.error_code == ERR_INVALID_STRUCTURE:
-        fix.append("Investigate the `atm members --json` response shape; the canonical ATM roster output was not in the expected format.")
-
-    return {
-        "status": "warning",
-        "error_code": "roster_pane_fallback",
-        "recipient": recipient,
-        "team": team,
-        "detail": detail,
-        "call_to_action": [
-            f"NOTICE: nudge already sent to pane {delivered_pane} from the .atm.toml fallback.",
-            f"NOW repair canonical ATM roster state so future nudges use SQLite-backed pane metadata first for '{recipient}@{team}'.",
-            "If you need to resend manually, use nudge_command below and verify the pane id first.",
-        ],
-        "nudge_command": build_nudge_command(delivered_pane, recipient, message),
-        "fix": fix,
-        "input": {
-            "recipient": recipient,
-            "team": team,
-            "message": message,
-            "cwd": cwd,
-            "claude_project_dir": os.environ.get("CLAUDE_PROJECT_DIR"),
-            "pwd": os.environ.get("PWD"),
-        },
-        "pane_resolution": {
-            "authoritative_source": "atm roster",
-            "delivered_pane": delivered_pane,
-            "delivered_source": ".atm.toml fallback",
-            "roster_lookup": roster.source_path,
-            "roster_error_code": roster.error_code,
-            "roster_error": roster.error_msg,
-            "toml_path": toml.source_path,
         },
     }
 
@@ -611,46 +411,16 @@ def main(argv: list[str]) -> int:
         nudge_pane(roster.pane_id, recipient, message)
         return 0
 
-    toml = read_pane_from_toml(recipient, team)
-
-    if toml.pane_id:
-        nudge_pane(toml.pane_id, recipient, message)
-        if roster.error_code:
-            warning = build_warning_payload(
-                recipient=recipient,
-                team=team,
-                message=message,
-                roster=roster,
-                delivered_pane=toml.pane_id,
-                toml=toml,
-            )
-            emit_json_stderr(warning)
-            emit_hook_result(
-                "warn",
-                warning["detail"],
-                {
-                    "recipient": recipient,
-                    "team": team,
-                    "delivered_pane": toml.pane_id,
-                    "nudge_command": warning["nudge_command"],
-                    "call_to_action": warning["call_to_action"],
-                    "roster_error_code": roster.error_code,
-                    "roster_error": roster.error_msg,
-                },
-            )
-        return 0
-
     payload = build_error_payload(
         recipient=recipient,
         team=team,
         message=message,
         roster=roster,
-        toml=toml,
     )
     emit_json_stderr(payload)
     log(
         f"error: pane resolution failed for {recipient}@{team}: "
-        f"roster={roster.error_code} toml={toml.error_code}"
+        f"roster={roster.error_code}"
     )
     return 1
 

--- a/scripts/atm-nudge.py
+++ b/scripts/atm-nudge.py
@@ -3,10 +3,10 @@
 
 atm-nudge.py [--pane <id>] <recipient> [<message>]
 
-This script is no longer a live post-send hook. Production `.atm.toml`
-post-send wiring routes through `scripts/atm-nudge.sh`, which requires
-authoritative pane metadata in `ATM_POST_SEND` and does not use `.atm.toml`
-pane routing truth.
+ATM now ships the built-in `atm internal-nudge` path as the default post-send
+emitter. This helper survives only as an explicit repo-local override or
+manual troubleshooting tool, and it must resolve pane routing from canonical
+ATM roster state or an explicit `--pane`.
 
 Legacy helper: nudge a named agent's tmux pane after successful send.
 

--- a/scripts/atm-nudge.sh
+++ b/scripts/atm-nudge.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # atm-nudge.sh [recipient]
 #
-# Payload-driven post-send hook helper for ATM.
-# The authoritative pane id must come from the ATM_POST_SEND payload.
+# Compatibility / explicit-override post-send helper for ATM.
+# This is not the shipped default nudge path; the built-in default is
+# `atm internal-nudge`. The authoritative pane id must come from the
+# ATM_POST_SEND payload.
 
 set -euo pipefail
 
@@ -25,16 +27,54 @@ payload = json.loads(sys.argv[1])
 recipient = payload.get("recipient") or sys.argv[2]
 team = payload.get("team") or ""
 pane = payload.get("recipient_pane_id") or ""
+from_value = payload.get("from") or ""
+message_id = payload.get("message_id") or ""
+task_id = payload.get("task_id") or ""
+description = payload.get("description") or payload.get("summary") or ""
+requires_ack = payload.get("requires_ack") is True
+is_ack = payload.get("is_ack") is True
+
+attrs = []
+if from_value:
+    attrs.append(f'from="{from_value}"')
+if message_id:
+    attrs.append(f'message-id="{message_id}"')
+base = "<atm" + (f" {' '.join(attrs)}" if attrs else "")
+
+if is_ack:
+    if task_id:
+        message = f'{base} kind="ack" task-id="{task_id}"/>'
+    else:
+        message = f'{base} kind="ack"/>'
+else:
+    parts = [f"{base}>", f"<action>read atm --team {team}</action>"]
+    if requires_ack:
+        parts.append("<action>ack the message</action>")
+    if task_id:
+        parts.append(f'<task id="{task_id}">{description}</task>')
+    else:
+        parts.append(f"<description>{description}</description>")
+    parts.extend(
+        [
+            "<action>execute the assigned task</action>",
+            '<when idle="immediate" busy="after-current-task"/>',
+            '<console announce="concise" pause="false"/>',
+            "</atm>",
+        ]
+    )
+    message = "".join(parts)
+
 print(recipient)
 print(team)
 print(pane)
+print(message)
 PY
 )
 
 RECIPIENT="${PAYLOAD_FIELDS[0]:-}"
 TEAM="${PAYLOAD_FIELDS[1]:-${ATM_TEAM:-atm-dev}}"
 PANE_ID="${PAYLOAD_FIELDS[2]:-}"
-MESSAGE="You have unread ATM messages. Run: atm read --team ${TEAM}"
+MESSAGE="${PAYLOAD_FIELDS[3]:-}"
 LOG_FILE="${TMPDIR:-/tmp}/atm-nudge.log"
 TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
@@ -42,8 +82,14 @@ if [[ -z "${PANE_ID:-}" ]]; then
     printf '%s recipient=%s missing authoritative pane id in ATM_POST_SEND payload\n' "$TIMESTAMP" "$RECIPIENT" >> "$LOG_FILE"
     exit 1
 fi
+if [[ -z "${MESSAGE:-}" ]]; then
+    printf '%s recipient=%s missing rendered nudge message\n' "$TIMESTAMP" "$RECIPIENT" >> "$LOG_FILE"
+    exit 1
+fi
 
 tmux send-keys -t "$PANE_ID" -l "$MESSAGE"
+tmux send-keys -t "$PANE_ID" Enter
+sleep 0.25
 tmux send-keys -t "$PANE_ID" Enter
 
 printf '%s nudged recipient=%s pane=%s\n' "$TIMESTAMP" "$RECIPIENT" "$PANE_ID" >> "$LOG_FILE"

--- a/scripts/test_atm_nudge.py
+++ b/scripts/test_atm_nudge.py
@@ -6,7 +6,6 @@ import io
 import json
 import os
 import shlex
-import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -18,9 +17,7 @@ _MOD = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MOD)
 
 PaneLookup = _MOD.PaneLookup
-ERR_AMBIGUOUS = _MOD.ERR_AMBIGUOUS
 ERR_EMPTY_PANE = _MOD.ERR_EMPTY_PANE
-ERR_FILE_MISSING = _MOD.ERR_FILE_MISSING
 ERR_INVALID_STRUCTURE = _MOD.ERR_INVALID_STRUCTURE
 ERR_NOT_FOUND = _MOD.ERR_NOT_FOUND
 ERR_PARSE_ERROR = _MOD.ERR_PARSE_ERROR
@@ -42,7 +39,6 @@ def _parse_json(text: str) -> dict:
 def _run_with_mocked_lookups(
     args: list[str],
     roster: PaneLookup,
-    toml: PaneLookup,
     *,
     team: str = TEST_TEAM,
 ) -> tuple[int, dict, dict, MagicMock]:
@@ -50,7 +46,6 @@ def _run_with_mocked_lookups(
     stdout_buf = io.StringIO()
     with (
         patch.object(_MOD, "read_pane_from_roster", return_value=roster),
-        patch.object(_MOD, "read_pane_from_toml", return_value=toml),
         patch.object(_MOD, "resolve_team", return_value=team),
         patch.object(_MOD, "read_post_send_payload", return_value={}),
         patch.object(_MOD, "nudge_pane") as mock_nudge,
@@ -174,128 +169,6 @@ class TestCandidateStartDirs(unittest.TestCase):
         self.assertEqual(dirs, [Path("/tmp/proj").resolve()])
 
 
-class TestReadPaneFromToml(unittest.TestCase):
-    def _with_project(self, toml_text: str, fn):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            project = root / "repo" / "nested"
-            project.mkdir(parents=True)
-            (root / "repo" / ".atm.toml").write_text(toml_text, encoding="utf-8")
-            with patch.dict(
-                os.environ,
-                {
-                    "CLAUDE_PROJECT_DIR": str(project),
-                    "PWD": str(project),
-                    "HOME": str(root / "home"),
-                    "USERPROFILE": str(root / "home"),
-                },
-                clear=False,
-            ):
-                with patch("os.getcwd", return_value=str(project)):
-                    fn(root / "repo" / ".atm.toml")
-
-    def test_reads_team_specific_match(self):
-        def run(path: Path):
-            result = _MOD.read_pane_from_toml(TEST_QM, TEST_TEAM)
-            self.assertEqual(result.pane_id, "%2")
-            self.assertEqual(Path(result.source_path), path.resolve())
-
-        self._with_project(
-            f"""
-[atm]
-default_team = "{TEST_TEAM}"
-
-[rmux]
-
-[[rmux.windows]]
-name = "agents"
-[[rmux.windows.panes]]
-name = "{TEST_QM}"
-tmux_pane_id = "%2"
-env = {{ ATM_TEAM = "{TEST_TEAM}" }}
-[[rmux.windows.panes]]
-name = "{TEST_QM}"
-tmux_pane_id = "%9"
-env = {{ ATM_TEAM = "schook" }}
-""",
-            run,
-        )
-
-    def test_falls_back_to_single_unscoped_match(self):
-        def run(_path: Path):
-            result = _MOD.read_pane_from_toml(TEST_AGENT, TEST_TEAM)
-            self.assertEqual(result.pane_id, "%1")
-
-        self._with_project(
-            f"""
-[atm]
-default_team = "{TEST_TEAM}"
-
-[rmux]
-
-[[rmux.windows]]
-name = "agents"
-[[rmux.windows.panes]]
-name = "{TEST_AGENT}"
-tmux_pane_id = "%1"
-""",
-            run,
-        )
-
-    def test_reports_ambiguous_same_team_match(self):
-        def run(_path: Path):
-            result = _MOD.read_pane_from_toml(TEST_QM, TEST_TEAM)
-            self.assertEqual(result.error_code, ERR_AMBIGUOUS)
-            self.assertIn("%2", result.error_msg)
-            self.assertIn("%7", result.error_msg)
-
-        self._with_project(
-            f"""
-[atm]
-default_team = "{TEST_TEAM}"
-
-[rmux]
-
-[[rmux.windows]]
-name = "agents"
-[[rmux.windows.panes]]
-name = "{TEST_QM}"
-tmux_pane_id = "%2"
-env = {{ ATM_TEAM = "{TEST_TEAM}" }}
-[[rmux.windows.panes]]
-name = "{TEST_QM}"
-tmux_pane_id = "%7"
-env = {{ ATM_TEAM = "{TEST_TEAM}" }}
-""",
-            run,
-        )
-
-    def test_reports_parse_error(self):
-        def run(path: Path):
-            result = _MOD.read_pane_from_toml(TEST_AGENT, TEST_TEAM)
-            self.assertEqual(result.error_code, ERR_PARSE_ERROR)
-            self.assertIn(str(path), result.error_msg)
-
-        self._with_project("not valid toml =", run)
-
-    def test_reports_file_missing(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            with patch.dict(
-                os.environ,
-                {
-                    "CLAUDE_PROJECT_DIR": str(root),
-                    "PWD": str(root),
-                    "HOME": str(root / "home"),
-                    "USERPROFILE": str(root / "home"),
-                },
-                clear=False,
-            ):
-                with patch("os.getcwd", return_value=str(root)):
-                    result = _MOD.read_pane_from_toml(TEST_AGENT, TEST_TEAM)
-        self.assertEqual(result.error_code, ERR_FILE_MISSING)
-
-
 class TestReadPaneFromRoster(unittest.TestCase):
     def test_reports_invalid_members_structure(self):
         process = MagicMock(returncode=0, stdout='{"members": {}}', stderr="")
@@ -355,14 +228,12 @@ class TestOverrideMode(unittest.TestCase):
         with (
             patch.object(_MOD, "nudge_pane") as mock_nudge,
             patch.object(_MOD, "read_pane_from_roster") as mock_roster,
-            patch.object(_MOD, "read_pane_from_toml") as mock_toml,
             patch.object(_MOD, "resolve_team", return_value=TEST_TEAM),
         ):
             rc = _MOD.main(["atm-nudge.py", "--pane", "%1", TEST_AGENT, "<atm/>"])
         self.assertEqual(rc, 0)
         mock_nudge.assert_called_once_with("%1", TEST_AGENT, "<atm/>")
         mock_roster.assert_not_called()
-        mock_toml.assert_not_called()
 
     def test_override_without_message_builds_default(self):
         with (
@@ -370,7 +241,6 @@ class TestOverrideMode(unittest.TestCase):
             patch.object(_MOD, "resolve_team", return_value=TEST_TEAM),
             patch.object(_MOD, "read_post_send_payload", return_value={}),
             patch.object(_MOD, "read_pane_from_roster"),
-            patch.object(_MOD, "read_pane_from_toml"),
         ):
             rc = _MOD.main(["atm-nudge.py", "--pane", "%1", TEST_AGENT])
         self.assertEqual(rc, 0)
@@ -385,14 +255,14 @@ class TestBuildMessage(unittest.TestCase):
         self.assertIn(f"read atm --team {TEST_TEAM}", message)
         self.assertIn("execute the assigned task", message)
         self.assertIn('busy="after-current-task"', message)
-        self.assertNotIn("message ", message)
+        self.assertIn("<description></description>", message)
 
-    def test_send_message_includes_message_id_when_present(self):
+    def test_send_message_includes_message_id_as_attribute_when_present(self):
         message = _MOD.build_message(
             TEST_TEAM,
             {"message_id": "01JSENDTEST0000000000000000"},
         )
-        self.assertIn("<message-id>01JSENDTEST0000000000000000</message-id>", message)
+        self.assertIn('message-id="01JSENDTEST0000000000000000"', message)
         self.assertIn("execute the assigned task", message)
 
     def test_send_message_includes_description_when_present(self):
@@ -403,23 +273,58 @@ class TestBuildMessage(unittest.TestCase):
                 "summary": "review failing smoke lane",
             },
         )
-        self.assertIn("<message-id>01JSENDTEST0000000000000000</message-id>", message)
+        self.assertIn('message-id="01JSENDTEST0000000000000000"', message)
         self.assertIn("<description>review failing smoke lane</description>", message)
 
-    def test_ack_message_requests_immediate_work_with_message_context(self):
+    def test_requires_ack_message_includes_ack_action(self):
         message = _MOD.build_message(
             TEST_TEAM,
-            {"is_ack": True, "message_id": "01JACKTEST00000000000000000"},
+            {"requires_ack": True, "message_id": "01JREQACK00000000000000000"},
         )
-        self.assertIn(f"read atm --team {TEST_TEAM}", message)
-        self.assertIn("<message-id>01JACKTEST00000000000000000</message-id>", message)
-        self.assertIn("message 01JACKTEST00000000000000000 acknowledged", message)
-        self.assertIn("complete associated work immediately", message)
-        self.assertIn(
-            'busy="complete tasks based on established priority"',
+        self.assertIn("<action>ack the message</action>", message)
+        self.assertIn('message-id="01JREQACK00000000000000000"', message)
+        self.assertIn("execute the assigned task", message)
+
+    def test_task_message_uses_task_element(self):
+        message = _MOD.build_message(
+            TEST_TEAM,
+            {
+                "message_id": "01JTASKTEST0000000000000000",
+                "task_id": "AD.22",
+                "description": "finish cleanup",
+            },
+        )
+        self.assertIn('<task id="AD.22">finish cleanup</task>', message)
+        self.assertNotIn("<description>", message)
+
+    def test_ack_message_uses_compact_ack_shape(self):
+        message = _MOD.build_message(
+            TEST_TEAM,
+            {
+                "is_ack": True,
+                "from": "team-lead@atm-dev",
+                "message_id": "01JACKTEST00000000000000000",
+            },
+        )
+        self.assertEqual(
             message,
+            '<atm from="team-lead@atm-dev" message-id="01JACKTEST00000000000000000" kind="ack"/>',
         )
-        self.assertNotIn("execute the assigned task", message)
+
+    def test_ack_task_message_uses_compact_ack_shape_with_task_id(self):
+        message = _MOD.build_message(
+            TEST_TEAM,
+            {
+                "is_ack": True,
+                "from": "team-lead@atm-dev",
+                "message_id": "01JACKTASK0000000000000000",
+                "task_id": "AD.22",
+            },
+        )
+        self.assertEqual(
+            message,
+            '<atm from="team-lead@atm-dev" message-id="01JACKTASK0000000000000000" kind="ack" task-id="AD.22"/>',
+        )
 
 
 class TestMainBehavior(unittest.TestCase):
@@ -427,85 +332,26 @@ class TestMainBehavior(unittest.TestCase):
         rc, stderr_json, stdout_json, mock_nudge = _run_with_mocked_lookups(
             [TEST_AGENT],
             PaneLookup("%1", None, None, "atm members --team <team> --json"),
-            PaneLookup("%1", None, None, "/repo/.atm.toml"),
         )
         self.assertEqual(rc, 0)
         mock_nudge.assert_called_once_with("%1", TEST_AGENT, unittest.mock.ANY)
         self.assertEqual(stderr_json, {})
         self.assertEqual(stdout_json, {})
 
-    def test_roster_match_skips_toml_fallback_lookup(self):
-        with (
-            patch.object(_MOD, "resolve_team", return_value=TEST_TEAM),
-            patch.object(_MOD, "read_post_send_payload", return_value={}),
-            patch.object(
-                _MOD,
-                "read_pane_from_roster",
-                return_value=PaneLookup(
-                    "%5",
-                    None,
-                    None,
-                    "atm members --team <team> --json",
-                ),
-            ),
-            patch.object(_MOD, "read_pane_from_toml") as mock_toml,
-            patch.object(_MOD, "nudge_pane") as mock_nudge,
-            patch.object(_MOD, "emit_json_stderr"),
-            patch.object(_MOD, "emit_hook_result"),
-            patch.object(_MOD, "log"),
-        ):
-            rc = _MOD.main(["atm-nudge.py", TEST_AGENT])
-
-        self.assertEqual(rc, 0)
-        mock_toml.assert_not_called()
-        mock_nudge.assert_called_once_with("%5", TEST_AGENT, unittest.mock.ANY)
-
-    def test_roster_pane_wins_when_roster_and_toml_disagree(self):
+    def test_roster_match_uses_roster_pane(self):
         rc, stderr_json, stdout_json, mock_nudge = _run_with_mocked_lookups(
             [TEST_AGENT],
             PaneLookup("%5", None, None, "atm members --team <team> --json"),
-            PaneLookup("%9", None, None, "/repo/.atm.toml"),
         )
         self.assertEqual(rc, 0)
         mock_nudge.assert_called_once_with("%5", TEST_AGENT, unittest.mock.ANY)
         self.assertEqual(stderr_json, {})
         self.assertEqual(stdout_json, {})
 
-    def test_toml_fallback_still_nudges_and_warns(self):
-        rc, stderr_json, stdout_json, mock_nudge = _run_with_mocked_lookups(
-            [TEST_AGENT],
-            PaneLookup(None, ERR_EMPTY_PANE, "missing roster pane", "atm members --team <team> --json"),
-            PaneLookup("%1", None, None, "/repo/.atm.toml"),
-        )
-        self.assertEqual(rc, 0)
-        mock_nudge.assert_called_once_with("%1", TEST_AGENT, unittest.mock.ANY)
-        self.assertEqual(stderr_json["status"], "warning")
-        self.assertIn(".atm.toml fallback", " ".join(stderr_json["call_to_action"]))
-        self.assertIn("SQLite-backed pane metadata", " ".join(stderr_json["call_to_action"]))
-        self.assertIn("--pane %1", stderr_json["nudge_command"])
-        self.assertEqual(stderr_json["pane_resolution"]["delivered_pane"], "%1")
-        self.assertEqual(stdout_json["level"], "warn")
-        self.assertEqual(stdout_json["fields"]["delivered_pane"], "%1")
-        self.assertEqual(stdout_json["fields"]["roster_error_code"], ERR_EMPTY_PANE)
-
-    def test_roster_command_failure_still_uses_toml_fallback(self):
-        rc, stderr_json, stdout_json, mock_nudge = _run_with_mocked_lookups(
-            [TEST_QM],
-            PaneLookup(None, ERR_COMMAND_FAILED, "atm members failed", "atm members --team <team> --json"),
-            PaneLookup("%2", None, None, "/repo/.atm.toml"),
-        )
-        self.assertEqual(rc, 0)
-        mock_nudge.assert_called_once_with("%2", TEST_QM, unittest.mock.ANY)
-        self.assertEqual(stderr_json["status"], "warning")
-        self.assertIn("already sent to pane %2", " ".join(stderr_json["call_to_action"]))
-        self.assertTrue(any("atm members --team test-team --json" in item for item in stderr_json["fix"]))
-        self.assertEqual(stdout_json["fields"]["roster_error_code"], ERR_COMMAND_FAILED)
-
-    def test_roster_and_toml_failure_emit_manual_nudge_and_fix_call_to_action(self):
+    def test_roster_failure_emits_manual_nudge_and_fix_call_to_action(self):
         rc, stderr_json, stdout_json, mock_nudge = _run_with_mocked_lookups(
             [TEST_QM],
             PaneLookup(None, ERR_EMPTY_PANE, "bad roster", "atm members --team <team> --json"),
-            PaneLookup(None, ERR_PARSE_ERROR, "bad toml", "/repo/.atm.toml"),
         )
         self.assertEqual(rc, 1)
         mock_nudge.assert_not_called()
@@ -515,13 +361,11 @@ class TestMainBehavior(unittest.TestCase):
         self.assertIn("VERIFY the pane id", " ".join(stderr_json["call_to_action"]))
         self.assertIn(f"--pane {CODEX_DEFAULT_PANE}", stderr_json["nudge_command"])
         self.assertIn("Repair canonical ATM roster pane metadata", " ".join(stderr_json["fix"]))
-        self.assertIn("Fix or restore the repo-local .atm.toml", " ".join(stderr_json["fix"]))
 
-    def test_neither_source_found_uses_default_pane(self):
+    def test_missing_roster_member_uses_default_manual_pane_hint(self):
         rc, stderr_json, stdout_json, mock_nudge = _run_with_mocked_lookups(
             [TEST_AGENT],
             PaneLookup(None, ERR_NOT_FOUND, "missing member", "atm members --team <team> --json"),
-            PaneLookup(None, ERR_NOT_FOUND, "missing recipient", "/repo/.atm.toml"),
         )
         self.assertEqual(rc, 1)
         mock_nudge.assert_not_called()
@@ -532,8 +376,7 @@ class TestMainBehavior(unittest.TestCase):
     def test_error_payload_includes_input_and_resolution_context(self):
         rc, stderr_json, _, _ = _run_with_mocked_lookups(
             [TEST_AGENT],
-            PaneLookup(None, ERR_FILE_MISSING, "missing", "atm members --team <team> --json"),
-            PaneLookup(None, ERR_FILE_MISSING, "missing", None),
+            PaneLookup(None, ERR_COMMAND_FAILED, "missing", "atm members --team <team> --json"),
         )
         self.assertEqual(rc, 1)
         self.assertIn("input", stderr_json)

--- a/scripts/test_atm_nudge.py
+++ b/scripts/test_atm_nudge.py
@@ -27,6 +27,7 @@ TEST_TEAM = "test-team"
 TEST_AGENT = "test-agent"
 TEST_TEAM_LEAD = "test-lead"
 TEST_QM = "test-qm"
+TEST_TEAM_LEAD_ADDR = f"{TEST_TEAM_LEAD}@{TEST_TEAM}"
 
 
 def _parse_json(text: str) -> dict:
@@ -200,6 +201,37 @@ class TestReadPaneFromRoster(unittest.TestCase):
         self.assertEqual(result.pane_id, "%17")
         self.assertEqual(result.source_path, "atm members --team <team> --json")
 
+    def test_roster_match_skips_toml_fallback_lookup(self):
+        process = MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "team": TEST_TEAM,
+                    "members": [
+                        {"name": TEST_AGENT, "tmux_pane_id": "%17"},
+                    ],
+                }
+            ),
+            stderr="",
+        )
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("subprocess.run", return_value=process) as mock_run,
+            patch.object(
+                _MOD,
+                "discover_atm_toml",
+                side_effect=AssertionError("pane lookup must not consult .atm.toml"),
+            ),
+        ):
+            result = _MOD.read_pane_from_roster(TEST_AGENT, TEST_TEAM, {"sender": TEST_TEAM_LEAD})
+        self.assertEqual(result.pane_id, "%17")
+        self.assertEqual(
+            mock_run.call_args.args[0],
+            ["atm", "members", "--team", TEST_TEAM, "--json"],
+        )
+        self.assertEqual(mock_run.call_args.kwargs["env"]["ATM_TEAM"], TEST_TEAM)
+        self.assertEqual(mock_run.call_args.kwargs["env"]["ATM_IDENTITY"], TEST_TEAM_LEAD)
+
     def test_reports_command_failure(self):
         process = MagicMock(returncode=1, stdout="", stderr="boom")
         with patch("subprocess.run", return_value=process):
@@ -302,13 +334,13 @@ class TestBuildMessage(unittest.TestCase):
             TEST_TEAM,
             {
                 "is_ack": True,
-                "from": "team-lead@atm-dev",
+                "from": TEST_TEAM_LEAD_ADDR,
                 "message_id": "01JACKTEST00000000000000000",
             },
         )
         self.assertEqual(
             message,
-            '<atm from="team-lead@atm-dev" message-id="01JACKTEST00000000000000000" kind="ack"/>',
+            f'<atm from="{TEST_TEAM_LEAD_ADDR}" message-id="01JACKTEST00000000000000000" kind="ack"/>',
         )
 
     def test_ack_task_message_uses_compact_ack_shape_with_task_id(self):
@@ -316,14 +348,14 @@ class TestBuildMessage(unittest.TestCase):
             TEST_TEAM,
             {
                 "is_ack": True,
-                "from": "team-lead@atm-dev",
+                "from": TEST_TEAM_LEAD_ADDR,
                 "message_id": "01JACKTASK0000000000000000",
                 "task_id": "AD.22",
             },
         )
         self.assertEqual(
             message,
-            '<atm from="team-lead@atm-dev" message-id="01JACKTASK0000000000000000" kind="ack" task-id="AD.22"/>',
+            f'<atm from="{TEST_TEAM_LEAD_ADDR}" message-id="01JACKTASK0000000000000000" kind="ack" task-id="AD.22"/>',
         )
 
 


### PR DESCRIPTION
## Summary
Sprint AD.22 (docs/plans/phase-AD/sprint-AD22.md) plus fix rounds for AD21-QA-1 and AD22-QA-1 blocking findings.

## Status
- AD22-FIX-1 dispatched to arch-ctm: closes AD21-QA-1's 5 carried-over blocking findings (BLOCKING-EMPTY-SKIP, BLOCKING-NO-WRITE-PATH, BLOCKING-PRECEDENCE-UNTESTED, BLOCKING-TEST-LITERALS, BLOCKING-GATE-ARTIFACT-OPEN)
- AD22-FIX-2 dispatched to arch-ctm (queued behind FIX-1): closes AD22-QA-1's 4 native findings (AD22-QA-002-ROSTER-STRUCT, AD22-QA-003-NO-TEST-COVERAGE, AD22-ARCH-001-README-STALE, AD22-ARCH-002-TEST-LITERAL)
- Triage records: .triage/phase-AD/findings/{BLOCKING-*,AD22-*}.ttl on integrate/phase-AD

PR opened now so CI runs in parallel with dev/QA cycles; findings will be appended as QA rounds complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)