### PR TITLE
AE.6: Help surfacing

### DIFF
--- a/crates/atm/src/commands/help.rs
+++ b/crates/atm/src/commands/help.rs
@@ -169,7 +169,10 @@ Commands:
         let readme = resolved_readme_string(executable_path);
         let topic_doc = resolved_topic_doc_string(executable_path, topic);
         let body = if let Some(topic_doc) = topic_doc.as_deref() {
-            format!("{}\nLong-form docs: {topic_doc}\nInstalled docs index: {readme}\n", topic.body())
+            format!(
+                "{}\nLong-form docs: {topic_doc}\nInstalled docs index: {readme}\n",
+                topic.body()
+            )
         } else {
             format!(
                 "{}\nInstalled docs index: {readme} (topic-specific docs resolve only from an installed atm binary)\n",
@@ -315,7 +318,7 @@ fn doc_link_for_topic(topic: HelpTopic) -> Option<HelpDocLink> {
         HelpTopic::Errors => "troubleshooting.md",
         HelpTopic::Hooks => "hooks.md",
         HelpTopic::Identity => "identity-and-team.md",
-        HelpTopic::Skills => "README.md",
+        HelpTopic::Skills => return None,
     };
     Some(HelpDocLink {
         topic,
@@ -484,8 +487,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        canonical_installed_doc_root, fallback_doc_readme_hint, HelpCommand, HelpResultKind,
-        HelpTopic, HelpTopicTier,
+        HelpCommand, HelpResultKind, HelpTopic, HelpTopicTier, canonical_installed_doc_root,
+        fallback_doc_readme_hint,
     };
 
     fn write_installed_tree(root: &Path) {
@@ -493,9 +496,17 @@ mod tests {
         fs::create_dir_all(root.join("share/doc/atm")).expect("doc root");
         fs::write(root.join("share/doc/atm/README.md"), "# ATM\n").expect("readme");
         fs::write(root.join("share/doc/atm/hooks.md"), "# Hooks\n").expect("hooks");
-        fs::write(root.join("share/doc/atm/identity-and-team.md"), "# Identity\n").expect("identity");
+        fs::write(
+            root.join("share/doc/atm/identity-and-team.md"),
+            "# Identity\n",
+        )
+        .expect("identity");
         fs::write(root.join("share/doc/atm/install-layout.md"), "# Install\n").expect("install");
-        fs::write(root.join("share/doc/atm/troubleshooting.md"), "# Troubleshooting\n").expect("troubleshooting");
+        fs::write(
+            root.join("share/doc/atm/troubleshooting.md"),
+            "# Troubleshooting\n",
+        )
+        .expect("troubleshooting");
     }
 
     #[cfg(unix)]
@@ -555,6 +566,12 @@ mod tests {
                 .iter()
                 .any(|topic| topic.name == "hooks" && topic.doc_relative_path == Some("hooks.md"))
         );
+        assert!(
+            result
+                .topics
+                .iter()
+                .any(|topic| topic.name == "skills" && topic.doc_relative_path.is_none())
+        );
     }
 
     #[test]
@@ -601,6 +618,21 @@ mod tests {
         assert!(!hooks.body.contains("Y.2 will"));
         assert!(!identity.body.contains("Y.2 will"));
         assert!(!skills.body.contains("Y.2 will"));
+    }
+
+    #[test]
+    fn skills_topic_does_not_claim_installed_long_form_docs() {
+        let result = HelpCommand {
+            target: Some("skills".to_string()),
+            list: false,
+            json: false,
+        }
+        .render()
+        .expect("skills help");
+
+        assert_eq!(result.installed_doc_topic_path, None);
+        assert!(result.body.contains("Installed docs index:"));
+        assert!(!result.body.contains("Long-form docs:"));
     }
 
     #[test]

--- a/crates/atm/src/commands/help.rs
+++ b/crates/atm/src/commands/help.rs
@@ -1,4 +1,5 @@
 use std::io::Cursor;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use atm_core::error::AtmError;
@@ -8,6 +9,12 @@ use super::Cli;
 use crate::observability::CliObservability;
 use crate::output;
 use crate::output_contract::{HelpResult, HelpResultKind, HelpTopicSummary, HelpTopicTier};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HelpDocLink {
+    pub topic: HelpTopic,
+    pub relative_path: &'static str,
+}
 
 #[derive(Debug, Args)]
 /// Show ATM-owned conceptual help or delegated clap subcommand help.
@@ -31,20 +38,25 @@ impl HelpCommand {
     }
 
     fn render(&self) -> Result<HelpResult> {
+        let executable = std::env::current_exe().ok();
+        self.render_for_executable(executable.as_deref())
+    }
+
+    fn render_for_executable(&self, executable_path: Option<&Path>) -> Result<HelpResult> {
         if self.list {
-            return Ok(HelpResult::topic_list());
+            return Ok(HelpResult::topic_list(executable_path));
         }
 
         let Some(target) = self.target.as_deref() else {
-            return Ok(HelpResult::overview());
+            return Ok(HelpResult::overview(executable_path));
         };
 
         if let Some(topic) = HelpTopic::parse(target) {
-            return Ok(HelpResult::concept_topic(topic));
+            return Ok(HelpResult::concept_topic(topic, executable_path));
         }
 
         if let Some(body) = render_subcommand_help(target)? {
-            return Ok(HelpResult::command_help(target, body));
+            return Ok(HelpResult::command_help(target, body, executable_path));
         }
 
         Err(
@@ -55,9 +67,10 @@ impl HelpCommand {
 }
 
 impl HelpResult {
-    fn overview() -> Self {
+    fn overview(executable_path: Option<&Path>) -> Self {
         let commands = top_level_command_names();
         let topics = help_topics();
+        let readme = resolved_readme_string(executable_path);
         Self {
             kind: HelpResultKind::Overview,
             requested_target: None,
@@ -85,31 +98,43 @@ Tier-2 concept topics:
 - identity
 - skills
 
+Installed user docs:
+- {}
+
 Available commands:
 - {}
 ",
+                readme,
                 commands.join("\n- ")
             ),
             commands,
             topics,
+            installed_doc_readme: Some(readme),
+            installed_doc_topic_path: None,
         }
     }
 
-    fn topic_list() -> Self {
+    fn topic_list(executable_path: Option<&Path>) -> Self {
         let commands = top_level_command_names();
         let topics = help_topics();
         let topic_lines = topics
             .iter()
             .map(|topic| {
+                let doc_suffix = topic
+                    .doc_relative_path
+                    .map(|path| format!(" [doc: {path}]"))
+                    .unwrap_or_default();
                 format!(
-                    "- {} ({}): {}",
+                    "- {} ({}): {}{}",
                     topic.name,
                     topic.tier.label(),
-                    topic.summary
+                    topic.summary,
+                    doc_suffix
                 )
             })
             .collect::<Vec<_>>()
             .join("\n");
+        let readme = resolved_readme_string(executable_path);
         Self {
             kind: HelpResultKind::TopicList,
             requested_target: None,
@@ -121,44 +146,65 @@ ATM Help Targets
 Concept topics:
 {}
 
+Installed user docs:
+- {}
+
 Commands:
 - {}
 ",
                 topic_lines,
+                readme,
                 commands.join("\n- ")
             ),
             commands,
             topics,
+            installed_doc_readme: Some(readme),
+            installed_doc_topic_path: None,
         }
     }
 
-    fn concept_topic(topic: HelpTopic) -> Self {
+    fn concept_topic(topic: HelpTopic, executable_path: Option<&Path>) -> Self {
         let commands = top_level_command_names();
         let topics = help_topics();
+        let readme = resolved_readme_string(executable_path);
+        let topic_doc = resolved_topic_doc_string(executable_path, topic);
+        let body = if let Some(topic_doc) = topic_doc.as_deref() {
+            format!("{}\nLong-form docs: {topic_doc}\nInstalled docs index: {readme}\n", topic.body())
+        } else {
+            format!(
+                "{}\nInstalled docs index: {readme} (topic-specific docs resolve only from an installed atm binary)\n",
+                topic.body()
+            )
+        };
         Self {
             kind: HelpResultKind::ConceptTopic,
             requested_target: Some(topic.name().to_string()),
             title: topic.title().to_string(),
-            body: topic.body().to_string(),
+            body,
             commands,
             topics,
+            installed_doc_readme: Some(readme),
+            installed_doc_topic_path: topic_doc,
         }
     }
 
-    fn command_help(target: &str, body: String) -> Self {
+    fn command_help(target: &str, body: String, executable_path: Option<&Path>) -> Self {
+        let readme = resolved_readme_string(executable_path);
         Self {
             kind: HelpResultKind::CommandHelp,
             requested_target: Some(target.to_string()),
             title: format!("ATM command help: {target}"),
-            body,
+            body: format!("{body}\n\nInstalled user docs: {readme}\n"),
             commands: top_level_command_names(),
             topics: help_topics(),
+            installed_doc_readme: Some(readme),
+            installed_doc_topic_path: None,
         }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HelpTopic {
+pub(crate) enum HelpTopic {
     Config,
     Errors,
     Hooks,
@@ -230,6 +276,55 @@ impl HelpTopic {
             Self::Skills => skills_body(),
         }
     }
+}
+
+fn resolved_readme_string(executable_path: Option<&Path>) -> String {
+    executable_path
+        .and_then(canonical_installed_doc_readme)
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| fallback_doc_readme_hint().to_string())
+}
+
+fn resolved_topic_doc_string(executable_path: Option<&Path>, topic: HelpTopic) -> Option<String> {
+    let link = doc_link_for_topic(topic)?;
+    let root = executable_path.and_then(canonical_installed_doc_root)?;
+    Some(root.join(link.relative_path).display().to_string())
+}
+
+fn canonical_installed_doc_root(executable_path: &Path) -> Option<PathBuf> {
+    let canonical = executable_path.canonicalize().ok()?;
+    let bin_dir = canonical.parent()?;
+    if bin_dir.file_name()?.to_str()? != "bin" {
+        return None;
+    }
+    let install_root = bin_dir.parent()?;
+    let doc_root = install_root.join("share").join("doc").join("atm");
+    if !doc_root.join("README.md").is_file() {
+        return None;
+    }
+    Some(doc_root)
+}
+
+fn canonical_installed_doc_readme(executable_path: &Path) -> Option<PathBuf> {
+    canonical_installed_doc_root(executable_path).map(|root| root.join("README.md"))
+}
+
+fn doc_link_for_topic(topic: HelpTopic) -> Option<HelpDocLink> {
+    let relative_path = match topic {
+        HelpTopic::Config => "install-layout.md",
+        HelpTopic::Errors => "troubleshooting.md",
+        HelpTopic::Hooks => "hooks.md",
+        HelpTopic::Identity => "identity-and-team.md",
+        HelpTopic::Skills => "README.md",
+    };
+    Some(HelpDocLink {
+        topic,
+        relative_path,
+    })
+}
+
+fn fallback_doc_readme_hint() -> &'static str {
+    "../share/doc/atm/README.md"
 }
 
 fn config_body() -> &'static str {
@@ -350,6 +445,7 @@ fn help_topics() -> Vec<HelpTopicSummary> {
             name: topic.name(),
             tier: topic.tier(),
             summary: topic.summary(),
+            doc_relative_path: doc_link_for_topic(topic).map(|link| link.relative_path),
         })
         .collect()
 }
@@ -382,7 +478,35 @@ fn render_subcommand_help(target: &str) -> Result<Option<String>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{HelpCommand, HelpResultKind, HelpTopic, HelpTopicTier};
+    use std::fs;
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::{
+        canonical_installed_doc_root, fallback_doc_readme_hint, HelpCommand, HelpResultKind,
+        HelpTopic, HelpTopicTier,
+    };
+
+    fn write_installed_tree(root: &Path) {
+        fs::create_dir_all(root.join("bin")).expect("bin dir");
+        fs::create_dir_all(root.join("share/doc/atm")).expect("doc root");
+        fs::write(root.join("share/doc/atm/README.md"), "# ATM\n").expect("readme");
+        fs::write(root.join("share/doc/atm/hooks.md"), "# Hooks\n").expect("hooks");
+        fs::write(root.join("share/doc/atm/identity-and-team.md"), "# Identity\n").expect("identity");
+        fs::write(root.join("share/doc/atm/install-layout.md"), "# Install\n").expect("install");
+        fs::write(root.join("share/doc/atm/troubleshooting.md"), "# Troubleshooting\n").expect("troubleshooting");
+    }
+
+    #[cfg(unix)]
+    fn symlink_file(src: &Path, dst: &Path) {
+        std::os::unix::fs::symlink(src, dst).expect("symlink");
+    }
+
+    #[cfg(windows)]
+    fn symlink_file(src: &Path, dst: &Path) {
+        std::os::windows::fs::symlink_file(src, dst).expect("symlink");
+    }
 
     #[test]
     fn overview_mentions_runtime_model() {
@@ -424,6 +548,12 @@ mod tests {
                 .topics
                 .iter()
                 .any(|topic| topic.name == "config" && topic.tier == HelpTopicTier::Tier1)
+        );
+        assert!(
+            result
+                .topics
+                .iter()
+                .any(|topic| topic.name == "hooks" && topic.doc_relative_path == Some("hooks.md"))
         );
     }
 
@@ -485,7 +615,77 @@ mod tests {
 
         assert_eq!(result.kind, HelpResultKind::CommandHelp);
         assert!(result.body.starts_with("Send one ATM mailbox message"));
+        assert!(result.body.contains(fallback_doc_readme_hint()));
         assert!(!result.body.is_empty());
+    }
+
+    #[test]
+    fn concept_topic_json_fields_point_at_installed_docs_when_available() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let install_root = tempdir.path().join("atm");
+        write_installed_tree(&install_root);
+        let executable = install_root.join("bin/atm");
+        fs::write(&executable, "atm").expect("atm binary");
+
+        let command = HelpCommand {
+            target: Some("hooks".to_string()),
+            list: false,
+            json: true,
+        };
+        let result = command
+            .render_for_executable(Some(&executable))
+            .expect("hooks help");
+        let canonical_install_root = install_root.canonicalize().expect("canonical install root");
+
+        assert_eq!(
+            result.installed_doc_readme.as_deref(),
+            Some(
+                canonical_install_root
+                    .join("share/doc/atm/README.md")
+                    .to_string_lossy()
+                    .as_ref()
+            )
+        );
+        assert_eq!(
+            result.installed_doc_topic_path.as_deref(),
+            Some(
+                canonical_install_root
+                    .join("share/doc/atm/hooks.md")
+                    .to_string_lossy()
+                    .as_ref()
+            )
+        );
+    }
+
+    #[test]
+    fn installed_doc_root_resolves_symlinked_executable() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let install_root = tempdir.path().join("versions/1.3.0");
+        write_installed_tree(&install_root);
+        let real_executable = install_root.join("bin/atm");
+        fs::write(&real_executable, "atm").expect("atm binary");
+
+        let shim_dir = tempdir.path().join("shims");
+        fs::create_dir_all(&shim_dir).expect("shim dir");
+        let shim = shim_dir.join("atm");
+        symlink_file(&real_executable, &shim);
+
+        let resolved = canonical_installed_doc_root(&shim).expect("installed doc root");
+        let expected = install_root
+            .canonicalize()
+            .expect("canonical install root")
+            .join("share/doc/atm");
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn installed_doc_root_returns_none_for_dev_build_layout() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let executable = tempdir.path().join("target/debug/atm");
+        fs::create_dir_all(executable.parent().expect("parent")).expect("debug dir");
+        fs::write(&executable, "atm").expect("atm binary");
+
+        assert_eq!(canonical_installed_doc_root(&executable), None);
     }
 
     #[test]

--- a/crates/atm/src/output_contract.rs
+++ b/crates/atm/src/output_contract.rs
@@ -30,6 +30,7 @@ pub(crate) struct HelpTopicSummary {
     pub(crate) name: &'static str,
     pub(crate) tier: HelpTopicTier,
     pub(crate) summary: &'static str,
+    pub(crate) doc_relative_path: Option<&'static str>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -40,4 +41,6 @@ pub(crate) struct HelpResult {
     pub(crate) body: String,
     pub(crate) commands: Vec<String>,
     pub(crate) topics: Vec<HelpTopicSummary>,
+    pub(crate) installed_doc_readme: Option<String>,
+    pub(crate) installed_doc_topic_path: Option<String>,
 }

--- a/docs/adr/ADR-025-installed-user-documentation-surface.md
+++ b/docs/adr/ADR-025-installed-user-documentation-surface.md
@@ -46,6 +46,10 @@ The accepted architecture is:
   dev build under `target/debug`), the installed-doc resolver returns no path
   and the help surface falls back to a deterministic README hint instead of
   consulting `ATM_HOME`
+- the help JSON surface publishes the same resolver output explicitly:
+  `installed_doc_readme` for every help result and
+  `installed_doc_topic_path` for concept topics that map to a long-form
+  installed document
 - runtime state under `~/.atm/` remains a distinct runtime/data tree and is
   not the installed doc root
 - `ATM_HOME` remains the runtime/data root and is not an installed-doc locator

--- a/docs/atm/commands/help.md
+++ b/docs/atm/commands/help.md
@@ -23,6 +23,12 @@ Concept/help policy:
   trying to inline the full manuals
 - installed-doc lookup is derived from the resolved installed `atm` binary
   location as `../share/doc/atm/`; it must not use `ATM_HOME`
+- `ATM_HOME` remains runtime-only and is not an installed-doc locator
+- the resolver canonicalizes the executable path first, so symlinked installs
+  still land on the real `<install-root>/share/doc/atm/` tree
+- when help runs from a dev-build layout such as `target/debug/atm`, the
+  resolver returns no installed-doc root and help falls back to the
+  deterministic executable-relative README hint `../share/doc/atm/README.md`
 - the conceptual `identity` topic must reinforce the accepted Phase AD rule:
   `atm peek` / `atm list` are inspection-only surfaces, while mutating
   commands resolve only the actual caller and do not expose impersonation
@@ -49,9 +55,10 @@ Output contract:
 
 - human output distinguishes command-help vs concept-topic results clearly
 - human topic output points to installed long-form docs when available
-- JSON output identifies the target and result kind and includes the rendered
-  help body
-- JSON topic output carries the same installed-doc pointer information
+- JSON output identifies the target and result kind, includes the rendered
+  help body, and carries `installed_doc_readme`
+- JSON concept-topic output also carries `installed_doc_topic_path` when the
+  topic has a long-form installed document
 
 JSON contract notes:
 

--- a/docs/plans/phase-AE/sprint-AE6.md
+++ b/docs/plans/phase-AE/sprint-AE6.md
@@ -83,8 +83,8 @@ Accepted lookup rule:
 
 ## Required Validation
 
-- `cargo test -p atm commands::help::tests::installed_doc_root_resolves_symlinked_executable -- --nocapture`
-- `cargo test -p atm commands::help::tests::installed_doc_root_returns_none_for_dev_build_layout -- --nocapture`
+- `cargo test -p agent-team-mail commands::help::tests::installed_doc_root_resolves_symlinked_executable -- --nocapture`
+- `cargo test -p agent-team-mail commands::help::tests::installed_doc_root_returns_none_for_dev_build_layout -- --nocapture`
 - `python3 -c "from pathlib import Path; help_rs = Path('crates/atm/src/commands/help.rs').read_text(); help_md = Path('docs/atm/commands/help.md').read_text(); assert 'current_exe' in help_rs; assert 'share/doc/atm' in help_rs; assert '../share/doc/atm/README.md' in help_rs; assert 'ATM_HOME' not in help_rs; assert 'ATM_HOME' in help_md and 'runtime-only' in help_md"`
 - `rg -n "canonicaliz|symlink|ATM_HOME|share/doc/atm" docs/adr/ADR-025-installed-user-documentation-surface.md`
 - `git diff --check`


### PR DESCRIPTION
Sprint AE.6 — atm help points to installed long-form corpus via canonicalized executable-relative doc resolution.

Sprint doc: docs/plans/phase-AE/sprint-AE6.md
Commit: e428a154