### PR TITLE
fix(phase-AI): close pre-AI.27 findings batch (AICH-S11-FIX-PREAI27)

### DIFF
--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -269,6 +269,49 @@ fn canonical_write_router_has_one_host_routing_decision() {
 }
 
 #[test]
+fn ai23_peer_adapter_never_matches_localhost_or_own_ip() {
+    let root = workspace_root();
+    let router_path = root.join("crates/atm-daemon/src/runtime_health/post_write_router.rs");
+    let source = read_source(&router_path);
+    let file = syn::parse_file(&source).unwrap_or_else(|error| {
+        panic!("{} must remain valid Rust: {error}", router_path.display())
+    });
+    let mut visitor = HostRoutingVisitor::default();
+    visitor.visit_file(&file);
+    assert!(
+        visitor
+            .functions
+            .iter()
+            .any(|function| function.is_post_write_dispatch),
+        "AI.23 requires the production PostWriteRouter::dispatch function"
+    );
+
+    let local_guard = source
+        .find("if message.prepared.is_peer_receipt() || host.is_none()")
+        .expect("the generic local/peer routing guard must remain explicit");
+    let peer_adapter = source
+        .find("resolve_peer_authority(host")
+        .expect("peer authority selection must remain in the generic peer branch");
+    assert!(
+        local_guard < peer_adapter,
+        "localhost and own-IP must be considered by the generic host guard before peer authority selection"
+    );
+    for forbidden in ["localhost", "127.0.0.1", "is_loopback", "is_loopback()"] {
+        assert!(
+            !source.contains(forbidden),
+            "AI.23 forbids a dedicated loopback/own-IP production branch: `{forbidden}`"
+        );
+    }
+
+    let negative_source = "fn dispatch() { if host.is_loopback() { local(); } else { resolve_peer_authority(host); } }";
+    syn::parse_file(negative_source).expect("negative loopback fixture must parse");
+    assert!(
+        negative_source.contains("is_loopback"),
+        "the structural test must be able to identify a forbidden loopback branch"
+    );
+}
+
+#[test]
 fn canonical_write_router_rejects_all_mandated_negative_fixtures() {
     for (name, source) in [
         (

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -286,14 +286,24 @@ fn ai23_peer_adapter_never_matches_localhost_or_own_ip() {
         "AI.23 requires the production PostWriteRouter::dispatch function"
     );
 
-    let local_guard = source
-        .find("if message.prepared.is_peer_receipt() || host.is_none()")
-        .expect("the generic local/peer routing guard must remain explicit");
-    let peer_adapter = source
+    let dispatch_start = source
+        .find("fn dispatch(")
+        .expect("the production PostWriteRouter::dispatch function must remain explicit");
+    let dispatch = &source[dispatch_start..];
+    let peer_receipt_guard = dispatch
+        .find("message.prepared.is_peer_receipt()")
+        .expect("the generic local/peer routing guard must handle peer receipts");
+    let host_guard = dispatch
+        .find("let Some(host) = message")
+        .expect("the generic local/peer routing guard must handle optional hosts");
+    let peer_branch = dispatch
+        .find("self.deliver_to_peer")
+        .expect("generic peer routing must remain behind the local/peer guard");
+    let _peer_adapter = source
         .find("resolve_peer_authority(host")
         .expect("peer authority selection must remain in the generic peer branch");
     assert!(
-        local_guard < peer_adapter,
+        peer_receipt_guard < peer_branch && host_guard < peer_branch,
         "localhost and own-IP must be considered by the generic host guard before peer authority selection"
     );
     for forbidden in ["localhost", "127.0.0.1", "is_loopback", "is_loopback()"] {

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use crate::boundary;
 use crate::error::AtmError;
 use crate::observability::{CommandEvent, ObservabilityPort, action_name, outcome_label};
+use crate::provenance::{WriteIngress, WriteProvenance, validate_write_provenance};
 use crate::schema::{AtmMessageId, InboxMessage, authenticated_source_host, peer_outbound_host};
 use crate::send::{SendMessageSource, SendOutcome, SendRequest, WriteOutcome};
 use crate::service_runtime::{LocalServiceRuntime, RetainedServiceRuntime};
@@ -207,6 +208,15 @@ pub(crate) fn resolve_acknowledgement_write<
     request: SendRequest,
     runtime: &R,
 ) -> Result<ResolvedAcknowledgement, AtmError> {
+    validate_write_provenance(
+        WriteIngress::Canonical,
+        WriteProvenance {
+            target_host: request.to.as_ref().and_then(|address| address.host()),
+            authenticated_source_host: request.authenticated_source_host.as_ref(),
+            origin_message_id: request.origin_message_id.is_some(),
+            origin_timestamp: request.origin_timestamp.is_some(),
+        },
+    )?;
     let request = AckRequest::from_unresolved_write(request)?;
     let actor = request.caller_identity.clone();
     let team = request.caller_team.clone();
@@ -251,6 +261,15 @@ pub(crate) fn resolve_received_acknowledgement_write<
     request: SendRequest,
     runtime: &R,
 ) -> Result<ResolvedAcknowledgement, AtmError> {
+    validate_write_provenance(
+        WriteIngress::Peer,
+        WriteProvenance {
+            target_host: request.to.as_ref().and_then(|address| address.host()),
+            authenticated_source_host: request.authenticated_source_host.as_ref(),
+            origin_message_id: request.origin_message_id.is_some(),
+            origin_timestamp: request.origin_timestamp.is_some(),
+        },
+    )?;
     let message_id = request.acknowledges_message_id.ok_or_else(|| {
         AtmError::validation("acknowledgement write is missing acknowledges_message_id")
     })?;
@@ -480,11 +499,21 @@ fn validate_reply_target<R: RetainedServiceRuntime>(
 
 fn reply_target_host(source: &InboxMessage) -> Result<Option<crate::types::HostName>, AtmError> {
     let authenticated = authenticated_source_host(source)?;
-    if authenticated.is_some() {
-        Ok(authenticated)
-    } else {
-        peer_outbound_host(source)
-    }
+    let outbound = peer_outbound_host(source)?;
+    let validated = validate_write_provenance(
+        WriteIngress::Canonical,
+        WriteProvenance {
+            target_host: outbound.as_ref(),
+            authenticated_source_host: authenticated.as_ref(),
+            origin_message_id: authenticated.is_some(),
+            origin_timestamp: authenticated.is_some(),
+        },
+    )?;
+    Ok(validated
+        .is_authenticated_peer()
+        .then_some(authenticated)
+        .flatten()
+        .or(outbound))
 }
 
 fn record_ack_telemetry(

--- a/crates/atm-core/src/delivery_policy.rs
+++ b/crates/atm-core/src/delivery_policy.rs
@@ -1,6 +1,6 @@
-use crate::address::AgentAddress;
 use crate::boundary::{RosterEntry, RosterHarness};
 use crate::error::AtmError;
+use crate::provenance::ValidatedWriteProvenance;
 use crate::schema::{AtmMessageId, ThreadMode};
 use crate::service_runtime::RetainedServiceRuntime;
 use crate::types::{AgentName, PaneId, TeamName};
@@ -349,11 +349,10 @@ impl DeliveryPolicyCoordinator {
     pub(crate) fn resolve_write_recipient_snapshot<R: RetainedServiceRuntime + ?Sized>(
         &self,
         runtime: &R,
-        address: &AgentAddress,
         recipient: &crate::send::ResolvedRecipient,
-        authenticated_source_host: bool,
+        provenance: ValidatedWriteProvenance,
     ) -> Result<DeliveryRecipientSnapshot, AtmError> {
-        if address.host().is_some() && !authenticated_source_host {
+        if provenance.is_remote_origin() {
             return Ok(DeliveryRecipientSnapshot::remote(
                 recipient.agent.clone(),
                 recipient.team.clone(),

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -55,6 +55,8 @@ pub(crate) mod persistence;
 pub mod process;
 /// Shared protocol DTOs used by boundary transport and adapter contracts.
 pub mod protocol;
+/// Shared authenticated/immutable write provenance validation.
+pub mod provenance;
 /// Mailbox read/query workflows and output models.
 pub mod read;
 /// Reserved production role constants shared across runtime and tests.

--- a/crates/atm-core/src/provenance.rs
+++ b/crates/atm-core/src/provenance.rs
@@ -1,0 +1,203 @@
+//! Shared validation for write provenance at transport and persistence seams.
+
+use crate::error::AtmError;
+use crate::types::HostName;
+
+/// Identifies the ingress policy that admitted a write request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteIngress {
+    /// A canonical local writer or an already-normalized internal request.
+    Canonical,
+    /// A request received through the local IPC/TCP boundary.
+    Local,
+    /// A request received through authenticated mutual TLS.
+    Peer,
+    /// A request received through the explicitly opt-in plaintext smoke path.
+    UntrustedSmoke,
+    /// A plaintext diagnostic request that cannot submit writes.
+    AnonymousSmoke,
+}
+
+/// The provenance fields relevant to one write admission decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WriteProvenance<'a> {
+    pub target_host: Option<&'a HostName>,
+    pub authenticated_source_host: Option<&'a HostName>,
+    pub origin_message_id: bool,
+    pub origin_timestamp: bool,
+}
+
+/// Validated provenance facts shared by self-send, delivery-policy, ACK, and
+/// daemon ingress decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ValidatedWriteProvenance {
+    target_host_qualified: bool,
+    authenticated_peer: bool,
+    origin_metadata: bool,
+}
+
+impl ValidatedWriteProvenance {
+    #[must_use]
+    pub const fn target_host_qualified(self) -> bool {
+        self.target_host_qualified
+    }
+
+    #[must_use]
+    pub const fn is_authenticated_peer(self) -> bool {
+        self.authenticated_peer
+    }
+
+    #[must_use]
+    pub const fn has_origin_metadata(self) -> bool {
+        self.origin_metadata
+    }
+
+    /// A host-qualified request without authenticated peer provenance is an
+    /// origin write that must be admitted as a remote target.
+    #[must_use]
+    pub const fn is_remote_origin(self) -> bool {
+        self.target_host_qualified && !self.authenticated_peer
+    }
+}
+
+/// Validate all write provenance combinations in one place.
+pub fn validate_write_provenance(
+    ingress: WriteIngress,
+    provenance: WriteProvenance<'_>,
+) -> Result<ValidatedWriteProvenance, AtmError> {
+    let has_any_origin_metadata = provenance.origin_message_id || provenance.origin_timestamp;
+    let has_complete_origin_metadata = provenance.origin_message_id && provenance.origin_timestamp;
+    if has_any_origin_metadata
+        && !has_complete_origin_metadata
+        && !matches!(ingress, WriteIngress::Canonical)
+    {
+        return Err(AtmError::validation(
+            "write provenance requires both origin_message_id and origin_timestamp; preserve the immutable origin metadata as a pair",
+        ));
+    }
+    let authenticated_peer = provenance.authenticated_source_host.is_some();
+    if authenticated_peer && !has_complete_origin_metadata {
+        return Err(AtmError::validation(
+            "authenticated peer writes require source host, origin_message_id, and origin_timestamp; retry through the authenticated peer adapter",
+        ));
+    }
+
+    match ingress {
+        WriteIngress::Canonical => {}
+        WriteIngress::Local if authenticated_peer || has_any_origin_metadata => {
+            return Err(AtmError::validation(
+                "local write requests must not supply authenticated peer provenance or origin metadata",
+            ));
+        }
+        WriteIngress::Peer if !authenticated_peer || !has_complete_origin_metadata => {
+            return Err(AtmError::validation(
+                "peer write requests require authenticated source provenance and immutable origin metadata",
+            ));
+        }
+        WriteIngress::UntrustedSmoke if authenticated_peer || !has_complete_origin_metadata => {
+            return Err(AtmError::validation(
+                "plaintext smoke ingress must carry origin metadata but no authenticated peer identity",
+            ));
+        }
+        WriteIngress::AnonymousSmoke => {
+            return Err(AtmError::validation(
+                "anonymous plaintext diagnostics cannot submit writes; include explicit peer provenance or use authenticated HTTPS",
+            ));
+        }
+        WriteIngress::Local | WriteIngress::Peer | WriteIngress::UntrustedSmoke => {}
+    }
+
+    Ok(ValidatedWriteProvenance {
+        target_host_qualified: provenance.target_host.is_some(),
+        authenticated_peer,
+        origin_metadata: has_complete_origin_metadata,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WriteIngress, WriteProvenance, validate_write_provenance};
+    use crate::types::HostName;
+
+    fn provenance(
+        target_host: bool,
+        authenticated_source_host: bool,
+        origin_message_id: bool,
+        origin_timestamp: bool,
+    ) -> WriteProvenance<'static> {
+        let target: &'static HostName = Box::leak(Box::new(
+            "peer.example.test".parse::<HostName>().expect("host"),
+        ));
+        WriteProvenance {
+            target_host: target_host.then_some(target),
+            authenticated_source_host: authenticated_source_host.then_some(target),
+            origin_message_id,
+            origin_timestamp,
+        }
+    }
+
+    #[test]
+    fn ingress_matrix_accepts_only_complete_provenance() {
+        assert!(
+            validate_write_provenance(WriteIngress::Local, provenance(false, false, false, false))
+                .is_ok()
+        );
+        assert!(
+            validate_write_provenance(WriteIngress::Peer, provenance(true, true, true, true))
+                .is_ok()
+        );
+        assert!(
+            validate_write_provenance(
+                WriteIngress::UntrustedSmoke,
+                provenance(false, false, true, true)
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_write_provenance(
+                WriteIngress::AnonymousSmoke,
+                provenance(false, false, false, false)
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn partial_or_forged_provenance_is_rejected_with_actionable_error() {
+        for input in [
+            provenance(false, true, true, false),
+            provenance(false, true, false, false),
+            provenance(false, false, true, false),
+        ] {
+            let error = validate_write_provenance(WriteIngress::Peer, input)
+                .expect_err("partial provenance must fail closed");
+            assert!(!error.message().is_empty());
+        }
+        assert!(
+            validate_write_provenance(WriteIngress::Local, provenance(false, true, true, true))
+                .is_err()
+        );
+        assert!(
+            validate_write_provenance(
+                WriteIngress::UntrustedSmoke,
+                provenance(false, true, true, true)
+            )
+            .is_err()
+        );
+        assert!(
+            validate_write_provenance(WriteIngress::Peer, provenance(false, false, true, true))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn remote_origin_is_host_qualified_without_authenticated_source() {
+        let validated = validate_write_provenance(
+            WriteIngress::Canonical,
+            provenance(true, false, false, false),
+        )
+        .expect("origin target is valid");
+        assert!(validated.is_remote_origin());
+        assert!(!validated.is_authenticated_peer());
+    }
+}

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -23,6 +23,9 @@ use crate::delivery_policy::{
 use crate::error::AtmError;
 use crate::error_codes::AtmErrorCode;
 use crate::observability::{CommandEvent, ObservabilityPort, action_name, outcome_label};
+use crate::provenance::{
+    ValidatedWriteProvenance, WriteIngress, WriteProvenance, validate_write_provenance,
+};
 use crate::schema::{
     AckIntentFields, AtmMessageId, InboxMessage, ThreadMode, set_authenticated_source_host,
     set_peer_outbound_write,
@@ -492,6 +495,15 @@ fn write_mail_with_runtime_impl<
     observability: &dyn ObservabilityPort,
     runtime: &R,
 ) -> Result<PreparedWrite, AtmError> {
+    let provenance = validate_write_provenance(
+        WriteIngress::Canonical,
+        WriteProvenance {
+            target_host: request.to.as_ref().and_then(|address| address.host()),
+            authenticated_source_host: request.authenticated_source_host.as_ref(),
+            origin_message_id: request.origin_message_id.is_some(),
+            origin_timestamp: request.origin_timestamp.is_some(),
+        },
+    )?;
     if request.acknowledges_message_id.is_none() {
         if request.to.is_none() {
             return Err(AtmError::validation(
@@ -500,11 +512,7 @@ fn write_mail_with_runtime_impl<
         }
         return prepare_persisted_write(request, observability, runtime, None);
     }
-    if request.to.is_some()
-        && request.authenticated_source_host.is_some()
-        && request.origin_message_id.is_some()
-        && request.origin_timestamp.is_some()
-    {
+    if request.to.is_some() && provenance.is_authenticated_peer() {
         let acknowledgement = crate::ack::resolve_received_acknowledgement_write(request, runtime)?;
         return prepare_persisted_write(
             acknowledgement.request(),
@@ -595,9 +603,16 @@ fn prepare_persisted_write<
 }
 
 fn has_authenticated_peer_provenance(request: &WriteRequest) -> bool {
-    request.authenticated_source_host.is_some()
-        && request.origin_message_id.is_some()
-        && request.origin_timestamp.is_some()
+    validate_write_provenance(
+        WriteIngress::Canonical,
+        WriteProvenance {
+            target_host: request.to.as_ref().and_then(|address| address.host()),
+            authenticated_source_host: request.authenticated_source_host.as_ref(),
+            origin_message_id: request.origin_message_id.is_some(),
+            origin_timestamp: request.origin_timestamp.is_some(),
+        },
+    )
+    .is_ok_and(ValidatedWriteProvenance::is_authenticated_peer)
 }
 
 #[cfg(test)]
@@ -797,16 +812,27 @@ fn prepare_send_context<
     let target = request.to.as_ref().ok_or_else(|| {
         AtmError::validation("write request destination must be resolved before persistence")
     })?;
+    let provenance = validate_write_provenance(
+        WriteIngress::Canonical,
+        WriteProvenance {
+            target_host: target.host(),
+            authenticated_source_host: request.authenticated_source_host.as_ref(),
+            origin_message_id: request.origin_message_id.is_some(),
+            origin_timestamp: request.origin_timestamp.is_some(),
+        },
+    )?;
     let recipient = resolve_recipient(target, &request.caller_team, command_config.as_ref())?;
-    validate_non_self_recipient(&canonical_sender, &request.caller_team, &recipient, target)?;
+    validate_non_self_recipient(
+        &canonical_sender,
+        &request.caller_team,
+        &recipient,
+        target,
+        provenance,
+    )?;
     let inbox_path = runtime.inbox_path(&request.home_dir, &recipient.team, &recipient.agent)?;
     let delivery_policy = DeliveryPolicyCoordinator::new();
-    let delivery_snapshot = delivery_policy.resolve_write_recipient_snapshot(
-        runtime,
-        target,
-        &recipient,
-        has_authenticated_peer_provenance(request),
-    )?;
+    let delivery_snapshot =
+        delivery_policy.resolve_write_recipient_snapshot(runtime, &recipient, provenance)?;
     let delivery_family = DeliveryPolicyCoordinator::resolve_send_family(
         request.parent_message_id,
         request.thread_mode,
@@ -963,6 +989,7 @@ pub(crate) fn validate_non_self_recipient(
     sender_team: &TeamName,
     recipient: &ResolvedRecipient,
     target: &AgentAddress,
+    provenance: ValidatedWriteProvenance,
 ) -> Result<(), AtmError> {
     let same_identity = sender
         .as_str()
@@ -970,7 +997,7 @@ pub(crate) fn validate_non_self_recipient(
         && sender_team
             .as_str()
             .eq_ignore_ascii_case(recipient.team.as_str());
-    if same_identity && target.host().is_none() {
+    if same_identity && target.host().is_none() && !provenance.is_authenticated_peer() {
         return Err(AtmError::self_addressed_send_invalid(format!(
             "self-addressed messages are invalid ATM input: '{sender}@{sender_team}' may not send to itself"
         )));
@@ -983,10 +1010,21 @@ mod self_address_tests {
     use super::{ResolvedRecipient, validate_non_self_recipient};
     use crate::address::AgentAddress;
     use crate::error_codes::AtmErrorCode;
+    use crate::provenance::{WriteIngress, WriteProvenance, validate_write_provenance};
     use crate::types::{AgentName, TeamName};
 
     #[test]
     fn validate_non_self_recipient_rejects_case_variant_self_target() {
+        let provenance = validate_write_provenance(
+            WriteIngress::Canonical,
+            WriteProvenance {
+                target_host: None,
+                authenticated_source_host: None,
+                origin_message_id: false,
+                origin_timestamp: false,
+            },
+        )
+        .expect("local provenance");
         let error = validate_non_self_recipient(
             &AgentName::from_validated("Sender-A"),
             &TeamName::from_validated("Test-Team"),
@@ -997,6 +1035,7 @@ mod self_address_tests {
             &"sender-a@test-team"
                 .parse::<AgentAddress>()
                 .expect("target"),
+            provenance,
         )
         .expect_err("case-variant self target must be rejected");
 
@@ -1005,6 +1044,19 @@ mod self_address_tests {
 
     #[test]
     fn validate_non_self_recipient_allows_host_qualified_self_target() {
+        let target = "sender-a@test-team.127.0.0.1"
+            .parse::<AgentAddress>()
+            .expect("host-qualified target");
+        let provenance = validate_write_provenance(
+            WriteIngress::Canonical,
+            WriteProvenance {
+                target_host: target.host(),
+                authenticated_source_host: None,
+                origin_message_id: false,
+                origin_timestamp: false,
+            },
+        )
+        .expect("host-qualified origin provenance");
         validate_non_self_recipient(
             &AgentName::from_validated("sender-a"),
             &TeamName::from_validated("test-team"),
@@ -1012,11 +1064,39 @@ mod self_address_tests {
                 agent: AgentName::from_validated("sender-a"),
                 team: TeamName::from_validated("test-team"),
             },
-            &"sender-a@test-team.127.0.0.1"
-                .parse::<AgentAddress>()
-                .expect("host-qualified target"),
+            &target,
+            provenance,
         )
         .expect("host-qualified self target must use the ordinary peer route");
+    }
+
+    #[test]
+    fn validate_non_self_recipient_allows_authenticated_peer_after_target_normalization() {
+        let target = "sender-a@test-team"
+            .parse::<AgentAddress>()
+            .expect("normalized target");
+        let peer_host = "peer.example.test".parse().expect("peer host");
+        let provenance = validate_write_provenance(
+            WriteIngress::Canonical,
+            WriteProvenance {
+                target_host: target.host(),
+                authenticated_source_host: Some(&peer_host),
+                origin_message_id: true,
+                origin_timestamp: true,
+            },
+        )
+        .expect("authenticated peer provenance");
+        validate_non_self_recipient(
+            &AgentName::from_validated("sender-a"),
+            &TeamName::from_validated("test-team"),
+            &ResolvedRecipient {
+                agent: AgentName::from_validated("sender-a"),
+                team: TeamName::from_validated("test-team"),
+            },
+            &target,
+            provenance,
+        )
+        .expect("authenticated peer receipt must not become a local self-send");
     }
 }
 

--- a/crates/atm-daemon/src/https_transport.rs
+++ b/crates/atm-daemon/src/https_transport.rs
@@ -7,7 +7,7 @@
 
 use std::fmt;
 use std::io::{Read, Write};
-use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
@@ -176,10 +176,11 @@ impl HttpsMessageTransport for HttpsTransport {
             HttpsTransportMode::MutualTls(identity) => {
                 apply_deadline(&stream, remaining_budget(deadline)?)?;
                 let config = client_config(identity, peer)?;
-                let server_name = ServerName::try_from(host.clone()).map_err(|_source| {
+                let server_name = ServerName::try_from(host.clone()).map_err(|source| {
                     AtmError::validation(
                         "configured HTTPS peer host is not a valid TLS server name",
                     )
+                    .with_cause(source)
                 })?;
                 let connection =
                     ClientConnection::new(Arc::new(config), server_name).map_err(|source| {
@@ -603,43 +604,6 @@ fn remaining_budget(deadline: RequestDeadline) -> Result<Duration, AtmError> {
     })
 }
 
-fn resolve_peer_addresses(
-    peer: &TrustedPeer,
-    timeout: Duration,
-) -> Result<Vec<std::net::IpAddr>, AtmError> {
-    let authority = format!("{}:{}", peer.host, peer.https_port);
-    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
-    std::thread::Builder::new()
-        .name("atm-peer-dns".to_string())
-        .spawn(move || {
-            let _ = sender.send(
-                authority
-                    .to_socket_addrs()
-                    .map(|a| a.map(|address| address.ip()).collect::<Vec<_>>()),
-            );
-        })
-        .map_err(|source| {
-            AtmError::daemon_unavailable_with_cause(
-                "failed to start bounded HTTPS DNS resolution",
-                source,
-            )
-        })?;
-    receiver
-        .recv_timeout(timeout)
-        .map_err(|source| {
-            AtmError::daemon_unavailable_with_cause(
-                "HTTPS DNS resolution timed out; verify peer forward DNS or retry",
-                source,
-            )
-        })?
-        .map_err(|source| {
-            AtmError::daemon_unavailable_with_cause(
-                "failed to resolve configured HTTPS peer; verify forward DNS",
-                source,
-            )
-        })
-}
-
 fn resolve_peer_address(host: &str, port: u16, timeout: Duration) -> Result<SocketAddr, AtmError> {
     let peer = TrustedPeer {
         host: host.parse().map_err(|source| {
@@ -652,7 +616,7 @@ fn resolve_peer_address(host: &str, port: u16, timeout: Duration) -> Result<Sock
         https_port: std::num::NonZeroU16::new(port)
             .ok_or_else(|| AtmError::validation("configured HTTPS peer port was zero"))?,
     };
-    resolve_peer_addresses(&peer, timeout)?
+    crate::peer_resolution::resolve_peer_socket_addresses(&peer, timeout)?
         .into_iter()
         .next()
         .map(|ip| SocketAddr::new(ip, port))
@@ -940,6 +904,31 @@ mod tests {
             error.code(),
             atm_core::error_codes::AtmErrorCode::RemoteDeliveryUnconfirmed
         );
+    }
+
+    #[test]
+    fn invalid_tls_server_name_preserves_the_parser_cause() {
+        let result: Result<ServerName<'static>, AtmError> =
+            ServerName::try_from("-invalid".to_string()).map_err(|source| {
+                AtmError::validation("configured HTTPS peer host is not a valid TLS server name")
+                    .with_cause(source)
+            });
+        let error = result.expect_err("invalid DNS label must fail validation");
+        assert_eq!(
+            error.code(),
+            atm_core::error_codes::AtmErrorCode::MessageValidationFailed
+        );
+        assert!(
+            error.cause().is_some(),
+            "TLS parser cause must be preserved"
+        );
+    }
+
+    #[test]
+    fn https_address_resolution_uses_the_shared_bounded_helper() {
+        let address = super::resolve_peer_address("localhost", 43101, Duration::from_secs(1))
+            .expect("localhost must resolve through the shared helper");
+        assert_eq!(address.port(), 43101);
     }
 
     #[test]

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -33,6 +33,7 @@ mod local_ipc_wake;
 mod local_tcp_transport;
 mod non_claude_outbound_runtime;
 mod peer_delivery_observability;
+mod peer_resolution;
 mod post_send_emitter;
 mod runtime_health;
 mod runtime_status_cache;

--- a/crates/atm-daemon/src/peer_resolution.rs
+++ b/crates/atm-daemon/src/peer_resolution.rs
@@ -1,0 +1,71 @@
+//! Shared bounded peer-authority DNS resolution used by both daemon callers.
+
+use std::net::{IpAddr, ToSocketAddrs};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use atm_core::error::AtmError;
+use atm_storage::TrustedPeer;
+
+/// Resolve a configured peer's hostname with one bounded worker and preserve
+/// the lower-level cause at every adapter boundary.
+pub(crate) fn resolve_peer_socket_addresses(
+    peer: &TrustedPeer,
+    timeout: Duration,
+) -> Result<Vec<IpAddr>, AtmError> {
+    let authority = format!("{}:{}", peer.host, peer.https_port);
+    let (sender, receiver) = mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("atm-peer-dns".to_string())
+        .spawn(move || {
+            let _ = sender.send(
+                authority
+                    .to_socket_addrs()
+                    .map(|addresses| addresses.map(|address| address.ip()).collect::<Vec<_>>()),
+            );
+        })
+        .map_err(|source| {
+            AtmError::daemon_unavailable_with_cause(
+                "failed to start bounded HTTPS DNS resolution",
+                source,
+            )
+        })?;
+    receiver
+        .recv_timeout(timeout)
+        .map_err(|source| {
+            AtmError::daemon_unavailable_with_cause(
+                "HTTPS DNS resolution timed out; verify peer forward DNS or retry",
+                source,
+            )
+        })?
+        .map_err(|source| {
+            AtmError::daemon_unavailable_with_cause(
+                "failed to resolve configured HTTPS peer; verify forward DNS",
+                source,
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_peer_socket_addresses;
+    use atm_core::error_codes::AtmErrorCode;
+    use atm_storage::TrustedPeer;
+    use std::num::NonZeroU16;
+    use std::time::Duration;
+
+    #[test]
+    fn failed_dns_resolution_preserves_the_underlying_cause() {
+        let peer = TrustedPeer {
+            host: "not-a-real-host.invalid".parse().expect("host"),
+            fingerprint: "00".repeat(32).parse().expect("fingerprint"),
+            enabled: true,
+            https_port: NonZeroU16::new(43101).expect("port"),
+        };
+        let error = resolve_peer_socket_addresses(&peer, Duration::from_secs(1))
+            .expect_err("reserved invalid host must fail");
+        assert_eq!(error.code(), AtmErrorCode::DaemonUnavailable);
+        assert!(error.cause().is_some(), "DNS source cause must be retained");
+        assert!(error.message().contains("verify forward DNS"));
+    }
+}

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -23,6 +23,7 @@ use atm_core::{
         CompatibilityVerdict, ReleaseVersion, RuntimeLivenessState, RuntimeStatusSnapshot,
         SendResponseEnvelope, TeamMemberHeartbeatRequest, TeamMemberHeartbeatResponse,
     },
+    provenance::{WriteIngress, WriteProvenance, validate_write_provenance},
     read::{peek_mail_with_runtime, read_mail_with_runtime},
     schema::canonical_home_dir,
     send::{PreparedWrite, WriteOutcome, WriteRequest, prepare_write_with_runtime},
@@ -850,43 +851,21 @@ impl ApiRouter for DaemonRequestDispatcher {
         }
         let request = request.into_inner();
         if let RequestEnvelope::Write(write) = &request {
-            match ingress {
-                AuthenticatedIngress::Local
-                    if write.authenticated_source_host.is_some()
-                        || write.origin_message_id.is_some()
-                        || write.origin_timestamp.is_some() =>
-                {
-                    return Err(AtmError::validation(
-                        "local write requests must not supply authenticated peer provenance or origin metadata",
-                    ));
-                }
-                AuthenticatedIngress::Peer
-                    if write.authenticated_source_host.is_none()
-                        || write.origin_message_id.is_none()
-                        || write.origin_timestamp.is_none() =>
-                {
-                    return Err(AtmError::validation(
-                        "peer write requests require authenticated source provenance and immutable origin metadata",
-                    ));
-                }
-                AuthenticatedIngress::UntrustedSmoke(_)
-                    if write.authenticated_source_host.is_some()
-                        || write.origin_message_id.is_none()
-                        || write.origin_timestamp.is_none() =>
-                {
-                    return Err(AtmError::validation(
-                        "plaintext smoke ingress must carry origin metadata but no authenticated peer identity",
-                    ));
-                }
-                AuthenticatedIngress::AnonymousSmoke => {
-                    return Err(AtmError::validation(
-                        "anonymous plaintext diagnostics cannot submit writes; include the X-ATM-Peer-Source-Host header only for an explicit smoke write",
-                    ));
-                }
-                AuthenticatedIngress::Local
-                | AuthenticatedIngress::Peer
-                | AuthenticatedIngress::UntrustedSmoke(_) => {}
-            }
+            let write_ingress = match &ingress {
+                AuthenticatedIngress::Local => WriteIngress::Local,
+                AuthenticatedIngress::Peer => WriteIngress::Peer,
+                AuthenticatedIngress::UntrustedSmoke(_) => WriteIngress::UntrustedSmoke,
+                AuthenticatedIngress::AnonymousSmoke => WriteIngress::AnonymousSmoke,
+            };
+            validate_write_provenance(
+                write_ingress,
+                WriteProvenance {
+                    target_host: write.to.as_ref().and_then(|address| address.host()),
+                    authenticated_source_host: write.authenticated_source_host.as_ref(),
+                    origin_message_id: write.origin_message_id.is_some(),
+                    origin_timestamp: write.origin_timestamp.is_some(),
+                },
+            )?;
         }
         self.dispatch_with_deadline(request, deadline)
             .map(ApiResponse::new)

--- a/crates/atm-daemon/src/runtime_health/peer_authority.rs
+++ b/crates/atm-daemon/src/runtime_health/peer_authority.rs
@@ -4,13 +4,14 @@
 //! peer receives a host-qualified message is routing policy, while the adapter
 //! only connects to the already-selected authority.
 
-use std::net::{IpAddr, ToSocketAddrs};
-use std::sync::mpsc;
+use std::net::IpAddr;
 use std::time::Duration;
 
 use atm_core::error::AtmError;
 use atm_core::types::HostName;
 use atm_storage::TrustedPeer;
+
+use crate::peer_resolution::resolve_peer_socket_addresses;
 
 const DNS_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(5);
 /// Literal-IP authority resolution is deliberately bounded. Operators should
@@ -49,7 +50,7 @@ pub(crate) fn resolve_peer_authority(
     let matches = enabled_peers
         .into_iter()
         .filter(|peer| {
-            resolve_peer_addresses(peer, DNS_RESOLUTION_TIMEOUT)
+            resolve_peer_socket_addresses(peer, DNS_RESOLUTION_TIMEOUT)
                 .is_ok_and(|addresses| addresses.contains(&ip))
         })
         .cloned()
@@ -65,40 +66,6 @@ pub(crate) fn resolve_peer_authority(
             "send to the intended registered hostname or correct the overlapping forward DNS records",
         )),
     }
-}
-
-fn resolve_peer_addresses(peer: &TrustedPeer, timeout: Duration) -> Result<Vec<IpAddr>, AtmError> {
-    let authority = format!("{}:{}", peer.host, peer.https_port);
-    let (sender, receiver) = mpsc::sync_channel(1);
-    std::thread::Builder::new()
-        .name("atm-peer-dns".to_string())
-        .spawn(move || {
-            let _ = sender.send(
-                authority
-                    .to_socket_addrs()
-                    .map(|addresses| addresses.map(|address| address.ip()).collect::<Vec<_>>()),
-            );
-        })
-        .map_err(|source| {
-            AtmError::daemon_unavailable_with_cause(
-                "failed to start bounded HTTPS DNS resolution",
-                source,
-            )
-        })?;
-    receiver
-        .recv_timeout(timeout)
-        .map_err(|source| {
-            AtmError::daemon_unavailable_with_cause(
-                "HTTPS DNS resolution timed out; verify peer forward DNS or retry",
-                source,
-            )
-        })?
-        .map_err(|source| {
-            AtmError::daemon_unavailable_with_cause(
-                "failed to resolve configured HTTPS peer; verify forward DNS",
-                source,
-            )
-        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Closes 5 findings still genuinely open on sprints before AI.27:
- AI25-RBP-F001 (residual): TLS cause preservation in https_transport.rs ServerName::try_from
- AI22-IMPORTANT-001: aligned validate_non_self_recipient with authenticated-host check pattern
- AI22-IMPORTANT-002: extracted shared provenance validator, wired to 4 call sites
- ATM-QA-003: added explicit test proving localhost/own-IP never match peer-adapter routing
- AI25-RBQA-F005-new: extracted shared resolve_peer_socket_addresses DNS helper

## Test plan
- [x] Focused tests passed (per Crimson's push report)
- [ ] Full `just lint` / `just test` — pending, Crimson to report
- [ ] quality-mgr QA verification — to dispatch once lint/test confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)