### PR TITLE
Prototype: CLI-surface additions-only diff-gate

### DIFF
--- a/crates/atm/examples/gen_cli_docs.rs
+++ b/crates/atm/examples/gen_cli_docs.rs
@@ -1,0 +1,112 @@
+//! Regenerates the committed CLI-surface diff-gate baseline and the
+//! customer-facing CLI reference doc from the live `atm` binary.
+//!
+//! `crates/atm` ships only a `[[bin]]` target (no library), so this example
+//! cannot import `commands::Cli` directly. Instead it builds (if needed) and
+//! shells out to the sibling `atm` binary with the hidden
+//! `ATM_CLI_SURFACE_DUMP` environment variable (see
+//! `crates/atm/src/cli_surface.rs` and `crates/atm/src/main.rs`), which walks
+//! the live `clap::Command` tree in-process and prints canonical output
+//! before any normal argument parsing occurs. This keeps a single source of
+//! truth for the walk/render logic — this example is just a thin driver that
+//! writes the two outputs to disk.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run -p agent-team-mail --example gen_cli_docs
+//! ```
+//!
+//! This regenerates:
+//! - `crates/atm/tests/cli_surface_baseline.json` (consumed by the
+//!   `cli_surface` diff-gate integration test)
+//! - `docs/atm/cli-reference.md` (a generated, human-readable CLI reference;
+//!   do not hand-edit)
+//!
+//! Run this in the same commit that adds or changes any `atm` subcommand or
+//! argument, then review the diff before committing.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn workspace_root() -> PathBuf {
+    manifest_dir()
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/atm has a workspace root two directories up")
+        .to_path_buf()
+}
+
+/// Locates the sibling `atm` binary alongside this example's own executable,
+/// building it first (matching this example's profile) if it isn't present.
+fn ensure_atm_binary_built() -> PathBuf {
+    let mut profile_dir = std::env::current_exe().expect("resolve current example executable path");
+    profile_dir.pop(); // drop the example executable's own file name
+    if profile_dir
+        .file_name()
+        .is_some_and(|name| name == "examples")
+    {
+        profile_dir.pop(); // target/<profile>/examples -> target/<profile>
+    }
+
+    let bin_name = if cfg!(windows) { "atm.exe" } else { "atm" };
+    let bin_path = profile_dir.join(bin_name);
+    if bin_path.is_file() {
+        return bin_path;
+    }
+
+    let release = profile_dir
+        .file_name()
+        .is_some_and(|name| name == "release");
+    let mut build = Command::new(env!("CARGO"));
+    build.args(["build", "--bin", "atm"]);
+    if release {
+        build.arg("--release");
+    }
+    build.current_dir(manifest_dir());
+
+    let status = build
+        .status()
+        .expect("invoke `cargo build --bin atm` to produce the introspection target");
+    assert!(status.success(), "cargo build --bin atm failed");
+    assert!(
+        bin_path.is_file(),
+        "expected atm binary at {} after build",
+        bin_path.display()
+    );
+    bin_path
+}
+
+fn dump(atm_bin: &Path, mode: &str) -> String {
+    let output = Command::new(atm_bin)
+        .env("ATM_CLI_SURFACE_DUMP", mode)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {} ({mode}): {error}", atm_bin.display()));
+    assert!(
+        output.status.success(),
+        "`atm` CLI-surface dump ({mode}) exited with {:?}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("CLI-surface dump output must be valid UTF-8")
+}
+
+fn main() {
+    let atm_bin = ensure_atm_binary_built();
+
+    let json = dump(&atm_bin, "json");
+    let baseline_path = manifest_dir().join("tests/cli_surface_baseline.json");
+    std::fs::write(&baseline_path, json)
+        .unwrap_or_else(|error| panic!("failed to write {}: {error}", baseline_path.display()));
+    println!("wrote {}", baseline_path.display());
+
+    let markdown = dump(&atm_bin, "markdown");
+    let doc_path = workspace_root().join("docs/atm/cli-reference.md");
+    std::fs::write(&doc_path, markdown)
+        .unwrap_or_else(|error| panic!("failed to write {}: {error}", doc_path.display()));
+    println!("wrote {}", doc_path.display());
+}

--- a/crates/atm/src/cli_surface.rs
+++ b/crates/atm/src/cli_surface.rs
@@ -1,0 +1,225 @@
+//! Introspection helpers that walk the live [`clap::Command`] tree produced
+//! by [`crate::commands::Cli`] and render it either as canonical
+//! machine-readable JSON or as human-readable Markdown documentation.
+//!
+//! Both renderers walk the exact same [`clap::Command`] structure returned by
+//! [`clap::CommandFactory::command`], so they can never drift from the real
+//! parser: there is no separate hand-maintained flag list to keep in sync.
+//! Adding, removing, or renaming a subcommand or argument anywhere in
+//! `crate::commands` is immediately visible to both outputs the next time
+//! they are regenerated.
+//!
+//! This module backs two maintainer-facing tools, both driven by the hidden
+//! `ATM_CLI_SURFACE_DUMP` environment variable checked early in
+//! [`crate::run`], before any normal argument parsing occurs:
+//!
+//! - `ATM_CLI_SURFACE_DUMP=json` prints [`command_surface_json`] output,
+//!   consumed by `crates/atm/tests/cli_surface.rs` and used to regenerate
+//!   `crates/atm/tests/cli_surface_baseline.json`.
+//! - `ATM_CLI_SURFACE_DUMP=markdown` prints [`command_surface_markdown`]
+//!   output, used to regenerate `docs/atm/cli-reference.md`.
+//!
+//! Neither mode is a documented `atm` subcommand or flag; both are
+//! test/tooling seams only, invoked out-of-band by
+//! `crates/atm/examples/gen_cli_docs.rs` and the CLI-surface diff test.
+
+use clap::{Arg, Command};
+use serde_json::{Value, json};
+
+/// Clap auto-injects `--help`/`--version` (and their short forms) on every
+/// command. These are parser plumbing, not CLI-surface content owned by
+/// `atm`, so both renderers exclude them from their output.
+fn is_auto_injected(arg: &Arg) -> bool {
+    matches!(arg.get_id().as_str(), "help" | "version")
+}
+
+/// Walks `command` (and all subcommands, recursively) into canonical JSON.
+///
+/// Only structural properties are captured: argument identity, long/short
+/// flags, requiredness, arity, and default-value presence. Help-text prose
+/// is deliberately omitted so that wording-only changes never trigger a
+/// false-positive diff against the committed baseline.
+///
+/// Both the argument list and the subcommand list are sorted by name so the
+/// output is stable across runs regardless of declaration order, which keeps
+/// diffs focused on real additions, removals, and renames.
+pub(crate) fn command_surface_json(command: &Command) -> Value {
+    let mut args: Vec<Value> = command
+        .get_arguments()
+        .filter(|arg| !is_auto_injected(arg))
+        .map(arg_surface_json)
+        .collect();
+    args.sort_by(|a, b| a["id"].as_str().cmp(&b["id"].as_str()));
+
+    let mut subcommands: Vec<Value> = command
+        .get_subcommands()
+        .map(command_surface_json)
+        .collect();
+    subcommands.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
+
+    json!({
+        "name": command.get_name(),
+        "args": args,
+        "subcommands": subcommands,
+    })
+}
+
+fn arg_surface_json(arg: &Arg) -> Value {
+    let num_args = arg.get_num_args().map(|range| {
+        json!({
+            "min": range.min_values(),
+            "max": range.max_values(),
+        })
+    });
+
+    json!({
+        "id": arg.get_id().as_str(),
+        "long": arg.get_long(),
+        "short": arg.get_short().map(|c| c.to_string()),
+        "required": arg.is_required_set(),
+        "num_args": num_args,
+        "has_default": !arg.get_default_values().is_empty(),
+    })
+}
+
+/// Renders `command` (recursively) as a customer-facing Markdown CLI
+/// reference, including descriptions and full argument tables.
+///
+/// Unlike [`command_surface_json`], this renderer intentionally includes
+/// help-text prose (`about`/`long_about`/per-argument help and `after_help`
+/// notes) — that prose is exactly what a human reader needs and is exactly
+/// what the JSON diff gate excludes to avoid false positives.
+pub(crate) fn command_surface_markdown(command: &Command) -> String {
+    let mut out = String::new();
+    out.push_str("# ATM CLI Reference\n\n");
+    out.push_str(
+        "This document is generated from the live `clap` command tree. Do \
+         not hand-edit it — regenerate with `cargo run -p agent-team-mail \
+         --example gen_cli_docs` (see `crates/atm/src/cli_surface.rs`).\n\n",
+    );
+    render_command_markdown(command, 2, &mut out, "atm");
+    out
+}
+
+fn render_command_markdown(
+    command: &Command,
+    heading_level: usize,
+    out: &mut String,
+    full_name: &str,
+) {
+    let heading = "#".repeat(heading_level.min(6));
+    out.push_str(&format!("{heading} `{full_name}`\n\n"));
+
+    if let Some(about) = command.get_long_about().or_else(|| command.get_about()) {
+        out.push_str(&about.to_string());
+        out.push_str("\n\n");
+    }
+
+    let args: Vec<&Arg> = command
+        .get_arguments()
+        .filter(|arg| !is_auto_injected(arg))
+        .collect();
+
+    if !args.is_empty() {
+        out.push_str("| Flag | Short | Required | Description |\n");
+        out.push_str("|------|-------|----------|-------------|\n");
+        for arg in &args {
+            let long = arg
+                .get_long()
+                .map(|long| format!("`--{long}`"))
+                .unwrap_or_else(|| format!("`<{}>`", arg.get_id()));
+            let short = arg
+                .get_short()
+                .map(|short| format!("`-{short}`"))
+                .unwrap_or_default();
+            let required = if arg.is_required_set() { "yes" } else { "no" };
+            let description = arg
+                .get_help()
+                .map(|help| help.to_string().replace('\n', " "))
+                .unwrap_or_default();
+            out.push_str(&format!(
+                "| {long} | {short} | {required} | {description} |\n"
+            ));
+        }
+        out.push('\n');
+    }
+
+    if let Some(after_help) = command
+        .get_after_help()
+        .or_else(|| command.get_after_long_help())
+    {
+        out.push_str("**Notes:**\n\n");
+        out.push_str(&after_help.to_string());
+        out.push_str("\n\n");
+    }
+
+    // Hidden subcommands (e.g. `internal-nudge`, used only for daemon/CLI
+    // internal plumbing) are intentionally absent from `--help` and are not
+    // part of the customer-facing surface this document describes. The JSON
+    // structural diff in `command_surface_json` still tracks them.
+    let mut subcommands: Vec<&Command> = command
+        .get_subcommands()
+        .filter(|sub| !sub.is_hide_set())
+        .collect();
+    subcommands.sort_by_key(|sub| sub.get_name().to_string());
+    for sub in subcommands {
+        let child_full_name = format!("{full_name} {}", sub.get_name());
+        render_command_markdown(sub, (heading_level + 1).min(6), out, &child_full_name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{Arg, Command};
+
+    use super::{command_surface_json, command_surface_markdown};
+
+    fn sample_command() -> Command {
+        Command::new("sample")
+            .about("Sample root command.")
+            .arg(Arg::new("help").long("help").short('h'))
+            .arg(
+                Arg::new("name")
+                    .long("name")
+                    .short('n')
+                    .required(true)
+                    .help("The name to greet."),
+            )
+            .subcommand(
+                Command::new("child")
+                    .about("Sample child command.")
+                    .arg(Arg::new("count").long("count").default_value("1")),
+            )
+    }
+
+    #[test]
+    fn json_surface_excludes_auto_injected_help_and_version() {
+        let surface = command_surface_json(&sample_command());
+        let args = surface["args"].as_array().expect("args array");
+        assert_eq!(args.len(), 1, "help/version args must be excluded");
+        assert_eq!(args[0]["id"], "name");
+        assert_eq!(args[0]["required"], true);
+    }
+
+    #[test]
+    fn json_surface_recurses_into_subcommands() {
+        let surface = command_surface_json(&sample_command());
+        let subcommands = surface["subcommands"]
+            .as_array()
+            .expect("subcommands array");
+        assert_eq!(subcommands.len(), 1);
+        assert_eq!(subcommands[0]["name"], "child");
+        let child_args = subcommands[0]["args"].as_array().expect("child args array");
+        assert_eq!(child_args[0]["id"], "count");
+        assert_eq!(child_args[0]["has_default"], true);
+    }
+
+    #[test]
+    fn markdown_surface_includes_help_text_and_tables() {
+        let markdown = command_surface_markdown(&sample_command());
+        assert!(markdown.contains("Sample root command."));
+        assert!(markdown.contains("The name to greet."));
+        assert!(markdown.contains("`--name`"));
+        assert!(markdown.contains("### `atm child`"));
+    }
+}

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -1,3 +1,4 @@
+mod cli_surface;
 mod commands;
 mod composition;
 mod constants;
@@ -22,8 +23,8 @@ use atm_core::observability::{
     standard_level_for_outcome,
 };
 use chrono::{DateTime, Utc};
-use clap::Parser;
 use clap::error::ErrorKind;
+use clap::{CommandFactory, Parser};
 #[cfg(any(test, feature = "fault-injection"))]
 use sc_observability::LogSink;
 #[cfg(any(test, feature = "fault-injection"))]
@@ -44,6 +45,11 @@ use tracing_subscriber::filter::LevelFilter as TracingLevelFilter;
 
 const ATM_COMMAND_TARGET: &str = "atm.command";
 const ATM_LOG_LEVEL_ENV: &str = "ATM_LOG";
+/// Hidden maintainer/test seam: when set to `json` or `markdown`, `run()`
+/// prints the live CLI-surface tree in that format and exits before any
+/// normal argument parsing occurs. Not a documented `atm` flag or
+/// subcommand — see `crate::cli_surface` for the rationale and consumers.
+const ATM_CLI_SURFACE_DUMP_ENV: &str = "ATM_CLI_SURFACE_DUMP";
 #[cfg(any(test, feature = "fault-injection"))]
 const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAINED_SINK_FAULT";
 const MAX_RETAINED_QUERY_RECORD_BYTES: usize = 64 * 1024;
@@ -153,6 +159,11 @@ fn exit_code_for_atm_error(error: &AtmError) -> i32 {
 }
 
 fn run() -> Result<(), AtmError> {
+    if let Ok(mode) = std::env::var(ATM_CLI_SURFACE_DUMP_ENV) {
+        dump_cli_surface(&mode)?;
+        return Ok(());
+    }
+
     let cli = match commands::Cli::try_parse() {
         Ok(cli) => cli,
         Err(error) => {
@@ -195,6 +206,35 @@ fn run() -> Result<(), AtmError> {
     match cli.run(&observability) {
         Ok(()) => Ok(()),
         Err(error) => Err(report_and_map_service_error(&observability, error)),
+    }
+}
+
+/// Prints the live CLI-surface tree in the requested `mode` (`json` or
+/// `markdown`) to stdout. Backs the hidden [`ATM_CLI_SURFACE_DUMP_ENV`] seam;
+/// see `crate::cli_surface` module docs for consumers and rationale.
+fn dump_cli_surface(mode: &str) -> Result<(), AtmError> {
+    let mut root = commands::Cli::command();
+    // `Command::build()` finalizes derived properties (e.g. `num_args`,
+    // default values) that clap otherwise only resolves lazily during
+    // parsing. Introspection without this call would see stale/empty
+    // values for those fields.
+    root.build();
+    match mode {
+        "json" => {
+            let surface = cli_surface::command_surface_json(&root);
+            let rendered = serde_json::to_string_pretty(&surface).map_err(|source| {
+                AtmError::validation("failed to render CLI-surface JSON").with_source(source)
+            })?;
+            println!("{rendered}");
+            Ok(())
+        }
+        "markdown" => {
+            println!("{}", cli_surface::command_surface_markdown(&root));
+            Ok(())
+        }
+        other => Err(AtmError::validation(format!(
+            "unsupported {ATM_CLI_SURFACE_DUMP_ENV} mode: {other} (expected \"json\" or \"markdown\")"
+        ))),
     }
 }
 

--- a/crates/atm/tests/cli_surface.rs
+++ b/crates/atm/tests/cli_surface.rs
@@ -1,0 +1,198 @@
+//! Diff-gate test proving the `atm` CLI's public surface (subcommands,
+//! arguments, flags) only ever grows across a release.
+//!
+//! This walks the *live* `clap::Command` tree of the real `atm` binary (via
+//! the hidden `ATM_CLI_SURFACE_DUMP=json` seam documented in
+//! `crates/atm/src/cli_surface.rs` and `crates/atm/src/main.rs` — not by
+//! parsing `--help` text) and diffs it structurally against the committed
+//! `cli_surface_baseline.json`. It hard-fails on:
+//!
+//! - any removed subcommand,
+//! - any removed or renamed argument (`id`, `long`, or `short`),
+//! - any argument whose `required` or arity (`num_args`) changed,
+//! - any **new** subcommand or argument not yet reflected in the baseline.
+//!
+//! That last point is deliberate: additions are allowed, but the baseline
+//! must be updated *in the same commit* that adds the new surface, not
+//! silently drift. Regenerate the baseline with:
+//!
+//! ```text
+//! UPDATE_ATM_CLI_SURFACE_BASELINE=1 cargo test -p agent-team-mail --test cli_surface
+//! ```
+//!
+//! or via `cargo run -p agent-team-mail --example gen_cli_docs`, which
+//! regenerates both this baseline and `docs/atm/cli-reference.md` from the
+//! same live tree in one step. No established bless/regen convention exists
+//! elsewhere in this repo (searched for `bless`/`UPDATE_*` env vars in
+//! existing golden-file tests and found none), so this follows the common
+//! Rust ecosystem `UPDATE_<THING>=1` pattern (cf. `UPDATE_EXPECT`,
+//! `INSTA_UPDATE`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+
+const BASELINE_PATH_COMPONENTS: &str = "tests/cli_surface_baseline.json";
+const BLESS_ENV: &str = "UPDATE_ATM_CLI_SURFACE_BASELINE";
+
+fn baseline_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(BASELINE_PATH_COMPONENTS)
+}
+
+/// Invokes the real `atm` binary's hidden CLI-surface JSON dump and parses
+/// the result. This is the exact same [`clap::Command`] tree `atm` uses at
+/// runtime — there is no separate/parallel definition to drift from it.
+fn live_surface_json() -> Value {
+    let atm_bin = env!("CARGO_BIN_EXE_atm");
+    let output = Command::new(atm_bin)
+        .env("ATM_CLI_SURFACE_DUMP", "json")
+        .output()
+        .expect("failed to run `atm` for CLI-surface introspection");
+    assert!(
+        output.status.success(),
+        "`atm` CLI-surface dump exited with {:?}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout =
+        String::from_utf8(output.stdout).expect("CLI-surface dump output must be valid UTF-8");
+    serde_json::from_str(&stdout).expect("CLI-surface dump output must be valid JSON")
+}
+
+fn as_str<'a>(value: &'a Value, field: &str) -> &'a str {
+    value[field]
+        .as_str()
+        .unwrap_or_else(|| panic!("expected string field {field:?} in {value}"))
+}
+
+fn as_array<'a>(value: &'a Value, field: &str) -> &'a [Value] {
+    value[field]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected array field {field:?} in {value}"))
+}
+
+/// Recursively diffs `baseline` against `live`, appending human-readable
+/// failure descriptions to `issues`. `path` tracks the current command path
+/// (e.g. `atm teams add-member`) for readable messages.
+fn diff_command(path: &str, baseline: &Value, live: &Value, issues: &mut Vec<String>) {
+    diff_args(
+        path,
+        as_array(baseline, "args"),
+        as_array(live, "args"),
+        issues,
+    );
+    diff_subcommands(
+        path,
+        as_array(baseline, "subcommands"),
+        as_array(live, "subcommands"),
+        issues,
+    );
+}
+
+fn diff_args(path: &str, baseline_args: &[Value], live_args: &[Value], issues: &mut Vec<String>) {
+    for baseline_arg in baseline_args {
+        let id = as_str(baseline_arg, "id");
+        match live_args.iter().find(|arg| as_str(arg, "id") == id) {
+            None => issues.push(format!("{path}: argument {id:?} was removed or renamed")),
+            Some(live_arg) => {
+                for field in ["long", "short", "required", "num_args"] {
+                    if baseline_arg[field] != live_arg[field] {
+                        issues.push(format!(
+                            "{path}: argument {id:?} field {field:?} changed: {:?} -> {:?}",
+                            baseline_arg[field], live_arg[field]
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    for live_arg in live_args {
+        let id = as_str(live_arg, "id");
+        if !baseline_args.iter().any(|arg| as_str(arg, "id") == id) {
+            issues.push(format!(
+                "{path}: argument {id:?} is new and not yet reflected in the baseline \
+                 (regenerate with `cargo run -p agent-team-mail --example gen_cli_docs`)"
+            ));
+        }
+    }
+}
+
+fn diff_subcommands(
+    path: &str,
+    baseline_subcommands: &[Value],
+    live_subcommands: &[Value],
+    issues: &mut Vec<String>,
+) {
+    for baseline_sub in baseline_subcommands {
+        let name = as_str(baseline_sub, "name");
+        let child_path = format!("{path} {name}");
+        match live_subcommands
+            .iter()
+            .find(|sub| as_str(sub, "name") == name)
+        {
+            None => issues.push(format!(
+                "{path}: subcommand {name:?} was removed or renamed"
+            )),
+            Some(live_sub) => diff_command(&child_path, baseline_sub, live_sub, issues),
+        }
+    }
+
+    for live_sub in live_subcommands {
+        let name = as_str(live_sub, "name");
+        if !baseline_subcommands
+            .iter()
+            .any(|sub| as_str(sub, "name") == name)
+        {
+            issues.push(format!(
+                "{path}: subcommand {name:?} is new and not yet reflected in the baseline \
+                 (regenerate with `cargo run -p agent-team-mail --example gen_cli_docs`)"
+            ));
+        }
+    }
+}
+
+#[test]
+fn cli_surface_matches_committed_baseline() {
+    let live = live_surface_json();
+
+    if std::env::var_os(BLESS_ENV).is_some() {
+        let pretty = serde_json::to_string_pretty(&live).expect("serialize live CLI surface");
+        std::fs::write(baseline_path(), format!("{pretty}\n"))
+            .expect("write regenerated CLI-surface baseline");
+        eprintln!(
+            "{BLESS_ENV} set: wrote {} — re-run without {BLESS_ENV} to verify the diff gate",
+            baseline_path().display()
+        );
+        return;
+    }
+
+    let baseline_raw = std::fs::read_to_string(baseline_path()).unwrap_or_else(|error| {
+        panic!(
+            "failed to read {}: {error} (generate it first with \
+             `cargo run -p agent-team-mail --example gen_cli_docs`)",
+            baseline_path().display()
+        )
+    });
+    let baseline: Value =
+        serde_json::from_str(&baseline_raw).expect("baseline CLI-surface JSON must parse");
+
+    assert_eq!(
+        as_str(&baseline, "name"),
+        as_str(&live, "name"),
+        "root command name changed"
+    );
+
+    let mut issues = Vec::new();
+    diff_command("atm", &baseline, &live, &mut issues);
+
+    assert!(
+        issues.is_empty(),
+        "atm CLI surface diverged from crates/atm/tests/cli_surface_baseline.json:\n{}\n\n\
+         If this is an intentional, reviewed addition, regenerate the baseline in the same \
+         commit with `cargo run -p agent-team-mail --example gen_cli_docs` (or \
+         `{BLESS_ENV}=1 cargo test -p agent-team-mail --test cli_surface`).",
+        issues.join("\n")
+    );
+}

--- a/crates/atm/tests/cli_surface_baseline.json
+++ b/crates/atm/tests/cli_surface_baseline.json
@@ -1,0 +1,1714 @@
+{
+  "args": [
+    {
+      "has_default": true,
+      "id": "stderr_logs",
+      "long": "stderr-logs",
+      "num_args": {
+        "max": 0,
+        "min": 0
+      },
+      "required": false,
+      "short": null
+    }
+  ],
+  "name": "atm",
+  "subcommands": [
+    {
+      "args": [
+        {
+          "has_default": true,
+          "id": "json",
+          "long": "json",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "message_id",
+          "long": null,
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": true,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "reply",
+          "long": null,
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": true,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "team",
+          "long": "team",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "ack",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
+          "has_default": true,
+          "id": "dry_run",
+          "long": "dry-run",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "idle_only",
+          "long": "idle-only",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "json",
+          "long": "json",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "older_than",
+          "long": "older-than",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "team",
+          "long": "team",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "clear",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
+          "has_default": true,
+          "id": "json",
+          "long": "json",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "team",
+          "long": "team",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "doctor",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
+          "has_default": true,
+          "id": "json",
+          "long": "json",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "list",
+          "long": "list",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "target",
+          "long": null,
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "help",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "internal-nudge",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
+          "has_default": false,
+          "id": "actor",
+          "long": "as",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "all",
+          "long": "all",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "contains",
+          "long": "contains",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "from",
+          "long": "from",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "json",
+          "long": "json",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "limit",
+          "long": "limit",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "pending_ack",
+          "long": "pending-ack",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "since",
+          "long": "since",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "target",
+          "long": null,
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "task",
+          "long": "task",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "team",
+          "long": "team",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "unread",
+          "long": "unread",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "list",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "log",
+      "subcommands": [
+        {
+          "args": [
+            {
+              "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "levels",
+              "long": "level",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "limit",
+              "long": "limit",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "matches",
+              "long": "match",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "since",
+              "long": "since",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            }
+          ],
+          "name": "filter",
+          "subcommands": []
+        },
+        {
+          "args": [
+            {
+              "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "levels",
+              "long": "level",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "limit",
+              "long": "limit",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "matches",
+              "long": "match",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "since",
+              "long": "since",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            }
+          ],
+          "name": "snapshot",
+          "subcommands": []
+        },
+        {
+          "args": [
+            {
+              "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "levels",
+              "long": "level",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "limit",
+              "long": "limit",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "matches",
+              "long": "match",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "poll_interval_ms",
+              "long": "poll-interval-ms",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "since",
+              "long": "since",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            }
+          ],
+          "name": "tail",
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "args": [
+        {
+          "has_default": true,
+          "id": "json",
+          "long": "json",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "team",
+          "long": "team",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "members",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
+          "has_default": false,
+          "id": "actor",
+          "long": "as",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "all",
+          "long": "all",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "contains",
+          "long": "contains",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "from",
+          "long": "from",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "history",
+          "long": "history",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "json",
+          "long": "json",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "message_id",
+          "long": "message-id",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "no_since_last_seen",
+          "long": "no-since-last-seen",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "pending_ack",
+          "long": "pending-ack",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "pending_ack_only",
+          "long": "pending-ack-only",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "since",
+          "long": "since",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "since_last_seen",
+          "long": "since-last-seen",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "target",
+          "long": null,
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "task",
+          "long": "task",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "team",
+          "long": "team",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "timeout",
+          "long": "timeout",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "unread",
+          "long": "unread",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "unread_only",
+          "long": "unread-only",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "peek",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
+          "has_default": true,
+          "id": "all",
+          "long": "all",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "contains",
+          "long": "contains",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "from",
+          "long": "from",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "history",
+          "long": "history",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "json",
+          "long": "json",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "message_id",
+          "long": "message-id",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "no_since_last_seen",
+          "long": "no-since-last-seen",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "pending_ack",
+          "long": "pending-ack",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "pending_ack_only",
+          "long": "pending-ack-only",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "since",
+          "long": "since",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "since_last_seen",
+          "long": "since-last-seen",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "task",
+          "long": "task",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "team",
+          "long": "team",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "timeout",
+          "long": "timeout",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "unread",
+          "long": "unread",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "unread_only",
+          "long": "unread-only",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "read",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
+          "has_default": true,
+          "id": "dry_run",
+          "long": "dry-run",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "file",
+          "long": "file",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "json",
+          "long": "json",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "message",
+          "long": null,
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "requires_ack",
+          "long": "requires-ack",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stdin",
+          "long": "stdin",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "summary",
+          "long": "summary",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "task_id",
+          "long": "task-id",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "team",
+          "long": "team",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": false,
+          "id": "to",
+          "long": null,
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": true,
+          "short": null
+        }
+      ],
+      "name": "send",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
+          "has_default": true,
+          "id": "json",
+          "long": "json",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "teams",
+      "subcommands": [
+        {
+          "args": [
+            {
+              "has_default": true,
+              "id": "agent_type",
+              "long": "agent-type",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "home_dir",
+              "long": "home-dir",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "member",
+              "long": null,
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "model",
+              "long": "model",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "pane_id",
+              "long": "pane-id",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "team",
+              "long": null,
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            }
+          ],
+          "name": "add-member",
+          "subcommands": []
+        },
+        {
+          "args": [
+            {
+              "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "team",
+              "long": null,
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            }
+          ],
+          "name": "backup",
+          "subcommands": []
+        },
+        {
+          "args": [
+            {
+              "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "kind",
+              "long": "kind",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "team",
+              "long": "team",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            }
+          ],
+          "name": "clear-nudge-template",
+          "subcommands": []
+        },
+        {
+          "args": [
+            {
+              "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "kind",
+              "long": "kind",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "team",
+              "long": "team",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            }
+          ],
+          "name": "disable-nudge-template",
+          "subcommands": []
+        },
+        {
+          "args": [
+            {
+              "has_default": true,
+              "id": "dry_run",
+              "long": "dry-run",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "from",
+              "long": "from",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "team",
+              "long": null,
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            }
+          ],
+          "name": "restore",
+          "subcommands": []
+        },
+        {
+          "args": [
+            {
+              "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "kind",
+              "long": "kind",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "team",
+              "long": "team",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "template_body",
+              "long": "template-body",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            }
+          ],
+          "name": "set-nudge-template",
+          "subcommands": []
+        },
+        {
+          "args": [
+            {
+              "has_default": false,
+              "id": "agent_type",
+              "long": "agent-type",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "harness",
+              "long": "harness",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "home_dir",
+              "long": "home-dir",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "member",
+              "long": null,
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "model",
+              "long": "model",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "pane_id",
+              "long": "pane-id",
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "team",
+              "long": null,
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            }
+          ],
+          "name": "update-member",
+          "subcommands": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/atm/cli-reference.md
+++ b/docs/atm/cli-reference.md
@@ -1,0 +1,291 @@
+# ATM CLI Reference
+
+This document is generated from the live `clap` command tree. Do not hand-edit it — regenerate with `cargo run -p agent-team-mail --example gen_cli_docs` (see `crates/atm/src/cli_surface.rs`).
+
+## `atm`
+
+ATM CLI
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm ack`
+
+Acknowledge one pending-ack message and emit a reply when required
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<message_id>` |  | yes |  |
+| `<reply>` |  | yes |  |
+| `--team` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm clear`
+
+Clear read or acknowledged messages from a mailbox
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no |  |
+| `--older-than` |  | no |  |
+| `--idle-only` |  | no |  |
+| `--dry-run` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm doctor`
+
+Run ATM health and configuration diagnostics
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no | Override the resolved team for the doctor check. |
+| `--json` |  | no | Emit the doctor report as JSON. |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm help`
+
+Show ATM-owned conceptual help or delegated clap subcommand help
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<target>` |  | no |  |
+| `--list` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm list`
+
+List one ATM mailbox surface as bounded metadata rows
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<target>` |  | no |  |
+| `--team` |  | no |  |
+| `--all` |  | no |  |
+| `--unread` |  | no |  |
+| `--pending-ack` |  | no |  |
+| `--limit` |  | no |  |
+| `--since` |  | no |  |
+| `--from` |  | no |  |
+| `--task` |  | no |  |
+| `--contains` |  | no |  |
+| `--json` |  | no |  |
+| `--as` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm log`
+
+Query or follow ATM retained observability records
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm log filter`
+
+Query ATM log records using explicit field filters
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--level` |  | no | Restrict results to one or more severity levels |
+| `--match` |  | no | Match one structured ATM field exactly, for example command=send |
+| `--since` |  | no | Inclusive lower time bound as RFC3339 or a relative duration like 15m |
+| `--limit` |  | no | Maximum number of returned records |
+| `--json` |  | no | Emit machine-readable JSON output |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm log snapshot`
+
+Query recent ATM log records
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--level` |  | no | Restrict results to one or more severity levels |
+| `--match` |  | no | Match one structured ATM field exactly, for example command=send |
+| `--since` |  | no | Inclusive lower time bound as RFC3339 or a relative duration like 15m |
+| `--limit` |  | no | Maximum number of returned records |
+| `--json` |  | no | Emit machine-readable JSON output |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm log tail`
+
+Follow new ATM log records as they arrive
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--level` |  | no | Restrict results to one or more severity levels |
+| `--match` |  | no | Match one structured ATM field exactly, for example command=send |
+| `--since` |  | no | Inclusive lower time bound as RFC3339 or a relative duration like 15m |
+| `--limit` |  | no | Maximum number of returned records |
+| `--json` |  | no | Emit machine-readable JSON output |
+| `--poll-interval-ms` |  | no | Poll interval in milliseconds between follow polls |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm members`
+
+List the current member roster for one ATM team
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm peek`
+
+Inspect one ATM mailbox message without mutating mailbox state
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<target>` |  | no |  |
+| `--team` |  | no |  |
+| `--all` |  | no |  |
+| `--unread` |  | no |  |
+| `--unread-only` |  | no |  |
+| `--pending-ack` |  | no |  |
+| `--pending-ack-only` |  | no |  |
+| `--history` |  | no |  |
+| `--message-id` |  | no |  |
+| `--task` |  | no |  |
+| `--contains` |  | no |  |
+| `--since-last-seen` |  | no |  |
+| `--no-since-last-seen` |  | no |  |
+| `--since` |  | no |  |
+| `--from` |  | no |  |
+| `--json` |  | no |  |
+| `--timeout` |  | no |  |
+| `--as` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm read`
+
+Read one ATM mailbox message and optionally update read state
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no |  |
+| `--all` |  | no |  |
+| `--unread` |  | no |  |
+| `--unread-only` |  | no |  |
+| `--pending-ack` |  | no |  |
+| `--pending-ack-only` |  | no |  |
+| `--history` |  | no |  |
+| `--message-id` |  | no |  |
+| `--task` |  | no |  |
+| `--contains` |  | no |  |
+| `--since-last-seen` |  | no |  |
+| `--no-since-last-seen` |  | no |  |
+| `--since` |  | no |  |
+| `--from` |  | no |  |
+| `--json` |  | no |  |
+| `--timeout` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm send`
+
+Send one ATM mailbox message
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<to>` |  | yes |  |
+| `<message>` |  | no |  |
+| `--team` |  | no |  |
+| `--file` |  | no |  |
+| `--stdin` |  | no |  |
+| `--summary` |  | no |  |
+| `--requires-ack` |  | no |  |
+| `--task-id` |  | no |  |
+| `--dry-run` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+**Notes:**
+
+Post-send hooks can be configured in .atm.toml via one or more [[atm.post_send_hooks]] rules with recipient = "name-or-*" and command = ["argv", ...]. Matching rules run after a successful non-dry-run send, in config order. Path-like command[0] values resolve relative to the declaring .atm.toml; bare executables like bash or python3 use normal PATH resolution. Recipient non-match is silent. For hook troubleshooting, combine --stderr-logs with ATM_LOG=debug to surface debug-level hook diagnostics on stderr.
+
+### `atm teams`
+
+List teams or run one team-administration subcommand
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams add-member`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `<member>` |  | yes |  |
+| `--agent-type` |  | no |  |
+| `--model` |  | no |  |
+| `--home-dir` |  | no |  |
+| `--pane-id` |  | no | tmux pane id in '%<number>' form or a bare numeric pane id |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams backup`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams clear-nudge-template`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | yes |  |
+| `--kind` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams disable-nudge-template`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | yes |  |
+| `--kind` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams restore`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `--from` |  | no |  |
+| `--dry-run` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams set-nudge-template`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | yes |  |
+| `--kind` |  | yes |  |
+| `--template-body` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams update-member`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `<member>` |  | yes |  |
+| `--home-dir` |  | no |  |
+| `--harness` |  | no |  |
+| `--agent-type` |  | no |  |
+| `--model` |  | no |  |
+| `--pane-id` |  | no | tmux pane id in '%<number>' form or a bare numeric pane id |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+


### PR DESCRIPTION
Prototype of the CLI/OpenAPI surface additions-only snapshot tool (clap introspection, --bless baseline, atm-architecture diff-gate). Work in progress by quality-mgr; posted for review per user request. See project_cli_api_additions_only memory for spec.