### PR TITLE
fix: centralize rusqlite timestamp parsing (RBP-F001/RBP-F002)

### DIFF
--- a/.triage/phase-AD/findings/RBP-F001.ttl
+++ b/.triage/phase-AD/findings/RBP-F001.ttl
@@ -1,0 +1,76 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/RBP-F001>
+  a triage:Finding ;
+  triage:findingId "RBP-F001" ;
+  triage:title "atm-storage-rusqlite hand-rolls IsoTimestamp parsing instead of using a shared IsoTimestamp constructor" ;
+  triage:description "RUSQLITE-COUPLING-FIX-1-QA identified that the ef873180 follow-up code was correct but the branch-local triage record was missing. The actual fix centralized RFC3339 timestamp parsing behind IsoTimestamp's shared FromStr constructor in crates/atm-storage/src/types.rs and repointed the rusqlite call sites to that shared parser while preserving each call site's field-specific AtmError context and recovery text." ;
+  triage:phaseId "phase-AD" ;
+  triage:triageMode "followup_pass" ;
+  triage:category "RBP" ;
+  triage:severity "important" ;
+  triage:repeatable true ;
+  triage:sweepScope "crate" ;
+  triage:status "closed" ;
+  triage:dispatchReady false ;
+  triage:closedAt "2026-07-11T02:39:00Z"^^xsd:dateTime ;
+  triage:resolutionNote "Resolved on fix/phase-AD-pm-boundary-violation @ ef873180 by adding a shared FromStr constructor for IsoTimestamp in crates/atm-storage/src/types.rs and making the atm-storage-rusqlite timestamp parse helpers delegate to that constructor instead of hand-rolled chrono DateTime<Utc> parsing. The call sites keep their existing field-specific AtmError validation text and recovery guidance." ;
+  triage:triagedAt "2026-07-11T02:39:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBP-F001/fix-phase-AD-pm-boundary-violation/1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBP-F001/fix-phase-AD-pm-boundary-violation/2> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBP-F001/fix-phase-AD-pm-boundary-violation/3> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBP-F001/fix-phase-AD-pm-boundary-violation/4> ;
+  triage:openOn <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> ;
+  triage:promoteTo <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> .
+
+<urn:atm:triage:occurrence/RBP-F001/fix-phase-AD-pm-boundary-violation/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-storage-rusqlite/src/mailbox_metadata.rs" ;
+  triage:line 32 ;
+  triage:snippet "fn parse_optional_timestamp(raw: Option<String>, field_name: &str) -> Result<Option<IsoTimestamp>, AtmError>" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:branch "fix/phase-AD-pm-boundary-violation" ;
+  triage:headSha "ef873180" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> .
+
+<urn:atm:triage:occurrence/RBP-F001/fix-phase-AD-pm-boundary-violation/2>
+  a triage:Occurrence ;
+  triage:file "crates/atm-storage-rusqlite/src/mailbox_metadata.rs" ;
+  triage:line 154 ;
+  triage:snippet "fn parse_message_at(value: &str) -> Result<IsoTimestamp, AtmError>" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:branch "fix/phase-AD-pm-boundary-violation" ;
+  triage:headSha "ef873180" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> .
+
+<urn:atm:triage:occurrence/RBP-F001/fix-phase-AD-pm-boundary-violation/3>
+  a triage:Occurrence ;
+  triage:file "crates/atm-storage-rusqlite/src/nudge_template_override_store.rs" ;
+  triage:line 157 ;
+  triage:snippet "fn parse_updated_at(raw: String) -> Result<IsoTimestamp, AtmError>" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:branch "fix/phase-AD-pm-boundary-violation" ;
+  triage:headSha "ef873180" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> .
+
+<urn:atm:triage:occurrence/RBP-F001/fix-phase-AD-pm-boundary-violation/4>
+  a triage:Occurrence ;
+  triage:file "crates/atm-storage-rusqlite/src/lib.rs" ;
+  triage:line 205 ;
+  triage:snippet "fn parse_optional_timestamp(raw: Option<String>, field_name: &str) -> Result<Option<IsoTimestamp>, AtmError>" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:branch "fix/phase-AD-pm-boundary-violation" ;
+  triage:headSha "ef873180" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> .
+
+<urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180>
+  a triage:WorktreeSnapshot ;
+  triage:branch "fix/phase-AD-pm-boundary-violation" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/fix/phase-AD-pm-boundary-violation" ;
+  triage:headSha "ef873180" ;
+  triage:orderIndex 999 .

--- a/.triage/phase-AD/findings/RBP-F002.ttl
+++ b/.triage/phase-AD/findings/RBP-F002.ttl
@@ -1,0 +1,57 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/RBP-F002>
+  a triage:Finding ;
+  triage:findingId "RBP-F002" ;
+  triage:title "MessageKey, TaskState, and AckTransition duplicate identical non-blank validation boilerplate" ;
+  triage:description "RUSQLITE-COUPLING-FIX-1-QA confirmed the code fix at ef873180 but found the branch-local triage record missing. The actual change extracted the repeated trim/is_empty validation into one shared require_non_blank helper in crates/atm-storage/src/contract.rs and repointed MessageKey::new, TaskState::new, and AckTransition::new to that helper without changing their emitted subject text or recovery guidance." ;
+  triage:phaseId "phase-AD" ;
+  triage:triageMode "followup_pass" ;
+  triage:category "RBP" ;
+  triage:severity "minor" ;
+  triage:repeatable true ;
+  triage:sweepScope "file_only" ;
+  triage:status "closed" ;
+  triage:dispatchReady false ;
+  triage:closedAt "2026-07-11T02:39:00Z"^^xsd:dateTime ;
+  triage:resolutionNote "Resolved on fix/phase-AD-pm-boundary-violation @ ef873180 by introducing require_non_blank in crates/atm-storage/src/contract.rs and making MessageKey::new, TaskState::new, and AckTransition::new delegate to that helper while preserving the existing validation subjects and recovery strings." ;
+  triage:triagedAt "2026-07-11T02:39:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBP-F002/fix-phase-AD-pm-boundary-violation/1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBP-F002/fix-phase-AD-pm-boundary-violation/2> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBP-F002/fix-phase-AD-pm-boundary-violation/3> ;
+  triage:openOn <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> ;
+  triage:promoteTo <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> .
+
+<urn:atm:triage:occurrence/RBP-F002/fix-phase-AD-pm-boundary-violation/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-storage/src/contract.rs" ;
+  triage:line 19 ;
+  triage:snippet "pub fn new(value: impl Into<String>) -> Result<Self, AtmError>" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:branch "fix/phase-AD-pm-boundary-violation" ;
+  triage:headSha "ef873180" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> .
+
+<urn:atm:triage:occurrence/RBP-F002/fix-phase-AD-pm-boundary-violation/2>
+  a triage:Occurrence ;
+  triage:file "crates/atm-storage/src/contract.rs" ;
+  triage:line 85 ;
+  triage:snippet "pub fn new(value: impl Into<String>) -> Result<Self, AtmError>" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:branch "fix/phase-AD-pm-boundary-violation" ;
+  triage:headSha "ef873180" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> .
+
+<urn:atm:triage:occurrence/RBP-F002/fix-phase-AD-pm-boundary-violation/3>
+  a triage:Occurrence ;
+  triage:file "crates/atm-storage/src/contract.rs" ;
+  triage:line 137 ;
+  triage:snippet "pub fn new(value: impl Into<String>) -> Result<Self, AtmError>" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:branch "fix/phase-AD-pm-boundary-violation" ;
+  triage:headSha "ef873180" ;
+  triage:occursIn <urn:atm:triage:worktree/fix-phase-AD-pm-boundary-violation/ef873180> .

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -206,7 +206,7 @@ impl SqliteMessageStore {
         raw: Option<String>,
         field_name: &str,
     ) -> Result<Option<IsoTimestamp>, AtmError> {
-        raw.map(|value| value.parse::<chrono::DateTime<chrono::Utc>>())
+        raw.map(|value| value.parse::<IsoTimestamp>())
             .transpose()
             .map_err(|error| {
                 AtmError::validation(format!(
@@ -217,7 +217,6 @@ impl SqliteMessageStore {
                 )
                 .with_source(error)
             })
-            .map(|value| value.map(IsoTimestamp::from_datetime))
     }
 
     fn load_message_state_row(

--- a/crates/atm-storage-rusqlite/src/mailbox_metadata.rs
+++ b/crates/atm-storage-rusqlite/src/mailbox_metadata.rs
@@ -33,7 +33,7 @@ fn parse_optional_timestamp(
     raw: Option<String>,
     field_name: &str,
 ) -> Result<Option<IsoTimestamp>, AtmError> {
-    raw.map(|value| value.parse::<chrono::DateTime<chrono::Utc>>())
+    raw.map(|value| value.parse::<IsoTimestamp>())
         .transpose()
         .map_err(|error| {
             AtmError::validation(format!(
@@ -44,7 +44,6 @@ fn parse_optional_timestamp(
             )
             .with_source(error)
         })
-        .map(|value| value.map(IsoTimestamp::from_datetime))
 }
 
 #[allow(dead_code, reason = "used by upcoming SQL server backend")]
@@ -152,16 +151,15 @@ fn parse_from_agent(value: &str, message_key: &str) -> Result<AgentName, AtmErro
 
 #[allow(dead_code, reason = "used by upcoming SQL server backend")]
 fn parse_message_at(value: &str) -> Result<IsoTimestamp, AtmError> {
-    value.parse::<chrono::DateTime<chrono::Utc>>()
-        .map(IsoTimestamp::from_datetime)
-        .map_err(|error| {
-            AtmError::validation(format!(
-                "failed to parse sqlite mailbox metadata timestamp: {error}"
-            ))
-            .with_recovery(
-                "Repair or remove the malformed sqlite mailbox timestamp row before retrying the metadata query.",
-            )
-        })
+    value.parse::<IsoTimestamp>().map_err(|error| {
+        AtmError::validation(format!(
+            "failed to parse sqlite mailbox metadata timestamp: {error}"
+        ))
+        .with_recovery(
+            "Repair or remove the malformed sqlite mailbox timestamp row before retrying the metadata query.",
+        )
+        .with_source(error)
+    })
 }
 
 #[allow(dead_code, reason = "used by upcoming SQL server backend")]

--- a/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
+++ b/crates/atm-storage-rusqlite/src/nudge_template_override_store.rs
@@ -155,16 +155,15 @@ impl NudgeTemplateOverrideStore for SqliteNudgeTemplateOverrideStore {
 }
 
 fn parse_updated_at(raw: String) -> Result<IsoTimestamp, AtmError> {
-    raw.parse::<chrono::DateTime<chrono::Utc>>()
-        .map(IsoTimestamp::from_datetime)
-        .map_err(|error| {
-            AtmError::validation(format!(
-                "failed to parse team_nudge_template_overrides.updated_at `{raw}`: {error}"
-            ))
-            .with_recovery(
-                "Repair the malformed team_nudge_template_overrides.updated_at row before retrying the override lookup.",
-            )
-        })
+    raw.parse::<IsoTimestamp>().map_err(|error| {
+        AtmError::validation(format!(
+            "failed to parse team_nudge_template_overrides.updated_at `{raw}`: {error}"
+        ))
+        .with_recovery(
+            "Repair the malformed team_nudge_template_overrides.updated_at row before retrying the override lookup.",
+        )
+        .with_source(error)
+    })
 }
 
 fn normalize_loaded_override_mode(

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -13,21 +13,31 @@ pub mod sealed {
     pub trait Sealed {}
 }
 
+fn require_non_blank(
+    value: String,
+    subject: &str,
+    recovery: &'static str,
+) -> Result<String, AtmError> {
+    if value.trim().is_empty() {
+        return Err(
+            AtmError::validation(format!("{subject} must not be blank")).with_recovery(recovery)
+        );
+    }
+    Ok(value)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(transparent)]
 pub struct MessageKey(String);
 
 impl MessageKey {
     pub fn new(value: impl Into<String>) -> Result<Self, AtmError> {
-        let value = value.into();
-        if value.trim().is_empty() {
-            return Err(
-                AtmError::validation("message key must not be blank").with_recovery(
-                    "Populate a stable ATM message key before calling the storage contract.",
-                ),
-            );
-        }
-        Ok(Self(value))
+        require_non_blank(
+            value.into(),
+            "message key",
+            "Populate a stable ATM message key before calling the storage contract.",
+        )
+        .map(Self)
     }
 
     pub fn into_inner(self) -> String {
@@ -84,15 +94,12 @@ pub struct TaskState(String);
 
 impl TaskState {
     pub fn new(value: impl Into<String>) -> Result<Self, AtmError> {
-        let value = value.into();
-        if value.trim().is_empty() {
-            return Err(
-                AtmError::validation("task state must not be blank").with_recovery(
-                    "Populate a non-empty task state before calling the storage contract.",
-                ),
-            );
-        }
-        Ok(Self(value))
+        require_non_blank(
+            value.into(),
+            "task state",
+            "Populate a non-empty task state before calling the storage contract.",
+        )
+        .map(Self)
     }
 }
 
@@ -136,15 +143,12 @@ pub struct AckTransition(String);
 
 impl AckTransition {
     pub fn new(value: impl Into<String>) -> Result<Self, AtmError> {
-        let value = value.into();
-        if value.trim().is_empty() {
-            return Err(
-                AtmError::validation("ack transition must not be blank").with_recovery(
-                    "Populate a non-empty ack transition before calling the storage contract.",
-                ),
-            );
-        }
-        Ok(Self(value))
+        require_non_blank(
+            value.into(),
+            "ack transition",
+            "Populate a non-empty ack transition before calling the storage contract.",
+        )
+        .map(Self)
     }
 }
 

--- a/crates/atm-storage/src/types.rs
+++ b/crates/atm-storage/src/types.rs
@@ -26,6 +26,14 @@ impl IsoTimestamp {
     }
 }
 
+impl FromStr for IsoTimestamp {
+    type Err = chrono::ParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        value.parse::<DateTime<Utc>>().map(Self::from_datetime)
+    }
+}
+
 impl From<DateTime<Utc>> for IsoTimestamp {
     fn from(datetime: DateTime<Utc>) -> Self {
         Self(datetime)
@@ -251,7 +259,7 @@ impl fmt::Display for TeamName {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentId, AgentName};
+    use super::{AgentId, AgentName, IsoTimestamp};
 
     #[test]
     fn agent_id_new_matches_agent_name_validation_for_valid_value() {
@@ -281,6 +289,13 @@ mod tests {
 
         let error = serde_json::from_str::<AgentId>("\"bad/name\"").expect_err("invalid id");
         assert!(error.to_string().contains("path separators"));
+    }
+
+    #[test]
+    fn iso_timestamp_from_str_round_trips_rfc3339_input() {
+        let timestamp: IsoTimestamp = "2026-07-11T01:20:17Z".parse().expect("timestamp");
+
+        assert_eq!(timestamp.to_string(), "2026-07-11T01:20:17+00:00");
     }
 }
 


### PR DESCRIPTION
## Summary
- RBP-F001: consolidates hand-rolled ISO-timestamp parsing across atm-storage-rusqlite into a single `IsoTimestamp` constructor
- RBP-F002: extracts shared blank-value validation helper for MessageKey::new / TaskState::new / AckTransition::new

## Context
RUSQLITE-COUPLING-IMPL-QA-1 merge-gate RBP findings, dispatched as RUSQLITE-COUPLING-FIX-1. PR #510 (this branch's original scope) was already merged before this commit was pushed, so this is a follow-up PR to land it in integrate/phase-AD.

## Test plan
- [ ] quality-mgr QA verdict pending
- [ ] CI green