### PR TITLE
fix(phase-ai): close-out round 2 easy-wins batch

### DIFF
--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -17,6 +17,10 @@ mod daemon_runtime_observability;
 // fork while only one daemon can publish the local IPC endpoint; see
 // tests::host_ownership_record_uses_pid_and_token_while_held_and_clears_on_release.
 mod host_ownership;
+// Resource-cost note (AI21-MINOR-003): the HTTPS accept loop currently uses
+// one OS thread per accepted connection without a configured concurrency cap.
+// This is a known non-blocking hardening item: the mTLS listener limits access
+// to trusted peers, while a bounded worker model remains follow-up work.
 mod https_transport;
 #[cfg_attr(windows, allow(dead_code))]
 mod lifecycle_control;

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -278,6 +278,25 @@ Phase AC supersession note:
 - `ack` remains a workflow/state concern, but thin-client protocol shape
   should carry it inside send-shaped requests rather than a separate top-level
   method family
+
+## 2.2 AI.23 Shared-Write Convergence Point
+
+AI.23 establishes one convergence point for every authenticated HTTP write.
+Local CLI HTTP, same-host advertised-IP HTTP, and remote peer HTTPS all decode
+the same transport-neutral `WriteRequest` and enter `ApiRouter::route`. The
+transport adapter owns authentication and ingress provenance only; it must not
+create a second persistence, acknowledgement, or notification path.
+
+`ApiRouter::route` delegates write handling to the daemon's
+`DaemonRequestDispatcher::route_write`, which invokes the canonical
+`MessageWriter::write` persistence operation before
+`PostWriteRouter::dispatch` selects the local nudge or host-qualified peer
+delivery. This ordering is the crate-level shared-write-resource invariant:
+every ingress uses the same dispatcher, persistence boundary, and post-write
+router. See [`../atm-daemon/http-api.md`](../atm-daemon/http-api.md),
+[`../adr/ADR-033-http-endpoint-contract.md`](../adr/ADR-033-http-endpoint-contract.md),
+and [`boundaries.md`](./boundaries.md) for the corresponding transport and
+boundary contracts.
 - queue inspection must not remain one "read many full messages" surface once
   SQLite-backed mailbox history becomes the ordinary durable source of truth
 

--- a/docs/atm-core/requirements.md
+++ b/docs/atm-core/requirements.md
@@ -214,6 +214,15 @@ Initial crate requirement IDs:
   later ACK derives its reply host from that retained origin destination
   metadata and still uses the canonical write. Satisfies:
   `REQ-P-CONTRACT-001`, `REQ-P-RELIABILITY-001`.
+- AI.23 shared-write convergence constraint: all local, same-host, and remote
+  HTTP writes must enter `ApiRouter::route` with the same `WriteRequest`, then
+  pass through `DaemonRequestDispatcher::route_write` and the canonical
+  `MessageWriter::write` persistence boundary. Persistence precedes exactly
+  one `PostWriteRouter::dispatch`; adapters may authenticate and label
+  provenance but may not implement a parallel write, acknowledgement, or
+  nudge path. This is the crate-level refinement of
+  `REQ-CORE-TRANSPORT-001`/`002` and the shared-write-resource contract in
+  [`../architecture.md`](../architecture.md).
 - `REQ-CORE-TRANSPORT-003` cross-host delivery owns no durable or in-memory
   per-message delivery state: no replay store, outbox, retry queue, receipt,
   remote ack state, or duplicate-delivery subsystem. The sole permitted


### PR DESCRIPTION
## Summary
- Round 2 close-out batch (easy/low-risk, doc/config/artifact only): AI23-IMPORTANT-005, AI21-MINOR-003, AI25-QA-002, ATM-QA-006.
- 2 of 4 findings were already resolved by prior work (no edit needed): AI23-IMPORTANT-005 evidence artifact already complete, AI25-QA-002 winget version already matched workspace 1.3.2-beta.25.
- Actual changes: resource-cost note in crates/atm-daemon/src/lib.rs (AI21-MINOR-003); AI.23 shared-write convergence/constraint doc sections in docs/atm-core/architecture.md and requirements.md (ATM-QA-006).

## Test plan
- [ ] quality-mgr QA verification (dispatched)

Assigned to Crimson-2f4c, tracked via ATM.