### PR TITLE
feat: graph-orchestration skill

### DIFF
--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -139,12 +139,14 @@ depends on which pass this is:
 - `req-qa`
 - `arch-qa`
 - `rust-qa-agent`
-- `flaky-test-qa` (when test instability risk is present)
 
 **QA-1 only** (first QA pass on a sprint node):
 - `ruthless-boundary-qa`
 - `rust-best-practices-agent`
 - `rust-service-hardening-agent`
+
+**Conditional:**
+- `flaky-test-qa` — only when flaky or long-running CI failures are present in this sprint
 
 **Subsequent passes:** these three run only if they have an open finding from
 this sprint node — i.e., they need to verify their own fix was addressed.

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -66,11 +66,12 @@ RESULT=$(next-dev-task F .sprints/F)
 PHASE=$(echo "$RESULT" | jq -r .phase)
 ```
 
-Three outcomes from the cursor query:
+Four outcomes from the cursor query:
 
 | `phase` | Meaning |
 |---|---|
-| `TRAVERSAL` | A sprint is ready (no unfulfilled Assignment, no valid Completion) — check triage-findings to pick template |
+| `TRAVERSAL` | A sprint is ready (no in-flight Assignment, no valid Completion) — check triage-findings to pick template |
+| `AWAITING` | Cursor is empty but some sprints lack valid Completions — in-flight assignments are being worked |
 | `CLEANUP` | All sprints have valid Completions but open non-blocking findings remain |
 | `DONE` | All sprints have valid Completions and no open non-blocking findings — phase complete |
 
@@ -84,6 +85,9 @@ cursor_result = next-dev-task F .sprints/F
 
 if cursor_result.phase == "DONE":
     → phase complete, merge
+
+if cursor_result.phase == "AWAITING":
+    → wait for in-flight dev work; poll again after expected delivery
 
 if cursor_result.phase == "CLEANUP":
     → dispatch dev-fix.xml.j2 for open non-blocking findings
@@ -112,6 +116,7 @@ else:
   non-blocking findings back to origin branches causes 3–4× more QA cycles —
   avoid unless there is a specific reason (e.g. a finding is isolated to an
   early sprint with no forward merge path).
+- **Team-lead is sole writer of TTL events. Never delegate TTL writes to dev agents.**
 
 ## Dev Dispatch (no blocking findings)
 
@@ -164,6 +169,10 @@ triage-findings to determine template selection.
 
 ## Appending Events
 
+**Team-lead is the sole writer of TTL events.** Agents (dev, QA) never append to
+`.sprints/` files directly. Dev sends an ATM completion message; team-lead
+appends triage:Completion and triage:Resolution events, then validates.
+
 Assignments and Completions go into `events.ttl`. They are file-appended and
 committed immediately. Use UTC timestamps from the local clock — never from
 agent self-report.
@@ -177,22 +186,28 @@ triage:a<N> a triage:Assignment ;
     triage:assignedAt "<UTC>"^^xsd:dateTime .
 TTL
 git add .sprints/<PHASE>/events.ttl && git commit -m "event: Assignment <PHASE>-S<n>"
+# Validate after every append
+.claude/skills/graph-orchestration/scripts/next-dev-task F .sprints/F --validate-only
 
-# Completion — append when a sprint's dev pass is accepted
+# Completion — append when team-lead receives dev's ATM completion message
 cat >> .sprints/<PHASE>/events.ttl <<'TTL'
 triage:c<N> a triage:Completion ;
     triage:ofSprint triage:Phase<X>-S<n> ;
     triage:at "<UTC>"^^xsd:dateTime .
 TTL
 git add .sprints/<PHASE>/events.ttl && git commit -m "event: Completion <PHASE>-S<n>"
+# Validate after every append
+.claude/skills/graph-orchestration/scripts/next-dev-task F .sprints/F --validate-only
 
-# Resolution — append when a non-blocking finding is actually fixed
+# Resolution — append when team-lead confirms a non-blocking finding is fixed
 cat >> .sprints/<PHASE>/events.ttl <<'TTL'
 triage:r<N> a triage:Resolution ;
     triage:resolves triage:f<N> ;
     triage:resolvedAt "<UTC>"^^xsd:dateTime .
 TTL
 git add .sprints/<PHASE>/events.ttl && git commit -m "event: Resolution f<N>"
+# Validate after every append
+.claude/skills/graph-orchestration/scripts/next-dev-task F .sprints/F --validate-only
 ```
 
 **Assignment uniqueness**: Each Assignment must include the dev agent name and
@@ -261,10 +276,12 @@ A Completion is valid only if no blocking finding for that sprint was filed
 with `foundAt > completedAt`. If QA files a blocking finding after a
 Completion, the Completion is invalidated:
 
-1. `cursor.sparql` snaps back to that sprint (the unfulfilled Assignment
-   filter does not block — a new Assignment is required)
+1. `cursor.sparql` snaps back to that sprint (the truly-in-flight filter
+   does not block — dev has sent a Completion, so the sprint is not in-flight;
+   a new Assignment is required for re-dispatch)
 2. Team-lead appends a new Assignment event to events.ttl for the sprint
-3. Dev fixes the blocker and appends a new Completion
+3. Dev fixes the blocker and sends an ATM completion message; team-lead
+   appends a new Completion
 4. Dev merges forward into the next sprint's worktree, picking up any
    important/minor findings on the way (Step 4 in the j2 template)
 
@@ -316,13 +333,13 @@ graph-orchestration:
 |---|---|---|
 | `triage:Phase` | — | Phase identity node |
 | `triage:Sprint` | `inPhase`, `order`, `criteria` | One per sprint; `order` is unique within a phase |
-| `triage:Assignment` | `ofSprint`, `assignedTo`, `assignedAt` | Appended when team-lead dispatches; must be unique per sprint |
-| `triage:Completion` | `ofSprint`, `at` | Appended when sprint dev pass is accepted; may be invalidated by a later blocking finding |
-| `triage:Resolution` | `resolves`, `resolvedAt` | Appended when a non-blocking finding is fixed; blocking findings need no Resolution |
+| `triage:Assignment` | `ofSprint`, `assignedTo`, `assignedAt` | Appended by team-lead when dispatching; must be unique per sprint |
+| `triage:Completion` | `ofSprint`, `at` | Appended by team-lead on receipt of dev's ATM completion message; may be invalidated by a later blocking finding |
+| `triage:Resolution` | `resolves`, `resolvedAt` | Appended by team-lead when a non-blocking finding is confirmed fixed; blocking findings need no Resolution |
 
 Findings are defined by the triage-findings skill and live in
 `.triage/*/findings/*.ttl`. Resolution events referencing those findings are
-appended to events.ttl by the orchestrator.
+appended to events.ttl by team-lead.
 
 ## Scripts
 
@@ -332,9 +349,11 @@ All scripts live in `.claude/skills/graph-orchestration/scripts/`:
 |---|---|
 | `next-dev-task` | Entry point: cursor resolution, returns JSON |
 | `query_runner.py` | Python SPARQL runner (rdflib) |
-| `cursor.sparql` | Returns cursor sprint (lowest-ordered sprint without an unfulfilled Assignment or valid Completion); parameter: `$PHASE` |
+| `cursor.sparql` | Returns cursor sprint (lowest-ordered sprint without a truly in-flight Assignment or valid Completion); parameter: `$PHASE` |
 | `open-findings-sprint.sparql` | Returns open non-blocking findings across the phase (used for CLEANUP detection); parameter: `$PHASE` |
+| `all-complete.sparql` | Returns sprints lacking a valid Completion; zero rows = all sprints done, proceed to CLEANUP/DONE check; parameter: `$PHASE` |
 | `validate-structure.sparql` | Phase structure integrity check — zero rows = valid; parameter: `$PHASE` |
+| `test_queries.py` | pytest unit tests for all SPARQL queries (run: `python3 -m pytest scripts/test_queries.py -v`) |
 
 Usage:
 ```bash
@@ -352,6 +371,15 @@ Output JSON (TRAVERSAL):
     "sprint_order": 1,
     "criteria_doc": "ac/FS1.md"
   }
+}
+```
+
+Output JSON (AWAITING):
+```json
+{
+  "phase": "AWAITING",
+  "vars": {},
+  "_incomplete_sprints": ["urn:atm:triage:PhaseF-S1"]
 }
 ```
 

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: graph-orchestration
+version: 0.4.0
+description: TTL/SPARQL-driven phase orchestration. The orchestrator runs a deterministic query loop — cursor → triage-findings check → dispatch → await Completion → re-query. No agent ever decides phase, cursor position, or done-ness; queries answer all of it. Derived from codex-orchestration; replaces static sprint-doc assignments with a live RDF event log. Adds Assignment events (collision prevention), Completion invalidation (blocking post-Completion finding snaps cursor back), and CLEANUP phase (non-blocking findings after all sprints complete).
+repo: atm-core
+depends_on:
+  codex-orchestration: 0.x
+  quality-management-gh: 1.x
+  quality-mgr: 0.x
+  req-qa: 0.x
+  arch-qa: 0.x
+  flaky-test-qa: 0.x
+  ruthless-boundary-qa: 0.x
+  rust-qa-agent: 0.x
+  rust-best-practices-agent: 0.x
+  rust-service-hardening-agent: 0.x
+  triage-findings: 1.x
+---
+
+# Graph Orchestration
+
+Mechanical phase orchestration backed by an append-only RDF event log.
+Every orchestration decision is a SPARQL query result. Agents never decide
+phase, cursor position, or whether a sprint is done.
+
+## Defaults
+
+| Setting | Default |
+|---|---|
+| RDF runner | Python 3 + rdflib |
+| Phase TTL location | `sprints/<PHASE>/structure.ttl` + `sprints/<PHASE>/events.ttl` (relative to repo root) |
+| Findings storage | `.triage/*/findings/*.ttl` — managed by triage-findings skill |
+| Test command | `just test` |
+| Dev assignee | Set per-sprint at dispatch time (j2 variable) |
+| QA reviewer set | `req-qa` + `arch-qa` (language-agnostic) |
+
+## Phase Setup
+
+Before starting a phase, create two TTL files:
+
+**`sprints/<PHASE>/structure.ttl`** — phase identity and sprint list:
+
+```turtle
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+triage:Phase<PHASE> a triage:Phase .
+
+triage:<PHASE>-S1 a triage:Sprint ; triage:inPhase triage:Phase<PHASE> ; triage:order 1 ; triage:criteria "ac/<PHASE>S1.md" .
+triage:<PHASE>-S2 a triage:Sprint ; triage:inPhase triage:Phase<PHASE> ; triage:order 2 ; triage:criteria "ac/<PHASE>S2.md" .
+# ... one entry per sprint, orders unique and contiguous from 1
+```
+
+**`sprints/<PHASE>/events.ttl`** — empty initially; events (Assignments, Completions)
+are appended here as sprints progress. Never edited or deleted.
+
+**`ac/<PHASE>S*.md`** — acceptance criteria documents, one per sprint. The
+`triage:criteria` value must be a resolvable path. Create all `ac/` docs before
+the phase starts.
+
+Run `validate-structure.sparql` at creation. It must return zero rows.
+
+## Orchestrator Loop
+
+```bash
+RESULT=$(next-dev-task F sprints/F)
+PHASE=$(echo "$RESULT" | jq -r .phase)
+```
+
+Three outcomes from the cursor query:
+
+| `phase` | Meaning |
+|---|---|
+| `TRAVERSAL` | A sprint is ready (no unfulfilled Assignment, no valid Completion) — check triage-findings to pick template |
+| `CLEANUP` | All sprints have valid Completions but open non-blocking findings remain |
+| `DONE` | All sprints have valid Completions and no open non-blocking findings — phase complete |
+
+After getting a `TRAVERSAL` result, the orchestrator:
+1. Appends an Assignment event to events.ttl for this sprint
+2. Checks `.triage/` for blocking/important/minor findings (via triage-findings skill)
+3. Picks the template: no findings → dev-task.xml.j2; blocking findings present → dev-fix.xml.j2
+
+```
+cursor_result = next-dev-task F sprints/F
+
+if cursor_result.phase == "DONE":
+    → phase complete, merge
+
+if cursor_result.phase == "CLEANUP":
+    → dispatch dev-fix.xml.j2 for open non-blocking findings
+
+# TRAVERSAL path
+append Assignment event to events.ttl for cursor sprint
+findings = run triage-findings skill for cursor sprint
+
+if findings has blocking:
+    → dispatch dev-fix.xml.j2
+else:
+    → dispatch dev-task.xml.j2
+```
+
+**Hard rules:**
+- Never cache phase or cursor across events. Re-run `next-dev-task` after every
+  Completion or Assignment.
+- Never interpret findings in this skill — that is triage-findings' job. If
+  the orchestrator is tempted to reason about the graph, the model is broken —
+  file a design issue, do not improvise.
+- QA runs after every dev Completion. Trigger immediately on Completion receipt.
+- A Completion can be invalidated: if QA files a blocking finding with
+  foundAt > completedAt, the Completion is invalid and the cursor snaps back.
+  Team-lead re-dispatches by appending a new Assignment.
+- Default to consolidated CLEANUP on the highest sprint branch. Dispatching
+  non-blocking findings back to origin branches causes 3–4× more QA cycles —
+  avoid unless there is a specific reason (e.g. a finding is isolated to an
+  early sprint with no forward merge path).
+
+## Dev Dispatch (no blocking findings)
+
+`next-dev-task` returns the cursor sprint, its order, and its criteria path.
+Populate and send `dev-task.xml.j2`:
+
+| j2 variable | Source |
+|---|---|
+| `sprint` | `result.vars.sprint` |
+| `sprint_order` | `result.vars.sprint_order` |
+| `criteria_doc` | `result.vars.criteria_doc` |
+
+## Fix Dispatch (blocking findings present)
+
+Same cursor sprint, but triage-findings reports blocking findings on it.
+Use `dev-fix.xml.j2` instead. The findings payload comes from triage-findings,
+not from events.ttl.
+
+## QA Gate
+
+After every dev Completion, assign QA to `quality-mgr` using the existing
+`quality-mgr` prompt. For atm-core, `quality-mgr` launches the full Rust
+reviewer set (same as codex-orchestration):
+
+- `req-qa`
+- `arch-qa`
+- `ruthless-boundary-qa` (every round until team-lead explicitly narrows)
+- `rust-qa-agent`
+- `rust-best-practices-agent` (QA-1 only)
+- `rust-service-hardening-agent` (QA-1 only)
+- `flaky-test-qa` (when test instability risk is present)
+
+QA rules:
+- QA never edits existing findings. Re-assessments file a **new** finding at
+  the new severity.
+- QA appends findings to `.triage/` via the triage-findings skill — not to
+  events.ttl.
+- Merge gate: 0 Blocking + 0 Important + 0 Minor, no exceptions.
+
+After QA completes, re-run `next-dev-task` to get the new cursor, then run
+triage-findings to determine template selection.
+
+## Appending Events
+
+Assignments and Completions go into `events.ttl`. They are file-appended and
+committed immediately. Use UTC timestamps from the local clock — never from
+agent self-report.
+
+```bash
+# Assignment — append when team-lead dispatches a sprint to a dev agent
+cat >> sprints/<PHASE>/events.ttl <<'TTL'
+triage:a<N> a triage:Assignment ;
+    triage:ofSprint triage:Phase<X>-S<n> ;
+    triage:assignedTo "arch-ctm" ;
+    triage:assignedAt "<UTC>"^^xsd:dateTime .
+TTL
+git add sprints/<PHASE>/events.ttl && git commit -m "event: Assignment <PHASE>-S<n>"
+
+# Completion — append when a sprint's dev pass is accepted
+cat >> sprints/<PHASE>/events.ttl <<'TTL'
+triage:c<N> a triage:Completion ;
+    triage:ofSprint triage:Phase<X>-S<n> ;
+    triage:at "<UTC>"^^xsd:dateTime .
+TTL
+git add sprints/<PHASE>/events.ttl && git commit -m "event: Completion <PHASE>-S<n>"
+
+# Resolution — append when a non-blocking finding is actually fixed
+cat >> sprints/<PHASE>/events.ttl <<'TTL'
+triage:r<N> a triage:Resolution ;
+    triage:resolves triage:f<N> ;
+    triage:resolvedAt "<UTC>"^^xsd:dateTime .
+TTL
+git add sprints/<PHASE>/events.ttl && git commit -m "event: Resolution f<N>"
+```
+
+**Assignment uniqueness**: Each Assignment must include the dev agent name and
+be unique per sprint (use a monotonically increasing `<N>` suffix).
+
+**Blocking findings**: Closed by a new valid Completion — no Resolution needed.
+Blocking findings posted after a Completion invalidate it (see Completion
+Invalidation below).
+
+**Non-blocking findings**: Closed by an explicit Resolution in events.ttl.
+
+Findings live exclusively in `.triage/*/findings/*.ttl` and are managed by the
+triage-findings skill. Do not append raw finding data to events.ttl.
+
+## sc-compose Integration
+
+`next-dev-task` returns JSON shaped for direct sc-compose consumption:
+
+```json
+{
+  "phase": "TRAVERSAL",
+  "vars": {
+    "sprint": "S7",
+    "sprint_iri": "urn:atm:triage:S7",
+    "sprint_order": 1,
+    "criteria_doc": "ac/S7.md"
+  }
+}
+```
+
+The orchestrator saves `vars` to a temp file and adds non-graph variables.
+Template selection (`dev-task.xml.j2` vs `dev-fix.xml.j2`) is made after
+consulting triage-findings:
+
+```bash
+RESULT=$(next-dev-task F sprints/F)
+PHASE_VAL=$(echo "$RESULT" | jq -r .phase)
+
+if [ "$PHASE_VAL" = "DONE" ]; then
+  echo "Phase complete."
+  exit 0
+fi
+
+# Write graph-derived vars
+echo "$RESULT" | jq .vars > /tmp/graph-vars.json
+SPRINT=$(echo "$RESULT" | jq -r .vars.sprint)
+
+# Check findings via triage-findings skill (orchestrator step)
+# If blocking findings exist, use dev-fix.xml.j2; otherwise dev-task.xml.j2
+TEMPLATE="dev-task.xml.j2"   # set by orchestrator after triage-findings check
+
+# Render via sc-compose (orchestrator supplies remaining vars)
+sc-compose render \
+  --file ".claude/skills/graph-orchestration/$TEMPLATE" \
+  --var-file /tmp/graph-vars.json \
+  --var task_id="GO-$(date +%s)" \
+  --var worktree_path="$WORKTREE_PATH" \
+  --var branch="$BRANCH" \
+  --var pr_target="$PR_TARGET" \
+  --var assignee="arch-ctm"
+```
+
+## Completion Invalidation
+
+A Completion is valid only if no blocking finding for that sprint was filed
+with `foundAt > completedAt`. If QA files a blocking finding after a
+Completion, the Completion is invalidated:
+
+1. `cursor.sparql` snaps back to that sprint (the unfulfilled Assignment
+   filter does not block — a new Assignment is required)
+2. Team-lead appends a new Assignment event to events.ttl for the sprint
+3. Dev fixes the blocker and appends a new Completion
+4. Dev merges forward into the next sprint's worktree, picking up any
+   important/minor findings on the way (Step 4 in the j2 template)
+
+This guarantees QA always has the final word. A sprint is never permanently
+"done" while a blocking finding exists postdating its Completion.
+
+## Cleanup Pass
+
+When `next-dev-task` returns `phase: "CLEANUP"`, all sprint Completions are valid
+and CI is green, but open important/minor findings remain. Fix ALL of them in a
+single pass on the highest sprint branch.
+
+**Why consolidated:** fixing findings on the branch where they were found causes
+8–12 dev-QA cycles. Fixing all findings on one merged branch reduces this to 2–3.
+This 3–4× speedup is load-bearing — do not deviate.
+
+**Orchestrator steps (in order, before dispatching dev-fix):**
+
+1. Confirm all sprint Completions are valid and CI is green on each sprint branch.
+2. Merge sprint branches forward in sequence into the highest-order sprint branch:
+   - Merge S1 → S2's branch
+   - Merge S2 → S3's branch
+   - ... up to S(n-1) → S(n)'s branch
+3. Run CI on the merged S(n) branch. Fix any merge conflicts before proceeding.
+4. Collect all open important/minor findings via `open-findings-sprint.sparql`.
+5. Dispatch ONE dev-fix assignment to S(n)'s worktree with the full findings list.
+6. QA reviews the merged branch once.
+
+**Strong default:** Fix important/minor findings on the consolidated highest
+sprint branch during CLEANUP. Dispatching findings back to the branch where
+they were found causes 3–4× more QA cycles and is rarely worth it. Only
+deviate if a finding is completely isolated to an early sprint with no
+forward merge dependency and re-merging would be higher churn than fixing
+in place.
+
+**CLEANUP branch variables for sc-compose:**
+- `worktree_path` = highest-order sprint's worktree
+- `branch` = highest-order sprint's branch
+- `pr_target` = phase integration branch
+- `findings` = full output of `open-findings-sprint.sparql` (all open important/minor)
+- `cleanup_mode` = "true"
+
+## Ontology
+
+The `triage:` prefix maps to `urn:atm:triage:`. Classes used by
+graph-orchestration:
+
+| Class | Properties | Notes |
+|---|---|---|
+| `triage:Phase` | — | Phase identity node |
+| `triage:Sprint` | `inPhase`, `order`, `criteria` | One per sprint; `order` is unique within a phase |
+| `triage:Assignment` | `ofSprint`, `assignedTo`, `assignedAt` | Appended when team-lead dispatches; must be unique per sprint |
+| `triage:Completion` | `ofSprint`, `at` | Appended when sprint dev pass is accepted; may be invalidated by a later blocking finding |
+| `triage:Resolution` | `resolves`, `resolvedAt` | Appended when a non-blocking finding is fixed; blocking findings need no Resolution |
+
+Findings are defined by the triage-findings skill and live in
+`.triage/*/findings/*.ttl`. Resolution events referencing those findings are
+appended to events.ttl by the orchestrator.
+
+## Scripts
+
+All scripts live in `.claude/skills/graph-orchestration/scripts/`:
+
+| Script | Purpose |
+|---|---|
+| `next-dev-task` | Entry point: cursor resolution, returns JSON |
+| `query_runner.py` | Python SPARQL runner (rdflib) |
+| `cursor.sparql` | Returns cursor sprint (lowest-ordered sprint without an unfulfilled Assignment or valid Completion); parameter: `$PHASE` |
+| `open-findings-sprint.sparql` | Returns open non-blocking findings across the phase (used for CLEANUP detection); parameter: `$PHASE` |
+| `validate-structure.sparql` | Phase structure integrity check — zero rows = valid; parameter: `$PHASE` |
+
+Usage:
+```bash
+# From repo root — make executable first: chmod +x .claude/skills/graph-orchestration/scripts/next-dev-task
+.claude/skills/graph-orchestration/scripts/next-dev-task F sprints/F
+```
+
+Output JSON (TRAVERSAL):
+```json
+{
+  "phase": "TRAVERSAL",
+  "vars": {
+    "sprint": "PhaseF-S1",
+    "sprint_iri": "urn:atm:triage:PhaseF-S1",
+    "sprint_order": 1,
+    "criteria_doc": "ac/FS1.md"
+  }
+}
+```
+
+Output JSON (CLEANUP):
+```json
+{
+  "phase": "CLEANUP",
+  "vars": {},
+  "_findings_raw": [...]
+}
+```
+
+Output JSON (DONE):
+```json
+{
+  "phase": "DONE",
+  "vars": {},
+  "_findings_raw": []
+}
+```
+
+## Assignment Templates
+
+- `dev-task.xml.j2` — initial dev pass (no blocking findings)
+- `dev-fix.xml.j2` — fix pass (blocking findings identified by triage-findings)
+
+QA assignment uses the existing `quality-mgr` prompt directly — no new template.
+
+## Required Message Sequence
+
+Every ATM task message must follow:
+1. ACK
+2. Work
+3. Completion summary (including git push SHA)
+4. Completion ACK by receiver

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -27,7 +27,7 @@ phase, cursor position, or whether a sprint is done.
 | Setting | Default |
 |---|---|
 | RDF runner | Python 3 + rdflib |
-| Phase TTL location | `sprints/<PHASE>/structure.ttl` + `sprints/<PHASE>/events.ttl` (relative to repo root) |
+| Phase TTL location | `.sprints/<PHASE>/structure.ttl` + `.sprints/<PHASE>/events.ttl` (relative to repo root) |
 | Findings storage | `.triage/*/findings/*.ttl` — managed by triage-findings skill |
 | Test command | `just test` |
 | Dev assignee | Set per-sprint at dispatch time (j2 variable) |
@@ -37,7 +37,7 @@ phase, cursor position, or whether a sprint is done.
 
 Before starting a phase, create two TTL files:
 
-**`sprints/<PHASE>/structure.ttl`** — phase identity and sprint list:
+**`.sprints/<PHASE>/structure.ttl`** — phase identity and sprint list:
 
 ```turtle
 @prefix triage: <urn:atm:triage:> .
@@ -50,7 +50,7 @@ triage:<PHASE>-S2 a triage:Sprint ; triage:inPhase triage:Phase<PHASE> ; triage:
 # ... one entry per sprint, orders unique and contiguous from 1
 ```
 
-**`sprints/<PHASE>/events.ttl`** — empty initially; events (Assignments, Completions)
+**`.sprints/<PHASE>/events.ttl`** — empty initially; events (Assignments, Completions)
 are appended here as sprints progress. Never edited or deleted.
 
 **`ac/<PHASE>S*.md`** — acceptance criteria documents, one per sprint. The
@@ -62,7 +62,7 @@ Run `validate-structure.sparql` at creation. It must return zero rows.
 ## Orchestrator Loop
 
 ```bash
-RESULT=$(next-dev-task F sprints/F)
+RESULT=$(next-dev-task F .sprints/F)
 PHASE=$(echo "$RESULT" | jq -r .phase)
 ```
 
@@ -80,7 +80,7 @@ After getting a `TRAVERSAL` result, the orchestrator:
 3. Picks the template: no findings → dev-task.xml.j2; blocking findings present → dev-fix.xml.j2
 
 ```
-cursor_result = next-dev-task F sprints/F
+cursor_result = next-dev-task F .sprints/F
 
 if cursor_result.phase == "DONE":
     → phase complete, merge
@@ -170,29 +170,29 @@ agent self-report.
 
 ```bash
 # Assignment — append when team-lead dispatches a sprint to a dev agent
-cat >> sprints/<PHASE>/events.ttl <<'TTL'
+cat >> .sprints/<PHASE>/events.ttl <<'TTL'
 triage:a<N> a triage:Assignment ;
     triage:ofSprint triage:Phase<X>-S<n> ;
     triage:assignedTo "arch-ctm" ;
     triage:assignedAt "<UTC>"^^xsd:dateTime .
 TTL
-git add sprints/<PHASE>/events.ttl && git commit -m "event: Assignment <PHASE>-S<n>"
+git add .sprints/<PHASE>/events.ttl && git commit -m "event: Assignment <PHASE>-S<n>"
 
 # Completion — append when a sprint's dev pass is accepted
-cat >> sprints/<PHASE>/events.ttl <<'TTL'
+cat >> .sprints/<PHASE>/events.ttl <<'TTL'
 triage:c<N> a triage:Completion ;
     triage:ofSprint triage:Phase<X>-S<n> ;
     triage:at "<UTC>"^^xsd:dateTime .
 TTL
-git add sprints/<PHASE>/events.ttl && git commit -m "event: Completion <PHASE>-S<n>"
+git add .sprints/<PHASE>/events.ttl && git commit -m "event: Completion <PHASE>-S<n>"
 
 # Resolution — append when a non-blocking finding is actually fixed
-cat >> sprints/<PHASE>/events.ttl <<'TTL'
+cat >> .sprints/<PHASE>/events.ttl <<'TTL'
 triage:r<N> a triage:Resolution ;
     triage:resolves triage:f<N> ;
     triage:resolvedAt "<UTC>"^^xsd:dateTime .
 TTL
-git add sprints/<PHASE>/events.ttl && git commit -m "event: Resolution f<N>"
+git add .sprints/<PHASE>/events.ttl && git commit -m "event: Resolution f<N>"
 ```
 
 **Assignment uniqueness**: Each Assignment must include the dev agent name and
@@ -228,7 +228,7 @@ Template selection (`dev-task.xml.j2` vs `dev-fix.xml.j2`) is made after
 consulting triage-findings:
 
 ```bash
-RESULT=$(next-dev-task F sprints/F)
+RESULT=$(next-dev-task F .sprints/F)
 PHASE_VAL=$(echo "$RESULT" | jq -r .phase)
 
 if [ "$PHASE_VAL" = "DONE" ]; then
@@ -339,7 +339,7 @@ All scripts live in `.claude/skills/graph-orchestration/scripts/`:
 Usage:
 ```bash
 # From repo root — make executable first: chmod +x .claude/skills/graph-orchestration/scripts/next-dev-task
-.claude/skills/graph-orchestration/scripts/next-dev-task F sprints/F
+.claude/skills/graph-orchestration/scripts/next-dev-task F .sprints/F
 ```
 
 Output JSON (TRAVERSAL):

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -4,7 +4,6 @@ version: 0.4.0
 description: TTL/SPARQL-driven phase orchestration. The orchestrator runs a deterministic query loop — cursor → triage-findings check → dispatch → await Completion → re-query. No agent ever decides phase, cursor position, or done-ness; queries answer all of it. Derived from codex-orchestration; replaces static sprint-doc assignments with a live RDF event log. Adds Assignment events (collision prevention), Completion invalidation (blocking post-Completion finding snaps cursor back), and CLEANUP phase (non-blocking findings after all sprints complete).
 repo: atm-core
 depends_on:
-  codex-orchestration: 0.x
   quality-management-gh: 1.x
   quality-mgr: 0.x
   req-qa: 0.x

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -31,7 +31,7 @@ phase, cursor position, or whether a sprint is done.
 | Findings storage | `.triage/*/findings/*.ttl` — managed by triage-findings skill |
 | Test command | `just test` |
 | Dev assignee | Set per-sprint at dispatch time (j2 variable) |
-| QA reviewer set | `req-qa` + `arch-qa` (language-agnostic) |
+| QA reviewer set | `req-qa`, `arch-qa`, `rust-qa-agent` every pass; RBP/service-hardening/ruthless on QA-1 or finding recheck |
 
 ## Phase Setup
 
@@ -132,17 +132,23 @@ not from events.ttl.
 
 ## QA Gate
 
-After every dev Completion, assign QA to `quality-mgr` using the existing
-`quality-mgr` prompt. For atm-core, `quality-mgr` launches the full Rust
-reviewer set (same as codex-orchestration):
+After every dev Completion, assign QA to `quality-mgr`. Reviewer selection
+depends on which pass this is:
 
+**Every QA pass:**
 - `req-qa`
 - `arch-qa`
-- `ruthless-boundary-qa` (every round until team-lead explicitly narrows)
 - `rust-qa-agent`
-- `rust-best-practices-agent` (QA-1 only)
-- `rust-service-hardening-agent` (QA-1 only)
 - `flaky-test-qa` (when test instability risk is present)
+
+**QA-1 only** (first QA pass on a sprint node):
+- `ruthless-boundary-qa`
+- `rust-best-practices-agent`
+- `rust-service-hardening-agent`
+
+**Subsequent passes:** these three run only if they have an open finding from
+this sprint node — i.e., they need to verify their own fix was addressed.
+Do not re-run them if they filed nothing or all their findings are resolved.
 
 QA rules:
 - QA never edits existing findings. Re-assessments file a **new** finding at

--- a/.claude/skills/graph-orchestration/dev-fix.xml.j2
+++ b/.claude/skills/graph-orchestration/dev-fix.xml.j2
@@ -28,7 +28,7 @@ defaults:
      All prior sprint branches have been merged forward into this branch before dispatch.
      The findings list covers the ENTIRE phase — not just one sprint. Fix all findings here;
      do not return any finding to its origin branch. #}
-  <description>Fix pass on sprint node {{ node_id }} (order {{ node_order }}) in {{ sprint }}. Address all open findings listed below before appending Completion.</description>
+  <description>Fix pass on sprint node {{ node_id }} (order {{ node_order }}) in {{ sprint }}. Address all open findings listed below before sending ATM completion to team-lead.</description>
 
   <worktree>{{ worktree_path }}</worktree>
   <branch>{{ branch }}</branch>
@@ -47,10 +47,10 @@ defaults:
 
   <fix-instructions>
     <rule id="priority-order">Fix ALL findings in order: Blocking → Important → Minor. Do not defer non-blocking findings to a later pass.</rule>
-    <rule id="blocking">Blocking findings: fix completely. Closure is by timestamp — a triage:Completion event postdating the finding's foundAt closes it. Do NOT append a triage:Resolution for blocking findings. If the fix is inadequate, QA will file a new finding.</rule>
-    <rule id="non-blocking">Important/Minor: fix all. Append a triage:Resolution per finding fixed. Skip only if fixing conflicts with a blocking fix.</rule>
+    <rule id="blocking">Blocking findings: fix completely. Team-lead will append a triage:Completion event after verifying your fix. Do NOT append any triage events yourself.</rule>
+    <rule id="non-blocking">Important/Minor: fix all. Note each finding IRI in your ATM completion message — team-lead will append triage:Resolution events. Skip only if fixing conflicts with a blocking fix; explain the reason in your completion message.</rule>
     <rule id="immutability">Never amend, edit, or delete existing findings. Never reference the old finding when re-assessing — QA files a new finding at the new severity if needed.</rule>
-    <rule id="completion">Append exactly one triage:Completion for sprint {{ node_id }} when done, with an accurate UTC timestamp from the local clock.</rule>
+    <rule id="no-ttl-writes">Do NOT append any triage:Completion, triage:Resolution, or other triage events to any TTL file. Team-lead is the sole writer of TTL events.</rule>
   </fix-instructions>
 
   <workflow>
@@ -58,22 +58,21 @@ defaults:
     <step id="b">Read `{{ criteria_doc }}` before editing. All acceptance criteria must still be met — do not weaken or skip any criterion from the original spec.</step>
     <step id="c">Update the worktree from `{{ pr_target }}` before any edits: `git fetch origin && git merge origin/{{ pr_target }}`.</step>
     <step id="d">Work through every finding in `<open-findings>` in listed order. Fix all. For blocking: address root cause fully. For non-blocking: fix all; skip only on direct conflict with a blocking fix.</step>
-    <step id="e">Append triage:Resolution events for each non-blocking finding you fixed, then append the triage:Completion for this sprint. Both go in the same commit.</step>
   </workflow>
 
   <final-actions>
     {% if cleanup_mode == "true" %}
     <step id="0">Confirm this is the merged highest-sprint branch. Verify `git log --oneline` shows commits from all prior sprints in this phase — do not proceed if any sprint's work is missing.</step>
-    <step id="1">Fix ALL listed findings — important findings before minor. For each one fixed, append a triage:Resolution referencing that finding's IRI.</step>
+    <step id="1">Fix ALL listed findings — important findings before minor.</step>
     <step id="2">Run `{{ test_command }}` and confirm it passes with zero failures. Fix any failures before continuing.</step>
-    <step id="3">Commit all changes (including appended TTL events) and push to remote: `git push origin {{ branch }}`. Note the full commit SHA.</step>
-    <step id="4">Send a completion message to team-lead via ATM including: branch `{{ branch }}`, the full commit SHA, and the full list of Resolution IRIs appended in this pass.</step>
+    <step id="3">Commit all changes and push to remote: `git push origin {{ branch }}`. Note the full commit SHA.</step>
+    <step id="4">Send an ATM completion message to team-lead including: branch `{{ branch }}`, the full commit SHA, and for each finding in `<open-findings>`: its IRI, whether you fixed it, and a one-line note if skipped with reason. Do NOT append any triage events — team-lead handles all TTL writes.</step>
     <step id="5">Open a PR from `{{ branch }}` to `{{ pr_target }}` (the phase integration branch). Do NOT merge into a next sprint worktree — this branch is the final consolidated cleanup target.</step>
     {% else %}
     <step id="0">Critically review the sprint plan and your implementation. Confirm all blocking findings are fully resolved and every acceptance criterion in `{{ criteria_doc }}` is met. Do not proceed if any blocking finding is unaddressed or any criterion is incomplete.</step>
     <step id="1">Run `{{ test_command }}` and confirm it passes with zero failures. Fix any failures before continuing.</step>
-    <step id="2">Commit all changes (including appended TTL events) and push to remote: `git push origin {{ branch }}`. Note the full commit SHA.</step>
-    <step id="3">Send a completion message to team-lead via ATM including: node `{{ node_id }}`, branch `{{ branch }}`, the full commit SHA, and the list of finding IRIs for which you appended triage:Resolution events.</step>
+    <step id="2">Commit all changes and push to remote: `git push origin {{ branch }}`. Note the full commit SHA.</step>
+    <step id="3">Send an ATM completion message to team-lead including: node `{{ node_id }}`, branch `{{ branch }}`, the full commit SHA, and for each finding in `<open-findings>`: its IRI, whether you fixed it, and a one-line note if skipped with reason. Do NOT append any triage events — team-lead handles all TTL writes.</step>
     <step id="4">Merge this branch into the next sprint worktree: from within the next sprint's worktree, run `git fetch origin && git merge origin/{{ branch }}`.</step>
     {% endif %}
   </final-actions>

--- a/.claude/skills/graph-orchestration/dev-fix.xml.j2
+++ b/.claude/skills/graph-orchestration/dev-fix.xml.j2
@@ -1,0 +1,80 @@
+---
+name: graph-dev-fix
+version: 1.0.0
+description: Fix pass for a sprint node — includes all open findings at the cursor position. Used for both mid-sprint fix passes (TRAVERSAL with findings) and end-of-sprint cleanup (CLEANUP phase).
+format: xml
+required_variables:
+  - task_id
+  - sprint
+  - node_id
+  - node_order
+  - criteria_doc
+  - findings
+  - worktree_path
+  - branch
+  - pr_target
+  - assignee
+optional_variables:
+  - test_command
+  - references
+  - cleanup_mode
+defaults:
+  test_command: "just test"
+  references: ""
+  cleanup_mode: "false"
+---
+<atm-task id="{{ task_id }}" sprint="{{ sprint }}" node="{{ node_id }}" order="{{ node_order }}" assignee="{{ assignee }}" mode="fix"{% if cleanup_mode == "true" %} phase="CLEANUP"{% endif %}>
+  {# When cleanup_mode == "true": this is a CONSOLIDATED phase cleanup on the highest sprint's merged branch.
+     All prior sprint branches have been merged forward into this branch before dispatch.
+     The findings list covers the ENTIRE phase — not just one sprint. Fix all findings here;
+     do not return any finding to its origin branch. #}
+  <description>Fix pass on sprint node {{ node_id }} (order {{ node_order }}) in {{ sprint }}. Address all open findings listed below before appending Completion.</description>
+
+  <worktree>{{ worktree_path }}</worktree>
+  <branch>{{ branch }}</branch>
+  <pr-target>{{ pr_target }}</pr-target>
+  <acceptance-criteria-doc>{{ criteria_doc }}</acceptance-criteria-doc>
+
+  <open-findings>
+{{ findings }}
+  </open-findings>
+
+  {% if references %}
+  <references>
+{{ references }}
+  </references>
+  {% endif %}
+
+  <fix-instructions>
+    <rule id="priority-order">Fix ALL findings in order: Blocking → Important → Minor. Do not defer non-blocking findings to a later pass.</rule>
+    <rule id="blocking">Blocking findings: fix completely. Closure is by timestamp — a triage:Completion event postdating the finding's foundAt closes it. Do NOT append a triage:Resolution for blocking findings. If the fix is inadequate, QA will file a new finding.</rule>
+    <rule id="non-blocking">Important/Minor: fix all. Append a triage:Resolution per finding fixed. Skip only if fixing conflicts with a blocking fix.</rule>
+    <rule id="immutability">Never amend, edit, or delete existing findings. Never reference the old finding when re-assessing — QA files a new finding at the new severity if needed.</rule>
+    <rule id="completion">Append exactly one triage:Completion for sprint {{ node_id }} when done, with an accurate UTC timestamp from the local clock.</rule>
+  </fix-instructions>
+
+  <workflow>
+    <step id="a">ACK this message immediately.</step>
+    <step id="b">Read `{{ criteria_doc }}` before editing. All acceptance criteria must still be met — do not weaken or skip any criterion from the original spec.</step>
+    <step id="c">Update the worktree from `{{ pr_target }}` before any edits: `git fetch origin && git merge origin/{{ pr_target }}`.</step>
+    <step id="d">Work through every finding in `<open-findings>` in listed order. Fix all. For blocking: address root cause fully. For non-blocking: fix all; skip only on direct conflict with a blocking fix.</step>
+    <step id="e">Append triage:Resolution events for each non-blocking finding you fixed, then append the triage:Completion for this sprint. Both go in the same commit.</step>
+  </workflow>
+
+  <final-actions>
+    {% if cleanup_mode == "true" %}
+    <step id="0">Confirm this is the merged highest-sprint branch. Verify `git log --oneline` shows commits from all prior sprints in this phase — do not proceed if any sprint's work is missing.</step>
+    <step id="1">Fix ALL listed findings — important findings before minor. For each one fixed, append a triage:Resolution referencing that finding's IRI.</step>
+    <step id="2">Run `{{ test_command }}` and confirm it passes with zero failures. Fix any failures before continuing.</step>
+    <step id="3">Commit all changes (including appended TTL events) and push to remote: `git push origin {{ branch }}`. Note the full commit SHA.</step>
+    <step id="4">Send a completion message to team-lead via ATM including: branch `{{ branch }}`, the full commit SHA, and the full list of Resolution IRIs appended in this pass.</step>
+    <step id="5">Open a PR from `{{ branch }}` to `{{ pr_target }}` (the phase integration branch). Do NOT merge into a next sprint worktree — this branch is the final consolidated cleanup target.</step>
+    {% else %}
+    <step id="0">Critically review the sprint plan and your implementation. Confirm all blocking findings are fully resolved and every acceptance criterion in `{{ criteria_doc }}` is met. Do not proceed if any blocking finding is unaddressed or any criterion is incomplete.</step>
+    <step id="1">Run `{{ test_command }}` and confirm it passes with zero failures. Fix any failures before continuing.</step>
+    <step id="2">Commit all changes (including appended TTL events) and push to remote: `git push origin {{ branch }}`. Note the full commit SHA.</step>
+    <step id="3">Send a completion message to team-lead via ATM including: node `{{ node_id }}`, branch `{{ branch }}`, the full commit SHA, and the list of finding IRIs for which you appended triage:Resolution events.</step>
+    <step id="4">Merge this branch into the next sprint worktree: from within the next sprint's worktree, run `git fetch origin && git merge origin/{{ branch }}`.</step>
+    {% endif %}
+  </final-actions>
+</atm-task>

--- a/.claude/skills/graph-orchestration/dev-task.xml.j2
+++ b/.claude/skills/graph-orchestration/dev-task.xml.j2
@@ -46,7 +46,7 @@ defaults:
     <step id="0">Critically review the sprint plan and your implementation. Read `{{ criteria_doc }}` again and confirm every acceptance criterion is fully and completely met. Do not proceed if any criterion is unresolved or partially met.</step>
     <step id="1">Run `{{ test_command }}` and confirm it passes with zero failures. Fix any failures before continuing — do not proceed with a failing test suite.</step>
     <step id="2">Commit all remaining changes and push to remote: `git push origin {{ branch }}`. Note the full commit SHA.</step>
-    <step id="3">Send a completion message to team-lead via ATM including: node `{{ node_id }}`, branch `{{ branch }}`, and the full commit SHA from the push.</step>
+    <step id="3">Send a completion message to team-lead via ATM including: node `{{ node_id }}`, branch `{{ branch }}`, and the full commit SHA from the push. Do NOT append any triage events — team-lead handles all TTL event writes.</step>
     <step id="4">Merge this branch into the next sprint worktree: from within the next sprint's worktree, run `git fetch origin && git merge origin/{{ branch }}`.</step>
   </final-actions>
 </atm-task>

--- a/.claude/skills/graph-orchestration/dev-task.xml.j2
+++ b/.claude/skills/graph-orchestration/dev-task.xml.j2
@@ -1,0 +1,52 @@
+---
+name: graph-dev-task
+version: 1.0.0
+description: Initial dev pass for a sprint node in graph-orchestration. No prior findings on this node.
+format: xml
+required_variables:
+  - task_id
+  - sprint
+  - node_id
+  - node_order
+  - criteria_doc
+  - worktree_path
+  - branch
+  - pr_target
+  - assignee
+optional_variables:
+  - test_command
+  - references
+defaults:
+  test_command: "just test"
+  references: ""
+---
+<atm-task id="{{ task_id }}" sprint="{{ sprint }}" node="{{ node_id }}" order="{{ node_order }}" assignee="{{ assignee }}">
+  <description>Implement sprint node {{ node_id }} (order {{ node_order }}) in {{ sprint }}.</description>
+
+  <worktree>{{ worktree_path }}</worktree>
+  <branch>{{ branch }}</branch>
+  <pr-target>{{ pr_target }}</pr-target>
+  <acceptance-criteria-doc>{{ criteria_doc }}</acceptance-criteria-doc>
+
+  {% if references %}
+  <references>
+{{ references }}
+  </references>
+  {% endif %}
+
+  <workflow>
+    <step id="a">ACK this message immediately. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
+    <step id="b">Immediately after ACK, begin work in the same session.</step>
+    <step id="c">Read `{{ criteria_doc }}` before coding. This is the authoritative acceptance criteria for this node. Satisfy every criterion completely — do not weaken or skip any.</step>
+    <step id="d">Update the worktree from `{{ pr_target }}` before any edits: `git fetch origin && git merge origin/{{ pr_target }}`.</step>
+    <step id="e">Implement the work. Commit incrementally on `{{ branch }}`.</step>
+  </workflow>
+
+  <final-actions>
+    <step id="0">Critically review the sprint plan and your implementation. Read `{{ criteria_doc }}` again and confirm every acceptance criterion is fully and completely met. Do not proceed if any criterion is unresolved or partially met.</step>
+    <step id="1">Run `{{ test_command }}` and confirm it passes with zero failures. Fix any failures before continuing — do not proceed with a failing test suite.</step>
+    <step id="2">Commit all remaining changes and push to remote: `git push origin {{ branch }}`. Note the full commit SHA.</step>
+    <step id="3">Send a completion message to team-lead via ATM including: node `{{ node_id }}`, branch `{{ branch }}`, and the full commit SHA from the push.</step>
+    <step id="4">Merge this branch into the next sprint worktree: from within the next sprint's worktree, run `git fetch origin && git merge origin/{{ branch }}`.</step>
+  </final-actions>
+</atm-task>

--- a/.claude/skills/graph-orchestration/scripts/all-complete.sparql
+++ b/.claude/skills/graph-orchestration/scripts/all-complete.sparql
@@ -1,0 +1,30 @@
+# all-complete.sparql — Returns sprints that are NOT cleanly done.
+#
+# A sprint is NOT cleanly done if it lacks a valid Completion.
+# A Completion is valid iff no blocking finding was filed with foundAt > completedAt.
+#
+# Used after cursor returns empty to distinguish:
+#   - AWAITING: cursor is empty but some sprints lack valid Completions
+#     (e.g. they have in-flight Assignments with no Completion yet — which
+#     cursor skips — but we need to surface this rather than falsely declaring DONE)
+#   - CLEANUP/DONE: all sprints have valid Completions
+#
+# Zero rows = all sprints have valid Completions → proceed to CLEANUP/DONE check.
+# Non-zero rows = some sprints are incomplete → return AWAITING.
+#
+# Parameter: $PHASE (bound via initBindings)
+
+PREFIX triage: <urn:atm:triage:>
+
+SELECT ?sprint WHERE {
+  ?sprint a triage:Sprint ; triage:inPhase $PHASE .
+
+  # Keep sprints that lack a valid Completion
+  FILTER NOT EXISTS {
+    ?c a triage:Completion ; triage:ofSprint ?sprint ; triage:at ?ct .
+    FILTER NOT EXISTS {
+      ?f a triage:Finding ; triage:foundIn ?sprint ; triage:severity "blocking" ; triage:foundAt ?ft .
+      FILTER (?ft > ?ct)
+    }
+  }
+}

--- a/.claude/skills/graph-orchestration/scripts/cursor.sparql
+++ b/.claude/skills/graph-orchestration/scripts/cursor.sparql
@@ -1,14 +1,24 @@
 # cursor.sparql — Returns the current sprint cursor.
 #
 # A sprint is "ready" iff:
-#   1. It has no unfulfilled Assignment (assigned to an agent but no valid Completion yet), AND
+#   1. It has no truly in-flight Assignment (dev has been assigned but has NOT
+#      yet sent ANY Completion after that Assignment), AND
 #   2. It has no valid Completion.
+#
+# KEY DISTINCTION — in-flight vs. completed-but-invalidated:
+#   - In-flight: Assignment exists, dev has not sent any Completion after it.
+#     → Skip. Dev is still working.
+#   - Assignment + Completion (invalid) + no new Assignment: dev sent a
+#     Completion but QA filed a blocking finding that postdates it. Dev is
+#     done; team-lead must re-dispatch. → Cursor returns this sprint.
+#   - Assignment + Completion (invalid) + new Assignment in-flight: re-dispatch
+#     already issued, dev working again. → Skip.
 #
 # A Completion is VALID iff no blocking finding for that sprint was filed
 # with foundAt > completedAt. A blocking finding postdating a Completion
 # invalidates it, snapping the cursor back to that sprint.
 #
-# Returns: zero rows (all sprints complete or assigned) or one row
+# Returns: zero rows (all sprints complete or in-flight) or one row
 #   (?sprint, ?order, ?criteria)
 # Parameter: $PHASE (bound via initBindings)
 
@@ -21,32 +31,24 @@ SELECT ?sprint ?order ?criteria WHERE {
           triage:order ?order ;
           triage:criteria ?criteria .
 
-  # Skip sprints with an unfulfilled Assignment
-  # (assigned but lacking a valid Completion after the assignment)
+  # Skip sprints with a truly in-flight Assignment:
+  # Assignment exists AND dev has not sent ANY Completion after it yet.
   FILTER NOT EXISTS {
     ?a a triage:Assignment ;
        triage:ofSprint ?sprint ;
        triage:assignedAt ?at .
 
-    # Assignment is unfulfilled if no valid Completion exists after it
+    # Truly in-flight: no Completion at all after this Assignment
     FILTER NOT EXISTS {
       ?c a triage:Completion ;
          triage:ofSprint ?sprint ;
          triage:at ?ct .
       FILTER (?ct > ?at)
-
-      # And that Completion is valid (no blocking finding postdates it)
-      FILTER NOT EXISTS {
-        ?f a triage:Finding ;
-           triage:foundIn ?sprint ;
-           triage:severity "blocking" ;
-           triage:foundAt ?ft .
-        FILTER (?ft > ?ct)
-      }
     }
   }
 
   # Skip sprints with a valid Completion
+  # (valid = no blocking finding postdates the Completion)
   FILTER NOT EXISTS {
     ?c a triage:Completion ;
        triage:ofSprint ?sprint ;

--- a/.claude/skills/graph-orchestration/scripts/cursor.sparql
+++ b/.claude/skills/graph-orchestration/scripts/cursor.sparql
@@ -1,0 +1,65 @@
+# cursor.sparql — Returns the current sprint cursor.
+#
+# A sprint is "ready" iff:
+#   1. It has no unfulfilled Assignment (assigned to an agent but no valid Completion yet), AND
+#   2. It has no valid Completion.
+#
+# A Completion is VALID iff no blocking finding for that sprint was filed
+# with foundAt > completedAt. A blocking finding postdating a Completion
+# invalidates it, snapping the cursor back to that sprint.
+#
+# Returns: zero rows (all sprints complete or assigned) or one row
+#   (?sprint, ?order, ?criteria)
+# Parameter: $PHASE (bound via initBindings)
+
+PREFIX triage: <urn:atm:triage:>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?sprint ?order ?criteria WHERE {
+  ?sprint a triage:Sprint ;
+          triage:inPhase $PHASE ;
+          triage:order ?order ;
+          triage:criteria ?criteria .
+
+  # Skip sprints with an unfulfilled Assignment
+  # (assigned but lacking a valid Completion after the assignment)
+  FILTER NOT EXISTS {
+    ?a a triage:Assignment ;
+       triage:ofSprint ?sprint ;
+       triage:assignedAt ?at .
+
+    # Assignment is unfulfilled if no valid Completion exists after it
+    FILTER NOT EXISTS {
+      ?c a triage:Completion ;
+         triage:ofSprint ?sprint ;
+         triage:at ?ct .
+      FILTER (?ct > ?at)
+
+      # And that Completion is valid (no blocking finding postdates it)
+      FILTER NOT EXISTS {
+        ?f a triage:Finding ;
+           triage:foundIn ?sprint ;
+           triage:severity "blocking" ;
+           triage:foundAt ?ft .
+        FILTER (?ft > ?ct)
+      }
+    }
+  }
+
+  # Skip sprints with a valid Completion
+  FILTER NOT EXISTS {
+    ?c a triage:Completion ;
+       triage:ofSprint ?sprint ;
+       triage:at ?ct .
+
+    FILTER NOT EXISTS {
+      ?f a triage:Finding ;
+         triage:foundIn ?sprint ;
+         triage:severity "blocking" ;
+         triage:foundAt ?ft .
+      FILTER (?ft > ?ct)
+    }
+  }
+}
+ORDER BY ?order
+LIMIT 1

--- a/.claude/skills/graph-orchestration/scripts/next-dev-task
+++ b/.claude/skills/graph-orchestration/scripts/next-dev-task
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# next-dev-task — Cursor resolution for graph-orchestration.
+#
+# Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR>
+#   PHASE_LOCAL  e.g. "F" (expanded to urn:atm:triage:PhaseF)
+#   TTL_DIR      path to directory containing structure.ttl and events.ttl
+#
+# Returns JSON on stdout:
+#   { "phase": "TRAVERSAL", "vars": { "sprint": "...", "sprint_iri": "...", "sprint_order": N, "criteria_doc": "..." } }
+#   { "phase": "DONE", "vars": {} }
+#
+# Exits non-zero on error; error details on stderr.
+
+set -euo pipefail
+
+PHASE="${1:?Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR>}"
+TTL_DIR="${2:?Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Verify Python 3 and rdflib are available
+if ! python3 -c "import rdflib" 2>/dev/null; then
+  echo >&2 "ERROR: rdflib not found. Install with: pip3 install rdflib"
+  exit 1
+fi
+
+exec python3 "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR"

--- a/.claude/skills/graph-orchestration/scripts/next-dev-task
+++ b/.claude/skills/graph-orchestration/scripts/next-dev-task
@@ -2,6 +2,7 @@
 # next-dev-task — Cursor resolution for graph-orchestration.
 #
 # Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR>
+# TTL_DIR: path to .sprints/<PHASE>/ on the integrate/phase-N branch
 #   PHASE_LOCAL  e.g. "F" (expanded to urn:atm:triage:PhaseF)
 #   TTL_DIR      path to directory containing structure.ttl and events.ttl
 #

--- a/.claude/skills/graph-orchestration/scripts/open-findings-sprint.sparql
+++ b/.claude/skills/graph-orchestration/scripts/open-findings-sprint.sparql
@@ -26,7 +26,8 @@ SELECT ?finding ?sprint ?severity ?foundAt ?description WHERE {
 
   # Open: no Resolution references this finding
   FILTER NOT EXISTS { ?r a triage:Resolution ; triage:resolves ?finding . }
+
+  # Sort key: important before minor, then by time
+  BIND(IF(?severity = "important", 0, 1) AS ?sev_order)
 }
-ORDER BY
-  (IF(?severity = "important", 0, 1))
-  ?foundAt
+ORDER BY ?sev_order ?foundAt

--- a/.claude/skills/graph-orchestration/scripts/open-findings-sprint.sparql
+++ b/.claude/skills/graph-orchestration/scripts/open-findings-sprint.sparql
@@ -1,0 +1,32 @@
+# open-findings-sprint.sparql — All open non-blocking findings across the phase.
+#
+# Used to detect CLEANUP phase: all sprints have valid Completions but
+# non-blocking findings remain.
+#
+# Blocking findings are excluded here: if any exist, cursor.sparql would
+# have returned a sprint (Completion invalidated).
+#
+# Returns: ?finding ?sprint ?severity ?foundAt ?description
+# Parameter: $PHASE (bound via initBindings)
+
+PREFIX triage: <urn:atm:triage:>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?finding ?sprint ?severity ?foundAt ?description WHERE {
+  ?sprint a triage:Sprint ; triage:inPhase $PHASE .
+
+  ?finding a triage:Finding ;
+           triage:foundIn ?sprint ;
+           triage:severity ?severity ;
+           triage:foundAt ?foundAt ;
+           triage:description ?description .
+
+  # Non-blocking only
+  FILTER (?severity != "blocking")
+
+  # Open: no Resolution references this finding
+  FILTER NOT EXISTS { ?r a triage:Resolution ; triage:resolves ?finding . }
+}
+ORDER BY
+  (IF(?severity = "important", 0, 1))
+  ?foundAt

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -33,7 +33,7 @@ Assignments are appended to events.ttl by the orchestrator after dispatch.
 
 Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR>
   PHASE_LOCAL  e.g. "F"
-  TTL_DIR      path containing structure.ttl + events.ttl
+  TTL_DIR      path to .sprints/<PHASE>/ directory on integrate/phase-N branch
   SCRIPT_DIR   path to this script's directory (for .sparql files)
 """
 

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -15,6 +15,13 @@ Output shape (TRAVERSAL):
     }
   }
 
+Output shape (AWAITING):
+  {
+    "phase": "AWAITING",
+    "vars": {},
+    "_incomplete_sprints": ["urn:atm:triage:PhaseF-S1", ...]
+  }
+
 Output shape (CLEANUP):
   {
     "phase": "CLEANUP",
@@ -52,6 +59,19 @@ TRIAGE_BASE = "urn:atm:triage:"
 TRIAGE = Namespace(TRIAGE_BASE)
 
 
+def _find_repo_root(start: Path):
+    """Walk up from start to find the directory containing .triage/"""
+    current = start.resolve()
+    for _ in range(10):  # max 10 levels up
+        if (current / ".triage").exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
 def load_graph(ttl_dir: str) -> Graph:
     g = Graph()
     base = Path(ttl_dir)
@@ -63,6 +83,12 @@ def load_graph(ttl_dir: str) -> Graph:
     g.parse(str(structure), format="turtle")
     if events.exists():
         g.parse(str(events), format="turtle")
+    # Load triage findings from repo root .triage/ (relative to TTL dir's parent)
+    # Walk up from ttl_dir to find repo root (contains .triage/)
+    repo_root = _find_repo_root(base)
+    if repo_root:
+        for findings_file in sorted(repo_root.glob(".triage/*/findings/*.ttl")):
+            g.parse(str(findings_file), format="turtle")
     return g
 
 
@@ -82,6 +108,13 @@ def main():
 
     phase_iri = URIRef(f"{TRIAGE_BASE}Phase{phase_local}")
     g = load_graph(ttl_dir)
+
+    # ── Validate structure before cursor ─────────────────────────────────────
+    validate_rows = run_sparql(g, script_dir / "validate-structure.sparql", {"PHASE": phase_iri})
+    if validate_rows:
+        for row in validate_rows:
+            print(f"ERROR: structure violation: {row[0]} — {row[1]}", file=sys.stderr)
+        sys.exit(1)
 
     # ── Cursor ───────────────────────────────────────────────────────────────
     cursor_rows = run_sparql(g, script_dir / "cursor.sparql", {"PHASE": phase_iri})
@@ -103,7 +136,18 @@ def main():
         }, indent=2))
         return
 
-    # ── Cursor empty — check for open non-blocking findings (CLEANUP) ────────
+    # ── Cursor empty — verify all sprints have valid Completions ─────────────
+    incomplete_rows = run_sparql(g, script_dir / "all-complete.sparql", {"PHASE": phase_iri})
+    if incomplete_rows:
+        # Some sprints are in-flight or have invalid Completions
+        print(json.dumps({
+            "phase": "AWAITING",
+            "vars": {},
+            "_incomplete_sprints": [str(r[0]) for r in incomplete_rows],
+        }, indent=2))
+        return
+
+    # ── Check for open non-blocking findings (CLEANUP) ───────────────────────
     cleanup_rows = run_sparql(
         g, script_dir / "open-findings-sprint.sparql", {"PHASE": phase_iri}
     )

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+query_runner.py — Cursor resolution for graph-orchestration.
+
+Called by next-dev-task. Returns JSON to stdout; errors to stderr.
+
+Output shape (TRAVERSAL):
+  {
+    "phase": "TRAVERSAL",
+    "vars": {
+      "sprint": "PhaseF-S1",      # local sprint label
+      "sprint_iri": "...",
+      "sprint_order": 1,
+      "criteria_doc": "..."
+    }
+  }
+
+Output shape (CLEANUP):
+  {
+    "phase": "CLEANUP",
+    "vars": {}
+  }
+
+Output shape (DONE):
+  {
+    "phase": "DONE",
+    "vars": {}
+  }
+
+Findings are NOT resolved here. The orchestrator checks .triage/ via
+triage-findings skill to decide between dev-task.xml.j2 and dev-fix.xml.j2.
+Assignments are appended to events.ttl by the orchestrator after dispatch.
+
+Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR>
+  PHASE_LOCAL  e.g. "F"
+  TTL_DIR      path containing structure.ttl + events.ttl
+  SCRIPT_DIR   path to this script's directory (for .sparql files)
+"""
+
+import sys
+import json
+from pathlib import Path
+
+try:
+    from rdflib import Graph, URIRef, Namespace
+    from rdflib.namespace import XSD
+except ImportError:
+    print("ERROR: rdflib not installed. Run: pip3 install rdflib", file=sys.stderr)
+    sys.exit(1)
+
+TRIAGE_BASE = "urn:atm:triage:"
+TRIAGE = Namespace(TRIAGE_BASE)
+
+
+def load_graph(ttl_dir: str) -> Graph:
+    g = Graph()
+    base = Path(ttl_dir)
+    structure = base / "structure.ttl"
+    events = base / "events.ttl"
+    if not structure.exists():
+        print(f"ERROR: structure.ttl not found at {structure}", file=sys.stderr)
+        sys.exit(1)
+    g.parse(str(structure), format="turtle")
+    if events.exists():
+        g.parse(str(events), format="turtle")
+    return g
+
+
+def run_sparql(g: Graph, sparql_file: Path, bindings: dict) -> list:
+    results = g.query(sparql_file.read_text(), initBindings=bindings)
+    return list(results)
+
+
+def main():
+    if len(sys.argv) != 4:
+        print("Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR>", file=sys.stderr)
+        sys.exit(1)
+
+    phase_local = sys.argv[1]
+    ttl_dir = sys.argv[2]
+    script_dir = Path(sys.argv[3])
+
+    phase_iri = URIRef(f"{TRIAGE_BASE}Phase{phase_local}")
+    g = load_graph(ttl_dir)
+
+    # ── Cursor ───────────────────────────────────────────────────────────────
+    cursor_rows = run_sparql(g, script_dir / "cursor.sparql", {"PHASE": phase_iri})
+
+    if cursor_rows:
+        sprint_iri = str(cursor_rows[0][0])
+        order = int(cursor_rows[0][1])
+        criteria = str(cursor_rows[0][2])
+        sprint_local = sprint_iri.split(":")[-1] if ":" in sprint_iri else sprint_iri
+
+        print(json.dumps({
+            "phase": "TRAVERSAL",
+            "vars": {
+                "sprint": sprint_local,
+                "sprint_iri": sprint_iri,
+                "sprint_order": order,
+                "criteria_doc": criteria,
+            },
+        }, indent=2))
+        return
+
+    # ── Cursor empty — check for open non-blocking findings (CLEANUP) ────────
+    cleanup_rows = run_sparql(
+        g, script_dir / "open-findings-sprint.sparql", {"PHASE": phase_iri}
+    )
+
+    if cleanup_rows:
+        findings = [
+            {
+                "sprint_iri": str(r[1]),
+                "severity": str(r[2]),
+                "foundAt": str(r[3]),
+                "description": str(r[4]),
+            }
+            for r in cleanup_rows
+        ]
+        print(json.dumps({
+            "phase": "CLEANUP",
+            "vars": {},
+            "_findings_raw": findings,
+        }, indent=2))
+    else:
+        print(json.dumps({
+            "phase": "DONE",
+            "vars": {},
+            "_findings_raw": [],
+        }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+test_queries.py — Unit tests for graph-orchestration SPARQL queries.
+
+Run from skill root: python3 -m pytest scripts/test_queries.py -v
+Requires: rdflib, pytest
+"""
+import pytest
+from pathlib import Path
+from rdflib import Graph, URIRef, Namespace
+from rdflib.namespace import XSD
+
+SCRIPTS = Path(__file__).parent
+TRIAGE = "urn:atm:triage:"
+T = Namespace(TRIAGE)
+
+PREFIX = f"@prefix triage: <{TRIAGE}> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+PHASE = URIRef(f"{TRIAGE}PhaseF")
+
+
+def sparql(query_file: str, bindings: dict, *ttl_strings: str) -> list:
+    g = Graph()
+    for ttl in ttl_strings:
+        g.parse(data=ttl, format="turtle")
+    results = g.query((SCRIPTS / query_file).read_text(), initBindings=bindings)
+    return list(results)
+
+
+def structure(sprints: list) -> str:
+    """Build structure TTL for a phase with N sprints.
+    sprints = [(order, sprint_id), ...]
+    """
+    lines = [PREFIX, "triage:PhaseF a triage:Phase ."]
+    for order, sid in sprints:
+        lines.append(
+            f'triage:{sid} a triage:Sprint ; triage:inPhase triage:PhaseF ;'
+            f' triage:order {order} ; triage:criteria "ac/{sid}.md" .'
+        )
+    return "\n".join(lines)
+
+
+# ── cursor tests ──────────────────────────────────────────────────────────────
+
+class TestCursor:
+    def test_returns_lowest_unstarted_sprint(self):
+        s = structure([(1, "S1"), (2, "S2")])
+        rows = sparql("cursor.sparql", {"PHASE": PHASE}, s)
+        assert len(rows) == 1
+        assert str(rows[0][1]) == "1"  # order 1
+
+    def test_skips_in_flight_sprint(self):
+        """Sprint with Assignment but no Completion is in-flight — skip it."""
+        s = structure([(1, "S1"), (2, "S2")])
+        events = PREFIX + """
+triage:a1 a triage:Assignment ; triage:ofSprint triage:S1 ;
+    triage:assignedTo "arch-ctm" ;
+    triage:assignedAt "2026-07-01T10:00:00Z"^^xsd:dateTime .
+"""
+        rows = sparql("cursor.sparql", {"PHASE": PHASE}, s, events)
+        assert len(rows) == 1
+        assert str(rows[0][1]) == "2"  # S1 in-flight, returns S2
+
+    def test_skips_validly_completed_sprint(self):
+        """Sprint with valid Completion is done — skip it."""
+        s = structure([(1, "S1"), (2, "S2")])
+        events = PREFIX + """
+triage:a1 a triage:Assignment ; triage:ofSprint triage:S1 ;
+    triage:assignedTo "arch-ctm" ;
+    triage:assignedAt "2026-07-01T10:00:00Z"^^xsd:dateTime .
+triage:c1 a triage:Completion ; triage:ofSprint triage:S1 ;
+    triage:at "2026-07-01T12:00:00Z"^^xsd:dateTime .
+"""
+        rows = sparql("cursor.sparql", {"PHASE": PHASE}, s, events)
+        assert len(rows) == 1
+        assert str(rows[0][1]) == "2"
+
+    def test_returns_sprint_when_completion_invalidated(self):
+        """Sprint with Completion + blocking finding after = invalid.
+        Dev finished but QA invalidated. No new Assignment yet →
+        cursor must return this sprint for re-dispatch."""
+        s = structure([(1, "S1"), (2, "S2")])
+        events = PREFIX + """
+triage:a1 a triage:Assignment ; triage:ofSprint triage:S1 ;
+    triage:assignedTo "arch-ctm" ;
+    triage:assignedAt "2026-07-01T10:00:00Z"^^xsd:dateTime .
+triage:c1 a triage:Completion ; triage:ofSprint triage:S1 ;
+    triage:at "2026-07-01T12:00:00Z"^^xsd:dateTime .
+triage:f1 a triage:Finding ; triage:foundIn triage:S1 ;
+    triage:severity "blocking" ;
+    triage:foundAt "2026-07-01T14:00:00Z"^^xsd:dateTime ;
+    triage:description "Test failure" .
+"""
+        rows = sparql("cursor.sparql", {"PHASE": PHASE}, s, events)
+        assert len(rows) == 1
+        assert str(rows[0][1]) == "1"  # S1 must be returned for re-dispatch
+
+    def test_skips_re_dispatched_sprint(self):
+        """Sprint with invalid Completion + new Assignment (in-flight re-dispatch) → skip."""
+        s = structure([(1, "S1"), (2, "S2")])
+        events = PREFIX + """
+triage:a1 a triage:Assignment ; triage:ofSprint triage:S1 ;
+    triage:assignedTo "arch-ctm" ;
+    triage:assignedAt "2026-07-01T10:00:00Z"^^xsd:dateTime .
+triage:c1 a triage:Completion ; triage:ofSprint triage:S1 ;
+    triage:at "2026-07-01T12:00:00Z"^^xsd:dateTime .
+triage:f1 a triage:Finding ; triage:foundIn triage:S1 ;
+    triage:severity "blocking" ;
+    triage:foundAt "2026-07-01T14:00:00Z"^^xsd:dateTime ;
+    triage:description "Test failure" .
+triage:a2 a triage:Assignment ; triage:ofSprint triage:S1 ;
+    triage:assignedTo "arch-ctm" ;
+    triage:assignedAt "2026-07-01T15:00:00Z"^^xsd:dateTime .
+"""
+        rows = sparql("cursor.sparql", {"PHASE": PHASE}, s, events)
+        assert len(rows) == 1
+        assert str(rows[0][1]) == "2"  # S1 re-dispatched/in-flight → returns S2
+
+    def test_returns_empty_when_all_complete(self):
+        """All sprints with valid Completions → cursor empty."""
+        s = structure([(1, "S1"), (2, "S2")])
+        events = PREFIX + """
+triage:c1 a triage:Completion ; triage:ofSprint triage:S1 ;
+    triage:at "2026-07-01T12:00:00Z"^^xsd:dateTime .
+triage:c2 a triage:Completion ; triage:ofSprint triage:S2 ;
+    triage:at "2026-07-01T14:00:00Z"^^xsd:dateTime .
+"""
+        rows = sparql("cursor.sparql", {"PHASE": PHASE}, s, events)
+        assert len(rows) == 0
+
+
+# ── validate-structure tests ──────────────────────────────────────────────────
+
+class TestValidateStructure:
+    def test_valid_structure_returns_zero_rows(self):
+        s = structure([(1, "S1"), (2, "S2")])
+        rows = sparql("validate-structure.sparql", {"PHASE": PHASE}, s)
+        assert len(rows) == 0
+
+    def test_detects_duplicate_order(self):
+        ttl = PREFIX + """
+triage:PhaseF a triage:Phase .
+triage:S1 a triage:Sprint ; triage:inPhase triage:PhaseF ; triage:order 1 ; triage:criteria "ac/S1.md" .
+triage:S2 a triage:Sprint ; triage:inPhase triage:PhaseF ; triage:order 1 ; triage:criteria "ac/S2.md" .
+"""
+        rows = sparql("validate-structure.sparql", {"PHASE": PHASE}, ttl)
+        violations = [str(r[0]) for r in rows]
+        assert "duplicate-order" in violations
+
+    def test_detects_missing_criteria(self):
+        ttl = PREFIX + """
+triage:PhaseF a triage:Phase .
+triage:S1 a triage:Sprint ; triage:inPhase triage:PhaseF ; triage:order 1 .
+"""
+        rows = sparql("validate-structure.sparql", {"PHASE": PHASE}, ttl)
+        violations = [str(r[0]) for r in rows]
+        assert "missing-criteria" in violations
+
+
+# ── open-findings-sprint tests ────────────────────────────────────────────────
+
+class TestOpenFindingsSprint:
+    def test_excludes_blocking_findings(self):
+        s = structure([(1, "S1")])
+        findings = PREFIX + """
+triage:f1 a triage:Finding ; triage:foundIn triage:S1 ;
+    triage:severity "blocking" ;
+    triage:foundAt "2026-07-01T12:00:00Z"^^xsd:dateTime ;
+    triage:description "blocker" .
+"""
+        rows = sparql("open-findings-sprint.sparql", {"PHASE": PHASE}, s, findings)
+        assert len(rows) == 0
+
+    def test_returns_important_before_minor(self):
+        s = structure([(1, "S1")])
+        findings = PREFIX + """
+triage:f1 a triage:Finding ; triage:foundIn triage:S1 ;
+    triage:severity "minor" ;
+    triage:foundAt "2026-07-01T10:00:00Z"^^xsd:dateTime ;
+    triage:description "minor issue" .
+triage:f2 a triage:Finding ; triage:foundIn triage:S1 ;
+    triage:severity "important" ;
+    triage:foundAt "2026-07-01T11:00:00Z"^^xsd:dateTime ;
+    triage:description "important issue" .
+"""
+        rows = sparql("open-findings-sprint.sparql", {"PHASE": PHASE}, s, findings)
+        assert len(rows) == 2
+        severities = [str(r[2]) for r in rows]
+        assert severities[0] == "important"
+        assert severities[1] == "minor"
+
+    def test_excludes_resolved_findings(self):
+        s = structure([(1, "S1")])
+        data = PREFIX + """
+triage:f1 a triage:Finding ; triage:foundIn triage:S1 ;
+    triage:severity "important" ;
+    triage:foundAt "2026-07-01T10:00:00Z"^^xsd:dateTime ;
+    triage:description "issue" .
+triage:r1 a triage:Resolution ; triage:resolves triage:f1 ;
+    triage:resolvedAt "2026-07-01T12:00:00Z"^^xsd:dateTime .
+"""
+        rows = sparql("open-findings-sprint.sparql", {"PHASE": PHASE}, s, data)
+        assert len(rows) == 0
+
+
+if __name__ == "__main__":
+    import subprocess, sys
+    sys.exit(subprocess.call(["python3", "-m", "pytest", __file__, "-v"]))

--- a/.claude/skills/graph-orchestration/scripts/validate-structure.sparql
+++ b/.claude/skills/graph-orchestration/scripts/validate-structure.sparql
@@ -1,0 +1,40 @@
+# validate-structure.sparql — Phase structure integrity check.
+#
+# Run once at phase start. Zero rows = valid. Any rows = malformed.
+#
+# Checks:
+#   1. Duplicate triage:order values on different sprints
+#   2. Sprints without triage:criteria
+#   3. Sprints without triage:order
+#
+# Parameter: $PHASE (bound via initBindings)
+
+PREFIX triage: <urn:atm:triage:>
+
+SELECT ?violation ?detail WHERE {
+  {
+    # Rule 1: duplicate order values
+    ?s1 a triage:Sprint ; triage:inPhase $PHASE ; triage:order ?order .
+    ?s2 a triage:Sprint ; triage:inPhase $PHASE ; triage:order ?order .
+    FILTER (?s1 != ?s2)
+    BIND("duplicate-order" AS ?violation)
+    BIND(STR(?order) AS ?detail)
+  }
+  UNION
+  {
+    # Rule 2: sprint missing triage:criteria
+    ?s1 a triage:Sprint ; triage:inPhase $PHASE .
+    FILTER NOT EXISTS { ?s1 triage:criteria ?c . }
+    BIND("missing-criteria" AS ?violation)
+    BIND(STR(?s1) AS ?detail)
+  }
+  UNION
+  {
+    # Rule 3: sprint missing triage:order
+    ?s1 a triage:Sprint ; triage:inPhase $PHASE .
+    FILTER NOT EXISTS { ?s1 triage:order ?o . }
+    BIND("missing-order" AS ?violation)
+    BIND(STR(?s1) AS ?detail)
+  }
+}
+ORDER BY ?violation ?detail


### PR DESCRIPTION
## Summary

Adds the `graph-orchestration` skill to atm-core -- a TTL/SPARQL-driven mechanical sprint orchestration system. Derived from `codex-orchestration`; replaces static sprint-doc assignments with a live RDF event log queried via SPARQL.

**Skill location:** `.claude/skills/graph-orchestration/`

---

## Original Design Document

# Mechanical Sprint Orchestration -- TTL Model, Queries, and Prompt Requirements

**Status:** Design v1.0 -- basis for rewriting orchestration and triage skill/task prompts.

## 1. Purpose and Invariants

Orchestration must never make a decision that requires thinking. Every question the
orchestrator asks -- *what is the next node? what phase are we in? is the sprint done?* --
is answered by a deterministic query over an append-only RDF event log. The orchestrator
is a loop: **query -> dispatch -> await event append -> re-query.**

Invariants the entire system rests on:

1. **Append-only.** State is never mutated. Completions, findings, and resolutions are
   events with timestamps. Nothing is ever edited or deleted.
2. **Findings are immutable.** A finding's severity never changes. If QA re-assesses and
   the situation improved, QA files a *new, separate* finding at the lesser severity.
   Every finding is associated with exactly one sprint.
3. **Derived, never stored.** Cursor position, phase, validity of completions, and
   done-ness are all query results. There is no status field anywhere.
4. **Sequential traversal.** Sprint nodes carry explicit ordinals (`td:order`). Dev
   traverses in ascending order. A blocking finding snaps the cursor back via `min()`;
   no reset operation exists.
5. **Full replay.** Sprints run on branches with the previous sprint merged forward.
   A blocking finding at order *k* invalidates every completion at order >= *k* that
   predates it -- downstream work was built on a bad base and must be re-traversed.

## 2. Ontology (TTL Vocabulary)

```turtle
@prefix td:  <https://synaptic-canvas.dev/ont/taskdag#> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

## ---- Classes ----
# td:Sprint       -- a sprint (branch scope)
# td:Node         -- a unit of work within a sprint, ordered
# td:Completion   -- event: dev finished a pass on a node
# td:Finding      -- event: QA identified an issue (immutable)
# td:Resolution   -- event: a specific non-blocking finding was fixed

## ---- Severity individuals ----
# td:Blocking     -- closure criteria not met OR an unacceptable issue was introduced
# td:Important    -- must be fixed before merge; does not reset the cursor
# td:Minor        -- should be fixed; does not reset the cursor

## ---- Properties ----
# td:inSprint     Node|Finding -> Sprint
# td:order        Node -> xsd:integer          (unique per sprint, ascending)
# td:criteria     Node -> IRI or literal       (pointer to acceptance criteria doc)
# td:ofNode       Completion -> Node
# td:at           Completion -> xsd:dateTime
# td:foundIn      Finding -> Node
# td:severity     Finding -> {td:Blocking, td:Important, td:Minor}
# td:foundAt      Finding -> xsd:dateTime
# td:description  Finding -> literal
# td:resolves     Resolution -> Finding
# td:resolvedAt   Resolution -> xsd:dateTime
```

## 3. Event Rules

| Event | Appended by | When |
|---|---|---|
| `td:Completion` | Dev agent | On finishing any pass over a node (initial or replay). |
| `td:Finding` | QA agent | On identifying an issue during review. Never modified afterward. |
| `td:Resolution` | Dev agent | When a specific **non-blocking** finding is fixed. |

## 4. Derived State

### 4.1 Completion validity (full replay)

> A Completion of node N (order *n*) is **valid** iff no Blocking finding exists on any
> node M in the same sprint with `order(M) <= n` and `foundAt > completion.at`.

### 4.2 Cursor

> **cursor** = the node with minimum `td:order` among nodes lacking a valid Completion.

### 4.3 Phase

| Cursor query | Open non-blocking findings | Phase | Orchestrator action |
|---|---|---|---|
| returns node | (irrelevant) | **TRAVERSAL** | Dispatch that node |
| empty | non-empty | **CLEANUP** | Dispatch consolidation task |
| empty | empty | **DONE** | Merge; sprint closed |

## 5. Files in This Skill

- `SKILL.md` -- orchestrator loop instructions
- `dev-task.xml.j2` -- Jinja2 template for TRAVERSAL task prompts
- `dev-fix.xml.j2` -- Jinja2 template for fix-pass task prompts
- `scripts/next-dev-task` -- bash driver: runs cursor.sparql, determines phase, renders template
- `scripts/cursor.sparql` -- SPARQL: next node with valid-completion semantics
- `scripts/open-findings-sprint.sparql` -- SPARQL: all open non-blocking findings (CLEANUP/DONE)
- `scripts/validate-structure.sparql` -- SPARQL: structure integrity check at sprint creation
- `scripts/query_runner.py` -- Python (rdflib) runner for SPARQL queries over TTL files