### PR TITLE
Harden agent/team identifier charset validation

### DIFF
--- a/crates/atm-core/src/address.rs
+++ b/crates/atm-core/src/address.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+pub use atm_storage::validate_path_segment;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AtmError;
@@ -41,43 +42,6 @@ impl fmt::Display for AgentAddress {
             None => f.write_str(&self.agent),
         }
     }
-}
-
-pub(crate) fn validate_path_segment(value: &str, kind: &str) -> Result<(), AtmError> {
-    if value.is_empty() {
-        return Err(AtmError::address_parse(format!(
-            "{kind} name must not be empty"
-        )));
-    }
-
-    if value.starts_with('.') {
-        return Err(AtmError::address_parse(format!(
-            "{kind} name must not start with '.'"
-        )));
-    }
-
-    if value.contains("..") {
-        return Err(AtmError::address_parse(format!(
-            "{kind} name must not contain '..'"
-        )));
-    }
-
-    if value.contains(['/', '\\']) {
-        return Err(AtmError::address_parse(format!(
-            "{kind} name must not contain path separators"
-        )));
-    }
-
-    if !value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
-    {
-        return Err(AtmError::address_parse(format!(
-            "{kind} name contains invalid characters"
-        )));
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -121,14 +85,16 @@ mod tests {
         assert!(AgentAddress::from_str("team/subdir").is_err());
         assert!(AgentAddress::from_str(r"team\\subdir").is_err());
         assert!(AgentAddress::from_str(".hidden").is_err());
+        assert!(AgentAddress::from_str("bad:name").is_err());
+        assert!(AgentAddress::from_str("bad name").is_err());
         assert!(AgentAddress::from_str("a..b@team").is_err());
         assert!(AgentAddress::from_str("a...b@team").is_err());
     }
 
     #[test]
     fn accepts_valid_segment_characters() {
-        let parsed = AgentAddress::from_str("valid-team_name.1").expect("address");
-        assert_eq!(parsed.agent, AgentName::from_validated("valid-team_name.1"));
+        let parsed = AgentAddress::from_str("valid-team_name1").expect("address");
+        assert_eq!(parsed.agent, AgentName::from_validated("valid-team_name1"));
         assert_eq!(parsed.team, None);
 
         let parsed = AgentAddress::from_str(TEST_SENDER_ADDRESS).expect("address");

--- a/crates/atm-core/src/config/discovery.rs
+++ b/crates/atm-core/src/config/discovery.rs
@@ -359,7 +359,7 @@ mod tests {
         assert!(
             error
                 .message
-                .contains("hook recipient name must not contain path separators")
+                .contains("hook recipient name must use only ASCII letters, digits, '-' or '_'")
         );
     }
 

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -112,7 +112,7 @@ fn parse_default_team(raw_team: Option<String>, path: &Path) -> Result<Option<Te
                     format!("invalid default team in {}: {}", path.display(), error.message),
                 )
                 .with_recovery(
-                    "Use a valid ATM team name in [atm].default_team or default_team without path separators or surrounding whitespace.",
+                    "Use a valid ATM team name in [atm].default_team or default_team using only ASCII letters, digits, '-' or '_'.",
                 )
             })
         })
@@ -454,7 +454,7 @@ fn normalize_team_members(values: Vec<String>, path: &Path) -> Result<Vec<TeamNa
                     format!("invalid [atm].team_members entry in {}: {error}", path.display()),
                 )
                 .with_recovery(
-                    "Use valid ATM team-member names in [atm].team_members without path separators or surrounding whitespace.",
+                    "Use valid ATM team-member names in [atm].team_members using only ASCII letters, digits, '-' or '_'.",
                 )
             })
         })

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -21,3 +21,4 @@ pub use error::{AtmError, AtmErrorKind};
 pub use error_codes::AtmErrorCode;
 pub use schema::{AlertKind, AtmMessageId, InboxMessage, MessageEnvelope, PendingAck, ThreadMode};
 pub use types::{AgentId, AgentName, IsoTimestamp, ModelName, PaneId, TaskId, TeamName};
+pub use validation::validate_path_segment;

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -21,4 +21,4 @@ pub use error::{AtmError, AtmErrorKind};
 pub use error_codes::AtmErrorCode;
 pub use schema::{AlertKind, AtmMessageId, InboxMessage, MessageEnvelope, PendingAck, ThreadMode};
 pub use types::{AgentId, AgentName, IsoTimestamp, ModelName, PaneId, TaskId, TeamName};
-pub use validation::validate_path_segment;
+pub use validation::{validate_agent_at_team, validate_path_segment};

--- a/crates/atm-storage/src/types.rs
+++ b/crates/atm-storage/src/types.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::error::AtmError;
-use crate::validation::validate_path_segment;
+use crate::validation::{validate_agent_at_team, validate_path_segment};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -125,13 +125,7 @@ impl AgentId {
     pub fn new(value: impl Into<String>) -> Result<Self, AtmError> {
         let value = value.into();
         let trimmed = value.trim();
-        match trimmed.split_once('@') {
-            Some((agent, team)) => {
-                validate_path_segment(agent, "agent id")?;
-                validate_path_segment(team, "agent id")?;
-            }
-            None => validate_path_segment(trimmed, "agent id")?,
-        }
+        validate_agent_at_team(trimmed, "agent id")?;
         Ok(Self(trimmed.to_string()))
     }
 
@@ -271,7 +265,14 @@ mod tests {
 
     #[test]
     fn agent_id_new_rejects_invalid_path_segments() {
-        for invalid in ["", ".hidden", "two..dots", "bad/name", "bad name"] {
+        for invalid in [
+            "",
+            ".hidden",
+            "two..dots",
+            "bad/name",
+            "bad name",
+            "role@bad.team",
+        ] {
             assert!(
                 AgentId::new(invalid).is_err(),
                 "expected `{invalid}` to fail"

--- a/crates/atm-storage/src/types.rs
+++ b/crates/atm-storage/src/types.rs
@@ -288,7 +288,11 @@ mod tests {
         assert_eq!(compound.as_str(), "worker-2@test-team");
 
         let error = serde_json::from_str::<AgentId>("\"bad/name\"").expect_err("invalid id");
-        assert!(error.to_string().contains("path separators"));
+        assert!(
+            error
+                .to_string()
+                .contains("must use only ASCII letters, digits, '-' or '_'")
+        );
     }
 
     #[test]

--- a/crates/atm-storage/src/validation.rs
+++ b/crates/atm-storage/src/validation.rs
@@ -1,36 +1,18 @@
 use crate::error::AtmError;
 
-pub(crate) fn validate_path_segment(value: &str, kind: &str) -> Result<(), AtmError> {
+pub fn validate_path_segment(value: &str, kind: &str) -> Result<(), AtmError> {
     if value.is_empty() {
         return Err(AtmError::address_parse(format!(
             "{kind} name must not be empty"
         )));
     }
 
-    if value.starts_with('.') {
-        return Err(AtmError::address_parse(format!(
-            "{kind} name must not start with '.'"
-        )));
-    }
-
-    if value.contains("..") {
-        return Err(AtmError::address_parse(format!(
-            "{kind} name must not contain '..'"
-        )));
-    }
-
-    if value.contains(['/', '\\']) {
-        return Err(AtmError::address_parse(format!(
-            "{kind} name must not contain path separators"
-        )));
-    }
-
     if !value
         .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
     {
         return Err(AtmError::address_parse(format!(
-            "{kind} name contains invalid characters"
+            "{kind} name must use only ASCII letters, digits, '-' or '_'"
         )));
     }
 
@@ -47,31 +29,32 @@ mod tests {
     }
 
     #[test]
-    fn validate_path_segment_rejects_dot_prefixed_values() {
-        let error = validate_path_segment(".agent", "agent").expect_err("dot prefix");
-        assert!(error.to_string().contains("must not start with '.'"));
-    }
+    fn validate_path_segment_accepts_safe_set_and_rejects_reserved_characters() {
+        for valid in ["team-lead", "arch_ctm", "atm123", "A_B-9"] {
+            validate_path_segment(valid, "agent").expect("valid");
+        }
 
-    #[test]
-    fn validate_path_segment_rejects_double_dot_values() {
-        let error = validate_path_segment("agent..name", "agent").expect_err("double dot");
-        assert!(error.to_string().contains("must not contain '..'"));
-    }
-
-    #[test]
-    fn validate_path_segment_rejects_path_separators() {
-        let slash = validate_path_segment("bad/name", "agent").expect_err("slash");
-        let backslash = validate_path_segment("bad\\name", "agent").expect_err("backslash");
-
-        assert!(slash.to_string().contains("path separators"));
-        assert!(backslash.to_string().contains("path separators"));
-    }
-
-    #[test]
-    fn validate_path_segment_rejects_invalid_characters_and_accepts_valid_names() {
-        let error = validate_path_segment("bad name", "agent").expect_err("space");
-        assert!(error.to_string().contains("invalid characters"));
-
-        validate_path_segment("valid_name-1.2", "agent").expect("valid");
+        for invalid in [
+            ".agent",
+            "agent..name",
+            "bad/name",
+            "bad\\name",
+            "bad name",
+            "bad\tname",
+            "bad:name",
+            "bad.name",
+            "bad*name",
+            "bad?name",
+            "bad[name",
+            "bad]name",
+        ] {
+            let error = validate_path_segment(invalid, "agent").expect_err("invalid");
+            assert!(
+                error
+                    .to_string()
+                    .contains("must use only ASCII letters, digits, '-' or '_'"),
+                "{invalid}: {error}"
+            );
+        }
     }
 }

--- a/crates/atm-storage/src/validation.rs
+++ b/crates/atm-storage/src/validation.rs
@@ -19,9 +19,21 @@ pub fn validate_path_segment(value: &str, kind: &str) -> Result<(), AtmError> {
     Ok(())
 }
 
+pub fn validate_agent_at_team(value: &str, kind: &str) -> Result<(), AtmError> {
+    match value.split_once('@') {
+        Some((agent, team)) => {
+            validate_path_segment(agent, kind)?;
+            validate_path_segment(team, kind)?;
+        }
+        None => validate_path_segment(value, kind)?,
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::validate_path_segment;
+    use super::{validate_agent_at_team, validate_path_segment};
 
     #[test]
     fn validate_path_segment_rejects_empty_values() {
@@ -30,7 +42,7 @@ mod tests {
 
     #[test]
     fn validate_path_segment_accepts_safe_set_and_rejects_reserved_characters() {
-        for valid in ["team-lead", "arch_ctm", "atm123", "A_B-9"] {
+        for valid in ["alpha-beta", "ops-team", "atm123", "A_B-9"] {
             validate_path_segment(valid, "agent").expect("valid");
         }
 
@@ -54,6 +66,32 @@ mod tests {
                     .to_string()
                     .contains("must use only ASCII letters, digits, '-' or '_'"),
                 "{invalid}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_agent_at_team_accepts_safe_set_shapes_and_rejects_invalid_segments() {
+        for valid in [
+            "alpha-beta@ops-team",
+            "route_mgr@qa-lab",
+            "notify-node@alpha_beta",
+            "relay7",
+        ] {
+            validate_agent_at_team(valid, "agent id").expect("valid");
+        }
+
+        for invalid in [
+            "bad.name@ops-team",
+            "alpha-beta@bad.team",
+            "bad:name@ops-team",
+            "alpha-beta@bad team",
+            "alpha-beta@",
+            "@ops-team",
+        ] {
+            assert!(
+                validate_agent_at_team(invalid, "agent id").is_err(),
+                "expected `{invalid}` to fail"
             );
         }
     }

--- a/docs/adr/ADR-031-remote-target-contract-and-cross-host-dispatch.md
+++ b/docs/adr/ADR-031-remote-target-contract-and-cross-host-dispatch.md
@@ -81,8 +81,17 @@ pub enum CrossHostDeliveryInfraError {
 
 Parser and normalization rules:
 
-- agent/member names must not contain `.`
-- team names must not contain `.`
+- agent/member names and team names are path-segment-like identifiers rather
+  than free-form labels
+- the only allowed characters in agent/member names and team names are ASCII
+  letters, ASCII digits, `-`, and `_`
+- agent/member names and team names must reject:
+  - path delimiters: `/` and `\`
+  - traversal forms: `.` and `..`
+  - reserved address delimiters: `.` and `:`
+  - whitespace
+  - wildcard or pattern characters that could be interpreted by current or
+    future parsers, including at minimum `*`, `?`, `[` and `]`
 - inline parsing splits on the final `.` after `@`
 - the suffix after that final `.` is the remote host
 - the prefix before that final `.` is the team name
@@ -91,8 +100,10 @@ Parser and normalization rules:
 - each parser rejection maps to one stable error code / variant:
   - missing team => `MissingTeam`
   - missing host => `MissingHost`
-  - dot in agent/member name => `InvalidAgentNameDot`
-  - dot in team name => `InvalidTeamNameDot`
+  - reserved or unsupported agent/member charset => stable typed validation
+    failure on the agent segment
+  - reserved or unsupported team charset => stable typed validation failure on
+    the team segment
   - mixed inline-host plus `--host` => `MixedInlineAndExplicitHost`
   - malformed final-dot split / otherwise invalid inline form =>
     `MalformedInlineRemoteTarget`

--- a/docs/plans/sprint-agent-team-charset-hardening.md
+++ b/docs/plans/sprint-agent-team-charset-hardening.md
@@ -79,28 +79,25 @@ sprint should centralize these rather than patching each one independently.
    authoritative identifier policy and have the second seam delegate to it
    instead of preserving two hand-maintained allowlists.
 
-2. Send-target parsing carries its own extra delimiter rule on top of the base
-   validator.
+2. Historical AG send-target parser references were removed before this
+   develop-based fix branch was cut.
    - `crates/atm-core/src/send/mod.rs::validate_send_target_segment`
    - `crates/atm-core/src/send/mod.rs::parse_send_target_impl`
-   This path currently re-checks `.` locally because inline remote-target
-   parsing splits `<agent>@<team>.<host>` on `.` after `@`. Once the shared
-   identifier policy reserves delimiter characters globally, this seam should
-   stop owning a second local charset rule and should rely on the centralized
-   identifier validator plus the shared address parser contract.
+   do not exist in this worktree. They remain historical AG planning notes,
+   not active seams on this branch.
 
-3. Address parsing and reply-target parsing each own their own delimiter split
-   logic.
+3. The current live split seams on this branch are narrower than the AG notes
+   originally described.
    - `crates/atm-core/src/address.rs::AgentAddress::from_str` uses
      `split_once('@')`
-   - `crates/atm-core/src/send/mod.rs::parse_send_target_impl` uses
-     `split_once('@')`, `split_once('.')`, and inline/local mixed-form checks
-   - `crates/atm-core/src/ack/mod.rs` parses reply targets with
-     `split_once('.')` on the `team_and_host` portion
-   The code sprint should identify whether these should share one parsed-address
-   model or one parser boundary, so that future forms such as
-   `<agent>:<session>@<team>.<host>` do not spread delimiter ownership across
-   unrelated modules.
+   - `crates/atm-core/src/ack/mod.rs::ReplyTarget::deserialize` uses
+     `split_once('@')`
+   - `crates/atm-storage/src/validation.rs::validate_agent_at_team` now owns
+     the shared `agent@team` split+validate helper used by
+     `crates/atm-storage/src/types.rs::AgentId::new`
+   Future work should decide whether these should collapse into one typed
+   parser boundary so later forms such as `<agent>:<session>@<team>.<host>` do
+   not spread delimiter ownership across unrelated modules.
 
 4. Storage-side typed constructors depend directly on the storage validator.
    - `crates/atm-storage/src/types.rs::AgentName::from_str`
@@ -137,6 +134,10 @@ sprint should centralize these rather than patching each one independently.
 - `crates/atm-storage/src/validation.rs` is the authoritative validator.
 - `crates/atm-core/src/address.rs` now delegates to the shared validator
   instead of carrying a second hand-maintained implementation.
+- `crates/atm-storage/src/validation.rs::validate_agent_at_team` is now the
+  shared `agent@team` validation helper used by `AgentId::new`; the stale AG
+  send-target parser references in the earlier inventory were historical and
+  are not present on this branch.
 - PR #572 is superseded by this broader fix if this branch lands first.
 
 ## Acceptance Criteria

--- a/docs/plans/sprint-agent-team-charset-hardening.md
+++ b/docs/plans/sprint-agent-team-charset-hardening.md
@@ -1,0 +1,152 @@
+---
+status: complete
+branch: fix/agent-team-name-charset-validation
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/fix/agent-team-name-charset-validation
+---
+
+# Sprint: agent/team name charset hardening
+
+## Motivation
+
+Cross-host addressing parses `<agent>@<team>.<host>` and uses `:` and `.` as
+reserved delimiters. PR #572 (companion branch off `feature/pAG-s15-othermac-smoke`)
+already closed the narrow case of `.` in team/agent names causing inline-host-syntax
+ambiguity (AG-FIND-007). The user has asked for the general rule to be applied
+repo-wide, off `develop`, independent of the phase-AG branch: `<agent>` and `<team>`
+must be treated as path-segment-like identifiers, not free-form labels.
+
+## Rule
+
+`<agent>` and `<team>` must reject:
+- path delimiters: `/` `\`
+- traversal forms: `.` `..`
+- reserved address delimiters: `.` `:`
+- whitespace
+- wildcard/pattern characters if any parser might treat them specially later (e.g. `*` `?` `[` `]`)
+
+Practical safe set: allow only ASCII letters, digits, `-`, `_`.
+
+## Deliverables
+
+1. Identify every validation site that currently constrains agent/team name
+   charset (this repo already has at least two copies of `validate_path_segment`
+   — `crates/atm-storage/src/validation.rs` and `crates/atm-core/src/address.rs`
+   — plus any daemon/CLI-side duplicate checks) and converge them on the safe
+   set above (ASCII letters, digits, `-`, `_` only), rejecting everything else
+   including whitespace and wildcard/pattern characters, not just `.`/`:`/`/`/`\`.
+2. Confirm this supersedes/broadens PR #572's `.`-only fix rather than
+   conflicting with it — if PR #572 merges to develop before this branch, merge
+   develop forward into this worktree and adjust; if this branch lands first,
+   note that PR #572 becomes redundant with this fix.
+3. Update or add regression tests proving each rejected character class is
+   actually rejected (not just `.`), and that the safe set (letters, digits,
+   `-`, `_`) is still accepted.
+4. Update requirements/ADR text describing agent/team naming constraints if it
+   currently under-specifies the charset (grep for the existing team/agent name
+   validation requirement and tighten the wording to state the full safe set,
+   not just "no dots").
+
+## Implementation Addendum
+
+This sprint closes with a centralized execution path: `atm-storage` owns the
+canonical identifier validator and `atm-core` delegates to that shared rule.
+Any future follow-up must preserve that single-policy ownership instead of
+reintroducing crate-local charset drift. The constraints remain:
+
+1. Centralize the identifier-charset rule in one authoritative validation
+   policy instead of letting `atm-core` and `atm-storage` drift through
+   hand-maintained duplicate allowlists.
+2. Any retained wrapper/helper in another crate may delegate to that policy,
+   but must not redefine the accepted or rejected character set locally.
+3. The code change must preserve the existing valid names already in active
+   use (`team-lead`, `arch-ctm`, `quality-mgr`, `atm-dev`) while rejecting the
+   newly reserved delimiter set consistently everywhere.
+4. If the eventual implementation cannot remove duplication entirely, the
+   sprint must document the exact remaining duplication seam and why it is
+   temporarily unavoidable.
+
+### Phase-AG code scan: centralization inventory
+
+The current Phase-AG line already shows exactly where identifier validation and
+delimiter handling have drifted into multiple local seams. The follow-up code
+sprint should centralize these rather than patching each one independently.
+
+1. Duplicate path-segment validators exist in two crates today.
+   - `crates/atm-core/src/address.rs::validate_path_segment`
+   - `crates/atm-storage/src/validation.rs::validate_path_segment`
+   These two functions currently carry duplicated character-policy logic and
+   have already drifted historically. The code sprint should make one
+   authoritative identifier policy and have the second seam delegate to it
+   instead of preserving two hand-maintained allowlists.
+
+2. Send-target parsing carries its own extra delimiter rule on top of the base
+   validator.
+   - `crates/atm-core/src/send/mod.rs::validate_send_target_segment`
+   - `crates/atm-core/src/send/mod.rs::parse_send_target_impl`
+   This path currently re-checks `.` locally because inline remote-target
+   parsing splits `<agent>@<team>.<host>` on `.` after `@`. Once the shared
+   identifier policy reserves delimiter characters globally, this seam should
+   stop owning a second local charset rule and should rely on the centralized
+   identifier validator plus the shared address parser contract.
+
+3. Address parsing and reply-target parsing each own their own delimiter split
+   logic.
+   - `crates/atm-core/src/address.rs::AgentAddress::from_str` uses
+     `split_once('@')`
+   - `crates/atm-core/src/send/mod.rs::parse_send_target_impl` uses
+     `split_once('@')`, `split_once('.')`, and inline/local mixed-form checks
+   - `crates/atm-core/src/ack/mod.rs` parses reply targets with
+     `split_once('.')` on the `team_and_host` portion
+   The code sprint should identify whether these should share one parsed-address
+   model or one parser boundary, so that future forms such as
+   `<agent>:<session>@<team>.<host>` do not spread delimiter ownership across
+   unrelated modules.
+
+4. Storage-side typed constructors depend directly on the storage validator.
+   - `crates/atm-storage/src/types.rs::AgentName::from_str`
+   - `crates/atm-storage/src/types.rs::AgentId::new`
+   - `crates/atm-storage/src/types.rs::TeamName::from_str`
+   Any centralization plan must preserve these typed constructors as the
+   durable-entry gate, but the underlying charset policy they call should stop
+   being storage-local policy drift.
+
+5. Multiple other call sites consume the validator and should remain
+   delegation-only.
+   Current examples on the AG line:
+   - `crates/atm-core/src/home.rs`
+   - `crates/atm-core/src/read/seen_state.rs`
+   - `crates/atm-core/src/team_admin/filesystem.rs`
+   - `crates/atm-core/src/config/discovery.rs`
+   - `crates/atm-core/src/doctor/mod.rs`
+   These are not separate policy owners today; they are downstream consumers.
+   The code sprint should keep them that way and avoid introducing additional
+   local character checks there.
+
+6. The centralization sprint should explicitly decide the ownership boundary:
+   either
+   - one shared identifier-policy type/function exported across the relevant
+     crates, or
+   - one canonical crate-level validator plus thin delegating adapters
+   but not two independent implementations that must be kept in sync by
+   convention.
+
+## Closure Notes
+
+- `REQ-SEC-001`, `REQ-CORE-TRANSPORT-002`, and `ADR-031` now use the same
+  safe-set wording: ASCII letters, ASCII digits, `-`, `_` only.
+- `crates/atm-storage/src/validation.rs` is the authoritative validator.
+- `crates/atm-core/src/address.rs` now delegates to the shared validator
+  instead of carrying a second hand-maintained implementation.
+- PR #572 is superseded by this broader fix if this branch lands first.
+
+## Acceptance Criteria
+
+- Every agent/team name validation site in the workspace enforces exactly the
+  safe set (ASCII letters, digits, `-`, `_`); no site allows `.`, `:`, `/`, `\`,
+  whitespace, or wildcard characters.
+- New/updated tests cover rejection of each forbidden character class and
+  acceptance of the safe set.
+- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`,
+  and `cargo fmt --all --check` all pass.
+- No regression to existing valid agent/team names already in use (e.g.
+  `team-lead`, `arch-ctm`, `quality-mgr`, `atm-dev`).

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -96,6 +96,12 @@ Phase-AG planning note:
   `feature/pAG-s11-remote-target-contract`
 - transport security / encryption remains a later AG sprint concern and must
   not be implied by earlier functional cross-host closure
+- standalone follow-up fix work also exists off `develop` for identifier
+  hardening: `fix/agent-team-name-charset-validation`, tracked by
+  [`docs/plans/sprint-agent-team-charset-hardening.md`](./plans/sprint-agent-team-charset-hardening.md).
+  Its scope is to tighten the repo-wide `<agent>` / `<team>` charset contract
+  to path-segment-safe, delimiter-safe identifiers and to inject the matching
+  centralized validation change through the normal develop-based path.
 
 Phase-AD planning note:
 - `Phase AD` is the active release-blocking correction line for caller

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -467,16 +467,17 @@ Product requirement IDs:
 
 Required behavior:
 - valid team/agent path-segment characters are limited to:
-  - alphanumeric
+  - ASCII letters
+  - ASCII digits
   - hyphen
   - underscore
-  - period
 - team/agent segments must reject:
   - empty strings
   - path separators
-  - `..` sequences
-  - consecutive periods
-  - leading periods
+  - reserved address delimiters including `.` and `:`
+  - traversal forms including `.` and `..`
+  - whitespace
+  - wildcard or pattern characters including at minimum `*`, `?`, `[` and `]`
   - platform-specific path escapes that could break out of the intended ATM
     home subtree
 - validation must happen before any path construction in address parsing or
@@ -3562,7 +3563,17 @@ mail correctness.
   Required behavior:
   - native agent/plugin code talks only to the local daemon
   - cross-host delivery happens only between daemons
-  - agent/member names and team names must not contain `.`
+  - agent/member names and team names are path-segment-like identifiers, not
+    free-form labels
+  - the only allowed characters in agent/member names and team names are ASCII
+    letters, ASCII digits, `-`, and `_`
+  - agent/member names and team names must reject:
+    - path delimiters: `/` and `\`
+    - traversal forms: `.` and `..`
+    - reserved address delimiters: `.` and `:`
+    - whitespace
+    - wildcard or pattern characters that could be interpreted by current or
+      future parsers, including at minimum `*`, `?`, `[` and `]`
   - the supported remote-send CLI forms are exactly:
     - `atm send <agent>@<team>.<host> ...`
     - `atm send <agent>@<team> --host <host> ...`


### PR DESCRIPTION
## Summary
- centralize agent/team identifier validation in atm-storage and delegate from atm-core
- tighten requirements and ADR text to the ASCII letter/digit/hyphen/underscore safe set
- add regression coverage for reserved delimiters, whitespace, and wildcard characters

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

## Notes
- supersedes the narrower dot-only hardening in #572 if this lands first