### PR TITLE
fix: advertised-IP loopback test gap + AI.19 frozen-commit doc citation

### DIFF
--- a/crates/atm-daemon/src/https_transport.rs
+++ b/crates/atm-daemon/src/https_transport.rs
@@ -943,7 +943,7 @@ fn normalize_fingerprint(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{TcpListener, TcpStream};
+    use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream, UdpSocket};
     use std::str::FromStr as _;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
@@ -977,6 +977,23 @@ mod tests {
             enabled: true,
             https_port: std::num::NonZeroU16::new(43101).expect("non-zero"),
         }
+    }
+
+    /// Resolve an address owned by this host without relying on a fixed
+    /// workstation subnet. UDP connect selects the route's local address but
+    /// does not send a packet, making this suitable for an in-process proof.
+    fn non_loopback_interface() -> (IpAddr, HostName) {
+        let probe = UdpSocket::bind(("0.0.0.0", 0)).expect("bind route probe");
+        probe
+            .connect(("192.0.2.1", 9))
+            .expect("select a non-loopback route");
+        let address = probe.local_addr().expect("inspect route probe").ip();
+        assert!(
+            !address.is_loopback() && !address.is_unspecified(),
+            "the advertised-IP proof requires a non-loopback interface, got {address}"
+        );
+        let host = address.to_string().parse().expect("route host");
+        (address, host)
     }
 
     use rustls::pki_types::ServerName;
@@ -1200,6 +1217,7 @@ mod tests {
     #[serial_test::serial(env)]
     fn advertised_ip_peer_write_uses_real_dispatcher_persists_and_nudges() {
         crate::tests::install_retained_runtime_factory();
+        let (advertised_ip, advertised_host) = non_loopback_interface();
         let tempdir = tempfile::TempDir::new().expect("tempdir");
         let atm_home = tempdir.path().join("atm-home");
         let workspace_dir = tempdir.path().join("workspace");
@@ -1274,14 +1292,14 @@ mod tests {
         ));
         let certificate = test_certificate();
         let peer = TrustedPeer {
-            host: "localhost".parse().expect("peer host"),
+            host: advertised_host.clone(),
             fingerprint: certificate.fingerprint.clone(),
             enabled: true,
             https_port: std::num::NonZeroU16::new(43101).expect("peer port"),
         };
         let listener = HttpsListenerSet::bind_enabled(
             &[HttpsInterface {
-                bind_addr: "127.0.0.1:0".parse().expect("advertised-IP bind"),
+                bind_addr: SocketAddr::new(advertised_ip, 0),
                 advertise_host: peer.host.clone(),
                 enabled: true,
             }],
@@ -1295,7 +1313,7 @@ mod tests {
         let config = client_config(&identity, &peer).expect("client config");
         let connection = ClientConnection::new(
             Arc::new(config),
-            ServerName::try_from("localhost".to_string()).expect("server name"),
+            ServerName::try_from(peer.host.to_string()).expect("server name"),
         )
         .expect("client connection");
         let stream = TcpStream::connect(address).expect("connect advertised IP listener");
@@ -1307,7 +1325,7 @@ mod tests {
                 atm_home.clone(),
                 workspace_dir.clone(),
                 ROLE_TEAM_LEAD.parse().expect("sender"),
-                "qa-a@test-team.127.0.0.1",
+                &format!("qa-a@test-team.{advertised_host}"),
                 team.clone(),
                 SendMessageSource::Inline("advertised-IP real peer write".to_string()),
                 None,
@@ -1464,19 +1482,20 @@ mod tests {
 
     #[test]
     fn advertised_ip_peer_send_and_ack_reach_the_shared_router() {
+        let (advertised_ip, advertised_host) = non_loopback_interface();
         let certificate = test_certificate();
         let identity = TlsIdentity::load(&certificate).expect("load test identity");
         let router = Arc::new(RecordingRouter::default());
         let peer = TrustedPeer {
-            host: "localhost".parse().expect("host"),
+            host: advertised_host.clone(),
             fingerprint: certificate.fingerprint.clone(),
             enabled: true,
             https_port: std::num::NonZeroU16::new(43101).expect("non-zero"),
         };
         let listener = HttpsListenerSet::bind_enabled(
             &[HttpsInterface {
-                bind_addr: "127.0.0.1:0".parse().expect("bind address"),
-                advertise_host: "localhost".parse().expect("host"),
+                bind_addr: SocketAddr::new(advertised_ip, 0),
+                advertise_host: peer.host.clone(),
                 enabled: true,
             }],
             &certificate,
@@ -1488,7 +1507,7 @@ mod tests {
         let config = client_config(&identity, &peer).expect("client config");
         let connection = ClientConnection::new(
             Arc::new(config),
-            ServerName::try_from("localhost".to_string()).expect("server name"),
+            ServerName::try_from(peer.host.to_string()).expect("server name"),
         )
         .expect("client connection");
         let mut tls = StreamOwned::new(connection, stream);
@@ -1497,7 +1516,7 @@ mod tests {
             std::env::temp_dir(),
             std::env::temp_dir(),
             "sender".parse().expect("sender"),
-            "recipient@test-team.192.168.128.82",
+            &format!("recipient@test-team.{advertised_host}"),
             "test-team".parse().expect("team"),
             SendMessageSource::Inline("message".to_string()),
             None,
@@ -1545,7 +1564,7 @@ mod tests {
         assert_eq!(write.origin_message_id, Some(origin_message_id));
         assert_eq!(
             write.to.as_ref().expect("destination").host(),
-            Some(&"192.168.128.82".parse().expect("advertised IP"))
+            Some(&advertised_host)
         );
         assert!(write.acknowledges_message_id.is_none());
         let ApiRequest::Write(ack) = &requests[1] else {

--- a/docs/plans/phase-ai/readiness-ai17-21-hermes-graft.md
+++ b/docs/plans/phase-ai/readiness-ai17-21-hermes-graft.md
@@ -11,7 +11,7 @@ closure evidence.
 |---|---|---|
 | AI.17 | `PARTIAL` | Ambient `ATM_CHAT_ID` resolution feeds existing Phase AI `chat_id`; Hermes is the first client; no new schema or CLI grammar |
 | AI.18 | `PENDING` | Python binding preserves the full supported graft host surface: typed canonical address, client operations, session lifecycle/snapshot, and canonical nudge callback |
-| AI.19 | `FROZEN` | `5947858a406fbfc8b8f07487880fa13ff53bbb1e` freezes `crates/atm-graft-python/python/atm_graft_hermes_bridge.py`; configuration inputs are `ATM_IDENTITY`, `ATM_TEAM`, and optional `ATM_CHAT_ID` when constructing the typed caller, plus per-profile `PyGraftSessionOptions`; readiness probes are `just test-hermes-graft-bridge` and `PyGraftSession.snapshot()` |
+| AI.19 | `FROZEN` | `5947858a406fbfc8b8f07487880fa13ff53bbb1e` freezes `crates/atm-graft-python/python/atm_graft_hermes_bridge.py`; reviewed/approved readiness record: `bedc1bf1` (docs-only, with no bridge source changes); configuration inputs are `ATM_IDENTITY`, `ATM_TEAM`, and optional `ATM_CHAT_ID` when constructing the typed caller, plus per-profile `PyGraftSessionOptions`; readiness probes are `just test-hermes-graft-bridge` and `PyGraftSession.snapshot()` |
 | AI.20 | `PENDING` | each bridge is launchd-supervised with a reproducible runbook |
 | AI.21 | `PENDING` | four production stories have complete evidence and explicit verdicts |
 


### PR DESCRIPTION
## Summary
- ATM-QA-002B: adds a genuine non-loopback advertised-IP test path for the shared HTTPS dispatcher (previously only loopback 127.0.0.1 was exercised, not satisfying sprint-ai-23's advertised-IP acceptance criteria).
- AI19-QA1-ATM-QA-004-FROZEN-COMMIT-MISMATCH: readiness-ai17-21-hermes-graft.md AI.19 row now cites both the frozen bridge-code commit (5947858a) and the reviewed/approved record commit (bedc1bf1).

## Test plan
- [x] Non-loopback advertised-IP HTTPS tests pass (focused run per Crimson's report)
- [ ] quality-mgr fix-verification QA (dispatching next)
- [ ] `just lint` / `just test` full run confirmed by QA
- [ ] CI green on all legs

🤖 Generated with [Claude Code](https://claude.com/claude-code)