### PR TITLE
fix(doctor): thread caller identity through IPC instead of daemon's frozen launch-time env

### DIFF
--- a/crates/atm-core/src/caller_context.rs
+++ b/crates/atm-core/src/caller_context.rs
@@ -58,6 +58,36 @@ pub fn read_cli_team_from_env() -> Result<Option<TeamName>, AtmError> {
     read_env_raw("ATM_TEAM")?.map(parse_team).transpose()
 }
 
+pub fn read_cli_identity_from_env_or_warn(warning_site: &'static str) -> Option<AgentName> {
+    match read_cli_identity_from_env() {
+        Ok(identity) => identity,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                warning_site,
+                env_var = "ATM_IDENTITY",
+                "ignoring malformed caller identity environment variable during doctor context capture"
+            );
+            None
+        }
+    }
+}
+
+pub fn read_cli_team_from_env_or_warn(warning_site: &'static str) -> Option<TeamName> {
+    match read_cli_team_from_env() {
+        Ok(team) => team,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                warning_site,
+                env_var = "ATM_TEAM",
+                "ignoring malformed caller team environment variable during doctor context capture"
+            );
+            None
+        }
+    }
+}
+
 fn resolve_identity_component(explicit: Option<&str>) -> Result<AgentName, AtmError> {
     let raw = match explicit {
         Some(value) => value.to_string(),
@@ -130,7 +160,8 @@ mod tests {
 
     use super::{
         CallerContextOverrides, CallerIdentityOverride, CallerTeamOverride,
-        read_cli_identity_from_env, read_cli_team_from_env, resolve_cli_inspection_caller_context,
+        read_cli_identity_from_env, read_cli_identity_from_env_or_warn, read_cli_team_from_env,
+        read_cli_team_from_env_or_warn, resolve_cli_inspection_caller_context,
         resolve_cli_mutation_caller_context,
     };
 
@@ -218,5 +249,24 @@ mod tests {
 
         assert_eq!(context.caller_identity.as_str(), TEST_SENDER);
         assert_eq!(context.caller_team.as_str(), TEST_TEAM);
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn lossy_identity_env_read_warns_and_falls_back_to_none() {
+        let _env = EnvGuard::set_many([("ATM_IDENTITY", Some("   ")), ("ATM_TEAM", None)]);
+
+        assert_eq!(
+            read_cli_identity_from_env_or_warn("caller_context test"),
+            None
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn lossy_team_env_read_warns_and_falls_back_to_none() {
+        let _env = EnvGuard::set_many([("ATM_IDENTITY", None), ("ATM_TEAM", Some("   "))]);
+
+        assert_eq!(read_cli_team_from_env_or_warn("caller_context test"), None);
     }
 }

--- a/crates/atm-core/src/doctor/health.rs
+++ b/crates/atm-core/src/doctor/health.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::caller_context::{read_cli_identity_from_env, read_cli_team_from_env};
+use crate::caller_context::{read_cli_identity_from_env_or_warn, read_cli_team_from_env_or_warn};
 use crate::doctor::report::{
     DoctorEnvironmentVisibility, DoctorFinding, DoctorSeverity, DoctorStatus,
 };
@@ -36,11 +36,16 @@ pub fn environment_visibility(
     caller_identity: Option<AgentName>,
 ) -> DoctorEnvironmentVisibility {
     DoctorEnvironmentVisibility {
+        // `atm_home` intentionally continues to reflect this process env
+        // directly; re-plumbing ATM_HOME precedence is out of scope for #548.
         atm_home: std::env::var_os("ATM_HOME")
             .map(PathBuf::from)
             .or(Some(home_dir)),
-        atm_team: caller_team.or_else(|| read_cli_team_from_env().ok().flatten()),
-        atm_identity: caller_identity.or_else(|| read_cli_identity_from_env().ok().flatten()),
+        atm_team: caller_team
+            .or_else(|| read_cli_team_from_env_or_warn("atm_core::doctor::environment_visibility")),
+        atm_identity: caller_identity.or_else(|| {
+            read_cli_identity_from_env_or_warn("atm_core::doctor::environment_visibility")
+        }),
         team_override,
     }
 }

--- a/crates/atm-core/src/doctor/health.rs
+++ b/crates/atm-core/src/doctor/health.rs
@@ -7,7 +7,7 @@ use crate::doctor::report::{
 use crate::error::AtmError;
 use crate::error_codes::AtmErrorCode;
 use crate::observability::{AtmObservabilityHealth, AtmObservabilityHealthState};
-use crate::types::TeamName;
+use crate::types::{AgentName, TeamName};
 
 pub fn unavailable_snapshot(detail: String) -> AtmObservabilityHealth {
     AtmObservabilityHealth {
@@ -20,16 +20,27 @@ pub fn unavailable_snapshot(detail: String) -> AtmObservabilityHealth {
     }
 }
 
+/// Assemble the caller-facing environment visibility for a doctor report.
+///
+/// The `caller_team`/`caller_identity` arguments carry the invoking CLI
+/// process's resolved `ATM_TEAM`/`ATM_IDENTITY`. They take precedence over
+/// reading the process environment directly, which is essential when this code
+/// runs inside the long-lived daemon whose own environment is frozen at launch
+/// time and does not reflect the requesting shell. The direct-read fallback is
+/// only used for the in-process direct-local doctor path, where the current
+/// process environment already is the caller's.
 pub fn environment_visibility(
     home_dir: PathBuf,
     team_override: Option<TeamName>,
+    caller_team: Option<TeamName>,
+    caller_identity: Option<AgentName>,
 ) -> DoctorEnvironmentVisibility {
     DoctorEnvironmentVisibility {
         atm_home: std::env::var_os("ATM_HOME")
             .map(PathBuf::from)
             .or(Some(home_dir)),
-        atm_team: read_cli_team_from_env().ok().flatten(),
-        atm_identity: read_cli_identity_from_env().ok().flatten(),
+        atm_team: caller_team.or_else(|| read_cli_team_from_env().ok().flatten()),
+        atm_identity: caller_identity.or_else(|| read_cli_identity_from_env().ok().flatten()),
         team_override,
     }
 }
@@ -113,5 +124,66 @@ fn render_state(state: AtmObservabilityHealthState) -> &'static str {
         AtmObservabilityHealthState::Healthy => "healthy",
         AtmObservabilityHealthState::Degraded => "degraded",
         AtmObservabilityHealthState::Unavailable => "unavailable",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::environment_visibility;
+    use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM};
+    use crate::types::{AgentName, TeamName};
+
+    // Synthetic stand-ins for the daemon's frozen launch-time environment.
+    // Deliberately distinct from the caller's values so the test proves the
+    // caller wins even when the ambient process env disagrees (issue #548).
+    const DAEMON_LAUNCH_TEAM: &str = "daemon-launch-team";
+    const DAEMON_LAUNCH_IDENTITY: &str = "daemon-launch-identity";
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn caller_values_win_over_process_environment() {
+        // Simulate the daemon process whose env was frozen at launch time.
+        let _env = EnvGuard::set_many([
+            ("ATM_TEAM", Some(DAEMON_LAUNCH_TEAM)),
+            ("ATM_IDENTITY", Some(DAEMON_LAUNCH_IDENTITY)),
+        ]);
+
+        let visibility = environment_visibility(
+            PathBuf::from("/home"),
+            None,
+            Some(TEST_TEAM.parse::<TeamName>().expect("team")),
+            Some(TEST_SENDER.parse::<AgentName>().expect("identity")),
+        );
+
+        assert_eq!(
+            visibility.atm_team.as_ref().map(TeamName::as_str),
+            Some(TEST_TEAM)
+        );
+        assert_eq!(
+            visibility.atm_identity.as_ref().map(AgentName::as_str),
+            Some(TEST_SENDER)
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn falls_back_to_process_environment_when_caller_absent() {
+        let _env = EnvGuard::set_many([
+            ("ATM_TEAM", Some(TEST_TEAM)),
+            ("ATM_IDENTITY", Some(TEST_SENDER)),
+        ]);
+
+        let visibility = environment_visibility(PathBuf::from("/home"), None, None, None);
+
+        assert_eq!(
+            visibility.atm_team.as_ref().map(TeamName::as_str),
+            Some(TEST_TEAM)
+        );
+        assert_eq!(
+            visibility.atm_identity.as_ref().map(AgentName::as_str),
+            Some(TEST_SENDER)
+        );
     }
 }

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -85,82 +85,41 @@ pub fn run_doctor_with_runtime(
     runtime: &LocalServiceRuntime,
 ) -> Result<DoctorReport, crate::error::AtmError> {
     let config = runtime.load_config(&query.current_dir)?;
-    let home_dir = query.home_dir.clone();
-    let initial_lock_snapshot = snapshot_mailbox_lock_paths(&home_dir);
-    let resolved_team = resolved_doctor_team(&query, config.as_ref());
-    let environment = health::environment_visibility(
-        query.home_dir,
-        query.team_override,
-        query.caller_team,
-        query.caller_identity,
-    );
+    let doctor_context = doctor_run_context(&query, config.as_ref());
     let (observability_health, finding) = doctor_observability_status(observability);
     let mut findings = Vec::new();
-    if config
-        .as_ref()
-        .is_some_and(|config| config.obsolete_identity.is_some())
-    {
-        findings.push(DoctorFinding {
-            severity: DoctorSeverity::Warning,
-            code: AtmErrorCode::WarningIdentityDrift,
-            message: "obsolete config identity is still present in .atm.toml (`[atm].identity` or legacy top-level `identity`); ATM no longer uses config identity as a runtime fallback.".to_string(),
-            remediation: Some(
-                "Remove `[atm].identity` or the legacy top-level `identity` key from `.atm.toml` and set `ATM_IDENTITY` in the active agent environment instead."
-                    .to_string(),
-            ),
-        });
-    }
-    let member_roster = resolved_team.as_ref().and_then(|team| {
+    push_obsolete_identity_warning(config.as_ref(), &mut findings);
+    let member_roster = doctor_context.resolved_team.as_ref().and_then(|team| {
         load_member_roster(
             runtime,
-            &home_dir,
+            &doctor_context.home_dir,
             team,
             config.as_ref(),
-            environment.atm_identity.as_ref(),
+            doctor_context.environment.atm_identity.as_ref(),
             Some(query.current_dir.as_path()),
             &mut findings,
         )
     });
     push_stale_mailbox_lock_findings(
-        &initial_lock_snapshot,
-        &snapshot_mailbox_lock_paths(&home_dir),
+        &doctor_context.initial_lock_snapshot,
+        &snapshot_mailbox_lock_paths(&doctor_context.home_dir),
         &mut findings,
     );
     findings.push(finding);
-    let summary = summarize_doctor_findings(&findings);
-    let recommendations = findings
-        .iter()
-        .filter_map(|finding| finding.remediation.clone())
-        .collect::<Vec<_>>();
-
-    Ok(DoctorReport {
-        summary,
+    Ok(build_doctor_report(
         findings,
-        recommendations,
-        environment: environment.clone(),
-        client_context: report::DoctorExecutionContext {
-            // A `--team` override reflects the team the caller explicitly asked
-            // the doctor to inspect, so it takes precedence over the ambient
-            // `ATM_TEAM` in the reported client context.
-            team: environment
-                .team_override
-                .clone()
-                .or_else(|| environment.atm_team.clone()),
-            identity: environment.atm_identity.clone(),
-            version: Some(crate::protocol::ReleaseVersion::current()),
-        },
-        daemon_context: None,
+        doctor_context.environment,
         member_roster,
-        observability: observability_health,
-        post_send: PostSendDoctorReport::default(),
-        config: crate::boundary::ConfigDoctorReport::default(),
-        mail_store: crate::boundary::MailStoreDoctorReport::default(),
-        roster_store: crate::boundary::RosterStoreDoctorReport::default(),
-        daemon_runtime: None,
-        drift_findings: Vec::new(),
-        runtime_status: None,
-        bootstrap_trace: None,
-    })
+        PostSendDoctorReport::default(),
+        crate::boundary::ConfigDoctorReport::default(),
+        crate::boundary::MailStoreDoctorReport::default(),
+        crate::boundary::RosterStoreDoctorReport::default(),
+        None,
+        Vec::new(),
+        observability_health,
+        None,
+        None,
+    ))
 }
 
 pub fn run_doctor_with_runtime_ports(
@@ -171,34 +130,26 @@ pub fn run_doctor_with_runtime_ports(
     daemon_runtime: Option<report::DaemonRuntimeDoctorReport>,
 ) -> Result<DoctorReport, crate::error::AtmError> {
     let config = runtime.load_config(&query.current_dir)?;
-    let home_dir = query.home_dir.clone();
-    let initial_lock_snapshot = snapshot_mailbox_lock_paths(&home_dir);
-    let resolved_team = resolved_doctor_team(&query, config.as_ref());
-    let environment = health::environment_visibility(
-        query.home_dir,
-        query.team_override,
-        query.caller_team,
-        query.caller_identity,
-    );
+    let doctor_context = doctor_run_context(&query, config.as_ref());
     let (observability_health, observability_finding) = doctor_observability_status(observability);
     let mut general_findings = Vec::new();
     let mut drift_findings = Vec::new();
     let mut reports = inspect_runtime_doctor_sections(runtime_doctors, &mut general_findings);
     push_obsolete_identity_finding(config.as_ref(), &mut reports.config);
-    let member_roster = resolved_team.as_ref().and_then(|team| {
+    let member_roster = doctor_context.resolved_team.as_ref().and_then(|team| {
         load_member_roster(
             runtime,
-            &home_dir,
+            &doctor_context.home_dir,
             team,
             config.as_ref(),
-            environment.atm_identity.as_ref(),
+            doctor_context.environment.atm_identity.as_ref(),
             Some(query.current_dir.as_path()),
             &mut drift_findings,
         )
     });
     push_stale_mailbox_lock_findings(
-        &initial_lock_snapshot,
-        &snapshot_mailbox_lock_paths(&home_dir),
+        &doctor_context.initial_lock_snapshot,
+        &snapshot_mailbox_lock_paths(&doctor_context.home_dir),
         &mut drift_findings,
     );
     let findings = collect_doctor_findings(
@@ -208,43 +159,120 @@ pub fn run_doctor_with_runtime_ports(
         observability_finding,
         daemon_runtime.as_ref(),
     );
-    let summary = summarize_doctor_findings(&findings);
-    let recommendations = collect_recommendations(&findings);
     let post_send = post_send_doctor_report(
         config.as_ref(),
         member_roster.as_ref(),
         runtime,
-        resolved_team.as_ref(),
+        doctor_context.resolved_team.as_ref(),
     );
 
-    Ok(DoctorReport {
+    Ok(build_doctor_report(
+        findings,
+        doctor_context.environment,
+        member_roster,
+        post_send,
+        reports.config,
+        reports.mail_store,
+        reports.roster_store,
+        daemon_runtime,
+        drift_findings,
+        observability_health,
+        None,
+        None,
+    ))
+}
+
+struct DoctorRunContext {
+    home_dir: PathBuf,
+    initial_lock_snapshot: BTreeSet<PathBuf>,
+    resolved_team: Option<TeamName>,
+    environment: DoctorEnvironmentVisibility,
+}
+
+fn doctor_run_context(
+    query: &DoctorQuery,
+    config: Option<&crate::config::AtmConfig>,
+) -> DoctorRunContext {
+    let home_dir = query.home_dir.clone();
+    DoctorRunContext {
+        initial_lock_snapshot: snapshot_mailbox_lock_paths(&home_dir),
+        resolved_team: resolved_doctor_team(query, config),
+        environment: health::environment_visibility(
+            query.home_dir.clone(),
+            query.team_override.clone(),
+            query.caller_team.clone(),
+            query.caller_identity.clone(),
+        ),
+        home_dir,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_doctor_report(
+    findings: Vec<DoctorFinding>,
+    environment: DoctorEnvironmentVisibility,
+    member_roster: Option<MembersList>,
+    post_send: PostSendDoctorReport,
+    config: crate::boundary::ConfigDoctorReport,
+    mail_store: crate::boundary::MailStoreDoctorReport,
+    roster_store: crate::boundary::RosterStoreDoctorReport,
+    daemon_runtime: Option<report::DaemonRuntimeDoctorReport>,
+    drift_findings: Vec<DoctorFinding>,
+    observability_health: crate::observability::AtmObservabilityHealth,
+    runtime_status: Option<crate::protocol::RuntimeStatusSnapshot>,
+    bootstrap_trace: Option<BootstrapTraceReport>,
+) -> DoctorReport {
+    let summary = summarize_doctor_findings(&findings);
+    let recommendations = collect_recommendations(&findings);
+    DoctorReport {
         summary,
         findings,
         recommendations,
         environment: environment.clone(),
-        client_context: report::DoctorExecutionContext {
-            // A `--team` override reflects the team the caller explicitly asked
-            // the doctor to inspect, so it takes precedence over the ambient
-            // `ATM_TEAM` in the reported client context.
-            team: environment
-                .team_override
-                .clone()
-                .or_else(|| environment.atm_team.clone()),
-            identity: environment.atm_identity.clone(),
-            version: Some(crate::protocol::ReleaseVersion::current()),
-        },
+        client_context: doctor_client_context(&environment),
         daemon_context: None,
         member_roster,
         observability: observability_health,
         post_send,
-        config: reports.config,
-        mail_store: reports.mail_store,
-        roster_store: reports.roster_store,
+        config,
+        mail_store,
+        roster_store,
         daemon_runtime,
         drift_findings,
-        runtime_status: None,
-        bootstrap_trace: None,
-    })
+        runtime_status,
+        bootstrap_trace,
+    }
+}
+
+fn doctor_client_context(environment: &DoctorEnvironmentVisibility) -> DoctorExecutionContext {
+    DoctorExecutionContext {
+        // A `--team` override reflects the team the caller explicitly asked
+        // the doctor to inspect, so it takes precedence over the ambient
+        // `ATM_TEAM` in the reported client context.
+        team: environment
+            .team_override
+            .clone()
+            .or_else(|| environment.atm_team.clone()),
+        identity: environment.atm_identity.clone(),
+        version: Some(crate::protocol::ReleaseVersion::current()),
+    }
+}
+
+fn push_obsolete_identity_warning(
+    config: Option<&crate::config::AtmConfig>,
+    findings: &mut Vec<DoctorFinding>,
+) {
+    if config.is_some_and(|config| config.obsolete_identity.is_some()) {
+        findings.push(DoctorFinding {
+            severity: DoctorSeverity::Warning,
+            code: AtmErrorCode::WarningIdentityDrift,
+            message: "obsolete config identity is still present in .atm.toml (`[atm].identity` or legacy top-level `identity`); ATM no longer uses config identity as a runtime fallback.".to_string(),
+            remediation: Some(
+                "Remove `[atm].identity` or the legacy top-level `identity` key from `.atm.toml` and set `ATM_IDENTITY` in the active agent environment instead."
+                    .to_string(),
+            ),
+        });
+    }
 }
 
 fn post_send_doctor_report(

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -26,11 +26,26 @@ pub use report::{
     RecipientDeliveryPath, RecipientDeliveryPathReport,
 };
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+/// Inputs for a doctor run, including the caller's resolved identity.
+///
+/// When the doctor request is serviced over IPC by the long-lived daemon
+/// singleton, the daemon process cannot observe the requesting shell's
+/// `ATM_TEAM`/`ATM_IDENTITY`; its own process environment is frozen at launch
+/// time. The `caller_team` and `caller_identity` fields carry the invoking
+/// CLI process's resolved values across the IPC boundary so the resulting
+/// report's `client_context` reflects the real caller rather than whatever
+/// environment happens to be visible where the report is evaluated.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct DoctorQuery {
     pub home_dir: PathBuf,
     pub current_dir: PathBuf,
     pub team_override: Option<TeamName>,
+    /// Caller's `ATM_TEAM`, captured in the invoking CLI process.
+    #[serde(default)]
+    pub caller_team: Option<TeamName>,
+    /// Caller's `ATM_IDENTITY`, captured in the invoking CLI process.
+    #[serde(default)]
+    pub caller_identity: Option<AgentName>,
 }
 
 #[derive(Clone)]
@@ -73,7 +88,12 @@ pub fn run_doctor_with_runtime(
     let home_dir = query.home_dir.clone();
     let initial_lock_snapshot = snapshot_mailbox_lock_paths(&home_dir);
     let resolved_team = resolved_doctor_team(&query, config.as_ref());
-    let environment = health::environment_visibility(query.home_dir, query.team_override);
+    let environment = health::environment_visibility(
+        query.home_dir,
+        query.team_override,
+        query.caller_team,
+        query.caller_identity,
+    );
     let (observability_health, finding) = doctor_observability_status(observability);
     let mut findings = Vec::new();
     if config
@@ -119,7 +139,13 @@ pub fn run_doctor_with_runtime(
         recommendations,
         environment: environment.clone(),
         client_context: report::DoctorExecutionContext {
-            team: environment.atm_team.clone(),
+            // A `--team` override reflects the team the caller explicitly asked
+            // the doctor to inspect, so it takes precedence over the ambient
+            // `ATM_TEAM` in the reported client context.
+            team: environment
+                .team_override
+                .clone()
+                .or_else(|| environment.atm_team.clone()),
             identity: environment.atm_identity.clone(),
             version: Some(crate::protocol::ReleaseVersion::current()),
         },
@@ -148,7 +174,12 @@ pub fn run_doctor_with_runtime_ports(
     let home_dir = query.home_dir.clone();
     let initial_lock_snapshot = snapshot_mailbox_lock_paths(&home_dir);
     let resolved_team = resolved_doctor_team(&query, config.as_ref());
-    let environment = health::environment_visibility(query.home_dir, query.team_override);
+    let environment = health::environment_visibility(
+        query.home_dir,
+        query.team_override,
+        query.caller_team,
+        query.caller_identity,
+    );
     let (observability_health, observability_finding) = doctor_observability_status(observability);
     let mut general_findings = Vec::new();
     let mut drift_findings = Vec::new();
@@ -192,7 +223,13 @@ pub fn run_doctor_with_runtime_ports(
         recommendations,
         environment: environment.clone(),
         client_context: report::DoctorExecutionContext {
-            team: environment.atm_team.clone(),
+            // A `--team` override reflects the team the caller explicitly asked
+            // the doctor to inspect, so it takes precedence over the ambient
+            // `ATM_TEAM` in the reported client context.
+            team: environment
+                .team_override
+                .clone()
+                .or_else(|| environment.atm_team.clone()),
             identity: environment.atm_identity.clone(),
             version: Some(crate::protocol::ReleaseVersion::current()),
         },
@@ -1140,6 +1177,7 @@ mod tests {
             home_dir: paths.home_dir.clone(),
             current_dir: paths.current_dir.clone(),
             team_override: Some(TEST_TEAM.parse().expect("team")),
+            ..DoctorQuery::default()
         }
     }
 
@@ -1177,6 +1215,7 @@ mod tests {
                 home_dir: paths.home_dir.clone(),
                 current_dir: paths.current_dir.clone(),
                 team_override: Some(crate::types::TeamName::from_validated("../evil")),
+                ..DoctorQuery::default()
             },
             &StubObservability {
                 health: StubHealth::Ok(AtmObservabilityHealth {
@@ -1571,6 +1610,84 @@ mod tests {
                     && finding.message.contains(&stale_lock.display().to_string())
             }),
             "{report:#?}"
+        );
+    }
+
+    fn healthy_observability(paths: &TestPaths) -> StubObservability {
+        StubObservability {
+            health: StubHealth::Ok(AtmObservabilityHealth {
+                active_log_path: Some(paths.active_log_path.clone()),
+                logging_state: AtmObservabilityHealthState::Healthy,
+                query_state: Some(AtmObservabilityHealthState::Healthy),
+                maintenance: None,
+                diagnostic: None,
+                detail: None,
+            }),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn client_context_reflects_caller_not_ambient_environment() {
+        let paths = TestPaths::new();
+        paths.write_team_layout(&[TEST_SENDER]);
+        // Ambient process env stands in for the long-lived daemon's frozen
+        // launch-time identity; the caller's threaded values must win.
+        let _env = crate::test_support::EnvGuard::set_many([
+            ("ATM_TEAM", Some("daemon-launch-team")),
+            ("ATM_IDENTITY", Some("daemon-launch-identity")),
+        ]);
+        let query = DoctorQuery {
+            home_dir: paths.home_dir.clone(),
+            current_dir: paths.current_dir.clone(),
+            team_override: None,
+            caller_team: Some(TEST_TEAM.parse().expect("team")),
+            caller_identity: Some(TEST_SENDER.parse().expect("identity")),
+        };
+
+        let report =
+            run_doctor(&paths, query, &healthy_observability(&paths)).expect("doctor report");
+
+        assert_eq!(
+            report.client_context.team.as_ref().map(TeamName::as_str),
+            Some(TEST_TEAM)
+        );
+        assert_eq!(
+            report
+                .client_context
+                .identity
+                .as_ref()
+                .map(AgentName::as_str),
+            Some(TEST_SENDER)
+        );
+        assert_eq!(
+            report.environment.atm_team.as_ref().map(TeamName::as_str),
+            Some(TEST_TEAM)
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn team_override_is_reflected_in_client_context() {
+        let paths = TestPaths::new();
+        paths.write_team_layout(&[TEST_SENDER]);
+        let _env =
+            crate::test_support::EnvGuard::set_many([("ATM_TEAM", None), ("ATM_IDENTITY", None)]);
+        let override_team = format!("{TEST_TEAM}-override");
+        let query = DoctorQuery {
+            home_dir: paths.home_dir.clone(),
+            current_dir: paths.current_dir.clone(),
+            team_override: Some(override_team.parse().expect("team override")),
+            caller_team: Some(TEST_TEAM.parse().expect("team")),
+            caller_identity: Some(TEST_SENDER.parse().expect("identity")),
+        };
+
+        let report =
+            run_doctor(&paths, query, &healthy_observability(&paths)).expect("doctor report");
+
+        assert_eq!(
+            report.client_context.team.as_ref().map(TeamName::as_str),
+            Some(override_team.as_str())
         );
     }
 }

--- a/crates/atm-daemon/src/local_ipc_transport/accept_loop.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/accept_loop.rs
@@ -288,6 +288,7 @@ mod tests {
                     home_dir: client_tempdir.join("home"),
                     current_dir: client_tempdir.join("cwd"),
                     team_override: None,
+                    ..DoctorQuery::default()
                 }),
             )
             .expect("request frame");

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -564,6 +564,7 @@ mod tests {
             home_dir: tmp.clone(),
             current_dir: tmp,
             team_override: None,
+            ..DoctorQuery::default()
         });
         assert_eq!(
             request_execution_risk(&request),

--- a/crates/atm-daemon/src/peer_transport.rs
+++ b/crates/atm-daemon/src/peer_transport.rs
@@ -1488,6 +1488,7 @@ mod tests {
             home_dir: tempdir.path().to_path_buf(),
             current_dir: tempdir.path().to_path_buf(),
             team_override: None,
+            ..DoctorQuery::default()
         });
 
         thread::spawn(move || {

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -821,6 +821,14 @@ impl DaemonRequestDispatcher {
             error_count,
         };
         report.runtime_status = Some(runtime_status);
+        // `daemon_context` reports the daemon process's own launch-time
+        // environment, which is frozen when the singleton starts and does NOT
+        // track the requesting shell. It is deliberately distinct from
+        // `client_context` (threaded through the request payload in
+        // `DoctorQuery::caller_*`), which reflects the invoking CLI process.
+        // Surfacing the daemon's launch-time identity is diagnostically useful:
+        // it explains why an earlier release appeared to report a stale team or
+        // identity for every caller (see issue #548).
         report.daemon_context = Some(DoctorExecutionContext {
             team: atm_core::caller_context::read_cli_team_from_env()
                 .ok()

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -830,12 +830,12 @@ impl DaemonRequestDispatcher {
         // it explains why an earlier release appeared to report a stale team or
         // identity for every caller (see issue #548).
         report.daemon_context = Some(DoctorExecutionContext {
-            team: atm_core::caller_context::read_cli_team_from_env()
-                .ok()
-                .flatten(),
-            identity: atm_core::caller_context::read_cli_identity_from_env()
-                .ok()
-                .flatten(),
+            team: atm_core::caller_context::read_cli_team_from_env_or_warn(
+                "atm_daemon::runtime_health::daemon_context",
+            ),
+            identity: atm_core::caller_context::read_cli_identity_from_env_or_warn(
+                "atm_daemon::runtime_health::daemon_context",
+            ),
             version: Some(ReleaseVersion::current()),
         });
         Ok(report)

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -128,6 +128,7 @@ fn local_ipc_runtime_round_trips_doctor_requests_on_shared_transport() {
         home_dir: tempdir.path().join("home"),
         current_dir: tempdir.path().join("cwd"),
         team_override: None,
+        ..DoctorQuery::default()
     });
     let request_id = atm_core::protocol::next_request_id();
     let frame = atm_core::protocol::request_to_frame_payload(request_id, request).expect("frame");
@@ -205,6 +206,7 @@ fn compose_runtime_start_writes_retained_log_and_reports_healthy_observability()
         home_dir: atm_home.clone(),
         current_dir: atm_home.clone(),
         team_override: None,
+        ..DoctorQuery::default()
     });
     let request_id = atm_core::protocol::next_request_id();
     let frame = atm_core::protocol::request_to_frame_payload(request_id, request).expect("frame");
@@ -391,6 +393,7 @@ fn heartbeat_updates_status_cache_and_doctor_projection() {
             home_dir: atm_home.clone(),
             current_dir: atm_home.clone(),
             team_override: Some(team.clone()),
+            ..atm_core::doctor::DoctorQuery::default()
         }))
         .expect("doctor response");
     match doctor {
@@ -807,6 +810,7 @@ fn doctor_projects_degraded_runtime_when_member_identity_conflicts_exist() {
             home_dir: atm_home.clone(),
             current_dir: atm_home,
             team_override: Some(test_team().clone()),
+            ..atm_core::doctor::DoctorQuery::default()
         }))
         .expect("doctor response");
 
@@ -863,6 +867,7 @@ fn doctor_projects_unavailable_runtime_when_all_members_are_offline() {
                 home_dir: atm_home.clone(),
                 current_dir: atm_home,
                 team_override: Some(test_team().clone()),
+                ..atm_core::doctor::DoctorQuery::default()
             }))
         })
         .expect("doctor response");
@@ -883,6 +888,77 @@ fn doctor_projects_unavailable_runtime_when_all_members_are_offline() {
                 .expect("runtime finding");
             assert!(finding.message.contains("owner_pid="));
             assert!(finding.message.contains("degraded_ingest=false"));
+        }
+        other => panic!("expected doctor response, got {other:?}"),
+    }
+}
+
+#[test]
+#[serial_test::serial(env)]
+fn doctor_client_context_reflects_caller_over_daemon_launch_environment() {
+    install_retained_runtime_factory();
+    let tempdir = TempDir::new().expect("tempdir");
+    let atm_home = tempdir.path().join("atm-home");
+    std::fs::create_dir_all(&atm_home).expect("atm home dir");
+    let db_path = tempdir.path().join("mail.db");
+    // The daemon process env stands in for the frozen launch-time identity of
+    // the long-lived singleton. It must not leak into the caller-facing
+    // `client_context` (issue #548).
+    let _env = EnvGuard::set_many([
+        (
+            SQLITE_RUNTIME_PATH_ENV,
+            Some(db_path.to_str().expect("utf8 sqlite db path")),
+        ),
+        ("ATM_TEAM", Some("daemon-launch-team")),
+        ("ATM_IDENTITY", Some("daemon-launch-identity")),
+    ]);
+
+    install_test_roster(&db_path, &[ROLE_TEAM_LEAD]);
+    write_team_config(&atm_home, &[ROLE_TEAM_LEAD]);
+
+    let status_cache = RuntimeStatusCache::new();
+    let dispatcher = DaemonRequestDispatcher::new_for_test(atm_home.clone(), status_cache, db_path);
+
+    let doctor = dispatcher
+        .dispatch(RequestEnvelope::Doctor(DoctorQuery {
+            home_dir: atm_home.clone(),
+            current_dir: atm_home,
+            team_override: None,
+            caller_team: Some(test_team().clone()),
+            caller_identity: Some(
+                atm_core::test_support::TEST_SENDER
+                    .parse()
+                    .expect("caller identity"),
+            ),
+        }))
+        .expect("doctor response");
+
+    match doctor {
+        ResponseEnvelope::Doctor(report) => {
+            // client_context tracks the caller threaded through the request.
+            assert_eq!(
+                report.client_context.team.as_ref().map(TeamName::as_str),
+                Some(TEST_TEAM)
+            );
+            assert_eq!(
+                report
+                    .client_context
+                    .identity
+                    .as_ref()
+                    .map(AgentName::as_str),
+                Some(atm_core::test_support::TEST_SENDER)
+            );
+            // daemon_context stays distinct: it reports the daemon's own
+            // launch-time process env, not the caller.
+            let daemon_context = report.daemon_context.expect("daemon context");
+            assert_eq!(
+                daemon_context.team.as_ref().map(TeamName::as_str),
+                Some("daemon-launch-team")
+            );
+            assert_eq!(
+                daemon_context.identity.as_ref().map(AgentName::as_str),
+                Some("daemon-launch-identity")
+            );
         }
         other => panic!("expected doctor response, got {other:?}"),
     }

--- a/crates/atm-daemon/src/tests/local_ipc_depth.rs
+++ b/crates/atm-daemon/src/tests/local_ipc_depth.rs
@@ -70,6 +70,7 @@ fn send_doctor_request(
         home_dir,
         current_dir,
         team_override: None,
+        ..DoctorQuery::default()
     });
     let request_id = atm_core::protocol::next_request_id();
     let frame = atm_core::protocol::request_to_frame_payload(request_id, request).expect("frame");

--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -59,12 +59,11 @@ impl DoctorCommand {
         // serviced over IPC by the long-lived daemon, the daemon cannot read
         // these values from its own frozen launch-time environment, so they
         // must ride along in the request payload.
-        let caller_team = atm_core::caller_context::read_cli_team_from_env()
-            .ok()
-            .flatten();
-        let caller_identity = atm_core::caller_context::read_cli_identity_from_env()
-            .ok()
-            .flatten();
+        let caller_team =
+            atm_core::caller_context::read_cli_team_from_env_or_warn("atm::doctor::build_query");
+        let caller_identity = atm_core::caller_context::read_cli_identity_from_env_or_warn(
+            "atm::doctor::build_query",
+        );
         Ok(DoctorQuery {
             home_dir,
             current_dir,

--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -54,10 +54,23 @@ impl DoctorCommand {
                 })
             })
             .transpose()?;
+        // Capture the invoking CLI process's identity here, where the process
+        // environment is genuinely the caller's. When the doctor request is
+        // serviced over IPC by the long-lived daemon, the daemon cannot read
+        // these values from its own frozen launch-time environment, so they
+        // must ride along in the request payload.
+        let caller_team = atm_core::caller_context::read_cli_team_from_env()
+            .ok()
+            .flatten();
+        let caller_identity = atm_core::caller_context::read_cli_identity_from_env()
+            .ok()
+            .flatten();
         Ok(DoctorQuery {
             home_dir,
             current_dir,
             team_override,
+            caller_team,
+            caller_identity,
         })
     }
 

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -1027,6 +1027,7 @@ mod tests {
                 home_dir: self.home_dir.clone(),
                 current_dir: self.current_dir.clone(),
                 team_override: Some(TEST_TEAM.parse().expect("team")),
+                ..DoctorQuery::default()
             }
         }
 
@@ -1078,6 +1079,7 @@ mod tests {
                 home_dir: tempdir.path().join("home"),
                 current_dir: tempdir.path().join("cwd"),
                 team_override: None,
+                ..atm_core::doctor::DoctorQuery::default()
             }))
             .expect_err("protocol error");
 

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -393,7 +393,7 @@ fn print_doctor_environment(report: &DoctorReport) {
             || daemon_context.identity.is_some()
             || daemon_context.version.is_some())
     {
-        println!("  daemon_context:");
+        println!("  daemon_context (daemon launch-time process env, not the caller):");
         if let Some(team) = &daemon_context.team {
             println!("    team={team}");
         }


### PR DESCRIPTION
## Summary
Fixes #548 — `atm doctor` reported the daemon singleton's frozen launch-time ATM_TEAM/ATM_IDENTITY for every caller instead of the invoking shell's actual identity.

- Root cause: `atm doctor` routes through the long-lived daemon singleton over IPC; both client_context and daemon_context were built from env reads that, on the daemon side, reflect the daemon process's launch-time environment, not the calling client's.
- Fix: thread the invoking CLI process's real ATM_TEAM/ATM_IDENTITY (and --team override) through the IPC request payload (new DoctorQuery::caller_team/caller_identity, #[serde(default)] for backward compat); client_context now honors these and the --team override; daemon_context is retained but clearly relabeled as daemon launch-time diagnostics, distinct from the caller's context.
- Not a hardcoded-literal bug — confirmed no "atm-dev"/"arch-ctm" literals exist in the doctor code path; test literals use synthetic values per RULE-008.

## Test plan
- [x] cargo build (workspace) — clean
- [x] cargo test -p agent-team-mail-core doctor — 20 passed
- [x] cargo test -p atm-daemon doctor — 6 passed (incl. new doctor_client_context_reflects_caller_over_daemon_launch_environment)
- [x] cargo test -p agent-team-mail doctor — 6 passed
- [x] cargo fmt --all
- [x] cargo clippy --all-targets -- -D warnings — clean
- [ ] quality-mgr QA-1 (full reviewer set incl. rust-best-practices-agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)