### PR TITLE
docs(phase-AI): reconcile readiness/project-plan and correct stale TTL citations

### DIFF
--- a/.triage/phase-AI/findings/AI11-BLOCKING-03-POSTWRITEROUTER-NOOP.ttl
+++ b/.triage/phase-AI/findings/AI11-BLOCKING-03-POSTWRITEROUTER-NOOP.ttl
@@ -15,15 +15,17 @@
   triage:repeatable true ;
   triage:sweepScope "crate" ;
   triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-27T00:00:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:dispatchReady false ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI11-BLOCKING-03/pAI-11/1>, <urn:atm:triage:occurrence/AI11-BLOCKING-03/pAI-11/2>, <urn:atm:triage:occurrence/AI11-BLOCKING-03/pAI-11/3> ;
   triage:openOn <urn:atm:triage:worktree/pAI-integrate/8d0ccf01> ;
-  triage:promoteTo <urn:atm:triage:worktree/pAI-s20/bed07594> ;
-  triage:highestOpenBranch "feature/pAI-s20-hermes-bridge-deployment" ;
-  triage:highestFixedBranch "none" ;
+  triage:highestOpenBranch "none" ;
+  triage:highestFixedBranch "integrate/phase-AI" ;
   triage:triagedAt "2026-07-21T00:00:00Z"^^xsd:dateTime ;
   triage:reviewedBy "qa-triage", "quality-mgr" ;
-  triage:notes "Post-merge audit finding. CRITICAL: dispatchReady=false because this requires explicit scope decision (move host check vs correct contract). Scope: crates/atm-daemon/src/runtime_health.rs + sprint-ai-7.md + crates/atm-architecture/tests/boundary_enforcement.rs. This finding SUPERSEDES AI7-BLOCKING-02-POSTWRITEROUTER-ROUTING: prior finding acknowledged no-op PostWriteRouter but incorrectly characterized it as 'correctly deferred' when it is structurally incompatible with the written contract and should have been marked OPEN. Option A (preferred per contract): move request.to...host.is_some() check from route_write into PostWriteRouter::dispatch, making PostWriteRouter the single host-routing decision point. Option B: update sprint-ai-7.md contract lines 40-41 to document that route_write makes the local/remote decision, and PostWriteRouter is only for local-nudge handling. Either option requires updating boundary_enforcement.rs to match the chosen contract. BLOCKING: cannot dispatch fixes before scope decision is made. STALE-POINTER FIX (2026-07-22 sweep): promoteTo/highestOpenBranch previously targeted feature/pAI-s11-post-merge-remediation, which merged (PR #607); re-verified against current integrate/phase-AI and confirmed route_write still makes the host-branch decision at runtime_health.rs before calling MessageWriter::write, and PostWriteRouter::dispatch remains the same no-op (debug_assert + let _ = message; Ok(())). Finding remains genuinely open and was redirected to the current highest open branch, feature/pAI-s20-hermes-bridge-deployment." .
+  triage:notes "Post-merge audit finding. The historical route_write host-check, dispatch_remote_write path, and no-op router were superseded by the current write-then-delegate implementation. Citation-only closure verified against integrate/phase-AI: runtime_health.rs:558-566 delegates and runtime_health/peer_delivery_router.rs:14-53 is the sole host-routing/delivery point. No remediation dispatch is required for this record." .
 
 <urn:atm:triage:occurrence/AI11-BLOCKING-03/pAI-11/1>
   a triage:Occurrence ;
@@ -32,7 +34,7 @@
   triage:snippet "fn route_write(&self, request: WriteRequest) -> Result<ResponseEnvelope, AtmError> { if request.to.as_ref().is_some_and(|address| address.host.is_some()) { return self.dispatch_remote_write(request); }" ;
   triage:status "fixed" ;
   triage:closed true ;
-  triage:closureNote "quality-mgr: verified against integrate/phase-AI head — code refactored away. dispatch_remote_write function eliminated. route_write (runtime_health.rs line 539) now calls MessageWriter::write, then conditionally calls PostWriteRouter::dispatch. No host-check in route_write; routing decision moved to PostWriteRouter::dispatch (post_write_router.rs line 14-92). Contract now enforced: PostWriteRouter is sole host-routing point. (2026-07-26)" ;
+  triage:closureNote "quality-mgr: verified against integrate/phase-AI head -- runtime_health.rs:558-566 writes and delegates; the sole host-routing/delivery point is runtime_health/peer_delivery_router.rs:14-53. (2026-07-27)" ;
   triage:branch "integrate/phase-AI" ;
   triage:headSha "8d0ccf01" ;
   triage:occursIn <urn:atm:triage:worktree/pAI-integrate/8d0ccf01> .
@@ -44,7 +46,7 @@
   triage:snippet "fn dispatch_remote_write(&self, request: WriteRequest) -> Result<ResponseEnvelope, AtmError> { ... transport.deliver(request, &peer, HttpsRequestDeadline::default()) }" ;
   triage:status "fixed" ;
   triage:closed true ;
-  triage:closureNote "quality-mgr: verified against integrate/phase-AI head — dispatch_remote_write function removed. All peer delivery now goes through PostWriteRouter::dispatch (post_write_router.rs line 14). Contract violation fixed: PostWriteRouter is now the sole peer delivery routing point. (2026-07-26)" ;
+  triage:closureNote "quality-mgr: verified against integrate/phase-AI head -- runtime_health.rs:558-566 performs the write/delegation and runtime_health/peer_delivery_router.rs:14-53 is the sole host-routing/delivery point; no separate dispatch_remote_write path remains. (2026-07-27)" ;
   triage:branch "integrate/phase-AI" ;
   triage:headSha "8d0ccf01" ;
   triage:occursIn <urn:atm:triage:worktree/pAI-integrate/8d0ccf01> .
@@ -56,7 +58,7 @@
   triage:snippet "impl PostWriteRouter for DaemonRequestDispatcher { fn dispatch(&self, request: &WriteRequest, message: &MessageRecord) -> Result<(), AtmError> { debug_assert!(...); let _ = message; Ok(()) } }" ;
   triage:status "fixed" ;
   triage:closed true ;
-  triage:closureNote "quality-mgr: verified against integrate/phase-AI head — PostWriteRouter::dispatch is no longer a no-op. Current implementation (post_write_router.rs line 14-92) performs full peer delivery routing and observability recording. Trait method signature changed; now receives deadline parameter and performs actual routing work. Contract violation fixed. (2026-07-26)" ;
+  triage:closureNote "quality-mgr: verified against integrate/phase-AI head -- runtime_health/peer_delivery_router.rs:14-53 performs the host-routing/delivery work and observability recording after runtime_health.rs:558-566 delegates. (2026-07-27)" ;
   triage:branch "integrate/phase-AI" ;
   triage:headSha "8d0ccf01" ;
   triage:occursIn <urn:atm:triage:worktree/pAI-integrate/8d0ccf01> .

--- a/.triage/phase-AI/findings/AI12-QA1-BLOCKING-02.ttl
+++ b/.triage/phase-AI/findings/AI12-QA1-BLOCKING-02.ttl
@@ -15,6 +15,9 @@
   triage:repeatable true ;
   triage:sweepScope "crates/atm-core/src/send/mod.rs and crates/atm-daemon/src/runtime_health.rs for any nudge/hook::emit_post_send_effects call sites outside PostWriteRouter::dispatch" ;
   triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-27T00:00:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:dispatchReady false ;
   triage:triagedAt "2026-07-26T00:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI12-QA1-BLOCKING-02/s20/1> ;
@@ -28,7 +31,7 @@
   triage:snippet "prepared.emit_local_post_write_with_runtime(runtime, post_send_emitter);" ;
   triage:status "fixed" ;
   triage:closed true ;
-  triage:closureNote "quality-mgr: verified against integrate/phase-AI head -- early emit_local_post_write_with_runtime call removed from production path (line 618 now uses emit_local_post_write_for_test in test-only harness). Production emission now exclusively via PostWriteRouter::dispatch (runtime_health/post_write_router.rs:38). Stale occurrence from superseded branch feature/pAI-s20-hermes-bridge-deployment; closing to match reality. (2026-07-26)" ;
+  triage:closureNote "quality-mgr: verified against integrate/phase-AI head -- atm-core/src/send/mod.rs:243-261 exposes post-write emission, with test-only use at :632-633; production emission is exclusively runtime_health/peer_delivery_router.rs:57-73. Stale occurrence from superseded branch; closing to match current reality. (2026-07-27)" ;
   triage:branch "feature/pAI-s20-hermes-bridge-deployment" ;
   triage:headSha "34392e5c" ;
   triage:description "Early emit_local_post_write_with_runtime call in MessageWriter::write for any non-dry-run message, BEFORE router is invoked" ;
@@ -41,7 +44,7 @@
   triage:snippet "message.prepared.emit_local_post_write(&self.service_runtime, &post_send_emitter);" ;
   triage:status "fixed" ;
   triage:closed true ;
-  triage:closureNote "quality-mgr: verified against integrate/phase-AI head -- double-emit issue resolved. Early emit removed from production path; production emission now exclusively via PostWriteRouter::dispatch (runtime_health/post_write_router.rs:38) when is_peer_receipt() OR host.is_none(). Router is the single source of truth for nudge emission. Stale occurrence from superseded branch feature/pAI-s20-hermes-bridge-deployment; closing to match reality. (2026-07-26)" ;
+  triage:closureNote "quality-mgr: verified against integrate/phase-AI head -- atm-core/src/send/mod.rs:243-261 is the post-write emission surface (test-only use at :632-633); production emission is exclusively runtime_health/peer_delivery_router.rs:57-73. Router is the single source of truth for nudge emission. Stale occurrence from superseded branch; closing to match current reality. (2026-07-27)" ;
   triage:branch "feature/pAI-s20-hermes-bridge-deployment" ;
   triage:headSha "34392e5c" ;
   triage:description "Router DOES emit nudge when host is None, but this is AFTER the writer already emitted it" ;

--- a/.triage/phase-AI/findings/RSH-003.ttl
+++ b/.triage/phase-AI/findings/RSH-003.ttl
@@ -27,12 +27,12 @@
 
 <urn:atm:triage:occurrence/RSH-003/pAI-s24/1>
   a triage:Occurrence ;
-  triage:file "crates/atm-daemon/src/runtime_health.rs" ;
-  triage:line 716 ;
-  triage:snippet "let mut progress = self.peer_sync_progress.lock().map_err(...)?; ... self.reconcile_peer(...)?;" ;
+  triage:file "crates/atm-daemon/src/peer_drain_coordinator.rs" ;
+  triage:line 162 ;
+  triage:snippet "PeerDrainCoordinator acquires/releases per-host slot state before and after drain network I/O" ;
   triage:status "fixed" ;
   triage:closed true ;
-  triage:closureNote "quality-mgr: verified against integrate/phase-AI head — peer_sync (peer_sync.rs) now releases the per-peer progress lock via drop(state) at line 112 before calling reconcile_peer at line 115. Lock scope narrowed from entire network I/O to just cooldown-state read/write. (2026-07-26)" ;
+  triage:closureNote "quality-mgr: verified against integrate/phase-AI head — PeerDrainCoordinator slot acquisition/release is confined to peer_drain_coordinator.rs:162-197 and :277-345; drain network I/O runs outside the slots mutex. Regression coverage: crates/atm-daemon/src/tests/runtime_root/peer_reconciliation.rs:426-535. (2026-07-27)" ;
   triage:branch "feature/pAI-s24-host-qualified-ack-receipt" ;
   triage:headSha "c326cbe7" ;
   triage:occursIn <urn:atm:triage:worktree/pAI-s24/c326cbe7> .

--- a/docs/plans/phase-ai/readiness.md
+++ b/docs/plans/phase-ai/readiness.md
@@ -47,15 +47,17 @@ substitutes TCP reachability for message delivery.
    duplicate-ULID idempotence, unavailable-peer, and failed-ack non-mutation
    evidence in this record.
 
-## AI.14 execution record
+## AI.14 execution record (historical / superseded)
 
-AI.14 Role A preflight at `ef0e5e2b` is **BLOCKED before peer traffic**.
-The branch client issues an HTTP `POST` over local UDS, while the branch daemon
-rejects it as a retired framed-protocol request (`unsupported ATM daemon frame
-magic 0x504f5354`). `atm doctor --json` remains healthy because its request
-does not exercise the write path. The sanitized record is
-`artifacts/phase-ai/ai14/local-preflight-failure.json`.
+The AI.14 Role A preflight at `ef0e5e2b` recorded a **historical** branch-state
+failure before peer traffic: the branch client issued an HTTP `POST` over local
+UDS while that branch daemon still rejected the request as retired framed
+protocol (`unsupported ATM daemon frame magic 0x504f5354`). The sanitized record
+is `artifacts/phase-ai/ai14/local-preflight-failure.json`.
 
-This is a local transport compatibility defect, not a two-Mac result. No
-physical-peer case is claimed and AI.14 remains open until the owning prior
-transport sprint restores the compatible local HTTP path.
+That incident is superseded by the current canonical route: the daemon writes
+and delegates from `crates/atm-daemon/src/runtime_health.rs:558-577`, and
+`crates/atm-daemon/src/runtime_health/peer_delivery_router.rs:14-53` owns the
+post-write routing decision. It is not current evidence for a transport
+failure, and it does not claim physical-peer proof. The release blocker remains
+the unsatisfied two-Mac and Mac↔Windows evidence in the rows above.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -948,10 +948,15 @@ Acceptance:
   - branch: `chore/docs-restructure`
   - authoritative source: `docs/adr/INDEX.md`
 
-## 40. Phase AI — HTTP daemon and minimal cross-host transport [PLANNED]
+## 40. Phase AI — HTTP daemon and minimal cross-host transport [ACTIVE — implementation through AI.30; readiness blocked]
 
 Planning branch: `plan/phase-ai-planning`
 Integration branch: `integrate/phase-AI`
+
+Implementation is merged through AI.30. Post-AI.30 legacy-finding and
+hardening cleanup is in progress on follow-up branches. This implementation
+status does not close the phase: [`docs/plans/phase-ai/readiness.md`](./plans/phase-ai/readiness.md)
+still blocks release pending physical two-Mac and Mac↔Windows peer evidence.
 
 AI.1 (`feature/pAI-1-daemon-preag-reset`, PR #592) is the reviewed deletion
 baseline. It retains only the local-IPC singleton while deleting peer transport,
@@ -972,12 +977,30 @@ Implementation Branches:
 | `AI.5` | `complete` | `feature/pAI-s5-chat-address-identity` | chat-address identity contract aligned for HTTP daemon ingress |
 | `AI.6` | `complete` | `feature/pAI-s6-http-uds-router` | REST router and HTTP-over-UDS local daemon transport, with AI.7 write-graph waiver recorded |
 | `AI.7` | `complete` | `feature/pAI-s7-canonical-write-path` | canonical write request, single host-routing seam, and collapsed send/ack ingress |
-| `AI.8` | `in progress` | `feature/pAI-s8-crosshost-control-plane` | durable HTTPS interface, certificate, and trust configuration |
-| `AI.9` | `in progress` | `feature/pAI-s9-https-peer-transport` | peer HTTPS transport |
-| `AI.10` | `in progress` | `feature/pAI-s10-crosshost-proof-closeout` | proof matrix and closeout |
-| `AI.11` | `in progress` | `feature/pAI-s11-post-merge-remediation` | route-specific HTTP bodies and Windows loopback-TCP local transport |
+| `AI.8` | `complete` | `feature/pAI-s8-crosshost-control-plane` | durable HTTPS interface, certificate, and trust configuration |
+| `AI.9` | `complete` | `feature/pAI-s9-https-peer-transport` | peer HTTPS transport |
+| `AI.10` | `complete` | `feature/pAI-s10-crosshost-proof-closeout` | proof matrix and closeout; live physical-peer rows remain readiness blockers |
+| `AI.11` | `complete` | `feature/pAI-s11-post-merge-remediation` | route-specific HTTP bodies and Windows loopback-TCP local transport |
 | `AI.12` | `complete` | `feature/pAI-s12-post-write-router` | canonical post-write peer routing and immutable outbound persistence |
 | `AI.13` | `complete` | `feature/pAI-s13-peer-smoke-contract` | repository-owned peer-pair smoke runner and release evidence contract |
+| `AI.14` | `complete` | `feature/pAI-s14-mac-peer-smoke` | physical Mac↔Mac peer-pair proof implementation; live evidence remains blocked |
+| `AI.15` | `complete` | `feature/pAI-s15-windows-peer-smoke` | physical Mac↔Windows peer-pair proof implementation; live evidence remains blocked |
+| `AI.16` | `complete` | `feature/pAI-s16-offline-reconciliation` | durable-age-bounded canonical-message reconciliation |
+| `AI.17` | `complete` | `feature/pAI-s17-hermes-chat-identity` | ambient `ATM_CHAT_ID` identity context |
+| `AI.18` | `complete` | `feature/pAI-s18-graft-python-bindings` | PyO3/Maturin graft client/nudge binding |
+| `AI.19` | `complete` | `feature/pAI-s19-hermes-graft-integration` | typed Hermes graft bridge after canonical persistence |
+| `AI.20` | `complete` | `feature/pAI-s20-hermes-bridge-deployment` | per-profile launchd bridge deployment and runbook |
+| `AI.21` | `complete` | `feature/pAI-s21-hermes-closure` | retained Hermes end-to-end production evidence |
+| `AI.21-pre` | `complete` | `feature/pAI-s21pre-crosshost-evidence-harness` | supported peer-smoke harness and plaintext-test diagnostic profile |
+| `AI.22` | `complete` | `feature/pAI-s22-loopback-self-send-exemption` | host-qualified self-send exemption and advertised-IP proof path |
+| `AI.23` | `complete` | `feature/pAI-s23-crosshost-shared-write-path` | one shared HTTP write path and post-write router |
+| `AI.24` | `complete` | `feature/pAI-s24-host-qualified-ack-receipt` | host-qualified ACK receipt and peer nudge |
+| `AI.25` | `complete` | `feature/pAI-s25-peer-authority-resolution` | hostname/pin peer authority and live trust refresh |
+| `AI.26` | `complete` | `feature/pAI-s26-peer-write-deadline` | propagated peer-write deadline |
+| `AI.27` | `complete` | `feature/pAI-s27-peer-delivery-observability` | truthful peer delivery outcomes and terminal events |
+| `AI.28` | `complete` | `feature/pAI-s28-bounded-peer-recovery` | bounded recovery after connectivity loss |
+| `AI.29` | `complete` | `feature/pAI-s29-crosshost-smoke-rerun` | receiver-proven physical smoke implementation; live evidence remains blocked |
+| `AI.30` | `complete` | `feature/pAI-s30-semver-http-compatibility` | schema/HTTP compatibility admission and SemVer prerelease distribution |
 
 Authoritative plan: [Phase AI plan](./plans/phase-ai/plan-phase-ai.md).
 


### PR DESCRIPTION
## Summary
- Reconciled docs/project-plan.md's stale Phase AI status table (was PLANNED/AI.8-AI.11) against docs/plans/phase-ai/plan-phase-ai.md's authoritative AI.1-AI.30 sequence.
- readiness.md's `status: blocked` is preserved -- physical two-Mac / Mac-Windows cross-host evidence blocker text is intentionally kept, per user decision to defer physical-hardware evidence to a scheduled 2026-07-28 session (PR-AI-001/ATM-QA-101/ATM-QA-102, not fixed by this PR).
- Corrected stale citations on RSH-003, AI11-BLOCKING-03, AI12-QA1-BLOCKING-02 (citation-only drift, per arch-ctm's architecture-confirmation review -- underlying code already correct).
- RSH-004 intentionally NOT touched: quality-mgr already closed it directly on integrate/phase-AI as part of PR #666's QA-1. This branch should merge/forward past that commit, not conflict with it.

## Validation (Crimson-2f4c)
- All 5 touched TTL records (plus untouched RSH-004) parse via rdflib
- `git diff --check` clean
- readiness.md physical-peer blocker text verified preserved

## Triage records
- .triage/phase-AI/findings/PR-AI-002.ttl
- .triage/phase-AI/findings/RSH-003.ttl
- .triage/phase-AI/findings/AI11-BLOCKING-03-POSTWRITEROUTER-NOOP.ttl
- .triage/phase-AI/findings/AI12-QA1-BLOCKING-02.ttl

🤖 Generated with [Claude Code](https://claude.com/claude-code)