### PR TITLE
Draft: next-dispatch lifecycle and TTL-based triage reporting

### DIFF
--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: graph-orchestration
-version: 0.5.0
-description: TTL/SPARQL-driven phase orchestration. The orchestrator runs a deterministic query loop — cursor → triaging-findings check → dispatch → await Completion → re-query. No agent ever decides phase, cursor position, or done-ness; queries answer all of it. Derived from codex-orchestration; replaces static sprint-doc assignments with a live RDF event log. Adds Assignment events (collision prevention), Completion invalidation (blocking post-Completion finding snaps cursor back), and CLEANUP phase (non-blocking findings after all sprints complete).
+version: 0.6.0
+description: TTL/SPARQL-driven phase orchestration. The orchestrator runs a deterministic next-dispatch state machine; no agent may choose a sprint, branch, finding list, or done-ness. QAClosed is immutable, closed targets are refused, and late findings are promoted to the earliest eligible open descendant.
 repo: atm-core
 requires:
   cli:
@@ -34,12 +34,13 @@ depends_on:
 
 Mechanical phase orchestration backed by an append-only RDF event log.
 Every orchestration decision is a SPARQL query result. Agents never decide
-phase, cursor position, or whether a sprint is done.
+phase, dispatch target, finding IDs, or whether a sprint is done. Merge order
+is a separate gate and does not prevent dispatching later non-blocked work.
 
 ## Step 1 — Verify dependencies
 
 Run the dependency preflight as the first executable step, before discovering
-the phase, invoking an agent, reading the cursor, or appending a TTL event:
+the phase, invoking an agent, reading dispatch state, or appending a TTL event:
 
 ```bash
 .claude/skills/graph-orchestration/scripts/preflight
@@ -89,7 +90,8 @@ triage:<PHASE>-S2 a triage:Sprint ; triage:inPhase triage:Phase<PHASE> ; triage:
 # ... one entry per sprint, orders unique and contiguous from 1
 ```
 
-**`.sprints/<PHASE>/events.ttl`** — empty initially; events (Assignments, Completions)
+**`.sprints/<PHASE>/events.ttl`** — empty initially; append-only events
+(Assignments, Completions, and immutable QAClosed records)
 are appended here as sprints progress. Never edited or deleted.
 
 **`ac/<PHASE>S*.md`** — acceptance criteria documents, one per sprint. The
@@ -98,7 +100,7 @@ the phase starts.
 
 Run `validate-structure.sparql` at creation. It must return zero rows.
 
-Before relying on cursor output, validate the raw findings directory as well:
+Before relying on scheduler output, validate the raw findings directory as well:
 
 ```bash
 python3 .claude/skills/graph-orchestration/scripts/validate-findings.py \
@@ -123,7 +125,7 @@ missing input, invalid regex, or a broken query). The CLI exits 0, 1, and 2 for
 those outcomes respectively; `--json` emits the tagged result for callers.
 
 `query_runner.py` invokes this validator before loading the graph, including
-for `--validate-only`; `next-dev-task` therefore cannot resolve a cursor while
+for `--validate-only`; `next-dispatch` therefore cannot resolve a target while
 any `.triage/*/findings` directory contains an error-level diagnostic. It
 validates every findings directory (not only the directory name that appears
 to match the current phase), then scopes findings by the phase's declared
@@ -131,68 +133,60 @@ to match the current phase), then scopes findings by the phase's declared
 records from disappearing in the membership filter. A `validation:fail` blocks
 with exit 1, and a validator execution `error` blocks with exit 2.
 
-## Orchestrator Loop
+## Next-dispatch loop
 
 ```bash
-RESULT=$(next-dev-task F .sprints/F)
-PHASE=$(echo "$RESULT" | jq -r .phase)
+RESULT=$(next-dispatch F .sprints/F)
+ACTION=$(echo "$RESULT" | jq -r .dispatch)
 ```
 
-Four outcomes from the cursor query:
+The result is a discriminated union. The dispatcher is the only authority for
+the target and exact finding IDs:
 
-| `phase` | Meaning |
+| `dispatch` | Meaning |
 |---|---|
-| `TRAVERSAL` | A sprint is ready (no in-flight Assignment, no valid Completion) — check triaging-findings to pick template |
-| `AWAITING` | Cursor is empty but some sprints lack valid Completions — in-flight assignments are being worked |
-| `CLEANUP` | All sprints have valid Completions but open non-blocking findings remain |
-| `DONE` | All sprints have valid Completions and no open non-blocking findings — phase complete |
+| `dispatch_task` | The exact open sprint is eligible for new work. |
+| `dispatch_fix` | The exact open sprint must fix the returned `outstanding_finding_ids`; promoted findings are included. |
+| `awaiting_qa` | Work is assigned or a completion is awaiting QA/QAClosed. |
+| `blocked` | Every remaining open sprint has an unresolved native blocker. |
+| `done` | Every sprint has an immutable QAClosed event and no late finding requires remediation. |
 
-After getting a `TRAVERSAL` result, the orchestrator:
-1. Appends an Assignment event to events.ttl for this sprint
-2. Checks `.triage/` for blocking/important/minor findings (via triaging-findings skill)
-3. Picks the template: no findings → dev-task.xml.j2; blocking findings present → dev-fix.xml.j2
+The wrapper refuses manual sprint, branch, target, or finding overrides. A
+`dispatch_fix` is valid only for the exact target and exact IDs returned by the
+same invocation. Team-lead appends the Assignment only after the required ATM
+acknowledgement, then re-runs `next-dispatch` after every event.
 
+QA closure is terminal for assignment. An assignment at or after
+`triage:closedAt` fails with:
+
+```text
+REFUSED: AICH-S22 is CLOSED. Post-closure findings must target the earliest open descendant or remediation sprint.
 ```
-cursor_result = next-dev-task F .sprints/F
 
-if cursor_result.phase == "DONE":
-    → phase complete, merge
-
-if cursor_result.phase == "AWAITING":
-    → wait for in-flight dev work; poll again after expected delivery
-
-if cursor_result.phase == "CLEANUP":
-    → dispatch dev-fix.xml.j2 for open non-blocking findings
-
-# TRAVERSAL path
-append Assignment event to events.ttl for cursor sprint
-findings = run triaging-findings skill for cursor sprint
-
-if findings has blocking:
-    → dispatch dev-fix.xml.j2
-else:
-    → dispatch dev-task.xml.j2
-```
+Findings retain their immutable `triage:foundIn` origin. If `foundAt` is later
+than QAClosed, `post-closure-remediation.sparql` promotes the finding forward;
+the scheduler never reopens the closed sprint. A blocked sprint is skipped so
+the next eligible non-blocked sprint can proceed.
 
 **Hard rules:**
-- Never cache phase or cursor across events. Re-run `next-dev-task` after every
+- Never cache phase or dispatch target across events. Re-run `next-dispatch` after every
   Completion or Assignment.
 - Never interpret findings in this skill — that is triaging-findings' job. If
   the orchestrator is tempted to reason about the graph, the model is broken —
   file a design issue, do not improvise.
 - QA runs after every dev Completion. Trigger immediately on Completion receipt.
-- A Completion can be invalidated: if QA files a blocking finding with
-  foundAt > completedAt, the Completion is invalid and the cursor snaps back.
-  Team-lead re-dispatches by appending a new Assignment.
-- Default to consolidated CLEANUP on the highest sprint branch. Dispatching
+- A Completion can be followed by findings, but it does not reopen a QAClosed
+  sprint. Late findings are promoted forward and require a returned
+  `dispatch_fix` target.
+- Default to consolidated remediation on the highest sprint branch. Dispatching
   non-blocking findings back to origin branches causes 3–4× more QA cycles —
   avoid unless there is a specific reason (e.g. a finding is isolated to an
   early sprint with no forward merge path).
 - **Team-lead is sole writer of TTL events. Never delegate TTL writes to dev agents.**
 
-## Dev Dispatch (no blocking findings)
+## Dev Dispatch (no outstanding findings)
 
-`next-dev-task` returns the cursor sprint, its order, and its criteria path.
+`next-dispatch` returns the exact sprint, its order, and its criteria path.
 Populate and send `dev-task.xml.j2`:
 
 | j2 variable | Source |
@@ -201,11 +195,11 @@ Populate and send `dev-task.xml.j2`:
 | `sprint_order` | `result.vars.sprint_order` |
 | `criteria_doc` | `result.vars.criteria_doc` |
 
-## Fix Dispatch (blocking findings present)
+## Fix Dispatch (outstanding findings present)
 
-Same cursor sprint, but triaging-findings reports blocking findings on it.
-Use `dev-fix.xml.j2` instead. The findings payload comes from triaging-findings,
-not from events.ttl.
+Use `dev-fix.xml.j2` when `dispatch` is `dispatch_fix`. The findings payload
+comes from `outstanding_finding_ids` in the scheduler result, including any
+forward promotions; it must not be recomputed or edited by an agent.
 
 ## QA Gate
 
@@ -236,8 +230,9 @@ QA rules:
   events.ttl.
 - Merge gate: 0 Blocking + 0 Important + 0 Minor, no exceptions.
 
-After QA completes, re-run `next-dev-task` to get the new cursor, then run
-triaging-findings to determine template selection.
+After QA completes, append QAClosed when the sprint is closed, then re-run
+`next-dispatch`. A QA verdict that remains open is represented by findings and
+will return `dispatch_fix` or a later eligible target.
 
 ## Appending Events
 
@@ -259,7 +254,7 @@ triage:a<N> a triage:Assignment ;
 TTL
 git add .sprints/<PHASE>/events.ttl && git commit -m "event: Assignment <PHASE>-S<n>"
 # Validate after every append
-.claude/skills/graph-orchestration/scripts/next-dev-task F .sprints/F --validate-only
+.claude/skills/graph-orchestration/scripts/next-dispatch F .sprints/F --validate-only
 
 # Completion — append when team-lead receives dev's ATM completion message
 cat >> .sprints/<PHASE>/events.ttl <<'TTL'
@@ -269,7 +264,7 @@ triage:c<N> a triage:Completion ;
 TTL
 git add .sprints/<PHASE>/events.ttl && git commit -m "event: Completion <PHASE>-S<n>"
 # Validate after every append
-.claude/skills/graph-orchestration/scripts/next-dev-task F .sprints/F --validate-only
+.claude/skills/graph-orchestration/scripts/next-dispatch F .sprints/F --validate-only
 
 # Resolution — append when team-lead confirms a non-blocking finding is fixed
 cat >> .sprints/<PHASE>/events.ttl <<'TTL'
@@ -279,7 +274,7 @@ triage:r<N> a triage:Resolution ;
 TTL
 git add .sprints/<PHASE>/events.ttl && git commit -m "event: Resolution f<N>"
 # Validate after every append
-.claude/skills/graph-orchestration/scripts/next-dev-task F .sprints/F --validate-only
+.claude/skills/graph-orchestration/scripts/next-dispatch F .sprints/F --validate-only
 ```
 
 **Assignment uniqueness**: Each Assignment must include the dev agent name and
@@ -294,42 +289,56 @@ Invalidation below).
 Findings live exclusively in `.triage/*/findings/*.ttl` and are managed by the
 triaging-findings skill. Do not append raw finding data to events.ttl.
 
+**QA closure — append exactly once when QA accepts the sprint:**
+
+```turtle
+triage:q<N> a triage:QAClosed ;
+    triage:ofSprint triage:Phase<X>-S<n> ;
+    triage:closedAt "<UTC>"^^xsd:dateTime .
+```
+
+`QAClosed` is immutable. Duplicate closure events, missing timestamps, and
+assignments at or after closure are validation errors. Historical assignments
+before closure remain evidence and are not rewritten.
+
 ## sc-compose Integration
 
-`next-dev-task` returns JSON shaped for direct sc-compose consumption:
+`next-dispatch` returns JSON shaped for direct sc-compose consumption:
 
 ```json
 {
-  "phase": "TRAVERSAL",
-  "vars": {
+  "schema": "next-dispatch/v1",
+  "dispatch": "dispatch_fix",
+  "target": {
     "sprint": "S7",
     "sprint_iri": "urn:atm:triage:S7",
     "sprint_order": 1,
     "criteria_doc": "ac/S7.md"
-  }
+  },
+  "outstanding_finding_ids": ["F-123"],
+  "promotions": []
 }
 ```
 
 The orchestrator saves `vars` to a temp file and adds non-graph variables.
-Template selection (`dev-task.xml.j2` vs `dev-fix.xml.j2`) is made after
-consulting triaging-findings:
+Template selection (`dev-task.xml.j2` vs `dev-fix.xml.j2`) follows the
+discriminant; agents must not recompute it from a second graph scan:
 
 ```bash
-RESULT=$(next-dev-task F .sprints/F)
-PHASE_VAL=$(echo "$RESULT" | jq -r .phase)
+RESULT=$(next-dispatch F .sprints/F)
+ACTION=$(echo "$RESULT" | jq -r .dispatch)
 
-if [ "$PHASE_VAL" = "DONE" ]; then
+if [ "$ACTION" = "done" ]; then
   echo "Phase complete."
   exit 0
 fi
 
 # Write graph-derived vars
 echo "$RESULT" | jq .vars > /tmp/graph-vars.json
-SPRINT=$(echo "$RESULT" | jq -r .vars.sprint)
+SPRINT=$(echo "$RESULT" | jq -r .target.sprint)
 
-# Check findings via triaging-findings skill (orchestrator step)
-# If blocking findings exist, use dev-fix.xml.j2; otherwise dev-task.xml.j2
-TEMPLATE="dev-task.xml.j2"   # set by orchestrator after triaging-findings check
+TEMPLATE="dev-fix.xml.j2"
+if [ "$ACTION" = "dispatch_task" ]; then TEMPLATE="dev-task.xml.j2"; fi
 
 # Render via sc-compose (orchestrator supplies remaining vars)
 sc-compose render \
@@ -342,29 +351,24 @@ sc-compose render \
   --var assignee="arch-ctm"
 ```
 
-## Completion Invalidation
+## Completion and closure
 
-A Completion is valid only if no blocking finding for that sprint was filed
-with `foundAt > completedAt`. If QA files a blocking finding after a
-Completion, the Completion is invalidated:
+A Completion records developer delivery; it is not QA acceptance. QA acceptance
+is recorded separately by exactly one immutable `QAClosed` event. A finding
+filed after Completion is open until a Resolution or a later valid fix pass.
+When it is filed after QAClosed, the finding remains tied to its original
+`foundIn` sprint and is promoted by `post-closure-remediation.sparql`.
 
-1. `cursor.sparql` snaps back to that sprint (the truly-in-flight filter
-   does not block — dev has sent a Completion, so the sprint is not in-flight;
-   a new Assignment is required for re-dispatch)
-2. Team-lead appends a new Assignment event to events.ttl for the sprint
-3. Dev fixes the blocker and sends an ATM completion message; team-lead
-   appends a new Completion
-4. Dev merges forward into the next sprint's worktree, picking up any
-   important/minor findings on the way (Step 4 in the j2 template)
+This guarantees QA always has the final word without reopening history. Genuine
+merge order remains strictly ordered, but a later open sprint without native
+blockers can be dispatched while an earlier sprint's merge is pending.
 
-This guarantees QA always has the final word. A sprint is never permanently
-"done" while a blocking finding exists postdating its Completion.
+## Consolidated remediation
 
-## Cleanup Pass
-
-When `next-dev-task` returns `phase: "CLEANUP"`, all sprint Completions are valid
-and CI is green, but open important/minor findings remain. Fix ALL of them in a
-single pass on the highest sprint branch.
+When `next-dispatch` returns `dispatch_fix`, fix the exact returned IDs on the
+returned target. A phase-wide cleanup can still be consolidated on the highest
+merged branch, but it is an explicit merge/assignment decision; it is not a
+hidden `CLEANUP` state and must not alter the scheduler's target.
 
 **Why consolidated:** fixing findings on the branch where they were found causes
 8–12 dev-QA cycles. Fixing all findings on one merged branch reduces this to 2–3.
@@ -378,18 +382,18 @@ This 3–4× speedup is load-bearing — do not deviate.
    - Merge S2 → S3's branch
    - ... up to S(n-1) → S(n)'s branch
 3. Run CI on the merged S(n) branch. Fix any merge conflicts before proceeding.
-4. Collect all open important/minor findings via `open-findings-sprint.sparql`.
-5. Dispatch ONE dev-fix assignment to S(n)'s worktree with the full findings list.
+4. Collect the exact IDs from `next-dispatch`.
+5. Dispatch ONE dev-fix assignment to the returned worktree with that list.
 6. QA reviews the merged branch once.
 
 **Strong default:** Fix important/minor findings on the consolidated highest
-sprint branch during CLEANUP. Dispatching findings back to the branch where
+sprint branch when the integration plan explicitly calls for consolidation. Dispatching findings back to the branch where
 they were found causes 3–4× more QA cycles and is rarely worth it. Only
 deviate if a finding is completely isolated to an early sprint with no
 forward merge dependency and re-merging would be higher churn than fixing
 in place.
 
-**CLEANUP branch variables for sc-compose:**
+**Remediation branch variables for sc-compose:**
 - `worktree_path` = highest-order sprint's worktree
 - `branch` = highest-order sprint's branch
 - `pr_target` = phase integration branch
@@ -406,7 +410,8 @@ graph-orchestration:
 | `triage:Phase` | — | Phase identity node |
 | `triage:Sprint` | `inPhase`, `order`, `criteria` | One per sprint; `order` is unique within a phase |
 | `triage:Assignment` | `ofSprint`, `assignedTo`, `assignedAt` | Appended by team-lead when dispatching; must be unique per sprint |
-| `triage:Completion` | `ofSprint`, `at` | Appended by team-lead on receipt of dev's ATM completion message; may be invalidated by a later blocking finding |
+| `triage:Completion` | `ofSprint`, `at` | Appended by team-lead on receipt of dev's ATM completion message; delivery is distinct from QA closure |
+| `triage:QAClosed` | `ofSprint`, `closedAt` | Immutable terminal QA acceptance; exactly one per sprint |
 | `triage:Resolution` | `resolves`, `resolvedAt` | Appended by team-lead when a non-blocking finding is confirmed fixed; blocking findings need no Resolution |
 
 Findings are defined by the triaging-findings skill and live in
@@ -419,67 +424,72 @@ All scripts live in `.claude/skills/graph-orchestration/scripts/`:
 
 | Script | Purpose |
 |---|---|
-| `next-dev-task` | Entry point: cursor resolution, returns JSON |
+| `next-dispatch` | Canonical entry point: deterministic tagged dispatch result |
+| `dispatch` | Guarded wrapper; refuses manual sprint/branch/finding overrides |
+| `next-dev-task` | Deprecated cursor-shaped compatibility projection |
 | `preflight` | First-step dependency gate; requires CLI + Python binding `sc-compose >= 1.2.0`, `jq`, and `python3` + `rdflib` |
 | `validate-findings.py` | Mandatory raw findings/provenance gate invoked before query resolution |
 | `query_runner.py` | Python SPARQL runner (rdflib) |
+| `next-dispatch.sparql` | Selects earliest open, non-in-flight, non-blocked sprint; parameter: `$PHASE` |
+| `closed-sprint-targets.sparql` | Finds assignments at/after QAClosed; non-zero rows refuse dispatch; parameter: `$PHASE` |
+| `post-closure-remediation.sparql` | Promotes late findings to later eligible descendants without changing `foundIn`; parameter: `$PHASE` |
 | `cursor.sparql` | Returns cursor sprint (lowest-ordered sprint without a truly in-flight Assignment or valid Completion); parameter: `$PHASE` |
-| `open-findings-sprint.sparql` | Returns open non-blocking findings across the phase (used for CLEANUP detection); parameter: `$PHASE` |
-| `all-complete.sparql` | Returns sprints lacking a valid Completion; zero rows = all sprints done, proceed to CLEANUP/DONE check; parameter: `$PHASE` |
+| `open-findings-sprint.sparql` | Legacy report of open non-blocking findings; not a dispatch authority; parameter: `$PHASE` |
+| `all-complete.sparql` | Legacy completion report; not a dispatch authority; parameter: `$PHASE` |
 | `validate-structure.sparql` | Phase structure integrity check — zero rows = valid; parameter: `$PHASE` |
 | `test_queries.py` | pytest unit tests for all SPARQL queries (run: `python3 -m pytest scripts/test_queries.py -v`) |
 
 Usage:
 ```bash
-# From repo root — dependency gate must pass before the cursor is queried
+# From repo root — dependency gate must pass before dispatch is queried
 .claude/skills/graph-orchestration/scripts/preflight
-.claude/skills/graph-orchestration/scripts/next-dev-task F .sprints/F
+.claude/skills/graph-orchestration/scripts/next-dispatch F .sprints/F
 ```
 
-Output JSON (TRAVERSAL):
+Output JSON (`dispatch_task`):
 ```json
 {
-  "phase": "TRAVERSAL",
-  "vars": {
+  "schema": "next-dispatch/v1",
+  "dispatch": "dispatch_task",
+  "target": {
     "sprint": "PhaseF-S1",
     "sprint_iri": "urn:atm:triage:PhaseF-S1",
     "sprint_order": 1,
     "criteria_doc": "ac/FS1.md"
-  }
+  },
+  "outstanding_finding_ids": [],
+  "promotions": []
 }
 ```
 
-Output JSON (AWAITING):
+Output JSON (`dispatch_fix`):
 ```json
 {
-  "phase": "AWAITING",
-  "vars": {},
-  "_incomplete_sprints": ["urn:atm:triage:PhaseF-S1"]
+  "schema": "next-dispatch/v1",
+  "dispatch": "dispatch_fix",
+  "target": {"sprint": "PhaseF-S1", "sprint_order": 1, "criteria_doc": "ac/FS1.md"},
+  "outstanding_finding_ids": ["F-123"],
+  "promotions": []
 }
 ```
 
-Output JSON (CLEANUP):
+Output JSON (`awaiting_qa`, `blocked`, or `done`):
 ```json
 {
-  "phase": "CLEANUP",
-  "vars": {},
-  "_findings_raw": [...]
-}
-```
-
-Output JSON (DONE):
-```json
-{
-  "phase": "DONE",
-  "vars": {},
-  "_findings_raw": []
+  "schema": "next-dispatch/v1",
+  "dispatch": "awaiting_qa",
+  "target": null,
+  "outstanding_finding_ids": [],
+  "promotions": [],
+  "blocked_sprints": [],
+  "in_flight_sprints": ["PhaseF-S1"]
 }
 ```
 
 ## Assignment Templates
 
-- `dev-task.xml.j2` — initial dev pass (no blocking findings)
-- `dev-fix.xml.j2` — fix pass (blocking findings identified by triaging-findings)
+- `dev-task.xml.j2` — initial dev pass for a `dispatch_task` result
+- `dev-fix.xml.j2` — fix pass only for a `dispatch_fix` result and its exact IDs
 
 QA assignment uses the existing `quality-mgr` prompt directly — no new template.
 

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -68,12 +68,30 @@ small (progressive disclosure).
 |---|---|
 | RDF runner | Python 3 + rdflib |
 | Phase TTL location | `.sprints/<PHASE>/structure.ttl` + `.sprints/<PHASE>/events.ttl` (relative to repo root) |
+| Current phase source | `.sprints/current-phase.ttl`; optional host-local overlay `.sprints/current-phase.local.ttl` |
 | Findings storage | `.triage/*/findings/*.ttl` — managed by triaging-findings skill |
 | Test command | `just test` |
 | Dev assignee | Set per-sprint at dispatch time (j2 variable) |
 | QA reviewer set | `req-qa`, `arch-qa`, `rust-qa-agent` every pass; RBP/service-hardening/ruthless on QA-1 or finding recheck |
 
 ## Phase Setup
+
+Before dispatching, commit `.sprints/current-phase.ttl` with the phase-local
+identifier, phase IRI, relative structure directory, plan directory, and
+integration branch. The no-argument `next-dispatch` command reads this file;
+the optional ignored `current-phase.local.ttl` maps hostnames to absolute
+integration worktree paths. This keeps machine paths out of the shared graph.
+
+```turtle
+@prefix sprint: <urn:atm:sprint:> .
+@prefix triage: <urn:atm:triage:> .
+sprint:CurrentPhase a sprint:PhaseContext ;
+    sprint:phaseLocal "AICH" ;
+    sprint:phaseIri triage:PhaseAICH ;
+    sprint:structureDir ".sprints/AICH" ;
+    sprint:planDir "docs/plans/phase-ai" ;
+    sprint:integrationBranch "integrate/phase-AI" .
+```
 
 Before starting a phase, create two TTL files:
 
@@ -136,7 +154,7 @@ with exit 1, and a validator execution `error` blocks with exit 2.
 ## Next-dispatch loop
 
 ```bash
-RESULT=$(next-dispatch F .sprints/F)
+RESULT=$(next-dispatch)
 ACTION=$(echo "$RESULT" | jq -r .dispatch)
 ```
 
@@ -155,6 +173,11 @@ The wrapper refuses manual sprint, branch, target, or finding overrides. A
 `dispatch_fix` is valid only for the exact target and exact IDs returned by the
 same invocation. Team-lead appends the Assignment only after the required ATM
 acknowledgement, then re-runs `next-dispatch` after every event.
+
+Severity is case-normalized; reviewer-native `critical` maps to `blocking`.
+Any other severity is an `error` result with code
+`INVALID_FINDING_SEVERITY` and a nonzero exit. Finding status is metadata only;
+it cannot hide an unresolved finding without a Resolution event.
 
 QA closure is terminal for assignment. An assignment at or after
 `triage:closedAt` fails with:
@@ -303,7 +326,9 @@ before closure remain evidence and are not rewritten.
 
 ## sc-compose Integration
 
-`next-dispatch` returns JSON shaped for direct sc-compose consumption:
+`next-dispatch` returns JSON shaped for direct sc-compose consumption. With no
+arguments it resolves `.sprints/current-phase.ttl`; explicit phase/TTL
+arguments remain a compatibility mode for diagnostics:
 
 ```json
 {
@@ -316,6 +341,7 @@ before closure remain evidence and are not rewritten.
     "criteria_doc": "ac/S7.md"
   },
   "outstanding_finding_ids": ["F-123"],
+  "outstanding_findings": [],
   "promotions": []
 }
 ```
@@ -325,7 +351,7 @@ Template selection (`dev-task.xml.j2` vs `dev-fix.xml.j2`) follows the
 discriminant; agents must not recompute it from a second graph scan:
 
 ```bash
-RESULT=$(next-dispatch F .sprints/F)
+RESULT=$(next-dispatch)
 ACTION=$(echo "$RESULT" | jq -r .dispatch)
 
 if [ "$ACTION" = "done" ]; then
@@ -348,7 +374,10 @@ sc-compose render \
   --var worktree_path="$WORKTREE_PATH" \
   --var branch="$BRANCH" \
   --var pr_target="$PR_TARGET" \
-  --var assignee="arch-ctm"
+  --var assignee="arch-ctm" \
+  --var phase_local="$(echo "$RESULT" | jq -r .context.phase_local)" \
+  --var ttl_dir="$(echo "$RESULT" | jq -r .context.ttl_dir)" \
+  --var finding_ids="$(echo "$RESULT" | jq -r '.outstanding_finding_ids | join(" ")')"
 ```
 
 ## Completion and closure
@@ -405,6 +434,13 @@ in place.
 The `triage:` prefix maps to `urn:atm:triage:`. Classes used by
 graph-orchestration:
 
+The portable phase context uses the repository-neutral `sprint:` prefix
+(`urn:atm:sprint:`), deliberately separate from triage finding/event data:
+
+| Class | Properties | Notes |
+|---|---|---|
+| `sprint:PhaseContext` | `phaseLocal`, `phaseIri`, `structureDir`, `planDir`, `integrationBranch` | Exactly one committed context in `current-phase.ttl`; host paths live in the ignored overlay |
+
 | Class | Properties | Notes |
 |---|---|---|
 | `triage:Phase` | — | Phase identity node |
@@ -424,7 +460,7 @@ All scripts live in `.claude/skills/graph-orchestration/scripts/`:
 
 | Script | Purpose |
 |---|---|
-| `next-dispatch` | Canonical entry point: deterministic tagged dispatch result |
+| `next-dispatch` | Canonical entry point: deterministic tagged dispatch result; reads current-phase.ttl by default |
 | `dispatch` | Guarded wrapper; refuses manual sprint/branch/finding overrides |
 | `next-dev-task` | Deprecated cursor-shaped compatibility projection |
 | `preflight` | First-step dependency gate; requires CLI + Python binding `sc-compose >= 1.2.0`, `jq`, and `python3` + `rdflib` |
@@ -433,6 +469,7 @@ All scripts live in `.claude/skills/graph-orchestration/scripts/`:
 | `next-dispatch.sparql` | Selects earliest open, non-in-flight, non-blocked sprint; parameter: `$PHASE` |
 | `closed-sprint-targets.sparql` | Finds assignments at/after QAClosed; non-zero rows refuse dispatch; parameter: `$PHASE` |
 | `post-closure-remediation.sparql` | Promotes late findings to later eligible descendants without changing `foundIn`; parameter: `$PHASE` |
+| `current-phase.ttl` | Portable phase/plan/integration-branch source of truth; no command parameters required |
 | `cursor.sparql` | Returns cursor sprint (lowest-ordered sprint without a truly in-flight Assignment or valid Completion); parameter: `$PHASE` |
 | `open-findings-sprint.sparql` | Legacy report of open non-blocking findings; not a dispatch authority; parameter: `$PHASE` |
 | `all-complete.sparql` | Legacy completion report; not a dispatch authority; parameter: `$PHASE` |
@@ -443,7 +480,7 @@ Usage:
 ```bash
 # From repo root — dependency gate must pass before dispatch is queried
 .claude/skills/graph-orchestration/scripts/preflight
-.claude/skills/graph-orchestration/scripts/next-dispatch F .sprints/F
+.claude/skills/graph-orchestration/scripts/next-dispatch
 ```
 
 Output JSON (`dispatch_task`):
@@ -485,6 +522,10 @@ Output JSON (`awaiting_qa`, `blocked`, or `done`):
   "in_flight_sprints": ["PhaseF-S1"]
 }
 ```
+
+Data-integrity failures use the same union with `dispatch: "error"`, an
+`error.code`, and JSON-safe finding details; they exit nonzero and are never
+treated as an expected `blocked` or `done` result.
 
 ## Assignment Templates
 

--- a/.claude/skills/graph-orchestration/dev-fix.xml.j2
+++ b/.claude/skills/graph-orchestration/dev-fix.xml.j2
@@ -1,7 +1,7 @@
 ---
 name: graph-dev-fix
 version: 1.0.0
-description: Fix pass for a sprint node — includes all open findings at the cursor position. Used for both mid-sprint fix passes (TRAVERSAL with findings) and end-of-sprint cleanup (CLEANUP phase).
+description: Fix pass for the exact target and finding IDs returned by next-dispatch. A closed sprint is never reopened and a manually selected target is invalid.
 format: xml
 required_variables:
   - task_id
@@ -24,7 +24,7 @@ defaults:
   cleanup_mode: "false"
 ---
 <atm-task id="{{ task_id }}" sprint="{{ sprint }}" node="{{ node_id }}" order="{{ node_order }}" assignee="{{ assignee }}" mode="fix"{% if cleanup_mode == "true" %} phase="CLEANUP"{% endif %}>
-  {# When cleanup_mode == "true": this is a CONSOLIDATED phase cleanup on the highest sprint's merged branch.
+  {# When cleanup_mode == "true": this is an explicit CONSOLIDATED phase remediation on the highest sprint's merged branch.
      All prior sprint branches have been merged forward into this branch before dispatch.
      The findings list covers the ENTIRE phase — not just one sprint. Fix all findings here;
      do not return any finding to its origin branch. #}
@@ -55,9 +55,10 @@ defaults:
 
   <workflow>
     <step id="a">ACK this message immediately.</step>
-    <step id="b">Read `{{ criteria_doc }}` before editing. All acceptance criteria must still be met — do not weaken or skip any criterion from the original spec.</step>
-    <step id="c">Update the worktree from `{{ pr_target }}` before any edits: `git fetch origin && git merge origin/{{ pr_target }}`.</step>
-    <step id="d">Work through every finding in `<open-findings>` in listed order. Fix all. For blocking: address root cause fully. For non-blocking: fix all; skip only on direct conflict with a blocking fix.</step>
+    <step id="b">Before reading code or editing, verify this assignment was produced by `next-dispatch` with `dispatch_fix` for this exact open sprint and the exact finding IDs in `<open-findings>`. If not, stop and report the invalid assignment.</step>
+    <step id="c">Read `{{ criteria_doc }}` before editing. All acceptance criteria must still be met — do not weaken or skip any criterion from the original spec.</step>
+    <step id="d">Update the worktree from `{{ pr_target }}` before any edits: `git fetch origin && git merge origin/{{ pr_target }}`.</step>
+    <step id="e">Work through every finding in `<open-findings>` in listed order. Fix all. For blocking: address root cause fully. For non-blocking: fix all; skip only on direct conflict with a blocking fix.</step>
   </workflow>
 
   <final-actions>

--- a/.claude/skills/graph-orchestration/dev-task.xml.j2
+++ b/.claude/skills/graph-orchestration/dev-task.xml.j2
@@ -36,7 +36,7 @@ defaults:
 
   <workflow>
     <step id="a">ACK this message immediately. Make reasonable assumptions and do not ask clarifying questions unless a real blocker prevents execution.</step>
-    <step id="b">Before reading code or editing, verify this is either a new/greenfield sprint or a fix task with an assigned, open Blocking finding on this exact sprint. If neither condition is true, stop and report the invalid assignment. Then begin work in the same session.</step>
+    <step id="b">Before reading code or editing, run `.claude/skills/graph-orchestration/scripts/next-dispatch` and retain its JSON. Continue only if `dispatch` is `dispatch_task`, `target.sprint` is `{{ node_id }}`, and `outstanding_finding_ids` is empty. Any other result is an invalid assignment—stop and report it. The phase, TTL directory, integration branch, and host-local integration worktree come from `.sprints/current-phase.ttl` and its optional local overlay.</step>
     <step id="c">Read `{{ criteria_doc }}` before coding. This is the authoritative acceptance criteria for this node. Satisfy every criterion completely — do not weaken or skip any.</step>
     <step id="d">Update the worktree from `{{ pr_target }}` before any edits: `git fetch origin && git merge origin/{{ pr_target }}`.</step>
     <step id="e">Implement the work. Commit incrementally on `{{ branch }}`.</step>

--- a/.claude/skills/graph-orchestration/scripts/closed-sprint-targets.sparql
+++ b/.claude/skills/graph-orchestration/scripts/closed-sprint-targets.sparql
@@ -1,0 +1,20 @@
+# closed-sprint-targets.sparql — assignments that violate QA closure.
+#
+# Assignments made before the closure timestamp are historical evidence and
+# remain valid.  Any assignment at or after QAClosed is a dispatch violation.
+#
+# Parameter: $PHASE (bound via initBindings)
+
+PREFIX triage: <urn:atm:triage:>
+
+SELECT ?assignment ?sprint ?assignedAt ?closedAt WHERE {
+  ?sprint a triage:Sprint ; triage:inPhase $PHASE .
+  ?assignment a triage:Assignment ;
+              triage:ofSprint ?sprint ;
+              triage:assignedAt ?assignedAt .
+  ?closed a triage:QAClosed ;
+          triage:ofSprint ?sprint ;
+          (triage:closedAt|triage:at) ?closedAt .
+  FILTER (?assignedAt >= ?closedAt)
+}
+ORDER BY ?assignedAt ?sprint

--- a/.claude/skills/graph-orchestration/scripts/dispatch
+++ b/.claude/skills/graph-orchestration/scripts/dispatch
@@ -15,10 +15,16 @@ for arg in "$@"; do
   esac
 done
 
-if [[ $# -lt 2 || $# -gt 3 ]]; then
-  echo >&2 "Usage: dispatch <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+if [[ $# -eq 1 && "$1" != "--validate-only" || $# -gt 3 ]]; then
+  echo >&2 "Usage: dispatch [<PHASE_LOCAL> <TTL_DIR> [--validate-only]]"
   exit 1
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ $# -eq 0 ]]; then
+  exec "$SCRIPT_DIR/next-dispatch"
+fi
+if [[ $# -eq 1 ]]; then
+  exec "$SCRIPT_DIR/next-dispatch" --validate-only
+fi
 exec "$SCRIPT_DIR/next-dispatch" "$@"

--- a/.claude/skills/graph-orchestration/scripts/dispatch
+++ b/.claude/skills/graph-orchestration/scripts/dispatch
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# dispatch — guarded dispatch wrapper.
+#
+# The scheduler is the only source of truth for sprint/branch/finding targets.
+# Manual overrides are rejected instead of being treated as assertions.
+
+set -euo pipefail
+
+for arg in "$@"; do
+  case "$arg" in
+    --sprint=*|--branch=*|--target=*|--finding-id=*|--finding-ids=*|-s|--sprint|-b|--branch|-t|--target)
+      echo >&2 "REFUSED: manual sprint/branch/finding overrides are not allowed; run next-dispatch"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo >&2 "Usage: dispatch <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/next-dispatch" "$@"

--- a/.claude/skills/graph-orchestration/scripts/next-dev-task
+++ b/.claude/skills/graph-orchestration/scripts/next-dev-task
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # next-dev-task — Deprecated compatibility projection for graph-orchestration.
 #
-# Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]
+# Usage: next-dev-task [<PHASE_LOCAL> <TTL_DIR> [--validate-only]]
 # TTL_DIR: path to .sprints/<PHASE>/ on the integrate/phase-N branch
 #   PHASE_LOCAL  e.g. "F" (expanded to urn:atm:triage:PhaseF)
 #   TTL_DIR      path to directory containing structure.ttl and events.ttl
@@ -16,17 +16,11 @@
 
 set -euo pipefail
 
-if [[ $# -lt 2 || $# -gt 3 ]]; then
-  echo >&2 "Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+if [[ $# -eq 1 && "$1" != "--validate-only" || $# -gt 3 ]]; then
+  echo >&2 "Usage: next-dev-task [<PHASE_LOCAL> <TTL_DIR> [--validate-only]]"
   exit 1
 fi
 
-PHASE="$1"
-TTL_DIR="$2"
-if [[ $# -eq 3 && "$3" != "--validate-only" ]]; then
-  echo >&2 "Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
-  exit 1
-fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_BIN="${GRAPH_ORCH_PYTHON:-python3}"
 
@@ -36,6 +30,19 @@ if ! "$PYTHON_BIN" -c "import rdflib" 2>/dev/null; then
   exit 1
 fi
 
+if [[ $# -eq 0 ]]; then
+  exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" --current-phase "$SCRIPT_DIR" --legacy-cursor
+fi
+if [[ $# -eq 1 ]]; then
+  exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" --current-phase "$SCRIPT_DIR" --validate-only --legacy-cursor
+fi
+
+PHASE="$1"
+TTL_DIR="$2"
+if [[ $# -eq 3 && "$3" != "--validate-only" ]]; then
+  echo >&2 "Usage: next-dev-task [<PHASE_LOCAL> <TTL_DIR> [--validate-only]]"
+  exit 1
+fi
 if [[ $# -eq 3 ]]; then
   exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" --validate-only --legacy-cursor
 fi

--- a/.claude/skills/graph-orchestration/scripts/next-dev-task
+++ b/.claude/skills/graph-orchestration/scripts/next-dev-task
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# next-dev-task — Cursor resolution for graph-orchestration.
+# next-dev-task — Deprecated compatibility projection for graph-orchestration.
 #
 # Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]
 # TTL_DIR: path to .sprints/<PHASE>/ on the integrate/phase-N branch
 #   PHASE_LOCAL  e.g. "F" (expanded to urn:atm:triage:PhaseF)
 #   TTL_DIR      path to directory containing structure.ttl and events.ttl
 #
+# New orchestration must call next-dispatch. This wrapper preserves the old
+# cursor-shaped JSON for callers that have not migrated yet.
 # Returns JSON on stdout:
 #   { "phase": "TRAVERSAL", "vars": { "sprint": "...", "sprint_iri": "...", "sprint_order": N, "criteria_doc": "..." } }
 #   { "phase": "DONE", "vars": {} }
@@ -35,6 +37,6 @@ if ! "$PYTHON_BIN" -c "import rdflib" 2>/dev/null; then
 fi
 
 if [[ $# -eq 3 ]]; then
-  exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" --validate-only
+  exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" --validate-only --legacy-cursor
 fi
-exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR"
+exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" --legacy-cursor

--- a/.claude/skills/graph-orchestration/scripts/next-dispatch
+++ b/.claude/skills/graph-orchestration/scripts/next-dispatch
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# next-dispatch — canonical deterministic scheduler entry point.
+#
+# Usage: next-dispatch <PHASE_LOCAL> <TTL_DIR> [--validate-only]
+# The target sprint, branch, and finding IDs are always computed from the
+# phase graph.  There are deliberately no manual target overrides.
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo >&2 "Usage: next-dispatch <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+  exit 1
+fi
+
+PHASE="$1"
+TTL_DIR="$2"
+if [[ $# -eq 3 && "$3" != "--validate-only" ]]; then
+  echo >&2 "Usage: next-dispatch <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+  exit 1
+fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_BIN="${GRAPH_ORCH_PYTHON:-python3}"
+
+if ! "$PYTHON_BIN" -c "import rdflib" 2>/dev/null; then
+  echo >&2 "ERROR: rdflib not found. Install with: pip3 install rdflib"
+  exit 1
+fi
+
+if [[ $# -eq 3 ]]; then
+  exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" --validate-only
+fi
+exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR"

--- a/.claude/skills/graph-orchestration/scripts/next-dispatch
+++ b/.claude/skills/graph-orchestration/scripts/next-dispatch
@@ -1,23 +1,18 @@
 #!/usr/bin/env bash
 # next-dispatch — canonical deterministic scheduler entry point.
 #
-# Usage: next-dispatch <PHASE_LOCAL> <TTL_DIR> [--validate-only]
+# Usage: next-dispatch [<PHASE_LOCAL> <TTL_DIR> [--validate-only]]
+# With no arguments, resolve .sprints/current-phase.ttl.
 # The target sprint, branch, and finding IDs are always computed from the
 # phase graph.  There are deliberately no manual target overrides.
 
 set -euo pipefail
 
-if [[ $# -lt 2 || $# -gt 3 ]]; then
-  echo >&2 "Usage: next-dispatch <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+if [[ $# -eq 1 && "$1" != "--validate-only" || $# -gt 3 ]]; then
+  echo >&2 "Usage: next-dispatch [<PHASE_LOCAL> <TTL_DIR> [--validate-only]]"
   exit 1
 fi
 
-PHASE="$1"
-TTL_DIR="$2"
-if [[ $# -eq 3 && "$3" != "--validate-only" ]]; then
-  echo >&2 "Usage: next-dispatch <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
-  exit 1
-fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_BIN="${GRAPH_ORCH_PYTHON:-python3}"
 
@@ -26,6 +21,19 @@ if ! "$PYTHON_BIN" -c "import rdflib" 2>/dev/null; then
   exit 1
 fi
 
+if [[ $# -eq 0 ]]; then
+  exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" --current-phase "$SCRIPT_DIR"
+fi
+if [[ $# -eq 1 ]]; then
+  exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" --current-phase "$SCRIPT_DIR" --validate-only
+fi
+
+PHASE="$1"
+TTL_DIR="$2"
+if [[ $# -eq 3 && "$3" != "--validate-only" ]]; then
+  echo >&2 "Usage: next-dispatch [<PHASE_LOCAL> <TTL_DIR> [--validate-only]]"
+  exit 1
+fi
 if [[ $# -eq 3 ]]; then
   exec "$PYTHON_BIN" "$SCRIPT_DIR/query_runner.py" "$PHASE" "$TTL_DIR" "$SCRIPT_DIR" --validate-only
 fi

--- a/.claude/skills/graph-orchestration/scripts/next-dispatch.sparql
+++ b/.claude/skills/graph-orchestration/scripts/next-dispatch.sparql
@@ -1,0 +1,62 @@
+# next-dispatch.sparql — candidate sprint selection for the dispatcher.
+#
+# This query deliberately excludes closed, in-flight, and natively blocked
+# sprints.  Python assembles the final tagged result and adds any findings
+# promoted from a closed sprint.
+#
+# Parameter: $PHASE (bound via initBindings)
+
+PREFIX triage: <urn:atm:triage:>
+
+SELECT ?sprint ?order ?criteria WHERE {
+  ?sprint a triage:Sprint ;
+           triage:inPhase $PHASE ;
+           triage:order ?order ;
+           triage:criteria ?criteria .
+
+  # QAClosed is terminal for assignment.  A late finding is promoted by the
+  # post-closure-remediation query instead of reopening this sprint.
+  FILTER NOT EXISTS {
+    ?closed a triage:QAClosed ; triage:ofSprint ?sprint .
+  }
+
+  # Assignment without a later Completion is in flight.
+  FILTER NOT EXISTS {
+    ?assignment a triage:Assignment ;
+                triage:ofSprint ?sprint ;
+                triage:assignedAt ?assignedAt .
+    FILTER NOT EXISTS {
+      ?completion a triage:Completion ;
+                  triage:ofSprint ?sprint ;
+                  triage:at ?completedAt .
+      FILTER (?completedAt > ?assignedAt)
+    }
+  }
+
+  # An unresolved blocking finding makes this sprint ineligible.  It is not
+  # reopened by the scheduler; later non-blocked work may proceed.
+  FILTER NOT EXISTS {
+    ?finding a triage:Finding ;
+             triage:foundIn ?sprint ;
+             triage:severity "blocking" .
+    FILTER NOT EXISTS {
+      ?resolution a triage:Resolution ;
+                  triage:resolves ?finding .
+    }
+  }
+
+  # Include new work and completed sprints with open non-blocking findings.
+  FILTER (
+    NOT EXISTS { ?completion a triage:Completion ; triage:ofSprint ?sprint . }
+    || EXISTS {
+      ?finding a triage:Finding ;
+               triage:foundIn ?sprint ;
+               triage:severity ?severity .
+      FILTER (?severity != "blocking")
+      FILTER NOT EXISTS {
+        ?resolution a triage:Resolution ; triage:resolves ?finding .
+      }
+    }
+  )
+}
+ORDER BY ?order

--- a/.claude/skills/graph-orchestration/scripts/next-dispatch.sparql
+++ b/.claude/skills/graph-orchestration/scripts/next-dispatch.sparql
@@ -38,7 +38,9 @@ SELECT ?sprint ?order ?criteria WHERE {
   FILTER NOT EXISTS {
     ?finding a triage:Finding ;
              triage:foundIn ?sprint ;
-             triage:severity "blocking" .
+             triage:severity ?rawSeverity .
+    BIND(LCASE(STR(?rawSeverity)) AS ?severity)
+    FILTER (?severity IN ("blocking", "critical"))
     FILTER NOT EXISTS {
       ?resolution a triage:Resolution ;
                   triage:resolves ?finding .
@@ -50,9 +52,7 @@ SELECT ?sprint ?order ?criteria WHERE {
     NOT EXISTS { ?completion a triage:Completion ; triage:ofSprint ?sprint . }
     || EXISTS {
       ?finding a triage:Finding ;
-               triage:foundIn ?sprint ;
-               triage:severity ?severity .
-      FILTER (?severity != "blocking")
+               triage:foundIn ?sprint .
       FILTER NOT EXISTS {
         ?resolution a triage:Resolution ; triage:resolves ?finding .
       }

--- a/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
+++ b/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
@@ -1,0 +1,48 @@
+# open-findings-for-sprint.sparql — All unresolved findings for one sprint.
+#
+# Parameters: $SPRINT. A terminal triage:status excludes a finding. Existing
+# repository findings use that status as their closure record; Resolution
+# events are honored too when present. Results are ordered for dispatch review:
+# invalid severity first (fail closed), then Blocking, Important, and Minor;
+# ties use foundAt.
+
+PREFIX triage: <urn:atm:triage:>
+
+SELECT ?finding ?findingId ?severity ?rawSeverity ?status ?foundAt ?description WHERE {
+  ?finding a triage:Finding ;
+           triage:foundIn $SPRINT ;
+           triage:severity ?rawSeverity ;
+           triage:foundAt ?foundAt ;
+           triage:description ?description .
+  OPTIONAL { ?finding triage:findingId ?findingId . }
+  OPTIONAL { ?finding triage:status ?status . }
+  FILTER NOT EXISTS {
+    ?resolution a triage:Resolution ;
+                triage:resolves ?finding .
+  }
+  FILTER (
+    !BOUND(?status)
+    || !(
+      LCASE(STR(?status)) IN (
+        "absent", "accepted", "closed", "dismissed", "false_positive",
+        "fixed", "fixed-ci-green", "inherited-fix", "invalid", "merged", "waived"
+      )
+    )
+  )
+  BIND(LCASE(STR(?rawSeverity)) AS ?normalizedSeverity)
+  BIND(
+    IF(?normalizedSeverity IN ("blocking", "critical"), "blocking",
+      IF(?normalizedSeverity = "important", "important",
+        IF(?normalizedSeverity = "minor", "minor", "invalid")
+      )
+    ) AS ?severity
+  )
+  BIND(
+    IF(?severity = "invalid", -1,
+      IF(?severity = "blocking", 0,
+        IF(?severity = "important", 1, 2)
+      )
+    ) AS ?severityOrder
+  )
+}
+ORDER BY ?severityOrder ?foundAt ?finding

--- a/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
+++ b/.claude/skills/graph-orchestration/scripts/open-findings-for-sprint.sparql
@@ -1,21 +1,44 @@
 # open-findings-for-sprint.sparql — All unresolved findings for one sprint.
 #
-# Parameters: $SPRINT. A terminal triage:status excludes a finding. Existing
-# repository findings use that status as their closure record; Resolution
-# events are honored too when present. Results are ordered for dispatch review:
-# invalid severity first (fail closed), then Blocking, Important, and Minor;
-# ties use foundAt.
+# Parameters: $SPRINT. A terminal triage:status excludes a finding in the
+# legacy origin-sprint mode. When $BRANCH is bound, the query instead uses
+# occurrence-level state: a finding is returned only when its own occurrence on
+# that branch is still open. This lets triage-report count downstream
+# promotions on their branch without keeping a closed origin sprint blocked.
+# Resolution events are honored in both modes. Results are ordered for dispatch
+# review: invalid severity first (fail closed), then Blocking, Important, and
+# Minor; ties use foundAt.
 
 PREFIX triage: <urn:atm:triage:>
 
 SELECT ?finding ?findingId ?severity ?rawSeverity ?status ?foundAt ?description WHERE {
   ?finding a triage:Finding ;
-           triage:foundIn $SPRINT ;
+           triage:foundIn ?originSprint ;
            triage:severity ?rawSeverity ;
            triage:foundAt ?foundAt ;
            triage:description ?description .
   OPTIONAL { ?finding triage:findingId ?findingId . }
   OPTIONAL { ?finding triage:status ?status . }
+
+  FILTER (
+    (!BOUND(?BRANCH) && ?originSprint = $SPRINT)
+    ||
+    (BOUND(?BRANCH) && EXISTS {
+      ?finding triage:hasOccurrence ?branchOccurrence .
+      ?branchOccurrence triage:branch $BRANCH .
+      FILTER NOT EXISTS { ?branchOccurrence triage:closed true . }
+      FILTER NOT EXISTS {
+        ?branchOccurrence triage:status ?branchStatus .
+        FILTER (
+          LCASE(STR(?branchStatus)) IN (
+            "absent", "accepted", "closed", "dismissed", "false_positive",
+            "fixed", "fixed-ci-green", "inherited-fix", "invalid", "merged", "waived"
+          )
+        )
+      }
+    })
+  )
+
   FILTER NOT EXISTS {
     ?resolution a triage:Resolution ;
                 triage:resolves ?finding .

--- a/.claude/skills/graph-orchestration/scripts/post-closure-remediation.sparql
+++ b/.claude/skills/graph-orchestration/scripts/post-closure-remediation.sparql
@@ -1,0 +1,58 @@
+# post-closure-remediation.sparql — derive forward targets for late findings.
+#
+# The Finding's triage:foundIn remains the immutable discovery sprint.  This
+# query only derives later candidate sprints; it does not mutate the finding.
+# Python selects the earliest candidate that is not closed, in flight, or
+# natively blocked.
+#
+# Parameter: $PHASE (bound via initBindings)
+
+PREFIX triage: <urn:atm:triage:>
+
+SELECT ?finding ?findingId ?severity ?foundAt ?origin ?originOrder ?closedAt
+       ?candidate ?candidateOrder WHERE {
+  ?origin a triage:Sprint ;
+          triage:inPhase $PHASE ;
+          triage:order ?originOrder .
+  ?closed a triage:QAClosed ;
+          triage:ofSprint ?origin ;
+          (triage:closedAt|triage:at) ?closedAt .
+  ?finding a triage:Finding ;
+           triage:foundIn ?origin ;
+           triage:foundAt ?foundAt .
+  OPTIONAL { ?finding triage:findingId ?findingId . }
+  OPTIONAL { ?finding triage:severity ?severity . }
+  FILTER (?foundAt > ?closedAt)
+  FILTER NOT EXISTS {
+    ?resolution a triage:Resolution ; triage:resolves ?finding .
+  }
+
+  ?candidate a triage:Sprint ;
+             triage:inPhase $PHASE ;
+             triage:order ?candidateOrder .
+  FILTER (?candidateOrder > ?originOrder)
+  FILTER NOT EXISTS {
+    ?candidateClosed a triage:QAClosed ; triage:ofSprint ?candidate .
+  }
+  FILTER NOT EXISTS {
+    ?candidateFinding a triage:Finding ;
+                      triage:foundIn ?candidate ;
+                      triage:severity "blocking" .
+    FILTER NOT EXISTS {
+      ?candidateResolution a triage:Resolution ;
+                           triage:resolves ?candidateFinding .
+    }
+  }
+  FILTER NOT EXISTS {
+    ?candidateAssignment a triage:Assignment ;
+                          triage:ofSprint ?candidate ;
+                          triage:assignedAt ?candidateAssignedAt .
+    FILTER NOT EXISTS {
+      ?candidateCompletion a triage:Completion ;
+                           triage:ofSprint ?candidate ;
+                           triage:at ?candidateCompletedAt .
+      FILTER (?candidateCompletedAt > ?candidateAssignedAt)
+    }
+  }
+}
+ORDER BY ?finding ?candidateOrder

--- a/.claude/skills/graph-orchestration/scripts/post-closure-remediation.sparql
+++ b/.claude/skills/graph-orchestration/scripts/post-closure-remediation.sparql
@@ -37,7 +37,9 @@ SELECT ?finding ?findingId ?severity ?foundAt ?origin ?originOrder ?closedAt
   FILTER NOT EXISTS {
     ?candidateFinding a triage:Finding ;
                       triage:foundIn ?candidate ;
-                      triage:severity "blocking" .
+                      triage:severity ?candidateRawSeverity .
+    BIND(LCASE(STR(?candidateRawSeverity)) AS ?candidateSeverity)
+    FILTER (?candidateSeverity IN ("blocking", "critical"))
     FILTER NOT EXISTS {
       ?candidateResolution a triage:Resolution ;
                            triage:resolves ?candidateFinding .

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -1,53 +1,25 @@
 #!/usr/bin/env python3
 """
-query_runner.py — Cursor resolution for graph-orchestration.
+query_runner.py — deterministic next-dispatch resolution for graph-orchestration.
 
-Called by next-dev-task. Returns JSON to stdout; errors to stderr.
+Called by next-dispatch. Returns JSON to stdout; errors to stderr.
 
-Output shape (TRAVERSAL):
-  {
-    "phase": "TRAVERSAL",
-    "vars": {
-      "sprint": "PhaseF-S1",      # local sprint label
-      "sprint_iri": "...",
-      "sprint_order": 1,
-      "criteria_doc": "..."
-    }
-  }
-
-Output shape (AWAITING):
-  {
-    "phase": "AWAITING",
-    "vars": {},
-    "_incomplete_sprints": ["urn:atm:triage:PhaseF-S1", ...]
-  }
-
-Output shape (CLEANUP):
-  {
-    "phase": "CLEANUP",
-    "vars": {}
-  }
-
-Output shape (DONE):
-  {
-    "phase": "DONE",
-    "vars": {}
-  }
-
-Findings are NOT resolved here. The orchestrator checks .triage/ via
-triaging-findings skill to decide between dev-task.xml.j2 and dev-fix.xml.j2.
-Assignments are appended to events.ttl by the orchestrator after dispatch.
+The canonical result is a discriminated union with ``dispatch`` set to one of
+``dispatch_task``, ``dispatch_fix``, ``awaiting_qa``, ``blocked`` or ``done``.
+The old cursor-shaped result remains available only to the compatibility
+``next-dev-task`` wrapper; new orchestration must call ``next-dispatch``.
 
 Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> [--validate-only]
   PHASE_LOCAL  e.g. "F"
   TTL_DIR      path to .sprints/<PHASE>/ directory on integrate/phase-N branch
   SCRIPT_DIR   path to this script's directory (for .sparql files)
-  --validate-only  validate structure.ttl/events.ttl and stop before cursor resolution
+  --validate-only  validate structure.ttl/events.ttl and stop before dispatch resolution
 """
 
 import importlib.util
 import sys
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 try:
@@ -59,6 +31,8 @@ except ImportError:
 
 TRIAGE_BASE = "urn:atm:triage:"
 TRIAGE = Namespace(TRIAGE_BASE)
+QA_CLOSED = TRIAGE.QAClosed
+CLOSED_AT = TRIAGE.closedAt
 
 
 def _find_repo_root(start: Path):
@@ -240,6 +214,363 @@ def _cli_run_sparql(g: Graph, sparql_file: Path, bindings: dict) -> list:
         raise SystemExit(1) from exc
 
 
+def _timestamp(value):
+    """Return a timezone-aware datetime for an RDF timestamp, or ``None``."""
+
+    if value is None:
+        return None
+    try:
+        parsed = value.toPython() if hasattr(value, "toPython") else value
+        if isinstance(parsed, datetime):
+            if parsed.tzinfo is None:
+                return parsed.replace(tzinfo=timezone.utc)
+            return parsed
+    except (TypeError, ValueError, OverflowError):
+        pass
+    text = str(value).strip()
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _local_sprint(sprint_iri: str) -> str:
+    """Render an IRI as the stable local label used by task templates."""
+
+    return sprint_iri.rsplit(":", 1)[-1]
+
+
+def _qa_closed_state(g: Graph, phase_iri: URIRef) -> tuple[dict, list[str]]:
+    """Collect immutable QAClosed events and reject malformed lifecycle data."""
+
+    sprints = set(g.subjects(RDF.type, TRIAGE.Sprint))
+    sprints = {
+        sprint for sprint in sprints if (sprint, TRIAGE.inPhase, phase_iri) in g
+    }
+    closed: dict[URIRef, tuple[URIRef, datetime]] = {}
+    diagnostics: list[str] = []
+    for event in g.subjects(RDF.type, QA_CLOSED):
+        sprint = g.value(event, TRIAGE.ofSprint)
+        if sprint not in sprints:
+            diagnostics.append(
+                f"#error: QAClosed {event} targets undeclared sprint {sprint}"
+            )
+            continue
+        # closedAt is the canonical property.  triage:at is accepted for
+        # forward/backward compatibility with generic lifecycle events.
+        raw_closed_at = g.value(event, CLOSED_AT)
+        raw_at = g.value(event, TRIAGE.at)
+        if raw_closed_at is not None and raw_at is not None and str(raw_closed_at) != str(raw_at):
+            diagnostics.append(
+                f"#error: QAClosed {event} has conflicting triage:closedAt and triage:at"
+            )
+        raw_timestamp = raw_closed_at or raw_at
+        timestamp = _timestamp(raw_timestamp)
+        if timestamp is None:
+            diagnostics.append(
+                f"#error: QAClosed {event} requires a valid triage:closedAt timestamp"
+            )
+            continue
+        if sprint in closed:
+            diagnostics.append(
+                f"#error: sprint {_local_sprint(str(sprint))} has duplicate QAClosed events"
+            )
+            continue
+        closed[sprint] = (event, timestamp)
+
+    # Dispatch integrity also depends on assignment/completion timestamps. A
+    # malformed event must fail closed instead of silently disappearing from a
+    # SPARQL FILTER and allowing a duplicate assignment.
+    for event_type, timestamp_predicate, label in (
+        (TRIAGE.Assignment, TRIAGE.assignedAt, "Assignment"),
+        (TRIAGE.Completion, TRIAGE.at, "Completion"),
+    ):
+        for event in g.subjects(RDF.type, event_type):
+            sprint = g.value(event, TRIAGE.ofSprint)
+            if sprint not in sprints:
+                diagnostics.append(
+                    f"#error: {label} {event} targets undeclared sprint {sprint}"
+                )
+            if _timestamp(g.value(event, timestamp_predicate)) is None:
+                diagnostics.append(
+                    f"#error: {label} {event} requires a valid {timestamp_predicate.n3()} timestamp"
+                )
+    return closed, diagnostics
+
+
+def _findings_by_sprint(g: Graph) -> dict[URIRef, list[dict]]:
+    """Return unresolved findings grouped by origin sprint."""
+
+    findings: dict[URIRef, list[dict]] = {}
+    for finding in g.subjects(RDF.type, TRIAGE.Finding):
+        sprint = g.value(finding, TRIAGE.foundIn)
+        if sprint is None:
+            continue
+        # A Resolution points to its finding.  Keeping this as a direct graph
+        # lookup avoids treating unrelated resolution metadata as closure.
+        if any(True for _ in g.subjects(TRIAGE.resolves, finding)):
+            continue
+        raw_found_at = g.value(finding, TRIAGE.foundAt)
+        found_at = _timestamp(raw_found_at)
+        severity = str(g.value(finding, TRIAGE.severity) or "").lower()
+        finding_id = g.value(finding, TRIAGE.findingId)
+        findings.setdefault(sprint, []).append(
+            {
+                "iri": str(finding),
+                "id": str(finding_id) if finding_id is not None else None,
+                "severity": severity,
+                "found_at": found_at,
+                "found_at_raw": str(raw_found_at) if raw_found_at is not None else None,
+                "description": str(g.value(finding, TRIAGE.description) or ""),
+            }
+        )
+    for values in findings.values():
+        values.sort(key=lambda item: (item["found_at"] or datetime.min.replace(tzinfo=timezone.utc), item["iri"]))
+    return findings
+
+
+def _sprint_state(g: Graph, sprint: URIRef, findings: dict[URIRef, list[dict]]) -> dict:
+    """Summarize assignment/completion state for one sprint."""
+
+    assignments = []
+    for assignment in g.subjects(RDF.type, TRIAGE.Assignment):
+        if g.value(assignment, TRIAGE.ofSprint) != sprint:
+            continue
+        at = _timestamp(g.value(assignment, TRIAGE.assignedAt))
+        assignments.append((assignment, at))
+    completions = []
+    for completion in g.subjects(RDF.type, TRIAGE.Completion):
+        if g.value(completion, TRIAGE.ofSprint) != sprint:
+            continue
+        at = _timestamp(g.value(completion, TRIAGE.at))
+        completions.append((completion, at))
+    in_flight = any(
+        assigned_at is not None
+        and not any(completed_at is not None and completed_at > assigned_at for _, completed_at in completions)
+        for _, assigned_at in assignments
+    )
+    open_findings = findings.get(sprint, [])
+    blockers = [finding for finding in open_findings if finding["severity"] == "blocking"]
+    return {
+        "assignments": assignments,
+        "completions": completions,
+        "in_flight": in_flight,
+        "open_findings": open_findings,
+        "blockers": blockers,
+    }
+
+
+def _dispatch_result(
+    g: Graph,
+    phase_iri: URIRef,
+    script_dir: Path,
+) -> dict:
+    """Resolve the next exact dispatch target without accepting overrides."""
+
+    closed, closure_diagnostics = _qa_closed_state(g, phase_iri)
+    if closure_diagnostics:
+        raise ValueError("; ".join(closure_diagnostics))
+
+    # The explicit query is an integrity gate, not a hint.  Assignments made
+    # at/after closure are refusals even when a later sprint is available.
+    closed_rows = _cli_run_sparql(
+        g, script_dir / "closed-sprint-targets.sparql", {"PHASE": phase_iri}
+    )
+    if closed_rows:
+        sprint_label = _local_sprint(str(closed_rows[0][1]))
+        raise PermissionError(
+            f"REFUSED: {sprint_label} is CLOSED. Post-closure findings must target "
+            "the earliest open descendant or remediation sprint."
+        )
+
+    findings = _findings_by_sprint(g)
+    sprints = []
+    for sprint in g.subjects(RDF.type, TRIAGE.Sprint):
+        if (sprint, TRIAGE.inPhase, phase_iri) not in g:
+            continue
+        order = g.value(sprint, TRIAGE.order)
+        criteria = g.value(sprint, TRIAGE.criteria)
+        state = _sprint_state(g, sprint, findings)
+        sprints.append((int(order), sprint, str(criteria), state))
+    sprints.sort(key=lambda item: (item[0], str(item[1])))
+
+    # Derive late-finding promotions with the bundled query.  The graph-based
+    # map below selects the same earliest eligible target and retains the
+    # immutable origin on every promotion record.
+    promotion_rows = _cli_run_sparql(
+        g, script_dir / "post-closure-remediation.sparql", {"PHASE": phase_iri}
+    )
+    promotions_by_target: dict[URIRef, list[dict]] = {}
+    promotion_seen: set[tuple[str, str]] = set()
+    for row in promotion_rows:
+        finding_iri = URIRef(str(row[0]))
+        origin = URIRef(str(row[4]))
+        candidate = URIRef(str(row[7]))
+        key = (str(finding_iri), str(candidate))
+        if key in promotion_seen:
+            continue
+        promotion_seen.add(key)
+        # Only the earliest eligible candidate is a valid promotion target.
+        origin_order = int(row[5])
+        candidate_order = int(row[8])
+        target_entry = next((entry for entry in sprints if entry[1] == candidate), None)
+        if target_entry is None or target_entry[0] <= origin_order:
+            continue
+        target_state = target_entry[3]
+        if target_entry[1] in closed or target_state["in_flight"] or target_state["blockers"]:
+            continue
+        prior = promotions_by_target.setdefault(candidate, [])
+        if any(item["finding_iri"] == str(finding_iri) for item in prior):
+            continue
+        prior.append(
+            {
+                "finding_iri": str(finding_iri),
+                "finding_id": str(row[1]) if row[1] else None,
+                "severity": str(row[2] or "").lower(),
+                "origin_sprint": _local_sprint(str(origin)),
+                "target_sprint": _local_sprint(str(candidate)),
+                "found_at": str(row[3]),
+                "closed_at": str(row[6]),
+                "candidate_order": candidate_order,
+            }
+        )
+    for values in promotions_by_target.values():
+        values.sort(key=lambda item: (item["finding_id"] or "", item["finding_iri"]))
+
+    blocked_sprints = []
+    in_flight_sprints = []
+    for order, sprint, _, state in sprints:
+        if sprint in closed:
+            continue
+        if state["blockers"]:
+            blocked_sprints.append(
+                {
+                    "sprint": _local_sprint(str(sprint)),
+                    "sprint_iri": str(sprint),
+                    "order": order,
+                    "finding_ids": [item["id"] for item in state["blockers"] if item["id"]],
+                }
+            )
+        elif state["in_flight"]:
+            in_flight_sprints.append(_local_sprint(str(sprint)))
+
+    # next-dispatch.sparql is the canonical candidate ordering query.  The
+    # Python state checks classify the selected row and add promotions.
+    candidate_rows = _cli_run_sparql(
+        g, script_dir / "next-dispatch.sparql", {"PHASE": phase_iri}
+    )
+    candidate_iris = [URIRef(str(row[0])) for row in candidate_rows]
+    candidates = [entry for entry in sprints if entry[1] in candidate_iris or entry[1] in promotions_by_target]
+    candidates.sort(key=lambda item: (item[0], str(item[1])))
+
+    for order, sprint, criteria, state in candidates:
+        if sprint in closed or state["in_flight"] or state["blockers"]:
+            continue
+        own_findings = list(state["open_findings"])
+        promoted = promotions_by_target.get(sprint, [])
+        all_findings = own_findings + [
+            {
+                "id": item["finding_id"],
+                "iri": item["finding_iri"],
+                "severity": item["severity"],
+            }
+            for item in promoted
+        ]
+        all_findings.sort(key=lambda item: (item.get("id") or "", item["iri"]))
+        missing_ids = [item["iri"] for item in all_findings if not item.get("id")]
+        if missing_ids:
+            raise ValueError(
+                f"dispatch_fix requires findingId for every outstanding finding; missing on {', '.join(missing_ids)}"
+            )
+        target = {
+            "sprint": _local_sprint(str(sprint)),
+            "sprint_iri": str(sprint),
+            "sprint_order": order,
+            "criteria_doc": criteria,
+        }
+        dispatch = "dispatch_fix" if all_findings else "dispatch_task"
+        result = {
+            "schema": "next-dispatch/v1",
+            "dispatch": dispatch,
+            "target": target,
+            "outstanding_finding_ids": [item["id"] for item in all_findings],
+            "promotions": promoted,
+            "blocked_sprints": blocked_sprints,
+            "in_flight_sprints": in_flight_sprints,
+        }
+        # Keep a compact projection for sc-compose templates; this is derived
+        # output, never an input that can override the scheduler.
+        result["vars"] = target | {"finding_ids": result["outstanding_finding_ids"]}
+        return result
+
+    unresolved_late = [
+        promotion
+        for values in promotions_by_target.values()
+        for promotion in values
+    ]
+    # A late finding with no eligible descendant is a hard blocked state, not
+    # a completed phase. This prevents an all-closed graph from hiding a QA
+    # record that still needs remediation.
+    late_without_target = []
+    for origin, origin_findings in findings.items():
+        if origin not in closed:
+            continue
+        closed_at = closed[origin][1]
+        promoted_iris = {
+            item["finding_iri"] for item in unresolved_late
+        }
+        for item in origin_findings:
+            if item["found_at"] is not None and item["found_at"] > closed_at and item["iri"] not in promoted_iris:
+                late_without_target.append(item)
+    if late_without_target:
+        return {
+            "schema": "next-dispatch/v1",
+            "dispatch": "blocked",
+            "target": None,
+            "outstanding_finding_ids": [item["id"] for item in late_without_target if item["id"]],
+            "promotions": unresolved_late,
+            "blocked_sprints": blocked_sprints,
+            "in_flight_sprints": [],
+            "reason": "late findings have no eligible open descendant or remediation sprint",
+        }
+    if in_flight_sprints:
+        return {
+            "schema": "next-dispatch/v1",
+            "dispatch": "awaiting_qa",
+            "target": None,
+            "outstanding_finding_ids": [],
+            "promotions": unresolved_late,
+            "blocked_sprints": blocked_sprints,
+            "in_flight_sprints": in_flight_sprints,
+            "reason": "all eligible work is assigned and awaiting Completion/QA",
+        }
+    if blocked_sprints:
+        return {
+            "schema": "next-dispatch/v1",
+            "dispatch": "blocked",
+            "target": None,
+            "outstanding_finding_ids": [],
+            "promotions": unresolved_late,
+            "blocked_sprints": blocked_sprints,
+            "in_flight_sprints": [],
+            "reason": "all remaining open sprints have unresolved blocking findings",
+        }
+    all_closed = bool(sprints) and all(sprint in closed for _, sprint, _, _ in sprints)
+    return {
+        "schema": "next-dispatch/v1",
+        "dispatch": "done" if all_closed else "awaiting_qa",
+        "target": None,
+        "outstanding_finding_ids": [],
+        "promotions": unresolved_late,
+        "blocked_sprints": [],
+        "in_flight_sprints": [],
+        "reason": "all sprints are QAClosed" if all_closed else "all completions require QAClosed",
+    }
+
+
 def _load_validator(script_dir: Path):
     """Load the canonical findings validator without duplicating its rules."""
 
@@ -318,13 +649,52 @@ def _validate_findings_before_query(ttl_dir: str, script_dir: Path) -> None:
         raise SystemExit(1)
 
 
+def _legacy_cursor_result(g: Graph, phase_iri: URIRef, script_dir: Path) -> dict:
+    """Preserve the old cursor projection for existing consumers only."""
+
+    cursor_rows = _cli_run_sparql(g, script_dir / "cursor.sparql", {"PHASE": phase_iri})
+    if cursor_rows:
+        sprint_iri = str(cursor_rows[0][0])
+        return {
+            "phase": "TRAVERSAL",
+            "vars": {
+                "sprint": _local_sprint(sprint_iri),
+                "sprint_iri": sprint_iri,
+                "sprint_order": int(cursor_rows[0][1]),
+                "criteria_doc": str(cursor_rows[0][2]),
+            },
+        }
+    incomplete_rows = _cli_run_sparql(g, script_dir / "all-complete.sparql", {"PHASE": phase_iri})
+    if incomplete_rows:
+        return {
+            "phase": "AWAITING",
+            "vars": {},
+            "_incomplete_sprints": [str(row[0]) for row in incomplete_rows],
+        }
+    cleanup_rows = _cli_run_sparql(g, script_dir / "open-findings-sprint.sparql", {"PHASE": phase_iri})
+    if cleanup_rows:
+        return {
+            "phase": "CLEANUP",
+            "vars": {},
+            "_findings_raw": [
+                {
+                    "sprint_iri": str(row[1]),
+                    "severity": str(row[2]),
+                    "foundAt": str(row[3]),
+                    "description": str(row[4]),
+                }
+                for row in cleanup_rows
+            ],
+        }
+    return {"phase": "DONE", "vars": {}, "_findings_raw": []}
+
+
 def main():
-    if len(sys.argv) not in (4, 5) or (
-        len(sys.argv) == 5 and sys.argv[4] != "--validate-only"
-    ):
+    allowed_flags = {"--validate-only", "--legacy-cursor"}
+    if len(sys.argv) < 4 or len(sys.argv) > 6 or any(flag not in allowed_flags for flag in sys.argv[4:]):
         print(
             "Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> "
-            "[--validate-only]",
+            "[--validate-only] [--legacy-cursor]",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -332,11 +702,12 @@ def main():
     phase_local = sys.argv[1]
     ttl_dir = sys.argv[2]
     script_dir = Path(sys.argv[3])
-    validate_only = len(sys.argv) == 5
+    validate_only = "--validate-only" in sys.argv[4:]
+    legacy_cursor = "--legacy-cursor" in sys.argv[4:]
 
     phase_iri = URIRef(f"{TRIAGE_BASE}Phase{phase_local}")
     # This is deliberately before structure loading and before --validate-only:
-    # every query_runner entry point must prove that raw findings are valid.
+    # every entry point must prove that raw findings are valid.
     try:
         _validate_findings_before_query(ttl_dir, script_dir)
     except SystemExit:
@@ -345,13 +716,7 @@ def main():
         print(f"ERROR: findings validation could not run: {exc}", file=sys.stderr)
         raise SystemExit(2) from exc
 
-    # The raw findings gate above runs before structure validation so malformed
-    # or incomplete records cannot disappear during phase membership filtering.
-    # Once that gate passes, structure validation can report graph-shape errors
-    # without being conflated with finding-schema diagnostics.
     g = _cli_load_graph(ttl_dir, include_findings=not validate_only)
-
-    # ── Validate structure before cursor ─────────────────────────────────────
     validate_rows = _cli_run_sparql(
         g, script_dir / "validate-structure.sparql", {"PHASE": phase_iri}
     )
@@ -361,68 +726,40 @@ def main():
         sys.exit(1)
 
     if validate_only:
-        print(json.dumps({"phase": "VALIDATE_ONLY", "vars": {}}, indent=2))
+        try:
+            _, lifecycle_diagnostics = _qa_closed_state(g, phase_iri)
+            if lifecycle_diagnostics:
+                for diagnostic in lifecycle_diagnostics:
+                    print(f"ERROR: lifecycle violation: {diagnostic}", file=sys.stderr)
+                raise SystemExit(1)
+            closed_rows = _cli_run_sparql(
+                g, script_dir / "closed-sprint-targets.sparql", {"PHASE": phase_iri}
+            )
+            if closed_rows:
+                sprint_label = _local_sprint(str(closed_rows[0][1]))
+                print(
+                    f"REFUSED: {sprint_label} is CLOSED. Post-closure findings must target "
+                    "the earliest open descendant or remediation sprint.",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+        except SystemExit:
+            raise
+        except Exception as exc:  # noqa: BLE001 - CLI validation boundary
+            print(f"ERROR: lifecycle validation failed: {exc}", file=sys.stderr)
+            raise SystemExit(1) from exc
+        print(json.dumps({"schema": "next-dispatch/v1", "dispatch": "validate_only", "vars": {}}, indent=2))
         return
 
-    # ── Cursor ───────────────────────────────────────────────────────────────
-    cursor_rows = _cli_run_sparql(g, script_dir / "cursor.sparql", {"PHASE": phase_iri})
-
-    if cursor_rows:
-        sprint_iri = str(cursor_rows[0][0])
-        order = int(cursor_rows[0][1])
-        criteria = str(cursor_rows[0][2])
-        sprint_local = sprint_iri.split(":")[-1] if ":" in sprint_iri else sprint_iri
-
-        print(json.dumps({
-            "phase": "TRAVERSAL",
-            "vars": {
-                "sprint": sprint_local,
-                "sprint_iri": sprint_iri,
-                "sprint_order": order,
-                "criteria_doc": criteria,
-            },
-        }, indent=2))
-        return
-
-    # ── Cursor empty — verify all sprints have valid Completions ─────────────
-    incomplete_rows = _cli_run_sparql(
-        g, script_dir / "all-complete.sparql", {"PHASE": phase_iri}
-    )
-    if incomplete_rows:
-        # Some sprints are in-flight or have invalid Completions
-        print(json.dumps({
-            "phase": "AWAITING",
-            "vars": {},
-            "_incomplete_sprints": [str(r[0]) for r in incomplete_rows],
-        }, indent=2))
-        return
-
-    # ── Check for open non-blocking findings (CLEANUP) ───────────────────────
-    cleanup_rows = _cli_run_sparql(
-        g, script_dir / "open-findings-sprint.sparql", {"PHASE": phase_iri}
-    )
-
-    if cleanup_rows:
-        findings = [
-            {
-                "sprint_iri": str(r[1]),
-                "severity": str(r[2]),
-                "foundAt": str(r[3]),
-                "description": str(r[4]),
-            }
-            for r in cleanup_rows
-        ]
-        print(json.dumps({
-            "phase": "CLEANUP",
-            "vars": {},
-            "_findings_raw": findings,
-        }, indent=2))
-    else:
-        print(json.dumps({
-            "phase": "DONE",
-            "vars": {},
-            "_findings_raw": [],
-        }, indent=2))
+    try:
+        result = _legacy_cursor_result(g, phase_iri, script_dir) if legacy_cursor else _dispatch_result(g, phase_iri, script_dir)
+    except PermissionError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc
+    except ValueError as exc:
+        print(f"ERROR: dispatch validation failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print(json.dumps(result, indent=2))
 
 
 if __name__ == "__main__":

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -346,8 +346,28 @@ def load_graph(ttl_dir: str, *, include_findings: bool = True) -> Graph:
             if not in_scope_findings:
                 continue
             for finding in in_scope_findings:
-                for triple in file_graph.triples((finding, None, None)):
-                    g.add(triple)
+                # Keep occurrence/worktree provenance with the finding.  The
+                # live triage report uses occurrence branch/status to scope a
+                # gate, and dropping these linked records here would make the
+                # SPARQL query see no branch occurrence at all.
+                pending = [finding]
+                linked: set = set()
+                linked_predicates = {
+                    TRIAGE.hasOccurrence,
+                    TRIAGE.occursIn,
+                    TRIAGE.openOn,
+                    TRIAGE.promoteTo,
+                    TRIAGE.closedOn,
+                }
+                while pending:
+                    subject = pending.pop()
+                    if subject in linked:
+                        continue
+                    linked.add(subject)
+                    for predicate, obj in file_graph.predicate_objects(subject):
+                        g.add((subject, predicate, obj))
+                        if predicate in linked_predicates and isinstance(obj, URIRef):
+                            pending.append(obj)
                 for resolution in file_graph.subjects(TRIAGE.resolves, finding):
                     for triple in file_graph.triples((resolution, None, None)):
                         g.add(triple)

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -9,7 +9,8 @@ The canonical result is a discriminated union with ``dispatch`` set to one of
 The old cursor-shaped result remains available only to the compatibility
 ``next-dev-task`` wrapper; new orchestration must call ``next-dispatch``.
 
-Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> [--validate-only]
+Usage: query_runner.py --current-phase <SCRIPT_DIR> [--validate-only]
+   or: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> [--validate-only]
   PHASE_LOCAL  e.g. "F"
   TTL_DIR      path to .sprints/<PHASE>/ directory on integrate/phase-N branch
   SCRIPT_DIR   path to this script's directory (for .sparql files)
@@ -19,6 +20,7 @@ Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> [--validate-only]
 import importlib.util
 import sys
 import json
+import platform
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -31,8 +33,45 @@ except ImportError:
 
 TRIAGE_BASE = "urn:atm:triage:"
 TRIAGE = Namespace(TRIAGE_BASE)
+SPRINT = Namespace("urn:atm:sprint:")
 QA_CLOSED = TRIAGE.QAClosed
 CLOSED_AT = TRIAGE.closedAt
+SEVERITY_ORDER = {"invalid": -1, "blocking": 0, "important": 1, "minor": 2}
+
+
+class DispatchDataError(ValueError):
+    """A data error that must be returned as the dispatch union's error arm."""
+
+    def __init__(self, code: str, message: str, *, findings: list[dict] | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.findings = findings or []
+
+
+def _normalize_severity(value) -> tuple[str, str]:
+    """Return canonical severity and its original lower-case spelling."""
+
+    raw = str(value or "").strip().lower()
+    if raw == "critical":
+        return "blocking", raw
+    if raw in {"blocking", "important", "minor"}:
+        return raw, raw
+    return "invalid", raw
+
+
+def _finding_output(finding: dict) -> dict:
+    """Convert internal finding state to stable JSON-safe output."""
+
+    return {
+        "finding_iri": finding.get("iri") or finding.get("finding_iri"),
+        "finding_id": finding.get("id") or finding.get("finding_id"),
+        "severity": finding.get("severity"),
+        "raw_severity": finding.get("raw_severity", finding.get("severity")),
+        "status": finding.get("status"),
+        "found_at": finding.get("found_at_raw", finding.get("found_at")),
+        "description": finding.get("description", ""),
+    }
 
 
 def _find_repo_root(start: Path):
@@ -46,6 +85,132 @@ def _find_repo_root(start: Path):
             break
         current = parent
     return None
+
+
+def _repo_root_from_script(script_dir: Path) -> Path:
+    """Resolve the repository root for the no-argument phase API."""
+
+    cwd = Path.cwd().resolve()
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / ".sprints" / "current-phase.ttl").exists():
+            return candidate
+    root = _find_repo_root(script_dir)
+    if root is not None:
+        return root
+    # A worktree may not have a .triage directory yet. The scripts are always
+    # under <repo>/.claude/skills/graph-orchestration/scripts.
+    candidate = script_dir.resolve().parents[3]
+    if (candidate / ".git").exists():
+        return candidate
+    raise RuntimeError(f"cannot locate repository root from {script_dir}")
+
+
+def _load_current_phase(script_dir: Path) -> dict:
+    """Load the repository's committed phase context and host-local overlay.
+
+    ``.sprints/current-phase.ttl`` is the portable source of truth. A
+    gitignored ``.sprints/current-phase.local.ttl`` may add the absolute
+    integration worktree for the current hostname without leaking machine
+    paths into version control.
+    """
+
+    repo_root = _repo_root_from_script(script_dir)
+    config_path = repo_root / ".sprints" / "current-phase.ttl"
+    if not config_path.exists():
+        raise RuntimeError(
+            f"current phase not configured at {config_path}; create it from "
+            ".sprints/current-phase.ttl.example"
+        )
+    graph = Graph()
+    try:
+        graph.parse(str(config_path), format="turtle")
+    except Exception as exc:  # noqa: BLE001 - configuration boundary
+        raise RuntimeError(f"malformed current phase config {config_path}: {exc}") from exc
+
+    contexts = list(graph.subjects(RDF.type, SPRINT.PhaseContext))
+    if len(contexts) != 1:
+        raise RuntimeError(
+            f"{config_path} must declare exactly one sprint:PhaseContext (found {len(contexts)})"
+        )
+    context = contexts[0]
+
+    def required(predicate: URIRef, label: str) -> str:
+        values = list(graph.objects(context, predicate))
+        if len(values) != 1 or not str(values[0]).strip():
+            detail = "missing" if not values else f"ambiguous ({len(values)} values)"
+            raise RuntimeError(f"{config_path} {label} is {detail}")
+        return str(values[0]).strip()
+
+    phase_local = required(SPRINT.phaseLocal, "sprint:phaseLocal")
+    structure_dir = required(SPRINT.structureDir, "sprint:structureDir")
+    structure_path = Path(structure_dir)
+    if structure_path.is_absolute() or ".." in structure_path.parts:
+        raise RuntimeError("sprint:structureDir must be repository-relative")
+    phase_iri_values = list(graph.objects(context, SPRINT.phaseIri))
+    if len(phase_iri_values) > 1:
+        raise RuntimeError(f"{config_path} has ambiguous sprint:phaseIri")
+    phase_iri_value = phase_iri_values[0] if phase_iri_values else None
+    phase_iri = str(phase_iri_value) if phase_iri_value is not None else f"{TRIAGE_BASE}Phase{phase_local}"
+    plan_dir = required(SPRINT.planDir, "sprint:planDir")
+    plan_path = Path(plan_dir)
+    if plan_path.is_absolute() or ".." in plan_path.parts:
+        raise RuntimeError("sprint:planDir must be repository-relative")
+    integration_branch = required(SPRINT.integrationBranch, "sprint:integrationBranch")
+
+    integration_worktree = None
+    local_path = repo_root / ".sprints" / "current-phase.local.ttl"
+    if local_path.exists():
+        local_graph = Graph()
+        try:
+            local_graph.parse(str(local_path), format="turtle")
+        except Exception as exc:  # noqa: BLE001 - configuration boundary
+            raise RuntimeError(f"malformed local phase config {local_path}: {exc}") from exc
+        local_contexts = list(local_graph.subjects(RDF.type, SPRINT.PhaseContext))
+        if len(local_contexts) > 1:
+            raise RuntimeError(
+                f"{local_path} must declare at most one sprint:PhaseContext"
+            )
+        if local_contexts:
+            local_context = local_contexts[0]
+            local_phase = local_graph.value(local_context, SPRINT.phaseLocal)
+            if local_phase is not None and str(local_phase) != phase_local:
+                raise RuntimeError(
+                    f"{local_path} phaseLocal {local_phase} does not match {phase_local}"
+                )
+            hostname = platform.node()
+            for host in local_graph.objects(local_context, SPRINT.hostConfig):
+                host_name = local_graph.value(host, SPRINT.hostname)
+                if host_name is None or str(host_name) != hostname:
+                    continue
+                path_value = local_graph.value(host, SPRINT.integrationWorktree)
+                if path_value is not None:
+                    path = Path(str(path_value)).expanduser()
+                    if not path.is_absolute():
+                        raise RuntimeError(
+                            f"{local_path} integrationWorktree must be absolute"
+                        )
+                    integration_worktree = str(path)
+                    break
+
+    source_root = Path(integration_worktree) if integration_worktree else repo_root
+    ttl_path = source_root / structure_path
+    if not (ttl_path / "structure.ttl").exists():
+        raise RuntimeError(
+            f"current phase structure not found at {ttl_path}; check structureDir "
+            "and the host integrationWorktree overlay"
+        )
+
+    return {
+        "repo_root": repo_root,
+        "phase_local": phase_local,
+        "phase_iri": URIRef(phase_iri),
+        "ttl_dir": str(ttl_path),
+        "structure_dir": str(structure_path),
+        "plan_dir": str(plan_path),
+        "integration_branch": integration_branch,
+        "integration_worktree": integration_worktree,
+        "config": str(config_path),
+    }
 
 
 IGNORE_FILE_NAME = ".graph-orchestration-ignore"
@@ -315,20 +480,30 @@ def _findings_by_sprint(g: Graph) -> dict[URIRef, list[dict]]:
             continue
         raw_found_at = g.value(finding, TRIAGE.foundAt)
         found_at = _timestamp(raw_found_at)
-        severity = str(g.value(finding, TRIAGE.severity) or "").lower()
+        severity, raw_severity = _normalize_severity(g.value(finding, TRIAGE.severity))
         finding_id = g.value(finding, TRIAGE.findingId)
+        status_value = g.value(finding, TRIAGE.status)
         findings.setdefault(sprint, []).append(
             {
                 "iri": str(finding),
                 "id": str(finding_id) if finding_id is not None else None,
                 "severity": severity,
+                "raw_severity": raw_severity,
+                "status": str(status_value) if status_value is not None else None,
                 "found_at": found_at,
                 "found_at_raw": str(raw_found_at) if raw_found_at is not None else None,
                 "description": str(g.value(finding, TRIAGE.description) or ""),
             }
         )
     for values in findings.values():
-        values.sort(key=lambda item: (item["found_at"] or datetime.min.replace(tzinfo=timezone.utc), item["iri"]))
+        values.sort(
+            key=lambda item: (
+                SEVERITY_ORDER[item["severity"]],
+                item["found_at"] or datetime.min.replace(tzinfo=timezone.utc),
+                item["id"] or "",
+                item["iri"],
+            )
+        )
     return findings
 
 
@@ -387,6 +562,38 @@ def _dispatch_result(
         )
 
     findings = _findings_by_sprint(g)
+    invalid_findings = [
+        finding
+        for sprint_findings in findings.values()
+        for finding in sprint_findings
+        if finding["severity"] == "invalid"
+    ]
+    if invalid_findings:
+        ids = ", ".join(item["id"] or item["iri"] for item in invalid_findings)
+        raise DispatchDataError(
+            "INVALID_FINDING_SEVERITY",
+            f"unknown finding severity blocks dispatch: {ids}",
+            findings=invalid_findings,
+        )
+
+    closed_findings = []
+    for sprint, sprint_findings in findings.items():
+        if sprint not in closed:
+            continue
+        closed_at = closed[sprint][1]
+        closed_findings.extend(
+            finding
+            for finding in sprint_findings
+            if finding["found_at"] is None or finding["found_at"] <= closed_at
+        )
+    if closed_findings:
+        ids = ", ".join(item["id"] or item["iri"] for item in closed_findings)
+        raise DispatchDataError(
+            "CLOSED_SPRINT_HAS_UNRESOLVED_FINDINGS",
+            "QAClosed cannot hide unresolved findings discovered on/before closure: " + ids,
+            findings=closed_findings,
+        )
+
     sprints = []
     for sprint in g.subjects(RDF.type, TRIAGE.Sprint):
         if (sprint, TRIAGE.inPhase, phase_iri) not in g:
@@ -425,11 +632,13 @@ def _dispatch_result(
         prior = promotions_by_target.setdefault(candidate, [])
         if any(item["finding_iri"] == str(finding_iri) for item in prior):
             continue
+        promotion_severity, promotion_raw_severity = _normalize_severity(row[2])
         prior.append(
             {
                 "finding_iri": str(finding_iri),
                 "finding_id": str(row[1]) if row[1] else None,
-                "severity": str(row[2] or "").lower(),
+                "severity": promotion_severity,
+                "raw_severity": promotion_raw_severity,
                 "origin_sprint": _local_sprint(str(origin)),
                 "target_sprint": _local_sprint(str(candidate)),
                 "found_at": str(row[3]),
@@ -497,6 +706,7 @@ def _dispatch_result(
             "dispatch": dispatch,
             "target": target,
             "outstanding_finding_ids": [item["id"] for item in all_findings],
+            "outstanding_findings": [_finding_output(item) for item in all_findings],
             "promotions": promoted,
             "blocked_sprints": blocked_sprints,
             "in_flight_sprints": in_flight_sprints,
@@ -531,6 +741,7 @@ def _dispatch_result(
             "dispatch": "blocked",
             "target": None,
             "outstanding_finding_ids": [item["id"] for item in late_without_target if item["id"]],
+            "outstanding_findings": [_finding_output(item) for item in late_without_target],
             "promotions": unresolved_late,
             "blocked_sprints": blocked_sprints,
             "in_flight_sprints": [],
@@ -542,6 +753,7 @@ def _dispatch_result(
             "dispatch": "awaiting_qa",
             "target": None,
             "outstanding_finding_ids": [],
+            "outstanding_findings": [],
             "promotions": unresolved_late,
             "blocked_sprints": blocked_sprints,
             "in_flight_sprints": in_flight_sprints,
@@ -553,6 +765,7 @@ def _dispatch_result(
             "dispatch": "blocked",
             "target": None,
             "outstanding_finding_ids": [],
+            "outstanding_findings": [],
             "promotions": unresolved_late,
             "blocked_sprints": blocked_sprints,
             "in_flight_sprints": [],
@@ -564,6 +777,7 @@ def _dispatch_result(
         "dispatch": "done" if all_closed else "awaiting_qa",
         "target": None,
         "outstanding_finding_ids": [],
+        "outstanding_findings": [],
         "promotions": unresolved_late,
         "blocked_sprints": [],
         "in_flight_sprints": [],
@@ -689,23 +903,67 @@ def _legacy_cursor_result(g: Graph, phase_iri: URIRef, script_dir: Path) -> dict
     return {"phase": "DONE", "vars": {}, "_findings_raw": []}
 
 
+def _attach_phase_context(result: dict, context: dict | None) -> dict:
+    """Add portable phase metadata to scheduler output when config resolved."""
+
+    if context is None:
+        return result
+    result["context"] = {
+        "phase_local": context["phase_local"],
+        "phase_iri": str(context["phase_iri"]),
+        "ttl_dir": context["structure_dir"],
+        "plan_dir": context["plan_dir"],
+        "integration_branch": context["integration_branch"],
+        "integration_worktree": context["integration_worktree"],
+        "source": context["config"],
+    }
+    if isinstance(result.get("vars"), dict):
+        result["vars"].setdefault("phase_local", context["phase_local"])
+        result["vars"].setdefault("ttl_dir", context["structure_dir"])
+    return result
+
+
 def main():
     allowed_flags = {"--validate-only", "--legacy-cursor"}
-    if len(sys.argv) < 4 or len(sys.argv) > 6 or any(flag not in allowed_flags for flag in sys.argv[4:]):
+    current_phase_mode = len(sys.argv) >= 2 and sys.argv[1] == "--current-phase"
+    if current_phase_mode:
+        valid_current = len(sys.argv) in (3, 4) and all(
+            flag in {"--validate-only", "--legacy-cursor"} for flag in sys.argv[3:]
+        )
+    else:
+        valid_current = False
+    if (
+        (not current_phase_mode and (len(sys.argv) < 4 or len(sys.argv) > 6))
+        or (current_phase_mode and not valid_current)
+        or (not current_phase_mode and any(flag not in allowed_flags for flag in sys.argv[4:]))
+    ):
         print(
-            "Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> "
-            "[--validate-only] [--legacy-cursor]",
+            "Usage: query_runner.py [--current-phase SCRIPT_DIR | "
+            "PHASE_LOCAL TTL_DIR SCRIPT_DIR] [--validate-only] [--legacy-cursor]",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    phase_local = sys.argv[1]
-    ttl_dir = sys.argv[2]
-    script_dir = Path(sys.argv[3])
-    validate_only = "--validate-only" in sys.argv[4:]
-    legacy_cursor = "--legacy-cursor" in sys.argv[4:]
-
-    phase_iri = URIRef(f"{TRIAGE_BASE}Phase{phase_local}")
+    phase_context = None
+    if current_phase_mode:
+        script_dir = Path(sys.argv[2])
+        try:
+            phase_context = _load_current_phase(script_dir)
+        except Exception as exc:  # noqa: BLE001 - CLI configuration boundary
+            print(f"ERROR: current phase resolution failed: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
+        phase_local = phase_context["phase_local"]
+        ttl_dir = phase_context["ttl_dir"]
+        phase_iri = phase_context["phase_iri"]
+        flags = sys.argv[3:]
+    else:
+        phase_local = sys.argv[1]
+        ttl_dir = sys.argv[2]
+        script_dir = Path(sys.argv[3])
+        phase_iri = URIRef(f"{TRIAGE_BASE}Phase{phase_local}")
+        flags = sys.argv[4:]
+    validate_only = "--validate-only" in flags
+    legacy_cursor = "--legacy-cursor" in flags
     # This is deliberately before structure loading and before --validate-only:
     # every entry point must prove that raw findings are valid.
     try:
@@ -748,7 +1006,9 @@ def main():
         except Exception as exc:  # noqa: BLE001 - CLI validation boundary
             print(f"ERROR: lifecycle validation failed: {exc}", file=sys.stderr)
             raise SystemExit(1) from exc
-        print(json.dumps({"schema": "next-dispatch/v1", "dispatch": "validate_only", "vars": {}}, indent=2))
+        print(json.dumps(_attach_phase_context({
+            "schema": "next-dispatch/v1", "dispatch": "validate_only", "vars": {}
+        }, phase_context), indent=2))
         return
 
     try:
@@ -756,10 +1016,19 @@ def main():
     except PermissionError as exc:
         print(str(exc), file=sys.stderr)
         raise SystemExit(1) from exc
+    except DispatchDataError as exc:
+        print(json.dumps(_attach_phase_context({
+            "schema": "next-dispatch/v1",
+            "dispatch": "error",
+            "error": {"code": exc.code, "message": exc.message},
+            "findings": [_finding_output(item) for item in exc.findings],
+            "target": None,
+        }, phase_context), indent=2))
+        raise SystemExit(1) from exc
     except ValueError as exc:
         print(f"ERROR: dispatch validation failed: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
-    print(json.dumps(result, indent=2))
+    print(json.dumps(_attach_phase_context(result, phase_context), indent=2))
 
 
 if __name__ == "__main__":

--- a/.claude/skills/graph-orchestration/scripts/test_preflight.py
+++ b/.claude/skills/graph-orchestration/scripts/test_preflight.py
@@ -176,3 +176,4 @@ def test_cli_renders_graph_dev_template(tmp_path):
     assert result.returncode == 0, result.stderr or result.stdout
     rendered = output_path.read_text(encoding="utf-8")
     assert '<atm-task id="GO-TEST" sprint="AICH-S1"' in rendered
+    assert "next-dispatch" in rendered

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -8,6 +8,7 @@ Requires: rdflib, pytest
 import importlib.util
 import json
 import os
+import platform
 import subprocess
 import sys
 
@@ -837,6 +838,107 @@ triage:f1 a triage:Finding ; triage:findingId "F-1" ;
         payload = json.loads(result.stdout)
         assert payload["dispatch"] == "blocked"
         assert "no eligible open descendant" in payload["reason"]
+
+    def test_invalid_severity_returns_error_union(self, tmp_path):
+        finding = PREFIX + """
+triage:f1 a triage:Finding ; triage:findingId "F-1" ;
+    triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T12:00:00Z"^^xsd:dateTime ;
+    triage:severity "medium" ; triage:description "unknown severity" .
+"""
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]), findings={"F-1.ttl": finding})
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+        assert result.returncode == 1
+        payload = json.loads(result.stdout)
+        assert payload["dispatch"] == "error"
+        assert payload["error"]["code"] == "INVALID_FINDING_SEVERITY"
+        assert payload["findings"][0]["raw_severity"] == "medium"
+
+    def test_critical_severity_is_a_blocking_dispatch_gate(self, tmp_path):
+        finding = PREFIX + """
+triage:f1 a triage:Finding ; triage:findingId "F-1" ;
+    triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T12:00:00Z"^^xsd:dateTime ;
+    triage:severity "CRITICAL" ; triage:description "reviewer critical" .
+"""
+        repo = self._make_repo(
+            tmp_path,
+            structure([(1, "S1"), (2, "S2")]),
+            findings={"F-1.ttl": finding},
+        )
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["dispatch"] == "dispatch_task"
+        assert payload["target"]["sprint"] == "S2"
+        assert payload["blocked_sprints"][0]["finding_ids"] == ["F-1"]
+
+    def test_closed_sprint_with_unresolved_preclosure_finding_fails(self, tmp_path):
+        events = PREFIX + """
+triage:q1 a triage:QAClosed ; triage:ofSprint triage:S1 ;
+    triage:closedAt "2026-07-01T12:00:00Z"^^xsd:dateTime .
+"""
+        finding = PREFIX + """
+triage:f1 a triage:Finding ; triage:findingId "F-1" ;
+    triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T11:00:00Z"^^xsd:dateTime ;
+    triage:severity "minor" ; triage:status "fixed" ;
+    triage:description "missing Resolution" .
+"""
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]), events, {"F-1.ttl": finding})
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+        assert result.returncode == 1
+        payload = json.loads(result.stdout)
+        assert payload["dispatch"] == "error"
+        assert payload["error"]["code"] == "CLOSED_SPRINT_HAS_UNRESOLVED_FINDINGS"
+
+    def test_no_argument_api_resolves_current_phase_context(self, tmp_path):
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]))
+        config = repo / ".sprints" / "current-phase.ttl"
+        config.write_text(
+            """@prefix sprint: <urn:atm:sprint:> .
+@prefix triage: <urn:atm:triage:> .
+sprint:CurrentPhase a sprint:PhaseContext ;
+    sprint:phaseLocal "F" ; sprint:phaseIri triage:PhaseF ;
+    sprint:structureDir ".sprints/F" ;
+    sprint:planDir "docs/plans/phase-f" ;
+    sprint:integrationBranch "integrate/phase-F" .
+"""
+        )
+        result = self._run(repo, wrapper="next-dispatch")
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["dispatch"] == "dispatch_task"
+        assert payload["target"]["sprint"] == "S1"
+        assert payload["context"]["integration_branch"] == "integrate/phase-F"
+        assert payload["vars"]["ttl_dir"] == ".sprints/F"
+
+    def test_current_phase_local_overlay_selects_host_integration_worktree(self, tmp_path):
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]))
+        (repo / ".sprints" / "current-phase.ttl").write_text(
+            """@prefix sprint: <urn:atm:sprint:> .
+@prefix triage: <urn:atm:triage:> .
+sprint:CurrentPhase a sprint:PhaseContext ;
+    sprint:phaseLocal "F" ; sprint:phaseIri triage:PhaseF ;
+    sprint:structureDir ".sprints/F" ;
+    sprint:planDir "docs/plans/phase-f" ;
+    sprint:integrationBranch "integrate/phase-F" .
+"""
+        )
+        (repo / ".sprints" / "current-phase.local.ttl").write_text(
+            f"""@prefix sprint: <urn:atm:sprint:> .
+sprint:CurrentPhase a sprint:PhaseContext ;
+    sprint:phaseLocal "F" ;
+    sprint:hostConfig [
+        sprint:hostname "{platform.node()}" ;
+        sprint:integrationWorktree "{repo}"
+    ] .
+"""
+        )
+        result = self._run(repo, wrapper="next-dispatch")
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["context"]["integration_worktree"] == str(repo)
 
 
 # ── assignee-busy CLI tests ───────────────────────────────────────────────────

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -670,6 +670,175 @@ triage:S2 a triage:Sprint ; triage:inPhase triage:PhaseF ;
         assert "Usage: next-dev-task" in result.stderr
 
 
+# ── next-dispatch scheduler tests ────────────────────────────────────────────
+
+class TestNextDispatch:
+    def _make_repo(
+        self,
+        tmp_path: Path,
+        structure_ttl: str,
+        events_ttl: str = "",
+        findings: dict[str, str] | None = None,
+    ) -> Path:
+        repo = tmp_path / "repo"
+        ttl_dir = repo / ".sprints" / "F"
+        ttl_dir.mkdir(parents=True)
+        (ttl_dir / "structure.ttl").write_text(structure_ttl)
+        if events_ttl:
+            (ttl_dir / "events.ttl").write_text(events_ttl)
+        (repo / ".triage").mkdir()
+        for name, content in (findings or {}).items():
+            path = repo / ".triage" / "phase-F" / "findings" / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        return repo
+
+    def _run(self, repo: Path, *args: str, wrapper: str = "next-dispatch") -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        env["GRAPH_ORCH_PYTHON"] = sys.executable
+        return subprocess.run(
+            [str(SCRIPTS / wrapper), *args],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+    def test_closed_sprint_selects_next_open_sprint(self, tmp_path):
+        events = PREFIX + """
+triage:q1 a triage:QAClosed ; triage:ofSprint triage:S1 ;
+    triage:closedAt "2026-07-01T12:00:00Z"^^xsd:dateTime .
+"""
+        repo = self._make_repo(tmp_path, structure([(1, "S1"), (2, "S2")]), events)
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["dispatch"] == "dispatch_task"
+        assert payload["target"]["sprint"] == "S2"
+
+    def test_assignment_after_close_is_refused(self, tmp_path):
+        events = PREFIX + """
+triage:q1 a triage:QAClosed ; triage:ofSprint triage:S1 ;
+    triage:closedAt "2026-07-01T12:00:00Z"^^xsd:dateTime .
+triage:a1 a triage:Assignment ; triage:ofSprint triage:S1 ;
+    triage:assignedAt "2026-07-01T13:00:00Z"^^xsd:dateTime .
+"""
+        repo = self._make_repo(tmp_path, structure([(1, "S1"), (2, "S2")]), events)
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+
+        assert result.returncode == 1
+        assert result.stdout == ""
+        assert "REFUSED: S1 is CLOSED" in result.stderr
+
+    def test_validate_only_also_rejects_assignment_after_close(self, tmp_path):
+        events = PREFIX + """
+triage:q1 a triage:QAClosed ; triage:ofSprint triage:S1 ;
+    triage:closedAt "2026-07-01T12:00:00Z"^^xsd:dateTime .
+triage:a1 a triage:Assignment ; triage:ofSprint triage:S1 ;
+    triage:assignedAt "2026-07-01T13:00:00Z"^^xsd:dateTime .
+"""
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]), events)
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"), "--validate-only")
+        assert result.returncode == 1
+        assert result.stdout == ""
+        assert "REFUSED: S1 is CLOSED" in result.stderr
+
+    def test_late_finding_is_promoted_to_next_open_sprint(self, tmp_path):
+        events = PREFIX + """
+triage:q1 a triage:QAClosed ; triage:ofSprint triage:S1 ;
+    triage:closedAt "2026-07-01T12:00:00Z"^^xsd:dateTime .
+"""
+        finding = PREFIX + """
+triage:f1 a triage:Finding ; triage:findingId "F-1" ;
+    triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T13:00:00Z"^^xsd:dateTime ;
+    triage:severity "important" ; triage:description "late QA finding" .
+"""
+        repo = self._make_repo(
+            tmp_path,
+            structure([(1, "S1"), (2, "S2")]),
+            events,
+            {"F-1.ttl": finding},
+        )
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["dispatch"] == "dispatch_fix"
+        assert payload["target"]["sprint"] == "S2"
+        assert payload["outstanding_finding_ids"] == ["F-1"]
+        assert payload["promotions"][0]["origin_sprint"] == "S1"
+
+    def test_blocked_sprint_is_skipped_without_reopening_closed_sprint(self, tmp_path):
+        events = PREFIX + """
+triage:q1 a triage:QAClosed ; triage:ofSprint triage:S1 ;
+    triage:closedAt "2026-07-01T12:00:00Z"^^xsd:dateTime .
+"""
+        finding = PREFIX + """
+triage:f2 a triage:Finding ; triage:findingId "F-2" ;
+    triage:foundIn triage:S2 ;
+    triage:foundAt "2026-07-01T13:00:00Z"^^xsd:dateTime ;
+    triage:severity "blocking" ; triage:description "blocked S2" .
+"""
+        repo = self._make_repo(
+            tmp_path,
+            structure([(1, "S1"), (2, "S2"), (3, "S3")]),
+            events,
+            {"F-2.ttl": finding},
+        )
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["dispatch"] == "dispatch_task"
+        assert payload["target"]["sprint"] == "S3"
+        assert payload["blocked_sprints"][0]["sprint"] == "S2"
+
+    def test_dispatch_wrapper_rejects_manual_target_override(self, tmp_path):
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]))
+        result = self._run(
+            repo,
+            "F",
+            str(repo / ".sprints" / "F"),
+            "--sprint=S1",
+            wrapper="dispatch",
+        )
+        assert result.returncode == 1
+        assert "manual sprint/branch/finding overrides" in result.stderr
+
+    def test_duplicate_qaclosed_events_fail_closed(self, tmp_path):
+        events = PREFIX + """
+triage:q1 a triage:QAClosed ; triage:ofSprint triage:S1 ;
+    triage:closedAt "2026-07-01T12:00:00Z"^^xsd:dateTime .
+triage:q2 a triage:QAClosed ; triage:ofSprint triage:S1 ;
+    triage:closedAt "2026-07-01T13:00:00Z"^^xsd:dateTime .
+"""
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]), events)
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+        assert result.returncode == 1
+        assert "duplicate QAClosed" in result.stderr
+
+    def test_late_finding_with_no_descendant_is_not_done(self, tmp_path):
+        events = PREFIX + """
+triage:q1 a triage:QAClosed ; triage:ofSprint triage:S1 ;
+    triage:closedAt "2026-07-01T12:00:00Z"^^xsd:dateTime .
+"""
+        finding = PREFIX + """
+triage:f1 a triage:Finding ; triage:findingId "F-1" ;
+    triage:foundIn triage:S1 ;
+    triage:foundAt "2026-07-01T13:00:00Z"^^xsd:dateTime ;
+    triage:severity "minor" ; triage:description "late finding" .
+"""
+        repo = self._make_repo(tmp_path, structure([(1, "S1")]), events, {"F-1.ttl": finding})
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["dispatch"] == "blocked"
+        assert "no eligible open descendant" in payload["reason"]
+
+
 # ── assignee-busy CLI tests ───────────────────────────────────────────────────
 
 class TestAssigneeBusy:

--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -10,6 +10,12 @@ description: Produce an auditable phase triage report from the integration workt
 the machine-readable source of truth and its precomputed row strings are the
 inputs displayed by `sc-compose`; Jinja performs no gate arithmetic.
 
+Current B/I/M counts and merge readiness come from unresolved Turtle findings
+through graph-orchestration's existing `open-findings-for-sprint.sparql`
+query. QA evidence is review provenance only. PR, CI, and merge state are read
+from GitHub for the branch declared in Turtle (or derived from the documented
+criteria filename convention); no hand-maintained metadata file is used.
+
 ## Usage
 
 Run from the current `integrate/phase-*` worktree, or pass the worktree
@@ -26,14 +32,14 @@ python3 .claude/skills/triage-report/scripts/triage_report.py \
 When the command is not run from an integration worktree it searches Git
 worktrees. It fails with a structured JSON error (exit 2) when there is not
 exactly one `integrate/phase-*` candidate. Use `--integration-root` to remove
-that ambiguity. `--qa-master` and `--metadata` may be supplied when those
-artifacts are stored at non-default paths.
+that ambiguity. `--qa-master` may be supplied when QA evidence is stored at a
+non-default path.
 
 The default QA evidence path is
 `docs/plans/phase-<phase>/.audit/qa-evidence-master.json`. Only the latest
-`run_type: "qa"` run per sprint is authoritative; reviewer-only runs do not
-replace QA. Missing QA, PR, CI, branch, acknowledgement, or merge inputs stay
-`null` and are listed in `data_gaps`.
+`run_type: "qa"` run per sprint is displayed as QA provenance; reviewer-only
+runs do not replace QA. Missing QA or GitHub inputs stay `null` and are listed
+in `data_gaps`.
 
 The QA message/shared/temp path fields in machine rows are retained as
 host-local evidence pointers from the audit master for drill-down. They are
@@ -41,13 +47,11 @@ not canonical Turtle paths; triage record paths remain repository-relative.
 
 ## Calculated gates
 
-- `ready_to_merge` is true only when the authoritative blocker count is known
-  and zero; unknown counts produce `null`.
-- `ok_to_merge` is true only when `ready_to_merge` is true and every earlier
-  sprint has explicit `merged: true` metadata. No branch name, PR number, or
-  ancestry is treated as proof of merge.
-- `quality_gate` separately requires all known B/I/M counts to be zero and is
-  never used to silently convert missing counts to zero.
+- `ready_to_merge` is true only when the live unresolved Turtle blocker count
+  is zero.
+- `ok_to_merge` is true only when `ready_to_merge` is true and GitHub reports
+  every earlier sprint's current delivery attempt as merged.
+- `quality_gate` requires live unresolved Turtle B/I/M counts to be zero.
 
 The table uses the same DEV/QA/CI/PR icons as `/sprint-report`: `📥`, `🌀`,
 `✅`, `🚩`, `🔨`, `🚧`, `❌`, `🏁`, and `🚀`. Unknown values are shown as `?` or

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -19,10 +19,10 @@ from pathlib import Path
 from typing import Any
 
 try:
-    from rdflib import Graph, Namespace, RDF
+    from rdflib import Graph, Literal, Namespace, RDF
     _RDFLIB_ERROR = None
 except ImportError as exc:  # pragma: no cover - environment error
-    Graph = Namespace = RDF = None  # type: ignore[assignment]
+    Graph = Literal = Namespace = RDF = None  # type: ignore[assignment]
     _RDFLIB_ERROR = str(exc)
 
 
@@ -434,11 +434,18 @@ def _live_counts(phase_path: Path, sprints: list[dict[str, Any]]) -> dict[str, d
 
     results: dict[str, dict[str, int]] = {}
     for sprint in sprints:
+        branch = sprint["branch"] or _branch_from_criteria(sprint["criteria"])
+        bindings = {"SPRINT": runner.URIRef(sprint["iri"])}
+        if branch:
+            bindings["BRANCH"] = Literal(branch)
+        # Legacy structure rows may intentionally have no branch convention.
+        # Keep those rows on the query's origin-sprint compatibility path; all
+        # mapped delivery sprints use occurrence-level branch scoping.
         try:
             rows = runner.run_sparql(
                 graph,
                 query,
-                {"SPRINT": runner.URIRef(sprint["iri"])},
+                bindings,
             )
         except Exception as exc:  # noqa: BLE001 - normalize SPARQL failures
             raise ReportError(f"could not query live findings for {sprint['id']}: {exc}") from exc

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -9,6 +9,7 @@ only displays its already-calculated values.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import re
 import subprocess
@@ -152,10 +153,13 @@ def _sprints(structure: Graph, phase: str) -> list[dict[str, Any]]:
             continue
         order_values = list(structure.objects(subject, TRIAGE.order))
         criteria_values = list(structure.objects(subject, TRIAGE.criteria))
+        branch_values = list(structure.objects(subject, TRIAGE.branch))
         if len(order_values) != 1:
             raise ReportError(f"{_local(subject)} must have exactly one triage:order")
         if len(criteria_values) != 1:
             raise ReportError(f"{_local(subject)} must have exactly one triage:criteria")
+        if len(branch_values) > 1:
+            raise ReportError(f"{_local(subject)} may have at most one triage:branch")
         order_text = str(order_values[0]).strip()
         if not re.fullmatch(r"[0-9]+", order_text):
             raise ReportError(f"{_local(subject)} triage:order must be an integer")
@@ -166,8 +170,10 @@ def _sprints(structure: Graph, phase: str) -> list[dict[str, Any]]:
         result.append(
             {
                 "id": _local(subject),
+                "iri": str(subject),
                 "order": order,
                 "criteria": str(criteria_values[0]),
+                "branch": str(branch_values[0]) if branch_values else None,
             }
         )
     if not result:
@@ -225,28 +231,6 @@ def _qa_runs(master: Any) -> dict[str, dict[str, Any]]:
         if previous is None or (candidate and (previous_dt is None or candidate > previous_dt)):
             latest[sprint] = run
     return latest
-
-
-def _metadata(metadata: Any) -> dict[str, dict[str, Any]]:
-    if metadata is None:
-        return {}
-    if not isinstance(metadata, dict) or not isinstance(metadata.get("sprints"), list):
-        raise ReportError("metadata must contain a sprints array")
-    values = metadata["sprints"]
-    result: dict[str, dict[str, Any]] = {}
-    for item in values:
-        if not isinstance(item, dict) or not item.get("id"):
-            raise ReportError("metadata.sprints entries must be objects with an id")
-        key = str(item["id"])
-        if key in result:
-            raise ReportError(f"metadata contains duplicate sprint {key}")
-        result[key] = item
-    return result
-
-
-def _count(run: dict[str, Any] | None, name: str) -> int | None:
-    value = run.get(name) if run else None
-    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
 
 
 def _phase_sprint(criteria: str) -> str | None:
@@ -309,24 +293,6 @@ def _source_path(path: Path | None, root: Path) -> str | None:
         return str(path.relative_to(root))
     except ValueError:
         return f"<external>/{path.name}"
-
-
-def _validate_metadata(item: dict[str, Any], sprint: str) -> None:
-    for field in ("branch", "head_sha", "target_branch", "pr_url", "ci_status", "ci_url", "merge_commit", "merged_at_utc", "assignment_ack_message_id", "assignment_ack_time_utc"):
-        if item.get(field) is not None and not isinstance(item[field], str):
-            raise ReportError(f"metadata {sprint}.{field} must be a string or null")
-    if item.get("pr_number") is not None and (not isinstance(item["pr_number"], int) or isinstance(item["pr_number"], bool)):
-        raise ReportError(f"metadata {sprint}.pr_number must be an integer or null")
-    if item.get("merged") is not None and not isinstance(item["merged"], bool):
-        raise ReportError(f"metadata {sprint}.merged must be boolean or null")
-
-
-def _validate_qa(run: dict[str, Any] | None, sprint: str) -> None:
-    if run is None:
-        return
-    for field in ("blockers", "important", "minor"):
-        if field in run and run[field] is not None and (not isinstance(run[field], int) or isinstance(run[field], bool) or run[field] < 0):
-            raise ReportError(f"QA run {sprint}.{field} must be a non-negative integer or null")
 
 
 def _findings_dir(root: Path, plan_phase: str | None) -> Path:
@@ -427,11 +393,194 @@ def _run_findings_validator(
     return payload
 
 
+def _graph_runner():
+    """Load graph-orchestration's public graph/query helpers once.
+
+    The report must use the same finding membership and resolution semantics as
+    dispatch.  Loading that module is preferable to a parallel Turtle loader or
+    a report-specific copy of ``open-findings-for-sprint.sparql``.
+    """
+    runner_path = (
+        Path(__file__).resolve().parents[2]
+        / "graph-orchestration"
+        / "scripts"
+        / "query_runner.py"
+    )
+    spec = importlib.util.spec_from_file_location("triage_report_graph_runner", runner_path)
+    if spec is None or spec.loader is None:
+        raise ReportError(f"cannot load graph query runner: {runner_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _live_counts(phase_path: Path, sprints: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+    """Return unresolved B/I/M counts using graph-orchestration's query.
+
+    This is the report's gate source.  QA evidence records review provenance;
+    they never override the current unresolved-finding state.
+    """
+    runner = _graph_runner()
+    query = (
+        Path(__file__).resolve().parents[2]
+        / "graph-orchestration"
+        / "scripts"
+        / "open-findings-for-sprint.sparql"
+    )
+    try:
+        graph = runner.load_graph(str(phase_path))
+    except Exception as exc:  # noqa: BLE001 - normalize graph runner failures
+        raise ReportError(f"could not load live finding graph: {exc}") from exc
+
+    results: dict[str, dict[str, int]] = {}
+    for sprint in sprints:
+        try:
+            rows = runner.run_sparql(
+                graph,
+                query,
+                {"SPRINT": runner.URIRef(sprint["iri"])},
+            )
+        except Exception as exc:  # noqa: BLE001 - normalize SPARQL failures
+            raise ReportError(f"could not query live findings for {sprint['id']}: {exc}") from exc
+        counts = {"blockers": 0, "important": 0, "minor": 0}
+        for row in rows:
+            severity = str(row[2])
+            if severity == "blocking":
+                counts["blockers"] += 1
+            elif severity == "important":
+                counts["important"] += 1
+            elif severity == "minor":
+                counts["minor"] += 1
+            else:
+                raise ReportError(
+                    f"{sprint['id']}: live findings query returned invalid severity {severity!r}"
+                )
+        results[sprint["id"]] = counts
+    return results
+
+
+def _branch_from_criteria(criteria: str) -> str | None:
+    """Derive the documented sprint-branch convention from a criteria path.
+
+    ``triage:branch`` is preferred when a phase records it explicitly.  The
+    fallback keeps existing phase-AI records useful until that field is added
+    to their structure graph.
+    """
+    match = re.fullmatch(
+        r"sprint-([a-z][a-z0-9]*)-([0-9]+)(?:-(pre))?-(.+)",
+        Path(criteria).stem,
+    )
+    if not match:
+        return None
+    prefix, number, suffix, slug = match.groups()
+    return f"feature/p{prefix.upper()}-s{number}{suffix or ''}-{slug}"
+
+
+def _origin_repo(root: Path) -> str | None:
+    """Return owner/repo for a GitHub origin without hard-coding a repository."""
+    try:
+        origin = _git(root, "remote", "get-url", "origin")
+    except ReportError:
+        return None
+    match = re.search(r"github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?$", origin)
+    return f"{match.group(1)}/{match.group(2)}" if match else None
+
+
+def _github_prs(root: Path, repo: str, branch: str) -> list[dict[str, Any]] | None:
+    """Read the complete PR history for one branch; return None if unavailable."""
+    command = [
+        "gh", "pr", "list", "--repo", repo, "--head", branch, "--state", "all",
+        "--limit", "100", "--json",
+        "number,state,headRefName,headRefOid,baseRefName,mergeCommit,mergedAt,url,"
+        "statusCheckRollup,createdAt",
+    ]
+    try:
+        result = subprocess.run(command, cwd=root, text=True, capture_output=True, check=False)
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, list) else None
+
+
+def _ci_status(checks: Any) -> str | None:
+    if not isinstance(checks, list) or not checks:
+        return None
+    conclusions = [
+        str(check.get("conclusion") or check.get("status") or "").upper()
+        for check in checks if isinstance(check, dict)
+    ]
+    if any(value in {"FAILURE", "FAILED", "ERROR", "TIMED_OUT", "CANCELLED"} for value in conclusions):
+        return "fail"
+    if any(value in {"IN_PROGRESS", "QUEUED", "PENDING", "WAITING", "REQUESTED"} for value in conclusions):
+        return "pending"
+    if conclusions and all(value in {"SUCCESS", "NEUTRAL", "SKIPPED"} for value in conclusions):
+        return "pass"
+    return None
+
+
+def _current_pr(prs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Prefer the newest open replay over an older merged attempt."""
+    if not prs:
+        return None
+    open_prs = [pr for pr in prs if pr.get("state") == "OPEN"]
+    candidates = open_prs or prs
+    return max(candidates, key=lambda pr: str(pr.get("createdAt") or pr.get("mergedAt") or ""))
+
+
+def _github_state(root: Path, sprints: list[dict[str, Any]]) -> tuple[dict[str, dict[str, Any]], str | None]:
+    """Collect current PR/CI state and preserve replay history per sprint."""
+    repo = _origin_repo(root)
+    if repo is None:
+        return {}, None
+    states: dict[str, dict[str, Any]] = {}
+    for sprint in sprints:
+        branch = sprint["branch"] or _branch_from_criteria(sprint["criteria"])
+        if branch is None:
+            states[sprint["id"]] = {}
+            continue
+        prs = _github_prs(root, repo, branch)
+        if prs is None:
+            states[sprint["id"]] = {"branch": branch}
+            continue
+        current = _current_pr(prs)
+        if current is None:
+            states[sprint["id"]] = {"branch": branch, "delivery_attempts": []}
+            continue
+        merge = current.get("mergeCommit")
+        merge_oid = merge.get("oid") if isinstance(merge, dict) else None
+        states[sprint["id"]] = {
+            "branch": branch,
+            "head_sha": current.get("headRefOid"),
+            "target_branch": current.get("baseRefName"),
+            "pr_number": current.get("number"),
+            "pr_url": current.get("url"),
+            "ci_status": _ci_status(current.get("statusCheckRollup")),
+            "merged": current.get("state") == "MERGED",
+            "merge_commit": merge_oid,
+            "merged_at_utc": current.get("mergedAt"),
+            "delivery_attempts": [
+                {
+                    "pr_number": pr.get("number"),
+                    "head_sha": pr.get("headRefOid"),
+                    "state": pr.get("state"),
+                    "merged_at_utc": pr.get("mergedAt"),
+                    "url": pr.get("url"),
+                }
+                for pr in sorted(prs, key=lambda pr: str(pr.get("createdAt") or ""))
+            ],
+        }
+    return states, repo
+
+
 def build_report(
     integration_root: Path,
     phase: str | None = None,
     qa_master: Path | None = None,
-    metadata: Path | None = None,
 ) -> dict[str, Any]:
     """Build canonical report data. No presentation-layer inference occurs here."""
     if _RDFLIB_ERROR:
@@ -458,34 +607,28 @@ def build_report(
     if not qa_master.is_absolute():
         qa_master = root / qa_master
     qa_data = _json(qa_master)
-    if metadata is not None and not metadata.is_absolute():
-        metadata = root / metadata
-    metadata_data = _json(metadata) if metadata else None
     # Validate raw findings before calculating a single row.  This prevents
     # query_runner's phase scoping from hiding malformed or orphan records.
     findings_dir = _findings_dir(root, plan_phase)
     validation = _run_findings_validator(root, findings_dir, structure_path, events_path)
     qa = _qa_runs(qa_data)
-    meta = _metadata(metadata_data)
+    live_counts = _live_counts(phase_path, sprints)
+    github, github_repo = _github_state(root, sprints)
     dev = _dev_states(events)
     data_gaps: list[str] = []
     if events is None:
         data_gaps.append(f"events file not found: {events_path}")
     if qa_data is None:
         data_gaps.append(f"QA evidence master not found: {qa_master}")
-    if metadata is None:
-        data_gaps.append("PR/CI/branch/merge metadata not supplied; those cells are unknown")
-    elif metadata_data is None:
-        data_gaps.append(f"metadata not found: {metadata}")
+    if github_repo is None:
+        data_gaps.append("GitHub origin is unavailable; PR/CI/merge cells are unknown")
 
     rows: list[dict[str, Any]] = []
     for sprint in sprints:
         sid = sprint["id"]
         run = qa.get(sid)
-        item = meta.get(sid, {})
-        _validate_metadata(item, sid)
-        _validate_qa(run, sid)
-        counts = {name: _count(run, name) for name in ("blockers", "important", "minor")}
+        item = github.get(sid, {})
+        counts = live_counts[sid]
         verdict = str(run.get("verdict", "")) if run else None
         if not verdict and run and isinstance(run.get("pass"), bool):
             verdict = "PASS" if run["pass"] else "FAIL"
@@ -523,7 +666,11 @@ def build_report(
                     "blockers": counts["blockers"],
                     "important": counts["important"],
                     "minor": counts["minor"],
-                    "count_basis": run.get("count_basis") if run else None,
+                    "count_basis": "live unresolved TTL findings",
+                    "reported_counts": {
+                        name: run.get(name) if run else None
+                        for name in ("blockers", "important", "minor")
+                    },
                 },
                 "branch": item.get("branch"),
                 "head_sha": item.get("head_sha"),
@@ -535,23 +682,16 @@ def build_report(
                 "merged": item.get("merged") if isinstance(item.get("merged"), bool) else None,
                 "merge_commit": item.get("merge_commit"),
                 "merged_at_utc": item.get("merged_at_utc"),
-                "assignment_ack_message_id": item.get("assignment_ack_message_id"),
-                "assignment_ack_time_utc": item.get("assignment_ack_time_utc"),
+                "delivery_attempts": item.get("delivery_attempts", []),
                 "quality_gate": quality_gate,
                 "ready_to_merge": ready,
             }
         )
         if run is None:
             data_gaps.append(f"{sid}: no authoritative QA run")
-        else:
-            for field in ("blockers", "important", "minor"):
-                if counts[field] is None:
-                    data_gaps.append(f"{sid}: QA {field} count is missing or null")
-        if sid not in meta:
-            data_gaps.append(f"{sid}: no explicit PR/CI/branch/merge metadata")
-        for field in ("branch", "head_sha", "target_branch", "pr_number", "pr_url", "ci_status", "merged", "assignment_ack_message_id", "assignment_ack_time_utc"):
+        for field in ("branch", "head_sha", "target_branch", "pr_number", "pr_url", "ci_status", "merged"):
             if item.get(field) is None:
-                data_gaps.append(f"{sid}: metadata {field} is missing or null")
+                data_gaps.append(f"{sid}: GitHub {field} is missing or unknown")
 
     for index, row in enumerate(rows):
         previous = rows[:index]
@@ -624,7 +764,7 @@ def build_report(
             "structure": str(structure_path.relative_to(root)),
             "events": str(events_path.relative_to(root)) if events_path.is_file() else None,
             "qa_master": _source_path(qa_master, root),
-            "metadata": _source_path(metadata, root),
+            "github_repo": github_repo,
         },
     }
 
@@ -634,14 +774,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--integration-root", type=Path)
     parser.add_argument("--phase")
     parser.add_argument("--qa-master", type=Path)
-    parser.add_argument("--metadata", type=Path)
     parser.add_argument("--format", choices=("table", "detailed", "json", "vars"), default="table")
     parser.add_argument("--mode", choices=("table", "detailed"), default="table", help="template display mode for --format vars")
     parser.add_argument("--json", action="store_true", help="alias for --format json")
     args = parser.parse_args(argv)
     try:
         root = args.integration_root or discover_integration_root(Path.cwd())
-        report = build_report(root, args.phase, args.qa_master, args.metadata)
+        report = build_report(root, args.phase, args.qa_master)
     except ReportError as exc:
         print(json.dumps({"kind": "error", "error": str(exc)}, sort_keys=True))
         return 2

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -72,15 +72,24 @@ def _inputs(tmp_path: Path):
         + "triage:F1 a triage:Finding ; triage:findingId \"F1\" ; "
         + "triage:foundIn triage:AICH-S1 ; "
         + "triage:foundAt \"2026-07-25T03:00:00Z\"^^xsd:dateTime ; "
-        + "triage:severity \"blocking\" ; triage:description \"live blocker\" .\n"
+        + "triage:severity \"blocking\" ; triage:description \"live blocker\" ; "
+        + "triage:hasOccurrence triage:O1 .\n"
         + "triage:F2 a triage:Finding ; triage:findingId \"F2\" ; "
         + "triage:foundIn triage:AICH-S1 ; "
         + "triage:foundAt \"2026-07-25T04:00:00Z\"^^xsd:dateTime ; "
-        + "triage:severity \"minor\" ; triage:description \"live minor\" .\n"
+        + "triage:severity \"minor\" ; triage:description \"live minor\" ; "
+        + "triage:hasOccurrence triage:O2 .\n"
         + "triage:F3 a triage:Finding ; triage:findingId \"F3\" ; "
         + "triage:foundIn triage:AICH-S2 ; "
         + "triage:foundAt \"2026-07-25T05:00:00Z\"^^xsd:dateTime ; "
-        + "triage:severity \"blocking\" ; triage:description \"closed\" ; triage:status \"fixed\" .\n"
+        + "triage:severity \"blocking\" ; triage:description \"closed\" ; "
+        + "triage:status \"fixed\" ; triage:hasOccurrence triage:O3 .\n"
+        + "triage:O1 a triage:Occurrence ; triage:branch \"feature/s1\" ; "
+        + "triage:status \"open\" ; triage:closed false .\n"
+        + "triage:O2 a triage:Occurrence ; triage:branch \"feature/s1\" ; "
+        + "triage:status \"open\" ; triage:closed false .\n"
+        + "triage:O3 a triage:Occurrence ; triage:branch \"feature/s2\" ; "
+        + "triage:status \"fixed\" ; triage:closed true .\n"
     )
     qa_path = root / "qa.json"
     qa_path.write_text(json.dumps({"runs": [
@@ -127,6 +136,28 @@ def test_live_ttl_counts_do_not_require_qa_snapshot(tmp_path):
     assert first["qa"]["blockers"] == 1
     assert first["qa"]["important"] == 0
     assert "QA evidence master not found" in report["data_gaps"][0]
+
+
+def test_live_counts_scope_promoted_finding_to_open_downstream_branch(tmp_path):
+    root, qa = _inputs(tmp_path)
+    findings = root / ".triage" / "phase-AI" / "findings" / "S1.ttl"
+    with findings.open("a") as stream:
+        stream.write(
+            "triage:F4 a triage:Finding ; triage:findingId \"F4\" ; "
+            "triage:foundIn triage:AICH-S1 ; "
+            "triage:foundAt \"2026-07-25T06:00:00Z\"^^xsd:dateTime ; "
+            "triage:severity \"blocking\" ; triage:description \"promoted\" ; "
+            "triage:hasOccurrence triage:O4S1, triage:O4S2 .\n"
+            "triage:O4S1 a triage:Occurrence ; triage:branch \"feature/s1\" ; "
+            "triage:status \"closed\" ; triage:closed true .\n"
+            "triage:O4S2 a triage:Occurrence ; triage:branch \"feature/s2\" ; "
+            "triage:status \"open\" ; triage:closed false .\n"
+        )
+
+    report = triage_report.build_report(root, "AICH", qa)
+    first, second = report["rows"]
+    assert first["qa"]["blockers"] == 1  # F1; closed S1 occurrence of F4 is ignored
+    assert second["qa"]["blockers"] == 1  # F4 is open on S2's own branch
 
 
 def test_missing_integration_worktree_is_structured_error(tmp_path, monkeypatch):

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -10,6 +10,7 @@ spec = importlib.util.spec_from_file_location("triage_report", SCRIPT)
 triage_report = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(triage_report)
+GITHUB_STATE = triage_report._github_state
 
 PREFIX = "@prefix triage: <urn:atm:triage:> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
 
@@ -26,6 +27,26 @@ def _validator_passes(monkeypatch):
             "summary": {"files": 1, "findings": 1, "errors": 0, "warnings": 0},
         },
     )
+    monkeypatch.setattr(
+        triage_report,
+        "_github_state",
+        lambda _root, sprints: (
+            {
+                sprint["id"]: {
+                    "branch": sprint["branch"],
+                    "head_sha": f"{sprint['id']}-sha",
+                    "target_branch": "integrate/phase-ai",
+                    "pr_number": sprint["order"],
+                    "pr_url": f"https://example.test/pr/{sprint['order']}",
+                    "ci_status": "pass",
+                    "merged": sprint["order"] == 1,
+                    "delivery_attempts": [],
+                }
+                for sprint in sprints
+            },
+            "example/test",
+        ),
+    )
 
 
 def _inputs(tmp_path: Path):
@@ -35,8 +56,8 @@ def _inputs(tmp_path: Path):
     (structure_dir / "structure.ttl").write_text(
         PREFIX
         + "triage:PhaseAICH a triage:Phase .\n"
-        + "triage:AICH-S1 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 1 ; triage:criteria \"docs/plans/phase-ai/sprint-ai-21-pre.md\" .\n"
-        + "triage:AICH-S2 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 2 ; triage:criteria \"docs/plans/phase-ai/sprint-ai-22.md\" .\n"
+        + "triage:AICH-S1 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 1 ; triage:criteria \"docs/plans/phase-ai/sprint-ai-21-pre.md\" ; triage:branch \"feature/s1\" .\n"
+        + "triage:AICH-S2 a triage:Sprint ; triage:inPhase triage:PhaseAICH ; triage:order 2 ; triage:criteria \"docs/plans/phase-ai/sprint-ai-22.md\" ; triage:branch \"feature/s2\" .\n"
     )
     (structure_dir / "events.ttl").write_text(
         PREFIX
@@ -50,7 +71,16 @@ def _inputs(tmp_path: Path):
         PREFIX
         + "triage:F1 a triage:Finding ; triage:findingId \"F1\" ; "
         + "triage:foundIn triage:AICH-S1 ; "
-        + "triage:foundAt \"2026-07-25T03:00:00Z\"^^xsd:dateTime .\n"
+        + "triage:foundAt \"2026-07-25T03:00:00Z\"^^xsd:dateTime ; "
+        + "triage:severity \"blocking\" ; triage:description \"live blocker\" .\n"
+        + "triage:F2 a triage:Finding ; triage:findingId \"F2\" ; "
+        + "triage:foundIn triage:AICH-S1 ; "
+        + "triage:foundAt \"2026-07-25T04:00:00Z\"^^xsd:dateTime ; "
+        + "triage:severity \"minor\" ; triage:description \"live minor\" .\n"
+        + "triage:F3 a triage:Finding ; triage:findingId \"F3\" ; "
+        + "triage:foundIn triage:AICH-S2 ; "
+        + "triage:foundAt \"2026-07-25T05:00:00Z\"^^xsd:dateTime ; "
+        + "triage:severity \"blocking\" ; triage:description \"closed\" ; triage:status \"fixed\" .\n"
     )
     qa_path = root / "qa.json"
     qa_path.write_text(json.dumps({"runs": [
@@ -58,22 +88,21 @@ def _inputs(tmp_path: Path):
         {"run_id": "S1-review", "aich_sprint": "AICH-S1", "run_type": "reviewer-only", "result_time_utc": "2026-07-25T04:00:00Z", "verdict": "PASS", "blockers": 0, "important": 0, "minor": 0},
         {"run_id": "S2-QA1", "aich_sprint": "AICH-S2", "run_type": "qa", "result_time_utc": "2026-07-25T05:00:00Z", "verdict": "PASS", "blockers": 0, "important": 0, "minor": 0},
     ]}))
-    metadata = root / "metadata.json"
-    metadata.write_text(json.dumps({"sprints": [
-        {"id": "AICH-S1", "branch": "feature/s1", "head_sha": "abc", "pr_number": 1, "ci_status": "pass", "merged": True},
-        {"id": "AICH-S2", "branch": "feature/s2", "head_sha": "def", "pr_number": 2, "ci_status": "pending", "merged": False},
-    ]}))
-    return root, qa_path, metadata
+    return root, qa_path
 
 
-def test_latest_authoritative_qa_and_gates(tmp_path):
-    root, qa, metadata = _inputs(tmp_path)
-    report = triage_report.build_report(root, "AICH", qa, metadata)
+def test_live_ttl_counts_override_qa_snapshot_and_drive_gates(tmp_path):
+    root, qa = _inputs(tmp_path)
+    report = triage_report.build_report(root, "AICH", qa)
     first, second = report["rows"]
     assert first["qa"]["run_id"] == "S1-QA1"  # reviewer-only is excluded
     assert first["qa"]["blockers"] == 1
+    assert first["qa"]["important"] == 0  # live TTL, not QA snapshot's 2
+    assert first["qa"]["minor"] == 1
+    assert first["qa"]["reported_counts"] == {"blockers": 1, "important": 2, "minor": 0}
     assert first["ready_to_merge"] is False
     assert first["ok_to_merge"] is False
+    assert second["qa"]["blockers"] == 0  # fixed TTL finding is excluded
     assert second["ready_to_merge"] is True
     assert second["previous_sprints_merged"] is True
     assert second["ok_to_merge"] is True
@@ -81,15 +110,23 @@ def test_latest_authoritative_qa_and_gates(tmp_path):
     assert "| AICH-S1 (AI.21-pre) | ✅ | ❌ | ✅ | #1 🏁 |" in report["table"]
 
 
-def test_unknown_merge_is_fail_closed(tmp_path):
-    root, qa, _ = _inputs(tmp_path)
+def test_github_state_replaces_manual_metadata(tmp_path):
+    root, qa = _inputs(tmp_path)
     report = triage_report.build_report(root, "AICH", qa)
     first, second = report["rows"]
-    assert first["merged"] is None
-    assert first["ok_to_merge"] is False  # blockers are known and nonzero
-    assert second["previous_sprints_merged"] is None
-    assert second["ok_to_merge"] is None
-    assert report["data_gaps"]
+    assert first["merged"] is True
+    assert second["previous_sprints_merged"] is True
+    assert second["ok_to_merge"] is True
+    assert not any("metadata" in gap for gap in report["data_gaps"])
+
+
+def test_live_ttl_counts_do_not_require_qa_snapshot(tmp_path):
+    root, _ = _inputs(tmp_path)
+    report = triage_report.build_report(root, "AICH", root / "missing-qa.json")
+    first = report["rows"][0]
+    assert first["qa"]["blockers"] == 1
+    assert first["qa"]["important"] == 0
+    assert "QA evidence master not found" in report["data_gaps"][0]
 
 
 def test_missing_integration_worktree_is_structured_error(tmp_path, monkeypatch):
@@ -111,20 +148,8 @@ def test_malformed_structure_is_report_error(tmp_path):
         raise AssertionError("malformed structure must fail")
 
 
-def test_malformed_metadata_is_report_error(tmp_path):
-    root, qa, _ = _inputs(tmp_path)
-    metadata = root / "bad-metadata.json"
-    metadata.write_text(json.dumps({"sprints": [{"id": "AICH-S1", "ci_status": True}]}))
-    try:
-        triage_report.build_report(root, "AICH", qa, metadata)
-    except triage_report.ReportError as exc:
-        assert "ci_status" in str(exc)
-    else:
-        raise AssertionError("malformed metadata must fail")
-
-
 def test_duplicate_structure_orders_are_report_error(tmp_path):
-    root, _, _ = _inputs(tmp_path)
+    root, _ = _inputs(tmp_path)
     structure = root / ".sprints" / "AICH" / "structure.ttl"
     structure.write_text(
         PREFIX
@@ -141,7 +166,7 @@ def test_duplicate_structure_orders_are_report_error(tmp_path):
 
 
 def test_findings_validator_is_called_before_rows(tmp_path, monkeypatch):
-    root, qa, metadata = _inputs(tmp_path)
+    root, qa = _inputs(tmp_path)
     calls = []
 
     def validator(*args):
@@ -149,7 +174,7 @@ def test_findings_validator_is_called_before_rows(tmp_path, monkeypatch):
         return {"kind": "validation:pass", "diagnostics": []}
 
     monkeypatch.setattr(triage_report, "_run_findings_validator", validator)
-    report = triage_report.build_report(root, "AICH", qa, metadata)
+    report = triage_report.build_report(root, "AICH", qa)
     assert len(calls) == 1
     assert calls[0][1].name == "findings"
     assert calls[0][2].name == "structure.ttl"
@@ -158,7 +183,7 @@ def test_findings_validator_is_called_before_rows(tmp_path, monkeypatch):
 
 
 def test_findings_validator_subprocess_passes_for_valid_schema(tmp_path):
-    root, _, _ = _inputs(tmp_path)
+    root, _ = _inputs(tmp_path)
     findings_dir = root / ".triage" / "phase-AI" / "findings"
     result = triage_report._run_findings_validator(
         root,
@@ -170,7 +195,7 @@ def test_findings_validator_subprocess_passes_for_valid_schema(tmp_path):
 
 
 def test_validator_failure_blocks_report(tmp_path, monkeypatch):
-    root, qa, metadata = _inputs(tmp_path)
+    root, qa = _inputs(tmp_path)
 
     def validator(*args):
         raise triage_report.ReportError(
@@ -179,7 +204,7 @@ def test_validator_failure_blocks_report(tmp_path, monkeypatch):
 
     monkeypatch.setattr(triage_report, "_run_findings_validator", validator)
     with pytest.raises(triage_report.ReportError, match="validation blocked"):
-        triage_report.build_report(root, "AICH", qa, metadata)
+        triage_report.build_report(root, "AICH", qa)
 
 
 def test_phase_sprint_accepts_non_ai_prefix_and_rejects_bad_convention():
@@ -187,3 +212,68 @@ def test_phase_sprint_accepts_non_ai_prefix_and_rejects_bad_convention():
     assert triage_report._phase_sprint("docs/sprint-ak-7-pre-notes.md") == "AK.7-pre"
     with pytest.raises(triage_report.ReportError, match="unsupported sprint criteria"):
         triage_report._phase_sprint("docs/sprint-ak-not-number.md")
+
+
+def test_current_open_replay_beats_historical_merged_pr():
+    merged = {
+        "number": 631,
+        "state": "MERGED",
+        "createdAt": "2026-07-25T16:09:01Z",
+        "mergedAt": "2026-07-25T16:26:53Z",
+    }
+    replay = {
+        "number": 640,
+        "state": "OPEN",
+        "createdAt": "2026-07-25T22:38:23Z",
+    }
+    assert triage_report._current_pr([merged, replay]) == replay
+
+
+def test_branch_fallback_uses_ttl_criteria_name():
+    assert triage_report._branch_from_criteria(
+        "docs/plans/phase-ai/sprint-ai-21-pre-crosshost-evidence-harness.md"
+    ) == "feature/pAI-s21pre-crosshost-evidence-harness"
+    assert triage_report._branch_from_criteria(
+        "docs/plans/phase-ai/sprint-ai-22-loopback-self-send-exemption.md"
+    ) == "feature/pAI-s22-loopback-self-send-exemption"
+
+
+def test_github_state_prefers_open_replay_and_retains_merged_history(tmp_path, monkeypatch):
+    root, _ = _inputs(tmp_path)
+    structure = triage_report._parse_ttl(root / ".sprints" / "AICH" / "structure.ttl")
+    sprints = triage_report._sprints(structure, "AICH")
+    monkeypatch.setattr(triage_report, "_origin_repo", lambda _root: "example/test")
+    monkeypatch.setattr(
+        triage_report,
+        "_github_prs",
+        lambda _root, _repo, branch: [
+            {
+                "number": 631,
+                "state": "MERGED",
+                "createdAt": "2026-07-25T16:09:01Z",
+                "mergedAt": "2026-07-25T16:26:53Z",
+                "headRefOid": "old",
+                "baseRefName": "integrate/phase-ai",
+                "mergeCommit": {"oid": "merge"},
+                "url": "https://example.test/631",
+                "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+            },
+            {
+                "number": 640,
+                "state": "OPEN",
+                "createdAt": "2026-07-25T22:38:23Z",
+                "mergedAt": None,
+                "headRefOid": "new",
+                "baseRefName": "integrate/phase-ai",
+                "mergeCommit": None,
+                "url": "https://example.test/640",
+                "statusCheckRollup": [{"conclusion": "FAILURE"}],
+            },
+        ] if branch == "feature/s1" else [],
+    )
+    state, repo = GITHUB_STATE(root, sprints)
+    assert repo == "example/test"
+    assert state["AICH-S1"]["pr_number"] == 640
+    assert state["AICH-S1"]["merged"] is False
+    assert state["AICH-S1"]["ci_status"] == "fail"
+    assert [attempt["pr_number"] for attempt in state["AICH-S1"]["delivery_attempts"]] == [631, 640]

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ tmp/
 .claude/projects/
 .DS_Store
 
+# Host-specific phase integration worktree overlay; the portable phase
+# contract is committed in .sprints/current-phase.ttl.
+.sprints/current-phase.local.ttl
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/.sprints/current-phase.local.ttl.example
+++ b/.sprints/current-phase.local.ttl.example
@@ -1,0 +1,12 @@
+@prefix sprint: <urn:atm:sprint:> .
+
+# Copy this file to current-phase.local.ttl and replace the hostname/path.
+# The copied file is gitignored because integration worktree paths are host
+# specific. Multiple sprint:hostConfig entries may be declared for a shared
+# repository used by several machines.
+sprint:CurrentPhase a sprint:PhaseContext ;
+    sprint:phaseLocal "AICH" ;
+    sprint:hostConfig [
+        sprint:hostname "HOSTNAME" ;
+        sprint:integrationWorktree "/absolute/path/to/integrate-phase-AI"
+    ] .

--- a/.sprints/current-phase.ttl
+++ b/.sprints/current-phase.ttl
@@ -1,0 +1,13 @@
+@prefix sprint: <urn:atm:sprint:> .
+@prefix triage: <urn:atm:triage:> .
+
+# Portable phase source of truth. Host-specific absolute paths belong in the
+# gitignored current-phase.local.ttl overlay, never in this committed file.
+sprint:CurrentPhase a sprint:PhaseContext ;
+    sprint:contextVersion "1" ;
+    sprint:phaseLocal "AICH" ;
+    sprint:phaseIri triage:PhaseAICH ;
+    sprint:structureDir ".sprints/AICH" ;
+    sprint:planDir "docs/plans/phase-ai" ;
+    sprint:integrationBranch "integrate/phase-AI" ;
+    sprint:sprintPrefix "AICH-S" .


### PR DESCRIPTION
## Purpose

Preserve the ongoing graph-orchestration redesign for review against `develop`.

## Included

- `next-dispatch` lifecycle rules and closed-sprint/late-finding handling
- `.sprints/current-phase.ttl` source-of-truth resolution and host-local overlay
- TTL-derived triage-report B/I/M gates and GitHub delivery state
- Branch-scoped finding occurrences so downstream promotions do not block the origin sprint
- Validation, wrappers, templates, and regression tests

## Verification

- Combined graph-orchestration and triage-report tests: 80 passed
- Phase-AI live report validation: 199 findings, 0 validation errors/warnings
- AICH-S5 branch-scoped blockers: 0

This is intentionally a draft for review; do not merge automatically.