### PR TITLE
feat(cli): add atm teams remove-member subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- add `atm teams remove-member` for authorized local roster removal
 - `DAEMON-PREAG-RESET-1`: reset the daemon to a local-IPC-only singleton by
   deleting the entire cross-host/peer-transport subsystem (`peer_transport`,
   `claude_compat`, `boundary_adapters`, `direct_boundaries`, the

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -1132,6 +1132,61 @@ mod tests {
     }
 
     #[test]
+    fn remove_member_allows_self_removal() {
+        let roster_store = RecordingRosterStore::default();
+        roster_store.seed_team(
+            TEST_TEAM,
+            vec![
+                roster_member(TEST_TEAM, TEST_SENDER),
+                roster_member(TEST_TEAM, TEST_RECIPIENT),
+            ],
+        );
+
+        remove_member_with_roster_store(
+            &roster_store,
+            RemoveMemberRequest::new(
+                TEST_SENDER.parse().expect("caller"),
+                TEST_TEAM.parse().expect("caller team"),
+                TEST_TEAM,
+                TEST_SENDER,
+            )
+            .expect("request"),
+        )
+        .expect("self removal");
+
+        let roster = roster_store
+            .load_roster(&TEST_TEAM.parse().expect("team"))
+            .expect("load roster");
+        assert_eq!(roster.len(), 1);
+        assert_eq!(roster[0].agent_name.as_str(), TEST_RECIPIENT);
+    }
+
+    #[test]
+    fn remove_member_allows_removing_last_member() {
+        let roster_store = RecordingRosterStore::default();
+        roster_store.seed_team(TEST_TEAM, vec![roster_member(TEST_TEAM, TEST_SENDER)]);
+
+        remove_member_with_roster_store(
+            &roster_store,
+            RemoveMemberRequest::new(
+                TEST_SENDER.parse().expect("caller"),
+                TEST_TEAM.parse().expect("caller team"),
+                TEST_TEAM,
+                TEST_SENDER,
+            )
+            .expect("request"),
+        )
+        .expect("last-member removal");
+
+        assert!(
+            roster_store
+                .load_roster(&TEST_TEAM.parse().expect("team"))
+                .expect("load roster")
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn remove_member_rejects_missing_member_without_mutation() {
         let roster_store = RecordingRosterStore::default();
         let initial = vec![roster_member(TEST_TEAM, TEST_SENDER)];
@@ -1178,6 +1233,34 @@ mod tests {
 
         assert_eq!(error.code(), AtmErrorCode::MessageValidationFailed);
         assert!(error.message().contains("caller team"));
+        assert_eq!(
+            roster_store
+                .load_roster(&TEST_TEAM.parse().expect("team"))
+                .expect("load roster"),
+            initial
+        );
+    }
+
+    #[test]
+    fn remove_member_rejects_same_team_missing_caller_before_mutation() {
+        let roster_store = RecordingRosterStore::default();
+        let initial = vec![roster_member(TEST_TEAM, TEST_RECIPIENT)];
+        roster_store.seed_team(TEST_TEAM, initial.clone());
+
+        let error = remove_member_with_roster_store(
+            &roster_store,
+            RemoveMemberRequest::new(
+                TEST_SENDER.parse().expect("caller"),
+                TEST_TEAM.parse().expect("caller team"),
+                TEST_TEAM,
+                TEST_RECIPIENT,
+            )
+            .expect("request"),
+        )
+        .expect_err("missing caller");
+
+        assert_eq!(error.code(), AtmErrorCode::MemberNotFound);
+        assert!(error.message().contains(TEST_SENDER));
         assert_eq!(
             roster_store
                 .load_roster(&TEST_TEAM.parse().expect("team"))

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -26,8 +26,9 @@ mod projection;
 mod restore;
 
 pub use member_mutation::{
-    AddMemberOutcome, AddMemberRequest, MemberName, UpdateMemberOutcome, UpdateMemberRequest,
-    add_member_with_roster_store, update_member_with_roster_store,
+    AddMemberOutcome, AddMemberRequest, MemberName, RemoveMemberOutcome, RemoveMemberRequest,
+    UpdateMemberOutcome, UpdateMemberRequest, add_member_with_roster_store,
+    remove_member_with_roster_store, update_member_with_roster_store,
 };
 
 /// One discovered team and its current member count.
@@ -452,11 +453,12 @@ mod tests {
 
     use super::{
         AddMemberRequest, BackupRequest, ClearNudgeTemplateOverrideRequest,
-        DisableNudgeTemplateOverrideRequest, MemberName, MembersQuery, RestoreRequest,
-        SetNudgeTemplateOverrideRequest, UpdateMemberRequest, add_member_with_roster_store,
-        backup_team_with_roster_store, clear_nudge_template_override_with_store,
-        disable_nudge_template_override_with_store, list_members_with_roster_store,
-        list_teams_with_roster_store, set_nudge_template_override_with_store,
+        DisableNudgeTemplateOverrideRequest, MemberName, MembersQuery, RemoveMemberRequest,
+        RestoreRequest, SetNudgeTemplateOverrideRequest, UpdateMemberRequest,
+        add_member_with_roster_store, backup_team_with_roster_store,
+        clear_nudge_template_override_with_store, disable_nudge_template_override_with_store,
+        list_members_with_roster_store, list_teams_with_roster_store,
+        remove_member_with_roster_store, set_nudge_template_override_with_store,
         update_member_with_roster_store,
     };
     use crate::boundary::{
@@ -1089,6 +1091,99 @@ mod tests {
         .expect_err("missing member");
 
         assert_eq!(error.code(), AtmErrorCode::MemberNotFound);
+    }
+
+    #[test]
+    fn remove_member_removes_exact_roster_entry() {
+        let roster_store = RecordingRosterStore::default();
+        roster_store.seed_team(
+            TEST_TEAM,
+            vec![
+                roster_member(TEST_TEAM, ROLE_TEAM_LEAD),
+                roster_member(TEST_TEAM, TEST_SENDER),
+                roster_member(TEST_TEAM, TEST_RECIPIENT),
+            ],
+        );
+
+        let outcome = remove_member_with_roster_store(
+            &roster_store,
+            RemoveMemberRequest::new(
+                TEST_SENDER.parse().expect("caller"),
+                TEST_TEAM.parse().expect("caller team"),
+                TEST_TEAM,
+                TEST_RECIPIENT,
+            )
+            .expect("request"),
+        )
+        .expect("remove member");
+
+        assert_eq!(outcome.action, "remove-member");
+        assert_eq!(outcome.member.as_str(), TEST_RECIPIENT);
+        let roster = roster_store
+            .load_roster(&TEST_TEAM.parse().expect("team"))
+            .expect("load roster");
+        assert_eq!(
+            roster
+                .iter()
+                .map(|member| member.agent_name.as_str())
+                .collect::<Vec<_>>(),
+            vec![ROLE_TEAM_LEAD, TEST_SENDER]
+        );
+    }
+
+    #[test]
+    fn remove_member_rejects_missing_member_without_mutation() {
+        let roster_store = RecordingRosterStore::default();
+        let initial = vec![roster_member(TEST_TEAM, TEST_SENDER)];
+        roster_store.seed_team(TEST_TEAM, initial.clone());
+
+        let error = remove_member_with_roster_store(
+            &roster_store,
+            RemoveMemberRequest::new(
+                TEST_SENDER.parse().expect("caller"),
+                TEST_TEAM.parse().expect("caller team"),
+                TEST_TEAM,
+                TEST_RECIPIENT,
+            )
+            .expect("request"),
+        )
+        .expect_err("missing member");
+
+        assert_eq!(error.code(), AtmErrorCode::MemberNotFound);
+        assert_eq!(
+            roster_store
+                .load_roster(&TEST_TEAM.parse().expect("team"))
+                .expect("load roster"),
+            initial
+        );
+    }
+
+    #[test]
+    fn remove_member_rejects_cross_team_caller_before_mutation() {
+        let roster_store = RecordingRosterStore::default();
+        let initial = vec![roster_member(TEST_TEAM, TEST_SENDER)];
+        roster_store.seed_team(TEST_TEAM, initial.clone());
+
+        let error = remove_member_with_roster_store(
+            &roster_store,
+            RemoveMemberRequest::new(
+                TEST_SENDER.parse().expect("caller"),
+                "other-team".parse().expect("caller team"),
+                TEST_TEAM,
+                TEST_SENDER,
+            )
+            .expect("request"),
+        )
+        .expect_err("cross-team caller");
+
+        assert_eq!(error.code(), AtmErrorCode::MessageValidationFailed);
+        assert!(error.message().contains("caller team"));
+        assert_eq!(
+            roster_store
+                .load_roster(&TEST_TEAM.parse().expect("team"))
+                .expect("load roster"),
+            initial
+        );
     }
 
     #[test]

--- a/crates/atm-core/src/team_admin/member_mutation.rs
+++ b/crates/atm-core/src/team_admin/member_mutation.rs
@@ -211,6 +211,12 @@ pub fn update_member_with_roster_store(
 }
 
 /// Remove one member record from a team roster.
+///
+/// # Errors
+///
+/// Returns [`AtmError`] when the caller does not belong to the target team,
+/// the target team or member is missing, or loading/persisting the roster
+/// fails. It never removes inbox data.
 pub fn remove_member_with_roster_store(
     roster_store: &(dyn RosterStore + Send + Sync),
     request: RemoveMemberRequest,
@@ -260,22 +266,13 @@ fn validate_update_member_caller(
     roster_store: &dyn RosterStore,
     request: &UpdateMemberRequest,
 ) -> Result<(), AtmError> {
-    if request.caller_team != request.team {
-        return Err(AtmError::validation(format!(
-            "caller team '{}' does not match update-member target team '{}'",
-            request.caller_team, request.team
-        )));
-    }
-
-    let caller_entry = roster_store.query_membership(&request.team, &request.caller_identity)?;
-    if caller_entry.is_none() {
-        return Err(AtmError::member_not_found(
-            request.caller_identity.as_str(),
-            request.team.as_str(),
-        ));
-    }
-
-    Ok(())
+    validate_member_mutation_caller(
+        roster_store,
+        &request.caller_identity,
+        &request.caller_team,
+        &request.team,
+        "update-member",
+    )
 }
 
 fn ensure_member_present(
@@ -296,18 +293,38 @@ fn validate_remove_member_caller(
     roster_store: &dyn RosterStore,
     request: &RemoveMemberRequest,
 ) -> Result<(), AtmError> {
-    if request.caller_team != request.team {
+    validate_member_mutation_caller(
+        roster_store,
+        &request.caller_identity,
+        &request.caller_team,
+        &request.team,
+        "remove-member",
+    )
+}
+
+/// Require a caller from the team that the mutation targets.
+///
+/// Keeping this in one helper makes `update-member` and `remove-member`
+/// enforce the same membership gate while retaining action-specific errors.
+fn validate_member_mutation_caller(
+    roster_store: &dyn RosterStore,
+    caller_identity: &AgentName,
+    caller_team: &TeamName,
+    target_team: &TeamName,
+    action: &str,
+) -> Result<(), AtmError> {
+    if caller_team != target_team {
         return Err(AtmError::validation(format!(
-            "caller team '{}' does not match remove-member target team '{}'",
-            request.caller_team, request.team
+            "caller team '{}' does not match {action} target team '{target_team}'",
+            caller_team,
         )));
     }
 
-    let caller_entry = roster_store.query_membership(&request.team, &request.caller_identity)?;
+    let caller_entry = roster_store.query_membership(target_team, caller_identity)?;
     if caller_entry.is_none() {
         return Err(AtmError::member_not_found(
-            request.caller_identity.as_str(),
-            request.team.as_str(),
+            caller_identity.as_str(),
+            target_team.as_str(),
         ));
     }
 

--- a/crates/atm-core/src/team_admin/member_mutation.rs
+++ b/crates/atm-core/src/team_admin/member_mutation.rs
@@ -111,6 +111,42 @@ pub struct UpdateMemberOutcome {
     pub member: AgentName,
 }
 
+/// Parameters for removing one member from a team roster.
+///
+/// Removal is authorized using the caller identity and team, matching the
+/// authorization contract of `update-member`.
+#[derive(Debug, Clone)]
+pub struct RemoveMemberRequest {
+    pub caller_identity: AgentName,
+    pub caller_team: TeamName,
+    pub team: TeamName,
+    pub member: AgentName,
+}
+
+impl RemoveMemberRequest {
+    pub fn new(
+        caller_identity: AgentName,
+        caller_team: TeamName,
+        team: &str,
+        member: &str,
+    ) -> Result<Self, AtmError> {
+        Ok(Self {
+            caller_identity,
+            caller_team,
+            team: team.parse()?,
+            member: member.parse()?,
+        })
+    }
+}
+
+/// Result of removing one member from a team roster.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RemoveMemberOutcome {
+    pub action: &'static str,
+    pub team: TeamName,
+    pub member: AgentName,
+}
+
 struct MemberAddContext {
     existing_roster: Vec<RosterEntry>,
 }
@@ -174,6 +210,24 @@ pub fn update_member_with_roster_store(
     })
 }
 
+/// Remove one member record from a team roster.
+pub fn remove_member_with_roster_store(
+    roster_store: &(dyn RosterStore + Send + Sync),
+    request: RemoveMemberRequest,
+) -> Result<RemoveMemberOutcome, AtmError> {
+    validate_remove_member_caller(roster_store, &request)?;
+    let mut existing_roster = projection::load_team_roster(roster_store, &request.team)?;
+    ensure_member_present(&existing_roster, &request.team, &request.member)?;
+    existing_roster.retain(|entry| entry.agent_name != request.member);
+    roster_store.replace_roster(&request.team, &existing_roster)?;
+
+    Ok(RemoveMemberOutcome {
+        action: "remove-member",
+        team: request.team,
+        member: request.member,
+    })
+}
+
 pub(crate) const MAX_MEMBER_METADATA_FIELD_LEN: usize = 256;
 
 fn load_member_add_context(
@@ -209,6 +263,42 @@ fn validate_update_member_caller(
     if request.caller_team != request.team {
         return Err(AtmError::validation(format!(
             "caller team '{}' does not match update-member target team '{}'",
+            request.caller_team, request.team
+        )));
+    }
+
+    let caller_entry = roster_store.query_membership(&request.team, &request.caller_identity)?;
+    if caller_entry.is_none() {
+        return Err(AtmError::member_not_found(
+            request.caller_identity.as_str(),
+            request.team.as_str(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn ensure_member_present(
+    existing_roster: &[RosterEntry],
+    team: &TeamName,
+    member: &AgentName,
+) -> Result<(), AtmError> {
+    if !existing_roster
+        .iter()
+        .any(|existing_member| existing_member.agent_name == *member)
+    {
+        return Err(AtmError::member_not_found(member.as_str(), team.as_str()));
+    }
+    Ok(())
+}
+
+fn validate_remove_member_caller(
+    roster_store: &dyn RosterStore,
+    request: &RemoveMemberRequest,
+) -> Result<(), AtmError> {
+    if request.caller_team != request.team {
+        return Err(AtmError::validation(format!(
+            "caller team '{}' does not match remove-member target team '{}'",
             request.caller_team, request.team
         )));
     }

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use atm_core::home;
 use atm_core::team_admin::{
     self, AddMemberRequest, BackupRequest, ClearNudgeTemplateOverrideRequest,
-    DisableNudgeTemplateOverrideRequest, RestoreRequest, RestoreResult,
+    DisableNudgeTemplateOverrideRequest, RemoveMemberRequest, RestoreRequest, RestoreResult,
     SetNudgeTemplateOverrideRequest, UpdateMemberRequest,
 };
 use atm_daemon_bootstrap::with_default_nudge_template_override_store;
@@ -36,6 +36,7 @@ pub struct TeamsCommand {
 enum TeamsSubcommand {
     AddMember(AddMemberCommand),
     UpdateMember(UpdateMemberCommand),
+    RemoveMember(RemoveMemberCommand),
     SetNudgeTemplate(SetNudgeTemplateCommand),
     DisableNudgeTemplate(DisableNudgeTemplateCommand),
     ClearNudgeTemplate(ClearNudgeTemplateCommand),
@@ -89,6 +90,15 @@ struct UpdateMemberCommand {
         help = "tmux pane id in '%<number>' form or a bare numeric pane id"
     )]
     pane_id: Option<String>,
+
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct RemoveMemberCommand {
+    team: String,
+    member: String,
 
     #[arg(long)]
     json: bool,
@@ -169,6 +179,7 @@ impl TeamsCommand {
             }
             Some(TeamsSubcommand::AddMember(command)) => command.run(home_dir),
             Some(TeamsSubcommand::UpdateMember(command)) => command.run(home_dir, caller_context),
+            Some(TeamsSubcommand::RemoveMember(command)) => command.run(caller_context),
             Some(TeamsSubcommand::SetNudgeTemplate(command)) => command.run(caller_context),
             Some(TeamsSubcommand::DisableNudgeTemplate(command)) => command.run(caller_context),
             Some(TeamsSubcommand::ClearNudgeTemplate(command)) => command.run(caller_context),
@@ -317,6 +328,27 @@ impl UpdateMemberCommand {
     }
 }
 
+impl RemoveMemberCommand {
+    fn run(self, caller_context: CallerContext) -> Result<()> {
+        let json = self.json;
+        let request = self.build_request(caller_context)?;
+        let outcome = with_retained_roster_store(|roster_store| {
+            team_admin::remove_member_with_roster_store(roster_store, request)
+        })?;
+        output::print_remove_member_result(&outcome, json)
+    }
+
+    fn build_request(self, caller_context: CallerContext) -> Result<RemoveMemberRequest> {
+        RemoveMemberRequest::new(
+            caller_context.caller_identity,
+            caller_context.caller_team,
+            &self.team,
+            &self.member,
+        )
+        .map_err(Into::into)
+    }
+}
+
 impl RestoreCommand {
     fn run(self, home_dir: PathBuf) -> Result<()> {
         let json = self.json;
@@ -353,7 +385,8 @@ mod tests {
     use super::TeamsCommand;
     use super::{
         AddMemberCommand, BackupCommand, ClearNudgeTemplateCommand, DisableNudgeTemplateCommand,
-        RestoreCommand, SetNudgeTemplateCommand, TeamsSubcommand, UpdateMemberCommand,
+        RemoveMemberCommand, RestoreCommand, SetNudgeTemplateCommand, TeamsSubcommand,
+        UpdateMemberCommand,
     };
     use crate::commands::caller_context::CallerContext;
     use crate::observability::CliObservability;
@@ -713,6 +746,52 @@ mod tests {
             Some(member_home_dir.as_path())
         );
         assert_eq!(request.tmux_pane_id.as_deref(), Some("%17"));
+    }
+
+    #[test]
+    fn remove_member_build_request_preserves_target_and_caller_context() {
+        let command = RemoveMemberCommand {
+            team: TEST_TEAM.to_string(),
+            member: TEST_SENDER.to_string(),
+            json: true,
+        };
+
+        let request = command
+            .build_request(CallerContext {
+                caller_identity: TEST_SENDER.parse().expect("caller"),
+                caller_chat_id: None,
+                caller_team: TEST_TEAM.parse().expect("team"),
+            })
+            .expect("request");
+
+        assert_eq!(request.team.as_str(), TEST_TEAM);
+        assert_eq!(request.member.as_str(), TEST_SENDER);
+        assert_eq!(request.caller_identity.as_str(), TEST_SENDER);
+        assert_eq!(request.caller_team.as_str(), TEST_TEAM);
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn remove_member_rejects_cross_team_caller() {
+        let fixture = Fixture::new();
+        let command = RemoveMemberCommand {
+            team: TEST_TEAM.to_string(),
+            member: TEST_SENDER.to_string(),
+            json: false,
+        };
+
+        fixture.with_env_and_cwd(|| {
+            let error = command
+                .run(CallerContext {
+                    caller_identity: TEST_SENDER.parse().expect("caller"),
+                    caller_chat_id: None,
+                    caller_team: "other-team".parse().expect("team"),
+                })
+                .expect_err("cross-team caller");
+            let atm_error = error.downcast_ref::<AtmError>().expect("AtmError");
+            assert_eq!(atm_error.code(), AtmErrorCode::MessageValidationFailed);
+            assert!(atm_error.message().contains("caller team"));
+        });
     }
 
     #[test]

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -13,8 +13,8 @@ use atm_core::read::ReadOutcome;
 use atm_core::send::SendOutcome;
 use atm_core::team_admin::{
     AddMemberOutcome, BackupOutcome, ClearNudgeTemplateOverrideOutcome,
-    DisableNudgeTemplateOverrideOutcome, MembersList, RestoreOutcome, RestorePlan,
-    SetNudgeTemplateOverrideOutcome, TeamsList, UpdateMemberOutcome,
+    DisableNudgeTemplateOverrideOutcome, MembersList, RemoveMemberOutcome, RestoreOutcome,
+    RestorePlan, SetNudgeTemplateOverrideOutcome, TeamsList, UpdateMemberOutcome,
 };
 
 /// Print one send result in human-readable or JSON form.
@@ -557,6 +557,16 @@ pub fn print_update_member_result(outcome: &UpdateMemberOutcome, json: bool) -> 
         println!("{}", serde_json::to_string_pretty(outcome)?);
     } else {
         println!("Updated member {} in {}", outcome.member, outcome.team);
+    }
+    Ok(())
+}
+
+/// Print one remove-member result in human-readable or JSON form.
+pub fn print_remove_member_result(outcome: &RemoveMemberOutcome, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+    } else {
+        println!("Removed member {} from {}", outcome.member, outcome.team);
     }
     Ok(())
 }

--- a/crates/atm/tests/cli_surface_baseline.json
+++ b/crates/atm/tests/cli_surface_baseline.json
@@ -2026,6 +2026,56 @@
           "args": [
             {
               "has_default": true,
+              "id": "json",
+              "long": "json",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "member",
+              "long": null,
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            },
+            {
+              "has_default": true,
+              "id": "stderr_logs",
+              "long": "stderr-logs",
+              "num_args": {
+                "max": 0,
+                "min": 0
+              },
+              "required": false,
+              "short": null
+            },
+            {
+              "has_default": false,
+              "id": "team",
+              "long": null,
+              "num_args": {
+                "max": 1,
+                "min": 1
+              },
+              "required": true,
+              "short": null
+            }
+          ],
+          "name": "remove-member",
+          "subcommands": []
+        },
+        {
+          "args": [
+            {
+              "has_default": true,
               "id": "dry_run",
               "long": "dry-run",
               "num_args": {

--- a/docs/atm/cli-reference-1-4-0-beta-ai.md
+++ b/docs/atm/cli-reference-1-4-0-beta-ai.md
@@ -1,0 +1,448 @@
+# ATM CLI Reference
+
+This document is generated from the live `clap` command tree. Do not hand-edit it — regenerate with `cargo run -p agent-team-mail --example gen_cli_docs` (see `crates/atm/src/cli_surface.rs`).
+
+## `atm`
+
+ATM CLI
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm ack`
+
+Acknowledge one pending-ack message and emit a reply when required
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<message_id>` |  | yes |  |
+| `<reply>` |  | yes |  |
+| `--team` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm api`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm api spec`
+
+Print the versioned daemon OpenAPI contract
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--format` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm clear`
+
+Clear read or acknowledged messages from a mailbox
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no |  |
+| `--older-than` |  | no |  |
+| `--idle-only` |  | no |  |
+| `--dry-run` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm doctor`
+
+Run ATM health and configuration diagnostics
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no | Override the resolved team for the doctor check. |
+| `--json` |  | no | Emit the doctor report as JSON. |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm help`
+
+Show ATM-owned conceptual help or delegated clap subcommand help
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<target>` |  | no |  |
+| `--list` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm list`
+
+List one ATM mailbox surface as bounded metadata rows
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<target>` |  | no |  |
+| `--team` |  | no |  |
+| `--all` |  | no |  |
+| `--unread` |  | no |  |
+| `--pending-ack` |  | no |  |
+| `--limit` |  | no |  |
+| `--since` |  | no |  |
+| `--from` |  | no |  |
+| `--task` |  | no |  |
+| `--contains` |  | no |  |
+| `--json` |  | no |  |
+| `--as` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm log`
+
+Query or follow ATM retained observability records
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm log filter`
+
+Query ATM log records using explicit field filters
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--level` |  | no | Restrict results to one or more severity levels |
+| `--match` |  | no | Match one structured ATM field exactly, for example command=send |
+| `--since` |  | no | Inclusive lower time bound as RFC3339 or a relative duration like 15m |
+| `--limit` |  | no | Maximum number of returned records |
+| `--json` |  | no | Emit machine-readable JSON output |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm log snapshot`
+
+Query recent ATM log records
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--level` |  | no | Restrict results to one or more severity levels |
+| `--match` |  | no | Match one structured ATM field exactly, for example command=send |
+| `--since` |  | no | Inclusive lower time bound as RFC3339 or a relative duration like 15m |
+| `--limit` |  | no | Maximum number of returned records |
+| `--json` |  | no | Emit machine-readable JSON output |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm log tail`
+
+Follow new ATM log records as they arrive
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--level` |  | no | Restrict results to one or more severity levels |
+| `--match` |  | no | Match one structured ATM field exactly, for example command=send |
+| `--since` |  | no | Inclusive lower time bound as RFC3339 or a relative duration like 15m |
+| `--limit` |  | no | Maximum number of returned records |
+| `--json` |  | no | Emit machine-readable JSON output |
+| `--poll-interval-ms` |  | no | Poll interval in milliseconds between follow polls |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm members`
+
+List the current member roster for one ATM team
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm peek`
+
+Inspect one ATM mailbox message without mutating mailbox state
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<target>` |  | no |  |
+| `--team` |  | no |  |
+| `--all` |  | no |  |
+| `--unread` |  | no |  |
+| `--unread-only` |  | no |  |
+| `--pending-ack` |  | no |  |
+| `--pending-ack-only` |  | no |  |
+| `--history` |  | no |  |
+| `--message-id` |  | no |  |
+| `--task` |  | no |  |
+| `--contains` |  | no |  |
+| `--since-last-seen` |  | no |  |
+| `--no-since-last-seen` |  | no |  |
+| `--since` |  | no |  |
+| `--from` |  | no |  |
+| `--json` |  | no |  |
+| `--timeout` |  | no |  |
+| `--as` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm peer`
+
+Manage durable cross-host HTTPS control-plane configuration
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm peer certificate`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer certificate init`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--fingerprint` |  | yes |  |
+| `--private-key-ref` |  | yes |  |
+| `--yes` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer certificate show`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm peer interface`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer interface list`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer interface remove`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--bind` |  | yes |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer interface set`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--bind` |  | yes |  |
+| `--advertise-host` |  | yes |  |
+| `--enabled` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm peer sync`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<peer>` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm peer sync-policy`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer sync-policy set`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<peer>` |  | yes |  |
+| `--max-message-age` |  | yes |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer sync-policy show`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<peer>` |  | yes |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm peer trust`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer trust add`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--host` |  | yes |  |
+| `--fingerprint` |  | yes |  |
+| `--https-port` |  | no |  |
+| `--yes` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer trust list`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer trust replace`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--host` |  | yes |  |
+| `--fingerprint` |  | yes |  |
+| `--https-port` |  | no |  |
+| `--yes` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+##### `atm peer trust revoke`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--host` |  | yes |  |
+| `--yes` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm read`
+
+Read one ATM mailbox message and optionally update read state
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | no |  |
+| `--chat-id` |  | no |  |
+| `--as` |  | no |  |
+| `--all` |  | no |  |
+| `--unread` |  | no |  |
+| `--unread-only` |  | no |  |
+| `--pending-ack` |  | no |  |
+| `--pending-ack-only` |  | no |  |
+| `--history` |  | no |  |
+| `--message-id` |  | no |  |
+| `--task` |  | no |  |
+| `--contains` |  | no |  |
+| `--since-last-seen` |  | no |  |
+| `--no-since-last-seen` |  | no |  |
+| `--since` |  | no |  |
+| `--from` |  | no |  |
+| `--json` |  | no |  |
+| `--timeout` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+### `atm send`
+
+Send one ATM mailbox message
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<to>` |  | yes |  |
+| `<message>` |  | no |  |
+| `--team` |  | no |  |
+| `--chat-id` |  | no |  |
+| `--as` |  | no |  |
+| `--file` |  | no |  |
+| `--stdin` |  | no |  |
+| `--summary` |  | no |  |
+| `--requires-ack` |  | no |  |
+| `--task-id` |  | no |  |
+| `--dry-run` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+**Notes:**
+
+Post-send hooks can be configured in .atm.toml via one or more [[atm.post_send_hooks]] rules with recipient = "name-or-*" and command = ["argv", ...]. Matching rules run after a successful non-dry-run send, in config order. Path-like command[0] values resolve relative to the declaring .atm.toml; bare executables like bash or python3 use normal PATH resolution. Recipient non-match is silent. For hook troubleshooting, combine --stderr-logs with ATM_LOG=debug to surface debug-level hook diagnostics on stderr.
+
+### `atm teams`
+
+List teams or run one team-administration subcommand
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams add-member`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `<member>` |  | yes |  |
+| `--agent-type` |  | no |  |
+| `--model` |  | no |  |
+| `--home-dir` |  | no |  |
+| `--pane-id` |  | no | tmux pane id in '%<number>' form or a bare numeric pane id |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams backup`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams clear-nudge-template`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | yes |  |
+| `--kind` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams disable-nudge-template`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | yes |  |
+| `--kind` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams remove-member`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `<member>` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams restore`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `--from` |  | no |  |
+| `--dry-run` |  | no |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams set-nudge-template`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--team` |  | yes |  |
+| `--kind` |  | yes |  |
+| `--template-body` |  | yes |  |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+#### `atm teams update-member`
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `<team>` |  | yes |  |
+| `<member>` |  | yes |  |
+| `--home-dir` |  | no |  |
+| `--harness` |  | no |  |
+| `--agent-type` |  | no |  |
+| `--model` |  | no |  |
+| `--pane-id` |  | no | tmux pane id in '%<number>' form or a bare numeric pane id |
+| `--json` |  | no |  |
+| `--stderr-logs` |  | no | Route retained observability console logs to stderr |
+
+

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2129,6 +2129,9 @@ JSON output must include:
 `update-member` JSON output must additionally include:
 - `member`
 
+`remove-member` JSON output must additionally include:
+- `member`
+
 `backup` JSON output must additionally include:
 - `backup_path`
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2029,6 +2029,7 @@ The retained `teams` surface for initial release is:
 - `atm teams`
 - `atm teams add-member`
 - `atm teams update-member`
+- `atm teams remove-member`
 - `atm teams backup`
 - `atm teams restore`
 
@@ -2037,7 +2038,6 @@ orchestration commands such as:
 - `spawn`
 - `join`
 - `resume`
-- `remove-member`
 - `cleanup`
 
 ### 12.3 Required Behavior
@@ -2073,6 +2073,14 @@ Bare `atm teams` must:
 - project the repaired metadata deterministically into compatibility
   `config.json`
 - preserve unchanged member metadata when a field is not supplied
+
+`atm teams remove-member` must:
+- require the caller identity to belong to the target team
+- validate that the target team and member exist
+- remove exactly the requested member from the canonical roster
+- allow removing the last member or the currently authenticated caller
+- leave the removed member's inbox state untouched
+- support human-readable and pretty-printed JSON output
 
 `atm teams backup` must:
 - create a timestamped snapshot under the ATM team backup area


### PR DESCRIPTION
## Summary
- Adds `atm teams remove-member` subcommand mirroring `update-member`'s caller-team authorization gate, per `docs/plans/teams-remove-member/sprint-02.md`
- Implements roster removal in `team_admin` (new `member_mutation.rs` module) with JSON and human-readable output
- Adds unit and CLI-level tests; regenerates the CLI surface baseline (`crates/atm/tests/cli_surface_baseline.json`)
- Updates `docs/requirements.md`, `CHANGELOG.md`, and adds CLI reference docs (`docs/atm/cli-reference-1-4-0-beta-ai.md`)

Plan reviewed and QA-approved by quality-mgr in a separate plan PR (#673).

## Test plan
- [x] `cargo test` (unit + CLI surface tests) covering the new subcommand
- [x] CLI surface baseline regenerated and checked in