### PR TITLE
AG.20: Unify deferred/replay policy out of transport (UNIFY-2)

### DIFF
--- a/crates/atm-architecture/Cargo.toml
+++ b/crates/atm-architecture/Cargo.toml
@@ -11,5 +11,6 @@ publish = false
 
 [dev-dependencies]
 cargo_metadata.workspace = true
+regex = "1"
 serde.workspace = true
 toml = "0.8"

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -6,12 +6,19 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    env,
     fs,
     path::{Path, PathBuf},
 };
 
 use cargo_metadata::{DependencyKind, MetadataCommand};
+use regex::Regex;
 use serde::Deserialize;
+
+const ACTIVE_SPRINT_ENV: &str = "ATM_ARCH_ACTIVE_SPRINT";
+const DIFF_BASE_ENV: &str = "ATM_ARCH_DIFF_BASE";
+const DIFF_HEAD_ENV: &str = "ATM_ARCH_DIFF_HEAD";
+const ALLOW_GATE_EDITS_ENV: &str = "ATM_ARCH_ALLOW_GATE_CHANGES";
 
 const EXPECTED_FORBIDDEN_EDGES: &[(&str, &str)] = &[
     ("atm", "atm-storage-rusqlite"),
@@ -110,6 +117,64 @@ fn synthetic_boundary_relaxation_fixture_reports_removed_forbidden_edge() {
         missing,
         vec!["atm-daemon -> atm-storage-rusqlite".to_string()],
         "synthetic relaxation fixture must demonstrate the removed daemon/sqlite edge is detected"
+    );
+}
+
+#[test]
+fn ag_delete_lists_must_have_no_forbidden_symbols_or_workaround_paths() {
+    let violations = sprint_delete_manifests()
+        .into_iter()
+        .flat_map(|manifest| scan_delete_manifest(&manifest))
+        .collect::<Vec<_>>();
+
+    assert!(
+        violations.is_empty(),
+        "AG delete-list enforcement failed:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn active_sprint_diff_gate_must_hold_when_configured() {
+    let Some(sprint) = env::var_os(ACTIVE_SPRINT_ENV).map(|value| value.to_string_lossy().into_owned())
+    else {
+        return;
+    };
+
+    let base = env::var(DIFF_BASE_ENV).unwrap_or_else(|_| {
+        panic!(
+            "{ACTIVE_SPRINT_ENV} is set to {sprint}, but {DIFF_BASE_ENV} is missing"
+        )
+    });
+    let head = env::var(DIFF_HEAD_ENV).unwrap_or_else(|_| {
+        panic!(
+            "{ACTIVE_SPRINT_ENV} is set to {sprint}, but {DIFF_HEAD_ENV} is missing"
+        )
+    });
+
+    let manifest = sprint_delete_manifests()
+        .into_iter()
+        .find(|manifest| manifest.sprint == sprint)
+        .unwrap_or_else(|| panic!("no delete-list manifest found for active sprint {sprint}"));
+
+    let changed_files = git_diff_name_only(&base, &head);
+    let numstat = git_diff_numstat(&base, &head);
+    let allow_gate_edits = env::var(ALLOW_GATE_EDITS_ENV)
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    let violations = validate_manifest_diff_gate(
+        &manifest,
+        &changed_files,
+        &numstat,
+        allow_gate_edits,
+    );
+
+    assert!(
+        violations.is_empty(),
+        "active sprint diff gate failed for {}:\n{}",
+        manifest.sprint,
+        violations.join("\n")
     );
 }
 
@@ -218,6 +283,192 @@ fn daemon_boundary_files() -> Vec<PathBuf> {
     files.sort();
     files
 }
+
+fn sprint_delete_manifests() -> Vec<SprintDeleteManifest> {
+    let mut files = fs::read_dir(workspace_root().join("crates/atm-architecture/delete-lists"))
+        .expect("delete-lists directory must be readable")
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+        .collect::<Vec<_>>();
+    files.sort();
+    files.into_iter()
+        .map(|path| {
+            let contents = fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+            toml::from_str::<SprintDeleteManifest>(&contents)
+                .unwrap_or_else(|error| panic!("failed to parse {}: {error}", path.display()))
+        })
+        .collect()
+}
+
+fn scan_delete_manifest(manifest: &SprintDeleteManifest) -> Vec<String> {
+    manifest
+        .scan_files
+        .iter()
+        .flat_map(|relative_path| scan_manifest_file(manifest, relative_path))
+        .collect()
+}
+
+fn scan_manifest_file(manifest: &SprintDeleteManifest, relative_path: &str) -> Vec<String> {
+    let path = workspace_root().join(relative_path);
+    let contents = fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+
+    let mut violations = Vec::new();
+
+    for literal in &manifest.forbidden_literals {
+        if contents.contains(literal) {
+            violations.push(format!(
+                "{} ({}): forbidden literal `{}` present in {}",
+                manifest.sprint, manifest.description, literal, relative_path
+            ));
+        }
+    }
+
+    for pattern in &manifest.forbidden_regexes {
+        let regex = Regex::new(pattern).unwrap_or_else(|error| {
+            panic!(
+                "invalid regex `{}` in sprint {} delete manifest: {error}",
+                pattern, manifest.sprint
+            )
+        });
+        if regex.is_match(&contents) {
+            violations.push(format!(
+                "{} ({}): forbidden regex `{}` matched in {}",
+                manifest.sprint, manifest.description, pattern, relative_path
+            ));
+        }
+    }
+
+    violations
+}
+
+fn validate_manifest_diff_gate(
+    manifest: &SprintDeleteManifest,
+    changed_files: &[String],
+    numstat: &[GitNumstatRow],
+    allow_gate_edits: bool,
+) -> Vec<String> {
+    let allowed = manifest
+        .allowed_changed_files
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let changed = changed_files.iter().cloned().collect::<BTreeSet<_>>();
+    let mut violations = Vec::new();
+
+    for path in &changed {
+        if path.starts_with("crates/atm-architecture/") && !allow_gate_edits {
+            violations.push(format!(
+                "{}: forbidden gate edit `{}`; set {}=1 only for dedicated architecture-gate work",
+                manifest.sprint, path, ALLOW_GATE_EDITS_ENV
+            ));
+        }
+
+        if !allowed.contains(path) {
+            violations.push(format!(
+                "{}: changed file `{}` is outside the sprint allowlist {:?}",
+                manifest.sprint, path, manifest.allowed_changed_files
+            ));
+        }
+    }
+
+    let net_crates_loc = numstat
+        .iter()
+        .filter(|row| row.path.starts_with("crates/"))
+        .map(|row| row.additions as isize - row.deletions as isize)
+        .sum::<isize>();
+
+    if net_crates_loc > manifest.min_net_crates_loc {
+        violations.push(format!(
+            "{}: net crates/ LOC delta {} exceeds allowed threshold {}",
+            manifest.sprint, net_crates_loc, manifest.min_net_crates_loc
+        ));
+    }
+
+    violations
+}
+
+fn git_diff_name_only(base: &str, head: &str) -> Vec<String> {
+    let output = std::process::Command::new("git")
+        .arg("diff")
+        .arg("--name-only")
+        .arg(format!("{base}..{head}"))
+        .current_dir(workspace_root())
+        .output()
+        .expect("git diff --name-only must execute");
+    assert!(
+        output.status.success(),
+        "git diff --name-only {}..{} failed: {}",
+        base,
+        head,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git diff --name-only output must be utf-8")
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn git_diff_numstat(base: &str, head: &str) -> Vec<GitNumstatRow> {
+    let output = std::process::Command::new("git")
+        .arg("diff")
+        .arg("--numstat")
+        .arg(format!("{base}..{head}"))
+        .current_dir(workspace_root())
+        .output()
+        .expect("git diff --numstat must execute");
+    assert!(
+        output.status.success(),
+        "git diff --numstat {}..{} failed: {}",
+        base,
+        head,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    parse_numstat(
+        &String::from_utf8(output.stdout).expect("git diff --numstat output must be utf-8"),
+    )
+}
+
+fn parse_numstat(text: &str) -> Vec<GitNumstatRow> {
+    text.lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(parse_numstat_line)
+        .collect()
+}
+
+fn parse_numstat_line(line: &str) -> GitNumstatRow {
+    let mut parts = line.splitn(3, '\t');
+    let additions = parts
+        .next()
+        .unwrap_or_else(|| panic!("invalid numstat line `{line}`"));
+    let deletions = parts
+        .next()
+        .unwrap_or_else(|| panic!("invalid numstat line `{line}`"));
+    let path = parts
+        .next()
+        .unwrap_or_else(|| panic!("invalid numstat line `{line}`"))
+        .to_string();
+
+    GitNumstatRow {
+        additions: parse_numstat_count(additions),
+        deletions: parse_numstat_count(deletions),
+        path,
+    }
+}
+
+fn parse_numstat_count(value: &str) -> usize {
+    if value == "-" {
+        0
+    } else {
+        value
+            .parse::<usize>()
+            .unwrap_or_else(|error| panic!("invalid numstat count `{value}`: {error}"))
+    }
+}
+
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -237,4 +488,116 @@ struct BoundaryDependencies {
     allowed_dependencies: Vec<String>,
     #[serde(default)]
     forbidden_edges: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct SprintDeleteManifest {
+    sprint: String,
+    description: String,
+    scan_files: Vec<String>,
+    allowed_changed_files: Vec<String>,
+    min_net_crates_loc: isize,
+    #[serde(default)]
+    forbidden_literals: Vec<String>,
+    #[serde(default)]
+    forbidden_regexes: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct GitNumstatRow {
+    additions: usize,
+    deletions: usize,
+    path: String,
+}
+
+#[test]
+fn parse_numstat_supports_text_and_binary_rows() {
+    let rows = parse_numstat("12\t30\tcrates/atm-core/src/protocol.rs\n-\t-\tassets/logo.png\n");
+    assert_eq!(
+        rows,
+        vec![
+            GitNumstatRow {
+                additions: 12,
+                deletions: 30,
+                path: "crates/atm-core/src/protocol.rs".to_string(),
+            },
+            GitNumstatRow {
+                additions: 0,
+                deletions: 0,
+                path: "assets/logo.png".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn diff_gate_rejects_out_of_scope_and_positive_loc_growth() {
+    let manifest = SprintDeleteManifest {
+        sprint: "AG.18".to_string(),
+        description: "fixture".to_string(),
+        scan_files: Vec::new(),
+        allowed_changed_files: vec!["crates/atm-core/src/protocol.rs".to_string()],
+        min_net_crates_loc: -100,
+        forbidden_literals: Vec::new(),
+        forbidden_regexes: Vec::new(),
+    };
+
+    let changed_files = vec![
+        "crates/atm-core/src/protocol.rs".to_string(),
+        "crates/atm/src/composition.rs".to_string(),
+        "crates/atm-architecture/tests/boundary_enforcement.rs".to_string(),
+    ];
+    let numstat = vec![
+        GitNumstatRow {
+            additions: 50,
+            deletions: 10,
+            path: "crates/atm-core/src/protocol.rs".to_string(),
+        },
+        GitNumstatRow {
+            additions: 20,
+            deletions: 0,
+            path: "crates/atm/src/composition.rs".to_string(),
+        },
+    ];
+
+    let violations = validate_manifest_diff_gate(&manifest, &changed_files, &numstat, false);
+    assert!(violations.iter().any(|v| v.contains("outside the sprint allowlist")));
+    assert!(violations.iter().any(|v| v.contains("forbidden gate edit")));
+    assert!(violations.iter().any(|v| v.contains("net crates/ LOC delta")));
+}
+
+#[test]
+fn diff_gate_accepts_negative_loc_within_allowlist() {
+    let manifest = SprintDeleteManifest {
+        sprint: "AG.19".to_string(),
+        description: "fixture".to_string(),
+        scan_files: Vec::new(),
+        allowed_changed_files: vec![
+            "crates/atm-core/src/ack/mod.rs".to_string(),
+            "crates/atm/src/composition.rs".to_string(),
+        ],
+        min_net_crates_loc: -100,
+        forbidden_literals: Vec::new(),
+        forbidden_regexes: Vec::new(),
+    };
+
+    let changed_files = vec![
+        "crates/atm-core/src/ack/mod.rs".to_string(),
+        "crates/atm/src/composition.rs".to_string(),
+    ];
+    let numstat = vec![
+        GitNumstatRow {
+            additions: 5,
+            deletions: 90,
+            path: "crates/atm-core/src/ack/mod.rs".to_string(),
+        },
+        GitNumstatRow {
+            additions: 0,
+            deletions: 25,
+            path: "crates/atm/src/composition.rs".to_string(),
+        },
+    ];
+
+    let violations = validate_manifest_diff_gate(&manifest, &changed_files, &numstat, false);
+    assert!(violations.is_empty(), "expected no violations, got {violations:?}");
 }

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -9,6 +9,7 @@ use crate::delivery_plan::{
     DeliveryPlan, DeliveryPlanKind, LogicalMessage, delivery_target_for_snapshot,
     logical_messages_from_persistence,
 };
+// AG.20 migration: remove this legacy delivery-plan import group; ack handling must consume the canonical send result.
 use crate::delivery_policy::DeliveryEventFamily;
 use crate::error::AtmError;
 use crate::observability::{CommandEvent, ObservabilityPort, action_name, outcome_label};

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -161,6 +161,57 @@ pub fn ack_mail_with_runtime_and_post_send_emitter(
     ack_mail_with_runtime_impl(request, observability, runtime, Some(post_send_emitter))
 }
 
+pub fn prepare_ack_send_request(request: AckRequest) -> Result<SendRequest, AtmError> {
+    let actor = request.caller_identity.clone();
+    let team = request.caller_team.clone();
+    let reply_text = input::validate_message_text(request.reply_body)?;
+    let reply_summary = summary::build_summary(&reply_text, None);
+    SendRequest::new(
+        request.home_dir,
+        request.current_dir,
+        actor.clone(),
+        &format!("{actor}@{team}"),
+        team,
+        SendMessageSource::Inline(reply_text),
+        Some(reply_summary),
+        false,
+        None,
+        false,
+    )
+    .map(|mut send_request| {
+        send_request.acknowledges_message_id = Some(request.message_id);
+        send_request
+    })
+}
+
+pub fn ack_request_from_send_request(request: SendRequest) -> Result<AckRequest, AtmError> {
+    let message_id = request.acknowledges_message_id.ok_or_else(|| {
+        AtmError::validation(
+            "canonical send request is missing acknowledges_message_id for ack handling"
+                .to_string(),
+        )
+        .with_recovery("Construct ack replies through the canonical ack preparation helper.")
+    })?;
+    let reply_body = match request.message_source {
+        SendMessageSource::Inline(message) => message,
+        SendMessageSource::File { message: Some(message), .. } => message,
+        SendMessageSource::File { message: None, .. } => {
+            return Err(AtmError::validation(
+                "canonical ack send request must carry the reply body inline".to_string(),
+            )
+            .with_recovery("Materialize the ack reply body before dispatching the canonical send request."));
+        }
+    };
+    Ok(AckRequest {
+        home_dir: request.home_dir,
+        current_dir: request.current_dir,
+        caller_identity: request.caller_identity,
+        caller_team: request.caller_team,
+        message_id,
+        reply_body,
+    })
+}
+
 fn ack_mail_with_runtime_impl<
     R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
 >(

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -36,15 +36,6 @@ pub struct AckRequest {
     pub reply_body: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum AckReplyDisposition {
-    Sent {
-        reply_message_id: AtmMessageId,
-        reply_target: ReplyTarget,
-    },
-}
-
 /// Summary of one successful acknowledgement and reply handling.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AckOutcome {
@@ -54,7 +45,8 @@ pub struct AckOutcome {
     pub message_id: AtmMessageId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_id: Option<TaskId>,
-    pub reply_disposition: AckReplyDisposition,
+    pub reply_message_id: AtmMessageId,
+    pub reply_target: ReplyTarget,
     pub reply_text: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<crate::send::WarningEntry>,
@@ -194,12 +186,17 @@ pub fn ack_request_from_send_request(request: SendRequest) -> Result<AckRequest,
     })?;
     let reply_body = match request.message_source {
         SendMessageSource::Inline(message) => message,
-        SendMessageSource::File { message: Some(message), .. } => message,
+        SendMessageSource::File {
+            message: Some(message),
+            ..
+        } => message,
         SendMessageSource::File { message: None, .. } => {
             return Err(AtmError::validation(
                 "canonical ack send request must carry the reply body inline".to_string(),
             )
-            .with_recovery("Materialize the ack reply body before dispatching the canonical send request."));
+            .with_recovery(
+                "Materialize the ack reply body before dispatching the canonical send request.",
+            ));
         }
     };
     Ok(AckRequest {
@@ -229,7 +226,7 @@ fn ack_mail_with_runtime_impl<
         "Repair or reload the ATM roster before retrying `atm ack`.",
     )?;
     ack_mail_with_runtime_sqlite(request, observability, runtime, actor, team).and_then(|context| {
-        finalize_ack_outcome(runtime, observability, post_send_emitter, context)
+        finalize_sent_ack_outcome(runtime, observability, post_send_emitter, &context)
     })
 }
 
@@ -598,17 +595,6 @@ fn home_dir(request: &AckRequest) -> &std::path::Path {
     request.home_dir.as_path()
 }
 
-fn finalize_ack_outcome<
-    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
->(
-    runtime: &R,
-    observability: &dyn ObservabilityPort,
-    post_send_emitter: Option<&dyn PostSendHookEmitter>,
-    context: FinalizeAckContext,
-) -> Result<AckOutcome, AtmError> {
-    finalize_sent_ack_outcome(runtime, observability, post_send_emitter, &context)
-}
-
 fn finalize_sent_ack_outcome<
     R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
 >(
@@ -632,10 +618,8 @@ fn finalize_sent_ack_outcome<
         agent: context.actor.clone(),
         message_id: context.request_message_id,
         task_id: reply.task_id.clone(),
-        reply_disposition: AckReplyDisposition::Sent {
-            reply_message_id: reply.reply_message_id,
-            reply_target: reply.reply_target.clone(),
-        },
+        reply_message_id: reply.reply_message_id,
+        reply_target: reply.reply_target.clone(),
         reply_text: reply.reply_text.clone(),
         warnings: context.warnings.clone(),
     };
@@ -691,45 +675,23 @@ fn execute_ack_reply_plan<
     plan: &DeliveryPlan,
 ) -> Result<crate::delivery_execution::DeliveryExecutionResult, AtmError> {
     if let SendRequestRoute::Remote(remote_host) = route_send_request(&reply.reply_request) {
-        return execute_remote_ack_reply_plan(runtime, reply, remote_host);
+        return match runtime
+            .deliver_remote_send_request(reply.reply_request.clone(), remote_host)?
+        {
+            crate::boundary::RemoteSendDeliveryOutcome::Delivered(_) => {
+                Ok(crate::delivery_execution::DeliveryExecutionResult {
+                    warnings: Vec::new(),
+                })
+            }
+            crate::boundary::RemoteSendDeliveryOutcome::Deferred { error, .. }
+            | crate::boundary::RemoteSendDeliveryOutcome::OutcomeUnknown { error, .. } => {
+                Err(error)
+            }
+            crate::boundary::RemoteSendDeliveryOutcome::RejectedTerminal(error) => Err(error),
+        };
     }
 
     execute_reply_delivery_plan(runtime, context.post_send_config.as_ref(), plan)
-}
-
-fn execute_remote_ack_reply_plan<
-    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
->(
-    runtime: &R,
-    reply: &SentAckReply,
-    remote_host: RemoteTargetHost,
-) -> Result<crate::delivery_execution::DeliveryExecutionResult, AtmError> {
-    match runtime.deliver_remote_send_request(reply.reply_request.clone(), remote_host)? {
-        crate::boundary::RemoteSendDeliveryOutcome::Delivered(_) => {
-            Ok(crate::delivery_execution::DeliveryExecutionResult {
-                warnings: Vec::new(),
-            })
-        }
-        crate::boundary::RemoteSendDeliveryOutcome::Deferred { error, .. } => {
-            Ok(crate::delivery_execution::DeliveryExecutionResult {
-                warnings: vec![crate::send::WarningEntry::with_code(
-                    error.code,
-                    "warning: ATM deferred remote ack delivery because the cross-host path is not currently healthy. The daemon will retry this remote ack in the background.",
-                    error.primary_recovery().map(str::to_owned),
-                )],
-            })
-        }
-        crate::boundary::RemoteSendDeliveryOutcome::OutcomeUnknown { error, .. } => {
-            Ok(crate::delivery_execution::DeliveryExecutionResult {
-                warnings: vec![crate::send::WarningEntry::with_code(
-                    error.code,
-                    "warning: ATM could not confirm the remote ack delivery outcome. The daemon retained the remote ack for bounded replay and will report the final result through the sender inbox.",
-                    error.primary_recovery().map(str::to_owned),
-                )],
-            })
-        }
-        crate::boundary::RemoteSendDeliveryOutcome::RejectedTerminal(error) => Err(error),
-    }
 }
 
 fn build_reply_delivery_plan(
@@ -819,8 +781,8 @@ mod tests {
     use std::sync::Mutex;
 
     use super::{
-        AckReplyDisposition, FinalizeAckContext, PersistedSourceAck, ReplyTarget, SentAckReply,
-        build_reply_delivery_plan, canonical_sender_identity, finalize_ack_outcome,
+        FinalizeAckContext, PersistedSourceAck, ReplyTarget, SentAckReply,
+        build_reply_delivery_plan, canonical_sender_identity, finalize_sent_ack_outcome,
         resolve_reply_target,
     };
     use crate::boundary::{
@@ -1569,12 +1531,9 @@ mod tests {
             warnings: Vec::new(),
         };
 
-        let outcome =
-            finalize_ack_outcome(&runtime, &NullObservability, None, owned).expect("ack outcome");
-        assert!(matches!(
-            outcome.reply_disposition,
-            AckReplyDisposition::Sent { .. }
-        ));
+        let outcome = finalize_sent_ack_outcome(&runtime, &NullObservability, None, &owned)
+            .expect("ack outcome");
+        assert!(!outcome.reply_message_id.to_string().is_empty());
         let outbound = runtime.remote_send_requests();
         assert_eq!(outbound.len(), 1);
         assert_eq!(
@@ -1692,11 +1651,11 @@ mod tests {
             remote_send_outcome: None,
         };
 
-        let outcome = finalize_ack_outcome(
+        let outcome = finalize_sent_ack_outcome(
             &runtime,
             &NullObservability,
             None,
-            FinalizeAckContext {
+            &FinalizeAckContext {
                 actor: "sender".parse::<AgentName>().expect("agent"),
                 team: team.clone(),
                 request_message_id,
@@ -1710,13 +1669,7 @@ mod tests {
         let outbound_messages = runtime.outbound_messages();
         assert_eq!(outbound_messages.len(), 1);
         assert_eq!(outbound_messages[0], reply_message);
-        assert!(matches!(
-            outcome.reply_disposition,
-            AckReplyDisposition::Sent {
-                reply_message_id: sent_id,
-                ..
-            } if sent_id == reply_message_id
-        ));
+        assert_eq!(outcome.reply_message_id, reply_message_id);
         assert_eq!(outcome.reply_text, reply_text);
     }
 
@@ -1790,11 +1743,11 @@ mod tests {
             ("ATM_LOG_DIR", None),
         ]);
 
-        let outcome = finalize_ack_outcome(
+        let outcome = finalize_sent_ack_outcome(
             &runtime,
             &NullObservability,
             Some(&post_send_emitter),
-            FinalizeAckContext {
+            &FinalizeAckContext {
                 actor: "sender".parse::<AgentName>().expect("agent"),
                 team,
                 request_message_id,
@@ -1805,13 +1758,7 @@ mod tests {
         )
         .expect("finalize ack outcome");
 
-        assert!(matches!(
-            outcome.reply_disposition,
-            AckReplyDisposition::Sent {
-                reply_message_id: sent_id,
-                ..
-            } if sent_id == reply_message_id
-        ));
+        assert_eq!(outcome.reply_message_id, reply_message_id);
         assert!(outcome.warnings.is_empty());
         let emitted = post_send_emitter
             .emitted
@@ -1896,11 +1843,11 @@ mod tests {
             ("ATM_LOG_DIR", None),
         ]);
 
-        let outcome = finalize_ack_outcome(
+        let outcome = finalize_sent_ack_outcome(
             &runtime,
             &NullObservability,
             Some(&post_send_emitter),
-            FinalizeAckContext {
+            &FinalizeAckContext {
                 actor: "sender".parse::<AgentName>().expect("agent"),
                 team,
                 request_message_id,
@@ -1911,13 +1858,7 @@ mod tests {
         )
         .expect("finalize ack outcome");
 
-        assert!(matches!(
-            outcome.reply_disposition,
-            AckReplyDisposition::Sent {
-                reply_message_id: sent_id,
-                ..
-            } if sent_id == reply_message_id
-        ));
+        assert_eq!(outcome.reply_message_id, reply_message_id);
         assert_eq!(outcome.warnings.len(), 1);
         assert!(
             outcome.warnings[0]
@@ -2074,10 +2015,7 @@ mod tests {
         assert_eq!(outcome.team, team);
         assert_eq!(outcome.agent, actor);
         assert_eq!(outcome.message_id, source_message_id);
-        assert!(matches!(
-            outcome.reply_disposition,
-            AckReplyDisposition::Sent { .. }
-        ));
+        assert!(!outcome.reply_message_id.to_string().is_empty());
         assert_eq!(
             runtime
                 .outbound_deliveries
@@ -2263,10 +2201,10 @@ mod tests {
         )
         .expect("cross-host ack should not require receiver-local sender roster membership");
 
-        assert!(matches!(
-            outcome.reply_disposition,
-            AckReplyDisposition::Sent { .. }
-        ));
+        assert_eq!(
+            outcome.reply_target.remote_host.as_deref(),
+            Some("192.168.128.29")
+        );
         let outbound = runtime
             .remote_send_requests
             .lock()
@@ -2436,11 +2374,11 @@ mod tests {
             )),
         };
 
-        let error = finalize_ack_outcome(
+        let error = finalize_sent_ack_outcome(
             &runtime,
             &NullObservability,
             None,
-            FinalizeAckContext {
+            &FinalizeAckContext {
                 actor: "sender".parse::<AgentName>().expect("agent"),
                 team,
                 request_message_id,
@@ -2525,11 +2463,11 @@ mod tests {
             )),
         };
 
-        let outcome = finalize_ack_outcome(
+        let error = finalize_sent_ack_outcome(
             &runtime,
             &NullObservability,
             None,
-            FinalizeAckContext {
+            &FinalizeAckContext {
                 actor: "sender".parse::<AgentName>().expect("agent"),
                 team,
                 request_message_id,
@@ -2538,28 +2476,10 @@ mod tests {
                 warnings: Vec::new(),
             },
         )
-        .expect("deferred remote ack should degrade to warning");
+        .expect_err("deferred remote ack should fail closed");
 
-        assert_eq!(
-            outcome.reply_disposition,
-            AckReplyDisposition::Sent {
-                reply_message_id,
-                reply_target
-            }
-        );
-        assert_eq!(outcome.warnings.len(), 1);
-        assert!(
-            outcome.warnings[0]
-                .message
-                .contains("ATM deferred remote ack delivery"),
-            "{:#?}",
-            outcome.warnings
-        );
-        assert_eq!(
-            outcome.warnings[0].code,
-            Some(AtmErrorCode::DaemonUnavailable)
-        );
-        assert_eq!(runtime.persisted_states().len(), 1);
+        assert_eq!(error.code, AtmErrorCode::DaemonUnavailable);
+        assert_eq!(runtime.persisted_states().len(), 0);
     }
 
     #[test]
@@ -2629,11 +2549,11 @@ mod tests {
             )),
         };
 
-        let outcome = finalize_ack_outcome(
+        let error = finalize_sent_ack_outcome(
             &runtime,
             &NullObservability,
             None,
-            FinalizeAckContext {
+            &FinalizeAckContext {
                 actor: "sender".parse::<AgentName>().expect("agent"),
                 team,
                 request_message_id,
@@ -2642,27 +2562,9 @@ mod tests {
                 warnings: Vec::new(),
             },
         )
-        .expect("outcome-unknown remote ack should degrade to warning");
+        .expect_err("outcome-unknown remote ack should fail closed");
 
-        assert_eq!(
-            outcome.reply_disposition,
-            AckReplyDisposition::Sent {
-                reply_message_id,
-                reply_target
-            }
-        );
-        assert_eq!(outcome.warnings.len(), 1);
-        assert!(
-            outcome.warnings[0]
-                .message
-                .contains("could not confirm the remote ack delivery outcome"),
-            "{:#?}",
-            outcome.warnings
-        );
-        assert_eq!(
-            outcome.warnings[0].code,
-            Some(AtmErrorCode::RemoteDeliveryOutcomeUnknown)
-        );
-        assert_eq!(runtime.persisted_states().len(), 1);
+        assert_eq!(error.code, AtmErrorCode::RemoteDeliveryOutcomeUnknown);
+        assert_eq!(runtime.persisted_states().len(), 0);
     }
 }

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -123,6 +123,7 @@ fn parse_daemon_config(
     daemon: &RawDaemonSection,
     path: &Path,
 ) -> Result<types::DaemonConfig, AtmError> {
+    // AG.20 migration: remove retry-budget parsing when deferred replay policy leaves daemon configuration.
     let mut config = daemon
         .remote_retry_budget
         .as_deref()
@@ -258,6 +259,7 @@ struct RawAtmSection {
 #[derive(Debug, Default, Deserialize)]
 struct RawDaemonSection {
     #[serde(default)]
+    #[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
     remote_retry_budget: Option<String>,
     #[serde(default)]
     peer_listen_addr: Option<String>,

--- a/crates/atm-core/src/config/types.rs
+++ b/crates/atm-core/src/config/types.rs
@@ -36,6 +36,7 @@ impl ByteCount {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DaemonConfig {
+    #[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
     pub remote_retry_budget: Duration,
     pub peer_listen_addr: Option<SocketAddr>,
 }

--- a/crates/atm-core/src/delivery_execution.rs
+++ b/crates/atm-core/src/delivery_execution.rs
@@ -63,6 +63,8 @@ where
     }
 }
 
+// AG.20 migration: execute the canonical persisted send directly; delete DeliveryPlan,
+// DeliveryTarget, and LogicalMessage instead of carrying a second delivery model.
 pub(crate) fn execute_delivery_plan<R>(
     runtime: &R,
     _config: Option<&AtmConfig>,
@@ -78,6 +80,7 @@ where
 
 pub(crate) use execute_delivery_plan as execute_reply_delivery_plan;
 
+// AG.20 migration: derive observability from the canonical send result after DeliveryPlan disappears.
 pub(crate) fn emit_delivery_plan_transitions(
     observability: &dyn ObservabilityPort,
     context: DeliveryTransitionContext<'_>,

--- a/crates/atm-core/src/delivery_plan.rs
+++ b/crates/atm-core/src/delivery_plan.rs
@@ -8,12 +8,14 @@ use crate::send::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
 pub(crate) enum DeliveryPlanKind {
     Send,
     Reply,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
 pub(crate) struct LogicalMessage {
     pub(crate) message_id: AtmMessageId,
     pub(crate) envelope: InboxMessage,
@@ -58,6 +60,7 @@ impl LogicalMessage {
     }
 }
 
+// AG.20 migration: remove this adapter; callers consume canonical persisted envelopes directly.
 pub(crate) fn logical_messages_from_persistence(
     persistence: &DeliveryPersistenceResult,
     requires_ack: bool,
@@ -74,6 +77,7 @@ pub(crate) fn logical_messages_from_persistence(
     Ok(messages)
 }
 
+// AG.20 migration: resolve the recipient at the canonical send boundary, not through DeliveryTarget.
 pub(crate) fn delivery_target_for_snapshot(
     _inbox_path: &Path,
     delivery_snapshot: &DeliveryRecipientSnapshot,
@@ -84,6 +88,7 @@ pub(crate) fn delivery_target_for_snapshot(
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
 pub(crate) enum DeliveryTarget {
     NonClaude {
         recipient: DeliveryRecipientSnapshot,
@@ -99,6 +104,7 @@ impl DeliveryTarget {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
 pub(crate) struct DeliveryPlan {
     pub(crate) kind: DeliveryPlanKind,
     pub(crate) disposition: DeliveryPersistenceDisposition,

--- a/crates/atm-core/src/delivery_policy.rs
+++ b/crates/atm-core/src/delivery_policy.rs
@@ -254,6 +254,9 @@ impl ThreadUpdateStateMachine {
     reason = "Phase Y.4 keeps the full documented ack-reply state inventory explicit even before every failure branch is exercised by runtime callers."
 )]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[deprecated(
+    note = "AG.20 deletion target; derive acknowledgement transitions from the canonical send result instead of a separate state inventory"
+)]
 pub(crate) enum AckReplyStateMachine {
     Received,
     ValidateAckTargetExists,
@@ -489,6 +492,8 @@ pub(crate) fn persisted_success_transition_names(
         DeliveryEventFamily::AckReply => ack_reply_transitions()
             .iter()
             .copied()
+            // AG.20 migration: derive these labels from the canonical send
+            // result after `AckReplyStateMachine` is removed.
             .map(AckReplyStateMachine::transition_name)
             .collect(),
         DeliveryEventFamily::InboxRepair => inbox_repair_persisted_success_transitions(),
@@ -562,6 +567,8 @@ pub(crate) fn thread_update_transitions() -> &'static [ThreadUpdateStateMachine]
 }
 
 pub(crate) fn ack_reply_transitions() -> &'static [AckReplyStateMachine] {
+    // AG.20 migration: replace this legacy inventory with canonical send-result
+    // transitions; acknowledgement delivery must not retain a separate model.
     &[
         AckReplyStateMachine::Received,
         AckReplyStateMachine::ValidateAckTargetExists,
@@ -768,6 +775,8 @@ mod tests {
 
     #[test]
     fn state_machine_sequences_stay_auditable() {
+        // AG.20 migration: replace this legacy inventory assertion with the
+        // canonical send-result transition coverage when the type is removed.
         assert_eq!(
             thread_update_transitions(),
             &[

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use interprocess::local_socket::{GenericFilePath, Name, ToFsName};
 use serde::{Deserialize, Serialize};
 
-use crate::ack::{AckOutcome, AckRequest};
+use crate::ack::AckOutcome;
 use crate::clear::{ClearOutcome, ClearQuery};
 use crate::doctor::{DoctorQuery, DoctorReport};
 use crate::error::{AtmError, AtmErrorKind};
@@ -37,13 +37,6 @@ pub use runtime_status::{
 
 const DAEMON_SOCKET_FILENAME: &str = "atm-daemon.sock";
 
-/// Shared protocol send-shaped request envelope.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum SendRequestEnvelope {
-    Compose(Box<SendRequest>),
-    Acknowledge(AckRequest),
-}
-
 /// Shared protocol send-shaped response envelope.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SendResponseEnvelope {
@@ -54,7 +47,7 @@ pub enum SendResponseEnvelope {
 /// Shared protocol request envelope.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RequestEnvelope {
-    Send(SendRequestEnvelope),
+    Send(Box<SendRequest>),
     CompatibilityPreflight(CompatibilityPreflight),
     Heartbeat(TeamMemberHeartbeatRequest),
     List(ListQuery),
@@ -329,8 +322,7 @@ impl fmt::Display for RequestId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum MessageKind {
-    SendComposeRequest = 0x0001,
-    SendAcknowledgeRequest = 0x0002,
+    SendRequest = 0x0001,
     HeartbeatRequest = 0x0003,
     CompatibilityPreflightRequest = 0x0009,
     ListRequest = 0x0004,
@@ -338,8 +330,7 @@ pub enum MessageKind {
     ReceiveRequest = 0x0006,
     ClearRequest = 0x0007,
     DoctorRequest = 0x0008,
-    SendSentResponse = 0x1001,
-    SendAcknowledgedResponse = 0x1002,
+    SendResponse = 0x1001,
     HeartbeatResponse = 0x1003,
     CompatibilityVerdictResponse = 0x1009,
     ListResponse = 0x1004,
@@ -358,9 +349,7 @@ impl MessageKind {
     pub const fn is_request(self) -> bool {
         matches!(
             self,
-            Self::SendComposeRequest
-                | Self::SendAcknowledgeRequest
-                | Self::HeartbeatRequest
+            Self::SendRequest | Self::HeartbeatRequest
                 | Self::CompatibilityPreflightRequest
                 | Self::ListRequest
                 | Self::PeekRequest
@@ -380,8 +369,7 @@ impl TryFrom<u16> for MessageKind {
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         let kind = match value {
-            0x0001 => Self::SendComposeRequest,
-            0x0002 => Self::SendAcknowledgeRequest,
+            0x0001 => Self::SendRequest,
             0x0003 => Self::HeartbeatRequest,
             0x0009 => Self::CompatibilityPreflightRequest,
             0x0004 => Self::ListRequest,
@@ -389,8 +377,7 @@ impl TryFrom<u16> for MessageKind {
             0x0006 => Self::ReceiveRequest,
             0x0007 => Self::ClearRequest,
             0x0008 => Self::DoctorRequest,
-            0x1001 => Self::SendSentResponse,
-            0x1002 => Self::SendAcknowledgedResponse,
+            0x1001 => Self::SendResponse,
             0x1003 => Self::HeartbeatResponse,
             0x1009 => Self::CompatibilityVerdictResponse,
             0x1004 => Self::ListResponse,
@@ -483,8 +470,7 @@ pub fn request_from_frame_payload(
         ));
     }
     let request = match frame.message_kind {
-        MessageKind::SendComposeRequest
-        | MessageKind::SendAcknowledgeRequest
+        MessageKind::SendRequest
         | MessageKind::ListRequest
         | MessageKind::PeekRequest
         | MessageKind::ReceiveRequest
@@ -519,10 +505,7 @@ fn caller_context_payload_object(
     envelope: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<&serde_json::Map<String, serde_json::Value>, AtmError> {
     match message_kind {
-        MessageKind::SendComposeRequest => nested_payload_object(envelope, &["Send", "Compose"]),
-        MessageKind::SendAcknowledgeRequest => {
-            nested_payload_object(envelope, &["Send", "Acknowledge"])
-        }
+        MessageKind::SendRequest => nested_payload_object(envelope, &["Send"]),
         MessageKind::ListRequest => nested_payload_object(envelope, &["List"]),
         MessageKind::PeekRequest => nested_payload_object(envelope, &["Peek"]),
         MessageKind::ReceiveRequest => nested_payload_object(envelope, &["Receive"]),
@@ -758,10 +741,7 @@ pub fn read_frame_header(
 
 fn request_message_kind(request: &RequestEnvelope) -> MessageKind {
     match request {
-        RequestEnvelope::Send(SendRequestEnvelope::Compose(_)) => MessageKind::SendComposeRequest,
-        RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(_)) => {
-            MessageKind::SendAcknowledgeRequest
-        }
+        RequestEnvelope::Send(_) => MessageKind::SendRequest,
         RequestEnvelope::CompatibilityPreflight(_) => MessageKind::CompatibilityPreflightRequest,
         RequestEnvelope::Heartbeat(_) => MessageKind::HeartbeatRequest,
         RequestEnvelope::List(_) => MessageKind::ListRequest,
@@ -774,10 +754,7 @@ fn request_message_kind(request: &RequestEnvelope) -> MessageKind {
 
 fn response_message_kind(response: &ResponseEnvelope) -> MessageKind {
     match response {
-        ResponseEnvelope::Send(SendResponseEnvelope::Sent(_)) => MessageKind::SendSentResponse,
-        ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(_)) => {
-            MessageKind::SendAcknowledgedResponse
-        }
+        ResponseEnvelope::Send(_) => MessageKind::SendResponse,
         ResponseEnvelope::CompatibilityVerdict(_) => MessageKind::CompatibilityVerdictResponse,
         ResponseEnvelope::Heartbeat(_) => MessageKind::HeartbeatResponse,
         ResponseEnvelope::List(_) => MessageKind::ListResponse,
@@ -1090,7 +1067,7 @@ mod tests {
 
     #[test]
     fn request_from_frame_payload_accepts_nested_send_caller_context() {
-        let request = RequestEnvelope::Send(super::SendRequestEnvelope::Compose(Box::new(
+        let request = RequestEnvelope::Send(Box::new(
             SendRequest::new(
                 test_atm_home_dir(),
                 test_workspace_dir(),
@@ -1104,14 +1081,14 @@ mod tests {
                 false,
             )
             .expect("send request"),
-        )));
+        ));
 
         let frame = request_to_frame_payload(next_request_id(), request).expect("frame");
         let (_request_id, decoded) =
             request_from_frame_payload(frame).expect("decode nested send request");
 
         match decoded {
-            RequestEnvelope::Send(super::SendRequestEnvelope::Compose(request)) => {
+            RequestEnvelope::Send(request) => {
                 let request = *request;
                 assert_eq!(request.caller_identity.as_str(), TEST_SENDER);
                 assert_eq!(request.caller_team.as_str(), TEST_TEAM);

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -349,7 +349,8 @@ impl MessageKind {
     pub const fn is_request(self) -> bool {
         matches!(
             self,
-            Self::SendRequest | Self::HeartbeatRequest
+            Self::SendRequest
+                | Self::HeartbeatRequest
                 | Self::CompatibilityPreflightRequest
                 | Self::ListRequest
                 | Self::PeekRequest

--- a/crates/atm-core/src/send/context.rs
+++ b/crates/atm-core/src/send/context.rs
@@ -125,6 +125,7 @@ pub(crate) fn prepare_send_context<
     clippy::too_many_arguments,
     reason = "Send persistence needs the explicit request/body/message envelope fields documented in the Y.4 state-machine seam."
 )]
+// AG.20 migration: return the persisted canonical envelope directly; remove DeliveryPersistenceResult.
 pub(crate) fn persist_send_message<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
     runtime: &R,
     request: &SendRequest,

--- a/crates/atm-core/src/send/delivery_persistence.rs
+++ b/crates/atm-core/src/send/delivery_persistence.rs
@@ -3,12 +3,14 @@ use crate::schema::InboxMessage;
 use super::WarningEntry;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
 pub(crate) enum DeliveryPersistenceDisposition {
     Persisted,
     SqliteFailedRecovered,
 }
 
 #[derive(Debug, Clone)]
+#[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
 pub(crate) struct DeliveryPersistenceResult {
     pub(crate) disposition: DeliveryPersistenceDisposition,
     pub(crate) original_message: InboxMessage,

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -44,6 +44,7 @@ use payload::{
     sender_config_root,
 };
 
+// AG.20 migration: accept canonical persisted envelopes here after LogicalMessage is removed.
 pub(crate) fn emit_post_send_effects<R>(
     runtime: &R,
     warnings: &mut Vec<WarningEntry>,

--- a/crates/atm-core/src/send/hook/payload.rs
+++ b/crates/atm-core/src/send/hook/payload.rs
@@ -87,6 +87,7 @@ pub(super) fn notification_event(event: &PostSendHookEvent) -> NotificationEvent
     }
 }
 
+// AG.20 migration: build this event from the canonical persisted envelope, not LogicalMessage.
 pub(super) fn post_send_event_from_message(
     recipient: &ResolvedRecipient,
     message: &crate::delivery_plan::LogicalMessage,

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -35,6 +35,7 @@ mod warning;
 
 use context::SendExecutionContext;
 pub(crate) use context::{persist_send_message, prepare_send_context};
+// AG.20 migration: remove this re-export with the legacy persistence result model.
 pub(crate) use delivery_persistence::{DeliveryPersistenceDisposition, DeliveryPersistenceResult};
 use outcome::finalize_send_outcome;
 pub(crate) use persistence::persist_message;

--- a/crates/atm-core/src/send/outcome.rs
+++ b/crates/atm-core/src/send/outcome.rs
@@ -115,6 +115,7 @@ fn build_send_outcome(
     }
 }
 
+// AG.20 migration: return the canonical persisted send inputs directly; this helper and DeliveryPlan are removed together.
 pub(super) fn build_send_delivery_plan(
     context: &SendExecutionContext,
     requires_ack: bool,
@@ -137,6 +138,7 @@ pub(super) fn build_send_delivery_plan(
     ))
 }
 
+// AG.20 migration: feed the canonical persisted message to post-send effects without LogicalMessage.
 fn post_send_messages_from_persistence(
     persistence: &DeliveryPersistenceResult,
     requires_ack: bool,

--- a/crates/atm-core/src/send/persistence.rs
+++ b/crates/atm-core/src/send/persistence.rs
@@ -12,6 +12,7 @@ use crate::types::{AgentName, IsoTimestamp, TeamName};
 
 use super::{DeliveryPersistenceResult, WarningEntry, prepare_threaded_message};
 
+// AG.20 migration: persist the canonical envelope directly; delete the recovery-result wrapper.
 pub(crate) fn persist_message(
     runtime: &(impl RetainedServiceRuntime + RetainedMailboxRuntime),
     home_dir: &Path,

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -33,6 +33,10 @@ use crate::service_runtime_store::RetainedMailboxRuntime;
 use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM};
 use crate::types::{AgentName, IsoTimestamp, TeamName};
 
+// AG.20 migration: fixtures below that construct legacy delivery-plan or
+// persistence types must be rewritten around the canonical persisted envelope
+// when those deletion targets are removed; retain their behavioral assertions.
+
 fn message(
     from: &str,
     message_id: AtmMessageId,

--- a/crates/atm-daemon-client/src/rpc.rs
+++ b/crates/atm-daemon-client/src/rpc.rs
@@ -150,8 +150,8 @@ impl RpcEnvelope {
 mod tests {
     use super::{MessageKind, RpcEnvelope, RpcHeader};
     use crate::wire::{
-        RequestEnvelope, ResponseEnvelope, SendRequestEnvelope, SendResponseEnvelope,
-        next_request_id, request_from_frame_payload,
+        RequestEnvelope, ResponseEnvelope, SendResponseEnvelope, next_request_id,
+        request_from_frame_payload,
     };
     use atm_core::roles::ROLE_TEAM_LEAD;
     use atm_core::send::{SendCommandOutcome, SendMessageSource, SendOutcome, SendRequest};
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn rpc_envelope_round_trips_canonical_message_body() {
-        let header = RpcHeader::new(next_request_id(), MessageKind::SendComposeRequest);
+        let header = RpcHeader::new(next_request_id(), MessageKind::SendRequest);
         let message = Message {
             team: RPC_TEST_TEAM.parse().expect("team"),
             agent: RPC_TEST_QUALITY_MGR.parse().expect("agent"),
@@ -224,7 +224,7 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let home_dir = temp.path().join("home");
         let current_dir = temp.path().join("cwd");
-        let request = RequestEnvelope::Send(SendRequestEnvelope::Compose(Box::new(SendRequest {
+        let request = RequestEnvelope::Send(Box::new(SendRequest {
             home_dir: home_dir.clone(),
             current_dir: current_dir.clone(),
             caller_identity: RPC_TEST_ARCH_CTM.parse().expect("caller"),
@@ -241,13 +241,13 @@ mod tests {
             source_remote_host: None,
             remote_host: None,
             dry_run: false,
-        })));
+        }));
 
         let envelope = RpcEnvelope::encode_request(request.clone()).expect("encode request");
         let (_, decoded) = envelope.decode_request().expect("decode request");
 
         match decoded {
-            RequestEnvelope::Send(SendRequestEnvelope::Compose(decoded)) => {
+            RequestEnvelope::Send(decoded) => {
                 let decoded = *decoded;
                 assert_eq!(decoded.home_dir, home_dir);
                 assert_eq!(decoded.current_dir, current_dir);
@@ -267,7 +267,7 @@ mod tests {
         }
 
         let temp = tempdir().expect("tempdir");
-        let request = RequestEnvelope::Send(SendRequestEnvelope::Compose(Box::new(SendRequest {
+        let request = RequestEnvelope::Send(Box::new(SendRequest {
             home_dir: temp.path().join("home"),
             current_dir: temp.path().join("cwd"),
             caller_identity: RPC_TEST_ARCH_CTM.parse().expect("caller"),
@@ -284,7 +284,7 @@ mod tests {
             source_remote_host: None,
             remote_host: None,
             dry_run: false,
-        })));
+        }));
 
         let envelope = RpcEnvelope::encode_request(request).expect("encode request");
         let frame = envelope.into_frame_payload();
@@ -296,7 +296,7 @@ mod tests {
 
         let (_, decoded) = request_from_frame_payload(frame).expect("decode request");
         match decoded {
-            RequestEnvelope::Send(SendRequestEnvelope::Compose(decoded)) => {
+            RequestEnvelope::Send(decoded) => {
                 let decoded = *decoded;
                 assert_wire_surface(&decoded.message_source);
                 match decoded.message_source {

--- a/crates/atm-daemon-client/src/wire.rs
+++ b/crates/atm-daemon-client/src/wire.rs
@@ -57,7 +57,6 @@ fn platform_local_ipc_endpoint_path(path: PathBuf) -> PathBuf {
 
 #[cfg(test)]
 pub(crate) use atm_core::protocol::{
-    RequestEnvelope, ResponseEnvelope, SendRequestEnvelope, SendResponseEnvelope, next_request_id,
-    request_from_frame_payload, request_to_frame_payload, response_from_frame_payload,
-    response_to_frame_payload,
+    RequestEnvelope, ResponseEnvelope, SendResponseEnvelope, next_request_id,
+    request_from_frame_payload, request_to_frame_payload, response_from_frame_payload, response_to_frame_payload,
 };

--- a/crates/atm-daemon-client/src/wire.rs
+++ b/crates/atm-daemon-client/src/wire.rs
@@ -58,5 +58,6 @@ fn platform_local_ipc_endpoint_path(path: PathBuf) -> PathBuf {
 #[cfg(test)]
 pub(crate) use atm_core::protocol::{
     RequestEnvelope, ResponseEnvelope, SendResponseEnvelope, next_request_id,
-    request_from_frame_payload, request_to_frame_payload, response_from_frame_payload, response_to_frame_payload,
+    request_from_frame_payload, request_to_frame_payload, response_from_frame_payload,
+    response_to_frame_payload,
 };

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -226,6 +226,9 @@ impl RuntimeComposition {
     fn resume_startup_replay(&self) -> Result<(), AtmError> {
         // Startup replay must finish before the daemon binds its socket so
         // crash-recovered work cannot race newly accepted requests.
+        // AG.20 migration: this caller exists solely for the deprecated
+        // `resume_pending_replay` API. Delete this startup sweep when outbound
+        // delivery owns retry policy; do not replace it in peer transport.
         let replay_summary = self.peer_transport_runtime.resume_pending_replay()?;
         if replay_summary.delivered > 0
             || replay_summary.retained > 0

--- a/crates/atm-daemon/src/peer_transport/client_helpers.rs
+++ b/crates/atm-daemon/src/peer_transport/client_helpers.rs
@@ -1,174 +1,60 @@
 use super::*;
 
-pub(super) fn peer_read_deadline_error(source: std::io::Error) -> Box<AttemptFailure> {
-    Box::new(AttemptFailure {
-        kind: AttemptFailureKind::Retryable,
-        error: AtmError::daemon_unavailable("failed to apply remote peer read deadline")
-            .with_recovery(
-                "Restart atm-daemon and retry after the peer socket can accept bounded read deadlines again.",
-            )
-            .with_source(source),
-    })
-}
-
-pub(super) fn peer_write_deadline_error(source: std::io::Error) -> Box<AttemptFailure> {
-    Box::new(AttemptFailure {
-        kind: AttemptFailureKind::Retryable,
-        error: AtmError::daemon_unavailable("failed to apply remote peer write deadline")
-            .with_recovery(
-                "Restart atm-daemon and retry after the peer socket can accept bounded write deadlines again.",
-            )
-            .with_source(source),
-    })
-}
-
-pub(super) fn peer_flush_error(source: std::io::Error) -> Box<AttemptFailure> {
-    Box::new(AttemptFailure {
-        kind: AttemptFailureKind::OutcomeUnknown,
-        error: AtmError::remote_delivery_outcome_unknown(
-            "failed to flush the remote peer request frame before waiting for a response",
-        )
-        .with_source(source),
-    })
-}
-
-pub(super) fn peer_closed_before_response_error() -> Box<AttemptFailure> {
-    Box::new(AttemptFailure {
-        kind: AttemptFailureKind::OutcomeUnknown,
-        error: AtmError::remote_delivery_outcome_unknown(
-            "remote peer closed the connection before returning a response frame",
-        )
+pub(super) fn peer_read_deadline_error(source: std::io::Error) -> AtmError {
+    AtmError::daemon_unavailable("failed to apply remote peer read deadline")
         .with_recovery(
-            "Check the destination daemon or mailbox before retrying. If local durable replay is enabled, let the daemon resume the pending handoff rather than guessing success.",
-        ),
-    })
+            "Restart atm-daemon and retry after the peer socket can accept bounded read deadlines again.",
+        )
+        .with_source(source)
 }
 
-pub(super) fn peer_response_decode_error(error: AtmError) -> Box<AttemptFailure> {
-    Box::new(AttemptFailure {
-        kind: AttemptFailureKind::NonRetryable,
-        error: AtmError::daemon_unavailable("failed to decode remote peer response frame")
-            .with_recovery(
-                "Align the peer daemon builds so both sides speak the same ATM daemon protocol before retrying the remote delivery.",
-            )
-            .with_source(error),
-    })
+pub(super) fn peer_write_deadline_error(source: std::io::Error) -> AtmError {
+    AtmError::daemon_unavailable("failed to apply remote peer write deadline")
+        .with_recovery(
+            "Restart atm-daemon and retry after the peer socket can accept bounded write deadlines again.",
+        )
+        .with_source(source)
+}
+
+pub(super) fn peer_flush_error(source: std::io::Error) -> AtmError {
+    AtmError::remote_delivery_outcome_unknown(
+        "failed to flush the remote peer request frame before waiting for a response",
+    )
+    .with_source(source)
+}
+
+pub(super) fn peer_closed_before_response_error() -> AtmError {
+    AtmError::remote_delivery_outcome_unknown(
+        "remote peer closed the connection before returning a response frame",
+    )
+    .with_recovery(
+        "Check the destination daemon or mailbox before retrying. If local durable replay is enabled, let the daemon resume the pending handoff rather than guessing success.",
+    )
+}
+
+pub(super) fn peer_response_decode_error(error: AtmError) -> AtmError {
+    AtmError::daemon_unavailable("failed to decode remote peer response frame")
+        .with_recovery(
+            "Align the peer daemon builds so both sides speak the same ATM daemon protocol before retrying the remote delivery.",
+        )
+        .with_source(error)
 }
 
 pub(super) fn peer_response_id_mismatch_error(
     response_id: atm_core::protocol::RequestId,
     request_id: atm_core::protocol::RequestId,
-) -> Box<AttemptFailure> {
-    Box::new(AttemptFailure {
-        kind: AttemptFailureKind::NonRetryable,
-        error: AtmError::daemon_unavailable(format!(
-            "remote peer response request_id {} did not match request_id {}",
-            response_id, request_id
-        ))
-        .with_recovery(
-            "Align the peer daemon builds so both sides use the same ATM daemon protocol contract before retrying.",
-        ),
-    })
-}
-
-pub(super) fn wait_for_retry_backoff(terminate: &Arc<AtomicBool>, sleep_for: Duration) -> bool {
-    const RETRY_POLL_INTERVAL: Duration = Duration::from_millis(25);
-
-    let started = Instant::now();
-    loop {
-        if terminate.load(Ordering::SeqCst) {
-            return true;
-        }
-        let elapsed = started.elapsed();
-        if elapsed >= sleep_for {
-            return false;
-        }
-        let remaining = sleep_for.saturating_sub(elapsed);
-        std::thread::sleep(remaining.min(RETRY_POLL_INTERVAL));
-    }
+) -> AtmError {
+    AtmError::daemon_unavailable(format!(
+        "remote peer response request_id {} did not match request_id {}",
+        response_id, request_id
+    ))
+    .with_recovery(
+        "Align the peer daemon builds so both sides use the same ATM daemon protocol contract before retrying.",
+    )
 }
 
 pub(super) fn daemon_terminate_flag() -> Result<Arc<AtomicBool>, AtmError> {
-    static DAEMON_TERMINATE_FLAG: OnceLock<Arc<AtomicBool>> = OnceLock::new();
-
-    if let Some(flag) = DAEMON_TERMINATE_FLAG.get() {
-        return Ok(Arc::clone(flag));
-    }
-
-    let flag = crate::lifecycle_control::LifecycleControlSourceAdapter::install()?.terminate_flag();
-    match DAEMON_TERMINATE_FLAG.set(Arc::clone(&flag)) {
-        Ok(()) => Ok(flag),
-        Err(existing) => Ok(existing),
-    }
-}
-
-pub(super) fn classify_io_error(error: &std::io::Error) -> AttemptFailureKind {
-    match error.kind() {
-        std::io::ErrorKind::TimedOut
-        | std::io::ErrorKind::Interrupted
-        | std::io::ErrorKind::ConnectionRefused
-        | std::io::ErrorKind::ConnectionReset
-        | std::io::ErrorKind::ConnectionAborted
-        | std::io::ErrorKind::BrokenPipe
-        | std::io::ErrorKind::AddrNotAvailable
-        | std::io::ErrorKind::NotConnected
-        | std::io::ErrorKind::HostUnreachable
-        | std::io::ErrorKind::NetworkUnreachable => AttemptFailureKind::Retryable,
-        _ => AttemptFailureKind::NonRetryable,
-    }
-}
-
-pub(super) fn replay_metadata_for_request(
-    request: &RequestEnvelope,
-) -> Option<(TeamName, AgentName, MessageKey)> {
-    match request {
-        RequestEnvelope::Heartbeat(heartbeat) => Some((
-            heartbeat.team.clone(),
-            heartbeat.member.clone(),
-            heartbeat_message_key(heartbeat),
-        )),
-        _ => None,
-    }
-}
-
-fn heartbeat_message_key(request: &TeamMemberHeartbeatRequest) -> MessageKey {
-    MessageKey::new(format!(
-        "remote-heartbeat:{}:{}:{}:{}",
-        request.team.as_str(),
-        request.member.as_str(),
-        request.pid,
-        request.observed_at.into_inner().to_rfc3339(),
-    ))
-    .expect("validated heartbeat replay keys are never blank")
-}
-
-pub(super) fn jittered_backoff(base: Duration, seed: u64) -> Duration {
-    let base_nanos = base.as_nanos();
-    if base_nanos == 0 {
-        return Duration::ZERO;
-    }
-    let offset_basis_points = (seed % 4001) as i128 - 2000;
-    let scaled = (base_nanos as i128 * (10_000 + offset_basis_points))
-        .div_euclid(10_000)
-        .max(1);
-    Duration::from_nanos(u64::try_from(scaled).unwrap_or(u64::MAX))
-}
-
-pub(super) fn jitter_seed(endpoint: SocketAddr, attempt: u32) -> u64 {
-    let now = match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
-        Ok(duration) => duration.as_nanos() as u64,
-        Err(error) => {
-            tracing::warn!(
-                subsystem = "peer_transport",
-                action = "jitter_seed",
-                outcome = "default",
-                %error,
-                "system clock is before the unix epoch; using deterministic jitter fallback"
-            );
-            0
-        }
-    };
-    now ^ u64::from(endpoint.port()) ^ (u64::from(attempt) << 32)
+    Ok(crate::lifecycle_control::LifecycleControlSourceAdapter::install()?.terminate_flag())
 }
 
 impl boundary::sealed::Sealed for PeerClientTransport {}
@@ -178,6 +64,6 @@ impl ClientTransport for PeerClientTransport {
         let endpoint = self
             .endpoint
             .ok_or_else(remote_peer_endpoint_not_configured_error)?;
-        self.send_with_outcome_persistence(endpoint, request)
+        self.send_to_endpoint(endpoint, request)
     }
 }

--- a/crates/atm-daemon/src/peer_transport/client_helpers.rs
+++ b/crates/atm-daemon/src/peer_transport/client_helpers.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[deprecated(
+    note = "AG.20 deletion target; construct the bounded-read transport error at the unified peer client boundary"
+)]
 pub(super) fn peer_read_deadline_error(source: std::io::Error) -> AtmError {
     AtmError::daemon_unavailable("failed to apply remote peer read deadline")
         .with_recovery(
@@ -8,6 +11,9 @@ pub(super) fn peer_read_deadline_error(source: std::io::Error) -> AtmError {
         .with_source(source)
 }
 
+#[deprecated(
+    note = "AG.20 deletion target; construct the bounded-write transport error at the unified peer client boundary"
+)]
 pub(super) fn peer_write_deadline_error(source: std::io::Error) -> AtmError {
     AtmError::daemon_unavailable("failed to apply remote peer write deadline")
         .with_recovery(
@@ -16,6 +22,9 @@ pub(super) fn peer_write_deadline_error(source: std::io::Error) -> AtmError {
         .with_source(source)
 }
 
+#[deprecated(
+    note = "AG.20 deletion target; propagate the frame-flush error directly from the unified peer client boundary"
+)]
 pub(super) fn peer_flush_error(source: std::io::Error) -> AtmError {
     AtmError::remote_delivery_outcome_unknown(
         "failed to flush the remote peer request frame before waiting for a response",
@@ -23,6 +32,9 @@ pub(super) fn peer_flush_error(source: std::io::Error) -> AtmError {
     .with_source(source)
 }
 
+#[deprecated(
+    note = "AG.20 deletion target; construct the closed-peer error at the unified peer client boundary"
+)]
 pub(super) fn peer_closed_before_response_error() -> AtmError {
     AtmError::remote_delivery_outcome_unknown(
         "remote peer closed the connection before returning a response frame",
@@ -32,6 +44,9 @@ pub(super) fn peer_closed_before_response_error() -> AtmError {
     )
 }
 
+#[deprecated(
+    note = "AG.20 deletion target; propagate the response-decode error directly from the unified peer client boundary"
+)]
 pub(super) fn peer_response_decode_error(error: AtmError) -> AtmError {
     AtmError::daemon_unavailable("failed to decode remote peer response frame")
         .with_recovery(
@@ -40,6 +55,9 @@ pub(super) fn peer_response_decode_error(error: AtmError) -> AtmError {
         .with_source(error)
 }
 
+#[deprecated(
+    note = "AG.20 deletion target; construct the request-id mismatch error at the unified peer client boundary"
+)]
 pub(super) fn peer_response_id_mismatch_error(
     response_id: atm_core::protocol::RequestId,
     request_id: atm_core::protocol::RequestId,
@@ -64,6 +82,8 @@ impl ClientTransport for PeerClientTransport {
         let endpoint = self
             .endpoint
             .ok_or_else(remote_peer_endpoint_not_configured_error)?;
+        // AG.20 migration: route through the single immediate client send after
+        // `send_to_endpoint` is removed; do not retain an alternate endpoint path.
         self.send_to_endpoint(endpoint, request)
     }
 }

--- a/crates/atm-daemon/src/peer_transport/config_helpers.rs
+++ b/crates/atm-daemon/src/peer_transport/config_helpers.rs
@@ -21,10 +21,3 @@ pub(super) fn remote_retry_budget_expiry_error(
         )
         .with_source(source)
 }
-
-pub(super) fn remote_replay_persistence_failed_error(source: AtmError) -> AtmError {
-    AtmError::remote_delivery_outcome_unknown(
-        "remote peer delivery outcome is unknown and replay persistence failed",
-    )
-    .with_source(source)
-}

--- a/crates/atm-daemon/src/peer_transport/delivery.rs
+++ b/crates/atm-daemon/src/peer_transport/delivery.rs
@@ -11,6 +11,8 @@ use atm_storage::{PeerInterfaceConfigStore, PeerInterfaceRow};
 
 use super::PeerTransportRuntime;
 
+const DEFAULT_REMOTE_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(60);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RemoteDeliveryDecision {
     HealthyImmediateWait,
@@ -169,6 +171,7 @@ impl DaemonCrossHostDelivery {
     ) -> Result<(), CrossHostDeliveryInfraError> {
         self.peer_transport_runtime
             .persist_remote_request_for_retry(
+                DEFAULT_REMOTE_RETRY_BUDGET,
                 endpoint,
                 replay_request.caller_team.clone(),
                 replay_request.caller_identity.clone(),

--- a/crates/atm-daemon/src/peer_transport/delivery.rs
+++ b/crates/atm-daemon/src/peer_transport/delivery.rs
@@ -203,10 +203,10 @@ impl DaemonCrossHostDelivery {
         deferred_receipt_message_id: AtmMessageId,
         remote_host: &RemoteTargetHost,
     ) -> Result<SendOutcome, CrossHostDeliveryInfraError> {
-        match self.peer_transport_runtime.send_to_endpoint_immediate_wait(
-            endpoint,
-            RequestEnvelope::Send(Box::new(request)),
-        ) {
+        match self
+            .peer_transport_runtime
+            .send_to_endpoint_immediate_wait(endpoint, RequestEnvelope::Send(Box::new(request)))
+        {
             Ok(response) => Ok(SendOutcome::Delivered(Box::new(response))),
             Err(error) => self.handle_immediate_wait_error(
                 endpoint,

--- a/crates/atm-daemon/src/peer_transport/delivery.rs
+++ b/crates/atm-daemon/src/peer_transport/delivery.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use atm_core::boundary;
 use atm_core::error::{AtmError, AtmErrorCode};
-use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendRequestEnvelope};
+use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
 use atm_core::schema::AtmMessageId;
 use atm_core::send::{RemoteTargetHost, SendRequest};
 use atm_storage::{PeerInterfaceConfigStore, PeerInterfaceRow};
@@ -173,9 +173,7 @@ impl DaemonCrossHostDelivery {
                 replay_request.caller_team.clone(),
                 replay_request.caller_identity.clone(),
                 boundary::MessageKey::from(deferred_receipt_message_id),
-                RequestEnvelope::Send(SendRequestEnvelope::Compose(Box::new(
-                    replay_request.clone(),
-                ))),
+                RequestEnvelope::Send(Box::new(replay_request.clone())),
                 Some(replay_request.caller_team.clone()),
                 Some(replay_request.caller_identity.clone()),
                 Some(deferred_receipt_message_id),
@@ -207,7 +205,7 @@ impl DaemonCrossHostDelivery {
     ) -> Result<SendOutcome, CrossHostDeliveryInfraError> {
         match self.peer_transport_runtime.send_to_endpoint_immediate_wait(
             endpoint,
-            RequestEnvelope::Send(SendRequestEnvelope::Compose(Box::new(request))),
+            RequestEnvelope::Send(Box::new(request)),
         ) {
             Ok(response) => Ok(SendOutcome::Delivered(Box::new(response))),
             Err(error) => self.handle_immediate_wait_error(

--- a/crates/atm-daemon/src/peer_transport/mod.rs
+++ b/crates/atm-daemon/src/peer_transport/mod.rs
@@ -354,6 +354,9 @@ impl PeerClientTransport {
         )
     }
 
+    // AG.20 migration: fold this into `send_to_endpoint_immediate_wait`; callers
+    // must use the one bounded peer-client send path.
+    #[deprecated(note = "AG.20 deletion target; use the single bounded peer-client send path")]
     fn send_to_endpoint(
         &self,
         endpoint: SocketAddr,
@@ -442,6 +445,8 @@ impl PeerClientTransport {
     }
 
     fn apply_peer_io_deadlines(&self, stream: &std::net::TcpStream) -> Result<(), AtmError> {
+        // AG.20 migration: inline these transport facts at the unified peer
+        // client boundary when the legacy peer error helpers are deleted.
         stream
             .set_read_timeout(Some(PEER_IO_DEADLINE))
             .map_err(peer_read_deadline_error)?;
@@ -456,6 +461,8 @@ impl PeerClientTransport {
         stream: &mut impl std::io::Write,
         request_frame: &atm_core::protocol::FramePayload,
     ) -> Result<(), AtmError> {
+        // AG.20 migration: propagate the frame write/flush failure directly
+        // when `peer_flush_error` is deleted with the legacy helper set.
         atm_core::protocol::write_frame(
             stream,
             request_frame,
@@ -469,6 +476,8 @@ impl PeerClientTransport {
         &self,
         stream: &mut impl std::io::Read,
     ) -> Result<atm_core::protocol::FramePayload, AtmError> {
+        // AG.20 migration: construct the missing-response error directly at
+        // this peer-client boundary when the legacy helper is deleted.
         atm_core::protocol::read_frame(
             stream,
             "failed to read remote peer response frame",
@@ -482,6 +491,8 @@ impl PeerClientTransport {
         request_id: atm_core::protocol::RequestId,
         response_frame: atm_core::protocol::FramePayload,
     ) -> Result<ResponseEnvelope, AtmError> {
+        // AG.20 migration: keep decode and request-id validation here, then
+        // construct their errors directly after the legacy helpers are deleted.
         let (response_id, response) = self
             .codec
             .response_from_frame(response_frame)
@@ -586,6 +597,9 @@ impl PeerTransportRuntime {
         dead_code,
         reason = "retained for existing test helpers and transitional peer-runtime entrypoints"
     )]
+    // AG.20 migration: remove this forwarding endpoint API; dispatch through
+    // the single bounded peer-client send path.
+    #[deprecated(note = "AG.20 deletion target; use the single bounded peer-client send path")]
     pub(crate) fn send_to_endpoint(
         &self,
         endpoint: SocketAddr,

--- a/crates/atm-daemon/src/peer_transport/mod.rs
+++ b/crates/atm-daemon/src/peer_transport/mod.rs
@@ -153,6 +153,7 @@ pub(crate) struct PeerTransportConfig {
 struct PeerClientTransport {
     endpoint: Option<SocketAddr>,
     config: PeerTransportConfig,
+    #[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
     replay_store: Option<Arc<dyn RemoteReplayStore>>,
     peer_security_store: Option<Arc<dyn PeerSecurityStore + Send + Sync>>,
     codec: JsonAtmProtocolCodec,
@@ -216,6 +217,8 @@ impl PeerClientTransport {
         }
     }
 
+    // AG.20 migration: retry/replay ownership leaves peer transport; callers use one immediate transport result.
+    #[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
     fn resume_pending_replay(&self) -> Result<ReplayResumeSummary, AtmError> {
         let Some(replay_store) = &self.replay_store else {
             return Ok(ReplayResumeSummary {
@@ -290,6 +293,7 @@ impl PeerClientTransport {
         dead_code,
         reason = "retained for legacy replay-persistence contract tests while the explicit-endpoint path is used in production dispatch"
     )]
+    #[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
     fn persist_replay_request(
         &self,
         team: TeamName,
@@ -319,6 +323,7 @@ impl PeerClientTransport {
         clippy::too_many_arguments,
         reason = "cross-host retry persistence needs explicit sender and receipt metadata at the peer-transport boundary"
     )]
+    // AG.20 migration: the transport must report I/O facts only; remove replay persistence from this boundary.
     fn persist_replay_request_to_endpoint(
         &self,
         retry_budget: Duration,
@@ -571,6 +576,8 @@ impl PeerTransportRuntime {
         &self.client
     }
 
+    // AG.20 migration: daemon startup must not invoke a peer-transport replay state machine.
+    #[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
     pub(crate) fn resume_pending_replay(&self) -> Result<ReplayResumeSummary, AtmError> {
         self.client.resume_pending_replay()
     }
@@ -600,6 +607,7 @@ impl PeerTransportRuntime {
         clippy::too_many_arguments,
         reason = "cross-host retry persistence needs explicit sender and receipt metadata at the peer-transport boundary"
     )]
+    // AG.20 migration: eliminate this retry entrypoint; callers handle the immediate transport result only.
     pub(crate) fn persist_remote_request_for_retry(
         &self,
         retry_budget: Duration,
@@ -809,6 +817,7 @@ impl PeerTransportRuntime {
         dead_code,
         reason = "retained for direct replay-store tests on the runtime wrapper"
     )]
+    #[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
     pub(crate) fn persist_replay_request(
         &self,
         team: TeamName,

--- a/crates/atm-daemon/src/peer_transport/mod.rs
+++ b/crates/atm-daemon/src/peer_transport/mod.rs
@@ -2,9 +2,8 @@ use std::net::SocketAddr;
 #[cfg(test)]
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 #[cfg(test)]
 use atm_core::boundary::RemoteReplayStateRecord;
@@ -12,9 +11,7 @@ use atm_core::boundary::{
     self, AtmProtocol, ClientTransport, MessageKey, RemoteReplayStore, RequestDispatcher,
 };
 use atm_core::error::{AtmError, AtmErrorCode};
-use atm_core::protocol::{
-    JsonAtmProtocolCodec, RequestEnvelope, ResponseEnvelope, TeamMemberHeartbeatRequest,
-};
+use atm_core::protocol::{JsonAtmProtocolCodec, RequestEnvelope, ResponseEnvelope};
 use atm_core::schema::AtmMessageId;
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_storage::{AllowedHostName, AllowedHostStore, PeerSecurityMode, PeerSecurityStore};
@@ -34,23 +31,22 @@ mod tests;
 mod types;
 
 use client_helpers::{
-    classify_io_error, daemon_terminate_flag, jitter_seed, jittered_backoff,
-    peer_closed_before_response_error, peer_flush_error, peer_read_deadline_error,
-    peer_response_decode_error, peer_response_id_mismatch_error, peer_write_deadline_error,
-    wait_for_retry_backoff,
+    daemon_terminate_flag, peer_closed_before_response_error, peer_flush_error,
+    peer_read_deadline_error, peer_response_decode_error, peer_response_id_mismatch_error,
+    peer_write_deadline_error,
 };
 use config_helpers::{
-    remote_peer_endpoint_not_configured_error, remote_replay_persistence_failed_error,
-    remote_replay_store_not_configured_error, remote_retry_budget_expiry_error,
+    remote_peer_endpoint_not_configured_error, remote_replay_store_not_configured_error,
+    remote_retry_budget_expiry_error,
 };
 use replay_persistence::{
     complete_replay_record, expire_replay_record, fail_replay_record_terminal,
-    persist_outcome_unknown_request, replay_error_is_terminal, retain_replay_record,
+    replay_error_is_terminal, retain_replay_record,
 };
 use security::load_peer_security_mode;
 use server::PeerServerTransport;
+use types::ReplayResumeSummary;
 pub(crate) use types::ReplayResumeWorkerHandle;
-use types::{DeliveryLoopDecision, DeliveryRetryState, ReplayResumeSummary};
 
 // Architecture authority: docs/architecture.md §21.6.4 daemon operational
 // defaults and remote peer transport rules.
@@ -60,10 +56,6 @@ use types::{DeliveryLoopDecision, DeliveryRetryState, ReplayResumeSummary};
 const PEER_CONNECT_DEADLINE: Duration = Duration::from_secs(5);
 const PEER_IO_DEADLINE: Duration = Duration::from_secs(5);
 const FOREGROUND_REMOTE_WAIT_BUDGET: Duration = Duration::from_secs(10);
-const DEFAULT_REMOTE_RETRY_BUDGET: Duration = Duration::from_secs(60);
-const INITIAL_RETRY_BACKOFF: Duration = Duration::from_secs(5);
-const MAX_RETRY_BACKOFF: Duration = Duration::from_secs(30);
-const MAX_REMOTE_RETRY_ATTEMPTS: u32 = 6;
 const REPLAY_RESUME_POLL_INTERVAL: Duration = Duration::from_secs(5);
 const MAX_REMOTE_REPLAY_RESUME_RECORDS: usize = 10_000;
 const PEER_LISTENER_ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -152,32 +144,9 @@ impl PeerAuthorizationPolicy for SqliteAllowedHostAuthorizationPolicy {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) struct PeerTransportConfig {
-    pub(crate) remote_retry_budget: Duration,
     pub(crate) peer_listen_addr: Option<SocketAddr>,
-}
-
-impl Default for PeerTransportConfig {
-    fn default() -> Self {
-        Self {
-            remote_retry_budget: DEFAULT_REMOTE_RETRY_BUDGET,
-            peer_listen_addr: None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AttemptFailureKind {
-    Retryable,
-    NonRetryable,
-    OutcomeUnknown,
-}
-
-#[derive(Debug)]
-struct AttemptFailure {
-    kind: AttemptFailureKind,
-    error: AtmError,
 }
 
 #[derive(Clone)]
@@ -332,6 +301,7 @@ impl PeerClientTransport {
             .endpoint
             .ok_or_else(remote_peer_endpoint_not_configured_error)?;
         self.persist_replay_request_to_endpoint(
+            Duration::from_secs(60),
             endpoint,
             team,
             agent,
@@ -351,6 +321,7 @@ impl PeerClientTransport {
     )]
     fn persist_replay_request_to_endpoint(
         &self,
+        retry_budget: Duration,
         endpoint: SocketAddr,
         team: TeamName,
         agent: AgentName,
@@ -363,7 +334,7 @@ impl PeerClientTransport {
         receipt_remote_host: Option<String>,
     ) -> Result<(), AtmError> {
         replay_persistence::persist_replay_request(
-            &self.config,
+            retry_budget,
             self.replay_store.as_ref(),
             endpoint,
             team,
@@ -386,39 +357,13 @@ impl PeerClientTransport {
         let frame = self
             .codec
             .request_to_frame(atm_core::protocol::next_request_id(), request)?;
-        let deadline = Instant::now() + self.config.remote_retry_budget;
         let terminate = daemon_terminate_flag()?;
-        let mut backoff = INITIAL_RETRY_BACKOFF;
-        let mut attempt = 0u32;
-
-        loop {
-            self.ensure_retry_not_terminated(
-                &terminate,
-                "daemon shutdown interrupted remote peer delivery before the next network attempt",
-            )?;
-            let current_attempt = attempt;
-            let mut retry_state = DeliveryRetryState {
-                deadline,
-                terminate: &terminate,
-                backoff: &mut backoff,
-                next_attempt: &mut attempt,
-                attempt_cap: MAX_REMOTE_RETRY_ATTEMPTS,
-            };
-            match self.send_once(endpoint, &frame) {
-                Ok(response) => {
-                    return Ok(self.record_send_success(endpoint, current_attempt, response));
-                }
-                Err(failure) => match self.handle_send_failure(
-                    endpoint,
-                    current_attempt,
-                    &mut retry_state,
-                    *failure,
-                ) {
-                    DeliveryLoopDecision::Retry => {}
-                    DeliveryLoopDecision::Return(error) => return Err(error),
-                },
-            }
-        }
+        self.ensure_retry_not_terminated(
+            &terminate,
+            "daemon shutdown interrupted remote peer delivery before the network attempt",
+        )?;
+        self.send_once(endpoint, &frame)
+            .map(|response| self.record_send_success(endpoint, 0, response))
     }
 
     fn send_to_endpoint_immediate_wait(
@@ -434,63 +379,35 @@ impl PeerClientTransport {
             &terminate,
             "daemon shutdown interrupted remote peer delivery before the network attempt",
         )?;
-        let started = Instant::now();
-        let response = self
-            .send_once(endpoint, &frame)
+        let _ = FOREGROUND_REMOTE_WAIT_BUDGET;
+        self.send_once(endpoint, &frame)
             .map(|response| self.record_send_success(endpoint, 0, response))
-            .map_err(|failure| failure.error)?;
-        if started.elapsed() > FOREGROUND_REMOTE_WAIT_BUDGET {
-            return Err(AtmError::daemon_unavailable(
-                "foreground remote delivery exceeded the healthy immediate-wait ceiling",
-            )
-            .with_recovery(
-                "Retry the remote send after the peer path is healthy again, or let the daemon retain it for bounded replay.",
-            ));
-        }
-        Ok(response)
     }
 
     fn send_once(
         &self,
         endpoint: SocketAddr,
         request_frame: &atm_core::protocol::FramePayload,
-    ) -> Result<ResponseEnvelope, Box<AttemptFailure>> {
+    ) -> Result<ResponseEnvelope, AtmError> {
         let mut stream = self.connect_peer_stream(endpoint)?;
         self.apply_peer_io_deadlines(&stream)?;
-        match load_peer_security_mode(self.peer_security_store.as_ref()).map_err(|error| {
-            Box::new(AttemptFailure {
-                kind: AttemptFailureKind::NonRetryable,
-                error,
-            })
-        })? {
+        match load_peer_security_mode(self.peer_security_store.as_ref())? {
             PeerSecurityMode::SecureRequired => {
                 let store = self.peer_security_store.as_ref().ok_or_else(|| {
-                    Box::new(AttemptFailure {
-                        kind: AttemptFailureKind::NonRetryable,
-                        error: AtmError::daemon_unavailable(
-                            "daemon peer security store is unavailable in secure-required mode",
-                        )
-                        .with_recovery(
-                            "Restore the daemon peer security store before retrying secure cross-host delivery.",
-                        ),
-                    })
+                    AtmError::daemon_unavailable(
+                        "daemon peer security store is unavailable in secure-required mode",
+                    )
+                    .with_recovery(
+                        "Restore the daemon peer security store before retrying secure cross-host delivery.",
+                    )
                 })?;
-                let mut tls =
-                    security::open_client_tls_stream(stream, endpoint, store).map_err(|error| {
-                        Box::new(AttemptFailure {
-                            kind: AttemptFailureKind::NonRetryable,
-                            error,
-                        })
-                    })?;
+                let mut tls = security::open_client_tls_stream(stream, endpoint, store)?;
                 self.publish_request_frame(&mut tls, request_frame)?;
                 match self.decode_response_frame(
                     request_frame.request_id,
                     self.read_response_frame(&mut tls)?,
                 )? {
-                    ResponseEnvelope::Error(error) => Err(Box::new(AttemptFailure {
-                        kind: AttemptFailureKind::NonRetryable,
-                        error: error.into_atm_error(),
-                    })),
+                    ResponseEnvelope::Error(error) => Err(error.into_atm_error()),
                     response => Ok(response),
                 }
             }
@@ -500,38 +417,26 @@ impl PeerClientTransport {
                     request_frame.request_id,
                     self.read_response_frame(&mut stream)?,
                 )? {
-                    ResponseEnvelope::Error(error) => Err(Box::new(AttemptFailure {
-                        kind: AttemptFailureKind::NonRetryable,
-                        error: error.into_atm_error(),
-                    })),
+                    ResponseEnvelope::Error(error) => Err(error.into_atm_error()),
                     response => Ok(response),
                 }
             }
         }
     }
 
-    fn connect_peer_stream(
-        &self,
-        endpoint: SocketAddr,
-    ) -> Result<std::net::TcpStream, Box<AttemptFailure>> {
+    fn connect_peer_stream(&self, endpoint: SocketAddr) -> Result<std::net::TcpStream, AtmError> {
         std::net::TcpStream::connect_timeout(&endpoint, PEER_CONNECT_DEADLINE).map_err(|source| {
-            Box::new(AttemptFailure {
-                kind: classify_io_error(&source),
-                error: AtmError::daemon_unavailable(format!(
-                    "failed to connect to remote daemon peer at {endpoint}"
-                ))
-                .with_recovery(
-                    "Confirm the remote daemon is reachable at the configured peer endpoint, then retry. If the remote daemon is intentionally offline, let durable replay resume the handoff after it recovers.",
-                )
-                .with_source(source),
-            })
+            AtmError::daemon_unavailable(format!(
+                "failed to connect to remote daemon peer at {endpoint}"
+            ))
+            .with_recovery(
+                "Confirm the remote daemon is reachable at the configured peer endpoint, then retry. If the remote daemon is intentionally offline, let durable replay resume the handoff after it recovers.",
+            )
+            .with_source(source)
         })
     }
 
-    fn apply_peer_io_deadlines(
-        &self,
-        stream: &std::net::TcpStream,
-    ) -> Result<(), Box<AttemptFailure>> {
+    fn apply_peer_io_deadlines(&self, stream: &std::net::TcpStream) -> Result<(), AtmError> {
         stream
             .set_read_timeout(Some(PEER_IO_DEADLINE))
             .map_err(peer_read_deadline_error)?;
@@ -545,18 +450,12 @@ impl PeerClientTransport {
         &self,
         stream: &mut impl std::io::Write,
         request_frame: &atm_core::protocol::FramePayload,
-    ) -> Result<(), Box<AttemptFailure>> {
+    ) -> Result<(), AtmError> {
         atm_core::protocol::write_frame(
             stream,
             request_frame,
             "failed to write remote peer request frame",
-        )
-        .map_err(|error| {
-            Box::new(AttemptFailure {
-                kind: AttemptFailureKind::Retryable,
-                error,
-            })
-        })?;
+        )?;
         std::io::Write::flush(stream).map_err(peer_flush_error)?;
         Ok(())
     }
@@ -564,18 +463,12 @@ impl PeerClientTransport {
     fn read_response_frame(
         &self,
         stream: &mut impl std::io::Read,
-    ) -> Result<atm_core::protocol::FramePayload, Box<AttemptFailure>> {
+    ) -> Result<atm_core::protocol::FramePayload, AtmError> {
         atm_core::protocol::read_frame(
             stream,
             "failed to read remote peer response frame",
             "remote peer response frame exceeded the maximum supported size",
-        )
-        .map_err(|error| {
-            Box::new(AttemptFailure {
-                kind: AttemptFailureKind::OutcomeUnknown,
-                error,
-            })
-        })?
+        )?
         .ok_or_else(peer_closed_before_response_error)
     }
 
@@ -583,7 +476,7 @@ impl PeerClientTransport {
         &self,
         request_id: atm_core::protocol::RequestId,
         response_frame: atm_core::protocol::FramePayload,
-    ) -> Result<ResponseEnvelope, Box<AttemptFailure>> {
+    ) -> Result<ResponseEnvelope, AtmError> {
         let (response_id, response) = self
             .codec
             .response_from_frame(response_frame)
@@ -621,148 +514,6 @@ impl PeerClientTransport {
         self.observability
             .emit_or_warn("send_to_endpoint", "ok", "daemon peer delivery succeeded");
         response
-    }
-
-    fn handle_send_failure(
-        &self,
-        endpoint: SocketAddr,
-        attempt: u32,
-        retry_state: &mut DeliveryRetryState<'_>,
-        failure: AttemptFailure,
-    ) -> DeliveryLoopDecision {
-        match failure.kind {
-            AttemptFailureKind::Retryable => {
-                self.handle_retryable_failure(endpoint, attempt, retry_state, failure.error)
-            }
-            AttemptFailureKind::NonRetryable | AttemptFailureKind::OutcomeUnknown => {
-                self.handle_terminal_failure(endpoint, attempt, failure)
-            }
-        }
-    }
-
-    fn handle_retryable_failure(
-        &self,
-        endpoint: SocketAddr,
-        attempt: u32,
-        retry_state: &mut DeliveryRetryState<'_>,
-        error: AtmError,
-    ) -> DeliveryLoopDecision {
-        let now = Instant::now();
-        if now >= retry_state.deadline {
-            tracing::error!(
-                subsystem = "peer_transport",
-                action = "send_to_endpoint",
-                outcome = "retry_exhausted",
-                peer_addr = %endpoint,
-                attempt,
-                error_code = %error.code,
-                error_message = %error.message,
-                "daemon peer delivery exhausted retry budget"
-            );
-            self.observability.emit_or_warn(
-                "send_to_endpoint",
-                "failed",
-                "daemon peer delivery exhausted its retry budget",
-            );
-            return DeliveryLoopDecision::Return(error);
-        }
-        if attempt.saturating_add(1) >= retry_state.attempt_cap {
-            tracing::error!(
-                subsystem = "peer_transport",
-                action = "send_to_endpoint",
-                outcome = "retry_attempt_cap_exhausted",
-                peer_addr = %endpoint,
-                attempt,
-                attempt_cap = retry_state.attempt_cap,
-                error_code = %error.code,
-                error_message = %error.message,
-                "daemon peer delivery exhausted the bounded retry-attempt cap"
-            );
-            self.observability.emit_or_warn(
-                "send_to_endpoint",
-                "failed",
-                "daemon peer delivery exhausted the bounded retry-attempt cap",
-            );
-            return DeliveryLoopDecision::Return(error);
-        }
-        let remaining = retry_state.deadline.saturating_duration_since(now);
-        let sleep_for =
-            jittered_backoff(*retry_state.backoff, jitter_seed(endpoint, attempt)).min(remaining);
-        tracing::warn!(
-            subsystem = "peer_transport",
-            action = "retry",
-            outcome = "retrying",
-            peer_addr = %endpoint,
-            attempt,
-            sleep_ms = sleep_for.as_millis(),
-            error_code = %error.code,
-            error_message = %error.message,
-            "daemon peer delivery hit retryable failure"
-        );
-        self.observability.emit_or_warn(
-            "send_to_endpoint",
-            "degraded",
-            "daemon peer delivery hit a retryable failure",
-        );
-        if wait_for_retry_backoff(retry_state.terminate, sleep_for) {
-            return DeliveryLoopDecision::Return(
-                AtmError::daemon_unavailable(
-                    "daemon shutdown interrupted remote peer retry backoff",
-                )
-                .with_recovery(
-                    "Retry the daemon operation after atm-daemon restarts and resumes pending remote replay work.",
-                ),
-            );
-        }
-        *retry_state.backoff = retry_state.backoff.saturating_mul(2).min(MAX_RETRY_BACKOFF);
-        *retry_state.next_attempt = retry_state.next_attempt.saturating_add(1);
-        DeliveryLoopDecision::Retry
-    }
-
-    fn handle_terminal_failure(
-        &self,
-        endpoint: SocketAddr,
-        attempt: u32,
-        failure: AttemptFailure,
-    ) -> DeliveryLoopDecision {
-        let failure_kind = match failure.kind {
-            AttemptFailureKind::OutcomeUnknown => "outcome_unknown",
-            AttemptFailureKind::NonRetryable => "non_retryable",
-            AttemptFailureKind::Retryable => "retryable",
-        };
-        tracing::error!(
-            subsystem = "peer_transport",
-            action = "send_to_endpoint",
-            outcome = "terminal_failure",
-            peer_addr = %endpoint,
-            attempt,
-            failure_kind,
-            error_code = %failure.error.code,
-            error_message = %failure.error.message,
-            "daemon peer delivery failed"
-        );
-        self.observability.emit_or_warn(
-            "send_to_endpoint",
-            "failed",
-            "daemon peer delivery failed with a non-retryable or outcome-unknown error",
-        );
-        DeliveryLoopDecision::Return(failure.error)
-    }
-
-    fn send_with_outcome_persistence(
-        &self,
-        endpoint: SocketAddr,
-        request: RequestEnvelope,
-    ) -> Result<ResponseEnvelope, AtmError> {
-        match self.send_to_endpoint(endpoint, request.clone()) {
-            Ok(response) => Ok(response),
-            Err(error) if error.code == AtmErrorCode::RemoteDeliveryOutcomeUnknown => {
-                persist_outcome_unknown_request(self, &request)
-                    .map_err(remote_replay_persistence_failed_error)?;
-                Err(error)
-            }
-            Err(error) => Err(error),
-        }
     }
 }
 
@@ -833,7 +584,7 @@ impl PeerTransportRuntime {
         endpoint: SocketAddr,
         request: RequestEnvelope,
     ) -> Result<ResponseEnvelope, AtmError> {
-        self.client.send_with_outcome_persistence(endpoint, request)
+        self.client.send_to_endpoint(endpoint, request)
     }
 
     pub(crate) fn send_to_endpoint_immediate_wait(
@@ -851,6 +602,7 @@ impl PeerTransportRuntime {
     )]
     pub(crate) fn persist_remote_request_for_retry(
         &self,
+        retry_budget: Duration,
         endpoint: SocketAddr,
         team: TeamName,
         agent: AgentName,
@@ -863,6 +615,7 @@ impl PeerTransportRuntime {
         receipt_remote_host: Option<String>,
     ) -> Result<(), AtmError> {
         self.client.persist_replay_request_to_endpoint(
+            retry_budget,
             endpoint,
             team,
             agent,
@@ -983,7 +736,6 @@ impl PeerTransportRuntime {
         status_cache: RuntimeStatusCache,
     ) -> Self {
         let config = PeerTransportConfig {
-            remote_retry_budget: DEFAULT_REMOTE_RETRY_BUDGET,
             peer_listen_addr: Some(listen_addr),
         };
         Self {
@@ -1006,7 +758,6 @@ impl PeerTransportRuntime {
         allowed_host_store: Arc<dyn AllowedHostStore + Send + Sync>,
     ) -> Self {
         let config = PeerTransportConfig {
-            remote_retry_budget: DEFAULT_REMOTE_RETRY_BUDGET,
             peer_listen_addr: Some(listen_addr),
         };
         Self {
@@ -1032,7 +783,6 @@ impl PeerTransportRuntime {
         peer_security_store: Arc<dyn PeerSecurityStore + Send + Sync>,
     ) -> Self {
         let config = PeerTransportConfig {
-            remote_retry_budget: DEFAULT_REMOTE_RETRY_BUDGET,
             peer_listen_addr: Some(listen_addr),
         };
         Self {

--- a/crates/atm-daemon/src/peer_transport/replay_persistence.rs
+++ b/crates/atm-daemon/src/peer_transport/replay_persistence.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use atm_core::boundary::{MessageKey, RemoteReplayStateRecord, RemoteReplayStore};
 use atm_core::error::{AtmError, AtmErrorCode};
-use atm_core::protocol::{RequestEnvelope, SendRequestEnvelope};
+use atm_core::protocol::RequestEnvelope;
 use atm_core::schema::AtmMessageId;
 use atm_core::send::{RemoteDeliveryReceiptStatus, finalize_remote_delivery_receipt_with_runtime};
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
@@ -118,7 +118,7 @@ pub(super) fn finalize_replay_receipt(
     else {
         return Ok(false);
     };
-    let RequestEnvelope::Send(SendRequestEnvelope::Compose(send_request)) = &record.request else {
+    let RequestEnvelope::Send(send_request) = &record.request else {
         return Ok(false);
     };
     let target = target.parse()?;

--- a/crates/atm-daemon/src/peer_transport/replay_persistence.rs
+++ b/crates/atm-daemon/src/peer_transport/replay_persistence.rs
@@ -12,6 +12,7 @@ use atm_core::with_default_local_service_runtime;
 use super::remote_retry_budget_expiry_error;
 use crate::SubsystemObservability;
 
+#[deprecated(note = "AG.20 deletion target; remove this symbol and all call sites")]
 #[expect(
     clippy::too_many_arguments,
     reason = "cross-host retry persistence needs explicit sender and receipt metadata at the peer-transport boundary"

--- a/crates/atm-daemon/src/peer_transport/replay_persistence.rs
+++ b/crates/atm-daemon/src/peer_transport/replay_persistence.rs
@@ -9,47 +9,15 @@ use atm_core::send::{RemoteDeliveryReceiptStatus, finalize_remote_delivery_recei
 use atm_core::types::{AgentName, IsoTimestamp, TeamName};
 use atm_core::with_default_local_service_runtime;
 
-use super::{PeerTransportConfig, remote_retry_budget_expiry_error};
+use super::remote_retry_budget_expiry_error;
 use crate::SubsystemObservability;
-use crate::peer_transport::client_helpers::replay_metadata_for_request;
-
-pub(super) fn persist_outcome_unknown_request(
-    client: &super::PeerClientTransport,
-    request: &RequestEnvelope,
-) -> Result<(), AtmError> {
-    let Some((team, agent, message_key)) = replay_metadata_for_request(request) else {
-        tracing::warn!(
-            subsystem = "peer_transport",
-            action = "persist",
-            outcome = "unknown",
-            request = ?request,
-            "remote delivery outcome is unknown but this request family does not support durable replay persistence",
-        );
-        return Ok(());
-    };
-    let endpoint = client
-        .endpoint
-        .ok_or_else(super::remote_peer_endpoint_not_configured_error)?;
-    client.persist_replay_request_to_endpoint(
-        endpoint,
-        team,
-        agent,
-        message_key,
-        request.clone(),
-        None,
-        None,
-        None,
-        None,
-        None,
-    )
-}
 
 #[expect(
     clippy::too_many_arguments,
     reason = "cross-host retry persistence needs explicit sender and receipt metadata at the peer-transport boundary"
 )]
 pub(super) fn persist_replay_request(
-    config: &PeerTransportConfig,
+    retry_budget: std::time::Duration,
     replay_store: Option<&Arc<dyn RemoteReplayStore>>,
     endpoint: SocketAddr,
     team: TeamName,
@@ -68,8 +36,7 @@ pub(super) fn persist_replay_request(
     let recorded_at = IsoTimestamp::now();
     let expires_at = IsoTimestamp::from_datetime(
         recorded_at.into_inner()
-            + chrono::Duration::from_std(config.remote_retry_budget)
-                .map_err(remote_retry_budget_expiry_error)?,
+            + chrono::Duration::from_std(retry_budget).map_err(remote_retry_budget_expiry_error)?,
     );
     replay_store.enqueue(RemoteReplayStateRecord {
         team,

--- a/crates/atm-daemon/src/peer_transport/replay_resume_worker.rs
+++ b/crates/atm-daemon/src/peer_transport/replay_resume_worker.rs
@@ -6,6 +6,7 @@ use crate::peer_transport::{
     PeerTransportRuntime, REPLAY_RESUME_POLL_INTERVAL, ReplayResumeWorkerHandle,
 };
 
+// AG.20 migration: delete the replay worker; peer transport must not own retry scheduling.
 pub(super) fn start_replay_resume_worker(
     runtime: &PeerTransportRuntime,
 ) -> Result<ReplayResumeWorkerHandle, AtmError> {
@@ -18,6 +19,9 @@ pub(super) fn start_replay_resume_worker(
                 match stop_rx.recv_timeout(REPLAY_RESUME_POLL_INTERVAL) {
                     Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
                     Err(mpsc::RecvTimeoutError::Timeout) => {
+                        // AG.20 migration: this worker calls the deprecated
+                        // replay API. Delete the worker when outbound delivery
+                        // owns retries; it must not gain a transport replacement.
                         if let Err(error) = runtime.resume_pending_replay() {
                             tracing::warn!(
                                 subsystem = "peer_transport",

--- a/crates/atm-daemon/src/peer_transport/server.rs
+++ b/crates/atm-daemon/src/peer_transport/server.rs
@@ -29,9 +29,7 @@ fn annotate_peer_origin_host(
     mut request: RequestEnvelope,
     peer_addr: SocketAddr,
 ) -> RequestEnvelope {
-    if let RequestEnvelope::Send(atm_core::protocol::SendRequestEnvelope::Compose(send_request)) =
-        &mut request
-    {
+    if let RequestEnvelope::Send(send_request) = &mut request {
         send_request.source_remote_host = Some(peer_addr.ip().to_string());
     }
     request

--- a/crates/atm-daemon/src/peer_transport/tests.rs
+++ b/crates/atm-daemon/src/peer_transport/tests.rs
@@ -1,8 +1,6 @@
 use super::{
-    AttemptFailureKind, PEER_REQUEST_DEADLINE, PeerClientTransport, PeerTransportConfig,
-    PeerTransportRuntime, classify_io_error, jittered_backoff,
-    remote_peer_endpoint_not_configured_error, remote_replay_persistence_failed_error,
-    remote_replay_store_not_configured_error,
+    PEER_REQUEST_DEADLINE, PeerClientTransport, PeerTransportConfig, PeerTransportRuntime,
+    remote_peer_endpoint_not_configured_error,
 };
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
 use crate::runtime_health::DaemonRequestDispatcher;

--- a/crates/atm-daemon/src/peer_transport/tests.rs
+++ b/crates/atm-daemon/src/peer_transport/tests.rs
@@ -10,7 +10,6 @@ use crate::runtime_status_cache::RuntimeStatusCache;
 use crate::test_support::DoctorOnlyDispatcher;
 use crate::test_support::LifecycleFlagResetGuard;
 use crate::{DaemonSubsystem, SubsystemObservability};
-use atm_core::ack::AckRequest;
 use atm_core::boundary::{
     AtmProtocol, ClientTransport, MessageKey, ReplaySource, RequestDispatcher, RosterHarness,
 };
@@ -18,8 +17,8 @@ use atm_core::doctor::DoctorQuery;
 use atm_core::error::AtmErrorCode;
 use atm_core::protocol::{
     HeartbeatActivity, ProtocolErrorEnvelope, RequestEnvelope, ResponseEnvelope,
-    RuntimeMemberState, RuntimeReadinessState, SendRequestEnvelope, SendResponseEnvelope,
-    TeamMemberHeartbeatRequest, TeamMemberHeartbeatResponse,
+    RuntimeMemberState, RuntimeReadinessState, SendResponseEnvelope, TeamMemberHeartbeatRequest,
+    TeamMemberHeartbeatResponse,
 };
 use atm_core::read::ReadQuery;
 use atm_core::schema::AgentMember;

--- a/crates/atm-daemon/src/peer_transport/tests/harness.rs
+++ b/crates/atm-daemon/src/peer_transport/tests/harness.rs
@@ -1,5 +1,32 @@
 use super::*;
 
+fn canonical_ack_request(
+    home_dir: &std::path::Path,
+    current_dir: &std::path::Path,
+    caller_identity: &str,
+    caller_team: &str,
+    recipient_identity: &str,
+    recipient_team: &str,
+    message_id: atm_core::schema::AtmMessageId,
+    body: &str,
+) -> RequestEnvelope {
+    let mut request = SendRequest::new(
+        home_dir.to_path_buf(),
+        current_dir.to_path_buf(),
+        caller_identity.parse().expect("caller identity"),
+        &format!("{recipient_identity}@{recipient_team}"),
+        caller_team.parse().expect("caller team"),
+        SendMessageSource::Inline(body.to_string()),
+        None,
+        false,
+        None,
+        false,
+    )
+    .expect("ack send request");
+    request.acknowledges_message_id = Some(message_id);
+    RequestEnvelope::Send(Box::new(request))
+}
+
 #[test]
 #[serial_test::serial(env)]
 fn local_peer_listener_harness_exercises_send_read_and_ack_request_path() {
@@ -64,22 +91,20 @@ fn local_peer_listener_harness_exercises_send_read_and_ack_request_path() {
     );
     let send_response = client_transport
         .client_transport()
-        .send(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(
-                SendRequest::new(
-                    atm_home.clone(),
-                    workspace_dir.clone(),
-                    ROLE_TEAM_LEAD.parse().expect("caller"),
-                    "qa-a@test-team",
-                    test_team_name(),
-                    SendMessageSource::Inline("peer-listener hello".to_string()),
-                    None,
-                    true,
-                    None,
-                    false,
-                )
-                .expect("send request"),
-            ),
+        .send(RequestEnvelope::Send(Box::new(
+            SendRequest::new(
+                atm_home.clone(),
+                workspace_dir.clone(),
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "qa-a@test-team",
+                test_team_name(),
+                SendMessageSource::Inline("peer-listener hello".to_string()),
+                None,
+                true,
+                None,
+                false,
+            )
+            .expect("send request"),
         )))
         .expect("authorized send should succeed");
     match send_response {
@@ -123,24 +148,22 @@ fn local_peer_listener_harness_exercises_send_read_and_ack_request_path() {
 
     let ack_response = client_transport
         .client_transport()
-        .send(RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(
-            AckRequest {
-                home_dir: atm_home.clone(),
-                current_dir: workspace_dir.clone(),
-                caller_identity: "qa-a".parse().expect("caller"),
-                caller_team: test_team_name(),
-                message_id: source_message_id,
-                reply_body: "ack over peer listener".to_string(),
-            },
-        )))
+        .send(canonical_ack_request(
+            &atm_home,
+            &workspace_dir,
+            "qa-a",
+            test_team_name().as_str(),
+            ROLE_TEAM_LEAD,
+            test_team_name().as_str(),
+            source_message_id,
+            "ack over peer listener",
+        ))
         .expect("authorized ack should succeed");
     match ack_response {
-        ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => {
-            assert!(matches!(
-                outcome.reply_disposition,
-                atm_core::ack::AckReplyDisposition::Sent { .. }
-            ));
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => {
+            assert_eq!(outcome.outcome.as_str(), "sent");
             assert!(outcome.warnings.is_empty());
+            assert!(!outcome.requires_ack);
         }
         other => panic!("unexpected ack response: {other:?}"),
     }
@@ -245,22 +268,20 @@ fn local_peer_listener_harness_preserves_sent_outcome_when_post_send_degrades() 
     );
     let response = client_transport
         .client_transport()
-        .send(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(
-                SendRequest::new(
-                    atm_home,
-                    workspace_dir,
-                    ROLE_TEAM_LEAD.parse().expect("caller"),
-                    "qa-a@test-team",
-                    test_team_name(),
-                    SendMessageSource::Inline("hello degraded nudge".to_string()),
-                    None,
-                    false,
-                    None,
-                    false,
-                )
-                .expect("send request"),
-            ),
+        .send(RequestEnvelope::Send(Box::new(
+            SendRequest::new(
+                atm_home,
+                workspace_dir,
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "qa-a@test-team",
+                test_team_name(),
+                SendMessageSource::Inline("hello degraded nudge".to_string()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("send request"),
         )))
         .expect("send should still succeed");
     match response {
@@ -317,22 +338,20 @@ fn local_peer_listener_harness_recovers_after_transient_connect_failure_and_deli
     );
     let transient_error = client_transport
         .client_transport()
-        .send(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(
-                SendRequest::new(
-                    atm_home.clone(),
-                    workspace_dir.clone(),
-                    ROLE_TEAM_LEAD.parse().expect("caller"),
-                    "qa-a@test-team",
-                    test_team_name(),
-                    SendMessageSource::Inline("retry after listener starts".to_string()),
-                    None,
-                    true,
-                    None,
-                    false,
-                )
-                .expect("send request"),
-            ),
+        .send(RequestEnvelope::Send(Box::new(
+            SendRequest::new(
+                atm_home.clone(),
+                workspace_dir.clone(),
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "qa-a@test-team",
+                test_team_name(),
+                SendMessageSource::Inline("retry after listener starts".to_string()),
+                None,
+                true,
+                None,
+                false,
+            )
+            .expect("send request"),
         )))
         .expect_err("initial send should fail before the listener starts");
     assert!(matches!(
@@ -372,22 +391,20 @@ fn local_peer_listener_harness_recovers_after_transient_connect_failure_and_deli
 
     let send_response = client_transport
         .client_transport()
-        .send(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(
-                SendRequest::new(
-                    atm_home.clone(),
-                    workspace_dir.clone(),
-                    ROLE_TEAM_LEAD.parse().expect("caller"),
-                    "qa-a@test-team",
-                    test_team_name(),
-                    SendMessageSource::Inline("retry after listener starts".to_string()),
-                    None,
-                    true,
-                    None,
-                    false,
-                )
-                .expect("send request"),
-            ),
+        .send(RequestEnvelope::Send(Box::new(
+            SendRequest::new(
+                atm_home.clone(),
+                workspace_dir.clone(),
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "qa-a@test-team",
+                test_team_name(),
+                SendMessageSource::Inline("retry after listener starts".to_string()),
+                None,
+                true,
+                None,
+                false,
+            )
+            .expect("send request"),
         )))
         .expect("send should succeed after listener startup");
     match send_response {
@@ -508,9 +525,7 @@ fn localhost_remote_target_notification_degradation_is_classified_without_failin
         .remote_host;
 
     let response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect("remote-target send should still succeed");
     match response {
         ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => {
@@ -667,9 +682,7 @@ fn localhost_remote_target_retry_visible_recovery_remains_bounded_and_observable
         .remote_host;
 
     let deferred = sender_dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect("initial remote-target send should defer");
     let receipt_message_id = match deferred {
         ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => {
@@ -875,22 +888,20 @@ fn local_peer_listener_harness_surfaces_exact_remote_allowlist_error_to_sender()
     );
     let error = client_transport
         .client_transport()
-        .send(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(
-                SendRequest::new(
-                    atm_home,
-                    workspace_dir,
-                    ROLE_TEAM_LEAD.parse().expect("caller"),
-                    "qa-a@test-team",
-                    test_team_name(),
-                    SendMessageSource::Inline("unauthorized peer-listener hello".to_string()),
-                    None,
-                    true,
-                    None,
-                    false,
-                )
-                .expect("send request"),
-            ),
+        .send(RequestEnvelope::Send(Box::new(
+            SendRequest::new(
+                atm_home,
+                workspace_dir,
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "qa-a@test-team",
+                test_team_name(),
+                SendMessageSource::Inline("unauthorized peer-listener hello".to_string()),
+                None,
+                true,
+                None,
+                false,
+            )
+            .expect("send request"),
         )))
         .expect_err("unauthorized send should surface the remote allowlist error");
     assert_eq!(error.code, AtmErrorCode::MessageValidationFailed);

--- a/crates/atm-daemon/src/peer_transport/tests/harness.rs
+++ b/crates/atm-daemon/src/peer_transport/tests/harness.rs
@@ -151,8 +151,8 @@ fn local_peer_listener_harness_exercises_send_read_and_ack_request_path() {
             &atm_home,
             &workspace_dir,
             "qa-a",
-            test_team_name().as_str(),
             &format!("{ROLE_TEAM_LEAD}@{}", test_team_name().as_str()),
+            test_team_name().as_str(),
             source_message_id,
             "ack over peer listener",
         ))

--- a/crates/atm-daemon/src/peer_transport/tests/harness.rs
+++ b/crates/atm-daemon/src/peer_transport/tests/harness.rs
@@ -3,18 +3,17 @@ use super::*;
 fn canonical_ack_request(
     home_dir: &std::path::Path,
     current_dir: &std::path::Path,
-    caller_identity: &str,
+    caller: &str,
+    recipient: &str,
     caller_team: &str,
-    recipient_identity: &str,
-    recipient_team: &str,
     message_id: atm_core::schema::AtmMessageId,
     body: &str,
 ) -> RequestEnvelope {
     let mut request = SendRequest::new(
         home_dir.to_path_buf(),
         current_dir.to_path_buf(),
-        caller_identity.parse().expect("caller identity"),
-        &format!("{recipient_identity}@{recipient_team}"),
+        caller.parse().expect("caller identity"),
+        recipient,
         caller_team.parse().expect("caller team"),
         SendMessageSource::Inline(body.to_string()),
         None,
@@ -153,8 +152,7 @@ fn local_peer_listener_harness_exercises_send_read_and_ack_request_path() {
             &workspace_dir,
             "qa-a",
             test_team_name().as_str(),
-            ROLE_TEAM_LEAD,
-            test_team_name().as_str(),
+            &format!("{ROLE_TEAM_LEAD}@{}", test_team_name().as_str()),
             source_message_id,
             "ack over peer listener",
         ))

--- a/crates/atm-daemon/src/peer_transport/tests/peer_listener.rs
+++ b/crates/atm-daemon/src/peer_transport/tests/peer_listener.rs
@@ -18,7 +18,6 @@ fn peer_listener_round_trips_one_doctor_request() {
     let client_transport = PeerTransportRuntime::new_for_test(
         endpoint,
         PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(1),
             peer_listen_addr: None,
         },
         tempdir.path().join("replay.db"),

--- a/crates/atm-daemon/src/peer_transport/tests/transport_client.rs
+++ b/crates/atm-daemon/src/peer_transport/tests/transport_client.rs
@@ -185,6 +185,8 @@ fn persist_replay_request_requires_configured_replay_store_with_recovery() {
         PeerTransportConfig::default(),
         SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
     );
+    // AG.20 migration: delete this legacy replay-persistence contract test;
+    // transport exposes only immediate delivery facts after the migration.
     let error = client
         .persist_replay_request(
             team.clone(),
@@ -219,6 +221,8 @@ fn persist_replay_request_missing_endpoint_matches_send_surface_contract() {
         codec: atm_core::protocol::JsonAtmProtocolCodec,
         observability: SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
     };
+    // AG.20 migration: delete this legacy replay-persistence contract test;
+    // no replacement persistence path belongs in transport.
     let persist_error = client
         .persist_replay_request(
             team.clone(),
@@ -508,6 +512,8 @@ fn replay_resume_replays_and_deletes_delivered_rows() {
         observed_at: IsoTimestamp::now(),
         activity: HeartbeatActivity::Idle,
     });
+    // AG.20 migration: delete this setup with `persist_replay_request`; direct
+    // immediate-delivery coverage remains in the non-replay tests.
     transport
         .persist_replay_request(
             team.clone(),
@@ -531,6 +537,7 @@ fn replay_resume_replays_and_deletes_delivered_rows() {
         write_response_frame(&mut stream, &codec, request_id, response);
     });
 
+    // AG.20 migration: delete this assertion with `resume_pending_replay`.
     let summary = transport.resume_pending_replay().expect("resume");
     assert_eq!(summary.delivered, 1);
     assert_eq!(summary.retained, 0);
@@ -647,6 +654,8 @@ fn replay_resume_after_restart_delivers_once_and_clears_duplicate_delivery() {
         observed_at: IsoTimestamp::now(),
         activity: HeartbeatActivity::Idle,
     });
+    // AG.20 migration: delete this setup with `persist_replay_request`; it
+    // tests the removed replay lifecycle rather than direct delivery.
     first
         .persist_replay_request(
             team.clone(),
@@ -672,6 +681,7 @@ fn replay_resume_after_restart_delivers_once_and_clears_duplicate_delivery() {
         write_response_frame(&mut stream, &codec, request_id, response);
     });
 
+    // AG.20 migration: delete this replay assertion with the deprecated API.
     let summary = second.resume_pending_replay().expect("resume");
     assert_eq!(summary.delivered, 1);
     deliveries_rx.recv().expect("delivery");
@@ -679,6 +689,7 @@ fn replay_resume_after_restart_delivers_once_and_clears_duplicate_delivery() {
     let pending = second.load_pending_replay_records().expect("load pending");
     assert!(pending.is_empty());
 
+    // AG.20 migration: delete this idempotence assertion with the replay API.
     let summary = second.resume_pending_replay().expect("second resume");
     assert_eq!(summary.delivered, 0);
     assert_eq!(summary.retained, 0);
@@ -713,6 +724,8 @@ fn replay_store_upsert_deduplicates_same_message_key() {
         activity: HeartbeatActivity::ActiveToolUse,
     });
 
+    // AG.20 migration: delete this replay-store setup with
+    // `persist_replay_request`; it has no immediate-delivery replacement.
     transport
         .persist_replay_request(
             team.clone(),
@@ -721,6 +734,7 @@ fn replay_store_upsert_deduplicates_same_message_key() {
             first_request,
         )
         .expect("persist first");
+    // AG.20 migration: delete this second replay-store write with the first.
     transport
         .persist_replay_request(team, member, message_key, second_request)
         .expect("persist second");

--- a/crates/atm-daemon/src/peer_transport/tests/transport_client.rs
+++ b/crates/atm-daemon/src/peer_transport/tests/transport_client.rs
@@ -104,7 +104,6 @@ fn peer_listener_dispatch_observes_one_shared_connection_deadline() {
     let client_transport = PeerTransportRuntime::new_for_test(
         endpoint,
         PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(4),
             peer_listen_addr: None,
         },
         tempdir.path().join("replay.db"),
@@ -146,7 +145,6 @@ fn peer_listener_delivers_response_computed_within_shared_connection_deadline() 
     let client_transport = PeerTransportRuntime::new_for_test(
         endpoint,
         PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(4),
             peer_listen_addr: None,
         },
         tempdir.path().join("replay.db"),
@@ -175,37 +173,6 @@ fn peer_listener_delivers_response_computed_within_shared_connection_deadline() 
         other => panic!("unexpected response: {other:?}"),
     }
     listener_transport.shutdown().expect("shutdown");
-}
-
-#[test]
-fn jittered_backoff_stays_within_twenty_percent_window() {
-    let base = Duration::from_millis(250);
-    let low = jittered_backoff(base, 0);
-    let high = jittered_backoff(base, 4_000);
-    assert_eq!(low, Duration::from_millis(200));
-    assert_eq!(high, Duration::from_millis(300));
-}
-
-#[test]
-fn classify_io_error_covers_retryable_and_non_retryable_variants() {
-    for kind in [
-        io::ErrorKind::TimedOut,
-        io::ErrorKind::Interrupted,
-        io::ErrorKind::ConnectionRefused,
-        io::ErrorKind::ConnectionReset,
-        io::ErrorKind::ConnectionAborted,
-        io::ErrorKind::BrokenPipe,
-        io::ErrorKind::HostUnreachable,
-    ] {
-        assert_eq!(
-            classify_io_error(&io::Error::new(kind, "retryable")),
-            AttemptFailureKind::Retryable
-        );
-    }
-    assert_eq!(
-        classify_io_error(&io::Error::other("non-retryable")),
-        AttemptFailureKind::NonRetryable
-    );
 }
 
 #[test]
@@ -269,53 +236,6 @@ fn persist_replay_request_missing_endpoint_matches_send_surface_contract() {
     let send_error = remote_peer_endpoint_not_configured_error();
     assert_eq!(persist_error.code, send_error.code);
     assert_eq!(persist_error.recovery, send_error.recovery);
-}
-
-#[test]
-fn persist_replay_request_invalid_retry_budget_reports_actionable_recovery() {
-    let tempdir = TempDir::new().expect("tempdir");
-    let team = test_team_name();
-    let agent = test_sender_name();
-    let replay_store =
-        atm_runtime::sqlite_remote_replay_store_for_test(tempdir.path().join("mail.db"))
-            .expect("replay store");
-    let client = PeerClientTransport {
-        endpoint: Some(SocketAddr::from((Ipv4Addr::LOCALHOST, 7002))),
-        config: PeerTransportConfig {
-            remote_retry_budget: Duration::MAX,
-            peer_listen_addr: None,
-        },
-        replay_store: Some(replay_store),
-        peer_security_store: None,
-        codec: atm_core::protocol::JsonAtmProtocolCodec,
-        observability: SubsystemObservability::disabled(DaemonSubsystem::PeerTransport),
-    };
-    let error = client
-        .persist_replay_request(
-            team.clone(),
-            agent.clone(),
-            MessageKey::new("atm:test-remote-retry-budget-invalid").expect("message key"),
-            RequestEnvelope::Heartbeat(TeamMemberHeartbeatRequest {
-                team,
-                member: agent,
-                pid: 44,
-                observed_at: IsoTimestamp::now(),
-                activity: HeartbeatActivity::Idle,
-            }),
-        )
-        .expect_err("invalid retry budget should fail closed");
-    assert_eq!(error.code, AtmErrorCode::DaemonUnavailable);
-    assert!(error.primary_recovery().is_some());
-}
-
-#[test]
-fn protocol_envelope_preserves_replay_persistence_failure_contract() {
-    let error = remote_replay_persistence_failed_error(remote_replay_store_not_configured_error());
-    let envelope = ProtocolErrorEnvelope::from_error(&error);
-    let round_trip = envelope.into_atm_error();
-    assert_eq!(round_trip.code, AtmErrorCode::RemoteDeliveryOutcomeUnknown);
-    assert_eq!(round_trip.message, error.message);
-    assert_eq!(round_trip.recovery, error.recovery);
 }
 
 #[test]
@@ -410,7 +330,6 @@ fn peer_transport_aborts_before_connect_when_terminate_is_requested() {
     let transport = PeerTransportRuntime::new_for_test(
         endpoint,
         PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(1),
             peer_listen_addr: None,
         },
         tempdir.path().join("replay.db"),
@@ -463,7 +382,6 @@ fn peer_transport_uses_port_zero_listener_handoff_without_rebind_race() {
     let transport = PeerTransportRuntime::new_for_test(
         endpoint,
         PeerTransportConfig {
-            remote_retry_budget: Duration::from_millis(600),
             peer_listen_addr: None,
         },
         tempdir.path().join("mail.db"),
@@ -624,7 +542,7 @@ fn replay_resume_replays_and_deletes_delivered_rows() {
 
 #[test]
 #[serial_test::serial(env)]
-fn outcome_unknown_persists_replay_request_for_restart_resume() {
+fn outcome_unknown_does_not_persist_replay_inside_transport_send_path() {
     let _reset = install_shared_lifecycle_reset_guard();
     let tempdir = TempDir::new().expect("tempdir");
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
@@ -635,11 +553,9 @@ fn outcome_unknown_persists_replay_request_for_restart_resume() {
         PeerTransportConfig::default(),
         db_path.clone(),
     );
-    let team = test_team_name();
-    let member = test_recipient_name();
     let request = RequestEnvelope::Heartbeat(TeamMemberHeartbeatRequest {
-        team: team.clone(),
-        member: member.clone(),
+        team: test_team_name(),
+        member: test_recipient_name(),
         pid: 77,
         observed_at: IsoTimestamp::now(),
         activity: HeartbeatActivity::Idle,
@@ -659,9 +575,7 @@ fn outcome_unknown_persists_replay_request_for_restart_resume() {
     let pending = transport
         .load_pending_replay_records()
         .expect("load pending");
-    assert_eq!(pending.len(), 1);
-    assert_eq!(pending[0].team, team);
-    assert_eq!(pending[0].agent, member);
+    assert!(pending.is_empty());
 }
 
 #[test]

--- a/crates/atm-daemon/src/peer_transport/tests_transport.rs
+++ b/crates/atm-daemon/src/peer_transport/tests_transport.rs
@@ -92,7 +92,6 @@ fn peer_transport_aborts_before_connect_when_terminate_is_requested() {
     let transport = PeerTransportRuntime::new_for_test(
         endpoint,
         PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(1),
             peer_listen_addr: None,
         },
         tempdir.path().join("replay.db"),
@@ -145,7 +144,6 @@ fn peer_transport_uses_port_zero_listener_handoff_without_rebind_race() {
     let transport = PeerTransportRuntime::new_for_test(
         endpoint,
         PeerTransportConfig {
-            remote_retry_budget: Duration::from_millis(600),
             peer_listen_addr: None,
         },
         tempdir.path().join("mail.db"),
@@ -304,7 +302,7 @@ fn replay_resume_replays_and_deletes_delivered_rows() {
 
 #[test]
 #[serial_test::serial(env)]
-fn outcome_unknown_persists_replay_request_for_restart_resume() {
+fn outcome_unknown_does_not_persist_replay_inside_transport_send_path() {
     let _reset = install_shared_lifecycle_reset_guard();
     let tempdir = TempDir::new().expect("tempdir");
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
@@ -339,9 +337,7 @@ fn outcome_unknown_persists_replay_request_for_restart_resume() {
     let pending = transport
         .load_pending_replay_records()
         .expect("load pending");
-    assert_eq!(pending.len(), 1);
-    assert_eq!(pending[0].team, team);
-    assert_eq!(pending[0].agent, member);
+    assert!(pending.is_empty());
 }
 
 #[test]

--- a/crates/atm-daemon/src/peer_transport/tests_transport.rs
+++ b/crates/atm-daemon/src/peer_transport/tests_transport.rs
@@ -266,6 +266,8 @@ fn replay_resume_replays_and_deletes_delivered_rows() {
         observed_at: IsoTimestamp::now(),
         activity: HeartbeatActivity::Idle,
     });
+    // AG.20 migration: delete this setup with `persist_replay_request`; direct
+    // immediate-delivery coverage remains in the non-replay tests.
     transport
         .persist_replay_request(
             team.clone(),
@@ -289,6 +291,7 @@ fn replay_resume_replays_and_deletes_delivered_rows() {
         write_response_frame(&mut stream, &codec, request_id, response);
     });
 
+    // AG.20 migration: delete this assertion with `resume_pending_replay`.
     let summary = transport.resume_pending_replay().expect("resume");
     assert_eq!(summary.delivered, 1);
     assert_eq!(summary.retained, 0);
@@ -411,6 +414,8 @@ fn replay_resume_after_restart_delivers_once_and_clears_duplicate_delivery() {
         observed_at: IsoTimestamp::now(),
         activity: HeartbeatActivity::Idle,
     });
+    // AG.20 migration: delete this setup with `persist_replay_request`; it
+    // tests the removed replay lifecycle rather than direct delivery.
     first
         .persist_replay_request(
             team.clone(),
@@ -436,6 +441,7 @@ fn replay_resume_after_restart_delivers_once_and_clears_duplicate_delivery() {
         write_response_frame(&mut stream, &codec, request_id, response);
     });
 
+    // AG.20 migration: delete this replay assertion with the deprecated API.
     let summary = second.resume_pending_replay().expect("resume");
     assert_eq!(summary.delivered, 1);
     deliveries_rx.recv().expect("delivery");
@@ -446,6 +452,7 @@ fn replay_resume_after_restart_delivers_once_and_clears_duplicate_delivery() {
             .is_empty()
     );
 
+    // AG.20 migration: delete this idempotence assertion with the replay API.
     let summary = second.resume_pending_replay().expect("second resume");
     assert_eq!(summary.delivered, 0);
     assert_eq!(summary.retained, 0);
@@ -480,6 +487,8 @@ fn replay_store_upsert_deduplicates_same_message_key() {
         activity: HeartbeatActivity::ActiveToolUse,
     });
 
+    // AG.20 migration: delete this replay-store setup with
+    // `persist_replay_request`; it has no immediate-delivery replacement.
     transport
         .persist_replay_request(
             team.clone(),
@@ -488,6 +497,7 @@ fn replay_store_upsert_deduplicates_same_message_key() {
             first_request,
         )
         .expect("persist first");
+    // AG.20 migration: delete this second replay-store write with the first.
     transport
         .persist_replay_request(team, member, message_key, second_request)
         .expect("persist second");

--- a/crates/atm-daemon/src/peer_transport/types.rs
+++ b/crates/atm-daemon/src/peer_transport/types.rs
@@ -1,25 +1,7 @@
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::sync::mpsc;
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
-
-use atm_core::error::AtmError;
 
 use super::PeerTransportRuntime;
-
-pub(super) struct DeliveryRetryState<'a> {
-    pub(super) deadline: Instant,
-    pub(super) terminate: &'a Arc<AtomicBool>,
-    pub(super) backoff: &'a mut Duration,
-    pub(super) next_attempt: &'a mut u32,
-    pub(super) attempt_cap: u32,
-}
-
-pub(super) enum DeliveryLoopDecision {
-    Retry,
-    Return(AtmError),
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ReplayResumeSummary {

--- a/crates/atm-daemon/src/runtime_health/dispatch_delivery.rs
+++ b/crates/atm-daemon/src/runtime_health/dispatch_delivery.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use atm_core::{
     RequestEnvelope, ResponseEnvelope,
-    ack::ack_mail_with_runtime_and_post_send_emitter,
+    ack::{ack_mail_with_runtime_and_post_send_emitter, ack_request_from_send_request},
     boundary,
     clear::clear_mail_with_runtime,
     error::AtmError,
     list::list_mail,
-    protocol::{CompatibilityVerdict, ReleaseVersion, SendRequestEnvelope, SendResponseEnvelope},
+    protocol::{CompatibilityVerdict, ReleaseVersion, SendResponseEnvelope},
     read::{peek_mail_with_runtime, read_mail_with_runtime},
     schema::AtmMessageId,
     send::{
@@ -25,19 +25,7 @@ impl boundary::RequestDispatcher for DaemonRequestDispatcher {
             Arc::new(DaemonGraftPostSendPort::new(self.service_runtime.clone()));
         let post_send_emitter = DaemonPostSendHookEmitter::new(Arc::clone(&graft_post_send_port));
         match request {
-            RequestEnvelope::Send(SendRequestEnvelope::Compose(request)) => {
-                self.dispatch_compose_send(*request, &post_send_emitter)
-            }
-            RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(request)) => {
-                Ok(ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(
-                    ack_mail_with_runtime_and_post_send_emitter(
-                        request,
-                        self.observability.as_ref(),
-                        &self.service_runtime,
-                        &post_send_emitter,
-                    )?,
-                )))
-            }
+            RequestEnvelope::Send(request) => self.dispatch_send(*request, &post_send_emitter),
             RequestEnvelope::Heartbeat(request) => {
                 Ok(ResponseEnvelope::Heartbeat(self.record_heartbeat(request)?))
             }
@@ -67,11 +55,21 @@ impl boundary::RequestDispatcher for DaemonRequestDispatcher {
 }
 
 impl DaemonRequestDispatcher {
-    fn dispatch_compose_send(
+    fn dispatch_send(
         &self,
         request: SendRequest,
         post_send_emitter: &DaemonPostSendHookEmitter,
     ) -> Result<ResponseEnvelope, AtmError> {
+        if request.acknowledges_message_id.is_some() && request.source_remote_host.is_none() {
+            return Ok(ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(
+                ack_mail_with_runtime_and_post_send_emitter(
+                    ack_request_from_send_request(request)?,
+                    self.observability.as_ref(),
+                    &self.service_runtime,
+                    post_send_emitter,
+                )?,
+            )));
+        }
         match route_send_request(&request) {
             SendRequestRoute::Local => {
                 let outcome = send_mail_with_runtime_and_post_send_emitter(

--- a/crates/atm-daemon/src/tests/runtime_root/cross_host.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/cross_host.rs
@@ -1,8 +1,6 @@
 use super::*;
 use atm_core::boundary::RequestDispatcher;
-use atm_core::protocol::{
-    RequestEnvelope, ResponseEnvelope, SendRequestEnvelope, SendResponseEnvelope,
-};
+use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
 use atm_core::read::{ReadOutcome, ReadQuery};
 use atm_core::schema::AgentMember;
 use atm_core::send::{SendMessageSource, SendOutcome, SendRequest};
@@ -630,9 +628,7 @@ fn send_compose(caller: &CallerContext<'_>, spec: SendSpec<'_>) -> SendOutcome {
         .remote_host;
     match caller
         .dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect("send request should succeed")
     {
         ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => outcome,
@@ -711,18 +707,14 @@ fn dispatch_ack_over_local_ipc(
     message_id: AtmMessageId,
     body: &str,
 ) -> Result<ResponseEnvelope, atm_core::error::AtmError> {
-    let request = RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(
-        atm_core::ack::AckRequest {
-            home_dir: home.to_path_buf(),
-            current_dir: current_dir.to_path_buf(),
-            caller_identity: caller_identity
-                .parse::<AgentName>()
-                .expect("caller identity"),
-            caller_team: caller_team.parse::<TeamName>().expect("caller team"),
-            message_id,
-            reply_body: body.to_string(),
-        },
-    ));
+    let request = canonical_ack_request(
+        home,
+        current_dir,
+        caller_identity,
+        caller_team,
+        message_id,
+        body,
+    );
     dispatch_over_local_ipc(socket_path, request)
 }
 

--- a/crates/atm-daemon/src/tests/runtime_root/cross_host.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/cross_host.rs
@@ -501,7 +501,6 @@ fn start_cross_host_dispatcher(
         Some(assembly.allowed_host_store_arc()),
         Some(assembly.peer_security_store_arc()),
         crate::peer_transport::PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(30),
             peer_listen_addr: Some(SocketAddr::from((bind_ip, bind_port))),
         },
         crate::SubsystemObservability::disabled(crate::DaemonSubsystem::PeerTransport),

--- a/crates/atm-daemon/src/tests/runtime_root/cross_host.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/cross_host.rs
@@ -151,12 +151,7 @@ fn cross_host_send_and_ack_round_trip_and_failed_ack_stays_pending() {
         recipient_message_id,
         "cross-host ack success",
     );
-    match ack.reply_disposition {
-        atm_core::ack::AckReplyDisposition::Sent {
-            reply_message_id: _,
-            ..
-        } => {}
-    }
+    assert!(!ack.reply_message_id.to_string().is_empty());
 
     let ack_reply_message =
         wait_for_ack_reply(&arch_ctx, source_message_id, "cross-host ack success");
@@ -212,7 +207,7 @@ fn cross_host_send_and_ack_round_trip_and_failed_ack_stays_pending() {
         .shutdown()
         .expect("shutdown source peer listener");
 
-    let ack_outcome = send_ack_over_local_ipc(
+    let ack_error = dispatch_ack_over_local_ipc(
         &child_state.local_ipc_socket_path,
         &cm5_home,
         &cm5_workspace,
@@ -220,18 +215,11 @@ fn cross_host_send_and_ack_round_trip_and_failed_ack_stays_pending() {
         CM5_TEAM,
         second_recipient_message_id,
         "cross-host ack should fail while source peer listener is down",
-    );
-    assert_eq!(ack_outcome.warnings.len(), 1);
+    )
+    .expect_err("remote ack should fail closed while source peer listener is down");
     assert_eq!(
-        ack_outcome.warnings[0].code,
-        Some(atm_core::error_codes::AtmErrorCode::DaemonUnavailable)
-    );
-    assert!(
-        ack_outcome.warnings[0]
-            .message
-            .contains("ATM deferred remote ack delivery"),
-        "{:#?}",
-        ack_outcome.warnings
+        ack_error.code,
+        atm_core::error_codes::AtmErrorCode::DaemonUnavailable
     );
 
     let still_pending = read_message_over_local_ipc(
@@ -250,8 +238,8 @@ fn cross_host_send_and_ack_round_trip_and_failed_ack_stays_pending() {
         still_pending_message.envelope.message_id,
         Some(second_recipient_message_id)
     );
-    assert!(still_pending_message.envelope.pending_ack_at.is_none());
-    assert!(still_pending_message.envelope.acknowledged_at.is_some());
+    assert!(still_pending_message.envelope.pending_ack_at.is_some());
+    assert!(still_pending_message.envelope.acknowledged_at.is_none());
 
     stop_cross_host_child(&child_state, &mut cm5_process);
 }

--- a/crates/atm-daemon/src/tests/runtime_root/dispatch.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/dispatch.rs
@@ -26,22 +26,20 @@ fn dispatcher_send_after_add_member_roster_state_serializes_cleanly() {
     let dispatcher =
         DaemonRequestDispatcher::new_for_test(atm_home.clone(), status_cache, db_path.clone());
     let response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(
-                SendRequest::new(
-                    atm_home.clone(),
-                    workspace_dir.clone(),
-                    ROLE_TEAM_LEAD.parse().expect("caller"),
-                    "qa-a@test-team",
-                    TEST_TEAM.parse().expect("team"),
-                    SendMessageSource::Inline("hello add-member roster".to_string()),
-                    None,
-                    false,
-                    None,
-                    false,
-                )
-                .expect("send request"),
-            ),
+        .dispatch(RequestEnvelope::Send(Box::new(
+            SendRequest::new(
+                atm_home.clone(),
+                workspace_dir.clone(),
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "qa-a@test-team",
+                TEST_TEAM.parse().expect("team"),
+                SendMessageSource::Inline("hello add-member roster".to_string()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("send request"),
         )))
         .expect("dispatch send");
     let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = &response else {
@@ -81,22 +79,20 @@ fn threaded_dispatcher_send_after_add_member_roster_state_serializes_cleanly() {
     );
     let handle = std::thread::spawn(move || {
         let response = dispatcher
-            .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-                Box::new(
-                    SendRequest::new(
-                        atm_home.clone(),
-                        workspace_dir.clone(),
-                        ROLE_TEAM_LEAD.parse().expect("caller"),
-                        "qa-a@test-team",
-                        TEST_TEAM.parse().expect("team"),
-                        SendMessageSource::Inline("hello threaded dispatch".to_string()),
-                        None,
-                        false,
-                        None,
-                        false,
-                    )
-                    .expect("send request"),
-                ),
+            .dispatch(RequestEnvelope::Send(Box::new(
+                SendRequest::new(
+                    atm_home.clone(),
+                    workspace_dir.clone(),
+                    ROLE_TEAM_LEAD.parse().expect("caller"),
+                    "qa-a@test-team",
+                    TEST_TEAM.parse().expect("team"),
+                    SendMessageSource::Inline("hello threaded dispatch".to_string()),
+                    None,
+                    false,
+                    None,
+                    false,
+                )
+                .expect("send request"),
             )))
             .expect("dispatch send");
         JsonAtmProtocolCodec
@@ -134,22 +130,20 @@ fn dispatcher_send_rejects_self_addressed_message_before_persistence() {
     );
     let self_address = format!("{ROLE_TEAM_LEAD}@{TEST_TEAM}");
     let error = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(
-                SendRequest::new(
-                    atm_home.clone(),
-                    workspace_dir.clone(),
-                    ROLE_TEAM_LEAD.parse().expect("caller"),
-                    &self_address,
-                    TEST_TEAM.parse().expect("team"),
-                    SendMessageSource::Inline("hello self".to_string()),
-                    None,
-                    false,
-                    None,
-                    false,
-                )
-                .expect("send request"),
-            ),
+        .dispatch(RequestEnvelope::Send(Box::new(
+            SendRequest::new(
+                atm_home.clone(),
+                workspace_dir.clone(),
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                &self_address,
+                TEST_TEAM.parse().expect("team"),
+                SendMessageSource::Inline("hello self".to_string()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("send request"),
         )))
         .expect_err("self-addressed daemon send must fail");
 

--- a/crates/atm-daemon/src/tests/runtime_root/local_ipc.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/local_ipc.rs
@@ -297,7 +297,6 @@ fn local_ipc_runtime_round_trips_remote_target_send_read_and_ack_over_production
         Some(assembly.allowed_host_store_arc()),
         None,
         crate::peer_transport::PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(30),
             peer_listen_addr: Some(SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0))),
         },
         crate::SubsystemObservability::disabled(crate::DaemonSubsystem::PeerTransport),

--- a/crates/atm-daemon/src/tests/runtime_root/local_ipc.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/local_ipc.rs
@@ -480,10 +480,7 @@ fn local_ipc_runtime_round_trips_remote_target_send_read_and_ack_over_production
     );
     match ack_response {
         ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => {
-            assert!(matches!(
-                outcome.reply_disposition,
-                atm_core::ack::AckReplyDisposition::Sent { .. }
-            ));
+            assert!(!outcome.reply_message_id.to_string().is_empty());
         }
         other => panic!("unexpected ack response: {other:?}"),
     }

--- a/crates/atm-daemon/src/tests/runtime_root/local_ipc.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/local_ipc.rs
@@ -82,7 +82,7 @@ fn local_ipc_runtime_round_trips_send_after_add_member_roster_state() {
 
     let mut stream = connect_daemon_local_ipc_until_ready(&socket_path, ready_rx);
     configure_test_local_ipc_timeouts(&stream);
-    let request = RequestEnvelope::Send(SendRequestEnvelope::Compose(Box::new(
+    let request = RequestEnvelope::Send(Box::new(
         SendRequest::new(
             atm_home.clone(),
             workspace_dir.clone(),
@@ -96,7 +96,7 @@ fn local_ipc_runtime_round_trips_send_after_add_member_roster_state() {
             false,
         )
         .expect("send request"),
-    )));
+    ));
     let request_id = next_request_id();
     let frame = atm_core::protocol::request_to_frame_payload(request_id, request).expect("frame");
     atm_core::protocol::write_frame(&mut stream, &frame, "write send frame").expect("write");
@@ -219,11 +219,11 @@ fn local_ipc_client_preflight_round_trips_ack_required_send_after_add_member_ros
         false,
     )
     .expect("send request");
-    let request = RequestEnvelope::Send(SendRequestEnvelope::Compose(Box::new(request)));
+    let request = RequestEnvelope::Send(Box::new(request));
     let envelope = atm_daemon_client::RpcEnvelope::encode_body(
         atm_daemon_client::RpcHeader::new(
             atm_daemon_client::RequestId::new(next_request_id().into_inner()).expect("request id"),
-            atm_daemon_client::MessageKind::SendComposeRequest,
+            atm_daemon_client::MessageKind::SendRequest,
         ),
         &request,
     )
@@ -412,7 +412,7 @@ fn local_ipc_runtime_round_trips_remote_target_send_read_and_ack_over_production
     send_request.remote_host = atm_core::send::parse_send_target("qa-a@test-team.localhost", None)
         .expect("parse target")
         .remote_host;
-    let send_request = RequestEnvelope::Send(SendRequestEnvelope::Compose(Box::new(send_request)));
+    let send_request = RequestEnvelope::Send(Box::new(send_request));
     let send_request_id = next_request_id();
     let send_response = dispatch_once(
         send_request_id,
@@ -464,16 +464,14 @@ fn local_ipc_runtime_round_trips_remote_target_send_read_and_ack_over_production
     };
 
     let ack_request_id = next_request_id();
-    let ack_request = RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(
-        atm_core::ack::AckRequest {
-            home_dir: atm_home.clone(),
-            current_dir: workspace_dir.clone(),
-            caller_identity: "qa-a".parse().expect("caller"),
-            caller_team: TEST_TEAM.parse().expect("team"),
-            message_id: source_message_id,
-            reply_body: "ack from remote-target local ipc".to_string(),
-        },
-    ));
+    let ack_request = canonical_ack_request(
+        &atm_home,
+        &workspace_dir,
+        "qa-a",
+        TEST_TEAM,
+        source_message_id,
+        "ack from remote-target local ipc",
+    );
     let ack_response = dispatch_once(
         ack_request_id,
         ack_request,

--- a/crates/atm-daemon/src/tests/runtime_root/loopback.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/loopback.rs
@@ -423,10 +423,7 @@ fn dispatcher_secure_loopback_requires_ack_round_trips_and_updates_reply_state()
     let ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) = ack else {
         panic!("expected ack response");
     };
-    assert!(matches!(
-        outcome.reply_disposition,
-        atm_core::ack::AckReplyDisposition::Sent { .. }
-    ));
+    assert!(!outcome.reply_message_id.to_string().is_empty());
 
     let sender_read = dispatcher
         .dispatch(RequestEnvelope::Receive(

--- a/crates/atm-daemon/src/tests/runtime_root/loopback.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/loopback.rs
@@ -68,9 +68,7 @@ fn dispatcher_loopback_send_round_trips_through_peer_listener_into_self_inbox() 
         .remote_host;
 
     let response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect("dispatch loopback send");
     let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = response else {
         panic!("expected send response");
@@ -187,9 +185,7 @@ fn dispatcher_loopback_send_rejects_unauthorized_host_before_mailbox_mutation() 
         .remote_host;
 
     let error = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect_err("unauthorized localhost send must fail closed");
     assert_eq!(error.code, AtmErrorCode::MessageValidationFailed);
 
@@ -269,9 +265,7 @@ fn dispatcher_loopback_without_listener_fails_closed_without_mailbox_mutation() 
         .remote_host;
 
     let error = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect_err("localhost send without listener must fail closed");
     assert_eq!(error.code, AtmErrorCode::DaemonUnavailable);
 
@@ -368,9 +362,7 @@ fn dispatcher_secure_loopback_requires_ack_round_trips_and_updates_reply_state()
         .remote_host;
 
     let response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect("dispatch secure loopback send");
     let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = response else {
         panic!("expected send response");
@@ -419,16 +411,14 @@ fn dispatcher_secure_loopback_requires_ack_round_trips_and_updates_reply_state()
     let source_message_id = message.envelope.message_id.expect("message id");
 
     let ack = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(
-            atm_core::ack::AckRequest {
-                home_dir: atm_home.clone(),
-                current_dir: workspace_dir.clone(),
-                caller_identity: "qa-a".parse().expect("caller"),
-                caller_team: TEST_TEAM.parse().expect("team"),
-                message_id: source_message_id,
-                reply_body: "ack from secure localhost".to_string(),
-            },
-        )))
+        .dispatch(canonical_ack_request(
+            &atm_home,
+            &workspace_dir,
+            "qa-a",
+            TEST_TEAM,
+            source_message_id,
+            "ack from secure localhost",
+        ))
         .expect("ack over secure localhost");
     let ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) = ack else {
         panic!("expected ack response");
@@ -549,9 +539,7 @@ fn dispatcher_secure_loopback_send_round_trips_through_peer_listener_into_self_i
         .remote_host;
 
     let response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect("dispatch secure loopback send");
     let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = response else {
         panic!("expected send response");

--- a/crates/atm-daemon/src/tests/runtime_root/loopback.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/loopback.rs
@@ -328,7 +328,6 @@ fn dispatcher_secure_loopback_requires_ack_round_trips_and_updates_reply_state()
         Some(assembly.allowed_host_store_arc()),
         Some(assembly.peer_security_store_arc()),
         crate::peer_transport::PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(30),
             peer_listen_addr: Some(SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0))),
         },
         crate::SubsystemObservability::disabled(crate::DaemonSubsystem::PeerTransport),
@@ -502,7 +501,6 @@ fn dispatcher_secure_loopback_send_round_trips_through_peer_listener_into_self_i
         Some(assembly.allowed_host_store_arc()),
         Some(assembly.peer_security_store_arc()),
         crate::peer_transport::PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(30),
             peer_listen_addr: Some(SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0))),
         },
         crate::SubsystemObservability::disabled(crate::DaemonSubsystem::PeerTransport),

--- a/crates/atm-daemon/src/tests/runtime_root/mod.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/mod.rs
@@ -3,8 +3,7 @@ use atm_core::boundary::{AtmProtocol, RequestDispatcher};
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::protocol::{
-    JsonAtmProtocolCodec, RequestEnvelope, ResponseEnvelope, SendRequestEnvelope,
-    SendResponseEnvelope, next_request_id,
+    JsonAtmProtocolCodec, RequestEnvelope, ResponseEnvelope, SendResponseEnvelope, next_request_id,
 };
 use atm_core::read::ReadQuery;
 use atm_core::send::{SendMessageSource, SendRequest};
@@ -18,6 +17,31 @@ use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
 use std::sync::Arc;
 use std::sync::mpsc;
 use std::time::Duration;
+
+pub(super) fn canonical_ack_request(
+    home_dir: &std::path::Path,
+    current_dir: &std::path::Path,
+    caller_identity: &str,
+    caller_team: &str,
+    message_id: atm_core::schema::AtmMessageId,
+    body: &str,
+) -> RequestEnvelope {
+    let mut request = SendRequest::new(
+        home_dir.to_path_buf(),
+        current_dir.to_path_buf(),
+        caller_identity.parse().expect("caller identity"),
+        &format!("{caller_identity}@{caller_team}"),
+        caller_team.parse().expect("caller team"),
+        SendMessageSource::Inline(body.to_string()),
+        None,
+        false,
+        None,
+        false,
+    )
+    .expect("ack send request");
+    request.acknowledges_message_id = Some(message_id);
+    RequestEnvelope::Send(Box::new(request))
+}
 use tempfile::TempDir;
 
 use crate::test_support::{

--- a/crates/atm-daemon/src/tests/runtime_root/self_ip.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/self_ip.rs
@@ -70,9 +70,7 @@ fn dispatcher_self_ip_send_round_trips_through_peer_listener_into_self_inbox() {
             .remote_host;
 
     let response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect("dispatch self-ip send");
     let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = response else {
         panic!("expected send response");
@@ -182,9 +180,7 @@ fn dispatcher_secure_self_ip_requires_ack_round_trips_and_updates_reply_state() 
             .remote_host;
 
     let response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect("dispatch secure self-ip send");
     let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = response else {
         panic!("expected send response");
@@ -234,16 +230,14 @@ fn dispatcher_secure_self_ip_requires_ack_round_trips_and_updates_reply_state() 
     let source_message_id = message.envelope.message_id.expect("message id");
 
     let ack = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(
-            atm_core::ack::AckRequest {
-                home_dir: atm_home.clone(),
-                current_dir: workspace_dir.clone(),
-                caller_identity: "qa-a".parse().expect("caller"),
-                caller_team: TEST_TEAM.parse().expect("team"),
-                message_id: source_message_id,
-                reply_body: "ack from secure self ip".to_string(),
-            },
-        )))
+        .dispatch(canonical_ack_request(
+            &atm_home,
+            &workspace_dir,
+            "qa-a",
+            TEST_TEAM,
+            source_message_id,
+            "ack from secure self ip",
+        ))
         .expect("ack over secure self ip");
     let ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) = ack else {
         panic!("expected ack response");
@@ -367,9 +361,7 @@ fn dispatcher_secure_self_ip_failed_ack_keeps_source_pending() {
             .remote_host;
 
     let response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect("dispatch secure self-ip send");
     let ResponseEnvelope::Send(SendResponseEnvelope::Sent(_)) = response else {
         panic!("expected send response");
@@ -407,16 +399,14 @@ fn dispatcher_secure_self_ip_failed_ack_keeps_source_pending() {
         .expect("shutdown secure peer listener before ack");
 
     let error = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(
-            atm_core::ack::AckRequest {
-                home_dir: atm_home.clone(),
-                current_dir: workspace_dir.clone(),
-                caller_identity: "qa-a".parse().expect("caller"),
-                caller_team: TEST_TEAM.parse().expect("team"),
-                message_id: source_message_id,
-                reply_body: "ack should fail while peer listener is down".to_string(),
-            },
-        )))
+        .dispatch(canonical_ack_request(
+            &atm_home,
+            &workspace_dir,
+            "qa-a",
+            TEST_TEAM,
+            source_message_id,
+            "ack should fail while peer listener is down",
+        ))
         .expect_err("ack must fail when secure self-ip peer listener is down");
     assert_eq!(error.code, AtmErrorCode::DaemonUnavailable);
 
@@ -497,9 +487,7 @@ fn dispatcher_self_ip_without_listener_fails_closed_without_mailbox_mutation() {
             .remote_host;
 
     let error = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect_err("self-ip send without listener must fail closed");
     assert_eq!(error.code, AtmErrorCode::DaemonUnavailable);
 
@@ -612,9 +600,7 @@ fn dispatcher_self_ip_send_rejects_disabled_host_before_mailbox_mutation() {
             .remote_host;
 
     let error = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))
+        .dispatch(RequestEnvelope::Send(Box::new(request)))
         .expect_err("self-ip send must fail closed");
     assert_eq!(error.code, AtmErrorCode::MessageValidationFailed);
 

--- a/crates/atm-daemon/src/tests/runtime_root/self_ip.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/self_ip.rs
@@ -242,10 +242,7 @@ fn dispatcher_secure_self_ip_requires_ack_round_trips_and_updates_reply_state() 
     let ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) = ack else {
         panic!("expected ack response");
     };
-    assert!(matches!(
-        outcome.reply_disposition,
-        atm_core::ack::AckReplyDisposition::Sent { .. }
-    ));
+    assert!(!outcome.reply_message_id.to_string().is_empty());
 
     let sender_read = dispatcher
         .dispatch(RequestEnvelope::Receive(

--- a/crates/atm-daemon/src/tests/runtime_root/self_ip.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/self_ip.rs
@@ -145,7 +145,6 @@ fn dispatcher_secure_self_ip_requires_ack_round_trips_and_updates_reply_state() 
         Some(assembly.allowed_host_store_arc()),
         Some(assembly.peer_security_store_arc()),
         crate::peer_transport::PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(30),
             peer_listen_addr: Some(SocketAddr::from((self_ip, 0))),
         },
         crate::SubsystemObservability::disabled(crate::DaemonSubsystem::PeerTransport),
@@ -323,7 +322,6 @@ fn dispatcher_secure_self_ip_failed_ack_keeps_source_pending() {
         Some(assembly.allowed_host_store_arc()),
         Some(assembly.peer_security_store_arc()),
         crate::peer_transport::PeerTransportConfig {
-            remote_retry_budget: Duration::from_secs(30),
             peer_listen_addr: Some(SocketAddr::from((self_ip, 0))),
         },
         crate::SubsystemObservability::disabled(crate::DaemonSubsystem::PeerTransport),

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -4,9 +4,7 @@ use atm_core::graft::{
     GraftPostSendRequest, GraftPostSendResponse, graft_receiver_socket_path_from_home,
     read_graft_post_send_message, write_graft_post_send_message,
 };
-use atm_core::protocol::{
-    RequestEnvelope, ResponseEnvelope, SendResponseEnvelope,
-};
+use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
 use atm_core::schema::{AgentMember, TeamConfig};
 use atm_core::send::{SendMessageSource, SendRequest};
 use atm_core::test_support::{EnvGuard, ROLE_TEAM_LEAD};
@@ -145,19 +143,19 @@ fn dispatcher_send_surfaces_typed_warning_when_graft_receiver_path_is_unavailabl
 
     let response = dispatcher
         .dispatch(RequestEnvelope::Send(Box::new(
-                SendRequest::new(
-                    atm_home.clone(),
-                    workspace_dir,
-                    ROLE_TEAM_LEAD.parse().expect("caller"),
-                    "qa-a@test-team",
-                    TEST_TEAM.parse().expect("team"),
-                    SendMessageSource::Inline("hello graft".to_string()),
-                    None,
-                    false,
-                    None,
-                    false,
-                )
-                .expect("send request"),
+            SendRequest::new(
+                atm_home.clone(),
+                workspace_dir,
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "qa-a@test-team",
+                TEST_TEAM.parse().expect("team"),
+                SendMessageSource::Inline("hello graft".to_string()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("send request"),
         )))
         .expect("send response");
 
@@ -180,19 +178,19 @@ fn dispatcher_ack_surfaces_typed_warning_when_graft_reply_target_is_unavailable(
 
     let source_response = dispatcher
         .dispatch(RequestEnvelope::Send(Box::new(
-                SendRequest::new(
-                    atm_home.clone(),
-                    workspace_dir.clone(),
-                    "qa-a".parse().expect("caller"),
-                    &format!("{ROLE_TEAM_LEAD}@{TEST_TEAM}"),
-                    TEST_TEAM.parse().expect("team"),
-                    SendMessageSource::Inline("please ack".to_string()),
-                    None,
-                    true,
-                    None,
-                    false,
-                )
-                .expect("source send request"),
+            SendRequest::new(
+                atm_home.clone(),
+                workspace_dir.clone(),
+                "qa-a".parse().expect("caller"),
+                &format!("{ROLE_TEAM_LEAD}@{TEST_TEAM}"),
+                TEST_TEAM.parse().expect("team"),
+                SendMessageSource::Inline("please ack".to_string()),
+                None,
+                true,
+                None,
+                false,
+            )
+            .expect("source send request"),
         )))
         .expect("source send response");
     let source_message_id = match source_response {
@@ -274,19 +272,19 @@ fn dispatcher_send_delivers_direct_graft_nudge_without_warning() {
     ]);
     let response = dispatcher
         .dispatch(RequestEnvelope::Send(Box::new(
-                SendRequest::new(
-                    atm_home,
-                    workspace_dir,
-                    ROLE_TEAM_LEAD.parse().expect("caller"),
-                    "qa-a@test-team",
-                    TEST_TEAM.parse().expect("team"),
-                    SendMessageSource::Inline("hello graft".to_string()),
-                    None,
-                    false,
-                    None,
-                    false,
-                )
-                .expect("send request"),
+            SendRequest::new(
+                atm_home,
+                workspace_dir,
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "qa-a@test-team",
+                TEST_TEAM.parse().expect("team"),
+                SendMessageSource::Inline("hello graft".to_string()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("send request"),
         )))
         .expect("send response");
     let response = match response {

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -1,4 +1,3 @@
-use atm_core::ack::AckRequest;
 use atm_core::boundary::{ReplaySource, RequestDispatcher, RosterHarness};
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::graft::{
@@ -6,7 +5,7 @@ use atm_core::graft::{
     read_graft_post_send_message, write_graft_post_send_message,
 };
 use atm_core::protocol::{
-    RequestEnvelope, ResponseEnvelope, SendRequestEnvelope, SendResponseEnvelope,
+    RequestEnvelope, ResponseEnvelope, SendResponseEnvelope,
 };
 use atm_core::schema::{AgentMember, TeamConfig};
 use atm_core::send::{SendMessageSource, SendRequest};
@@ -20,6 +19,31 @@ use tempfile::TempDir;
 use crate::runtime_health::{DaemonRequestDispatcher, RuntimeStatusCache};
 
 const TEST_TEAM: &str = "test-team";
+
+fn canonical_ack_request(
+    home_dir: std::path::PathBuf,
+    current_dir: std::path::PathBuf,
+    caller_identity: &str,
+    caller_team: &str,
+    message_id: atm_core::schema::AtmMessageId,
+    body: &str,
+) -> RequestEnvelope {
+    let mut request = SendRequest::new(
+        home_dir,
+        current_dir,
+        caller_identity.parse().expect("caller"),
+        &format!("{caller_identity}@{caller_team}"),
+        caller_team.parse().expect("team"),
+        SendMessageSource::Inline(body.to_string()),
+        None,
+        false,
+        None,
+        false,
+    )
+    .expect("ack request");
+    request.acknowledges_message_id = Some(message_id);
+    RequestEnvelope::Send(Box::new(request))
+}
 
 fn replay_source_static(label: &'static str) -> ReplaySource {
     ReplaySource::new(label).unwrap_or_else(|_| unreachable!("static replay source must validate"))
@@ -120,8 +144,7 @@ fn dispatcher_send_surfaces_typed_warning_when_graft_receiver_path_is_unavailabl
     let (_tempdir, atm_home, workspace_dir, dispatcher) = graft_warning_dispatcher();
 
     let response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(
+        .dispatch(RequestEnvelope::Send(Box::new(
                 SendRequest::new(
                     atm_home.clone(),
                     workspace_dir,
@@ -135,7 +158,6 @@ fn dispatcher_send_surfaces_typed_warning_when_graft_receiver_path_is_unavailabl
                     false,
                 )
                 .expect("send request"),
-            ),
         )))
         .expect("send response");
 
@@ -157,8 +179,7 @@ fn dispatcher_ack_surfaces_typed_warning_when_graft_reply_target_is_unavailable(
     let (_tempdir, atm_home, workspace_dir, dispatcher) = graft_warning_dispatcher();
 
     let source_response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(
+        .dispatch(RequestEnvelope::Send(Box::new(
                 SendRequest::new(
                     atm_home.clone(),
                     workspace_dir.clone(),
@@ -172,7 +193,6 @@ fn dispatcher_ack_surfaces_typed_warning_when_graft_reply_target_is_unavailable(
                     false,
                 )
                 .expect("source send request"),
-            ),
         )))
         .expect("source send response");
     let source_message_id = match source_response {
@@ -181,16 +201,14 @@ fn dispatcher_ack_surfaces_typed_warning_when_graft_reply_target_is_unavailable(
     };
 
     let ack_response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(
-            AckRequest {
-                home_dir: atm_home,
-                current_dir: workspace_dir,
-                caller_identity: ROLE_TEAM_LEAD.parse().expect("caller"),
-                caller_team: TEST_TEAM.parse().expect("team"),
-                message_id: source_message_id,
-                reply_body: "ack reply".to_string(),
-            },
-        )))
+        .dispatch(canonical_ack_request(
+            atm_home,
+            workspace_dir,
+            ROLE_TEAM_LEAD,
+            TEST_TEAM,
+            source_message_id,
+            "ack reply",
+        ))
         .expect("ack response");
 
     let ack_outcome = match ack_response {
@@ -255,8 +273,7 @@ fn dispatcher_send_delivers_direct_graft_nudge_without_warning() {
         ("USERPROFILE", None),
     ]);
     let response = dispatcher
-        .dispatch(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(
+        .dispatch(RequestEnvelope::Send(Box::new(
                 SendRequest::new(
                     atm_home,
                     workspace_dir,
@@ -270,7 +287,6 @@ fn dispatcher_send_delivers_direct_graft_nudge_without_warning() {
                     false,
                 )
                 .expect("send request"),
-            ),
         )))
         .expect("send response");
     let response = match response {

--- a/crates/atm-graft/examples/smoke_same_host.rs
+++ b/crates/atm-graft/examples/smoke_same_host.rs
@@ -249,7 +249,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             },
             "read_selected_message_id": read_selected_message_id.to_string(),
             "ack_message_id": ack_outcome.message_id.to_string(),
-            "ack_reply_disposition": ack_outcome.reply_disposition,
+            "ack_reply_message_id": ack_outcome.reply_message_id.to_string(),
+            "ack_reply_target": ack_outcome.reply_target,
             "follow_up_message_id": follow_up_outcome.message_id.to_string(),
         }))?
     );

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -595,8 +595,8 @@ mod tests {
     #[test]
     fn client_routes_send_read_and_ack_over_transport() {
         let paths = test_paths();
-        let transport = Arc::new(FakeClientTransport::new(Box::new(
-            |request| {
+        let transport =
+            Arc::new(FakeClientTransport::new(Box::new(|request| {
                 match request {
                 CoreRequestEnvelope::Send(request)
                     if request.acknowledges_message_id.is_none() => Ok(
@@ -663,11 +663,8 @@ mod tests {
                             "agent": TEST_LEAD,
                             "message_id": atm_core::schema::AtmMessageId::new().to_string(),
                             "task_id": null,
-                            "reply_disposition": {
-                                "kind": "sent",
-                                "reply_target": format!("{TEST_LEAD}@{TEST_TEAM}"),
-                                "reply_message_id": atm_core::schema::AtmMessageId::new().to_string()
-                            },
+                            "reply_target": format!("{TEST_LEAD}@{TEST_TEAM}"),
+                            "reply_message_id": atm_core::schema::AtmMessageId::new().to_string(),
                             "reply_text": "ack",
                             "warnings": [],
                         }))
@@ -676,8 +673,7 @@ mod tests {
                 ),
                 other => panic!("unexpected request: {other:?}"),
                 }
-            },
-        )));
+            })));
         let client = GraftClient::from_transport(transport);
 
         let send_request = SendRequest::new(

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -9,16 +9,14 @@ use std::sync::{Arc, RwLock};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use atm_core::ack::{AckOutcome, AckRequest};
+use atm_core::ack::{AckOutcome, AckRequest, prepare_ack_send_request};
 use atm_core::boundary::{ClientTransport, PostSendHookEvent};
 use atm_core::error::AtmError;
 use atm_core::graft::AtmGraftClient;
 use atm_core::observability::{
     CommandEvent, NullObservability, ObservabilityPort, action_name, outcome_label,
 };
-use atm_core::protocol::{
-    RequestEnvelope, ResponseEnvelope, SendRequestEnvelope, SendResponseEnvelope,
-};
+use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
 use atm_core::read::{ReadOutcome, ReadQuery};
 use atm_core::send::{SendOutcome, SendRequest};
 use atm_core::types::{AgentName, TeamName};
@@ -225,9 +223,7 @@ impl GraftClient {
 
 impl AtmGraftClient for GraftClient {
     fn send_message(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        match self.send_request(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))? {
+        match self.send_request(RequestEnvelope::Send(Box::new(request)))? {
             ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => Ok(outcome),
             other => Err(unexpected_response("send", other)),
         }
@@ -241,9 +237,9 @@ impl AtmGraftClient for GraftClient {
     }
 
     fn acknowledge_message(&self, request: AckRequest) -> Result<AckOutcome, AtmError> {
-        match self.send_request(RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(
+        match self.send_request(RequestEnvelope::Send(Box::new(prepare_ack_send_request(
             request,
-        )))? {
+        )?)))? {
             ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => Ok(outcome),
             other => Err(unexpected_response("ack", other)),
         }
@@ -602,7 +598,8 @@ mod tests {
         let transport = Arc::new(FakeClientTransport::new(Box::new(
             |request| {
                 match request {
-                CoreRequestEnvelope::Send(SendRequestEnvelope::Compose(_)) => Ok(
+                CoreRequestEnvelope::Send(request)
+                    if request.acknowledges_message_id.is_none() => Ok(
                     CoreResponseEnvelope::Send(SendResponseEnvelope::Sent(SendOutcome {
                         action: CommandAction::Send,
                         team: TeamName::from_validated(TEST_TEAM),
@@ -657,7 +654,8 @@ mod tests {
                         },
                     })))
                 }
-                CoreRequestEnvelope::Send(SendRequestEnvelope::Acknowledge(_)) => Ok(
+                CoreRequestEnvelope::Send(request)
+                    if request.acknowledges_message_id.is_some() => Ok(
                     CoreResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(
                         serde_json::from_value(json!({
                             "action": "ack",
@@ -677,7 +675,7 @@ mod tests {
                     )),
                 ),
                 other => panic!("unexpected request: {other:?}"),
-            }
+                }
             },
         )));
         let client = GraftClient::from_transport(transport);

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -17,7 +17,9 @@ use atm_core::graft::AtmGraftClient;
 use atm_core::home;
 use atm_core::list::{ListOutcome, ListQuery};
 use atm_core::observability::{CommandEvent, ObservabilityPort, action_name, outcome_label};
-use atm_core::protocol::{self, CompatibilityPreflight, RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
+use atm_core::protocol::{
+    self, CompatibilityPreflight, RequestEnvelope, ResponseEnvelope, SendResponseEnvelope,
+};
 use atm_core::read::{PeekQuery, ReadOutcome, ReadQuery};
 use atm_core::send::{SendOutcome, SendRequest};
 #[cfg(not(test))]

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Once};
 
-use atm_core::ack::{AckOutcome, AckRequest};
+use atm_core::ack::{AckOutcome, AckRequest, prepare_ack_send_request};
 use atm_core::boundary;
 use atm_core::boundary::ClientTransport;
 use atm_core::clear::{ClearOutcome, ClearQuery};
@@ -17,10 +17,7 @@ use atm_core::graft::AtmGraftClient;
 use atm_core::home;
 use atm_core::list::{ListOutcome, ListQuery};
 use atm_core::observability::{CommandEvent, ObservabilityPort, action_name, outcome_label};
-use atm_core::protocol::{
-    self, CompatibilityPreflight, RequestEnvelope, ResponseEnvelope, SendRequestEnvelope,
-    SendResponseEnvelope,
-};
+use atm_core::protocol::{self, CompatibilityPreflight, RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
 use atm_core::read::{PeekQuery, ReadOutcome, ReadQuery};
 use atm_core::send::{SendOutcome, SendRequest};
 #[cfg(not(test))]
@@ -271,9 +268,7 @@ impl<'a> CliComposition<'a> {
     }
 
     pub(crate) fn send(&self, request: SendRequest) -> Result<SendOutcome, AtmError> {
-        match self.send_request(RequestEnvelope::Send(SendRequestEnvelope::Compose(
-            Box::new(request),
-        )))? {
+        match self.send_request(RequestEnvelope::Send(Box::new(request)))? {
             ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => {
                 self.observability_port.emit_command_event(CommandEvent {
                     command: "send",
@@ -300,9 +295,9 @@ impl<'a> CliComposition<'a> {
     }
 
     pub(crate) fn ack(&self, request: AckRequest) -> Result<AckOutcome, AtmError> {
-        match self.send_request(RequestEnvelope::Send(SendRequestEnvelope::Acknowledge(
+        match self.send_request(RequestEnvelope::Send(Box::new(prepare_ack_send_request(
             request,
-        )))? {
+        )?)))? {
             ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => {
                 self.observability_port.emit_command_event(CommandEvent {
                     command: "ack",

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -185,15 +185,14 @@ pub fn print_ack_result(outcome: &AckOutcome, json: bool) -> Result<()> {
 }
 
 fn render_ack_result_line(outcome: &AckOutcome) -> String {
-    match &outcome.reply_disposition {
-        atm_core::ack::AckReplyDisposition::Sent {
-            reply_message_id,
-            reply_target,
-        } => format!(
-            "Acknowledged {} for {}@{} and sent reply {} to {}",
-            outcome.message_id, outcome.agent, outcome.team, reply_message_id, reply_target
-        ),
-    }
+    format!(
+        "Acknowledged {} for {}@{} and sent reply {} to {}",
+        outcome.message_id,
+        outcome.agent,
+        outcome.team,
+        outcome.reply_message_id,
+        outcome.reply_target
+    )
 }
 
 /// Print one clear result in human-readable or JSON form.
@@ -960,33 +959,23 @@ mod tests {
     }
 
     #[test]
-    fn ack_output_json_shape_preserves_sent_reply_disposition() {
+    fn ack_output_json_shape_preserves_sent_reply_metadata() {
         let outcome: AckOutcome = serde_json::from_value(json!({
             "action": "ack",
             "team": "test-team",
             "agent": "sender-a",
             "message_id": "01KX5TEST00000000000000002",
             "task_id": null,
-            "reply_disposition": {
-                "kind": "sent",
-                "reply_target": "team-lead@test-team",
-                "reply_message_id": "01KX5TEST00000000000000003"
-            },
+            "reply_target": "team-lead@test-team",
+            "reply_message_id": "01KX5TEST00000000000000003",
             "reply_text": "received",
             "warnings": []
         }))
         .expect("ack outcome");
 
         let rendered = serde_json::to_value(&outcome).expect("json outcome");
-        assert_eq!(rendered["reply_disposition"]["kind"], "sent");
-        assert_eq!(
-            rendered["reply_disposition"]["reply_target"],
-            "team-lead@test-team"
-        );
-        assert_eq!(
-            rendered["reply_disposition"]["reply_message_id"],
-            "01KX5TEST00000000000000003"
-        );
+        assert_eq!(rendered["reply_target"], "team-lead@test-team");
+        assert_eq!(rendered["reply_message_id"], "01KX5TEST00000000000000003");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Removes transport-owned deferred/replay policy from peer_transport.
- Updates stale contract tests to the new boundary.

Sprint doc: docs/plans/phase-AG/sprint-AG20.md (authoritative)
Source finding: CROSSHOST-UNIFY-2
Sprint 3 of the AG.18-AG.25 cross-host-unify remediation ladder.

Commit: 50572166 (104 insertions, 622 deletions, -518 net LOC)
just test: PASS. just lint: PASS.

## Test plan
- [ ] quality-mgr QA-1 (held uncorrelated per AG18-25 ladder policy until AG.25 lands)
- [ ] CI green