### PR TITLE
Add env-var-boundary lint: forbid ATM_TEAM/ATM_IDENTITY reads in atm-core/atm-daemon

### DIFF
--- a/.just/allowlists/env_var_boundary_allowlist.toml
+++ b/.just/allowlists/env_var_boundary_allowlist.toml
@@ -1,0 +1,58 @@
+# Known-debt exceptions for the ATM-ENV-BOUNDARY lint (issue #548 follow-up).
+#
+# ATM_TEAM/ATM_IDENTITY must only be read at client entry points (the `atm`
+# CLI and the `atm-graft` client) and resolved into explicit parameters from
+# there on. The call sites below are pre-existing violations that predate
+# this lint; they are allowlisted here rather than fixed in place because
+# refactoring them to accept already-resolved values requires touching every
+# caller of `atm_core::config::resolve_team`,
+# `atm_core::identity::resolve_runtime_sender_identity`,
+# `atm_core::doctor::health::environment_visibility`, and the atm-daemon
+# doctor/runtime-health report assembly across both the `atm` CLI and
+# `atm-daemon` binaries. That refactor is tracked as follow-up work and is
+# out of scope for adding this lint prospectively.
+#
+# Do not add new entries here for new code; new ATM_TEAM/ATM_IDENTITY reads
+# in atm-core/atm-daemon must be refactored to accept resolved parameters.
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/caller_context.rs"
+symbol = "read_cli_identity_from_env"
+why = "canonical CLI-identity env reader; forwards the ATM_IDENTITY literal into env::var_os via read_env_raw. This is the intended single choke point today, but the whole module belongs at the atm/atm-graft client boundary, not in atm-core."
+sunset_sprint = "follow-up: push caller_context env reads to the atm CLI / atm-graft entry points"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/caller_context.rs"
+symbol = "read_cli_team_from_env"
+why = "canonical CLI-identity env reader; forwards the ATM_TEAM literal into env::var_os via read_env_raw. This is the intended single choke point today, but the whole module belongs at the atm/atm-graft client boundary, not in atm-core."
+sunset_sprint = "follow-up: push caller_context env reads to the atm CLI / atm-graft entry points"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/config/mod.rs"
+symbol = "resolve_team"
+why = "resolve_team falls back to read_cli_team_from_env() when no explicit team_override is supplied; needs a signature change (explicit resolved team parameter) so every caller passes an already-resolved value instead."
+sunset_sprint = "follow-up: require resolve_team callers to pass an already-resolved team instead of falling back to env"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/identity/mod.rs"
+symbol = "resolve_runtime_sender_identity"
+why = "obsolete caller-owned identity fallback (already dead_code-gated for Phase AD removal); still reads ATM_IDENTITY via read_cli_identity_from_env() until the retirement sprint deletes the module."
+sunset_sprint = "follow-up: delete the obsolete identity module once its remaining test coverage is retired"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/doctor/health.rs"
+symbol = "environment_visibility"
+why = "doctor diagnostic snapshot reports the currently-visible ATM_TEAM/ATM_IDENTITY values for troubleshooting; needs the caller (CLI doctor command) to resolve and pass these values explicitly instead of reading them again inside atm-core."
+sunset_sprint = "follow-up: have the atm CLI doctor command pass resolved team/identity into environment_visibility"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-daemon/src/runtime_health.rs"
+symbol = "project_doctor_report"
+why = "daemon-side doctor report assembly reports the daemon process's own ATM_TEAM/ATM_IDENTITY for diagnostic context; needs the daemon bootstrap boundary to resolve and pass these values explicitly instead of reading them again inside atm-daemon."
+sunset_sprint = "follow-up: have daemon bootstrap pass resolved team/identity into project_doctor_report"

--- a/.just/allowlists/env_var_boundary_allowlist.toml
+++ b/.just/allowlists/env_var_boundary_allowlist.toml
@@ -70,6 +70,22 @@ sunset_sprint = "follow-up: have the atm CLI doctor command pass resolved team/i
 
 [[allow]]
 rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/doctor/health.rs"
+symbol = "environment_visibility"
+line = '.or_else(|| read_cli_team_from_env_or_warn("atm_core::doctor::environment_visibility")),'
+why = "doctor diagnostic snapshot now routes malformed ATM_TEAM handling through the wrapper helper, but still performs the same known-debt env read inside atm-core until the caller passes already-resolved values."
+sunset_sprint = "follow-up: have the atm CLI doctor command pass resolved team/identity into environment_visibility"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/doctor/health.rs"
+symbol = "environment_visibility"
+line = 'read_cli_identity_from_env_or_warn("atm_core::doctor::environment_visibility")'
+why = "doctor diagnostic snapshot now routes malformed ATM_IDENTITY handling through the wrapper helper, but still performs the same known-debt env read inside atm-core until the caller passes already-resolved values."
+sunset_sprint = "follow-up: have the atm CLI doctor command pass resolved team/identity into environment_visibility"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
 path = "crates/atm-daemon/src/runtime_health.rs"
 symbol = "project_doctor_report"
 line = "team: atm_core::caller_context::read_cli_team_from_env()"
@@ -82,4 +98,20 @@ path = "crates/atm-daemon/src/runtime_health.rs"
 symbol = "project_doctor_report"
 line = "identity: atm_core::caller_context::read_cli_identity_from_env()"
 why = "daemon-side doctor report assembly reports the daemon process's own ATM_TEAM/ATM_IDENTITY for diagnostic context; needs the daemon bootstrap boundary to resolve and pass these values explicitly instead of reading them again inside atm-daemon."
+sunset_sprint = "follow-up: have daemon bootstrap pass resolved team/identity into project_doctor_report"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-daemon/src/runtime_health.rs"
+symbol = "project_doctor_report"
+line = "team: atm_core::caller_context::read_cli_team_from_env_or_warn("
+why = "daemon-side doctor report assembly now routes malformed ATM_TEAM handling through the wrapper helper, but still performs the same known-debt launch-time env read inside atm-daemon until daemon bootstrap passes resolved values explicitly."
+sunset_sprint = "follow-up: have daemon bootstrap pass resolved team/identity into project_doctor_report"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-daemon/src/runtime_health.rs"
+symbol = "project_doctor_report"
+line = "identity: atm_core::caller_context::read_cli_identity_from_env_or_warn("
+why = "daemon-side doctor report assembly now routes malformed ATM_IDENTITY handling through the wrapper helper, but still performs the same known-debt launch-time env read inside atm-daemon until daemon bootstrap passes resolved values explicitly."
 sunset_sprint = "follow-up: have daemon bootstrap pass resolved team/identity into project_doctor_report"

--- a/.just/allowlists/env_var_boundary_allowlist.toml
+++ b/.just/allowlists/env_var_boundary_allowlist.toml
@@ -12,13 +12,19 @@
 # `atm-daemon` binaries. That refactor is tracked as follow-up work and is
 # out of scope for adding this lint prospectively.
 #
-# Do not add new entries here for new code; new ATM_TEAM/ATM_IDENTITY reads
-# in atm-core/atm-daemon must be refactored to accept resolved parameters.
+# Entries are keyed on (path, symbol, exact violated line text). This scopes
+# suppression to the specific call site that was reviewed, not the whole
+# enclosing function: adding a *new* env-boundary violation inside one of
+# these functions still requires its own allowlist entry and will be caught
+# by the lint. Do not add new entries here for new code; new ATM_TEAM/
+# ATM_IDENTITY reads in atm-core/atm-daemon must be refactored to accept
+# resolved parameters.
 
 [[allow]]
 rule = "ATM-ENV-BOUNDARY-001"
 path = "crates/atm-core/src/caller_context.rs"
 symbol = "read_cli_identity_from_env"
+line = 'read_env_raw("ATM_IDENTITY")?'
 why = "canonical CLI-identity env reader; forwards the ATM_IDENTITY literal into env::var_os via read_env_raw. This is the intended single choke point today, but the whole module belongs at the atm/atm-graft client boundary, not in atm-core."
 sunset_sprint = "follow-up: push caller_context env reads to the atm CLI / atm-graft entry points"
 
@@ -26,6 +32,7 @@ sunset_sprint = "follow-up: push caller_context env reads to the atm CLI / atm-g
 rule = "ATM-ENV-BOUNDARY-001"
 path = "crates/atm-core/src/caller_context.rs"
 symbol = "read_cli_team_from_env"
+line = 'read_env_raw("ATM_TEAM")?.map(parse_team).transpose()'
 why = "canonical CLI-identity env reader; forwards the ATM_TEAM literal into env::var_os via read_env_raw. This is the intended single choke point today, but the whole module belongs at the atm/atm-graft client boundary, not in atm-core."
 sunset_sprint = "follow-up: push caller_context env reads to the atm CLI / atm-graft entry points"
 
@@ -33,6 +40,7 @@ sunset_sprint = "follow-up: push caller_context env reads to the atm CLI / atm-g
 rule = "ATM-ENV-BOUNDARY-001"
 path = "crates/atm-core/src/config/mod.rs"
 symbol = "resolve_team"
+line = ".or_else(|| read_cli_team_from_env().ok().flatten())"
 why = "resolve_team falls back to read_cli_team_from_env() when no explicit team_override is supplied; needs a signature change (explicit resolved team parameter) so every caller passes an already-resolved value instead."
 sunset_sprint = "follow-up: require resolve_team callers to pass an already-resolved team instead of falling back to env"
 
@@ -40,6 +48,7 @@ sunset_sprint = "follow-up: require resolve_team callers to pass an already-reso
 rule = "ATM-ENV-BOUNDARY-001"
 path = "crates/atm-core/src/identity/mod.rs"
 symbol = "resolve_runtime_sender_identity"
+line = "read_cli_identity_from_env()?.ok_or_else(AtmError::identity_unavailable)"
 why = "obsolete caller-owned identity fallback (already dead_code-gated for Phase AD removal); still reads ATM_IDENTITY via read_cli_identity_from_env() until the retirement sprint deletes the module."
 sunset_sprint = "follow-up: delete the obsolete identity module once its remaining test coverage is retired"
 
@@ -47,6 +56,15 @@ sunset_sprint = "follow-up: delete the obsolete identity module once its remaini
 rule = "ATM-ENV-BOUNDARY-001"
 path = "crates/atm-core/src/doctor/health.rs"
 symbol = "environment_visibility"
+line = "atm_team: read_cli_team_from_env().ok().flatten(),"
+why = "doctor diagnostic snapshot reports the currently-visible ATM_TEAM/ATM_IDENTITY values for troubleshooting; needs the caller (CLI doctor command) to resolve and pass these values explicitly instead of reading them again inside atm-core."
+sunset_sprint = "follow-up: have the atm CLI doctor command pass resolved team/identity into environment_visibility"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/doctor/health.rs"
+symbol = "environment_visibility"
+line = "atm_identity: read_cli_identity_from_env().ok().flatten(),"
 why = "doctor diagnostic snapshot reports the currently-visible ATM_TEAM/ATM_IDENTITY values for troubleshooting; needs the caller (CLI doctor command) to resolve and pass these values explicitly instead of reading them again inside atm-core."
 sunset_sprint = "follow-up: have the atm CLI doctor command pass resolved team/identity into environment_visibility"
 
@@ -54,5 +72,14 @@ sunset_sprint = "follow-up: have the atm CLI doctor command pass resolved team/i
 rule = "ATM-ENV-BOUNDARY-001"
 path = "crates/atm-daemon/src/runtime_health.rs"
 symbol = "project_doctor_report"
+line = "team: atm_core::caller_context::read_cli_team_from_env()"
+why = "daemon-side doctor report assembly reports the daemon process's own ATM_TEAM/ATM_IDENTITY for diagnostic context; needs the daemon bootstrap boundary to resolve and pass these values explicitly instead of reading them again inside atm-daemon."
+sunset_sprint = "follow-up: have daemon bootstrap pass resolved team/identity into project_doctor_report"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-daemon/src/runtime_health.rs"
+symbol = "project_doctor_report"
+line = "identity: atm_core::caller_context::read_cli_identity_from_env()"
 why = "daemon-side doctor report assembly reports the daemon process's own ATM_TEAM/ATM_IDENTITY for diagnostic context; needs the daemon bootstrap boundary to resolve and pass these values explicitly instead of reading them again inside atm-daemon."
 sunset_sprint = "follow-up: have daemon bootstrap pass resolved team/identity into project_doctor_report"

--- a/.just/check_env_var_boundary.py
+++ b/.just/check_env_var_boundary.py
@@ -72,6 +72,7 @@ class AllowlistEntry:
     rule: str
     path: Path
     symbol: str
+    line: str
     why: str
     sunset_sprint: str
 
@@ -120,7 +121,7 @@ def load_allowlist(repo_root: Path) -> list[AllowlistEntry]:
     for index, raw_entry in enumerate(raw_entries):
         if not isinstance(raw_entry, dict):
             raise SystemExit(f"[allow][{index}] must be a TOML table")
-        required = ("rule", "path", "symbol", "why", "sunset_sprint")
+        required = ("rule", "path", "symbol", "line", "why", "sunset_sprint")
         for field in required:
             value = raw_entry.get(field)
             if not isinstance(value, str) or not value.strip():
@@ -130,6 +131,7 @@ def load_allowlist(repo_root: Path) -> list[AllowlistEntry]:
                 rule=raw_entry["rule"],
                 path=Path(raw_entry["path"]),
                 symbol=raw_entry["symbol"],
+                line=raw_entry["line"],
                 why=raw_entry["why"],
                 sunset_sprint=raw_entry["sunset_sprint"],
             )
@@ -142,8 +144,20 @@ def is_allowlisted(
     *,
     rel_path: Path,
     symbol: str,
+    line: str,
 ) -> bool:
-    return any(entry.path == rel_path and entry.symbol == symbol for entry in entries)
+    """Match an exact previously-reviewed call site, not the whole function.
+
+    Allowlist entries are keyed on (path, symbol, exact violated line text) so
+    that a genuinely new env-boundary violation added inside an already
+    allowlisted function -- even one that shares the same enclosing symbol --
+    still requires its own allowlist entry instead of being silently
+    swallowed by the enclosing function's existing entry.
+    """
+    return any(
+        entry.path == rel_path and entry.symbol == symbol and entry.line == line
+        for entry in entries
+    )
 
 
 def restricted_rust_files(repo_root: Path, restricted_crate_roots: tuple[Path, ...]) -> list[Path]:
@@ -312,7 +326,12 @@ def collect_env_var_boundary_violations(
             boundary_reader_definition_files=boundary_reader_definition_files,
         )
         for violation in file_violations:
-            if is_allowlisted(allowlist, rel_path=rel_path, symbol=violation.symbol):
+            if is_allowlisted(
+                allowlist,
+                rel_path=rel_path,
+                symbol=violation.symbol,
+                line=violation.line,
+            ):
                 continue
             violations.append(violation)
 

--- a/.just/check_env_var_boundary.py
+++ b/.just/check_env_var_boundary.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Enforce the ATM_TEAM/ATM_IDENTITY client-boundary rule.
+
+ATM_TEAM and ATM_IDENTITY are CLI-identity environment variables that must
+only be read at client entry points (the `atm` CLI and the `atm-graft`
+client). Library crates (`atm-core`, `atm-daemon`) must receive already
+resolved values as parameters instead of reading these variables themselves.
+
+This lint flags:
+  * direct `env::var("ATM_TEAM"/"ATM_IDENTITY")` /
+    `env::var_os("ATM_TEAM"/"ATM_IDENTITY")` calls,
+  * calls that route one of the forbidden literals through a same-file helper
+    function whose body forwards its string parameter straight into
+    `env::var`/`env::var_os` (e.g. `read_env_raw("ATM_IDENTITY")` where
+    `read_env_raw(key: &str)` calls `env::var_os(key)`), and
+  * calls to the explicitly configured `boundary_reader_functions` (the
+    known CLI-only resolver functions that read these variables internally),
+    from any other production source file in the restricted crate roots.
+
+Findings for pre-existing call sites may be allowlisted in
+`.just/allowlists/env_var_boundary_allowlist.toml` while the follow-up
+refactor to push these reads out to the client boundary is scheduled.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+import sys
+import tomllib
+
+from lint_common import build_report
+from lint_common import discover_repo_root
+from lint_common import is_code_line
+from lint_common import load_lint_config
+from lint_common import monotonic_now
+from lint_common import print_report
+from lint_common import rust_file_test_scope
+from lint_common import workspace_crate_section_lines
+
+
+LINT_NAME = "env-var-boundary"
+ALLOWLIST_PATH = Path(".just/allowlists/env_var_boundary_allowlist.toml")
+
+ENV_CALL_RE = re.compile(
+    r"\b(?:std::)?env::var(?:_os)?\s*\(\s*(?:\"(?P<literal>[^\"]*)\"|(?P<ident>[A-Za-z_][A-Za-z0-9_]*))\s*\)"
+)
+FN_SINGLE_STR_PARAM_RE = re.compile(
+    r"\bfn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*&str\s*\)"
+)
+CALL_LITERAL_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\"(?P<literal>[^\"]*)\"")
+FN_DEF_RE = re.compile(r"^(?:pub(?:\([^)]*\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+@dataclass(frozen=True)
+class EnvVarViolation:
+    path: str
+    line_number: int
+    line: str
+    symbol: str
+    kind: str
+
+    def render(self) -> str:
+        return f"{self.path}:{self.line_number}: [{self.kind}] {self.line}"
+
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    rule: str
+    path: Path
+    symbol: str
+    why: str
+    sunset_sprint: str
+
+
+def env_boundary_config(repo_root: Path) -> dict:
+    config = load_lint_config(repo_root).get("env_var_boundary", {})
+    if not isinstance(config, dict):
+        raise SystemExit("[env_var_boundary] must be a TOML table")
+    return config
+
+
+def load_forbidden_env_vars(repo_root: Path) -> tuple[str, ...]:
+    config = env_boundary_config(repo_root)
+    values = config.get("forbidden_env_vars")
+    if not isinstance(values, list) or not all(isinstance(item, str) for item in values):
+        raise SystemExit("[env_var_boundary].forbidden_env_vars must be an array of strings")
+    return tuple(values)
+
+
+def load_restricted_crate_roots(repo_root: Path) -> tuple[Path, ...]:
+    config = env_boundary_config(repo_root)
+    values = config.get("restricted_crate_roots")
+    if not isinstance(values, list) or not all(isinstance(item, str) for item in values):
+        raise SystemExit("[env_var_boundary].restricted_crate_roots must be an array of strings")
+    return tuple(Path(item) for item in values)
+
+
+def load_boundary_reader_functions(repo_root: Path) -> tuple[str, ...]:
+    config = env_boundary_config(repo_root)
+    values = config.get("boundary_reader_functions", [])
+    if not isinstance(values, list) or not all(isinstance(item, str) for item in values):
+        raise SystemExit("[env_var_boundary].boundary_reader_functions must be an array of strings")
+    return tuple(values)
+
+
+def load_allowlist(repo_root: Path) -> list[AllowlistEntry]:
+    allowlist_path = repo_root / ALLOWLIST_PATH
+    if not allowlist_path.exists():
+        return []
+    data = tomllib.loads(allowlist_path.read_text(encoding="utf-8"))
+    raw_entries = data.get("allow", [])
+    if not isinstance(raw_entries, list):
+        raise SystemExit("[allow] must be an array of tables")
+
+    entries: list[AllowlistEntry] = []
+    for index, raw_entry in enumerate(raw_entries):
+        if not isinstance(raw_entry, dict):
+            raise SystemExit(f"[allow][{index}] must be a TOML table")
+        required = ("rule", "path", "symbol", "why", "sunset_sprint")
+        for field in required:
+            value = raw_entry.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise SystemExit(f"[allow][{index}].{field} must be a non-empty string")
+        entries.append(
+            AllowlistEntry(
+                rule=raw_entry["rule"],
+                path=Path(raw_entry["path"]),
+                symbol=raw_entry["symbol"],
+                why=raw_entry["why"],
+                sunset_sprint=raw_entry["sunset_sprint"],
+            )
+        )
+    return entries
+
+
+def is_allowlisted(
+    entries: list[AllowlistEntry],
+    *,
+    rel_path: Path,
+    symbol: str,
+) -> bool:
+    return any(entry.path == rel_path and entry.symbol == symbol for entry in entries)
+
+
+def restricted_rust_files(repo_root: Path, restricted_crate_roots: tuple[Path, ...]) -> list[Path]:
+    paths: list[Path] = []
+    for root in restricted_crate_roots:
+        root_dir = repo_root / root
+        if root_dir.exists():
+            paths.extend(sorted(root_dir.rglob("*.rs")))
+    return sorted(set(paths))
+
+
+def enclosing_function_name(lines: list[str], line_number: int) -> str:
+    for index in range(line_number - 1, -1, -1):
+        match = FN_DEF_RE.match(lines[index].strip())
+        if match is not None:
+            return match.group(1)
+    return "<module scope>"
+
+
+def function_body_bounds(lines: list[str], signature_line_index: int) -> tuple[int, int]:
+    """Return the (start, end) 0-indexed line range spanned by a function body."""
+    depth = 0
+    started = False
+    end_index = signature_line_index
+    for index in range(signature_line_index, len(lines)):
+        depth += lines[index].count("{") - lines[index].count("}")
+        if lines[index].count("{") > 0:
+            started = True
+        end_index = index
+        if started and depth <= 0:
+            break
+    return signature_line_index, end_index
+
+
+def collect_same_file_forwarding_functions(lines: list[str]) -> set[str]:
+    """Find functions whose body forwards their single &str parameter into env::var(_os)."""
+    forwarding: set[str] = set()
+    for index, line in enumerate(lines):
+        match = FN_SINGLE_STR_PARAM_RE.search(line)
+        if match is None:
+            continue
+        function_name, param_name = match.group(1), match.group(2)
+        start, end = function_body_bounds(lines, index)
+        for body_line in lines[start : end + 1]:
+            for call_match in ENV_CALL_RE.finditer(body_line):
+                if call_match.group("ident") == param_name:
+                    forwarding.add(function_name)
+                    break
+    return forwarding
+
+
+def find_boundary_reader_definition_files(
+    file_lines: dict[Path, list[str]],
+    boundary_reader_functions: tuple[str, ...],
+) -> dict[str, Path]:
+    """Map each configured boundary-reader function name to the file that defines it.
+
+    Calls to a boundary-reader function from within its own defining file are
+    internal implementation details of that resolver (already covered, and
+    allowlisted where needed, via the forwarding-function detection), not a
+    new client of the env read, so they are excluded from Rule C.
+    """
+    definition_files: dict[str, Path] = {}
+    for rel_path, lines in file_lines.items():
+        for line in lines:
+            match = FN_DEF_RE.match(line.strip())
+            if match is not None and match.group(1) in boundary_reader_functions:
+                definition_files.setdefault(match.group(1), rel_path)
+    return definition_files
+
+
+def collect_file_violations(
+    *,
+    rel_path: Path,
+    lines: list[str],
+    scope: list[bool],
+    forbidden_env_vars: tuple[str, ...],
+    boundary_reader_functions: tuple[str, ...],
+    boundary_reader_definition_files: dict[str, Path],
+) -> list[EnvVarViolation]:
+    violations: list[EnvVarViolation] = []
+    forwarding_functions = collect_same_file_forwarding_functions(lines)
+
+    for line_number, (line, in_test_scope) in enumerate(zip(lines, scope, strict=True), start=1):
+        if in_test_scope or not is_code_line(line):
+            continue
+
+        for call_match in ENV_CALL_RE.finditer(line):
+            literal = call_match.group("literal")
+            if literal is not None and literal in forbidden_env_vars:
+                violations.append(
+                    EnvVarViolation(
+                        path=rel_path.as_posix(),
+                        line_number=line_number,
+                        line=line.strip(),
+                        symbol=enclosing_function_name(lines, line_number),
+                        kind="direct_literal_env_read",
+                    )
+                )
+
+        for call_match in CALL_LITERAL_RE.finditer(line):
+            func_name = call_match.group(1)
+            literal = call_match.group("literal")
+            if literal not in forbidden_env_vars:
+                continue
+            if FN_DEF_RE.match(line.strip()):
+                continue
+            if func_name in forwarding_functions:
+                violations.append(
+                    EnvVarViolation(
+                        path=rel_path.as_posix(),
+                        line_number=line_number,
+                        line=line.strip(),
+                        symbol=enclosing_function_name(lines, line_number),
+                        kind="env_var_via_forwarding_function",
+                    )
+                )
+
+        stripped = line.strip()
+        if FN_DEF_RE.match(stripped):
+            continue
+        for function_name in boundary_reader_functions:
+            if boundary_reader_definition_files.get(function_name) == rel_path:
+                continue
+            if re.search(rf"\b(?:[A-Za-z_][A-Za-z0-9_]*::)*{re.escape(function_name)}\s*\(", line):
+                violations.append(
+                    EnvVarViolation(
+                        path=rel_path.as_posix(),
+                        line_number=line_number,
+                        line=line.strip(),
+                        symbol=enclosing_function_name(lines, line_number),
+                        kind="boundary_reader_function_call",
+                    )
+                )
+
+    return violations
+
+
+def collect_env_var_boundary_violations(
+    repo_root: Path,
+    *,
+    forbidden_env_vars: tuple[str, ...],
+    restricted_crate_roots: tuple[Path, ...],
+    boundary_reader_functions: tuple[str, ...],
+    allowlist: list[AllowlistEntry],
+) -> list[EnvVarViolation]:
+    violations: list[EnvVarViolation] = []
+    file_lines: dict[Path, list[str]] = {}
+    for abs_path in restricted_rust_files(repo_root, restricted_crate_roots):
+        rel_path = abs_path.relative_to(repo_root)
+        file_lines[rel_path] = abs_path.read_text(encoding="utf-8").splitlines()
+
+    boundary_reader_definition_files = find_boundary_reader_definition_files(
+        file_lines, boundary_reader_functions
+    )
+
+    for rel_path, lines in file_lines.items():
+        scope = rust_file_test_scope(rel_path, lines)
+
+        file_violations = collect_file_violations(
+            rel_path=rel_path,
+            lines=lines,
+            scope=scope,
+            forbidden_env_vars=forbidden_env_vars,
+            boundary_reader_functions=boundary_reader_functions,
+            boundary_reader_definition_files=boundary_reader_definition_files,
+        )
+        for violation in file_violations:
+            if is_allowlisted(allowlist, rel_path=rel_path, symbol=violation.symbol):
+                continue
+            violations.append(violation)
+
+    return violations
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reject ATM_TEAM/ATM_IDENTITY environment reads inside atm-core/atm-daemon library code."
+    )
+    parser.add_argument("--root", help="Repo root to inspect.")
+    return parser.parse_args(argv[1:])
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = discover_repo_root(args.root)
+    started_at = datetime.now(timezone.utc)
+    start_time = monotonic_now()
+
+    forbidden_env_vars = load_forbidden_env_vars(repo_root)
+    restricted_crate_roots = load_restricted_crate_roots(repo_root)
+    boundary_reader_functions = load_boundary_reader_functions(repo_root)
+    allowlist = load_allowlist(repo_root)
+
+    violations = collect_env_var_boundary_violations(
+        repo_root,
+        forbidden_env_vars=forbidden_env_vars,
+        restricted_crate_roots=restricted_crate_roots,
+        boundary_reader_functions=boundary_reader_functions,
+        allowlist=allowlist,
+    )
+    duration_seconds = monotonic_now() - start_time
+
+    findings = [violation.render() for violation in violations]
+    transcript_lines = [
+        *workspace_crate_section_lines(repo_root),
+        "findings:",
+        *(findings or ["none"]),
+    ]
+    report = build_report(
+        lint_name=LINT_NAME,
+        repo_root=repo_root,
+        passed=not violations,
+        summary=(
+            "ATM_TEAM/ATM_IDENTITY environment reads found inside restricted library crates"
+            if violations
+            else "no disallowed ATM_TEAM/ATM_IDENTITY environment reads found inside restricted library crates"
+        ),
+        findings=findings,
+        transcript_lines=transcript_lines,
+        started_at=started_at,
+        duration_seconds=duration_seconds,
+    )
+
+    for line in workspace_crate_section_lines(repo_root):
+        print(line)
+
+    if not report.passed:
+        print(
+            "ATM-ENV-BOUNDARY violation: ATM_TEAM/ATM_IDENTITY must only be read at "
+            "client entry points (the atm CLI and atm-graft), not inside atm-core/atm-daemon."
+        )
+        for finding in report.findings:
+            print(finding)
+        print(f"total violations: {len(report.findings)}")
+        print_report(report, repo_root=repo_root, preview_limit=0, direct_threshold=0)
+        return 1
+
+    print_report(report, repo_root=repo_root, preview_limit=0, direct_threshold=0)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.just/check_env_var_boundary.py
+++ b/.just/check_env_var_boundary.py
@@ -13,9 +13,10 @@ This lint flags:
     function whose body forwards its string parameter straight into
     `env::var`/`env::var_os` (e.g. `read_env_raw("ATM_IDENTITY")` where
     `read_env_raw(key: &str)` calls `env::var_os(key)`), and
-  * calls to the explicitly configured `boundary_reader_functions` (the
-    known CLI-only resolver functions that read these variables internally),
-    from any other production source file in the restricted crate roots.
+  * calls to the explicitly configured `boundary_reader_functions` and any
+    same-file wrapper functions that call them transitively (the known
+    CLI-only resolver functions that read these variables internally), from
+    any other production source file in the restricted crate roots.
 
 Findings for pre-existing call sites may be allowlisted in
 `.just/allowlists/env_var_boundary_allowlist.toml` while the follow-up
@@ -229,6 +230,58 @@ def find_boundary_reader_definition_files(
     return definition_files
 
 
+def find_function_definition_line(lines: list[str], function_name: str) -> int | None:
+    for index, line in enumerate(lines):
+        match = FN_DEF_RE.match(line.strip())
+        if match is not None and match.group(1) == function_name:
+            return index
+    return None
+
+
+def expand_boundary_reader_functions(
+    file_lines: dict[Path, list[str]],
+    boundary_reader_functions: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Treat same-file wrappers around boundary readers as boundary readers too.
+
+    The configured names are the seed readers at the actual client boundary.
+    Any function defined in the same file that calls one of those readers is
+    itself also a boundary reader, because callers outside that file still
+    trigger an ATM_TEAM/ATM_IDENTITY read indirectly through the wrapper.
+    """
+    expanded = set(boundary_reader_functions)
+    definition_files = find_boundary_reader_definition_files(file_lines, boundary_reader_functions)
+    boundary_files = {path for path in definition_files.values()}
+
+    changed = True
+    while changed:
+        changed = False
+        for rel_path in boundary_files:
+            lines = file_lines[rel_path]
+            for index, line in enumerate(lines):
+                match = FN_DEF_RE.match(line.strip())
+                if match is None:
+                    continue
+                function_name = match.group(1)
+                if function_name in expanded:
+                    continue
+                start = index
+                _, end = function_body_bounds(lines, start)
+                body_lines = lines[start : end + 1]
+                if any(
+                    re.search(
+                        rf"\b(?:[A-Za-z_][A-Za-z0-9_]*::)*{re.escape(boundary_reader)}\s*\(",
+                        body_line,
+                    )
+                    for boundary_reader in expanded
+                    for body_line in body_lines
+                ):
+                    expanded.add(function_name)
+                    changed = True
+
+    return tuple(sorted(expanded))
+
+
 def collect_file_violations(
     *,
     rel_path: Path,
@@ -310,6 +363,7 @@ def collect_env_var_boundary_violations(
         rel_path = abs_path.relative_to(repo_root)
         file_lines[rel_path] = abs_path.read_text(encoding="utf-8").splitlines()
 
+    boundary_reader_functions = expand_boundary_reader_functions(file_lines, boundary_reader_functions)
     boundary_reader_definition_files = find_boundary_reader_definition_files(
         file_lines, boundary_reader_functions
     )

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -24,6 +24,8 @@ config_home_env = "ATM_CONFIG_HOME"
 [env_var_boundary]
 forbidden_env_vars = ["ATM_TEAM", "ATM_IDENTITY"]
 restricted_crate_roots = ["crates/atm-core/src", "crates/atm-daemon/src"]
+# Seed boundary readers. The lint expands this set transitively to include
+# same-file wrappers (for example `*_or_warn`) that call these functions.
 boundary_reader_functions = [
   "read_cli_identity_from_env",
   "read_cli_team_from_env",

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -21,6 +21,14 @@ allowed_paths = ["crates/atm-core/tests/mailbox_locking.rs"]
 [portability]
 config_home_env = "ATM_CONFIG_HOME"
 
+[env_var_boundary]
+forbidden_env_vars = ["ATM_TEAM", "ATM_IDENTITY"]
+restricted_crate_roots = ["crates/atm-core/src", "crates/atm-daemon/src"]
+boundary_reader_functions = [
+  "read_cli_identity_from_env",
+  "read_cli_team_from_env",
+]
+
 [line_counts]
 max_total_lines = 0
 max_production_lines = 1000

--- a/.just/print_help.py
+++ b/.just/print_help.py
@@ -49,6 +49,7 @@ SECTIONS = (
             ("lint capability-degradation", "Run the replay capability no-degradation regression gate."),
             ("lint version", "Run only the version alignment checks."),
             ("lint identities", "Run the identity literal guard."),
+            ("lint env-var-boundary", "Run the ATM_TEAM/ATM_IDENTITY client-boundary guard."),
             ("lint fixed-sleep", "Run the fixed thread::sleep test-hygiene gate."),
             ("lint ttl-triage", "Run the triage Turtle consistency gate."),
             ("lint lines", "Run only the RULE-003 line-count guard."),

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -31,6 +31,7 @@ PYTHON_LINT_ORDER = (
     "legacy-mailbox-paths",
     "capability-degradation",
     "identities",
+    "env-var-boundary",
     "fixed-sleep",
     "ttl-triage",
     "lines",
@@ -91,6 +92,9 @@ def build_tasks(repo_root: Path) -> dict[str, LintTask]:
         "version": LintTask("version", [*python_command, str(repo_root / ".just/check_version_sync.py")]),
         "identities": LintTask(
             "identities", [*python_command, str(repo_root / ".just/check_test_identity_literals.py")]
+        ),
+        "env-var-boundary": LintTask(
+            "env-var-boundary", [*python_command, str(repo_root / ".just/check_env_var_boundary.py")]
         ),
         "lines": LintTask("lines", [*python_command, str(repo_root / ".just/check_line_counts.py")]),
         "boundaries": LintTask("boundaries", [*python_command, str(repo_root / ".just/lint_boundaries.py")]),

--- a/.just/tests/test_check_env_var_boundary.py
+++ b/.just/tests/test_check_env_var_boundary.py
@@ -283,6 +283,7 @@ pub fn resolve_team_from_env() -> Option<String> {
 rule = "ATM-ENV-BOUNDARY-001"
 path = "crates/atm-core/src/example.rs"
 symbol = "resolve_team_from_env"
+line = 'env::var("ATM_TEAM").ok()'
 why = "test fixture"
 sunset_sprint = "n/a"
 """,
@@ -292,6 +293,48 @@ sunset_sprint = "n/a"
             violations = self.collect(repo_root)
 
             self.assertEqual(violations, [])
+
+    def test_allowlist_does_not_suppress_a_new_violation_in_the_same_function(self) -> None:
+        """A second, distinct env-read line added to an already-allowlisted
+        function must still be reported -- the allowlist entry only covers
+        the exact call site it was written for, not the whole enclosing
+        function body."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/src/example.rs").write_text(
+                """\
+use std::env;
+
+pub fn resolve_team_from_env() -> Option<String> {
+    let _ = env::var("ATM_TEAM").ok();
+    env::var("ATM_IDENTITY").ok()
+}
+""",
+                encoding="utf-8",
+            )
+            (repo_root / ".just/allowlists").mkdir(parents=True)
+            (repo_root / ".just/allowlists/env_var_boundary_allowlist.toml").write_text(
+                """\
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/example.rs"
+symbol = "resolve_team_from_env"
+line = 'let _ = env::var("ATM_TEAM").ok();'
+why = "test fixture: only the ATM_TEAM read is reviewed/allowlisted"
+sunset_sprint = "n/a"
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            # The allowlisted ATM_TEAM line is suppressed, but the new
+            # ATM_IDENTITY read in the same function must still be flagged.
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].path, "crates/atm-core/src/example.rs")
+            self.assertEqual(violations[0].symbol, "resolve_team_from_env")
+            self.assertEqual(violations[0].line, 'env::var("ATM_IDENTITY").ok()')
 
 
 if __name__ == "__main__":

--- a/.just/tests/test_check_env_var_boundary.py
+++ b/.just/tests/test_check_env_var_boundary.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from check_env_var_boundary import collect_env_var_boundary_violations
+from check_env_var_boundary import load_allowlist
+from check_env_var_boundary import load_boundary_reader_functions
+from check_env_var_boundary import load_forbidden_env_vars
+from check_env_var_boundary import load_restricted_crate_roots
+
+
+LINT_CONFIG = """\
+[env_var_boundary]
+forbidden_env_vars = ["ATM_TEAM", "ATM_IDENTITY"]
+restricted_crate_roots = ["crates/atm-core/src", "crates/atm-daemon/src"]
+boundary_reader_functions = [
+  "read_cli_identity_from_env",
+  "read_cli_team_from_env",
+]
+"""
+
+ROOT_MANIFEST = """\
+[workspace]
+members = ["crates/atm-core", "crates/atm-daemon", "crates/atm"]
+resolver = "2"
+"""
+
+
+class CheckEnvVarBoundaryTests(unittest.TestCase):
+    def write_repo(self, repo_root: Path) -> None:
+        (repo_root / ".just").mkdir()
+        (repo_root / ".just/lint-config.toml").write_text(LINT_CONFIG, encoding="utf-8")
+        (repo_root / "Cargo.toml").write_text(ROOT_MANIFEST, encoding="utf-8")
+        for crate, lib_name in (
+            ("atm-core", "atm_core"),
+            ("atm-daemon", "atm_daemon"),
+            ("atm", "atm"),
+        ):
+            crate_dir = repo_root / "crates" / crate
+            (crate_dir / "src").mkdir(parents=True)
+            (crate_dir / "Cargo.toml").write_text(
+                f"""\
+[package]
+name = "{crate}"
+version = "0.1.0"
+
+[lib]
+name = "{lib_name}"
+""",
+                encoding="utf-8",
+            )
+
+    def collect(self, repo_root: Path):
+        return collect_env_var_boundary_violations(
+            repo_root,
+            forbidden_env_vars=load_forbidden_env_vars(repo_root),
+            restricted_crate_roots=load_restricted_crate_roots(repo_root),
+            boundary_reader_functions=load_boundary_reader_functions(repo_root),
+            allowlist=load_allowlist(repo_root),
+        )
+
+    def test_load_config_reads_forbidden_env_vars(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+
+            self.assertEqual(load_forbidden_env_vars(repo_root), ("ATM_TEAM", "ATM_IDENTITY"))
+            self.assertEqual(
+                load_restricted_crate_roots(repo_root),
+                (Path("crates/atm-core/src"), Path("crates/atm-daemon/src")),
+            )
+            self.assertEqual(
+                load_boundary_reader_functions(repo_root),
+                ("read_cli_identity_from_env", "read_cli_team_from_env"),
+            )
+
+    def test_flags_direct_env_var_literal_in_atm_core(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/src/example.rs").write_text(
+                """\
+use std::env;
+
+pub fn resolve_team_from_env() -> Option<String> {
+    env::var("ATM_TEAM").ok()
+}
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].path, "crates/atm-core/src/example.rs")
+            self.assertEqual(violations[0].symbol, "resolve_team_from_env")
+            self.assertEqual(violations[0].kind, "direct_literal_env_read")
+
+    def test_flags_direct_env_var_os_literal_in_atm_daemon(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-daemon/src/example.rs").write_text(
+                """\
+pub fn resolve_identity_from_env() -> Option<std::ffi::OsString> {
+    std::env::var_os("ATM_IDENTITY")
+}
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].path, "crates/atm-daemon/src/example.rs")
+            self.assertEqual(violations[0].symbol, "resolve_identity_from_env")
+            self.assertEqual(violations[0].kind, "direct_literal_env_read")
+
+    def test_flags_literal_forwarded_through_same_file_helper(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/src/example.rs").write_text(
+                """\
+use std::env;
+
+pub fn read_cli_team_from_env_example() -> Option<String> {
+    read_env_raw("ATM_TEAM")
+}
+
+fn read_env_raw(key: &str) -> Option<String> {
+    env::var(key).ok()
+}
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].kind, "env_var_via_forwarding_function")
+            self.assertEqual(violations[0].symbol, "read_cli_team_from_env_example")
+
+    def test_flags_calls_to_configured_boundary_reader_functions_from_other_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/src/caller_context.rs").write_text(
+                """\
+use std::env;
+
+pub fn read_cli_team_from_env() -> Option<String> {
+    env::var("ATM_TEAM").ok()
+}
+""",
+                encoding="utf-8",
+            )
+            (repo_root / "crates/atm-core/src/config.rs").write_text(
+                """\
+use crate::caller_context::read_cli_team_from_env;
+
+pub fn resolve_team() -> Option<String> {
+    read_cli_team_from_env()
+}
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            kinds = {(violation.path, violation.symbol, violation.kind) for violation in violations}
+            self.assertIn(
+                (
+                    "crates/atm-core/src/caller_context.rs",
+                    "read_cli_team_from_env",
+                    "direct_literal_env_read",
+                ),
+                kinds,
+            )
+            self.assertIn(
+                (
+                    "crates/atm-core/src/config.rs",
+                    "resolve_team",
+                    "boundary_reader_function_call",
+                ),
+                kinds,
+            )
+
+    def test_does_not_flag_internal_calls_within_the_defining_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/src/caller_context.rs").write_text(
+                """\
+use std::env;
+
+pub fn read_cli_team_from_env() -> Option<String> {
+    env::var("ATM_TEAM").ok()
+}
+
+fn resolve_team_component() -> Option<String> {
+    read_cli_team_from_env()
+}
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            symbols = {violation.symbol for violation in violations}
+            self.assertNotIn("resolve_team_component", symbols)
+
+    def test_allows_legitimate_cli_reads_outside_restricted_crate_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm/src/main.rs").write_text(
+                """\
+use std::env;
+
+pub fn resolve_team_from_env() -> Option<String> {
+    env::var("ATM_TEAM").ok()
+}
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            self.assertEqual(violations, [])
+
+    def test_does_not_flag_test_scope_env_manipulation(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/src/example.rs").write_text(
+                """\
+pub fn production() {}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    #[test]
+    fn example() {
+        let _ = env::var_os("ATM_TEAM");
+    }
+}
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            self.assertEqual(violations, [])
+
+    def test_allowlisted_call_site_is_suppressed(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/src/example.rs").write_text(
+                """\
+use std::env;
+
+pub fn resolve_team_from_env() -> Option<String> {
+    env::var("ATM_TEAM").ok()
+}
+""",
+                encoding="utf-8",
+            )
+            (repo_root / ".just/allowlists").mkdir(parents=True)
+            (repo_root / ".just/allowlists/env_var_boundary_allowlist.toml").write_text(
+                """\
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/example.rs"
+symbol = "resolve_team_from_env"
+why = "test fixture"
+sunset_sprint = "n/a"
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_check_env_var_boundary.py
+++ b/.just/tests/test_check_env_var_boundary.py
@@ -194,6 +194,55 @@ pub fn resolve_team() -> Option<String> {
                 kinds,
             )
 
+    def test_flags_calls_to_same_file_wrapper_boundary_reader_functions(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/src/caller_context.rs").write_text(
+                """\
+use std::env;
+
+pub fn read_cli_team_from_env() -> Option<String> {
+    env::var("ATM_TEAM").ok()
+}
+
+pub fn read_cli_team_from_env_or_warn() -> Option<String> {
+    read_cli_team_from_env()
+}
+""",
+                encoding="utf-8",
+            )
+            (repo_root / "crates/atm-core/src/health.rs").write_text(
+                """\
+use crate::caller_context::read_cli_team_from_env_or_warn;
+
+pub fn environment_visibility() -> Option<String> {
+    read_cli_team_from_env_or_warn()
+}
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            kinds = {(violation.path, violation.symbol, violation.kind) for violation in violations}
+            self.assertIn(
+                (
+                    "crates/atm-core/src/caller_context.rs",
+                    "read_cli_team_from_env",
+                    "direct_literal_env_read",
+                ),
+                kinds,
+            )
+            self.assertIn(
+                (
+                    "crates/atm-core/src/health.rs",
+                    "environment_visibility",
+                    "boundary_reader_function_call",
+                ),
+                kinds,
+            )
+
     def test_does_not_flag_internal_calls_within_the_defining_file(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)

--- a/Justfile
+++ b/Justfile
@@ -97,6 +97,10 @@ _lint-identities:
     {{python_cmd}} .just/check_test_identity_literals.py
 
 [private]
+_lint-env-var-boundary:
+    {{python_cmd}} .just/check_env_var_boundary.py
+
+[private]
 _lint-fixed-sleep:
     {{python_cmd}} .just/check_fixed_sleep_hygiene.py
 


### PR DESCRIPTION
## Summary
- Adds a new prospective boundary lint (`env-var-boundary`) flagging direct `ATM_TEAM`/`ATM_IDENTITY` environment reads inside `crates/atm-core/src` and `crates/atm-daemon/src`.
- Rationale: these are CLI-identity env vars that should only be resolved at client entry points (CLI in `crates/atm`, atm-graft) into explicit parameters — library crates should never read them directly. Surfaced during the issue #548 root-cause investigation.
- Catches direct `env::var`/`var_os` literal calls, same-file forwarding helpers, and configured boundary-reader functions (`read_cli_identity_from_env`/`read_cli_team_from_env`) called from any other restricted-root file.
- CLI code in `crates/atm` and atm-graft is out of scope entirely — legitimate client-boundary reads are never flagged.
- Current known call sites (`caller_context.rs`, `config/mod.rs`, `identity/mod.rs`, `doctor/health.rs`, `atm-daemon/runtime_health.rs`) are allowlisted with documented follow-up refactor scope — no behavior changes attempted in this PR.

## Test plan
- [x] `python3 -m unittest discover -s .just/tests -p 'test_check_env_var_boundary.py' -v` — 9/9 passed
- [x] `python3 .just/run_pytests.py` — 205/205 passed
- [x] `python3 .just/run_lint.py all` — 22/22 lint checks passed
- [x] `python3 .just/check_env_var_boundary.py` — clean against current repo state

🤖 Generated with [Claude Code](https://claude.com/claude-code)