### PR TITLE
docs: route team messaging through ATM

### DIFF
--- a/.claude/skills/plan-hardening/steps/step-6.md
+++ b/.claude/skills/plan-hardening/steps/step-6.md
@@ -49,9 +49,15 @@ memory.
 
 **2. Send to `quality-mgr`**
 
-Use the SendMessage tool to send the rendered XML content from
-`/tmp/step-6-message.xml` to the named teammate `quality-mgr`.
-Do not use `atm send` for this step.
+Use native ATM messaging to send the rendered task to the named teammate
+`quality-mgr`:
+
+```bash
+atm send quality-mgr --file /tmp/step-6-message.xml --team <team> --task-id <task_id>
+```
+
+Always use `--file` for this handoff. Do not use `--stdin`: its known input
+handling bug is tracked separately.
 
 **3. Handoff**
 

--- a/.claude/skills/restore-team-communications/SKILL.md
+++ b/.claude/skills/restore-team-communications/SKILL.md
@@ -2,9 +2,9 @@
 name: restore-team-communications
 version: 0.2.0
 description: >
-  Repair Claude teammate routing after same-session compaction or resume when
-  atm-dev still exists on disk and the saved leadSessionId still matches the
-  current SESSION_ID, but SendMessage or teammate reachability is broken.
+  Repair ATM teammate coordination after same-session compaction or resume
+  when atm-dev still exists on disk and the saved leadSessionId still matches
+  the current SESSION_ID, but named-teammate ATM reachability is broken.
 ---
 
 # Restore Team Communications
@@ -14,7 +14,7 @@ Use this skill only when all of these are true:
 - `SESSION_ID` still matches `leadSessionId` in
   `~/.claude/teams/atm-dev/config.json`
 - the team directory still exists on disk
-- Claude teammate communication is broken or suspect after compaction or resume
+- teammate ATM communication is broken or suspect after compaction or resume
 
 Do not use this skill for fresh startup or after `clear`. If the current
 `SESSION_ID` does not match `leadSessionId`, use `/team-lead` and follow the
@@ -22,10 +22,11 @@ full restore procedure instead.
 
 ## Step 0 — Prove Whether Repair Is Needed
 
-First, try normal Claude-to-Claude communication before changing anything:
+First, try native ATM communication with a named teammate before changing
+anything:
 
-```text
-SendMessage(to="<claude-teammate>", message="ping: verify atm-dev communications path")
+```bash
+atm send <teammate> "ping: verify atm-dev communications path" --team atm-dev --requires-ack
 ```
 
 If the message is delivered and acknowledged, stop. No repair is needed.
@@ -74,12 +75,14 @@ atm teams restore atm-dev --from "$BACKUP_PATH"
 
 If required members are missing after restore, add them before verification.
 
-## Step 4 — Verify Both Communication Layers
+## Step 4 — Verify Native ATM Communication
 
 Repair is not complete until all checks pass:
 
-1. `SendMessage` to another Claude teammate.
-2. `atm send` to a non-Claude model.
+1. `atm send --requires-ack` to another named teammate and receive its native
+   ATM acknowledgement.
+2. `atm send` to `quality-mgr` when that teammate is active, and verify ATM
+   mailbox routing.
 3. `atm send` to Codex and verify the nudge fires.
 
 For Codex-directed ATM sends, the nudge must include a clear call to action, not

--- a/.claude/skills/team-lead/backup-and-restore-team.md
+++ b/.claude/skills/team-lead/backup-and-restore-team.md
@@ -120,8 +120,10 @@ atm gh pr list
 ```
 
 Communication verification is also mandatory:
-1. `SendMessage` to another Claude teammate to prove Claude-side routing works.
-2. `atm send` to a non-Claude model to prove ATM mailbox routing works.
+1. `atm send --requires-ack` to another named teammate and receive its native
+   ATM acknowledgement.
+2. `atm send` to `quality-mgr` when that teammate is active to prove ATM
+   mailbox routing works.
 3. `atm send` to Codex and confirm the Codex-side nudge fires.
 
 ## Step 8 — Read Project Context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,8 +142,9 @@ main
 
 - **Team**: `atm-dev` (persistent across sessions)
 - **ARCH-ATM** (you) is `team-lead` — start and maintain the `atm-dev` team for the session duration
-- **ARCH-CTM** is a Codex agent — communicates **exclusively** via ATM CLI messages (not Claude Code team API)
-- **All other Claude agents** communicate using Claude Code's built-in team messaging API (`SendMessage` tool)
+- **All team agents**, including Claude and Codex agents, communicate
+  **exclusively** through native ATM CLI messages (`atm send`, `atm read`, and
+  `atm ack`); Claude Code team messaging is not a supported routing channel
 
 ### Identity
 
@@ -151,9 +152,10 @@ ATM CLI commands that require caller context must receive it explicitly from the
 
 **Note**: ARCH-CTM gets his identity from `ATM_IDENTITY=arch-ctm` set in his tmux session (via rmux or manually).
 
-### Communicating with ARCH-CTM (Codex)
+### Communicating with Team Agents
 
-ARCH-CTM does **not** monitor Claude Code messages. Use ATM CLI only:
+Team agents do **not** use Claude Code messaging for team coordination. Use ATM
+CLI only:
 
 **Send a message:**
 ```bash

--- a/tools/schema_models/test_schema_models.py
+++ b/tools/schema_models/test_schema_models.py
@@ -26,8 +26,8 @@ TEST_TEAM = "test-team"
 TEST_SENDER = "test-agent"
 TEST_TEAM_LEAD = "test-lead"
 TEST_QM = "test-qm"
-# Claude Code protocol identity — 'team-lead' is the reserved sender identity
-# for the Claude Code native messaging API (SendMessage tool). This is NOT a
+# Claude Code protocol compatibility identity — 'team-lead' is the reserved
+# sender identity in the retained Claude message schema. This is NOT a
 # synthetic test fixture. Do not rename or inline this constant. See:
 # crates/atm-core/src/roles.rs and docs/claude-code-message-schema.md.
 ROLE_TEAM_LEAD = "team-lead"


### PR DESCRIPTION
Replaces obsolete Claude `SendMessage` routing instructions with native ATM messaging.

- updates the CLAUDE team-routing policy
- updates plan QA and team-restore handoffs
- preserves the schema compatibility identity without claiming the retired tool

Validation: stale-instruction and arch-ctm/quality-mgr route sweeps pass.