### PR TITLE
fix(legacy): ATM-QA-002-S15-R3 structured daemon rejection evidence

### DIFF
--- a/.just/tests/test_peer_pair_smoke.py
+++ b/.just/tests/test_peer_pair_smoke.py
@@ -37,6 +37,13 @@ READ_OUTCOME = {
     "bucket_counts": {"unread": 0, "pending_ack": 1, "history": 0},
     "message": {"message_id": "01TEST", "requires_ack": True},
 }
+REJECTION_EVENT = {
+    "action": "request",
+    "outcome": "rejected",
+    "message": "HTTPS peer request was rejected before or during shared API routing",
+    "fields": {"subsystem": "https_transport"},
+}
+ROUTING_EVENT = {"action": "peer_delivery", "outcome": "write_persisted"}
 
 
 def assertion(path: str, value: object = "$message_ulid") -> dict[str, object]:
@@ -85,7 +92,8 @@ def sample_config(log: Path) -> dict[str, object]:
         if case["expect"] == "typed_error":
             case["typed_error_code"] = "ATM_REJECTED"
         if case_id == "untrusted_or_allowlist_rejection":
-            case["verification"]["forbidden_daemon_log_entries"] = ["routing-attempt"]
+            case["verification"]["required_daemon_log_events"] = [REJECTION_EVENT]
+            case["verification"]["forbidden_daemon_log_events"] = [ROUTING_EVENT]
         cases.append(case)
     return {
         "schema_version": 1,
@@ -142,15 +150,20 @@ class PeerPairSmokeTests(unittest.TestCase):
             RUNNER.run_command = original
         self.assertEqual(result["status"], "pass")
 
-    def test_semantic_verification_rejects_routing_after_rejection(self):
+    def test_semantic_verification_rejects_missing_structured_rejection_event(self):
         with tempfile.TemporaryDirectory() as temp:
             log = Path(temp) / "daemon.log"
-            log.write_text("before\nrouting-attempt\n", encoding="utf-8")
+            log.write_text(
+                "before\n"
+                + json.dumps({"action": "peer_delivery", "outcome": "write_persisted"})
+                + "\n",
+                encoding="utf-8",
+            )
             case = {
                 "message_ulid": "01TEST",
                 "verification": {
                     "assertions": {"rejected_before_routing": assertion("count", 0)},
-                    "forbidden_daemon_log_entries": ["routing-attempt"],
+                    "required_daemon_log_events": [REJECTION_EVENT],
                 },
             }
             original = RUNNER.run_command
@@ -163,7 +176,7 @@ class PeerPairSmokeTests(unittest.TestCase):
             finally:
                 RUNNER.run_command = original
             self.assertEqual(result["status"], "fail")
-            self.assertIn("forbidden post-rejection", result["failures"][0])
+            self.assertIn("required structured rejection event", result["failures"][-1])
 
     def test_teardown_never_deletes_runtime_without_matching_pid_marker(self):
         with tempfile.TemporaryDirectory() as temp:

--- a/docs/peer-pair-smoke.md
+++ b/docs/peer-pair-smoke.md
@@ -72,7 +72,7 @@ capabilities, or secrets. It has this shape:
     {"id": "requires_ack_reply", "expect": "success", "message_ulid": "<ulid>", "command": ["atm", "send", "..."], "verification": {"assertions": {"ack_reply_visible": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "selected_message_id", "equals": "$message_ulid"}}}},
     {"id": "duplicate_ulid", "expect": "success", "message_ulid": "<ulid>", "command": ["atm", "send", "..."], "verification": {"assertions": {"receiver_visible": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "selected_message_id", "equals": "$message_ulid"}, "single_record_retained": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "match_count", "equals": 1}, "no_repeat_nudge": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "additional_match_count", "equals": 0}, "no_ack_mutation": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "message.acknowledgedAt", "absent": true}}}},
     {"id": "unavailable_peer", "expect": "typed_error", "typed_error_code": "<code>", "message_ulid": "<ulid>", "command": ["atm", "send", "..."], "verification": {"assertions": {"no_prohibited_delivery_state": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "count", "equals": 0}}}},
-    {"id": "untrusted_or_allowlist_rejection", "expect": "typed_error", "typed_error_code": "<code>", "message_ulid": "<ulid>", "command": ["atm", "send", "..."], "verification": {"assertions": {"rejected_before_routing": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "count", "equals": 0}}, "forbidden_daemon_log_entries": ["<configured-routing-attempt-record>"]}},
+    {"id": "untrusted_or_allowlist_rejection", "expect": "typed_error", "typed_error_code": "<code>", "message_ulid": "<ulid>", "command": ["atm", "send", "..."], "verification": {"assertions": {"rejected_before_routing": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "count", "equals": 0}}, "required_daemon_log_events": [{"action": "request", "outcome": "rejected", "message": "HTTPS peer request was rejected before or during shared API routing", "fields": {"subsystem": "https_transport"}}], "forbidden_daemon_log_events": [{"action": "peer_delivery", "outcome": "write_persisted"}]}},
     {"id": "failed_remote_ack", "expect": "typed_error", "typed_error_code": "<code>", "message_ulid": "<ulid>", "command": ["atm", "ack", "..."], "verification": {"assertions": {"ack_source_unchanged": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "message.requires_ack", "equals": true}, "no_remote_ack_state": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "message.acknowledgedAt", "absent": true}}}}
   ]
 }
@@ -91,6 +91,16 @@ an omitted JSON field (for example `message.acknowledgedAt`).
 The runner writes sanitized JSON evidence with transport and semantic results,
 daemon/client versions, trust identity, log window, role, identities, ULID, and
 teardown.
+
+Daemon log assertions use exact structured event selectors against the retained
+JSONL delta. A selector may match top-level `action`, `outcome`, `message`,
+`level`, `service`, or `target` fields and scalar values under `fields`; it is
+not a free-form substring search. The untrusted/allowlist case requires the
+real HTTPS rejection event (`action=request`, `outcome=rejected`,
+`fields.subsystem=https_transport`) to appear after the command. Optional
+`forbidden_daemon_log_events` selectors must not appear. Rotation, truncation,
+malformed JSONL, or a missing required event fails the case and is recorded in
+the evidence with an actionable message.
 
 The runner accepts `launch_command` only with non-empty
 `owned_runtime_paths`. It records the launched PID in its ownership marker,

--- a/scripts/smoke/run_peer_pair.py
+++ b/scripts/smoke/run_peer_pair.py
@@ -129,6 +129,51 @@ def require_semantic_assertion(value: Any, name: str) -> None:
         fail(f"config field `{name}.equals` must be a scalar")
 
 
+LOG_EVENT_SELECTOR_KEYS = frozenset({
+    "action",
+    "level",
+    "message",
+    "outcome",
+    "service",
+    "target",
+    "fields",
+})
+
+
+def require_log_event_selector(value: Any, name: str) -> None:
+    if not isinstance(value, dict) or not value:
+        fail(f"config field `{name}` must be a non-empty event selector object")
+    if not all(isinstance(key, str) and key for key in value):
+        fail(f"config field `{name}` must use non-empty string selector keys")
+    unknown = sorted(set(value).difference(LOG_EVENT_SELECTOR_KEYS))
+    if unknown:
+        fail(f"config field `{name}` has unsupported selector keys: {', '.join(unknown)}")
+    for key, expected in value.items():
+        if key == "fields":
+            if not isinstance(expected, dict) or not expected:
+                fail(f"config field `{name}.fields` must be a non-empty object")
+            if not all(
+                isinstance(field, str)
+                and field
+                and isinstance(field_value, (str, int, float, bool, type(None)))
+                and (not isinstance(field_value, str) or field_value.strip())
+                for field, field_value in expected.items()
+            ):
+                fail(f"config field `{name}.fields` must map names to scalar values")
+        elif isinstance(expected, str) and not expected.strip():
+            fail(f"config field `{name}.{key}` must be a non-empty scalar")
+        elif not isinstance(expected, (str, int, float, bool, type(None))):
+            fail(f"config field `{name}.{key}` must be a scalar")
+
+
+def require_log_event_selectors(value: Any, name: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        fail(f"config field `{name}` must be an array of event selector objects")
+    for index, selector in enumerate(value):
+        require_log_event_selector(selector, f"{name}[{index}]")
+    return value
+
+
 def require_semantic_verification(case: dict[str, Any], name: str, daemon_has_log_file: bool) -> None:
     verification = case.get("verification")
     if not isinstance(verification, dict):
@@ -150,16 +195,26 @@ def require_semantic_verification(case: dict[str, Any], name: str, daemon_has_lo
                 f"config field `{name}.verification.assertions.{assertion_name}.equals` "
                 "must bind to `$message_ulid`"
             )
-    forbidden_log_entries = verification.get("forbidden_daemon_log_entries", [])
-    if not isinstance(forbidden_log_entries, list) or not all(
-        isinstance(entry, str) and entry for entry in forbidden_log_entries
-    ):
-        fail(f"config field `{name}.verification.forbidden_daemon_log_entries` must be a string array")
+    if "forbidden_daemon_log_entries" in verification:
+        fail(
+            f"config field `{name}.verification.forbidden_daemon_log_entries` was removed; "
+            "use required_daemon_log_events or forbidden_daemon_log_events"
+        )
+    required_log_events = require_log_event_selectors(
+        verification.get("required_daemon_log_events", []),
+        f"{name}.verification.required_daemon_log_events",
+    )
+    forbidden_log_events = require_log_event_selectors(
+        verification.get("forbidden_daemon_log_events", []),
+        f"{name}.verification.forbidden_daemon_log_events",
+    )
+    if (required_log_events or forbidden_log_events) and not daemon_has_log_file:
+        fail(f"{name}.verification daemon log events require daemon.log_file")
     if case["id"] == "untrusted_or_allowlist_rejection":
         if not daemon_has_log_file:
             fail("untrusted_or_allowlist_rejection requires daemon.log_file")
-        if not forbidden_log_entries:
-            fail("untrusted_or_allowlist_rejection requires forbidden_daemon_log_entries")
+        if not required_log_events:
+            fail("untrusted_or_allowlist_rejection requires required_daemon_log_events")
 
 
 def validate(config: dict[str, Any]) -> None:
@@ -263,6 +318,79 @@ def resolved_expectation(value: Any, case: dict[str, Any]) -> Any:
     return case["message_ulid"] if value == "$message_ulid" else value
 
 
+def daemon_log_event_matches(event: dict[str, Any], selector: dict[str, Any]) -> bool:
+    fields = event.get("fields")
+    nested_fields = fields if isinstance(fields, dict) else {}
+    for key, expected in selector.items():
+        if key == "fields":
+            if not all(nested_fields.get(field) == value for field, value in expected.items()):
+                return False
+            continue
+        observed = event.get(key)
+        if observed is None and key in nested_fields:
+            observed = nested_fields[key]
+        if observed != expected:
+            return False
+    return True
+
+
+def parse_daemon_log_events(delta: str) -> tuple[list[dict[str, Any]], int]:
+    events: list[dict[str, Any]] = []
+    malformed_lines = 0
+    for line in delta.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            malformed_lines += 1
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+        else:
+            malformed_lines += 1
+    return events, malformed_lines
+
+
+def verify_daemon_log_events(
+    verification: dict[str, Any],
+    daemon_log_before: str,
+    daemon_log_file: Any,
+    outcome: dict[str, Any],
+) -> None:
+    required = verification.get("required_daemon_log_events", [])
+    forbidden = verification.get("forbidden_daemon_log_events", [])
+    if not required and not forbidden:
+        return
+    after = log_snapshot(daemon_log_file)
+    if not after.startswith(daemon_log_before):
+        outcome["failures"].append(
+            "daemon log rotated or truncated during semantic verification; refusing an unverified delta"
+        )
+        outcome["daemon_log_delta"] = sanitize(after)[-8192:]
+        return
+    delta = after[len(daemon_log_before) :]
+    events, malformed_lines = parse_daemon_log_events(delta)
+    outcome["daemon_log_delta"] = sanitize(delta)[-8192:]
+    outcome["daemon_log_event_count"] = len(events)
+    outcome["daemon_log_malformed_lines"] = malformed_lines
+    if malformed_lines:
+        outcome["failures"].append(
+            f"daemon log delta contains {malformed_lines} non-JSON line(s); "
+            "cannot verify structured daemon log events"
+        )
+    for selector in required:
+        if not any(daemon_log_event_matches(event, selector) for event in events):
+            outcome["failures"].append(
+                f"daemon log did not contain required structured rejection event {selector!r}"
+            )
+    for selector in forbidden:
+        if any(daemon_log_event_matches(event, selector) for event in events):
+            outcome["failures"].append(
+                f"daemon log recorded forbidden structured event {selector!r}"
+            )
+
+
 def verify_semantics(
     case: dict[str, Any], timeout: float, daemon_log_before: str, daemon_log_file: Any
 ) -> dict[str, Any]:
@@ -295,21 +423,7 @@ def verify_semantics(
             outcome["failures"].append(
                 f"semantic assertion `{assertion_name}` expected {expected!r}, got {actual!r}"
             )
-    if forbidden := verification.get("forbidden_daemon_log_entries", []):
-        after = log_snapshot(daemon_log_file)
-        if not after.startswith(daemon_log_before):
-            outcome["failures"].append(
-                "daemon log rotated or truncated during semantic verification; refusing an unverified delta"
-            )
-            outcome["daemon_log_delta"] = sanitize(after)[-8192:]
-            return outcome
-        delta = after[len(daemon_log_before):]
-        for entry in forbidden:
-            if entry in delta:
-                outcome["failures"].append(
-                    f"daemon log recorded forbidden post-rejection entry {entry!r}"
-                )
-        outcome["daemon_log_delta"] = sanitize(delta)[-8192:]
+    verify_daemon_log_events(verification, daemon_log_before, daemon_log_file, outcome)
     if not outcome["failures"]:
         outcome["status"] = "pass"
     return outcome

--- a/scripts/smoke/test_run_peer_pair.py
+++ b/scripts/smoke/test_run_peer_pair.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import tempfile
 from pathlib import Path
 import unittest
@@ -25,6 +26,24 @@ VERIFY_MESSAGE = [
     "-c",
     "import json; print(json.dumps({'message': {'message_id': '01TEST'}}))",
 ]
+REJECTION_EVENT = {
+    "action": "request",
+    "outcome": "rejected",
+    "message": "HTTPS peer request was rejected before or during shared API routing",
+    "fields": {"subsystem": "https_transport"},
+}
+ROUTING_EVENT = {"action": "peer_delivery", "outcome": "write_persisted"}
+
+
+def encoded_event() -> str:
+    return json.dumps(
+        {
+            "action": "request",
+            "outcome": "rejected",
+            "message": "HTTPS peer request was rejected before or during shared API routing",
+            "fields": {"subsystem": "https_transport", "error_code": "ATM_REJECTED"},
+        }
+    )
 
 
 def public_atm_command(command, _timeout):
@@ -53,7 +72,14 @@ class PeerPairSemanticVerificationTests(unittest.TestCase):
             config = sample_config(log)
 
             with patch.object(RUNNER.shutil, "which", return_value=str(Path(__file__).resolve())):
-                with patch.object(RUNNER, "run_command", side_effect=public_atm_command):
+                def command_with_rejection_event(command, timeout):
+                    result = public_atm_command(command, timeout)
+                    if command[1:] == ["reject"]:
+                        with log.open("a", encoding="utf-8") as stream:
+                            stream.write(f"{encoded_event()}\n")
+                    return result
+
+                with patch.object(RUNNER, "run_command", side_effect=command_with_rejection_event):
                     self.assertEqual(RUNNER.execute(config, root / "evidence", 2), 0)
             evidence = (root / "evidence" / "peer-smoke-evidence.json").read_text(
                 encoding="utf-8"
@@ -61,10 +87,10 @@ class PeerPairSemanticVerificationTests(unittest.TestCase):
             self.assertIn('"semantic_verification"', evidence)
             self.assertIn('"status": "passed"', evidence)
 
-    def test_rejection_fails_when_new_log_window_shows_delivery(self):
+    def test_required_rejection_event_is_verified_from_structured_log(self):
         with tempfile.TemporaryDirectory() as temp:
             log = Path(temp) / "daemon.log"
-            log.write_text("before\npeer delivery\n", encoding="utf-8")
+            log.write_text(f"before\n{encoded_event()}\n", encoding="utf-8")
             case = {
                 "message_ulid": "01TEST",
                 "verification": {
@@ -75,14 +101,64 @@ class PeerPairSemanticVerificationTests(unittest.TestCase):
                             "equals": "$message_ulid",
                         }
                     },
-                    "forbidden_daemon_log_entries": ["peer delivery"],
+                    "required_daemon_log_events": [REJECTION_EVENT],
+                    "forbidden_daemon_log_events": [ROUTING_EVENT],
+                },
+            }
+
+            result = RUNNER.verify_semantics(case, 2, "before\n", str(log))
+
+            self.assertEqual(result["status"], "pass")
+            self.assertEqual(result["daemon_log_event_count"], 1)
+
+    def test_synthetic_token_does_not_satisfy_required_rejection_event(self):
+        with tempfile.TemporaryDirectory() as temp:
+            log = Path(temp) / "daemon.log"
+            log.write_text("before\nlegacy-token\n", encoding="utf-8")
+            case = {
+                "message_ulid": "01TEST",
+                "verification": {
+                    "assertions": {
+                        "receiver_visible": {
+                            "command": VERIFY_MESSAGE,
+                            "json_path": "message.message_id",
+                            "equals": "$message_ulid",
+                        }
+                    },
+                    "required_daemon_log_events": [REJECTION_EVENT],
                 },
             }
 
             result = RUNNER.verify_semantics(case, 2, "before\n", str(log))
 
             self.assertEqual(result["status"], "fail")
-            self.assertIn("forbidden post-rejection", result["failures"][0])
+            self.assertIn("required structured rejection event", result["failures"][-1])
+
+    def test_forbidden_structured_event_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp:
+            log = Path(temp) / "daemon.log"
+            log.write_text(
+                f"before\n{encoded_event()}\n{json.dumps(ROUTING_EVENT)}\n",
+                encoding="utf-8",
+            )
+            case = {
+                "message_ulid": "01TEST",
+                "verification": {
+                    "assertions": {
+                        "receiver_visible": {
+                            "command": VERIFY_MESSAGE,
+                            "json_path": "message.message_id",
+                            "equals": "$message_ulid",
+                        }
+                    },
+                    "forbidden_daemon_log_events": [ROUTING_EVENT],
+                },
+            }
+
+            result = RUNNER.verify_semantics(case, 2, "before\n", str(log))
+
+            self.assertEqual(result["status"], "fail")
+            self.assertIn("forbidden structured event", result["failures"][-1])
 
     def test_rejection_fails_closed_when_daemon_log_rotates(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -98,7 +174,7 @@ class PeerPairSemanticVerificationTests(unittest.TestCase):
                             "equals": "$message_ulid",
                         }
                     },
-                    "forbidden_daemon_log_entries": ["peer delivery"],
+                    "required_daemon_log_events": [REJECTION_EVENT],
                 },
             }
 
@@ -106,6 +182,29 @@ class PeerPairSemanticVerificationTests(unittest.TestCase):
 
             self.assertEqual(result["status"], "fail")
             self.assertIn("rotated or truncated", result["failures"][0])
+
+    def test_rejection_fails_closed_when_log_delta_is_not_jsonl(self):
+        with tempfile.TemporaryDirectory() as temp:
+            log = Path(temp) / "daemon.log"
+            log.write_text("before\nnot a structured event\n", encoding="utf-8")
+            case = {
+                "message_ulid": "01TEST",
+                "verification": {
+                    "assertions": {
+                        "receiver_visible": {
+                            "command": VERIFY_MESSAGE,
+                            "json_path": "message.message_id",
+                            "equals": "$message_ulid",
+                        }
+                    },
+                    "required_daemon_log_events": [REJECTION_EVENT],
+                },
+            }
+
+            result = RUNNER.verify_semantics(case, 2, "before\n", str(log))
+
+            self.assertEqual(result["status"], "fail")
+            self.assertIn("non-JSON line", result["failures"][0])
 
     def test_validation_rejects_constant_message_assertion(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -117,6 +216,36 @@ class PeerPairSemanticVerificationTests(unittest.TestCase):
 
             with patch.object(RUNNER.shutil, "which", return_value=str(Path(__file__).resolve())):
                 with self.assertRaisesRegex(RuntimeError, "must bind to `\\$message_ulid`"):
+                    RUNNER.validate(config)
+
+    def test_validation_rejects_legacy_synthetic_log_entry_field(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            log = root / "daemon.log"
+            log.write_text("ready\n", encoding="utf-8")
+            config = sample_config(log)
+            rejection = next(
+                case for case in config["cases"] if case["id"] == "untrusted_or_allowlist_rejection"
+            )
+            rejection["verification"]["forbidden_daemon_log_entries"] = ["legacy-token"]
+
+            with patch.object(RUNNER.shutil, "which", return_value=str(Path(__file__).resolve())):
+                with self.assertRaisesRegex(RuntimeError, "was removed"):
+                    RUNNER.validate(config)
+
+    def test_validation_requires_structured_rejection_event(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            log = root / "daemon.log"
+            log.write_text("ready\n", encoding="utf-8")
+            config = sample_config(log)
+            rejection = next(
+                case for case in config["cases"] if case["id"] == "untrusted_or_allowlist_rejection"
+            )
+            del rejection["verification"]["required_daemon_log_events"]
+
+            with patch.object(RUNNER.shutil, "which", return_value=str(Path(__file__).resolve())):
+                with self.assertRaisesRegex(RuntimeError, "requires required_daemon_log_events"):
                     RUNNER.validate(config)
 
     def test_validation_rejects_path_shadow_when_install_root_is_selected(self):
@@ -162,7 +291,8 @@ def sample_config(log: Path):
         if typed_error:
             case["typed_error_code"] = "ATM_REJECTED"
         if case_id == "untrusted_or_allowlist_rejection":
-            case["verification"]["forbidden_daemon_log_entries"] = ["peer delivery"]
+            case["verification"]["required_daemon_log_events"] = [REJECTION_EVENT]
+            case["verification"]["forbidden_daemon_log_events"] = [ROUTING_EVENT]
         cases.append(case)
     return {
         "schema_version": 1,


### PR DESCRIPTION
## Summary
- Finding ATM-QA-002-S15-R3 (blocking): `forbidden_daemon_log_entries` strings never matched real daemon log output.
- `scripts/smoke/run_peer_pair.py` now requires exact structured JSONL daemon rejection events instead of legacy string matching; `forbidden_daemon_log_events` matches actual `peer_delivery`/`write_persisted` routing events.
- Updated unit tests and `docs/peer-pair-smoke.md`.

## Test plan
- Focused smoke tests: 10 + 5 passed
- `just lint`: 22 checks passed (incl. 282 Python tests)
- `just test`: Python suite passed; 120/121 atm-daemon tests passed — 1 pre-existing unrelated failure at `crates/atm-daemon/src/peer_resolution.rs:69` (`failed_dns_resolution_preserves_the_underlying_cause`, DNS timeout text drift, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)