### PR TITLE
Fix Phase AG plan metadata

### DIFF
--- a/docs/plans/phase-AG/plan-phase-AG.md
+++ b/docs/plans/phase-AG/plan-phase-AG.md
@@ -1,8 +1,8 @@
 ---
 title: Phase AG Plan
 status: planned
-branch: docs/cross-host-remote-target-contract
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
+branch: develop
+worktree: ../atm-core
 ---
 
 # Phase AG Plan
@@ -88,7 +88,8 @@ Phase `AG` now has three distinct records:
 - historical early execution on `feature/cross-host-communication`
 - reviewed corrective replan history on
   `plan/phase-ag-multihost-advertise-allowlist`
-- current hardened planning source on `docs/cross-host-remote-target-contract`
+- current hardened planning source merged into `develop`, with execution on
+  separate sprint worktrees
 
 The historical lines remain important evidence, but they no longer define the
 forward phase sequence by themselves. The current branch is the planning source

--- a/docs/plans/phase-AG/sprint-AG10.md
+++ b/docs/plans/phase-AG/sprint-AG10.md
@@ -2,8 +2,8 @@
 id: AG.10
 title: Secured Cross-Host Transport Implementation
 status: planned
-branch: plan/phase-ag-multihost-advertise-allowlist
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
+branch: feature/pAG-s10-secured-transport
+worktree: ../atm-core-worktrees/feature/pAG-s10-secured-transport
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.10
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
-branch: plan/phase-ag-multihost-advertise-allowlist
+worktree: ../atm-core-worktrees/feature/pAG-s10-secured-transport
+branch: feature/pAG-s10-secured-transport
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG11.md
+++ b/docs/plans/phase-AG/sprint-AG11.md
@@ -2,8 +2,8 @@
 id: AG.11
 title: Corrective Remote-Target Contract And Dispatch Routing
 status: planned
-branch: docs/cross-host-remote-target-contract
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
+branch: feature/pAG-s11-remote-target-contract
+worktree: ../atm-core-worktrees/feature/pAG-s11-remote-target-contract
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.11
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
-branch: docs/cross-host-remote-target-contract
+worktree: ../atm-core-worktrees/feature/pAG-s11-remote-target-contract
+branch: feature/pAG-s11-remote-target-contract
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG12.md
+++ b/docs/plans/phase-AG/sprint-AG12.md
@@ -2,8 +2,8 @@
 id: AG.12
 title: Localhost Full-Function Same-Host Remote-Target Proof
 status: planned
-branch: docs/cross-host-remote-target-contract
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
+branch: feature/pAG-s12-localhost-proof
+worktree: ../atm-core-worktrees/feature/pAG-s12-localhost-proof
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.12
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
-branch: docs/cross-host-remote-target-contract
+worktree: ../atm-core-worktrees/feature/pAG-s12-localhost-proof
+branch: feature/pAG-s12-localhost-proof
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG13.md
+++ b/docs/plans/phase-AG/sprint-AG13.md
@@ -2,8 +2,8 @@
 id: AG.13
 title: Self-IP Full-Function Same-Host Proof
 status: planned
-branch: docs/cross-host-remote-target-contract
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
+branch: feature/pAG-s13-selfip-proof
+worktree: ../atm-core-worktrees/feature/pAG-s13-selfip-proof
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.13
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
-branch: docs/cross-host-remote-target-contract
+worktree: ../atm-core-worktrees/feature/pAG-s13-selfip-proof
+branch: feature/pAG-s13-selfip-proof
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG14.md
+++ b/docs/plans/phase-AG/sprint-AG14.md
@@ -2,8 +2,8 @@
 id: AG.14
 title: Automated Integration Coverage For The Corrective Path
 status: planned
-branch: docs/cross-host-remote-target-contract
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
+branch: feature/pAG-s14-integration-coverage
+worktree: ../atm-core-worktrees/feature/pAG-s14-integration-coverage
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.14
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
-branch: docs/cross-host-remote-target-contract
+worktree: ../atm-core-worktrees/feature/pAG-s14-integration-coverage
+branch: feature/pAG-s14-integration-coverage
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG15.md
+++ b/docs/plans/phase-AG/sprint-AG15.md
@@ -2,8 +2,8 @@
 id: AG.15
 title: Other-Mac Cross-Host Smoke
 status: planned
-branch: docs/cross-host-remote-target-contract
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
+branch: feature/pAG-s15-othermac-smoke
+worktree: ../atm-core-worktrees/feature/pAG-s15-othermac-smoke
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.15
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
-branch: docs/cross-host-remote-target-contract
+worktree: ../atm-core-worktrees/feature/pAG-s15-othermac-smoke
+branch: feature/pAG-s15-othermac-smoke
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG16.md
+++ b/docs/plans/phase-AG/sprint-AG16.md
@@ -2,8 +2,8 @@
 id: AG.16
 title: Windows/macOS Cross-Host Smoke
 status: planned
-branch: docs/cross-host-remote-target-contract
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
+branch: TBD
+worktree: TBD
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.16
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
-branch: docs/cross-host-remote-target-contract
+worktree: TBD
+branch: TBD
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG17.md
+++ b/docs/plans/phase-AG/sprint-AG17.md
@@ -2,8 +2,8 @@
 id: AG.17
 title: Corrective Copied-State Revalidation And Release Verdict
 status: planned
-branch: docs/cross-host-remote-target-contract
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
+branch: TBD
+worktree: TBD
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.17
-worktree: ../atm-core-worktrees/docs/cross-host-remote-target-contract
-branch: docs/cross-host-remote-target-contract
+worktree: TBD
+branch: TBD
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG4.md
+++ b/docs/plans/phase-AG/sprint-AG4.md
@@ -2,8 +2,8 @@
 id: AG.4
 title: Durable Interface Configuration And Binding
 status: planned
-branch: plan/phase-ag-multihost-advertise-allowlist
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
+branch: feature/pAG-s4-durable-interface-config
+worktree: ../atm-core-worktrees/feature/pAG-s4-durable-interface-config
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.4
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
-branch: plan/phase-ag-multihost-advertise-allowlist
+worktree: ../atm-core-worktrees/feature/pAG-s4-durable-interface-config
+branch: feature/pAG-s4-durable-interface-config
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG5.md
+++ b/docs/plans/phase-AG/sprint-AG5.md
@@ -2,8 +2,8 @@
 id: AG.5
 title: Durable Host Allowlist Enforcement
 status: planned
-branch: plan/phase-ag-multihost-advertise-allowlist
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
+branch: feature/pAG-s5-host-allowlist
+worktree: ../atm-core-worktrees/feature/pAG-s5-host-allowlist
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.5
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
-branch: plan/phase-ag-multihost-advertise-allowlist
+worktree: ../atm-core-worktrees/feature/pAG-s5-host-allowlist
+branch: feature/pAG-s5-host-allowlist
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG6.md
+++ b/docs/plans/phase-AG/sprint-AG6.md
@@ -2,8 +2,8 @@
 id: AG.6
 title: Doctor Visibility For The Cross-Host Control Plane
 status: planned
-branch: plan/phase-ag-multihost-advertise-allowlist
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
+branch: feature/pAG-s6-doctor-visibility
+worktree: ../atm-core-worktrees/feature/pAG-s6-doctor-visibility
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.6
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
-branch: plan/phase-ag-multihost-advertise-allowlist
+worktree: ../atm-core-worktrees/feature/pAG-s6-doctor-visibility
+branch: feature/pAG-s6-doctor-visibility
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG7.md
+++ b/docs/plans/phase-AG/sprint-AG7.md
@@ -2,8 +2,8 @@
 id: AG.7
 title: Live Cross-Host Revalidation
 status: planned
-branch: plan/phase-ag-multihost-advertise-allowlist
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
+branch: feature/pAG-s7-live-revalidation
+worktree: ../atm-core-worktrees/feature/pAG-s7-live-revalidation
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.7
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
-branch: plan/phase-ag-multihost-advertise-allowlist
+worktree: ../atm-core-worktrees/feature/pAG-s7-live-revalidation
+branch: feature/pAG-s7-live-revalidation
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG8.md
+++ b/docs/plans/phase-AG/sprint-AG8.md
@@ -2,8 +2,8 @@
 id: AG.8
 title: Transport Security And Encryption Hardening
 status: planned
-branch: plan/phase-ag-multihost-advertise-allowlist
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
+branch: feature/pAG-s8-transport-security-planning
+worktree: ../atm-core-worktrees/feature/pAG-s8-transport-security-planning
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.8
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
-branch: plan/phase-ag-multihost-advertise-allowlist
+worktree: ../atm-core-worktrees/feature/pAG-s8-transport-security-planning
+branch: feature/pAG-s8-transport-security-planning
 status: planned
 estimated_scope: medium
 ```

--- a/docs/plans/phase-AG/sprint-AG9.md
+++ b/docs/plans/phase-AG/sprint-AG9.md
@@ -2,8 +2,8 @@
 id: AG.9
 title: Copied-State Revalidation And Release Verdict
 status: planned
-branch: plan/phase-ag-multihost-advertise-allowlist
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
+branch: feature/pAG-s9-release-verdict
+worktree: ../atm-core-worktrees/feature/pAG-s9-release-verdict
 target: develop
 ---
 
@@ -13,8 +13,8 @@ target: develop
 plan_type: sprint_plan
 phase: AG
 sprint: AG.9
-worktree: ../atm-core-worktrees/plan/phase-ag-multihost-advertise-allowlist
-branch: plan/phase-ag-multihost-advertise-allowlist
+worktree: ../atm-core-worktrees/feature/pAG-s9-release-verdict
+branch: feature/pAG-s9-release-verdict
 status: planned
 estimated_scope: medium
 ```

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -91,8 +91,9 @@ Phase-AG planning note:
   - retained loopback self-test support as a supported diagnostic mode
 - only after that product work lands does AG return to live Windows/macOS
   host-pair validation and copied-state release proof
-- the current AG corrective planning branch for the remote-target routing and
-  revalidation line is `docs/cross-host-remote-target-contract`
+- the AG corrective routing/revalidation plan is now merged into `develop`, and
+  execution proceeds on separate per-sprint worktrees beginning with
+  `feature/pAG-s11-remote-target-contract`
 - transport security / encryption remains a later AG sprint concern and must
   not be implied by earlier functional cross-host closure
 
@@ -691,16 +692,20 @@ Status summary:
 Planning branch:
 - historical early execution: `feature/cross-host-communication`
 - earlier corrective replan: `plan/phase-ag-multihost-advertise-allowlist`
-- current corrective routing/revalidation planning branch:
-  `docs/cross-host-remote-target-contract`
+- current corrective routing/revalidation plan source: `develop`
 
 Branch-routing note:
 - PR #542 (`feature/cross-host-communication` -> `develop`) is retained as the
   historical early-AG planning/execution record
 - PR #555 (`plan/phase-ag-multihost-advertise-allowlist` -> `develop`) is the
   earlier corrective AG replanning line
-- `docs/cross-host-remote-target-contract` is the current AG planning line for
-  AG.11 through AG.17 plan hardening
+- the hardened AG.11 through AG.15 execution line now uses separate sprint
+  branches/worktrees:
+  `feature/pAG-s11-remote-target-contract`,
+  `feature/pAG-s12-localhost-proof`,
+  `feature/pAG-s13-selfip-proof`,
+  `feature/pAG-s14-integration-coverage`, and
+  `feature/pAG-s15-othermac-smoke`
 - if AG later opens product-code fixes from concrete findings, those follow-up
   branches must declare their own normal integration path explicitly
 


### PR DESCRIPTION
## Summary
- Metadata-only correction to phase-AG plan docs (AG.4-AG.15) so they reflect actual execution branches/worktrees
- Removes stale reference implying the old shared planning branch is current execution truth

## Test plan
- Docs-only change; no code/test impact
- CI lint/format checks run as safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)