### PR TITLE
chore: bump version 1.2.3 -> 1.3.0

### DIFF
--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.2.3
+PackageVersion: 1.3.0
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.2.3/atm_1.2.3_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.3.0/atm_1.3.0_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.2.3
+ManifestVersion: 1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 ## Unreleased
 
+## 1.3.0
+
 - complete the `AD.13` through `AD.30` corrective line by tightening caller
   identity ownership, restoring direct post-send emission, and deleting
   retired daemon-side Claude/reconcile paths
 - restore Windows daemon CI depth coverage for same-host local IPC shutdown,
   injected accept-failure, and post-terminate rejection without accepting
   flaky or hang-prone test behavior
+- converge the Phase AD messaging protocol: mailbox peek surface, owner-only
+  mutation reset, self-addressed send rejection, self-ack loop termination,
+  and historical poison cleanup
+- close out the rusqlite storage/core coupling remediation and the
+  daemon-bootstrap boundary drift plan
 
 ## 1.2.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "atm-runtime-test-support",
  "atm-storage",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "cargo_metadata",
  "serde",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "agent-team-mail-core",
  "arc-swap",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-client",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "serde",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "atm-storage",
  "chrono",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "atm-storage",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.3"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -20,7 +20,7 @@ name = "atm_core"
 test-utils = []
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.2.3" }
+atm-storage = { path = "../atm-storage", version = "1.3.0" }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -10,5 +10,5 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
-atm-runtime = { path = "../atm-runtime", version = "1.2.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0" }
+atm-runtime = { path = "../atm-runtime", version = "1.3.0" }

--- a/crates/atm-daemon-client/Cargo.toml
+++ b/crates/atm-daemon-client/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
-atm-storage = { path = "../atm-storage", version = "1.2.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0" }
+atm-storage = { path = "../atm-storage", version = "1.3.0" }
 bytes = "1"
 fs2 = "0.4"
 interprocess = "2.4.2"
@@ -20,5 +20,5 @@ serde_json = { workspace = true }
 tracing = "0.1"
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0" }
 tempfile = "3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -10,9 +10,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
-atm-runtime = { path = "../atm-runtime", version = "1.2.3" }
-atm-storage = { path = "../atm-storage", version = "1.2.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0" }
+atm-runtime = { path = "../atm-runtime", version = "1.3.0" }
+atm-storage = { path = "../atm-storage", version = "1.3.0" }
 arc-swap.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 fs2 = "0.4"
@@ -29,8 +29,8 @@ signal-hook = "0.3"
 signal-hook = "0.3"
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3", features = ["test-utils"] }
-atm-runtime = { path = "../atm-runtime", version = "1.2.3", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0", features = ["test-utils"] }
+atm-runtime = { path = "../atm-runtime", version = "1.3.0", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"

--- a/crates/atm-graft/Cargo.toml
+++ b/crates/atm-graft/Cargo.toml
@@ -10,13 +10,13 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.3.0" }
 interprocess = "2.4.2"
 serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0", features = ["test-utils"] }
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-runtime-test-support/Cargo.toml
+++ b/crates/atm-runtime-test-support/Cargo.toml
@@ -14,6 +14,6 @@ publish = false
 name = "atm_runtime_test_support"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3", features = ["test-utils"] }
-atm-runtime = { path = "../atm-runtime", version = "1.2.3" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.2.3", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0", features = ["test-utils"] }
+atm-runtime = { path = "../atm-runtime", version = "1.3.0" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.3.0", features = ["test-support"] }

--- a/crates/atm-runtime/Cargo.toml
+++ b/crates/atm-runtime/Cargo.toml
@@ -16,7 +16,7 @@ name = "atm_runtime"
 test-utils = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
-atm-storage = { path = "../atm-storage", version = "1.2.3" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.2.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0" }
+atm-storage = { path = "../atm-storage", version = "1.3.0" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.3.0" }
 serde_json.workspace = true

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -16,7 +16,7 @@ name = "atm_storage_rusqlite"
 test-support = []
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.2.3" }
+atm-storage = { path = "../atm-storage", version = "1.3.0" }
 serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm-storage-sqlserver-proof/Cargo.toml
+++ b/crates/atm-storage-sqlserver-proof/Cargo.toml
@@ -14,4 +14,4 @@ publish = false
 name = "atm_storage_sqlserver_proof"
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.2.3" }
+atm-storage = { path = "../atm-storage", version = "1.3.0" }

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -22,10 +22,10 @@ path = "src/main.rs"
 fault-injection = ["sc-observability/fault-injection"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.2.3" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.2.3" }
-atm-runtime = { path = "../atm-runtime", version = "1.2.3" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0" }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.3.0" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.3.0" }
+atm-runtime = { path = "../atm-runtime", version = "1.3.0" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -39,7 +39,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.2.3", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.0", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"


### PR DESCRIPTION
## Summary
- Bump workspace version 1.2.3 -> 1.3.0 in Cargo.toml following the Phase AD merge (PR #462) to develop
- Regenerate Cargo.lock
- Restructure CHANGELOG.md: move accumulated Unreleased entries into a real 1.3.0 section
- Fix 27 hardcoded intra-workspace path-dependency version pins (`version = "1.2.3"`) across 10 crate manifests that must track the workspace version per `crates/atm/tests/version_alignment.rs`

## Test plan
- [x] `just test` run via background agent: full PASS, `atm_core_dep_version_matches_workspace_version` passes, no regressions
- [x] Working tree clean, single commit