### PR TITLE
fix(daemon-switch): verify managed daemon pair restart safety

### DIFF
--- a/.claude/skills/daemon-switch/scripts/daemon-switch.py
+++ b/.claude/skills/daemon-switch/scripts/daemon-switch.py
@@ -8,6 +8,7 @@ import json
 import os
 from pathlib import Path
 import platform
+import plistlib
 import shutil
 import subprocess
 import sys
@@ -168,9 +169,61 @@ def validate_selectors(cli_link: Path, daemon_link: Path) -> None:
             raise SwitchError(f"refusing to replace non-symlink {label} selector: {link}")
 
 
+def validate_macos_launch_agent(args: argparse.Namespace, daemon_link: Path) -> None:
+    """Require the managed LaunchAgent to execute the daemon selector itself.
+
+    A plist which names a Cellar/worktree binary bypasses the pair switch and
+    can leave a new CLI talking to an old daemon.  The service must execute the
+    selector path so both binaries move as one controlled unit.
+    """
+    if platform.system() != "Darwin":
+        return
+    if not args.launch_agent_plist:
+        raise SwitchError("macOS requires --launch-agent-plist for controlled singleton restart")
+    plist_path = Path(args.launch_agent_plist).expanduser()
+    try:
+        with plist_path.open("rb") as handle:
+            plist = plistlib.load(handle)
+    except (OSError, plistlib.InvalidFileException) as error:
+        raise SwitchError(f"cannot read LaunchAgent plist {plist_path}: {error}") from error
+    program_arguments = plist.get("ProgramArguments") if isinstance(plist, dict) else None
+    if not isinstance(program_arguments, list) or not program_arguments or not isinstance(program_arguments[0], str):
+        raise SwitchError(f"LaunchAgent plist {plist_path} has no executable ProgramArguments entry")
+    if Path(program_arguments[0]).expanduser().absolute() != daemon_link:
+        raise SwitchError(
+            "LaunchAgent daemon executable must be the daemon selector "
+            f"{daemon_link}, not {program_arguments[0]}"
+        )
+
+
+def daemon_version_from_doctor(report: dict[str, object]) -> str | None:
+    context = report.get("daemon_context")
+    if not isinstance(context, dict):
+        return None
+    value = context.get("version")
+    return value if isinstance(value, str) else None
+
+
+def verify_live_pair(cli: Path, expected_cli_version: str | None) -> None:
+    """Fail closed unless the selected CLI reaches a healthy matching daemon."""
+    report = doctor(cli)
+    if "error" in report:
+        raise SwitchError(f"managed daemon failed doctor after switch: {report['error']}")
+    daemon_version = daemon_version_from_doctor(report)
+    if not expected_cli_version or not daemon_version:
+        raise SwitchError("cannot verify selected CLI and daemon versions after switch")
+    normalized_cli = expected_cli_version.removeprefix("atm ").strip()
+    if daemon_version != normalized_cli:
+        raise SwitchError(
+            "managed daemon version does not match the selected CLI: "
+            f"daemon={daemon_version}, cli={normalized_cli}"
+        )
+
+
 def switch_pair(args: argparse.Namespace, cli_target: Path, daemon_target: Path) -> None:
     cli_link, daemon_link = selected_links(args)
     validate_selectors(cli_link, daemon_link)
+    validate_macos_launch_agent(args, daemon_link)
     old_cli = require_executable(cli_link, "selected atm CLI")
     old_daemon = require_executable(daemon_link, "selected atm daemon")
     cli_target = require_executable(cli_target, "target atm CLI")
@@ -179,9 +232,6 @@ def switch_pair(args: argparse.Namespace, cli_target: Path, daemon_target: Path)
         raise SwitchError(
             "refusing targets from different release directories; build or install the matched pair together"
         )
-    if cli_link.resolve() == cli_target and daemon_link.resolve() == daemon_target:
-        print("already selected; service left running")
-        return
     if args.dry_run:
         print(json.dumps({"cli_link": str(cli_link), "daemon_link": str(daemon_link), "cli_target": str(cli_target), "daemon_target": str(daemon_target)}, indent=2))
         return
@@ -190,14 +240,18 @@ def switch_pair(args: argparse.Namespace, cli_target: Path, daemon_target: Path)
     save_default_pair(old_cli, old_daemon)
     run_service(args, "stop", allow_absent=True)
     try:
-        replace_link(cli_link, cli_target)
-        replace_link(daemon_link, daemon_target)
+        if cli_link.resolve() != cli_target:
+            replace_link(cli_link, cli_target)
+        if daemon_link.resolve() != daemon_target:
+            replace_link(daemon_link, daemon_target)
         run_service(args, "start")
+        verify_live_pair(cli_link, version(cli_link))
     except Exception:
         replace_link(cli_link, old_cli)
         replace_link(daemon_link, old_daemon)
         try:
             run_service(args, "start")
+            verify_live_pair(cli_link, version(cli_link))
         except SwitchError:
             pass
         raise

--- a/.just/tests/test_daemon_switch.py
+++ b/.just/tests/test_daemon_switch.py
@@ -47,6 +47,8 @@ class DaemonSwitchTests(unittest.TestCase):
             save_default_pair=mock.DEFAULT,
             replace_link=mock.DEFAULT,
             run_service=mock.DEFAULT,
+            validate_macos_launch_agent=mock.DEFAULT,
+            verify_live_pair=mock.DEFAULT,
         )
 
     def test_switch_pair_stops_then_replaces_both_selectors_then_starts(self) -> None:
@@ -77,6 +79,7 @@ class DaemonSwitchTests(unittest.TestCase):
                 mock.call(self.daemon_link, self.new_daemon),
             ],
         )
+        patched["verify_live_pair"].assert_called_once()
 
     def test_switch_pair_rolls_back_both_selectors_and_restarts_after_replace_failure(self) -> None:
         with self.patch_switch_inputs() as patched:
@@ -108,6 +111,33 @@ class DaemonSwitchTests(unittest.TestCase):
                 mock.call(self.args, "start"),
             ],
         )
+
+    def test_switch_restarts_and_verifies_when_selectors_already_match(self) -> None:
+        with self.patch_switch_inputs() as patched:
+            patched["selected_links"].return_value = (self.new_cli, self.new_daemon)
+            patched["require_executable"].side_effect = [
+                self.new_cli,
+                self.new_daemon,
+                self.new_cli,
+                self.new_daemon,
+            ]
+            self.module.switch_pair(self.args, self.new_cli, self.new_daemon)
+
+        self.assertEqual(
+            patched["run_service"].call_args_list,
+            [mock.call(self.args, "stop", allow_absent=True), mock.call(self.args, "start")],
+        )
+        patched["replace_link"].assert_not_called()
+        patched["verify_live_pair"].assert_called_once()
+
+    def test_verify_live_pair_rejects_stale_daemon(self) -> None:
+        with mock.patch.object(
+            self.module,
+            "doctor",
+            return_value={"daemon_context": {"version": "1.3.1"}},
+        ):
+            with self.assertRaisesRegex(self.module.SwitchError, "does not match"):
+                self.module.verify_live_pair(Path("/selectors/atm"), "atm 1.3.2-beta.21")
 
     def test_invalid_selector_is_rejected_before_service_stop(self) -> None:
         with self.patch_switch_inputs() as patched:

--- a/.triage/phase-daemon-switch-restart-safety/findings/ARCH-001.ttl
+++ b/.triage/phase-daemon-switch-restart-safety/findings/ARCH-001.ttl
@@ -1,0 +1,38 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ARCH-001>
+  a triage:Finding ;
+  triage:findingId "ARCH-001" ;
+  triage:title "verify_live_pair derives expected version via hardcoded string-stripping instead of the canonical ReleaseVersion type" ;
+  triage:description "verify_live_pair() derives the expected version by hardcoded-string-stripping `atm --version` output (daemon-switch.py:215, removeprefix(\"atm \")) instead of going through the canonical ReleaseVersion type / CompatibilityPreflight mechanism already defined in crates/atm-core/src/protocol.rs:99-154. Breaks silently if clap's version-string format or the atm command name changes." ;
+  triage:phaseId "phase-daemon-switch-restart-safety" ;
+  triage:triageMode "initial_pass" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:category "ARCH" ;
+  triage:severity "Important" ;
+  triage:triagedAt "2026-07-24T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-001/feature-daemon-switch-restart-safety/1> ;
+  triage:openOn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> ;
+  triage:promoteTo <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:occurrence/ARCH-001/feature-daemon-switch-restart-safety/1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/daemon-switch/scripts/daemon-switch.py" ;
+  triage:line 215 ;
+  triage:snippet "normalized_cli = expected_cli_version.removeprefix(\"atm \").strip()" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/daemon-switch-tooling" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-daemon-switch-restart-safety/findings/ARCH-002.ttl
+++ b/.triage/phase-daemon-switch-restart-safety/findings/ARCH-002.ttl
@@ -1,0 +1,38 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ARCH-002>
+  a triage:Finding ;
+  triage:findingId "ARCH-002" ;
+  triage:title "removal of switch_pair's early-return is undocumented inline" ;
+  triage:description "The removal of switch_pair's old early-return (matched selectors → no-op) means every switch/restore now unconditionally restarts the singleton daemon — a deliberate, justified change, but undocumented inline; a future maintainer could \"optimize\" the early-return back in and silently reintroduce the incident class." ;
+  triage:phaseId "phase-daemon-switch-restart-safety" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "documentation" ;
+  triage:severity "Minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "single-occurrence" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-24T22:09:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-002/feature-daemon-switch-restart-safety/1> ;
+  triage:openOn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> ;
+  triage:promoteTo <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:occurrence/ARCH-002/feature-daemon-switch-restart-safety/1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/daemon-switch/scripts/daemon-switch.py" ;
+  triage:line 223 ;
+  triage:snippet "def switch_pair(args: argparse.Namespace, cli_target: Path, daemon_target: Path) -> None:" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/daemon-switch-tooling" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-daemon-switch-restart-safety/findings/ARCH-003.ttl
+++ b/.triage/phase-daemon-switch-restart-safety/findings/ARCH-003.ttl
@@ -1,0 +1,50 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ARCH-003>
+  a triage:Finding ;
+  triage:findingId "ARCH-003" ;
+  triage:title "restart+verify pair duplicated verbatim between normal and rollback paths" ;
+  triage:description "The restart+verify pair (run_service(start) + verify_live_pair(...)) is duplicated verbatim between the normal path (daemon-switch.py:247-248) and the rollback path (:253-254); should be a shared helper." ;
+  triage:phaseId "phase-daemon-switch-restart-safety" ;
+  triage:triageMode "initial_pass" ;
+  triage:repeatable false ;
+  triage:sweepScope "single-occurrence" ;
+  triage:category "code-quality" ;
+  triage:severity "Minor" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-003/1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-003/2> ;
+  triage:openOn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> ;
+  triage:promoteTo <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> ;
+  triage:triagedAt "2026-07-24T00:00:00Z"^^xsd:dateTime .
+
+<urn:atm:triage:occurrence/ARCH-003/1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/daemon-switch/scripts/daemon-switch.py" ;
+  triage:line 247 ;
+  triage:snippet "run_service(args, \"start\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:occurrence/ARCH-003/2>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/daemon-switch/scripts/daemon-switch.py" ;
+  triage:line 253 ;
+  triage:snippet "run_service(args, \"start\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/daemon-switch-tooling" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-daemon-switch-restart-safety/findings/ARCH-004.ttl
+++ b/.triage/phase-daemon-switch-restart-safety/findings/ARCH-004.ttl
@@ -1,0 +1,38 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ARCH-004>
+  a triage:Finding ;
+  triage:findingId "ARCH-004" ;
+  triage:title "validate_macos_launch_agent only covers Darwin/launchctl, no tracking issue for other platforms" ;
+  triage:description "validate_macos_launch_agent only covers Darwin/launchctl; the same incident class is architecturally possible via a systemd ExecStart= or Windows service binPath if/when this tool grows support for those platforms — no tracking issue recorded. Non-blocking, informational." ;
+  triage:phaseId "phase-daemon-switch-restart-safety" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ARCH" ;
+  triage:severity "Minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "single-occurrence" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:triagedAt "2026-07-24T22:10:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ARCH-004/feature-daemon-switch-restart-safety/1> ;
+  triage:openOn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> ;
+  triage:promoteTo <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:occurrence/ARCH-004/feature-daemon-switch-restart-safety/1>
+  a triage:Occurrence ;
+  triage:file "scripts/daemon-switch.py" ;
+  triage:line -1 ;
+  triage:snippet "validate_macos_launch_agent: Darwin/launchctl only; missing tracking issues for systemd/Windows service variants" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/daemon-switch-tooling" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-daemon-switch-restart-safety/findings/ATM-QA-001.ttl
+++ b/.triage/phase-daemon-switch-restart-safety/findings/ATM-QA-001.ttl
@@ -1,0 +1,38 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ATM-QA-001>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-001" ;
+  triage:title "restart subcommand bypasses both new safety checks entirely" ;
+  triage:description "daemon-switch.py:272-276 (restart()) only calls run_service(stop) + run_service(start) — no call to validate_macos_launch_agent() or verify_live_pair(). main() at daemon-switch.py:343-344 routes the bare `restart` command straight to this function, never through switch_pair(). `restart` is documented as the sanctioned command for reloading the singleton daemon without changing the binary pair — exactly the operation during which the original incident (LaunchAgent plist pointing at a bypassing Cellar/worktree binary) could recur, with zero detection." ;
+  triage:category "missing-guard-on-alternate-entrypoint" ;
+  triage:phaseId "phase-daemon-switch-restart-safety" ;
+  triage:triageMode "initial_pass" ;
+  triage:severity "Blocking" ;
+  triage:repeatable false ;
+  triage:sweepScope "single-occurrence" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-24T21:50:21Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-001/restart-safety/1> ;
+  triage:openOn <urn:atm:triage:worktree/daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> ;
+  triage:promoteTo <urn:atm:triage:worktree/daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:occurrence/ATM-QA-001/restart-safety/1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/daemon-switch/scripts/daemon-switch.py" ;
+  triage:line 272 ;
+  triage:snippet "def restart(args: argparse.Namespace) -> None:" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:worktree/daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/daemon-switch-tooling" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-daemon-switch-restart-safety/findings/ATM-QA-002.ttl
+++ b/.triage/phase-daemon-switch-restart-safety/findings/ATM-QA-002.ttl
@@ -1,0 +1,38 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ATM-QA-002>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-002" ;
+  triage:title "rollback reverification failure is silently swallowed" ;
+  triage:description "daemon-switch.py:249-257, in switch_pair's exception handler — after restoring the old cli/daemon links, run_service(start) and verify_live_pair(...) are both wrapped in `except SwitchError: pass`, then the function unconditionally re-raises only the original exception. If the rollback restart or its reverification itself fails, that second failure is completely discarded — no print, no log, nothing. The operator sees only the original error with no way to know whether recovery left the system verified-good or unknown/broken. This reproduces the exact \"silently mismatched pair\" failure class the fix exists to close, relocated to the rollback path." ;
+  triage:phaseId "phase-daemon-switch-restart-safety" ;
+  triage:triageMode "initial_pass" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:category "QA" ;
+  triage:severity "Blocking" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-24T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-002/feature-daemon-switch-restart-safety/1> ;
+  triage:openOn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> ;
+  triage:promoteTo <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:occurrence/ATM-QA-002/feature-daemon-switch-restart-safety/1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/daemon-switch/scripts/daemon-switch.py" ;
+  triage:line 255 ;
+  triage:snippet "except SwitchError:\n            pass" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/daemon-switch-tooling" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-daemon-switch-restart-safety/findings/ATM-QA-003.ttl
+++ b/.triage/phase-daemon-switch-restart-safety/findings/ATM-QA-003.ttl
@@ -1,0 +1,38 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/ATM-QA-003>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-003" ;
+  triage:title "validate_macos_launch_agent() has zero direct test coverage; restart() untested" ;
+  triage:description "validate_macos_launch_agent() has zero direct test coverage of its own plist-parsing/comparison logic — every switch_pair test mocks it away via patch_switch_inputs() (.just/tests/test_daemon_switch.py:50), and no test exercises restart() at all. Confirmed via grep: validate_macos_launch_agent appears in the test file only as a mocked default." ;
+  triage:phaseId "phase-daemon-switch-restart-safety" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "missing-test-coverage" ;
+  triage:severity "important" ;
+  triage:repeatable false ;
+  triage:sweepScope "single-occurrence" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-24T22:08:30Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-003/feature-daemon-switch-restart-safety/1> ;
+  triage:openOn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> ;
+  triage:promoteTo <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:occurrence/ATM-QA-003/feature-daemon-switch-restart-safety/1>
+  a triage:Occurrence ;
+  triage:file ".just/tests/test_daemon_switch.py" ;
+  triage:line 50 ;
+  triage:snippet "validate_macos_launch_agent=mock.DEFAULT" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/daemon-switch-tooling" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-daemon-switch-restart-safety/findings/RBQA-F003.ttl
+++ b/.triage/phase-daemon-switch-restart-safety/findings/RBQA-F003.ttl
@@ -1,0 +1,38 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/RBQA-F003>
+  a triage:Finding ;
+  triage:findingId "RBQA-F003" ;
+  triage:title "plain string equality in verify_live_pair can't distinguish differently-built binaries sharing an unbumped version string" ;
+  triage:description "The version check in verify_live_pair() (daemon-switch.py:216) uses plain string equality, which can't distinguish two different branch/worktree builds that happen to share an unbumped version string (e.g. both report 0.15.0-dev) — exactly the tool's documented primary use case per its own --cli/--daemon help text (\"branch/release atm binary\")." ;
+  triage:phaseId "phase-daemon-switch-restart-safety" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "RBQA" ;
+  triage:severity "Important" ;
+  triage:repeatable false ;
+  triage:sweepScope "single-occurrence" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-24T22:08:30Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F003/daemon-switch-restart-safety/1> ;
+  triage:openOn <urn:atm:triage:worktree/daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> ;
+  triage:promoteTo <urn:atm:triage:worktree/daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:occurrence/RBQA-F003/daemon-switch-restart-safety/1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/daemon-switch/scripts/daemon-switch.py" ;
+  triage:line 216 ;
+  triage:snippet "if daemon_version != normalized_cli:" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:worktree/daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/daemon-switch-tooling" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-daemon-switch-restart-safety/findings/RBQA-F004.ttl
+++ b/.triage/phase-daemon-switch-restart-safety/findings/RBQA-F004.ttl
@@ -1,0 +1,50 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/RBQA-F004>
+  a triage:Finding ;
+  triage:findingId "RBQA-F004" ;
+  triage:title "Darwin requires --launch-agent-plist precondition is duplicated in two places" ;
+  triage:description "The \"Darwin requires --launch-agent-plist\" precondition is independently implemented in two places (service_commands() at daemon-switch.py:104-105 and validate_macos_launch_agent() at :181-182) — duplicated decision logic that can silently drift apart." ;
+  triage:phaseId "phase-daemon-switch-restart-safety" ;
+  triage:triageMode "initial_pass" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:category "RBQA" ;
+  triage:severity "Important" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-24T00:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F004/feature-daemon-switch-restart-safety/1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F004/feature-daemon-switch-restart-safety/2> ;
+  triage:openOn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94> ;
+  triage:promoteTo <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94> .
+
+<urn:atm:triage:occurrence/RBQA-F004/feature-daemon-switch-restart-safety/1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/daemon-switch/scripts/daemon-switch.py" ;
+  triage:line 104 ;
+  triage:snippet "if not args.launch_agent_plist: raise SwitchError(\"macOS requires --launch-agent-plist for controlled singleton restart\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94> .
+
+<urn:atm:triage:occurrence/RBQA-F004/feature-daemon-switch-restart-safety/2>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/daemon-switch/scripts/daemon-switch.py" ;
+  triage:line 181 ;
+  triage:snippet "if not args.launch_agent_plist: raise SwitchError(\"macOS requires --launch-agent-plist for controlled singleton restart\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94> .
+
+<urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/daemon-switch-tooling" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-daemon-switch-restart-safety/findings/RBQA-F005.ttl
+++ b/.triage/phase-daemon-switch-restart-safety/findings/RBQA-F005.ttl
@@ -1,0 +1,38 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/RBQA-F005>
+  a triage:Finding ;
+  triage:findingId "RBQA-F005" ;
+  triage:title "TOCTOU gap between plist validation and launchctl bootstrap" ;
+  triage:description "The plist is read/validated once, well before the actual launchctl bootstrap call later in the same switch_pair invocation — nothing pins the validated bytes. Narrow, compounds with the version-string false-negative (RBQA-F003)." ;
+  triage:phaseId "phase-daemon-switch-restart-safety" ;
+  triage:triageMode "initial_pass" ;
+  triage:repeatable false ;
+  triage:sweepScope "single-occurrence" ;
+  triage:category "restart-safety" ;
+  triage:severity "minor" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-24T22:09:15Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-F005/feature-daemon-switch-restart-safety/1> ;
+  triage:openOn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> ;
+  triage:promoteTo <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:occurrence/RBQA-F005/feature-daemon-switch-restart-safety/1>
+  a triage:Occurrence ;
+  triage:file ".claude/skills/daemon-switch/scripts/daemon-switch.py" ;
+  triage:line 226 ;
+  triage:snippet "validate_macos_launch_agent(args, daemon_link) [...] run_service(args, \"start\")" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:occursIn <urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1> .
+
+<urn:atm:triage:worktree/feature-daemon-switch-restart-safety/42589c94f9c5a1a946a38e3deb4f327796e1c2a1>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/daemon-switch-restart-safety" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/daemon-switch-tooling" ;
+  triage:headSha "42589c94f9c5a1a946a38e3deb4f327796e1c2a1" ;
+  triage:orderIndex 1 .


### PR DESCRIPTION
## Summary
- Post-merge follow-up to #617 (daemon-switch tooling): adds restart-safety verification for the managed daemon pair.
- Branched fresh off current `develop` (not a reopen of the already-merged `feature/daemon-switch-tooling`); contains only the new restart-safety commit `42589c94`.

## Validation
- daemon-switch unit tests: pass
- `just test`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)