### PR TITLE
fix(qa-triage): foundIn/foundAt schema hardening + triage-report tool

### DIFF
--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -1,6 +1,6 @@
 ---
 name: qa-triage
-version: 1.1.0
+version: 1.2.0
 description: Pre-dispatch QA triage agent. Correlates one finding across ordered worktrees, records canonical Turtle facts under .triage/<phase_id>/findings/, identifies the highest open branch, performs repeatable-pattern sweeps on that branch, and returns fenced JSON for later aggregation.
 model: haiku
 ---
@@ -34,6 +34,8 @@ with free-form input.
   "integration_branch": "integrate/phase-R",
   "integration_worktree_path": "/abs/integrate-phase-R",
   "finding_id": "FTQ-001",
+  "found_in": "AICH-S7",
+  "found_at": "2026-07-25T16:26:33Z",
   "title": "Process-global shutdown state in tests",
   "description": "Global OnceLock / static shutdown state leaks across test cases.",
   "category": "FTQ",
@@ -75,9 +77,13 @@ Input rules:
 - `triage_mode` is required. Allowed values: `initial_pass`, `followup_pass`.
 - `phase_id` is required.
 - `integration_branch` and `integration_worktree_path` are required.
-- `finding_id`, `title`, `description`, `category`, `severity`, `pattern`,
-  `worktrees`, `integration_branch`, `integration_worktree_path`, and
-  `triage_root` are required.
+- `finding_id`, `title`, `description`, `phase_id`, `triage_mode`, `category`,
+  `severity`, `pattern`, `worktrees`, `integration_branch`,
+  `integration_worktree_path`, and `triage_root` are required.
+- `found_in` is required and must be the declared sprint local id (for example,
+  `AICH-S7`) that will render as `triage:AICH-S7`.
+- `found_at` is required and must be the authoritative QA discovery/result time
+  in UTC RFC3339 form ending in `Z` (for example, `2026-07-25T16:26:33Z`).
 - `worktrees` must already be listed in the desired promotion order. Do not
   invent or infer branch priority from branch names.
 - `repeatable` is required.
@@ -153,9 +159,11 @@ Mode rules:
    - `propagated`: fixed on all branches where it previously existed
    - `merge_forward_needed`: fixed on some higher branch but still open below it
    - `regressed`: fixed before, open again now
-11. Write the canonical Turtle record:
-   - `<triage_root>/<phase_id>/findings/<finding_id>.ttl`
-12. Validate the Turtle output:
+11. Render the canonical Turtle record from
+    `.claude/skills/triaging-findings/triage-record.ttl.j2` using the vars
+    contract below. Do not hand-write a replacement record:
+    - `<triage_root>/<phase_id>/findings/<finding_id>.ttl`
+12. Validate the rendered Turtle output:
    - use a temporary Oxigraph store and `oxigraph load` against the TTL file
    - fail if the Turtle cannot be parsed
 13. Return enough information for the team-lead batch commit step:
@@ -177,6 +185,8 @@ Primary node types:
 Required edges:
 - `triage:Finding -> triage:hasOccurrence -> triage:Occurrence`
 - `triage:Occurrence -> triage:occursIn -> triage:WorktreeSnapshot`
+- `triage:Finding -> triage:foundIn -> triage:Sprint`
+- `triage:Finding -> triage:foundAt -> xsd:dateTime` (UTC)
 
 Recommended derived edges:
 - `triage:Finding -> triage:openOn -> triage:WorktreeSnapshot`
@@ -196,6 +206,8 @@ Minimum Finding properties:
 - `triage:status`
 - `triage:dispatchReady`
 - `triage:triagedAt`
+- `triage:foundIn`
+- `triage:foundAt` (UTC `xsd:dateTime`)
 
 Minimum Occurrence properties:
 - `triage:file`
@@ -219,44 +231,65 @@ Use these prefixes:
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 ```
 
-Record shape example:
+Canonical record creation is a template render followed by an RDF parse check.
+The template's frontmatter declares all required scalar variables. Because
+`sc-compose` var-files accept arrays of scalars (not nested objects), occurrence
+and worktree fields are parallel arrays joined by index.
 
-```turtle
-@prefix triage: <urn:atm:triage:> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+```bash
+cat > /tmp/triage-record-vars.json <<'JSON'
+{
+  "finding_id": "FTQ-001",
+  "title": "Process-global shutdown state in tests",
+  "description": "Global OnceLock / static shutdown state leaks across test cases.",
+  "phase_id": "phase-R",
+  "triage_mode": "followup_pass",
+  "category": "FTQ",
+  "severity": "important",
+  "repeatable": true,
+  "sweep_scope": "crate",
+  "status": "fixed_partial",
+  "dispatch_ready": true,
+  "triaged_at": "2026-07-25T16:30:00Z",
+  "found_in": "AICH-S7",
+  "found_at": "2026-07-25T16:26:33Z",
+  "occurrences": ["R17-1"],
+  "occurrence_files": ["crates/atm-daemon/src/tests.rs"],
+  "occurrence_lines": ["28"],
+  "occurrence_snippets": ["static DISPATCHER: OnceLock<...>"],
+  "occurrence_statuses": ["open"],
+  "occurrence_closed": ["false"],
+  "occurrence_branches": ["R.17"],
+  "occurrence_head_shas": ["9421e9f"],
+  "occurrence_worktree_ids": ["R17/9421e9f"],
+  "worktrees": ["R17/9421e9f"],
+  "worktree_branches": ["R.17"],
+  "worktree_paths": ["/abs/worktree-r17"],
+  "worktree_head_shas": ["9421e9f"],
+  "worktree_order_indices": ["17"]
+}
+JSON
 
-<urn:atm:triage:finding/FTQ-001>
-  a triage:Finding ;
-  triage:findingId "FTQ-001" ;
-  triage:title "Process-global shutdown state in tests" ;
-  triage:phaseId "phase-R" ;
-  triage:triageMode "followup_pass" ;
-  triage:repeatable true ;
-  triage:sweepScope "crate" ;
-  triage:status "fixed_partial" ;
-  triage:dispatchReady true ;
-  triage:hasOccurrence <urn:atm:triage:occurrence/FTQ-001/R17/1> ;
-  triage:openOn <urn:atm:triage:worktree/R17/9421e9f> ;
-  triage:fixedOn <urn:atm:triage:worktree/R16/c7b4455> ;
-  triage:promoteTo <urn:atm:triage:worktree/R17/9421e9f> .
+TRIAGE_ROOT=/abs/integrate-phase-R/.triage
+PHASE_ID=phase-R
+FINDING_ID=FTQ-001
+OUTPUT="$TRIAGE_ROOT/$PHASE_ID/findings/$FINDING_ID.ttl"
+mkdir -p "$(dirname "$OUTPUT")"
+sc-compose render \
+  --root . \
+  --file .claude/skills/triaging-findings/triage-record.ttl.j2 \
+  --var-file /tmp/triage-record-vars.json \
+  --output "$OUTPUT"
 
-<urn:atm:triage:occurrence/FTQ-001/R17/1>
-  a triage:Occurrence ;
-  triage:file "crates/atm-daemon/src/tests.rs" ;
-  triage:line 28 ;
-  triage:snippet "static DISPATCHER: OnceLock<...>" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:branch "R.17" ;
-  triage:occursIn <urn:atm:triage:worktree/R17/9421e9f> .
-
-<urn:atm:triage:worktree/R17/9421e9f>
-  a triage:WorktreeSnapshot ;
-  triage:branch "R.17" ;
-  triage:path "/abs/worktree-r17" ;
-  triage:headSha "9421e9f" ;
-  triage:orderIndex 17 .
+STORE=$(mktemp -d)
+trap 'rm -rf "$STORE"' EXIT
+oxigraph load --location "$STORE" --file "$OUTPUT" --format ttl
 ```
+
+The vars file must provide `found_in` as a declared sprint local id and
+`found_at` as the authoritative QA result/discovery timestamp in UTC ending in
+`Z`. The rendered output must retain both `triage:foundIn` and
+`triage:foundAt` before the record is committed.
 
 ## Output Format
 

--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -33,8 +33,10 @@ with free-form input.
   "phase_id": "phase-R",
   "integration_branch": "integrate/phase-R",
   "integration_worktree_path": "/abs/integrate-phase-R",
+  "structure_path": "/abs/integrate-phase-R/.sprints/R/structure.ttl",
+  "events_path": "/abs/integrate-phase-R/.sprints/R/events.ttl",
   "finding_id": "FTQ-001",
-  "found_in": "AICH-S7",
+  "found_in": "R-S1",
   "found_at": "2026-07-25T16:26:33Z",
   "title": "Process-global shutdown state in tests",
   "description": "Global OnceLock / static shutdown state leaks across test cases.",
@@ -77,11 +79,14 @@ Input rules:
 - `triage_mode` is required. Allowed values: `initial_pass`, `followup_pass`.
 - `phase_id` is required.
 - `integration_branch` and `integration_worktree_path` are required.
+- `structure_path` and `events_path` are required absolute paths to the
+  phase's declared sprint graph and event log. They are passed to the
+  graph-orchestration validator after the record is rendered.
 - `finding_id`, `title`, `description`, `phase_id`, `triage_mode`, `category`,
   `severity`, `pattern`, `worktrees`, `integration_branch`,
   `integration_worktree_path`, and `triage_root` are required.
 - `found_in` is required and must be the declared sprint local id (for example,
-  `AICH-S7`) that will render as `triage:AICH-S7`.
+  `R-S1`) that will render as `triage:R-S1`.
 - `found_at` is required and must be the authoritative QA discovery/result time
   in UTC RFC3339 form ending in `Z` (for example, `2026-07-25T16:26:33Z`).
 - `worktrees` must already be listed in the desired promotion order. Do not
@@ -92,6 +97,7 @@ Input rules:
 - `file_filter` is optional.
 - `triage_root` must be an absolute path.
 - `integration_worktree_path` must be an absolute path.
+- `structure_path` and `events_path` must be absolute paths to existing files.
 - `triage_root` must live under `integration_worktree_path`.
 - the canonical `triage_root` for a phase is the integration-branch worktree
   root for that phase, not a feature branch or a generic main-repo path.
@@ -167,10 +173,31 @@ Mode rules:
     `.claude/skills/triaging-findings/triage-record.ttl.j2` using the vars
     contract below. Do not hand-write a replacement record:
     - `<triage_root>/<phase_id>/findings/<finding_id>.ttl`
-12. Validate the rendered Turtle output:
+12. Validate the rendered Turtle output immediately after writing it:
    - run `oxigraph convert --from-file <ttl> --from-format ttl --to-file
      <temporary-output> --to-format ttl`
    - fail on a nonzero exit status when the Turtle cannot be parsed
+   - then run the canonical schema/provenance validator from the integration
+     worktree. The validator must cover the complete phase findings directory
+     and both phase graph inputs:
+
+     ```bash
+     VALIDATION_JSON=$(python3 \
+       "$integration_worktree_path/.claude/skills/graph-orchestration/scripts/validate-findings.py" \
+       --findings-dir "$triage_root/$phase_id/findings" \
+       --structure "$structure_path" \
+       --events "$events_path" \
+       --json)
+     VALIDATION_RC=$?
+     ```
+
+   - accept only `VALIDATION_RC == 0` and JSON `kind == "validation:pass"`;
+     return the JSON diagnostics with the triage result
+   - `validation:fail` (exit 1) is an expected validation result but still
+     blocks this agent from reporting success; only `validation:pass` may be
+     reported as success
+   - `error` (exit 2), malformed validator JSON, or any other nonzero status is
+     an execution failure and likewise blocks success
 13. Return enough information for the team-lead batch commit step:
    - `integration_branch`
    - `integration_worktree_path`
@@ -224,14 +251,15 @@ Minimum Occurrence properties:
 - `triage:closed`
 
 Minimum WorktreeSnapshot properties:
+- `triage:path` (repository-relative worktree label; never a host checkout path)
 - `triage:branch`
 - `triage:headSha`
 - `triage:orderIndex`
 
-The runtime `worktrees[].path` value is intentionally omitted from
-`triage:WorktreeSnapshot`: an external-worktree checkout path is host-layout
-specific, not a stable repository-relative fact. Branch, head SHA, and
-promotion order remain canonical.
+The runtime `worktrees[].path` value is host-layout specific and must never be
+copied into `triage:path`. Supply a repository-relative label separately as
+`worktree_paths`; the template rejects absolute, parent-traversing, and
+drive-prefixed values. Branch, head SHA, and promotion order remain canonical.
 
 Use these prefixes:
 
@@ -260,7 +288,7 @@ cat > /tmp/triage-record-vars.json <<'JSON'
   "status": "fixed_partial",
   "dispatch_ready": true,
   "triaged_at": "2026-07-25T16:30:00Z",
-  "found_in": "AICH-S7",
+  "found_in": "R-S1",
   "found_at": "2026-07-25T16:26:33Z",
   "occurrences": ["R17-1"],
   "occurrence_files": ["crates/atm-daemon/src/tests.rs"],
@@ -272,14 +300,18 @@ cat > /tmp/triage-record-vars.json <<'JSON'
   "occurrence_head_shas": ["9421e9f"],
   "occurrence_worktree_ids": ["R17/9421e9f"],
   "worktrees": ["R17/9421e9f"],
+  "worktree_paths": [".worktrees/R17"],
   "worktree_branches": ["R.17"],
   "worktree_head_shas": ["9421e9f"],
   "worktree_order_indices": ["17"]
 }
 JSON
 
-TRIAGE_ROOT=/abs/integrate-phase-R/.triage
+INTEGRATION_WORKTREE_PATH=/abs/integrate-phase-R
+TRIAGE_ROOT="$INTEGRATION_WORKTREE_PATH/.triage"
 PHASE_ID=phase-R
+STRUCTURE_PATH="$INTEGRATION_WORKTREE_PATH/.sprints/R/structure.ttl"
+EVENTS_PATH="$INTEGRATION_WORKTREE_PATH/.sprints/R/events.ttl"
 FINDING_ID=FTQ-001
 OUTPUT="$TRIAGE_ROOT/$PHASE_ID/findings/$FINDING_ID.ttl"
 mkdir -p "$(dirname "$OUTPUT")"
@@ -296,6 +328,23 @@ oxigraph convert \
   --from-format ttl \
   --to-file "$PARSED" \
   --to-format ttl
+
+# Schema/provenance validation is a separate gate from Turtle parseability.
+VALIDATION_JSON=$(python3 \
+  "$INTEGRATION_WORKTREE_PATH/.claude/skills/graph-orchestration/scripts/validate-findings.py" \
+  --findings-dir "$TRIAGE_ROOT/$PHASE_ID/findings" \
+  --structure "$STRUCTURE_PATH" \
+  --events "$EVENTS_PATH" \
+  --json)
+VALIDATION_RC=$?
+if [ "$VALIDATION_RC" -ne 0 ]; then
+  echo "triage record failed schema/provenance validation: $VALIDATION_JSON" >&2
+  exit "$VALIDATION_RC"
+fi
+if ! printf '%s' "$VALIDATION_JSON" | rg -q '"kind"\s*:\s*"validation:pass"'; then
+  echo "triage record did not return validation:pass: $VALIDATION_JSON" >&2
+  exit 1
+fi
 ```
 
 The vars file must provide `found_in` as a declared sprint local id and

--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -95,6 +95,10 @@ Input rules:
 - `triage_root` must live under `integration_worktree_path`.
 - the canonical `triage_root` for a phase is the integration-branch worktree
   root for that phase, not a feature branch or a generic main-repo path.
+- `integration_worktree_path`, `triage_root`, and each input
+  `worktrees[].path` are runtime checkout paths. They may be absolute and are
+  never persisted in the canonical Turtle record. Persist occurrence file
+  locations as repository-relative paths only.
 
 Mode rules:
 - `initial_pass`:
@@ -220,9 +224,13 @@ Minimum Occurrence properties:
 
 Minimum WorktreeSnapshot properties:
 - `triage:branch`
-- `triage:path`
 - `triage:headSha`
 - `triage:orderIndex`
+
+The runtime `worktrees[].path` value is intentionally omitted from
+`triage:WorktreeSnapshot`: an external-worktree checkout path is host-layout
+specific, not a stable repository-relative fact. Branch, head SHA, and
+promotion order remain canonical.
 
 Use these prefixes:
 
@@ -264,7 +272,6 @@ cat > /tmp/triage-record-vars.json <<'JSON'
   "occurrence_worktree_ids": ["R17/9421e9f"],
   "worktrees": ["R17/9421e9f"],
   "worktree_branches": ["R.17"],
-  "worktree_paths": ["/abs/worktree-r17"],
   "worktree_head_shas": ["9421e9f"],
   "worktree_order_indices": ["17"]
 }

--- a/.claude/agents/qa-triage.md
+++ b/.claude/agents/qa-triage.md
@@ -168,8 +168,9 @@ Mode rules:
     contract below. Do not hand-write a replacement record:
     - `<triage_root>/<phase_id>/findings/<finding_id>.ttl`
 12. Validate the rendered Turtle output:
-   - use a temporary Oxigraph store and `oxigraph load` against the TTL file
-   - fail if the Turtle cannot be parsed
+   - run `oxigraph convert --from-file <ttl> --from-format ttl --to-file
+     <temporary-output> --to-format ttl`
+   - fail on a nonzero exit status when the Turtle cannot be parsed
 13. Return enough information for the team-lead batch commit step:
    - `integration_branch`
    - `integration_worktree_path`
@@ -288,9 +289,13 @@ sc-compose render \
   --var-file /tmp/triage-record-vars.json \
   --output "$OUTPUT"
 
-STORE=$(mktemp -d)
-trap 'rm -rf "$STORE"' EXIT
-oxigraph load --location "$STORE" --file "$OUTPUT" --format ttl
+PARSED=$(mktemp)
+trap 'rm -f "$PARSED"' EXIT
+oxigraph convert \
+  --from-file "$OUTPUT" \
+  --from-format ttl \
+  --to-file "$PARSED" \
+  --to-format ttl
 ```
 
 The vars file must provide `found_in` as a declared sprint local id and

--- a/.claude/lib/__init__.py
+++ b/.claude/lib/__init__.py
@@ -1,0 +1,1 @@
+"""Shared implementation helpers for repository-local Claude skills."""

--- a/.claude/lib/sc_compose_dependency.py
+++ b/.claude/lib/sc_compose_dependency.py
@@ -1,0 +1,25 @@
+"""Single source of truth for the sc-compose dependency contract."""
+
+from __future__ import annotations
+
+import re
+
+
+MIN_SC_COMPOSE = (1, 2, 0)
+MIN_SC_COMPOSE_TEXT = ">= 1.2.0"
+SC_COMPOSE_INSTALL = (
+    "python3 -m pip install --user --break-system-packages "
+    "'sc-compose>=1.2.0'"
+)
+_VERSION_RE = re.compile(
+    r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?"
+)
+
+
+def parse_version(text: str | None) -> tuple[int, int, int] | None:
+    """Extract a comparable semantic version from tool output."""
+
+    if not text:
+        return None
+    match = _VERSION_RE.search(text)
+    return tuple(int(part) for part in match.groups()) if match else None

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -200,6 +200,9 @@ Populate and send `dev-task.xml.j2`:
 | `sprint` | `result.vars.sprint` |
 | `sprint_order` | `result.vars.sprint_order` |
 | `criteria_doc` | `result.vars.criteria_doc` |
+| `phase_local` | Graph phase argument passed to `next-dev-task` |
+| `ttl_dir` | Phase TTL directory passed to `next-dev-task` |
+| `finding_ids` | Space-separated assigned Blocking finding ids; empty only for greenfield |
 
 ## Fix Dispatch (blocking findings present)
 
@@ -306,9 +309,23 @@ triaging-findings skill. Do not append raw finding data to events.ttl.
     "sprint_iri": "urn:atm:triage:S7",
     "sprint_order": 1,
     "criteria_doc": "ac/S7.md"
-  }
+  },
+  "findings": [
+    {
+      "finding_iri": "urn:atm:triage:f-123",
+      "finding_id": "AI22-BLOCK-001",
+      "severity": "blocking",
+      "found_at": "2026-07-26T00:00:00Z",
+      "description": "..."
+    }
+  ]
 }
 ```
+
+For `TRAVERSAL`, `findings` contains every unresolved finding on the returned
+sprint, ordered Blocking, Important, Minor. An empty array is the only
+greenfield result. The developer must use this JSON to verify the rendered
+node and any assigned Blocking finding ids before editing.
 
 The orchestrator saves `vars` to a temp file and adds non-graph variables.
 Template selection (`dev-task.xml.j2` vs `dev-fix.xml.j2`) is made after
@@ -445,7 +462,8 @@ Output JSON (TRAVERSAL):
     "sprint_iri": "urn:atm:triage:PhaseF-S1",
     "sprint_order": 1,
     "criteria_doc": "ac/FS1.md"
-  }
+  },
+  "findings": []
 }
 ```
 

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -76,6 +76,13 @@ command; missing `triage:findingId`, `triage:severity`, or
 restrict an audit to a known sprint range and `--max-results N` to truncate
 repetitive output while preserving the failure status.
 
+The validator API and JSON CLI use a discriminated result contract:
+`validation:pass` means execution completed with no `#error` diagnostics,
+`validation:fail` means execution completed and the data failed its gate, and
+`error` means the validator itself could not run (for example malformed Turtle,
+missing input, invalid regex, or a broken query). The CLI exits 0, 1, and 2 for
+those outcomes respectively; `--json` emits the tagged result for callers.
+
 ## Orchestrator Loop
 
 ```bash

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -325,11 +325,12 @@ triaging-findings skill. Do not append raw finding data to events.ttl.
 For `TRAVERSAL`, `findings` contains every dispatch-open finding on the
 returned sprint, ordered invalid severity, Blocking, Important, Minor.
 Severity is case-normalized; reviewer-native `critical` maps to `blocking`.
-An unknown value is returned as `invalid` with `raw_severity` preserved and
-must stop dispatch. Terminal `triage:status` values are excluded for routing
-only; this does not change Completion or QA lifecycle semantics. An empty
-array is the only greenfield result. The developer must use this JSON to
-verify the rendered node and any assigned Blocking finding ids before editing.
+An unknown value returns `phase: "INVALID_FINDING_SEVERITY"` with
+`raw_severity` preserved and exits nonzero. `status` is output as metadata but
+does not hide a finding: event-log Completion/Resolution remains the cursor's
+lifecycle source. An empty array is the only greenfield result. The developer
+must use this JSON to verify the rendered node and any assigned Blocking
+finding ids before editing.
 
 The orchestrator saves `vars` to a temp file and adds non-graph variables.
 Template selection (`dev-task.xml.j2` vs `dev-fix.xml.j2`) is made after
@@ -360,7 +361,10 @@ sc-compose render \
   --var worktree_path="$WORKTREE_PATH" \
   --var branch="$BRANCH" \
   --var pr_target="$PR_TARGET" \
-  --var assignee="arch-ctm"
+  --var assignee="arch-ctm" \
+  --var phase_local="F" \
+  --var ttl_dir=".sprints/F" \
+  --var finding_ids="$FINDING_IDS"
 ```
 
 ## Completion Invalidation

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: graph-orchestration
 version: 0.5.0
-description: TTL/SPARQL-driven phase orchestration. The orchestrator runs a deterministic query loop — cursor → triage-findings check → dispatch → await Completion → re-query. No agent ever decides phase, cursor position, or done-ness; queries answer all of it. Derived from codex-orchestration; replaces static sprint-doc assignments with a live RDF event log. Adds Assignment events (collision prevention), Completion invalidation (blocking post-Completion finding snaps cursor back), and CLEANUP phase (non-blocking findings after all sprints complete).
+description: TTL/SPARQL-driven phase orchestration. The orchestrator runs a deterministic query loop — cursor → triaging-findings check → dispatch → await Completion → re-query. No agent ever decides phase, cursor position, or done-ness; queries answer all of it. Derived from codex-orchestration; replaces static sprint-doc assignments with a live RDF event log. Adds Assignment events (collision prevention), Completion invalidation (blocking post-Completion finding snaps cursor back), and CLEANUP phase (non-blocking findings after all sprints complete).
 repo: atm-core
 requires:
   cli:
@@ -27,7 +27,7 @@ depends_on:
   rust-qa-agent: 0.x
   rust-best-practices-agent: 0.x
   rust-service-hardening-agent: 0.x
-  triage-findings: 1.x
+  triaging-findings: 1.x
 ---
 
 # Graph Orchestration
@@ -67,7 +67,7 @@ small (progressive disclosure).
 |---|---|
 | RDF runner | Python 3 + rdflib |
 | Phase TTL location | `.sprints/<PHASE>/structure.ttl` + `.sprints/<PHASE>/events.ttl` (relative to repo root) |
-| Findings storage | `.triage/*/findings/*.ttl` — managed by triage-findings skill |
+| Findings storage | `.triage/*/findings/*.ttl` — managed by triaging-findings skill |
 | Test command | `just test` |
 | Dev assignee | Set per-sprint at dispatch time (j2 variable) |
 | QA reviewer set | `req-qa`, `arch-qa`, `rust-qa-agent` every pass; RBP/service-hardening/ruthless on QA-1 or finding recheck |
@@ -122,6 +122,15 @@ The validator API and JSON CLI use a discriminated result contract:
 missing input, invalid regex, or a broken query). The CLI exits 0, 1, and 2 for
 those outcomes respectively; `--json` emits the tagged result for callers.
 
+`query_runner.py` invokes this validator before loading the graph, including
+for `--validate-only`; `next-dev-task` therefore cannot resolve a cursor while
+any `.triage/*/findings` directory contains an error-level diagnostic. It
+validates every findings directory (not only the directory name that appears
+to match the current phase), then scopes findings by the phase's declared
+`triage:foundIn` sprint IRIs. This ordering prevents malformed or incomplete
+records from disappearing in the membership filter. A `validation:fail` blocks
+with exit 1, and a validator execution `error` blocks with exit 2.
+
 ## Orchestrator Loop
 
 ```bash
@@ -133,14 +142,14 @@ Four outcomes from the cursor query:
 
 | `phase` | Meaning |
 |---|---|
-| `TRAVERSAL` | A sprint is ready (no in-flight Assignment, no valid Completion) — check triage-findings to pick template |
+| `TRAVERSAL` | A sprint is ready (no in-flight Assignment, no valid Completion) — check triaging-findings to pick template |
 | `AWAITING` | Cursor is empty but some sprints lack valid Completions — in-flight assignments are being worked |
 | `CLEANUP` | All sprints have valid Completions but open non-blocking findings remain |
 | `DONE` | All sprints have valid Completions and no open non-blocking findings — phase complete |
 
 After getting a `TRAVERSAL` result, the orchestrator:
 1. Appends an Assignment event to events.ttl for this sprint
-2. Checks `.triage/` for blocking/important/minor findings (via triage-findings skill)
+2. Checks `.triage/` for blocking/important/minor findings (via triaging-findings skill)
 3. Picks the template: no findings → dev-task.xml.j2; blocking findings present → dev-fix.xml.j2
 
 ```
@@ -157,7 +166,7 @@ if cursor_result.phase == "CLEANUP":
 
 # TRAVERSAL path
 append Assignment event to events.ttl for cursor sprint
-findings = run triage-findings skill for cursor sprint
+findings = run triaging-findings skill for cursor sprint
 
 if findings has blocking:
     → dispatch dev-fix.xml.j2
@@ -168,7 +177,7 @@ else:
 **Hard rules:**
 - Never cache phase or cursor across events. Re-run `next-dev-task` after every
   Completion or Assignment.
-- Never interpret findings in this skill — that is triage-findings' job. If
+- Never interpret findings in this skill — that is triaging-findings' job. If
   the orchestrator is tempted to reason about the graph, the model is broken —
   file a design issue, do not improvise.
 - QA runs after every dev Completion. Trigger immediately on Completion receipt.
@@ -194,8 +203,8 @@ Populate and send `dev-task.xml.j2`:
 
 ## Fix Dispatch (blocking findings present)
 
-Same cursor sprint, but triage-findings reports blocking findings on it.
-Use `dev-fix.xml.j2` instead. The findings payload comes from triage-findings,
+Same cursor sprint, but triaging-findings reports blocking findings on it.
+Use `dev-fix.xml.j2` instead. The findings payload comes from triaging-findings,
 not from events.ttl.
 
 ## QA Gate
@@ -223,12 +232,12 @@ Do not re-run them if they filed nothing or all their findings are resolved.
 QA rules:
 - QA never edits existing findings. Re-assessments file a **new** finding at
   the new severity.
-- QA appends findings to `.triage/` via the triage-findings skill — not to
+- QA appends findings to `.triage/` via the triaging-findings skill — not to
   events.ttl.
 - Merge gate: 0 Blocking + 0 Important + 0 Minor, no exceptions.
 
 After QA completes, re-run `next-dev-task` to get the new cursor, then run
-triage-findings to determine template selection.
+triaging-findings to determine template selection.
 
 ## Appending Events
 
@@ -283,7 +292,7 @@ Invalidation below).
 **Non-blocking findings**: Closed by an explicit Resolution in events.ttl.
 
 Findings live exclusively in `.triage/*/findings/*.ttl` and are managed by the
-triage-findings skill. Do not append raw finding data to events.ttl.
+triaging-findings skill. Do not append raw finding data to events.ttl.
 
 ## sc-compose Integration
 
@@ -303,7 +312,7 @@ triage-findings skill. Do not append raw finding data to events.ttl.
 
 The orchestrator saves `vars` to a temp file and adds non-graph variables.
 Template selection (`dev-task.xml.j2` vs `dev-fix.xml.j2`) is made after
-consulting triage-findings:
+consulting triaging-findings:
 
 ```bash
 RESULT=$(next-dev-task F .sprints/F)
@@ -318,9 +327,9 @@ fi
 echo "$RESULT" | jq .vars > /tmp/graph-vars.json
 SPRINT=$(echo "$RESULT" | jq -r .vars.sprint)
 
-# Check findings via triage-findings skill (orchestrator step)
+# Check findings via triaging-findings skill (orchestrator step)
 # If blocking findings exist, use dev-fix.xml.j2; otherwise dev-task.xml.j2
-TEMPLATE="dev-task.xml.j2"   # set by orchestrator after triage-findings check
+TEMPLATE="dev-task.xml.j2"   # set by orchestrator after triaging-findings check
 
 # Render via sc-compose (orchestrator supplies remaining vars)
 sc-compose render \
@@ -400,7 +409,7 @@ graph-orchestration:
 | `triage:Completion` | `ofSprint`, `at` | Appended by team-lead on receipt of dev's ATM completion message; may be invalidated by a later blocking finding |
 | `triage:Resolution` | `resolves`, `resolvedAt` | Appended by team-lead when a non-blocking finding is confirmed fixed; blocking findings need no Resolution |
 
-Findings are defined by the triage-findings skill and live in
+Findings are defined by the triaging-findings skill and live in
 `.triage/*/findings/*.ttl`. Resolution events referencing those findings are
 appended to events.ttl by team-lead.
 
@@ -412,6 +421,7 @@ All scripts live in `.claude/skills/graph-orchestration/scripts/`:
 |---|---|
 | `next-dev-task` | Entry point: cursor resolution, returns JSON |
 | `preflight` | First-step dependency gate; requires CLI + Python binding `sc-compose >= 1.2.0`, `jq`, and `python3` + `rdflib` |
+| `validate-findings.py` | Mandatory raw findings/provenance gate invoked before query resolution |
 | `query_runner.py` | Python SPARQL runner (rdflib) |
 | `cursor.sparql` | Returns cursor sprint (lowest-ordered sprint without a truly in-flight Assignment or valid Completion); parameter: `$PHASE` |
 | `open-findings-sprint.sparql` | Returns open non-blocking findings across the phase (used for CLEANUP detection); parameter: `$PHASE` |
@@ -469,7 +479,7 @@ Output JSON (DONE):
 ## Assignment Templates
 
 - `dev-task.xml.j2` — initial dev pass (no blocking findings)
-- `dev-fix.xml.j2` — fix pass (blocking findings identified by triage-findings)
+- `dev-fix.xml.j2` — fix pass (blocking findings identified by triaging-findings)
 
 QA assignment uses the existing `quality-mgr` prompt directly — no new template.
 

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -59,6 +59,23 @@ the phase starts.
 
 Run `validate-structure.sparql` at creation. It must return zero rows.
 
+Before relying on cursor output, validate the raw findings directory as well:
+
+```bash
+python3 .claude/skills/graph-orchestration/scripts/validate-findings.py \
+  --findings-dir .triage/phase-AI/findings \
+  --structure .sprints/AICH/structure.ttl \
+  --events .sprints/AICH/events.ttl
+```
+
+This check runs before `query_runner.py`'s sprint-membership filter, so a
+finding cannot disappear merely because `triage:foundIn` is absent. Missing
+`triage:foundIn` or `triage:foundAt` is reported as `#error` and fails the
+command; missing `triage:findingId`, `triage:severity`, or
+`triage:description` is reported as `#warning`. Use `--finding-id-regex` to
+restrict an audit to a known sprint range and `--max-results N` to truncate
+repetitive output while preserving the failure status.
+
 ## Orchestrator Loop
 
 ```bash

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -1,8 +1,22 @@
 ---
 name: graph-orchestration
-version: 0.4.0
+version: 0.5.0
 description: TTL/SPARQL-driven phase orchestration. The orchestrator runs a deterministic query loop — cursor → triage-findings check → dispatch → await Completion → re-query. No agent ever decides phase, cursor position, or done-ness; queries answer all of it. Derived from codex-orchestration; replaces static sprint-doc assignments with a live RDF event log. Adds Assignment events (collision prevention), Completion invalidation (blocking post-Completion finding snaps cursor back), and CLEANUP phase (non-blocking findings after all sprints complete).
 repo: atm-core
+requires:
+  cli:
+    - name: sc-compose
+      minimum_version: 1.2.0
+    - name: jq
+  python:
+    - package: rdflib
+      purpose: RDF/Turtle parsing and SPARQL queries
+    - package: sc-compose
+      import_name: sc_compose
+      minimum_version: 1.2.0
+      purpose: Python/maturin rendering integrations
+  test:
+    - package: pytest
 depends_on:
   quality-management-gh: 1.x
   quality-mgr: 0.x
@@ -21,6 +35,31 @@ depends_on:
 Mechanical phase orchestration backed by an append-only RDF event log.
 Every orchestration decision is a SPARQL query result. Agents never decide
 phase, cursor position, or whether a sprint is done.
+
+## Step 1 — Verify dependencies
+
+Run the dependency preflight as the first executable step, before discovering
+the phase, invoking an agent, reading the cursor, or appending a TTL event:
+
+```bash
+.claude/skills/graph-orchestration/scripts/preflight
+```
+
+It checks the `sc-compose >= 1.2.0` CLI, the matching `sc_compose >= 1.2.0`
+Python/maturin binding, `jq`, and a `python3` interpreter that can import
+`rdflib`. The command always emits a structured JSON result and exits `0`
+only when all runtime checks pass; exit `2` is an operational dependency error
+and must stop the workflow. For test work, include pytest:
+
+```bash
+.claude/skills/graph-orchestration/scripts/preflight --for-tests
+```
+
+If the check fails, read
+`references/installation-and-troubleshooting.md`, correct the environment,
+and rerun preflight. Do not proceed with a degraded or guessed dependency.
+The reference is intentionally separate so the normal skill entry point stays
+small (progressive disclosure).
 
 ## Defaults
 
@@ -372,6 +411,7 @@ All scripts live in `.claude/skills/graph-orchestration/scripts/`:
 | Script | Purpose |
 |---|---|
 | `next-dev-task` | Entry point: cursor resolution, returns JSON |
+| `preflight` | First-step dependency gate; requires CLI + Python binding `sc-compose >= 1.2.0`, `jq`, and `python3` + `rdflib` |
 | `query_runner.py` | Python SPARQL runner (rdflib) |
 | `cursor.sparql` | Returns cursor sprint (lowest-ordered sprint without a truly in-flight Assignment or valid Completion); parameter: `$PHASE` |
 | `open-findings-sprint.sparql` | Returns open non-blocking findings across the phase (used for CLEANUP detection); parameter: `$PHASE` |
@@ -381,7 +421,8 @@ All scripts live in `.claude/skills/graph-orchestration/scripts/`:
 
 Usage:
 ```bash
-# From repo root — make executable first: chmod +x .claude/skills/graph-orchestration/scripts/next-dev-task
+# From repo root — dependency gate must pass before the cursor is queried
+.claude/skills/graph-orchestration/scripts/preflight
 .claude/skills/graph-orchestration/scripts/next-dev-task F .sprints/F
 ```
 

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -322,10 +322,14 @@ triaging-findings skill. Do not append raw finding data to events.ttl.
 }
 ```
 
-For `TRAVERSAL`, `findings` contains every unresolved finding on the returned
-sprint, ordered Blocking, Important, Minor. An empty array is the only
-greenfield result. The developer must use this JSON to verify the rendered
-node and any assigned Blocking finding ids before editing.
+For `TRAVERSAL`, `findings` contains every dispatch-open finding on the
+returned sprint, ordered invalid severity, Blocking, Important, Minor.
+Severity is case-normalized; an unknown value is returned as `invalid` with
+`raw_severity` preserved and must stop dispatch. Terminal `triage:status`
+values are excluded for routing only; this does not change Completion or QA
+lifecycle semantics. An empty array is the only greenfield result. The
+developer must use this JSON to verify the rendered node and any assigned
+Blocking finding ids before editing.
 
 The orchestrator saves `vars` to a temp file and adds non-graph variables.
 Template selection (`dev-task.xml.j2` vs `dev-fix.xml.j2`) is made after

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -324,12 +324,12 @@ triaging-findings skill. Do not append raw finding data to events.ttl.
 
 For `TRAVERSAL`, `findings` contains every dispatch-open finding on the
 returned sprint, ordered invalid severity, Blocking, Important, Minor.
-Severity is case-normalized; an unknown value is returned as `invalid` with
-`raw_severity` preserved and must stop dispatch. Terminal `triage:status`
-values are excluded for routing only; this does not change Completion or QA
-lifecycle semantics. An empty array is the only greenfield result. The
-developer must use this JSON to verify the rendered node and any assigned
-Blocking finding ids before editing.
+Severity is case-normalized; reviewer-native `critical` maps to `blocking`.
+An unknown value is returned as `invalid` with `raw_severity` preserved and
+must stop dispatch. Terminal `triage:status` values are excluded for routing
+only; this does not change Completion or QA lifecycle semantics. An empty
+array is the only greenfield result. The developer must use this JSON to
+verify the rendered node and any assigned Blocking finding ids before editing.
 
 The orchestrator saves `vars` to a temp file and adds non-graph variables.
 Template selection (`dev-task.xml.j2` vs `dev-fix.xml.j2`) is made after

--- a/.claude/skills/graph-orchestration/dev-task.xml.j2
+++ b/.claude/skills/graph-orchestration/dev-task.xml.j2
@@ -36,7 +36,7 @@ defaults:
 
   <workflow>
     <step id="a">ACK this message immediately. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
-    <step id="b">Immediately after ACK, begin work in the same session.</step>
+    <step id="b">Before reading code or editing, verify this is either a new/greenfield sprint or a fix task with an assigned, open Blocking finding on this exact sprint. If neither condition is true, stop and report the invalid assignment. Then begin work in the same session.</step>
     <step id="c">Read `{{ criteria_doc }}` before coding. This is the authoritative acceptance criteria for this node. Satisfy every criterion completely — do not weaken or skip any.</step>
     <step id="d">Update the worktree from `{{ pr_target }}` before any edits: `git fetch origin && git merge origin/{{ pr_target }}`.</step>
     <step id="e">Implement the work. Commit incrementally on `{{ branch }}`.</step>

--- a/.claude/skills/graph-orchestration/dev-task.xml.j2
+++ b/.claude/skills/graph-orchestration/dev-task.xml.j2
@@ -13,12 +13,16 @@ required_variables:
   - branch
   - pr_target
   - assignee
+  - phase_local
+  - ttl_dir
 optional_variables:
+  - finding_ids
   - test_command
   - references
 defaults:
   test_command: "just test"
   references: ""
+  finding_ids: ""
 ---
 <atm-task id="{{ task_id }}" sprint="{{ sprint }}" node="{{ node_id }}" order="{{ node_order }}" assignee="{{ assignee }}">
   <description>Implement sprint node {{ node_id }} (order {{ node_order }}) in {{ sprint }}.</description>
@@ -36,7 +40,7 @@ defaults:
 
   <workflow>
     <step id="a">ACK this message immediately. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
-    <step id="b">Before reading code or editing, verify this is either a new/greenfield sprint or a fix task with an assigned, open Blocking finding on this exact sprint. If neither condition is true, stop and report the invalid assignment. Then begin work in the same session.</step>
+    <step id="b">Before reading code or editing, run `.claude/skills/graph-orchestration/scripts/next-dev-task {{ phase_local }} {{ ttl_dir }}` and retain its JSON. Continue only if `phase` is `TRAVERSAL` and `vars.sprint` is `{{ node_id }}`. With an empty `findings` array this is a new/greenfield sprint. Otherwise, `{{ finding_ids }}` must be non-empty and every listed id must appear in `findings` with severity `blocking`; any other result is an invalid assignment—stop and report it. The array is ordered Blocking, Important, Minor.</step>
     <step id="c">Read `{{ criteria_doc }}` before coding. This is the authoritative acceptance criteria for this node. Satisfy every criterion completely — do not weaken or skip any.</step>
     <step id="d">Update the worktree from `{{ pr_target }}` before any edits: `git fetch origin && git merge origin/{{ pr_target }}`.</step>
     <step id="e">Implement the work. Commit incrementally on `{{ branch }}`.</step>

--- a/.claude/skills/graph-orchestration/references/installation-and-troubleshooting.md
+++ b/.claude/skills/graph-orchestration/references/installation-and-troubleshooting.md
@@ -29,7 +29,7 @@ The required runtime dependencies are:
 |---|---:|---|
 | `sc-compose` CLI | **1.2.0** | Rendering fenced Jinja templates and agent prompts |
 | `sc_compose` Python binding | **1.2.0** | Python/maturin rendering integrations and wrappers |
-| Python 3 + `rdflib` | supported Python 3 | RDF/Turtle parsing and SPARQL queries |
+| Python + `rdflib` | **3.11+** | RDF/Turtle parsing and SPARQL queries |
 | `jq` | any current release | Reading the JSON cursor contract |
 | `pytest` | any current release | Unit tests (only required with `--for-tests`) |
 
@@ -44,7 +44,7 @@ command -v jq && jq --version
 command -v python3 && python3 -c 'import rdflib; print(rdflib.__version__)'
 python3 -c 'from importlib.metadata import version; import sc_compose; print(version("sc-compose"))'
 
-for p in "$HOME/.local/bin" "$HOME/.venvs/graph-orchestration/bin" \
+for p in "$HOME/.local/bin" \
   "/opt/homebrew/bin" "/usr/local/bin"; do
   [ -x "$p/sc-compose" ] && echo "sc-compose: $p/sc-compose"
   [ -x "$p/python3" ] && echo "python3: $p/python3"
@@ -77,32 +77,25 @@ For the CLI (Homebrew tap):
 brew install randlee/tap/sc-compose
 ```
 
-For the Python/maturin binding and RDF/test packages (no administrator access
-required):
+For the Python/maturin binding (a one-time per-machine setup; no activation
+step):
 
 ```bash
-python3 -m pip install --user --upgrade 'sc-compose>=1.2.0' rdflib pytest
+python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'
 brew install jq
 ```
 
-If the system `python3` is managed by another tool, use a venv instead:
-
-```bash
-python3 -m venv .venv-graph-orchestration
-.venv-graph-orchestration/bin/python -m pip install --upgrade pip
-.venv-graph-orchestration/bin/python -m pip install 'sc-compose>=1.2.0' rdflib pytest
-export PATH="$PWD/.venv-graph-orchestration/bin:$PATH"
-brew install randlee/tap/sc-compose
-brew install jq
-```
+The `--user` target keeps the wheel out of Homebrew-managed site-packages;
+`--break-system-packages` is the explicit Python override for this trusted,
+user-owned install.  The wheel is published on PyPI and provides the
+`sc_compose` binding (Python 3.11+; prebuilt platform wheels).  It does not install the standalone CLI, so keep the
+Homebrew CLI install above as a separate step.  This is done once per machine;
+callers only perform a guarded `import sc_compose` on each invocation.
 
 ### Linux
 
 ```bash
-python3 -m venv .venv-graph-orchestration
-.venv-graph-orchestration/bin/python -m pip install --upgrade pip
-.venv-graph-orchestration/bin/python -m pip install 'sc-compose>=1.2.0' rdflib pytest
-export PATH="$PWD/.venv-graph-orchestration/bin:$PATH"
+python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'
 sudo apt-get install jq                 # Debian/Ubuntu; use the native package manager otherwise
 ```
 
@@ -111,29 +104,18 @@ CLI. Install the CLI from the v1.2.0 release or from a source checkout with
 the upstream `cargo install --path crates/sc-compose` procedure, then rerun
 preflight.
 
-If distribution Python permits a user install, the equivalent is:
-
-```bash
-python3 -m pip install --user --upgrade 'sc-compose>=1.2.0' rdflib pytest
-export PATH="$HOME/.local/bin:$PATH"
-```
-
 Install the `sc-compose` CLI from the project release channel for the
 platform (Homebrew tap, package manager, or a release binary); the pip wheel
 above is the Python binding and is not a CLI installation.
-
-Prefer the venv commands when distribution Python refuses user installs
-(PEP 668). Do not bypass the protection with `--break-system-packages`.
+If the invoking Python is not `python3`, substitute that interpreter in the
+one-time install command and in the preflight.
 
 ### Windows (PowerShell)
 
 ```powershell
-py -m venv .venv-graph-orchestration
-.venv-graph-orchestration\Scripts\python -m pip install --upgrade pip
-.venv-graph-orchestration\Scripts\python -m pip install 'sc-compose>=1.2.0' rdflib pytest
+py -m pip install --user --break-system-packages "sc-compose>=1.2.0"
 winget install randlee.sc-compose
 winget install jqlang.jq
-$env:Path = "$PWD\.venv-graph-orchestration\Scripts;$env:Path"
 ```
 
 The PyPI package and the standalone Windows CLI are separate artifacts. Restart
@@ -160,8 +142,10 @@ preflight: dependency errors are distinct from expected validation failures.
   often point at different interpreters.  Compare `command -v python3` with
   `python3 -m pip --version`, then use the same interpreter for installation or
   set `GRAPH_ORCH_PYTHON`.
-- **PEP 668 blocks `pip install`.** Use the venv commands above; do not bypass
-  the protection with `--break-system-packages` for this workflow.
+- **PEP 668 blocks `pip install`.** Run the sanctioned one-time user install:
+  `python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'`.
+  No venv or activation step is required.  If that interpreter is not the one
+  used by the skill, repeat the command with the exact invoking interpreter.
 - **The CLI works in Terminal but not in Claude Code.** Add the discovered
   directory to `PATH` in the current command/session.  Shell startup files are
   not guaranteed to be loaded.

--- a/.claude/skills/graph-orchestration/references/installation-and-troubleshooting.md
+++ b/.claude/skills/graph-orchestration/references/installation-and-troubleshooting.md
@@ -1,0 +1,176 @@
+# Installation and troubleshooting
+
+This reference is loaded only when the dependency preflight fails.  The
+graph-orchestration entry point is intentionally fail-closed: do not dispatch
+an agent or mutate phase TTL while a required dependency is missing or below
+the minimum version.
+
+## Check first
+
+From the repository root, run the preflight before any graph query or event
+write:
+
+```bash
+.claude/skills/graph-orchestration/scripts/preflight
+```
+
+The command emits a JSON response with `success`, `data.checks`, and `error`.
+Exit `0` means all runtime checks passed.  Exit `2` means an operational
+dependency error; inspect the check details and fix the environment.  For the
+test suite, include pytest:
+
+```bash
+.claude/skills/graph-orchestration/scripts/preflight --for-tests
+```
+
+The required runtime dependencies are:
+
+| Dependency | Minimum | Used for |
+|---|---:|---|
+| `sc-compose` CLI | **1.2.0** | Rendering fenced Jinja templates and agent prompts |
+| `sc_compose` Python binding | **1.2.0** | Python/maturin rendering integrations and wrappers |
+| Python 3 + `rdflib` | supported Python 3 | RDF/Turtle parsing and SPARQL queries |
+| `jq` | any current release | Reading the JSON cursor contract |
+| `pytest` | any current release | Unit tests (only required with `--for-tests`) |
+
+## Find an existing install
+
+Claude Code may start with a smaller `PATH` than an interactive shell.  Check
+both the command lookup and common user/Homebrew locations:
+
+```bash
+command -v sc-compose && sc-compose --version
+command -v jq && jq --version
+command -v python3 && python3 -c 'import rdflib; print(rdflib.__version__)'
+python3 -c 'from importlib.metadata import version; import sc_compose; print(version("sc-compose"))'
+
+for p in "$HOME/.local/bin" "$HOME/.venvs/graph-orchestration/bin" \
+  "/opt/homebrew/bin" "/usr/local/bin"; do
+  [ -x "$p/sc-compose" ] && echo "sc-compose: $p/sc-compose"
+  [ -x "$p/python3" ] && echo "python3: $p/python3"
+  [ -x "$p/jq" ] && echo "jq: $p/jq"
+done
+```
+
+If `rdflib` is installed for a different interpreter, put that interpreter's
+directory first for this session, or set `GRAPH_ORCH_PYTHON` to its full path:
+
+```bash
+export PATH="/opt/homebrew/bin:$PATH"       # adjust to the path found above
+export GRAPH_ORCH_PYTHON="/opt/homebrew/bin/python3"  # optional explicit path
+```
+
+Run preflight again after changing `PATH`.  Do not work around a failed check
+by invoking `query_runner.py` directly; doing so bypasses the dependency gate.
+
+## Install or upgrade
+
+### macOS
+
+The executable and Python binding are separate artifacts.  Installing the
+PyPI wheel does **not** guarantee that a `sc-compose` executable is on `PATH`.
+Install both and keep them at the same minimum version.
+
+For the CLI (Homebrew tap):
+
+```bash
+brew install randlee/tap/sc-compose
+```
+
+For the Python/maturin binding and RDF/test packages (no administrator access
+required):
+
+```bash
+python3 -m pip install --user --upgrade 'sc-compose>=1.2.0' rdflib pytest
+brew install jq
+```
+
+If the system `python3` is managed by another tool, use a venv instead:
+
+```bash
+python3 -m venv .venv-graph-orchestration
+.venv-graph-orchestration/bin/python -m pip install --upgrade pip
+.venv-graph-orchestration/bin/python -m pip install 'sc-compose>=1.2.0' rdflib pytest
+export PATH="$PWD/.venv-graph-orchestration/bin:$PATH"
+brew install randlee/tap/sc-compose
+brew install jq
+```
+
+### Linux
+
+```bash
+python3 -m venv .venv-graph-orchestration
+.venv-graph-orchestration/bin/python -m pip install --upgrade pip
+.venv-graph-orchestration/bin/python -m pip install 'sc-compose>=1.2.0' rdflib pytest
+export PATH="$PWD/.venv-graph-orchestration/bin:$PATH"
+sudo apt-get install jq                 # Debian/Ubuntu; use the native package manager otherwise
+```
+
+The PyPI package supplies the `sc_compose` Python binding, not the standalone
+CLI. Install the CLI from the v1.2.0 release or from a source checkout with
+the upstream `cargo install --path crates/sc-compose` procedure, then rerun
+preflight.
+
+If distribution Python permits a user install, the equivalent is:
+
+```bash
+python3 -m pip install --user --upgrade 'sc-compose>=1.2.0' rdflib pytest
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Install the `sc-compose` CLI from the project release channel for the
+platform (Homebrew tap, package manager, or a release binary); the pip wheel
+above is the Python binding and is not a CLI installation.
+
+Prefer the venv commands when distribution Python refuses user installs
+(PEP 668). Do not bypass the protection with `--break-system-packages`.
+
+### Windows (PowerShell)
+
+```powershell
+py -m venv .venv-graph-orchestration
+.venv-graph-orchestration\Scripts\python -m pip install --upgrade pip
+.venv-graph-orchestration\Scripts\python -m pip install 'sc-compose>=1.2.0' rdflib pytest
+winget install randlee.sc-compose
+winget install jqlang.jq
+$env:Path = "$PWD\.venv-graph-orchestration\Scripts;$env:Path"
+```
+
+The PyPI package and the standalone Windows CLI are separate artifacts. Restart
+the shell if either executable remains invisible.
+
+## Validate after setup
+
+```bash
+.claude/skills/graph-orchestration/scripts/preflight --for-tests
+python3 -m pytest .claude/skills/graph-orchestration/scripts/test_queries.py -v
+python3 -m pytest .claude/skills/graph-orchestration/scripts/test_validate_findings.py -v
+```
+
+The first command must return `"success": true` and report
+`sc-compose` version `1.2.0` or newer.  A test pass does not override a failed
+preflight: dependency errors are distinct from expected validation failures.
+
+## Known issues
+
+- **`sc-compose 1.0.x` is rejected.** Upgrade it; do not lower the requirement.
+  Version 1.2.0 supplies the bindings and rendering behavior used by these
+  skills.
+- **`rdflib` import fails although it was installed.** `pip` and `python3`
+  often point at different interpreters.  Compare `command -v python3` with
+  `python3 -m pip --version`, then use the same interpreter for installation or
+  set `GRAPH_ORCH_PYTHON`.
+- **PEP 668 blocks `pip install`.** Use the venv commands above; do not bypass
+  the protection with `--break-system-packages` for this workflow.
+- **The CLI works in Terminal but not in Claude Code.** Add the discovered
+  directory to `PATH` in the current command/session.  Shell startup files are
+  not guaranteed to be loaded.
+- **`jq` is missing on a minimal machine.** Install it with the platform
+  package manager; the graph cursor JSON must not be parsed with ad-hoc text
+  tools.
+- **`pytest` is missing.** It is a test-time dependency, not a runtime query
+  dependency.  Install it or run preflight without `--for-tests` when only
+  dispatching a phase.
+- **A command returns a malformed version.** The preflight reports a structured
+  error and stops.  Check that the command is the real executable rather than
+  a shell alias or wrapper emitting extra text.

--- a/.claude/skills/graph-orchestration/scripts/assignee-busy
+++ b/.claude/skills/graph-orchestration/scripts/assignee-busy
@@ -25,10 +25,11 @@ PHASE="$1"
 TTL_DIR="$2"
 ASSIGNEE="$3"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_BIN="${GRAPH_ORCH_PYTHON:-python3}"
 
-if ! python3 -c "import rdflib" 2>/dev/null; then
+if ! "$PYTHON_BIN" -c "import rdflib" 2>/dev/null; then
   echo >&2 "ERROR: rdflib not found. Install with: pip3 install rdflib"
   exit 1
 fi
 
-exec python3 "$SCRIPT_DIR/check_assignee.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" "$ASSIGNEE"
+exec "$PYTHON_BIN" "$SCRIPT_DIR/check_assignee.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" "$ASSIGNEE"

--- a/.claude/skills/graph-orchestration/scripts/assignee-busy
+++ b/.claude/skills/graph-orchestration/scripts/assignee-busy
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# assignee-busy — Is this assignee already working on something in this phase?
+#
+# Usage: assignee-busy <PHASE_LOCAL> <TTL_DIR> <ASSIGNEE>
+#   PHASE_LOCAL  e.g. "AICH" (expanded to urn:atm:triage:PhaseAICH)
+#   TTL_DIR      path to directory containing structure.ttl and events.ttl
+#   ASSIGNEE     agent name exactly as used in triage:assignedTo, e.g. "arch-ctm"
+#
+# Team-lead MUST run this before appending any new Assignment event for an
+# agent and get "busy": false. This check is independent of cursor.sparql —
+# a sprint being "ready" per the cursor never overrides an agent already
+# having an open, unfinished Assignment. One task per developer, no
+# redirects, no exceptions.
+#
+# Returns JSON on stdout; exits non-zero on error.
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo >&2 "Usage: assignee-busy <PHASE_LOCAL> <TTL_DIR> <ASSIGNEE>"
+  exit 1
+fi
+
+PHASE="$1"
+TTL_DIR="$2"
+ASSIGNEE="$3"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! python3 -c "import rdflib" 2>/dev/null; then
+  echo >&2 "ERROR: rdflib not found. Install with: pip3 install rdflib"
+  exit 1
+fi
+
+exec python3 "$SCRIPT_DIR/check_assignee.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" "$ASSIGNEE"

--- a/.claude/skills/graph-orchestration/scripts/assignee-busy.sparql
+++ b/.claude/skills/graph-orchestration/scripts/assignee-busy.sparql
@@ -1,0 +1,37 @@
+# assignee-busy.sparql — Is this assignee already working on something?
+#
+# An assignee is BUSY iff they have a truly in-flight Assignment in this
+# phase: an Assignment exists for them and no Completion for that
+# Assignment's sprint postdates it.
+#
+# This is deliberately independent of cursor.sparql / sprint order. It does
+# not matter which sprint the cursor says is "ready" — if the assignee
+# already has open work, they must finish it before receiving anything
+# else. Team-lead must run this and get zero rows before appending any new
+# Assignment event for a given assignee, regardless of cursor output.
+#
+# Returns: zero rows (assignee is free) or one row per open sprint
+#   (?sprint, ?assignedAt)
+# Parameters: $PHASE, $ASSIGNEE (a plain literal, e.g. "arch-ctm")
+
+PREFIX triage: <urn:atm:triage:>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?sprint ?assignedAt WHERE {
+  ?sprint a triage:Sprint ;
+          triage:inPhase $PHASE .
+
+  ?a a triage:Assignment ;
+     triage:ofSprint ?sprint ;
+     triage:assignedTo $ASSIGNEE ;
+     triage:assignedAt ?assignedAt .
+
+  # Truly in-flight: no Completion at all after this Assignment
+  FILTER NOT EXISTS {
+    ?c a triage:Completion ;
+       triage:ofSprint ?sprint ;
+       triage:at ?ct .
+    FILTER (?ct > ?assignedAt)
+  }
+}
+ORDER BY ?assignedAt

--- a/.claude/skills/graph-orchestration/scripts/check_assignee.py
+++ b/.claude/skills/graph-orchestration/scripts/check_assignee.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+check_assignee.py — Is a given assignee already busy in this phase?
+
+Called by assignee-busy. Returns JSON to stdout; errors to stderr.
+
+Team-lead must run this (via the assignee-busy wrapper) and confirm
+"busy": false before appending any new Assignment event for an agent,
+regardless of what cursor.sparql / next-dev-task returns. Cursor readiness
+and assignee availability are two independent checks — a sprint being
+"ready" never overrides an agent already having open work.
+
+Output shape:
+  {
+    "busy": true,
+    "assignee": "arch-ctm",
+    "open_assignments": [
+      {"sprint": "urn:atm:triage:AICH-S2", "assignedAt": "2026-07-25T04:45:03Z"}
+    ]
+  }
+
+Usage: check_assignee.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> <ASSIGNEE>
+"""
+
+import sys
+import json
+from pathlib import Path
+
+from rdflib import URIRef, Literal
+
+from query_runner import load_graph, run_sparql, TRIAGE_BASE
+
+
+def main() -> int:
+    if len(sys.argv) != 5:
+        print(
+            "Usage: check_assignee.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> <ASSIGNEE>",
+            file=sys.stderr,
+        )
+        return 1
+
+    phase_local = sys.argv[1]
+    ttl_dir = sys.argv[2]
+    script_dir = Path(sys.argv[3])
+    assignee = sys.argv[4]
+
+    phase_iri = URIRef(f"{TRIAGE_BASE}Phase{phase_local}")
+    try:
+        g = load_graph(ttl_dir)
+        rows = run_sparql(
+            g,
+            script_dir / "assignee-busy.sparql",
+            {"PHASE": phase_iri, "ASSIGNEE": Literal(assignee)},
+        )
+    except Exception as exc:  # noqa: BLE001 - CLI boundary must be one-line
+        print(f"ERROR: assignee check failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps({
+        "busy": bool(rows),
+        "assignee": assignee,
+        "open_assignments": [
+            {"sprint": str(r[0]), "assignedAt": str(r[1])} for r in rows
+        ],
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/graph-orchestration/scripts/next-dev-task
+++ b/.claude/skills/graph-orchestration/scripts/next-dev-task
@@ -26,14 +26,15 @@ if [[ $# -eq 3 && "$3" != "--validate-only" ]]; then
   exit 1
 fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_BIN="${GRAPH_ORCH_PYTHON:-python3}"
 
 # Verify Python 3 and rdflib are available
-if ! python3 -c "import rdflib" 2>/dev/null; then
+if ! "$PYTHON_BIN" -c "import rdflib" 2>/dev/null; then
   echo >&2 "ERROR: rdflib not found. Install with: pip3 install rdflib"
   exit 1
 fi
 
 if [[ $# -eq 3 ]]; then
-  exec python3 "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" --validate-only
+  exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" --validate-only
 fi
-exec python3 "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR"
+exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR"

--- a/.claude/skills/graph-orchestration/scripts/next-dev-task
+++ b/.claude/skills/graph-orchestration/scripts/next-dev-task
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # next-dev-task — Cursor resolution for graph-orchestration.
 #
-# Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR>
+# Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]
 # TTL_DIR: path to .sprints/<PHASE>/ on the integrate/phase-N branch
 #   PHASE_LOCAL  e.g. "F" (expanded to urn:atm:triage:PhaseF)
 #   TTL_DIR      path to directory containing structure.ttl and events.ttl
@@ -14,8 +14,17 @@
 
 set -euo pipefail
 
-PHASE="${1:?Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR>}"
-TTL_DIR="${2:?Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR>}"
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo >&2 "Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+  exit 1
+fi
+
+PHASE="$1"
+TTL_DIR="$2"
+if [[ $# -eq 3 && "$3" != "--validate-only" ]]; then
+  echo >&2 "Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+  exit 1
+fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Verify Python 3 and rdflib are available
@@ -24,4 +33,7 @@ if ! python3 -c "import rdflib" 2>/dev/null; then
   exit 1
 fi
 
+if [[ $# -eq 3 ]]; then
+  exec python3 "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" --validate-only
+fi
 exec python3 "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR"

--- a/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
+++ b/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
@@ -1,10 +1,10 @@
 # open-findings-for-sprint.sparql — All unresolved findings for one sprint.
 #
-# Parameters: $SPRINT. Status is returned as metadata but does not hide a
-# finding: event-log Completion/Resolution is the lifecycle source used by the
-# cursor, and this result must stay consistent with that cursor. Results are
-# ordered for dispatch review: invalid severity first (fail closed), then
-# Blocking, Important, and Minor; ties use foundAt.
+# Parameters: $SPRINT. A terminal triage:status excludes a finding. Existing
+# repository findings use that status as their closure record; Resolution
+# events are honored too when present. Results are ordered for dispatch review:
+# invalid severity first (fail closed), then Blocking, Important, and Minor;
+# ties use foundAt.
 
 PREFIX triage: <urn:atm:triage:>
 
@@ -20,6 +20,15 @@ SELECT ?finding ?findingId ?severity ?rawSeverity ?status ?foundAt ?description 
     ?resolution a triage:Resolution ;
                 triage:resolves ?finding .
   }
+  FILTER (
+    !BOUND(?status)
+    || !(
+      LCASE(STR(?status)) IN (
+        "absent", "accepted", "closed", "dismissed", "false_positive",
+        "fixed", "fixed-ci-green", "inherited-fix", "invalid", "merged", "waived"
+      )
+    )
+  )
   BIND(LCASE(STR(?rawSeverity)) AS ?normalizedSeverity)
   BIND(
     IF(?normalizedSeverity IN ("blocking", "critical"), "blocking",

--- a/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
+++ b/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
@@ -1,0 +1,27 @@
+# open-findings-for-sprint.sparql — All unresolved findings for one sprint.
+#
+# Parameters: $SPRINT. Results are ordered for dispatch review: Blocking,
+# Important, Minor, then unknown severity; ties use foundAt.
+
+PREFIX triage: <urn:atm:triage:>
+
+SELECT ?finding ?findingId ?severity ?foundAt ?description WHERE {
+  ?finding a triage:Finding ;
+           triage:foundIn $SPRINT ;
+           triage:severity ?severity ;
+           triage:foundAt ?foundAt ;
+           triage:description ?description .
+  OPTIONAL { ?finding triage:findingId ?findingId . }
+  FILTER NOT EXISTS {
+    ?resolution a triage:Resolution ;
+                triage:resolves ?finding .
+  }
+  BIND(
+    IF(?severity = "blocking", 0,
+      IF(?severity = "important", 1,
+        IF(?severity = "minor", 2, 3)
+      )
+    ) AS ?severityOrder
+  )
+}
+ORDER BY ?severityOrder ?foundAt ?finding

--- a/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
+++ b/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
@@ -1,25 +1,45 @@
 # open-findings-for-sprint.sparql — All unresolved findings for one sprint.
 #
-# Parameters: $SPRINT. Results are ordered for dispatch review: Blocking,
-# Important, Minor, then unknown severity; ties use foundAt.
+# Parameters: $SPRINT. `triage:status` controls dispatch routing only; it does
+# not alter the event-log Completion/QA lifecycle. Results are ordered for
+# dispatch review: invalid severity first (fail closed), then Blocking,
+# Important, and Minor; ties use foundAt.
 
 PREFIX triage: <urn:atm:triage:>
 
-SELECT ?finding ?findingId ?severity ?foundAt ?description WHERE {
+SELECT ?finding ?findingId ?severity ?rawSeverity ?foundAt ?description WHERE {
   ?finding a triage:Finding ;
            triage:foundIn $SPRINT ;
-           triage:severity ?severity ;
+           triage:severity ?rawSeverity ;
            triage:foundAt ?foundAt ;
            triage:description ?description .
   OPTIONAL { ?finding triage:findingId ?findingId . }
+  OPTIONAL { ?finding triage:status ?status . }
   FILTER NOT EXISTS {
     ?resolution a triage:Resolution ;
                 triage:resolves ?finding .
   }
+  FILTER (
+    !BOUND(?status)
+    || !(
+      LCASE(STR(?status)) IN (
+        "absent", "accepted", "closed", "dismissed", "false_positive",
+        "fixed", "fixed-ci-green", "inherited-fix", "invalid", "merged", "waived"
+      )
+    )
+  )
+  BIND(LCASE(STR(?rawSeverity)) AS ?normalizedSeverity)
   BIND(
-    IF(?severity = "blocking", 0,
-      IF(?severity = "important", 1,
-        IF(?severity = "minor", 2, 3)
+    IF(?normalizedSeverity = "blocking", "blocking",
+      IF(?normalizedSeverity = "important", "important",
+        IF(?normalizedSeverity = "minor", "minor", "invalid")
+      )
+    ) AS ?severity
+  )
+  BIND(
+    IF(?severity = "invalid", -1,
+      IF(?severity = "blocking", 0,
+        IF(?severity = "important", 1, 2)
       )
     ) AS ?severityOrder
   )

--- a/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
+++ b/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
@@ -30,7 +30,7 @@ SELECT ?finding ?findingId ?severity ?rawSeverity ?foundAt ?description WHERE {
   )
   BIND(LCASE(STR(?rawSeverity)) AS ?normalizedSeverity)
   BIND(
-    IF(?normalizedSeverity = "blocking", "blocking",
+    IF(?normalizedSeverity IN ("blocking", "critical"), "blocking",
       IF(?normalizedSeverity = "important", "important",
         IF(?normalizedSeverity = "minor", "minor", "invalid")
       )

--- a/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
+++ b/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
@@ -1,13 +1,14 @@
 # open-findings-for-sprint.sparql — All unresolved findings for one sprint.
 #
-# Parameters: $SPRINT. `triage:status` controls dispatch routing only; it does
-# not alter the event-log Completion/QA lifecycle. Results are ordered for
-# dispatch review: invalid severity first (fail closed), then Blocking,
-# Important, and Minor; ties use foundAt.
+# Parameters: $SPRINT. Status is returned as metadata but does not hide a
+# finding: event-log Completion/Resolution is the lifecycle source used by the
+# cursor, and this result must stay consistent with that cursor. Results are
+# ordered for dispatch review: invalid severity first (fail closed), then
+# Blocking, Important, and Minor; ties use foundAt.
 
 PREFIX triage: <urn:atm:triage:>
 
-SELECT ?finding ?findingId ?severity ?rawSeverity ?foundAt ?description WHERE {
+SELECT ?finding ?findingId ?severity ?rawSeverity ?status ?foundAt ?description WHERE {
   ?finding a triage:Finding ;
            triage:foundIn $SPRINT ;
            triage:severity ?rawSeverity ;
@@ -19,15 +20,6 @@ SELECT ?finding ?findingId ?severity ?rawSeverity ?foundAt ?description WHERE {
     ?resolution a triage:Resolution ;
                 triage:resolves ?finding .
   }
-  FILTER (
-    !BOUND(?status)
-    || !(
-      LCASE(STR(?status)) IN (
-        "absent", "accepted", "closed", "dismissed", "false_positive",
-        "fixed", "fixed-ci-green", "inherited-fix", "invalid", "merged", "waived"
-      )
-    )
-  )
   BIND(LCASE(STR(?rawSeverity)) AS ?normalizedSeverity)
   BIND(
     IF(?normalizedSeverity IN ("blocking", "critical"), "blocking",

--- a/.claude/skills/graph-orchestration/scripts/preflight
+++ b/.claude/skills/graph-orchestration/scripts/preflight
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Dependency preflight wrapper.  Prefer PATH's python3, then common macOS/Linux
+# locations; preflight.py itself reports whether that interpreter has rdflib.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for candidate in "${GRAPH_ORCH_PYTHON:-}" "$(command -v python3 2>/dev/null || true)" \
+  "$HOME/.local/bin/python3" "/opt/homebrew/bin/python3" "/usr/local/bin/python3"; do
+  if [[ -n "$candidate" && -x "$candidate" ]]; then
+    exec "$candidate" "$SCRIPT_DIR/preflight.py" "$@"
+  fi
+done
+
+printf '%s\n' '{"success":false,"data":null,"error":{"code":"DEPENDENCY.PYTHON_NOT_FOUND","message":"python3 was not found; read references/installation-and-troubleshooting.md"}}'
+exit 2

--- a/.claude/skills/graph-orchestration/scripts/preflight.py
+++ b/.claude/skills/graph-orchestration/scripts/preflight.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Dependency preflight for graph-orchestration.
+
+The command deliberately has no workflow side effects.  It emits one JSON
+object and exits 0 only when every required runtime dependency is usable.
+Missing dependencies, an unusable Python environment, and old sc-compose
+versions are operational errors (exit 2), so callers cannot silently proceed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+
+MIN_SC_COMPOSE = (1, 2, 0)
+_VERSION_RE = re.compile(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?")
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    ok: bool
+    detail: str
+    path: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        value: dict[str, object] = {
+            "name": self.name,
+            "ok": self.ok,
+            "detail": self.detail,
+        }
+        if self.path is not None:
+            value["path"] = self.path
+        return value
+
+
+def _version(text: str) -> tuple[int, int, int] | None:
+    match = _VERSION_RE.search(text)
+    return tuple(int(part) for part in match.groups()) if match else None
+
+
+def _run(command: list[str], *, timeout: float = 5.0) -> tuple[int, str, str]:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 127, "", str(exc)
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def _find_command(name: str, fallbacks: Iterable[str] = ()) -> str | None:
+    found = shutil.which(name)
+    if found:
+        return found
+    for candidate in fallbacks:
+        if candidate and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def check_sc_compose() -> Check:
+    path = _find_command(
+        "sc-compose",
+        (
+            os.path.expanduser("~/.local/bin/sc-compose"),
+            "/opt/homebrew/bin/sc-compose",
+            "/usr/local/bin/sc-compose",
+        ),
+    )
+    if path is None:
+        return Check(
+            "sc-compose",
+            False,
+            "not found; install sc-compose>=1.2.0 (see references/installation-and-troubleshooting.md)",
+        )
+    rc, stdout, stderr = _run([path, "--version"])
+    version = _version(" ".join((stdout, stderr)))
+    if rc != 0 or version is None:
+        return Check(
+            "sc-compose",
+            False,
+            f"{path} did not return a parseable version: {stderr or stdout or 'no output'}",
+            path,
+        )
+    if version < MIN_SC_COMPOSE:
+        return Check(
+            "sc-compose",
+            False,
+            f"{path} reports {version[0]}.{version[1]}.{version[2]}; required >= 1.2.0",
+            path,
+        )
+    return Check("sc-compose", True, f"version {version[0]}.{version[1]}.{version[2]}", path)
+
+
+def check_jq() -> Check:
+    path = _find_command("jq", ("/opt/homebrew/bin/jq", "/usr/local/bin/jq"))
+    if path is None:
+        return Check("jq", False, "not found; install jq (see references/installation-and-troubleshooting.md)")
+    rc, stdout, stderr = _run([path, "--version"])
+    if rc != 0:
+        return Check("jq", False, f"{path} failed --version: {stderr or stdout}", path)
+    return Check("jq", True, stdout or "version reported", path)
+
+
+def _python_candidates() -> list[str]:
+    # The graph scripts invoke python3 (or GRAPH_ORCH_PYTHON), so checking a
+    # different interpreter would produce a false green preflight.  Only use
+    # fallback interpreters when python3 is absent; when it is present, tell
+    # the caller to fix PATH or set GRAPH_ORCH_PYTHON instead.
+    explicit = os.environ.get("GRAPH_ORCH_PYTHON")
+    if explicit:
+        return [explicit] if os.access(explicit, os.X_OK) else []
+    resolved = shutil.which("python3")
+    if resolved:
+        return [resolved]
+    return [
+        path
+        for path in (
+            os.path.expanduser("~/.local/bin/python3"),
+            "/opt/homebrew/bin/python3",
+            "/usr/local/bin/python3",
+        )
+        if os.access(path, os.X_OK)
+    ]
+
+
+def check_rdflib() -> Check:
+    candidates = _python_candidates()
+    if not candidates:
+        return Check("python3/rdflib", False, "python3 not found")
+    failures: list[str] = []
+    for path in candidates:
+        rc, stdout, stderr = _run(
+            [path, "-c", "import rdflib; print(rdflib.__version__)"],
+        )
+        if rc == 0 and stdout:
+            return Check("python3/rdflib", True, f"{path} rdflib {stdout}", path)
+        failures.append(f"{path}: {stderr or stdout or 'import failed'}")
+    return Check(
+        "python3/rdflib",
+        False,
+        "rdflib is unavailable to every discovered python3 interpreter: " + "; ".join(failures),
+    )
+
+
+def check_sc_compose_binding() -> Check:
+    """Verify the maturin/PyO3 binding is installed beside the chosen Python.
+
+    The CLI and Python wheel are separate artifacts.  Keeping this check here
+    catches a split environment where the CLI is 1.2.x but ``sc_compose`` is
+    an older wheel (or belongs to another interpreter).
+    """
+
+    candidates = _python_candidates()
+    if not candidates:
+        return Check("python3/sc_compose", False, "python3 not found")
+    failures: list[str] = []
+    probe = (
+        "from importlib.metadata import version; "
+        "import sc_compose; "
+        "print(version('sc-compose'))"
+    )
+    for path in candidates:
+        rc, stdout, stderr = _run([path, "-c", probe])
+        parsed = _version(stdout)
+        if rc == 0 and parsed is not None:
+            if parsed < MIN_SC_COMPOSE:
+                return Check(
+                    "python3/sc_compose",
+                    False,
+                    f"{path} has sc-compose {stdout}; required >= 1.2.0",
+                    path,
+                )
+            return Check("python3/sc_compose", True, f"{path} binding {stdout}", path)
+        failures.append(f"{path}: {stderr or stdout or 'import failed'}")
+    return Check(
+        "python3/sc_compose",
+        False,
+        "sc_compose binding is unavailable to the selected python3 interpreter: "
+        + "; ".join(failures),
+    )
+
+
+def check_pytest() -> Check:
+    path = _find_command("pytest", ("/opt/homebrew/bin/pytest", "/usr/local/bin/pytest"))
+    if path is None:
+        return Check("pytest", False, "not found; install pytest for the test suite")
+    rc, stdout, stderr = _run([path, "--version"])
+    if rc != 0:
+        return Check("pytest", False, f"{path} failed --version: {stderr or stdout}", path)
+    return Check("pytest", True, stdout or "version reported", path)
+
+
+def run_preflight(*, for_tests: bool = False, checks: Iterable[Callable[[], Check]] | None = None) -> dict[str, object]:
+    selected = list(checks) if checks is not None else [
+        check_sc_compose,
+        check_sc_compose_binding,
+        check_jq,
+        check_rdflib,
+    ]
+    if for_tests and checks is None:
+        selected.append(check_pytest)
+    results = [check().as_dict() for check in selected]
+    failures = [result for result in results if not result["ok"]]
+    return {
+        "success": not failures,
+        "data": {"checks": results, "required_sc_compose": ">=1.2.0", "for_tests": for_tests},
+        "error": None
+        if not failures
+        else {
+            "code": "DEPENDENCY.PREFLIGHT_FAILED",
+            "message": "one or more graph-orchestration dependencies are missing or unsupported",
+            "checks": failures,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify graph-orchestration dependencies")
+    parser.add_argument("--for-tests", action="store_true", help="also require pytest")
+    args = parser.parse_args(argv)
+    result = run_preflight(for_tests=args.for_tests)
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["success"] else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/graph-orchestration/scripts/preflight.py
+++ b/.claude/skills/graph-orchestration/scripts/preflight.py
@@ -12,17 +12,23 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable, Iterable
 
+_CLAUDE_DIR = Path(__file__).resolve().parents[3]
+if str(_CLAUDE_DIR) not in sys.path:
+    sys.path.insert(0, str(_CLAUDE_DIR))
 
-MIN_SC_COMPOSE = (1, 2, 0)
-SC_COMPOSE_INSTALL = "python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'"
-_VERSION_RE = re.compile(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?")
+from lib.sc_compose_dependency import (  # noqa: E402
+    MIN_SC_COMPOSE,
+    MIN_SC_COMPOSE_TEXT,
+    SC_COMPOSE_INSTALL,
+    parse_version as _version,
+)
 
 
 @dataclass(frozen=True)
@@ -41,11 +47,6 @@ class Check:
         if self.path is not None:
             value["path"] = self.path
         return value
-
-
-def _version(text: str) -> tuple[int, int, int] | None:
-    match = _VERSION_RE.search(text)
-    return tuple(int(part) for part in match.groups()) if match else None
 
 
 def _run(command: list[str], *, timeout: float = 5.0) -> tuple[int, str, str]:
@@ -85,7 +86,8 @@ def check_sc_compose() -> Check:
         return Check(
             "sc-compose",
             False,
-            "not found; install sc-compose>=1.2.0 (see references/installation-and-troubleshooting.md)",
+            "not found; install sc-compose"
+            f"{MIN_SC_COMPOSE_TEXT} (see references/installation-and-troubleshooting.md)",
         )
     rc, stdout, stderr = _run([path, "--version"])
     version = _version(" ".join((stdout, stderr)))
@@ -100,7 +102,8 @@ def check_sc_compose() -> Check:
         return Check(
             "sc-compose",
             False,
-            f"{path} reports {version[0]}.{version[1]}.{version[2]}; required >= 1.2.0",
+            f"{path} reports {version[0]}.{version[1]}.{version[2]}; "
+            f"required {MIN_SC_COMPOSE_TEXT}",
             path,
         )
     return Check("sc-compose", True, f"version {version[0]}.{version[1]}.{version[2]}", path)

--- a/.claude/skills/graph-orchestration/scripts/preflight.py
+++ b/.claude/skills/graph-orchestration/scripts/preflight.py
@@ -21,6 +21,7 @@ from typing import Callable, Iterable
 
 
 MIN_SC_COMPOSE = (1, 2, 0)
+SC_COMPOSE_INSTALL = "python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'"
 _VERSION_RE = re.compile(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?")
 
 
@@ -166,7 +167,11 @@ def check_sc_compose_binding() -> Check:
 
     candidates = _python_candidates()
     if not candidates:
-        return Check("python3/sc_compose", False, "python3 not found")
+        return Check(
+            "python3/sc_compose",
+            False,
+            "python3 not found; install the binding with: " + SC_COMPOSE_INSTALL,
+        )
     failures: list[str] = []
     probe = (
         "from importlib.metadata import version; "
@@ -181,7 +186,8 @@ def check_sc_compose_binding() -> Check:
                 return Check(
                     "python3/sc_compose",
                     False,
-                    f"{path} has sc-compose {stdout}; required >= 1.2.0",
+                    f"{path} has sc-compose {stdout}; required >= 1.2.0; "
+                    "reinstall with: " + SC_COMPOSE_INSTALL,
                     path,
                 )
             return Check("python3/sc_compose", True, f"{path} binding {stdout}", path)
@@ -189,7 +195,10 @@ def check_sc_compose_binding() -> Check:
     return Check(
         "python3/sc_compose",
         False,
-        "sc_compose binding is unavailable to the selected python3 interpreter: "
+        "sc_compose binding is unavailable to the selected python3 interpreter; "
+        "install it with: "
+        + SC_COMPOSE_INSTALL
+        + ". Details: "
         + "; ".join(failures),
     )
 

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -38,10 +38,11 @@ Findings are NOT resolved here. The orchestrator checks .triage/ via
 triage-findings skill to decide between dev-task.xml.j2 and dev-fix.xml.j2.
 Assignments are appended to events.ttl by the orchestrator after dispatch.
 
-Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR>
+Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> [--validate-only]
   PHASE_LOCAL  e.g. "F"
   TTL_DIR      path to .sprints/<PHASE>/ directory on integrate/phase-N branch
   SCRIPT_DIR   path to this script's directory (for .sparql files)
+  --validate-only  validate structure.ttl/events.ttl and stop before cursor resolution
 """
 
 import sys
@@ -107,7 +108,7 @@ def _load_ignored_phase_dirs(repo_root: Path) -> set:
     return names
 
 
-def load_graph(ttl_dir: str) -> Graph:
+def load_graph(ttl_dir: str, *, include_findings: bool = True) -> Graph:
     g = Graph()
     base = Path(ttl_dir)
     structure = base / "structure.ttl"
@@ -127,6 +128,9 @@ def load_graph(ttl_dir: str) -> Graph:
     # defeated by a future phase reusing an unprefixed or colliding local
     # sprint label.
     known_sprints = set(g.subjects(RDF.type, TRIAGE.Sprint))
+
+    if not include_findings:
+        return g
 
     # Load triage findings from repo root .triage/ (relative to TTL dir's parent)
     # Walk up from ttl_dir to find repo root (contains .triage/)
@@ -216,16 +220,27 @@ def run_sparql(g: Graph, sparql_file: Path, bindings: dict) -> list:
 
 
 def main():
-    if len(sys.argv) != 4:
-        print("Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR>", file=sys.stderr)
+    if len(sys.argv) not in (4, 5) or (
+        len(sys.argv) == 5 and sys.argv[4] != "--validate-only"
+    ):
+        print(
+            "Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> "
+            "[--validate-only]",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     phase_local = sys.argv[1]
     ttl_dir = sys.argv[2]
     script_dir = Path(sys.argv[3])
+    validate_only = len(sys.argv) == 5
 
     phase_iri = URIRef(f"{TRIAGE_BASE}Phase{phase_local}")
-    g = load_graph(ttl_dir)
+    # Structure validation must not depend on findings being parseable. In
+    # particular, a legacy malformed finding elsewhere in the repository
+    # should never make the documented post-event validation command fail for
+    # an otherwise valid structure.
+    g = load_graph(ttl_dir, include_findings=not validate_only)
 
     # ── Validate structure before cursor ─────────────────────────────────────
     validate_rows = run_sparql(g, script_dir / "validate-structure.sparql", {"PHASE": phase_iri})
@@ -233,6 +248,10 @@ def main():
         for row in validate_rows:
             print(f"ERROR: structure violation: {row[0]} — {row[1]}", file=sys.stderr)
         sys.exit(1)
+
+    if validate_only:
+        print(json.dumps({"phase": "VALIDATE_ONLY", "vars": {}}, indent=2))
+        return
 
     # ── Cursor ───────────────────────────────────────────────────────────────
     cursor_rows = run_sparql(g, script_dir / "cursor.sparql", {"PHASE": phase_iri})

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -219,6 +219,26 @@ def run_sparql(g: Graph, sparql_file: Path, bindings: dict) -> list:
     return list(results)
 
 
+def _cli_load_graph(ttl_dir: str, *, include_findings: bool) -> Graph:
+    """Load a graph while keeping malformed input errors CLI-friendly."""
+    try:
+        return load_graph(ttl_dir, include_findings=include_findings)
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - CLI boundary
+        print(f"ERROR: query runner failed to load graph: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+def _cli_run_sparql(g: Graph, sparql_file: Path, bindings: dict) -> list:
+    """Run one bundled query while keeping query errors one-line."""
+    try:
+        return run_sparql(g, sparql_file, bindings)
+    except Exception as exc:  # noqa: BLE001 - CLI boundary
+        print(f"ERROR: query runner failed to run {sparql_file}: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
 def main():
     if len(sys.argv) not in (4, 5) or (
         len(sys.argv) == 5 and sys.argv[4] != "--validate-only"
@@ -240,10 +260,12 @@ def main():
     # particular, a legacy malformed finding elsewhere in the repository
     # should never make the documented post-event validation command fail for
     # an otherwise valid structure.
-    g = load_graph(ttl_dir, include_findings=not validate_only)
+    g = _cli_load_graph(ttl_dir, include_findings=not validate_only)
 
     # ── Validate structure before cursor ─────────────────────────────────────
-    validate_rows = run_sparql(g, script_dir / "validate-structure.sparql", {"PHASE": phase_iri})
+    validate_rows = _cli_run_sparql(
+        g, script_dir / "validate-structure.sparql", {"PHASE": phase_iri}
+    )
     if validate_rows:
         for row in validate_rows:
             print(f"ERROR: structure violation: {row[0]} — {row[1]}", file=sys.stderr)
@@ -254,7 +276,7 @@ def main():
         return
 
     # ── Cursor ───────────────────────────────────────────────────────────────
-    cursor_rows = run_sparql(g, script_dir / "cursor.sparql", {"PHASE": phase_iri})
+    cursor_rows = _cli_run_sparql(g, script_dir / "cursor.sparql", {"PHASE": phase_iri})
 
     if cursor_rows:
         sprint_iri = str(cursor_rows[0][0])
@@ -274,7 +296,9 @@ def main():
         return
 
     # ── Cursor empty — verify all sprints have valid Completions ─────────────
-    incomplete_rows = run_sparql(g, script_dir / "all-complete.sparql", {"PHASE": phase_iri})
+    incomplete_rows = _cli_run_sparql(
+        g, script_dir / "all-complete.sparql", {"PHASE": phase_iri}
+    )
     if incomplete_rows:
         # Some sprints are in-flight or have invalid Completions
         print(json.dumps({
@@ -285,7 +309,7 @@ def main():
         return
 
     # ── Check for open non-blocking findings (CLEANUP) ───────────────────────
-    cleanup_rows = run_sparql(
+    cleanup_rows = _cli_run_sparql(
         g, script_dir / "open-findings-sprint.sparql", {"PHASE": phase_iri}
     )
 

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -51,7 +51,7 @@ from pathlib import Path
 
 try:
     from rdflib import Graph, URIRef, Namespace
-    from rdflib.namespace import RDF, XSD
+    from rdflib.namespace import RDF
 except ImportError:
     print("ERROR: rdflib not installed. Run: pip3 install rdflib", file=sys.stderr)
     sys.exit(1)

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -383,11 +383,29 @@ def main():
                 "finding_id": str(row[1]) if row[1] is not None else None,
                 "severity": str(row[2]),
                 "raw_severity": str(row[3]),
-                "found_at": str(row[4]),
-                "description": str(row[5]),
+                "status": str(row[4]) if row[4] is not None else None,
+                "found_at": str(row[5]),
+                "description": str(row[6]),
             }
             for row in finding_rows
         ]
+
+        invalid_findings = [
+            finding for finding in findings if finding["severity"] == "invalid"
+        ]
+        if invalid_findings:
+            print(json.dumps({
+                "phase": "INVALID_FINDING_SEVERITY",
+                "vars": {
+                    "sprint": sprint_local,
+                    "sprint_iri": sprint_iri,
+                    "sprint_order": order,
+                    "criteria_doc": criteria,
+                },
+                "findings": findings,
+                "error": "unknown finding severity blocks dispatch",
+            }, indent=2))
+            raise SystemExit(1)
 
         print(json.dumps({
             "phase": "TRAVERSAL",

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -35,7 +35,7 @@ Output shape (DONE):
   }
 
 Findings are NOT resolved here. The orchestrator checks .triage/ via
-triage-findings skill to decide between dev-task.xml.j2 and dev-fix.xml.j2.
+triaging-findings skill to decide between dev-task.xml.j2 and dev-fix.xml.j2.
 Assignments are appended to events.ttl by the orchestrator after dispatch.
 
 Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> [--validate-only]
@@ -45,6 +45,7 @@ Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> [--validate-only]
   --validate-only  validate structure.ttl/events.ttl and stop before cursor resolution
 """
 
+import importlib.util
 import sys
 import json
 from pathlib import Path
@@ -239,6 +240,84 @@ def _cli_run_sparql(g: Graph, sparql_file: Path, bindings: dict) -> list:
         raise SystemExit(1) from exc
 
 
+def _load_validator(script_dir: Path):
+    """Load the canonical findings validator without duplicating its rules."""
+
+    validator_path = script_dir / "validate-findings.py"
+    if not validator_path.exists():
+        raise RuntimeError(f"validate-findings.py not found at {validator_path}")
+    spec = importlib.util.spec_from_file_location("graph_orchestration_validator", validator_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load validator at {validator_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _validate_findings_before_query(ttl_dir: str, script_dir: Path) -> None:
+    """Run raw findings validation before *any* graph query.
+
+    ``load_graph`` intentionally scopes findings by ``foundIn``.  Running this
+    gate first prevents malformed or incomplete records from disappearing in
+    that scope filter.  A normal validation failure (exit-1 equivalent) and a
+    validator execution error both stop cursor resolution; warnings alone are
+    allowed by the validator's discriminated result contract.
+    """
+
+    repo_root = _find_repo_root(Path(ttl_dir))
+    if repo_root is None:
+        raise RuntimeError(
+            "cannot locate repository root containing .triage; findings validation cannot run"
+        )
+    triage_root = repo_root / ".triage"
+    findings_dirs = sorted(
+        path for path in triage_root.glob("*/findings") if path.is_dir()
+    ) if triage_root.exists() else []
+    # An existing but empty .triage tree is a valid no-findings input.  Passing
+    # the root directory still exercises the validator and gives a structured
+    # error if the directory itself is missing or unreadable.
+    if not findings_dirs:
+        findings_dirs = [triage_root]
+
+    validator = _load_validator(script_dir)
+    structure = Path(ttl_dir) / "structure.ttl"
+    events_path = Path(ttl_dir) / "events.ttl"
+    events = events_path if events_path.exists() else None
+
+    for findings_dir in findings_dirs:
+        result = validator.run_validation(
+            findings_dir=findings_dir,
+            structure=structure,
+            events=events,
+            script_dir=script_dir,
+        )
+        if result.kind == "validation:pass":
+            continue
+        summary = getattr(result, "summary", None)
+        counts = (
+            f" ({summary.errors} error(s), {summary.warnings} warning(s))"
+            if summary is not None
+            else ""
+        )
+        print(
+            f"ERROR: findings validation blocked query resolution for {findings_dir}"
+            f"{counts}",
+            file=sys.stderr,
+        )
+        for diagnostic in result.diagnostics[:20]:
+            print(diagnostic, file=sys.stderr)
+        if len(result.diagnostics) > 20:
+            print(
+                f"… {len(result.diagnostics) - 20} diagnostic line(s) truncated; "
+                "run validate-findings.py directly for the full report",
+                file=sys.stderr,
+            )
+        if result.kind == "error":
+            raise SystemExit(2)
+        raise SystemExit(1)
+
+
 def main():
     if len(sys.argv) not in (4, 5) or (
         len(sys.argv) == 5 and sys.argv[4] != "--validate-only"
@@ -256,10 +335,20 @@ def main():
     validate_only = len(sys.argv) == 5
 
     phase_iri = URIRef(f"{TRIAGE_BASE}Phase{phase_local}")
-    # Structure validation must not depend on findings being parseable. In
-    # particular, a legacy malformed finding elsewhere in the repository
-    # should never make the documented post-event validation command fail for
-    # an otherwise valid structure.
+    # This is deliberately before structure loading and before --validate-only:
+    # every query_runner entry point must prove that raw findings are valid.
+    try:
+        _validate_findings_before_query(ttl_dir, script_dir)
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - CLI boundary
+        print(f"ERROR: findings validation could not run: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    # The raw findings gate above runs before structure validation so malformed
+    # or incomplete records cannot disappear during phase membership filtering.
+    # Once that gate passes, structure validation can report graph-shape errors
+    # without being conflated with finding-schema diagnostics.
     g = _cli_load_graph(ttl_dir, include_findings=not validate_only)
 
     # ── Validate structure before cursor ─────────────────────────────────────

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -372,6 +372,21 @@ def main():
         order = int(cursor_rows[0][1])
         criteria = str(cursor_rows[0][2])
         sprint_local = sprint_iri.split(":")[-1] if ":" in sprint_iri else sprint_iri
+        finding_rows = _cli_run_sparql(
+            g,
+            script_dir / "open-findings-for-sprint.sparql",
+            {"SPRINT": URIRef(sprint_iri)},
+        )
+        findings = [
+            {
+                "finding_iri": str(row[0]),
+                "finding_id": str(row[1]) if row[1] is not None else None,
+                "severity": str(row[2]),
+                "found_at": str(row[3]),
+                "description": str(row[4]),
+            }
+            for row in finding_rows
+        ]
 
         print(json.dumps({
             "phase": "TRAVERSAL",
@@ -381,6 +396,7 @@ def main():
                 "sprint_order": order,
                 "criteria_doc": criteria,
             },
+            "findings": findings,
         }, indent=2))
         return
 

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -382,8 +382,9 @@ def main():
                 "finding_iri": str(row[0]),
                 "finding_id": str(row[1]) if row[1] is not None else None,
                 "severity": str(row[2]),
-                "found_at": str(row[3]),
-                "description": str(row[4]),
+                "raw_severity": str(row[3]),
+                "found_at": str(row[4]),
+                "description": str(row[5]),
             }
             for row in finding_rows
         ]

--- a/.claude/skills/graph-orchestration/scripts/test_preflight.py
+++ b/.claude/skills/graph-orchestration/scripts/test_preflight.py
@@ -59,6 +59,19 @@ def test_binding_rejects_old_python_wheel(monkeypatch):
     assert "required >= 1.2.0" in result.detail
 
 
+def test_binding_failure_has_actionable_install_hint(monkeypatch):
+    preflight = _module()
+    monkeypatch.setattr(preflight, "_python_candidates", lambda: ["/fake/python3"])
+    monkeypatch.setattr(
+        preflight,
+        "_run",
+        lambda *_args, **_kwargs: (1, "", "ModuleNotFoundError: sc_compose"),
+    )
+    result = preflight.check_sc_compose_binding()
+    assert not result.ok
+    assert "python3 -m pip install --user --break-system-packages" in result.detail
+
+
 def test_missing_rdflib_is_a_structured_failure(monkeypatch):
     preflight = _module()
     monkeypatch.setattr(preflight, "_python_candidates", lambda: ["/fake/python3"])
@@ -117,8 +130,10 @@ def test_python_binding_render_integration_when_1_2_or_newer_is_installed():
         import sc_compose
     except (importlib.metadata.PackageNotFoundError, ImportError) as exc:
         raise AssertionError(
-            "install sc-compose>=1.2.0 in the invoking Python before running "
-            f"binding integration tests: {exc}"
+            "sc-compose Python bindings not installed. Run: "
+            "python3 -m pip install --user --break-system-packages "
+            "'sc-compose>=1.2.0' before running binding integration tests: "
+            f"{exc}"
         ) from exc
     if _module()._version(version) < (1, 2, 0):
         raise AssertionError(f"sc-compose Python binding {version} is below 1.2.0")

--- a/.claude/skills/graph-orchestration/scripts/test_preflight.py
+++ b/.claude/skills/graph-orchestration/scripts/test_preflight.py
@@ -1,0 +1,163 @@
+"""Unit tests for the graph-orchestration dependency gate."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+
+SCRIPTS = Path(__file__).parent
+REPO_ROOT = SCRIPTS.resolve().parents[3]
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("graph_preflight", SCRIPTS / "preflight.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_version_floor_is_semver_and_inclusive():
+    preflight = _module()
+    assert preflight._version("sc-compose 1.2.0") == (1, 2, 0)
+    assert preflight._version("sc-compose 1.2.9") > preflight.MIN_SC_COMPOSE
+    assert preflight._version("sc-compose 1.1.99") < preflight.MIN_SC_COMPOSE
+    assert preflight._version("unknown") is None
+
+
+def test_sc_compose_rejects_old_cli(monkeypatch):
+    preflight = _module()
+    monkeypatch.setattr(preflight, "_find_command", lambda *_args: "/fake/sc-compose")
+    monkeypatch.setattr(
+        preflight,
+        "_run",
+        lambda *_args, **_kwargs: (0, "sc-compose 1.1.9", ""),
+    )
+    result = preflight.check_sc_compose()
+    assert not result.ok
+    assert "required >= 1.2.0" in result.detail
+
+
+def test_binding_rejects_old_python_wheel(monkeypatch):
+    preflight = _module()
+    monkeypatch.setattr(preflight, "_python_candidates", lambda: ["/fake/python3"])
+    monkeypatch.setattr(
+        preflight,
+        "_run",
+        lambda *_args, **_kwargs: (0, "1.1.0", ""),
+    )
+    result = preflight.check_sc_compose_binding()
+    assert not result.ok
+    assert "required >= 1.2.0" in result.detail
+
+
+def test_missing_rdflib_is_a_structured_failure(monkeypatch):
+    preflight = _module()
+    monkeypatch.setattr(preflight, "_python_candidates", lambda: ["/fake/python3"])
+    monkeypatch.setattr(
+        preflight,
+        "_run",
+        lambda *_args, **_kwargs: (1, "", "ModuleNotFoundError: rdflib"),
+    )
+    result = preflight.check_rdflib()
+    assert not result.ok
+    assert "rdflib" in result.detail
+
+
+def test_run_preflight_success_and_failure_envelopes():
+    preflight = _module()
+
+    def good():
+        return preflight.Check("fake", True, "ok")
+
+    def bad():
+        return preflight.Check("fake", False, "missing")
+
+    success = preflight.run_preflight(checks=[good])
+    failure = preflight.run_preflight(checks=[bad])
+    assert success == {
+        "success": True,
+        "data": {"checks": [{"name": "fake", "ok": True, "detail": "ok"}], "required_sc_compose": ">=1.2.0", "for_tests": False},
+        "error": None,
+    }
+    assert failure["success"] is False
+    assert failure["error"]["code"] == "DEPENDENCY.PREFLIGHT_FAILED"
+
+
+def test_cli_returns_exit_two_and_json_on_forced_bad_python():
+    script = SCRIPTS / "preflight.py"
+    env = os.environ.copy()
+    env["GRAPH_ORCH_PYTHON"] = str(SCRIPTS / "does-not-exist")
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "DEPENDENCY.PREFLIGHT_FAILED"
+
+
+def test_python_binding_render_integration_when_1_2_or_newer_is_installed():
+    """Exercise the required maturin binding; missing setup is a test failure."""
+
+    try:
+        version = importlib.metadata.version("sc-compose")
+        import sc_compose
+    except (importlib.metadata.PackageNotFoundError, ImportError) as exc:
+        raise AssertionError(
+            "install sc-compose>=1.2.0 in the invoking Python before running "
+            f"binding integration tests: {exc}"
+        ) from exc
+    if _module()._version(version) < (1, 2, 0):
+        raise AssertionError(f"sc-compose Python binding {version} is below 1.2.0")
+    assert sc_compose.render_template("Hello {{ name }}", {"name": "graph"}) == "Hello graph"
+
+
+def test_cli_renders_graph_dev_template(tmp_path):
+    variables = {
+        "task_id": "GO-TEST",
+        "sprint": "AICH-S1",
+        "node_id": "AICH-S1",
+        "node_order": "1",
+        "criteria_doc": "docs/plans/phase-ai/sprint-ai-21-pre.md",
+        "worktree_path": "/tmp/worktree",
+        "branch": "feature/test",
+        "pr_target": "integrate/phase-AI",
+        "assignee": "arch-ctm",
+    }
+    vars_path = tmp_path / "vars.json"
+    output_path = tmp_path / "task.xml"
+    vars_path.write_text(json.dumps(variables), encoding="utf-8")
+    result = subprocess.run(
+        [
+            "sc-compose",
+            "render",
+            "--root",
+            str(REPO_ROOT),
+            "--file",
+            ".claude/skills/graph-orchestration/dev-task.xml.j2",
+            "--var-file",
+            str(vars_path),
+            "--output",
+            str(output_path),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    rendered = output_path.read_text(encoding="utf-8")
+    assert '<atm-task id="GO-TEST" sprint="AICH-S1"' in rendered

--- a/.claude/skills/graph-orchestration/scripts/test_preflight.py
+++ b/.claude/skills/graph-orchestration/scripts/test_preflight.py
@@ -151,6 +151,9 @@ def test_cli_renders_graph_dev_template(tmp_path):
         "branch": "feature/test",
         "pr_target": "integrate/phase-AI",
         "assignee": "arch-ctm",
+        "phase_local": "AICH",
+        "ttl_dir": ".sprints/AICH",
+        "finding_ids": "",
     }
     vars_path = tmp_path / "vars.json"
     output_path = tmp_path / "task.xml"

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -154,8 +154,10 @@ triage:blocking a triage:Finding ; triage:findingId "B-1" ; triage:foundIn triag
     triage:foundAt "2026-07-01T11:00:00Z"^^xsd:dateTime ; triage:severity "BLOCKING" ; triage:description "blocking" .
 triage:resolved a triage:Finding ; triage:findingId "R-1" ; triage:foundIn triage:S1 ;
     triage:foundAt "2026-07-01T08:00:00Z"^^xsd:dateTime ; triage:severity "Blocking" ; triage:status "fixed" ; triage:description "resolved" .
+triage:critical a triage:Finding ; triage:findingId "C-1" ; triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T12:00:00Z"^^xsd:dateTime ; triage:severity "critical" ; triage:description "critical" .
 triage:unknown a triage:Finding ; triage:findingId "U-1" ; triage:foundIn triage:S1 ;
-    triage:foundAt "2026-07-01T12:00:00Z"^^xsd:dateTime ; triage:severity "critical" ; triage:description "invalid severity" .
+    triage:foundAt "2026-07-01T13:00:00Z"^^xsd:dateTime ; triage:severity "medium" ; triage:description "invalid severity" .
 """
         rows = sparql(
             "open-findings-for-sprint.sparql",
@@ -163,8 +165,9 @@ triage:unknown a triage:Finding ; triage:findingId "U-1" ; triage:foundIn triage
             findings,
         )
         assert [(str(row[1]), str(row[2]), str(row[3])) for row in rows] == [
-            ("U-1", "invalid", "critical"),
+            ("U-1", "invalid", "medium"),
             ("B-1", "blocking", "BLOCKING"),
+            ("C-1", "blocking", "critical"),
             ("I-1", "important", "Important"),
             ("M-1", "minor", "MINOR"),
         ]

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -170,6 +170,41 @@ triage:S1 a triage:Sprint ; triage:inPhase triage:PhaseF ; triage:order 1 .
         assert "missing-criteria" in violations
 
 
+# ── validate-findings tests ───────────────────────────────────────────────────
+
+class TestValidateFindings:
+    def test_complete_finding_returns_zero_rows(self):
+        findings = PREFIX + """
+triage:f1 a triage:Finding ; triage:findingId "F-1" ;
+    triage:foundIn triage:S1 ; triage:foundAt
+      "2026-07-01T12:00:00Z"^^xsd:dateTime ;
+    triage:severity "important" ; triage:description "Issue" .
+"""
+        rows = sparql("validate-findings.sparql", {}, findings)
+        assert rows == []
+
+    def test_missing_graph_critical_fields_are_errors(self):
+        findings = PREFIX + """
+triage:f1 a triage:Finding ; triage:findingId "F-1" ;
+    triage:severity "important" ; triage:description "Issue" .
+"""
+        rows = sparql("validate-findings.sparql", {}, findings)
+        levels = {(str(row[0]), str(row[2])) for row in rows}
+        assert ("#error", "triage:foundIn") in levels
+        assert ("#error", "triage:foundAt") in levels
+
+    def test_missing_descriptive_fields_are_warnings(self):
+        findings = PREFIX + """
+triage:f1 a triage:Finding ; triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T12:00:00Z"^^xsd:dateTime .
+"""
+        rows = sparql("validate-findings.sparql", {}, findings)
+        levels = {(str(row[0]), str(row[2])) for row in rows}
+        assert ("#warning", "triage:findingId") in levels
+        assert ("#warning", "triage:severity") in levels
+        assert ("#warning", "triage:description") in levels
+
+
 # ── open-findings-sprint tests ────────────────────────────────────────────────
 
 class TestOpenFindingsSprint:

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -143,6 +143,27 @@ triage:c2 a triage:Completion ; triage:ofSprint triage:S2 ;
         assert len(rows) == 0
 
 
+class TestOpenFindingsForSprint:
+    def test_orders_open_findings_blocking_then_important_then_minor(self):
+        findings = PREFIX + """
+triage:minor a triage:Finding ; triage:findingId "M-1" ; triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T09:00:00Z"^^xsd:dateTime ; triage:severity "minor" ; triage:description "minor" .
+triage:important a triage:Finding ; triage:findingId "I-1" ; triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T10:00:00Z"^^xsd:dateTime ; triage:severity "important" ; triage:description "important" .
+triage:blocking a triage:Finding ; triage:findingId "B-1" ; triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T11:00:00Z"^^xsd:dateTime ; triage:severity "blocking" ; triage:description "blocking" .
+triage:resolved a triage:Finding ; triage:findingId "R-1" ; triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T08:00:00Z"^^xsd:dateTime ; triage:severity "blocking" ; triage:description "resolved" .
+triage:r1 a triage:Resolution ; triage:resolves triage:resolved .
+"""
+        rows = sparql(
+            "open-findings-for-sprint.sparql",
+            {"SPRINT": URIRef(f"{TRIAGE}S1")},
+            findings,
+        )
+        assert [str(row[1]) for row in rows] == ["B-1", "I-1", "M-1"]
+
+
 # ── validate-structure tests ──────────────────────────────────────────────────
 
 class TestValidateStructure:
@@ -598,7 +619,18 @@ class TestNextDevTaskValidation:
         result = self._run(repo, "F", str(repo / ".sprints" / "F"))
 
         assert result.returncode == 0, result.stderr
-        assert json.loads(result.stdout)["phase"] == "TRAVERSAL"
+        payload = json.loads(result.stdout)
+        assert payload["phase"] == "TRAVERSAL"
+        assert payload["vars"]["sprint"] == "S1"
+        assert payload["findings"] == [
+            {
+                "finding_iri": f"{TRIAGE}f1",
+                "finding_id": "F-1",
+                "severity": "important",
+                "found_at": "2026-07-01T12:00:00+00:00",
+                "description": "clean",
+            }
+        ]
 
     def test_validate_only_reports_structure_errors(self, tmp_path):
         invalid = PREFIX + """

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -10,10 +10,8 @@ import json
 import subprocess
 import sys
 
-import pytest
 from pathlib import Path
 from rdflib import Graph, URIRef, Namespace
-from rdflib.namespace import XSD
 
 SCRIPTS = Path(__file__).parent
 TRIAGE = "urn:atm:triage:"
@@ -688,5 +686,4 @@ triage:c1 a triage:Completion ; triage:ofSprint triage:S1 ;
 
 
 if __name__ == "__main__":
-    import subprocess, sys
     sys.exit(subprocess.call(["python3", "-m", "pytest", __file__, "-v"]))

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -144,7 +144,7 @@ triage:c2 a triage:Completion ; triage:ofSprint triage:S2 ;
 
 
 class TestOpenFindingsForSprint:
-    def test_normalizes_case_orders_findings_and_hides_terminal_status(self):
+    def test_normalizes_case_orders_findings_and_retains_status_metadata(self):
         findings = PREFIX + """
 triage:minor a triage:Finding ; triage:findingId "M-1" ; triage:foundIn triage:S1 ;
     triage:foundAt "2026-07-01T09:00:00Z"^^xsd:dateTime ; triage:severity "MINOR" ; triage:description "minor" .
@@ -166,6 +166,7 @@ triage:unknown a triage:Finding ; triage:findingId "U-1" ; triage:foundIn triage
         )
         assert [(str(row[1]), str(row[2]), str(row[3])) for row in rows] == [
             ("U-1", "invalid", "medium"),
+            ("R-1", "blocking", "Blocking"),
             ("B-1", "blocking", "BLOCKING"),
             ("C-1", "blocking", "critical"),
             ("I-1", "important", "Important"),
@@ -637,10 +638,30 @@ class TestNextDevTaskValidation:
                 "finding_id": "F-1",
                 "severity": "important",
                 "raw_severity": "important",
+                "status": None,
                 "found_at": "2026-07-01T12:00:00+00:00",
                 "description": "clean",
             }
         ]
+
+    def test_invalid_severity_returns_json_and_fails_closed(self, tmp_path):
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]))
+        findings = repo / ".triage" / "phase-F" / "findings"
+        findings.mkdir(parents=True)
+        (findings / "F-1.ttl").write_text(
+            PREFIX
+            + 'triage:f1 a triage:Finding ; triage:findingId "F-1" ; '
+            'triage:foundIn triage:S1 ; '
+            'triage:foundAt "2026-07-01T12:00:00Z"^^xsd:dateTime ; '
+            'triage:severity "medium" ; triage:description "unknown" .\n'
+        )
+
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+
+        assert result.returncode == 1, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["phase"] == "INVALID_FINDING_SEVERITY"
+        assert payload["findings"][0]["raw_severity"] == "medium"
 
     def test_validate_only_reports_structure_errors(self, tmp_path):
         invalid = PREFIX + """

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -144,7 +144,7 @@ triage:c2 a triage:Completion ; triage:ofSprint triage:S2 ;
 
 
 class TestOpenFindingsForSprint:
-    def test_normalizes_case_orders_findings_and_retains_status_metadata(self):
+    def test_normalizes_case_orders_and_excludes_terminal_statuses(self):
         findings = PREFIX + """
 triage:minor a triage:Finding ; triage:findingId "M-1" ; triage:foundIn triage:S1 ;
     triage:foundAt "2026-07-01T09:00:00Z"^^xsd:dateTime ; triage:severity "MINOR" ; triage:description "minor" .
@@ -166,7 +166,6 @@ triage:unknown a triage:Finding ; triage:findingId "U-1" ; triage:foundIn triage
         )
         assert [(str(row[1]), str(row[2]), str(row[3])) for row in rows] == [
             ("U-1", "invalid", "medium"),
-            ("R-1", "blocking", "Blocking"),
             ("B-1", "blocking", "BLOCKING"),
             ("C-1", "blocking", "critical"),
             ("I-1", "important", "Important"),

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -144,24 +144,30 @@ triage:c2 a triage:Completion ; triage:ofSprint triage:S2 ;
 
 
 class TestOpenFindingsForSprint:
-    def test_orders_open_findings_blocking_then_important_then_minor(self):
+    def test_normalizes_case_orders_findings_and_hides_terminal_status(self):
         findings = PREFIX + """
 triage:minor a triage:Finding ; triage:findingId "M-1" ; triage:foundIn triage:S1 ;
-    triage:foundAt "2026-07-01T09:00:00Z"^^xsd:dateTime ; triage:severity "minor" ; triage:description "minor" .
+    triage:foundAt "2026-07-01T09:00:00Z"^^xsd:dateTime ; triage:severity "MINOR" ; triage:description "minor" .
 triage:important a triage:Finding ; triage:findingId "I-1" ; triage:foundIn triage:S1 ;
-    triage:foundAt "2026-07-01T10:00:00Z"^^xsd:dateTime ; triage:severity "important" ; triage:description "important" .
+    triage:foundAt "2026-07-01T10:00:00Z"^^xsd:dateTime ; triage:severity "Important" ; triage:description "important" .
 triage:blocking a triage:Finding ; triage:findingId "B-1" ; triage:foundIn triage:S1 ;
-    triage:foundAt "2026-07-01T11:00:00Z"^^xsd:dateTime ; triage:severity "blocking" ; triage:description "blocking" .
+    triage:foundAt "2026-07-01T11:00:00Z"^^xsd:dateTime ; triage:severity "BLOCKING" ; triage:description "blocking" .
 triage:resolved a triage:Finding ; triage:findingId "R-1" ; triage:foundIn triage:S1 ;
-    triage:foundAt "2026-07-01T08:00:00Z"^^xsd:dateTime ; triage:severity "blocking" ; triage:description "resolved" .
-triage:r1 a triage:Resolution ; triage:resolves triage:resolved .
+    triage:foundAt "2026-07-01T08:00:00Z"^^xsd:dateTime ; triage:severity "Blocking" ; triage:status "fixed" ; triage:description "resolved" .
+triage:unknown a triage:Finding ; triage:findingId "U-1" ; triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T12:00:00Z"^^xsd:dateTime ; triage:severity "critical" ; triage:description "invalid severity" .
 """
         rows = sparql(
             "open-findings-for-sprint.sparql",
             {"SPRINT": URIRef(f"{TRIAGE}S1")},
             findings,
         )
-        assert [str(row[1]) for row in rows] == ["B-1", "I-1", "M-1"]
+        assert [(str(row[1]), str(row[2]), str(row[3])) for row in rows] == [
+            ("U-1", "invalid", "critical"),
+            ("B-1", "blocking", "BLOCKING"),
+            ("I-1", "important", "Important"),
+            ("M-1", "minor", "MINOR"),
+        ]
 
 
 # ── validate-structure tests ──────────────────────────────────────────────────
@@ -627,6 +633,7 @@ class TestNextDevTaskValidation:
                 "finding_iri": f"{TRIAGE}f1",
                 "finding_id": "F-1",
                 "severity": "important",
+                "raw_severity": "important",
                 "found_at": "2026-07-01T12:00:00+00:00",
                 "description": "clean",
             }

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -7,6 +7,7 @@ Requires: rdflib, pytest
 """
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 
@@ -536,15 +537,21 @@ class TestNextDevTaskValidation:
         return repo
 
     def _run(self, repo: Path, *args: str) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        # Keep the shell wrapper and query runner on the same interpreter as
+        # pytest; this also exercises the GRAPH_ORCH_PYTHON escape hatch used
+        # by the dependency preflight.
+        env["GRAPH_ORCH_PYTHON"] = sys.executable
         return subprocess.run(
             [str(SCRIPTS / "next-dev-task"), *args],
             cwd=repo,
             text=True,
             capture_output=True,
+            env=env,
             check=False,
         )
 
-    def test_validate_only_returns_success_json_without_loading_findings(self, tmp_path):
+    def test_validate_only_blocks_malformed_findings_before_structure_query(self, tmp_path):
         repo = self._make_repo(tmp_path, structure([(1, "S1")]))
         malformed = repo / ".triage" / "phase-U" / "findings"
         malformed.mkdir(parents=True)
@@ -552,9 +559,46 @@ class TestNextDevTaskValidation:
 
         result = self._run(repo, "F", str(repo / ".sprints" / "F"), "--validate-only")
 
+        assert result.returncode == 2, result.stderr
+        assert result.stdout == ""
+        assert "findings validation could not run" not in result.stderr
+        assert "findings validation blocked query resolution" in result.stderr
+        assert "malformed Turtle" in result.stderr
+
+    def test_cursor_resolution_is_blocked_by_missing_provenance(self, tmp_path):
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]))
+        findings = repo / ".triage" / "phase-F" / "findings"
+        findings.mkdir(parents=True)
+        (findings / "F-1.ttl").write_text(
+            PREFIX
+            + 'triage:f1 a triage:Finding ; triage:findingId "F-1" ; '
+            'triage:severity "important" ; triage:description "missing provenance" .\n'
+        )
+
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+
+        assert result.returncode == 1, result.stderr
+        assert result.stdout == ""
+        assert "findings validation blocked query resolution" in result.stderr
+        assert "triage:foundIn" in result.stderr
+        assert "triage:foundAt" in result.stderr
+
+    def test_cursor_resolution_runs_after_clean_findings_validation(self, tmp_path):
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]))
+        findings = repo / ".triage" / "phase-F" / "findings"
+        findings.mkdir(parents=True)
+        (findings / "F-1.ttl").write_text(
+            PREFIX
+            + 'triage:f1 a triage:Finding ; triage:findingId "F-1" ; '
+            'triage:foundIn triage:S1 ; '
+            'triage:foundAt "2026-07-01T12:00:00Z"^^xsd:dateTime ; '
+            'triage:severity "important" ; triage:description "clean" .\n'
+        )
+
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+
         assert result.returncode == 0, result.stderr
-        assert json.loads(result.stdout) == {"phase": "VALIDATE_ONLY", "vars": {}}
-        assert "malformed findings file" not in result.stderr
+        assert json.loads(result.stdout)["phase"] == "TRAVERSAL"
 
     def test_validate_only_reports_structure_errors(self, tmp_path):
         invalid = PREFIX + """
@@ -577,10 +621,12 @@ triage:S2 a triage:Sprint ; triage:inPhase triage:PhaseF ;
 
         result = self._run(repo, "F", str(repo / ".sprints" / "F"))
 
-        assert result.returncode == 1
+        # Findings validation is intentionally the first gate, so malformed
+        # structure is reported by the validator before the RDF loader runs.
+        assert result.returncode == 2
         assert result.stdout == ""
         assert "Traceback" not in result.stderr
-        assert "ERROR: query runner failed to load graph" in result.stderr
+        assert "findings validation blocked query resolution" in result.stderr
 
     def test_broken_sparql_is_reported_without_traceback(self, tmp_path):
         repo = self._make_repo(tmp_path, structure([(1, "S1")]))
@@ -588,6 +634,12 @@ triage:S2 a triage:Sprint ; triage:inPhase triage:PhaseF ;
         broken_scripts.mkdir()
         (broken_scripts / "validate-structure.sparql").write_text(
             "SELECT definitely broken"
+        )
+        (broken_scripts / "validate-findings.py").write_text(
+            (SCRIPTS / "validate-findings.py").read_text()
+        )
+        (broken_scripts / "validate-findings.sparql").write_text(
+            (SCRIPTS / "validate-findings.sparql").read_text()
         )
 
         result = subprocess.run(
@@ -632,11 +684,14 @@ class TestAssigneeBusy:
         return repo
 
     def _run(self, repo: Path, *args: str) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        env["GRAPH_ORCH_PYTHON"] = sys.executable
         return subprocess.run(
             [str(SCRIPTS / "assignee-busy"), *args],
             cwd=repo,
             text=True,
             capture_output=True,
+            env=env,
             check=False,
         )
 

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -6,6 +6,8 @@ Run from skill root: python3 -m pytest scripts/test_queries.py -v
 Requires: rdflib, pytest
 """
 import importlib.util
+import json
+import subprocess
 import sys
 
 import pytest
@@ -290,6 +292,7 @@ class TestLoadGraphFindingsIsolation:
         assert len(rows) == 1
         assert str(rows[0][1]) == "1"
 
+
     def test_wellformed_findings_in_queried_phase_still_loaded(self, tmp_path):
         """A well-formed, relevant findings file is still parsed and correctly
         drives Completion-invalidation, even with an unrelated malformed
@@ -521,6 +524,130 @@ triage:fcross a triage:Finding ; triage:foundIn triage:YS1 ;
         )
         assert len(rows) == 1
         assert str(rows[0][1]) == "1"
+
+
+# ── next-dev-task CLI tests ───────────────────────────────────────────────────
+
+class TestNextDevTaskValidation:
+    def _make_repo(self, tmp_path: Path, structure_ttl: str) -> Path:
+        repo = tmp_path / "repo"
+        ttl_dir = repo / ".sprints" / "F"
+        ttl_dir.mkdir(parents=True)
+        (ttl_dir / "structure.ttl").write_text(structure_ttl)
+        (repo / ".triage").mkdir()
+        return repo
+
+    def _run(self, repo: Path, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [str(SCRIPTS / "next-dev-task"), *args],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_validate_only_returns_success_json_without_loading_findings(self, tmp_path):
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]))
+        malformed = repo / ".triage" / "phase-U" / "findings"
+        malformed.mkdir(parents=True)
+        (malformed / "LEGACY.ttl").write_text("finding_id: LEGACY-001\n")
+
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"), "--validate-only")
+
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout) == {"phase": "VALIDATE_ONLY", "vars": {}}
+        assert "malformed findings file" not in result.stderr
+
+    def test_validate_only_reports_structure_errors(self, tmp_path):
+        invalid = PREFIX + """
+triage:PhaseF a triage:Phase .
+triage:S1 a triage:Sprint ; triage:inPhase triage:PhaseF ;
+    triage:order 1 ; triage:criteria "ac/S1.md" .
+triage:S2 a triage:Sprint ; triage:inPhase triage:PhaseF ;
+    triage:order 1 ; triage:criteria "ac/S2.md" .
+"""
+        repo = self._make_repo(tmp_path, invalid)
+
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"), "--validate-only")
+
+        assert result.returncode == 1
+        assert "ERROR: structure violation" in result.stderr
+        assert result.stdout == ""
+
+    def test_unknown_optional_argument_is_rejected(self, tmp_path):
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]))
+
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"), "--bogus")
+
+        assert result.returncode == 1
+        assert "Usage: next-dev-task" in result.stderr
+
+
+# ── assignee-busy CLI tests ───────────────────────────────────────────────────
+
+class TestAssigneeBusy:
+    def _make_repo(self, tmp_path: Path, events_ttl: str | None = None) -> Path:
+        repo = tmp_path / "repo"
+        ttl_dir = repo / ".sprints" / "F"
+        ttl_dir.mkdir(parents=True)
+        (ttl_dir / "structure.ttl").write_text(structure([(1, "S1")]))
+        if events_ttl is not None:
+            (ttl_dir / "events.ttl").write_text(events_ttl)
+        (repo / ".triage").mkdir()
+        return repo
+
+    def _run(self, repo: Path, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [str(SCRIPTS / "assignee-busy"), *args],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_reports_only_truly_in_flight_assignments(self, tmp_path):
+        events = PREFIX + """
+triage:a1 a triage:Assignment ; triage:ofSprint triage:S1 ;
+    triage:assignedTo "arch-ctm" ;
+    triage:assignedAt "2026-07-01T10:00:00Z"^^xsd:dateTime .
+triage:c1 a triage:Completion ; triage:ofSprint triage:S1 ;
+    triage:at "2026-07-01T12:00:00Z"^^xsd:dateTime .
+"""
+        repo = self._make_repo(tmp_path, events)
+
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"), "arch-ctm")
+
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout) == {
+            "busy": False,
+            "assignee": "arch-ctm",
+            "open_assignments": [],
+        }
+
+    def test_rejects_extra_arguments(self, tmp_path):
+        repo = self._make_repo(tmp_path)
+
+        result = self._run(
+            repo,
+            "F",
+            str(repo / ".sprints" / "F"),
+            "arch-ctm",
+            "unexpected",
+        )
+
+        assert result.returncode == 1
+        assert "Usage: assignee-busy" in result.stderr
+
+    def test_reports_malformed_structure_as_cli_error(self, tmp_path):
+        repo = self._make_repo(tmp_path)
+        (repo / ".sprints" / "F" / "structure.ttl").write_text("not valid turtle [")
+
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"), "arch-ctm")
+
+        assert result.returncode == 1
+        assert result.stdout == ""
+        assert "Traceback" not in result.stderr
+        assert "ERROR:" in result.stderr
 
 
 if __name__ == "__main__":

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -574,6 +574,43 @@ triage:S2 a triage:Sprint ; triage:inPhase triage:PhaseF ;
         assert "ERROR: structure violation" in result.stderr
         assert result.stdout == ""
 
+    def test_malformed_structure_is_reported_without_traceback(self, tmp_path):
+        repo = self._make_repo(tmp_path, "not valid Turtle [")
+
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+
+        assert result.returncode == 1
+        assert result.stdout == ""
+        assert "Traceback" not in result.stderr
+        assert "ERROR: query runner failed to load graph" in result.stderr
+
+    def test_broken_sparql_is_reported_without_traceback(self, tmp_path):
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]))
+        broken_scripts = tmp_path / "scripts"
+        broken_scripts.mkdir()
+        (broken_scripts / "validate-structure.sparql").write_text(
+            "SELECT definitely broken"
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS / "query_runner.py"),
+                "F",
+                str(repo / ".sprints" / "F"),
+                str(broken_scripts),
+            ],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode == 1
+        assert result.stdout == ""
+        assert "Traceback" not in result.stderr
+        assert "ERROR: query runner failed to run" in result.stderr
+
     def test_unknown_optional_argument_is_rejected(self, tmp_path):
         repo = self._make_repo(tmp_path, structure([(1, "S1")]))
 

--- a/.claude/skills/graph-orchestration/scripts/test_validate_findings.py
+++ b/.claude/skills/graph-orchestration/scripts/test_validate_findings.py
@@ -288,3 +288,36 @@ def test_regex_limits_validation_scope(tmp_path, capsys):
     assert "1 finding(s)" in output
     assert "AI21-001" in output
     assert "AI10-001" not in output
+
+
+def test_path_validation_respects_finding_id_scope(tmp_path):
+    validator = _validator()
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    (findings / "mixed.ttl").write_text(
+        PREFIX
+        + (
+            "triage:a a triage:Finding ; triage:findingId \"AI21-001\" ; "
+            "triage:foundIn triage:S1 ; "
+            "triage:foundAt \"2026-07-01T12:00:00Z\"^^xsd:dateTime ; "
+            "triage:severity \"important\" ; triage:description \"A\" ; "
+            "triage:hasOccurrence triage:oa .\n"
+            "triage:oa triage:file \"/abs/selected.rs\" .\n"
+            "triage:b a triage:Finding ; triage:findingId \"AI10-001\" ; "
+            "triage:foundIn triage:S1 ; "
+            "triage:foundAt \"2026-07-01T12:00:00Z\"^^xsd:dateTime ; "
+            "triage:severity \"important\" ; triage:description \"B\" ; "
+            "triage:hasOccurrence triage:ob .\n"
+            "triage:ob triage:file \"/abs/unselected.rs\" .\n"
+        )
+    )
+
+    result = validator.run_validation(
+        findings_dir=findings,
+        finding_id_regex=r"^AI21-",
+    )
+
+    assert result.kind == "validation:fail"
+    assert result.summary.findings == 1
+    assert len(result.diagnostics) == 1
+    assert "selected.rs" in result.diagnostics[0]

--- a/.claude/skills/graph-orchestration/scripts/test_validate_findings.py
+++ b/.claude/skills/graph-orchestration/scripts/test_validate_findings.py
@@ -123,8 +123,8 @@ def test_rejects_non_repository_relative_occurrence_and_legacy_worktree_paths(
 
     assert result.kind == "validation:fail"
     assert result.summary.errors == 3
-    assert any("triage:file" in line for line in result.diagnostics)
-    assert sum("triage:path" in line for line in result.diagnostics) == 2
+    assert any("invalid triage:file" in line for line in result.diagnostics)
+    assert sum("invalid triage:path" in line for line in result.diagnostics) == 2
 
 
 def test_warning_only_metadata_is_validation_pass(tmp_path):

--- a/.claude/skills/graph-orchestration/scripts/test_validate_findings.py
+++ b/.claude/skills/graph-orchestration/scripts/test_validate_findings.py
@@ -1,0 +1,81 @@
+"""Integration tests for the raw findings validator."""
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).parent
+PREFIX = (
+    "@prefix triage: <urn:atm:triage:> .\n"
+    "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+)
+
+
+def _validator():
+    spec = importlib.util.spec_from_file_location(
+        "validate_findings", SCRIPTS / "validate-findings.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _structure() -> str:
+    return PREFIX + (
+        "triage:S1 a triage:Sprint ; triage:order 1 .\n"
+    )
+
+
+def test_reports_missing_fields_and_fails(tmp_path, capsys):
+    validator = _validator()
+    structure = tmp_path / "structure.ttl"
+    structure.write_text(_structure())
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    (findings / "F-1.ttl").write_text(
+        PREFIX
+        + "triage:f1 a triage:Finding ; triage:findingId \"F-1\" .\n"
+    )
+
+    rc = validator.main(
+        [
+            "--findings-dir",
+            str(findings),
+            "--structure",
+            str(structure),
+            "--max-results",
+            "2",
+        ]
+    )
+    output = capsys.readouterr().out
+    assert rc == 1
+    assert "validated 1 file(s), 1 finding(s)" in output
+    assert "#error:" in output
+    assert "truncated" in output
+
+
+def test_regex_limits_validation_scope(tmp_path, capsys):
+    validator = _validator()
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    for name in ("AI21-001", "AI10-001"):
+        (findings / f"{name}.ttl").write_text(
+            PREFIX
+            + f"<urn:atm:triage:finding/{name}> a triage:Finding ; "
+            + f"triage:findingId \"{name}\" .\n"
+        )
+
+    rc = validator.main(
+        [
+            "--findings-dir",
+            str(findings),
+            "--finding-id-regex",
+            r"^AI21-",
+        ]
+    )
+    output = capsys.readouterr().out
+    assert rc == 1
+    assert "1 finding(s)" in output
+    assert "AI21-001" in output
+    assert "AI10-001" not in output

--- a/.claude/skills/graph-orchestration/scripts/test_validate_findings.py
+++ b/.claude/skills/graph-orchestration/scripts/test_validate_findings.py
@@ -93,6 +93,40 @@ def test_valid_finding_is_validation_pass(tmp_path):
     assert result.diagnostics == ()
 
 
+def test_rejects_non_repository_relative_occurrence_and_legacy_worktree_paths(
+    tmp_path,
+):
+    validator = _validator()
+    structure = tmp_path / "structure.ttl"
+    structure.write_text(_structure())
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    (findings / "F-1.ttl").write_text(
+        PREFIX
+        + (
+            "triage:f1 a triage:Finding ; triage:findingId \"F-1\" ; "
+            "triage:foundIn triage:S1 ; "
+            "triage:foundAt \"2026-07-01T12:00:00Z\"^^xsd:dateTime ; "
+            "triage:severity \"important\" ; triage:description \"Issue\" ; "
+            "triage:hasOccurrence triage:o1 .\n"
+            "triage:o1 a triage:Occurrence ; "
+            "triage:file \"/checkout/src/lib.rs\" ; "
+            "triage:occursIn triage:w1 .\n"
+            "triage:w1 a triage:WorktreeSnapshot ; "
+            "triage:path \"../feature-worktree\" .\n"
+            "triage:w2 a triage:WorktreeSnapshot ; "
+            "triage:path \"/abs/orphan-worktree\" .\n"
+        )
+    )
+
+    result = validator.run_validation(findings_dir=findings, structure=structure)
+
+    assert result.kind == "validation:fail"
+    assert result.summary.errors == 3
+    assert any("triage:file" in line for line in result.diagnostics)
+    assert sum("triage:path" in line for line in result.diagnostics) == 2
+
+
 def test_warning_only_metadata_is_validation_pass(tmp_path):
     validator = _validator()
     findings = tmp_path / "findings"

--- a/.claude/skills/graph-orchestration/scripts/test_validate_findings.py
+++ b/.claude/skills/graph-orchestration/scripts/test_validate_findings.py
@@ -1,6 +1,13 @@
-"""Integration tests for the raw findings validator."""
+"""Unit/integration tests for the raw findings validator.
+
+The validator has three observable outcomes.  ``validation:pass`` and
+``validation:fail`` are successful executions (the latter is a normal gate
+failure caused by finding metadata); ``error`` means the validator itself
+could not complete.
+"""
 
 import importlib.util
+import json
 from pathlib import Path
 
 
@@ -53,6 +60,174 @@ def test_reports_missing_fields_and_fails(tmp_path, capsys):
     assert "validated 1 file(s), 1 finding(s)" in output
     assert "#error:" in output
     assert "truncated" in output
+
+    result = validator.run_validation(
+        findings_dir=findings,
+        structure=structure,
+    )
+    assert result.kind == "validation:fail"
+    assert result.summary.errors == 2
+    assert result.summary.warnings == 2
+    assert all(line.startswith(("#error:", "#warning:")) for line in result.diagnostics)
+
+
+def test_valid_finding_is_validation_pass(tmp_path):
+    validator = _validator()
+    structure = tmp_path / "structure.ttl"
+    structure.write_text(_structure())
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    (findings / "F-1.ttl").write_text(
+        PREFIX
+        + (
+            "triage:f1 a triage:Finding ; triage:findingId \"F-1\" ; "
+            "triage:foundIn triage:S1 ; "
+            "triage:foundAt \"2026-07-01T12:00:00Z\"^^xsd:dateTime ; "
+            "triage:severity \"important\" ; triage:description \"Issue\" .\n"
+        )
+    )
+
+    result = validator.run_validation(findings_dir=findings, structure=structure)
+    assert result.kind == "validation:pass"
+    assert result.summary == validator.ValidationSummary(files=1, findings=1)
+    assert result.diagnostics == ()
+
+
+def test_warning_only_metadata_is_validation_pass(tmp_path):
+    validator = _validator()
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    (findings / "F-1.ttl").write_text(
+        PREFIX
+        + (
+            "triage:f1 a triage:Finding ; triage:foundIn triage:S1 ; "
+            "triage:foundAt \"2026-07-01T12:00:00Z\"^^xsd:dateTime .\n"
+        )
+    )
+
+    result = validator.run_validation(findings_dir=findings)
+    assert result.kind == "validation:pass"
+    assert result.summary.errors == 0
+    assert result.summary.warnings == 3
+    assert all(line.startswith("#warning:") for line in result.diagnostics)
+
+
+def test_malformed_turtle_is_error_result(tmp_path):
+    validator = _validator()
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    (findings / "BROKEN.ttl").write_text("this is not valid Turtle [")
+
+    result = validator.run_validation(findings_dir=findings)
+    assert result.kind == "error"
+    assert result.summary.errors == 1
+    assert result.summary.findings == 0
+    assert result.diagnostics[0].startswith("#error:")
+    assert "malformed Turtle" in result.diagnostics[0]
+
+
+def test_missing_directory_is_error_result(tmp_path):
+    validator = _validator()
+    result = validator.run_validation(findings_dir=tmp_path / "does-not-exist")
+    assert result.kind == "error"
+    assert result.summary.errors == 1
+    assert "findings directory does not exist" in result.diagnostics[0]
+
+
+def test_missing_structure_input_is_error_result(tmp_path):
+    validator = _validator()
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    result = validator.run_validation(
+        findings_dir=findings,
+        structure=tmp_path / "missing-structure.ttl",
+    )
+    assert result.kind == "error"
+    assert result.summary.errors == 1
+    assert "input file does not exist" in result.diagnostics[0]
+
+
+def test_declared_scope_rejects_finding_for_undeclared_sprint(tmp_path):
+    validator = _validator()
+    structure = tmp_path / "structure.ttl"
+    structure.write_text(PREFIX + "triage:PhaseF a triage:Phase .\n")
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    (findings / "F-1.ttl").write_text(
+        PREFIX
+        + (
+            "triage:f1 a triage:Finding ; triage:findingId \"F-1\" ; "
+            "triage:foundIn triage:S1 ; "
+            "triage:foundAt \"2026-07-01T12:00:00Z\"^^xsd:dateTime ; "
+            "triage:severity \"important\" ; triage:description \"Issue\" .\n"
+        )
+    )
+
+    result = validator.run_validation(findings_dir=findings, structure=structure)
+
+    assert result.kind == "validation:fail"
+    assert result.summary.errors == 1
+    assert "undeclared sprint" in result.diagnostics[0]
+
+
+def test_invalid_regex_is_error_result_and_cli_exit_two(tmp_path, capsys):
+    validator = _validator()
+    findings = tmp_path / "findings"
+    findings.mkdir()
+
+    result = validator.run_validation(
+        findings_dir=findings,
+        finding_id_regex="[unterminated",
+    )
+    assert result.kind == "error"
+    assert "invalid validator configuration" in result.message
+
+    rc = validator.main(
+        [
+            "--findings-dir",
+            str(findings),
+            "--finding-id-regex",
+            "[unterminated",
+            "--json",
+        ]
+    )
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "error"
+    assert payload["diagnostics"] == []
+
+
+def test_json_result_is_discriminated_and_preserves_validation_fail(tmp_path, capsys):
+    validator = _validator()
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    (findings / "F-1.ttl").write_text(
+        PREFIX + "triage:f1 a triage:Finding ; triage:findingId \"F-1\" .\n"
+    )
+
+    rc = validator.main(["--findings-dir", str(findings), "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "validation:fail"
+    assert payload["summary"]["errors"] == 2
+    assert sum(item.startswith("#error:") for item in payload["diagnostics"]) == 2
+    assert sum(item.startswith("#warning:") for item in payload["diagnostics"]) == 2
+
+
+def test_broken_sparql_is_error_result(tmp_path):
+    validator = _validator()
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    broken_scripts = tmp_path / "scripts"
+    broken_scripts.mkdir()
+    (broken_scripts / "validate-findings.sparql").write_text("SELECT definitely broken")
+
+    result = validator.run_validation(
+        findings_dir=findings,
+        script_dir=broken_scripts,
+    )
+    assert result.kind == "error"
+    assert "SPARQL query failed" in result.message
 
 
 def test_regex_limits_validation_scope(tmp_path, capsys):

--- a/.claude/skills/graph-orchestration/scripts/validate-findings.py
+++ b/.claude/skills/graph-orchestration/scripts/validate-findings.py
@@ -39,6 +39,9 @@ except ImportError:
 TRIAGE_BASE = "urn:atm:triage:"
 TRIAGE = Namespace(TRIAGE_BASE)
 SCRIPT_DIR = Path(__file__).resolve().parent
+_INVALID_REPOSITORY_PATH = re.compile(
+    r"(^/|^[A-Za-z]:[/\\]|(^|[/\\])\.\.(?:[/\\]|$))"
+)
 
 
 @dataclass(frozen=True)
@@ -107,15 +110,30 @@ def _parse_file(path: Path, graph: Graph, *, errors: list[str]) -> dict:
     }
 
 
+def _is_invalid_persisted_path(value: object) -> bool:
+    """Return whether a persisted path is absolute or escapes its repository."""
+
+    return _INVALID_REPOSITORY_PATH.search(str(value)) is not None
+
+
 def _load_graph(
     findings_dir: Path,
     structure: Path | None,
     events: Path | None,
     finding_id_pattern: re.Pattern[str] | None,
-) -> tuple[Graph, dict[str, Path], set[URIRef], list[str], int]:
+) -> tuple[
+    Graph,
+    dict[str, Path],
+    set[URIRef],
+    list[str],
+    int,
+    list[str],
+]:
     graph = Graph()
     finding_files: dict[str, Path] = {}
     diagnostics: list[str] = []
+    path_diagnostics: list[str] = []
+    reported_paths: set[tuple[str, str, str]] = set()
 
     known_sprints: set[URIRef] = set()
     for path in (structure, events):
@@ -132,10 +150,10 @@ def _load_graph(
 
     if not findings_dir.exists():
         diagnostics.append(f"#error: {findings_dir}: findings directory does not exist")
-        return graph, finding_files, known_sprints, diagnostics, 0
+        return graph, finding_files, known_sprints, diagnostics, 0, path_diagnostics
     if not findings_dir.is_dir():
         diagnostics.append(f"#error: {findings_dir}: findings path is not a directory")
-        return graph, finding_files, known_sprints, diagnostics, 0
+        return graph, finding_files, known_sprints, diagnostics, 0, path_diagnostics
 
     parsed_files = 0
     finding_graph = Graph()
@@ -159,12 +177,53 @@ def _load_graph(
         }
         for finding in selected:
             finding_files[str(finding)] = path
+            linked_records: set[object] = set()
             for triple in parsed.triples((finding, None, None)):
                 finding_graph.add(triple)
+            # Include occurrence/worktree metadata reachable from this
+            # finding. The validator's query intentionally scopes findings by
+            # ID, but path invariants live on the linked records rather than
+            # on the Finding subject itself.
+            for occurrence in parsed.objects(finding, TRIAGE.hasOccurrence):
+                linked_records.add(occurrence)
+                for triple in parsed.triples((occurrence, None, None)):
+                    finding_graph.add(triple)
+                for worktree in parsed.objects(occurrence, TRIAGE.occursIn):
+                    linked_records.add(worktree)
+                    for triple in parsed.triples((worktree, None, None)):
+                        finding_graph.add(triple)
+
+            # The SPARQL query validates paths reachable through the canonical
+            # Finding -> Occurrence -> WorktreeSnapshot edges above. Keep a
+            # parse-time check for legacy/unlinked records in the same selected
+            # TTL file so absolute paths cannot evade the gate.
+            for subject, predicate, value in parsed:
+                if predicate not in (TRIAGE.file, TRIAGE.path):
+                    continue
+                if subject in linked_records or not _is_invalid_persisted_path(value):
+                    continue
+                field_name = (
+                    "triage:file" if predicate == TRIAGE.file else "triage:path"
+                )
+                key = (str(subject), field_name, str(value))
+                if key in reported_paths:
+                    continue
+                reported_paths.add(key)
+                path_diagnostics.append(
+                    f"#error: {path}: {subject} invalid {field_name} — "
+                    "persisted path must be repository-relative"
+                )
 
     for triple in finding_graph:
         graph.add(triple)
-    return graph, finding_files, known_sprints, diagnostics, parsed_files
+    return (
+        graph,
+        finding_files,
+        known_sprints,
+        diagnostics,
+        parsed_files,
+        path_diagnostics,
+    )
 
 
 def _run_query(graph: Graph, script_dir: Path) -> list:
@@ -182,7 +241,12 @@ def _diagnostic_line(row, finding_files: dict[str, Path]) -> str:
     # Most query rows represent an absent predicate.  The wrapper also adds a
     # row when ``foundIn`` is present but points at an undeclared sprint; call
     # that invalid rather than claiming the field is missing.
-    verb = "invalid" if "undeclared sprint" in detail else "missing"
+    verb = (
+        "invalid"
+        if "undeclared sprint" in detail
+        or field in {"triage:file", "triage:path"}
+        else "missing"
+    )
     return f"{level}: {location}{finding} {verb} {field} — {detail}"
 
 
@@ -237,9 +301,14 @@ def run_validation(
         return ValidationError(message=f"invalid validator configuration: {exc}")
 
     try:
-        graph, finding_files, known_sprints, input_diagnostics, parsed_files = (
-            _load_graph(findings_dir, structure, events, finding_id_pattern)
-        )
+        (
+            graph,
+            finding_files,
+            known_sprints,
+            input_diagnostics,
+            parsed_files,
+            path_diagnostics,
+        ) = _load_graph(findings_dir, structure, events, finding_id_pattern)
         # Input diagnostics are operational errors, not validation findings:
         # returning an Error keeps malformed files from being mistaken for a
         # successful run that merely found invalid records.
@@ -279,7 +348,8 @@ def run_validation(
                         )
 
         diagnostics = tuple(
-            _diagnostic_line(row, finding_files) for row in rows
+            [_diagnostic_line(row, finding_files) for row in rows]
+            + path_diagnostics
         )
         summary = _summary(
             parsed_files,

--- a/.claude/skills/graph-orchestration/scripts/validate-findings.py
+++ b/.claude/skills/graph-orchestration/scripts/validate-findings.py
@@ -133,7 +133,6 @@ def _load_graph(
     finding_files: dict[str, Path] = {}
     diagnostics: list[str] = []
     path_diagnostics: list[str] = []
-    reported_paths: set[tuple[str, str, str]] = set()
 
     known_sprints: set[URIRef] = set()
     for path in (structure, events):
@@ -205,10 +204,6 @@ def _load_graph(
                 field_name = (
                     "triage:file" if predicate == TRIAGE.file else "triage:path"
                 )
-                key = (str(subject), field_name, str(value))
-                if key in reported_paths:
-                    continue
-                reported_paths.add(key)
                 path_diagnostics.append(
                     f"#error: {path}: {subject} invalid {field_name} — "
                     "persisted path must be repository-relative"

--- a/.claude/skills/graph-orchestration/scripts/validate-findings.py
+++ b/.claude/skills/graph-orchestration/scripts/validate-findings.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Validate raw triage findings before graph-orchestration scoping.
+
+``query_runner.py`` intentionally drops findings that do not point at a
+declared sprint.  That is correct for cursor resolution, but it also means
+invalid findings can disappear before they are reported.  This command parses
+the raw findings directory first and emits one ``#error``/``#warning`` line
+per missing (or invalid) field.
+
+Usage::
+
+    validate-findings.py \\
+      --findings-dir .triage/phase-AI/findings \\
+      [--structure .sprints/AICH/structure.ttl] \\
+      [--events .sprints/AICH/events.ttl]
+
+Exit status is non-zero when at least one ``#error`` is found.  Warnings do
+not fail the command.  ``--max-results`` truncates printed detail without
+changing validation or the exit status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+try:
+    from rdflib import Graph, URIRef, Namespace
+    from rdflib.namespace import RDF
+except ImportError:
+    print("ERROR: rdflib not installed. Run: pip3 install rdflib", file=sys.stderr)
+    raise SystemExit(1)
+
+
+TRIAGE_BASE = "urn:atm:triage:"
+TRIAGE = Namespace(TRIAGE_BASE)
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _parse_file(path: Path, graph: Graph, *, errors: list[str]) -> dict:
+    """Parse one Turtle file, recording its Finding subjects by URI."""
+    parsed = Graph()
+    try:
+        parsed.parse(str(path), format="turtle")
+    except Exception as exc:  # noqa: BLE001 - report all bad files together
+        errors.append(f"#error: {path}: malformed Turtle ({exc})")
+        return {}
+
+    graph += parsed
+    return {
+        str(finding): path
+        for finding in parsed.subjects(RDF.type, TRIAGE.Finding)
+    }
+
+
+def _load_graph(
+    findings_dir: Path,
+    structure: Path | None,
+    events: Path | None,
+    finding_id_pattern: re.Pattern[str] | None,
+) -> tuple[Graph, dict[str, Path], set[URIRef], list[str], int]:
+    graph = Graph()
+    finding_files: dict[str, Path] = {}
+    diagnostics: list[str] = []
+
+    known_sprints: set[URIRef] = set()
+    for path in (structure, events):
+        if path is None:
+            continue
+        if not path.exists():
+            diagnostics.append(f"#error: {path}: input file does not exist")
+            continue
+        try:
+            graph.parse(str(path), format="turtle")
+        except Exception as exc:  # noqa: BLE001 - report malformed input
+            diagnostics.append(f"#error: {path}: malformed Turtle ({exc})")
+    known_sprints.update(graph.subjects(RDF.type, TRIAGE.Sprint))
+
+    if not findings_dir.exists():
+        diagnostics.append(f"#error: {findings_dir}: findings directory does not exist")
+        return graph, finding_files, known_sprints, diagnostics
+    if not findings_dir.is_dir():
+        diagnostics.append(f"#error: {findings_dir}: findings path is not a directory")
+        return graph, finding_files, known_sprints, diagnostics
+
+    parsed_files = 0
+    finding_graph = Graph()
+    for path in sorted(findings_dir.glob("*.ttl")):
+        parsed = Graph()
+        try:
+            parsed.parse(str(path), format="turtle")
+        except Exception as exc:  # noqa: BLE001 - report all bad files together
+            diagnostics.append(f"#error: {path}: malformed Turtle ({exc})")
+            continue
+        parsed_files += 1
+        file_findings = list(parsed.subjects(RDF.type, TRIAGE.Finding))
+        selected = {
+            finding
+            for finding in file_findings
+            if finding_id_pattern is None
+            or any(
+                finding_id_pattern.search(str(value))
+                for value in parsed.objects(finding, TRIAGE.findingId)
+            )
+        }
+        for finding in selected:
+            finding_files[str(finding)] = path
+            for triple in parsed.triples((finding, None, None)):
+                finding_graph.add(triple)
+
+    for triple in finding_graph:
+        graph.add(triple)
+    return graph, finding_files, known_sprints, diagnostics, parsed_files
+
+
+def _run_query(graph: Graph, script_dir: Path) -> list:
+    query_path = script_dir / "validate-findings.sparql"
+    try:
+        return list(graph.query(query_path.read_text()))
+    except Exception as exc:  # noqa: BLE001 - present an actionable diagnostic
+        print(f"#error: {query_path}: SPARQL query failed ({exc})", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def _diagnostic_line(row, finding_files: dict[str, Path], known_sprints: set[URIRef]) -> str:
+    level, finding, field, detail = (str(value) for value in row)
+    source = finding_files.get(finding)
+    location = f"{source}: " if source else ""
+    return f"{level}: {location}{finding} missing {field} — {detail}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--findings-dir", type=Path, required=True)
+    parser.add_argument("--structure", type=Path)
+    parser.add_argument("--events", type=Path)
+    parser.add_argument(
+        "--finding-id-regex",
+        help="validate only findings whose triage:findingId matches this regex",
+    )
+    parser.add_argument(
+        "--script-dir",
+        type=Path,
+        default=SCRIPT_DIR,
+        help="directory containing validate-findings.sparql (default: script directory)",
+    )
+    parser.add_argument(
+        "--max-results",
+        type=int,
+        default=0,
+        help="print at most N detail lines (0 means all; exit status is unaffected)",
+    )
+    args = parser.parse_args(argv)
+    if args.max_results < 0:
+        parser.error("--max-results must be >= 0")
+
+    try:
+        finding_id_pattern = (
+            re.compile(args.finding_id_regex) if args.finding_id_regex else None
+        )
+    except re.error as exc:
+        parser.error(f"invalid --finding-id-regex: {exc}")
+
+    graph, finding_files, known_sprints, diagnostics, parsed_files = _load_graph(
+        args.findings_dir, args.structure, args.events, finding_id_pattern
+    )
+    rows = _run_query(graph, args.script_dir)
+
+    # A foundIn value that points outside the supplied phase graph is an error,
+    # not merely an out-of-scope finding.  Without this check, a typo would
+    # look identical to an intentionally unscoped record.
+    if known_sprints:
+        for finding in sorted(graph.subjects(RDF.type, TRIAGE.Finding), key=str):
+            for sprint in graph.objects(finding, TRIAGE.foundIn):
+                if sprint not in known_sprints:
+                    rows.append(
+                        (
+                            "#error",
+                            finding,
+                            "triage:foundIn",
+                            "finding references an undeclared sprint",
+                        )
+                    )
+
+    detail_lines = [
+        _diagnostic_line(row, finding_files, known_sprints)
+        for row in rows
+    ]
+    diagnostics.extend(detail_lines)
+
+    counts = Counter(line.split(":", 1)[0] for line in diagnostics)
+    files = parsed_files
+    findings = len(finding_files)
+    scope = "selected " if finding_id_pattern else ""
+    print(
+        f"validated {files} file(s), {scope}{findings} finding(s): "
+        f"{counts.get('#error', 0)} error(s), {counts.get('#warning', 0)} warning(s)"
+    )
+
+    limit = args.max_results or len(diagnostics)
+    for line in diagnostics[:limit]:
+        print(line)
+    suppressed = len(diagnostics) - min(limit, len(diagnostics))
+    if suppressed:
+        print(f"… {suppressed} diagnostic line(s) truncated; use --max-results 0 for all")
+
+    return 1 if counts.get("#error", 0) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/graph-orchestration/scripts/validate-findings.py
+++ b/.claude/skills/graph-orchestration/scripts/validate-findings.py
@@ -174,6 +174,13 @@ def _load_graph(
                 for value in parsed.objects(finding, TRIAGE.findingId)
             )
         }
+        all_linked_records: set[object] = set()
+        for finding in file_findings:
+            for occurrence in parsed.objects(finding, TRIAGE.hasOccurrence):
+                all_linked_records.add(occurrence)
+                all_linked_records.update(
+                    parsed.objects(occurrence, TRIAGE.occursIn)
+                )
         for finding in selected:
             finding_files[str(finding)] = path
             linked_records: set[object] = set()
@@ -199,7 +206,11 @@ def _load_graph(
             for subject, predicate, value in parsed:
                 if predicate not in (TRIAGE.file, TRIAGE.path):
                     continue
-                if subject in linked_records or not _is_invalid_persisted_path(value):
+                if (
+                    subject in linked_records
+                    or subject in all_linked_records
+                    or not _is_invalid_persisted_path(value)
+                ):
                     continue
                 field_name = (
                     "triage:file" if predicate == TRIAGE.file else "triage:path"

--- a/.claude/skills/graph-orchestration/scripts/validate-findings.py
+++ b/.claude/skills/graph-orchestration/scripts/validate-findings.py
@@ -19,13 +19,14 @@ not fail the command.  ``--max-results`` truncates printed detail without
 changing validation or the exit status.
 """
 
-from __future__ import annotations
-
 import argparse
+import json
 import re
 import sys
 from collections import Counter
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import Literal, Union
 
 try:
     from rdflib import Graph, URIRef, Namespace
@@ -38,6 +39,56 @@ except ImportError:
 TRIAGE_BASE = "urn:atm:triage:"
 TRIAGE = Namespace(TRIAGE_BASE)
 SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+@dataclass(frozen=True)
+class ValidationSummary:
+    """Counts produced by a validation run.
+
+    The counts describe the input that was actually selected.  In particular,
+    ``findings`` is the count after ``--finding-id-regex`` filtering.
+    """
+
+    files: int = 0
+    findings: int = 0
+    errors: int = 0
+    warnings: int = 0
+    scoped: bool = False
+
+
+@dataclass(frozen=True)
+class ValidationPass:
+    """The validator ran successfully and found no error-level diagnostics."""
+
+    kind: Literal["validation:pass"] = field(
+        default="validation:pass", init=False
+    )
+    diagnostics: tuple[str, ...] = ()
+    summary: ValidationSummary = field(default_factory=ValidationSummary)
+
+
+@dataclass(frozen=True)
+class ValidationFail:
+    """The validator ran successfully, but the data failed validation."""
+
+    kind: Literal["validation:fail"] = field(
+        default="validation:fail", init=False
+    )
+    diagnostics: tuple[str, ...] = ()
+    summary: ValidationSummary = field(default_factory=ValidationSummary)
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    """The validator could not complete (bad input, query, or configuration)."""
+
+    kind: Literal["error"] = field(default="error", init=False)
+    message: str = ""
+    diagnostics: tuple[str, ...] = ()
+    summary: ValidationSummary | None = None
+
+
+ValidationResult = Union[ValidationPass, ValidationFail, ValidationError]
 
 
 def _parse_file(path: Path, graph: Graph, *, errors: list[str]) -> dict:
@@ -81,10 +132,10 @@ def _load_graph(
 
     if not findings_dir.exists():
         diagnostics.append(f"#error: {findings_dir}: findings directory does not exist")
-        return graph, finding_files, known_sprints, diagnostics
+        return graph, finding_files, known_sprints, diagnostics, 0
     if not findings_dir.is_dir():
         diagnostics.append(f"#error: {findings_dir}: findings path is not a directory")
-        return graph, finding_files, known_sprints, diagnostics
+        return graph, finding_files, known_sprints, diagnostics, 0
 
     parsed_files = 0
     finding_graph = Graph()
@@ -121,15 +172,178 @@ def _run_query(graph: Graph, script_dir: Path) -> list:
     try:
         return list(graph.query(query_path.read_text()))
     except Exception as exc:  # noqa: BLE001 - present an actionable diagnostic
-        print(f"#error: {query_path}: SPARQL query failed ({exc})", file=sys.stderr)
-        raise SystemExit(1)
+        raise RuntimeError(f"{query_path}: SPARQL query failed ({exc})") from exc
 
 
-def _diagnostic_line(row, finding_files: dict[str, Path], known_sprints: set[URIRef]) -> str:
+def _diagnostic_line(row, finding_files: dict[str, Path]) -> str:
     level, finding, field, detail = (str(value) for value in row)
     source = finding_files.get(finding)
     location = f"{source}: " if source else ""
-    return f"{level}: {location}{finding} missing {field} — {detail}"
+    # Most query rows represent an absent predicate.  The wrapper also adds a
+    # row when ``foundIn`` is present but points at an undeclared sprint; call
+    # that invalid rather than claiming the field is missing.
+    verb = "invalid" if "undeclared sprint" in detail else "missing"
+    return f"{level}: {location}{finding} {verb} {field} — {detail}"
+
+
+def _summary(
+    files: int,
+    findings: int,
+    diagnostics: list[str] | tuple[str, ...],
+    *,
+    scoped: bool = False,
+) -> ValidationSummary:
+    counts = Counter(line.split(":", 1)[0] for line in diagnostics)
+    return ValidationSummary(
+        files=files,
+        findings=findings,
+        errors=counts.get("#error", 0),
+        warnings=counts.get("#warning", 0),
+        scoped=scoped,
+    )
+
+
+def run_validation(
+    *,
+    findings_dir: Path,
+    structure: Path | None = None,
+    events: Path | None = None,
+    finding_id_regex: str | None = None,
+    script_dir: Path = SCRIPT_DIR,
+) -> ValidationResult:
+    """Run the validator and return a discriminated result.
+
+    ``ValidationPass`` and ``ValidationFail`` both mean the command completed
+    normally.  A ``ValidationFail`` is the expected result when finding data
+    has ``#error`` diagnostics; it is not an exception.  ``ValidationError``
+    is reserved for operational failures such as malformed Turtle, missing
+    paths, an invalid regex, or a broken SPARQL query.
+    """
+
+    try:
+        if not isinstance(findings_dir, Path):
+            findings_dir = Path(findings_dir)
+        if structure is not None and not isinstance(structure, Path):
+            structure = Path(structure)
+        if events is not None and not isinstance(events, Path):
+            events = Path(events)
+        if not isinstance(script_dir, Path):
+            script_dir = Path(script_dir)
+
+        finding_id_pattern = (
+            re.compile(finding_id_regex) if finding_id_regex else None
+        )
+    except (OSError, re.error, TypeError, ValueError) as exc:
+        return ValidationError(message=f"invalid validator configuration: {exc}")
+
+    try:
+        graph, finding_files, known_sprints, input_diagnostics, parsed_files = (
+            _load_graph(findings_dir, structure, events, finding_id_pattern)
+        )
+        # Input diagnostics are operational errors, not validation findings:
+        # returning an Error keeps malformed files from being mistaken for a
+        # successful run that merely found invalid records.
+        if input_diagnostics:
+            return ValidationError(
+                message="validator input could not be loaded",
+                diagnostics=tuple(input_diagnostics),
+                summary=_summary(
+                    parsed_files,
+                    len(finding_files),
+                    input_diagnostics,
+                    scoped=bool(finding_id_pattern),
+                ),
+            )
+
+        rows = _run_query(graph, script_dir)
+
+        # A foundIn value that points outside the supplied phase graph is an
+        # error, not merely an out-of-scope finding.  Without this check, a
+        # typo would look identical to an intentionally unscoped record.
+        # When a structure/events graph was supplied, every foundIn target
+        # must resolve to a declared sprint.  Do not guard this on
+        # ``known_sprints`` being non-empty: an empty (but valid) phase graph
+        # is still authoritative, and otherwise every finding would silently
+        # pass as if no scope had been requested.
+        if structure is not None or events is not None:
+            for finding in sorted(graph.subjects(RDF.type, TRIAGE.Finding), key=str):
+                for sprint in graph.objects(finding, TRIAGE.foundIn):
+                    if sprint not in known_sprints:
+                        rows.append(
+                            (
+                                "#error",
+                                finding,
+                                "triage:foundIn",
+                                "finding references an undeclared sprint",
+                            )
+                        )
+
+        diagnostics = tuple(
+            _diagnostic_line(row, finding_files) for row in rows
+        )
+        summary = _summary(
+            parsed_files,
+            len(finding_files),
+            diagnostics,
+            scoped=bool(finding_id_pattern),
+        )
+        if summary.errors:
+            return ValidationFail(diagnostics=diagnostics, summary=summary)
+        return ValidationPass(diagnostics=diagnostics, summary=summary)
+    except Exception as exc:  # noqa: BLE001 - API boundary must not leak errors
+        return ValidationError(
+            message=f"validator execution failed: {type(exc).__name__}: {exc}"
+        )
+
+
+def _result_payload(result: ValidationResult) -> dict:
+    """Convert a result union member to a stable JSON-compatible object."""
+
+    payload = asdict(result)
+    payload["diagnostics"] = list(result.diagnostics)
+    if result.summary is not None:
+        payload["summary"] = asdict(result.summary)
+    return payload
+
+
+def _print_result(
+    result: ValidationResult,
+    *,
+    max_results: int = 0,
+    as_json: bool = False,
+) -> None:
+    # ``main`` turns a negative value into an Error result.  Clamp it here so
+    # error rendering never accidentally uses Python's negative slicing.
+    if max_results < 0:
+        max_results = 0
+    diagnostics = list(result.diagnostics)
+    limit = max_results or len(diagnostics)
+    shown = diagnostics[:limit]
+    suppressed = len(diagnostics) - len(shown)
+
+    if as_json:
+        payload = _result_payload(result)
+        payload["diagnostics"] = shown
+        payload["suppressed"] = suppressed
+        print(json.dumps(payload, sort_keys=True))
+        return
+
+    if isinstance(result, ValidationError):
+        print(f"error: {result.message}")
+    else:
+        summary = result.summary
+        scope = "selected " if summary.scoped else ""
+        print(
+            f"validated {summary.files} file(s), {scope}{summary.findings} finding(s): "
+            f"{summary.errors} error(s), {summary.warnings} warning(s)"
+        )
+    for line in shown:
+        print(line)
+    if suppressed:
+        print(
+            f"… {suppressed} diagnostic line(s) truncated; "
+            "use --max-results 0 for all"
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -153,61 +367,32 @@ def main(argv: list[str] | None = None) -> int:
         default=0,
         help="print at most N detail lines (0 means all; exit status is unaffected)",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the discriminated result as one JSON object",
+    )
     args = parser.parse_args(argv)
     if args.max_results < 0:
-        parser.error("--max-results must be >= 0")
-
-    try:
-        finding_id_pattern = (
-            re.compile(args.finding_id_regex) if args.finding_id_regex else None
+        # Keep this an Error result instead of argparse's SystemExit so callers
+        # using the API and callers using the CLI observe the same contract.
+        result: ValidationResult = ValidationError(
+            message="invalid validator configuration: --max-results must be >= 0"
         )
-    except re.error as exc:
-        parser.error(f"invalid --finding-id-regex: {exc}")
-
-    graph, finding_files, known_sprints, diagnostics, parsed_files = _load_graph(
-        args.findings_dir, args.structure, args.events, finding_id_pattern
-    )
-    rows = _run_query(graph, args.script_dir)
-
-    # A foundIn value that points outside the supplied phase graph is an error,
-    # not merely an out-of-scope finding.  Without this check, a typo would
-    # look identical to an intentionally unscoped record.
-    if known_sprints:
-        for finding in sorted(graph.subjects(RDF.type, TRIAGE.Finding), key=str):
-            for sprint in graph.objects(finding, TRIAGE.foundIn):
-                if sprint not in known_sprints:
-                    rows.append(
-                        (
-                            "#error",
-                            finding,
-                            "triage:foundIn",
-                            "finding references an undeclared sprint",
-                        )
-                    )
-
-    detail_lines = [
-        _diagnostic_line(row, finding_files, known_sprints)
-        for row in rows
-    ]
-    diagnostics.extend(detail_lines)
-
-    counts = Counter(line.split(":", 1)[0] for line in diagnostics)
-    files = parsed_files
-    findings = len(finding_files)
-    scope = "selected " if finding_id_pattern else ""
-    print(
-        f"validated {files} file(s), {scope}{findings} finding(s): "
-        f"{counts.get('#error', 0)} error(s), {counts.get('#warning', 0)} warning(s)"
-    )
-
-    limit = args.max_results or len(diagnostics)
-    for line in diagnostics[:limit]:
-        print(line)
-    suppressed = len(diagnostics) - min(limit, len(diagnostics))
-    if suppressed:
-        print(f"… {suppressed} diagnostic line(s) truncated; use --max-results 0 for all")
-
-    return 1 if counts.get("#error", 0) else 0
+    else:
+        result = run_validation(
+            findings_dir=args.findings_dir,
+            structure=args.structure,
+            events=args.events,
+            finding_id_regex=args.finding_id_regex,
+            script_dir=args.script_dir,
+        )
+    _print_result(result, max_results=args.max_results, as_json=args.json)
+    if result.kind == "validation:pass":
+        return 0
+    if result.kind == "validation:fail":
+        return 1
+    return 2
 
 
 if __name__ == "__main__":

--- a/.claude/skills/graph-orchestration/scripts/validate-findings.sparql
+++ b/.claude/skills/graph-orchestration/scripts/validate-findings.sparql
@@ -14,7 +14,7 @@
 PREFIX triage: <urn:atm:triage:>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
-SELECT ?level ?finding ?field ?detail WHERE {
+SELECT DISTINCT ?level ?finding ?field ?detail WHERE {
   ?finding a triage:Finding .
 
   {
@@ -62,7 +62,10 @@ SELECT ?level ?finding ?field ?detail WHERE {
     )
     BIND("#error" AS ?level)
     BIND("triage:file" AS ?field)
-    BIND("occurrence path must be repository-relative" AS ?detail)
+    BIND(
+      CONCAT("occurrence path must be repository-relative: ", STR(?file))
+      AS ?detail
+    )
   }
   UNION
   {
@@ -76,7 +79,13 @@ SELECT ?level ?finding ?field ?detail WHERE {
     )
     BIND("#error" AS ?level)
     BIND("triage:path" AS ?field)
-    BIND("legacy worktree path must not be absolute or escape repository" AS ?detail)
+    BIND(
+      CONCAT(
+        "legacy worktree path must not be absolute or escape repository: ",
+        STR(?path)
+      )
+      AS ?detail
+    )
   }
 }
 ORDER BY ?level ?finding ?field

--- a/.claude/skills/graph-orchestration/scripts/validate-findings.sparql
+++ b/.claude/skills/graph-orchestration/scripts/validate-findings.sparql
@@ -7,6 +7,7 @@
 # Levels:
 #   #error   fields required for cursor invalidation and phase scoping
 #   #warning descriptive/routing fields needed by cleanup and dispatch output
+#   #error   persisted file paths must not escape the repository
 #
 # Parameter: none
 
@@ -49,6 +50,33 @@ SELECT ?level ?finding ?field ?detail WHERE {
     BIND("#warning" AS ?level)
     BIND("triage:description" AS ?field)
     BIND("dispatch and cleanup output lack a description" AS ?detail)
+  }
+  UNION
+  {
+    ?finding triage:hasOccurrence ?occurrence .
+    ?occurrence triage:file ?file .
+    FILTER (
+      STRSTARTS(STR(?file), "/")
+      || REGEX(STR(?file), "(^|[/\\\\])\\.\\.(?:[/\\\\]|$)")
+      || REGEX(STR(?file), "^[A-Za-z]:[/\\\\]")
+    )
+    BIND("#error" AS ?level)
+    BIND("triage:file" AS ?field)
+    BIND("occurrence path must be repository-relative" AS ?detail)
+  }
+  UNION
+  {
+    ?finding triage:hasOccurrence ?occurrence .
+    ?occurrence triage:occursIn ?worktree .
+    ?worktree triage:path ?path .
+    FILTER (
+      STRSTARTS(STR(?path), "/")
+      || REGEX(STR(?path), "(^|[/\\\\])\\.\\.(?:[/\\\\]|$)")
+      || REGEX(STR(?path), "^[A-Za-z]:[/\\\\]")
+    )
+    BIND("#error" AS ?level)
+    BIND("triage:path" AS ?field)
+    BIND("legacy worktree path must not be absolute or escape repository" AS ?detail)
   }
 }
 ORDER BY ?level ?finding ?field

--- a/.claude/skills/graph-orchestration/scripts/validate-findings.sparql
+++ b/.claude/skills/graph-orchestration/scripts/validate-findings.sparql
@@ -1,0 +1,54 @@
+# validate-findings.sparql — Finding metadata integrity check.
+#
+# Run against the phase structure/events graph plus the raw findings files.
+# The query deliberately runs before membership filtering so a finding with no
+# triage:foundIn cannot disappear silently.
+#
+# Levels:
+#   #error   fields required for cursor invalidation and phase scoping
+#   #warning descriptive/routing fields needed by cleanup and dispatch output
+#
+# Parameter: none
+
+PREFIX triage: <urn:atm:triage:>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?level ?finding ?field ?detail WHERE {
+  ?finding a triage:Finding .
+
+  {
+    FILTER NOT EXISTS { ?finding triage:findingId ?id . }
+    BIND("#warning" AS ?level)
+    BIND("triage:findingId" AS ?field)
+    BIND("stable finding identity is missing" AS ?detail)
+  }
+  UNION
+  {
+    FILTER NOT EXISTS { ?finding triage:foundIn ?sprint . }
+    BIND("#error" AS ?level)
+    BIND("triage:foundIn" AS ?field)
+    BIND("finding cannot be assigned to a sprint" AS ?detail)
+  }
+  UNION
+  {
+    FILTER NOT EXISTS { ?finding triage:foundAt ?found_at . }
+    BIND("#error" AS ?level)
+    BIND("triage:foundAt" AS ?field)
+    BIND("completion invalidation cannot be time-ordered" AS ?detail)
+  }
+  UNION
+  {
+    FILTER NOT EXISTS { ?finding triage:severity ?severity . }
+    BIND("#warning" AS ?level)
+    BIND("triage:severity" AS ?field)
+    BIND("blocking/important/minor routing cannot be determined" AS ?detail)
+  }
+  UNION
+  {
+    FILTER NOT EXISTS { ?finding triage:description ?description . }
+    BIND("#warning" AS ?level)
+    BIND("triage:description" AS ?field)
+    BIND("dispatch and cleanup output lack a description" AS ?detail)
+  }
+}
+ORDER BY ?level ?finding ?field

--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: triage-report
+version: 1.0.0
+description: Produce an auditable phase triage report from the integration worktree source of truth.
+---
+
+# Triage Report
+
+`triage_report.py` is the single producer for this report. Its JSON output is
+the machine-readable source of truth and its precomputed row strings are the
+inputs displayed by `sc-compose`; Jinja performs no gate arithmetic.
+
+## Usage
+
+Run from the current `integrate/phase-*` worktree, or pass the worktree
+explicitly:
+
+```bash
+python3 .claude/skills/triage-report/scripts/triage_report.py \
+  --phase AICH --format table
+python3 .claude/skills/triage-report/scripts/triage_report.py \
+  --phase AICH --format json > /tmp/triage-report.json
+```
+
+When the command is not run from an integration worktree it searches Git
+worktrees. It fails with a structured JSON error (exit 2) when there is not
+exactly one `integrate/phase-*` candidate. Use `--integration-root` to remove
+that ambiguity. `--qa-master` and `--metadata` may be supplied when those
+artifacts are stored at non-default paths.
+
+The default QA evidence path is
+`docs/plans/phase-<phase>/.audit/qa-evidence-master.json`. Only the latest
+`run_type: "qa"` run per sprint is authoritative; reviewer-only runs do not
+replace QA. Missing QA, PR, CI, branch, acknowledgement, or merge inputs stay
+`null` and are listed in `data_gaps`.
+
+## Calculated gates
+
+- `ready_to_merge` is true only when the authoritative blocker count is known
+  and zero; unknown counts produce `null`.
+- `ok_to_merge` is true only when `ready_to_merge` is true and every earlier
+  sprint has explicit `merged: true` metadata. No branch name, PR number, or
+  ancestry is treated as proof of merge.
+- `quality_gate` separately requires all known B/I/M counts to be zero and is
+  never used to silently convert missing counts to zero.
+
+The table uses the same DEV/QA/CI/PR icons as `/sprint-report`: `📥`, `🌀`,
+`✅`, `🚩`, `🔨`, `🚧`, `❌`, `🏁`, and `🚀`. Unknown values are shown as `?` or
+`—`, not guessed by the agent.
+
+## Rendering through sc-compose
+
+The JSON contains `mode`, `phase`, `sprint_rows`, `integration_row`, and
+`detailed_rows` variables for the templates in this directory:
+
+```bash
+python3 -m pip install --upgrade 'sc-compose>=1.2,<1.3'
+sc-compose render .claude/skills/triage-report/report.md.j2 \
+  --var-file <(python3 .claude/skills/triage-report/scripts/triage_report.py \
+    --phase AICH --format vars)
+```
+
+`--format vars` is a scalar-only projection of the same canonical result for
+the `sc-compose` var-file boundary. The report script remains the calculation
+boundary even when a newer `sc-compose` release is installed; the template
+only renders its values.

--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -16,6 +16,7 @@ Run from the current `integrate/phase-*` worktree, or pass the worktree
 explicitly:
 
 ```bash
+python3 -m pip install --upgrade rdflib
 python3 .claude/skills/triage-report/scripts/triage_report.py \
   --phase AICH --format table
 python3 .claude/skills/triage-report/scripts/triage_report.py \

--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -59,7 +59,9 @@ The JSON contains `mode`, `phase`, `sprint_rows`, `integration_row`, and
 `detailed_rows` variables for the templates in this directory:
 
 ```bash
-python3 -m pip install --upgrade 'sc-compose>=1.2,<1.3'
+# Install the standalone CLI from the platform release channel first, e.g.:
+brew install randlee/tap/sc-compose
+sc-compose --version  # must be 1.2.0 or newer; no upper bound is enforced
 sc-compose render --root . --file .claude/skills/triage-report/report.md.j2 \
   --var-file <(python3 .claude/skills/triage-report/scripts/triage_report.py \
     --phase AICH --format vars)

--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -61,7 +61,8 @@ sc-compose render .claude/skills/triage-report/report.md.j2 \
     --phase AICH --format vars)
 ```
 
-Use `--mode detailed --format vars` for the detailed template view.
+Use the same `--mode detailed --format vars` projection with
+`report-detailed.md.j2` for the detailed template view.
 
 `--format vars` is a scalar-only projection of the same canonical result for
 the `sc-compose` var-file boundary. The report script remains the calculation

--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -35,6 +35,10 @@ The default QA evidence path is
 replace QA. Missing QA, PR, CI, branch, acknowledgement, or merge inputs stay
 `null` and are listed in `data_gaps`.
 
+The QA message/shared/temp path fields in machine rows are retained as
+host-local evidence pointers from the audit master for drill-down. They are
+not canonical Turtle paths; triage record paths remain repository-relative.
+
 ## Calculated gates
 
 - `ready_to_merge` is true only when the authoritative blocker count is known

--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -56,13 +56,19 @@ The JSON contains `mode`, `phase`, `sprint_rows`, `integration_row`, and
 
 ```bash
 python3 -m pip install --upgrade 'sc-compose>=1.2,<1.3'
-sc-compose render .claude/skills/triage-report/report.md.j2 \
+sc-compose render --root . --file .claude/skills/triage-report/report.md.j2 \
   --var-file <(python3 .claude/skills/triage-report/scripts/triage_report.py \
     --phase AICH --format vars)
 ```
 
 Use the same `--mode detailed --format vars` projection with
 `report-detailed.md.j2` for the detailed template view.
+
+```bash
+sc-compose render --root . --file .claude/skills/triage-report/report-detailed.md.j2 \
+  --var-file <(python3 .claude/skills/triage-report/scripts/triage_report.py \
+    --phase AICH --mode detailed --format vars)
+```
 
 `--format vars` is a scalar-only projection of the same canonical result for
 the `sc-compose` var-file boundary. The report script remains the calculation

--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -60,6 +60,8 @@ sc-compose render .claude/skills/triage-report/report.md.j2 \
     --phase AICH --format vars)
 ```
 
+Use `--mode detailed --format vars` for the detailed template view.
+
 `--format vars` is a scalar-only projection of the same canonical result for
 the `sc-compose` var-file boundary. The report script remains the calculation
 boundary even when a newer `sc-compose` release is installed; the template

--- a/.claude/skills/triage-report/report-detailed.md.j2
+++ b/.claude/skills/triage-report/report-detailed.md.j2
@@ -1,0 +1,12 @@
+---
+name: triage-report-detailed
+version: 1.0.0
+description: Detailed deterministic triage status report.
+format: markdown
+required_variables:
+  - detailed_rows
+  - integration_row
+---
+{{ detailed_rows }}
+────────────────────────────────────────
+{{ integration_row }}

--- a/.claude/skills/triage-report/report.md.j2
+++ b/.claude/skills/triage-report/report.md.j2
@@ -1,0 +1,22 @@
+---
+name: triage-report
+version: 1.0.0
+description: Deterministic triage status report for an integration phase.
+format: markdown
+required_variables:
+  - mode
+  - phase
+  - sprint_rows
+  - integration_row
+  - detailed_rows
+---
+{% if mode == "detailed" %}
+{{ detailed_rows }}
+────────────────────────────────────────
+{{ integration_row }}
+{% else %}
+| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |
+|--------|-----|----|----|----|---|---|---|-------|----|
+{{ sprint_rows }}
+{{ integration_row }}
+{% endif %}

--- a/.claude/skills/triage-report/report.md.j2
+++ b/.claude/skills/triage-report/report.md.j2
@@ -4,19 +4,10 @@ version: 1.0.0
 description: Deterministic triage status report for an integration phase.
 format: markdown
 required_variables:
-  - mode
-  - phase
   - sprint_rows
   - integration_row
-  - detailed_rows
 ---
-{% if mode == "detailed" %}
-{{ detailed_rows }}
-────────────────────────────────────────
-{{ integration_row }}
-{% else %}
 | Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |
 |--------|-----|----|----|----|---|---|---|-------|----|
 {{ sprint_rows }}
 {{ integration_row }}
-{% endif %}

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -145,20 +145,37 @@ def _json(path: Path) -> Any:
 def _sprints(structure: Graph, phase: str) -> list[dict[str, Any]]:
     result = []
     for subject in structure.subjects(RDF.type, TRIAGE.Sprint):
-        phase_ref = next(structure.objects(subject, TRIAGE.inPhase), None)
-        if phase_ref is not None and _local(phase_ref) != f"Phase{phase}":
+        phase_refs = list(structure.objects(subject, TRIAGE.inPhase))
+        if len(phase_refs) != 1:
+            raise ReportError(f"{_local(subject)} must have exactly one triage:inPhase")
+        if _local(phase_refs[0]) != f"Phase{phase}":
             continue
-        order = next(structure.objects(subject, TRIAGE.order), None)
+        order_values = list(structure.objects(subject, TRIAGE.order))
+        criteria_values = list(structure.objects(subject, TRIAGE.criteria))
+        if len(order_values) != 1:
+            raise ReportError(f"{_local(subject)} must have exactly one triage:order")
+        if len(criteria_values) != 1:
+            raise ReportError(f"{_local(subject)} must have exactly one triage:criteria")
+        order_text = str(order_values[0]).strip()
+        if not re.fullmatch(r"[0-9]+", order_text):
+            raise ReportError(f"{_local(subject)} triage:order must be an integer")
+        try:
+            order = int(order_text)
+        except ValueError as exc:
+            raise ReportError(f"{_local(subject)} triage:order must be an integer") from exc
         result.append(
             {
                 "id": _local(subject),
-                "order": int(order) if order is not None else 10**9,
-                "criteria": str(next(structure.objects(subject, TRIAGE.criteria), "")),
+                "order": order,
+                "criteria": str(criteria_values[0]),
             }
         )
     if not result:
         raise ReportError(f"{structure}: no sprints declared for phase {phase}")
-    return sorted(result, key=lambda row: (row["order"], row["id"]))
+    result.sort(key=lambda row: (row["order"], row["id"]))
+    if any(left["order"] == right["order"] for left, right in zip(result, result[1:])):
+        raise ReportError(f"{phase}: sprint orders must be unique")
+    return result
 
 
 def _dev_states(events: Graph | None) -> dict[str, dict[str, Any]]:
@@ -189,11 +206,15 @@ def _dev_states(events: Graph | None) -> dict[str, dict[str, Any]]:
 
 
 def _qa_runs(master: Any) -> dict[str, dict[str, Any]]:
-    if not isinstance(master, dict):
+    if master is None:
         return {}
+    if not isinstance(master, dict) or not isinstance(master.get("runs"), list):
+        raise ReportError("QA evidence master must contain a runs array")
     latest: dict[str, dict[str, Any]] = {}
     for run in master.get("runs", []):
-        if not isinstance(run, dict) or run.get("run_type", "qa") != "qa":
+        if not isinstance(run, dict):
+            raise ReportError("QA evidence master runs entries must be objects")
+        if run.get("run_type", "qa") != "qa":
             continue
         sprint = run.get("aich_sprint")
         if not sprint:
@@ -207,11 +228,15 @@ def _qa_runs(master: Any) -> dict[str, dict[str, Any]]:
 
 
 def _metadata(metadata: Any) -> dict[str, dict[str, Any]]:
-    values = metadata.get("sprints", []) if isinstance(metadata, dict) else []
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, dict) or not isinstance(metadata.get("sprints"), list):
+        raise ReportError("metadata must contain a sprints array")
+    values = metadata["sprints"]
     result: dict[str, dict[str, Any]] = {}
     for item in values:
         if not isinstance(item, dict) or not item.get("id"):
-            continue
+            raise ReportError("metadata.sprints entries must be objects with an id")
         key = str(item["id"])
         if key in result:
             raise ReportError(f"metadata contains duplicate sprint {key}")
@@ -231,10 +256,8 @@ def _phase_sprint(criteria: str) -> str | None:
     return f"AI.{match.group(1)}{'-pre' if match.group(2) else ''}"
 
 
-def _status_icon(status: str | None, merged: bool | None) -> str:
-    if merged is True:
-        return ICONS["merged"]
-    normalized = (status or "").lower().replace("-", "_")
+def _status_icon(status: str | None) -> str:
+    normalized = status.lower().replace("-", "_") if isinstance(status, str) else ""
     if normalized in {"pass", "passed", "success", "green", "ok"}:
         return ICONS["done"]
     if normalized in {"fail", "failed", "failure", "red"}:
@@ -257,8 +280,35 @@ def _gate_icon(value: bool | None) -> str:
 def _pr_cell(meta: dict[str, Any]) -> str:
     number = meta.get("pr_number")
     if isinstance(number, int) and not isinstance(number, bool):
-        return f"#{number}"
+        return f"#{number}{' ' + ICONS['merged'] if meta.get('merged') is True else ''}"
     return "—"
+
+
+def _source_path(path: Path | None, root: Path) -> str | None:
+    if path is None:
+        return None
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return f"<external>/{path.name}"
+
+
+def _validate_metadata(item: dict[str, Any], sprint: str) -> None:
+    for field in ("branch", "head_sha", "target_branch", "pr_url", "ci_status", "ci_url", "merge_commit", "merged_at_utc", "assignment_ack_message_id", "assignment_ack_time_utc"):
+        if item.get(field) is not None and not isinstance(item[field], str):
+            raise ReportError(f"metadata {sprint}.{field} must be a string or null")
+    if item.get("pr_number") is not None and (not isinstance(item["pr_number"], int) or isinstance(item["pr_number"], bool)):
+        raise ReportError(f"metadata {sprint}.pr_number must be an integer or null")
+    if item.get("merged") is not None and not isinstance(item["merged"], bool):
+        raise ReportError(f"metadata {sprint}.merged must be boolean or null")
+
+
+def _validate_qa(run: dict[str, Any] | None, sprint: str) -> None:
+    if run is None:
+        return
+    for field in ("blockers", "important", "minor"):
+        if field in run and run[field] is not None and (not isinstance(run[field], int) or isinstance(run[field], bool) or run[field] < 0):
+            raise ReportError(f"QA run {sprint}.{field} must be a non-negative integer or null")
 
 
 def build_report(
@@ -299,6 +349,8 @@ def build_report(
     meta = _metadata(metadata_data)
     dev = _dev_states(events)
     data_gaps: list[str] = []
+    if events is None:
+        data_gaps.append(f"events file not found: {events_path}")
     if qa_data is None:
         data_gaps.append(f"QA evidence master not found: {qa_master}")
     if metadata is None:
@@ -311,6 +363,8 @@ def build_report(
         sid = sprint["id"]
         run = qa.get(sid)
         item = meta.get(sid, {})
+        _validate_metadata(item, sid)
+        _validate_qa(run, sid)
         counts = {name: _count(run, name) for name in ("blockers", "important", "minor")}
         verdict = str(run.get("verdict", "")) if run else None
         if not verdict and run and isinstance(run.get("pass"), bool):
@@ -318,8 +372,11 @@ def build_report(
         dev_state = dev.get(sid, {})
         completion = dev_state.get("completion_dt")
         assignment = dev_state.get("assignment_dt")
-        dev_done = completion is not None and (assignment is None or completion >= assignment)
+        orphan_completion = completion is not None and assignment is None
+        dev_done = completion is not None and assignment is not None and completion >= assignment
         dev_status = "done" if dev_done else ("in_progress" if assignment else None)
+        if orphan_completion:
+            data_gaps.append(f"{sid}: completion exists without an assignment")
         known_counts = all(value is not None for value in counts.values())
         quality_gate = (all(value == 0 for value in counts.values()) if known_counts else None)
         ready = None if counts["blockers"] is None else counts["blockers"] == 0
@@ -332,7 +389,15 @@ def build_report(
                 "dev_completion_at_utc": dev_state.get("completion_at"),
                 "qa": {
                     "run_id": run.get("run_id") if run else None,
+                    "assignment_time_utc": run.get("assignment_time_utc") if run else None,
+                    "assignment_time_pst": run.get("assignment_time_pst") if run else None,
+                    "assignment_message_id": run.get("assignment_message_id") if run else None,
+                    "result_message_id": run.get("result_message_id") if run else None,
                     "result_time_utc": run.get("result_time_utc") if run else None,
+                    "result_time_pst": run.get("result_time_pst") if run else None,
+                    "assignment_shared_path": run.get("assignment_shared_path") if run else None,
+                    "result_shared_path": run.get("result_shared_path") if run else None,
+                    "result_temp_path": run.get("result_temp_path") if run else None,
                     "verdict": verdict or None,
                     "pass": run.get("pass") if run else None,
                     "blockers": counts["blockers"],
@@ -358,8 +423,15 @@ def build_report(
         )
         if run is None:
             data_gaps.append(f"{sid}: no authoritative QA run")
+        else:
+            for field in ("blockers", "important", "minor"):
+                if counts[field] is None:
+                    data_gaps.append(f"{sid}: QA {field} count is missing or null")
         if sid not in meta:
             data_gaps.append(f"{sid}: no explicit PR/CI/branch/merge metadata")
+        for field in ("branch", "head_sha", "target_branch", "pr_number", "pr_url", "ci_status", "merged", "assignment_ack_message_id", "assignment_ack_time_utc"):
+            if item.get(field) is None:
+                data_gaps.append(f"{sid}: metadata {field} is missing or null")
 
     for index, row in enumerate(rows):
         previous = rows[:index]
@@ -380,7 +452,7 @@ def build_report(
         row["dev_icon"] = ICONS.get(row["dev_status"], "—")
         qa_value = row["qa"]["verdict"]
         row["qa_icon"] = "✅" if qa_value and qa_value.upper() == "PASS" else (ICONS["fail"] if qa_value else "—")
-        row["ci_icon"] = _status_icon(row["ci_status"], row["merged"])
+        row["ci_icon"] = _status_icon(row["ci_status"])
         row["ready_icon"] = _gate_icon(row["ready_to_merge"])
         row["ok_icon"] = _gate_icon(row["ok_to_merge"])
 
@@ -403,7 +475,9 @@ def build_report(
             f"{q['important'] if q['important'] is not None else '?'} / "
             f"{q['minor'] if q['minor'] is not None else '?'}  "
             f"Ready: {row['ready_icon']}  OK: {row['ok_icon']}\n"
-            f"Branch: {row['branch'] or 'unknown'}  Commit: {row['head_sha'] or 'unknown'}"
+            f"QA assignment PST: {q['assignment_time_pst'] or 'unknown'}  result PST: {q['result_time_pst'] or 'unknown'}\n"
+            f"Branch: {row['branch'] or 'unknown'}  Commit: {row['head_sha'] or 'unknown'}\n"
+            f"PR URL: {row['pr_url'] or 'unknown'}"
         )
     integration_row = f"| **integrate/{plan_phase or ('phase-' + phase_name)}** | | — | — | — | — | — | — | — | — |"
     table = (
@@ -416,7 +490,7 @@ def build_report(
         "mode": "table",
         "phase": phase_name,
         "plan_phase": plan_phase,
-        "timezone": "UTC (source timestamps); render PST separately when required",
+        "timezone": "PST (UTC-08:00; fixed offset) for QA display; UTC is retained for source timestamps",
         "generated_at_utc": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "rows": rows,
         "sprint_rows": "\n".join(lines),
@@ -425,11 +499,11 @@ def build_report(
         "table": table,
         "data_gaps": data_gaps,
         "sources": {
-            "integration_root": str(root),
+            "integration_root": ".",
             "structure": str(structure_path.relative_to(root)),
             "events": str(events_path.relative_to(root)) if events_path.is_file() else None,
-            "qa_master": str(qa_master.relative_to(root)) if qa_master.is_relative_to(root) else str(qa_master),
-            "metadata": str(metadata.relative_to(root)) if metadata and metadata.is_relative_to(root) else (str(metadata) if metadata else None),
+            "qa_master": _source_path(qa_master, root),
+            "metadata": _source_path(metadata, root),
         },
     }
 

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""Produce the canonical triage status report for a phase.
+
+The calculations in this module are deliberately independent of presentation.
+The JSON emitted by this command is the source of truth; the markdown template
+only displays its already-calculated values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from rdflib import Graph, Namespace, RDF
+except ImportError as exc:  # pragma: no cover - environment error
+    raise SystemExit("rdflib is required; install it with pip install rdflib") from exc
+
+
+TRIAGE = Namespace("urn:atm:triage:")
+UTC = timezone.utc
+ICONS = {
+    "assigned": "📥",
+    "in_progress": "🌀",
+    "done": "✅",
+    "findings": "🚩",
+    "fixing": "🔨",
+    "blocked": "🚧",
+    "fail": "❌",
+    "merged": "🏁",
+    "ready": "🚀",
+}
+
+
+class ReportError(RuntimeError):
+    """An operational error which prevents a trustworthy report."""
+
+
+def _git(cwd: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args], cwd=cwd, text=True, capture_output=True, check=True
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise ReportError(f"git {' '.join(args)} failed: {detail.strip()}") from exc
+    return result.stdout.strip()
+
+
+def discover_integration_root(cwd: Path) -> Path:
+    """Find the one current-phase integration worktree, fail closed if unclear."""
+    cwd = Path(_git(cwd, "rev-parse", "--show-toplevel"))
+    branch = _git(cwd, "branch", "--show-current")
+    if re.fullmatch(r"integrate/phase-.+", branch):
+        return cwd
+    worktrees = []
+    current_path: Path | None = None
+    current_branch: str | None = None
+    for line in _git(cwd, "worktree", "list", "--porcelain").splitlines() + [""]:
+        if line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree "))
+        elif line.startswith("branch refs/heads/integrate/phase-"):
+            current_branch = line.removeprefix("branch refs/heads/")
+        elif not line.strip():
+            if current_path is not None and current_branch is not None:
+                worktrees.append((current_path, current_branch))
+            current_path = current_branch = None
+    if len(worktrees) != 1:
+        names = ", ".join(str(path) for path, _ in worktrees) or "none"
+        raise ReportError(
+            "cannot determine a unique integrate/phase-* worktree; "
+            f"found {len(worktrees)} ({names}); pass --integration-root"
+        )
+    return worktrees[0][0]
+
+
+def _phase_dir(root: Path, requested: str | None) -> tuple[str, Path]:
+    sprints = root / ".sprints"
+    if requested:
+        phase = requested.removeprefix("phase-")
+        path = sprints / phase
+        if not (path / "structure.ttl").is_file():
+            raise ReportError(f"missing phase structure: {path / 'structure.ttl'}")
+        return phase, path
+    candidates = sorted(p.parent for p in sprints.glob("*/structure.ttl"))
+    if len(candidates) != 1:
+        raise ReportError(
+            "cannot determine a unique phase under .sprints; "
+            f"found {len(candidates)}; pass --phase"
+        )
+    return candidates[0].name, candidates[0]
+
+
+def _parse_ttl(path: Path) -> Graph:
+    graph = Graph()
+    try:
+        graph.parse(path, format="turtle")
+    except Exception as exc:  # noqa: BLE001 - convert parser failures to JSON error
+        raise ReportError(f"{path}: malformed Turtle ({exc})") from exc
+    return graph
+
+
+def _local(value: Any) -> str:
+    text = str(value)
+    return text.rsplit(":", 1)[-1]
+
+
+def _timestamp(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _timestamp_text(value: Any) -> str | None:
+    parsed = _timestamp(value)
+    return parsed.isoformat().replace("+00:00", "Z") if parsed else None
+
+
+def _json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReportError(f"{path}: cannot read JSON ({exc})") from exc
+
+
+def _sprints(structure: Graph, phase: str) -> list[dict[str, Any]]:
+    result = []
+    for subject in structure.subjects(RDF.type, TRIAGE.Sprint):
+        phase_ref = next(structure.objects(subject, TRIAGE.inPhase), None)
+        if phase_ref is not None and _local(phase_ref) != f"Phase{phase}":
+            continue
+        order = next(structure.objects(subject, TRIAGE.order), None)
+        result.append(
+            {
+                "id": _local(subject),
+                "order": int(order) if order is not None else 10**9,
+                "criteria": str(next(structure.objects(subject, TRIAGE.criteria), "")),
+            }
+        )
+    if not result:
+        raise ReportError(f"{structure}: no sprints declared for phase {phase}")
+    return sorted(result, key=lambda row: (row["order"], row["id"]))
+
+
+def _dev_states(events: Graph | None) -> dict[str, dict[str, Any]]:
+    states: dict[str, dict[str, Any]] = {}
+    if events is None:
+        return states
+    for subject in events.subjects(RDF.type, TRIAGE.Assignment):
+        sprint = next(events.objects(subject, TRIAGE.ofSprint), None)
+        if sprint is None:
+            continue
+        key = _local(sprint)
+        stamp = next(events.objects(subject, TRIAGE.assignedAt), None)
+        candidate = _timestamp(stamp)
+        current = states.setdefault(key, {})
+        if candidate and (current.get("assignment_dt") is None or candidate > current["assignment_dt"]):
+            current.update({"assignment_dt": candidate, "assignment_at": _timestamp_text(stamp)})
+    for subject in events.subjects(RDF.type, TRIAGE.Completion):
+        sprint = next(events.objects(subject, TRIAGE.ofSprint), None)
+        if sprint is None:
+            continue
+        key = _local(sprint)
+        stamp = next(events.objects(subject, TRIAGE.at), None)
+        candidate = _timestamp(stamp)
+        current = states.setdefault(key, {})
+        if candidate and (current.get("completion_dt") is None or candidate > current["completion_dt"]):
+            current.update({"completion_dt": candidate, "completion_at": _timestamp_text(stamp)})
+    return states
+
+
+def _qa_runs(master: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(master, dict):
+        return {}
+    latest: dict[str, dict[str, Any]] = {}
+    for run in master.get("runs", []):
+        if not isinstance(run, dict) or run.get("run_type", "qa") != "qa":
+            continue
+        sprint = run.get("aich_sprint")
+        if not sprint:
+            continue
+        candidate = _timestamp(run.get("result_time_utc") or run.get("assignment_time_utc"))
+        previous = latest.get(sprint)
+        previous_dt = _timestamp(previous.get("result_time_utc")) if previous else None
+        if previous is None or (candidate and (previous_dt is None or candidate > previous_dt)):
+            latest[sprint] = run
+    return latest
+
+
+def _metadata(metadata: Any) -> dict[str, dict[str, Any]]:
+    values = metadata.get("sprints", []) if isinstance(metadata, dict) else []
+    result: dict[str, dict[str, Any]] = {}
+    for item in values:
+        if not isinstance(item, dict) or not item.get("id"):
+            continue
+        key = str(item["id"])
+        if key in result:
+            raise ReportError(f"metadata contains duplicate sprint {key}")
+        result[key] = item
+    return result
+
+
+def _count(run: dict[str, Any] | None, name: str) -> int | None:
+    value = run.get(name) if run else None
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _phase_sprint(criteria: str) -> str | None:
+    match = re.search(r"sprint-(?:ai|AI)-([0-9]+)(-pre)?", criteria)
+    if not match:
+        return None
+    return f"AI.{match.group(1)}{'-pre' if match.group(2) else ''}"
+
+
+def _status_icon(status: str | None, merged: bool | None) -> str:
+    if merged is True:
+        return ICONS["merged"]
+    normalized = (status or "").lower().replace("-", "_")
+    if normalized in {"pass", "passed", "success", "green", "ok"}:
+        return ICONS["done"]
+    if normalized in {"fail", "failed", "failure", "red"}:
+        return ICONS["fail"]
+    if normalized in {"blocked", "failing", "error"}:
+        return ICONS["blocked"]
+    if normalized in {"pending", "running", "in_progress", "queued"}:
+        return ICONS["in_progress"]
+    return "—"
+
+
+def _gate_icon(value: bool | None) -> str:
+    if value is True:
+        return ICONS["ready"]
+    if value is False:
+        return ICONS["blocked"]
+    return "?"
+
+
+def _pr_cell(meta: dict[str, Any]) -> str:
+    number = meta.get("pr_number")
+    if isinstance(number, int) and not isinstance(number, bool):
+        return f"#{number}"
+    return "—"
+
+
+def build_report(
+    integration_root: Path,
+    phase: str | None = None,
+    qa_master: Path | None = None,
+    metadata: Path | None = None,
+) -> dict[str, Any]:
+    """Build canonical report data. No presentation-layer inference occurs here."""
+    root = Path(integration_root).resolve()
+    phase_name, phase_path = _phase_dir(root, phase)
+    structure_path = phase_path / "structure.ttl"
+    events_path = phase_path / "events.ttl"
+    structure = _parse_ttl(structure_path)
+    events = _parse_ttl(events_path) if events_path.is_file() else None
+    sprints = _sprints(structure, phase_name)
+
+    plan_phase = None
+    for candidate in sprints:
+        match = re.search(r"docs/plans/([^/]+)/", candidate.get("criteria", ""))
+        if match:
+            plan_phase = match.group(1)
+            break
+    if qa_master is None:
+        # The criteria document is the phase-name source of truth. This keeps
+        # AICH (the graph namespace) distinct from phase-ai (the plan folder).
+        qa_master = root / "docs" / "plans" / (plan_phase or f"phase-{phase_name.lower()}") / ".audit" / "qa-evidence-master.json"
+    qa_master = Path(qa_master)
+    if not qa_master.is_absolute():
+        qa_master = root / qa_master
+    qa_data = _json(qa_master)
+    if metadata is not None and not metadata.is_absolute():
+        metadata = root / metadata
+    metadata_data = _json(metadata) if metadata else None
+    qa = _qa_runs(qa_data)
+    meta = _metadata(metadata_data)
+    dev = _dev_states(events)
+    data_gaps: list[str] = []
+    if qa_data is None:
+        data_gaps.append(f"QA evidence master not found: {qa_master}")
+    if metadata is None:
+        data_gaps.append("PR/CI/branch/merge metadata not supplied; those cells are unknown")
+    elif metadata_data is None:
+        data_gaps.append(f"metadata not found: {metadata}")
+
+    rows: list[dict[str, Any]] = []
+    for sprint in sprints:
+        sid = sprint["id"]
+        run = qa.get(sid)
+        item = meta.get(sid, {})
+        counts = {name: _count(run, name) for name in ("blockers", "important", "minor")}
+        verdict = str(run.get("verdict", "")) if run else None
+        if not verdict and run and isinstance(run.get("pass"), bool):
+            verdict = "PASS" if run["pass"] else "FAIL"
+        dev_state = dev.get(sid, {})
+        completion = dev_state.get("completion_dt")
+        assignment = dev_state.get("assignment_dt")
+        dev_done = completion is not None and (assignment is None or completion >= assignment)
+        dev_status = "done" if dev_done else ("in_progress" if assignment else None)
+        known_counts = all(value is not None for value in counts.values())
+        quality_gate = (all(value == 0 for value in counts.values()) if known_counts else None)
+        ready = None if counts["blockers"] is None else counts["blockers"] == 0
+        rows.append(
+            {
+                **sprint,
+                "phase_sprint": (run or {}).get("phase_sprint") or _phase_sprint(sprint["criteria"]),
+                "dev_status": dev_status,
+                "dev_assignment_at_utc": dev_state.get("assignment_at"),
+                "dev_completion_at_utc": dev_state.get("completion_at"),
+                "qa": {
+                    "run_id": run.get("run_id") if run else None,
+                    "result_time_utc": run.get("result_time_utc") if run else None,
+                    "verdict": verdict or None,
+                    "pass": run.get("pass") if run else None,
+                    "blockers": counts["blockers"],
+                    "important": counts["important"],
+                    "minor": counts["minor"],
+                    "count_basis": run.get("count_basis") if run else None,
+                },
+                "branch": item.get("branch"),
+                "head_sha": item.get("head_sha"),
+                "target_branch": item.get("target_branch"),
+                "pr_number": item.get("pr_number"),
+                "pr_url": item.get("pr_url"),
+                "ci_status": item.get("ci_status"),
+                "ci_url": item.get("ci_url"),
+                "merged": item.get("merged") if isinstance(item.get("merged"), bool) else None,
+                "merge_commit": item.get("merge_commit"),
+                "merged_at_utc": item.get("merged_at_utc"),
+                "assignment_ack_message_id": item.get("assignment_ack_message_id"),
+                "assignment_ack_time_utc": item.get("assignment_ack_time_utc"),
+                "quality_gate": quality_gate,
+                "ready_to_merge": ready,
+            }
+        )
+        if run is None:
+            data_gaps.append(f"{sid}: no authoritative QA run")
+        if sid not in meta:
+            data_gaps.append(f"{sid}: no explicit PR/CI/branch/merge metadata")
+
+    for index, row in enumerate(rows):
+        previous = rows[:index]
+        if not previous:
+            previous_merged: bool | None = True
+        elif any(item["merged"] is False for item in previous):
+            previous_merged = False
+        elif any(item["merged"] is None for item in previous):
+            previous_merged = None
+        else:
+            previous_merged = True
+        row["previous_sprints_merged"] = previous_merged
+        ready = row["ready_to_merge"]
+        row["ok_to_merge"] = (
+            True if ready is True and previous_merged is True else
+            False if ready is False or previous_merged is False else None
+        )
+        row["dev_icon"] = ICONS.get(row["dev_status"], "—")
+        qa_value = row["qa"]["verdict"]
+        row["qa_icon"] = "✅" if qa_value and qa_value.upper() == "PASS" else (ICONS["fail"] if qa_value else "—")
+        row["ci_icon"] = _status_icon(row["ci_status"], row["merged"])
+        row["ready_icon"] = _gate_icon(row["ready_to_merge"])
+        row["ok_icon"] = _gate_icon(row["ok_to_merge"])
+
+    lines = []
+    detailed = []
+    for row in rows:
+        q = row["qa"]
+        phase_sprint = row["phase_sprint"] or "—"
+        lines.append(
+            f"| {row['id']} ({phase_sprint}) | {row['dev_icon']} | {row['qa_icon']} | "
+            f"{row['ci_icon']} | {_pr_cell(row)} | {q['blockers'] if q['blockers'] is not None else '?'} | "
+            f"{q['important'] if q['important'] is not None else '?'} | {q['minor'] if q['minor'] is not None else '?'} | "
+            f"{row['ready_icon']} | {row['ok_icon']} |"
+        )
+        detailed.append(
+            f"Sprint: {row['id']} ({phase_sprint})\n"
+            f"DEV: {row['dev_icon']}  QA: {row['qa_icon']} {q['verdict'] or 'UNKNOWN'}  "
+            f"CI: {row['ci_icon']}  PR: {_pr_cell(row)}\n"
+            f"B/I/M: {q['blockers'] if q['blockers'] is not None else '?'} / "
+            f"{q['important'] if q['important'] is not None else '?'} / "
+            f"{q['minor'] if q['minor'] is not None else '?'}  "
+            f"Ready: {row['ready_icon']}  OK: {row['ok_icon']}\n"
+            f"Branch: {row['branch'] or 'unknown'}  Commit: {row['head_sha'] or 'unknown'}"
+        )
+    integration_row = f"| **integrate/{plan_phase or ('phase-' + phase_name)}** | | — | — | — | — | — | — | — | — |"
+    table = (
+        "| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |\n"
+        "|--------|-----|----|----|----|---|---|---|-------|----|\n"
+        + "\n".join(lines) + "\n" + integration_row
+    )
+    return {
+        "kind": "triage-report/v1",
+        "mode": "table",
+        "phase": phase_name,
+        "plan_phase": plan_phase,
+        "timezone": "UTC (source timestamps); render PST separately when required",
+        "generated_at_utc": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "rows": rows,
+        "sprint_rows": "\n".join(lines),
+        "integration_row": integration_row,
+        "detailed_rows": "\n────────────────────────────────────────\n".join(detailed),
+        "table": table,
+        "data_gaps": data_gaps,
+        "sources": {
+            "integration_root": str(root),
+            "structure": str(structure_path.relative_to(root)),
+            "events": str(events_path.relative_to(root)) if events_path.is_file() else None,
+            "qa_master": str(qa_master.relative_to(root)) if qa_master.is_relative_to(root) else str(qa_master),
+            "metadata": str(metadata.relative_to(root)) if metadata and metadata.is_relative_to(root) else (str(metadata) if metadata else None),
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--integration-root", type=Path)
+    parser.add_argument("--phase")
+    parser.add_argument("--qa-master", type=Path)
+    parser.add_argument("--metadata", type=Path)
+    parser.add_argument("--format", choices=("table", "detailed", "json", "vars"), default="table")
+    parser.add_argument("--json", action="store_true", help="alias for --format json")
+    args = parser.parse_args(argv)
+    try:
+        root = args.integration_root or discover_integration_root(Path.cwd())
+        report = build_report(root, args.phase, args.qa_master, args.metadata)
+    except ReportError as exc:
+        print(json.dumps({"kind": "error", "error": str(exc)}, sort_keys=True))
+        return 2
+    output_format = "json" if args.json else args.format
+    if output_format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif output_format == "vars":
+        # sc-compose var-files intentionally accept scalar/array values, not
+        # the nested evidence objects in the canonical machine report.
+        print(json.dumps({key: report[key] for key in (
+            "mode", "phase", "plan_phase", "sprint_rows", "integration_row", "detailed_rows"
+        )}, indent=2, sort_keys=True))
+    elif output_format == "detailed":
+        print(report["detailed_rows"])
+    else:
+        print(report["table"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -250,10 +250,28 @@ def _count(run: dict[str, Any] | None, name: str) -> int | None:
 
 
 def _phase_sprint(criteria: str) -> str | None:
-    match = re.search(r"sprint-(?:ai|AI)-([0-9]+)(-pre)?", criteria)
+    """Derive the human phase sprint label from a criteria filename.
+
+    Criteria are conventionally named ``sprint-<prefix>-<number>`` (with an
+    optional suffix such as ``-pre``).  Prefixes are intentionally not
+    hard-coded to AI: the same report producer is used by every phase.  A
+    path that advertises the convention but cannot be parsed is rejected so
+    a row is never silently labelled with the wrong sprint.
+    """
+    basename = Path(criteria).name
+    match = re.search(
+        r"^sprint-([A-Za-z][A-Za-z0-9]*)[-.]([0-9]+)(?:-([A-Za-z][A-Za-z0-9]*))?",
+        basename,
+    )
     if not match:
+        if basename.lower().startswith("sprint-"):
+            raise ReportError(
+                f"unsupported sprint criteria filename {basename!r}; expected "
+                "sprint-<prefix>-<number>[-suffix]"
+            )
         return None
-    return f"AI.{match.group(1)}{'-pre' if match.group(2) else ''}"
+    suffix = f"-{match.group(3)}" if match.group(3) else ""
+    return f"{match.group(1).upper()}.{match.group(2)}{suffix}"
 
 
 def _status_icon(status: str | None) -> str:
@@ -311,6 +329,104 @@ def _validate_qa(run: dict[str, Any] | None, sprint: str) -> None:
             raise ReportError(f"QA run {sprint}.{field} must be a non-negative integer or null")
 
 
+def _findings_dir(root: Path, plan_phase: str | None) -> Path:
+    """Resolve the phase findings directory without guessing across phases."""
+    if not plan_phase:
+        raise ReportError(
+            "cannot locate findings: sprint criteria do not declare a plan phase"
+        )
+    suffix = plan_phase.removeprefix("phase-")
+    candidates = [
+        root / ".triage" / plan_phase,
+        root / ".triage" / f"phase-{suffix.upper()}",
+        root / ".triage" / f"phase-{suffix}",
+    ]
+    existing: list[Path] = []
+    # macOS's default filesystem is case-insensitive even though Path keeps
+    # the spelling supplied by the caller; compare case-folded real paths.
+    existing_real: set[str] = set()
+    for candidate in candidates:
+        findings = candidate / "findings"
+        if findings.is_dir():
+            resolved = findings.resolve()
+            identity = str(resolved).casefold()
+            if identity not in existing_real:
+                existing_real.add(identity)
+                existing.append(resolved)
+    if len(existing) != 1:
+        listed = ", ".join(str(item) for item in existing) or "none"
+        raise ReportError(
+            f"cannot determine unique findings directory for {plan_phase}: "
+            f"found {len(existing)} ({listed})"
+        )
+    return existing[0]
+
+
+def _run_findings_validator(
+    root: Path,
+    findings_dir: Path,
+    structure_path: Path,
+    events_path: Path,
+) -> dict[str, Any]:
+    """Run the canonical findings validator before any report is produced.
+
+    ``validation:fail`` is a completed validation with invalid records, and
+    therefore blocks report generation just like an operational validator
+    error.  Keeping this subprocess boundary means this script always uses
+    the exact validator shipped by graph-orchestration.
+    """
+    validator = (
+        Path(__file__).resolve().parents[2]
+        / "graph-orchestration"
+        / "scripts"
+        / "validate-findings.py"
+    )
+    if not validator.is_file():
+        raise ReportError(f"findings validator not found: {validator}")
+    command = [
+        sys.executable,
+        str(validator),
+        "--findings-dir",
+        str(findings_dir),
+        "--structure",
+        str(structure_path),
+        "--events",
+        str(events_path),
+        "--json",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            cwd=root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise ReportError(f"could not execute findings validator: {exc}") from exc
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        detail = (result.stderr or result.stdout).strip()
+        raise ReportError(
+            f"findings validator returned non-JSON (exit {result.returncode}): {detail}"
+        ) from exc
+    if not isinstance(payload, dict) or payload.get("kind") not in {
+        "validation:pass",
+        "validation:fail",
+        "error",
+    }:
+        raise ReportError("findings validator returned an invalid result object")
+    if payload.get("kind") != "validation:pass" or result.returncode != 0:
+        diagnostics = payload.get("diagnostics") or []
+        detail = "; ".join(str(item) for item in diagnostics[:8])
+        message = payload.get("message") or payload.get("kind") or "unknown result"
+        if detail:
+            message = f"{message}: {detail}"
+        raise ReportError(f"findings validation blocked report: {message}")
+    return payload
+
+
 def build_report(
     integration_root: Path,
     phase: str | None = None,
@@ -345,6 +461,10 @@ def build_report(
     if metadata is not None and not metadata.is_absolute():
         metadata = root / metadata
     metadata_data = _json(metadata) if metadata else None
+    # Validate raw findings before calculating a single row.  This prevents
+    # query_runner's phase scoping from hiding malformed or orphan records.
+    findings_dir = _findings_dir(root, plan_phase)
+    validation = _run_findings_validator(root, findings_dir, structure_path, events_path)
     qa = _qa_runs(qa_data)
     meta = _metadata(metadata_data)
     dev = _dev_states(events)
@@ -498,6 +618,7 @@ def build_report(
         "detailed_rows": "\n────────────────────────────────────────\n".join(detailed),
         "table": table,
         "data_gaps": data_gaps,
+        "validation": validation,
         "sources": {
             "integration_root": ".",
             "structure": str(structure_path.relative_to(root)),

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -19,11 +19,13 @@ from typing import Any
 
 try:
     from rdflib import Graph, Namespace, RDF
+    _RDFLIB_ERROR = None
 except ImportError as exc:  # pragma: no cover - environment error
-    raise SystemExit("rdflib is required; install it with pip install rdflib") from exc
+    Graph = Namespace = RDF = None  # type: ignore[assignment]
+    _RDFLIB_ERROR = str(exc)
 
 
-TRIAGE = Namespace("urn:atm:triage:")
+TRIAGE = Namespace("urn:atm:triage:") if Namespace else None
 UTC = timezone.utc
 ICONS = {
     "assigned": "📥",
@@ -266,6 +268,8 @@ def build_report(
     metadata: Path | None = None,
 ) -> dict[str, Any]:
     """Build canonical report data. No presentation-layer inference occurs here."""
+    if _RDFLIB_ERROR:
+        raise ReportError(f"rdflib is required; install it with pip install rdflib ({_RDFLIB_ERROR})")
     root = Path(integration_root).resolve()
     phase_name, phase_path = _phase_dir(root, phase)
     structure_path = phase_path / "structure.ttl"
@@ -437,6 +441,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--qa-master", type=Path)
     parser.add_argument("--metadata", type=Path)
     parser.add_argument("--format", choices=("table", "detailed", "json", "vars"), default="table")
+    parser.add_argument("--mode", choices=("table", "detailed"), default="table", help="template display mode for --format vars")
     parser.add_argument("--json", action="store_true", help="alias for --format json")
     args = parser.parse_args(argv)
     try:
@@ -446,6 +451,7 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps({"kind": "error", "error": str(exc)}, sort_keys=True))
         return 2
     output_format = "json" if args.json else args.format
+    report["mode"] = "detailed" if args.format == "detailed" else args.mode
     if output_format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))
     elif output_format == "vars":

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -1,0 +1,87 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "triage_report.py"
+spec = importlib.util.spec_from_file_location("triage_report", SCRIPT)
+triage_report = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(triage_report)
+
+PREFIX = "@prefix triage: <urn:atm:triage:> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+
+
+def _inputs(tmp_path: Path):
+    root = tmp_path / "repo"
+    structure_dir = root / ".sprints" / "AICH"
+    structure_dir.mkdir(parents=True)
+    (structure_dir / "structure.ttl").write_text(
+        PREFIX
+        + "triage:PhaseAICH a triage:Phase .\n"
+        + "triage:AICH-S1 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 1 ; triage:criteria \"docs/s1.md\" .\n"
+        + "triage:AICH-S2 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 2 ; triage:criteria \"docs/s2.md\" .\n"
+    )
+    (structure_dir / "events.ttl").write_text(
+        PREFIX
+        + "triage:a1 a triage:Assignment ; triage:ofSprint triage:AICH-S1 ; triage:assignedAt \"2026-07-25T01:00:00Z\"^^xsd:dateTime .\n"
+        + "triage:c1 a triage:Completion ; triage:ofSprint triage:AICH-S1 ; triage:at \"2026-07-25T02:00:00Z\"^^xsd:dateTime .\n"
+        + "triage:a2 a triage:Assignment ; triage:ofSprint triage:AICH-S2 ; triage:assignedAt \"2026-07-25T03:00:00Z\"^^xsd:dateTime .\n"
+    )
+    qa_path = root / "qa.json"
+    qa_path.write_text(json.dumps({"runs": [
+        {"run_id": "S1-QA1", "aich_sprint": "AICH-S1", "run_type": "qa", "result_time_utc": "2026-07-25T03:00:00Z", "verdict": "FAIL", "blockers": 1, "important": 2, "minor": 0, "count_basis": "headline"},
+        {"run_id": "S1-review", "aich_sprint": "AICH-S1", "run_type": "reviewer-only", "result_time_utc": "2026-07-25T04:00:00Z", "verdict": "PASS", "blockers": 0, "important": 0, "minor": 0},
+        {"run_id": "S2-QA1", "aich_sprint": "AICH-S2", "run_type": "qa", "result_time_utc": "2026-07-25T05:00:00Z", "verdict": "PASS", "blockers": 0, "important": 0, "minor": 0},
+    ]}))
+    metadata = root / "metadata.json"
+    metadata.write_text(json.dumps({"sprints": [
+        {"id": "AICH-S1", "branch": "feature/s1", "head_sha": "abc", "pr_number": 1, "ci_status": "pass", "merged": True},
+        {"id": "AICH-S2", "branch": "feature/s2", "head_sha": "def", "pr_number": 2, "ci_status": "pending", "merged": False},
+    ]}))
+    return root, qa_path, metadata
+
+
+def test_latest_authoritative_qa_and_gates(tmp_path):
+    root, qa, metadata = _inputs(tmp_path)
+    report = triage_report.build_report(root, "AICH", qa, metadata)
+    first, second = report["rows"]
+    assert first["qa"]["run_id"] == "S1-QA1"  # reviewer-only is excluded
+    assert first["qa"]["blockers"] == 1
+    assert first["ready_to_merge"] is False
+    assert first["ok_to_merge"] is False
+    assert second["ready_to_merge"] is True
+    assert second["previous_sprints_merged"] is True
+    assert second["ok_to_merge"] is True
+    assert "| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |" in report["table"]
+    assert "❌" in report["table"] and "🏁" in report["table"]
+
+
+def test_unknown_merge_is_fail_closed(tmp_path):
+    root, qa, _ = _inputs(tmp_path)
+    report = triage_report.build_report(root, "AICH", qa)
+    first, second = report["rows"]
+    assert first["merged"] is None
+    assert first["ok_to_merge"] is False  # blockers are known and nonzero
+    assert second["previous_sprints_merged"] is None
+    assert second["ok_to_merge"] is None
+    assert report["data_gaps"]
+
+
+def test_missing_integration_worktree_is_structured_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(triage_report, "_git", lambda *args: "develop")
+    result = triage_report.main([])
+    assert result == 2
+
+
+def test_malformed_structure_is_report_error(tmp_path):
+    root = tmp_path / "repo"
+    phase = root / ".sprints" / "AICH"
+    phase.mkdir(parents=True)
+    (phase / "structure.ttl").write_text("not turtle [")
+    try:
+        triage_report.build_report(root, "AICH")
+    except triage_report.ReportError as exc:
+        assert "malformed Turtle" in str(exc)
+    else:
+        raise AssertionError("malformed structure must fail")

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -19,8 +19,8 @@ def _inputs(tmp_path: Path):
     (structure_dir / "structure.ttl").write_text(
         PREFIX
         + "triage:PhaseAICH a triage:Phase .\n"
-        + "triage:AICH-S1 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 1 ; triage:criteria \"docs/s1.md\" .\n"
-        + "triage:AICH-S2 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 2 ; triage:criteria \"docs/s2.md\" .\n"
+        + "triage:AICH-S1 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 1 ; triage:criteria \"docs/plans/phase-ai/sprint-ai-21-pre.md\" .\n"
+        + "triage:AICH-S2 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 2 ; triage:criteria \"docs/plans/phase-ai/sprint-ai-22.md\" .\n"
     )
     (structure_dir / "events.ttl").write_text(
         PREFIX
@@ -54,7 +54,7 @@ def test_latest_authoritative_qa_and_gates(tmp_path):
     assert second["previous_sprints_merged"] is True
     assert second["ok_to_merge"] is True
     assert "| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |" in report["table"]
-    assert "❌" in report["table"] and "🏁" in report["table"]
+    assert "| AICH-S1 (AI.21-pre) | ✅ | ❌ | ✅ | #1 🏁 |" in report["table"]
 
 
 def test_unknown_merge_is_fail_closed(tmp_path):
@@ -85,3 +85,32 @@ def test_malformed_structure_is_report_error(tmp_path):
         assert "malformed Turtle" in str(exc)
     else:
         raise AssertionError("malformed structure must fail")
+
+
+def test_malformed_metadata_is_report_error(tmp_path):
+    root, qa, _ = _inputs(tmp_path)
+    metadata = root / "bad-metadata.json"
+    metadata.write_text(json.dumps({"sprints": [{"id": "AICH-S1", "ci_status": True}]}))
+    try:
+        triage_report.build_report(root, "AICH", qa, metadata)
+    except triage_report.ReportError as exc:
+        assert "ci_status" in str(exc)
+    else:
+        raise AssertionError("malformed metadata must fail")
+
+
+def test_duplicate_structure_orders_are_report_error(tmp_path):
+    root, _, _ = _inputs(tmp_path)
+    structure = root / ".sprints" / "AICH" / "structure.ttl"
+    structure.write_text(
+        PREFIX
+        + "triage:PhaseAICH a triage:Phase .\n"
+        + "triage:AICH-S1 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 1 ; triage:criteria \"docs/s1.md\" .\n"
+        + "triage:AICH-S2 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 1 ; triage:criteria \"docs/s2.md\" .\n"
+    )
+    try:
+        triage_report.build_report(root, "AICH")
+    except triage_report.ReportError as exc:
+        assert "orders must be unique" in str(exc)
+    else:
+        raise AssertionError("duplicate sprint orders must fail")

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -2,6 +2,8 @@ import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "triage_report.py"
 spec = importlib.util.spec_from_file_location("triage_report", SCRIPT)
@@ -10,6 +12,20 @@ assert spec.loader is not None
 spec.loader.exec_module(triage_report)
 
 PREFIX = "@prefix triage: <urn:atm:triage:> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+
+
+@pytest.fixture(autouse=True)
+def _validator_passes(monkeypatch):
+    """Keep report unit tests hermetic; validator invocation has a dedicated test."""
+    monkeypatch.setattr(
+        triage_report,
+        "_run_findings_validator",
+        lambda *args: {
+            "kind": "validation:pass",
+            "diagnostics": [],
+            "summary": {"files": 1, "findings": 1, "errors": 0, "warnings": 0},
+        },
+    )
 
 
 def _inputs(tmp_path: Path):
@@ -27,6 +43,14 @@ def _inputs(tmp_path: Path):
         + "triage:a1 a triage:Assignment ; triage:ofSprint triage:AICH-S1 ; triage:assignedAt \"2026-07-25T01:00:00Z\"^^xsd:dateTime .\n"
         + "triage:c1 a triage:Completion ; triage:ofSprint triage:AICH-S1 ; triage:at \"2026-07-25T02:00:00Z\"^^xsd:dateTime .\n"
         + "triage:a2 a triage:Assignment ; triage:ofSprint triage:AICH-S2 ; triage:assignedAt \"2026-07-25T03:00:00Z\"^^xsd:dateTime .\n"
+    )
+    findings_dir = root / ".triage" / "phase-AI" / "findings"
+    findings_dir.mkdir(parents=True)
+    (findings_dir / "S1.ttl").write_text(
+        PREFIX
+        + "triage:F1 a triage:Finding ; triage:findingId \"F1\" ; "
+        + "triage:foundIn triage:AICH-S1 ; "
+        + "triage:foundAt \"2026-07-25T03:00:00Z\"^^xsd:dateTime .\n"
     )
     qa_path = root / "qa.json"
     qa_path.write_text(json.dumps({"runs": [
@@ -114,3 +138,52 @@ def test_duplicate_structure_orders_are_report_error(tmp_path):
         assert "orders must be unique" in str(exc)
     else:
         raise AssertionError("duplicate sprint orders must fail")
+
+
+def test_findings_validator_is_called_before_rows(tmp_path, monkeypatch):
+    root, qa, metadata = _inputs(tmp_path)
+    calls = []
+
+    def validator(*args):
+        calls.append(args)
+        return {"kind": "validation:pass", "diagnostics": []}
+
+    monkeypatch.setattr(triage_report, "_run_findings_validator", validator)
+    report = triage_report.build_report(root, "AICH", qa, metadata)
+    assert len(calls) == 1
+    assert calls[0][1].name == "findings"
+    assert calls[0][2].name == "structure.ttl"
+    assert calls[0][3].name == "events.ttl"
+    assert report["validation"]["kind"] == "validation:pass"
+
+
+def test_findings_validator_subprocess_passes_for_valid_schema(tmp_path):
+    root, _, _ = _inputs(tmp_path)
+    findings_dir = root / ".triage" / "phase-AI" / "findings"
+    result = triage_report._run_findings_validator(
+        root,
+        findings_dir,
+        root / ".sprints" / "AICH" / "structure.ttl",
+        root / ".sprints" / "AICH" / "events.ttl",
+    )
+    assert result["kind"] == "validation:pass"
+
+
+def test_validator_failure_blocks_report(tmp_path, monkeypatch):
+    root, qa, metadata = _inputs(tmp_path)
+
+    def validator(*args):
+        raise triage_report.ReportError(
+            "findings validation blocked report: validation:fail"
+        )
+
+    monkeypatch.setattr(triage_report, "_run_findings_validator", validator)
+    with pytest.raises(triage_report.ReportError, match="validation blocked"):
+        triage_report.build_report(root, "AICH", qa, metadata)
+
+
+def test_phase_sprint_accepts_non_ai_prefix_and_rejects_bad_convention():
+    assert triage_report._phase_sprint("docs/sprint-ak-7.md") == "AK.7"
+    assert triage_report._phase_sprint("docs/sprint-ak-7-pre-notes.md") == "AK.7-pre"
+    with pytest.raises(triage_report.ReportError, match="unsupported sprint criteria"):
+        triage_report._phase_sprint("docs/sprint-ak-not-number.md")

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -1,7 +1,18 @@
 ---
 name: triaging-findings
-version: 1.2.0
+version: 1.3.0
 description: Orchestrate pre-dispatch QA finding triage as team-lead. Launch one qa-triage agent per finding, collect phase-scoped Turtle records, aggregate by promoted branch, and only then dispatch branch-scoped fix assignments to arch-ctm.
+requires:
+  cli:
+    - name: sc-compose
+      minimum_version: 1.2.0
+    - name: oxigraph
+    - name: rg
+  python:
+    - package: rdflib
+    - package: sc-compose
+      import_name: sc_compose
+      minimum_version: 1.2.0
 depends_on:
   codex-orchestration: 0.x
   quality-management-gh: 1.x
@@ -14,6 +25,25 @@ Audience: `team-lead` only.
 Use this skill when QA has produced findings and you need to correlate them
 across worktrees before any fix work is sent to `arch-ctm`.
 
+## Step 1 — Verify CLI dependencies
+
+Run this preflight before reading inputs, delegating agents, or rendering a
+record:
+
+```bash
+python3 .claude/skills/triaging-findings/scripts/check_dependencies.py
+```
+
+The preflight requires the `sc-compose` CLI and Python `sc_compose` binding at
+`>= 1.2.0`, plus `oxigraph`, `rg`, and Python `rdflib`. It checks PATH plus
+common Homebrew/Cargo/user-install locations and returns a structured result.
+A non-zero result is a hard stop; read
+`references/installation-and-troubleshooting.md`, fix the environment, and
+rerun the preflight. Do not silently continue with a missing or old CLI.
+
+The installation reference is intentionally separate from this entry point so
+it is loaded only when setup or troubleshooting is needed.
+
 For phase-end learning and process hardening, also read:
 - `references/post-mortem.md`
 
@@ -24,8 +54,8 @@ Before using this workflow:
 2. The target phase has an explicit `phase_id` such as `phase-R`.
 3. The ordered worktree list is known in promotion order.
 4. QA findings exist in a structured form with stable finding ids.
-5. `sc-compose` and `oxigraph` are installed for rendering and parsing
-   canonical Turtle records.
+5. The Step 1 preflight passes: `sc-compose >= 1.2.0` CLI and Python binding,
+   `oxigraph`, `rg`, and Python `rdflib` are available.
 
 ## Ownership Model
 

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -74,6 +74,8 @@ For each triage batch, assemble:
 - `integration_worktree_path`
 - `triage_root`
 - ordered `worktrees` with branch, absolute path, head SHA, and order index
+- repository-relative `worktree_paths` labels aligned with `worktrees` (never
+  copy the runtime checkout paths)
 - finding records with:
   - `finding_id`
   - `title`
@@ -106,10 +108,11 @@ Required ownership rule:
 Runtime checkout paths (`integration_worktree_path`, `triage_root`, and
 `worktrees[].path`) may be absolute while the sweep runs, but they are not
 canonical finding data and must not be copied into the Turtle record. The
-`triage:Occurrence` `triage:file` value must be repository-relative (no
-leading `/`, any `..` path component, or drive prefix). External worktree checkout paths
-are intentionally omitted from `triage:WorktreeSnapshot`; persist only its
-branch, head SHA, and promotion order.
+`triage:Occurrence` `triage:file` and `triage:WorktreeSnapshot`
+`triage:path` values must be repository-relative (no leading `/` or `\\`, any
+`..` path component, or drive prefix). Supply a repository-relative worktree
+label in `worktree_paths`; never pass the runtime checkout path in that array.
+The template rejects invalid values before the Turtle parse check.
 
 ## Canonical Turtle rendering
 
@@ -120,7 +123,7 @@ including `found_in` and `found_at`. The occurrence and worktree inputs are
 parallel scalar arrays (`occurrences` with `occurrence_files`,
 `occurrence_lines`, `occurrence_snippets`, `occurrence_statuses`,
 `occurrence_closed`, `occurrence_branches`, `occurrence_head_shas`, and
-`occurrence_worktree_ids`; likewise `worktrees` with
+`occurrence_worktree_ids`; likewise `worktrees` with `worktree_paths`,
 `worktree_branches`, `worktree_head_shas`, and `worktree_order_indices`). Keep
 each array aligned by index.
 
@@ -252,31 +255,6 @@ Reason:
 Do not dispatch dev work from uncommitted `.ttl` state.
 
 The per-finding `.ttl` record is canonical. Aggregation is derived.
-
-### 3.1 Commit triage artifacts before dispatch
-
-After all `qa-triage` agents in the batch have finished and after aggregation
-confirms the `.ttl` set is complete, stage, commit, and push the triage
-artifacts to git before sending any dev assignment to `arch-ctm`.
-
-Required commit scope:
-- the phase findings under `<triage_root>/<phase_id>/findings/`
-- any phase-local triage metadata needed for later follow-up, such as
-  worktree inventories under `<triage_root>/<phase_id>/`
-
-Required timing:
-- after triage batch aggregation
-- before branch-scoped fix dispatch
-- on the phase integration-branch worktree identified by
-  `integration_branch` / `integration_worktree_path`
-
-Reason:
-- parallel `qa-triage` agents write into one shared triage root
-- committing inside each agent would create batch races and partial evidence
-- leaving `.ttl` records untracked until phase end risks silent loss of the
-  canonical QA evidence
-
-Do not dispatch dev work from uncommitted `.ttl` state.
 
 ### 4. Dispatch branch-scoped fix work to `arch-ctm`
 

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triaging-findings
-version: 1.1.0
+version: 1.2.0
 description: Orchestrate pre-dispatch QA finding triage as team-lead. Launch one qa-triage agent per finding, collect phase-scoped Turtle records, aggregate by promoted branch, and only then dispatch branch-scoped fix assignments to arch-ctm.
 depends_on:
   codex-orchestration: 0.x
@@ -24,7 +24,8 @@ Before using this workflow:
 2. The target phase has an explicit `phase_id` such as `phase-R`.
 3. The ordered worktree list is known in promotion order.
 4. QA findings exist in a structured form with stable finding ids.
-5. `sc-compose` is installed for rendering assignment templates.
+5. `sc-compose` and `oxigraph` are installed for rendering and parsing
+   canonical Turtle records.
 
 ## Ownership Model
 
@@ -47,10 +48,19 @@ For each triage batch, assemble:
   - `finding_id`
   - `title`
   - `description`
+  - `phase_id`
+  - `triage_mode`
+  - `category`
   - `severity`
   - `pattern`
   - `repeatable`
   - `sweep_scope`
+  - `status`
+  - `dispatch_ready`
+  - `triaged_at`
+  - `found_in` (declared sprint local id, such as `AICH-S7`)
+  - `found_at` (authoritative QA discovery/result timestamp in UTC ending in
+    `Z`)
 - triage mode:
   - `initial_pass`
   - `followup_pass`
@@ -62,6 +72,43 @@ Required ownership rule:
 - `triage_root` must live under `integration_worktree_path`
 - the phase integration worktree is the canonical source of truth for triage
   artifacts
+
+## Canonical Turtle rendering
+
+Every finding record must be rendered from
+`.claude/skills/triaging-findings/triage-record.ttl.j2`; do not hand-write a
+parallel Turtle shape. Its frontmatter declares the required variables above,
+including `found_in` and `found_at`. The occurrence and worktree inputs are
+parallel scalar arrays (`occurrences` with `occurrence_files`,
+`occurrence_lines`, `occurrence_snippets`, `occurrence_statuses`,
+`occurrence_closed`, `occurrence_branches`, `occurrence_head_shas`, and
+`occurrence_worktree_ids`; likewise `worktrees` with
+`worktree_branches`, `worktree_paths`, `worktree_head_shas`, and
+`worktree_order_indices`). Keep each array aligned by index.
+
+Render to the canonical path and parse it before committing the batch:
+
+```bash
+TRIAGE_ROOT=/abs/integrate-phase-R/.triage
+PHASE_ID=phase-R
+FINDING_ID=FTQ-001
+OUTPUT="$TRIAGE_ROOT/$PHASE_ID/findings/$FINDING_ID.ttl"
+mkdir -p "$(dirname "$OUTPUT")"
+sc-compose render \
+  --root . \
+  --file .claude/skills/triaging-findings/triage-record.ttl.j2 \
+  --var-file /tmp/triage-record-vars.json \
+  --output "$OUTPUT"
+STORE=$(mktemp -d)
+trap 'rm -rf "$STORE"' EXIT
+oxigraph load --location "$STORE" --file "$OUTPUT" --format ttl
+```
+
+The rendered Finding must contain `triage:foundIn triage:<declared-sprint>` and
+`triage:foundAt "<UTC timestamp ending in Z>"^^xsd:dateTime`. Missing required
+vars must fail the render through the template frontmatter contract; malformed
+Turtle must fail the Oxigraph parse. Do not add `--strict` to this render until
+`sc-compose` supports loop-local names in strict token validation.
 
 ## Triage Modes
 

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -73,6 +73,14 @@ Required ownership rule:
 - the phase integration worktree is the canonical source of truth for triage
   artifacts
 
+Runtime checkout paths (`integration_worktree_path`, `triage_root`, and
+`worktrees[].path`) may be absolute while the sweep runs, but they are not
+canonical finding data and must not be copied into the Turtle record. The
+`triage:Occurrence` `triage:file` value must be repository-relative (no
+leading `/`, any `..` path component, or drive prefix). External worktree checkout paths
+are intentionally omitted from `triage:WorktreeSnapshot`; persist only its
+branch, head SHA, and promotion order.
+
 ## Canonical Turtle rendering
 
 Every finding record must be rendered from
@@ -83,8 +91,8 @@ parallel scalar arrays (`occurrences` with `occurrence_files`,
 `occurrence_lines`, `occurrence_snippets`, `occurrence_statuses`,
 `occurrence_closed`, `occurrence_branches`, `occurrence_head_shas`, and
 `occurrence_worktree_ids`; likewise `worktrees` with
-`worktree_branches`, `worktree_paths`, `worktree_head_shas`, and
-`worktree_order_indices`). Keep each array aligned by index.
+`worktree_branches`, `worktree_head_shas`, and `worktree_order_indices`). Keep
+each array aligned by index.
 
 Render to the canonical path and parse it before committing the batch:
 
@@ -106,9 +114,11 @@ oxigraph load --location "$STORE" --file "$OUTPUT" --format ttl
 
 The rendered Finding must contain `triage:foundIn triage:<declared-sprint>` and
 `triage:foundAt "<UTC timestamp ending in Z>"^^xsd:dateTime`. Missing required
-vars must fail the render through the template frontmatter contract; malformed
-Turtle must fail the Oxigraph parse. Do not add `--strict` to this render until
-`sc-compose` supports loop-local names in strict token validation.
+vars must fail the render through the template frontmatter contract; a
+non-repository-relative occurrence path renders an invalid sentinel and must
+fail the Oxigraph parse. Malformed Turtle must likewise fail the Oxigraph
+parse. Do not add `--strict` to this render until `sc-compose` supports
+loop-local names in strict token validation.
 
 ## Triage Modes
 

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -107,18 +107,22 @@ sc-compose render \
   --file .claude/skills/triaging-findings/triage-record.ttl.j2 \
   --var-file /tmp/triage-record-vars.json \
   --output "$OUTPUT"
-STORE=$(mktemp -d)
-trap 'rm -rf "$STORE"' EXIT
-oxigraph load --location "$STORE" --file "$OUTPUT" --format ttl
+PARSED=$(mktemp)
+trap 'rm -f "$PARSED"' EXIT
+oxigraph convert \
+  --from-file "$OUTPUT" \
+  --from-format ttl \
+  --to-file "$PARSED" \
+  --to-format ttl
 ```
 
 The rendered Finding must contain `triage:foundIn triage:<declared-sprint>` and
 `triage:foundAt "<UTC timestamp ending in Z>"^^xsd:dateTime`. Missing required
 vars must fail the render through the template frontmatter contract; a
 non-repository-relative occurrence path renders an invalid sentinel and must
-fail the Oxigraph parse. Malformed Turtle must likewise fail the Oxigraph
-parse. Do not add `--strict` to this render until `sc-compose` supports
-loop-local names in strict token validation.
+make `oxigraph convert` exit nonzero. Malformed Turtle must likewise make the
+conversion fail. Do not add `--strict` to this render until `sc-compose`
+supports loop-local names in strict token validation.
 
 ## Triage Modes
 

--- a/.claude/skills/triaging-findings/references/installation-and-troubleshooting.md
+++ b/.claude/skills/triaging-findings/references/installation-and-troubleshooting.md
@@ -9,7 +9,7 @@ requires:
 | Python `sc_compose` binding | **1.2.0** | Native Python rendering/API tests |
 | `oxigraph` | supported installed release | Parse/validate rendered Turtle |
 | `rg` | installed | Sweep source worktrees |
-| Python `rdflib` | installed in the invoking Python | Graph/query support |
+| Python `rdflib` | **3.11+**, installed in the invoking Python | Graph/query support |
 
 ## Check first
 
@@ -24,18 +24,19 @@ locations. If it reports success, do not reinstall anything.
 
 ## Install
 
-macOS (recommended, avoids PEP 668 system-Python restrictions):
+macOS (one-time per-machine setup):
 
 ```bash
 brew install randlee/tap/sc-compose
-python3 -m venv .venv-triaging-findings
-.venv-triaging-findings/bin/python -m pip install --upgrade pip
-.venv-triaging-findings/bin/python -m pip install 'sc-compose>=1.2.0' rdflib pytest
-export PATH="$PWD/.venv-triaging-findings/bin:$PATH"
+python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'
 cargo install oxigraph-cli
 ```
 
-The PyPI package supplies the `sc_compose` Python binding; it does not replace
+The `--user` target avoids Homebrew-managed site-packages and
+`--break-system-packages` is Python's sanctioned override for this trusted
+user-owned wheel. Do not create or activate a venv for this setup. The PyPI
+package supplies the `sc_compose` Python binding (Python 3.11+; prebuilt
+platform wheels); it does not replace
 the standalone `sc-compose` CLI. On Linux without Homebrew, install the CLI
 from the v1.2.0 release or from a source checkout with the upstream
 `cargo install --path crates/sc-compose` procedure.
@@ -43,10 +44,7 @@ from the v1.2.0 release or from a source checkout with the upstream
 Linux:
 
 ```bash
-python3 -m venv .venv-triaging-findings
-.venv-triaging-findings/bin/python -m pip install --upgrade pip
-.venv-triaging-findings/bin/python -m pip install 'sc-compose>=1.2.0' rdflib pytest
-export PATH="$PWD/.venv-triaging-findings/bin:$PATH"
+python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'
 # Install the standalone CLI from the v1.2.0 release, or from source:
 # cargo install --path crates/sc-compose
 cargo install oxigraph-cli
@@ -62,9 +60,7 @@ sudo apt-get install ripgrep         # Debian/Ubuntu
 Windows PowerShell:
 
 ```powershell
-py -m venv .venv-triaging-findings
-.venv-triaging-findings\Scripts\python -m pip install --upgrade pip
-.venv-triaging-findings\Scripts\python -m pip install "sc-compose>=1.2.0" rdflib pytest
+py -m pip install --user --break-system-packages "sc-compose>=1.2.0"
 cargo install oxigraph-cli
 winget install BurntSushi.ripgrep.MSVC
 ```
@@ -113,9 +109,11 @@ python3 .claude/skills/triaging-findings/scripts/check_dependencies.py
 - Installing with one Python and invoking the skill with another leaves
   `rdflib` unavailable. Compare `python3 -c 'import sys; print(sys.executable)'`
   with the interpreter used for installation.
-- Homebrew/system Python may reject global `pip install` with an
-  `externally-managed-environment` (PEP 668) error. Use the venv commands above;
-  do not bypass the protection with `--break-system-packages` for this workflow.
+- Homebrew/system Python may reject plain `pip install` with an
+  `externally-managed-environment` (PEP 668) error. Use the sanctioned,
+  one-time user install `python3 -m pip install --user
+  --break-system-packages 'sc-compose>=1.2.0'`; no venv or activation step is
+  required.
 - `cargo install` puts `oxigraph` under `~/.cargo/bin`; ensure that directory is
   visible to the Claude Code shell.
 - If a dependency is unavailable, stop the triage workflow. Do not write a

--- a/.claude/skills/triaging-findings/references/installation-and-troubleshooting.md
+++ b/.claude/skills/triaging-findings/references/installation-and-troubleshooting.md
@@ -1,0 +1,122 @@
+# Triaging-findings dependency setup
+
+This reference is loaded only when the Step 1 preflight fails. The skill
+requires:
+
+| Dependency | Minimum | Purpose |
+|---|---:|---|
+| `sc-compose` CLI | **1.2.0** | Render canonical Turtle records |
+| Python `sc_compose` binding | **1.2.0** | Native Python rendering/API tests |
+| `oxigraph` | supported installed release | Parse/validate rendered Turtle |
+| `rg` | installed | Sweep source worktrees |
+| Python `rdflib` | installed in the invoking Python | Graph/query support |
+
+## Check first
+
+From the repository root, run:
+
+```bash
+python3 .claude/skills/triaging-findings/scripts/check_dependencies.py
+```
+
+The checker searches PATH and common Homebrew, Cargo, user-bin, and Windows
+locations. If it reports success, do not reinstall anything.
+
+## Install
+
+macOS (recommended, avoids PEP 668 system-Python restrictions):
+
+```bash
+brew install randlee/tap/sc-compose
+python3 -m venv .venv-triaging-findings
+.venv-triaging-findings/bin/python -m pip install --upgrade pip
+.venv-triaging-findings/bin/python -m pip install 'sc-compose>=1.2.0' rdflib pytest
+export PATH="$PWD/.venv-triaging-findings/bin:$PATH"
+cargo install oxigraph-cli
+```
+
+The PyPI package supplies the `sc_compose` Python binding; it does not replace
+the standalone `sc-compose` CLI. On Linux without Homebrew, install the CLI
+from the v1.2.0 release or from a source checkout with the upstream
+`cargo install --path crates/sc-compose` procedure.
+
+Linux:
+
+```bash
+python3 -m venv .venv-triaging-findings
+.venv-triaging-findings/bin/python -m pip install --upgrade pip
+.venv-triaging-findings/bin/python -m pip install 'sc-compose>=1.2.0' rdflib pytest
+export PATH="$PWD/.venv-triaging-findings/bin:$PATH"
+# Install the standalone CLI from the v1.2.0 release, or from source:
+# cargo install --path crates/sc-compose
+cargo install oxigraph-cli
+```
+
+Install `ripgrep` with the platform package manager if `rg` is absent:
+
+```bash
+brew install ripgrep                 # macOS
+sudo apt-get install ripgrep         # Debian/Ubuntu
+```
+
+Windows PowerShell:
+
+```powershell
+py -m venv .venv-triaging-findings
+.venv-triaging-findings\Scripts\python -m pip install --upgrade pip
+.venv-triaging-findings\Scripts\python -m pip install "sc-compose>=1.2.0" rdflib pytest
+cargo install oxigraph-cli
+winget install BurntSushi.ripgrep.MSVC
+```
+
+`winget install randlee.sc-compose` installs the standalone Windows CLI; the
+PyPI install above supplies the Python binding.
+
+Install into the same interpreter used to invoke `check_dependencies.py`.
+
+## PATH troubleshooting
+
+Claude Code may start with a smaller PATH than an interactive shell. Locate
+the binaries explicitly:
+
+```bash
+for name in sc-compose oxigraph rg; do
+  command -v "$name" || true
+done
+printf '%s\n' "$PATH"
+```
+
+Common fixes:
+
+```bash
+export PATH="/opt/homebrew/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+```
+
+Alternatively invoke the absolute path printed by the checker. Do not place a
+host-specific absolute checkout path in a canonical Turtle record.
+
+## Validate after setup
+
+```bash
+sc-compose --version       # CLI must be 1.2.0 or newer
+oxigraph --version
+rg --version
+python3 -c 'import rdflib; print(rdflib.__version__)'
+python3 -c 'import sc_compose, importlib.metadata as m; print(m.version("sc-compose"))'
+python3 .claude/skills/triaging-findings/scripts/check_dependencies.py
+```
+
+## Known issues
+
+- `sc-compose 1.0.x` is insufficient; upgrade rather than suppressing the
+  version failure.
+- Installing with one Python and invoking the skill with another leaves
+  `rdflib` unavailable. Compare `python3 -c 'import sys; print(sys.executable)'`
+  with the interpreter used for installation.
+- Homebrew/system Python may reject global `pip install` with an
+  `externally-managed-environment` (PEP 668) error. Use the venv commands above;
+  do not bypass the protection with `--break-system-packages` for this workflow.
+- `cargo install` puts `oxigraph` under `~/.cargo/bin`; ensure that directory is
+  visible to the Claude Code shell.
+- If a dependency is unavailable, stop the triage workflow. Do not write a
+  partial `.ttl` record or dispatch a fix assignment.

--- a/.claude/skills/triaging-findings/scripts/check_dependencies.py
+++ b/.claude/skills/triaging-findings/scripts/check_dependencies.py
@@ -6,17 +6,23 @@ from __future__ import annotations
 import json
 import importlib.metadata
 import os
-import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
+_CLAUDE_DIR = Path(__file__).resolve().parents[3]
+if str(_CLAUDE_DIR) not in sys.path:
+    sys.path.insert(0, str(_CLAUDE_DIR))
+
+from lib.sc_compose_dependency import (  # noqa: E402
+    MIN_SC_COMPOSE,
+    SC_COMPOSE_INSTALL,
+    parse_version as _version,
+)
 
 REFERENCE = "references/installation-and-troubleshooting.md"
-MIN_SC_COMPOSE = (1, 2, 0)
-SC_COMPOSE_INSTALL = "python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'"
 
 
 def _candidates(name: str) -> list[Path]:
@@ -55,13 +61,6 @@ def _run_version(path: Path) -> tuple[str | None, str | None]:
         return None, str(exc)
     output = (result.stdout or result.stderr).strip()
     return output if result.returncode == 0 else None, output
-
-
-def _version(text: str | None) -> tuple[int, int, int] | None:
-    if not text:
-        return None
-    match = re.search(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?!\d)", text)
-    return tuple(int(part) for part in match.groups()) if match else None
 
 
 def _entry(name: str, required: str, *, minimum: tuple[int, int, int] | None = None) -> dict[str, Any]:

--- a/.claude/skills/triaging-findings/scripts/check_dependencies.py
+++ b/.claude/skills/triaging-findings/scripts/check_dependencies.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Fail-closed dependency preflight for the triaging-findings skill."""
+
+from __future__ import annotations
+
+import json
+import importlib.metadata
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REFERENCE = "references/installation-and-troubleshooting.md"
+MIN_SC_COMPOSE = (1, 2, 0)
+
+
+def _candidates(name: str) -> list[Path]:
+    home = Path.home()
+    values = [
+        Path(shutil.which(name) or ""),
+        home / ".local" / "bin" / name,
+        home / ".cargo" / "bin" / name,
+        Path(sys.prefix) / "bin" / name,
+        Path("/opt/homebrew/bin") / name,
+        Path("/usr/local/bin") / name,
+    ]
+    if sys.platform == "win32":
+        values.extend([
+            home / "AppData" / "Local" / "Programs" / name / name,
+            home / "AppData" / "Roaming" / "Python" / "Scripts" / f"{name}.exe",
+        ])
+    return list(dict.fromkeys(path for path in values if str(path)))
+
+
+def _find(name: str) -> Path | None:
+    return next(
+        (
+            path
+            for path in _candidates(name)
+            if path.is_file() and (sys.platform == "win32" or os.access(path, os.X_OK))
+        ),
+        None,
+    )
+
+
+def _run_version(path: Path) -> tuple[str | None, str | None]:
+    try:
+        result = subprocess.run([str(path), "--version"], capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, str(exc)
+    output = (result.stdout or result.stderr).strip()
+    return output if result.returncode == 0 else None, output
+
+
+def _version(text: str | None) -> tuple[int, int, int] | None:
+    if not text:
+        return None
+    match = re.search(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?!\d)", text)
+    return tuple(int(part) for part in match.groups()) if match else None
+
+
+def _entry(name: str, required: str, *, minimum: tuple[int, int, int] | None = None) -> dict[str, Any]:
+    path = _find(name)
+    if path is None:
+        return {"name": name, "required": required, "ok": False, "error": "not found on PATH or fallback paths"}
+    version_text, detail = _run_version(path)
+    parsed = _version(version_text)
+    if version_text is None:
+        return {"name": name, "required": required, "path": str(path), "ok": False, "error": detail or "--version failed"}
+    if minimum is not None and (parsed is None or parsed < minimum):
+        return {"name": name, "required": required, "path": str(path), "version": version_text, "ok": False, "error": f"requires >= {'.'.join(map(str, minimum))}"}
+    return {"name": name, "required": required, "path": str(path), "version": version_text, "ok": True}
+
+
+def _python_binding_entry() -> dict[str, Any]:
+    try:
+        import sc_compose  # noqa: F401
+        installed = _version(importlib.metadata.version("sc-compose"))
+        version_text = importlib.metadata.version("sc-compose")
+    except (ImportError, importlib.metadata.PackageNotFoundError) as exc:
+        return {"name": "sc_compose", "required": "Python binding >=1.2.0", "path": sys.executable, "ok": False, "error": str(exc)}
+    if installed is None or installed < MIN_SC_COMPOSE:
+        return {"name": "sc_compose", "required": "Python binding >=1.2.0", "path": sys.executable, "version": version_text, "ok": False, "error": "requires >= 1.2.0"}
+    return {"name": "sc_compose", "required": "Python binding >=1.2.0", "path": sys.executable, "version": version_text, "ok": True}
+
+
+def run() -> dict[str, Any]:
+    checks = [
+        _entry("sc-compose", ">=1.2.0", minimum=MIN_SC_COMPOSE),
+        _entry("oxigraph", "installed"),
+        _entry("rg", "installed"),
+    ]
+    try:
+        import rdflib  # noqa: F401
+        checks.append({"name": "rdflib", "required": "importable by this Python", "path": sys.executable, "version": getattr(rdflib, "__version__", "unknown"), "ok": True})
+    except ImportError as exc:
+        checks.append({"name": "rdflib", "required": "importable by this Python", "path": sys.executable, "ok": False, "error": str(exc)})
+    checks.append(_python_binding_entry())
+    failures = [item for item in checks if not item["ok"]]
+    return {
+        "success": not failures,
+        "data": {"dependencies": checks, "reference": REFERENCE} if not failures else None,
+        "error": None if not failures else {"code": "EXECUTION.DEPENDENCY", "message": "dependency preflight failed", "failures": failures, "reference": REFERENCE},
+    }
+
+
+def main() -> int:
+    result = run()
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["success"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/triaging-findings/scripts/check_dependencies.py
+++ b/.claude/skills/triaging-findings/scripts/check_dependencies.py
@@ -16,6 +16,7 @@ from typing import Any
 
 REFERENCE = "references/installation-and-troubleshooting.md"
 MIN_SC_COMPOSE = (1, 2, 0)
+SC_COMPOSE_INSTALL = "python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'"
 
 
 def _candidates(name: str) -> list[Path]:
@@ -81,10 +82,26 @@ def _python_binding_entry() -> dict[str, Any]:
         import sc_compose  # noqa: F401
         installed = _version(importlib.metadata.version("sc-compose"))
         version_text = importlib.metadata.version("sc-compose")
-    except (ImportError, importlib.metadata.PackageNotFoundError) as exc:
-        return {"name": "sc_compose", "required": "Python binding >=1.2.0", "path": sys.executable, "ok": False, "error": str(exc)}
+    except (ImportError, importlib.metadata.PackageNotFoundError):
+        return {
+            "name": "sc_compose",
+            "required": "Python binding >=1.2.0",
+            "path": sys.executable,
+            "ok": False,
+            "error": (
+                "sc-compose Python bindings not installed. Run: "
+                + SC_COMPOSE_INSTALL
+            ),
+        }
     if installed is None or installed < MIN_SC_COMPOSE:
-        return {"name": "sc_compose", "required": "Python binding >=1.2.0", "path": sys.executable, "version": version_text, "ok": False, "error": "requires >= 1.2.0"}
+        return {
+            "name": "sc_compose",
+            "required": "Python binding >=1.2.0",
+            "path": sys.executable,
+            "version": version_text,
+            "ok": False,
+            "error": "requires >= 1.2.0; reinstall with: " + SC_COMPOSE_INSTALL,
+        }
     return {"name": "sc_compose", "required": "Python binding >=1.2.0", "path": sys.executable, "version": version_text, "ok": True}
 
 

--- a/.claude/skills/triaging-findings/tests/test_check_dependencies.py
+++ b/.claude/skills/triaging-findings/tests/test_check_dependencies.py
@@ -37,6 +37,16 @@ def test_old_sc_compose_is_a_structured_failure(monkeypatch):
     assert any(item["name"] == "sc-compose" for item in result["error"]["failures"])
 
 
+def test_missing_python_binding_has_actionable_install_hint(monkeypatch):
+    def missing(_name):
+        raise check_dependencies.importlib.metadata.PackageNotFoundError("sc-compose")
+
+    monkeypatch.setattr(check_dependencies.importlib.metadata, "version", missing)
+    result = check_dependencies._python_binding_entry()
+    assert result["ok"] is False
+    assert "python3 -m pip install --user --break-system-packages" in result["error"]
+
+
 def test_cli_emits_json_success_contract():
     result = subprocess.run(
         [sys.executable, str(SCRIPT)],

--- a/.claude/skills/triaging-findings/tests/test_check_dependencies.py
+++ b/.claude/skills/triaging-findings/tests/test_check_dependencies.py
@@ -1,0 +1,49 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "check_dependencies.py"
+spec = importlib.util.spec_from_file_location("check_dependencies", SCRIPT)
+check_dependencies = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(check_dependencies)
+
+
+def test_version_parser():
+    assert check_dependencies._version("sc-compose 1.2.0") == (1, 2, 0)
+    assert check_dependencies._version("oxigraph 0.5.7") == (0, 5, 7)
+    assert check_dependencies._version("missing") is None
+
+
+def test_preflight_passes_in_current_environment(monkeypatch):
+    monkeypatch.setattr(check_dependencies, "_find", lambda name: Path("/bin/true"))
+    monkeypatch.setattr(check_dependencies, "_run_version", lambda path: ("tool 1.2.0", "tool 1.2.0"))
+    monkeypatch.setattr(check_dependencies, "_python_binding_entry", lambda: {"name": "sc_compose", "ok": True})
+    result = check_dependencies.run()
+    assert result["success"] is True
+    assert result["error"] is None
+
+
+def test_old_sc_compose_is_a_structured_failure(monkeypatch):
+    monkeypatch.setattr(check_dependencies, "_find", lambda name: Path("/bin/true"))
+    monkeypatch.setattr(check_dependencies, "_run_version", lambda path: ("sc-compose 1.0.1", "sc-compose 1.0.1"))
+    monkeypatch.setattr(check_dependencies, "_python_binding_entry", lambda: {"name": "sc_compose", "ok": True})
+    result = check_dependencies.run()
+    assert result["success"] is False
+    assert result["error"]["code"] == "EXECUTION.DEPENDENCY"
+    assert any(item["name"] == "sc-compose" for item in result["error"]["failures"])
+
+
+def test_cli_emits_json_success_contract():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["success"] is True
+    assert payload["error"] is None

--- a/.claude/skills/triaging-findings/tests/test_qa_triage_prompt.py
+++ b/.claude/skills/triaging-findings/tests/test_qa_triage_prompt.py
@@ -1,0 +1,31 @@
+"""Contract checks for the qa-triage agent prompt's validation gate."""
+
+from pathlib import Path
+
+
+PROMPT = Path(__file__).resolve().parents[3] / "agents" / "qa-triage.md"
+
+
+def test_qa_triage_prompt_validates_the_complete_phase_after_render() -> None:
+    text = PROMPT.read_text(encoding="utf-8")
+
+    assert "validate-findings.py" in text
+    assert "--findings-dir \"$triage_root/$phase_id/findings\"" in text
+    assert "--structure \"$structure_path\"" in text
+    assert "--events \"$events_path\"" in text
+    assert "--json" in text
+    assert 'kind == "validation:pass"' in text
+    assert "validation:fail" in text
+    assert "error" in text
+
+
+def test_qa_triage_prompt_does_not_treat_validation_fail_as_success() -> None:
+    text = PROMPT.read_text(encoding="utf-8")
+
+    gate = text[
+        text.index("12. Validate the rendered Turtle") : text.index(
+            "13. Return enough information"
+        )
+    ]
+    assert "blocks this agent from reporting success" in gate
+    assert "only `validation:pass`" in gate

--- a/.claude/skills/triaging-findings/tests/test_triage_record_template.py
+++ b/.claude/skills/triaging-findings/tests/test_triage_record_template.py
@@ -1,0 +1,120 @@
+"""Focused render and Turtle-parse tests for the canonical triage record."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+TEMPLATE = ".claude/skills/triaging-findings/triage-record.ttl.j2"
+
+
+def _vars() -> dict:
+    return {
+        "finding_id": "FTQ-001",
+        "title": "Process-global shutdown state in tests",
+        "description": "Global state leaks across test cases.",
+        "phase_id": "phase-R",
+        "triage_mode": "initial_pass",
+        "category": "FTQ",
+        "severity": "important",
+        "repeatable": True,
+        "sweep_scope": "crate",
+        "status": "open",
+        "dispatch_ready": True,
+        "triaged_at": "2026-07-25T16:30:00Z",
+        "found_in": "AICH-S7",
+        "found_at": "2026-07-25T16:26:33Z",
+        # sc-compose var-files intentionally accept scalar arrays only. The
+        # parallel arrays below are joined by index in the Turtle template.
+        "occurrences": ["R17-1"],
+        "occurrence_files": ["crates/atm-daemon/src/tests.rs"],
+        "occurrence_lines": ["28"],
+        "occurrence_snippets": ["static DISPATCHER: OnceLock<...>"],
+        "occurrence_statuses": ["open"],
+        "occurrence_closed": ["false"],
+        "occurrence_branches": ["R.17"],
+        "occurrence_head_shas": ["9421e9f"],
+        "occurrence_worktree_ids": ["R17/9421e9f"],
+        "worktrees": ["R17/9421e9f"],
+        "worktree_branches": ["R.17"],
+        "worktree_paths": ["/abs/worktree-r17"],
+        "worktree_head_shas": ["9421e9f"],
+        "worktree_order_indices": ["17"],
+    }
+
+
+def _render(tmp_path: Path, variables: dict) -> subprocess.CompletedProcess[str]:
+    vars_path = tmp_path / "vars.json"
+    output_path = tmp_path / "FTQ-001.ttl"
+    vars_path.write_text(json.dumps(variables), encoding="utf-8")
+    return subprocess.run(
+        [
+            "sc-compose",
+            "render",
+            "--root",
+            str(REPO_ROOT),
+            "--file",
+            TEMPLATE,
+            "--var-file",
+            str(vars_path),
+            "--output",
+            str(output_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "NO_COLOR": "1"},
+    )
+
+
+def _parse_turtle(path: Path, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    store = tmp_path / "oxigraph"
+    return subprocess.run(
+        [
+            "oxigraph",
+            "load",
+            "--location",
+            str(store),
+            "--file",
+            str(path),
+            "--format",
+            "ttl",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_render_includes_found_provenance_and_parses_as_turtle(tmp_path: Path) -> None:
+    result = _render(tmp_path, _vars())
+    assert result.returncode == 0, result.stderr or result.stdout
+
+    output = tmp_path / "FTQ-001.ttl"
+    rendered = output.read_text(encoding="utf-8")
+    assert "triage:foundIn triage:AICH-S7" in rendered
+    assert 'triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime' in rendered
+    assert "triage:hasOccurrence" in rendered
+    assert "a triage:WorktreeSnapshot" in rendered
+
+    parsed = _parse_turtle(output, tmp_path)
+    assert parsed.returncode == 0, parsed.stderr or parsed.stdout
+
+
+@pytest.mark.parametrize("missing", ["found_in", "found_at"])
+def test_render_rejects_missing_provenance_variable(
+    tmp_path: Path, missing: str
+) -> None:
+    variables = _vars()
+    del variables[missing]
+
+    result = _render(tmp_path, variables)
+
+    assert result.returncode != 0
+    diagnostic = f"{result.stdout}\n{result.stderr}".lower()
+    assert missing in diagnostic

--- a/.claude/skills/triaging-findings/tests/test_triage_record_template.py
+++ b/.claude/skills/triaging-findings/tests/test_triage_record_template.py
@@ -114,10 +114,12 @@ def test_python_binding_renders_canonical_template() -> None:
     try:
         import importlib.metadata
         import sc_compose
-    except ImportError as exc:  # pragma: no cover - dependency preflight owns setup
+    except (ImportError, importlib.metadata.PackageNotFoundError) as exc:  # pragma: no cover - dependency preflight owns setup
         pytest.fail(
-            "install sc-compose>=1.2.0 in the invoking Python before running "
-            f"binding tests: {exc}"
+            "sc-compose Python bindings not installed. Run: "
+            "python3 -m pip install --user --break-system-packages "
+            "'sc-compose>=1.2.0' before running binding tests: "
+            f"{exc}"
         )
     assert tuple(int(part) for part in importlib.metadata.version("sc-compose").split(".")[:3]) >= (1, 2, 0)
     rendered = sc_compose.render_template(

--- a/.claude/skills/triaging-findings/tests/test_triage_record_template.py
+++ b/.claude/skills/triaging-findings/tests/test_triage_record_template.py
@@ -43,7 +43,6 @@ def _vars() -> dict:
         "occurrence_worktree_ids": ["R17/9421e9f"],
         "worktrees": ["R17/9421e9f"],
         "worktree_branches": ["R.17"],
-        "worktree_paths": ["/abs/worktree-r17"],
         "worktree_head_shas": ["9421e9f"],
         "worktree_order_indices": ["17"],
     }
@@ -118,3 +117,32 @@ def test_render_rejects_missing_provenance_variable(
     assert result.returncode != 0
     diagnostic = f"{result.stdout}\n{result.stderr}".lower()
     assert missing in diagnostic
+
+
+@pytest.mark.parametrize(
+    "path_value",
+    [
+        "/abs/integrate-phase-R/crates/atm-daemon/src/tests.rs",
+        "../outside-repository.rs",
+        "crates/../outside-repository.rs",
+        r"C:\\checkout\\crates\\atm-daemon\\src\\tests.rs",
+    ],
+)
+def test_render_rejects_non_repository_relative_occurrence_path(
+    tmp_path: Path, path_value: str
+) -> None:
+    variables = _vars()
+    variables["occurrence_files"] = [path_value]
+
+    result = _render(tmp_path, variables)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+    output = tmp_path / "FTQ-001.ttl"
+    rendered = output.read_text(encoding="utf-8")
+    assert "__ERROR_REPOSITORY_RELATIVE_OCCURRENCE_PATH_REQUIRED__" in rendered
+
+    parsed = _parse_turtle(output, tmp_path)
+    # oxigraph currently reports parser failures on stderr while retaining a
+    # zero process exit status for the `load` command. Treat the diagnostic as
+    # the validation result rather than trusting the exit code alone.
+    assert "parser error" in parsed.stderr.lower()

--- a/.claude/skills/triaging-findings/tests/test_triage_record_template.py
+++ b/.claude/skills/triaging-findings/tests/test_triage_record_template.py
@@ -109,6 +109,24 @@ def test_render_includes_found_provenance_and_parses_as_turtle(tmp_path: Path) -
     assert parsed.returncode == 0, parsed.stderr or parsed.stdout
 
 
+def test_python_binding_renders_canonical_template() -> None:
+    """The pip/maturin binding must render the same template tokens as the CLI."""
+    try:
+        import importlib.metadata
+        import sc_compose
+    except ImportError as exc:  # pragma: no cover - dependency preflight owns setup
+        pytest.fail(
+            "install sc-compose>=1.2.0 in the invoking Python before running "
+            f"binding tests: {exc}"
+        )
+    assert tuple(int(part) for part in importlib.metadata.version("sc-compose").split(".")[:3]) >= (1, 2, 0)
+    rendered = sc_compose.render_template(
+        (REPO_ROOT / TEMPLATE).read_text(encoding="utf-8"), _vars()
+    )
+    assert "triage:foundIn triage:AICH-S7" in rendered
+    assert 'triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime' in rendered
+
+
 @pytest.mark.parametrize("missing", ["found_in", "found_at"])
 def test_render_rejects_missing_provenance_variable(
     tmp_path: Path, missing: str

--- a/.claude/skills/triaging-findings/tests/test_triage_record_template.py
+++ b/.claude/skills/triaging-findings/tests/test_triage_record_template.py
@@ -72,17 +72,21 @@ def _render(tmp_path: Path, variables: dict) -> subprocess.CompletedProcess[str]
     )
 
 
-def _parse_turtle(path: Path, tmp_path: Path) -> subprocess.CompletedProcess[str]:
-    store = tmp_path / "oxigraph"
+def _parse_turtle(
+    path: Path, tmp_path: Path
+) -> subprocess.CompletedProcess[str]:
+    converted = tmp_path / "parsed.ttl"
     return subprocess.run(
         [
             "oxigraph",
-            "load",
-            "--location",
-            str(store),
-            "--file",
+            "convert",
+            "--from-file",
             str(path),
-            "--format",
+            "--from-format",
+            "ttl",
+            "--to-file",
+            str(converted),
+            "--to-format",
             "ttl",
         ],
         text=True,
@@ -142,7 +146,4 @@ def test_render_rejects_non_repository_relative_occurrence_path(
     assert "__ERROR_REPOSITORY_RELATIVE_OCCURRENCE_PATH_REQUIRED__" in rendered
 
     parsed = _parse_turtle(output, tmp_path)
-    # oxigraph currently reports parser failures on stderr while retaining a
-    # zero process exit status for the `load` command. Treat the diagnostic as
-    # the validation result rather than trusting the exit code alone.
-    assert "parser error" in parsed.stderr.lower()
+    assert parsed.returncode != 0

--- a/.claude/skills/triaging-findings/tests/test_triage_record_template.py
+++ b/.claude/skills/triaging-findings/tests/test_triage_record_template.py
@@ -42,6 +42,7 @@ def _vars() -> dict:
         "occurrence_head_shas": ["9421e9f"],
         "occurrence_worktree_ids": ["R17/9421e9f"],
         "worktrees": ["R17/9421e9f"],
+        "worktree_paths": [".worktrees/R17"],
         "worktree_branches": ["R.17"],
         "worktree_head_shas": ["9421e9f"],
         "worktree_order_indices": ["17"],
@@ -104,6 +105,7 @@ def test_render_includes_found_provenance_and_parses_as_turtle(tmp_path: Path) -
     assert 'triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime' in rendered
     assert "triage:hasOccurrence" in rendered
     assert "a triage:WorktreeSnapshot" in rendered
+    assert 'triage:path ".worktrees/R17"' in rendered
 
     parsed = _parse_turtle(output, tmp_path)
     assert parsed.returncode == 0, parsed.stderr or parsed.stdout
@@ -129,7 +131,7 @@ def test_python_binding_renders_canonical_template() -> None:
     assert 'triage:foundAt "2026-07-25T16:26:33Z"^^xsd:dateTime' in rendered
 
 
-@pytest.mark.parametrize("missing", ["found_in", "found_at"])
+@pytest.mark.parametrize("missing", ["found_in", "found_at", "worktree_paths"])
 def test_render_rejects_missing_provenance_variable(
     tmp_path: Path, missing: str
 ) -> None:
@@ -144,26 +146,39 @@ def test_render_rejects_missing_provenance_variable(
 
 
 @pytest.mark.parametrize(
-    "path_value",
+    ("variable", "path_value"),
     [
-        "/abs/integrate-phase-R/crates/atm-daemon/src/tests.rs",
-        "../outside-repository.rs",
-        "crates/../outside-repository.rs",
-        r"C:\\checkout\\crates\\atm-daemon\\src\\tests.rs",
+        (
+            "occurrence_files",
+            "/abs/integrate-phase-R/crates/atm-daemon/src/tests.rs",
+        ),
+        ("occurrence_files", "../outside-repository.rs"),
+        ("occurrence_files", "crates/../outside-repository.rs"),
+        ("occurrence_files", r"C:\\checkout\\crates\\atm-daemon\\src\\tests.rs"),
+        ("worktree_paths", "/abs/integrate-phase-R"),
+        ("worktree_paths", "../outside-repository"),
+        ("worktree_paths", "worktrees/../outside-repository"),
+        ("worktree_paths", r"C:\\checkout\\integrate-phase-R"),
+        ("worktree_paths", r"\\server\\share\\integrate-phase-R"),
     ],
 )
-def test_render_rejects_non_repository_relative_occurrence_path(
-    tmp_path: Path, path_value: str
+def test_render_rejects_non_repository_relative_persisted_paths(
+    tmp_path: Path, variable: str, path_value: str
 ) -> None:
     variables = _vars()
-    variables["occurrence_files"] = [path_value]
+    variables[variable] = [path_value]
 
     result = _render(tmp_path, variables)
     assert result.returncode == 0, result.stderr or result.stdout
 
     output = tmp_path / "FTQ-001.ttl"
     rendered = output.read_text(encoding="utf-8")
-    assert "__ERROR_REPOSITORY_RELATIVE_OCCURRENCE_PATH_REQUIRED__" in rendered
+    marker = (
+        "__ERROR_REPOSITORY_RELATIVE_OCCURRENCE_PATH_REQUIRED__"
+        if variable == "occurrence_files"
+        else "__ERROR_REPOSITORY_RELATIVE_WORKTREE_PATH_REQUIRED__"
+    )
+    assert marker in rendered
 
     parsed = _parse_turtle(output, tmp_path)
     assert parsed.returncode != 0

--- a/.claude/skills/triaging-findings/triage-record.ttl.j2
+++ b/.claude/skills/triaging-findings/triage-record.ttl.j2
@@ -1,0 +1,76 @@
+---
+name: triage-record
+version: 1.0.0
+description: Canonical one-finding Turtle record for pre-dispatch QA triage.
+format: ttl
+required_variables:
+  - finding_id
+  - title
+  - description
+  - phase_id
+  - triage_mode
+  - category
+  - severity
+  - repeatable
+  - sweep_scope
+  - status
+  - dispatch_ready
+  - triaged_at
+  - found_in
+  - found_at
+  - occurrences
+  - occurrence_files
+  - occurrence_lines
+  - occurrence_snippets
+  - occurrence_statuses
+  - occurrence_closed
+  - occurrence_branches
+  - occurrence_head_shas
+  - occurrence_worktree_ids
+  - worktrees
+  - worktree_branches
+  - worktree_paths
+  - worktree_head_shas
+  - worktree_order_indices
+---
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/{{ finding_id }}>
+  a triage:Finding ;
+  triage:findingId "{{ finding_id }}" ;
+  triage:title "{{ title }}" ;
+  triage:description "{{ description }}" ;
+  triage:phaseId "{{ phase_id }}" ;
+  triage:triageMode "{{ triage_mode }}" ;
+  triage:category "{{ category }}" ;
+  triage:severity "{{ severity }}" ;
+  triage:repeatable {% if repeatable %}true{% else %}false{% endif %} ;
+  triage:sweepScope "{{ sweep_scope }}" ;
+  triage:status "{{ status }}" ;
+  triage:dispatchReady {% if dispatch_ready %}true{% else %}false{% endif %} ;
+  triage:triagedAt "{{ triaged_at }}"^^xsd:dateTime ;
+  triage:foundIn triage:{{ found_in }} ;
+  triage:foundAt "{{ found_at }}"^^xsd:dateTime ;
+{% for occurrence_id in occurrences %}  triage:hasOccurrence <urn:atm:triage:occurrence/{{ finding_id }}/{{ occurrence_id }}> ;
+{% endfor %}  triage:triageRecordVersion "1" .
+
+{% for occurrence_id in occurrences %}<urn:atm:triage:occurrence/{{ finding_id }}/{{ occurrence_id }}>
+  a triage:Occurrence ;
+  triage:file "{{ occurrence_files[loop.index0] }}" ;
+  triage:line {{ occurrence_lines[loop.index0] }} ;
+  triage:snippet "{{ occurrence_snippets[loop.index0] }}" ;
+  triage:status "{{ occurrence_statuses[loop.index0] }}" ;
+  triage:closed {% if occurrence_closed[loop.index0] == "true" %}true{% else %}false{% endif %} ;
+  triage:branch "{{ occurrence_branches[loop.index0] }}" ;
+  triage:headSha "{{ occurrence_head_shas[loop.index0] }}" ;
+  triage:occursIn <urn:atm:triage:worktree/{{ occurrence_worktree_ids[loop.index0] }}> .
+
+{% endfor %}{% for worktree_id in worktrees %}<urn:atm:triage:worktree/{{ worktree_id }}>
+  a triage:WorktreeSnapshot ;
+  triage:branch "{{ worktree_branches[loop.index0] }}" ;
+  triage:path "{{ worktree_paths[loop.index0] }}" ;
+  triage:headSha "{{ worktree_head_shas[loop.index0] }}" ;
+  triage:orderIndex {{ worktree_order_indices[loop.index0] }} .
+
+{% endfor %}

--- a/.claude/skills/triaging-findings/triage-record.ttl.j2
+++ b/.claude/skills/triaging-findings/triage-record.ttl.j2
@@ -29,12 +29,14 @@ required_variables:
   - occurrence_worktree_ids
   - worktrees
   - worktree_branches
-  - worktree_paths
   - worktree_head_shas
   - worktree_order_indices
 ---
 @prefix triage: <urn:atm:triage:> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
 
 <urn:atm:triage:finding/{{ finding_id }}>
   a triage:Finding ;
@@ -57,6 +59,8 @@ required_variables:
 
 {% for occurrence_id in occurrences %}<urn:atm:triage:occurrence/{{ finding_id }}/{{ occurrence_id }}>
   a triage:Occurrence ;
+{% if occurrence_files[loop.index0][0:1] == "/" or ".." in occurrence_files[loop.index0] or occurrence_files[loop.index0][1:2] == ":" %}__ERROR_REPOSITORY_RELATIVE_OCCURRENCE_PATH_REQUIRED__ .
+{% endif %}
   triage:file "{{ occurrence_files[loop.index0] }}" ;
   triage:line {{ occurrence_lines[loop.index0] }} ;
   triage:snippet "{{ occurrence_snippets[loop.index0] }}" ;
@@ -69,7 +73,6 @@ required_variables:
 {% endfor %}{% for worktree_id in worktrees %}<urn:atm:triage:worktree/{{ worktree_id }}>
   a triage:WorktreeSnapshot ;
   triage:branch "{{ worktree_branches[loop.index0] }}" ;
-  triage:path "{{ worktree_paths[loop.index0] }}" ;
   triage:headSha "{{ worktree_head_shas[loop.index0] }}" ;
   triage:orderIndex {{ worktree_order_indices[loop.index0] }} .
 

--- a/.claude/skills/triaging-findings/triage-record.ttl.j2
+++ b/.claude/skills/triaging-findings/triage-record.ttl.j2
@@ -28,6 +28,7 @@ required_variables:
   - occurrence_head_shas
   - occurrence_worktree_ids
   - worktrees
+  - worktree_paths
   - worktree_branches
   - worktree_head_shas
   - worktree_order_indices
@@ -72,6 +73,9 @@ required_variables:
 
 {% endfor %}{% for worktree_id in worktrees %}<urn:atm:triage:worktree/{{ worktree_id }}>
   a triage:WorktreeSnapshot ;
+{% if worktree_paths[loop.index0][0:1] == "/" or worktree_paths[loop.index0][0:1] == "\\" or ".." in worktree_paths[loop.index0] or worktree_paths[loop.index0][1:2] == ":" %}__ERROR_REPOSITORY_RELATIVE_WORKTREE_PATH_REQUIRED__ .
+{% endif %}
+  triage:path "{{ worktree_paths[loop.index0] }}" ;
   triage:branch "{{ worktree_branches[loop.index0] }}" ;
   triage:headSha "{{ worktree_head_shas[loop.index0] }}" ;
   triage:orderIndex {{ worktree_order_indices[loop.index0] }} .

--- a/scripts/test_triage_carry_forward.py
+++ b/scripts/test_triage_carry_forward.py
@@ -138,6 +138,27 @@ class TestTriageCarryForward(unittest.TestCase):
             ],
         )
 
+    def test_invalid_query_json_fails_with_actionable_error(self):
+        completed = _MOD.subprocess.CompletedProcess(
+            args=["oxigraph", "query"], returncode=0, stdout="not-json", stderr=""
+        )
+        with patch.object(_MOD.subprocess, "run", return_value=completed):
+            with self.assertRaises(SystemExit) as exc:
+                _MOD.query_records(Path("/tmp/store"), "R.17")
+        self.assertIn("invalid JSON", str(exc.exception))
+
+    def test_malformed_query_binding_fails_with_row_number(self):
+        completed = _MOD.subprocess.CompletedProcess(
+            args=["oxigraph", "query"],
+            returncode=0,
+            stdout=json.dumps({"results": {"bindings": [{"finding_id": {}}]}}),
+            stderr="",
+        )
+        with patch.object(_MOD.subprocess, "run", return_value=completed):
+            with self.assertRaises(SystemExit) as exc:
+                _MOD.query_records(Path("/tmp/store"), "R.17")
+        self.assertIn("invalid binding at row 0", str(exc.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/triage_carry_forward.py
+++ b/scripts/triage_carry_forward.py
@@ -116,20 +116,37 @@ def query_records(store_dir: Path, branch: str) -> list[dict[str, object]]:
     if result.returncode != 0:
         raise SystemExit(result.stderr.strip() or "oxigraph query failed")
 
-    data = json.loads(result.stdout)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"oxigraph query returned invalid JSON: {exc}") from exc
+
+    if not isinstance(data, dict) or not isinstance(data.get("results"), dict):
+        raise SystemExit("oxigraph query returned an invalid results object")
+    bindings = data["results"].get("bindings", [])
+    if not isinstance(bindings, list):
+        raise SystemExit("oxigraph query returned an invalid bindings array")
+
     rows: list[dict[str, object]] = []
-    for binding in data.get("results", {}).get("bindings", []):
-        line_term = binding.get("line")
-        rows.append(
-            {
-                "id": binding["finding_id"]["value"],
-                "category": binding.get("category", {}).get("value"),
-                "severity": binding.get("severity", {}).get("value"),
-                "file": binding["file"]["value"],
-                "line": int(line_term["value"]) if line_term else None,
-                "summary": binding["summary"]["value"],
-            }
-        )
+    for index, binding in enumerate(bindings):
+        try:
+            if not isinstance(binding, dict):
+                raise TypeError("binding is not an object")
+            line_term = binding.get("line")
+            rows.append(
+                {
+                    "id": binding["finding_id"]["value"],
+                    "category": binding.get("category", {}).get("value"),
+                    "severity": binding.get("severity", {}).get("value"),
+                    "file": binding["file"]["value"],
+                    "line": int(line_term["value"]) if line_term else None,
+                    "summary": binding["summary"]["value"],
+                }
+            )
+        except (KeyError, TypeError, ValueError, AttributeError) as exc:
+            raise SystemExit(
+                f"oxigraph query returned invalid binding at row {index}: {exc}"
+            ) from exc
     return rows
 
 


### PR DESCRIPTION
## Summary
- Hardens the graph-orchestration validator's path/provenance checks (with tests) for `foundIn`/`foundAt` on triage records
- Adds canonical `triage-record.ttl.j2` template with repo-relative path enforcement
- Adds an sc-compose/Oxigraph parse gate
- Updates the `qa-triage` prompt and `triaging-findings` skill docs
- Adds new `.claude/skills/triage-report` producer, templates, and tests (`--format json` canonical, `--format vars` for sc-compose, `--mode` detailed rendering)
- Validates structure/metadata/QA schema, records per-field data gaps, keeps CI vs merged icons distinct, uses portable source paths, includes PST QA timestamps/PR URL in detailed output

## Test evidence (per Crimson-2f4c)
- graph-orchestration suite: 42 passed
- triaging-findings suite: 7 passed
- triage-report suite: 55 passed
- py_compile / diff checks clean
- sc-compose diagnostics empty

Head SHA: 34b43139

🤖 Generated with [Claude Code](https://claude.com/claude-code)