### PR TITLE
fix(AI27/28): cleanup-2 -- cause preservation, deadline-bounded paging, test/doc gaps

### DIFF
--- a/artifacts/phase-ai/ai27/doctor-version-evidence.json
+++ b/artifacts/phase-ai/ai27/doctor-version-evidence.json
@@ -1,0 +1,18 @@
+{
+  "format": "phase-ai-ai27-doctor-version-evidence/v1",
+  "finding_id": "AI27-ATMQA-004",
+  "captured_at_utc": "2026-07-26T23:19:40Z",
+  "source_commit": "5e91a889",
+  "expected_release": "1.3.2-beta.27",
+  "command": "HOME=<isolated> ATM_HOME=<isolated> ATM_TEAM=atm-dev ATM_IDENTITY=doctor-evidence cargo run -p agent-team-mail --bin atm -- doctor --json",
+  "cli_binary_version": "atm 1.3.2-beta.27",
+  "doctor_json": {
+    "client_context.version": "1.3.2-beta.29",
+    "daemon_context.version": "1.3.2-beta.29",
+    "summary.status": "healthy",
+    "summary.error_count": 0
+  },
+  "result": "not_matching",
+  "limitation": "The beta.27 CLI correctly built from source commit 5e91a889, but doctor routes through the host-wide singleton endpoint. The already-running singleton daemon is beta.29, and the current protocol does not permit an alternate socket or per-ATM_HOME daemon. Stopping or replacing that daemon would alter shared host state, so this artifact records the observed mismatch instead of claiming beta.27 client/daemon evidence.",
+  "next_action": "Re-run the same command after the host singleton is intentionally stopped and a beta.27 atm-daemon binary is launched for this evidence capture."
+}

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -903,10 +903,13 @@ impl HostRoutingVisitor {
 
     fn is_runtime_dispatcher_source(&self) -> bool {
         self.source_path.as_ref().is_some_and(|path| {
-            path.ends_with(Path::new("crates/atm-daemon/src/runtime_health.rs"))
-                || path.ends_with(Path::new(
+            is_path_suffix(
+                path,
+                &[
+                    "crates/atm-daemon/src/runtime_health.rs",
                     "crates/atm-daemon/src/runtime_health/peer_sync.rs",
-                ))
+                ],
+            )
         })
     }
 
@@ -918,15 +921,22 @@ impl HostRoutingVisitor {
 
     fn is_post_write_router_helper(&self, name: &str) -> bool {
         self.source_path.as_ref().is_some_and(|path| {
-            path.ends_with(Path::new(
-                "crates/atm-daemon/src/runtime_health/peer_delivery_router.rs",
-            )) && matches!(name, "emit_local_post_write" | "deliver_to_peer")
+            is_path_suffix(
+                path,
+                &["crates/atm-daemon/src/runtime_health/peer_delivery_router.rs"],
+            ) && is_delivery_function_name(name)
         })
     }
 }
 
 fn is_delivery_function_name(name: &str) -> bool {
     name.starts_with("emit_local_post_write") || name == "deliver_to_peer"
+}
+
+fn is_path_suffix(path: &Path, suffixes: &[&str]) -> bool {
+    suffixes
+        .iter()
+        .any(|suffix| path.ends_with(Path::new(suffix)))
 }
 
 fn collect_use_aliases(file: &syn::File, aliases: &mut Vec<(String, String)>) {

--- a/crates/atm-daemon/src/peer_delivery_observability.rs
+++ b/crates/atm-daemon/src/peer_delivery_observability.rs
@@ -52,6 +52,10 @@ pub(crate) struct PeerDeliveryEvent {
 
 #[derive(Debug, Default)]
 pub(crate) struct PeerDeliveryProjection {
+    // This map is tiny, bounded, and updated/read as a whole snapshot. A
+    // Mutex keeps projection and sequence updates atomic; lock hold time is
+    // limited to the in-memory BTreeMap work, so writer contention is bounded
+    // and a RwLock would add complexity without useful concurrent read width.
     statuses: Mutex<PeerDeliveryProjectionState>,
 }
 

--- a/crates/atm-daemon/src/peer_drain_coordinator.rs
+++ b/crates/atm-daemon/src/peer_drain_coordinator.rs
@@ -70,6 +70,15 @@ pub(crate) fn is_retryable_peer_error(error: &AtmError) -> bool {
     )
 }
 
+fn remote_delivery_error_with_cause(error: AtmError) -> AtmError {
+    let detail = error.detail().to_owned();
+    let source = error
+        .cause()
+        .map(|cause| format!("{}; source cause: {cause}", error.message()))
+        .unwrap_or_else(|| error.message().to_owned());
+    AtmError::remote_delivery_unconfirmed(detail).with_cause(source)
+}
+
 pub(crate) trait PeerDeliveryCoordinator: Send + Sync {
     fn deliver_after_persist(
         &self,
@@ -269,8 +278,7 @@ impl PeerDrainCoordinator {
                 );
             }
             let page =
-                self.outbound
-                    .page_for_peer(host, not_before, after, policy.max_batch_messages)?;
+                self.page_for_peer(host, not_before, after, policy.max_batch_messages, deadline)?;
             if deadline.expired() {
                 return self.failed(
                     host,
@@ -291,8 +299,7 @@ impl PeerDrainCoordinator {
             let responses = match transport.deliver_page(&requests, &peer, deadline) {
                 Ok(responses) => responses,
                 Err(error) => {
-                    return self
-                        .failed(host, AtmError::remote_delivery_unconfirmed(error.message()));
+                    return self.failed(host, remote_delivery_error_with_cause(error));
                 }
             };
             if responses.len() != page.len() {
@@ -320,13 +327,31 @@ impl PeerDrainCoordinator {
         }
     }
 
+    fn page_for_peer(
+        &self,
+        host: &HostName,
+        not_before: IsoTimestamp,
+        after: Option<(IsoTimestamp, atm_core::schema::AtmMessageId)>,
+        limit: std::num::NonZeroU16,
+        deadline: RequestDeadline,
+    ) -> Result<Vec<atm_storage::StoredPeerWrite>, AtmError> {
+        let budget = deadline.remaining().ok_or_else(|| {
+            AtmError::remote_delivery_unconfirmed(
+                "peer reconciliation exceeded its bounded request deadline",
+            )
+        })?;
+        self.outbound
+            .page_for_peer(host, not_before, after, limit, budget)
+    }
+
     fn decode_page_requests(
         page: &[atm_storage::StoredPeerWrite],
     ) -> Result<Vec<WriteRequest>, AtmError> {
         page.iter()
             .map(|stored| {
-                serde_json::from_str(&stored.request_json).map_err(|_| {
+                serde_json::from_str(&stored.request_json).map_err(|source| {
                     AtmError::mailbox_read("stored immutable peer outbound write is invalid")
+                        .with_cause(source)
                 })
             })
             .collect()
@@ -432,7 +457,13 @@ impl PeerDrainCoordinator {
             );
             if self
                 .outbound
-                .page_for_peer(&peer.host, not_before, None, policy.max_batch_messages)?
+                .page_for_peer(
+                    &peer.host,
+                    not_before,
+                    None,
+                    policy.max_batch_messages,
+                    Duration::from_secs(5),
+                )?
                 .is_empty()
             {
                 continue;
@@ -645,6 +676,7 @@ mod tests {
             _: IsoTimestamp,
             _: Option<(IsoTimestamp, atm_core::schema::AtmMessageId)>,
             _: std::num::NonZeroU16,
+            _: Duration,
         ) -> Result<Vec<StoredPeerWrite>, AtmError> {
             Ok(Vec::new())
         }
@@ -695,6 +727,24 @@ mod tests {
         assert!(!is_retryable_peer_error(&AtmError::peer_config_validation(
             "bad peer"
         )));
+    }
+
+    #[test]
+    fn malformed_stored_request_preserves_the_json_parser_cause() {
+        let error = PeerDrainCoordinator::decode_page_requests(&[StoredPeerWrite {
+            created_at: IsoTimestamp::now(),
+            message_id: atm_core::schema::AtmMessageId::new(),
+            request_json: "{malformed".to_string(),
+        }])
+        .expect_err("malformed retained JSON must be rejected");
+        assert_eq!(
+            error.code(),
+            atm_core::error_codes::AtmErrorCode::MailboxReadFailed
+        );
+        assert!(
+            error.cause().is_some_and(|cause| !cause.is_empty()),
+            "the parser diagnostic must remain available as the structured cause"
+        );
     }
 
     #[test]

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -61,6 +61,15 @@ static SHUTDOWN_FINALIZER_THREADS: std::sync::Mutex<Vec<std::thread::JoinHandle<
 const GRAFT_POST_SEND_CONNECT_DEADLINE: Duration = Duration::from_millis(250);
 const GRAFT_POST_SEND_IO_DEADLINE: Duration = Duration::from_secs(3);
 
+fn lock_runtime_mutex<'a, T>(
+    mutex: &'a std::sync::Mutex<T>,
+    poisoned_message: &'static str,
+) -> Result<std::sync::MutexGuard<'a, T>, AtmError> {
+    mutex
+        .lock()
+        .map_err(|_| AtmError::daemon_unavailable(poisoned_message))
+}
+
 #[derive(Debug, Clone)]
 struct DaemonGraftPostSendPort {
     runtime: LocalServiceRuntime,
@@ -467,19 +476,19 @@ impl DaemonRequestDispatcher {
         &self,
         transport: Arc<dyn HttpsMessageTransport>,
     ) -> Result<(), AtmError> {
-        let mut slot = self
-            .https_transport
-            .lock()
-            .map_err(|_| AtmError::daemon_unavailable("HTTPS peer transport slot lock poisoned"))?;
+        let mut slot = lock_runtime_mutex(
+            &self.https_transport,
+            "HTTPS peer transport slot lock poisoned",
+        )?;
         *slot = Some(transport);
         Ok(())
     }
 
     pub(crate) fn clear_https_transport(&self) -> Result<(), AtmError> {
-        let mut slot = self
-            .https_transport
-            .lock()
-            .map_err(|_| AtmError::daemon_unavailable("HTTPS peer transport slot lock poisoned"))?;
+        let mut slot = lock_runtime_mutex(
+            &self.https_transport,
+            "HTTPS peer transport slot lock poisoned",
+        )?;
         *slot = None;
         Ok(())
     }
@@ -706,19 +715,20 @@ impl DaemonRequestDispatcher {
         &self,
         hook: RuntimeReloadHook,
     ) -> Result<(), AtmError> {
-        let mut slot = self.runtime_reload_hook.lock().map_err(|_| {
-            AtmError::daemon_unavailable("daemon runtime reload hook lock poisoned")
-        })?;
+        let mut slot = lock_runtime_mutex(
+            &self.runtime_reload_hook,
+            "daemon runtime reload hook lock poisoned",
+        )?;
         *slot = Some(hook);
         Ok(())
     }
 
     fn refresh_https_trust(&self) -> Result<(), AtmError> {
-        let hook = self
-            .runtime_reload_hook
-            .lock()
-            .map_err(|_| AtmError::daemon_unavailable("daemon runtime reload hook lock poisoned"))?
-            .clone();
+        let hook = lock_runtime_mutex(
+            &self.runtime_reload_hook,
+            "daemon runtime reload hook lock poisoned",
+        )?
+        .clone();
         if let Some(hook) = hook {
             hook()?;
         }

--- a/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
+++ b/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
@@ -6,7 +6,6 @@ use atm_core::error::AtmError;
 use atm_core::protocol::next_request_id;
 
 use crate::peer_delivery_observability::{PeerDeliveryEvent, PeerDeliveryEventKind};
-use crate::peer_drain_coordinator::is_retryable_peer_error;
 use crate::post_send_emitter::DaemonPostSendHookEmitter;
 
 use super::peer_authority::resolve_peer_authority;
@@ -91,25 +90,14 @@ impl DaemonRequestDispatcher {
             .peer_delivery_coordinator
             .deliver_after_persist(&message.outbound_request, deadline)
         {
-            return if is_retryable_peer_error(&error) {
-                self.peer_delivery_unconfirmed(peer, request_id, message_id, error)
-            } else {
-                self.peer_delivery_terminal_error(peer, request_id, message_id, error)
-            };
+            // Retry classification and scheduling belong to the coordinator;
+            // every foreground failure has the same retained projection event.
+            return self.peer_delivery_error(peer, request_id, message_id, error);
         }
         Ok(())
     }
-    fn peer_delivery_unconfirmed(
-        &self,
-        peer: atm_core::types::HostName,
-        request_id: atm_core::protocol::RequestId,
-        message_id: Option<atm_core::schema::AtmMessageId>,
-        error: AtmError,
-    ) -> Result<(), AtmError> {
-        self.peer_delivery_terminal_error(peer, request_id, message_id, error)
-    }
 
-    fn peer_delivery_terminal_error(
+    fn peer_delivery_error(
         &self,
         peer: atm_core::types::HostName,
         request_id: atm_core::protocol::RequestId,

--- a/crates/atm-daemon/src/tests/runtime_root.rs
+++ b/crates/atm-daemon/src/tests/runtime_root.rs
@@ -121,40 +121,66 @@ impl HttpsMessageTransport for RecordingHttpsDelivery {
 }
 
 #[derive(Default)]
-struct FailingHttpsDelivery {
+struct ConnectionHandlerFailure {
     attempted: std::sync::Mutex<Vec<WriteRequest>>,
-    unavailable: bool,
 }
 
-impl FailingHttpsDelivery {
-    fn daemon_unavailable() -> Self {
-        Self {
-            attempted: std::sync::Mutex::new(Vec::new()),
-            unavailable: true,
-        }
-    }
+#[derive(Default)]
+struct RouteFailure {
+    attempted: std::sync::Mutex<Vec<WriteRequest>>,
 }
 
-impl HttpsMessageTransport for FailingHttpsDelivery {
+#[derive(Default)]
+struct ResponseWriteFailure {
+    attempted: std::sync::Mutex<Vec<WriteRequest>>,
+}
+
+fn record_failed_delivery(attempted: &std::sync::Mutex<Vec<WriteRequest>>, request: WriteRequest) {
+    attempted
+        .lock()
+        .expect("peer transport recording lock")
+        .push(request);
+}
+
+impl HttpsMessageTransport for ConnectionHandlerFailure {
     fn deliver(
         &self,
         request: WriteRequest,
         _peer: &TrustedPeer,
         _deadline: RequestDeadline,
     ) -> Result<ResponseEnvelope, AtmError> {
-        self.attempted
-            .lock()
-            .expect("peer transport recording lock")
-            .push(request);
-        if self.unavailable {
-            Err(AtmError::daemon_unavailable(
-                "intentional local transport failure",
-            ))
-        } else {
-            Err(AtmError::remote_delivery_unconfirmed(
-                "intentional peer transport uncertainty",
-            ))
-        }
+        record_failed_delivery(&self.attempted, request);
+        Err(AtmError::daemon_unavailable(
+            "intentional connection-handler failure",
+        ))
+    }
+}
+
+impl HttpsMessageTransport for RouteFailure {
+    fn deliver(
+        &self,
+        request: WriteRequest,
+        _peer: &TrustedPeer,
+        _deadline: RequestDeadline,
+    ) -> Result<ResponseEnvelope, AtmError> {
+        record_failed_delivery(&self.attempted, request);
+        Err(AtmError::remote_delivery_unconfirmed(
+            "intentional route failure",
+        ))
+    }
+}
+
+impl HttpsMessageTransport for ResponseWriteFailure {
+    fn deliver(
+        &self,
+        request: WriteRequest,
+        _peer: &TrustedPeer,
+        _deadline: RequestDeadline,
+    ) -> Result<ResponseEnvelope, AtmError> {
+        record_failed_delivery(&self.attempted, request);
+        Err(AtmError::remote_delivery_unconfirmed(
+            "intentional response-write failure",
+        ))
     }
 }
 
@@ -332,7 +358,7 @@ fn failed_peer_route_returns_transport_error_after_canonical_persistence() {
 
     let dispatcher =
         DaemonRequestDispatcher::new_for_test(atm_home.clone(), RuntimeStatusCache::new(), db_path);
-    let transport = Arc::new(FailingHttpsDelivery::default());
+    let transport = Arc::new(RouteFailure::default());
     dispatcher
         .install_https_transport(transport.clone())
         .expect("install failing HTTPS delivery");

--- a/crates/atm-daemon/src/tests/runtime_root/peer_observability.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/peer_observability.rs
@@ -118,7 +118,7 @@ fn peer_link_status_json_round_trip_exposes_no_authority_secrets() {
 
 #[test]
 #[serial_test::serial(env)]
-fn local_https_delivery_failure_preserves_daemon_unavailable() {
+fn connection_handler_failure_preserves_daemon_unavailable() {
     install_retained_runtime_factory();
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
@@ -148,7 +148,7 @@ fn local_https_delivery_failure_preserves_daemon_unavailable() {
     let dispatcher =
         DaemonRequestDispatcher::new_for_test(atm_home.clone(), RuntimeStatusCache::new(), db_path);
     dispatcher
-        .install_https_transport(Arc::new(FailingHttpsDelivery::daemon_unavailable()))
+        .install_https_transport(Arc::new(ConnectionHandlerFailure::default()))
         .expect("install unavailable HTTPS delivery");
 
     let error = dispatcher

--- a/crates/atm-daemon/src/tests/runtime_root/peer_reconciliation.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/peer_reconciliation.rs
@@ -32,7 +32,7 @@ impl HttpsMessageTransport for BlockingPeerDelivery {
 
 #[test]
 #[serial_test::serial(env)]
-fn failed_peer_ack_keeps_source_pending_until_the_shared_write_retries() {
+fn response_write_failure_keeps_source_pending_until_the_shared_write_retries() {
     install_retained_runtime_factory();
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
@@ -98,7 +98,7 @@ fn failed_peer_ack_keeps_source_pending_until_the_shared_write_retries() {
         message_id: source_message_id,
         reply_body: "acknowledged".to_string(),
     };
-    let failing = Arc::new(FailingHttpsDelivery::default());
+    let failing = Arc::new(ResponseWriteFailure::default());
     dispatcher
         .install_https_transport(failing.clone())
         .expect("install failing transport");

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -23,10 +23,10 @@ chrono = { version = "0.4", features = ["serde"] }
 tracing.workspace = true
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-rusqlite = { version = "0.33.0", features = ["bundled"] }
+rusqlite = { version = "0.33.0", features = ["bundled", "hooks"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-rusqlite = { version = "0.33.0", features = ["bundled-windows", "modern_sqlite"] }
+rusqlite = { version = "0.33.0", features = ["bundled-windows", "modern_sqlite", "hooks"] }
 
 [dev-dependencies]
 serde = { version = "1.0.140", features = ["derive"] }

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -60,8 +60,9 @@ impl OutboundMessageQuery for SqliteOutboundMessageQuery {
         not_before: StorageIsoTimestamp,
         after: Option<(StorageIsoTimestamp, AtmMessageId)>,
         limit: std::num::NonZeroU16,
+        budget: std::time::Duration,
     ) -> Result<Vec<StoredPeerWrite>, AtmError> {
-        self.db.with_connection(|connection| {
+        self.db.with_connection_budget(budget, |connection| {
             let mut statement = connection
                 .prepare(
                     "SELECT message_at, message_key, json_extract(envelope_json, '$.peerOutbound.request')
@@ -718,6 +719,7 @@ mod tests {
                 not_before,
                 None,
                 NonZeroU16::new(10).expect("nonzero limit"),
+                std::time::Duration::from_secs(1),
             )
             .expect("query peer outbound writes");
 
@@ -757,6 +759,7 @@ mod tests {
                 timestamp,
                 None,
                 NonZeroU16::new(1).expect("nonzero limit"),
+                std::time::Duration::from_secs(1),
             )
             .expect("first page");
         assert_eq!(first_page.len(), 1, "page respects its configured cap");
@@ -767,6 +770,7 @@ mod tests {
                 timestamp,
                 Some((first_page[0].created_at, first_page[0].message_id)),
                 NonZeroU16::new(1).expect("nonzero limit"),
+                std::time::Duration::from_secs(1),
             )
             .expect("next page");
         assert_eq!(
@@ -775,6 +779,23 @@ mod tests {
             "exclusive cursor returns the next write"
         );
         assert_ne!(first_page[0].message_id, next_page[0].message_id);
+    }
+
+    #[test]
+    fn page_for_peer_rejects_an_expired_budget_before_opening_a_reader() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let target: HostName = "peer.example.test".parse().expect("target host");
+        let result = backend.outbound_message_query().page_for_peer(
+            &target,
+            IsoTimestamp::now(),
+            None,
+            NonZeroU16::new(1).expect("nonzero limit"),
+            std::time::Duration::ZERO,
+        );
+        assert!(
+            result.is_err(),
+            "an expired request must not start a DB read"
+        );
     }
 
     #[test]

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 /// Keep one permanent writer handle plus at most three concurrent reader handles so the
 /// same-process SQLite budget stays explicit under WAL mode without turning read bursts into an
@@ -273,6 +274,37 @@ impl SharedDb {
         let _connection_guard = self.acquire_connection_guard()?;
         let mut connection = self.open_connection()?;
         operation(&mut connection)
+    }
+
+    /// Runs one read with a caller-owned execution budget. SQLite's progress
+    /// callback interrupts VM execution when the budget expires, while the
+    /// matching busy timeout bounds lock acquisition. This is deliberately a
+    /// separate path so ordinary storage reads retain their existing policy.
+    pub(crate) fn with_connection_budget<T>(
+        &self,
+        budget: Duration,
+        operation: impl FnOnce(&mut Connection) -> Result<T, AtmError>,
+    ) -> Result<T, AtmError> {
+        debug_assert_blocking_only("SharedDb::with_connection_budget");
+        if budget.is_zero() {
+            return Err(AtmError::mailbox_lock(
+                "sqlite query budget expired before the read started",
+            ));
+        }
+        let _connection_guard = self.acquire_connection_guard()?;
+        let mut connection = self.open_connection()?;
+        connection.busy_timeout(budget).map_err(|error| {
+            sqlite_error(
+                self.target.as_ref(),
+                "failed to configure sqlite query budget",
+                error,
+            )
+        })?;
+        let expires_at = Instant::now() + budget;
+        connection.progress_handler(1_000, Some(move || Instant::now() >= expires_at));
+        let result = operation(&mut connection);
+        connection.progress_handler(0, None::<fn() -> bool>);
+        result
     }
 
     /// Call only from blocking code paths; async callers must enter
@@ -734,6 +766,13 @@ pub(crate) fn sqlite_error(
                         "timed out waiting for sqlite database lock on {}",
                         target.display()
                     )),
+                },
+                rusqlite::ffi::ErrorCode::OperationInterrupted => match target {
+                    SharedDbTarget::Path(path) => AtmError::mailbox_lock_timeout(path),
+                    #[cfg(test)]
+                    SharedDbTarget::InMemory { .. } => AtmError::mailbox_lock(
+                        "sqlite query exceeded its caller-provided execution budget",
+                    ),
                 },
                 rusqlite::ffi::ErrorCode::CannotOpen => AtmError::mailbox_write(message),
                 rusqlite::ffi::ErrorCode::ReadOnly => AtmError::mailbox_write(message),

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -666,6 +666,7 @@ pub trait OutboundMessageQuery: Send + Sync {
         not_before: IsoTimestamp,
         after: Option<(IsoTimestamp, AtmMessageId)>,
         limit: NonZeroU16,
+        budget: std::time::Duration,
     ) -> Result<Vec<StoredPeerWrite>, AtmError>;
 }
 


### PR DESCRIPTION
## Summary
Follow-up cleanup round for AI.27/AI.28 triage findings, dispatched after quality-mgr's consolidated sweep against merged integrate/phase-AI (276ce44f) confirmed these were genuinely still open (not stale occurrences):

- AI28-RBP-001 (peer_drain_coordinator.rs portion): preserve underlying error cause on transport/JSON decode failures instead of collapsing to message-only.
- AI28-RSH-004: `page_for_peer` DB read is now deadline-bounded (SQLite paging with progress interrupt / busy budget), not just bracketed by before/after expiry checks.
- AI27-ATMQA-005: split the single generic FailingHttpsDelivery mock into named connection-handler / route / response-write scenarios.
- AI27-RBP-F004: added Mutex concurrency-rationale comment; extracted shared lock-poison helper.
- AI27-RBQA-F003: unified peer failure recording into one function.
- AI27-RBQA-F004: consolidated duplicate path-matcher helpers.

AI27-ATMQA-004 (doctor-evidence artifact) is committed but flagged not-truthfully-closable: the shared daemon singleton is currently pinned to 1.3.2-beta.29 (from AI.29 smoke work) while the deliverable requires beta.27 evidence -- this is an environment-state constraint, not a code defect, and will need to be recaptured once the daemon is back on a matching pair.

## Test plan
- [x] Targeted storage/daemon tests pass
- [ ] Full `just lint` / `just test` (Crimson reports still running as of push)
- [ ] quality-mgr QA-1 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)