### PR TITLE
AE.5: Installed copy packaging

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -18,6 +18,7 @@ permissions:
 
 env:
   RELEASE_ARTIFACT_MANIFEST: release/publish-artifacts.toml
+  STAGED_INSTALL_ROOT: target/phase-ae/staged-install-root
 
 jobs:
   preflight:
@@ -87,6 +88,15 @@ jobs:
           echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
           echo "release_version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Stage installed docs for validation
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "${STAGED_INSTALL_ROOT}"
+          python3 scripts/release_artifacts.py stage-install-docs \
+            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+            --output-root "${STAGED_INSTALL_ROOT}"
+
       - name: Run canonical retained release validation suite
         id: validate
         continue-on-error: true
@@ -95,6 +105,7 @@ jobs:
           set -euo pipefail
           python3 scripts/validate_release.py all \
             --version '${{ steps.meta.outputs.release_version }}' \
+            --staged-install-root "${STAGED_INSTALL_ROOT}" \
             --findings release-findings.json
 
       - name: Upload release findings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   RELEASE_ARTIFACT_MANIFEST: release/publish-artifacts.toml
+  STAGED_INSTALL_ROOT: target/phase-ae/staged-install-root
 
 jobs:
   gate-and-tag:
@@ -282,21 +283,46 @@ jobs:
           bin_args="$(python3 scripts/release_artifacts.py cargo-build-bin-args --manifest "${RELEASE_ARTIFACT_MANIFEST}")"
           cargo build --release --target ${{ matrix.target }} ${bin_args}
 
+      - name: Stage installed release tree (unix)
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "${STAGED_INSTALL_ROOT}"
+          mkdir -p "${STAGED_INSTALL_ROOT}/bin"
+          while IFS= read -r bin; do
+            [[ -n "$bin" ]] || continue
+            cp "target/${{ matrix.target }}/release/${bin}" "${STAGED_INSTALL_ROOT}/bin/${bin}"
+          done < <(python3 scripts/release_artifacts.py list-release-binaries --manifest "${RELEASE_ARTIFACT_MANIFEST}")
+          python3 scripts/release_artifacts.py stage-install-docs \
+            --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
+            --output-root "${STAGED_INSTALL_ROOT}"
+
+      - name: Stage installed release tree (windows)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          if (Test-Path $env:STAGED_INSTALL_ROOT) {
+            Remove-Item -Recurse -Force $env:STAGED_INSTALL_ROOT
+          }
+          New-Item -ItemType Directory -Force -Path "$env:STAGED_INSTALL_ROOT/bin" | Out-Null
+          $bins = python3 scripts/release_artifacts.py list-release-binaries --manifest $env:RELEASE_ARTIFACT_MANIFEST
+          foreach ($bin in $bins) {
+            Copy-Item "target/${{ matrix.target }}/release/$bin.exe" "$env:STAGED_INSTALL_ROOT/bin/$bin.exe"
+          }
+          python3 scripts/release_artifacts.py stage-install-docs `
+            --manifest $env:RELEASE_ARTIFACT_MANIFEST `
+            --output-root $env:STAGED_INSTALL_ROOT
+
       - name: Package (unix)
         if: matrix.archive == 'tar.gz'
         shell: bash
         run: |
           set -euo pipefail
+          export COPYFILE_DISABLE=1
           VERSION='${{ needs.gate-and-tag.outputs.release_version }}'
           ARCHIVE="atm_${VERSION}_${{ matrix.target }}.tar.gz"
-          cd target/${{ matrix.target }}/release
-          bins=()
-          while IFS= read -r bin; do
-            [[ -n "$bin" ]] || continue
-            bins+=("$bin")
-          done < <(python3 ../../../scripts/release_artifacts.py list-release-binaries --manifest ../../../release/publish-artifacts.toml)
-          tar czf "../../../${ARCHIVE}" "${bins[@]}"
-          cd ../../..
+          tar czf "${ARCHIVE}" -C "${STAGED_INSTALL_ROOT}" .
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
       - name: Package (windows)
@@ -305,11 +331,7 @@ jobs:
         run: |
           $VERSION = '${{ needs.gate-and-tag.outputs.release_version }}'
           $ARCHIVE = "atm_${VERSION}_${{ matrix.target }}.zip"
-          $bins = python3 scripts/release_artifacts.py list-release-binaries --manifest release/publish-artifacts.toml
-          $paths = @()
-          foreach ($bin in $bins) {
-            $paths += "target/${{ matrix.target }}/release/$bin.exe"
-          }
+          $paths = Join-Path $env:STAGED_INSTALL_ROOT '*'
           Compress-Archive -Path $paths -DestinationPath $ARCHIVE
           echo "ARCHIVE=$ARCHIVE" | Out-File -FilePath $env:GITHUB_ENV -Append
 

--- a/.just/tests/test_release_artifacts.py
+++ b/.just/tests/test_release_artifacts.py
@@ -24,9 +24,11 @@ class ReleaseArtifactsTests(unittest.TestCase):
         workspace_toml = self.root / "Cargo.toml"
         manifest_toml = self.root / "release" / "publish-artifacts.toml"
         crate_toml = self.root / "crates" / "demo-crate" / "Cargo.toml"
+        docs_readme = self.root / "docs" / "user-documents" / "README.md"
 
         manifest_toml.parent.mkdir(parents=True, exist_ok=True)
         crate_toml.parent.mkdir(parents=True, exist_ok=True)
+        docs_readme.parent.mkdir(parents=True, exist_ok=True)
 
         workspace_toml.write_text(
             textwrap.dedent(
@@ -65,6 +67,11 @@ class ReleaseArtifactsTests(unittest.TestCase):
 
                 [[release_binaries]]
                 name = "atm"
+
+                [installed_docs]
+                source_root = "docs/user-documents"
+                install_root = "share/doc/atm"
+                entrypoint = "share/doc/atm/README.md"
                 """
             ).strip()
             + "\n",
@@ -75,6 +82,7 @@ class ReleaseArtifactsTests(unittest.TestCase):
             textwrap.dedent(crate_package_block).strip() + "\n",
             encoding="utf-8",
         )
+        docs_readme.write_text("# Demo ATM Docs\n", encoding="utf-8")
         return workspace_toml, manifest_toml
 
     def run_validate_manifest(self, *, workspace_toml: Path, manifest_toml: Path) -> subprocess.CompletedProcess[str]:

--- a/.just/tests/test_release_preflight.py
+++ b/.just/tests/test_release_preflight.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-preflight.yml"
+
+
+class ReleasePreflightWorkflowTests(unittest.TestCase):
+    def test_release_preflight_stages_installed_docs_before_validation(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("python3 scripts/release_artifacts.py stage-install-docs", text)
+        self.assertIn("--output-root \"${STAGED_INSTALL_ROOT}\"", text)
+
+    def test_release_preflight_passes_staged_install_root_to_validator(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("python3 scripts/validate_release.py all \\", text)
+        self.assertIn("--staged-install-root \"${STAGED_INSTALL_ROOT}\"", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/release/publish-artifacts.toml
+++ b/release/publish-artifacts.toml
@@ -104,3 +104,8 @@ name = "atm"
 
 [[release_binaries]]
 name = "atm-daemon"
+
+[installed_docs]
+source_root = "docs/user-documents"
+install_root = "share/doc/atm"
+entrypoint = "share/doc/atm/README.md"

--- a/release/release-notes.md
+++ b/release/release-notes.md
@@ -71,6 +71,10 @@ partial, abandoned attempt; `v1.2.3` is the clean tag+publish line.
 - GitHub Releases: `atm` + `atm-daemon` archives for
   `x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, and
   `x86_64-pc-windows-msvc`, with checksums.
+- Installed user documentation ships inside every install/archive at
+  `share/doc/atm/`, with the primary entrypoint at `share/doc/atm/README.md`.
+  The installed binary/doc relationship is fixed as `<install-root>/bin/atm`
+  plus `<install-root>/share/doc/atm/README.md`.
 - Homebrew: tap `randlee/homebrew-tap`, formulas `agent-team-mail.rb` and
   `atm.rb` updated to 1.2.3.
 - winget: package `randlee.agent-team-mail` at 1.2.3. Microsoft review normally

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -13,6 +14,17 @@ from pathlib import Path
 
 PREFLIGHT_FULL = "full"
 PREFLIGHT_LOCKED = "locked"
+
+
+def require_relpath(obj: dict, key: str, label: str) -> Path:
+    value = Path(require_str(obj, key, label))
+    if value.is_absolute():
+        raise SystemExit(f"{label}.{key} must be a relative path")
+    return value
+
+
+def manifest_repo_root(manifest_path: Path) -> Path:
+    return manifest_path.resolve().parent.parent
 
 
 def load_manifest(path: Path) -> dict:
@@ -68,8 +80,27 @@ def load_manifest(path: Path) -> dict:
             raise SystemExit(f"duplicate release binary {name}")
         seen_bins.add(name)
 
+    installed_docs = data.get("installed_docs")
+    if not isinstance(installed_docs, dict):
+        raise SystemExit("manifest must define [installed_docs]")
+    source_root = require_relpath(installed_docs, "source_root", "installed_docs")
+    install_root = require_relpath(installed_docs, "install_root", "installed_docs")
+    entrypoint = require_relpath(installed_docs, "entrypoint", "installed_docs")
+    try:
+        entrypoint.relative_to(install_root)
+    except ValueError as exc:
+        raise SystemExit("installed_docs.entrypoint must live under installed_docs.install_root") from exc
+
     crates.sort(key=lambda item: (item["publish_order"], item["artifact"]))
-    return {"crates": crates, "release_binaries": binaries}
+    return {
+        "crates": crates,
+        "release_binaries": binaries,
+        "installed_docs": {
+            "source_root": source_root,
+            "install_root": install_root,
+            "entrypoint": entrypoint,
+        },
+    }
 
 
 def require_str(obj: dict, key: str, label: str) -> str:
@@ -156,6 +187,49 @@ def list_publish_plan(args: argparse.Namespace) -> int:
 def list_release_binaries(args: argparse.Namespace) -> int:
     for entry in load_manifest(Path(args.manifest))["release_binaries"]:
         print(entry["name"])
+    return 0
+
+
+def installed_doc_source_files(manifest_path: Path) -> list[Path]:
+    manifest = load_manifest(manifest_path)
+    repo_root = manifest_repo_root(manifest_path)
+    source_root = repo_root / manifest["installed_docs"]["source_root"]
+    if not source_root.is_dir():
+        raise SystemExit(f"installed docs source root does not exist: {source_root}")
+    return sorted(path for path in source_root.rglob("*") if path.is_file())
+
+
+def installed_doc_members(manifest_path: Path) -> list[Path]:
+    manifest = load_manifest(manifest_path)
+    repo_root = manifest_repo_root(manifest_path)
+    source_root = repo_root / manifest["installed_docs"]["source_root"]
+    install_root = manifest["installed_docs"]["install_root"]
+    members: list[Path] = []
+    for path in installed_doc_source_files(manifest_path):
+        members.append(install_root / path.relative_to(source_root))
+    return members
+
+
+def list_installed_doc_members(args: argparse.Namespace) -> int:
+    for member in installed_doc_members(Path(args.manifest)):
+        print(member.as_posix())
+    return 0
+
+
+def stage_install_docs(args: argparse.Namespace) -> int:
+    manifest_path = Path(args.manifest)
+    manifest = load_manifest(manifest_path)
+    repo_root = manifest_repo_root(manifest_path)
+    source_root = repo_root / manifest["installed_docs"]["source_root"]
+    install_root = Path(args.output_root) / manifest["installed_docs"]["install_root"]
+    if install_root.exists():
+        shutil.rmtree(install_root)
+    install_root.mkdir(parents=True, exist_ok=True)
+    for source_path in installed_doc_source_files(manifest_path):
+        destination = install_root / source_path.relative_to(source_root)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, destination)
+    print(install_root)
     return 0
 
 
@@ -459,6 +533,15 @@ def build_parser() -> argparse.ArgumentParser:
     list_bins.add_argument("--manifest", required=True)
     list_bins.set_defaults(func=list_release_binaries)
 
+    list_docs = subparsers.add_parser("list-installed-doc-members")
+    list_docs.add_argument("--manifest", required=True)
+    list_docs.set_defaults(func=list_installed_doc_members)
+
+    stage_docs = subparsers.add_parser("stage-install-docs")
+    stage_docs.add_argument("--manifest", required=True)
+    stage_docs.add_argument("--output-root", required=True)
+    stage_docs.set_defaults(func=stage_install_docs)
+
     validate_bins = subparsers.add_parser("validate-release-binaries")
     validate_bins.add_argument("--manifest", required=True)
     validate_bins.add_argument("--required", action="append", default=[])
@@ -475,17 +558,17 @@ def build_parser() -> argparse.ArgumentParser:
 
     validate_m = subparsers.add_parser("validate-manifest")
     validate_m.add_argument("--manifest", required=True)
-    validate_m.add_argument("--workspace-toml", required=True)
+    validate_m.add_argument("--workspace-toml", default="Cargo.toml")
     validate_m.set_defaults(func=validate_manifest)
 
     validate_p = subparsers.add_parser("validate-preflight-checks")
     validate_p.add_argument("--manifest", required=True)
-    validate_p.add_argument("--workspace-toml", required=True)
+    validate_p.add_argument("--workspace-toml", default="Cargo.toml")
     validate_p.set_defaults(func=validate_preflight_checks)
 
     validate_o = subparsers.add_parser("validate-publish-order")
     validate_o.add_argument("--manifest", required=True)
-    validate_o.add_argument("--workspace-toml", required=True)
+    validate_o.add_argument("--workspace-toml", default="Cargo.toml")
     validate_o.set_defaults(func=validate_publish_order)
 
     return parser

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -16,6 +16,9 @@ from datetime import datetime
 from datetime import timezone
 from pathlib import Path
 
+from release_artifacts import installed_doc_members
+from release_artifacts import load_manifest
+
 
 REQUIRED_RELEASE_FILES = (
     "release/publish-artifacts.toml",
@@ -147,7 +150,41 @@ def validate_lint(root: Path, findings: list[Finding]) -> None:
     )
 
 
-def validate_manifest(root: Path, findings: list[Finding]) -> None:
+def validate_staged_install_docs(
+    root: Path,
+    findings: list[Finding],
+    *,
+    manifest_path: Path,
+    staged_install_root: Path | None,
+) -> None:
+    if staged_install_root is None:
+        return
+
+    manifest = load_manifest(manifest_path)
+    entrypoint = staged_install_root / manifest["installed_docs"]["entrypoint"]
+    if not entrypoint.is_file():
+        findings.append(
+            Finding(
+                check="installed-docs-entrypoint",
+                severity="error",
+                summary="installed docs entrypoint is missing from the staged install root",
+                detail=str(entrypoint.relative_to(root)),
+            )
+        )
+
+    missing = [member for member in installed_doc_members(manifest_path) if not (staged_install_root / member).is_file()]
+    if missing:
+        findings.append(
+            Finding(
+                check="installed-docs-membership",
+                severity="error",
+                summary="staged install root is missing installed doc members",
+                detail=", ".join(member.as_posix() for member in missing),
+            )
+        )
+
+
+def validate_manifest(root: Path, findings: list[Finding], *, staged_install_root: Path | None) -> None:
     commands = (
         (
             "manifest-coverage",
@@ -192,6 +229,12 @@ def validate_manifest(root: Path, findings: list[Finding]) -> None:
     for check, cmd, summary in commands:
         completed = run_capture(cmd, cwd=root)
         append_completed_findings(findings, check, completed, f"{check} passed", summary)
+    validate_staged_install_docs(
+        root,
+        findings,
+        manifest_path=root / "release" / "publish-artifacts.toml",
+        staged_install_root=staged_install_root,
+    )
 
 
 def validate_release_binaries(root: Path, findings: list[Finding]) -> None:
@@ -759,6 +802,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--version", help="Release version to validate; defaults to workspace.package.version")
     parser.add_argument("--findings", default="release-findings.json", help="Path to findings JSON output")
+    parser.add_argument(
+        "--staged-install-root",
+        help="Optional deterministic staged install root to validate installed docs against",
+    )
     return parser
 
 
@@ -767,6 +814,7 @@ def main(argv: list[str] | None = None) -> int:
     root = repo_root()
     explicit_version = args.version is not None
     version = args.version or workspace_version(root)
+    staged_install_root = Path(args.staged_install_root).resolve() if args.staged_install_root else None
     if version != workspace_version(root):
         raise SystemExit(
             f"release version mismatch: expected workspace version {workspace_version(root)}, got {version}"
@@ -776,7 +824,7 @@ def main(argv: list[str] | None = None) -> int:
     actions = {
         "support-files": lambda: validate_support_files(root, findings),
         "lint": lambda: validate_lint(root, findings),
-        "manifest": lambda: validate_manifest(root, findings),
+        "manifest": lambda: validate_manifest(root, findings, staged_install_root=staged_install_root),
         "publish-surface": lambda: validate_publish_surface(
             root,
             version,

--- a/scripts/verify_release_archive.py
+++ b/scripts/verify_release_archive.py
@@ -6,23 +6,29 @@ import tarfile
 import zipfile
 from pathlib import Path
 
+from release_artifacts import installed_doc_members
+from release_artifacts import load_manifest
+
 
 def expected_members(manifest_path: Path, windows: bool) -> set[str]:
-    import tomllib
+    manifest = load_manifest(manifest_path)
+    names = {entry["name"] for entry in manifest["release_binaries"]}
+    binary_members = {f"bin/{name}.exe" if windows else f"bin/{name}" for name in names}
+    doc_members = {member.as_posix() for member in installed_doc_members(manifest_path)}
+    return binary_members | doc_members
 
-    data = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
-    binaries = data.get("release_binaries", [])
-    names = {entry["name"] for entry in binaries}
-    return {f"{name}.exe" if windows else name for name in names}
+
+def normalize_member(name: str) -> str:
+    return name.removeprefix("./").strip("/")
 
 
 def archive_members(archive_path: Path) -> set[str]:
     if archive_path.suffix == ".zip":
         with zipfile.ZipFile(archive_path) as archive:
-            return {Path(name).name for name in archive.namelist() if not name.endswith("/")}
+            return {normalize_member(name) for name in archive.namelist() if not name.endswith("/")}
     if archive_path.suffixes[-2:] == [".tar", ".gz"]:
         with tarfile.open(archive_path, "r:gz") as archive:
-            return {Path(member.name).name for member in archive.getmembers() if member.isfile()}
+            return {normalize_member(member.name) for member in archive.getmembers() if member.isfile()}
     raise SystemExit(f"unsupported archive type: {archive_path}")
 
 


### PR DESCRIPTION
Sprint AE.5 — release/archive assembly ships docs/user-documents/ under share/doc/atm/, installed doc entrypoint README.md, deterministic staged-install-root path.

Sprint doc: docs/plans/phase-AE/sprint-AE5.md
Commit: eeb76e0d