### PR TITLE
docs(graph-orchestration): populate ignore-list for closed phase-U/V/W findings

### DIFF
--- a/.triage/.graph-orchestration-ignore
+++ b/.triage/.graph-orchestration-ignore
@@ -1,0 +1,17 @@
+# Phase directories under .triage/ that the graph-orchestration skill's
+# load_graph() should skip entirely, without opening or parsing any file
+# in <name>/findings/*.ttl. One directory name per line; # comments and
+# blank lines are ignored. See .claude/skills/graph-orchestration/scripts/
+# query_runner.py for the loader that reads this file.
+#
+# Listed phases are closed/dead: their findings predate the Turtle schema
+# and use an old pre-Turtle format (plain "key: value" or TOML-like
+# "key = \"value\""), so they will never parse and will never be migrated.
+# The membership-based scoping in load_graph() already guarantees these
+# files can't contaminate any other phase's cursor resolution even if
+# left out of this list — this file exists purely to stop the repeated
+# per-run "skipping malformed findings file" warning noise for files that
+# are permanently, deliberately unparseable, not to enforce correctness.
+phase-U
+phase-V
+phase-W


### PR DESCRIPTION
## Summary
- Populates `.triage/.graph-orchestration-ignore` (mechanism merged in #626) with `phase-U`, `phase-V`, `phase-W` — closed phases whose findings predate the Turtle schema and will never parse.
- Pure noise suppression: correctness is already guaranteed by the sprint-membership scoping added in #626, independent of this file's contents.

## Note on scope
`_find_repo_root()` resolves relative to the TTL_DIR passed to `load_graph()`, so this file only silences warnings for invocations whose repo root is this worktree's checkout. Long-lived branches forked before this file existed (e.g. `integrate/phase-AI`) won't see the suppression until they merge/rebase forward from `develop` — expected branch lag, not a defect in this fix.

## Test plan
- [x] `.triage/.graph-orchestration-ignore` present with phase-U/V/W listed
- [x] Existing test suite (18/18) from #626 still covers ignore-file-present/absent behavior