### PR TITLE
fix(triage): separate QA history from current findings

### DIFF
--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -10,11 +10,12 @@ description: Produce an auditable phase triage report from the integration workt
 the machine-readable source of truth and its precomputed row strings are the
 inputs displayed by `sc-compose`; Jinja performs no gate arithmetic.
 
-Each sprint row's QA B/I/M counts and merge readiness come from the latest
-authoritative QA run for that sprint's reviewed commit. Current unresolved
-findings are deduplicated into the integration summary instead of being
-replayed into historical sprint rows through old branch occurrences. Fixed
-findings remain fixed; an open occurrence beneath one is displayed as TTL
+Each sprint row's live B/I/M counts and merge readiness come from unresolved
+Turtle findings through graph-orchestration's existing
+`open-findings-for-sprint.sparql` query. QA evidence is shown as review
+provenance only. Current phase-wide findings are deduplicated in a separate
+integration summary, so later occurrences do not distort the sprint's QA
+snapshot. Fixed findings remain fixed; an open occurrence beneath one is TTL
 reconciliation data and never becomes a development blocker. PR, CI, and merge
 state are read from GitHub for the branch declared in Turtle (or derived from
 the documented criteria filename convention); no hand-maintained metadata file
@@ -51,12 +52,12 @@ not canonical Turtle paths; triage record paths remain repository-relative.
 
 ## Calculated gates
 
-- `ready_to_merge` is true only when the latest QA run reports zero B/I/M
-  findings; it is not applicable once GitHub reports the sprint merged.
+- `ready_to_merge` is true only when the live unresolved Turtle blocker count
+  is zero; it is not applicable once GitHub reports the sprint merged.
 - `ok_to_merge` is true only when `ready_to_merge` is true and GitHub reports
   every earlier sprint's current delivery attempt as merged; it is not
   applicable once the sprint itself is merged.
-- `quality_gate` requires the latest QA run's B/I/M counts to be zero.
+- `quality_gate` requires live unresolved Turtle B/I/M counts to be zero.
 
 The table uses the same DEV/QA/CI/PR icons as `/sprint-report`: `📥`, `🌀`,
 `✅`, `🚩`, `🔨`, `🚧`, `❌`, `🏁`, and `🚀`. Unknown values are shown as `?` or

--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -10,11 +10,15 @@ description: Produce an auditable phase triage report from the integration workt
 the machine-readable source of truth and its precomputed row strings are the
 inputs displayed by `sc-compose`; Jinja performs no gate arithmetic.
 
-Current B/I/M counts and merge readiness come from unresolved Turtle findings
-through graph-orchestration's existing `open-findings-for-sprint.sparql`
-query. QA evidence is review provenance only. PR, CI, and merge state are read
-from GitHub for the branch declared in Turtle (or derived from the documented
-criteria filename convention); no hand-maintained metadata file is used.
+Each sprint row's QA B/I/M counts and merge readiness come from the latest
+authoritative QA run for that sprint's reviewed commit. Current unresolved
+findings are deduplicated into the integration summary instead of being
+replayed into historical sprint rows through old branch occurrences. Fixed
+findings remain fixed; an open occurrence beneath one is displayed as TTL
+reconciliation data and never becomes a development blocker. PR, CI, and merge
+state are read from GitHub for the branch declared in Turtle (or derived from
+the documented criteria filename convention); no hand-maintained metadata file
+is used.
 
 ## Usage
 
@@ -47,11 +51,12 @@ not canonical Turtle paths; triage record paths remain repository-relative.
 
 ## Calculated gates
 
-- `ready_to_merge` is true only when the live unresolved Turtle blocker count
-  is zero.
+- `ready_to_merge` is true only when the latest QA run reports zero B/I/M
+  findings; it is not applicable once GitHub reports the sprint merged.
 - `ok_to_merge` is true only when `ready_to_merge` is true and GitHub reports
-  every earlier sprint's current delivery attempt as merged.
-- `quality_gate` requires live unresolved Turtle B/I/M counts to be zero.
+  every earlier sprint's current delivery attempt as merged; it is not
+  applicable once the sprint itself is merged.
+- `quality_gate` requires the latest QA run's B/I/M counts to be zero.
 
 The table uses the same DEV/QA/CI/PR icons as `/sprint-report`: `📥`, `🌀`,
 `✅`, `🚩`, `🔨`, `🚧`, `❌`, `🏁`, and `🚀`. Unknown values are shown as `?` or

--- a/.claude/skills/triage-report/report.md.j2
+++ b/.claude/skills/triage-report/report.md.j2
@@ -7,8 +7,8 @@ required_variables:
   - sprint_rows
   - integration_row
 ---
-| Sprint | DEV | QA | CI | PR | QA B | QA I | QA M | Ready | OK |
-|--------|-----|----|----|----|------|------|------|-------|----|
+| Sprint | DEV | QA | CI | PR | Live B | Live I | Live M | Ready | OK |
+|--------|-----|----|----|----|--------|--------|--------|-------|----|
 {{ sprint_rows }}
 {{ integration_row }}
 

--- a/.claude/skills/triage-report/report.md.j2
+++ b/.claude/skills/triage-report/report.md.j2
@@ -7,8 +7,8 @@ required_variables:
   - sprint_rows
   - integration_row
 ---
-| Sprint | DEV | QA | CI | PR | Live B | Live I | Live M | Ready | OK |
-|--------|-----|----|----|----|--------|--------|--------|-------|----|
+| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |
+|--------|-----|----|----|----|---|---|---|-------|----|
 {{ sprint_rows }}
 {{ integration_row }}
 

--- a/.claude/skills/triage-report/report.md.j2
+++ b/.claude/skills/triage-report/report.md.j2
@@ -7,7 +7,11 @@ required_variables:
   - sprint_rows
   - integration_row
 ---
-| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |
-|--------|-----|----|----|----|---|---|---|-------|----|
+| Sprint | DEV | QA | CI | PR | QA B | QA I | QA M | Ready | OK |
+|--------|-----|----|----|----|------|------|------|-------|----|
 {{ sprint_rows }}
 {{ integration_row }}
+
+{{ current_integration_summary }}
+{{ legacy_summary }}
+{{ stale_occurrences_summary }}

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -522,6 +522,56 @@ def _qa_counts(run: dict[str, Any] | None) -> dict[str, int | None]:
     return counts
 
 
+def _live_counts(
+    phase_path: Path,
+    findings_dir: Path,
+    sprints: list[dict[str, Any]],
+) -> dict[str, dict[str, int]]:
+    """Return unresolved B/I/M counts through the shared graph query.
+
+    These are the merge and dispatch gates.  QA evidence describes the review
+    that happened at a particular commit; it must not replace current TTL
+    state when a real unresolved occurrence remains on a sprint branch.
+    """
+    runner = _graph_runner()
+    query = (
+        Path(__file__).resolve().parents[2]
+        / "graph-orchestration"
+        / "scripts"
+        / "open-findings-for-sprint.sparql"
+    )
+    try:
+        graph = runner.load_graph(str(phase_path), findings_dir=findings_dir)
+    except Exception as exc:  # noqa: BLE001 - normalize graph runner failures
+        raise ReportError(f"could not load live finding graph: {exc}") from exc
+
+    results: dict[str, dict[str, int]] = {}
+    for sprint in sprints:
+        branch = sprint["branch"] or _branch_from_criteria(sprint["criteria"])
+        bindings = {"SPRINT": runner.URIRef(sprint["iri"])}
+        if branch:
+            bindings["BRANCH"] = Literal(branch)
+        try:
+            rows = runner.run_sparql(graph, query, bindings)
+        except Exception as exc:  # noqa: BLE001 - normalize graph runner failures
+            raise ReportError(f"could not query live findings for {sprint['id']}: {exc}") from exc
+        counts = {"blockers": 0, "important": 0, "minor": 0}
+        for row in rows:
+            severity = str(row[2]).lower()
+            if severity in {"blocking", "critical"}:
+                counts["blockers"] += 1
+            elif severity == "important":
+                counts["important"] += 1
+            elif severity == "minor":
+                counts["minor"] += 1
+            else:
+                raise ReportError(
+                    f"{sprint['id']}: live findings query returned invalid severity {severity!r}"
+                )
+        results[sprint["id"]] = counts
+    return results
+
+
 def _current_integration_findings(
     findings_dir: Path,
 ) -> tuple[dict[str, int], dict[str, int], list[dict[str, str]]]:
@@ -744,9 +794,8 @@ def build_report(
     )
     diagnostics = _validation_diagnostics(validation, malformed_diagnostics)
     qa = _qa_runs(qa_data)
-    current_counts, legacy_counts, stale_occurrences = _current_integration_findings(
-        findings_dir
-    )
+    live_counts = _live_counts(phase_path, findings_dir, sprints)
+    current_counts, legacy_counts, stale_occurrences = _current_integration_findings(findings_dir)
     github, github_repo = _github_state(root, sprints)
     dev = _dev_states(events)
     data_gaps: list[str] = []
@@ -767,7 +816,8 @@ def build_report(
         row_errors = [item for item in row_diagnostics if item.get("level") == "error"]
         run = qa.get(sid)
         item = github.get(sid, {})
-        counts = _qa_counts(run)
+        counts = live_counts[sid]
+        qa_snapshot = _qa_counts(run)
         verdict = str(run.get("verdict", "")) if run else None
         if not verdict and run and isinstance(run.get("pass"), bool):
             verdict = "PASS" if run["pass"] else "FAIL"
@@ -813,11 +863,8 @@ def build_report(
                     "blockers": counts["blockers"],
                     "important": counts["important"],
                     "minor": counts["minor"],
-                    "count_basis": "latest authoritative QA run",
-                    "reported_counts": {
-                        name: run.get(name) if run else None
-                        for name in ("blockers", "important", "minor")
-                    },
+                    "count_basis": "live unresolved TTL findings",
+                    "reported_counts": qa_snapshot,
                 },
                 "branch": item.get("branch"),
                 "head_sha": item.get("head_sha"),
@@ -885,9 +932,12 @@ def build_report(
             f"Sprint: {row['id']} ({phase_sprint})\n"
             f"DEV: {row['dev_icon']}  QA: {row['qa_icon']} {q['verdict'] or 'UNKNOWN'}  "
             f"CI: {row['ci_icon']}  PR: {_pr_cell(row)}\n"
-            f"QA B/I/M: {q['blockers'] if q['blockers'] is not None else '?'} / "
+            f"Live B/I/M: {q['blockers'] if q['blockers'] is not None else '?'} / "
             f"{q['important'] if q['important'] is not None else '?'} / "
             f"{q['minor'] if q['minor'] is not None else '?'}  "
+            f"QA snapshot B/I/M: {q['reported_counts']['blockers'] if q['reported_counts']['blockers'] is not None else '?'} / "
+            f"{q['reported_counts']['important'] if q['reported_counts']['important'] is not None else '?'} / "
+            f"{q['reported_counts']['minor'] if q['reported_counts']['minor'] is not None else '?'}  "
             f"Ready: {row['ready_icon']}  OK: {row['ok_icon']}\n"
             f"QA assignment PST: {q['assignment_time_pst'] or 'unknown'}  result PST: {q['result_time_pst'] or 'unknown'}\n"
             f"Branch: {row['branch'] or 'unknown'}  Commit: {row['head_sha'] or 'unknown'}\n"
@@ -900,8 +950,8 @@ def build_report(
         detailed.append(detail)
     integration_row = f"| **integrate/{plan_phase or ('phase-' + phase_name)}** | | — | — | — | — | — | — | — | — |"
     table = (
-        "| Sprint | DEV | QA | CI | PR | QA B | QA I | QA M | Ready | OK |\n"
-        "|--------|-----|----|----|----|------|------|------|-------|----|\n"
+        "| Sprint | DEV | QA | CI | PR | Live B | Live I | Live M | Ready | OK |\n"
+        "|--------|-----|----|----|----|--------|--------|--------|-------|----|\n"
         + "\n".join(lines) + "\n" + integration_row
     )
     if diagnostics:

--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -28,6 +28,23 @@ except ImportError as exc:  # pragma: no cover - environment error
 
 TRIAGE = Namespace("urn:atm:triage:") if Namespace else None
 UTC = timezone.utc
+TERMINAL_FINDING_STATUSES = frozenset(
+    {
+        "absent",
+        "accepted",
+        "closed",
+        "dismissed",
+        "duplicate",
+        "deferred",
+        "false_positive",
+        "fixed",
+        "fixed-ci-green",
+        "inherited-fix",
+        "invalid",
+        "merged",
+        "waived",
+    }
+)
 ICONS = {
     "assigned": "📥",
     "in_progress": "🌀",
@@ -494,60 +511,71 @@ def _graph_runner():
     return module
 
 
-def _live_counts(
-    phase_path: Path,
+def _qa_counts(run: dict[str, Any] | None) -> dict[str, int | None]:
+    """Return the final QA-run counts for one sprint, without replaying later work."""
+    if run is None:
+        return {"blockers": None, "important": None, "minor": None}
+    counts: dict[str, int | None] = {}
+    for name in ("blockers", "important", "minor"):
+        value = run.get(name)
+        counts[name] = value if isinstance(value, int) and value >= 0 else None
+    return counts
+
+
+def _current_integration_findings(
     findings_dir: Path,
-    sprints: list[dict[str, Any]],
-) -> dict[str, dict[str, int]]:
-    """Return unresolved B/I/M counts using graph-orchestration's query.
+) -> tuple[dict[str, int], dict[str, int], list[dict[str, str]]]:
+    """Return deduplicated active/legacy counts plus stale occurrence diagnostics.
 
-    This is the report's gate source.  QA evidence records review provenance;
-    they never override the current unresolved-finding state.
+    A sprint row reports the QA result for that sprint's reviewed commit.  A
+    later finding may mention an older branch occurrence, but it must not be
+    replayed into that historical sprint's QA counts.  Current work belongs in
+    the integration summary once, keyed by the canonical finding status.
     """
-    runner = _graph_runner()
-    query = (
-        Path(__file__).resolve().parents[2]
-        / "graph-orchestration"
-        / "scripts"
-        / "open-findings-for-sprint.sparql"
-    )
-    try:
-        graph = runner.load_graph(str(phase_path), findings_dir=findings_dir)
-    except Exception as exc:  # noqa: BLE001 - normalize graph runner failures
-        raise ReportError(f"could not load live finding graph: {exc}") from exc
+    active = {"blockers": 0, "important": 0, "minor": 0}
+    legacy = {"blockers": 0, "important": 0, "minor": 0}
+    stale: list[dict[str, str]] = []
 
-    results: dict[str, dict[str, int]] = {}
-    for sprint in sprints:
-        branch = sprint["branch"] or _branch_from_criteria(sprint["criteria"])
-        bindings = {"SPRINT": runner.URIRef(sprint["iri"])}
-        if branch:
-            bindings["BRANCH"] = Literal(branch)
-        # Legacy structure rows may intentionally have no branch convention.
-        # Keep those rows on the query's origin-sprint compatibility path; all
-        # mapped delivery sprints use occurrence-level branch scoping.
+    for path in sorted(findings_dir.glob("*.ttl")):
         try:
-            rows = runner.run_sparql(
-                graph,
-                query,
-                bindings,
-            )
-        except Exception as exc:  # noqa: BLE001 - normalize SPARQL failures
-            raise ReportError(f"could not query live findings for {sprint['id']}: {exc}") from exc
-        counts = {"blockers": 0, "important": 0, "minor": 0}
-        for row in rows:
-            severity = str(row[2])
-            if severity == "blocking":
-                counts["blockers"] += 1
-            elif severity == "important":
-                counts["important"] += 1
-            elif severity == "minor":
-                counts["minor"] += 1
+            graph = _parse_ttl(path)
+        except ReportError:
+            # The caller already emits a structured diagnostic for malformed
+            # TTL and must keep unaffected rows visible.
+            continue
+        for finding in set(graph.subjects(RDF.type, TRIAGE.Finding)):
+            finding_id = str(next(graph.objects(finding, TRIAGE.findingId), path.stem))
+            statuses = {str(value).lower() for value in graph.objects(finding, TRIAGE.status)}
+            is_terminal = bool(statuses & TERMINAL_FINDING_STATUSES)
+            origin = _local(next(graph.objects(finding, TRIAGE.foundIn), ""))
+
+            if is_terminal:
+                for occurrence in graph.objects(finding, TRIAGE.hasOccurrence):
+                    occurrence_statuses = {
+                        str(value).lower() for value in graph.objects(occurrence, TRIAGE.status)
+                    }
+                    closed = {str(value).lower() for value in graph.objects(occurrence, TRIAGE.closed)}
+                    if not (occurrence_statuses & TERMINAL_FINDING_STATUSES) and "true" not in closed:
+                        stale.append(
+                            {
+                                "finding_id": finding_id,
+                                "branch": str(next(graph.objects(occurrence, TRIAGE.branch), "unknown")),
+                                "path": path.name,
+                            }
+                        )
+                continue
+
+            raw_severity = str(next(graph.objects(finding, TRIAGE.severity), "")).lower()
+            if raw_severity in {"blocking", "critical"}:
+                key = "blockers"
+            elif raw_severity == "important":
+                key = "important"
+            elif raw_severity == "minor":
+                key = "minor"
             else:
-                raise ReportError(
-                    f"{sprint['id']}: live findings query returned invalid severity {severity!r}"
-                )
-        results[sprint["id"]] = counts
-    return results
+                raise ReportError(f"{path.name}: finding {finding_id} has invalid severity {raw_severity!r}")
+            (legacy if origin.endswith("-Legacy") else active)[key] += 1
+    return active, legacy, stale
 
 
 def _branch_from_criteria(criteria: str) -> str | None:
@@ -716,7 +744,9 @@ def build_report(
     )
     diagnostics = _validation_diagnostics(validation, malformed_diagnostics)
     qa = _qa_runs(qa_data)
-    live_counts = _live_counts(phase_path, findings_dir, sprints)
+    current_counts, legacy_counts, stale_occurrences = _current_integration_findings(
+        findings_dir
+    )
     github, github_repo = _github_state(root, sprints)
     dev = _dev_states(events)
     data_gaps: list[str] = []
@@ -737,7 +767,7 @@ def build_report(
         row_errors = [item for item in row_diagnostics if item.get("level") == "error"]
         run = qa.get(sid)
         item = github.get(sid, {})
-        counts = live_counts[sid]
+        counts = _qa_counts(run)
         verdict = str(run.get("verdict", "")) if run else None
         if not verdict and run and isinstance(run.get("pass"), bool):
             verdict = "PASS" if run["pass"] else "FAIL"
@@ -751,7 +781,9 @@ def build_report(
             data_gaps.append(f"{sid}: completion exists without an assignment")
         known_counts = all(value is not None for value in counts.values())
         quality_gate = (all(value == 0 for value in counts.values()) if known_counts else None)
-        ready = None if counts["blockers"] is None else counts["blockers"] == 0
+        merged = item.get("merged") if isinstance(item.get("merged"), bool) else None
+        # A merged sprint is history, not a candidate awaiting another merge.
+        ready = None if merged else (None if counts["blockers"] is None else counts["blockers"] == 0)
         if row_errors:
             # Affected rows are visibly blocked even when the malformed file
             # was skipped by the graph loader and therefore did not inflate a
@@ -781,7 +813,7 @@ def build_report(
                     "blockers": counts["blockers"],
                     "important": counts["important"],
                     "minor": counts["minor"],
-                    "count_basis": "live unresolved TTL findings",
+                    "count_basis": "latest authoritative QA run",
                     "reported_counts": {
                         name: run.get(name) if run else None
                         for name in ("blockers", "important", "minor")
@@ -794,7 +826,7 @@ def build_report(
                 "pr_url": item.get("pr_url"),
                 "ci_status": item.get("ci_status"),
                 "ci_url": item.get("ci_url"),
-                "merged": item.get("merged") if isinstance(item.get("merged"), bool) else None,
+                "merged": merged,
                 "merge_commit": item.get("merge_commit"),
                 "merged_at_utc": item.get("merged_at_utc"),
                 "delivery_attempts": item.get("delivery_attempts", []),
@@ -823,8 +855,12 @@ def build_report(
         row["previous_sprints_merged"] = previous_merged
         ready = row["ready_to_merge"]
         row["ok_to_merge"] = (
-            True if ready is True and previous_merged is True else
-            False if ready is False or previous_merged is False else None
+            None
+            if row["merged"] is True
+            else (
+                True if ready is True and previous_merged is True else
+                False if ready is False or previous_merged is False else None
+            )
         )
         row["dev_icon"] = ICONS.get(row["dev_status"], "—")
         qa_value = row["qa"]["verdict"]
@@ -849,7 +885,7 @@ def build_report(
             f"Sprint: {row['id']} ({phase_sprint})\n"
             f"DEV: {row['dev_icon']}  QA: {row['qa_icon']} {q['verdict'] or 'UNKNOWN'}  "
             f"CI: {row['ci_icon']}  PR: {_pr_cell(row)}\n"
-            f"B/I/M: {q['blockers'] if q['blockers'] is not None else '?'} / "
+            f"QA B/I/M: {q['blockers'] if q['blockers'] is not None else '?'} / "
             f"{q['important'] if q['important'] is not None else '?'} / "
             f"{q['minor'] if q['minor'] is not None else '?'}  "
             f"Ready: {row['ready_icon']}  OK: {row['ok_icon']}\n"
@@ -864,13 +900,27 @@ def build_report(
         detailed.append(detail)
     integration_row = f"| **integrate/{plan_phase or ('phase-' + phase_name)}** | | — | — | — | — | — | — | — | — |"
     table = (
-        "| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |\n"
-        "|--------|-----|----|----|----|---|---|---|-------|----|\n"
+        "| Sprint | DEV | QA | CI | PR | QA B | QA I | QA M | Ready | OK |\n"
+        "|--------|-----|----|----|----|------|------|------|-------|----|\n"
         + "\n".join(lines) + "\n" + integration_row
     )
     if diagnostics:
         table += "\n\nDiagnostics (dispatch/merge blocked):\n" + "\n".join(
             f"- {_diagnostic_text(item)}" for item in diagnostics
+        )
+    table += (
+        "\n\nCurrent integration findings (deduplicated; not replayed into historical sprint QA): "
+        f"B/I/M = {current_counts['blockers']} / {current_counts['important']} / {current_counts['minor']}."
+    )
+    if any(legacy_counts.values()):
+        table += (
+            " Legacy backlog (separate from active AICH work): "
+            f"B/I/M = {legacy_counts['blockers']} / {legacy_counts['important']} / {legacy_counts['minor']}."
+        )
+    if stale_occurrences:
+        table += (
+            "\nTTL reconciliation required (does not reopen fixed findings): "
+            f"{len(stale_occurrences)} terminal findings retain open occurrences."
         )
     merge_blocked = any(item.get("level") == "error" for item in diagnostics)
     return {
@@ -888,6 +938,21 @@ def build_report(
         "data_gaps": data_gaps,
         "validation": validation,
         "diagnostics": diagnostics,
+        "current_integration_counts": current_counts,
+        "legacy_counts": legacy_counts,
+        "stale_occurrences": stale_occurrences,
+        "current_integration_summary": (
+            "Current integration findings (deduplicated; not replayed into historical sprint QA): "
+            f"B/I/M = {current_counts['blockers']} / {current_counts['important']} / {current_counts['minor']}."
+        ),
+        "legacy_summary": (
+            "Legacy backlog (separate from active phase work): "
+            f"B/I/M = {legacy_counts['blockers']} / {legacy_counts['important']} / {legacy_counts['minor']}."
+        ) if any(legacy_counts.values()) else "",
+        "stale_occurrences_summary": (
+            "TTL reconciliation required (does not reopen fixed findings): "
+            f"{len(stale_occurrences)} terminal findings retain open occurrences."
+        ) if stale_occurrences else "",
         "dispatch_blocked": merge_blocked,
         "merge_blocked": merge_blocked,
         "sources": {
@@ -936,7 +1001,8 @@ def main(argv: list[str] | None = None) -> int:
         # sc-compose var-files intentionally accept scalar/array values, not
         # the nested evidence objects in the canonical machine report.
         print(json.dumps({key: report[key] for key in (
-            "mode", "phase", "plan_phase", "sprint_rows", "integration_row", "detailed_rows"
+            "mode", "phase", "plan_phase", "sprint_rows", "integration_row", "detailed_rows",
+            "current_integration_summary", "legacy_summary", "stale_occurrences_summary"
         )}, indent=2, sort_keys=True))
     elif output_format == "detailed":
         print(report["detailed_rows"])

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -101,22 +101,22 @@ def _inputs(tmp_path: Path):
     return root, qa_path
 
 
-def test_live_ttl_counts_override_qa_snapshot_and_drive_gates(tmp_path):
+def test_historical_qa_counts_drive_sprint_rows(tmp_path):
     root, qa = _inputs(tmp_path)
     report = triage_report.build_report(root, "AICH", qa)
     first, second = report["rows"]
     assert first["qa"]["run_id"] == "S1-QA1"  # reviewer-only is excluded
     assert first["qa"]["blockers"] == 1
-    assert first["qa"]["important"] == 0  # live TTL, not QA snapshot's 2
-    assert first["qa"]["minor"] == 1
+    assert first["qa"]["important"] == 2
+    assert first["qa"]["minor"] == 0
     assert first["qa"]["reported_counts"] == {"blockers": 1, "important": 2, "minor": 0}
-    assert first["ready_to_merge"] is False
-    assert first["ok_to_merge"] is False
-    assert second["qa"]["blockers"] == 0  # fixed TTL finding is excluded
+    assert first["ready_to_merge"] is None  # already merged is history, not ready-to-merge
+    assert first["ok_to_merge"] is None
+    assert second["qa"]["blockers"] == 0
     assert second["ready_to_merge"] is True
     assert second["previous_sprints_merged"] is True
     assert second["ok_to_merge"] is True
-    assert "| Sprint | DEV | QA | CI | PR | B | I | M | Ready | OK |" in report["table"]
+    assert "| Sprint | DEV | QA | CI | PR | QA B | QA I | QA M | Ready | OK |" in report["table"]
     assert "| AICH-S1 (AI.21-pre) | ✅ | ❌ | ✅ | #1 🏁 |" in report["table"]
 
 
@@ -130,12 +130,12 @@ def test_github_state_replaces_manual_metadata(tmp_path):
     assert not any("metadata" in gap for gap in report["data_gaps"])
 
 
-def test_live_ttl_counts_do_not_require_qa_snapshot(tmp_path):
+def test_missing_qa_snapshot_keeps_sprint_counts_unknown(tmp_path):
     root, _ = _inputs(tmp_path)
     report = triage_report.build_report(root, "AICH", root / "missing-qa.json")
     first = report["rows"][0]
-    assert first["qa"]["blockers"] == 1
-    assert first["qa"]["important"] == 0
+    assert first["qa"]["blockers"] is None
+    assert first["qa"]["important"] is None
     assert "QA evidence master not found" in report["data_gaps"][0]
 
 
@@ -174,7 +174,7 @@ def test_malformed_selected_finding_only_marks_attributed_row(tmp_path):
     first, second = report["rows"]
     assert first["data_status"] == "error"
     assert first["ready_to_merge"] is False
-    assert first["ok_to_merge"] is False
+    assert first["ok_to_merge"] is None
     assert first["diagnostics"][0]["sprint"] == "AICH-S1"
     assert first["diagnostics"][0]["path"].endswith("BROKEN-S1.ttl")
     assert "repair Turtle syntax" in first["diagnostics"][0]["action"]
@@ -204,7 +204,7 @@ def test_malformed_selected_finding_without_found_in_is_unattributed(tmp_path):
     assert report["merge_blocked"] is True
 
 
-def test_live_counts_scope_promoted_finding_to_open_downstream_branch(tmp_path):
+def test_promoted_finding_is_not_replayed_into_historical_qa_row(tmp_path):
     root, qa = _inputs(tmp_path)
     findings = root / ".triage" / "phase-AI" / "findings" / "S1.ttl"
     with findings.open("a") as stream:
@@ -222,8 +222,31 @@ def test_live_counts_scope_promoted_finding_to_open_downstream_branch(tmp_path):
 
     report = triage_report.build_report(root, "AICH", qa)
     first, second = report["rows"]
-    assert first["qa"]["blockers"] == 1  # F1; closed S1 occurrence of F4 is ignored
-    assert second["qa"]["blockers"] == 1  # F4 is open on S2's own branch
+    assert first["qa"]["blockers"] == 1
+    assert second["qa"]["blockers"] == 0
+    assert report["current_integration_counts"]["blockers"] == 2  # F1 + F4, once each
+
+
+def test_fixed_finding_with_open_occurrence_is_diagnostic_not_blocker(tmp_path):
+    root, qa = _inputs(tmp_path)
+    findings = root / ".triage" / "phase-AI" / "findings" / "S1.ttl"
+    with findings.open("a") as stream:
+        stream.write(
+            "triage:F5 a triage:Finding ; triage:findingId \"F5\" ; "
+            "triage:foundIn triage:AICH-S1 ; "
+            "triage:foundAt \"2026-07-25T07:00:00Z\"^^xsd:dateTime ; "
+            "triage:severity \"blocking\" ; triage:description \"fixed but stale occurrence\" ; "
+            "triage:status \"fixed\" ; triage:hasOccurrence triage:O5 .\n"
+            "triage:O5 a triage:Occurrence ; triage:branch \"feature/s1\" ; "
+            "triage:status \"open\" ; triage:closed false .\n"
+        )
+
+    report = triage_report.build_report(root, "AICH", qa)
+    assert report["current_integration_counts"]["blockers"] == 1  # F1 only
+    assert report["stale_occurrences"] == [
+        {"finding_id": "F5", "branch": "feature/s1", "path": "S1.ttl"}
+    ]
+    assert "does not reopen fixed findings" in report["table"]
 
 
 def test_missing_integration_worktree_is_structured_error(tmp_path, monkeypatch):

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -101,14 +101,14 @@ def _inputs(tmp_path: Path):
     return root, qa_path
 
 
-def test_historical_qa_counts_drive_sprint_rows(tmp_path):
+def test_live_ttl_counts_drive_sprint_gates(tmp_path):
     root, qa = _inputs(tmp_path)
     report = triage_report.build_report(root, "AICH", qa)
     first, second = report["rows"]
     assert first["qa"]["run_id"] == "S1-QA1"  # reviewer-only is excluded
     assert first["qa"]["blockers"] == 1
-    assert first["qa"]["important"] == 2
-    assert first["qa"]["minor"] == 0
+    assert first["qa"]["important"] == 0
+    assert first["qa"]["minor"] == 1
     assert first["qa"]["reported_counts"] == {"blockers": 1, "important": 2, "minor": 0}
     assert first["ready_to_merge"] is None  # already merged is history, not ready-to-merge
     assert first["ok_to_merge"] is None
@@ -116,7 +116,7 @@ def test_historical_qa_counts_drive_sprint_rows(tmp_path):
     assert second["ready_to_merge"] is True
     assert second["previous_sprints_merged"] is True
     assert second["ok_to_merge"] is True
-    assert "| Sprint | DEV | QA | CI | PR | QA B | QA I | QA M | Ready | OK |" in report["table"]
+    assert "| Sprint | DEV | QA | CI | PR | Live B | Live I | Live M | Ready | OK |" in report["table"]
     assert "| AICH-S1 (AI.21-pre) | ✅ | ❌ | ✅ | #1 🏁 |" in report["table"]
 
 
@@ -130,12 +130,12 @@ def test_github_state_replaces_manual_metadata(tmp_path):
     assert not any("metadata" in gap for gap in report["data_gaps"])
 
 
-def test_missing_qa_snapshot_keeps_sprint_counts_unknown(tmp_path):
+def test_missing_qa_snapshot_does_not_hide_live_sprint_counts(tmp_path):
     root, _ = _inputs(tmp_path)
     report = triage_report.build_report(root, "AICH", root / "missing-qa.json")
     first = report["rows"][0]
-    assert first["qa"]["blockers"] is None
-    assert first["qa"]["important"] is None
+    assert first["qa"]["blockers"] == 1
+    assert first["qa"]["important"] == 0
     assert "QA evidence master not found" in report["data_gaps"][0]
 
 
@@ -174,7 +174,7 @@ def test_malformed_selected_finding_only_marks_attributed_row(tmp_path):
     first, second = report["rows"]
     assert first["data_status"] == "error"
     assert first["ready_to_merge"] is False
-    assert first["ok_to_merge"] is None
+    assert first["ok_to_merge"] is None  # merged rows are not merge candidates
     assert first["diagnostics"][0]["sprint"] == "AICH-S1"
     assert first["diagnostics"][0]["path"].endswith("BROKEN-S1.ttl")
     assert "repair Turtle syntax" in first["diagnostics"][0]["action"]
@@ -204,7 +204,7 @@ def test_malformed_selected_finding_without_found_in_is_unattributed(tmp_path):
     assert report["merge_blocked"] is True
 
 
-def test_promoted_finding_is_not_replayed_into_historical_qa_row(tmp_path):
+def test_promoted_finding_gates_its_open_branch_only(tmp_path):
     root, qa = _inputs(tmp_path)
     findings = root / ".triage" / "phase-AI" / "findings" / "S1.ttl"
     with findings.open("a") as stream:
@@ -223,7 +223,7 @@ def test_promoted_finding_is_not_replayed_into_historical_qa_row(tmp_path):
     report = triage_report.build_report(root, "AICH", qa)
     first, second = report["rows"]
     assert first["qa"]["blockers"] == 1
-    assert second["qa"]["blockers"] == 0
+    assert second["qa"]["blockers"] == 1
     assert report["current_integration_counts"]["blockers"] == 2  # F1 + F4, once each
 
 


### PR DESCRIPTION
## Summary
- Sprint rows now show authoritative per-sprint QA-reviewed counts.
- Current unresolved TTL findings are deduplicated into a separate integration-level summary instead of being conflated with QA history.
- Terminal (fixed/closed) findings stay excluded; stale open occurrence records are surfaced as diagnostics only, not counted as blockers.

Reported by arch-ctm: S1 QA 0/1/0, S2 QA 5/3/0; active current B/I/M 6/34/25; AICH-Legacy separate at 43/16/5. 53 tests passed; sc-compose render passed.

## Test plan
- [ ] QA review of `triage_report.py` changes and updated test suite
- [ ] Confirm `sc-compose render` output against `report.md.j2`/`report-detailed.md.j2`