### PR TITLE
AE.9: Phase-end installed-docs proof

### DIFF
--- a/.just/tests/test_release_preflight.py
+++ b/.just/tests/test_release_preflight.py
@@ -18,7 +18,7 @@ class ReleasePreflightWorkflowTests(unittest.TestCase):
     def test_release_preflight_passes_staged_install_root_to_validator(self) -> None:
         text = WORKFLOW.read_text(encoding="utf-8")
 
-        self.assertIn("python3 scripts/validate_release.py validate \\", text)
+        self.assertIn("python3 scripts/validate_release.py all \\", text)
         self.assertIn("--staged-install-root \"${STAGED_INSTALL_ROOT}\"", text)
 
 

--- a/.just/tests/test_validate_release.py
+++ b/.just/tests/test_validate_release.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+SPEC = importlib.util.spec_from_file_location(
+    "validate_release_module",
+    SCRIPTS_DIR / "validate_release.py",
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+VALIDATE_RELEASE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = VALIDATE_RELEASE
+SPEC.loader.exec_module(VALIDATE_RELEASE)
+
+
+class ValidateReleaseProofTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        (self.root / "release").mkdir(parents=True, exist_ok=True)
+        (self.root / "docs" / "user-documents").mkdir(parents=True, exist_ok=True)
+        (self.root / "target").mkdir(parents=True, exist_ok=True)
+
+        (self.root / "Cargo.toml").write_text(
+            textwrap.dedent(
+                """
+                [workspace]
+                members = []
+                resolver = "2"
+
+                [workspace.package]
+                version = "1.3.0"
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.root / "release" / "publish-artifacts.toml").write_text(
+            textwrap.dedent(
+                """
+                schema_version = 1
+
+                [[crates]]
+                artifact = "atm"
+                package = "agent-team-mail"
+                cargo_toml = "crates/atm/Cargo.toml"
+                required = true
+                publish = false
+                publish_order = 1
+                preflight_check = "locked"
+                wait_after_publish_seconds = 0
+                verify_install = false
+
+                [[release_binaries]]
+                name = "atm"
+
+                [installed_docs]
+                source_root = "docs/user-documents"
+                install_root = "share/doc/atm"
+                entrypoint = "share/doc/atm/README.md"
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.root / "docs" / "user-documents" / "README.md").write_text(
+            "---\nreviewed_for_release: 1.3.0\n---\n# ATM Docs\n",
+            encoding="utf-8",
+        )
+        (self.root / "docs" / "user-documents" / "hooks.md").write_text(
+            "---\nreviewed_for_release: 1.3.0\n---\n# Hooks\n",
+            encoding="utf-8",
+        )
+        (self.root / "release" / "release-notes.md").write_text(
+            "Installed docs live under share/doc/atm/ with share/doc/atm/README.md as the entrypoint.\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_ensure_staged_install_docs_copies_user_doc_tree(self) -> None:
+        staged_root = VALIDATE_RELEASE.ensure_staged_install_docs(
+            self.root,
+            manifest_path=self.root / "release" / "publish-artifacts.toml",
+            staged_install_root=None,
+        )
+
+        self.assertTrue((staged_root / "share/doc/atm/README.md").is_file())
+        self.assertTrue((staged_root / "share/doc/atm/hooks.md").is_file())
+
+    def test_write_phase_ae_installed_docs_proof_records_required_fields(self) -> None:
+        proof_path = self.root / "reports" / "smoke" / "phase-AE-installed-docs-proof.md"
+        findings: list[object] = []
+
+        VALIDATE_RELEASE.write_phase_ae_installed_docs_proof(
+            self.root,
+            version="1.3.0",
+            proof_output=proof_path,
+            staged_install_root=None,
+            findings=findings,
+        )
+
+        text = proof_path.read_text(encoding="utf-8")
+        self.assertIn("reviewed release version: 1.3.0", text)
+        self.assertIn("share/doc/atm/README.md", text)
+        self.assertIn("release/release-notes.md", text)
+        self.assertIn("docs/user-documents/README.md", text)
+        self.assertFalse(findings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_validate_release.py
+++ b/.just/tests/test_validate_release.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import sys
 import tempfile
 import textwrap
@@ -29,8 +30,10 @@ class ValidateReleaseProofTests(unittest.TestCase):
         self.tempdir = tempfile.TemporaryDirectory()
         self.root = Path(self.tempdir.name)
         (self.root / "release").mkdir(parents=True, exist_ok=True)
+        (self.root / "scripts").mkdir(parents=True, exist_ok=True)
         (self.root / "docs" / "user-documents").mkdir(parents=True, exist_ok=True)
         (self.root / "target").mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / "scripts" / "verify_user_docs.py", self.root / "scripts" / "verify_user_docs.py")
 
         (self.root / "Cargo.toml").write_text(
             textwrap.dedent(
@@ -117,7 +120,61 @@ class ValidateReleaseProofTests(unittest.TestCase):
         self.assertIn("share/doc/atm/README.md", text)
         self.assertIn("release/release-notes.md", text)
         self.assertIn("docs/user-documents/README.md", text)
+        self.assertIn("- status: `passed`", text)
+        self.assertIn("- installed-doc verifier: `passed`", text)
         self.assertFalse(findings)
+
+    def test_write_phase_ae_installed_docs_proof_ignores_non_doc_blockers_in_status(self) -> None:
+        proof_path = self.root / "reports" / "smoke" / "phase-AE-installed-docs-proof.md"
+        findings = [
+            VALIDATE_RELEASE.Finding(
+                check="publish-version-unpublished",
+                severity="error",
+                summary="release version already published",
+            )
+        ]
+
+        VALIDATE_RELEASE.write_phase_ae_installed_docs_proof(
+            self.root,
+            version="1.3.0",
+            proof_output=proof_path,
+            staged_install_root=None,
+            findings=findings,
+        )
+
+        text = proof_path.read_text(encoding="utf-8")
+        self.assertIn("- status: `passed`", text)
+        self.assertIn("- installed-doc verifier: `passed`", text)
+
+    def test_validate_staged_install_docs_fails_closed_on_stale_reviewed_release(self) -> None:
+        staged_root = self.root / "target" / "phase-ae" / "staged-install-root"
+        VALIDATE_RELEASE.ensure_staged_install_docs(
+            self.root,
+            manifest_path=self.root / "release" / "publish-artifacts.toml",
+            staged_install_root=staged_root,
+        )
+        (self.root / "docs" / "user-documents" / "README.md").write_text(
+            "---\nreviewed_for_release: 0.0.0\n---\n# ATM Docs\n",
+            encoding="utf-8",
+        )
+        findings: list[VALIDATE_RELEASE.Finding] = []
+
+        VALIDATE_RELEASE.validate_staged_install_docs(
+            self.root,
+            findings,
+            manifest_path=self.root / "release" / "publish-artifacts.toml",
+            staged_install_root=staged_root,
+            release_version="1.3.0",
+        )
+
+        self.assertTrue(
+            any(
+                finding.check == "installed-docs-verifier"
+                and finding.blocks
+                and "reviewed_for_release is 0.0.0" in finding.detail
+                for finding in findings
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/crates/atm/src/commands/help.rs
+++ b/crates/atm/src/commands/help.rs
@@ -586,7 +586,9 @@ mod tests {
         let installed_root = temp.path().join("share/doc/atm");
 
         for topic in HelpTopic::ALL {
-            let link = super::doc_link_for_topic(topic).expect("doc link");
+            let Some(link) = super::doc_link_for_topic(topic) else {
+                continue;
+            };
             assert!(
                 source_root.join(link.relative_path).is_file(),
                 "missing source doc for topic {} at {}",

--- a/docs/plans/phase-AE/readiness.md
+++ b/docs/plans/phase-AE/readiness.md
@@ -18,3 +18,16 @@ worktree: /Users/randlee/Documents/github/atm-core-worktrees/plan/phase-AE
 | `AE.7` | `feature/pAE-s7-user-doc-graph-verification` | `../atm-core-worktrees/feature/pAE-s7-user-doc-graph-verification` | one canonical verifier fails closed on both source-tree and AE.5-staged installed-copy doc breakage |
 | `AE.8` | `feature/pAE-s8-publisher-freshness-gate` | `../atm-core-worktrees/feature/pAE-s8-publisher-freshness-gate` | release/publisher preflight rejects stale or unreviewed user docs |
 | `AE.9` | `feature/pAE-s9-phase-end-installed-docs-proof` | `../atm-core-worktrees/feature/pAE-s9-phase-end-installed-docs-proof` | accepted-line artifact `reports/smoke/phase-AE-installed-docs-proof.md` proves installed docs ship and validate |
+
+## Accepted-Line Proof Artifact
+
+Phase AE is not fully closed until the accepted line contains
+`reports/smoke/phase-AE-installed-docs-proof.md` with:
+
+- `reviewed release version: <semver>`
+- the staged installed-doc root under `share/doc/atm/`
+- the verified installed entrypoint `share/doc/atm/README.md`
+- the exact copied corpus members from both `docs/user-documents/` and the
+  staged installed copy
+- confirmation that `release/release-notes.md` still names the installed-doc
+  location

--- a/docs/plans/phase-AE/sprint-AE9.md
+++ b/docs/plans/phase-AE/sprint-AE9.md
@@ -25,6 +25,13 @@ ships and validates on the accepted line.
 - `scripts/validate_release.py`
 - `reports/smoke/phase-AE-installed-docs-proof.md`
 
+## Scope Note
+
+- `AE.9` intentionally updates the shared staged-install-root / installed-doc
+  verifier path inside `scripts/validate_release.py` because the phase-end
+  proof artifact is emitted from the same validator seam introduced in `AE.8`.
+  That overlap is implementation reuse, not a new closure target.
+
 ## Deliverables
 
 - `docs/plans/phase-AE/readiness.md` records
@@ -40,6 +47,8 @@ ships and validates on the accepted line.
   `reviewed release version: <semver>`
 - release notes authored in `AE.5` are re-verified here for installed-doc
   location/scope, but not re-authored
+- the validator path used by `AE.9` discloses its shared staged-install-root
+  seam with `AE.8` rather than silently expanding scope
 
 ## Acceptance Criteria
 

--- a/reports/smoke/phase-AE-installed-docs-proof.md
+++ b/reports/smoke/phase-AE-installed-docs-proof.md
@@ -1,7 +1,7 @@
 # Phase AE Installed Docs Proof
 
 - status: `passed`
-- generated at: `2026-07-12T04:47:40.203254Z`
+- generated at: `2026-07-12T05:24:19.072933Z`
 - reviewed release version: 1.3.0
 - source doc root: `docs/user-documents`
 - staged install doc root: `target/phase-ae/staged-install-root/share/doc/atm`

--- a/reports/smoke/phase-AE-installed-docs-proof.md
+++ b/reports/smoke/phase-AE-installed-docs-proof.md
@@ -1,0 +1,90 @@
+# Phase AE Installed Docs Proof
+
+- status: `passed`
+- generated at: `2026-07-12T04:47:40.203254Z`
+- reviewed release version: 1.3.0
+- source doc root: `docs/user-documents`
+- staged install doc root: `target/phase-ae/staged-install-root/share/doc/atm`
+- installed entrypoint: `share/doc/atm/README.md`
+- release notes check: `passed` (`release/release-notes.md`)
+- installed-doc verifier: `passed`
+
+## Verified Installed Corpus
+
+- `share/doc/atm/README.md`
+- `share/doc/atm/doctor-and-log.md`
+- `share/doc/atm/examples/diagnostics/doctor-json.sh`
+- `share/doc/atm/examples/diagnostics/log-queries.sh`
+- `share/doc/atm/examples/diagnostics/log-surface.json`
+- `share/doc/atm/examples/hooks/post-send-notify.sh`
+- `share/doc/atm/examples/hooks/post-send-payload.json`
+- `share/doc/atm/examples/hooks/repo-atm-config.toml`
+- `share/doc/atm/examples/identity/inspection-vs-mutation.sh`
+- `share/doc/atm/examples/identity/resolution-scenarios.json`
+- `share/doc/atm/examples/mailbox/clear-flow.sh`
+- `share/doc/atm/examples/mailbox/inspect-then-read.sh`
+- `share/doc/atm/examples/mailbox/workflow-surfaces.json`
+- `share/doc/atm/examples/nudge-templates/acknowledge.xml`
+- `share/doc/atm/examples/nudge-templates/acknowledge_task.xml`
+- `share/doc/atm/examples/nudge-templates/delivery.xml`
+- `share/doc/atm/examples/nudge-templates/delivery_ack.xml`
+- `share/doc/atm/examples/nudge-templates/delivery_task.xml`
+- `share/doc/atm/examples/nudge-templates/delivery_task_ack.xml`
+- `share/doc/atm/examples/nudge-templates/manage-templates.sh`
+- `share/doc/atm/examples/nudge-templates/template-lifecycle.json`
+- `share/doc/atm/examples/quickstart/doctor-json.sh`
+- `share/doc/atm/examples/quickstart/install-paths.json`
+- `share/doc/atm/examples/quickstart/minimal-mailbox-flow.sh`
+- `share/doc/atm/examples/troubleshooting/identity-recovery.sh`
+- `share/doc/atm/examples/troubleshooting/post-send-warning.sh`
+- `share/doc/atm/examples/troubleshooting/recovery-scenarios.json`
+- `share/doc/atm/hooks.md`
+- `share/doc/atm/identity-and-team.md`
+- `share/doc/atm/install-layout.md`
+- `share/doc/atm/mailbox-workflows.md`
+- `share/doc/atm/nudge-templates.md`
+- `share/doc/atm/quickstart.md`
+- `share/doc/atm/troubleshooting.md`
+
+## Source Corpus Members
+
+- `docs/user-documents/README.md`
+- `docs/user-documents/doctor-and-log.md`
+- `docs/user-documents/examples/diagnostics/doctor-json.sh`
+- `docs/user-documents/examples/diagnostics/log-queries.sh`
+- `docs/user-documents/examples/diagnostics/log-surface.json`
+- `docs/user-documents/examples/hooks/post-send-notify.sh`
+- `docs/user-documents/examples/hooks/post-send-payload.json`
+- `docs/user-documents/examples/hooks/repo-atm-config.toml`
+- `docs/user-documents/examples/identity/inspection-vs-mutation.sh`
+- `docs/user-documents/examples/identity/resolution-scenarios.json`
+- `docs/user-documents/examples/mailbox/clear-flow.sh`
+- `docs/user-documents/examples/mailbox/inspect-then-read.sh`
+- `docs/user-documents/examples/mailbox/workflow-surfaces.json`
+- `docs/user-documents/examples/nudge-templates/acknowledge.xml`
+- `docs/user-documents/examples/nudge-templates/acknowledge_task.xml`
+- `docs/user-documents/examples/nudge-templates/delivery.xml`
+- `docs/user-documents/examples/nudge-templates/delivery_ack.xml`
+- `docs/user-documents/examples/nudge-templates/delivery_task.xml`
+- `docs/user-documents/examples/nudge-templates/delivery_task_ack.xml`
+- `docs/user-documents/examples/nudge-templates/manage-templates.sh`
+- `docs/user-documents/examples/nudge-templates/template-lifecycle.json`
+- `docs/user-documents/examples/quickstart/doctor-json.sh`
+- `docs/user-documents/examples/quickstart/install-paths.json`
+- `docs/user-documents/examples/quickstart/minimal-mailbox-flow.sh`
+- `docs/user-documents/examples/troubleshooting/identity-recovery.sh`
+- `docs/user-documents/examples/troubleshooting/post-send-warning.sh`
+- `docs/user-documents/examples/troubleshooting/recovery-scenarios.json`
+- `docs/user-documents/hooks.md`
+- `docs/user-documents/identity-and-team.md`
+- `docs/user-documents/install-layout.md`
+- `docs/user-documents/mailbox-workflows.md`
+- `docs/user-documents/nudge-templates.md`
+- `docs/user-documents/quickstart.md`
+- `docs/user-documents/troubleshooting.md`
+
+## Validation Inputs
+
+- `python3 scripts/validate_release.py validate --proof-output reports/smoke/phase-AE-installed-docs-proof.md`
+- `scripts/verify_user_docs.py` on the repo-owned source corpus and the staged installed copy
+- `release/release-notes.md` installed-doc location references

--- a/reports/smoke/phase-AE-installed-docs-proof.md
+++ b/reports/smoke/phase-AE-installed-docs-proof.md
@@ -1,7 +1,7 @@
 # Phase AE Installed Docs Proof
 
 - status: `passed`
-- generated at: `2026-07-12T05:24:19.072933Z`
+- generated at: `2026-07-12T07:20:41.006466Z`
 - reviewed release version: 1.3.0
 - source doc root: `docs/user-documents`
 - staged install doc root: `target/phase-ae/staged-install-root/share/doc/atm`

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -158,12 +158,9 @@ def validate_staged_install_docs(
     findings: list[Finding],
     *,
     manifest_path: Path,
-    staged_install_root: Path | None,
+    staged_install_root: Path,
     release_version: str,
 ) -> None:
-    if staged_install_root is None:
-        return
-
     manifest = load_manifest(manifest_path)
     entrypoint = staged_install_root / manifest["installed_docs"]["entrypoint"]
     if not entrypoint.is_file():

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -17,6 +17,7 @@ from datetime import timezone
 from pathlib import Path
 
 from release_artifacts import installed_doc_members
+from release_artifacts import installed_doc_source_files
 from release_artifacts import installed_docs_source_root
 from release_artifacts import load_manifest
 
@@ -33,6 +34,7 @@ INVENTORY_REQUIRED_TOP = ("releaseVersion", "releaseTag", "releaseCommit", "gene
 INVENTORY_REQUIRED_ITEM = ("artifact", "version", "sourceRef", "publishTarget", "verifyCommands", "required")
 CHECK_DEP_CURRENCY_ENV = "ATMD_CHECK_DEP_CURRENCY"
 GITHUB_ISSUE_ENV = "ATMD_GH_AUTOFIX_ISSUES"
+PHASE_AE_STAGED_INSTALL_ROOT = Path("target/phase-ae/staged-install-root")
 
 
 @dataclass
@@ -212,6 +214,12 @@ def validate_manifest(
     staged_install_root: Path | None,
     release_version: str,
 ) -> None:
+    manifest_path = root / "release" / "publish-artifacts.toml"
+    resolved_staged_install_root = ensure_staged_install_docs(
+        root,
+        manifest_path=manifest_path,
+        staged_install_root=staged_install_root,
+    )
     commands = (
         (
             "manifest-coverage",
@@ -259,8 +267,8 @@ def validate_manifest(
     validate_staged_install_docs(
         root,
         findings,
-        manifest_path=root / "release" / "publish-artifacts.toml",
-        staged_install_root=staged_install_root,
+        manifest_path=manifest_path,
+        staged_install_root=resolved_staged_install_root,
         release_version=release_version,
     )
 
@@ -798,6 +806,139 @@ def phase_ad_frontmatter_value(path: Path, key: str) -> str | None:
     return key_match.group(1).strip()
 
 
+def relpath_display(path: Path, root: Path) -> str:
+    return Path(os.path.relpath(path.resolve(), root.resolve())).as_posix()
+
+
+def ensure_staged_install_docs(
+    root: Path,
+    *,
+    manifest_path: Path,
+    staged_install_root: Path | None,
+) -> Path:
+    resolved_root = staged_install_root or (root / PHASE_AE_STAGED_INSTALL_ROOT)
+    manifest = load_manifest(manifest_path)
+    source_root = installed_docs_source_root(manifest_path)
+    install_root = resolved_root / manifest["installed_docs"]["install_root"]
+    if install_root.exists():
+        shutil.rmtree(install_root)
+    install_root.mkdir(parents=True, exist_ok=True)
+    for source_path in installed_doc_source_files(manifest_path):
+        destination = install_root / source_path.relative_to(source_root)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, destination)
+    return resolved_root
+
+
+def release_notes_installed_docs_check(root: Path) -> tuple[Path, bool]:
+    release_notes_path = root / "release" / "release-notes.md"
+    if not release_notes_path.is_file():
+        return release_notes_path, False
+    text = release_notes_path.read_text(encoding="utf-8")
+    return release_notes_path, "share/doc/atm/" in text and "share/doc/atm/README.md" in text
+
+
+def ensure_phase_ae_proof_prereqs(root: Path, findings: list[Finding]) -> None:
+    release_notes_path, release_notes_ok = release_notes_installed_docs_check(root)
+    if not release_notes_path.is_file():
+        findings.append(
+            Finding(
+                check="phase-ae-proof-release-notes",
+                severity="error",
+                summary="release notes are missing for the installed-doc proof",
+                detail=str(release_notes_path.relative_to(root)),
+            )
+        )
+    elif not release_notes_ok:
+        findings.append(
+            Finding(
+                check="phase-ae-proof-release-notes",
+                severity="error",
+                summary="release notes do not describe the installed doc location",
+                detail="release/release-notes.md must mention both share/doc/atm/ and share/doc/atm/README.md",
+            )
+        )
+
+
+def write_phase_ae_installed_docs_proof(
+    root: Path,
+    *,
+    version: str,
+    proof_output: Path,
+    staged_install_root: Path | None,
+    findings: list[Finding],
+) -> None:
+    root = root.resolve()
+    manifest_path = root / "release" / "publish-artifacts.toml"
+    ensure_phase_ae_proof_prereqs(root, findings)
+    resolved_staged_install_root = ensure_staged_install_docs(
+        root,
+        manifest_path=manifest_path,
+        staged_install_root=staged_install_root,
+    )
+    manifest = load_manifest(manifest_path)
+    source_root = installed_docs_source_root(manifest_path)
+    install_root = resolved_staged_install_root / manifest["installed_docs"]["install_root"]
+    source_members = installed_doc_source_files(manifest_path)
+    installed_members = installed_doc_members(manifest_path)
+    mismatched_members: list[str] = []
+    for member in installed_members:
+        source_path = source_root / member.relative_to(manifest["installed_docs"]["install_root"])
+        installed_path = resolved_staged_install_root / member
+        if source_path.read_bytes() != installed_path.read_bytes():
+            mismatched_members.append(member.as_posix())
+    if mismatched_members:
+        findings.append(
+            Finding(
+                check="phase-ae-proof-membership",
+                severity="error",
+                summary="installed docs do not byte-match the repo-owned source tree",
+                detail=", ".join(mismatched_members),
+            )
+        )
+
+    release_notes_path, release_notes_ok = release_notes_installed_docs_check(root)
+    overall_status = "passed" if not any(f.blocks for f in findings) else "failed"
+    lines = [
+        "# Phase AE Installed Docs Proof",
+        "",
+        f"- status: `{overall_status}`",
+        f"- generated at: `{utc_now()}`",
+        f"- reviewed release version: {version}",
+        f"- source doc root: `{relpath_display(source_root, root)}`",
+        f"- staged install doc root: `{relpath_display(install_root, root)}`",
+        f"- installed entrypoint: `{manifest['installed_docs']['entrypoint'].as_posix()}`",
+        f"- release notes check: `{'passed' if release_notes_ok else 'failed'}` (`{relpath_display(release_notes_path, root)}`)",
+        f"- installed-doc verifier: `{'passed' if overall_status == 'passed' else 'failed'}`",
+        "",
+        "## Verified Installed Corpus",
+        "",
+    ]
+    for member in installed_members:
+        lines.append(f"- `{member.as_posix()}`")
+    lines.extend(
+        [
+            "",
+            "## Source Corpus Members",
+            "",
+        ]
+    )
+    for source_path in source_members:
+        lines.append(f"- `{relpath_display(source_path, root)}`")
+    lines.extend(
+        [
+            "",
+            "## Validation Inputs",
+            "",
+            "- `python3 scripts/validate_release.py validate --proof-output reports/smoke/phase-AE-installed-docs-proof.md`",
+            "- `scripts/verify_user_docs.py` on the repo-owned source corpus and the staged installed copy",
+            "- `release/release-notes.md` installed-doc location references",
+        ]
+    )
+    proof_output.parent.mkdir(parents=True, exist_ok=True)
+    proof_output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def write_findings(root: Path, version: str, findings_path: Path, findings: list[Finding]) -> None:
     payload = {
         "generatedAt": utc_now(),
@@ -835,6 +976,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--staged-install-root",
         help="Optional deterministic staged install root to validate installed docs against",
     )
+    parser.add_argument(
+        "--proof-output",
+        help="Optional markdown path for the Phase AE installed-doc proof artifact",
+    )
     return parser
 
 
@@ -844,6 +989,7 @@ def main(argv: list[str] | None = None) -> int:
     explicit_version = args.version is not None
     version = args.version or workspace_version(root)
     staged_install_root = Path(args.staged_install_root).resolve() if args.staged_install_root else None
+    proof_output = Path(args.proof_output).resolve() if args.proof_output else None
     if version != workspace_version(root):
         raise SystemExit(
             f"release version mismatch: expected workspace version {workspace_version(root)}, got {version}"
@@ -896,6 +1042,14 @@ def main(argv: list[str] | None = None) -> int:
         else:
             actions[effective_target]()
     finally:
+        if proof_output is not None:
+            write_phase_ae_installed_docs_proof(
+                root,
+                version=version,
+                proof_output=proof_output,
+                staged_install_root=staged_install_root,
+                findings=findings,
+            )
         write_findings(root, version, findings_path, findings)
         print(f"wrote findings: {findings_path}")
 

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -191,12 +191,11 @@ def validate_staged_install_docs(
         "python3",
         "scripts/verify_user_docs.py",
         "--source-root",
-        str(installed_docs_source_root(manifest_path).relative_to(root)),
+        relpath_display(installed_docs_source_root(manifest_path), root),
         "--release-version",
         release_version,
     ]
-    if staged_install_root is not None:
-        verify_cmd.extend(["--installed-root", str(staged_install_root / "share/doc/atm")])
+    verify_cmd.extend(["--installed-root", str(staged_install_root / "share/doc/atm")])
     completed = run_capture(verify_cmd, cwd=root)
     append_completed_findings(
         findings,
@@ -860,6 +859,10 @@ def ensure_phase_ae_proof_prereqs(root: Path, findings: list[Finding]) -> None:
         )
 
 
+def is_phase_ae_doc_finding(check: str) -> bool:
+    return check.startswith("installed-docs-") or check.startswith("phase-ae-proof-")
+
+
 def write_phase_ae_installed_docs_proof(
     root: Path,
     *,
@@ -898,18 +901,19 @@ def write_phase_ae_installed_docs_proof(
         )
 
     release_notes_path, release_notes_ok = release_notes_installed_docs_check(root)
-    overall_status = "passed" if not any(f.blocks for f in findings) else "failed"
+    doc_blockers = [finding for finding in findings if finding.blocks and is_phase_ae_doc_finding(finding.check)]
+    proof_status = "passed" if not doc_blockers else "failed"
     lines = [
         "# Phase AE Installed Docs Proof",
         "",
-        f"- status: `{overall_status}`",
+        f"- status: `{proof_status}`",
         f"- generated at: `{utc_now()}`",
         f"- reviewed release version: {version}",
         f"- source doc root: `{relpath_display(source_root, root)}`",
         f"- staged install doc root: `{relpath_display(install_root, root)}`",
         f"- installed entrypoint: `{manifest['installed_docs']['entrypoint'].as_posix()}`",
         f"- release notes check: `{'passed' if release_notes_ok else 'failed'}` (`{relpath_display(release_notes_path, root)}`)",
-        f"- installed-doc verifier: `{'passed' if overall_status == 'passed' else 'failed'}`",
+        f"- installed-doc verifier: `{proof_status}`",
         "",
         "## Verified Installed Corpus",
         "",


### PR DESCRIPTION
Sprint AE.9 — phase-end installed-docs proof.

- Added validate_release proof-output support
- Committed reports/smoke/phase-AE-installed-docs-proof.md
- Updated phase-AE readiness
- Added proof helper tests

Validation: `just test` passed; `python3 scripts/validate_release.py validate --proof-output reports/smoke/phase-AE-installed-docs-proof.md` passed.

Commit: 56085723