### PR TITLE
AE1-FIX-1: close AE1-QA-1 findings (post-merge)

### DIFF
--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -127,6 +127,11 @@ Follow-up work:
   document corpus itself.
 - installed-doc lookup for `atm help` is executable-relative from the resolved
   installed `atm` binary location and must not be derived from `ATM_HOME`.
+- the installed-user-documentation-surface follows ADR-025:
+  - the repo-owned source corpus is `docs/user-documents/`
+  - packaging installs that corpus under `<install-root>/share/doc/atm/`
+  - long-form help lookup resolves from the installed binary using the
+    executable-relative path `../share/doc/atm/`
 - `atm` owns the structured construction contract for the concrete adapter:
   `CliObservability::new(home_dir, CliObservabilityOptions)`.
 - `atm` may retain `init(...)` only as a delegating helper.

--- a/docs/documentation-guidelines.md
+++ b/docs/documentation-guidelines.md
@@ -111,6 +111,7 @@ docs/
     requirements.md
     architecture.md
     commands/
+      help.md
       send.md
       read.md
       ack.md

--- a/docs/plans/phase-AE/issues.md
+++ b/docs/plans/phase-AE/issues.md
@@ -22,6 +22,10 @@ worktree: /Users/randlee/Documents/github/atm-core-worktrees/plan/phase-AE
 ## Closure Notes
 
 - `AE.1` defines the corpus contract, metadata header, and required tree.
+- `AE.1` also fixes the accepted corpus/install contract used by
+  `integrate/phase-AE`:
+  - repo-owned end-user docs live in `docs/user-documents/`
+  - installed long-form docs ship under `share/doc/atm/`
 - `AE.2` through `AE.4` author the actual end-user content in bounded groups.
 - `AE.5` through `AE.8` make the corpus shippable, discoverable, and gated.
 - `AE.9` is the only sprint allowed to claim the installed-doc release proof.


### PR DESCRIPTION
PR #516 merged before AE1-FIX-1 was pushed, so the fix commit never landed in integrate/phase-AE. This PR carries that single commit forward.

Closes ATM-QA-001/002/003 from AE1-QA-1 (docs/atm/architecture.md installed-user-documentation-surface subsection, docs/plans/phase-AE/issues.md corpus-location/integrate-phase-AE contract reference, documentation-guidelines.md help.md command-tree entry).

AE1-QA-2 already PASSED this commit (2c910b02) — 0B/0I/0m, CI green 8/8. Re-running CI here since it's a new PR.

Commit: 2c910b02