### PR TITLE
fix: replace atm gh pr invocations with direct gh pr commands

### DIFF
--- a/.claude/agents/publisher.md
+++ b/.claude/agents/publisher.md
@@ -222,9 +222,10 @@ gh release edit v{VERSION} --notes "$(cat release/release-notes.md)"
    - `version=<X.Y.Z or vX.Y.Z>`
    - `run_by_agent=publisher`
 10. Monitor in parallel:
-   - PR CI (if a release PR or release-fix PR is open): `atm gh monitor pr <PR_NUMBER>` — reports merge_conflict, CI pass/fail
-   - Preflight: `atm gh monitor run <run-id>` (fallback: `gh run watch --exit-status <run-id>`)
-   - If `atm gh monitor pr` returns `merge_conflict`, stop and report to `team-lead`.
+   - PR CI (if a release PR or release-fix PR is open): `gh pr checks <PR_NUMBER> --watch` + `gh pr view <PR_NUMBER> --json mergeStateStatus,statusCheckRollup,reviewDecision` — reports pass/fail + merge state
+   - Preflight: `gh run watch --exit-status <run-id>` (polls until workflow finishes with exit code reflecting conclusion); for failure detail use `gh run view <run-id> --log-failed` or `gh run view <run-id> --json jobs --jq '.jobs[] | select(.conclusion=="failure") | {name,conclusion,steps: (.steps[] | select(.conclusion=="failure"))}'`
+   - If `gh pr view` reports `mergeStateStatus == DIRTY` or `mergeable == CONFLICTING`, stop and report to `team-lead`.
+   - do NOT use `atm gh ...` commands — they no longer exist in the toolchain
 11. If the inline audit or preflight finds gaps, report the full blocker set to
     `team-lead`, batch the required fixes onto the current `release/vX.Y.Z`
     branch, and avoid one-blocker-per-PR churn.

--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -126,14 +126,16 @@ TODO-specific rule:
    Before citing any reviewer-supplied `file:line`, re-resolve it in the
    current branch/worktree. Missing or stale evidence is a finding.
 9. Check PR CI state when a PR number is present:
-   - prefer `atm gh monitor status`
-   - prefer `atm gh monitor pr <PR> --start-timeout 120`
-   - prefer `atm gh pr report <PR> --json`
-   - fall back to `gh pr checks <PR> --watch` and
-     `gh pr view <PR> --json mergeStateStatus,reviewDecision` if the repo-level
-     `atm gh` flow is unavailable
+   - poll with `gh pr checks <PR> --watch` until all required checks complete
+   - fetch structured state with `gh pr view <PR> --json mergeStateStatus,reviewDecision,statusCheckRollup`
+   - for per-job failure detail: `gh run view <run-id> --log-failed` (or `gh run view <run-id> --json jobs --jq '.jobs[] | select(.conclusion=="failure")'`)
+   - do NOT use `atm gh ...` commands — they no longer exist in the toolchain
 10. Publish the PR update using the templates from
-   `.claude/skills/quality-management-gh/`.
+   `.claude/skills/quality-management-gh/`:
+   - render the appropriate template (findings-report.md.j2 or quality-report.md.j2)
+   - POST the rendered body with `gh pr comment <PR> --body-file <path>`
+   - verify the comment landed with `gh pr view <PR> --json comments --jq '.comments | length'`
+   - this step is MANDATORY for audit trail; findings must live on the PR, not only in ATM messages
 11. Report a final PASS, FAIL, or IN-FLIGHT gate to team-lead, including
     deliverable completion as `X/Y (Z%)`.
 

--- a/.claude/agents/scrum-master.md
+++ b/.claude/agents/scrum-master.md
@@ -136,9 +136,10 @@ After QA passes:
 ### Phase 5: CI Monitoring
 
 After PR creation:
-- prefer `atm gh monitor pr <PR> --start-timeout 120`
-- fall back to `gh pr checks <PR> --watch` if repo-specific monitoring is not
-  available
+- poll CI with `gh pr checks <PR> --watch` until all required checks complete
+- fetch structured state with `gh pr view <PR> --json mergeStateStatus,reviewDecision,statusCheckRollup`
+- for long-running checks, use `gh pr view <PR> --json statusCheckRollup --jq '.statusCheckRollup[] | select(.status=="IN_PROGRESS")'`
+- do NOT use `atm gh ...` commands — they no longer exist in the toolchain
 
 ### Phase 6: CI Fix Loop
 

--- a/.claude/skills/quality-management-gh/SKILL.md
+++ b/.claude/skills/quality-management-gh/SKILL.md
@@ -76,17 +76,13 @@ Do not treat QA as single-shot.
 
 ## CI Monitoring
 
-Preferred repo-specific flow:
-- use `atm gh monitor status` to verify monitor health when available
-- use `atm gh monitor pr <PR> --start-timeout 120` to start or attach a PR monitor when available
-- use `atm gh pr report <PR> --json` for one-shot structured status when available
+Use the native `gh` CLI — `atm gh ...` commands no longer exist in the toolchain:
+- poll CI with `gh pr checks <PR> --watch` until all required checks complete
+- fetch structured PR state: `gh pr view <PR> --json mergeStateStatus,reviewDecision,statusCheckRollup`
+- per-job failure detail: `gh run view <run-id> --log-failed` (or `gh run view <run-id> --json jobs --jq '.jobs[] | select(.conclusion=="failure") | {name,conclusion,steps: (.steps[] | select(.conclusion=="failure"))}'`)
+- long-running check: `gh run watch <run-id> --exit-status` (blocks until workflow finishes)
 
-Fallback when repo-specific `atm gh` tooling is unavailable or not yet wired:
-- `gh pr checks <PR> --watch`
-- `gh pr view <PR> --json mergeStateStatus,reviewDecision`
-
-If monitoring cannot start, include the failure in QA status and proceed with
-one-shot PR report data.
+If CI cannot be reached (network/auth failure), report the failure as a QA observation and proceed with whatever structured data is available.
 
 ## Findings Report to PR (Blocking)
 

--- a/.claude/skills/sprint-report/SKILL.md
+++ b/.claude/skills/sprint-report/SKILL.md
@@ -19,15 +19,15 @@ Default: `--table`
 
 ## Data Source
 
-**Always use `atm gh pr list` first** - single call, returns all open PRs with CI and merge state:
+**Use `gh pr list --json` directly** — single call, returns all open PRs with CI and merge state:
 
 ```bash
-atm gh pr list
+gh pr list --state open --json number,title,headRefName,mergeable,mergeStateStatus,statusCheckRollup
 ```
 
-This is faster and sufficient for populating `sprint_rows` and `integration_row`. Only drill into individual `gh run view` calls if you need failure details for a specific job.
+This is the primary source for populating `sprint_rows` and `integration_row`. Only drill into individual `gh run view` calls if you need failure details for a specific job (see CI Monitoring section above).
 
-**Dogfooding rule**: If `atm gh pr list` output is missing information needed to fill the report (e.g., no per-job failure detail, no QA state, truncated CI summary), **file a GitHub issue** describing what field or format change would make it sufficient, then improve the command. Do not silently work around gaps with extra `gh` CLI calls - surface them as product issues.
+**Dogfooding rule**: If `gh pr list --json` output is missing information needed to fill the report (e.g., no per-job failure detail, no QA state, truncated CI summary), **check the GitHub CLI documentation** for additional JSON fields. If the field exists but wasn't included in the query, add it. If the field doesn't exist in `gh pr list --json`, file a GitHub issue on the GitHub CLI repository describing what field would make it sufficient. Do not silently work around gaps - surface them as product issues.
 
 ## Render Command
 


### PR DESCRIPTION
## Summary

The `atm gh …` subcommands no longer exist in the toolchain. Replace every
call site that was using them as the primary CI / PR path with the equivalent
native `gh` commands. This is not a refactor under a fallback — `atm gh` is
simply gone.

## Files changed

- **`.claude/agents/quality-mgr.md`** — Step 9 now polls with
  `gh pr checks --watch`, fetches structured state via `gh pr view --json`, and
  gets per-job failure detail with `gh run view --log-failed`. Step 10 now
  explicitly POSTs the rendered quality report as a PR comment via
  `gh pr comment <PR> --body-file`, verifying it landed.
- **`.claude/agents/scrum-master.md`** — Phase 5 (CI Monitoring) primary
  invocation is now `gh pr checks --watch` + `gh pr view --json`.
- **`.claude/agents/publisher.md`** — Release step 10 preflight now uses
  `gh pr checks --watch`, `gh pr view --json mergeStateStatus,statusCheckRollup`,
  and `gh run watch --exit-status` / `gh run view --log-failed`.
- **`.claude/skills/quality-management-gh/SKILL.md`** — Removed the
  `atm gh`-first preference list and the "fallback when atm gh is unavailable"
  paragraph. Native `gh pr` / `gh run` commands are now the primary path.
- **`.claude/skills/sprint-report/SKILL.md`** — Data source is now
  `gh pr list --state open --json number,title,headRefName,mergeable,mergeStateStatus,statusCheckRollup`.
  Dogfooding rule rewritten to file issues on `gh` (GitHub CLI) when a needed
  field is missing.

## Verification

- `grep -rn 'atm gh'` on the modified tree returns only the intentional
  "do NOT use `atm gh ...` commands" warnings.
- No code changes; only agent instructions and skill docs.