### PR TITLE
docs: plan phase ad ATM messaging follow-up

### DIFF
--- a/docs/plans/phase-AD-followup/plan-atm-messaging-fixes.md
+++ b/docs/plans/phase-AD-followup/plan-atm-messaging-fixes.md
@@ -99,6 +99,9 @@ The sprint line below is built around these contract decisions:
   `docs/plans/phase-AD/sprint-AD35.md`
 - `docs/plans/phase-AD/plan-phase-AD.md` updated to include the new follow-up
   line
+- `docs/plans/phase-AD/readiness.md` updated so the authoritative readiness
+  artifact reflects the added `AD.31` through `AD.35` closure gate and
+  `AD.35`'s sole-authorship role for the final Phase `AD` verdict
 - `docs/project-plan.md` updated to list the new follow-up sprint line inside
   Phase `AD`
 

--- a/docs/plans/phase-AD-followup/plan-atm-messaging-fixes.md
+++ b/docs/plans/phase-AD-followup/plan-atm-messaging-fixes.md
@@ -1,0 +1,120 @@
+---
+title: Phase AD Follow-Up ATM Messaging Fixes
+status: complete
+branch: plan/phase-ad-followup-atm-messaging-fixes
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/plan/phase-ad-followup-atm-messaging-fixes
+target: develop
+---
+
+# Phase AD Follow-Up ATM Messaging Fixes
+
+## Goal
+
+Author the Phase `AD` follow-up sprint line for the three release-blocking ATM
+messaging defects captured in GitHub issues:
+
+- `#498` ATM allows self-addressed messages (`from == to`) to be created
+- `#499` `atm ack` on a self-addressed message creates an unbreakable ack
+  reply loop
+- `#500` `atm read` still manufactures ack obligations on display instead of
+  respecting sender-owned durable intent
+
+This follow-up stays inside Phase `AD` because it tightens the same caller
+ownership, send/read/ack contract, and dogfood messaging model that the rest
+of the Phase `AD` correction line already owns.
+
+## Why This Is Still Phase AD
+
+The new defects do not open a new product direction. They are still part of
+the same release-blocking correction line because they all violate the Phase
+`AD` target model:
+
+- caller identity must be explicit and owner-controlled
+- send owns message creation
+- read must not fabricate new workflow obligations
+- ack must terminate required acknowledgement state instead of expanding it
+
+Creating a separate phase would hide that these are still mandatory fixes to
+the same accepted ATM behavior model.
+
+## Root-Cause Summary
+
+`#500` is the structural defect. The current accepted line still lets the read
+path create ack-required state on display, which means ack obligation is not a
+sender-owned durable property of the message. `#498` and `#499` are poison
+paths exposed by that looser model:
+
+- self-addressed sends should never be created
+- even if a historical self-addressed message exists, acking it must converge
+  instead of producing a new self-addressed pending-ack message
+
+## Recommended Sprint Line
+
+This follow-up is split into five sprints so each closure type stays
+production-ready and mechanically reviewable on its own:
+
+1. `AD.31` command-surface and ownership reset
+2. `AD.32` durable ack-intent persistence and read-semantics reset
+3. `AD.33` self-addressed send rejection
+4. `AD.34` self-ack loop termination and historical poison handling
+5. `AD.35` operator protocol, docs, and end-to-end regression closeout
+
+The split is deliberate:
+
+- `AD.31` resets the mutating-vs-inspection API boundary
+- `AD.32` fixes the structural message-state model
+- `AD.33` and `AD.34` close the two remaining poison paths independently
+- `AD.35` is the only sprint allowed to call the new operator/documentation
+  surface complete after the regression matrix is green
+
+## Sprint Map
+
+| Sprint | Closure | Primary issues |
+| --- | --- | --- |
+| `AD.31` | replace `atm read --no-mark` with an explicit non-mutating `atm peek` command and remove impersonation from all mutating mailbox/message commands | `#500` |
+| `AD.32` | make `requires_ack` a durable persisted message field and delete read-time ack creation | `#500` |
+| `AD.33` | reject self-addressed sends in the shared send path before persistence | `#498` |
+| `AD.34` | make `atm ack` terminate historical self-addressed poison messages without emitting a new reply | `#499` |
+| `AD.35` | update team protocol, command docs, help text, and land one authoritative messaging regression matrix | `#498`, `#499`, `#500` |
+
+## New Contract Direction
+
+The sprint line below is built around these contract decisions:
+
+- mutating commands act only as the resolved caller identity
+- mutating commands fail closed if caller identity or team is unresolved
+- no mutating command may impersonate another member, even when
+  `ATM_IDENTITY` is absent
+- inspection-only commands may inspect another member's queue state
+- `atm read` remains the owner-only mutating command
+- `atm peek` becomes the explicit non-mutating inspection command
+- sender intent to require acknowledgement is durable message data, not a
+  display-time side effect
+- ack replies are explicitly non-ack-requiring unless a future approved
+  requirement says otherwise
+
+## Deliverables
+
+- `docs/plans/phase-AD/sprint-AD31.md` through
+  `docs/plans/phase-AD/sprint-AD35.md`
+- `docs/plans/phase-AD/plan-phase-AD.md` updated to include the new follow-up
+  line
+- `docs/project-plan.md` updated to list the new follow-up sprint line inside
+  Phase `AD`
+
+## Acceptance
+
+- every issue in `#498`, `#499`, and `#500` has one clear sprint owner
+- the `#498` / `#499` dependency relationship is called out explicitly:
+  `AD.33` is the root-cause send-side closure and `AD.34` is the ack-side
+  defense-in-depth plus historical poison cleanup
+- each sprint doc has:
+  - complete frontmatter
+  - explicit exact targets
+  - explicit interface/code samples where implementation choices would
+    otherwise drift
+  - one authoritative deliverables list
+  - one authoritative acceptance-criteria list
+  - one authoritative required-validation list
+- the new plan is ready for plan-hardening and quality review without needing
+  more scoping work

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -578,6 +578,11 @@ Phase `AD` orchestration rule:
 26. [AD.28 `atm-graft` Host-Nudge Deadline Race Hardening](./sprint-AD28.md)
 27. [AD.29 Phase AD Post-Send Smoke Matrix Closeout](./sprint-AD29.md)
 28. [AD.30 Windows Daemon Integration-Depth Coverage Closeout](./sprint-AD30.md)
+29. [AD.31 Mailbox Peek Surface And Owner-Only Mutation Reset](./sprint-AD31.md)
+30. [AD.32 Durable Ack Intent And Read Semantics Reset](./sprint-AD32.md)
+31. [AD.33 Self-Addressed Send Rejection](./sprint-AD33.md)
+32. [AD.34 Self-Ack Loop Termination And Historical Poison Cleanup](./sprint-AD34.md)
+33. [AD.35 Messaging Protocol And Regression Closeout](./sprint-AD35.md)
 
 ## Phase Exit Criteria
 
@@ -669,9 +674,17 @@ Phase `AD` closes only when:
   - built-in fallback
   - override reset-to-default
   - override disable behavior when that state is retained
-- `docs/plans/phase-AD/readiness.md` exists on the accepted line and is the
-  sole authoritative closeout artifact for the `AD.25` through `AD.30`
+- `docs/plans/phase-AD/readiness.md` exists on the accepted line and remains
+  the sole authoritative closeout artifact for the `AD.25` through `AD.35`
   follow-up line
+- `AD.31` through `AD.35` all pass on the accepted line before `Phase AD`
+  may close
+- `docs/plans/phase-AD/readiness.md` records dual closeout ownership
+  correctly:
+  - `AD.30` authors the Windows/post-send `AD.25` through `AD.30` sub-line
+    closeout record
+  - `AD.35` authors the final Phase `AD` verdict after the messaging
+    follow-up line is complete
 - `.triage/phase-AD/direct-fix-track.md` exists on the accepted line and names
   the closure-artifact owner for the non-code obligations surfaced during plan
   review

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -357,6 +357,11 @@ Phase `AD` may:
 - restore a shipped built-in post-send nudge path for normal ATM installs
 - allow bounded built-in nudge template overrides without requiring teams to
   copy repo-local scripts across many repos
+- make built-in nudge override lifecycle explicit with first-class override,
+  disable, and reset-to-default semantics instead of hidden empty-string state
+- make the accepted post-send seams real on the production send/ack path,
+  including mixed-success hook accounting that preserves successful emission
+  even when a sibling matching rule warns or fails
 - add or tighten trait contracts for local tmux-backed and graft-backed
   post-send emission
 - remove graft-only session registration, fetch/drain, queue, and advisory
@@ -377,6 +382,12 @@ Phase `AD` may:
   `live_cwd`, and log-only startup `launch_cwd` remain
 - remove committed pane-id routing state from repo config and keep live pane
   routing in SQLite roster state plus CLI repair/update flows only
+- add one authoritative end-to-end smoke/service-hardening lane for the
+  repaired Phase AD post-send matrix without duplicating the sibling harness
+  planning scope
+- restore the missing Windows daemon local-IPC integration-depth coverage in
+  CI for dispatcher panic during shutdown, accept-error handling, and
+  post-terminate connection rejection
 - add smoke and doctor coverage required to keep these regressions closed
 
 Phase `AD` must not:

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -197,6 +197,7 @@ The governing rules are:
 - the accepted mandatory caller-context inventory for this rule is:
   - `send`
   - `read`
+  - `peek`
   - `ack`
   - `list`
   - `clear`
@@ -207,6 +208,13 @@ The governing rules are:
   - `teams update-member`
   - `teams backup`
   - `teams restore`
+- `atm peek` is inspection-only, but it is still caller-context resolver
+  required rather than resolver-exempt:
+  - it shares the retained mailbox query surface with `list` / `read`
+  - it may inspect another member with `--as`, so actor/team overrides must be
+    validated through the shared CLI-owned resolver instead of command-local
+    parsing
+  - unlike `doctor`, it is not an identity-free diagnostic exception
 - `atm doctor` is diagnostic-only and must not require caller identity; its
   `--team` override remains optional diagnostic scope, not mandatory caller
   context
@@ -332,11 +340,17 @@ The governing rules are:
 Phase `AD` may:
 
 - fix caller context ownership on the full retained ATM command surface
+- split mailbox inspection from mailbox mutation by introducing `atm peek` as
+  the explicit non-mutating mailbox-inspection command while keeping `atm
+  read` owner-only and mutating
 - make caller identity and caller team transport explicit and required for
   daemon-backed caller-owned commands
 - make local retained command entry points consume the same shared
   caller-context resolver rather than carrying duplicate command-specific
   fallback logic
+- keep one shared caller-context resolver with explicit modes:
+  - owner-only mutation for mutating commands
+  - inspection-mode override resolution for `peek` / `list`
 - preserve diagnostic commands that do not need caller identity; `doctor`
   remains identity-free with optional team scoping
 - simplify the post-send nudge path to one post-commit emission seam

--- a/docs/plans/phase-AD/plan-phase-AD.md
+++ b/docs/plans/phase-AD/plan-phase-AD.md
@@ -129,6 +129,29 @@ The authoritative follow-up blockers are:
 `AD.23` remains reserved outside this worktree, and `AD.24` is the sibling
 smoke-harness planning slot consumed by `AD.29` rather than renumbered here.
 
+## Post-AD30 Dogfood Messaging Blockers
+
+The accepted `AD.30` line still leaves three serious dogfood-discovered ATM
+messaging defects open:
+
+- `#498` ATM still allows self-addressed messages to be created
+- `#499` `atm ack` on a historical self-addressed message can still create a
+  replacement self-addressed message instead of terminating the queue item
+- `#500` the product still conflates mailbox inspection with mailbox mutation,
+  and the read path can still create ack obligations on display instead of
+  respecting sender-owned durable message state
+
+These are still Phase `AD` blockers because they violate the same caller
+ownership, send/read/ack contract that `AD.1` through `AD.30` were meant to
+restore. Phase `AD` therefore extends again with the `AD.31` through `AD.35`
+follow-up line:
+
+- `AD.31` mailbox peek surface and owner-only mutation reset
+- `AD.32` durable ack intent and read semantics reset
+- `AD.33` self-addressed send rejection
+- `AD.34` self-ack loop termination and historical poison cleanup
+- `AD.35` messaging protocol and regression closeout
+
 ## Follow-Up Closure Artifact Ownership
 
 The `AD.25` through `AD.30` follow-up line splits technical-fix ownership from
@@ -143,13 +166,15 @@ one explicit home:
 | historical `FTQ-001` env-race record reconciliation | accepted-line code fix predates this follow-up | `AD.30` | `.triage/phase-AD/direct-fix-track.md` plus `docs/plans/phase-AD/readiness.md` |
 | phase-AD triage sweep ledger | `AD.30` | `AD.30` | `.triage/phase-AD/direct-fix-track.md` |
 | release-facing `CHANGELOG.md` entry for `AD.13` through `AD.30` | `AD.30` | `AD.30` | `CHANGELOG.md` plus `docs/plans/phase-AD/readiness.md` |
-| final phase-close verdict artifact | `AD.30` | `AD.30` | `docs/plans/phase-AD/readiness.md` |
+| intermediate `AD.25` through `AD.30` closeout record | `AD.30` | `AD.30` | `docs/plans/phase-AD/readiness.md` |
+| final phase-close verdict artifact for the messaging follow-up line | `AD.35` | `AD.35` | `docs/plans/phase-AD/readiness.md` |
 
 Notes:
 
-- `AD.29` feeds the authoritative post-send smoke evidence into the final
-  closure record, but `AD.30` is the only sprint allowed to author the
-  phase-close verdict in `docs/plans/phase-AD/readiness.md`.
+- `AD.29` feeds the authoritative post-send smoke evidence into the
+  `AD.30` closeout record for that sub-line, but `AD.35` is the only sprint
+  allowed to author the final Phase `AD` readiness verdict once the messaging
+  follow-up line is complete.
 - `FTQ-001` is a historical phase-`Xb` discovery record. If the accepted line
   keeps that historical TTL open as snapshot provenance, `AD.30` must record
   the reason explicitly in the readiness/direct-fix artifacts so the code fix
@@ -163,6 +188,12 @@ The governing rules are:
 
 - caller identity and caller team are mandatory only for retained ATM commands
   that require caller-owned state or routing context
+- mutating message/mailbox commands act only as the resolved caller identity
+- ATM does not implement a special impersonation exception when
+  `ATM_IDENTITY` is unset; if the caller is unresolved, mutating commands fail
+  closed
+- inspection-only commands may inspect another member's queue state, but they
+  must not mutate seen state, pending-ack state, or acknowledgement state
 - the accepted mandatory caller-context inventory for this rule is:
   - `send`
   - `read`
@@ -205,7 +236,13 @@ The governing rules are:
 - the daemon must execute caller-owned commands against declared request
   identity and team only and must never consult daemon ambient
   `ATM_IDENTITY` or `ATM_TEAM` to fill missing caller context
+- `atm peek` is the accepted explicit non-mutating mailbox inspection command
+- `atm read` remains the owner-only mutating mailbox-read command
+- `atm read --no-mark` is not an accepted long-term surface; inspection and
+  mutation must be split into different commands
 - message persistence is the send success boundary
+- self-addressed messages (`from == to` within the same team) are invalid ATM
+  input and must be rejected before persistence
 - post-send behavior is a post-commit side effect only
 - post-send behavior is event-driven; it is not planned through a generic
   delivery-plan abstraction
@@ -239,6 +276,10 @@ The governing rules are:
   second-`Enter` operational path, with the delay treated as an
   implementation-tuning parameter rather than an unspecified side effect
 - `atm read` is a database read path only
+- `atm read` and `atm peek` must never create new ack-required state as a side
+  effect of display
+- sender-owned durable message data, not display-time mutation, decides whether
+  a message requires acknowledgement
 - active `tmux_pane_id` already exists in SQLite roster state and must remain
   authoritative there rather than drifting back to repo config assumptions
 - pane metadata must be settable and repairable from the CLI

--- a/docs/plans/phase-AD/readiness.md
+++ b/docs/plans/phase-AD/readiness.md
@@ -2,15 +2,18 @@
 
 ## Goal
 
-Track the authoritative closeout state for the `AD.25` through `AD.30`
+Track the authoritative closeout state for the `AD.25` through `AD.35`
 follow-up line on top of the already accepted `AD.1` through `AD.22`
 corrective release work.
 
 Authoring ownership:
 
 - `AD.29` supplies the authoritative post-send smoke evidence
-- `AD.30` is the sole sprint allowed to author the final close/not-close
-  verdict in this file
+- `AD.30` is the sole sprint allowed to author the Windows/post-send
+  `AD.25` through `AD.30` sub-line close/not-close record in this file
+- `AD.35` is the sole sprint allowed to author the final Phase `AD`
+  close/not-close verdict in this file after the messaging follow-up line is
+  complete
 
 Companion closure ledger:
 
@@ -25,7 +28,12 @@ Companion closure ledger:
 | `AD.27` | `planned` | `feature/pAD-s27-upstream-built-in-template-resolution` | `../atm-core-worktrees/feature/pAD-s27-upstream-built-in-template-resolution` | `ADR-019-EXC-AD26-001` is closed and built-in override lookup is upstream of `PostSendHookEmitter` |
 | `AD.28` | `planned` | `feature/pAD-s28-graft-host-nudge-deadline-race-hardening` | `../atm-core-worktrees/feature/pAD-s28-graft-host-nudge-deadline-race-hardening` | the graft host-nudge readiness race is closed through deterministic readiness, not timeout luck |
 | `AD.29` | `planned` | `feature/pAD-s29-phase-ad-post-send-smoke-matrix` | `../atm-core-worktrees/feature/pAD-s29-phase-ad-post-send-smoke-matrix` | one authoritative smoke lane proves the repaired post-send matrix |
-| `AD.30` | `planned` | `feature/pAD-s30-windows-daemon-integration-depth` | `../atm-core-worktrees/feature/pAD-s30-windows-daemon-integration-depth` | Windows local-IPC depth coverage is restored, the direct-fix ledger is closed, and this readiness file records the final verdict |
+| `AD.30` | `planned` | `feature/pAD-s30-windows-daemon-integration-depth` | `../atm-core-worktrees/feature/pAD-s30-windows-daemon-integration-depth` | Windows local-IPC depth coverage is restored, the direct-fix ledger is closed, and this readiness file records the `AD.25` through `AD.30` sub-line verdict |
+| `AD.31` | `planned` | `feature/pAD-s31-mailbox-peek-and-owner-only-mutation` | `../atm-core-worktrees/feature/pAD-s31-mailbox-peek-and-owner-only-mutation` | mailbox inspection is split from mutation and owner-only mutation becomes the enforced command contract |
+| `AD.32` | `planned` | `feature/pAD-s32-durable-ack-intent-reset` | `../atm-core-worktrees/feature/pAD-s32-durable-ack-intent-reset` | durable `requires_ack` state replaces read-time ack creation and legacy compatibility is explicit |
+| `AD.33` | `planned` | `feature/pAD-s33-self-address-send-rejection` | `../atm-core-worktrees/feature/pAD-s33-self-address-send-rejection` | self-addressed sends are rejected before persistence on every send entry path |
+| `AD.34` | `planned` | `feature/pAD-s34-self-ack-loop-termination` | `../atm-core-worktrees/feature/pAD-s34-self-ack-loop-termination` | historical self-addressed poison messages can be acknowledged without emitting replacement replies |
+| `AD.35` | `planned` | `feature/pAD-s35-messaging-protocol-and-regression-closeout` | `../atm-core-worktrees/feature/pAD-s35-messaging-protocol-and-regression-closeout` | the operator protocol/docs/regression matrix close the messaging follow-up line and this readiness file records the final Phase `AD` verdict |
 
 ## Direct-Fix Carry-Forward Ledger
 
@@ -47,6 +55,7 @@ by a new code sprint:
 true:
 
 - `AD.25` through `AD.30` all pass on the accepted line
+- `AD.31` through `AD.35` all pass on the accepted line
 - `docs/plans/phase-AD/readiness.md` exists and records the final verdict on
   the accepted line
 - `.triage/phase-AD/direct-fix-track.md` exists and names the final owner plus
@@ -80,3 +89,5 @@ true:
 - the phase-close artifacts explicitly reconcile the historical `FTQ-001`
   discovery ledger with the accepted-line code fix so that historical
   provenance is not silently inconsistent with the current runtime
+- the final close/not-close verdict in this file is authored only by `AD.35`
+  after the `AD.31` through `AD.35` messaging follow-up line is complete

--- a/docs/plans/phase-AD/sprint-AD31.md
+++ b/docs/plans/phase-AD/sprint-AD31.md
@@ -178,6 +178,8 @@ The accepted operator contract after this sprint is:
   - `atm read` owner-only mutation
   - `atm send`, `atm read`, `atm ack`, and `atm clear` impersonation flag
     rejection
-- targeted runtime tests proving `peek` leaves `seen_at`, `pending_ack_at`,
-  and `acknowledged_at` unchanged
+- targeted runtime tests proving `peek` leaves per-message `read`,
+  `pending_ack_at`, and `acknowledged_at` unchanged, and does not advance the
+  per-agent seen-state watermark stored by
+  `crates/atm-core/src/read/seen_state.rs`
 - `git diff --check`

--- a/docs/plans/phase-AD/sprint-AD31.md
+++ b/docs/plans/phase-AD/sprint-AD31.md
@@ -1,0 +1,183 @@
+---
+id: AD.31
+title: Mailbox Peek Surface And Owner-Only Mutation Reset
+status: planned
+branch: feature/pAD-s31-mailbox-peek-and-owner-only-mutation
+worktree: ../atm-core-worktrees/feature/pAD-s31-mailbox-peek-and-owner-only-mutation
+target: integrate/phase-AD
+---
+
+# Sprint AD.31 — Mailbox Peek Surface And Owner-Only Mutation Reset
+
+## Goal
+
+- split mailbox inspection from mailbox mutation by adding `atm peek`
+- remove impersonation from every mutating mailbox/message command
+
+## Hard Dependencies
+
+- accepted `AD.30` baseline merged into `integrate/phase-AD`
+- `docs/plans/phase-AD-followup/plan-atm-messaging-fixes.md`
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- GitHub issues `#498`, `#499`, `#500`
+
+## Exact Targets
+
+- `crates/atm/src/commands/peek.rs`
+- `crates/atm/src/commands/read.rs`
+- `crates/atm/src/commands/send.rs`
+- `crates/atm/src/commands/ack.rs`
+- `crates/atm/src/commands/clear.rs`
+- `crates/atm/src/commands/help.rs`
+- `crates/atm/src/main.rs`
+- `crates/atm/src/composition.rs`
+- `crates/atm-core/src/identity/mod.rs`
+- `crates/atm-core/src/read/mod.rs`
+- `crates/atm-core/src/ack/mod.rs`
+- `crates/atm-core/src/clear/mod.rs`
+- `crates/atm-core/src/send/mod.rs`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm/requirements.md`
+- `docs/atm/architecture.md`
+- `docs/atm/commands/peek.md`
+- `docs/atm/commands/read.md`
+- `docs/atm/commands/list.md`
+- `docs/atm/commands/send.md`
+- `docs/atm/commands/ack.md`
+- `docs/atm/commands/clear.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/adr/ADR-021-owner-only-message-mutation.md`
+- `docs/project-plan.md`
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- `docs/plans/phase-AD/sprint-AD31.md`
+
+## Interfaces To Add Or Modify
+
+The accepted CLI/runtime ownership contract after this sprint is:
+
+```rust
+pub struct PeekQuery {
+    pub home_dir: PathBuf,
+    pub current_dir: PathBuf,
+    pub actor_override: Option<AgentName>,
+    pub target_address: Option<AgentAddress>,
+    pub team_override: Option<TeamName>,
+    pub selection_mode: ReadSelection,
+    pub seen_state_filter: bool,
+    pub message_id_filter: Option<AtmMessageId>,
+    pub sender_filter: Option<AgentName>,
+    pub timestamp_filter: Option<IsoTimestamp>,
+    pub task_filter: Option<TaskId>,
+    pub contains_filter: Option<String>,
+    pub timeout_secs: Option<u64>,
+}
+
+pub struct ReadQuery {
+    pub home_dir: PathBuf,
+    pub current_dir: PathBuf,
+    pub actor: AgentName,
+    pub target_address: Option<AgentAddress>,
+    pub team: TeamName,
+    pub selection_mode: ReadSelection,
+    pub seen_state_filter: bool,
+    pub seen_state_update: bool,
+    pub message_id_filter: Option<AtmMessageId>,
+    pub sender_filter: Option<AgentName>,
+    pub timestamp_filter: Option<IsoTimestamp>,
+    pub task_filter: Option<TaskId>,
+    pub contains_filter: Option<String>,
+    pub timeout_secs: Option<u64>,
+}
+
+pub struct AckRequest {
+    pub home_dir: PathBuf,
+    pub current_dir: PathBuf,
+    pub actor: AgentName,
+    pub team: TeamName,
+    pub message_id: AtmMessageId,
+    pub reply_body: String,
+}
+
+pub struct ClearQuery {
+    pub home_dir: PathBuf,
+    pub current_dir: PathBuf,
+    pub actor: AgentName,
+    pub team: TeamName,
+    pub selection_mode: ClearSelection,
+    pub dry_run: bool,
+}
+
+pub struct SendRequest {
+    pub home_dir: PathBuf,
+    pub current_dir: PathBuf,
+    pub sender: AgentName,
+    pub team: TeamName,
+    pub to: AgentAddress,
+    // remaining fields omitted
+}
+```
+
+The accepted operator contract after this sprint is:
+
+- `atm read` is owner-only and mutates mailbox state
+- `atm peek` is non-mutating and may inspect another member with `--as`
+- `atm send`, `atm read`, `atm ack`, and `atm clear` must not expose sender or
+  actor impersonation flags
+- mutating commands fail closed when caller identity or team is unresolved
+- ATM does not implement a special exception for "maybe the actual agent" when
+  `ATM_IDENTITY` is unset
+- `atm list` may continue to allow `--as` because it is inspection-only
+
+## Paths To Delete
+
+- `--no-mark` from the public `atm read` CLI surface
+- `--as` from `atm read`, `atm ack`, and any mutating mailbox command help
+  surface
+- `--from` / sender override from the public `atm send` CLI surface
+- `actor_override` / `sender_override` fields from mutating request types
+- any product or command doc that still describes mutating impersonation as an
+  accepted operation
+
+## Deliverables
+
+- `atm peek` exists as the explicit non-mutating mailbox inspection command
+- `atm read` remains the owner-only mutating command
+- mutating commands no longer accept impersonation
+- the shared identity helpers are split so inspection-only surfaces may still
+  resolve `--as`, while mutating surfaces resolve only the actual caller
+- requirements, architecture, command docs, and a new ADR define the
+  owner-only mutation rule unambiguously
+
+## This Sprint Does Not Close
+
+- durable `requires_ack` persistence
+- read-time ack creation removal
+- self-addressed send rejection
+- self-ack poison termination
+
+## Acceptance Criteria
+
+- `atm peek` accepts the selection/filter surface that `atm read --no-mark`
+  used to own, but performs no seen-state or ack-state mutation
+- `atm read` no longer exposes `--no-mark`
+- `atm send`, `atm read`, `atm ack`, and `atm clear` no longer expose sender
+  or actor impersonation flags
+- mutating commands fail closed when caller identity/team cannot be resolved
+- docs and help text state clearly that only inspection-only commands may
+  impersonate another member
+
+## Required Validation
+
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 .just/run_lint.py all`
+- targeted CLI tests covering:
+  - `atm peek --as` inspection success without mutation
+  - `atm read` owner-only mutation
+  - `atm send`, `atm read`, `atm ack`, and `atm clear` impersonation flag
+    rejection
+- targeted runtime tests proving `peek` leaves `seen_at`, `pending_ack_at`,
+  and `acknowledged_at` unchanged
+- `git diff --check`

--- a/docs/plans/phase-AD/sprint-AD31.md
+++ b/docs/plans/phase-AD/sprint-AD31.md
@@ -23,6 +23,8 @@ target: integrate/phase-AD
 
 ## Exact Targets
 
+- `crates/atm-core/src/protocol.rs`
+- `crates/atm-core/src/transport/testing.rs`
 - `crates/atm/src/commands/peek.rs`
 - `crates/atm/src/commands/read.rs`
 - `crates/atm/src/commands/send.rs`
@@ -36,6 +38,8 @@ target: integrate/phase-AD
 - `crates/atm-core/src/ack/mod.rs`
 - `crates/atm-core/src/clear/mod.rs`
 - `crates/atm-core/src/send/mod.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/local_ipc_transport/request_worker.rs`
 - `docs/requirements.md`
 - `docs/architecture.md`
 - `docs/atm/requirements.md`
@@ -58,12 +62,10 @@ target: integrate/phase-AD
 The accepted CLI/runtime ownership contract after this sprint is:
 
 ```rust
-pub struct PeekQuery {
+pub struct MailboxQueryFields {
     pub home_dir: PathBuf,
     pub current_dir: PathBuf,
-    pub actor_override: Option<AgentName>,
     pub target_address: Option<AgentAddress>,
-    pub team_override: Option<TeamName>,
     pub selection_mode: ReadSelection,
     pub seen_state_filter: bool,
     pub message_id_filter: Option<AtmMessageId>,
@@ -74,21 +76,17 @@ pub struct PeekQuery {
     pub timeout_secs: Option<u64>,
 }
 
+pub struct PeekQuery {
+    pub mailbox: MailboxQueryFields,
+    pub actor_override: Option<AgentName>,
+    pub team_override: Option<TeamName>,
+}
+
 pub struct ReadQuery {
-    pub home_dir: PathBuf,
-    pub current_dir: PathBuf,
+    pub mailbox: MailboxQueryFields,
     pub actor: AgentName,
-    pub target_address: Option<AgentAddress>,
     pub team: TeamName,
-    pub selection_mode: ReadSelection,
-    pub seen_state_filter: bool,
     pub seen_state_update: bool,
-    pub message_id_filter: Option<AtmMessageId>,
-    pub sender_filter: Option<AgentName>,
-    pub timestamp_filter: Option<IsoTimestamp>,
-    pub task_filter: Option<TaskId>,
-    pub contains_filter: Option<String>,
-    pub timeout_secs: Option<u64>,
 }
 
 pub struct AckRequest {
@@ -117,6 +115,18 @@ pub struct SendRequest {
     pub to: AgentAddress,
     // remaining fields omitted
 }
+
+pub enum RequestEnvelope {
+    // existing variants omitted
+    Peek(PeekQuery),
+    Receive(ReadQuery),
+}
+
+pub enum ResponseEnvelope {
+    // existing variants omitted
+    Peek(Box<ReadOutcome>),
+    Receive(Box<ReadOutcome>),
+}
 ```
 
 The accepted operator contract after this sprint is:
@@ -129,6 +139,15 @@ The accepted operator contract after this sprint is:
 - ATM does not implement a special exception for "maybe the actual agent" when
   `ATM_IDENTITY` is unset
 - `atm list` may continue to allow `--as` because it is inspection-only
+- `MailboxQueryFields` is the only accepted shared query-field surface for
+  `PeekQuery` and `ReadQuery`; filter/selection additions must land there so
+  `peek` and `read` cannot drift silently
+- `atm peek` uses the same daemon-backed transport family as `atm read`, with
+  a distinct `RequestEnvelope::Peek` / `ResponseEnvelope::Peek` pair routed
+  through `crates/atm-core/src/protocol.rs`,
+  `crates/atm-daemon/src/runtime_health.rs`,
+  `crates/atm-daemon/src/local_ipc_transport/request_worker.rs`, and the
+  loopback/testing transport instead of bypassing the daemon
 
 ## Paths To Delete
 
@@ -147,6 +166,11 @@ The accepted operator contract after this sprint is:
 - mutating commands no longer accept impersonation
 - the shared identity helpers are split so inspection-only surfaces may still
   resolve `--as`, while mutating surfaces resolve only the actual caller
+- one shared `MailboxQueryFields` surface owns the common filter/selection
+  fields consumed by both `PeekQuery` and `ReadQuery`
+- the daemon protocol and every `RequestEnvelope` dispatch site compile with a
+  distinct non-mutating `Peek` request/response path rather than treating peek
+  as a CLI-only special case
 - requirements, architecture, command docs, and a new ADR define the
   owner-only mutation rule unambiguously
 
@@ -167,6 +191,8 @@ The accepted operator contract after this sprint is:
 - mutating commands fail closed when caller identity/team cannot be resolved
 - docs and help text state clearly that only inspection-only commands may
   impersonate another member
+- daemon-backed, loopback, and direct CLI `peek` paths all compile and route
+  through the distinct non-mutating daemon protocol surface
 
 ## Required Validation
 

--- a/docs/plans/phase-AD/sprint-AD32.md
+++ b/docs/plans/phase-AD/sprint-AD32.md
@@ -1,0 +1,141 @@
+---
+id: AD.32
+title: Durable Ack Intent And Read Semantics Reset
+status: planned
+branch: feature/pAD-s32-durable-ack-intent-reset
+worktree: ../atm-core-worktrees/feature/pAD-s32-durable-ack-intent-reset
+target: integrate/phase-AD
+---
+
+# Sprint AD.32 — Durable Ack Intent And Read Semantics Reset
+
+## Goal
+
+- make ack requirement a durable sender-owned message property
+- delete read-time ack creation
+
+## Hard Dependencies
+
+- `AD.31` complete
+- `docs/plans/phase-AD-followup/plan-atm-messaging-fixes.md`
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- GitHub issue `#500`
+
+## Exact Targets
+
+- `crates/atm-core/src/schema/inbox_message.rs`
+- `crates/atm-core/src/types.rs`
+- `crates/atm-core/src/read/mod.rs`
+- `crates/atm-core/src/read/state.rs`
+- `crates/atm-core/src/read/metadata_selection.rs`
+- `crates/atm-core/src/send/mod.rs`
+- `crates/atm-core/src/send/persistence.rs`
+- `crates/atm-core/src/ack/mod.rs`
+- `crates/atm-core/src/threading.rs`
+- `crates/atm-core/src/workflow.rs`
+- `crates/atm-core/src/mailbox/store.rs`
+- `crates/atm-core/tests/mailbox_locking.rs`
+- `crates/atm/src/commands/read.rs`
+- `crates/atm/src/composition.rs`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm/requirements.md`
+- `docs/atm/architecture.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/adr/ADR-021-owner-only-message-mutation.md`
+- `docs/project-plan.md`
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- `docs/plans/phase-AD/sprint-AD32.md`
+
+## Interfaces To Add Or Modify
+
+The durable message contract after this sprint is:
+
+```rust
+pub struct InboxMessage {
+    pub schema_version: u32,
+    pub message_id: AtmMessageId,
+    pub from: AgentName,
+    pub text: String,
+    pub timestamp: IsoTimestamp,
+    pub requires_ack: bool,
+    pub pending_ack_at: Option<IsoTimestamp>,
+    pub acknowledged_at: Option<IsoTimestamp>,
+    pub acknowledges_message_id: Option<AtmMessageId>,
+    pub task_id: Option<TaskId>,
+    // remaining fields omitted
+}
+
+pub enum AckRequirementState {
+    NotRequired,
+    RequiredPending,
+    RequiredAcknowledged,
+}
+
+pub fn derive_ack_requirement(message: &InboxMessage) -> AckRequirementState;
+```
+
+The accepted behavior after this sprint is:
+
+- `requires_ack` is persisted on every message
+- only send/ack creation paths may set `requires_ack`
+- read and peek must never create ack-required state
+- `AckActivationMode::PromoteDisplayedUnread` is deleted
+- ack replies persist `requires_ack = false`
+- the compatibility rule for legacy rows with no explicit `requires_ack`
+  field is deterministic:
+  - `requires_ack = true` only when the legacy row has
+    `pending_ack_at.is_some()` and `acknowledges_message_id.is_none()`
+  - `requires_ack = false` otherwise
+
+That compatibility rule is intentional because it preserves legitimate
+historical sender-required messages while preventing legacy ack replies from
+re-qualifying as ack-required just because they were displayed.
+
+## Paths To Delete
+
+- `AckActivationMode::PromoteDisplayedUnread`
+- any read-path code that sets `pending_ack_at` because a message was displayed
+- any requirement or doc wording that says read creates ack-required state
+- any test that still treats `atm read` display as the source of ack
+  obligation
+
+## Deliverables
+
+- `InboxMessage` persists a durable `requires_ack` field
+- read/peek semantics no longer create pending-ack state
+- ack state is derived from sender-owned durable intent plus acknowledgement
+  completion, not display-time mutation
+- the accepted compatibility rule for legacy rows is implemented and tested
+
+## This Sprint Does Not Close
+
+- self-addressed send rejection
+- self-ack poison termination
+- operator protocol / wrapper closeout
+
+## Acceptance Criteria
+
+- a plain informational send persists `requires_ack = false`
+- an explicit `--requires-ack` send persists `requires_ack = true`
+- task sends persist `requires_ack = true`
+- ack replies persist `requires_ack = false`
+- `atm read` and `atm peek` never create `pending_ack_at`
+- legacy ack replies with `acknowledges_message_id` do not become ack-required
+  during compatibility load
+
+## Required Validation
+
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 .just/run_lint.py all`
+- targeted schema/runtime tests covering:
+  - plain send
+  - `--requires-ack` send
+  - task send
+  - ack reply
+  - legacy row compatibility load with and without
+    `acknowledges_message_id`
+- targeted read/peek tests proving no display-time ack promotion remains
+- `git diff --check`

--- a/docs/plans/phase-AD/sprint-AD32.md
+++ b/docs/plans/phase-AD/sprint-AD32.md
@@ -23,6 +23,8 @@ target: integrate/phase-AD
 
 ## Exact Targets
 
+- `crates/atm-storage/src/schema/inbox_message.rs`
+- `crates/atm-storage/src/contract.rs`
 - `crates/atm-core/src/schema/inbox_message.rs`
 - `crates/atm-core/src/types.rs`
 - `crates/atm-core/src/read/mod.rs`
@@ -31,12 +33,15 @@ target: integrate/phase-AD
 - `crates/atm-core/src/send/mod.rs`
 - `crates/atm-core/src/send/persistence.rs`
 - `crates/atm-core/src/ack/mod.rs`
+- `crates/atm-core/src/graft.rs`
 - `crates/atm-core/src/threading.rs`
 - `crates/atm-core/src/workflow.rs`
 - `crates/atm-core/src/mailbox/store.rs`
 - `crates/atm-core/tests/mailbox_locking.rs`
 - `crates/atm/src/commands/read.rs`
 - `crates/atm/src/composition.rs`
+- `crates/atm-graft/src/lib.rs`
+- `crates/atm-graft/examples/smoke_same_host.rs`
 - `docs/requirements.md`
 - `docs/architecture.md`
 - `docs/atm/requirements.md`
@@ -44,6 +49,7 @@ target: integrate/phase-AD
 - `docs/atm-core/requirements.md`
 - `docs/atm-core/architecture.md`
 - `docs/adr/ADR-021-owner-only-message-mutation.md`
+- `docs/adr/ADR-022-durable-ack-intent.md`
 - `docs/project-plan.md`
 - `docs/plans/phase-AD/plan-phase-AD.md`
 - `docs/plans/phase-AD/sprint-AD32.md`
@@ -78,6 +84,9 @@ pub fn derive_ack_requirement(message: &InboxMessage) -> AckRequirementState;
 
 The accepted behavior after this sprint is:
 
+- the canonical durable `InboxMessage` field set lives in
+  `crates/atm-storage/src/schema/inbox_message.rs`; the atm-core schema module
+  remains a re-export/update consequence, not the source of truth
 - `requires_ack` is persisted on every message
 - only send/ack creation paths may set `requires_ack`
 - read and peek must never create ack-required state
@@ -93,6 +102,12 @@ That compatibility rule is intentional because it preserves legitimate
 historical sender-required messages while preventing legacy ack replies from
 re-qualifying as ack-required just because they were displayed.
 
+`derive_ack_requirement` is the sole accepted classifier for durable
+ack-required state after this sprint. The read/render path in
+`crates/atm-core/src/read/mod.rs` and any other mailbox-state presentation code
+must call it instead of reconstructing ack intent ad hoc from
+`pending_ack_at` / `acknowledged_at`.
+
 ## Paths To Delete
 
 - `AckActivationMode::PromoteDisplayedUnread`
@@ -103,11 +118,17 @@ re-qualifying as ack-required just because they were displayed.
 
 ## Deliverables
 
-- `InboxMessage` persists a durable `requires_ack` field
+- the canonical `InboxMessage` in `atm-storage` persists a durable
+  `requires_ack` field, with atm-core's schema re-export updated accordingly
 - read/peek semantics no longer create pending-ack state
 - ack state is derived from sender-owned durable intent plus acknowledgement
   completion, not display-time mutation
 - the accepted compatibility rule for legacy rows is implemented and tested
+- `ReadQuery` / `AckActivationMode` shape changes are carried through the
+  graft boundary and smoke/example call sites so workspace/example builds stay
+  green
+- `ADR-022` records the durable-ack-intent decision separately from
+  `ADR-021`'s owner-only mutation boundary
 
 ## This Sprint Does Not Close
 
@@ -124,6 +145,9 @@ re-qualifying as ack-required just because they were displayed.
 - `atm read` and `atm peek` never create `pending_ack_at`
 - legacy ack replies with `acknowledges_message_id` do not become ack-required
   during compatibility load
+- `cargo test --workspace` is green after the `ReadQuery` /
+  `AckActivationMode` shape change, including the `atm-graft` crate tests and
+  `crates/atm-graft/examples/smoke_same_host.rs`
 
 ## Required Validation
 

--- a/docs/plans/phase-AD/sprint-AD33.md
+++ b/docs/plans/phase-AD/sprint-AD33.md
@@ -15,7 +15,10 @@ target: integrate/phase-AD
 
 ## Hard Dependencies
 
-- `AD.32` complete
+- `AD.32` merged forward before implementation starts because both sprint
+  lines touch shared send/read-facing surfaces and would otherwise create
+  avoidable merge conflicts; this is a merge-order dependency, not a
+  functional prerequisite for self-send rejection
 - `docs/plans/phase-AD-followup/plan-atm-messaging-fixes.md`
 - `docs/plans/phase-AD/plan-phase-AD.md`
 - GitHub issue `#498`

--- a/docs/plans/phase-AD/sprint-AD33.md
+++ b/docs/plans/phase-AD/sprint-AD33.md
@@ -1,0 +1,98 @@
+---
+id: AD.33
+title: Self-Addressed Send Rejection
+status: planned
+branch: feature/pAD-s33-self-address-send-rejection
+worktree: ../atm-core-worktrees/feature/pAD-s33-self-address-send-rejection
+target: integrate/phase-AD
+---
+
+# Sprint AD.33 — Self-Addressed Send Rejection
+
+## Goal
+
+- reject self-addressed messages before persistence
+
+## Hard Dependencies
+
+- `AD.32` complete
+- `docs/plans/phase-AD-followup/plan-atm-messaging-fixes.md`
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- GitHub issue `#498`
+
+## Exact Targets
+
+- `crates/atm-core/src/send/mod.rs`
+- `crates/atm-core/src/send/tests.rs`
+- `crates/atm/src/commands/send.rs`
+- `crates/atm/src/composition.rs`
+- `crates/atm-daemon/src/tests.rs`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm/requirements.md`
+- `docs/atm/architecture.md`
+- `docs/atm/commands/send.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/project-plan.md`
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- `docs/plans/phase-AD/sprint-AD33.md`
+
+## Interfaces To Add Or Modify
+
+The accepted send validation contract after this sprint is:
+
+```rust
+pub fn validate_non_self_recipient(
+    sender: &AgentName,
+    sender_team: &TeamName,
+    recipient: &ResolvedRecipient,
+) -> Result<(), AtmError>;
+```
+
+The accepted behavior after this sprint is:
+
+- ATM rejects `from == to` within the same team before persistence
+- the rejection occurs for plain sends, threaded sends, task sends, and dry
+  runs
+- the shared `atm-core` send path owns the validation so CLI, loopback, and
+  daemon-backed sends all fail the same way
+
+## Paths To Delete
+
+- any path that allows a message whose resolved sender and recipient are the
+  same member in the same team
+- any CLI/runtime test that still treats self-addressed sends as valid
+
+## Deliverables
+
+- self-addressed sends are rejected in the shared send path
+- one stable typed error contract documents the failure
+- all send entry paths surface the same rejection
+
+## This Sprint Does Not Close
+
+- historical self-addressed poison messages already persisted in a mailbox
+- ack-loop termination for those historical messages
+- operator protocol / wrapper closeout
+
+## Acceptance Criteria
+
+- no self-addressed message can be persisted
+- `--dry-run` does not report success for a self-addressed send
+- loopback, direct CLI, and daemon-backed send paths all surface the same
+  validation failure
+- docs state clearly that self-addressed messages are invalid ATM input
+
+## Required Validation
+
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 .just/run_lint.py all`
+- targeted send tests covering:
+  - plain send rejection
+  - task send rejection
+  - dry-run rejection
+  - loopback transport rejection
+  - daemon-backed send rejection
+- `git diff --check`

--- a/docs/plans/phase-AD/sprint-AD34.md
+++ b/docs/plans/phase-AD/sprint-AD34.md
@@ -71,6 +71,10 @@ The accepted behavior after this sprint is:
 - if the ack target is not self-addressed, normal reply behavior continues
 - the output contract explicitly distinguishes "ack succeeded with no reply
   because self-ack was suppressed" from normal reply emission
+- when `reply_disposition == AckReplyDisposition::SuppressedSelfAck`,
+  `reply_text` remains the validated operator-supplied reply body even though
+  no reply message is emitted, so CLI/JSON output can report exactly what was
+  suppressed without fabricating a sent reply
 
 ## Paths To Delete
 

--- a/docs/plans/phase-AD/sprint-AD34.md
+++ b/docs/plans/phase-AD/sprint-AD34.md
@@ -1,0 +1,110 @@
+---
+id: AD.34
+title: Self-Ack Loop Termination And Historical Poison Cleanup
+status: planned
+branch: feature/pAD-s34-self-ack-loop-termination
+worktree: ../atm-core-worktrees/feature/pAD-s34-self-ack-loop-termination
+target: integrate/phase-AD
+---
+
+# Sprint AD.34 — Self-Ack Loop Termination And Historical Poison Cleanup
+
+## Goal
+
+- make `atm ack` converge when a historical self-addressed poison message
+  already exists
+
+## Hard Dependencies
+
+- `AD.33` complete
+- `docs/plans/phase-AD-followup/plan-atm-messaging-fixes.md`
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- GitHub issue `#499`
+
+## Exact Targets
+
+- `crates/atm-core/src/ack/mod.rs`
+- `crates/atm/src/commands/ack.rs`
+- `crates/atm/src/output.rs`
+- `crates/atm/src/composition.rs`
+- `crates/atm-core/tests/mailbox_locking.rs`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm/requirements.md`
+- `docs/atm/architecture.md`
+- `docs/atm/commands/ack.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/project-plan.md`
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- `docs/plans/phase-AD/sprint-AD34.md`
+
+## Interfaces To Add Or Modify
+
+The accepted ack reply-disposition contract after this sprint is:
+
+```rust
+pub enum AckReplyDisposition {
+    SuppressedSelfAck,
+    Sent {
+        reply_message_id: AtmMessageId,
+        reply_target: ReplyTarget,
+    },
+}
+
+pub struct AckOutcome {
+    pub action: CommandAction,
+    pub team: TeamName,
+    pub agent: AgentName,
+    pub message_id: AtmMessageId,
+    pub task_id: Option<TaskId>,
+    pub reply_disposition: AckReplyDisposition,
+    pub reply_text: String,
+    pub warnings: Vec<WarningEntry>,
+}
+```
+
+The accepted behavior after this sprint is:
+
+- if the ack target is self-addressed, ATM marks it acknowledged and emits no
+  reply message
+- if the ack target is not self-addressed, normal reply behavior continues
+- the output contract explicitly distinguishes "ack succeeded with no reply
+  because self-ack was suppressed" from normal reply emission
+
+## Paths To Delete
+
+- any ack path that emits a new reply back to the same actor for a
+  self-addressed message
+- any output contract that assumes every successful ack produced a reply
+  message
+
+## Deliverables
+
+- historical self-addressed poison messages can be acknowledged to completion
+- self-ack no longer creates a replacement pending-ack message
+- ack output and JSON shape describe suppressed-self-ack success explicitly
+
+## This Sprint Does Not Close
+
+- operator protocol / wrapper closeout
+- the full cross-agent regression matrix
+
+## Acceptance Criteria
+
+- acking a historical self-addressed message marks it acknowledged
+- acking a historical self-addressed message emits no new reply message
+- non-self ack behavior remains unchanged
+- CLI and JSON output distinguish suppressed self-ack from normal reply-send
+  success
+
+## Required Validation
+
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 .just/run_lint.py all`
+- targeted ack tests covering:
+  - historical self-addressed poison message termination
+  - normal non-self ack reply behavior unchanged
+  - JSON/human output for suppressed self-ack
+- `git diff --check`

--- a/docs/plans/phase-AD/sprint-AD35.md
+++ b/docs/plans/phase-AD/sprint-AD35.md
@@ -1,0 +1,105 @@
+---
+id: AD.35
+title: Messaging Protocol And Regression Closeout
+status: planned
+branch: feature/pAD-s35-messaging-protocol-and-regression-closeout
+worktree: ../atm-core-worktrees/feature/pAD-s35-messaging-protocol-and-regression-closeout
+target: integrate/phase-AD
+---
+
+# Sprint AD.35 — Messaging Protocol And Regression Closeout
+
+## Goal
+
+- make the repaired ATM messaging model the only documented and regression
+  tested operator path
+
+## Hard Dependencies
+
+- `AD.34` complete
+- `docs/plans/phase-AD-followup/plan-atm-messaging-fixes.md`
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- GitHub issues `#498`, `#499`, `#500`
+
+## Exact Targets
+
+- `docs/team-protocol.md`
+- `docs/requirements.md`
+- `docs/architecture.md`
+- `docs/atm/requirements.md`
+- `docs/atm/architecture.md`
+- `docs/atm/commands/read.md`
+- `docs/atm/commands/list.md`
+- `docs/atm/commands/send.md`
+- `docs/atm/commands/ack.md`
+- `docs/atm/commands/clear.md`
+- `docs/atm/commands/help.md`
+- `docs/atm-core/requirements.md`
+- `docs/atm-core/architecture.md`
+- `docs/adr/ADR-021-owner-only-message-mutation.md`
+- `crates/atm/src/commands/help.rs`
+- `crates/atm/src/composition.rs`
+- `crates/atm-core/tests/mailbox_locking.rs`
+- `docs/project-plan.md`
+- `docs/plans/phase-AD/plan-phase-AD.md`
+- `docs/plans/phase-AD/readiness.md`
+- `docs/plans/phase-AD/sprint-AD35.md`
+
+## Interfaces To Add Or Modify
+
+No additional core protocol type is introduced in this sprint. This sprint
+closes the operator/documentation contract around the types and behaviors
+landed in `AD.31` through `AD.34`.
+
+The accepted operator contract after this sprint is:
+
+- `atm peek` is the only documented non-mutating mailbox inspection path
+- informational review uses `atm peek`, not `atm read --no-mark`
+- only inspection surfaces may impersonate another member
+- mutating surfaces fail closed when caller identity/team is unresolved
+- only sender-owned durable `requires_ack` data may require acknowledgement
+
+## Paths To Delete
+
+- `atm read --no-mark` from all operator and command documentation
+- any protocol text that tells agents to ack every displayed message without
+  distinguishing requires-ack vs informational classes
+- any help text that still advertises mutating impersonation
+
+## Deliverables
+
+- team protocol and command docs reflect the new `peek`/owner-only mutation
+  model
+- help text is aligned with the shipped command surface
+- one authoritative end-to-end regression matrix covers `#498`, `#499`, and
+  `#500`
+- the Phase `AD` readiness/project-plan records show the new follow-up line as
+  closed only through these regression gates
+
+## This Sprint Does Not Close
+
+- no additional runtime behavior beyond the AD.31-AD.34 contract
+
+## Acceptance Criteria
+
+- docs no longer mention `atm read --no-mark`
+- docs no longer advertise mutating impersonation
+- the end-to-end regression matrix covers:
+  - `peek --as` inspection without mutation
+  - owner-only `read` mutation
+  - explicit `--requires-ack` send
+  - plain informational send with no ack requirement
+  - task send
+  - self-addressed send rejection
+  - historical self-ack poison termination
+  - cross-agent ack reply not re-promoted into pending-ack
+- `docs/plans/phase-AD/readiness.md` is updated only when the full AD.31-AD.35
+  follow-up line is actually green
+
+## Required Validation
+
+- `cargo test --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 .just/run_lint.py all`
+- one authoritative end-to-end regression suite covering the matrix above
+- `git diff --check`

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -93,6 +93,11 @@ Phase-AD planning note:
   are required closure sprints for the graft-boundary reset, ULID-only
   identity cleanup, raw CLI runtime-root unification, and read-path
   consistency repair
+- the corrective release line extends again through `AD.25` to `AD.30` for
+  post-send closeout and Windows daemon-depth proof
+- the corrective release line extends again through `AD.31` to `AD.35` for
+  the mailbox peek surface, owner-only mutation reset, durable ack intent,
+  self-address/self-ack closure, and final messaging regression closeout
 
 Phase R execution entry:
 - Wave 1 deliverable: the new Phase R skeleton
@@ -676,6 +681,16 @@ Deliverables:
   - one authoritative Phase AD post-send smoke matrix
   - separate Windows daemon integration-depth proof for the remaining local IPC
     shutdown/error/rejection cases
+- follow-up `AD.31` through `AD.35` closure of:
+  - explicit split between non-mutating `atm peek` inspection and owner-only
+    mutating `atm read`
+  - owner-only mutation for `send`, `read`, `ack`, and `clear`, with no
+    mutating impersonation path
+  - durable sender-owned `requires_ack` message state and deletion of
+    read-time ack creation
+  - self-addressed send rejection and self-ack poison termination
+  - operator-protocol/help/regression closeout for the repaired messaging
+    model
 
 Sprint line:
 - `AD.1` `feature/pAD-s1-caller-identity-ownership-restore`
@@ -706,16 +721,22 @@ Sprint line:
 - `AD.28` `feature/pAD-s28-graft-host-nudge-deadline-race-hardening`
 - `AD.29` `feature/pAD-s29-phase-ad-post-send-smoke-matrix`
 - `AD.30` `feature/pAD-s30-windows-daemon-integration-depth`
+- `AD.31` `feature/pAD-s31-mailbox-peek-and-owner-only-mutation`
+- `AD.32` `feature/pAD-s32-durable-ack-intent-reset`
+- `AD.33` `feature/pAD-s33-self-address-send-rejection`
+- `AD.34` `feature/pAD-s34-self-ack-loop-termination`
+- `AD.35` `feature/pAD-s35-messaging-protocol-and-regression-closeout`
 
 Acceptance:
 - the phase closes only through
   [`docs/plans/phase-AD/readiness.md`](./plans/phase-AD/readiness.md)
 - readiness is valid only if `AD.1` through `AD.11`, `AD.12` through
-  `AD.22`, and `AD.25` through `AD.30` all pass on the accepted line
-- `AD.30` is the sole sprint allowed to author the final
-  `docs/plans/phase-AD/readiness.md` verdict, incorporating smoke evidence from
-  `AD.29`, Windows daemon-depth evidence from `AD.30`, and the direct-fix
-  closure ledger in `.triage/phase-AD/direct-fix-track.md`
+  `AD.22`, `AD.25` through `AD.30`, and `AD.31` through `AD.35` all pass on
+  the accepted line
+- `AD.30` is the sole sprint allowed to author the Windows/post-send
+  sub-line closeout record in `docs/plans/phase-AD/readiness.md`, while
+  `AD.35` is the sole sprint allowed to author the final Phase `AD` messaging
+  follow-up verdict after `AD.31` through `AD.35` are complete
 - `AD.24` is reserved in the sibling smoke-test planning worktree and is
   consumed by `AD.29`; its harness scope must not be duplicated in the
   follow-up line


### PR DESCRIPTION
## Summary
- add the Phase AD follow-up plan for ATM messaging issues #498, #499, and #500
- add sprint plans AD.31 through AD.35 and wire them into the phase/project plans
- document the owner-only mutation, durable ack-intent, self-send rejection, and regression-closeout line

## Testing
- not run (docs-only planning change)
