### PR TITLE
fix(phase-AI): gate SQLite writer-lock test-support internals behind cfg

### DIFF
--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -37,6 +37,7 @@ use shared_db::{SharedDb, deserialize_json};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Debug)]
 pub(crate) struct SqliteWriterLockGuard {
     connection: Connection,
@@ -115,6 +116,7 @@ impl OutboundMessageQuery for SqliteOutboundMessageQuery {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl Drop for SqliteWriterLockGuard {
     fn drop(&mut self) {
         let _ = self.connection.execute_batch("ROLLBACK;");
@@ -127,6 +129,7 @@ pub struct TestOnlySqliteWriterLockGuard {
     _guard: SqliteWriterLockGuard,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) fn hold_sqlite_writer_lock(
     path: impl AsRef<Path>,
 ) -> Result<SqliteWriterLockGuard, AtmError> {


### PR DESCRIPTION
## Summary
DEADCODE-STORAGE-001: `SqliteWriterLockGuard`, its `Drop` impl, and `hold_sqlite_writer_lock` in `crates/atm-storage-rusqlite/src/lib.rs` were private internals of a test-support-only public API, unconditionally compiled into release builds and triggering dead_code warnings. Gated behind `#[cfg(any(test, feature = "test-support"))]`, matching the already-gated wrapper `hold_sqlite_writer_lock_for_test`.

## Validation (Crimson-2f4c)
- `cargo test -p atm-storage-rusqlite --features test-support` (18/18)
- `cargo test -p agent-team-mail-core --features test-utils --test mailbox_locking` (19/19)
- `cargo check -p atm-storage-rusqlite`
- `cargo build --release --workspace`

## Triage records
- .triage/phase-AI/findings/DEADCODE-STORAGE-001.ttl

🤖 Generated with [Claude Code](https://claude.com/claude-code)