### PR TITLE
docs: AG.11 addendum + AG.10 lint-refactor recommendations

### DIFF
--- a/docs/adr/ADR-031-remote-target-contract-and-cross-host-dispatch.md
+++ b/docs/adr/ADR-031-remote-target-contract-and-cross-host-dispatch.md
@@ -21,6 +21,8 @@ The user-approved correction is intentionally narrow:
 - remote-target parsing must be explicit and operator-visible
 - localhost and the sender's own IP address must be ordinary remote-host
   values, not a special loopback-only mode
+- socket transport must reuse the same ATM wire message shapes already used on
+  other ATM transports
 - host-routing logic must stop at one typed boundary so socket logic does not
   leak through general send/runtime code
 
@@ -106,6 +108,8 @@ Dispatch rules:
   mailbox path
 - `localhost` and the sender host's own advertised or bound IP address are
   ordinary non-empty remote-host values on that same cross-host delivery path
+- no localhost-only or loopback-only dispatch branch exists in the production
+  contract
 
 Delivery-result rules:
 
@@ -148,6 +152,8 @@ Boundary rule:
 
 - parsing/normalization/classification ends at one typed remote-target
   contract
+- ATM payload framing and message shapes remain transport-invariant across
+  local IPC, socket transport, and any other supported ATM transport
 - socket and transport implementation details stay behind the cross-host
   delivery boundary and its storage/config boundaries
 

--- a/docs/plans/phase-AG/plan-phase-AG.md
+++ b/docs/plans/phase-AG/plan-phase-AG.md
@@ -713,6 +713,18 @@ Outputs:
   - unhealthy path => return immediate deferred-delivery result
   - daemon continues bounded retry for `60s..120s`
   - final delivery/failure receipt lands in sender inbox
+- socket transport reuses the same ATM wire message shapes already used on
+  other transports; no transport-specific socket schema is introduced
+- `localhost` and self-IP same-host rows remain ordinary non-empty remote-host
+  sends on that same branch; no localhost-special code path is allowed
+- one authoritative deletion/reduction ledger for retained AG.3-AG.10
+  cross-host surfaces:
+  - remove env-driven peer endpoint control (`ATM_DAEMON_PEER_ADDR`) from the
+    intended steady-state operator path
+  - remove CLI-only loopback transport compatibility paths that bypass the
+    daemon runtime
+  - reduce any cross-host parsing or socket-policy logic that leaks outside the
+    sealed delivery/storage boundaries
 - requirements / architecture / ADR updates aligned to that dispatch rule
 - finding handoff to `AG-FIND-005`
 

--- a/docs/plans/phase-AG/sprint-AG10.md
+++ b/docs/plans/phase-AG/sprint-AG10.md
@@ -30,6 +30,63 @@ security design/reconciliation work.
 - peer-auth / credential handling implementation
 - secure loopback validation support
 - secure LAN and routed/VPN validation support
+- large-module lint remediation plan and execution constraints for the AG.10
+  code line so AG.11+ can merge forward on smaller, stable files instead of
+  repeating structural churn
+
+## Refactor Tasks For Merge-Forward Stability
+
+These tasks are required AG.10 recommendations and are intended to be landed as
+behavior-preserving refactors. They exist to resolve `file too large` /
+function-length / lines failures in a way that reduces conflict pressure on the
+AG.11+ corrective line.
+
+- split oversized transport runtime code by responsibility instead of by test
+  accident:
+  - move socket server accept/bind lifecycle into a dedicated server module
+  - move handshake / authentication negotiation into a dedicated security or
+    handshake module
+  - move retry / receipt / outcome classification into a dedicated delivery
+    outcome module
+  - keep only top-level orchestration in the runtime entry module
+- split oversized CLI/runtime command files by boundary:
+  - parsing and normalization helpers separate from execution/orchestration
+  - user-facing output formatting separate from dispatch logic
+  - storage contract types separate from transport execution code
+- prefer extracting sealed internal modules over widening public APIs
+- preserve the AG.10 external behavior and wire contract while refactoring:
+  - no new CLI syntax
+  - no new environment-variable surface
+  - no change in message envelope shape
+  - no localhost-only fast path
+- place extracted modules where AG.11+ can either reuse them directly or delete
+  them cleanly without another large-file rewrite
+
+## Refactor Targets
+
+The AG.10 line should explicitly evaluate and, where practical, split these
+large surfaces first because they are the highest merge-conflict and lint-risk
+points for AG.11+:
+
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/composition.rs`
+- `crates/atm-core/src/send/mod.rs`
+- `crates/atm/src/commands/send.rs`
+
+Recommended split shape:
+
+- `runtime_health.rs`
+  - keep dispatch orchestration only
+  - extract retry policy, receipt handling, and remote/local branch helpers
+- `composition.rs`
+  - keep composition root only
+  - extract peer transport config loading / validation helpers
+- `send/mod.rs`
+  - keep public send entrypoints only
+  - extract target parsing / normalization and delivery-result helpers
+- `commands/send.rs`
+  - keep CLI command wiring only
+  - extract argument normalization and output rendering helpers
 
 ## Boundary And Type Contract
 
@@ -67,6 +124,12 @@ ownership for secure negotiation and credential lookup.
   implemented surface
 - secure routed/VPN host-pair rerun row `AG-VAL-015` executes on the
   implemented surface
+- refactor commits are behavior-preserving:
+  - no CLI surface drift
+  - no wire-message drift
+  - no new daemon/config control plane introduced as part of lint cleanup
+- the refactor shape demonstrably reduces the merge-forward surface into AG.11+
+  rather than creating additional top-level files with mixed responsibilities
 
 ## Unit-Test Plan
 
@@ -74,6 +137,8 @@ ownership for secure negotiation and credential lookup.
 - encryption negotiation failure does not fall back silently to insecure mode
 - loopback/local diagnostic surfaces remain explicitly scoped and do not
   accidentally widen remote trust
+- extracted helper modules retain their current behavior through targeted unit
+  coverage where splitting introduces private helper seams
 
 ## Integration-Test Plan
 
@@ -83,6 +148,8 @@ ownership for secure negotiation and credential lookup.
   (`AG-VAL-014`)
 - existing AG.7 functional rows still pass under the secured transport
   (`AG-VAL-013`, `AG-VAL-015`)
+- at least one AG.10 integration path exercises code that now crosses the new
+  internal module seams so the split is proven non-semantic
 
 ## Smoke-Test Plan
 
@@ -101,3 +168,7 @@ ownership for secure negotiation and credential lookup.
 - a Boundary And Type Contract exists for the secure transport surface
 - secure loopback, integration, and smoke coverage are all specified and
   required
+- AG.10 large-file lint remediation is handled through responsibility-based
+  internal module extraction, not by adding AG.11 corrective logic early
+- the AG.10 refactor shape leaves AG.11+ free to layer the remote-target
+  contract and same-host proofs on top without another broad file reshuffle

--- a/docs/plans/phase-AG/sprint-AG11.md
+++ b/docs/plans/phase-AG/sprint-AG11.md
@@ -53,6 +53,9 @@ contract instead of a local-mailbox fallthrough.
 - findings-ledger linkage to `AG-FIND-005`
 - one dedicated ADR (`ADR-031`) for the remote-target contract and dispatch
   boundary
+- one authoritative deletion/reduction ledger for stale AG.3-AG.10 cross-host
+  surfaces that must not survive the corrective line without an explicit
+  justification
 
 ## Boundary And Type Contract
 
@@ -123,6 +126,61 @@ Trait-surface rule:
 - the sprint requires one fixed production implementer set chosen by the
   composition root
 
+Transport and localhost invariants:
+
+- socket transport must reuse the same ATM wire message shapes already used on
+  the other transports; AG.11 must not introduce a transport-specific socket
+  message schema
+- `localhost` and self-IP same-host traffic are ordinary remote hosts routed
+  through the same parsing, dispatch, listener bind, and socket path as any
+  other host
+- no loopback-only branch, bypass flag, or localhost-special client path may be
+  introduced to make AG.12 or AG.13 pass
+
+## Paths To Delete Or Reduce
+
+This list is authoritative for the AG.11 corrective line. Any item retained
+after AG.11 must be justified explicitly in the AG.11 completion report and
+must remain behind the sealed cross-host delivery or storage boundary instead
+of leaking into general send/runtime code.
+
+- delete env-driven peer endpoint selection as an operator contract:
+  - `crates/atm-daemon/src/peer_transport.rs`
+    - `daemon_peer_endpoint_from_env`
+    - user-facing recovery/error text that instructs operators to set
+      `ATM_DAEMON_PEER_ADDR`
+  - `docs/plans/phase-AG/cross-host-setup-runbook.md`
+    - transitional `ATM_DAEMON_PEER_ADDR` setup steps must be removed once the
+      AG.4 / AG.5 SQLite-managed interface rows are the corrective authority
+- delete CLI-only loopback transport compatibility paths that bypass the daemon
+  runtime:
+  - `crates/atm-core/src/transport/testing.rs`
+    - `LoopbackClientTransport`
+    - loopback-only compatibility-preflight / heartbeat fallbacks
+  - `crates/atm/src/composition.rs`
+    - the `loopback_transport_*_without_daemon` test line must be replaced by
+      AG.12-AG.14 coverage that exercises the real remote-target path through
+      the daemon boundary
+- delete or reduce any cross-host parsing/classification logic that remains in
+  general runtime code after the typed `remote_host` contract exists:
+  - `crates/atm-daemon/src/runtime_health.rs`
+    - retain only the local-vs-remote branch decision and receipt/retry
+      orchestration that belongs above the delivery trait
+    - remove host-shape parsing, localhost special-casing, or socket-policy
+      decisions that can live inside the sealed delivery boundary instead
+- reduce composition-root leakage of transport configuration:
+  - `crates/atm-daemon/src/composition.rs`
+    - remove direct env-based peer transport configuration loading from the
+      production composition path
+    - retain only sealed storage-backed interface/allowlist loading and wiring
+      into the delivery runtime
+- delete any surviving documentation or test language that implies:
+  - loopback is a separate product mode rather than ordinary host routing
+  - special localhost handling is allowed
+  - socket transport may use a transport-specific message schema
+  - env variables remain the intended steady-state control plane for peer
+    routing
+
 ## Acceptance Criteria
 
 - both supported syntaxes normalize to the same typed remote-target field
@@ -135,6 +193,8 @@ Trait-surface rule:
 - local sends remain on the existing local mailbox path
 - same-host remote-target values do not require a dedicated loopback-only field
   or dispatch branch
+- same-host remote-target values use the same ATM wire message envelopes and
+  the same listener/socket path used for any other remote host
 - production composition installs a real non-test-double `CrossHostDelivery`
   implementation on the live send dispatch path
 - "healthy" means the daemon has a currently usable enabled interface row, a
@@ -142,6 +202,11 @@ Trait-surface rule:
   target host; otherwise the send takes the deferred branch immediately
 - the sprint closes only when the remote-target dispatch branch is observable in
   automated validation
+- the AG.11 completion report accounts for every entry in `Paths To Delete Or
+  Reduce` as either:
+  - deleted
+  - reduced behind the sealed delivery/storage boundary
+  - or explicitly deferred with a named follow-on finding
 
 ## Required Validation
 
@@ -159,6 +224,8 @@ Trait-surface rule:
   the Tier-3 end-to-end integration backstop is deferred to AG.14
 - one timeout-enforcement test proves the `10s` healthy-wait ceiling is a hard
   upper bound rather than best-effort behavior
+- one code-audit validation pass records the disposition of every entry under
+  `Paths To Delete Or Reduce`
 - requirements / architecture / ADR review proving the CLI contract and runtime
   branch are described consistently
 


### PR DESCRIPTION
## Summary
- AG.11 addendum: deletion/reduction ledger for retained AG.3-AG.10 cross-host code surviving the AG.11 reset, plus explicit transport constraints (same ATM wire message shapes across transports, no localhost-special-cased path).
- AG.10 addendum: large-module lint-refactor recommendations shaped to merge forward cleanly into AG.11+.

Restaged from a mistaken direct push to develop (reverted at 52e51a17); this PR carries the same content through normal review.

**Do not merge until user approves.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)