### PR TITLE
chore: restore .atm.toml post_send_hooks and tmux_pane_id

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -7,6 +7,18 @@ recipient = "team-lead"
 [atm.idle_notify.agent.arch-ctm]
 seconds = 60
 
+[[atm.post_send_hooks]]
+recipient = "team-lead"
+command = ["scripts/atm-nudge.sh", "team-lead"]
+
+[[atm.post_send_hooks]]
+recipient = "arch-ctm"
+command = ["scripts/atm-nudge.sh", "arch-ctm"]
+
+[[atm.post_send_hooks]]
+recipient = "quality-mgr"
+command = ["scripts/atm-nudge.sh", "quality-mgr"]
+
 [plugins.atm-agent-mcp]
 codex_bin = "codex"
 identity = "arch-ctm"
@@ -37,17 +49,20 @@ layout = "even-horizontal"
 
 [[rmux.windows.panes]]
 name = "team-lead"
+tmux_pane_id = "%0"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "team-lead", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
 
 [[rmux.windows.panes]]
 name = "arch-ctm"
+tmux_pane_id = "%1"
 command = "codex -c features.hooks=true --yolo"
 env = { ATM_IDENTITY = "arch-ctm", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }
 
 [[rmux.windows.panes]]
 name = "quality-mgr"
+tmux_pane_id = "%2"
 model = "sonnet"
 color = "blue"
 env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "atm-dev", CLAUDE_CODE_TASK_LIST_ID = "atm-dev" }


### PR DESCRIPTION
## Summary
- develop's committed .atm.toml was missing the post_send_hooks (nudge routing for team-lead/arch-ctm/quality-mgr) and the live tmux_pane_id entries that were already active in the working config.
- Restores those entries so develop matches the working ATM config.

## Test plan
- [x] Diffed against the working .atm.toml to confirm exact match, no other drift