### PR TITLE
release: atm-core v1.3.0 — merge-back to main

### DIFF
--- a/release/release-notes.md
+++ b/release/release-notes.md
@@ -1,93 +1,64 @@
 # Release Notes
 
 ## Summary
-- version: 1.2.3
-- release date: 2026-07-02
+- version: 1.3.0
+- release date: 2026-07-11
 - release owner: publisher (ATM release execution)
 
-This recovery release preserves the Phase AA, Phase AC, and release-readiness
-content already assembled for `v1.2.2`, but cuts a new immutable tag after two
-publish-blocking defects were discovered mid-release. `v1.2.2` remains as the
-partial, abandoned attempt; `v1.2.3` is the clean tag+publish line.
+This release lands the Phase AD corrective line on top of the retained 1.2.x
+publish surface. It tightens caller-identity ownership, restores direct
+post-send emission, removes retired daemon-side Claude/reconcile paths, restores
+Windows daemon CI depth coverage, and converges the Phase AD messaging protocol.
+No user-facing CLI behavior change is introduced.
 
 ## Included Changes
-
-### 1.2.3 — Recovery patch release
-- Add the missing `description` metadata to `atm-storage-claude` so crates.io
-  accepts the crate during ordered publish.
-- Replace bash-4-only `mapfile` usage in `release.yml` with bash-3.2-compatible
-  loops so macOS packaging works on GitHub-hosted runners.
-- Preserve the immutable `v1.2.2` tag and recover with a new `release/v1.2.3`
-  branch/tag instead of mutating the failed release attempt.
-
-### 1.2.2 — Phase AC + release readiness
-- Converge the storage layer on the `atm-storage` contract and canonical types,
-  unifying the SQLite backend and the RPC envelope/domain types on a single
-  shared type surface.
-- Close out storage cleanup and deletion handling and prove SQL Server readiness
-  for the storage backend contract.
-- Land the production-readiness boundary fixes so the retained runtime enforces
-  the storage boundary through live factory wiring.
-- Consolidate release readiness (PR #425): `release_gate.sh` branch-regex
-  enforcement, the canonical release validation suite (`validate_release.py`,
-  `verify_release_archive.py`), publisher release-branch discipline, and the
-  publishing-improvements plan docs.
-
-### 1.2.1 — Phase AA
-- Restate the daemon architecture and introduce subsystem doctor traits for
-  health/observability of daemon subsystems.
-- Clean up the mailbox path and remove the SQLite legacy-compatibility surface.
-- Relock and enforce the crate boundaries hardened during Phase AA.
-- Upgrade observability across the daemon subsystems.
-
-### Release-branch reconciliation (this release)
-- Merged `origin/main` into the release branch to retain the v1.2.0
-  publish-surface hotfixes (publish=false version-pin skips in the lint scripts,
-  cargo-deny path/wildcard allowance, dual-binary archive fixes) that had not
-  flowed to `develop`.
-- Removed the `sc-lint-attributes` dependency (and its `sc_lint` attribute call
-  sites) from the published `agent-team-mail-core` crate; `sc-lint` packages are
-  not publishable from this repository. The published surface no longer leaks an
-  internal lint-only crate.
-- Retained develop's full 1.2.2 publishable crate set and canonical storage
-  types.
+- Complete the `AD.13`–`AD.30` corrective line: tighten caller-identity
+  ownership, restore direct post-send emission, and delete retired daemon-side
+  Claude/reconcile paths.
+- Restore Windows daemon CI depth coverage for same-host local IPC shutdown,
+  injected accept-failure, and post-terminate rejection, without accepting
+  flaky or hang-prone test behavior.
+- Converge the Phase AD messaging protocol: mailbox peek surface, owner-only
+  mutation reset, self-addressed send rejection, self-ack loop termination, and
+  historical poison cleanup.
+- Close out the rusqlite storage/core coupling remediation and the
+  daemon-bootstrap boundary drift plan.
+- Retire the `atm-storage-claude` crate along with the daemon-side
+  Claude/reconcile paths; it is removed from the workspace and the crates.io
+  publish surface for 1.3.0 (it was last published at 1.2.3).
 
 ## Operator / User Impact
-- No user-facing CLI behavior change is introduced by the reconciliation itself.
-- Storage/runtime internals were converged onto the `atm-storage` contract
-  (Phase AC); existing on-disk mailbox and message flows are preserved.
-- The SQLite legacy-compatibility surface was removed (Phase AA); installations
-  relying on the retained Claude/SQLite paths continue to work through the
-  supported storage backends.
+- No user-facing CLI behavior change is introduced by this release.
+- Caller identity is now owned explicitly by the invoking shell/overrides;
+  `.atm.toml` is not a caller-identity fallback. Existing on-disk mailbox and
+  message flows are preserved.
+- Retired daemon-side Claude/reconcile paths are removed; supported storage
+  backends and messaging flows continue to work unchanged.
 - Windows installation remains first-class via the `winget` package and the
   Windows release archive — no Rust toolchain required.
 
 ## Packaging / Distribution Notes
-- crates.io: publishes the full retained dependency chain in dependency order —
+- crates.io: publishes the retained dependency chain in dependency order —
   `atm-storage`, `agent-team-mail-core`, `atm-storage-rusqlite`,
-  `atm-storage-claude`, `atm-daemon-client`, `atm-runtime`,
-  `atm-daemon-bootstrap`, `atm-daemon`, `atm-graft`, `agent-team-mail`. Publish
-  is idempotent and ordered so each crate's upstream is live before it ships.
+  `atm-daemon-client`, `atm-runtime`, `atm-daemon-bootstrap`, `atm-daemon`,
+  `atm-graft`, `agent-team-mail` (9 crates). Publish is idempotent and ordered
+  so each crate's upstream is live before it ships. The previously published
+  `atm-storage-claude` crate is retired and is not part of the 1.3.0 chain.
 - GitHub Releases: `atm` + `atm-daemon` archives for
   `x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, and
   `x86_64-pc-windows-msvc`, with checksums.
 - Homebrew: tap `randlee/homebrew-tap`, formulas `agent-team-mail.rb` and
-  `atm.rb` updated to 1.2.3.
-- winget: package `randlee.agent-team-mail` at 1.2.3. Microsoft review normally
+  `atm.rb` updated to 1.3.0.
+- winget: package `randlee.agent-team-mail` at 1.3.0. Microsoft review normally
   delays public `winget install` visibility by 1–2 days; submission success is
   the immediate release signal.
 
 ## Known Issues / Waivers
 - None. No verification waivers are required for this release.
-- Note (non-blocking): a standalone local `cargo publish -p agent-team-mail-core
-  --locked --dry-run` fails to resolve `atm-storage v1.2.3` because that new
-  crate is not yet on crates.io outside the ordered release run. This is an
-  ordering artifact, not a defect — the release workflow publishes `atm-storage`
-  first, and CI preflight runs the full package check only on the leaf crate.
 
 ## Follow-Up
 - After the GitHub Release is created, attach these notes to the release body.
-- After `release/v1.2.3` merges back to `main`, ensure a `main -> develop`
-  reconciliation PR exists so the publish-surface hotfixes and version updates
-  flow back to `develop`.
+- After `release/v1.3.0` merges back to `main`, ensure a `main -> develop`
+  reconciliation PR exists so release-window commits and version updates flow
+  back to `develop`.
 - Confirm `winget` public visibility 1–2 days post-submission.


### PR DESCRIPTION
Carries the v1.3.0 release-window commit back to \`main\`.

## Contents
- \`docs(release): update release notes for 1.3.0\` (5d9421ff) — refreshes \`release/release-notes.md\` for 1.3.0 and corrects the crates.io chain to the retained 9-crate publish surface (\`atm-storage-claude\` retired, last published at 1.2.3).

## Release status (v1.3.0, tag @ 5d9421ff)
- crates.io: all 9 crates published & verified at 1.3.0 ✅
- GitHub Release v1.3.0: live with archives + checksums ✅
- Homebrew (\`randlee/homebrew-tap\`): \`agent-team-mail.rb\` + \`atm.rb\` at 1.3.0 ✅
- winget: submission failed on token permission — tracked in #520 (WINGET_TOKEN provisioning + re-run of \`publish-winget\`)

## Follow-up
- \`main -> develop\` reconciliation PR to be opened later, coordinated with phase-AE branch state (per team-lead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)