### PR TITLE
feat(smoke): add cross-host evidence ladder

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -161,11 +161,11 @@ lint target='all':
 validate target='all':
     {{python_cmd}} scripts/validate_release.py {{target}}
 
-# Run one named smoke feature. `localhost` and `local-ip` exercise the
-# currently-running branch daemon. Cross-host stages use only public ATM CLI
-# commands over SSH against already-running peer daemons: preflight, exact
-# send/read, then the acknowledgement round trip. Fixture levels retain their
-# existing names.
+# Run one named smoke feature. `localhost` proves an ordinary self-send through
+# the advertised physical interface; `local-ip` then adds IPv4 loopback.
+# Cross-host stages use only public ATM CLI commands over SSH against
+# already-running peer daemons: preflight, exact send/read, then the
+# acknowledgement round trip. Fixture levels retain their existing names.
 smoke feature='normal' *hosts:
     {{python_cmd}} scripts/smoke/run_feature_smoke.py {{feature}} {{hosts}}
 

--- a/scripts/smoke/feature_smoke_report.py
+++ b/scripts/smoke/feature_smoke_report.py
@@ -1,0 +1,128 @@
+"""HTML rendering for progressive feature-smoke evidence."""
+from __future__ import annotations
+
+from html import escape
+import re
+from typing import Any
+
+
+def render_feature_pane(feature: str, cases: list[dict[str, Any]], host: str) -> str:
+    """Render one endpoint's local and cross-host evidence without prose."""
+    local_cases = [case for case in cases if case["origin"] == host and case["destination"] == host]
+    cross_cases = [
+        case
+        for case in cases
+        if case["origin"] != case["destination"] and host in {case["origin"], case["destination"]}
+    ]
+    peer_hosts = list(
+        dict.fromkeys(
+            endpoint
+            for case in cross_cases
+            for endpoint in (case["origin"], case["destination"])
+            if endpoint != host
+        )
+    )
+    header = render_host_header(host, local_cases)
+    local_ladder_cases = [
+        case
+        for case in local_cases
+        if case["name"] != "doctor"
+        and not case["name"].endswith("doctor/version")
+        and not case["name"].endswith("advertised host")
+    ]
+    local_section = render_case_section(f"ONE-COMPUTER TEST — {host}", local_ladder_cases)
+    cross_title = f"CROSS-HOST TEST — {host} ↔ {', '.join(peer_hosts)}" if peer_hosts else "CROSS-HOST TEST"
+    cross_section = render_cross_host_section(cross_title, [host, *peer_hosts], cases, cross_cases)
+    return f"<h1>{escape(host)} — ATM smoke: {escape(feature)}</h1>{header}{local_section}{cross_section}"
+
+
+def render_host_header(host: str, cases: list[dict[str, Any]]) -> str:
+    """Render the compact preflight facts that apply to one computer."""
+    ip_address, version, doctor_detail = host_preflight_facts(host, cases)
+    doctor_passed = doctor_detail.startswith("PASS")
+    return (
+        "<table><tbody>"
+        f"<tr><th>Advertised IP</th><td>{escape(ip_address)}</td></tr>"
+        f"<tr><th>ATM version</th><td>{escape(version)}</td></tr>"
+        f"<tr class=\"{'pass' if doctor_passed else 'fail'}\"><th>Doctor</th><td>{escape(doctor_detail)}</td></tr>"
+        "</tbody></table>"
+    )
+
+
+def host_preflight_facts(host: str, cases: list[dict[str, Any]]) -> tuple[str, str, str]:
+    """Extract one daemon's advertised IP, version, and doctor result."""
+    self_cases = [
+        case
+        for case in cases
+        if case.get("origin", host) == host and case.get("destination", host) == host
+    ]
+    doctor_cases = [case for case in self_cases if case["name"] == "doctor" or case["name"].endswith("doctor/version")]
+    doctor = doctor_cases[-1] if doctor_cases else None
+    advertised = next((case for case in reversed(self_cases) if case["name"].endswith("advertised host")), None)
+    ip_address = advertised["detail"] if advertised is not None else "unknown"
+    if doctor is None:
+        return ip_address, "unknown", "NOT RUN"
+    match = re.search(r"(?:ATM |client=)([^,;\s]+)", doctor["detail"])
+    version = match.group(1) if match is not None else "unknown"
+    doctor_passes = sum(case["status"] == "PASS" for case in doctor_cases)
+    doctor_result = (
+        f"PASS {doctor_passes}/{len(doctor_cases)}"
+        if doctor_passes == len(doctor_cases)
+        else f"FAIL {doctor_passes}/{len(doctor_cases)}: {next(case['detail'] for case in doctor_cases if case['status'] != 'PASS')}"
+    )
+    return ip_address, version, doctor_result
+
+
+def render_cross_host_section(title: str, hosts: list[str], all_cases: list[dict[str, Any]], cross_cases: list[dict[str, Any]]) -> str:
+    """Show both link endpoints before listing directional checks."""
+    preflight_rows = ""
+    for endpoint in hosts:
+        ip_address, version, doctor = host_preflight_facts(endpoint, all_cases)
+        preflight_rows += "<tr><td>{host}</td><td>{ip_address}</td><td>{version}</td><td>{doctor}</td></tr>".format(
+            host=escape(endpoint), ip_address=escape(ip_address), version=escape(version), doctor=escape(doctor)
+        )
+    return (
+        f"<h2>{escape(title)}</h2>"
+        "<table><thead><tr><th>Computer</th><th>IP address used</th><th>ATM version</th><th>Doctor</th></tr>"
+        f"</thead><tbody>{preflight_rows}</tbody></table>"
+        + render_case_section("Connection checks", cross_cases)
+    )
+
+
+def render_case_section(title: str, cases: list[dict[str, Any]]) -> str:
+    """Render one concise ladder table; no narrative or duplicate logs."""
+    rows = "".join(
+        "<tr class=\"{status}\"><td>{marker}</td><td>{origin}</td><td>{destination}</td><td>{name}</td><td>{detail}</td></tr>".format(
+            status="pass" if case["status"] == "PASS" else "fail",
+            marker="✓" if case["status"] == "PASS" else "✗",
+            origin=escape(case["origin"]), destination=escape(case["destination"]),
+            name=escape(case["name"]), detail=escape(case["detail"]),
+        )
+        for case in summarize_cases(cases)
+    )
+    return (
+        f"<h2>{escape(title)}</h2>"
+        "<table><thead><tr><th>Status</th><th>Origin</th><th>Destination</th><th>Ladder step</th><th>Result / message ID</th></tr>"
+        f"</thead><tbody>{rows}</tbody></table>"
+    )
+
+
+def summarize_cases(cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse repeated attempts into one visible row without discarding failures."""
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for case in cases:
+        grouped.setdefault((case["origin"], case["destination"], case["name"]), []).append(case)
+    summarized: list[dict[str, Any]] = []
+    for (origin, destination, name), attempts in grouped.items():
+        passed = [case for case in attempts if case["status"] == "PASS"]
+        total = len(attempts)
+        all_passed = len(passed) == total
+        evidence = attempts[-1]["detail"] if all_passed else next(
+            case["detail"] for case in attempts if case["status"] != "PASS"
+        )
+        summarized.append({
+            "origin": origin, "destination": destination, "name": name,
+            "status": "PASS" if all_passed else "FAIL",
+            "detail": f"{len(passed)}/{total} PASS · {evidence}",
+        })
+    return summarized

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -8,6 +8,7 @@ CLI environment: ``ATM_IDENTITY`` and ``ATM_TEAM``.
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from html import escape
 import json
@@ -177,6 +178,35 @@ def remote_shell(peer: str, script: str, timeout: float = 20.0) -> dict[str, Any
     return command(["ssh", peer, f"sh -lc {shlex.quote(script)}"], timeout=timeout)
 
 
+@contextmanager
+def remote_certificate_workspace(peer: str):
+    """Yield a unique remote certificate workspace and remove only its files."""
+    created = remote_shell(peer, "mktemp -d")
+    if created["exit_code"] != 0:
+        raise SmokeError(f"{peer} could not create a temporary certificate directory: {created['stderr'].strip()}")
+    workspace = created["stdout"].strip()
+    if not workspace:
+        raise SmokeError(f"{peer} returned no temporary certificate directory")
+
+    completed = False
+    try:
+        yield workspace
+        completed = True
+    finally:
+        local_public = f"{workspace}/local-public.pem"
+        peer_public = f"{workspace}/peer-public.pem"
+        cleanup = remote_shell(
+            peer,
+            "rm -f "
+            f"{shlex.quote(local_public)} {shlex.quote(peer_public)} "
+            f"&& rmdir {shlex.quote(workspace)}",
+        )
+        if completed and cleanup["exit_code"] != 0:
+            raise SmokeError(
+                f"{peer} could not remove temporary certificate workspace: {cleanup['stderr'].strip()}"
+            )
+
+
 def certificate_bundle(atm: str) -> str:
     certificate = parse_json(command([atm, "peer", "certificate", "show", "--json"]), "peer certificate show")
     bundle = certificate.get("private_key_ref") if isinstance(certificate, dict) else None
@@ -262,57 +292,38 @@ def curl_doctor(
             local_export = command(["openssl", "x509", "-in", local_bundle, "-out", str(local_public)])
             if local_export["exit_code"] != 0:
                 raise SmokeError(f"could not export local public certificate: {local_export['stderr'].strip()}")
-            remote_temp = remote_shell(peer, "mktemp -d")
-            if remote_temp["exit_code"] != 0:
-                raise SmokeError(f"{peer} could not create a temporary certificate directory: {remote_temp['stderr'].strip()}")
-            remote_tempdir = remote_temp["stdout"].strip()
-            if not remote_tempdir:
-                raise SmokeError(f"{peer} returned no temporary certificate directory")
-            remote_local_ca = f"{remote_tempdir}/local-public.pem"
-            remote_public_path = f"{remote_tempdir}/peer-public.pem"
-            export_remote = remote_shell(peer, f"openssl x509 -in {shlex.quote(remote_bundle)} -out {shlex.quote(remote_public_path)}")
-            if export_remote["exit_code"] != 0:
-                raise SmokeError(f"{peer} could not export public certificate: {export_remote['stderr'].strip()}")
-            copied_local = command(["scp", str(local_public), f"{peer}:{remote_local_ca}"])
-            if copied_local["exit_code"] != 0:
-                raise SmokeError(f"could not copy local public certificate to {peer}: {copied_local['stderr'].strip()}")
-            copied_remote = command(["scp", f"{peer}:{remote_public_path}", str(remote_public)])
-            if copied_remote["exit_code"] != 0:
-                raise SmokeError(f"could not copy {peer} public certificate: {copied_remote['stderr'].strip()}")
-            local_authority = certificate_authority(local_public)
-            remote_authority = certificate_authority(remote_public)
-            scheme = "http" if plaintext else "https"
-            local_url = f"{scheme}://{local_authority}:43101/v1/atm/doctor"
-            remote_url = f"{scheme}://{remote_authority}:43101/v1/atm/doctor"
-            headers = ["-H", "Content-Type: application/json"]
-            remote_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
-            if not plaintext:
-                remote_curl.extend(["--cert", remote_bundle, "--cacert", remote_local_ca])
-            remote_curl.extend(["--resolve", f"{local_authority}:43101:{advertised_host(atm)}", "--data", DOCTOR_BODY, local_url])
-            remote_result = remote_shell(peer, " ".join(shlex.quote(value) for value in remote_curl))
-            remote_report = parse_json(remote_result, f"{peer} curl doctor to local")
-            add_case(
-                cases,
-                f"{peer} curl {'plaintext' if plaintext else 'mTLS'} to local doctor",
-                doctor_ready(remote_report, expected_version),
-                "HTTP 200 real daemon doctor" if doctor_ready(remote_report, expected_version) else "doctor response was not healthy/ready",
-                origin=peer,
-                destination=platform.node(),
-            )
-            local_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
-            if not plaintext:
-                local_curl.extend(["--cert", local_bundle, "--cacert", str(remote_public)])
-            local_curl.extend(["--resolve", f"{remote_authority}:43101:{remote_host}", "--data", DOCTOR_BODY, remote_url])
-            local_result = command(local_curl)
-            local_report = parse_json(local_result, f"curl doctor to {peer}")
-            add_case(
-                cases,
-                f"local curl {'plaintext' if plaintext else 'mTLS'} to {peer} doctor",
-                doctor_ready(local_report, expected_version),
-                "HTTP 200 real daemon doctor" if doctor_ready(local_report, expected_version) else "doctor response was not healthy/ready",
-                origin=platform.node(),
-                destination=peer,
-            )
+            with remote_certificate_workspace(peer) as remote_tempdir:
+                remote_local_ca = f"{remote_tempdir}/local-public.pem"
+                remote_public_path = f"{remote_tempdir}/peer-public.pem"
+                export_remote = remote_shell(peer, f"openssl x509 -in {shlex.quote(remote_bundle)} -out {shlex.quote(remote_public_path)}")
+                if export_remote["exit_code"] != 0:
+                    raise SmokeError(f"{peer} could not export public certificate: {export_remote['stderr'].strip()}")
+                copied_local = command(["scp", str(local_public), f"{peer}:{remote_local_ca}"])
+                if copied_local["exit_code"] != 0:
+                    raise SmokeError(f"could not copy local public certificate to {peer}: {copied_local['stderr'].strip()}")
+                copied_remote = command(["scp", f"{peer}:{remote_public_path}", str(remote_public)])
+                if copied_remote["exit_code"] != 0:
+                    raise SmokeError(f"could not copy {peer} public certificate: {copied_remote['stderr'].strip()}")
+                local_authority = certificate_authority(local_public)
+                remote_authority = certificate_authority(remote_public)
+                scheme = "http" if plaintext else "https"
+                local_url = f"{scheme}://{local_authority}:43101/v1/atm/doctor"
+                remote_url = f"{scheme}://{remote_authority}:43101/v1/atm/doctor"
+                headers = ["-H", "Content-Type: application/json"]
+                remote_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
+                if not plaintext:
+                    remote_curl.extend(["--cert", remote_bundle, "--cacert", remote_local_ca])
+                remote_curl.extend(["--resolve", f"{local_authority}:43101:{advertised_host(atm)}", "--data", DOCTOR_BODY, local_url])
+                remote_result = remote_shell(peer, " ".join(shlex.quote(value) for value in remote_curl))
+                remote_report = parse_json(remote_result, f"{peer} curl doctor to local")
+                add_case(cases, f"{peer} curl {'plaintext' if plaintext else 'mTLS'} to local doctor", doctor_ready(remote_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(remote_report, expected_version) else "doctor response was not healthy/ready", origin=peer, destination=platform.node())
+                local_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
+                if not plaintext:
+                    local_curl.extend(["--cert", local_bundle, "--cacert", str(remote_public)])
+                local_curl.extend(["--resolve", f"{remote_authority}:43101:{remote_host}", "--data", DOCTOR_BODY, remote_url])
+                local_result = command(local_curl)
+                local_report = parse_json(local_result, f"curl doctor to {peer}")
+                add_case(cases, f"local curl {'plaintext' if plaintext else 'mTLS'} to {peer} doctor", doctor_ready(local_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(local_report, expected_version) else "doctor response was not healthy/ready", origin=platform.node(), destination=peer)
             # These checks use each host's ordinary DNS resolver. The mTLS
             # request below intentionally omits --resolve, proving that the
             # TCP connection follows DNS rather than the explicit-IP proof.

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -23,7 +23,13 @@ import tempfile
 import time
 from typing import Any
 
-from run_inbound_peer_smoke import PANE_TEMPLATE, compose
+from feature_smoke_report import (
+    render_cross_host_section,
+    render_feature_pane,
+    render_host_header,
+    summarize_cases,
+)
+from run_inbound_peer_smoke import PANE_TEMPLATE, SmokeError, compose, sanitize
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -42,16 +48,17 @@ DOCTOR_BODY = '{"home_dir":"","current_dir":"","team_override":null,"caller_team
 DEFAULT_LIVE_REPETITIONS = 10
 
 
-class SmokeError(RuntimeError):
-    """A smoke prerequisite or assertion failed."""
-
-
 def command(argv: list[str], timeout: float = 15.0) -> dict[str, Any]:
     try:
         completed = subprocess.run(argv, text=True, capture_output=True, check=False, timeout=timeout)
     except (OSError, subprocess.TimeoutExpired) as error:
-        return {"argv": argv, "exit_code": None, "stdout": "", "stderr": str(error)}
-    return {"argv": argv, "exit_code": completed.returncode, "stdout": completed.stdout, "stderr": completed.stderr}
+        return {"argv": argv, "exit_code": None, "stdout": "", "stderr": sanitize(str(error))}
+    return {
+        "argv": argv,
+        "exit_code": completed.returncode,
+        "stdout": sanitize(completed.stdout),
+        "stderr": sanitize(completed.stderr),
+    }
 
 
 def require_environment() -> tuple[str, str, str]:
@@ -450,145 +457,6 @@ def add_case(
     print(f"{'PASS' if passed else 'FAIL'} {origin} -> {destination} {name}: {detail}", flush=True)
 
 
-def render_feature_pane(feature: str, cases: list[dict[str, Any]], host: str) -> str:
-    """Render a short local test table and a short cross-host test table."""
-    local_cases = [case for case in cases if case["origin"] == host and case["destination"] == host]
-    cross_cases = [
-        case
-        for case in cases
-        if case["origin"] != case["destination"] and host in {case["origin"], case["destination"]}
-    ]
-    peer_hosts = list(
-        dict.fromkeys(
-            endpoint
-            for case in cross_cases
-            for endpoint in (case["origin"], case["destination"])
-            if endpoint != host
-        )
-    )
-    header = render_host_header(host, local_cases)
-    local_ladder_cases = [
-        case
-        for case in local_cases
-        if case["name"] != "doctor"
-        and not case["name"].endswith("doctor/version")
-        and not case["name"].endswith("advertised host")
-    ]
-    local_section = render_case_section(f"ONE-COMPUTER TEST — {host}", local_ladder_cases)
-    cross_title = f"CROSS-HOST TEST — {host} ↔ {', '.join(peer_hosts)}" if peer_hosts else "CROSS-HOST TEST"
-    cross_section = render_cross_host_section(cross_title, [host, *peer_hosts], cases, cross_cases)
-    return f"<h1>{escape(host)} — ATM smoke: {escape(feature)}</h1>{header}{local_section}{cross_section}"
-
-
-def render_host_header(host: str, cases: list[dict[str, Any]]) -> str:
-    """Render the compact preflight facts that apply to one computer."""
-    ip_address, version, doctor_detail = host_preflight_facts(host, cases)
-    doctor_passed = doctor_detail.startswith("PASS")
-    return (
-        "<table><tbody>"
-        f"<tr><th>Advertised IP</th><td>{escape(ip_address)}</td></tr>"
-        f"<tr><th>ATM version</th><td>{escape(version)}</td></tr>"
-        f"<tr class=\"{'pass' if doctor_passed else 'fail'}\"><th>Doctor</th><td>{escape(doctor_detail)}</td></tr>"
-        "</tbody></table>"
-    )
-
-
-def host_preflight_facts(host: str, cases: list[dict[str, Any]]) -> tuple[str, str, str]:
-    """Extract one daemon's advertised IP, version, and doctor result."""
-    # Unit-level callers may provide only the preflight facts. Runtime cases
-    # always carry endpoints, but omitted endpoints mean this host's local row.
-    self_cases = [
-        case
-        for case in cases
-        if case.get("origin", host) == host and case.get("destination", host) == host
-    ]
-    doctor_cases = [case for case in self_cases if case["name"] == "doctor" or case["name"].endswith("doctor/version")]
-    doctor = doctor_cases[-1] if doctor_cases else None
-    advertised = next((case for case in reversed(self_cases) if case["name"].endswith("advertised host")), None)
-    ip_address = advertised["detail"] if advertised is not None else "unknown"
-    if doctor is None:
-        return ip_address, "unknown", "NOT RUN"
-    match = re.search(r"(?:ATM |client=)([^,;\s]+)", doctor["detail"])
-    version = match.group(1) if match is not None else "unknown"
-    doctor_passes = sum(case["status"] == "PASS" for case in doctor_cases)
-    doctor_result = (
-        f"PASS {doctor_passes}/{len(doctor_cases)}"
-        if doctor_passes == len(doctor_cases)
-        else f"FAIL {doctor_passes}/{len(doctor_cases)}: {next(case['detail'] for case in doctor_cases if case['status'] != 'PASS')}"
-    )
-    return ip_address, version, doctor_result
-
-
-def render_cross_host_section(
-    title: str,
-    hosts: list[str],
-    all_cases: list[dict[str, Any]],
-    cross_cases: list[dict[str, Any]],
-) -> str:
-    """Show both link endpoints before listing their directional checks."""
-    preflight_rows = ""
-    for endpoint in hosts:
-        ip_address, version, doctor = host_preflight_facts(endpoint, all_cases)
-        preflight_rows += "<tr><td>{host}</td><td>{ip_address}</td><td>{version}</td><td>{doctor}</td></tr>".format(
-            host=escape(endpoint),
-            ip_address=escape(ip_address),
-            version=escape(version),
-            doctor=escape(doctor),
-        )
-    return (
-        f"<h2>{escape(title)}</h2>"
-        "<table><thead><tr><th>Computer</th><th>IP address used</th><th>ATM version</th><th>Doctor</th></tr>"
-        f"</thead><tbody>{preflight_rows}</tbody></table>"
-        + render_case_section("Connection checks", cross_cases)
-    )
-
-
-def render_case_section(title: str, cases: list[dict[str, Any]]) -> str:
-    """Render one concise ladder table; no narrative or duplicate logs."""
-    summarized = summarize_cases(cases)
-    rows = "".join(
-        "<tr class=\"{status}\"><td>{marker}</td><td>{origin}</td><td>{destination}</td><td>{name}</td><td>{detail}</td></tr>".format(
-            status="pass" if case["status"] == "PASS" else "fail",
-            marker="✓" if case["status"] == "PASS" else "✗",
-            origin=escape(case["origin"]),
-            destination=escape(case["destination"]),
-            name=escape(case["name"]),
-            detail=escape(case["detail"]),
-        )
-        for case in summarized
-    )
-    return (
-        f"<h2>{escape(title)}</h2>"
-        f"<table><thead><tr><th>Status</th><th>Origin</th><th>Destination</th><th>Ladder step</th><th>Result / message ID</th></tr>"
-        f"</thead><tbody>{rows}</tbody></table>"
-    )
-
-
-def summarize_cases(cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Collapse repeated attempts into one visible row without discarding failures."""
-    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
-    for case in cases:
-        grouped.setdefault((case["origin"], case["destination"], case["name"]), []).append(case)
-    summarized: list[dict[str, Any]] = []
-    for (origin, destination, name), attempts in grouped.items():
-        passed = [case for case in attempts if case["status"] == "PASS"]
-        total = len(attempts)
-        all_passed = len(passed) == total
-        evidence = attempts[-1]["detail"] if all_passed else next(
-            case["detail"] for case in attempts if case["status"] != "PASS"
-        )
-        summarized.append(
-            {
-                "origin": origin,
-                "destination": destination,
-                "name": name,
-                "status": "PASS" if all_passed else "FAIL",
-                "detail": f"{len(passed)}/{total} PASS · {evidence}",
-            }
-        )
-    return summarized
-
-
 def artifact_segment(value: str, label: str) -> str:
     """Return a stable, path-safe run or host label."""
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", value):
@@ -737,7 +605,7 @@ def crosshost_ack(
             return
         reply_body = f"smoke-crosshost-reply-{peer}-{stamp}"
         acknowledgement = parse_json(
-            remote_command(peer, remote_atm, ["ack", "--team", team, sent_id, reply_body, "--json"]),
+            remote_command(peer, remote_atm, ["ack", "--team", remote_team, sent_id, reply_body, "--json"]),
             f"{peer} acknowledgement of {sent_id}",
         )
         reply_id = reply_message_id(acknowledgement)

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -15,8 +15,10 @@ import os
 from pathlib import Path
 import platform
 import re
+import shlex
 import subprocess
 import sys
+import tempfile
 import time
 from typing import Any
 
@@ -28,10 +30,14 @@ FIXTURE_FEATURES = frozenset({"fast", "normal", "thorough"})
 LOCALHOST = "localhost"
 LOCAL_IP = "local-ip"
 LOCAL_IP_ALIAS = "local-up"
+LOOPBACK_IP = "127.0.0.1"
 CROSSHOST = "crosshost"
 PEER_PREFLIGHT = "peer-preflight"
 CROSSHOST_SEND = "crosshost-send"
 CROSSHOST_ACK = "crosshost-ack"
+CROSSHOST_CURL_PLAINTEXT = "crosshost-curl-plain"
+CROSSHOST_CURL_MTLS = "crosshost-curl-tls"
+DOCTOR_BODY = '{"home_dir":"","current_dir":"","team_override":null,"caller_team":null,"caller_identity":null}'
 
 
 class SmokeError(RuntimeError):
@@ -177,7 +183,110 @@ def doctor_ready(report: Any, expected_version: str) -> bool:
 
 def remote_command(peer: str, remote_atm: str, args: list[str], timeout: float = 20.0) -> dict[str, Any]:
     """Invoke only the public CLI on an already-running SSH peer."""
+    remote_identity = os.environ.get("ATM_SMOKE_REMOTE_IDENTITY", "").strip()
+    remote_team = os.environ.get("ATM_SMOKE_REMOTE_TEAM", "").strip()
+    if remote_identity and remote_team:
+        return command(
+            ["ssh", peer, "env", f"ATM_IDENTITY={remote_identity}", f"ATM_TEAM={remote_team}", remote_atm, *args],
+            timeout=timeout,
+        )
     return command(["ssh", peer, remote_atm, *args], timeout=timeout)
+
+
+def remote_context() -> tuple[str, str]:
+    """Return the explicit recipient identity required for live peer sends."""
+    identity = os.environ.get("ATM_SMOKE_REMOTE_IDENTITY", "").strip()
+    team = os.environ.get("ATM_SMOKE_REMOTE_TEAM", "").strip()
+    if not identity or not team:
+        raise SmokeError(
+            "set ATM_SMOKE_REMOTE_IDENTITY and ATM_SMOKE_REMOTE_TEAM for cross-host ATM delivery smoke"
+        )
+    return identity, team
+
+
+def remote_shell(peer: str, script: str, timeout: float = 20.0) -> dict[str, Any]:
+    """Run one bounded, quoted diagnostic command in the peer's shell."""
+    return command(["ssh", peer, f"sh -lc {shlex.quote(script)}"], timeout=timeout)
+
+
+def certificate_bundle(atm: str) -> str:
+    certificate = parse_json(command([atm, "peer", "certificate", "show", "--json"]), "peer certificate show")
+    bundle = certificate.get("private_key_ref") if isinstance(certificate, dict) else None
+    if not isinstance(bundle, str) or not bundle:
+        raise SmokeError("peer certificate show did not expose private_key_ref")
+    return bundle
+
+
+def certificate_authority(pem: Path) -> str:
+    result = command(["openssl", "x509", "-in", str(pem), "-noout", "-subject", "-nameopt", "RFC2253"])
+    if result["exit_code"] != 0:
+        raise SmokeError(f"could not inspect public certificate: {result['stderr'].strip()}")
+    match = re.search(r"CN=([^,\n]+)", result["stdout"])
+    if match is None:
+        raise SmokeError("public certificate subject has no common name")
+    return match.group(1)
+
+
+def curl_doctor(
+    cases: list[dict[str, Any]], peer: str, atm: str, remote_atm: str, remote_host: str, expected_version: str,
+    *, plaintext: bool,
+) -> None:
+    """Call the real peer doctor route with curl in both directions.
+
+    Plaintext mode is only meaningful after the caller has started both
+    managed smoke daemons with ``--peer-wire-security plaintext-test``. The
+    runner never changes that daemon state itself.
+    """
+    try:
+        local_bundle = certificate_bundle(atm)
+        remote_certificate = parse_json(
+            remote_command(peer, remote_atm, ["peer", "certificate", "show", "--json"]),
+            f"{peer} peer certificate show",
+        )
+        remote_bundle = remote_certificate.get("private_key_ref") if isinstance(remote_certificate, dict) else None
+        if not isinstance(remote_bundle, str) or not remote_bundle:
+            raise SmokeError(f"{peer} peer certificate show did not expose private_key_ref")
+        with tempfile.TemporaryDirectory(prefix="atm-smoke-certs-") as temp:
+            tempdir = Path(temp)
+            local_public = tempdir / "local-public.pem"
+            remote_public = tempdir / "remote-public.pem"
+            local_export = command(["openssl", "x509", "-in", local_bundle, "-out", str(local_public)])
+            if local_export["exit_code"] != 0:
+                raise SmokeError(f"could not export local public certificate: {local_export['stderr'].strip()}")
+            remote_id = artifact_segment(f"{platform.node()}-{peer}", "curl peer label")
+            remote_local_ca = f"/tmp/atm-smoke-{remote_id}-local.pem"
+            remote_public_path = f"/tmp/atm-smoke-{remote_id}-peer.pem"
+            export_remote = remote_shell(peer, f"openssl x509 -in {shlex.quote(remote_bundle)} -out {shlex.quote(remote_public_path)}")
+            if export_remote["exit_code"] != 0:
+                raise SmokeError(f"{peer} could not export public certificate: {export_remote['stderr'].strip()}")
+            copied_local = command(["scp", str(local_public), f"{peer}:{remote_local_ca}"])
+            if copied_local["exit_code"] != 0:
+                raise SmokeError(f"could not copy local public certificate to {peer}: {copied_local['stderr'].strip()}")
+            copied_remote = command(["scp", f"{peer}:{remote_public_path}", str(remote_public)])
+            if copied_remote["exit_code"] != 0:
+                raise SmokeError(f"could not copy {peer} public certificate: {copied_remote['stderr'].strip()}")
+            local_authority = certificate_authority(local_public)
+            remote_authority = certificate_authority(remote_public)
+            scheme = "http" if plaintext else "https"
+            local_url = f"{scheme}://{local_authority}:43101/v1/atm/doctor"
+            remote_url = f"{scheme}://{remote_authority}:43101/v1/atm/doctor"
+            headers = ["-H", "Content-Type: application/json"]
+            remote_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
+            if not plaintext:
+                remote_curl.extend(["--cert", remote_bundle, "--cacert", remote_local_ca])
+            remote_curl.extend(["--resolve", f"{local_authority}:43101:{advertised_host(atm)}", "--data", DOCTOR_BODY, local_url])
+            remote_result = remote_shell(peer, " ".join(shlex.quote(value) for value in remote_curl))
+            remote_report = parse_json(remote_result, f"{peer} curl doctor to local")
+            add_case(cases, f"{peer} curl {'plaintext' if plaintext else 'mTLS'} to local doctor", doctor_ready(remote_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(remote_report, expected_version) else "doctor response was not healthy/ready")
+            local_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
+            if not plaintext:
+                local_curl.extend(["--cert", local_bundle, "--cacert", str(remote_public)])
+            local_curl.extend(["--resolve", f"{remote_authority}:43101:{remote_host}", "--data", DOCTOR_BODY, remote_url])
+            local_result = command(local_curl)
+            local_report = parse_json(local_result, f"curl doctor to {peer}")
+            add_case(cases, f"local curl {'plaintext' if plaintext else 'mTLS'} to {peer} doctor", doctor_ready(local_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(local_report, expected_version) else "doctor response was not healthy/ready")
+    except SmokeError as error:
+        add_case(cases, f"{peer} curl {'plaintext' if plaintext else 'mTLS'} evidence", False, str(error))
 
 
 def remote_preflight(
@@ -264,7 +373,15 @@ def artifact_segment(value: str, label: str) -> str:
     return value
 
 
-def send_read_ack(cases: list[dict[str, Any]], atm: str, identity: str, team: str, host: str) -> None:
+def send_read_ack(
+    cases: list[dict[str, Any]],
+    atm: str,
+    identity: str,
+    team: str,
+    host: str,
+    *,
+    stage: str,
+) -> None:
     target = f"{identity}@{team}.{host}"
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     body = f"smoke-{host}-{stamp}"
@@ -273,9 +390,9 @@ def send_read_ack(cases: list[dict[str, Any]], atm: str, identity: str, team: st
         sent_id = message_id(parse_json(sent, f"send to {host}"))
         visible = wait_for_message(atm, team, sent_id)
         received = message_has_text(visible, body)
-        add_case(cases, f"{host} send/read/content", received, sent_id if received else "message body was not received exactly")
+        add_case(cases, f"{stage} send/read/content", received, sent_id if received else "message body was not received exactly")
     except SmokeError as error:
-        add_case(cases, f"{host} send/read/content", False, str(error))
+        add_case(cases, f"{stage} send/read/content", False, str(error))
     required_body = f"smoke-ack-{host}-{stamp}"
     required = command([atm, "send", target, required_body, "--requires-ack", "--json"])
     try:
@@ -283,7 +400,7 @@ def send_read_ack(cases: list[dict[str, Any]], atm: str, identity: str, team: st
         message = wait_for_message(atm, team, required_id)
         pending = bool(message and message.get("requires_ack", message.get("requiresAck")) is True)
         received = pending and message_has_text(message, required_body)
-        add_case(cases, f"{host} requires-ack delivery/content", received, required_id if received else "pending acknowledgement message or body was not received")
+        add_case(cases, f"{stage} requires-ack delivery/content", received, required_id if received else "pending acknowledgement message or body was not received")
         if pending:
             reply_body = f"smoke acknowledgement {stamp}"
             acknowledgement = command([atm, "ack", "--team", team, required_id, reply_body, "--json"])
@@ -294,22 +411,22 @@ def send_read_ack(cases: list[dict[str, Any]], atm: str, identity: str, team: st
                 and reply is not None
                 and reply.get("acknowledgesMessageId", reply.get("acknowledges_message_id")) == required_id
             )
-            add_case(cases, f"{host} acknowledgement reply delivery/content", reply_received, reply_id if reply_received else "acknowledgement reply was not delivered exactly")
+            add_case(cases, f"{stage} acknowledgement reply delivery/content", reply_received, reply_id if reply_received else "acknowledgement reply was not delivered exactly")
     except SmokeError as error:
-        add_case(cases, f"{host} requires-ack delivery/content", False, str(error))
+        add_case(cases, f"{stage} requires-ack delivery/content", False, str(error))
 
 
 def crosshost_send(
     cases: list[dict[str, Any]], atm: str, remote_atm: str, identity: str, team: str,
-    peer: str, remote_host: str,
+    remote_identity: str, remote_team: str, peer: str, remote_host: str, local_host: str,
 ) -> None:
-    """Stage one: local send followed by remote read of the exact ULID/body."""
-    target = f"{identity}@{team}.{remote_host}"
+    """Stage one: prove ordinary ATM delivery/read in each peer direction."""
+    target = f"{remote_identity}@{remote_team}.{remote_host}"
     body = f"smoke-crosshost-send-{peer}-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
     try:
         sent_id = message_id(parse_json(command([atm, "send", target, body, "--json"]), f"send to {peer}"))
         remote = parse_json(
-            remote_command(peer, remote_atm, ["read", "--team", team, "--message-id", sent_id, "--json"]),
+            remote_command(peer, remote_atm, ["read", "--team", remote_team, "--message-id", sent_id, "--json"]),
             f"{peer} read {sent_id}",
         )
         received = selected_message(remote, sent_id)
@@ -322,14 +439,33 @@ def crosshost_send(
         )
     except SmokeError as error:
         add_case(cases, f"{peer} crosshost send/read/content", False, str(error))
+    reverse_target = f"{identity}@{team}.{local_host}"
+    reverse_body = f"smoke-crosshost-send-reverse-{peer}-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+    try:
+        sent_id = message_id(
+            parse_json(
+                remote_command(peer, remote_atm, ["send", reverse_target, reverse_body, "--json"]),
+                f"{peer} send to local",
+            )
+        )
+        received = wait_for_message(atm, team, sent_id)
+        passed = message_has_text(received, reverse_body)
+        add_case(
+            cases,
+            f"{peer} reverse crosshost send/read/content",
+            passed,
+            sent_id if passed else "local read did not return the sent ULID and exact body",
+        )
+    except SmokeError as error:
+        add_case(cases, f"{peer} reverse crosshost send/read/content", False, str(error))
 
 
 def crosshost_ack(
     cases: list[dict[str, Any]], atm: str, remote_atm: str, identity: str, team: str,
-    peer: str, remote_host: str,
+    remote_identity: str, remote_team: str, peer: str, remote_host: str, local_host: str,
 ) -> None:
-    """Stage two: require an acknowledgement to traverse the reverse peer route."""
-    target = f"{identity}@{team}.{remote_host}"
+    """Stage two: prove required-ack delivery and reply in each peer direction."""
+    target = f"{remote_identity}@{remote_team}.{remote_host}"
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     body = f"smoke-crosshost-ack-{peer}-{stamp}"
     try:
@@ -340,7 +476,7 @@ def crosshost_ack(
             )
         )
         remote = parse_json(
-            remote_command(peer, remote_atm, ["read", "--team", team, "--message-id", sent_id, "--json"]),
+            remote_command(peer, remote_atm, ["read", "--team", remote_team, "--message-id", sent_id, "--json"]),
             f"{peer} read {sent_id}",
         )
         received = selected_message(remote, sent_id)
@@ -374,6 +510,50 @@ def crosshost_ack(
         )
     except SmokeError as error:
         add_case(cases, f"{peer} crosshost requires-ack", False, str(error))
+    reverse_target = f"{identity}@{team}.{local_host}"
+    reverse_body = f"smoke-crosshost-ack-reverse-{peer}-{stamp}"
+    try:
+        sent_id = message_id(
+            parse_json(
+                remote_command(peer, remote_atm, ["send", reverse_target, reverse_body, "--requires-ack", "--json"]),
+                f"{peer} ack-required send to local",
+            )
+        )
+        received = wait_for_message(atm, team, sent_id)
+        pending = bool(received and received.get("requires_ack", received.get("requiresAck")) is True)
+        delivered = pending and message_has_text(received, reverse_body)
+        add_case(
+            cases,
+            f"{peer} reverse crosshost requires-ack delivery/content",
+            delivered,
+            sent_id if delivered else "local read did not return the pending message and exact body",
+        )
+        if not delivered:
+            return
+        reply_body = f"smoke-crosshost-reverse-reply-{peer}-{stamp}"
+        acknowledgement = parse_json(
+            command([atm, "ack", "--team", team, sent_id, reply_body, "--json"]),
+            f"local acknowledgement of {sent_id}",
+        )
+        reply_id = reply_message_id(acknowledgement)
+        remote = parse_json(
+            remote_command(peer, remote_atm, ["read", "--team", remote_team, "--message-id", reply_id, "--json"]),
+            f"{peer} read acknowledgement {reply_id}",
+        )
+        reply = selected_message(remote, reply_id)
+        passed = (
+            message_has_text(reply, reply_body)
+            and reply is not None
+            and reply.get("acknowledgesMessageId", reply.get("acknowledges_message_id")) == sent_id
+        )
+        add_case(
+            cases,
+            f"{peer} reverse crosshost acknowledgement reply",
+            passed,
+            reply_id if passed else "remote read did not return the exact acknowledgement reply",
+        )
+    except SmokeError as error:
+        add_case(cases, f"{peer} reverse crosshost requires-ack", False, str(error))
 
 
 def write_report(feature: str, cases: list[dict[str, Any]]) -> Path:
@@ -465,26 +645,74 @@ def run_live(feature: str, peers: list[str]) -> int:
     if not all(case["status"] == "PASS" for case in cases):
         print(f"FAIL evidence: {write_report(feature, cases)}")
         return 1
-    send_read_ack(cases, atm, identity, team, "localhost")
+    # The first live stage deliberately targets the daemon's advertised
+    # physical interface.  It must be an ordinary host-qualified peer send;
+    # DNS `localhost` and a direct in-process route would hide that contract.
+    try:
+        physical_host = advertised_host(atm)
+        send_read_ack(
+            cases,
+            atm,
+            identity,
+            team,
+            physical_host,
+            stage="physical-interface",
+        )
+    except SmokeError as error:
+        add_case(cases, "physical-interface", False, str(error))
     if feature == LOCALHOST:
         pass
     elif feature == LOCAL_IP:
-        try:
-            send_read_ack(cases, atm, identity, team, advertised_host(atm))
-        except SmokeError as error:
-            add_case(cases, "advertised-IP", False, str(error))
+        send_read_ack(cases, atm, identity, team, LOOPBACK_IP, stage="loopback-IP")
     else:
+        send_read_ack(cases, atm, identity, team, LOOPBACK_IP, stage="loopback-IP")
         remote_atm = os.environ.get("ATM_SMOKE_REMOTE_ATM", "atm")
         expected_version = branch_version()
+        try:
+            remote_identity, remote_team = remote_context()
+        except SmokeError as error:
+            add_case(cases, "crosshost recipient identity", False, str(error))
+            remote_identity = ""
+            remote_team = ""
         if not peers:
             add_case(cases, "crosshost peers", False, "supply one or more SSH hostnames")
         for peer in peers:
+            if not remote_identity or not remote_team:
+                continue
             remote_host = remote_preflight(cases, peer, remote_atm, expected_version)
             if remote_host is None or feature == PEER_PREFLIGHT:
                 continue
-            crosshost_send(cases, atm, remote_atm, identity, team, peer, remote_host)
+            if feature == CROSSHOST_CURL_PLAINTEXT:
+                curl_doctor(cases, peer, atm, remote_atm, remote_host, expected_version, plaintext=True)
+                continue
+            if feature == CROSSHOST_CURL_MTLS:
+                curl_doctor(cases, peer, atm, remote_atm, remote_host, expected_version, plaintext=False)
+                continue
+            crosshost_send(
+                cases,
+                atm,
+                remote_atm,
+                identity,
+                team,
+                remote_identity,
+                remote_team,
+                peer,
+                remote_host,
+                physical_host,
+            )
             if feature == CROSSHOST_ACK:
-                crosshost_ack(cases, atm, remote_atm, identity, team, peer, remote_host)
+                crosshost_ack(
+                    cases,
+                    atm,
+                    remote_atm,
+                    identity,
+                    team,
+                    remote_identity,
+                    remote_team,
+                    peer,
+                    remote_host,
+                    physical_host,
+                )
     report = write_report(feature, cases)
     passed = all(case["status"] == "PASS" for case in cases)
     print(f"{'PASS' if passed else 'FAIL'} evidence: {report}")
@@ -504,11 +732,18 @@ def main() -> int:
     # `crosshost` remains a compatibility alias for the first explicit
     # cross-host stage; new automation should use `crosshost-send`.
     feature = CROSSHOST_SEND if feature == CROSSHOST else feature
-    crosshost_features = {PEER_PREFLIGHT, CROSSHOST_SEND, CROSSHOST_ACK}
+    crosshost_features = {
+        PEER_PREFLIGHT,
+        CROSSHOST_SEND,
+        CROSSHOST_ACK,
+        CROSSHOST_CURL_PLAINTEXT,
+        CROSSHOST_CURL_MTLS,
+    }
     if feature not in {LOCALHOST, LOCAL_IP, *crosshost_features}:
         raise SmokeError(
             "supported smoke features: fast, normal, thorough, localhost, local-ip, "
-            "peer-preflight, crosshost-send, crosshost-ack"
+            "peer-preflight, crosshost-curl-plain, crosshost-curl-tls, "
+            "crosshost-send, crosshost-ack"
         )
     if args.peers and feature not in crosshost_features:
         raise SmokeError("hostnames are only valid with a cross-host smoke feature")

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -29,7 +29,13 @@ from feature_smoke_report import (
     render_host_header,
     summarize_cases,
 )
-from run_inbound_peer_smoke import PANE_TEMPLATE, SmokeError, compose, sanitize
+from run_inbound_peer_smoke import PANE_TEMPLATE, compose
+from smoke_common import (
+    SmokeError,
+    advertised_host_from_value as advertised_host_from_json,
+    command_result as command,
+    message_id_from_value as message_id,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -46,19 +52,6 @@ CROSSHOST_CURL_PLAINTEXT = "crosshost-curl-plain"
 CROSSHOST_CURL_MTLS = "crosshost-curl-tls"
 DOCTOR_BODY = '{"home_dir":"","current_dir":"","team_override":null,"caller_team":null,"caller_identity":null}'
 DEFAULT_LIVE_REPETITIONS = 10
-
-
-def command(argv: list[str], timeout: float = 15.0) -> dict[str, Any]:
-    try:
-        completed = subprocess.run(argv, text=True, capture_output=True, check=False, timeout=timeout)
-    except (OSError, subprocess.TimeoutExpired) as error:
-        return {"argv": argv, "exit_code": None, "stdout": "", "stderr": sanitize(str(error))}
-    return {
-        "argv": argv,
-        "exit_code": completed.returncode,
-        "stdout": sanitize(completed.stdout),
-        "stderr": sanitize(completed.stderr),
-    }
 
 
 def require_environment() -> tuple[str, str, str]:
@@ -89,25 +82,6 @@ def branch_version() -> str:
     if len(versions) != 1 or not isinstance(next(iter(versions)), str):
         raise SmokeError("cargo metadata did not expose one shared atm/atm-daemon version")
     return next(iter(versions))
-
-
-def message_id(value: Any) -> str:
-    if isinstance(value, dict):
-        for key in ("message_id", "messageId"):
-            if isinstance(value.get(key), str) and value[key]:
-                return value[key]
-        for child in value.values():
-            try:
-                return message_id(child)
-            except SmokeError:
-                continue
-    if isinstance(value, list):
-        for child in value:
-            try:
-                return message_id(child)
-            except SmokeError:
-                continue
-    raise SmokeError("send JSON did not contain a message ID")
 
 
 def selected_message(value: Any, expected: str) -> dict[str, Any] | None:
@@ -162,21 +136,6 @@ def advertised_host(atm: str) -> str:
         return override
     interfaces = parse_json(command([atm, "peer", "interface", "list", "--json"]), "peer interface list")
     return advertised_host_from_json(interfaces)
-
-
-def advertised_host_from_json(interfaces: Any) -> str:
-    """Extract an enabled advertised host from the public interface response."""
-    stack = [interfaces]
-    while stack:
-        current = stack.pop()
-        if isinstance(current, dict):
-            host = current.get("advertise_host", current.get("advertised_host"))
-            if current.get("enabled") is not False and isinstance(host, str) and host:
-                return host
-            stack.extend(current.values())
-        elif isinstance(current, list):
-            stack.extend(current)
-    raise SmokeError("peer interface list JSON has no enabled advertised host")
 
 
 def doctor_ready(report: Any, expected_version: str) -> bool:
@@ -303,9 +262,14 @@ def curl_doctor(
             local_export = command(["openssl", "x509", "-in", local_bundle, "-out", str(local_public)])
             if local_export["exit_code"] != 0:
                 raise SmokeError(f"could not export local public certificate: {local_export['stderr'].strip()}")
-            remote_id = artifact_segment(f"{platform.node()}-{peer}", "curl peer label")
-            remote_local_ca = f"/tmp/atm-smoke-{remote_id}-local.pem"
-            remote_public_path = f"/tmp/atm-smoke-{remote_id}-peer.pem"
+            remote_temp = remote_shell(peer, "mktemp -d")
+            if remote_temp["exit_code"] != 0:
+                raise SmokeError(f"{peer} could not create a temporary certificate directory: {remote_temp['stderr'].strip()}")
+            remote_tempdir = remote_temp["stdout"].strip()
+            if not remote_tempdir:
+                raise SmokeError(f"{peer} returned no temporary certificate directory")
+            remote_local_ca = f"{remote_tempdir}/local-public.pem"
+            remote_public_path = f"{remote_tempdir}/peer-public.pem"
             export_remote = remote_shell(peer, f"openssl x509 -in {shlex.quote(remote_bundle)} -out {shlex.quote(remote_public_path)}")
             if export_remote["exit_code"] != 0:
                 raise SmokeError(f"{peer} could not export public certificate: {export_remote['stderr'].strip()}")
@@ -754,18 +718,12 @@ def run_live_attempt(feature: str, peers: list[str]) -> list[dict[str, Any]]:
     try:
         report = parse_json(doctor, "doctor")
         expected_version = branch_version()
-        client_version = report.get("client_context", {}).get("version")
         daemon_version = report.get("daemon_context", {}).get("version")
-        healthy = (
-            report.get("summary", {}).get("status") == "healthy"
-            and report.get("runtime_status", {}).get("readiness") == "ready"
-            and client_version == expected_version
-            and daemon_version == expected_version
-        )
+        healthy = doctor_ready(report, expected_version)
         detail = (
             f"READY · ATM {daemon_version}"
             if healthy
-            else f"expected={expected_version}; cli={client_version}; daemon={daemon_version}"
+            else f"expected={expected_version}; cli={report.get('client_context', {}).get('version')}; daemon={daemon_version}"
         )
         add_case(cases, "doctor", healthy, detail)
     except SmokeError as error:

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import platform
 import re
 import shlex
+import socket
 import subprocess
 import sys
 import tempfile
@@ -38,6 +39,7 @@ CROSSHOST_ACK = "crosshost-ack"
 CROSSHOST_CURL_PLAINTEXT = "crosshost-curl-plain"
 CROSSHOST_CURL_MTLS = "crosshost-curl-tls"
 DOCTOR_BODY = '{"home_dir":"","current_dir":"","team_override":null,"caller_team":null,"caller_identity":null}'
+DEFAULT_LIVE_REPETITIONS = 10
 
 
 class SmokeError(RuntimeError):
@@ -227,6 +229,47 @@ def certificate_authority(pem: Path) -> str:
     return match.group(1)
 
 
+def resolve_dns_addresses(host: str) -> list[str]:
+    """Return every address the local resolver provides for a peer hostname."""
+    try:
+        records = socket.getaddrinfo(host, 43101, type=socket.SOCK_STREAM)
+    except OSError as error:
+        raise SmokeError(f"DNS resolution for {host} failed: {error}") from error
+    return sorted({record[4][0] for record in records})
+
+
+def remote_resolve_dns_addresses(peer: str, host: str) -> list[str]:
+    """Resolve a hostname through the remote computer's normal resolver."""
+    script = (
+        "import json, socket; "
+        f"print(json.dumps(sorted({{item[4][0] for item in socket.getaddrinfo({host!r}, 43101, type=socket.SOCK_STREAM)}})))"
+    )
+    result = remote_shell(peer, f"python3 -c {shlex.quote(script)}")
+    try:
+        addresses = parse_json(result, f"{peer} DNS resolution for {host}")
+    except SmokeError:
+        raise
+    if not isinstance(addresses, list) or not all(isinstance(address, str) for address in addresses):
+        raise SmokeError(f"{peer} DNS resolution for {host} did not return an address list")
+    return addresses
+
+
+def add_dns_case(
+    cases: list[dict[str, Any]], name: str, origin: str, destination: str, hostname: str, expected_ip: str,
+    resolver: Any,
+) -> None:
+    """Record real OS DNS resolution and require the daemon's advertised IP."""
+    try:
+        addresses = resolver(hostname)
+        passed = expected_ip in addresses
+        detail = f"{hostname} -> {', '.join(addresses)}"
+        if not passed:
+            detail += f"; missing advertised IP {expected_ip}"
+        add_case(cases, name, passed, detail, origin=origin, destination=destination)
+    except SmokeError as error:
+        add_case(cases, name, False, str(error), origin=origin, destination=destination)
+
+
 def curl_doctor(
     cases: list[dict[str, Any]], peer: str, atm: str, remote_atm: str, remote_host: str, expected_version: str,
     *, plaintext: bool,
@@ -277,16 +320,76 @@ def curl_doctor(
             remote_curl.extend(["--resolve", f"{local_authority}:43101:{advertised_host(atm)}", "--data", DOCTOR_BODY, local_url])
             remote_result = remote_shell(peer, " ".join(shlex.quote(value) for value in remote_curl))
             remote_report = parse_json(remote_result, f"{peer} curl doctor to local")
-            add_case(cases, f"{peer} curl {'plaintext' if plaintext else 'mTLS'} to local doctor", doctor_ready(remote_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(remote_report, expected_version) else "doctor response was not healthy/ready")
+            add_case(
+                cases,
+                f"{peer} curl {'plaintext' if plaintext else 'mTLS'} to local doctor",
+                doctor_ready(remote_report, expected_version),
+                "HTTP 200 real daemon doctor" if doctor_ready(remote_report, expected_version) else "doctor response was not healthy/ready",
+                origin=peer,
+                destination=platform.node(),
+            )
             local_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
             if not plaintext:
                 local_curl.extend(["--cert", local_bundle, "--cacert", str(remote_public)])
             local_curl.extend(["--resolve", f"{remote_authority}:43101:{remote_host}", "--data", DOCTOR_BODY, remote_url])
             local_result = command(local_curl)
             local_report = parse_json(local_result, f"curl doctor to {peer}")
-            add_case(cases, f"local curl {'plaintext' if plaintext else 'mTLS'} to {peer} doctor", doctor_ready(local_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(local_report, expected_version) else "doctor response was not healthy/ready")
+            add_case(
+                cases,
+                f"local curl {'plaintext' if plaintext else 'mTLS'} to {peer} doctor",
+                doctor_ready(local_report, expected_version),
+                "HTTP 200 real daemon doctor" if doctor_ready(local_report, expected_version) else "doctor response was not healthy/ready",
+                origin=platform.node(),
+                destination=peer,
+            )
+            # These checks use each host's ordinary DNS resolver. The mTLS
+            # request below intentionally omits --resolve, proving that the
+            # TCP connection follows DNS rather than the explicit-IP proof.
+            add_dns_case(
+                cases,
+                f"local DNS resolves {peer} peer",
+                platform.node(),
+                peer,
+                remote_authority,
+                remote_host,
+                resolve_dns_addresses,
+            )
+            local_hostname = platform.node()
+            local_advertised_ip = advertised_host(atm)
+            add_dns_case(
+                cases,
+                f"{peer} DNS resolves local peer",
+                peer,
+                platform.node(),
+                local_hostname,
+                local_advertised_ip,
+                lambda hostname: remote_resolve_dns_addresses(peer, hostname),
+            )
+            dns_curl = [
+                "curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET",
+                *headers,
+            ]
+            if not plaintext:
+                dns_curl.extend(["--cert", local_bundle, "--cacert", str(remote_public)])
+            dns_curl.extend(["--data", DOCTOR_BODY, remote_url])
+            dns_report = parse_json(command(dns_curl), f"DNS curl doctor to {peer}")
+            add_case(
+                cases,
+                f"local DNS curl {'plaintext' if plaintext else 'mTLS'} to {peer} doctor",
+                doctor_ready(dns_report, expected_version),
+                "HTTP 200 real daemon doctor via DNS" if doctor_ready(dns_report, expected_version) else "doctor response was not healthy/ready",
+                origin=platform.node(),
+                destination=peer,
+            )
     except SmokeError as error:
-        add_case(cases, f"{peer} curl {'plaintext' if plaintext else 'mTLS'} evidence", False, str(error))
+        add_case(
+            cases,
+            f"{peer} curl {'plaintext' if plaintext else 'mTLS'} evidence",
+            False,
+            str(error),
+            origin=platform.node(),
+            destination=peer,
+        )
 
 
 def remote_preflight(
@@ -307,7 +410,7 @@ def remote_preflight(
             if isinstance(doctor, dict)
             else "doctor response was not an object"
         )
-        add_case(cases, f"{peer} doctor/version", ready, detail)
+        add_case(cases, f"{peer} doctor/version", ready, detail, origin=peer, destination=peer)
         if not ready:
             return None
         interfaces = parse_json(
@@ -315,55 +418,175 @@ def remote_preflight(
             f"{peer} peer interface list",
         )
         host = advertised_host_from_json(interfaces)
-        add_case(cases, f"{peer} advertised host", True, host)
+        add_case(cases, f"{peer} advertised host", True, host, origin=peer, destination=peer)
         return host
     except SmokeError as error:
-        add_case(cases, f"{peer} preflight", False, str(error))
+        add_case(cases, f"{peer} preflight", False, str(error), origin=peer, destination=peer)
         return None
 
 
-def add_case(cases: list[dict[str, Any]], name: str, passed: bool, detail: str) -> None:
-    cases.append({"name": name, "status": "PASS" if passed else "FAIL", "detail": detail})
-    print(f"{'PASS' if passed else 'FAIL'} {name}: {detail}", flush=True)
+def add_case(
+    cases: list[dict[str, Any]],
+    name: str,
+    passed: bool,
+    detail: str,
+    *,
+    origin: str | None = None,
+    destination: str | None = None,
+) -> None:
+    """Record one observable check with the host where it started and ended."""
+    local = platform.node()
+    origin = origin or local
+    destination = destination or origin
+    cases.append(
+        {
+            "name": name,
+            "status": "PASS" if passed else "FAIL",
+            "detail": detail,
+            "origin": origin,
+            "destination": destination,
+        }
+    )
+    print(f"{'PASS' if passed else 'FAIL'} {origin} -> {destination} {name}: {detail}", flush=True)
 
 
-def render_feature_pane(feature: str, cases: list[dict[str, Any]]) -> str:
-    """Render exactly the progressive live checks executed by this invocation."""
-    doctor = next((case for case in cases if case["name"] == "doctor"), None)
-    executed = [case for case in cases if case["name"] != "doctor"]
+def render_feature_pane(feature: str, cases: list[dict[str, Any]], host: str) -> str:
+    """Render a short local test table and a short cross-host test table."""
+    local_cases = [case for case in cases if case["origin"] == host and case["destination"] == host]
+    cross_cases = [
+        case
+        for case in cases
+        if case["origin"] != case["destination"] and host in {case["origin"], case["destination"]}
+    ]
+    peer_hosts = list(
+        dict.fromkeys(
+            endpoint
+            for case in cross_cases
+            for endpoint in (case["origin"], case["destination"])
+            if endpoint != host
+        )
+    )
+    header = render_host_header(host, local_cases)
+    local_ladder_cases = [
+        case
+        for case in local_cases
+        if case["name"] != "doctor"
+        and not case["name"].endswith("doctor/version")
+        and not case["name"].endswith("advertised host")
+    ]
+    local_section = render_case_section(f"ONE-COMPUTER TEST — {host}", local_ladder_cases)
+    cross_title = f"CROSS-HOST TEST — {host} ↔ {', '.join(peer_hosts)}" if peer_hosts else "CROSS-HOST TEST"
+    cross_section = render_cross_host_section(cross_title, [host, *peer_hosts], cases, cross_cases)
+    return f"<h1>{escape(host)} — ATM smoke: {escape(feature)}</h1>{header}{local_section}{cross_section}"
+
+
+def render_host_header(host: str, cases: list[dict[str, Any]]) -> str:
+    """Render the compact preflight facts that apply to one computer."""
+    ip_address, version, doctor_detail = host_preflight_facts(host, cases)
+    doctor_passed = doctor_detail.startswith("PASS")
+    return (
+        "<table><tbody>"
+        f"<tr><th>Advertised IP</th><td>{escape(ip_address)}</td></tr>"
+        f"<tr><th>ATM version</th><td>{escape(version)}</td></tr>"
+        f"<tr class=\"{'pass' if doctor_passed else 'fail'}\"><th>Doctor</th><td>{escape(doctor_detail)}</td></tr>"
+        "</tbody></table>"
+    )
+
+
+def host_preflight_facts(host: str, cases: list[dict[str, Any]]) -> tuple[str, str, str]:
+    """Extract one daemon's advertised IP, version, and doctor result."""
+    # Unit-level callers may provide only the preflight facts. Runtime cases
+    # always carry endpoints, but omitted endpoints mean this host's local row.
+    self_cases = [
+        case
+        for case in cases
+        if case.get("origin", host) == host and case.get("destination", host) == host
+    ]
+    doctor_cases = [case for case in self_cases if case["name"] == "doctor" or case["name"].endswith("doctor/version")]
+    doctor = doctor_cases[-1] if doctor_cases else None
+    advertised = next((case for case in reversed(self_cases) if case["name"].endswith("advertised host")), None)
+    ip_address = advertised["detail"] if advertised is not None else "unknown"
+    if doctor is None:
+        return ip_address, "unknown", "NOT RUN"
+    match = re.search(r"(?:ATM |client=)([^,;\s]+)", doctor["detail"])
+    version = match.group(1) if match is not None else "unknown"
+    doctor_passes = sum(case["status"] == "PASS" for case in doctor_cases)
+    doctor_result = (
+        f"PASS {doctor_passes}/{len(doctor_cases)}"
+        if doctor_passes == len(doctor_cases)
+        else f"FAIL {doctor_passes}/{len(doctor_cases)}: {next(case['detail'] for case in doctor_cases if case['status'] != 'PASS')}"
+    )
+    return ip_address, version, doctor_result
+
+
+def render_cross_host_section(
+    title: str,
+    hosts: list[str],
+    all_cases: list[dict[str, Any]],
+    cross_cases: list[dict[str, Any]],
+) -> str:
+    """Show both link endpoints before listing their directional checks."""
+    preflight_rows = ""
+    for endpoint in hosts:
+        ip_address, version, doctor = host_preflight_facts(endpoint, all_cases)
+        preflight_rows += "<tr><td>{host}</td><td>{ip_address}</td><td>{version}</td><td>{doctor}</td></tr>".format(
+            host=escape(endpoint),
+            ip_address=escape(ip_address),
+            version=escape(version),
+            doctor=escape(doctor),
+        )
+    return (
+        f"<h2>{escape(title)}</h2>"
+        "<table><thead><tr><th>Computer</th><th>IP address used</th><th>ATM version</th><th>Doctor</th></tr>"
+        f"</thead><tbody>{preflight_rows}</tbody></table>"
+        + render_case_section("Connection checks", cross_cases)
+    )
+
+
+def render_case_section(title: str, cases: list[dict[str, Any]]) -> str:
+    """Render one concise ladder table; no narrative or duplicate logs."""
+    summarized = summarize_cases(cases)
     rows = "".join(
-        "<tr class=\"{status}\"><td>{marker}</td><td>{name}</td><td>{detail}</td></tr>".format(
+        "<tr class=\"{status}\"><td>{marker}</td><td>{origin}</td><td>{destination}</td><td>{name}</td><td>{detail}</td></tr>".format(
             status="pass" if case["status"] == "PASS" else "fail",
             marker="✓" if case["status"] == "PASS" else "✗",
+            origin=escape(case["origin"]),
+            destination=escape(case["destination"]),
             name=escape(case["name"]),
             detail=escape(case["detail"]),
         )
-        for case in executed
-    )
-    logs = "".join(
-        f"<li><strong>{escape(case['name'])}</strong>: {escape(case['status'])}</li>" for case in executed
-    )
-    failures = [case["name"] for case in executed if case["status"] == "FAIL"]
-    preflight = (
-        f"<h2>Preflight</h2><p class=\"{'pass' if doctor['status'] == 'PASS' else 'fail'}\">"
-        f"<strong>Doctor {'passed' if doctor['status'] == 'PASS' else 'failed'}.</strong><br />"
-        f"{escape(doctor['detail']).replace(chr(10), '<br />')}</p>"
-        if doctor
-        else "<h2>Preflight</h2><p class=\"fail\">Doctor was not executed.</p>"
-    )
-    assessment = (
-        "Investigation required: " + "; ".join(failures)
-        if failures
-        else "No issues found by executed checks."
+        for case in summarized
     )
     return (
-        f"<h1>ATM smoke: {escape(feature)}</h1>"
-        f"{preflight}"
-        f"<table><thead><tr><th>Status</th><th>Test case</th><th>Result / message ID</th></tr>"
+        f"<h2>{escape(title)}</h2>"
+        f"<table><thead><tr><th>Status</th><th>Origin</th><th>Destination</th><th>Ladder step</th><th>Result / message ID</th></tr>"
         f"</thead><tbody>{rows}</tbody></table>"
-        f"<h2>Session log</h2><ul>{logs}</ul>"
-        f"<h2>Assessment</h2><p class=\"assessment\">{escape(assessment)}</p>"
     )
+
+
+def summarize_cases(cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse repeated attempts into one visible row without discarding failures."""
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for case in cases:
+        grouped.setdefault((case["origin"], case["destination"], case["name"]), []).append(case)
+    summarized: list[dict[str, Any]] = []
+    for (origin, destination, name), attempts in grouped.items():
+        passed = [case for case in attempts if case["status"] == "PASS"]
+        total = len(attempts)
+        all_passed = len(passed) == total
+        evidence = attempts[-1]["detail"] if all_passed else next(
+            case["detail"] for case in attempts if case["status"] != "PASS"
+        )
+        summarized.append(
+            {
+                "origin": origin,
+                "destination": destination,
+                "name": name,
+                "status": "PASS" if all_passed else "FAIL",
+                "detail": f"{len(passed)}/{total} PASS · {evidence}",
+            }
+        )
+    return summarized
 
 
 def artifact_segment(value: str, label: str) -> str:
@@ -397,23 +620,39 @@ def send_read_ack(
     required = command([atm, "send", target, required_body, "--requires-ack", "--json"])
     try:
         required_id = message_id(parse_json(required, f"ack-required send to {host}"))
-        message = wait_for_message(atm, team, required_id)
-        pending = bool(message and message.get("requires_ack", message.get("requiresAck")) is True)
-        received = pending and message_has_text(message, required_body)
-        add_case(cases, f"{stage} requires-ack delivery/content", received, required_id if received else "pending acknowledgement message or body was not received")
-        if pending:
-            reply_body = f"smoke acknowledgement {stamp}"
-            acknowledgement = command([atm, "ack", "--team", team, required_id, reply_body, "--json"])
-            reply_id = reply_message_id(parse_json(acknowledgement, f"acknowledgement of {required_id}"))
-            reply = wait_for_message(atm, team, reply_id)
-            reply_received = (
-                message_has_text(reply, reply_body)
-                and reply is not None
-                and reply.get("acknowledgesMessageId", reply.get("acknowledges_message_id")) == required_id
-            )
-            add_case(cases, f"{stage} acknowledgement reply delivery/content", reply_received, reply_id if reply_received else "acknowledgement reply was not delivered exactly")
     except SmokeError as error:
         add_case(cases, f"{stage} requires-ack delivery/content", False, str(error))
+        return
+    message = wait_for_message(atm, team, required_id)
+    pending = bool(message and message.get("requires_ack", message.get("requiresAck")) is True)
+    received = pending and message_has_text(message, required_body)
+    add_case(
+        cases,
+        f"{stage} requires-ack delivery/content",
+        received,
+        required_id if received else "pending acknowledgement message or body was not received",
+    )
+    if not received:
+        return
+    reply_body = f"smoke acknowledgement {stamp}"
+    acknowledgement = command([atm, "ack", "--team", team, required_id, reply_body, "--json"])
+    try:
+        reply_id = reply_message_id(parse_json(acknowledgement, f"acknowledgement of {required_id}"))
+    except SmokeError as error:
+        add_case(cases, f"{stage} acknowledgement reply delivery/content", False, str(error))
+        return
+    reply = wait_for_message(atm, team, reply_id)
+    reply_received = (
+        message_has_text(reply, reply_body)
+        and reply is not None
+        and reply.get("acknowledgesMessageId", reply.get("acknowledges_message_id")) == required_id
+    )
+    add_case(
+        cases,
+        f"{stage} acknowledgement reply delivery/content",
+        reply_received,
+        reply_id if reply_received else "acknowledgement reply was not delivered exactly",
+    )
 
 
 def crosshost_send(
@@ -436,9 +675,11 @@ def crosshost_send(
             f"{peer} crosshost send/read/content",
             passed,
             sent_id if passed else "remote read did not return the sent ULID and exact body",
+            origin=platform.node(),
+            destination=peer,
         )
     except SmokeError as error:
-        add_case(cases, f"{peer} crosshost send/read/content", False, str(error))
+        add_case(cases, f"{peer} crosshost send/read/content", False, str(error), origin=platform.node(), destination=peer)
     reverse_target = f"{identity}@{team}.{local_host}"
     reverse_body = f"smoke-crosshost-send-reverse-{peer}-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
     try:
@@ -455,9 +696,11 @@ def crosshost_send(
             f"{peer} reverse crosshost send/read/content",
             passed,
             sent_id if passed else "local read did not return the sent ULID and exact body",
+            origin=peer,
+            destination=platform.node(),
         )
     except SmokeError as error:
-        add_case(cases, f"{peer} reverse crosshost send/read/content", False, str(error))
+        add_case(cases, f"{peer} reverse crosshost send/read/content", False, str(error), origin=peer, destination=platform.node())
 
 
 def crosshost_ack(
@@ -487,6 +730,8 @@ def crosshost_ack(
             f"{peer} crosshost requires-ack delivery/content",
             received_exactly,
             sent_id if received_exactly else "remote read did not return the pending message and exact body",
+            origin=platform.node(),
+            destination=peer,
         )
         if not received_exactly:
             return
@@ -507,9 +752,11 @@ def crosshost_ack(
             f"{peer} crosshost acknowledgement reply",
             passed,
             reply_id if passed else "local read did not return the exact acknowledgement reply",
+            origin=peer,
+            destination=platform.node(),
         )
     except SmokeError as error:
-        add_case(cases, f"{peer} crosshost requires-ack", False, str(error))
+        add_case(cases, f"{peer} crosshost requires-ack", False, str(error), origin=platform.node(), destination=peer)
     reverse_target = f"{identity}@{team}.{local_host}"
     reverse_body = f"smoke-crosshost-ack-reverse-{peer}-{stamp}"
     try:
@@ -527,6 +774,8 @@ def crosshost_ack(
             f"{peer} reverse crosshost requires-ack delivery/content",
             delivered,
             sent_id if delivered else "local read did not return the pending message and exact body",
+            origin=peer,
+            destination=platform.node(),
         )
         if not delivered:
             return
@@ -551,9 +800,11 @@ def crosshost_ack(
             f"{peer} reverse crosshost acknowledgement reply",
             passed,
             reply_id if passed else "remote read did not return the exact acknowledgement reply",
+            origin=platform.node(),
+            destination=peer,
         )
     except SmokeError as error:
-        add_case(cases, f"{peer} reverse crosshost requires-ack", False, str(error))
+        add_case(cases, f"{peer} reverse crosshost requires-ack", False, str(error), origin=peer, destination=platform.node())
 
 
 def write_report(feature: str, cases: list[dict[str, Any]]) -> Path:
@@ -568,41 +819,46 @@ def write_report(feature: str, cases: list[dict[str, Any]]) -> Path:
     report = directory / f"{host}-{feature}.json"
     passed = all(case["status"] == "PASS" for case in cases)
     report.write_text(json.dumps({"feature": feature, "status": "PASS" if passed else "FAIL", "cases": cases}, indent=2) + "\n", encoding="utf-8")
-    # Reuse the established AI.21-pre XHTML pane template instead of creating
-    # a second report format for the same live-daemon evidence.
-    pane = report.with_suffix(".xhtml")
-    compose(
-        PANE_TEMPLATE,
-        {
-            "title": f"ATM smoke — {feature}",
-            "generated_at": datetime.now(timezone.utc).isoformat(),
-            "host": host,
-            "body_html": render_feature_pane(feature, cases),
-        },
-        pane,
-    )
+    hosts = list(dict.fromkeys(case["origin"] for case in cases))
+    for destination in (case["destination"] for case in cases):
+        if destination not in hosts:
+            hosts.append(destination)
+    panes: list[tuple[str, Path]] = []
+    for evidence_host in hosts:
+        pane = directory / f"{artifact_segment(evidence_host, 'evidence host')}-{feature}.xhtml"
+        compose(
+            PANE_TEMPLATE,
+            {
+                "title": f"ATM smoke — {evidence_host}",
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "host": evidence_host,
+                "body_html": render_feature_pane(feature, cases, evidence_host),
+            },
+            pane,
+        )
+        panes.append((evidence_host, pane))
+    local_pane = next((path for evidence_host, path in panes if evidence_host == host), panes[0][1])
     compose(
         ROOT / "templates" / "smoke-report" / "inbound-peer-frame.html.j2",
         {
             "title": f"ATM smoke — {feature}",
             "generated_at": datetime.now(timezone.utc).isoformat(),
-            "pane_src": pane.name,
+            "pane_src": local_pane.name,
         },
         report.with_suffix(".html"),
     )
-    panes = sorted(path for path in directory.glob("*.xhtml") if path.is_file())
     pane_html = "\n".join(
         "<section><h2>{label}</h2><iframe title=\"{title}\" src=\"{source}\"></iframe></section>".format(
-            label=escape(path.name),
-            title=escape(path.stem, quote=True),
+            label=escape(evidence_host),
+            title=escape(f"ATM smoke evidence for {evidence_host}", quote=True),
             source=escape(path.name, quote=True),
         )
-        for path in panes
+        for evidence_host, path in panes
     )
     compose(
         ROOT / "templates" / "smoke-report" / "inbound-peer-review.html.j2",
         {
-            "title": "ATM smoke evidence",
+            "title": "ATM cross-host smoke",
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "pane_html": pane_html,
         },
@@ -611,7 +867,19 @@ def write_report(feature: str, cases: list[dict[str, Any]]) -> Path:
     return report
 
 
-def run_live(feature: str, peers: list[str]) -> int:
+def smoke_repetitions() -> int:
+    """Return the required consecutive-attempt count for live smoke evidence."""
+    value = os.environ.get("ATM_SMOKE_REPETITIONS", str(DEFAULT_LIVE_REPETITIONS))
+    try:
+        repetitions = int(value)
+    except ValueError as error:
+        raise SmokeError("ATM_SMOKE_REPETITIONS must be a positive integer") from error
+    if not 1 <= repetitions <= 50:
+        raise SmokeError("ATM_SMOKE_REPETITIONS must be between 1 and 50")
+    return repetitions
+
+
+def run_live_attempt(feature: str, peers: list[str]) -> list[dict[str, Any]]:
     atm, identity, team = require_environment()
     cases: list[dict[str, Any]] = []
     doctor = command([atm, "doctor", "--json"])
@@ -627,29 +895,21 @@ def run_live(feature: str, peers: list[str]) -> int:
             and daemon_version == expected_version
         )
         detail = (
-            "status: healthy\n"
-            "readiness: ready\n"
-            f"expected version: {expected_version}\n"
-            f"CLI version: {client_version}\n"
-            f"daemon version: {daemon_version}"
+            f"READY · ATM {daemon_version}"
             if healthy
-            else (
-                f"expected version: {expected_version}\n"
-                f"CLI version: {client_version}\n"
-                f"daemon version: {daemon_version}"
-            )
+            else f"expected={expected_version}; cli={client_version}; daemon={daemon_version}"
         )
         add_case(cases, "doctor", healthy, detail)
     except SmokeError as error:
         add_case(cases, "doctor", False, str(error))
     if not all(case["status"] == "PASS" for case in cases):
-        print(f"FAIL evidence: {write_report(feature, cases)}")
-        return 1
+        return cases
     # The first live stage deliberately targets the daemon's advertised
     # physical interface.  It must be an ordinary host-qualified peer send;
     # DNS `localhost` and a direct in-process route would hide that contract.
     try:
         physical_host = advertised_host(atm)
+        add_case(cases, "advertised host", True, physical_host)
         send_read_ack(
             cases,
             atm,
@@ -713,6 +973,19 @@ def run_live(feature: str, peers: list[str]) -> int:
                     remote_host,
                     physical_host,
                 )
+    return cases
+
+
+def run_live(feature: str, peers: list[str]) -> int:
+    """Run each live ladder check repeatedly; one pass cannot hide a flake."""
+    cases: list[dict[str, Any]] = []
+    repetitions = smoke_repetitions()
+    for attempt in range(1, repetitions + 1):
+        print(f"LIVE SMOKE ATTEMPT {attempt}/{repetitions}", flush=True)
+        attempt_cases = run_live_attempt(feature, peers)
+        for case in attempt_cases:
+            case["attempt"] = attempt
+        cases.extend(attempt_cases)
     report = write_report(feature, cases)
     passed = all(case["status"] == "PASS" for case in cases)
     print(f"{'PASS' if passed else 'FAIL'} evidence: {report}")

--- a/scripts/smoke/run_inbound_peer_smoke.py
+++ b/scripts/smoke/run_inbound_peer_smoke.py
@@ -22,19 +22,15 @@ import tempfile
 import time
 from typing import Any
 
+from smoke_common import (
+    SmokeError,
+    command_result,
+    extract_advertised_host,
+    extract_message_id,
+    sanitize,
+)
 
-MAX_CAPTURE = 8192
-SECRET = re.compile(r"(?i)(-----BEGIN[^-]+-----|(?:token|secret|password|capability|private[_-]?key)\s*[=:]\s*[^\s,]+)")
 REQUIRED_LOCAL_CHECKS = frozenset({"localhost/local loopback", "own-IP", "nudge"})
-
-
-class SmokeError(RuntimeError):
-    """A configuration or smoke assertion error."""
-
-
-def sanitize(value: str) -> str:
-    return SECRET.sub("<redacted>", value)[-MAX_CAPTURE:]
-
 
 def require_argv(value: Any, field: str) -> list[str]:
     if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
@@ -113,14 +109,6 @@ def validate_host_config(config: dict[str, Any]) -> dict[str, Any]:
     return host
 
 
-def command_result(command: list[str], timeout: float) -> dict[str, Any]:
-    try:
-        completed = subprocess.run(command, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=timeout, check=False)
-        return {"command": command, "exit_code": completed.returncode, "stdout": sanitize(completed.stdout), "stderr": sanitize(completed.stderr)}
-    except (OSError, subprocess.TimeoutExpired) as error:
-        return {"command": command, "exit_code": None, "stdout": "", "stderr": sanitize(str(error))}
-
-
 def shell_quote_powershell(argument: str) -> str:
     return "'" + argument.replace("'", "''") + "'"
 
@@ -142,63 +130,6 @@ def remote_command(peer: dict[str, Any], argv: list[str], environment: dict[str,
 
 def local_command(local: dict[str, Any], argv: list[str]) -> list[str]:
     return require_argv(local["atm_command"], "local.atm_command") + argv
-
-
-def extract_message_id(raw: str) -> str:
-    try:
-        value = json.loads(raw)
-    except json.JSONDecodeError as error:
-        raise SmokeError(f"send did not return JSON: {error}") from error
-
-    def find(item: Any) -> str | None:
-        if isinstance(item, dict):
-            for key in ("message_id", "messageId"):
-                if isinstance(item.get(key), str) and item[key]:
-                    return item[key]
-            for nested in item.values():
-                found = find(nested)
-                if found:
-                    return found
-        elif isinstance(item, list):
-            for nested in item:
-                found = find(nested)
-                if found:
-                    return found
-        return None
-
-    found = find(value)
-    if not found:
-        raise SmokeError("send JSON did not include a message_id")
-    return found
-
-
-def extract_advertised_host(raw: str) -> str:
-    try:
-        value = json.loads(raw)
-    except json.JSONDecodeError as error:
-        raise SmokeError(f"peer interface list did not return JSON: {error}") from error
-
-    def walk(item: Any) -> str | None:
-        if isinstance(item, dict):
-            enabled = item.get("enabled")
-            host = item.get("advertise_host", item.get("advertised_host"))
-            if enabled is not False and isinstance(host, str) and host:
-                return host
-            for nested in item.values():
-                found = walk(nested)
-                if found:
-                    return found
-        elif isinstance(item, list):
-            for nested in item:
-                found = walk(nested)
-                if found:
-                    return found
-        return None
-
-    host = walk(value)
-    if not host:
-        raise SmokeError("peer interface list JSON has no enabled advertise_host; set local.advertised_host")
-    return host
 
 
 def message_from_read(raw: str) -> dict[str, Any] | None:

--- a/scripts/smoke/smoke_common.py
+++ b/scripts/smoke/smoke_common.py
@@ -1,0 +1,82 @@
+"""Small shared, sanitized primitives for ATM smoke runners."""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from typing import Any
+
+MAX_CAPTURE = 8192
+SECRET = re.compile(r"(?i)(-----BEGIN[^-]+-----|(?:token|secret|password|capability|private[_-]?key)\s*[=:]\s*[^\s,]+)")
+
+
+class SmokeError(RuntimeError):
+    """A smoke prerequisite or assertion failed."""
+
+
+def sanitize(value: str) -> str:
+    return SECRET.sub("<redacted>", value)[-MAX_CAPTURE:]
+
+
+def command_result(command: list[str], timeout: float = 15.0) -> dict[str, Any]:
+    """Run one command and retain only bounded, redacted evidence."""
+    try:
+        completed = subprocess.run(
+            command, capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=timeout, check=False,
+        )
+        return {
+            "command": command,
+            "exit_code": completed.returncode,
+            "stdout": sanitize(completed.stdout),
+            "stderr": sanitize(completed.stderr),
+        }
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return {"command": command, "exit_code": None, "stdout": "", "stderr": sanitize(str(error))}
+
+
+def message_id_from_value(value: Any) -> str:
+    if isinstance(value, dict):
+        for key in ("message_id", "messageId"):
+            if isinstance(value.get(key), str) and value[key]:
+                return value[key]
+        for child in value.values():
+            try:
+                return message_id_from_value(child)
+            except SmokeError:
+                continue
+    if isinstance(value, list):
+        for child in value:
+            try:
+                return message_id_from_value(child)
+            except SmokeError:
+                continue
+    raise SmokeError("ATM JSON did not contain a message ID")
+
+
+def extract_message_id(raw: str) -> str:
+    try:
+        return message_id_from_value(json.loads(raw))
+    except json.JSONDecodeError as error:
+        raise SmokeError(f"send did not return JSON: {error}") from error
+
+
+def advertised_host_from_value(interfaces: Any) -> str:
+    stack = [interfaces]
+    while stack:
+        value = stack.pop()
+        if isinstance(value, dict):
+            host = value.get("advertise_host", value.get("advertised_host"))
+            if value.get("enabled") is not False and isinstance(host, str) and host:
+                return host
+            stack.extend(value.values())
+        elif isinstance(value, list):
+            stack.extend(value)
+    raise SmokeError("peer interface list JSON has no enabled advertise_host; set local.advertised_host")
+
+
+def extract_advertised_host(raw: str) -> str:
+    try:
+        return advertised_host_from_value(json.loads(raw))
+    except json.JSONDecodeError as error:
+        raise SmokeError(f"peer interface list did not return JSON: {error}") from error

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -21,6 +21,8 @@ def load_runner():
 
 
 RUNNER = load_runner()
+TEST_SENDER = "test-agent"
+TEST_TEAM = "test-team"
 
 
 class FeatureSmokeTests(unittest.TestCase):
@@ -75,6 +77,13 @@ class FeatureSmokeTests(unittest.TestCase):
         with mock.patch.object(RUNNER, "command", return_value={"exit_code": 0, "stdout": __import__("json").dumps(metadata), "stderr": ""}):
             with self.assertRaisesRegex(RUNNER.SmokeError, "shared"):
                 RUNNER.branch_version()
+
+    def test_command_redacts_captured_secret_output(self):
+        completed = mock.Mock(returncode=1, stdout="token=must-not-appear", stderr="private_key=must-not-appear")
+        with mock.patch.object(RUNNER.subprocess, "run", return_value=completed):
+            result = RUNNER.command(["atm", "doctor"])
+        self.assertNotIn("must-not-appear", result["stdout"])
+        self.assertNotIn("must-not-appear", result["stderr"])
 
     def test_remote_hosts_are_rejected_for_localhost_feature(self):
         with mock.patch.object(RUNNER.sys, "argv", ["smoke", "localhost", "m5"]):
@@ -211,7 +220,7 @@ class FeatureSmokeTests(unittest.TestCase):
                 {"message_id": "01REQUIRED", "text": mock.ANY, "requires_ack": True},
             ],
         ), mock.patch.object(RUNNER, "message_has_text", return_value=True):
-            RUNNER.send_read_ack(cases, "atm", "arch-ctm", "atm-dev", "127.0.0.1", stage="loopback-IP")
+            RUNNER.send_read_ack(cases, "atm", TEST_SENDER, TEST_TEAM, "127.0.0.1", stage="loopback-IP")
         self.assertEqual(
             [(case["name"], case["status"]) for case in cases],
             [
@@ -378,6 +387,7 @@ class FeatureSmokeTests(unittest.TestCase):
         }
         remote_ack = {"reply_disposition": {"kind": "sent", "reply_message_id": "01REPLY"}}
         cases = []
+        remote_ack_teams = []
 
         class Clock:
             @staticmethod
@@ -398,6 +408,7 @@ class FeatureSmokeTests(unittest.TestCase):
                     }
                 }
             elif args[0] == "ack":
+                remote_ack_teams.append(args[args.index("--team") + 1])
                 response = remote_ack
             else:
                 response = sent
@@ -435,6 +446,7 @@ class FeatureSmokeTests(unittest.TestCase):
             )
         self.assertEqual([case["status"] for case in cases], ["PASS", "PASS", "PASS", "PASS"])
         self.assertEqual(cases[1]["detail"], "01REPLY")
+        self.assertEqual(remote_ack_teams, ["peer-team"])
 
 
 if __name__ == "__main__":

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -347,7 +347,8 @@ class FeatureSmokeTests(unittest.TestCase):
         self.assertIn("--resolve", curl_calls[0])
         self.assertNotIn("--resolve", curl_calls[1])
         self.assertIn("https://remote.example.test:43101/v1/atm/doctor", curl_calls[1])
-        self.assertTrue(all("/tmp/atm-smoke-" not in " ".join(call) for call in curl_calls))
+        local_ca_path = curl_calls[0][curl_calls[0].index("--cacert") + 1]
+        self.assertEqual(Path(local_ca_path).name, "remote-public.pem")
         cleanup_script = remote_shell.call_args_list[-1].args[1]
         self.assertIn("rm -f", cleanup_script)
         self.assertIn("local-public.pem", cleanup_script)

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -323,8 +323,9 @@ class FeatureSmokeTests(unittest.TestCase):
                 {"exit_code": 0, "stdout": "/private/var/folders/atm-smoke-certs-123\n", "stderr": ""},
                 result,
                 result,
+                {"exit_code": 0, "stdout": "", "stderr": ""},
             ],
-        ), mock.patch.object(
+        ) as remote_shell, mock.patch.object(
             RUNNER, "command", return_value=result
         ) as command, mock.patch.object(
             RUNNER, "certificate_authority", side_effect=["local.example.test", "remote.example.test"]
@@ -347,6 +348,11 @@ class FeatureSmokeTests(unittest.TestCase):
         self.assertNotIn("--resolve", curl_calls[1])
         self.assertIn("https://remote.example.test:43101/v1/atm/doctor", curl_calls[1])
         self.assertTrue(all("/tmp/atm-smoke-" not in " ".join(call) for call in curl_calls))
+        cleanup_script = remote_shell.call_args_list[-1].args[1]
+        self.assertIn("rm -f", cleanup_script)
+        self.assertIn("local-public.pem", cleanup_script)
+        self.assertIn("peer-public.pem", cleanup_script)
+        self.assertIn("rmdir", cleanup_script)
 
     def test_crosshost_send_requires_remote_exact_ulid_and_body(self):
         sent = {"message_id": "01SEND"}

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -86,7 +86,18 @@ class FeatureSmokeTests(unittest.TestCase):
             with mock.patch.dict(os.environ, {"ATM_SMOKE_RUN_ID": "smoke-42"}, clear=False):
                 with mock.patch.object(RUNNER, "ROOT", Path(temp)):
                     with mock.patch.object(RUNNER, "compose") as compose:
-                        report = RUNNER.write_report("localhost", [{"name": "doctor", "status": "PASS", "detail": "ready"}])
+                        report = RUNNER.write_report(
+                            "localhost",
+                            [
+                                {
+                                    "name": "doctor",
+                                    "status": "PASS",
+                                    "detail": "ready",
+                                    "origin": "local.example.test",
+                                    "destination": "local.example.test",
+                                }
+                            ],
+                        )
         self.assertEqual(compose.call_count, 3)
         self.assertEqual(compose.call_args_list[1].args[2], report.with_suffix(".html"))
         self.assertEqual(compose.call_args_list[2].args[2], report.parent / "index.html")
@@ -95,14 +106,79 @@ class FeatureSmokeTests(unittest.TestCase):
         pane = RUNNER.render_feature_pane(
             "localhost",
             [
-                {"name": "doctor", "status": "PASS", "detail": "status: healthy\nreadiness: ready"},
-                {"name": "localhost send/read", "status": "PASS", "detail": "01TEST"},
+                {
+                    "name": "doctor",
+                    "status": "PASS",
+                    "detail": "status: healthy\nreadiness: ready",
+                    "origin": "m4",
+                    "destination": "m4",
+                },
+                {
+                    "name": "localhost send/read",
+                    "status": "PASS",
+                    "detail": "01TEST",
+                    "origin": "m4",
+                    "destination": "m4",
+                },
+                {
+                    "name": "mTLS doctor",
+                    "status": "PASS",
+                    "detail": "HTTP 200",
+                    "origin": "m4",
+                    "destination": "m5",
+                },
             ],
+            "m4",
         )
         self.assertIn("localhost send/read", pane)
-        self.assertIn("Doctor passed", pane)
-        self.assertIn("healthy<br />readiness", pane)
-        self.assertNotIn("<td>doctor</td>", pane)
+        self.assertIn("ONE-COMPUTER TEST — m4", pane)
+        self.assertIn("CROSS-HOST TEST — m4 ↔ m5", pane)
+        self.assertIn("<th>Doctor</th><td>PASS 1/1</td>", pane)
+
+    def test_host_header_reports_advertised_ip_version_and_doctor(self):
+        header = RUNNER.render_host_header(
+            "m4",
+            [
+                {"name": "doctor", "status": "PASS", "detail": "READY · ATM 1.4.0-beta-ai"},
+                {"name": "advertised host", "status": "PASS", "detail": "192.0.2.10"},
+            ],
+        )
+        self.assertIn("Advertised IP</th><td>192.0.2.10", header)
+        self.assertIn("ATM version</th><td>1.4.0-beta-ai", header)
+        self.assertIn("Doctor</th><td>PASS 1/1", header)
+
+    def test_cross_host_section_reports_both_endpoint_preflights(self):
+        cases = [
+            {"name": "doctor", "status": "PASS", "detail": "READY · ATM 1.4.0-beta-ai", "origin": "m4", "destination": "m4"},
+            {"name": "advertised host", "status": "PASS", "detail": "192.0.2.10", "origin": "m4", "destination": "m4"},
+            {"name": "m5 doctor/version", "status": "PASS", "detail": "client=1.4.0-beta-ai, daemon=1.4.0-beta-ai", "origin": "m5", "destination": "m5"},
+            {"name": "m5 advertised host", "status": "PASS", "detail": "192.0.2.20", "origin": "m5", "destination": "m5"},
+            {"name": "mTLS doctor", "status": "PASS", "detail": "HTTP 200", "origin": "m4", "destination": "m5"},
+        ]
+        section = RUNNER.render_cross_host_section("CROSS-HOST TEST — m4 ↔ m5", ["m4", "m5"], cases, [cases[-1]])
+        self.assertIn("IP address used", section)
+        self.assertIn("192.0.2.10", section)
+        self.assertIn("192.0.2.20", section)
+        self.assertEqual(section.count("1.4.0-beta-ai"), 2)
+        self.assertGreaterEqual(section.count("PASS"), 2)
+
+    def test_repeated_cases_show_pass_count_and_first_failure(self):
+        summarized = RUNNER.summarize_cases(
+            [
+                {"origin": "m4", "destination": "m5", "name": "mTLS doctor", "status": "PASS", "detail": "01"},
+                {"origin": "m4", "destination": "m5", "name": "mTLS doctor", "status": "FAIL", "detail": "connection refused"},
+                {"origin": "m4", "destination": "m5", "name": "mTLS doctor", "status": "PASS", "detail": "03"},
+            ]
+        )
+        self.assertEqual(summarized[0]["status"], "FAIL")
+        self.assertEqual(summarized[0]["detail"], "2/3 PASS · connection refused")
+
+    def test_live_repetitions_default_to_ten_and_reject_invalid_values(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(RUNNER.smoke_repetitions(), 10)
+        with mock.patch.dict(os.environ, {"ATM_SMOKE_REPETITIONS": "zero"}, clear=False):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "positive integer"):
+                RUNNER.smoke_repetitions()
 
     def test_artifact_segment_rejects_path_traversal(self):
         with self.assertRaisesRegex(RUNNER.SmokeError, "ATM_SMOKE_RUN_ID"):
@@ -121,6 +197,29 @@ class FeatureSmokeTests(unittest.TestCase):
     def test_message_has_text_requires_exact_body(self):
         self.assertTrue(RUNNER.message_has_text({"text": "exact"}, "exact"))
         self.assertFalse(RUNNER.message_has_text({"text": "different"}, "exact"))
+
+    def test_ack_send_failure_records_only_the_reply_row(self):
+        cases = []
+        sent = {"exit_code": 0, "stdout": '{"message_id":"01NORMAL"}', "stderr": ""}
+        required = {"exit_code": 0, "stdout": '{"message_id":"01REQUIRED"}', "stderr": ""}
+        failed_ack = {"exit_code": 1, "stdout": "", "stderr": "temporary daemon failure"}
+        with mock.patch.object(RUNNER, "command", side_effect=[sent, required, failed_ack]), mock.patch.object(
+            RUNNER,
+            "wait_for_message",
+            side_effect=[
+                {"message_id": "01NORMAL", "text": mock.ANY},
+                {"message_id": "01REQUIRED", "text": mock.ANY, "requires_ack": True},
+            ],
+        ), mock.patch.object(RUNNER, "message_has_text", return_value=True):
+            RUNNER.send_read_ack(cases, "atm", "arch-ctm", "atm-dev", "127.0.0.1", stage="loopback-IP")
+        self.assertEqual(
+            [(case["name"], case["status"]) for case in cases],
+            [
+                ("loopback-IP send/read/content", "PASS"),
+                ("loopback-IP requires-ack delivery/content", "PASS"),
+                ("loopback-IP acknowledgement reply delivery/content", "FAIL"),
+            ],
+        )
 
     def test_doctor_ready_requires_health_readiness_and_matching_pair(self):
         report = {
@@ -142,6 +241,32 @@ class FeatureSmokeTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(RUNNER.SmokeError, "no enabled"):
             RUNNER.advertised_host_from_json({"interfaces": [{"enabled": False, "advertise_host": "old"}]})
+
+    def test_dns_resolution_uses_all_returned_addresses(self):
+        with mock.patch.object(
+            RUNNER.socket,
+            "getaddrinfo",
+            return_value=[
+                (2, 1, 6, "", ("192.0.2.10", 43101)),
+                (30, 1, 6, "", ("2001:db8::10", 43101, 0, 0)),
+                (2, 1, 6, "", ("192.0.2.10", 43101)),
+            ],
+        ):
+            self.assertEqual(RUNNER.resolve_dns_addresses("peer.example"), ["192.0.2.10", "2001:db8::10"])
+
+    def test_dns_case_requires_the_advertised_ip(self):
+        cases = []
+        RUNNER.add_dns_case(
+            cases,
+            "local DNS resolves m5 peer",
+            "m4",
+            "m5",
+            "m5.example",
+            "192.0.2.20",
+            lambda _hostname: ["2001:db8::20"],
+        )
+        self.assertEqual(cases[0]["status"], "FAIL")
+        self.assertIn("missing advertised IP 192.0.2.20", cases[0]["detail"])
 
     def test_remote_command_supplies_configured_peer_identity(self):
         result = {"exit_code": 0, "stdout": "{}", "stderr": ""}
@@ -186,7 +311,9 @@ class FeatureSmokeTests(unittest.TestCase):
             RUNNER, "command", return_value=result
         ) as command, mock.patch.object(
             RUNNER, "certificate_authority", side_effect=["local.example.test", "remote.example.test"]
-        ), mock.patch.object(RUNNER, "advertised_host", return_value="192.0.2.10"):
+        ), mock.patch.object(RUNNER, "advertised_host", return_value="192.0.2.10"), mock.patch.object(
+            RUNNER, "resolve_dns_addresses", return_value=["192.0.2.20"]
+        ), mock.patch.object(RUNNER, "remote_resolve_dns_addresses", return_value=["192.0.2.10"]):
             RUNNER.curl_doctor(
                 cases,
                 "m5",
@@ -196,10 +323,12 @@ class FeatureSmokeTests(unittest.TestCase):
                 "1.4.0-beta-ai",
                 plaintext=False,
             )
-        self.assertEqual([case["status"] for case in cases], ["PASS", "PASS"])
+        self.assertEqual([case["status"] for case in cases], ["PASS", "PASS", "PASS", "PASS", "PASS"])
         curl_calls = [call.args[0] for call in command.call_args_list if call.args[0][0] == "curl"]
-        self.assertEqual(len(curl_calls), 1)
-        self.assertIn("https://remote.example.test:43101/v1/atm/doctor", curl_calls[0])
+        self.assertEqual(len(curl_calls), 2)
+        self.assertIn("--resolve", curl_calls[0])
+        self.assertNotIn("--resolve", curl_calls[1])
+        self.assertIn("https://remote.example.test:43101/v1/atm/doctor", curl_calls[1])
 
     def test_crosshost_send_requires_remote_exact_ulid_and_body(self):
         sent = {"message_id": "01SEND"}

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -80,7 +80,7 @@ class FeatureSmokeTests(unittest.TestCase):
 
     def test_command_redacts_captured_secret_output(self):
         completed = mock.Mock(returncode=1, stdout="token=must-not-appear", stderr="private_key=must-not-appear")
-        with mock.patch.object(RUNNER.subprocess, "run", return_value=completed):
+        with mock.patch("smoke_common.subprocess.run", return_value=completed):
             result = RUNNER.command(["atm", "doctor"])
         self.assertNotIn("must-not-appear", result["stdout"])
         self.assertNotIn("must-not-appear", result["stderr"])
@@ -316,7 +316,15 @@ class FeatureSmokeTests(unittest.TestCase):
                 "stdout": __import__("json").dumps({"private_key_ref": "/tmp/remote-bundle.pem"}),
                 "stderr": "",
             },
-        ), mock.patch.object(RUNNER, "remote_shell", side_effect=[result, result]), mock.patch.object(
+        ), mock.patch.object(
+            RUNNER,
+            "remote_shell",
+            side_effect=[
+                {"exit_code": 0, "stdout": "/private/var/folders/atm-smoke-certs-123\n", "stderr": ""},
+                result,
+                result,
+            ],
+        ), mock.patch.object(
             RUNNER, "command", return_value=result
         ) as command, mock.patch.object(
             RUNNER, "certificate_authority", side_effect=["local.example.test", "remote.example.test"]
@@ -338,6 +346,7 @@ class FeatureSmokeTests(unittest.TestCase):
         self.assertIn("--resolve", curl_calls[0])
         self.assertNotIn("--resolve", curl_calls[1])
         self.assertIn("https://remote.example.test:43101/v1/atm/doctor", curl_calls[1])
+        self.assertTrue(all("/tmp/atm-smoke-" not in " ".join(call) for call in curl_calls))
 
     def test_crosshost_send_requires_remote_exact_ulid_and_body(self):
         sent = {"message_id": "01SEND"}

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -42,6 +42,12 @@ class FeatureSmokeTests(unittest.TestCase):
                 self.assertEqual(RUNNER.main(), 0)
         run_live.assert_called_once_with("crosshost-ack", ["m5"])
 
+    def test_crosshost_curl_tls_passes_all_hostnames_to_live_runner(self):
+        with mock.patch.object(RUNNER, "run_live", return_value=0) as run_live:
+            with mock.patch.object(RUNNER.sys, "argv", ["smoke", "crosshost-curl-tls", "m5"]):
+                self.assertEqual(RUNNER.main(), 0)
+        run_live.assert_called_once_with("crosshost-curl-tls", ["m5"])
+
     def test_crosshost_feature_requires_a_peer(self):
         with mock.patch.object(RUNNER.sys, "argv", ["smoke", "crosshost-send"]):
             with self.assertRaisesRegex(RUNNER.SmokeError, "requires one or more SSH hostnames"):
@@ -137,6 +143,64 @@ class FeatureSmokeTests(unittest.TestCase):
         with self.assertRaisesRegex(RUNNER.SmokeError, "no enabled"):
             RUNNER.advertised_host_from_json({"interfaces": [{"enabled": False, "advertise_host": "old"}]})
 
+    def test_remote_command_supplies_configured_peer_identity(self):
+        result = {"exit_code": 0, "stdout": "{}", "stderr": ""}
+        with mock.patch.dict(
+            os.environ,
+            {"ATM_SMOKE_REMOTE_IDENTITY": "cm5:smoke", "ATM_SMOKE_REMOTE_TEAM": "atm-m5"},
+            clear=False,
+        ), mock.patch.object(RUNNER, "command", return_value=result) as command:
+            self.assertEqual(RUNNER.remote_command("m5", "/opt/homebrew/bin/atm", ["doctor", "--json"]), result)
+        self.assertEqual(
+            command.call_args.args[0],
+            [
+                "ssh",
+                "m5",
+                "env",
+                "ATM_IDENTITY=cm5:smoke",
+                "ATM_TEAM=atm-m5",
+                "/opt/homebrew/bin/atm",
+                "doctor",
+                "--json",
+            ],
+        )
+
+    def test_curl_doctor_records_real_route_evidence_in_both_directions(self):
+        doctor = {
+            "summary": {"status": "healthy"},
+            "runtime_status": {"readiness": "ready"},
+            "client_context": {"version": "1.4.0-beta-ai"},
+            "daemon_context": {"version": "1.4.0-beta-ai"},
+        }
+        result = {"exit_code": 0, "stdout": __import__("json").dumps(doctor), "stderr": ""}
+        cases = []
+        with mock.patch.object(RUNNER, "certificate_bundle", return_value="/tmp/local-bundle.pem"), mock.patch.object(
+            RUNNER,
+            "remote_command",
+            return_value={
+                "exit_code": 0,
+                "stdout": __import__("json").dumps({"private_key_ref": "/tmp/remote-bundle.pem"}),
+                "stderr": "",
+            },
+        ), mock.patch.object(RUNNER, "remote_shell", side_effect=[result, result]), mock.patch.object(
+            RUNNER, "command", return_value=result
+        ) as command, mock.patch.object(
+            RUNNER, "certificate_authority", side_effect=["local.example.test", "remote.example.test"]
+        ), mock.patch.object(RUNNER, "advertised_host", return_value="192.0.2.10"):
+            RUNNER.curl_doctor(
+                cases,
+                "m5",
+                "atm",
+                "/opt/homebrew/bin/atm",
+                "192.0.2.20",
+                "1.4.0-beta-ai",
+                plaintext=False,
+            )
+        self.assertEqual([case["status"] for case in cases], ["PASS", "PASS"])
+        curl_calls = [call.args[0] for call in command.call_args_list if call.args[0][0] == "curl"]
+        self.assertEqual(len(curl_calls), 1)
+        self.assertIn("https://remote.example.test:43101/v1/atm/doctor", curl_calls[0])
+
     def test_crosshost_send_requires_remote_exact_ulid_and_body(self):
         sent = {"message_id": "01SEND"}
         remote_read = {"message": {"message_id": "01SEND", "text": "smoke-crosshost-send-m5-STAMP"}}
@@ -148,11 +212,31 @@ class FeatureSmokeTests(unittest.TestCase):
                 return type("FixedTime", (), {"strftime": lambda self, _format: "STAMP"})()
 
         with mock.patch.object(RUNNER, "command", return_value={"exit_code": 0, "stdout": __import__("json").dumps(sent), "stderr": ""}), mock.patch.object(
-            RUNNER, "remote_command", return_value={"exit_code": 0, "stdout": __import__("json").dumps(remote_read), "stderr": ""}
+            RUNNER, "remote_command", side_effect=lambda _peer, _atm, args, timeout=20.0: {
+                "exit_code": 0,
+                "stdout": __import__("json").dumps(remote_read if args[0] == "read" else sent),
+                "stderr": "",
+            }
+        ), mock.patch.object(
+            RUNNER,
+            "wait_for_message",
+            return_value={"message_id": "01SEND", "text": "smoke-crosshost-send-reverse-m5-STAMP"},
         ), mock.patch.object(RUNNER, "datetime", Clock):
-            RUNNER.crosshost_send(cases, "atm", "atm", "agent", "team", "m5", "m5.local")
-        self.assertEqual(cases[-1]["status"], "PASS")
-        self.assertEqual(cases[-1]["detail"], "01SEND")
+            RUNNER.crosshost_send(
+                cases,
+                "atm",
+                "atm",
+                "agent",
+                "team",
+                "peer",
+                "peer-team",
+                "m5",
+                "m5.local",
+                "127.0.0.1",
+            )
+        self.assertEqual([case["status"] for case in cases], ["PASS", "PASS"])
+        self.assertEqual(cases[0]["detail"], "01SEND")
+        self.assertEqual(cases[1]["detail"], "01SEND")
 
     def test_crosshost_ack_verifies_reverse_reply_linkage(self):
         sent = {"message_id": "01SEND"}
@@ -172,18 +256,35 @@ class FeatureSmokeTests(unittest.TestCase):
                 return type("FixedTime", (), {"strftime": lambda self, _format: "STAMP"})()
 
         def local_command(argv, timeout=15.0):
-            return {"exit_code": 0, "stdout": __import__("json").dumps(sent), "stderr": ""}
+            response = remote_ack if argv[1] == "ack" else sent
+            return {"exit_code": 0, "stdout": __import__("json").dumps(response), "stderr": ""}
 
         def remote(peer, atm, args, timeout=20.0):
             if args[0] == "read":
-                return {"exit_code": 0, "stdout": __import__("json").dumps(remote_read), "stderr": ""}
-            return {"exit_code": 0, "stdout": __import__("json").dumps(remote_ack), "stderr": ""}
+                response = remote_read if args[args.index("--message-id") + 1] == "01SEND" else {
+                    "message": {
+                        "message_id": "01REPLY",
+                        "text": "smoke-crosshost-reverse-reply-m5-STAMP",
+                        "acknowledgesMessageId": "01SEND",
+                    }
+                }
+            elif args[0] == "ack":
+                response = remote_ack
+            else:
+                response = sent
+            return {"exit_code": 0, "stdout": __import__("json").dumps(response), "stderr": ""}
 
         def local_reply(atm, team, expected, timeout=12.0):
+            if expected == "01REPLY":
+                return {
+                    "message_id": expected,
+                    "text": "smoke-crosshost-reply-m5-STAMP",
+                    "acknowledgesMessageId": "01SEND",
+                }
             return {
                 "message_id": expected,
-                "text": "smoke-crosshost-reply-m5-STAMP",
-                "acknowledgesMessageId": "01SEND",
+                "text": "smoke-crosshost-ack-reverse-m5-STAMP",
+                "requires_ack": True,
             }
 
         with mock.patch.object(RUNNER, "command", side_effect=local_command), mock.patch.object(
@@ -191,9 +292,20 @@ class FeatureSmokeTests(unittest.TestCase):
         ), mock.patch.object(RUNNER, "wait_for_message", side_effect=local_reply), mock.patch.object(
             RUNNER, "datetime", Clock
         ):
-            RUNNER.crosshost_ack(cases, "atm", "atm", "agent", "team", "m5", "m5.local")
-        self.assertEqual([case["status"] for case in cases], ["PASS", "PASS"])
-        self.assertEqual(cases[-1]["detail"], "01REPLY")
+            RUNNER.crosshost_ack(
+                cases,
+                "atm",
+                "atm",
+                "agent",
+                "team",
+                "peer",
+                "peer-team",
+                "m5",
+                "m5.local",
+                "127.0.0.1",
+            )
+        self.assertEqual([case["status"] for case in cases], ["PASS", "PASS", "PASS", "PASS"])
+        self.assertEqual(cases[1]["detail"], "01REPLY")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope
- add `just smoke FEATURE [HOST ...]` progressive local and cross-host evidence collection
- record ten-attempt results, endpoint identity/doctor data, DNS and mTLS-curl checks
- generate a combined HTML report plus endpoint XHTML panels

## Deliberately excluded
- daemon-switch compatibility work and blocked-M5 evidence are not in this PR
- async-admission/throughput requirements and sprint plans are separate planning work

## Validation
- `python3 -m unittest scripts/smoke/test_run_feature_smoke.py` — 28 tests passed
- `just lint` passed
- `git diff --check origin/develop...HEAD` passed