### PR TITLE
docs(phase-AI): reconcile AI27-CIREG-002/ATM-QA-103 as citation-only (no reproduction)

### DIFF
--- a/.triage/phase-AI/findings/AI27-CIREG-002.ttl
+++ b/.triage/phase-AI/findings/AI27-CIREG-002.ttl
@@ -15,9 +15,12 @@
   triage:severity "Blocking" ;
   triage:repeatable true ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
-  triage:dispatchReady true ;
-  triage:closureNote "PARTIAL: arch-ctm self-reported fix at 003d7e04 + 737ac7ea. Independently re-verified against feature/pAI-s28-bounded-peer-recovery current head c0445b1a: PeerDeliveryEvent's candidate_count/next_attempt_at fields are now initialized at every construction site (peer_delivery_observability.rs, incl. the previously-missing test-construction site). crates/atm-storage/Cargo.toml's atm-error path-dependency pin (1.3.2-beta.28) now matches the workspace version (Cargo.toml line 24) and Cargo.lock. gh pr checks 634: 8/8 green including windows-latest Clippy and Just-lint at c0445b1a, confirming the CI regression is genuinely resolved on s28, not just locally patched. Finding remains OPEN overall: s30 (PR #623) was not re-checked in this pass -- occurrences s30-1/s30-2 remain open pending independent verification on that branch, and this Finding's highestOpenBranch is s30." ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-27T00:00:00Z"^^xsd:dateTime ;
+  triage:closedBy "arch-ctm" ;
+  triage:dispatchReady false ;
+  triage:closureNote "Not reproducible on integrate/phase-AI@b0510a3e. PR #623 (merge a6342ba9) forward-merged AI.30; commits 003d7e04 and 737ac7ea update every PeerDeliveryEvent construction site with candidate_count/next_attempt_at, while b422978b and the current crates/atm-storage/Cargo.toml retain the matching atm-error 1.3.2-beta-30 pin. gh pr checks 623 reports all 8 checks green, including windows-latest Just lint. Local just lint also passes 22/22. Finding-level status is now consistent with all fixed occurrences; no code change was required on this reconciliation branch." ;
   triage:triagedAt "2026-07-26T21:35:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-26T21:25:00Z"^^xsd:dateTime ;
@@ -27,8 +30,8 @@
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-CIREG-002/s30-2> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s28/ab9e409f> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s30/9a4eda4e> ;
-  triage:promoteTo <urn:atm:triage:worktree/pAI-s30/9a4eda4e> ;
-  triage:highestOpenBranch "feature/pAI-s30-semver-http-compatibility" .
+  triage:highestOpenBranch "none" ;
+  triage:highestFixedBranch "integrate/phase-AI" .
 
 <urn:atm:triage:occurrence/AI27-CIREG-002/s28-1>
   a triage:Occurrence ;
@@ -59,11 +62,11 @@
   triage:file "crates/atm-daemon/src/peer_delivery_observability.rs" ;
   triage:line 0 ;
   triage:snippet "clippy error[E0063]: missing fields `candidate_count` and `next_attempt_at` in initializer of `peer_delivery_observability::PeerDeliveryEvent` (lib test build)" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAI-s30-semver-http-compatibility" ;
   triage:headSha "9a4eda4e" ;
-  triage:note "PR #623, gh api job 89843157264 log: identical clippy failure to s28, same PeerDeliveryEvent field-shape drift." ;
+  triage:note "Resolved before current integrate/phase-AI: PR #623 merge a6342ba9 plus 003d7e04/737ac7ea populate candidate_count/next_attempt_at at all construction sites. gh pr checks 623 windows-latest Just lint passed." ;
   triage:occursIn <urn:atm:triage:worktree/pAI-s30/9a4eda4e> .
 
 <urn:atm:triage:occurrence/AI27-CIREG-002/s30-2>
@@ -71,11 +74,11 @@
   triage:file "crates/atm-storage/Cargo.toml" ;
   triage:line 0 ;
   triage:snippet "internal path dependency version must match target crate version \"1.3.2-beta-30\" (atm-error)" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAI-s30-semver-http-compatibility" ;
   triage:headSha "9a4eda4e" ;
-  triage:note "PR #623, gh api job 89843157264 log: same stale atm-error path-dependency version-pin pattern as s28." ;
+  triage:note "Resolved before current integrate/phase-AI: PR #623 merge a6342ba9 and b422978b retain atm-error 1.3.2-beta-30 in crates/atm-storage/Cargo.toml, matching the workspace. gh pr checks 623 windows-latest Just lint passed." ;
   triage:occursIn <urn:atm:triage:worktree/pAI-s30/9a4eda4e> .
 
 <urn:atm:triage:worktree/pAI-s28/ab9e409f>

--- a/.triage/phase-AI/findings/AI27-CIREG-002.ttl
+++ b/.triage/phase-AI/findings/AI27-CIREG-002.ttl
@@ -15,12 +15,9 @@
   triage:severity "Blocking" ;
   triage:repeatable true ;
   triage:sweepScope "file_only" ;
-  triage:status "fixed" ;
-  triage:closed true ;
-  triage:closedAt "2026-07-27T00:00:00Z"^^xsd:dateTime ;
-  triage:closedBy "arch-ctm" ;
-  triage:dispatchReady false ;
-  triage:closureNote "Not reproducible on integrate/phase-AI@b0510a3e. PR #623 (merge a6342ba9) forward-merged AI.30; commits 003d7e04 and 737ac7ea update every PeerDeliveryEvent construction site with candidate_count/next_attempt_at, while b422978b and the current crates/atm-storage/Cargo.toml retain the matching atm-error 1.3.2-beta-30 pin. gh pr checks 623 reports all 8 checks green, including windows-latest Just lint. Local just lint also passes 22/22. Finding-level status is now consistent with all fixed occurrences; no code change was required on this reconciliation branch." ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:closureNote "PARTIAL: arch-ctm self-reported fix at 003d7e04 + 737ac7ea. Independently re-verified against feature/pAI-s28-bounded-peer-recovery current head c0445b1a: PeerDeliveryEvent's candidate_count/next_attempt_at fields are now initialized at every construction site (peer_delivery_observability.rs, incl. the previously-missing test-construction site). crates/atm-storage/Cargo.toml's atm-error path-dependency pin (1.3.2-beta.28) now matches the workspace version (Cargo.toml line 24) and Cargo.lock. gh pr checks 634: 8/8 green including windows-latest Clippy and Just-lint at c0445b1a, confirming the CI regression is genuinely resolved on s28, not just locally patched. Finding remains OPEN overall: s30 (PR #623) was not re-checked in this pass -- occurrences s30-1/s30-2 remain open pending independent verification on that branch, and this Finding's highestOpenBranch is s30." ;
   triage:triagedAt "2026-07-26T21:35:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-S7 ;
   triage:foundAt "2026-07-26T21:25:00Z"^^xsd:dateTime ;
@@ -30,8 +27,8 @@
   triage:hasOccurrence <urn:atm:triage:occurrence/AI27-CIREG-002/s30-2> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s28/ab9e409f> ;
   triage:openOn <urn:atm:triage:worktree/pAI-s30/9a4eda4e> ;
-  triage:highestOpenBranch "none" ;
-  triage:highestFixedBranch "integrate/phase-AI" .
+  triage:promoteTo <urn:atm:triage:worktree/pAI-s30/9a4eda4e> ;
+  triage:highestOpenBranch "feature/pAI-s30-semver-http-compatibility" .
 
 <urn:atm:triage:occurrence/AI27-CIREG-002/s28-1>
   a triage:Occurrence ;
@@ -62,11 +59,11 @@
   triage:file "crates/atm-daemon/src/peer_delivery_observability.rs" ;
   triage:line 0 ;
   triage:snippet "clippy error[E0063]: missing fields `candidate_count` and `next_attempt_at` in initializer of `peer_delivery_observability::PeerDeliveryEvent` (lib test build)" ;
-  triage:status "fixed" ;
-  triage:closed true ;
+  triage:status "open" ;
+  triage:closed false ;
   triage:branch "feature/pAI-s30-semver-http-compatibility" ;
   triage:headSha "9a4eda4e" ;
-  triage:note "Resolved before current integrate/phase-AI: PR #623 merge a6342ba9 plus 003d7e04/737ac7ea populate candidate_count/next_attempt_at at all construction sites. gh pr checks 623 windows-latest Just lint passed." ;
+  triage:note "PR #623, gh api job 89843157264 log: identical clippy failure to s28, same PeerDeliveryEvent field-shape drift." ;
   triage:occursIn <urn:atm:triage:worktree/pAI-s30/9a4eda4e> .
 
 <urn:atm:triage:occurrence/AI27-CIREG-002/s30-2>
@@ -74,11 +71,11 @@
   triage:file "crates/atm-storage/Cargo.toml" ;
   triage:line 0 ;
   triage:snippet "internal path dependency version must match target crate version \"1.3.2-beta-30\" (atm-error)" ;
-  triage:status "fixed" ;
-  triage:closed true ;
+  triage:status "open" ;
+  triage:closed false ;
   triage:branch "feature/pAI-s30-semver-http-compatibility" ;
   triage:headSha "9a4eda4e" ;
-  triage:note "Resolved before current integrate/phase-AI: PR #623 merge a6342ba9 and b422978b retain atm-error 1.3.2-beta-30 in crates/atm-storage/Cargo.toml, matching the workspace. gh pr checks 623 windows-latest Just lint passed." ;
+  triage:note "PR #623, gh api job 89843157264 log: same stale atm-error path-dependency version-pin pattern as s28." ;
   triage:occursIn <urn:atm:triage:worktree/pAI-s30/9a4eda4e> .
 
 <urn:atm:triage:worktree/pAI-s28/ab9e409f>
@@ -94,3 +91,31 @@
   triage:path "feature/pAI-s30-semver-http-compatibility" ;
   triage:headSha "9a4eda4e" ;
   triage:orderIndex 30 .
+
+# Append-only reconciliation closure. The original finding and open s30
+# occurrences above remain the historical record; these later blocks are the
+# authoritative last-block-wins state after independent current-tip and CI
+# verification.
+<urn:atm:triage:finding/AI27-CIREG-002>
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-27T06:40:00Z"^^xsd:dateTime ;
+  triage:closedBy "arch-ctm" ;
+  triage:dispatchReady false ;
+  triage:closureNote "Verified on integrate/phase-AI@b0510a3e: commits 003d7e04 and 737ac7ea initialize candidate_count and next_attempt_at at every PeerDeliveryEvent construction site; b422978b retains the matching atm-error 1.3.2-beta-30 path-dependency pin. PR #623 was merged and its 8/8 checks, including windows-latest Just lint, passed. Local just lint passes 22/22. No production-code change is required by this reconciliation." ;
+  triage:highestOpenBranch "none" ;
+  triage:highestFixedBranch "integrate/phase-AI" .
+
+<urn:atm:triage:occurrence/AI27-CIREG-002/s30-1>
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-27T06:40:00Z"^^xsd:dateTime ;
+  triage:closedBy "arch-ctm" ;
+  triage:note "Closed by independent current-tip inspection: PR #623 merge a6342ba9 plus 003d7e04/737ac7ea populate candidate_count and next_attempt_at at all construction sites; PR #623 windows-latest Just lint passed." .
+
+<urn:atm:triage:occurrence/AI27-CIREG-002/s30-2>
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-27T06:40:00Z"^^xsd:dateTime ;
+  triage:closedBy "arch-ctm" ;
+  triage:note "Closed by independent current-tip inspection: PR #623 merge a6342ba9 and b422978b retain atm-error 1.3.2-beta-30 in crates/atm-storage/Cargo.toml, matching the workspace; PR #623 windows-latest Just lint passed." .

--- a/.triage/phase-AI/findings/ATM-QA-103.ttl
+++ b/.triage/phase-AI/findings/ATM-QA-103.ttl
@@ -15,12 +15,8 @@
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "fixed" ;
-  triage:closed true ;
-  triage:closedAt "2026-07-27T00:00:00Z"^^xsd:dateTime ;
-  triage:closedBy "arch-ctm" ;
-  triage:dispatchReady false ;
-  triage:closureNote "Resolved in AI27-CIREG-002 reconciliation: finding-level status now matches all fixed occurrences after independent current-tip and CI verification. No code change was required." ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
   triage:triagedAt "2026-07-27T05:35:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-PHASE-END-QA-1 ;
   triage:foundAt "2026-07-27T05:30:00Z"^^xsd:dateTime ;
@@ -32,9 +28,8 @@
   triage:file ".triage/phase-AI/findings/AI27-CIREG-002.ttl" ;
   triage:line 18 ;
   triage:snippet "finding-level status open at line 18 and 74, contradicting occurrence-level fixed markers" ;
-  triage:status "fixed" ;
-  triage:closed true ;
-  triage:closureNote "AI27-CIREG-002 finding-level status was reconciled to fixed after current-tip source inspection, local just lint, and green PR #623 Windows Just lint." ;
+  triage:status "open" ;
+  triage:closed false ;
   triage:branch "integrate/phase-AI" ;
   triage:headSha "1ea59d89" ;
   triage:occursIn <urn:atm:triage:worktree/integrate_phase_ai_1ea59d89> .
@@ -45,3 +40,20 @@
   triage:branch "integrate/phase-AI" ;
   triage:headSha "1ea59d89" ;
   triage:orderIndex 999 .
+
+# Append-only reconciliation closure. The preceding open blocks preserve the
+# audit trail; this later block is the authoritative last-block-wins state.
+<urn:atm:triage:finding/ATM-QA-103>
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-27T06:40:00Z"^^xsd:dateTime ;
+  triage:closedBy "arch-ctm" ;
+  triage:dispatchReady false ;
+  triage:closureNote "Resolved by the append-only AI27-CIREG-002 reconciliation: current-tip source inspection, local just lint, and PR #623's green Windows Just lint establish that the finding-level status and all recorded occurrences are fixed. No code change is required." .
+
+<urn:atm:triage:occurrence/ATM-QA-103/1>
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-27T06:40:00Z"^^xsd:dateTime ;
+  triage:closedBy "arch-ctm" ;
+  triage:closureNote "Closed by the append-only AI27-CIREG-002 reconciliation after current-tip source inspection, local just lint, and PR #623's green Windows Just lint." .

--- a/.triage/phase-AI/findings/ATM-QA-103.ttl
+++ b/.triage/phase-AI/findings/ATM-QA-103.ttl
@@ -15,8 +15,12 @@
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
-  triage:dispatchReady true ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-27T00:00:00Z"^^xsd:dateTime ;
+  triage:closedBy "arch-ctm" ;
+  triage:dispatchReady false ;
+  triage:closureNote "Resolved in AI27-CIREG-002 reconciliation: finding-level status now matches all fixed occurrences after independent current-tip and CI verification. No code change was required." ;
   triage:triagedAt "2026-07-27T05:35:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AICH-PHASE-END-QA-1 ;
   triage:foundAt "2026-07-27T05:30:00Z"^^xsd:dateTime ;
@@ -28,8 +32,9 @@
   triage:file ".triage/phase-AI/findings/AI27-CIREG-002.ttl" ;
   triage:line 18 ;
   triage:snippet "finding-level status open at line 18 and 74, contradicting occurrence-level fixed markers" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closureNote "AI27-CIREG-002 finding-level status was reconciled to fixed after current-tip source inspection, local just lint, and green PR #623 Windows Just lint." ;
   triage:branch "integrate/phase-AI" ;
   triage:headSha "1ea59d89" ;
   triage:occursIn <urn:atm:triage:worktree/integrate_phase_ai_1ea59d89> .


### PR DESCRIPTION
## Summary
AI27-CIREG-002 (Windows just-lint red: PeerDeliveryEvent field-shape drift + atm-error version-pin mismatch) and ATM-QA-103 (contradictory finding-level "open" status despite fixed occurrences) do not reproduce against the current integrate/phase-AI tip: all PeerDeliveryEvent fields and the atm-error 1.3.2-beta-30 pin are present; PR #623 has 8/8 green checks including Windows Just lint; local `just lint` is 22/22. Both findings closed/reconciled at the TTL level; no code change was needed.

## Validation (Crimson-2f4c)
- Both TTL records parse as Turtle
- Source inspection: no missing PeerDeliveryEvent fields, atm-error pin matches
- `just lint` local: 22/22
- PR #623 `gh pr checks`: 8/8 green, including windows-latest Just lint

## Triage records
- .triage/phase-AI/findings/AI27-CIREG-002.ttl
- .triage/phase-AI/findings/ATM-QA-103.ttl

🤖 Generated with [Claude Code](https://claude.com/claude-code)