### PR TITLE
fix(atm): replace CLI-surface-dump env-var seam with hidden clap subcommand

### DIFF
--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -19,7 +19,18 @@ name = "atm"
 path = "src/main.rs"
 
 [features]
+cli-surface-dump = []
 fault-injection = ["sc-observability/fault-injection"]
+
+[[test]]
+name = "cli_surface"
+path = "tests/cli_surface.rs"
+required-features = ["cli-surface-dump"]
+
+[[example]]
+name = "gen_cli_docs"
+path = "examples/gen_cli_docs.rs"
+required-features = ["cli-surface-dump"]
 
 [dependencies]
 atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.3.1" }

--- a/crates/atm/examples/gen_cli_docs.rs
+++ b/crates/atm/examples/gen_cli_docs.rs
@@ -3,13 +3,12 @@
 //!
 //! `crates/atm` ships only a `[[bin]]` target (no library), so this example
 //! cannot import `commands::Cli` directly. Instead it builds (if needed) and
-//! shells out to the sibling `atm` binary with the hidden
-//! `ATM_CLI_SURFACE_DUMP` environment variable (see
-//! `crates/atm/src/cli_surface.rs` and `crates/atm/src/main.rs`), which walks
-//! the live `clap::Command` tree in-process and prints canonical output
-//! before any normal argument parsing occurs. This keeps a single source of
-//! truth for the walk/render logic — this example is just a thin driver that
-//! writes the two outputs to disk.
+//! shells out to the sibling `atm` binary with the hidden parsed
+//! `__dump-cli-surface` subcommand (see `crates/atm/src/cli_surface.rs` and
+//! `crates/atm/src/main.rs`), which walks the live `clap::Command` tree and
+//! prints canonical output through the normal CLI bootstrap path. This keeps a
+//! single source of truth for the walk/render logic — this example is just a
+//! thin driver that writes the two outputs to disk.
 //!
 //! # Usage
 //!
@@ -83,7 +82,7 @@ fn ensure_atm_binary_built() -> PathBuf {
 
 fn dump(atm_bin: &Path, mode: &str) -> String {
     let output = Command::new(atm_bin)
-        .env("ATM_CLI_SURFACE_DUMP", mode)
+        .args(["__dump-cli-surface", "--format", mode])
         .output()
         .unwrap_or_else(|error| panic!("failed to run {} ({mode}): {error}", atm_bin.display()));
     assert!(

--- a/crates/atm/examples/gen_cli_docs.rs
+++ b/crates/atm/examples/gen_cli_docs.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```text
-//! cargo run -p agent-team-mail --example gen_cli_docs
+//! cargo run -p agent-team-mail --features cli-surface-dump --example gen_cli_docs
 //! ```
 //!
 //! This regenerates:
@@ -62,7 +62,7 @@ fn ensure_atm_binary_built() -> PathBuf {
         .file_name()
         .is_some_and(|name| name == "release");
     let mut build = Command::new(env!("CARGO"));
-    build.args(["build", "--bin", "atm"]);
+    build.args(["build", "--bin", "atm", "--features", "cli-surface-dump"]);
     if release {
         build.arg("--release");
     }

--- a/crates/atm/src/cli_surface.rs
+++ b/crates/atm/src/cli_surface.rs
@@ -9,18 +9,17 @@
 //! `crate::commands` is immediately visible to both outputs the next time
 //! they are regenerated.
 //!
-//! This module backs two maintainer-facing tools, both driven by the hidden
-//! `ATM_CLI_SURFACE_DUMP` environment variable checked early in
-//! [`crate::run`], before any normal argument parsing occurs:
+//! This module backs two maintainer-facing tools through the hidden parsed
+//! `atm __dump-cli-surface --format <json|markdown>` subcommand:
 //!
-//! - `ATM_CLI_SURFACE_DUMP=json` prints [`command_surface_json`] output,
+//! - `atm __dump-cli-surface --format json` prints [`command_surface_json`] output,
 //!   consumed by `crates/atm/tests/cli_surface.rs` and used to regenerate
 //!   `crates/atm/tests/cli_surface_baseline.json`.
-//! - `ATM_CLI_SURFACE_DUMP=markdown` prints [`command_surface_markdown`]
+//! - `atm __dump-cli-surface --format markdown` prints [`command_surface_markdown`]
 //!   output, used to regenerate `docs/atm/cli-reference.md`.
 //!
-//! Neither mode is a documented `atm` subcommand or flag; both are
-//! test/tooling seams only, invoked out-of-band by
+//! The command is hidden from normal help but still uses the normal parse,
+//! tracing, and observability bootstrap path. It is invoked by
 //! `crates/atm/examples/gen_cli_docs.rs` and the CLI-surface diff test.
 
 use clap::{Arg, Command};

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 pub mod ack;
 pub(crate) mod caller_context;
@@ -31,6 +31,35 @@ pub use send::SendCommand;
 pub use teams::TeamsCommand;
 
 use crate::observability::CliObservability;
+
+/// Output format for the hidden maintainer CLI-surface dump command.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum CliSurfaceFormat {
+    Json,
+    Markdown,
+}
+
+impl CliSurfaceFormat {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Markdown => "markdown",
+        }
+    }
+}
+
+/// Emit the live clap command tree for maintainers and the structural CLI gate.
+#[derive(Debug, clap::Args)]
+pub(crate) struct DumpCliSurfaceCommand {
+    #[arg(long, value_enum)]
+    format: CliSurfaceFormat,
+}
+
+impl DumpCliSurfaceCommand {
+    fn run(self, _observability: &CliObservability) -> Result<()> {
+        crate::dump_cli_surface(self.format.as_str()).map_err(Into::into)
+    }
+}
 
 #[derive(Debug, Parser)]
 #[command(
@@ -77,6 +106,8 @@ enum Command {
     Help(HelpCommand),
     #[command(hide = true)]
     InternalNudge(InternalNudgeCommand),
+    #[command(name = "__dump-cli-surface", hide = true)]
+    DumpCliSurface(DumpCliSurfaceCommand),
     Teams(TeamsCommand),
     Members(MembersCommand),
 }
@@ -94,6 +125,7 @@ impl Command {
             Self::Doctor(command) => command.run(observability),
             Self::Help(command) => command.run(observability),
             Self::InternalNudge(command) => command.run(observability),
+            Self::DumpCliSurface(command) => command.run(observability),
             Self::Teams(command) => command.run(observability),
             Self::Members(command) => command.run(observability),
         }

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand, ValueEnum};
+#[cfg(any(test, feature = "cli-surface-dump"))]
+use clap::ValueEnum;
+use clap::{Parser, Subcommand};
 
 pub mod ack;
 pub(crate) mod caller_context;
@@ -33,31 +35,25 @@ pub use teams::TeamsCommand;
 use crate::observability::CliObservability;
 
 /// Output format for the hidden maintainer CLI-surface dump command.
+#[cfg(any(test, feature = "cli-surface-dump"))]
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub(crate) enum CliSurfaceFormat {
     Json,
     Markdown,
 }
 
-impl CliSurfaceFormat {
-    pub(crate) const fn as_str(self) -> &'static str {
-        match self {
-            Self::Json => "json",
-            Self::Markdown => "markdown",
-        }
-    }
-}
-
 /// Emit the live clap command tree for maintainers and the structural CLI gate.
+#[cfg(any(test, feature = "cli-surface-dump"))]
 #[derive(Debug, clap::Args)]
 pub(crate) struct DumpCliSurfaceCommand {
     #[arg(long, value_enum)]
     format: CliSurfaceFormat,
 }
 
+#[cfg(any(test, feature = "cli-surface-dump"))]
 impl DumpCliSurfaceCommand {
     fn run(self, _observability: &CliObservability) -> Result<()> {
-        crate::dump_cli_surface(self.format.as_str()).map_err(Into::into)
+        crate::dump_cli_surface(self.format).map_err(Into::into)
     }
 }
 
@@ -106,6 +102,7 @@ enum Command {
     Help(HelpCommand),
     #[command(hide = true)]
     InternalNudge(InternalNudgeCommand),
+    #[cfg(any(test, feature = "cli-surface-dump"))]
     #[command(name = "__dump-cli-surface", hide = true)]
     DumpCliSurface(DumpCliSurfaceCommand),
     Teams(TeamsCommand),
@@ -125,6 +122,7 @@ impl Command {
             Self::Doctor(command) => command.run(observability),
             Self::Help(command) => command.run(observability),
             Self::InternalNudge(command) => command.run(observability),
+            #[cfg(any(test, feature = "cli-surface-dump"))]
             Self::DumpCliSurface(command) => command.run(observability),
             Self::Teams(command) => command.run(observability),
             Self::Members(command) => command.run(observability),

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -45,11 +45,6 @@ use tracing_subscriber::filter::LevelFilter as TracingLevelFilter;
 
 const ATM_COMMAND_TARGET: &str = "atm.command";
 const ATM_LOG_LEVEL_ENV: &str = "ATM_LOG";
-/// Hidden maintainer/test seam: when set to `json` or `markdown`, `run()`
-/// prints the live CLI-surface tree in that format and exits before any
-/// normal argument parsing occurs. Not a documented `atm` flag or
-/// subcommand — see `crate::cli_surface` for the rationale and consumers.
-const ATM_CLI_SURFACE_DUMP_ENV: &str = "ATM_CLI_SURFACE_DUMP";
 #[cfg(any(test, feature = "fault-injection"))]
 const ATM_OBSERVABILITY_RETAINED_SINK_FAULT_ENV: &str = "ATM_OBSERVABILITY_RETAINED_SINK_FAULT";
 const MAX_RETAINED_QUERY_RECORD_BYTES: usize = 64 * 1024;
@@ -159,11 +154,6 @@ fn exit_code_for_atm_error(error: &AtmError) -> i32 {
 }
 
 fn run() -> Result<(), AtmError> {
-    if let Ok(mode) = std::env::var(ATM_CLI_SURFACE_DUMP_ENV) {
-        dump_cli_surface(&mode)?;
-        return Ok(());
-    }
-
     let cli = match commands::Cli::try_parse() {
         Ok(cli) => cli,
         Err(error) => {
@@ -210,9 +200,9 @@ fn run() -> Result<(), AtmError> {
 }
 
 /// Prints the live CLI-surface tree in the requested `mode` (`json` or
-/// `markdown`) to stdout. Backs the hidden [`ATM_CLI_SURFACE_DUMP_ENV`] seam;
-/// see `crate::cli_surface` module docs for consumers and rationale.
-fn dump_cli_surface(mode: &str) -> Result<(), AtmError> {
+/// `markdown`) to stdout. Called only by the hidden parsed
+/// `atm __dump-cli-surface --format <json|markdown>` command.
+pub(crate) fn dump_cli_surface(mode: &str) -> Result<(), AtmError> {
     let mut root = commands::Cli::command();
     // `Command::build()` finalizes derived properties (e.g. `num_args`,
     // default values) that clap otherwise only resolves lazily during
@@ -233,7 +223,7 @@ fn dump_cli_surface(mode: &str) -> Result<(), AtmError> {
             Ok(())
         }
         other => Err(AtmError::validation(format!(
-            "unsupported {ATM_CLI_SURFACE_DUMP_ENV} mode: {other} (expected \"json\" or \"markdown\")"
+            "unsupported CLI-surface format: {other} (expected \"json\" or \"markdown\")"
         ))),
     }
 }

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -1,3 +1,4 @@
+#[cfg(any(test, feature = "cli-surface-dump"))]
 mod cli_surface;
 mod commands;
 mod composition;
@@ -23,8 +24,10 @@ use atm_core::observability::{
     standard_level_for_outcome,
 };
 use chrono::{DateTime, Utc};
+#[cfg(any(test, feature = "cli-surface-dump"))]
+use clap::CommandFactory;
+use clap::Parser;
 use clap::error::ErrorKind;
-use clap::{CommandFactory, Parser};
 #[cfg(any(test, feature = "fault-injection"))]
 use sc_observability::LogSink;
 #[cfg(any(test, feature = "fault-injection"))]
@@ -202,7 +205,8 @@ fn run() -> Result<(), AtmError> {
 /// Prints the live CLI-surface tree in the requested `mode` (`json` or
 /// `markdown`) to stdout. Called only by the hidden parsed
 /// `atm __dump-cli-surface --format <json|markdown>` command.
-pub(crate) fn dump_cli_surface(mode: &str) -> Result<(), AtmError> {
+#[cfg(any(test, feature = "cli-surface-dump"))]
+pub(crate) fn dump_cli_surface(mode: commands::CliSurfaceFormat) -> Result<(), AtmError> {
     let mut root = commands::Cli::command();
     // `Command::build()` finalizes derived properties (e.g. `num_args`,
     // default values) that clap otherwise only resolves lazily during
@@ -210,7 +214,7 @@ pub(crate) fn dump_cli_surface(mode: &str) -> Result<(), AtmError> {
     // values for those fields.
     root.build();
     match mode {
-        "json" => {
+        commands::CliSurfaceFormat::Json => {
             let surface = cli_surface::command_surface_json(&root);
             let rendered = serde_json::to_string_pretty(&surface).map_err(|source| {
                 AtmError::validation("failed to render CLI-surface JSON").with_source(source)
@@ -218,13 +222,10 @@ pub(crate) fn dump_cli_surface(mode: &str) -> Result<(), AtmError> {
             println!("{rendered}");
             Ok(())
         }
-        "markdown" => {
+        commands::CliSurfaceFormat::Markdown => {
             println!("{}", cli_surface::command_surface_markdown(&root));
             Ok(())
         }
-        other => Err(AtmError::validation(format!(
-            "unsupported CLI-surface format: {other} (expected \"json\" or \"markdown\")"
-        ))),
     }
 }
 

--- a/crates/atm/tests/cli_surface.rs
+++ b/crates/atm/tests/cli_surface.rs
@@ -2,7 +2,7 @@
 //! arguments, flags) only ever grows across a release.
 //!
 //! This walks the *live* `clap::Command` tree of the real `atm` binary (via
-//! the hidden `ATM_CLI_SURFACE_DUMP=json` seam documented in
+//! the hidden `__dump-cli-surface --format json` command documented in
 //! `crates/atm/src/cli_surface.rs` and `crates/atm/src/main.rs` — not by
 //! parsing `--help` text) and diffs it structurally against the committed
 //! `cli_surface_baseline.json`. It hard-fails on:
@@ -40,13 +40,13 @@ fn baseline_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(BASELINE_PATH_COMPONENTS)
 }
 
-/// Invokes the real `atm` binary's hidden CLI-surface JSON dump and parses
-/// the result. This is the exact same [`clap::Command`] tree `atm` uses at
-/// runtime — there is no separate/parallel definition to drift from it.
+/// Invokes the real `atm` binary's hidden parsed CLI-surface JSON command and
+/// parses the result. This uses the normal parser/bootstrap path and the exact
+/// same [`clap::Command`] tree `atm` uses at runtime.
 fn live_surface_json() -> Value {
     let atm_bin = env!("CARGO_BIN_EXE_atm");
     let output = Command::new(atm_bin)
-        .env("ATM_CLI_SURFACE_DUMP", "json")
+        .args(["__dump-cli-surface", "--format", "json"])
         .output()
         .expect("failed to run `atm` for CLI-surface introspection");
     assert!(
@@ -58,6 +58,28 @@ fn live_surface_json() -> Value {
     let stdout =
         String::from_utf8(output.stdout).expect("CLI-surface dump output must be valid UTF-8");
     serde_json::from_str(&stdout).expect("CLI-surface dump output must be valid JSON")
+}
+
+#[test]
+fn legacy_environment_variable_cannot_bypass_clap_parsing() {
+    let atm_bin = env!("CARGO_BIN_EXE_atm");
+    let output = Command::new(atm_bin)
+        .env("ATM_CLI_SURFACE_DUMP", "json")
+        .arg("--version")
+        .output()
+        .expect("failed to run `atm --version`");
+
+    assert!(
+        output.status.success(),
+        "`atm --version` exited with {:?}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("version output must be valid UTF-8");
+    assert!(
+        stdout.starts_with("atm "),
+        "legacy environment variable must not replace parsed --version output: {stdout:?}"
+    );
 }
 
 fn as_str<'a>(value: &'a Value, field: &str) -> &'a str {

--- a/crates/atm/tests/cli_surface_baseline.json
+++ b/crates/atm/tests/cli_surface_baseline.json
@@ -17,6 +17,34 @@
     {
       "args": [
         {
+          "has_default": false,
+          "id": "format",
+          "long": "format",
+          "num_args": {
+            "max": 1,
+            "min": 1
+          },
+          "required": true,
+          "short": null
+        },
+        {
+          "has_default": true,
+          "id": "stderr_logs",
+          "long": "stderr-logs",
+          "num_args": {
+            "max": 0,
+            "min": 0
+          },
+          "required": false,
+          "short": null
+        }
+      ],
+      "name": "__dump-cli-surface",
+      "subcommands": []
+    },
+    {
+      "args": [
+        {
           "has_default": true,
           "id": "json",
           "long": "json",


### PR DESCRIPTION
## Summary
- Replaces the `ATM_CLI_SURFACE_DUMP` env-var early-exit in `run()` (which bypassed `Cli::try_parse()`, tracing init, and observability init) with a hidden, normally-parsed `__dump-cli-surface --format json|markdown` subcommand.
- Updates the CLI-surface generator/tests to invoke the new subcommand instead of setting the env var.
- Adds a structural proof that the legacy env var can no longer bypass Clap parsing.

## Test plan
- [x] `just lint`
- [x] `just test`

Non-blocking fix queued behind Phase AI sprint work; targets `develop` directly (found on develop via PR #594, not a Phase AI branch).