### PR TITLE
triage: persist AICH-S7 QA-1 findings

### DIFF
--- a/.triage/phase-AI/findings/AI26-ATMQA-001.ttl
+++ b/.triage/phase-AI/findings/AI26-ATMQA-001.ttl
@@ -21,7 +21,7 @@
   triage:closedBy "quality-mgr" ;
   triage:closureNote "Independently verified genuinely CLOSED during the AICH-S6-FIX-1 recheck (commit c088b878, 2026-07-25T08:19:43-07:00; 3 reviewers). complete_handshake_with_deadline at crates/atm-daemon/src/https_transport.rs (current lines ~469-484) now maps handshake io::Error via .map_err(|source| AtmError::remote_delivery_unconfirmed(format!(\"HTTPS peer mutual-TLS handshake was not confirmed before the shared deadline: {source}\"))), not daemon_unavailable -- the fix landed on commit 0265c94f ('fix: preserve HTTPS transport failure causes'), well before AI.27. Re-verified for this AI.27 QA-1 pass that https_transport.rs is genuinely untouched by 5e91a889: `git log --oneline -- crates/atm-daemon/src/https_transport.rs` shows its last touching commit is 0265c94f, and `git show 5e91a889 --stat` does not list https_transport.rs among changed files. Corrected from stale 'open'/Blocking status to 'fixed'/closed per this re-verification, citing the earlier FIX-1 verdict rather than re-deriving from scratch." ;
   triage:triagedAt "2026-07-25T14:15:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/s26/dc079fff> ;
+  triage:foundIn triage:AICH-S6 ;
   triage:foundAt "2026-07-25T14:15:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI26-ATMQA-001/s26/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI26-ATMQA-001/s27/1> ;

--- a/.triage/phase-AI/findings/AI26-ATMQA-001.ttl
+++ b/.triage/phase-AI/findings/AI26-ATMQA-001.ttl
@@ -4,7 +4,7 @@
 <urn:atm:triage:finding/AI26-ATMQA-001>
   a triage:Finding ;
   triage:findingId "AI26-ATMQA-001" ;
-  triage:foundAt "2026-07-25T07:54:44Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T15:12:03Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S6 ;
   triage:title "Handshake-phase timeout/disconnect still maps to DAEMON_UNAVAILABLE, violating AI.26 acceptance criterion 2" ;
   triage:description "crates/atm-daemon/src/https_transport.rs lines 470-482, function complete_handshake_with_deadline, unconditionally maps io::Error from stream.conn.complete_io() to AtmError::daemon_unavailable(\"HTTPS peer mutual-TLS handshake failed\"). However, when apply_deadline sets the socket's read/write timeout to the remaining shared budget just before this call, a timeout or disconnect occurring mid-handshake (exactly the scenario AI.26 exists to fix) surfaces as an io::Error and is unconditionally mapped to daemon_unavailable, not remote_delivery_unconfirmed. This violates sprint-ai-26 Deliverable 4 / acceptance criterion 2 (\"Timeout/disconnect never reports DAEMON_UNAVAILABLE while local daemon health is intact\"). All other outbound legs (DNS resolve, TCP connect) were correctly changed to map failures to AtmErrorCode::RemoteDeliveryUnconfirmed via remaining_budget(deadline). No test exercises this path — the only handshake-adjacent tests (e.g. expired_peer_budget_reports_remote_delivery_unconfirmed at line ~841) test the remaining_budget helper in isolation, not an actual expired-mid-handshake scenario through complete_handshake_with_deadline." ;
@@ -21,8 +21,6 @@
   triage:closedBy "quality-mgr" ;
   triage:closureNote "Independently verified genuinely CLOSED during the AICH-S6-FIX-1 recheck (commit c088b878, 2026-07-25T08:19:43-07:00; 3 reviewers). complete_handshake_with_deadline at crates/atm-daemon/src/https_transport.rs (current lines ~469-484) now maps handshake io::Error via .map_err(|source| AtmError::remote_delivery_unconfirmed(format!(\"HTTPS peer mutual-TLS handshake was not confirmed before the shared deadline: {source}\"))), not daemon_unavailable -- the fix landed on commit 0265c94f ('fix: preserve HTTPS transport failure causes'), well before AI.27. Re-verified for this AI.27 QA-1 pass that https_transport.rs is genuinely untouched by 5e91a889: `git log --oneline -- crates/atm-daemon/src/https_transport.rs` shows its last touching commit is 0265c94f, and `git show 5e91a889 --stat` does not list https_transport.rs among changed files. Corrected from stale 'open'/Blocking status to 'fixed'/closed per this re-verification, citing the earlier FIX-1 verdict rather than re-deriving from scratch." ;
   triage:triagedAt "2026-07-25T14:15:00Z"^^xsd:dateTime ;
-  triage:foundIn triage:AICH-S6 ;
-  triage:foundAt "2026-07-25T14:15:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI26-ATMQA-001/s26/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI26-ATMQA-001/s27/1> ;
   triage:openOn <urn:atm:triage:worktree/s26/dc079fff> ;

--- a/.triage/phase-AI/findings/AI26-ATMQA-001.ttl
+++ b/.triage/phase-AI/findings/AI26-ATMQA-001.ttl
@@ -14,9 +14,15 @@
   triage:severity "Blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file" ;
-  triage:status "open" ;
-  triage:dispatchReady true ;
+  triage:status "fixed" ;
+  triage:dispatchReady false ;
+  triage:closed true ;
+  triage:closedAt "2026-07-25T15:12:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "Independently verified genuinely CLOSED during the AICH-S6-FIX-1 recheck (commit c088b878, 2026-07-25T08:19:43-07:00; 3 reviewers). complete_handshake_with_deadline at crates/atm-daemon/src/https_transport.rs (current lines ~469-484) now maps handshake io::Error via .map_err(|source| AtmError::remote_delivery_unconfirmed(format!(\"HTTPS peer mutual-TLS handshake was not confirmed before the shared deadline: {source}\"))), not daemon_unavailable -- the fix landed on commit 0265c94f ('fix: preserve HTTPS transport failure causes'), well before AI.27. Re-verified for this AI.27 QA-1 pass that https_transport.rs is genuinely untouched by 5e91a889: `git log --oneline -- crates/atm-daemon/src/https_transport.rs` shows its last touching commit is 0265c94f, and `git show 5e91a889 --stat` does not list https_transport.rs among changed files. Corrected from stale 'open'/Blocking status to 'fixed'/closed per this re-verification, citing the earlier FIX-1 verdict rather than re-deriving from scratch." ;
   triage:triagedAt "2026-07-25T14:15:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/s26/dc079fff> ;
+  triage:foundAt "2026-07-25T14:15:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI26-ATMQA-001/s26/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI26-ATMQA-001/s27/1> ;
   triage:openOn <urn:atm:triage:worktree/s26/dc079fff> ;
@@ -27,22 +33,22 @@
   a triage:Occurrence ;
   triage:file "crates/atm-daemon/src/https_transport.rs" ;
   triage:line 479 ;
-  triage:snippet ".map_err(|_source| { AtmError::daemon_unavailable(\"HTTPS peer mutual-TLS handshake failed\") })" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:snippet "FIXED on 0265c94f: now .map_err(|source| AtmError::remote_delivery_unconfirmed(format!(\"HTTPS peer mutual-TLS handshake was not confirmed before the shared deadline: {source}\")))" ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAI-s26-peer-write-deadline" ;
-  triage:headSha "dc079fff" ;
+  triage:headSha "0265c94f" ;
   triage:occursIn <urn:atm:triage:worktree/s26/dc079fff> .
 
 <urn:atm:triage:occurrence/AI26-ATMQA-001/s27/1>
   a triage:Occurrence ;
   triage:file "crates/atm-daemon/src/https_transport.rs" ;
   triage:line 479 ;
-  triage:snippet ".map_err(|_source| { AtmError::daemon_unavailable(\"HTTPS peer mutual-TLS handshake failed\") })" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:snippet "FIXED (inherited from s26/0265c94f, untouched by 5e91a889): now .map_err(|source| AtmError::remote_delivery_unconfirmed(format!(\"HTTPS peer mutual-TLS handshake was not confirmed before the shared deadline: {source}\")))" ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAI-s27-peer-delivery-observability" ;
-  triage:headSha "dc079fff" ;
+  triage:headSha "5e91a889" ;
   triage:occursIn <urn:atm:triage:worktree/s27/dc079fff> .
 
 <urn:atm:triage:worktree/s21pre/42fbd9fa>

--- a/.triage/phase-AI/findings/AI27-ARCH-001.ttl
+++ b/.triage/phase-AI/findings/AI27-ARCH-001.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; deferred to phase-end CLEANUP. Pre-existing decomposition debt, not introduced by 5e91a889 -- this commit reduces the file by 32 net lines. No duplicate canonical record found elsewhere in .triage/phase-AI/findings/ for this file/rule; if a duplicate is later found upstream (e.g. under a different phase or a generic ARCH-001.ttl), merge and note this commit's improvement as an occurrence rather than opening a second finding. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ARCH-001/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
   triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ARCH-001.ttl
+++ b/.triage/phase-AI/findings/AI27-ARCH-001.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; deferred to phase-end CLEANUP. Pre-existing decomposition debt, not introduced by 5e91a889 -- this commit reduces the file by 32 net lines. No duplicate canonical record found elsewhere in .triage/phase-AI/findings/ for this file/rule; if a duplicate is later found upstream (e.g. under a different phase or a generic ARCH-001.ttl), merge and note this commit's improvement as an occurrence rather than opening a second finding. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ARCH-001/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ARCH-001.ttl
+++ b/.triage/phase-AI/findings/AI27-ARCH-001.ttl
@@ -1,0 +1,105 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-ARCH-001>
+  a triage:Finding ;
+  triage:findingId "AI27-ARCH-001" ;
+  triage:title "runtime_health.rs still exceeds RULE-003's 1000-line threshold (pre-existing debt, improved but not created by this commit)" ;
+  triage:description "crates/atm-daemon/src/runtime_health.rs confirmed at 1356 non-test lines (arch-qa reported ~1357), exceeding arch-qa RULE-003's 1000-line-of-non-test-code threshold. No prior canonical finding for this specific pre-existing debt was found in .triage/phase-AI/findings/ under an ARCH-001 or RULE-003 id after searching the phase-AI store (grep for 'runtime_health.rs', 'RULE-003', '1000-line', '1357' across all phase-AI findings returned no match), so this is recorded as a new canonical finding rather than a duplicate. This commit (5e91a889) is a net improvement to this file (-32 lines net per QA verdict), not the origin of the debt; the file was already over threshold before AI.27. Recorded severity Important per pre-existing-debt convention (not Blocking, since the commit does not create it and other ARCH-001 precedents across phases treat this as ongoing decomposition debt, not a gating defect)." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ARCH" ;
+  triage:severity "Important" ;
+  triage:repeatable true ;
+  triage:sweepScope "file" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; deferred to phase-end CLEANUP. Pre-existing decomposition debt, not introduced by 5e91a889 -- this commit reduces the file by 32 net lines. No duplicate canonical record found elsewhere in .triage/phase-AI/findings/ for this file/rule; if a duplicate is later found upstream (e.g. under a different phase or a generic ARCH-001.ttl), merge and note this commit's improvement as an occurrence rather than opening a second finding. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ARCH-001/pAI-s27/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-ARCH-001/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health.rs" ;
+  triage:line 1356 ;
+  triage:snippet "wc -l crates/atm-daemon/src/runtime_health.rs => 1356 lines total (arch-qa reported 1357 non-test); RULE-003 threshold is 1000; this commit improves it by -32 net lines vs. prior sprint, pre-existing debt not created here" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-ARCH-002.ttl
+++ b/.triage/phase-AI/findings/AI27-ARCH-002.ttl
@@ -19,7 +19,7 @@
   triage:closedBy "qa-triage" ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ARCH-002/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
   triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ARCH-002.ttl
+++ b/.triage/phase-AI/findings/AI27-ARCH-002.ttl
@@ -1,0 +1,107 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-ARCH-002>
+  a triage:Finding ;
+  triage:findingId "AI27-ARCH-002" ;
+  triage:title "emit_retained_event naming -- covered by existing RULE-002 structured-event naming exception, non-actionable" ;
+  triage:description "crates/atm-daemon/src/peer_delivery_observability.rs (~line 119) defines fn emit_retained_event(observability: &SubsystemObservability, event: &PeerDeliveryEvent), which matches arch-qa RULE-002's naming pattern ('No custom emit_* functions wrapping log output'). Verified against .claude/agents/arch-qa.md RULE-002 text: 'Exception: functions that emit structured ATM protocol messages rather than log events are allowed.' emit_retained_event constructs and records a structured PeerDeliveryEvent/retained-observability-event onto the SubsystemObservability projection (not a direct tracing::* log call wrapper), matching the intent of the documented exception. Correlation conclusion: this does not need its own dispatch-ready finding -- it is informational/non-actionable, covered by the existing RULE-002 exception, consistent with the QA-1 verdict's own characterization." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ARCH" ;
+  triage:severity "Minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "file" ;
+  triage:status "closed" ;
+  triage:dispatchReady false ;
+  triage:closureNote "Non-actionable / covered-by-exception: RULE-002's documented exception for functions emitting structured ATM protocol/observability messages (rather than raw log events) applies to emit_retained_event. Recorded as closed at triage time rather than left open for CLEANUP dispatch, since no code change is warranted absent a future RULE-002 exception-text change. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:closedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:closedBy "qa-triage" ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ARCH-002/pAI-s27/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-ARCH-002/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/peer_delivery_observability.rs" ;
+  triage:line 119 ;
+  triage:snippet "fn emit_retained_event(observability: &SubsystemObservability, event: &PeerDeliveryEvent) { ... } -- covered by RULE-002's structured-ATM-protocol-message exception" ;
+  triage:status "closed" ;
+  triage:closed true ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-ARCH-002.ttl
+++ b/.triage/phase-AI/findings/AI27-ARCH-002.ttl
@@ -18,7 +18,7 @@
   triage:closedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:closedBy "qa-triage" ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ARCH-002/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ATMQA-001.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-001.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP, not dispatched now. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-001/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ATMQA-001.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-001.ttl
@@ -1,0 +1,105 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-ATMQA-001>
+  a triage:Finding ;
+  triage:findingId "AI27-ATMQA-001" ;
+  triage:title "deliver_to_peer collapses distinct pre-dispatch vs post-dispatch failure classes into one RemoteDeliveryUnconfirmed outcome, discarding the original error code" ;
+  triage:description "Dedup of 3 QA-1 reviewers converging on the same root issue: ATM-QA-001 (req-qa), RBP-F001 (rust-best-practices), RBQA-F004 (ruthless-boundary-qa). crates/atm-daemon/src/runtime_health/peer_delivery_router.rs deliver_to_peer's `Err(error) if error.is_daemon_unavailable()` branch (~lines 91-96) routes both genuine pre-dispatch local failures (TLS/init errors surfaced from crates/atm-daemon/src/https_transport.rs lines ~100-299, before any bytes reach the peer) and true post-dispatch peer-acceptance uncertainty into a single peer_delivery_unconfirmed() call that reconstructs a new AtmError::remote_delivery_unconfirmed message and discards the original error code (peer_delivery_router.rs ~103-107). Classification of 'was this local or did it reach the peer' is split across the transport layer (https_transport.rs, which already correctly distinguishes RemoteDeliveryUnconfirmed vs DaemonUnavailable at the DNS/TCP/handshake legs per the AI26-ATMQA-001 fix) and the dispatcher layer (peer_delivery_router.rs, which re-collapses that distinction), instead of being owned once. Fix: propagate/preserve the original AtmErrorCode through peer_delivery_unconfirmed rather than discarding it, and consolidate classification ownership at the dispatcher so the transport's finer-grained signal is not thrown away." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ATM-QA" ;
+  triage:severity "Important" ;
+  triage:repeatable false ;
+  triage:sweepScope "file" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP, not dispatched now. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-001/pAI-s27/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-ATMQA-001/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health/peer_delivery_router.rs" ;
+  triage:line 91 ;
+  triage:snippet "Err(error) if error.is_daemon_unavailable() => { self.peer_delivery_unconfirmed(peer.host, request_id, message_id, error) }" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-ATMQA-001.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-001.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP, not dispatched now. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-001/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
   triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ATMQA-002.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-002.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-002/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ATMQA-002.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-002.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-002/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
   triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ATMQA-002.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-002.ttl
@@ -1,0 +1,105 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-ATMQA-002>
+  a triage:Finding ;
+  triage:findingId "AI27-ATMQA-002" ;
+  triage:title "doctor execute_direct_local() hardcodes peer_links: Vec::new(), missing 'one row per configured peer' on the fallback path" ;
+  triage:description "crates/atm/src/commands/doctor.rs execute_direct_local() (~line 109) hardcodes peer_links: Vec::new() when building the direct-local DaemonRuntimeDoctorReport, even though peer_config_store() is available in scope (used one line earlier, ~line 100, for doctor::peer_config_doctor_report). The daemon-routed doctor path correctly populates peer_links from the live PeerDeliveryProjection. Sprint AI.27's acceptance criterion 'one row per configured peer' is unmet specifically on this direct-local fallback path (used when the daemon is not reachable), producing an empty peer_links list instead of PeerLinkStatus::misconfigured() rows for each configured peer." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ATM-QA" ;
+  triage:severity "Important" ;
+  triage:repeatable false ;
+  triage:sweepScope "file" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-002/pAI-s27/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-ATMQA-002/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm/src/commands/doctor.rs" ;
+  triage:line 109 ;
+  triage:snippet "peer_links: Vec::new()," ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-ATMQA-003.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-003.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-003/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
   triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ATMQA-003.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-003.ttl
@@ -1,0 +1,105 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-ATMQA-003>
+  a triage:Finding ;
+  triage:findingId "AI27-ATMQA-003" ;
+  triage:title "No dedicated secret-exclusion test for PeerLinkStatus serde round-trip" ;
+  triage:description "No dedicated test proves PeerLinkStatus's serde round-trip is free of fingerprint/IP fields, unlike the sibling PeerConfigDoctorReport secret-exclusion test. Expected location: crates/atm-daemon/src/tests/runtime_root/peer_observability.rs." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ATM-QA" ;
+  triage:severity "Minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "file" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-003/pAI-s27/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-ATMQA-003/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/tests/runtime_root/peer_observability.rs" ;
+  triage:line 0 ;
+  triage:snippet "Missing test: PeerLinkStatus serde round-trip proving absence of fingerprint/IP fields (cf. sibling PeerConfigDoctorReport secret-exclusion test)" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-ATMQA-003.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-003.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-003/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ATMQA-004.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-004.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-004/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ATMQA-004.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-004.ttl
@@ -1,0 +1,105 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-ATMQA-004>
+  a triage:Finding ;
+  triage:findingId "AI27-ATMQA-004" ;
+  triage:title "Missing runtime-evidence artifact for 1.3.2-beta.27 client/daemon doctor --json version match" ;
+  triage:description "No runtime-evidence artifact was recorded showing matching client/daemon `atm doctor --json` values for the 1.3.2-beta.27 version-bump deliverable. No specific file location; this is an evidence-capture gap rather than a code defect." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ATM-QA" ;
+  triage:severity "Minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "repo_wide" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-004/pAI-s27/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-ATMQA-004/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "" ;
+  triage:line 0 ;
+  triage:snippet "Missing runtime-evidence artifact recording matching client/daemon atm doctor --json values for the 1.3.2-beta.27 version bump deliverable" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-ATMQA-004.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-004.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-004/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
   triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ATMQA-005.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-005.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-005/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-ATMQA-005.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-005.ttl
@@ -1,0 +1,105 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-ATMQA-005>
+  a triage:Finding ;
+  triage:findingId "AI27-ATMQA-005" ;
+  triage:title "Sprint doc names 3 distinct failure-test scenarios; tests collapse them into one generic mock case" ;
+  triage:description "The sprint doc names connection-handler / route / response-write as 3 distinct failure test scenarios, but the implementation and tests in crates/atm-daemon/src/tests/runtime_root.rs collapse them into one generic mock case (FailingHttpsDelivery), not separately named or scoped per the doc's 3-scenario breakdown." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ATM-QA" ;
+  triage:severity "Minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "file" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-005/pAI-s27/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-ATMQA-005/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/tests/runtime_root.rs" ;
+  triage:line 0 ;
+  triage:snippet "FailingHttpsDelivery mock case used generically, not split into connection-handler / route / response-write scenarios as named in the sprint doc" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-ATMQA-005.ttl
+++ b/.triage/phase-AI/findings/AI27-ATMQA-005.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-ATMQA-005/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
   triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-RBP-F002.ttl
+++ b/.triage/phase-AI/findings/AI27-RBP-F002.ttl
@@ -18,7 +18,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP. Repeatable-pattern sweep found the AI18-QA1-RBP-F001-OPAQUE-ERROR-MAPPING precedent (atm-graft-python FFI boundary) as thematically related but not the same finding (different crate/file/root site); left as separate record. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/2> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/3> ;

--- a/.triage/phase-AI/findings/AI27-RBP-F002.ttl
+++ b/.triage/phase-AI/findings/AI27-RBP-F002.ttl
@@ -17,7 +17,7 @@
   triage:relatedFinding <urn:atm:triage:finding/AI18-QA1-RBP-F001-OPAQUE-ERROR-MAPPING> ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP. Repeatable-pattern sweep found the AI18-QA1-RBP-F001-OPAQUE-ERROR-MAPPING precedent (atm-graft-python FFI boundary) as thematically related but not the same finding (different crate/file/root site); left as separate record. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/2> ;

--- a/.triage/phase-AI/findings/AI27-RBP-F002.ttl
+++ b/.triage/phase-AI/findings/AI27-RBP-F002.ttl
@@ -1,0 +1,130 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-RBP-F002>
+  a triage:Finding ;
+  triage:findingId "AI27-RBP-F002" ;
+  triage:title "Thread-spawn and JSON/duration-parse failures in runtime_health.rs use map_err(|_source| ...), discarding original error detail" ;
+  triage:description "Dedup of 2 rust-best-practices findings on the same opaque-error-mapping pattern (RBP-F002 / RBP-F003). crates/atm-daemon/src/runtime_health.rs: thread-spawn failures (~line 231, spawn_shutdown_step; ~line 290, spawn_shutdown_join_helper) and JSON/duration-parse failures (~line 658/682, reconcile_after_success) use map_err(|_source| ...) to construct a fixed AtmError message, discarding the original error detail (io::Error / serde_json::Error / chrono::OutOfRangeError) instead of embedding it via {source} interpolation or an error() chain. This mirrors the previously-flagged AI18-QA1-RBP-F001-OPAQUE-ERROR-MAPPING theme (opaque error mapping across the PyO3 FFI boundary in atm-graft-python) -- same underlying anti-pattern (discard original cause on map_err), but a structurally distinct occurrence in a different crate/file, so recorded as a related-but-separate finding rather than merged into AI18-QA1-RBP-F001-OPAQUE-ERROR-MAPPING." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "RBP" ;
+  triage:severity "Important" ;
+  triage:repeatable true ;
+  triage:sweepScope "file" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:relatedFinding <urn:atm:triage:finding/AI18-QA1-RBP-F001-OPAQUE-ERROR-MAPPING> ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP. Repeatable-pattern sweep found the AI18-QA1-RBP-F001-OPAQUE-ERROR-MAPPING precedent (atm-graft-python FFI boundary) as thematically related but not the same finding (different crate/file/root site); left as separate record. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/2> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/3> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health.rs" ;
+  triage:line 231 ;
+  triage:snippet ".map_err(|_source| { ... }) in spawn_shutdown_step, thread-spawn failure detail discarded" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/2>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health.rs" ;
+  triage:line 290 ;
+  triage:snippet ".map_err(|_source| { ... }) in spawn_shutdown_join_helper, thread-spawn failure detail discarded" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:occurrence/AI27-RBP-F002/pAI-s27/3>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health.rs" ;
+  triage:line 658 ;
+  triage:snippet "chrono::Duration::from_std(policy.max_message_age).map_err(|_source| { ... }) / serde_json::from_str(&stored.request_json).map_err(|_source| { ... }) in reconcile_after_success, JSON/duration-parse failure detail discarded" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-RBP-F004.ttl
+++ b/.triage/phase-AI/findings/AI27-RBP-F004.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/2> ;

--- a/.triage/phase-AI/findings/AI27-RBP-F004.ttl
+++ b/.triage/phase-AI/findings/AI27-RBP-F004.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/2> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/3> ;

--- a/.triage/phase-AI/findings/AI27-RBP-F004.ttl
+++ b/.triage/phase-AI/findings/AI27-RBP-F004.ttl
@@ -1,0 +1,165 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-RBP-F004>
+  a triage:Finding ;
+  triage:findingId "AI27-RBP-F004" ;
+  triage:title "Missing concurrency-rationale comments on Mutex field; duplicated mutex poison-handling boilerplate across 5 sites" ;
+  triage:description "Dedup of 2 rust-best-practices findings (RBP-F004 / RBP-F005). No concurrency-rationale comment explains why PeerDeliveryProjection's statuses field is a std::sync::Mutex<BTreeMap<...>> (crates/atm-daemon/src/peer_delivery_observability.rs ~line 54: pub(crate) struct PeerDeliveryProjection { statuses: Mutex<BTreeMap<HostName, PeerLinkStatus>> }) -- no comment on lock scope, contention expectations, or why Mutex over RwLock. Separately, mutex poison-handling boilerplate (`.lock().map_err(|_| AtmError::daemon_unavailable(\"...lock poisoned\"))` / the `let Ok(...) = ...lock() else { tracing::warn!(...); ... }` pattern) is duplicated near-verbatim across 5 sites in crates/atm-daemon/src/runtime_health.rs (~lines 447-450, 456-459, 636-639, 701-703, 794-796), a good candidate for a shared helper." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "RBP" ;
+  triage:severity "Minor" ;
+  triage:repeatable true ;
+  triage:sweepScope "file" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/2> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/3> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/4> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/5> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/6> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/peer_delivery_observability.rs" ;
+  triage:line 54 ;
+  triage:snippet "pub(crate) struct PeerDeliveryProjection { statuses: Mutex<BTreeMap<HostName, PeerLinkStatus>> } -- no concurrency-rationale comment" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/2>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health.rs" ;
+  triage:line 447 ;
+  triage:snippet "duplicated mutex poison-handling boilerplate site 1/5" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/3>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health.rs" ;
+  triage:line 456 ;
+  triage:snippet "duplicated mutex poison-handling boilerplate site 2/5" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/4>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health.rs" ;
+  triage:line 636 ;
+  triage:snippet "duplicated mutex poison-handling boilerplate site 3/5" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/5>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health.rs" ;
+  triage:line 701 ;
+  triage:snippet "duplicated mutex poison-handling boilerplate site 4/5" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:occurrence/AI27-RBP-F004/pAI-s27/6>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health.rs" ;
+  triage:line 794 ;
+  triage:snippet "duplicated mutex poison-handling boilerplate site 5/5" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-RBQA-F001.ttl
+++ b/.triage/phase-AI/findings/AI27-RBQA-F001.ttl
@@ -1,0 +1,129 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-RBQA-F001>
+  a triage:Finding ;
+  triage:findingId "AI27-RBQA-F001" ;
+  triage:title "AI.28 recovery variants/fields landed early, unused, dead-code-suppressed, with hardcoded placeholders at every call site" ;
+  triage:description "crates/atm-daemon/src/peer_delivery_observability.rs (~line 18) PeerDeliveryEventKind's 4 recovery variants (PeerRecoveryScheduled, PeerRecoveryAttempt, PeerRecoveryConfirmed, PeerRecoveryUnconfirmed) plus the candidate_count/next_attempt_at fields on PeerDeliveryEvent landed in this AI.27 commit but are unused outside of construction, gated by #[allow(dead_code)] with an inline comment ('AI.28 emits the retained recovery variants.'). Every call site in crates/atm-daemon/src/runtime_health/peer_delivery_router.rs (lines 37-45, 80-88, 121-129) passes hardcoded placeholder values (e.g. candidate_count: Some(1), next_attempt_at: None) rather than real recovery-scheduling data, since no recovery loop exists yet. Fix: defer landing the AI.28-only surface until the AI.28 branch actually consumes it, or scope it out of this commit." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "RBQA" ;
+  triage:severity "Important" ;
+  triage:repeatable false ;
+  triage:sweepScope "file" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP (or natural resolution on the AI.28 branch that consumes this surface). See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/1> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/2> ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/3> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/peer_delivery_observability.rs" ;
+  triage:line 18 ;
+  triage:snippet "#[allow(dead_code)] // AI.28 emits the retained recovery variants. pub(crate) enum PeerDeliveryEventKind { ... PeerRecoveryScheduled, PeerRecoveryAttempt, PeerRecoveryConfirmed, PeerRecoveryUnconfirmed }" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/2>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health/peer_delivery_router.rs" ;
+  triage:line 37 ;
+  triage:snippet "candidate_count: Some(1), next_attempt_at: None, (hardcoded placeholder at WritePersisted call site)" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/3>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health/peer_delivery_router.rs" ;
+  triage:line 121 ;
+  triage:snippet "candidate_count: Some(1), next_attempt_at: None, (hardcoded placeholder at peer_delivery_terminal_error call site)" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-RBQA-F001.ttl
+++ b/.triage/phase-AI/findings/AI27-RBQA-F001.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP (or natural resolution on the AI.28 branch that consumes this surface). See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/2> ;

--- a/.triage/phase-AI/findings/AI27-RBQA-F001.ttl
+++ b/.triage/phase-AI/findings/AI27-RBQA-F001.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP (or natural resolution on the AI.28 branch that consumes this surface). See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/2> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F001/pAI-s27/3> ;

--- a/.triage/phase-AI/findings/AI27-RBQA-F002.ttl
+++ b/.triage/phase-AI/findings/AI27-RBQA-F002.ttl
@@ -1,0 +1,105 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-RBQA-F002>
+  a triage:Finding ;
+  triage:findingId "AI27-RBQA-F002" ;
+  triage:title "No boundary TOML for the widened DaemonRuntimeDoctorReport/PeerLinkStatus contract" ;
+  triage:description "crates/atm-core/src/doctor/report.rs (~line 102) widens the DaemonRuntimeDoctorReport contract with the new peer_links: Vec<PeerLinkStatus> field and the new PeerLinkStatus struct (~line 135), but no boundary TOML record was added under boundaries/atm-core/ for this widened contract, unlike the sibling pattern for MailStoreDoctor (boundaries/atm-core/mail-store-doctor.toml) and the existing config-doctor.toml / roster-store-doctor.toml records. This leaves the doctor-report contract surface partially undocumented in the boundary registry." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "RBQA" ;
+  triage:severity "Important" ;
+  triage:repeatable false ;
+  triage:sweepScope "crate" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F002/pAI-s27/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-RBQA-F002/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-core/src/doctor/report.rs" ;
+  triage:line 102 ;
+  triage:snippet "pub struct DaemonRuntimeDoctorReport { ... pub peer_links: Vec<PeerLinkStatus>, ... } (no boundaries/atm-core/*.toml record added for this widened contract)" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-RBQA-F002.ttl
+++ b/.triage/phase-AI/findings/AI27-RBQA-F002.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F002/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-RBQA-F002.ttl
+++ b/.triage/phase-AI/findings/AI27-RBQA-F002.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Important finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F002/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
   triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-RBQA-F003.ttl
+++ b/.triage/phase-AI/findings/AI27-RBQA-F003.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F003/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-RBQA-F003.ttl
+++ b/.triage/phase-AI/findings/AI27-RBQA-F003.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F003/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
   triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-RBQA-F003.ttl
+++ b/.triage/phase-AI/findings/AI27-RBQA-F003.ttl
@@ -1,0 +1,105 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-RBQA-F003>
+  a triage:Finding ;
+  triage:findingId "AI27-RBQA-F003" ;
+  triage:title "peer_delivery_unconfirmed/peer_delivery_terminal_error are near-duplicate, differ only by message prefix" ;
+  triage:description "crates/atm-daemon/src/runtime_health/peer_delivery_router.rs (~line 100): peer_delivery_unconfirmed and peer_delivery_terminal_error are near-duplicate functions, differing only in that peer_delivery_unconfirmed wraps the error in a new remote_delivery_unconfirmed message before delegating to peer_delivery_terminal_error. Collapsible into one function with an optional wrap step." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "RBQA" ;
+  triage:severity "Minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "file" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RBQA-F003/pAI-s27/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-RBQA-F003/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/runtime_health/peer_delivery_router.rs" ;
+  triage:line 100 ;
+  triage:snippet "fn peer_delivery_unconfirmed(...) { ... self.peer_delivery_terminal_error(peer, request_id, message_id, unconfirmed) } -- near-duplicate of peer_delivery_terminal_error at line 114" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .

--- a/.triage/phase-AI/findings/AI27-RSH-001.ttl
+++ b/.triage/phase-AI/findings/AI27-RSH-001.ttl
@@ -17,7 +17,7 @@
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
-  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RSH-001/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
   triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-RSH-001.ttl
+++ b/.triage/phase-AI/findings/AI27-RSH-001.ttl
@@ -16,7 +16,7 @@
   triage:dispatchReady false ;
   triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
   triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
-  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RSH-001/pAI-s27/1> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;

--- a/.triage/phase-AI/findings/AI27-RSH-001.ttl
+++ b/.triage/phase-AI/findings/AI27-RSH-001.ttl
@@ -1,0 +1,105 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI27-RSH-001>
+  a triage:Finding ;
+  triage:findingId "AI27-RSH-001" ;
+  triage:title "MAX_PEER_LINK_STATUS_ENTRIES cap silently drops new entries instead of evicting oldest" ;
+  triage:description "crates/atm-daemon/src/peer_delivery_observability.rs: MAX_PEER_LINK_STATUS_ENTRIES = 256 cap silently drops new peer-status entries once the map is full (statuses.len() >= cap && !statuses.contains_key(peer) -> return early, warn-logged) rather than evicting the oldest entry (no LRU eviction). In practice this only matters when more than 256 distinct peers have ever been recorded, but the behavior is a silent-drop rather than a bounded, evicting cache." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "RSH" ;
+  triage:severity "Minor" ;
+  triage:repeatable false ;
+  triage:sweepScope "file" ;
+  triage:status "open" ;
+  triage:dispatchReady false ;
+  triage:closureNote "QA-1 gate was 0-Blocking-only; this Minor finding was explicitly deferred to phase-end CLEANUP. See PR #633 verdict comment https://github.com/randlee/atm-core/pull/633#issuecomment-5079255622." ;
+  triage:triagedAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:foundIn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:foundAt "2026-07-25T16:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI27-RSH-001/pAI-s27/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s27/5e91a889> ;
+  triage:highestOpenBranch "feature/pAI-s27-peer-delivery-observability" .
+
+<urn:atm:triage:occurrence/AI27-RSH-001/pAI-s27/1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-daemon/src/peer_delivery_observability.rs" ;
+  triage:line 97 ;
+  triage:snippet "const MAX_PEER_LINK_STATUS_ENTRIES: usize = 256; if statuses.len() >= MAX_PEER_LINK_STATUS_ENTRIES && !statuses.contains_key(&event.peer) { ...return; } -- silent drop, no LRU eviction" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-s27/5e91a889> .
+
+<urn:atm:triage:worktree/pAI-s21pre/42fbd9fa>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s21pre-crosshost-evidence-harness" ;
+  triage:headSha "42fbd9fa" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-s22/a5aa6813>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s22-loopback-self-send-exemption" ;
+  triage:headSha "a5aa6813" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-s23/c528137c>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s23-crosshost-shared-write-path" ;
+  triage:headSha "c528137c" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/pAI-s24/c326cbe7>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s24-host-qualified-ack-receipt" ;
+  triage:headSha "c326cbe7" ;
+  triage:orderIndex 4 .
+
+<urn:atm:triage:worktree/pAI-s25/0265c94f>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s25-peer-authority-resolution" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s25-peer-authority-resolution" ;
+  triage:headSha "0265c94f" ;
+  triage:orderIndex 5 .
+
+<urn:atm:triage:worktree/pAI-s26/dc079fff>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s26-peer-write-deadline" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s26-peer-write-deadline" ;
+  triage:headSha "dc079fff" ;
+  triage:orderIndex 6 .
+
+<urn:atm:triage:worktree/pAI-s27/5e91a889>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s27-peer-delivery-observability" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s27-peer-delivery-observability" ;
+  triage:headSha "5e91a889" ;
+  triage:orderIndex 7 .
+
+<urn:atm:triage:worktree/pAI-s28/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s28-bounded-peer-recovery" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s28-bounded-peer-recovery" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 8 .
+
+<urn:atm:triage:worktree/pAI-s29/b5eec1bf>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s29-crosshost-smoke-rerun" ;
+  triage:headSha "b5eec1bf" ;
+  triage:orderIndex 9 .
+
+<urn:atm:triage:worktree/pAI-s30/77252eca>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s30-semver-http-compatibility" ;
+  triage:path "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s30-semver-http-compatibility" ;
+  triage:headSha "77252eca" ;
+  triage:orderIndex 10 .


### PR DESCRIPTION
## Summary
- Add the 13 canonical AI27/AICH-S7 QA-1 finding records.
- Correct AI26-ATMQA-001 closure state as part of the source remediation commit.
- Preserve foundIn as `triage:AICH-S7` and foundAt as the authoritative QA result timestamp.

## Scope
Only 14 `.triage/phase-AI/findings/*.ttl` paths changed; no audit docs or product code. Cherry-picked source commits: `be2387cc`, `baaee8ad`, `599c8a67`.

## Validation
- `validate-findings.py` (AI27 regex): `validation:pass`, 13 findings, 0 errors, 0 warnings.
- AI26 + AI27 scoped validation: `validation:pass`, 14 findings, 0 errors, 0 warnings.
- Filename/findingId/URI aliases, AICH-S7 foundIn, occurrence refs, and foundAt timestamp checked.

## Caveat
AI27 severity literals are capitalized (`Important`/`Minor`) while the SPARQL query files compare lowercase literals. The repository already contains mixed casing; this PR preserves the source records and does not broaden scope to normalize existing data.