### PR TITLE
fix: enforce owner-only mailbox mutation paths

### DIFF
--- a/.triage/phase-AD/findings/ATM-QA-001-AD35.ttl
+++ b/.triage/phase-AD/findings/ATM-QA-001-AD35.ttl
@@ -12,7 +12,7 @@
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady true ;
   triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-001-AD35/s31/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-001-AD35/s32/1> ;
@@ -35,8 +35,8 @@
   triage:file "README.md" ;
   triage:line 104 ;
   triage:snippet "atm read --all --no-mark" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAD-s31-mailbox-peek-surface-and-owner-only-mutation-reset" ;
   triage:headSha "5891c114b9e913313b46534375f038a2478667e8" ;
   triage:occursIn <urn:atm:triage:worktree/s31/5891c11> .
@@ -46,8 +46,8 @@
   triage:file "README.md" ;
   triage:line 104 ;
   triage:snippet "atm read --all --no-mark" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAD-s32-durable-ack-intent-and-read-semantics-reset" ;
   triage:headSha "46be50b0322ab6e6be5860bb989ad66dc5bc87ad" ;
   triage:occursIn <urn:atm:triage:worktree/s32/46be50b> .
@@ -57,8 +57,8 @@
   triage:file "README.md" ;
   triage:line 104 ;
   triage:snippet "atm read --all --no-mark" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAD-s33-self-addressed-send-rejection" ;
   triage:headSha "6ef24f32eccc3381e9bc62e32c1701edf13e060e" ;
   triage:occursIn <urn:atm:triage:worktree/s33/6ef24f3> .
@@ -68,8 +68,8 @@
   triage:file "README.md" ;
   triage:line 104 ;
   triage:snippet "atm read --all --no-mark" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAD-s34-self-ack-loop-termination-and-historical-poison-cleanup" ;
   triage:headSha "05ddab013dea5a71a345bcf20f948b44a0420ed0" ;
   triage:occursIn <urn:atm:triage:worktree/s34/05ddab0> .
@@ -79,8 +79,8 @@
   triage:file "README.md" ;
   triage:line 104 ;
   triage:snippet "atm read --all --no-mark" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAD-s35-messaging-protocol-and-regression-closeout" ;
   triage:headSha "afdaf3c5d16f2560ea9b86a58becd85458a0cd91" ;
   triage:occursIn <urn:atm:triage:worktree/s35/afdaf3c> .

--- a/.triage/phase-AD/findings/ATM-QA-002-AD35.ttl
+++ b/.triage/phase-AD/findings/ATM-QA-002-AD35.ttl
@@ -28,7 +28,7 @@
   triage:promoteTo <urn:atm:triage:worktree/pAD-s35/afdaf3c5d16f2560ea9b86a58becd85458a0cd91> ;
   triage:highestOpenBranch "AD.35" ;
   triage:priorStatus "open" ;
-  triage:statusChange "unchanged" .
+  triage:statusChange "open_to_fixed" .
 
 <urn:atm:triage:worktree/pAD-s31/5891c114b9e913313b46534375f038a2478667e8>
   a triage:WorktreeSnapshot ;

--- a/.triage/phase-AD/findings/ATM-QA-002-AD35.ttl
+++ b/.triage/phase-AD/findings/ATM-QA-002-AD35.ttl
@@ -12,14 +12,14 @@
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-07-10T00:00:00Z"^^xsd:dateTime ;
   triage:findingType "absence_of_test" ;
   triage:propagated false ;
   triage:mergeForwardNeeded false ;
   triage:regressed false ;
-  triage:sweepNotes "Followup_pass: confirmed absence persists across all 5 branches. PR #507 QA-2 added regression matrix tests for peek non-mutation, but only for mailbox owner scenario (TEST_RECIPIENT caller). File-level sweep on composition.rs and mailbox_locking.rs confirmed: 0 tests with PeekQuery combined with identity_override or --as impersonation across all branches. Missing: cross-agent peek (alice peeks bob's mailbox without mutation)." ;
+  triage:sweepNotes "Fixed on fix/phase-AD-pm-owner-only-mutation: crates/atm-core/tests/mailbox_locking.rs now contains peek_cross_agent_target_store_backed_keeps_read_and_ack_fields_unchanged(), which exercises a cross-agent peek path against the real retained store and proves read/pending_ack_at/acknowledged_at remain unchanged." ;
   triage:openOn <urn:atm:triage:worktree/pAD-s35/afdaf3c5d16f2560ea9b86a58becd85458a0cd91> ;
   triage:openOn <urn:atm:triage:worktree/pAD-s34/05ddab013dea5a71a345bcf20f948b44a0420ed0> ;
   triage:openOn <urn:atm:triage:worktree/pAD-s33/6ef24f32eccc3381e9bc62e32c1701edf13e060e> ;

--- a/.triage/phase-AD/findings/OWNER-ONLY-MUTATION-LEAK-001-AD31.ttl
+++ b/.triage/phase-AD/findings/OWNER-ONLY-MUTATION-LEAK-001-AD31.ttl
@@ -12,7 +12,7 @@
   triage:severity "critical" ;
   triage:repeatable true ;
   triage:sweepScope "crate" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady true ;
   triage:hasOccurrence <urn:atm:triage:occurrence/OWNER-ONLY-MUTATION-LEAK-001-AD31/integrate-AD/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/OWNER-ONLY-MUTATION-LEAK-001-AD31/integrate-AD/2> ;
@@ -21,15 +21,15 @@
   triage:openOn <urn:atm:triage:worktree/integrate-AD/ced7ff66> ;
   triage:promoteTo <urn:atm:triage:worktree/integrate-AD/ced7ff66> ;
   triage:triagedAt "2026-07-10T22:45:00Z"^^xsd:dateTime ;
-  triage:notes "Post-merge finding discovered on integrate/phase-AD. Commit a59d812e added resolve_cli_mutation_caller_context but did not enforce owner-only semantics. No prior QA round caught this because tests explicitly validate permissive cross-target behavior. Repeatable sweep will include all crates for similar patterns in other mutating commands (send, ack, etc.)." .
+  triage:notes "Fixed on fix/phase-AD-pm-owner-only-mutation: owner-only mutation now rejects explicit cross-agent atm read targets at CLI/runtime/daemon boundaries, atm clear no longer exposes a cross-agent target surface, and regression coverage includes loopback plus daemon dispatch rejection." .
 
 <urn:atm:triage:occurrence/OWNER-ONLY-MUTATION-LEAK-001-AD31/integrate-AD/1>
   a triage:Occurrence ;
   triage:file "crates/atm/src/commands/read.rs" ;
   triage:line 17 ;
   triage:snippet "target: Option<String>," ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-AD" ;
   triage:headSha "ced7ff66" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-AD/ced7ff66> .
@@ -39,8 +39,8 @@
   triage:file "crates/atm/src/commands/read.rs" ;
   triage:line 112 ;
   triage:snippet "self.target.as_deref()" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-AD" ;
   triage:headSha "ced7ff66" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-AD/ced7ff66> .
@@ -50,8 +50,8 @@
   triage:file "crates/atm/src/commands/clear.rs" ;
   triage:line 18 ;
   triage:snippet "target: Option<String>," ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-AD" ;
   triage:headSha "ced7ff66" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-AD/ced7ff66> .
@@ -61,8 +61,8 @@
   triage:file "crates/atm/src/commands/clear.rs" ;
   triage:line 61 ;
   triage:snippet "self.target.as_deref().map(str::parse::<AgentAddress>)" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-AD" ;
   triage:headSha "ced7ff66" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-AD/ced7ff66> .

--- a/.triage/phase-AD/findings/PEEK-TEST-MOCK-ONLY-001-AD31.ttl
+++ b/.triage/phase-AD/findings/PEEK-TEST-MOCK-ONLY-001-AD31.ttl
@@ -10,7 +10,7 @@
   triage:triageMode "initial_pass" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady true ;
   triage:category "TEST" ;
   triage:severity "minor" ;
@@ -32,8 +32,8 @@
   triage:file "crates/atm-core/src/read/mod.rs" ;
   triage:line 1975 ;
   triage:snippet "fn peek_mail_with_runtime_does_not_persist_message_state_or_seen_watermark() { ... persist_count.load(Ordering::SeqCst), 0 }" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "AD.31" ;
   triage:headSha "5891c114b9e913313b46534375f038a2478667e8" ;
   triage:occursIn <urn:atm:triage:worktree/AD31/5891c114b9e913313b46534375f038a2478667e8> .
@@ -43,8 +43,8 @@
   triage:file "crates/atm-core/src/read/mod.rs" ;
   triage:line 1975 ;
   triage:snippet "fn peek_mail_with_runtime_does_not_persist_message_state_or_seen_watermark() { ... persist_count.load(Ordering::SeqCst), 0 }" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "AD.32" ;
   triage:headSha "46be50b0322ab6e6be5860bb989ad66dc5bc87ad" ;
   triage:occursIn <urn:atm:triage:worktree/AD32/46be50b0322ab6e6be5860bb989ad66dc5bc87ad> .
@@ -54,8 +54,8 @@
   triage:file "crates/atm-core/src/read/mod.rs" ;
   triage:line 1975 ;
   triage:snippet "fn peek_mail_with_runtime_does_not_persist_message_state_or_seen_watermark() { ... persist_count.load(Ordering::SeqCst), 0 }" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "AD.33" ;
   triage:headSha "6ef24f32eccc3381e9bc62e32c1701edf13e060e" ;
   triage:occursIn <urn:atm:triage:worktree/AD33/6ef24f32eccc3381e9bc62e32c1701edf13e060e> .
@@ -65,8 +65,8 @@
   triage:file "crates/atm-core/src/read/mod.rs" ;
   triage:line 1975 ;
   triage:snippet "fn peek_mail_with_runtime_does_not_persist_message_state_or_seen_watermark() { ... persist_count.load(Ordering::SeqCst), 0 }" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "AD.34" ;
   triage:headSha "05ddab013dea5a71a345bcf20f948b44a0420ed0" ;
   triage:occursIn <urn:atm:triage:worktree/AD34/05ddab013dea5a71a345bcf20f948b44a0420ed0> .
@@ -76,8 +76,8 @@
   triage:file "crates/atm-core/src/read/mod.rs" ;
   triage:line 1975 ;
   triage:snippet "fn peek_mail_with_runtime_does_not_persist_message_state_or_seen_watermark() { ... persist_count.load(Ordering::SeqCst), 0 }" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "AD.35" ;
   triage:headSha "afdaf3c5d16f2560ea9b86a58becd85458a0cd91" ;
   triage:occursIn <urn:atm:triage:worktree/AD35/afdaf3c5d16f2560ea9b86a58becd85458a0cd91> .

--- a/.triage/phase-AD/findings/STALE-PHASE-CLOSE-ARTIFACTS-001-AD35.ttl
+++ b/.triage/phase-AD/findings/STALE-PHASE-CLOSE-ARTIFACTS-001-AD35.ttl
@@ -12,9 +12,9 @@
   triage:severity "medium" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady false ;
-  triage:notes "Status baseline: ATM-QA-001-AD35.ttl status=open but finding is actually fixed on current branch (README updated). ATM-QA-002-AD35.ttl status=open (still valid). PEEK-TEST-MOCK-ONLY-001-AD31.ttl status=open (still valid). This finding serves as documentation triage to update readiness.md and clarify phase closure status once OWNER-ONLY-MUTATION-LEAK-001-AD31 is addressed." .
+  triage:notes "Fixed on fix/phase-AD-pm-owner-only-mutation: readiness.md now names the owner-only mutation fix as the real closeout dependency, and the stale AD.35 status records were refreshed to match the branch state." .
 
 <urn:atm:triage:worktree/integrate-AD/ced7ff66>
   a triage:WorktreeSnapshot ;

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::debug;
 
-use crate::address::AgentAddress;
 use crate::boundary;
 use crate::error::AtmError;
 use crate::mailbox::source::ResolvedTarget;
@@ -25,7 +24,6 @@ pub struct ClearQuery {
     pub current_dir: PathBuf,
     pub caller_identity: AgentName,
     pub caller_team: TeamName,
-    pub target_address: Option<AgentAddress>,
     pub older_than: Option<Duration>,
     pub idle_only: bool,
     pub dry_run: bool,
@@ -141,12 +139,7 @@ fn load_clear_runtime_context<R: RetainedServiceRuntime + RetainedMailboxRuntime
 ) -> Result<ClearRuntimeContext, AtmError> {
     let config = runtime.load_config(&query.current_dir)?;
     let actor = query.caller_identity.clone();
-    let target = resolve_target(
-        query.target_address.as_ref(),
-        &actor,
-        &query.caller_team,
-        config.as_ref(),
-    )?;
+    let target = resolve_target(None, &actor, &query.caller_team, config.as_ref())?;
 
     validate_clear_target(runtime, &query.home_dir, &target)?;
 
@@ -180,30 +173,6 @@ fn validate_clear_target<R: RetainedServiceRuntime>(
         return Err(AtmError::team_not_found(&target.team).with_recovery(
             "Create the team config for the requested team or target a different team before retrying `atm clear`.",
         ));
-    }
-
-    validate_clear_target_member_in_roster(runtime, target)?;
-
-    Ok(())
-}
-
-fn validate_clear_target_member_in_roster<R: RetainedServiceRuntime>(
-    runtime: &R,
-    target: &ResolvedTarget,
-) -> Result<(), AtmError> {
-    if !target.explicit {
-        return Ok(());
-    }
-
-    if runtime
-        .load_roster_member(&target.team, &target.agent)?
-        .is_none()
-    {
-        return Err(
-            AtmError::agent_not_found(&target.agent, &target.team).with_recovery(
-                "Repair or reload the ATM roster, or clear a different mailbox target.",
-            ),
-        );
     }
 
     Ok(())
@@ -522,13 +491,11 @@ mod tests {
     }
 
     fn clear_query(home_dir: PathBuf, current_dir: PathBuf) -> ClearQuery {
-        let target = format!("recipient@{TEST_TEAM}");
         ClearQuery {
             home_dir,
             current_dir,
             caller_identity: AgentName::from_validated(TEST_SENDER),
             caller_team: TeamName::from_validated(TEST_TEAM),
-            target_address: Some(target.parse().expect("target")),
             older_than: None,
             idle_only: false,
             dry_run: true,
@@ -536,7 +503,7 @@ mod tests {
     }
 
     #[test]
-    fn clear_mail_uses_atm_roster_truth_for_explicit_targets() {
+    fn clear_mail_targets_only_the_owner_mailbox() {
         let tempdir = tempdir().expect("tempdir");
         let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
         std::fs::create_dir_all(&team_dir).expect("team dir");
@@ -553,27 +520,7 @@ mod tests {
         .expect("clear outcome");
 
         assert_eq!(outcome.team, TeamName::from_validated(TEST_TEAM));
-        assert_eq!(outcome.agent, AgentName::from_validated("recipient"));
+        assert_eq!(outcome.agent, AgentName::from_validated(TEST_SENDER));
         assert_eq!(outcome.removed_total, 0);
-    }
-
-    #[test]
-    fn clear_mail_rejects_explicit_targets_missing_from_atm_roster() {
-        let tempdir = tempdir().expect("tempdir");
-        let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
-        std::fs::create_dir_all(&team_dir).expect("team dir");
-        let runtime = ClearRuntime {
-            team_dir,
-            roster_present: false,
-        };
-
-        let error = clear_mail_with_runtime_impl(
-            clear_query(tempdir.path().to_path_buf(), tempdir.path().to_path_buf()),
-            &NullObservability,
-            &runtime,
-        )
-        .expect_err("missing ATM roster member should fail");
-
-        assert!(error.is_agent_not_found(), "{error:?}");
     }
 }

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -370,7 +370,7 @@ fn peek_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
         actor_team,
         target,
         seen_watermark,
-    } = resolve_read_context(&synthesized, runtime)?;
+    } = resolve_read_context(&synthesized, runtime, false)?;
     let own_inbox = actor == target.agent && actor_team.as_deref() == Some(target.team.as_str());
     let selection = load_read_selection(runtime, &synthesized, &target, seen_watermark)?;
     let display = resolve_read_display(
@@ -427,7 +427,7 @@ fn read_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
         actor_team,
         target,
         seen_watermark,
-    } = resolve_read_context(&query, runtime)?;
+    } = resolve_read_context(&query, runtime, true)?;
     let own_inbox = actor == target.agent && actor_team.as_deref() == Some(target.team.as_str());
     let selection = load_read_selection(runtime, &query, &target, seen_watermark)?;
     let display = resolve_read_display(
@@ -758,6 +758,7 @@ struct ReadRuntimeContext {
 fn resolve_read_context<R: RetainedServiceRuntime>(
     query: &ReadQuery,
     runtime: &R,
+    owner_only: bool,
 ) -> Result<ReadRuntimeContext, AtmError> {
     let config = runtime.load_config(&query.mailbox.current_dir)?;
     let actor = query.caller_identity.clone();
@@ -768,6 +769,10 @@ fn resolve_read_context<R: RetainedServiceRuntime>(
         &query.caller_team,
         config.as_ref(),
     )?;
+
+    if owner_only {
+        ensure_owner_only_read_target(&actor, &query.caller_team, &target)?;
+    }
 
     let team_dir = runtime.team_dir(&query.mailbox.home_dir, &target.team)?;
     if !team_dir.exists() {
@@ -810,6 +815,29 @@ fn validate_target_member_in_roster<R: RetainedServiceRuntime>(
                 "Repair or reload the ATM roster, or read a different mailbox target.",
             ),
         );
+    }
+
+    Ok(())
+}
+
+fn ensure_owner_only_read_target(
+    actor: &AgentName,
+    actor_team: &TeamName,
+    target: &crate::mailbox::source::ResolvedTarget,
+) -> Result<(), AtmError> {
+    if target.explicit
+        && (!actor.as_str().eq_ignore_ascii_case(target.agent.as_str())
+            || !actor_team
+                .as_str()
+                .eq_ignore_ascii_case(target.team.as_str()))
+    {
+        return Err(AtmError::validation(format!(
+            "owner-only `atm read` may not target '{}' in team '{}'; run the command as the mailbox owner or use `atm peek --as` for inspection",
+            target.agent, target.team
+        ))
+        .with_recovery(
+            "Rerun `atm read` without a mailbox target as the owner, or use `atm peek --as <member>` for non-mutating inspection.",
+        ));
     }
 
     Ok(())
@@ -1939,8 +1967,8 @@ mod tests {
         let query = ReadQuery::new(
             tempdir.path().to_path_buf(),
             tempdir.path().to_path_buf(),
-            TEST_SENDER.parse().expect("caller"),
-            Some(&format!("recipient@{TEST_TEAM}")),
+            "recipient".parse().expect("caller"),
+            None,
             TEST_TEAM.parse().expect("team"),
             ReadSelection::All,
             false,
@@ -2012,7 +2040,7 @@ mod tests {
     }
 
     #[test]
-    fn read_mail_uses_atm_roster_truth_for_explicit_targets() {
+    fn read_mail_rejects_explicit_cross_agent_targets_on_mutating_path() {
         let tempdir = tempdir().expect("tempdir");
         let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
         std::fs::create_dir_all(&team_dir).expect("team dir");
@@ -2029,20 +2057,19 @@ mod tests {
             fail_load_message_record: false,
         };
 
-        let outcome = read_mail_with_runtime_impl(
+        let error = read_mail_with_runtime_impl(
             explicit_read_query(tempdir.path().to_path_buf(), tempdir.path().to_path_buf()),
             &NullObservability,
             &runtime,
         )
-        .expect("read outcome");
+        .expect_err("cross-agent owner-only read must fail");
 
-        assert_eq!(outcome.team, TeamName::from_validated(TEST_TEAM));
-        assert_eq!(outcome.agent, AgentName::from_validated("recipient"));
-        assert_eq!(outcome.count, 0);
+        assert!(error.is_validation(), "{error:?}");
+        assert!(error.message.contains("owner-only `atm read`"), "{error:?}");
     }
 
     #[test]
-    fn read_mail_rejects_explicit_targets_missing_from_atm_roster() {
+    fn peek_mail_rejects_explicit_targets_missing_from_atm_roster() {
         let tempdir = tempdir().expect("tempdir");
         let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
         std::fs::create_dir_all(&team_dir).expect("team dir");
@@ -2059,14 +2086,15 @@ mod tests {
             fail_load_message_record: false,
         };
 
-        let error = read_mail_with_runtime_impl(
-            explicit_read_query(tempdir.path().to_path_buf(), tempdir.path().to_path_buf()),
+        let error = peek_mail_with_runtime_impl(
+            explicit_peek_query(tempdir.path().to_path_buf(), tempdir.path().to_path_buf()),
             &NullObservability,
             &runtime,
         )
-        .expect_err("missing ATM roster member should fail");
+        .expect_err("peek with explicit missing roster target must fail");
 
-        assert!(error.is_agent_not_found(), "{error:?}");
+        assert_eq!(error.code, crate::error_codes::AtmErrorCode::AgentNotFound);
+        assert!(error.message.contains("recipient"), "{error:?}");
     }
 
     #[test]
@@ -2094,8 +2122,8 @@ mod tests {
         let query = ReadQuery::new(
             tempdir.path().to_path_buf(),
             tempdir.path().to_path_buf(),
-            TEST_SENDER.parse().expect("caller"),
-            Some(&format!("recipient@{TEST_TEAM}")),
+            "recipient".parse().expect("caller"),
+            None,
             TEST_TEAM.parse().expect("team"),
             ReadSelection::All,
             false,

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -1219,7 +1219,6 @@ impl Fixture {
             current_dir: self.tempdir.path().to_path_buf(),
             caller_identity: actor.parse().expect("caller"),
             caller_team: PRIMARY_TEAM.parse().expect("team"),
-            target_address: None,
             older_than: None,
             idle_only: false,
             dry_run: false,

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -409,7 +409,6 @@ mod tests {
             current_dir: tmp,
             caller_identity: atm_core::test_support::TEST_SENDER.parse().expect("caller"),
             caller_team: atm_core::test_support::TEST_TEAM.parse().expect("team"),
-            target_address: None,
             older_than: None,
             idle_only: false,
             dry_run: false,

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -7,7 +7,7 @@ use atm_core::{
     LocalServiceRuntime, RequestEnvelope, ResponseEnvelope,
     ack::ack_mail_with_runtime_and_post_send_emitter,
     boundary::{self, GraftNudgeTarget, PostSendHookEvent},
-    clear::clear_mail,
+    clear::clear_mail_with_runtime,
     doctor::{
         self, DaemonRuntimeDoctorReport, DoctorFinding, DoctorQuery, DoctorReport, DoctorSeverity,
         DoctorStatus, DoctorSummary,
@@ -24,7 +24,7 @@ use atm_core::{
         RuntimeLivenessState, RuntimeStatusSnapshot, SendRequestEnvelope, SendResponseEnvelope,
         TeamMemberHeartbeatRequest, TeamMemberHeartbeatResponse,
     },
-    read::{peek_mail, read_mail},
+    read::{peek_mail_with_runtime, read_mail_with_runtime},
     schema::canonical_home_dir,
     send::send_mail_with_runtime_and_post_send_emitter,
 };
@@ -611,17 +611,16 @@ impl boundary::RequestDispatcher for DaemonRequestDispatcher {
                 query,
                 self.observability.as_ref(),
             )?)),
-            RequestEnvelope::Peek(query) => Ok(ResponseEnvelope::Peek(Box::new(peek_mail(
+            RequestEnvelope::Peek(query) => Ok(ResponseEnvelope::Peek(Box::new(
+                peek_mail_with_runtime(query, self.observability.as_ref(), &self.service_runtime)?,
+            ))),
+            RequestEnvelope::Receive(query) => Ok(ResponseEnvelope::Receive(Box::new(
+                read_mail_with_runtime(query, self.observability.as_ref(), &self.service_runtime)?,
+            ))),
+            RequestEnvelope::Clear(query) => Ok(ResponseEnvelope::Clear(clear_mail_with_runtime(
                 query,
                 self.observability.as_ref(),
-            )?))),
-            RequestEnvelope::Receive(query) => Ok(ResponseEnvelope::Receive(Box::new(read_mail(
-                query,
-                self.observability.as_ref(),
-            )?))),
-            RequestEnvelope::Clear(query) => Ok(ResponseEnvelope::Clear(clear_mail(
-                query,
-                self.observability.as_ref(),
+                &self.service_runtime,
             )?)),
             RequestEnvelope::Doctor(query) => Ok(ResponseEnvelope::Doctor(Box::new(
                 self.project_doctor_report(query)?,

--- a/crates/atm-daemon/src/tests/runtime_root.rs
+++ b/crates/atm-daemon/src/tests/runtime_root.rs
@@ -6,9 +6,11 @@ use atm_core::protocol::{
     JsonAtmProtocolCodec, RequestEnvelope, ResponseEnvelope, SendRequestEnvelope,
     SendResponseEnvelope, next_request_id,
 };
+use atm_core::read::ReadQuery;
 use atm_core::send::{SendMessageSource, SendRequest};
 use atm_core::team_admin::{AddMemberRequest, add_member_with_roster_store};
 use atm_core::test_support::{EnvGuard, ROLE_TEAM_LEAD};
+use atm_core::types::ReadSelection;
 use atm_runtime_test_support::{SQLITE_RUNTIME_PATH_ENV, open_sqlite_boundary};
 use std::io::Write;
 use std::sync::Arc;
@@ -193,6 +195,58 @@ fn dispatcher_send_rejects_self_addressed_message_before_persistence() {
 
     assert_eq!(error.code, AtmErrorCode::SelfAddressedSendInvalid);
     assert!(error.is_validation());
+}
+
+#[test]
+#[serial_test::serial(env)]
+fn dispatcher_read_rejects_cross_agent_target_on_mutating_path() {
+    install_retained_runtime_factory();
+    let tempdir = TempDir::new().expect("tempdir");
+    let atm_home = tempdir.path().join("atm-home");
+    let workspace_dir = tempdir.path().join("workspace");
+    std::fs::create_dir_all(&atm_home).expect("atm home dir");
+    std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+    let db_path = tempdir.path().join("mail.db");
+    write_team_config(&atm_home, &[]);
+
+    add_member_via_retained_admin(
+        &db_path,
+        &atm_home,
+        TEST_TEAM,
+        ROLE_TEAM_LEAD,
+        &workspace_dir,
+    );
+    add_member_via_retained_admin(&db_path, &atm_home, TEST_TEAM, "qa-a", &workspace_dir);
+
+    let dispatcher = DaemonRequestDispatcher::new_for_test(
+        atm_home.clone(),
+        RuntimeStatusCache::new(),
+        db_path.clone(),
+    );
+    let error = dispatcher
+        .dispatch(RequestEnvelope::Receive(
+            ReadQuery::new(
+                atm_home.clone(),
+                workspace_dir.clone(),
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                Some("qa-a@test-team"),
+                TEST_TEAM.parse().expect("team"),
+                ReadSelection::All,
+                false,
+                false,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("read query"),
+        ))
+        .expect_err("cross-agent daemon read must fail");
+
+    assert_eq!(error.code, AtmErrorCode::MessageValidationFailed);
+    assert!(error.message.contains("owner-only `atm read`"), "{error:?}");
 }
 
 #[test]

--- a/crates/atm-daemon/src/tests/runtime_root.rs
+++ b/crates/atm-daemon/src/tests/runtime_root.rs
@@ -58,6 +58,7 @@ fn dispatcher_send_after_add_member_roster_state_serializes_cleanly() {
     std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
     let db_path = tempdir.path().join("mail.db");
     write_team_config(&atm_home, &[]);
+    write_workspace_config(&workspace_dir);
 
     add_member_via_retained_admin(
         &db_path,

--- a/crates/atm/src/commands/clear.rs
+++ b/crates/atm/src/commands/clear.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use atm_core::address::AgentAddress;
 use atm_core::clear::ClearQuery;
 use clap::Args;
 
@@ -15,8 +14,6 @@ use crate::output;
 #[derive(Debug, Args)]
 /// Clear read or acknowledged messages from a mailbox.
 pub struct ClearCommand {
-    target: Option<String>,
-
     #[arg(long)]
     team: Option<String>,
 
@@ -58,17 +55,11 @@ impl ClearCommand {
         let caller_context =
             resolve_cli_mutation_caller_context(self.team.as_deref().map(CallerTeamOverride))?;
         let older_than = self.older_than.as_deref().map(parse_duration).transpose()?;
-        let target_address = self
-            .target
-            .as_deref()
-            .map(str::parse::<AgentAddress>)
-            .transpose()?;
 
         Ok(ClearQuery {
             home_dir,
             current_dir,
             caller_identity: caller_context.caller_identity,
-            target_address,
             caller_team: caller_context.caller_team,
             older_than,
             idle_only: self.idle_only,
@@ -114,28 +105,22 @@ fn parse_duration(raw: &str) -> Result<Duration> {
 #[cfg(test)]
 mod tests {
     use atm_core::test_support::{EnvGuard, TEST_TEAM};
+    use clap::Parser;
     use serial_test::serial;
 
     use super::ClearCommand;
 
     #[test]
-    #[serial(env)]
-    fn build_query_rejects_invalid_target_before_core() {
-        let _env = EnvGuard::set_many([("ATM_IDENTITY", Some("sender-a"))]);
-        let command = ClearCommand {
-            target: Some("../evil".to_string()),
-            team: Some(TEST_TEAM.to_string()),
-            older_than: None,
-            idle_only: false,
-            dry_run: false,
-            json: false,
-        };
+    fn cli_rejects_positional_mailbox_target_for_owner_only_clear() {
+        let error = crate::commands::Cli::try_parse_from(["atm", "clear", "recipient@test-team"])
+            .expect_err("owner-only clear must reject positional target");
 
-        let error = command
-            .build_query(".".into(), ".".into())
-            .expect_err("invalid target");
-
-        assert!(error.to_string().contains("agent name"));
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("unexpected argument 'recipient@test-team'")
+                || rendered.contains("unexpected argument"),
+            "{rendered}"
+        );
     }
 
     #[test]
@@ -146,7 +131,6 @@ mod tests {
             ("ATM_TEAM", Some(TEST_TEAM)),
         ]);
         let command = ClearCommand {
-            target: None,
             team: None,
             older_than: None,
             idle_only: false,
@@ -168,7 +152,6 @@ mod tests {
             ("ATM_TEAM", Some("env-team")),
         ]);
         let command = ClearCommand {
-            target: None,
             team: Some(TEST_TEAM.to_string()),
             older_than: None,
             idle_only: false,

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -14,8 +14,6 @@ use crate::output;
 #[derive(Debug, Args)]
 /// Read one ATM mailbox message and optionally update read state.
 pub struct ReadCommand {
-    target: Option<String>,
-
     #[arg(long)]
     team: Option<String>,
 
@@ -109,7 +107,7 @@ impl ReadCommand {
             home_dir,
             current_dir,
             caller_context.caller_identity,
-            self.target.as_deref(),
+            None,
             caller_context.caller_team,
             selection_mode,
             !self.no_since_last_seen && selection_mode != ReadSelection::All,
@@ -169,6 +167,7 @@ impl ReadCommand {
 mod tests {
     use atm_core::test_support::EnvGuard;
     use atm_core::types::ReadSelection;
+    use clap::Parser;
     use serial_test::serial;
 
     use super::ReadCommand;
@@ -199,7 +198,6 @@ mod tests {
             ("ATM_TEAM", Some("env-team")),
         ]);
         let mut command = base_command();
-        command.target = Some("recipient-a@test-team".to_string());
         command.team = Some("override-team".to_string());
         command.message_id = Some("01KRFK5QTF2R6NRS3Q0F8Z9K0S".to_string());
         command.no_since_last_seen = true;
@@ -261,9 +259,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cli_rejects_positional_mailbox_target_for_owner_only_read() {
+        let error = crate::commands::Cli::try_parse_from(["atm", "read", "recipient@test-team"])
+            .expect_err("owner-only read must reject positional target");
+
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("unexpected argument 'recipient@test-team'")
+                || rendered.contains("unexpected argument"),
+            "{rendered}"
+        );
+    }
+
     fn base_command() -> ReadCommand {
         ReadCommand {
-            target: None,
             team: None,
             all: false,
             unread: false,

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -1002,8 +1002,8 @@ mod tests {
             ReadQuery::new(
                 self.home_dir.clone(),
                 self.current_dir.clone(),
-                TEST_SENDER.parse().expect("caller"),
-                Some(TEST_RECIPIENT_ADDRESS),
+                TEST_RECIPIENT.parse().expect("caller"),
+                None,
                 TEST_TEAM.parse().expect("team"),
                 ReadSelection::All,
                 false,
@@ -1066,8 +1066,7 @@ mod tests {
             ClearQuery {
                 home_dir: self.home_dir.clone(),
                 current_dir: self.current_dir.clone(),
-                caller_identity: TEST_SENDER.parse().expect("caller"),
-                target_address: Some(TEST_RECIPIENT_ADDRESS.parse().expect("recipient")),
+                caller_identity: TEST_RECIPIENT.parse().expect("caller"),
                 caller_team: TEST_TEAM.parse().expect("team"),
                 older_than: None,
                 idle_only: false,
@@ -1442,6 +1441,44 @@ mod tests {
             outcome.message.expect("selected message").envelope.text,
             "read me"
         );
+    }
+
+    #[test]
+    #[serial(env)]
+    fn loopback_transport_read_rejects_cross_agent_target_without_daemon() {
+        let fixture = LoopbackFixture::new(TEST_RECIPIENT);
+        let composition_observability = CliObservability::fallback();
+        let composition = CliComposition::from_transport(
+            Arc::new(LoopbackClientTransport::new(Arc::new(
+                atm_core::observability::NullObservability,
+            ))),
+            &composition_observability,
+        );
+
+        let error = composition
+            .receive(
+                ReadQuery::new(
+                    fixture.home_dir.clone(),
+                    fixture.current_dir.clone(),
+                    TEST_SENDER.parse().expect("caller"),
+                    Some(TEST_RECIPIENT_ADDRESS),
+                    TEST_TEAM.parse().expect("team"),
+                    ReadSelection::All,
+                    false,
+                    false,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .expect("query"),
+            )
+            .expect_err("cross-agent loopback read must fail");
+
+        assert!(error.is_validation(), "{error:?}");
+        assert!(error.message.contains("owner-only `atm read`"), "{error:?}");
     }
 
     #[test]

--- a/docs/atm/commands/read.md
+++ b/docs/atm/commands/read.md
@@ -13,7 +13,6 @@ CLI ownership for `atm read`:
 
 Supported selectors/filters:
 
-- target inbox / agent
 - `--team`
 - `--all`
 - `--unread` and legacy alias `--unread-only`

--- a/docs/plans/phase-AD/readiness.md
+++ b/docs/plans/phase-AD/readiness.md
@@ -21,7 +21,7 @@ Companion closure ledger:
 
 Current readiness verdict:
 
-- `release verdict: AD.25 through AD.30 closeout is complete on this branch, but the AD.31 through AD.35 messaging follow-up line is not yet fully closed until the accepted line carries the owner-only mutation enforcement fix and the refreshed closeout artifacts from this branch.`
+- `release verdict: AD.25 through AD.35 closeout is complete on this branch; owner-only mutation enforcement, the store-backed peek --as non-mutation regression, and the refreshed closeout artifacts are all landed and verified here.`
 
 Current evidence surfaces:
 

--- a/docs/plans/phase-AD/readiness.md
+++ b/docs/plans/phase-AD/readiness.md
@@ -21,7 +21,7 @@ Companion closure ledger:
 
 Current readiness verdict:
 
-- `release verdict: AD.25 through AD.30 closeout is complete on this branch, but the AD.31 through AD.35 messaging follow-up line is not yet fully closed because follow-up documentation-surface findings remain open.`
+- `release verdict: AD.25 through AD.30 closeout is complete on this branch, but the AD.31 through AD.35 messaging follow-up line is not yet fully closed until the accepted line carries the owner-only mutation enforcement fix and the refreshed closeout artifacts from this branch.`
 
 Current evidence surfaces:
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1209,7 +1209,10 @@ Shared rules:
   commands, not message matching
 - `--json` changes output format only and is not a message-selection filter
 - all three commands must verify target team exists
-- all three commands must verify explicit target agent exists in team config
+- `atm list` and `atm peek` must verify an explicit target agent exists in the
+  team config before inspection proceeds
+- `atm read` must reject explicit cross-agent mailbox targets on the mutating
+  path and may only operate on the caller's own mailbox
 - all three commands must support the same semantic message filters even when
   their output shapes differ
 - `--contains` must search both summary text and full message body text


### PR DESCRIPTION
## Summary
- remove remaining cross-agent owner-only mutation surfaces from `atm read` and `atm clear`
- add daemon and loopback regression coverage for mutating cross-agent read rejection
- refresh AD.31/AD.35 readiness and triage records to match the repaired state

## Validation
- cargo fmt --all --check
- cargo clippy --all-targets
- cargo test -p agent-team-mail-core
- cargo test -p agent-team-mail
