### PR TITLE
fix: correct per-platform Homebrew formula asset/sha256 mapping (#522)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -364,6 +364,10 @@ jobs:
     needs: [gate-and-tag, release]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate-and-tag.outputs.release_tag }}
+
       - name: Checkout homebrew-tap
         uses: actions/checkout@v4
         with:
@@ -371,33 +375,48 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
-      - name: Compute release tarball SHA256
-        id: sha
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect archives
         shell: bash
         run: |
           set -euo pipefail
-          tag='${{ needs.gate-and-tag.outputs.release_tag }}'
-          version='${{ needs.gate-and-tag.outputs.release_version }}'
-          tarball_path="${RUNNER_TEMP:?RUNNER_TEMP is required}/release.tar.gz"
-          # Homebrew automation requires HOMEBREW_TAP_TOKEN to be configured on the atm-core repo.
-          tarball_url="https://github.com/randlee/atm-core/releases/download/${tag}/atm_${version}_aarch64-apple-darwin.tar.gz"
-          echo "tarball_url=${tarball_url}" >> "$GITHUB_OUTPUT"
-          curl -fsSL --retry 5 --retry-delay 30 --retry-all-errors -o "${tarball_path}" "${tarball_url}"
-          sha256=$(sha256sum "${tarball_path}" | awk '{print $1}')
-          echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
+          mkdir -p release
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' \) -exec mv {} release/ \;
+          ls -la release/
+
+      - name: Generate checksums
+        working-directory: release
+        run: sha256sum * > checksums.txt
 
       - name: Update Homebrew formulas
         shell: bash
         run: |
           set -euo pipefail
           version='${{ needs.gate-and-tag.outputs.release_version }}'
-          sha256='${{ steps.sha.outputs.sha256 }}'
-          tarball_url='${{ steps.sha.outputs.tarball_url }}'
-          for formula in homebrew-tap/Formula/agent-team-mail.rb homebrew-tap/Formula/atm.rb; do
-            sed -i "s|version \"[^\"]*\"|version \"${version}\"|g" "$formula"
-            sed -i "s|url \"[^\"]*\"|url \"${tarball_url}\"|g" "$formula"
-            sed -i "s|sha256 \"[^\"]*\"|sha256 \"${sha256}\"|g" "$formula"
-          done
+          tag='${{ needs.gate-and-tag.outputs.release_tag }}'
+          python3 scripts/release_artifacts.py update-homebrew-formulas \
+            --release-dir release \
+            --version "${version}" \
+            --tag "${tag}" \
+            --formula homebrew-tap/Formula/agent-team-mail.rb \
+            --formula homebrew-tap/Formula/atm.rb
+
+      - name: Validate Homebrew formulas
+        shell: bash
+        run: |
+          set -euo pipefail
+          version='${{ needs.gate-and-tag.outputs.release_version }}'
+          tag='${{ needs.gate-and-tag.outputs.release_tag }}'
+          python3 scripts/release_artifacts.py validate-homebrew-formulas \
+            --release-dir release \
+            --version "${version}" \
+            --tag "${tag}" \
+            --formula homebrew-tap/Formula/agent-team-mail.rb \
+            --formula homebrew-tap/Formula/atm.rb
 
       - name: Commit and push to homebrew-tap
         shell: bash

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -89,8 +89,9 @@ file = ".github/workflows/release.yml"
 required_fragments = [
   "update-homebrew:",
   "repository: randlee/homebrew-tap",
-  "for formula in homebrew-tap/Formula/agent-team-mail.rb homebrew-tap/Formula/atm.rb; do",
-  "version='${{ needs.gate-and-tag.outputs.release_version }}'",
-  "tarball_url=\"https://github.com/randlee/atm-core/releases/download/${tag}/atm_${version}_aarch64-apple-darwin.tar.gz\"",
-  "sed -i \"s|version \\\"[^\\\"]*\\\"|version \\\"${version}\\\"|g\" \"$formula\"",
+  "python3 scripts/release_artifacts.py update-homebrew-formulas \\",
+  "python3 scripts/release_artifacts.py validate-homebrew-formulas \\",
+  "--release-dir release \\",
+  "--formula homebrew-tap/Formula/agent-team-mail.rb \\",
+  "--formula homebrew-tap/Formula/atm.rb",
 ]

--- a/.just/tests/test_release_artifacts.py
+++ b/.just/tests/test_release_artifacts.py
@@ -77,6 +77,77 @@ class ReleaseArtifactsTests(unittest.TestCase):
         )
         return workspace_toml, manifest_toml
 
+    def write_homebrew_fixture(self) -> tuple[Path, Path]:
+        release_dir = self.root / "release"
+        formula_path = self.root / "homebrew-tap" / "Formula" / "atm.rb"
+        release_dir.mkdir(parents=True, exist_ok=True)
+        formula_path.parent.mkdir(parents=True, exist_ok=True)
+        (release_dir / "checksums.txt").write_text(
+            textwrap.dedent(
+                """
+                linuxsha  atm_1.3.0_x86_64-unknown-linux-gnu.tar.gz
+                intelmacsha  atm_1.3.0_x86_64-apple-darwin.tar.gz
+                armmacsha  atm_1.3.0_aarch64-apple-darwin.tar.gz
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        formula_path.write_text(
+            textwrap.dedent(
+                """
+                # typed: false
+                # frozen_string_literal: true
+
+                class Atm < Formula
+                  desc "CLI for mail-like messaging with Claude agent teams"
+                  homepage "https://github.com/randlee/atm-core"
+                  version "1.2.3"
+                  license "MIT"
+
+                  on_macos do
+                    on_intel do
+                      url "https://github.com/randlee/atm-core/releases/download/v1.2.3/atm_1.2.3_aarch64-apple-darwin.tar.gz"
+                      sha256 "wrong-old-macos-intel"
+
+                      def install
+                        bin.install "atm"
+                      end
+                    end
+                    on_arm do
+                      url "https://github.com/randlee/atm-core/releases/download/v1.2.3/atm_1.2.3_aarch64-apple-darwin.tar.gz"
+                      sha256 "wrong-old-macos-arm"
+
+                      def install
+                        bin.install "atm"
+                      end
+                    end
+                  end
+
+                  on_linux do
+                    on_intel do
+                      if Hardware::CPU.is_64_bit?
+                        url "https://github.com/randlee/atm-core/releases/download/v1.2.3/atm_1.2.3_aarch64-apple-darwin.tar.gz"
+                        sha256 "wrong-old-linux"
+
+                        def install
+                          bin.install "atm"
+                        end
+                      end
+                    end
+                  end
+
+                  test do
+                    system "#{bin}/atm", "--version"
+                  end
+                end
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        return release_dir, formula_path
+
     def run_validate_manifest(self, *, workspace_toml: Path, manifest_toml: Path) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [
@@ -88,6 +159,16 @@ class ReleaseArtifactsTests(unittest.TestCase):
                 "--workspace-toml",
                 str(workspace_toml),
             ],
+            cwd=self.root,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+    def run_release_artifacts(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
             cwd=self.root,
             check=False,
             capture_output=True,
@@ -133,6 +214,91 @@ class ReleaseArtifactsTests(unittest.TestCase):
             "demo-crate: missing required publish metadata field(s): description, license or license-file",
             completed.stdout,
         )
+
+    def test_update_homebrew_formulas_rewrites_each_platform_block_to_its_own_asset(self) -> None:
+        release_dir, formula_path = self.write_homebrew_fixture()
+
+        completed = self.run_release_artifacts(
+            "update-homebrew-formulas",
+            "--release-dir",
+            str(release_dir),
+            "--version",
+            "1.3.0",
+            "--tag",
+            "v1.3.0",
+            "--formula",
+            str(formula_path),
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        text = formula_path.read_text(encoding="utf-8")
+        self.assertIn('version "1.3.0"', text)
+        self.assertIn(
+            'url "https://github.com/randlee/atm-core/releases/download/v1.3.0/atm_1.3.0_x86_64-apple-darwin.tar.gz"',
+            text,
+        )
+        self.assertIn(
+            'url "https://github.com/randlee/atm-core/releases/download/v1.3.0/atm_1.3.0_aarch64-apple-darwin.tar.gz"',
+            text,
+        )
+        self.assertIn(
+            'url "https://github.com/randlee/atm-core/releases/download/v1.3.0/atm_1.3.0_x86_64-unknown-linux-gnu.tar.gz"',
+            text,
+        )
+        self.assertIn('sha256 "intelmacsha"', text)
+        self.assertIn('sha256 "armmacsha"', text)
+        self.assertIn('sha256 "linuxsha"', text)
+
+    def test_validate_homebrew_formulas_rejects_cross_platform_asset_reuse(self) -> None:
+        release_dir, formula_path = self.write_homebrew_fixture()
+
+        completed = self.run_release_artifacts(
+            "validate-homebrew-formulas",
+            "--release-dir",
+            str(release_dir),
+            "--version",
+            "1.3.0",
+            "--tag",
+            "v1.3.0",
+            "--formula",
+            str(formula_path),
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("homebrew formula validation failed:", completed.stdout)
+        self.assertIn("on_macos/on_intel url mismatch", completed.stdout)
+        self.assertIn("on_linux/on_intel url mismatch", completed.stdout)
+
+    def test_validate_homebrew_formulas_passes_after_rewrite(self) -> None:
+        release_dir, formula_path = self.write_homebrew_fixture()
+
+        updated = self.run_release_artifacts(
+            "update-homebrew-formulas",
+            "--release-dir",
+            str(release_dir),
+            "--version",
+            "1.3.0",
+            "--tag",
+            "v1.3.0",
+            "--formula",
+            str(formula_path),
+        )
+        self.assertEqual(updated.returncode, 0, updated.stderr)
+
+        completed = self.run_release_artifacts(
+            "validate-homebrew-formulas",
+            "--release-dir",
+            str(release_dir),
+            "--version",
+            "1.3.0",
+            "--tag",
+            "v1.3.0",
+            "--formula",
+            str(formula_path),
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("ok: Homebrew formulas match expected platform assets and checksums", completed.stdout)
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_release_homebrew_workflow.py
+++ b/.just/tests/test_release_homebrew_workflow.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+class ReleaseHomebrewWorkflowTests(unittest.TestCase):
+    def test_update_homebrew_job_uses_scripted_formula_update_and_validation(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("update-homebrew:", text)
+        self.assertIn("python3 scripts/release_artifacts.py update-homebrew-formulas \\", text)
+        self.assertIn("python3 scripts/release_artifacts.py validate-homebrew-formulas \\", text)
+        self.assertIn("--release-dir release \\", text)
+        self.assertIn("--formula homebrew-tap/Formula/agent-team-mail.rb \\", text)
+        self.assertIn("--formula homebrew-tap/Formula/atm.rb", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/plans/issue-522/sprint-522.md
+++ b/docs/plans/issue-522/sprint-522.md
@@ -1,0 +1,101 @@
+---
+id: issue-522
+title: Homebrew Formula Platform Asset Mapping Fix
+status: complete
+branch: fix/issue-522-homebrew-formula-platform-assets
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/fix/issue-522-homebrew-formula-platform-assets
+---
+
+# Sprint 522 — Homebrew Formula Platform Asset Mapping Fix
+
+## Goals
+
+- stop `update-homebrew` from stamping every Homebrew platform block with the
+  Apple Silicon macOS archive and checksum
+- generate distinct URL + `sha256` pairs for:
+  - `on_macos/on_arm` -> `aarch64-apple-darwin`
+  - `on_macos/on_intel` -> `x86_64-apple-darwin`
+  - `on_linux/on_intel` -> `x86_64-unknown-linux-gnu`
+- add a ratchet that validates generated formulas against the release
+  archives/checksums inside the actual release pipeline so the mismatch cannot
+  silently regress
+- cover the formula generator and mismatch detection with unit tests that do
+  not require live GitHub access
+
+## Scope
+
+- in scope:
+  - `scripts/release_artifacts.py`
+  - `.github/workflows/release.yml`
+  - release validation/unit tests under `.just/tests/`
+  - release wiring lint fragments under `.just/lint-config.toml`
+- out of scope:
+  - correcting already-published formulas in `randlee/homebrew-tap`
+  - changing Windows release/publish behavior
+
+## Implementation Plan
+
+- move Homebrew formula mutation out of ad hoc workflow `sed` commands into
+  `scripts/release_artifacts.py`
+- teach the script two Homebrew-specific commands:
+  - `update-homebrew-formulas`
+  - `validate-homebrew-formulas`
+- drive both commands from the release job using the archives downloaded into
+  `release/` plus `release/checksums.txt`
+- validate both URL target triple selection and `sha256` selection against the
+  release archive checksum inventory
+- preserve the current formula file structure; only rewrite:
+  - top-level `version`
+  - platform-specific `url`
+  - platform-specific `sha256`
+
+## Release Pipeline Call Site
+
+- release ratchet is wired into `.github/workflows/release.yml` under the
+  `update-homebrew` job
+- that job now:
+  - checks out the tagged `atm-core` source
+  - downloads the release artifacts
+  - regenerates `release/checksums.txt`
+  - runs `python3 scripts/release_artifacts.py update-homebrew-formulas`
+  - immediately runs
+    `python3 scripts/release_artifacts.py validate-homebrew-formulas`
+- the validation step consumes the same downloaded release archives/checksums
+  the job is about to publish into the tap, so a target-triple or checksum
+  mismatch fails the release job before the tap commit/push step
+
+## Required Deliverables
+
+- `docs/plans/issue-522/sprint-522.md` exists with frontmatter
+- Homebrew formula updater maps each platform block to its correct target
+  triple archive and checksum
+- a validator fails when any formula block points at the wrong target triple
+  or wrong checksum
+- the validator is called from `.github/workflows/release.yml` in the
+  `update-homebrew` job after formulas are updated
+- unit tests cover:
+  - correct per-platform rewrite
+  - mismatch detection that would fail on the old all-arm formula state
+- `just test` passes
+- `just lint` passes
+
+## Acceptance Criteria
+
+- generated formulas contain three distinct archive targets across:
+  - macOS ARM
+  - macOS Intel
+  - Linux Intel
+- no platform block besides `on_macos/on_arm` references
+  `*_aarch64-apple-darwin.tar.gz`
+- the release workflow call site uses the repo script rather than inline
+  global `sed` replacement for URL/sha mutation
+- the release workflow contains an explicit validation step that can fail the
+  release if Homebrew formulas no longer match the downloaded release
+  archives/checksums
+- this sprint explicitly records that repairing already-published 1.2.3/1.3.0
+  formulas in `randlee/homebrew-tap` remains a separate manual/user follow-up
+
+## Follow-Up Left Out Of Scope
+
+- backfill/correct the already-published Homebrew formulas in the external
+  `randlee/homebrew-tap` repository after this generator fix merges

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import tomllib
@@ -13,6 +14,11 @@ from pathlib import Path
 
 PREFLIGHT_FULL = "full"
 PREFLIGHT_LOCKED = "locked"
+HOMEBREW_PLATFORM_TRIPLES = {
+    ("on_macos", "on_arm"): "aarch64-apple-darwin",
+    ("on_macos", "on_intel"): "x86_64-apple-darwin",
+    ("on_linux", "on_intel"): "x86_64-unknown-linux-gnu",
+}
 
 
 def load_manifest(path: Path) -> dict:
@@ -423,6 +429,194 @@ def validate_publish_order(args: argparse.Namespace) -> int:
     return 0
 
 
+def homebrew_archive_name(version: str, triple: str) -> str:
+    return f"atm_{version}_{triple}.tar.gz"
+
+
+def github_release_asset_url(tag: str, archive_name: str) -> str:
+    return f"https://github.com/randlee/atm-core/releases/download/{tag}/{archive_name}"
+
+
+def load_release_checksums(release_dir: Path) -> dict[str, str]:
+    checksums_path = release_dir / "checksums.txt"
+    if not checksums_path.exists():
+        raise SystemExit(f"missing checksums file: {checksums_path}")
+    checksums: dict[str, str] = {}
+    for line_no, raw_line in enumerate(checksums_path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            raise SystemExit(f"invalid checksums.txt line {line_no}: {raw_line!r}")
+        sha256, filename = parts
+        checksums[Path(filename).name] = sha256
+    return checksums
+
+
+def expected_homebrew_assets(version: str, tag: str, checksums: dict[str, str]) -> dict[tuple[str, str], tuple[str, str]]:
+    assets: dict[tuple[str, str], tuple[str, str]] = {}
+    for platform_key, triple in HOMEBREW_PLATFORM_TRIPLES.items():
+        archive_name = homebrew_archive_name(version, triple)
+        sha256 = checksums.get(archive_name)
+        if sha256 is None:
+            raise SystemExit(f"missing checksum for release archive {archive_name}")
+        assets[platform_key] = (github_release_asset_url(tag, archive_name), sha256)
+    return assets
+
+
+def homebrew_context_key(block_stack: list[str]) -> tuple[str, str] | None:
+    top_level = next((entry for entry in reversed(block_stack) if entry in {"on_macos", "on_linux"}), None)
+    arch = next((entry for entry in reversed(block_stack) if entry in {"on_arm", "on_intel"}), None)
+    if top_level is None or arch is None:
+        return None
+    candidate = (top_level, arch)
+    if candidate in HOMEBREW_PLATFORM_TRIPLES:
+        return candidate
+    return None
+
+
+def formula_block_push(stripped: str) -> str | None:
+    if stripped.endswith(" do"):
+        return stripped[:-3]
+    if stripped.startswith("if "):
+        return stripped
+    if stripped.startswith("def "):
+        return stripped
+    return None
+
+
+def rewrite_homebrew_formula(text: str, *, version: str, tag: str, checksums: dict[str, str]) -> str:
+    assets = expected_homebrew_assets(version, tag, checksums)
+    output: list[str] = []
+    block_stack: list[str] = []
+    for raw_line in text.splitlines(keepends=True):
+        stripped = raw_line.strip()
+        if stripped == "end":
+            if block_stack:
+                block_stack.pop()
+            output.append(raw_line)
+            continue
+
+        push_value = formula_block_push(stripped)
+        context_key = homebrew_context_key(block_stack)
+        indent = raw_line[: len(raw_line) - len(raw_line.lstrip())]
+
+        if stripped.startswith('version "'):
+            raw_line = f'{indent}version "{version}"\n'
+        elif context_key is not None and stripped.startswith('url "'):
+            expected_url, _ = assets[context_key]
+            raw_line = f'{indent}url "{expected_url}"\n'
+        elif context_key is not None and stripped.startswith('sha256 "'):
+            _, expected_sha = assets[context_key]
+            raw_line = f'{indent}sha256 "{expected_sha}"\n'
+
+        output.append(raw_line)
+        if push_value is not None:
+            block_stack.append(push_value)
+    return "".join(output)
+
+
+def validate_homebrew_formula_content(
+    text: str,
+    *,
+    version: str,
+    tag: str,
+    checksums: dict[str, str],
+    formula_label: str,
+) -> list[str]:
+    assets = expected_homebrew_assets(version, tag, checksums)
+    errors: list[str] = []
+    seen: dict[tuple[str, str], dict[str, int]] = {
+        key: {"url": 0, "sha256": 0} for key in HOMEBREW_PLATFORM_TRIPLES
+    }
+    version_match = re.search(r'^\s*version "([^"]+)"', text, re.MULTILINE)
+    if version_match is None:
+        errors.append(f"{formula_label}: missing version declaration")
+    elif version_match.group(1) != version:
+        errors.append(
+            f"{formula_label}: version mismatch: expected {version}, found {version_match.group(1)}"
+        )
+
+    block_stack: list[str] = []
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if stripped == "end":
+            if block_stack:
+                block_stack.pop()
+            continue
+
+        context_key = homebrew_context_key(block_stack)
+        if context_key is not None:
+            expected_url, expected_sha = assets[context_key]
+            if stripped.startswith('url "'):
+                seen[context_key]["url"] += 1
+                actual_url = stripped[len('url "') : -1]
+                if actual_url != expected_url:
+                    errors.append(
+                        f"{formula_label}:{line_no}: {context_key[0]}/{context_key[1]} url mismatch: "
+                        f"expected {expected_url}, found {actual_url}"
+                    )
+            elif stripped.startswith('sha256 "'):
+                seen[context_key]["sha256"] += 1
+                actual_sha = stripped[len('sha256 "') : -1]
+                if actual_sha != expected_sha:
+                    errors.append(
+                        f"{formula_label}:{line_no}: {context_key[0]}/{context_key[1]} sha256 mismatch: "
+                        f"expected {expected_sha}, found {actual_sha}"
+                    )
+
+        push_value = formula_block_push(stripped)
+        if push_value is not None:
+            block_stack.append(push_value)
+
+    for context_key, counters in seen.items():
+        for field, count in counters.items():
+            if count != 1:
+                errors.append(
+                    f"{formula_label}: expected exactly one {field} in {context_key[0]}/{context_key[1]}, found {count}"
+                )
+    return errors
+
+
+def update_homebrew_formulas(args: argparse.Namespace) -> int:
+    checksums = load_release_checksums(Path(args.release_dir))
+    updated = 0
+    for formula_path_str in args.formula:
+        formula_path = Path(formula_path_str)
+        text = formula_path.read_text(encoding="utf-8")
+        formula_path.write_text(
+            rewrite_homebrew_formula(text, version=args.version, tag=args.tag, checksums=checksums),
+            encoding="utf-8",
+        )
+        updated += 1
+    print(f"ok: updated {updated} Homebrew formula(s)")
+    return 0
+
+
+def validate_homebrew_formulas(args: argparse.Namespace) -> int:
+    checksums = load_release_checksums(Path(args.release_dir))
+    errors: list[str] = []
+    for formula_path_str in args.formula:
+        formula_path = Path(formula_path_str)
+        errors.extend(
+            validate_homebrew_formula_content(
+                formula_path.read_text(encoding="utf-8"),
+                version=args.version,
+                tag=args.tag,
+                checksums=checksums,
+                formula_label=str(formula_path),
+            )
+        )
+    if errors:
+        print("homebrew formula validation failed:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+    print("ok: Homebrew formulas match expected platform assets and checksums")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Release artifact manifest utilities")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -487,6 +681,20 @@ def build_parser() -> argparse.ArgumentParser:
     validate_o.add_argument("--manifest", required=True)
     validate_o.add_argument("--workspace-toml", required=True)
     validate_o.set_defaults(func=validate_publish_order)
+
+    update_homebrew = subparsers.add_parser("update-homebrew-formulas")
+    update_homebrew.add_argument("--release-dir", required=True)
+    update_homebrew.add_argument("--version", required=True)
+    update_homebrew.add_argument("--tag", required=True)
+    update_homebrew.add_argument("--formula", action="append", default=[])
+    update_homebrew.set_defaults(func=update_homebrew_formulas)
+
+    validate_homebrew = subparsers.add_parser("validate-homebrew-formulas")
+    validate_homebrew.add_argument("--release-dir", required=True)
+    validate_homebrew.add_argument("--version", required=True)
+    validate_homebrew.add_argument("--tag", required=True)
+    validate_homebrew.add_argument("--formula", action="append", default=[])
+    validate_homebrew.set_defaults(func=validate_homebrew_formulas)
 
     return parser
 


### PR DESCRIPTION
## Summary
- Fix `update-homebrew` formula generator so each platform block (on_arm/on_intel macOS, on_intel Linux) maps to its own correct release asset + sha256, instead of all three pointing at the arm64 macOS asset.
- Add a preflight/post-publish validation step (`validate-homebrew-formulas`) wired into `.github/workflows/release.yml` after `update-homebrew-formulas`, asserting each platform block's asset target-triple and sha256 match the published checksums.
- Add unit coverage for the generator/validator mismatch case.

Fixes #522.

## Test plan
- [x] `just lint` passes
- [x] `just test` passes
- [x] New unit tests cover per-platform asset/sha256 mapping and mismatch detection
- [ ] QA review (quality-mgr) pending

Note: backfilling the already-published 1.3.0/1.2.3 formulas in `randlee/homebrew-tap` is out of scope for this PR and will be handled separately.

🤖 Generated with Claude Code