### PR TITLE
fix(graph): scope cursor/assignee/sprint-report to integration-branch live data

### DIFF
--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -124,12 +124,12 @@ those outcomes respectively; `--json` emits the tagged result for callers.
 
 `query_runner.py` invokes this validator before loading the graph, including
 for `--validate-only`; `next-dev-task` therefore cannot resolve a cursor while
-any `.triage/*/findings` directory contains an error-level diagnostic. It
-validates every findings directory (not only the directory name that appears
-to match the current phase), then scopes findings by the phase's declared
-`triage:foundIn` sprint IRIs. This ordering prevents malformed or incomplete
-records from disappearing in the membership filter. A `validation:fail` blocks
-with exit 1, and a validator execution `error` blocks with exit 2.
+the current integration branch's project findings directory contains an
+error-level diagnostic. The caller's sprint worktree is never a data source:
+the resolver selects the unique `integrate/phase-*` worktree that owns the
+requested `.sprints/<phase>` directory, then validates only that integration
+branch's `.triage/<project-phase>/findings` directory. A `validation:fail`
+blocks with exit 1, and a validator execution `error` blocks with exit 2.
 
 ## Orchestrator Loop
 

--- a/.claude/skills/graph-orchestration/scripts/assignee-busy
+++ b/.claude/skills/graph-orchestration/scripts/assignee-busy
@@ -17,7 +17,9 @@
 set -euo pipefail
 
 if [[ $# -ne 3 ]]; then
-  echo >&2 "Usage: assignee-busy <PHASE_LOCAL> <TTL_DIR> <ASSIGNEE>"
+  message="Usage: assignee-busy <PHASE_LOCAL> <TTL_DIR> <ASSIGNEE>"
+  echo >&2 "$message"
+  printf '%s\n' "{\"schema\":\"graph-orchestration/v1\",\"kind\":\"error\",\"error_code\":\"usage\",\"message\":\"$message\",\"diagnostics\":[],\"dispatch_blocked\":true}"
   exit 1
 fi
 
@@ -28,7 +30,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_BIN="${GRAPH_ORCH_PYTHON:-python3}"
 
 if ! "$PYTHON_BIN" -c "import rdflib" 2>/dev/null; then
-  echo >&2 "ERROR: rdflib not found. Install with: pip3 install rdflib"
+  message="rdflib not found. Install with: pip3 install rdflib"
+  echo >&2 "ERROR: $message"
+  printf '%s\n' "{\"schema\":\"graph-orchestration/v1\",\"kind\":\"error\",\"error_code\":\"dependency\",\"message\":\"$message\",\"diagnostics\":[],\"dispatch_blocked\":true}"
   exit 1
 fi
 

--- a/.claude/skills/graph-orchestration/scripts/check_assignee.py
+++ b/.claude/skills/graph-orchestration/scripts/check_assignee.py
@@ -31,12 +31,24 @@ from rdflib import URIRef, Literal
 from query_runner import load_graph, resolve_phase_source, run_sparql, TRIAGE_BASE
 
 
+def _error_payload(code: str, message: str, diagnostics: list[str] | None = None) -> dict:
+    """Return the shared discriminated JSON error arm for CLI callers."""
+
+    return {
+        "schema": "graph-orchestration/v1",
+        "kind": "error",
+        "error_code": code,
+        "message": message,
+        "diagnostics": list(diagnostics or []),
+        "dispatch_blocked": True,
+    }
+
+
 def main() -> int:
     if len(sys.argv) != 5:
-        print(
-            "Usage: check_assignee.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> <ASSIGNEE>",
-            file=sys.stderr,
-        )
+        message = "Usage: check_assignee.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> <ASSIGNEE>"
+        print(message, file=sys.stderr)
+        print(json.dumps(_error_payload("usage", message)))
         return 1
 
     phase_local = sys.argv[1]
@@ -54,7 +66,9 @@ def main() -> int:
             {"PHASE": phase_iri, "ASSIGNEE": Literal(assignee)},
         )
     except Exception as exc:  # noqa: BLE001 - CLI boundary must be one-line
-        print(f"ERROR: assignee check failed: {exc}", file=sys.stderr)
+        message = f"assignee check failed: {exc}"
+        print(f"ERROR: {message}", file=sys.stderr)
+        print(json.dumps(_error_payload("assignee_check", message, [str(exc)])))
         return 1
 
     print(json.dumps({

--- a/.claude/skills/graph-orchestration/scripts/check_assignee.py
+++ b/.claude/skills/graph-orchestration/scripts/check_assignee.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 from rdflib import URIRef, Literal
 
-from query_runner import load_graph, run_sparql, TRIAGE_BASE
+from query_runner import load_graph, resolve_phase_source, run_sparql, TRIAGE_BASE
 
 
 def main() -> int:
@@ -46,7 +46,8 @@ def main() -> int:
 
     phase_iri = URIRef(f"{TRIAGE_BASE}Phase{phase_local}")
     try:
-        g = load_graph(ttl_dir)
+        source = resolve_phase_source(phase_local, ttl_dir)
+        g = load_graph(source.ttl_dir, findings_dir=source.findings_dir)
         rows = run_sparql(
             g,
             script_dir / "assignee-busy.sparql",

--- a/.claude/skills/graph-orchestration/scripts/next-dev-task
+++ b/.claude/skills/graph-orchestration/scripts/next-dev-task
@@ -15,14 +15,18 @@
 set -euo pipefail
 
 if [[ $# -lt 2 || $# -gt 3 ]]; then
-  echo >&2 "Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+  message="Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+  echo >&2 "$message"
+  printf '%s\n' "{\"schema\":\"graph-orchestration/v1\",\"kind\":\"error\",\"error_code\":\"usage\",\"message\":\"$message\",\"diagnostics\":[],\"dispatch_blocked\":true}"
   exit 1
 fi
 
 PHASE="$1"
 TTL_DIR="$2"
 if [[ $# -eq 3 && "$3" != "--validate-only" ]]; then
-  echo >&2 "Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+  message="Usage: next-dev-task <PHASE_LOCAL> <TTL_DIR> [--validate-only]"
+  echo >&2 "$message"
+  printf '%s\n' "{\"schema\":\"graph-orchestration/v1\",\"kind\":\"error\",\"error_code\":\"usage\",\"message\":\"$message\",\"diagnostics\":[],\"dispatch_blocked\":true}"
   exit 1
 fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -30,7 +34,9 @@ PYTHON_BIN="${GRAPH_ORCH_PYTHON:-python3}"
 
 # Verify Python 3 and rdflib are available
 if ! "$PYTHON_BIN" -c "import rdflib" 2>/dev/null; then
-  echo >&2 "ERROR: rdflib not found. Install with: pip3 install rdflib"
+  message="rdflib not found. Install with: pip3 install rdflib"
+  echo >&2 "ERROR: $message"
+  printf '%s\n' "{\"schema\":\"graph-orchestration/v1\",\"kind\":\"error\",\"error_code\":\"dependency\",\"message\":\"$message\",\"diagnostics\":[],\"dispatch_blocked\":true}"
   exit 1
 fi
 

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -48,6 +48,9 @@ Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> [--validate-only]
 import importlib.util
 import sys
 import json
+import re
+import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 try:
@@ -61,8 +64,8 @@ TRIAGE_BASE = "urn:atm:triage:"
 TRIAGE = Namespace(TRIAGE_BASE)
 
 
-def _find_repo_root(start: Path):
-    """Walk up from start to find the directory containing .triage/"""
+def _find_repo_root(start: Path) -> Path | None:
+    """Walk up from ``start`` to the repository's ``.triage`` directory."""
     current = start.resolve()
     for _ in range(10):  # max 10 levels up
         if (current / ".triage").exists():
@@ -74,42 +77,126 @@ def _find_repo_root(start: Path):
     return None
 
 
-IGNORE_FILE_NAME = ".graph-orchestration-ignore"
+@dataclass(frozen=True)
+class PhaseSource:
+    """Canonical current-integration inputs for one graph phase."""
+
+    root: Path
+    ttl_dir: Path
+    findings_dir: Path
+    branch: str | None
 
 
-def _load_ignored_phase_dirs(repo_root: Path) -> set:
-    """Read repo_root/.triage/.graph-orchestration-ignore into a set of names.
+def _integration_worktrees(repo_root: Path, phase_dir_name: str) -> list[tuple[Path, str]]:
+    """Return integration worktrees that own ``.sprints/<phase_dir_name>``."""
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return []
 
-    This is a purely optional, best-effort efficiency/noise-reduction layer:
-    it lets known-dead legacy phase directories (whose findings files use an
-    old pre-Turtle format and will never be migrated) be skipped entirely
-    before ever attempting to open or parse a file under them, avoiding both
-    wasted I/O and a repeated stderr `WARNING: skipping malformed findings
-    file ...` on every single invocation.
+    matches: list[tuple[Path, str]] = []
+    worktree: Path | None = None
+    branch: str | None = None
+    for line in [*result.stdout.splitlines(), ""]:
+        if line.startswith("worktree "):
+            worktree = Path(line.removeprefix("worktree "))
+        elif line.startswith("branch refs/heads/"):
+            branch = line.removeprefix("branch refs/heads/")
+        elif not line.strip():
+            if (
+                worktree is not None
+                and branch is not None
+                and branch.startswith("integrate/phase-")
+                and (worktree / ".sprints" / phase_dir_name / "structure.ttl").is_file()
+            ):
+                matches.append((worktree.resolve(), branch))
+            worktree = None
+            branch = None
+    return matches
 
-    It is NOT a correctness mechanism and must never be treated as one: the
-    membership-based scoping in `load_graph()` (via `known_sprints` /
-    `triage:foundIn`) is what actually prevents cross-phase contamination,
-    for *every* findings directory, including ones not listed here. Absence
-    of a directory from this ignore list — or absence of the file itself —
-    changes nothing about correctness, only about how much redundant parsing
-    and warning noise is produced for directories known in advance to be
-    dead.
+
+def _project_phase_from_ttl(ttl_dir: Path, fallback: str) -> str:
+    """Derive the plan phase only for isolated non-git test fixtures."""
+    graph = Graph()
+    try:
+        graph.parse(ttl_dir / "structure.ttl", format="turtle")
+    except Exception:  # The normal structure gate reports this after resolution.
+        return f"phase-{fallback}"
+    phases = {
+        match.group(1)
+        for criteria in graph.objects(None, TRIAGE.criteria)
+        if (match := re.search(r"docs/plans/(phase-[^/]+)/", str(criteria)))
+    }
+    return phases.pop() if len(phases) == 1 else f"phase-{fallback}"
+
+
+def resolve_phase_source(phase_local: str, requested_ttl_dir: str) -> PhaseSource:
+    """Resolve a phase to its sole current ``integrate/phase-*`` worktree.
+
+    Sprint worktrees are never a query source: their copied TTL can be stale.
+    The integration branch name is also the project triage namespace, so this
+    resolver selects exactly ``.triage/<phase-name>/findings`` rather than
+    scanning every historical phase.  Non-git unit fixtures retain a direct
+    local fallback using ``phase-<PHASE_LOCAL>``.
     """
-    ignore_path = repo_root / ".triage" / IGNORE_FILE_NAME
-    if not ignore_path.exists():
-        return set()
+    requested = Path(requested_ttl_dir).resolve()
+    if not (requested / "structure.ttl").is_file():
+        raise RuntimeError(f"structure.ttl not found at {requested / 'structure.ttl'}")
+    repo_root = _find_repo_root(requested)
+    if repo_root is None:
+        raise RuntimeError("cannot locate repository root containing .triage")
 
-    names = set()
-    for line in ignore_path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        names.add(line)
-    return names
+    candidates = _integration_worktrees(repo_root, requested.name)
+    if candidates:
+        if len(candidates) != 1:
+            names = ", ".join(f"{branch} ({path})" for path, branch in candidates)
+            raise RuntimeError(
+                f"cannot determine one current integration source for {requested.name}: {names}"
+            )
+        root, branch = candidates[0]
+        phase_name = branch.rsplit("/", 1)[-1]
+        return PhaseSource(
+            root=root,
+            ttl_dir=root / ".sprints" / requested.name,
+            findings_dir=root / ".triage" / phase_name / "findings",
+            branch=branch,
+        )
+
+    # Test fixtures are deliberately not git worktrees.  Do not make a
+    # production branch silently fall back to its potentially stale TTL.
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        project_phase = _project_phase_from_ttl(requested, phase_local)
+        return PhaseSource(
+            root=repo_root,
+            ttl_dir=requested,
+            findings_dir=repo_root / ".triage" / project_phase / "findings",
+            branch=None,
+        )
+    raise RuntimeError(
+        f"no integrate/phase-* worktree owns .sprints/{requested.name}; refusing stale branch data"
+    )
 
 
-def load_graph(ttl_dir: str, *, include_findings: bool = True) -> Graph:
+def load_graph(
+    ttl_dir: str | Path,
+    *,
+    findings_dir: Path | None = None,
+    include_findings: bool = True,
+) -> Graph:
     g = Graph()
     base = Path(ttl_dir)
     structure = base / "structure.ttl"
@@ -121,74 +208,18 @@ def load_graph(ttl_dir: str, *, include_findings: bool = True) -> Graph:
     if events.exists():
         g.parse(str(events), format="turtle")
 
-    # Collect the set of triage:Sprint subjects declared by *this phase's*
-    # structure.ttl (+ events.ttl, though sprints are only ever declared in
-    # structure.ttl in practice). This is the authoritative membership set
-    # used below to scope findings — it is derived from the graph itself,
-    # not from directory names or naming conventions, so it can't be
-    # defeated by a future phase reusing an unprefixed or colliding local
-    # sprint label.
     known_sprints = set(g.subjects(RDF.type, TRIAGE.Sprint))
 
     if not include_findings:
         return g
 
-    # Load triage findings from repo root .triage/ (relative to TTL dir's parent)
-    # Walk up from ttl_dir to find repo root (contains .triage/)
-    #
-    # Findings are filed under `.triage/<phase_id>/findings/*.ttl`, where
-    # `<phase_id>` (e.g. "phase-AI") is a project-phase directory that does
-    # not necessarily match the `PHASE_LOCAL` sprint-batch label (e.g.
-    # "AICH") passed to this script — there is no discoverable
-    # findings-path-to-phase mapping in structure.ttl today (no
-    # `triage:findingsPath` or similar property), so we cannot statically
-    # narrow the *glob* to "the one right directory" for a given phase.
-    #
-    # Directory-name matching was considered and rejected as the scoping
-    # mechanism: it's convention-dependent (relies on `phase-AI` matching
-    # `AICH`-prefixed sprint labels) and nothing enforces it — a future
-    # phase could reuse an unprefixed or colliding local sprint label with
-    # no directory-name collision to catch it, silently attaching a stray
-    # well-formed finding to the wrong phase's sprint and corrupting cursor
-    # resolution.
-    #
-    # Instead, each findings file is parsed into its own temporary Graph
-    # first (still isolated in try/except, see below), and only the triples
-    # belonging to findings whose `triage:foundIn` object is in
-    # `known_sprints` (this phase's *actual* declared triage:Sprint
-    # subjects, read directly from structure.ttl/events.ttl above) are
-    # merged into `g`. This is real membership scoping, not a naming
-    # convention: it is enforced by graph structure, so it cannot be
-    # defeated by directory or label collisions. Findings whose
-    # `triage:foundIn` points at a sprint outside this set are dropped
-    # silently — they're simply out of scope for this phase, not an error.
-    #
-    # A single malformed (non-Turtle) findings file anywhere in the repo
-    # must also not abort the entire parse and crash cursor resolution for
-    # every phase, including ones with no relationship to the offending
-    # file — hence the per-file try/except below, which remains necessary
-    # defense-in-depth independent of the scoping filter.
-    #
-    # Some `.triage/<phase_id>/` directories are permanently closed/dead
-    # legacy phases whose findings files were written in an old pre-Turtle
-    # format and will never be migrated. Repeatedly globbing, opening, and
-    # failing to parse those files on every single invocation is pure,
-    # predictable waste: the outcome never changes. `.triage/.graph-
-    # orchestration-ignore` (see `_load_ignored_phase_dirs`) lets such
-    # directories be named explicitly so they're skipped before `.parse()`
-    # is ever called on them — no warning is printed for these, since the
-    # directory was deliberately and explicitly acknowledged as dead, unlike
-    # an unexpected malformed file that wasn't. This is purely an efficiency
-    # optimization layered on top of the membership-based scoping above; it
-    # does not replace it, and directories absent from the ignore list are
-    # still fully protected by the `known_sprints` membership filter.
-    repo_root = _find_repo_root(base)
-    if repo_root:
-        ignored_phase_dirs = _load_ignored_phase_dirs(repo_root)
-        for findings_file in sorted(repo_root.glob(".triage/*/findings/*.ttl")):
-            phase_dir_name = findings_file.parent.parent.name
-            if phase_dir_name in ignored_phase_dirs:
-                continue
+    if findings_dir is None:
+        repo_root = _find_repo_root(base)
+        if repo_root is None:
+            raise RuntimeError("cannot locate repository root containing .triage")
+        findings_dir = repo_root / ".triage" / f"phase-{base.name}" / "findings"
+    if findings_dir.is_dir():
+        for findings_file in sorted(findings_dir.glob("*.ttl")):
             file_graph = Graph()
             try:
                 file_graph.parse(str(findings_file), format="turtle")
@@ -240,10 +271,14 @@ def run_sparql(g: Graph, sparql_file: Path, bindings: dict) -> list:
     return list(results)
 
 
-def _cli_load_graph(ttl_dir: str, *, include_findings: bool) -> Graph:
+def _cli_load_graph(source: PhaseSource, *, include_findings: bool) -> Graph:
     """Load a graph while keeping malformed input errors CLI-friendly."""
     try:
-        return load_graph(ttl_dir, include_findings=include_findings)
+        return load_graph(
+            source.ttl_dir,
+            findings_dir=source.findings_dir,
+            include_findings=include_findings,
+        )
     except SystemExit:
         raise
     except Exception as exc:  # noqa: BLE001 - CLI boundary
@@ -275,7 +310,7 @@ def _load_validator(script_dir: Path):
     return module
 
 
-def _validate_findings_before_query(ttl_dir: str, script_dir: Path) -> None:
+def _validate_findings_before_query(source: PhaseSource, script_dir: Path) -> None:
     """Run raw findings validation before *any* graph query.
 
     ``load_graph`` intentionally scopes findings by ``foundIn``.  Running this
@@ -285,35 +320,19 @@ def _validate_findings_before_query(ttl_dir: str, script_dir: Path) -> None:
     allowed by the validator's discriminated result contract.
     """
 
-    repo_root = _find_repo_root(Path(ttl_dir))
-    if repo_root is None:
-        raise RuntimeError(
-            "cannot locate repository root containing .triage; findings validation cannot run"
-        )
-    triage_root = repo_root / ".triage"
-    findings_dirs = sorted(
-        path for path in triage_root.glob("*/findings") if path.is_dir()
-    ) if triage_root.exists() else []
-    # An existing but empty .triage tree is a valid no-findings input.  Passing
-    # the root directory still exercises the validator and gives a structured
-    # error if the directory itself is missing or unreadable.
-    if not findings_dirs:
-        findings_dirs = [triage_root]
-
     validator = _load_validator(script_dir)
-    structure = Path(ttl_dir) / "structure.ttl"
-    events_path = Path(ttl_dir) / "events.ttl"
+    structure = source.ttl_dir / "structure.ttl"
+    events_path = source.ttl_dir / "events.ttl"
     events = events_path if events_path.exists() else None
-
-    for findings_dir in findings_dirs:
+    if source.findings_dir.is_dir():
         result = validator.run_validation(
-            findings_dir=findings_dir,
+            findings_dir=source.findings_dir,
             structure=structure,
             events=events,
             script_dir=script_dir,
         )
         if result.kind == "validation:pass":
-            continue
+            return
         summary = getattr(result, "summary", None)
         counts = (
             f" ({summary.errors} error(s), {summary.warnings} warning(s))"
@@ -321,7 +340,7 @@ def _validate_findings_before_query(ttl_dir: str, script_dir: Path) -> None:
             else ""
         )
         print(
-            f"ERROR: findings validation blocked query resolution for {findings_dir}"
+            f"ERROR: findings validation blocked query resolution for {source.findings_dir}"
             f"{counts}",
             file=sys.stderr,
         )
@@ -358,7 +377,8 @@ def main():
     # This is deliberately before structure loading and before --validate-only:
     # every query_runner entry point must prove that raw findings are valid.
     try:
-        _validate_findings_before_query(ttl_dir, script_dir)
+        source = resolve_phase_source(phase_local, ttl_dir)
+        _validate_findings_before_query(source, script_dir)
     except SystemExit:
         raise
     except Exception as exc:  # noqa: BLE001 - CLI boundary
@@ -369,7 +389,7 @@ def main():
     # or incomplete records cannot disappear during phase membership filtering.
     # Once that gate passes, structure validation can report graph-shape errors
     # without being conflated with finding-schema diagnostics.
-    g = _cli_load_graph(ttl_dir, include_findings=not validate_only)
+    g = _cli_load_graph(source, include_findings=not validate_only)
 
     # ── Validate structure before cursor ─────────────────────────────────────
     validate_rows = _cli_run_sparql(

--- a/.claude/skills/graph-orchestration/scripts/query_runner.py
+++ b/.claude/skills/graph-orchestration/scripts/query_runner.py
@@ -64,6 +64,36 @@ TRIAGE_BASE = "urn:atm:triage:"
 TRIAGE = Namespace(TRIAGE_BASE)
 
 
+class ValidationGateError(RuntimeError):
+    """A findings validation result that blocks dispatch but is reportable."""
+
+    def __init__(self, kind: str, message: str, diagnostics: list[str], exit_code: int):
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+        self.diagnostics = diagnostics
+        self.exit_code = exit_code
+
+
+def _error_payload(
+    code: str,
+    message: str,
+    *,
+    diagnostics: list[str] | None = None,
+    kind: str = "error",
+) -> dict:
+    """Return the stable JSON union arm used by every CLI error path."""
+
+    return {
+        "schema": "graph-orchestration/v1",
+        "kind": kind,
+        "error_code": code,
+        "message": message,
+        "diagnostics": list(diagnostics or []),
+        "dispatch_blocked": True,
+    }
+
+
 def _find_repo_root(start: Path) -> Path | None:
     """Walk up from ``start`` to the repository's ``.triage`` directory."""
     current = start.resolve()
@@ -280,9 +310,13 @@ def _cli_load_graph(source: PhaseSource, *, include_findings: bool) -> Graph:
             include_findings=include_findings,
         )
     except SystemExit:
+        message = f"query runner could not load graph at {source.ttl_dir}"
+        print(json.dumps(_error_payload("graph_load", message)))
         raise
     except Exception as exc:  # noqa: BLE001 - CLI boundary
-        print(f"ERROR: query runner failed to load graph: {exc}", file=sys.stderr)
+        message = f"query runner failed to load graph: {exc}"
+        print(f"ERROR: {message}", file=sys.stderr)
+        print(json.dumps(_error_payload("graph_load", message)))
         raise SystemExit(1) from exc
 
 
@@ -291,7 +325,9 @@ def _cli_run_sparql(g: Graph, sparql_file: Path, bindings: dict) -> list:
     try:
         return run_sparql(g, sparql_file, bindings)
     except Exception as exc:  # noqa: BLE001 - CLI boundary
-        print(f"ERROR: query runner failed to run {sparql_file}: {exc}", file=sys.stderr)
+        message = f"query runner failed to run {sparql_file}: {exc}"
+        print(f"ERROR: {message}", file=sys.stderr)
+        print(json.dumps(_error_payload("sparql_query", message)))
         raise SystemExit(1) from exc
 
 
@@ -353,19 +389,33 @@ def _validate_findings_before_query(source: PhaseSource, script_dir: Path) -> No
                 file=sys.stderr,
             )
         if result.kind == "error":
-            raise SystemExit(2)
-        raise SystemExit(1)
+            raise ValidationGateError(
+                "error",
+                "findings validation could not run",
+                list(result.diagnostics),
+                2,
+            )
+        raise ValidationGateError(
+            "validation:fail",
+            "findings validation failed",
+            list(result.diagnostics),
+            1,
+        )
 
 
 def main():
     if len(sys.argv) not in (4, 5) or (
         len(sys.argv) == 5 and sys.argv[4] != "--validate-only"
     ):
-        print(
+        message = (
             "Usage: query_runner.py <PHASE_LOCAL> <TTL_DIR> <SCRIPT_DIR> "
-            "[--validate-only]",
+            "[--validate-only]"
+        )
+        print(
+            message,
             file=sys.stderr,
         )
+        print(json.dumps(_error_payload("usage", message)))
         sys.exit(1)
 
     phase_local = sys.argv[1]
@@ -379,10 +429,24 @@ def main():
     try:
         source = resolve_phase_source(phase_local, ttl_dir)
         _validate_findings_before_query(source, script_dir)
+    except ValidationGateError as exc:
+        print(
+            json.dumps(
+                _error_payload(
+                    "findings_validation",
+                    exc.message,
+                    diagnostics=exc.diagnostics,
+                    kind=exc.kind,
+                )
+            )
+        )
+        raise SystemExit(exc.exit_code)
     except SystemExit:
         raise
     except Exception as exc:  # noqa: BLE001 - CLI boundary
-        print(f"ERROR: findings validation could not run: {exc}", file=sys.stderr)
+        message = f"findings validation could not run: {exc}"
+        print(f"ERROR: {message}", file=sys.stderr)
+        print(json.dumps(_error_payload("findings_validation", message)))
         raise SystemExit(2) from exc
 
     # The raw findings gate above runs before structure validation so malformed
@@ -396,8 +460,21 @@ def main():
         g, script_dir / "validate-structure.sparql", {"PHASE": phase_iri}
     )
     if validate_rows:
+        diagnostics = [
+            f"structure violation: {row[0]} — {row[1]}" for row in validate_rows
+        ]
         for row in validate_rows:
             print(f"ERROR: structure violation: {row[0]} — {row[1]}", file=sys.stderr)
+        print(
+            json.dumps(
+                _error_payload(
+                    "structure_validation",
+                    "structure validation failed",
+                    diagnostics=diagnostics,
+                    kind="validation:fail",
+                )
+            )
+        )
         sys.exit(1)
 
     if validate_only:

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -285,8 +285,7 @@ triage:r1 a triage:Resolution ; triage:resolves triage:f1 ;
 # ── load_graph filesystem tests ────────────────────────────────────────────────
 #
 # These need real files on disk (not the in-memory `sparql()` helper above),
-# since load_graph()'s repo-root discovery + glob + per-file parse is what's
-# under test.
+# since graph loading and phase-local finding selection are under test.
 
 class TestLoadGraphFindingsIsolation:
     def _make_repo(self, tmp_path: Path, phase_local: str, sprints: list) -> Path:
@@ -320,6 +319,27 @@ class TestLoadGraphFindingsIsolation:
         )
         assert len(rows) == 1
         assert str(rows[0][1]) == "1"
+
+    def test_resolver_uses_current_integration_worktree_and_namespace(self, tmp_path, monkeypatch):
+        """A sprint branch must never supply copied TTL or another phase's findings."""
+        query_runner = _load_query_runner()
+        branch_root = self._make_repo(tmp_path / "branch", "AICH", [(1, "S1")])
+        integration_root = self._make_repo(tmp_path / "integration", "AICH", [(1, "S1")])
+
+        monkeypatch.setattr(
+            query_runner,
+            "_integration_worktrees",
+            lambda _root, _phase: [(integration_root, "integrate/phase-AI")],
+        )
+
+        source = query_runner.resolve_phase_source(
+            "AICH", str(branch_root / ".sprints" / "AICH")
+        )
+
+        assert source.root == integration_root.resolve()
+        assert source.ttl_dir == integration_root / ".sprints" / "AICH"
+        assert source.findings_dir == integration_root / ".triage" / "phase-AI" / "findings"
+        assert source.branch == "integrate/phase-AI"
 
 
     def test_wellformed_findings_in_queried_phase_still_loaded(self, tmp_path):
@@ -483,11 +503,8 @@ triage:fcross a triage:Finding ; triage:foundIn triage:YS1 ;
         assert not list(g.triples((URIRef(f"{TRIAGE}fcross"), None, None)))
         assert len(rows) == 0  # PhaseX fully complete; no re-dispatch triggered
 
-    def test_no_ignore_file_warns_on_all_malformed_dirs(self, tmp_path, capsys):
-        """Backward compatibility: with no ignore file present, every
-        malformed findings file (regardless of directory) still produces a
-        stderr warning and is otherwise skipped, exactly as before this
-        feature was added."""
+    def test_unrelated_malformed_findings_are_never_opened(self, tmp_path, capsys):
+        """Historical phases cannot affect a current phase query at all."""
         query_runner = _load_query_runner()
         repo = self._make_repo(tmp_path, "F", [(1, "S1")])
 
@@ -499,8 +516,7 @@ triage:fcross a triage:Finding ; triage:foundIn triage:YS1 ;
 
         g = query_runner.load_graph(str(repo / ".sprints" / "F"))
         captured = capsys.readouterr()
-        assert "WARNING: skipping malformed findings file" in captured.err
-        assert "LEGACY-001.ttl" in captured.err
+        assert captured.err == ""
 
         rows = list(
             g.query(
@@ -511,38 +527,20 @@ triage:fcross a triage:Finding ; triage:foundIn triage:YS1 ;
         assert len(rows) == 1
         assert str(rows[0][1]) == "1"
 
-    def test_ignore_file_skips_listed_dir_without_warning(self, tmp_path, capsys):
-        """A directory listed in `.triage/.graph-orchestration-ignore` must be
-        skipped entirely (no `.parse()` call, no warning), while a
-        DIFFERENT, unignored directory with its own malformed file still
-        produces the usual warning."""
+    def test_selected_phase_malformed_findings_still_warn(self, tmp_path, capsys):
+        """The chosen project phase remains visible to the loader and validator."""
         query_runner = _load_query_runner()
         repo = self._make_repo(tmp_path, "F", [(1, "S1")])
-
-        (repo / ".triage" / query_runner.IGNORE_FILE_NAME).write_text(
-            "# closed/dead legacy phases, pre-Turtle findings format\n"
-            "phase-U\n"
-            "\n"
-            "phase-V\n"
-        )
-
-        ignored = repo / ".triage" / "phase-U" / "findings"
-        ignored.mkdir(parents=True)
-        (ignored / "LEGACY-001.ttl").write_text(
-            "finding_id: LEGACY-001\ntitle: pre-Turtle legacy finding\n"
-        )
-
-        unignored = repo / ".triage" / "phase-W" / "findings"
-        unignored.mkdir(parents=True)
-        (unignored / "LEGACY-002.ttl").write_text(
+        selected = repo / ".triage" / "phase-F" / "findings"
+        selected.mkdir(parents=True)
+        (selected / "BROKEN.ttl").write_text(
             "finding_id: LEGACY-002\ntitle: unexpected malformed finding\n"
         )
 
         g = query_runner.load_graph(str(repo / ".sprints" / "F"))
         captured = capsys.readouterr()
 
-        assert "LEGACY-001.ttl" not in captured.err
-        assert "LEGACY-002.ttl" in captured.err
+        assert "BROKEN.ttl" in captured.err
         assert "WARNING: skipping malformed findings file" in captured.err
 
         rows = list(
@@ -581,7 +579,7 @@ class TestNextDevTaskValidation:
             check=False,
         )
 
-    def test_validate_only_blocks_malformed_findings_before_structure_query(self, tmp_path):
+    def test_validate_only_ignores_unrelated_malformed_findings(self, tmp_path):
         repo = self._make_repo(tmp_path, structure([(1, "S1")]))
         malformed = repo / ".triage" / "phase-U" / "findings"
         malformed.mkdir(parents=True)
@@ -589,11 +587,8 @@ class TestNextDevTaskValidation:
 
         result = self._run(repo, "F", str(repo / ".sprints" / "F"), "--validate-only")
 
-        assert result.returncode == 2, result.stderr
-        assert result.stdout == ""
-        assert "findings validation could not run" not in result.stderr
-        assert "findings validation blocked query resolution" in result.stderr
-        assert "malformed Turtle" in result.stderr
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout)["phase"] == "VALIDATE_ONLY"
 
     def test_cursor_resolution_is_blocked_by_missing_provenance(self, tmp_path):
         repo = self._make_repo(tmp_path, structure([(1, "S1")]))
@@ -683,12 +678,10 @@ triage:S2 a triage:Sprint ; triage:inPhase triage:PhaseF ;
 
         result = self._run(repo, "F", str(repo / ".sprints" / "F"))
 
-        # Findings validation is intentionally the first gate, so malformed
-        # structure is reported by the validator before the RDF loader runs.
-        assert result.returncode == 2
+        assert result.returncode == 1
         assert result.stdout == ""
         assert "Traceback" not in result.stderr
-        assert "findings validation blocked query resolution" in result.stderr
+        assert "ERROR: query runner failed to load graph" in result.stderr
 
     def test_broken_sparql_is_reported_without_traceback(self, tmp_path):
         repo = self._make_repo(tmp_path, structure([(1, "S1")]))

--- a/.claude/skills/graph-orchestration/scripts/test_queries.py
+++ b/.claude/skills/graph-orchestration/scripts/test_queries.py
@@ -590,6 +590,26 @@ class TestNextDevTaskValidation:
         assert result.returncode == 0, result.stderr
         assert json.loads(result.stdout)["phase"] == "VALIDATE_ONLY"
 
+    def test_selected_malformed_findings_return_json_error_union(self, tmp_path):
+        repo = self._make_repo(tmp_path, structure([(1, "S1"), (2, "S2")]))
+        malformed = repo / ".triage" / "phase-F" / "findings"
+        malformed.mkdir(parents=True)
+        broken = malformed / "BROKEN-S1.ttl"
+        broken.write_text(
+            PREFIX
+            + "triage:broken a triage:Finding ; triage:foundIn triage:S1 ;\n"
+        )
+
+        result = self._run(repo, "F", str(repo / ".sprints" / "F"))
+
+        assert result.returncode == 2
+        payload = json.loads(result.stdout)
+        assert payload["kind"] == "error"
+        assert payload["error_code"] == "findings_validation"
+        assert payload["dispatch_blocked"] is True
+        assert any("BROKEN-S1.ttl" in item for item in payload["diagnostics"])
+        assert "findings validation blocked query resolution" in result.stderr
+
     def test_cursor_resolution_is_blocked_by_missing_provenance(self, tmp_path):
         repo = self._make_repo(tmp_path, structure([(1, "S1")]))
         findings = repo / ".triage" / "phase-F" / "findings"
@@ -603,7 +623,10 @@ class TestNextDevTaskValidation:
         result = self._run(repo, "F", str(repo / ".sprints" / "F"))
 
         assert result.returncode == 1, result.stderr
-        assert result.stdout == ""
+        payload = json.loads(result.stdout)
+        assert payload["kind"] == "validation:fail"
+        assert payload["error_code"] == "findings_validation"
+        assert payload["dispatch_blocked"] is True
         assert "findings validation blocked query resolution" in result.stderr
         assert "triage:foundIn" in result.stderr
         assert "triage:foundAt" in result.stderr
@@ -671,7 +694,9 @@ triage:S2 a triage:Sprint ; triage:inPhase triage:PhaseF ;
 
         assert result.returncode == 1
         assert "ERROR: structure violation" in result.stderr
-        assert result.stdout == ""
+        payload = json.loads(result.stdout)
+        assert payload["kind"] == "validation:fail"
+        assert payload["error_code"] == "structure_validation"
 
     def test_malformed_structure_is_reported_without_traceback(self, tmp_path):
         repo = self._make_repo(tmp_path, "not valid Turtle [")
@@ -679,9 +704,11 @@ triage:S2 a triage:Sprint ; triage:inPhase triage:PhaseF ;
         result = self._run(repo, "F", str(repo / ".sprints" / "F"))
 
         assert result.returncode == 1
-        assert result.stdout == ""
         assert "Traceback" not in result.stderr
         assert "ERROR: query runner failed to load graph" in result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["kind"] == "error"
+        assert payload["error_code"] == "graph_load"
 
     def test_broken_sparql_is_reported_without_traceback(self, tmp_path):
         repo = self._make_repo(tmp_path, structure([(1, "S1")]))
@@ -712,9 +739,11 @@ triage:S2 a triage:Sprint ; triage:inPhase triage:PhaseF ;
         )
 
         assert result.returncode == 1
-        assert result.stdout == ""
         assert "Traceback" not in result.stderr
         assert "ERROR: query runner failed to run" in result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["kind"] == "error"
+        assert payload["error_code"] == "sparql_query"
 
     def test_unknown_optional_argument_is_rejected(self, tmp_path):
         repo = self._make_repo(tmp_path, structure([(1, "S1")]))
@@ -790,9 +819,12 @@ triage:c1 a triage:Completion ; triage:ofSprint triage:S1 ;
         result = self._run(repo, "F", str(repo / ".sprints" / "F"), "arch-ctm")
 
         assert result.returncode == 1
-        assert result.stdout == ""
         assert "Traceback" not in result.stderr
         assert "ERROR:" in result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["kind"] == "error"
+        assert payload["error_code"] == "assignee_check"
+        assert payload["dispatch_blocked"] is True
 
 
 if __name__ == "__main__":

--- a/.claude/skills/sprint-report/SKILL.md
+++ b/.claude/skills/sprint-report/SKILL.md
@@ -19,15 +19,17 @@ Default: `--table`
 
 ## Data Source
 
-**Always use `atm gh pr list` first** - single call, returns all open PRs with CI and merge state:
+Use the canonical triage report. It resolves the current `integrate/phase-*`
+worktree and reads only that phase's Turtle findings; never assemble counts from
+a sprint worktree, a QA snapshot, or a hand-maintained metadata file.
 
 ```bash
-atm gh pr list
+python3 .claude/skills/triage-report/scripts/triage_report.py \
+  --phase AICH --format vars > /tmp/sprint-report.json
 ```
 
-This is faster and sufficient for populating `sprint_rows` and `integration_row`. Only drill into individual `gh run view` calls if you need failure details for a specific job.
-
-**Dogfooding rule**: If `atm gh pr list` output is missing information needed to fill the report (e.g., no per-job failure detail, no QA state, truncated CI summary), **file a GitHub issue** describing what field or format change would make it sufficient, then improve the command. Do not silently work around gaps with extra `gh` CLI calls - surface them as product issues.
+The command includes current GitHub PR/CI state. If its JSON reports a data
+gap, show it as unknown rather than substituting another data source.
 
 ## Render Command
 
@@ -35,7 +37,6 @@ The template path is relative - must run from the **main repo root** (not a work
 
 ```bash
 cd "${CLAUDE_PROJECT_DIR:-$(git worktree list | head -1 | awk '{print $1}')}"
-echo '<json>' > /tmp/sprint-report.json
 sc-compose render .claude/skills/sprint-report/report.md.j2 --var-file /tmp/sprint-report.json
 ```
 

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -40,6 +40,18 @@ ICONS = {
     "ready": "🚀",
 }
 
+# ``validate-findings.py`` deliberately treats malformed Turtle as an
+# operational error.  Reports are read-only, however, and must still render
+# the valid sprint rows so an operator can see what is affected.  Keep this
+# small recovery parser deliberately conservative: it only attributes a
+# malformed file when exactly one declared sprint can be recovered from an
+# explicit ``triage:foundIn`` token.  Anything else is unattributed and blocks
+# dispatch/merge globally.
+_FOUND_IN_TOKEN = re.compile(
+    r"(?:triage:foundIn|<urn:atm:triage:foundIn>)\s+"
+    r"(?:triage:([A-Za-z0-9_.-]+)|<([^>]+)>)"
+)
+
 
 class ReportError(RuntimeError):
     """An operational error which prevents a trustworthy report."""
@@ -350,14 +362,115 @@ def _run_findings_validator(
         "error",
     }:
         raise ReportError("findings validator returned an invalid result object")
-    if payload.get("kind") != "validation:pass" or result.returncode != 0:
-        diagnostics = payload.get("diagnostics") or []
-        detail = "; ".join(str(item) for item in diagnostics[:8])
-        message = payload.get("message") or payload.get("kind") or "unknown result"
-        if detail:
-            message = f"{message}: {detail}"
-        raise ReportError(f"findings validation blocked report: {message}")
-    return payload
+    # A validation failure is data that the report must display, not a reason
+    # to suppress every unaffected sprint row.  Operational validator errors
+    # (notably malformed finding TTL) are retained as ``kind:error`` and are
+    # converted into structured report diagnostics below.  The report remains
+    # merge/dispatch-blocked until those diagnostics are repaired.
+    if payload.get("kind") == "validation:pass" and result.returncode == 0:
+        return payload
+    if payload.get("kind") in {"validation:fail", "error"}:
+        return payload
+    diagnostics = payload.get("diagnostics") or []
+    detail = "; ".join(str(item) for item in diagnostics[:8])
+    message = payload.get("message") or payload.get("kind") or "unknown result"
+    if detail:
+        message = f"{message}: {detail}"
+    raise ReportError(f"findings validator returned inconsistent result: {message}")
+
+
+def _malformed_finding_diagnostics(
+    findings_dir: Path,
+    structure: Graph,
+    sprints: list[dict[str, Any]],
+    root: Path,
+) -> list[dict[str, Any]]:
+    """Return actionable diagnostics for malformed finding files.
+
+    ``load_graph`` skips an individual malformed file, which is exactly what
+    the read-only report needs.  We retain the parse error and recover
+    ``foundIn`` when the broken text still contains one unambiguous declared
+    sprint.  A file without a recoverable target is explicitly unattributed;
+    it still blocks dispatch/merge but cannot be blamed on a row.
+    """
+    if not findings_dir.is_dir():
+        return []
+    known = {str(item["iri"]): item["id"] for item in sprints}
+    # Prefix-local values such as ``triage:AICH-S1`` resolve against the
+    # canonical product namespace used by the graph.
+    known_local = {iri.rsplit(":", 1)[-1]: (iri, sid) for iri, sid in known.items()}
+    diagnostics: list[dict[str, Any]] = []
+    for path in sorted(findings_dir.glob("*.ttl")):
+        try:
+            parsed = Graph()
+            parsed.parse(str(path), format="turtle")
+            continue
+        except Exception as exc:  # noqa: BLE001 - report each bad file
+            text = path.read_text(encoding="utf-8", errors="replace")
+            candidates: set[str] = set()
+            for local, full in _FOUND_IN_TOKEN.findall(text):
+                iri = full or f"urn:atm:triage:{local}"
+                if iri in known:
+                    candidates.add(iri)
+                elif local in known_local:
+                    candidates.add(known_local[local][0])
+            sprint_iri = next(iter(candidates)) if len(candidates) == 1 else None
+            sprint_id = known.get(sprint_iri) if sprint_iri else None
+            try:
+                display_path = str(path.relative_to(root))
+            except ValueError:
+                display_path = str(path)
+            diagnostics.append(
+                {
+                    "code": "malformed_finding_ttl" if sprint_id else "unattributed_malformed_finding_ttl",
+                    "level": "error",
+                    "path": display_path,
+                    "absolute_path": str(path),
+                    "sprint": sprint_id,
+                    "sprint_iri": sprint_iri,
+                    "message": f"malformed Turtle: {exc}",
+                    "action": "repair Turtle syntax, then rerun validation before dispatch or merge",
+                }
+            )
+    return diagnostics
+
+
+def _validation_diagnostics(
+    validation: dict[str, Any],
+    malformed: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Normalize validator output into stable report diagnostics."""
+    diagnostics = list(malformed)
+    # Malformed parser diagnostics are represented with structured paths above;
+    # avoid duplicating their raw text from the validator payload.
+    malformed_paths = {item["path"] for item in malformed}
+    for detail in validation.get("diagnostics") or []:
+        text = str(detail)
+        if "malformed Turtle" in text and any(path in text for path in malformed_paths):
+            continue
+        diagnostics.append(
+            {
+                "code": "finding_validation",
+                "level": "error" if validation.get("kind") != "validation:pass" else "warning",
+                "path": None,
+                "absolute_path": None,
+                "sprint": None,
+                "sprint_iri": None,
+                "message": text,
+                "action": "repair the finding record and rerun validation before dispatch or merge",
+            }
+        )
+    return diagnostics
+
+
+def _diagnostic_text(diagnostic: dict[str, Any]) -> str:
+    """Render one diagnostic with the exact path and repair action."""
+    target = diagnostic.get("sprint") or "unattributed"
+    path = diagnostic.get("path") or diagnostic.get("absolute_path") or "unknown path"
+    return (
+        f"[{target}] {path}: {diagnostic.get('message', 'data error')} "
+        f"Action: {diagnostic.get('action', 'repair and revalidate')}"
+    )
 
 
 def _graph_runner():
@@ -592,10 +705,16 @@ def build_report(
     if not qa_master.is_absolute():
         qa_master = root / qa_master
     qa_data = _json(qa_master)
-    # Validate raw findings before calculating a single row.  This prevents
-    # query_runner's phase scoping from hiding malformed or orphan records.
+    # Validate raw findings before calculating rows.  Unlike dispatch, the
+    # read-only report keeps going after a malformed finding file so valid
+    # sprint rows remain visible.  ``diagnostics`` still blocks readiness and
+    # merge/dispatch globally.
     findings_dir = source.findings_dir
     validation = _run_findings_validator(root, findings_dir, structure_path, events_path)
+    malformed_diagnostics = _malformed_finding_diagnostics(
+        findings_dir, structure, sprints, root
+    )
+    diagnostics = _validation_diagnostics(validation, malformed_diagnostics)
     qa = _qa_runs(qa_data)
     live_counts = _live_counts(phase_path, findings_dir, sprints)
     github, github_repo = _github_state(root, sprints)
@@ -607,10 +726,15 @@ def build_report(
         data_gaps.append(f"QA evidence master not found: {qa_master}")
     if github_repo is None:
         data_gaps.append("GitHub origin is unavailable; PR/CI/merge cells are unknown")
+    data_gaps.extend(_diagnostic_text(item) for item in diagnostics)
 
     rows: list[dict[str, Any]] = []
     for sprint in sprints:
         sid = sprint["id"]
+        row_diagnostics = [
+            item for item in diagnostics if item.get("sprint") == sid
+        ]
+        row_errors = [item for item in row_diagnostics if item.get("level") == "error"]
         run = qa.get(sid)
         item = github.get(sid, {})
         counts = live_counts[sid]
@@ -628,6 +752,12 @@ def build_report(
         known_counts = all(value is not None for value in counts.values())
         quality_gate = (all(value == 0 for value in counts.values()) if known_counts else None)
         ready = None if counts["blockers"] is None else counts["blockers"] == 0
+        if row_errors:
+            # Affected rows are visibly blocked even when the malformed file
+            # was skipped by the graph loader and therefore did not inflate a
+            # B/I/M count.
+            quality_gate = False
+            ready = False
         rows.append(
             {
                 **sprint,
@@ -670,6 +800,8 @@ def build_report(
                 "delivery_attempts": item.get("delivery_attempts", []),
                 "quality_gate": quality_gate,
                 "ready_to_merge": ready,
+                "data_status": "error" if row_errors else ("warning" if row_diagnostics else "ok"),
+                "diagnostics": row_diagnostics,
             }
         )
         if run is None:
@@ -706,13 +838,14 @@ def build_report(
     for row in rows:
         q = row["qa"]
         phase_sprint = row["phase_sprint"] or "—"
+        marker = " ⚠️" if row.get("diagnostics") else ""
         lines.append(
-            f"| {row['id']} ({phase_sprint}) | {row['dev_icon']} | {row['qa_icon']} | "
+            f"| {row['id']} ({phase_sprint}){marker} | {row['dev_icon']} | {row['qa_icon']} | "
             f"{row['ci_icon']} | {_pr_cell(row)} | {q['blockers'] if q['blockers'] is not None else '?'} | "
             f"{q['important'] if q['important'] is not None else '?'} | {q['minor'] if q['minor'] is not None else '?'} | "
             f"{row['ready_icon']} | {row['ok_icon']} |"
         )
-        detailed.append(
+        detail = (
             f"Sprint: {row['id']} ({phase_sprint})\n"
             f"DEV: {row['dev_icon']}  QA: {row['qa_icon']} {q['verdict'] or 'UNKNOWN'}  "
             f"CI: {row['ci_icon']}  PR: {_pr_cell(row)}\n"
@@ -724,12 +857,22 @@ def build_report(
             f"Branch: {row['branch'] or 'unknown'}  Commit: {row['head_sha'] or 'unknown'}\n"
             f"PR URL: {row['pr_url'] or 'unknown'}"
         )
+        if row.get("diagnostics"):
+            detail += "\nData diagnostics:\n" + "\n".join(
+                f"- {_diagnostic_text(item)}" for item in row["diagnostics"]
+            )
+        detailed.append(detail)
     integration_row = f"| **integrate/{plan_phase or ('phase-' + phase_name)}** | | — | — | — | — | — | — | — | — |"
     table = (
         "| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |\n"
         "|--------|-----|----|----|----|---|---|---|-------|----|\n"
         + "\n".join(lines) + "\n" + integration_row
     )
+    if diagnostics:
+        table += "\n\nDiagnostics (dispatch/merge blocked):\n" + "\n".join(
+            f"- {_diagnostic_text(item)}" for item in diagnostics
+        )
+    merge_blocked = any(item.get("level") == "error" for item in diagnostics)
     return {
         "kind": "triage-report/v1",
         "mode": "table",
@@ -744,6 +887,9 @@ def build_report(
         "table": table,
         "data_gaps": data_gaps,
         "validation": validation,
+        "diagnostics": diagnostics,
+        "dispatch_blocked": merge_blocked,
+        "merge_blocked": merge_blocked,
         "sources": {
             "integration_root": ".",
             "structure": str(structure_path.relative_to(root)),
@@ -767,7 +913,20 @@ def main(argv: list[str] | None = None) -> int:
         root = args.integration_root or discover_integration_root(Path.cwd())
         report = build_report(root, args.phase, args.qa_master)
     except ReportError as exc:
-        print(json.dumps({"kind": "error", "error": str(exc)}, sort_keys=True))
+        print(
+            json.dumps(
+                {
+                    "schema": "triage-report/v1",
+                    "kind": "error",
+                    "error_code": "report",
+                    "message": str(exc),
+                    "diagnostics": [],
+                    "dispatch_blocked": True,
+                    "merge_blocked": True,
+                },
+                sort_keys=True,
+            )
+        )
         return 2
     output_format = "json" if args.json else args.format
     report["mode"] = "detailed" if args.format == "detailed" else args.mode

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -295,39 +295,6 @@ def _source_path(path: Path | None, root: Path) -> str | None:
         return f"<external>/{path.name}"
 
 
-def _findings_dir(root: Path, plan_phase: str | None) -> Path:
-    """Resolve the phase findings directory without guessing across phases."""
-    if not plan_phase:
-        raise ReportError(
-            "cannot locate findings: sprint criteria do not declare a plan phase"
-        )
-    suffix = plan_phase.removeprefix("phase-")
-    candidates = [
-        root / ".triage" / plan_phase,
-        root / ".triage" / f"phase-{suffix.upper()}",
-        root / ".triage" / f"phase-{suffix}",
-    ]
-    existing: list[Path] = []
-    # macOS's default filesystem is case-insensitive even though Path keeps
-    # the spelling supplied by the caller; compare case-folded real paths.
-    existing_real: set[str] = set()
-    for candidate in candidates:
-        findings = candidate / "findings"
-        if findings.is_dir():
-            resolved = findings.resolve()
-            identity = str(resolved).casefold()
-            if identity not in existing_real:
-                existing_real.add(identity)
-                existing.append(resolved)
-    if len(existing) != 1:
-        listed = ", ".join(str(item) for item in existing) or "none"
-        raise ReportError(
-            f"cannot determine unique findings directory for {plan_phase}: "
-            f"found {len(existing)} ({listed})"
-        )
-    return existing[0]
-
-
 def _run_findings_validator(
     root: Path,
     findings_dir: Path,
@@ -396,9 +363,9 @@ def _run_findings_validator(
 def _graph_runner():
     """Load graph-orchestration's public graph/query helpers once.
 
-    The report must use the same finding membership and resolution semantics as
-    dispatch.  Loading that module is preferable to a parallel Turtle loader or
-    a report-specific copy of ``open-findings-for-sprint.sparql``.
+    The report must use the same current-integration resolver, finding scope,
+    and resolution semantics as dispatch. Loading that module is preferable to
+    a parallel Turtle loader or report-specific query logic.
     """
     runner_path = (
         Path(__file__).resolve().parents[2]
@@ -414,7 +381,11 @@ def _graph_runner():
     return module
 
 
-def _live_counts(phase_path: Path, sprints: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+def _live_counts(
+    phase_path: Path,
+    findings_dir: Path,
+    sprints: list[dict[str, Any]],
+) -> dict[str, dict[str, int]]:
     """Return unresolved B/I/M counts using graph-orchestration's query.
 
     This is the report's gate source.  QA evidence records review provenance;
@@ -428,7 +399,7 @@ def _live_counts(phase_path: Path, sprints: list[dict[str, Any]]) -> dict[str, d
         / "open-findings-for-sprint.sparql"
     )
     try:
-        graph = runner.load_graph(str(phase_path))
+        graph = runner.load_graph(str(phase_path), findings_dir=findings_dir)
     except Exception as exc:  # noqa: BLE001 - normalize graph runner failures
         raise ReportError(f"could not load live finding graph: {exc}") from exc
 
@@ -593,7 +564,14 @@ def build_report(
     if _RDFLIB_ERROR:
         raise ReportError(f"rdflib is required; install it with pip install rdflib ({_RDFLIB_ERROR})")
     root = Path(integration_root).resolve()
-    phase_name, phase_path = _phase_dir(root, phase)
+    phase_name, requested_phase_path = _phase_dir(root, phase)
+    runner = _graph_runner()
+    try:
+        source = runner.resolve_phase_source(phase_name, str(requested_phase_path))
+    except Exception as exc:  # noqa: BLE001 - normalize shared source errors
+        raise ReportError(f"could not resolve current integration phase source: {exc}") from exc
+    root = source.root
+    phase_path = source.ttl_dir
     structure_path = phase_path / "structure.ttl"
     events_path = phase_path / "events.ttl"
     structure = _parse_ttl(structure_path)
@@ -616,10 +594,10 @@ def build_report(
     qa_data = _json(qa_master)
     # Validate raw findings before calculating a single row.  This prevents
     # query_runner's phase scoping from hiding malformed or orphan records.
-    findings_dir = _findings_dir(root, plan_phase)
+    findings_dir = source.findings_dir
     validation = _run_findings_validator(root, findings_dir, structure_path, events_path)
     qa = _qa_runs(qa_data)
-    live_counts = _live_counts(phase_path, sprints)
+    live_counts = _live_counts(phase_path, findings_dir, sprints)
     github, github_repo = _github_state(root, sprints)
     dev = _dev_states(events)
     data_gaps: list[str] = []

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -138,6 +138,18 @@ def test_live_ttl_counts_do_not_require_qa_snapshot(tmp_path):
     assert "QA evidence master not found" in report["data_gaps"][0]
 
 
+def test_report_ignores_unrelated_project_phase_findings(tmp_path):
+    """A historical malformed phase cannot block the current phase report."""
+    root, qa = _inputs(tmp_path)
+    unrelated = root / ".triage" / "phase-U" / "findings"
+    unrelated.mkdir(parents=True)
+    (unrelated / "legacy.ttl").write_text("finding_id: legacy\n")
+
+    report = triage_report.build_report(root, "AICH", qa)
+
+    assert report["rows"][0]["qa"]["blockers"] == 1
+
+
 def test_live_counts_scope_promoted_finding_to_open_downstream_branch(tmp_path):
     root, qa = _inputs(tmp_path)
     findings = root / ".triage" / "phase-AI" / "findings" / "S1.ttl"
@@ -170,6 +182,7 @@ def test_malformed_structure_is_report_error(tmp_path):
     root = tmp_path / "repo"
     phase = root / ".sprints" / "AICH"
     phase.mkdir(parents=True)
+    (root / ".triage").mkdir()
     (phase / "structure.ttl").write_text("not turtle [")
     try:
         triage_report.build_report(root, "AICH")

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -11,6 +11,7 @@ triage_report = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(triage_report)
 GITHUB_STATE = triage_report._github_state
+REAL_RUN_FINDINGS_VALIDATOR = triage_report._run_findings_validator
 
 PREFIX = "@prefix triage: <urn:atm:triage:> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
 
@@ -148,6 +149,59 @@ def test_report_ignores_unrelated_project_phase_findings(tmp_path):
     report = triage_report.build_report(root, "AICH", qa)
 
     assert report["rows"][0]["qa"]["blockers"] == 1
+
+
+def test_malformed_selected_finding_only_marks_attributed_row(tmp_path):
+    """A broken selected TTL must not hide valid sprint rows."""
+    root, qa = _inputs(tmp_path)
+    broken = root / ".triage" / "phase-AI" / "findings" / "BROKEN-S1.ttl"
+    broken.write_text(
+        PREFIX
+        + 'triage:broken a triage:Finding ; triage:foundIn triage:AICH-S1 ;\n'
+    )
+
+    validation = REAL_RUN_FINDINGS_VALIDATOR(
+        root,
+        root / ".triage" / "phase-AI" / "findings",
+        root / ".sprints" / "AICH" / "structure.ttl",
+        root / ".sprints" / "AICH" / "events.ttl",
+    )
+    assert validation["kind"] == "error"
+
+    report = triage_report.build_report(root, "AICH", qa)
+
+    assert [row["id"] for row in report["rows"]] == ["AICH-S1", "AICH-S2"]
+    first, second = report["rows"]
+    assert first["data_status"] == "error"
+    assert first["ready_to_merge"] is False
+    assert first["ok_to_merge"] is False
+    assert first["diagnostics"][0]["sprint"] == "AICH-S1"
+    assert first["diagnostics"][0]["path"].endswith("BROKEN-S1.ttl")
+    assert "repair Turtle syntax" in first["diagnostics"][0]["action"]
+    assert second["data_status"] == "ok"
+    assert second["ready_to_merge"] is True
+    assert report["merge_blocked"] is True
+    assert report["dispatch_blocked"] is True
+    assert "BROKEN-S1.ttl" in report["table"]
+    assert "Action: repair Turtle syntax" in report["table"]
+
+
+def test_malformed_selected_finding_without_found_in_is_unattributed(tmp_path):
+    """A broken TTL without a recoverable sprint is globally visible."""
+    root, qa = _inputs(tmp_path)
+    broken = root / ".triage" / "phase-AI" / "findings" / "BROKEN-UNKNOWN.ttl"
+    broken.write_text(PREFIX + "triage:broken a triage:Finding ;\n")
+
+    report = triage_report.build_report(root, "AICH", qa)
+
+    assert any(
+        item["code"] == "unattributed_malformed_finding_ttl"
+        and item["sprint"] is None
+        for item in report["diagnostics"]
+    )
+    assert "unattributed" in report["table"]
+    assert "BROKEN-UNKNOWN.ttl" in report["table"]
+    assert report["merge_blocked"] is True
 
 
 def test_live_counts_scope_promoted_finding_to_open_downstream_branch(tmp_path):


### PR DESCRIPTION
Makes cursor, assignee, and sprint-report queries read only current
integration-branch project triage data instead of stale/legacy snapshots.

Validation (arch-ctm): 71 tests passed; real Phase-AI AICH commands passed.

🤖 Generated with Claude Code