### PR TITLE
docs: modernize team-lead skills to atm 1.3.1 SQLite bootstrap

### DIFF
--- a/.claude/skills/restore-team-communications/SKILL.md
+++ b/.claude/skills/restore-team-communications/SKILL.md
@@ -1,107 +1,84 @@
 ---
 name: restore-team-communications
-version: 0.2.0
+version: 0.3.0
 description: >
-  Repair ATM teammate coordination after same-session compaction or resume
-  when atm-dev still exists on disk and the saved leadSessionId still matches
-  the current SESSION_ID, but named-teammate ATM reachability is broken.
+  Repair native ATM teammate reachability when the SQLite-backed roster is
+  healthy (per team-lead Step 1) but a specific teammate is unreachable —
+  typically a stale tmux pane id after compaction, resume, or a pane restart.
 ---
 
 # Restore Team Communications
 
 Use this skill only when all of these are true:
 - `ATM_IDENTITY=team-lead`
-- `SESSION_ID` still matches `leadSessionId` in
-  `~/.claude/teams/atm-dev/config.json`
-- the team directory still exists on disk
-- teammate ATM communication is broken or suspect after compaction or resume
+- `atm doctor --team "$ATM_TEAM"` and `atm members --team "$ATM_TEAM"` show a
+  healthy runtime and a complete roster (per `team-lead` Step 1)
+- one or more named teammates are unreachable or suspect despite the healthy
+  roster
 
-Do not use this skill for fresh startup or after `clear`. If the current
-`SESSION_ID` does not match `leadSessionId`, use `/team-lead` and follow the
-full restore procedure instead.
+If the roster itself is missing members or `atm doctor` reports findings, use
+`.claude/skills/team-lead/backup-and-restore-team.md` instead — this skill
+does not touch roster membership beyond a single member's connection details.
 
 ## Step 0 — Prove Whether Repair Is Needed
 
-First, try native ATM communication with a named teammate before changing
+First, try native ATM communication with the suspect teammate before changing
 anything:
 
 ```bash
-atm send <teammate> "ping: verify atm-dev communications path" --team atm-dev --requires-ack
+atm send <teammate> "ping: verify atm-dev communications path" --team "$ATM_TEAM" --requires-ack
 ```
 
 If the message is delivered and acknowledged, stop. No repair is needed.
 
-Do not read inbox files, session files, or tmux panes directly on this path.
-
-## Step 1 — Back Up Current State
-
-Back up before any destructive recovery:
+## Step 1 — Confirm Runtime And Roster Health
 
 ```bash
-atm teams backup atm-dev
-BACKUP_PATH=$(ls -td ~/.claude/teams/.backups/atm-dev/*/ | head -1)
-cp -r ~/.claude/tasks/agent-team-mail/ "$BACKUP_PATH/tasks-cc"
-echo "CC task list backed up to $BACKUP_PATH/tasks-cc"
+atm doctor --team "$ATM_TEAM"
+atm members --team "$ATM_TEAM"
 ```
 
-## Step 2 — Remove Broken Team Registration
+If either shows a problem outside a single member's connection details,
+stop and use `.claude/skills/team-lead/backup-and-restore-team.md` instead.
 
-Clear both live Claude routing state and the persisted team directory:
+## Step 2 — Repair The Stale Member Entry
 
-```text
-TeamDelete
-```
+The most common cause is a stale `tmuxPaneId` after the pane was restarted or
+reassigned. Discover the current pane, then update the member in place —
+never remove and re-add:
 
 ```bash
-rm -rf ~/.claude/teams/atm-dev
+tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_title} #{pane_current_command}'
+atm teams update-member "$ATM_TEAM" <teammate> --pane-id <correct-pane-id>
 ```
 
-If `TeamDelete` reports no active team name, proceed. That means live routing
-was already absent.
+`update-member` also accepts `--home-dir`, `--harness`, `--agent-type`, and
+`--model` if one of those drifted instead of the pane id.
 
-## Step 3 — Recreate Team And Restore ATM State
-
-Recreate the team:
-
-```text
-TeamCreate(team_name="atm-dev", description="ATM development team", agent_type="team-lead")
-```
-
-Then restore from the most recent backup:
-
-```bash
-atm teams restore atm-dev --from "$BACKUP_PATH"
-```
-
-If required members are missing after restore, add them before verification.
-
-## Step 4 — Verify Native ATM Communication
+## Step 3 — Verify Native ATM Communication
 
 Repair is not complete until all checks pass:
 
-1. `atm send --requires-ack` to another named teammate and receive its native
+1. `atm send --requires-ack` to the repaired teammate and receive its native
    ATM acknowledgement.
 2. `atm send` to `quality-mgr` when that teammate is active, and verify ATM
    mailbox routing.
-3. `atm send` to Codex and verify the nudge fires.
+3. `atm send` to `arch-ctm` (Codex) and verify the nudge fires. The recipient's
+   `.atm.toml` `post_send_hooks` fires this automatically on send — no manual
+   `tmux send-keys` nudge is needed. See `atm help hooks` if it doesn't fire.
 
-For Codex-directed ATM sends, the nudge must include a clear call to action, not
-just a passive unread-mail announcement. Preferred structured nudge payload:
+For Codex-directed ATM sends, the nudge must include a clear call to action,
+not just a passive unread-mail announcement. Preferred structured nudge
+payload:
 
 ```text
 <atm><action>read atm</action><action>ack <TASK-ID></action><action>execute assigned task</action><when idle="immediate" busy="after-current-task"/><console announce="concise" pause="false"/></atm>
 ```
 
-Fallback plain-text wording:
+If the task is queued behind active work, use a queued-task nudge instead of
+an interruptive one.
 
-```text
-read atm for task <TASK-ID> and complete it before stopping
-```
-
-If the task is queued behind active work, use a queued-task nudge instead of an
-interruptive one.
-
-## Step 5 — Resume Work Quietly
+## Step 4 — Resume Work Quietly
 
 If the repair succeeded:
 - do not broadcast internal restore diagnostics over ATM

--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: team-lead
-version: 0.2.0
+version: 0.3.0
 description: >
-  Session initialization for the team-lead identity. Confirms identity and
-  detects whether a full team restore is needed. Only run when
-  ATM_IDENTITY=team-lead.
+  Session initialization for the team-lead identity. Confirms identity,
+  verifies the ATM runtime and SQLite-backed roster, and bootstraps or
+  repairs the team when needed. Only run when ATM_IDENTITY=team-lead.
 ---
 
 # Team Lead Skill
 
 Trigger: run at the start of every fresh session where `ATM_IDENTITY=team-lead`.
-Do not use this skill for same-session compaction or resume unless the session id
-has changed.
+Do not use this skill for same-session compaction or resume unless the runtime
+checks in Step 1 show a problem.
 
 ## Step 0 — Confirm Identity
 
@@ -21,24 +21,53 @@ echo "ATM_IDENTITY=$ATM_IDENTITY"
 
 Stop if `ATM_IDENTITY` is not `team-lead`.
 
-## Step 1 — Detect Whether Restore Is Needed
+## Step 1 — Verify Runtime And Roster
 
-Get the current session id from the `SessionStart` hook output in context
-(`SESSION_ID=<uuid>`). Compare it with `leadSessionId` in the team config:
+atm-core 1.3.1+ has no Claude-Code-native team registry. The daemon's SQLite
+store is the sole source of truth for team membership; there is no
+`config.json` or `leadSessionId` to compare against. Verify runtime and
+roster directly:
 
 ```bash
-python3 -c "import json; print(json.load(open('/Users/randlee/.claude/teams/atm-dev/config.json'))['leadSessionId'])"
+which atm
+atm --version
+echo "$ATM_DAEMON_BIN"
+atm doctor --team "$ATM_TEAM"
+atm members --team "$ATM_TEAM"
 ```
 
-- Match: the current session already matches the persisted team state. Proceed to
-  reading `docs/project-plan.md` and outputting project status. Stay silent in
-  ATM unless teammate action is required. If teammate communications are broken
-  despite a match, stop and use `/restore-team-communications` instead of the
-  full restore flow.
-- Mismatch or missing config: this is the normal startup or `clear` case where
-  the live `SESSION_ID` changed and the saved `leadSessionId` no longer
-  matches. Follow the full restore procedure in
-  `.claude/skills/team-lead/backup-and-restore-team.md`.
+Branch on the result:
+
+- **Runtime healthy, roster complete** (team-lead, arch-ctm, quality-mgr all
+  present and active): proceed to reading `docs/project-plan.md` and
+  outputting project status. Stay silent in ATM unless teammate action is
+  required.
+- **Runtime healthy, roster missing or stale members**: follow
+  `.claude/skills/team-lead/backup-and-restore-team.md` to bootstrap or repair
+  the roster.
+- **Runtime unhealthy** (`atm doctor` reports findings, daemon unreachable,
+  binary path wrong): follow the diagnostics-capture step in
+  `.claude/skills/team-lead/backup-and-restore-team.md` before touching the
+  roster.
+- **Roster looks fine but native ATM communication is broken** (e.g. a
+  teammate doesn't ack a `--requires-ack` send): use
+  `/restore-team-communications` instead of re-running the bootstrap.
+
+## Documentation
+
+atm-core ships its own conceptual and command help — prefer it over
+re-deriving procedural detail here:
+
+```bash
+atm help --list        # list conceptual topics and command help targets
+atm help <topic>       # ATM-owned conceptual guidance (config, errors, hooks, identity, skills)
+atm help <subcommand>  # clap-generated command help, e.g. `atm help teams`
+atm <subcommand> --help
+```
+
+Tier-1/Tier-2 topics as of 1.3.1: `config`, `errors`, `hooks`, `identity`,
+`skills`. Check `atm help --list` each session — the topic set and the
+installed-docs index it reports can change between releases.
 
 ## Team-Lead Responsibilities
 
@@ -52,7 +81,7 @@ After initialization, use these repo-local skills to coordinate work:
 | `/todo-triage` | Run the repo TODO scan during sprint-end or integration review and route TODOs into QA findings/Turtle triage instead of silent deferral |
 | `/triaging-findings` | Correlate QA findings across branches before dispatching fixes to arch-ctm |
 | `/quality-management-gh` | Multi-pass QA on GitHub PRs; CI monitoring; findings/final quality reports |
-| `/restore-team-communications` | Repair same-session Claude teammate routing after compaction or resume without invoking full startup/clear restore |
+| `/restore-team-communications` | Repair native ATM teammate reachability when the roster is healthy but communication is broken |
 
 Additional orchestration guides live in `.claude/skills/*/SKILL.md`.
 
@@ -83,6 +112,9 @@ When assigning work to a teammate:
 - No ACK means the work is not being done.
 - Codex agents such as `arch-ctm` only see new ATM messages when they check
   mail after their current task completes.
+- Use native `atm send` / `atm read` / `atm ack` for all teammate messaging.
+  See `atm help identity` for how caller identity resolves for these
+  commands.
 
 ## PR and CI Protocol
 

--- a/.claude/skills/team-lead/backup-and-restore-team.md
+++ b/.claude/skills/team-lead/backup-and-restore-team.md
@@ -1,132 +1,108 @@
 ---
 name: backup-and-restore-team
-version: 0.2.0
-description: Procedure for backing up and restoring an ATM team. Referenced by the team-lead skill when a session ID mismatch is detected.
+version: 0.3.0
+description: Procedure for bootstrapping or repairing an ATM team's SQLite-backed roster. Referenced by the team-lead skill when Step 1's runtime/roster check finds a problem.
 ---
-# Team Backup And Restore Procedure
+# Team Bootstrap And Recovery Procedure
 
-Follow this procedure when Step 1 of the `team-lead` skill detects a session id
-mismatch and a full team restore is required. This is the startup or `clear`
-path where the live `SESSION_ID` changed and no longer matches
-`leadSessionId`.
+Follow this procedure when Step 1 of the `team-lead` skill finds the runtime
+unhealthy, or the roster missing/stale, for `$ATM_TEAM`.
 
-Do not use this procedure for same-session compaction or resume when the
-session id still matches. Use `/restore-team-communications` for that lighter
-repair path.
+atm-core 1.3.1+ keeps team membership in the daemon-owned SQLite store, not in
+`~/.claude/teams/<team>/config.json`. There is no `TeamCreate` / `TeamDelete` /
+`leadSessionId` model to reconcile — bootstrap and repair both go through
+`atm teams add-member` / `atm teams update-member`.
 
-## Step 2 — Backup Current State
+Do not use this procedure to repair native ATM communication when the roster
+is already healthy — use `/restore-team-communications` for that lighter path.
 
-Always back up before modifying the team:
-
-```bash
-atm teams backup atm-dev
-```
-
-Also back up the Claude Code project task list separately:
+## Step 1 — Confirm Runtime Health
 
 ```bash
-BACKUP_PATH=$(ls -td ~/.claude/teams/.backups/atm-dev/*/ | head -1)
-cp -r ~/.claude/tasks/agent-team-mail/ "$BACKUP_PATH/tasks-cc"
-echo "CC task list backed up to $BACKUP_PATH/tasks-cc"
+which atm
+atm --version
+echo "$ATM_DAEMON_BIN"
+atm doctor --team "$ATM_TEAM"
 ```
 
-Note: `atm teams backup` captures ATM team tasks under `~/.claude/tasks/atm-dev/`
-when present, but not the repo-local Claude Code task bucket
-`~/.claude/tasks/agent-team-mail/`.
+If `atm doctor` reports findings (daemon unreachable, binary mismatch, wrong
+`ATM_HOME`), resolve those first — a roster bootstrap on top of an unhealthy
+daemon will not stick. See `atm help errors` for how to read the reported
+error codes, and `atm help config` for the config surfaces `atm doctor`
+checks.
 
-## Step 3 — Clear Stale Team State
-
-```text
-TeamDelete
-```
-
-Then remove the stale team directory so the next create uses the correct name:
+## Step 2 — Check Current Roster
 
 ```bash
-rm -rf ~/.claude/teams/atm-dev
+atm members --team "$ATM_TEAM"
 ```
 
-If `TeamDelete` already removed the directory, the `rm -rf` is harmless.
+Compare against the expected roster for `atm-dev`:
 
-## Step 4 — Create Team
+| Member | Agent type | Model | Home dir |
+|--------|-----------|-------|----------|
+| team-lead | team-lead | claude-sonnet-4-6 (or current session model) | `/Users/randlee/Documents/github/atm-core` |
+| arch-ctm | codex | high | `/Users/randlee/Documents/github/atm-core` |
+| quality-mgr | quality-mgr | claude-sonnet-4-6 | `/Users/randlee/Documents/github/atm-core` |
 
-```text
-TeamCreate(team_name="atm-dev", description="ATM development team", agent_type="team-lead")
-```
-
-Verify that the returned team name is exactly `atm-dev`. If it is not, stop.
-
-Note: `/restore-team-communications` reuses this same `TeamCreate` primitive
-when communications are broken after compaction or resume, but that path should
-prove the failure first and avoid this destructive backup/delete/restore flow
-unless the lighter repair fails.
-
-## Step 5 — Restore Team Members And Inboxes
+If a member's `tmuxPaneId` is stale (pane no longer exists or now hosts a
+different agent), discover the correct pane before touching membership:
 
 ```bash
-atm teams restore atm-dev --from ~/.claude/teams/.backups/atm-dev/<timestamp>
+tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_title} #{pane_current_command}'
 ```
 
-Verify members:
+## Step 3 — Add Or Update Members
+
+Add any member missing from the roster:
 
 ```bash
-atm members
+atm teams add-member "$ATM_TEAM" team-lead --agent-type team-lead --model claude-sonnet-4-6 --home-dir /Users/randlee/Documents/github/atm-core --pane-id <pane>
+atm teams add-member "$ATM_TEAM" arch-ctm --agent-type codex --model high --home-dir /Users/randlee/Documents/github/atm-core --pane-id <pane>
+atm teams add-member "$ATM_TEAM" quality-mgr --agent-type quality-mgr --model claude-sonnet-4-6 --home-dir /Users/randlee/Documents/github/atm-core --pane-id <pane>
 ```
 
-If unexpected ghost members exist, trim the config manually:
+Note the flag is `--agent-type`, not `--type`.
+
+For a member that already exists but has a stale pane, model, or home dir,
+use `update-member` instead of re-adding:
 
 ```bash
-python3 -c "
-import json
-path = '/Users/randlee/.claude/teams/atm-dev/config.json'
-with open(path) as f:
-    cfg = json.load(f)
-keep = ['team-lead', 'arch-ctm', 'quality-mgr']
-cfg['members'] = [m for m in cfg['members'] if m['name'] in keep]
-with open(path, 'w') as f:
-    json.dump(cfg, f, indent=2)
-print('Members:', [m['name'] for m in cfg['members']])
-"
+atm teams update-member "$ATM_TEAM" <member> --pane-id <correct-pane-id>
 ```
 
-Adjust the `keep` list if additional named teammates are intentionally active.
+`update-member` also accepts `--home-dir`, `--harness`, `--agent-type`, and
+`--model` for other drifted fields.
 
-## Step 6 — Restore Claude Code Task List
+## Step 4 — Verify Roster And Runtime
 
 ```bash
-BACKUP_PATH=$(ls -td ~/.claude/teams/.backups/atm-dev/*/ | head -1)
-if [ -d "$BACKUP_PATH/tasks-cc" ]; then
-  mkdir -p ~/.claude/tasks/agent-team-mail
-  cp "$BACKUP_PATH/tasks-cc/"*.json ~/.claude/tasks/agent-team-mail/ 2>/dev/null || true
-  MAX_ID=$(ls ~/.claude/tasks/agent-team-mail/*.json 2>/dev/null \
-    | xargs -I{} basename {} .json \
-    | sort -n | tail -1)
-  [ -n "$MAX_ID" ] && echo -n "$MAX_ID" > ~/.claude/tasks/agent-team-mail/.highwatermark
-  echo "Task list restored. Highwatermark: $MAX_ID"
-else
-  echo "No tasks-cc/ in backup — task list not restored."
-fi
+atm members --team "$ATM_TEAM"
+atm doctor --team "$ATM_TEAM"
 ```
 
-The Claude Code UI task panel may not show restored tasks until one task is
-created through the task tool.
+Confirm all three expected members are present, active, and the pane ids
+resolve to real panes.
 
-## Step 7 — Verify Team Health
+## Step 5 — Minimal Functional Check
 
 ```bash
-atm members
-atm inbox
-atm gh pr list
+atm send team-lead@"$ATM_TEAM" "restart check ($SESSION_ID)"
+atm read --team "$ATM_TEAM"
 ```
 
-Communication verification is also mandatory:
-1. `atm send --requires-ack` to another named teammate and receive its native
-   ATM acknowledgement.
-2. `atm send` to `quality-mgr` when that teammate is active to prove ATM
-   mailbox routing works.
-3. `atm send` to Codex and confirm the Codex-side nudge fires.
+If this round-trip fails, capture and report the diagnostic bundle below
+rather than guessing further:
 
-## Step 8 — Read Project Context
+```bash
+which atm
+atm --version
+echo "$ATM_DAEMON_BIN"
+atm doctor --team "$ATM_TEAM"
+atm members --team "$ATM_TEAM"
+```
+
+## Step 6 — Read Project Context
 
 1. Read `docs/project-plan.md`.
 2. Recreate pending tasks if the task list is empty.
@@ -136,32 +112,37 @@ Communication verification is also mandatory:
    - active teammates and their last known task
    - next sprint or sprints ready to execute
 
-## Step 9 — Notify Teammates
+## Step 7 — Notify Teammates
 
 ```bash
-atm send arch-ctm "New session (session-id: <SESSION_ID>). Team atm-dev restored. Please acknowledge and confirm status."
+atm send arch-ctm "New session (session-id: $SESSION_ID). Team $ATM_TEAM verified. Please acknowledge and confirm status."
 ```
 
-If no response arrives within about 60 seconds, nudge via tmux. Preferred
-structured nudge payload when task metadata is available:
-
-```text
-<atm><action>read atm</action><action>ack <TASK-ID></action><action>execute assigned task</action><when idle="immediate" busy="after-current-task"/><console announce="concise" pause="false"/></atm>
-```
-
-Fallback plain-text nudge:
-
-```bash
-tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_title}'
-tmux send-keys -t <pane-id> "read atm for task <TASK-ID> and complete it before stopping" Enter
-```
+The recipient's `.atm.toml` `post_send_hooks` fires the nudge automatically on
+send — no manual `tmux send-keys` nudge is needed. See `atm help hooks` for
+how post-send hooks resolve and how to debug one that doesn't fire.
 
 ## Common Failure Modes
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `TeamCreate` returns random name | `~/.claude/teams/atm-dev` still exists | remove the directory and retry |
-| `TeamDelete` says no team name found | fresh session with no active team context | expected, proceed |
-| task list looks empty after restore | highwatermark mismatch or UI stale state | set `.highwatermark`, then create one real task |
-| `atm send` fails with agent not found | member missing after restore | add the member back to the team |
-| self-send or wrong identity routing | teammate launched with wrong `ATM_IDENTITY` | relaunch with the correct identity |
+| `atm teams add-member` rejects `--type` | flag was renamed | use `--agent-type` |
+| `atm doctor` reports daemon unreachable | daemon not running or wrong `ATM_DAEMON_BIN` | check `echo "$ATM_DAEMON_BIN"` matches the installed binary, restart daemon if needed |
+| member present in `atm members` but sends never land | stale `--pane-id` | `atm teams update-member "$ATM_TEAM" <member> --pane-id <correct-pane-id>` |
+| `atm send` fails with agent not found | member missing from roster | `atm teams add-member` per Step 3 |
+| self-send or wrong identity routing | teammate launched with wrong `ATM_IDENTITY` | relaunch with the correct identity; see `atm help identity` |
+| task list looks empty after a restart | Claude Code UI task panel stale state | create one real task through the task tool to refresh it |
+
+## Last Resort — Full Backup/Restore
+
+Only needed for disaster recovery (corrupted SQLite store, wrong team
+entirely). `atm teams backup` / `atm teams restore` operate on the real
+daemon-owned store:
+
+```bash
+atm teams backup "$ATM_TEAM"
+atm teams restore "$ATM_TEAM" --from <backup-path> --dry-run
+atm teams restore "$ATM_TEAM" --from <backup-path>
+```
+
+Always run `--dry-run` first and review the plan before the real restore.

--- a/.claude/skills/team-lead/backup-and-restore-team.md
+++ b/.claude/skills/team-lead/backup-and-restore-team.md
@@ -41,9 +41,9 @@ Compare against the expected roster for `atm-dev`:
 
 | Member | Agent type | Model | Home dir |
 |--------|-----------|-------|----------|
-| team-lead | team-lead | claude-sonnet-4-6 (or current session model) | `/Users/randlee/Documents/github/atm-core` |
+| team-lead | team-lead | sonnet (or current session model) | `/Users/randlee/Documents/github/atm-core` |
 | arch-ctm | codex | high | `/Users/randlee/Documents/github/atm-core` |
-| quality-mgr | quality-mgr | claude-sonnet-4-6 | `/Users/randlee/Documents/github/atm-core` |
+| quality-mgr | quality-mgr | sonnet | `/Users/randlee/Documents/github/atm-core` |
 
 If a member's `tmuxPaneId` is stale (pane no longer exists or now hosts a
 different agent), discover the correct pane before touching membership:
@@ -58,8 +58,8 @@ Add any member missing from the roster:
 
 ```bash
 atm teams add-member "$ATM_TEAM" team-lead --agent-type team-lead --model claude-sonnet-4-6 --home-dir /Users/randlee/Documents/github/atm-core --pane-id <pane>
-atm teams add-member "$ATM_TEAM" arch-ctm --agent-type codex --model high --home-dir /Users/randlee/Documents/github/atm-core --pane-id <pane>
-atm teams add-member "$ATM_TEAM" quality-mgr --agent-type quality-mgr --model claude-sonnet-4-6 --home-dir /Users/randlee/Documents/github/atm-core --pane-id <pane>
+atm teams add-member "$ATM_TEAM" {{TEAM_MEMBER}} --agent-type rust-arch --model codex-high --home-dir /Users/randlee/Documents/github/atm-core --pane-id <pane>
+atm teams add-member "$ATM_TEAM" quality-mgr --agent-type quality-mgr --model claude-sonnet --home-dir /Users/randlee/Documents/github/atm-core --pane-id <pane>
 ```
 
 Note the flag is `--agent-type`, not `--type`.

--- a/.claude/skills/team-lead/backup-and-restore-team.md
+++ b/.claude/skills/team-lead/backup-and-restore-team.md
@@ -86,8 +86,11 @@ resolve to real panes.
 
 ## Step 5 — Minimal Functional Check
 
+ATM rejects self-addressed sends (`team-lead@$ATM_TEAM` may not send to
+itself), so the round-trip must target another roster member:
+
 ```bash
-atm send team-lead@"$ATM_TEAM" "restart check ($SESSION_ID)"
+atm send arch-ctm "restart check ($SESSION_ID)" --team "$ATM_TEAM" --requires-ack
 atm read --team "$ATM_TEAM"
 ```
 


### PR DESCRIPTION
## Summary
- Replaces the obsolete `TeamCreate`/`TeamDelete`/`config.json`/`leadSessionId` model in `team-lead/SKILL.md`, `team-lead/backup-and-restore-team.md`, and `restore-team-communications/SKILL.md` with the atm-core 1.3.1 SQLite-backed `atm teams add-member`/`update-member`/`atm doctor` bootstrap flow.
- Corrects the `--type` -> `--agent-type` flag from the original bootstrap procedure.
- Points the skills at the installed `atm help --list` / `atm help <topic>` conceptual docs instead of re-deriving procedural detail.
- Narrows `restore-team-communications` to single-member connection repair (stale pane id) now that roster health is a separate, cheaper check.

## Test plan
- [ ] arch-ctm review before merge
- [ ] Manual dry-run of `team-lead` Step 1 in a live session