### PR TITLE
docs: plan asynchronous peer admission

### DIFF
--- a/docs/adr/ADR-035-canonical-write-ingress-and-host-routing.md
+++ b/docs/adr/ADR-035-canonical-write-ingress-and-host-routing.md
@@ -18,16 +18,18 @@ cross-host-specific mailbox, acknowledgement, or nudge branch.
 
 Routing is decided exactly once by the post-write event router:
 
-- an empty destination host selects local nudge delivery;
-- every validated present destination host selects the HTTPS transport adapter,
+- an empty destination host selects a local-nudge work key; and
+- every validated present destination host selects a peer-delivery work key,
   including `localhost` and this daemon's advertised or bound IP address.
 
 For a remote destination, the local write records the sender's immutable
-outbound message before this decision; the remote daemon performs the
-recipient-side write when it receives the same `WriteRequest`. A failed HTTPS
-attempt does not add local delivery state, a remote recipient row, a receipt,
-or a retry queue. It returns one transport error; a repeated write reuses the
-same immutable message ULID.
+outbound message before this decision; the router signals the bounded
+post-commit scheduler and returns the local admission response. The worker,
+not the router, invokes HTTPS; the remote daemon performs the recipient-side
+write when it receives the same `WriteRequest`. A failed HTTPS attempt does
+not add local delivery state, a remote recipient row, a receipt, or a retry
+queue. It records a typed asynchronous unconfirmed outcome; a repeated
+canonical write reuses the same immutable message ULID.
 
 The source host is durable message provenance. The destination host is an
 origin-side routing selector consumed before an authenticated peer ingress is
@@ -70,7 +72,10 @@ second routing or acknowledgement path.
 - No separate ack sender, ack transport, or sender-side ack state mutation.
 - No second routing decision in CLI, graft, HTTP, TLS, storage, or nudge code.
 - No cross-host-specific persistence or inbound nudge handler.
-- No host inspection before persistence or outside `PostWriteRouter`.
+- No host inspection before persistence or outside `PostWriteRouter`. The
+  router may read only its immutable daemon-owned runtime view; it must not
+  read a configuration/policy store, query outbound records, or invoke DNS,
+  socket, TLS, hook, nudge, or peer transport code.
 - No socket-family or socket-address inference of local versus peer ingress.
 
 Architecture checks must reject these shapes structurally, not merely by a

--- a/docs/adr/ADR-036-storage-boundary-and-composition-topology.md
+++ b/docs/adr/ADR-036-storage-boundary-and-composition-topology.md
@@ -31,6 +31,15 @@ and the bounded peer/direction/age query required by ADR-038. These are
 backend-neutral query methods, not SQLite tables or a daemon-owned persistence
 trait. Transport adapters receive canonical records only through those traits.
 
+The acknowledgement admission operation is one existing sealed,
+backend-neutral storage/runtime contract: it resolves source data, inserts the
+canonical acknowledgement, and conditionally transitions the source in one
+transaction. It returns typed domain outcomes, never SQLite rows or a
+daemon-feature-specific persistence trait. `atm-daemon` composition may
+publish an immutable admission runtime-view snapshot assembled from
+backend-neutral configuration/roster/trust DTOs, but that view is a read-only
+cache and cannot own durable delivery state or concrete backend types.
+
 ## Consequences
 
 The prior runtime indirection is not a justification for SQLite-backed daemon

--- a/docs/adr/ADR-038-bounded-peer-reconciliation.md
+++ b/docs/adr/ADR-038-bounded-peer-reconciliation.md
@@ -22,35 +22,34 @@ pub struct PeerSyncPolicy {
 
 The policy defaults to disabled. An operator enables it with the peer CLI and
 may request a one-shot sync. A host-qualified local outbound persistence or a
-peer-delivery failure signals the one bounded per-host drain coordinator. The
-coordinator queries storage for local outbound canonical records addressed to
-that exact peer and newer than `now - max_message_age`, then submits each
-unchanged record to `PeerHttpTransport`.
+peer-delivery failure signals the bounded non-durable scheduler. The scheduler
+queries storage for local outbound canonical records addressed to that exact
+peer and newer than `now - max_message_age`, then submits unchanged records to
+`PeerHttpTransport` as independent jobs.
 
-Each scan advances a transient exclusive `(created_at, message_ulid)` lower
-bound through pages of at most `max_batch_messages`, ordered oldest first,
-until it observes an empty page, a transport failure, or cancellation. One
-in-memory lease per `HostName` covers storage paging, one HTTP(S) connection in
-the active wire-security profile, sequential ordinary `WriteRequest`
-submissions, and final rescan. It carries only running
-state, a wake generation, next attempt time, and backoff; it stores no message
-ID, payload, cursor, receipt, or delivery result. A persisted write increments
-the generation. Before lease release, an empty final scan must observe the same
-generation; otherwise it scans again. A post-release signal starts the next
-lease.
+Each scheduler scan pages eligible records through the storage trait and
+enqueues ordinary `WriteRequest` jobs. Global and per-host bounds limit
+concurrent jobs; an in-flight ULID may be coalesced. The scheduler makes no
+delivery-order promise across independent messages, does not require a stream,
+and does not define a durable cursor. It holds only transient host/message-ID
+work markers, bounded timing, and backoff—never a payload, receipt, retry
+history, or delivery result. A persisted write signals the host. A signal that
+arrives during a scan or active job requires another eligibility scan before
+the host becomes idle; a restart safely drops transient work and later
+rediscovers immutable records through normal idempotent delivery.
 
 The post-write router calls the one coordinator handoff for every
-host-qualified origin write after canonical persistence. A foreground request
-waits behind that same host lease and older ordered records only within its
-existing request deadline; it never opens a second socket. This transient
-request-local wait is neither a coordinator slot field nor durable delivery
-state. Its timeout is the one truthful unconfirmed outcome defined by ADR-041.
+host-qualified origin write after canonical persistence. It signals bounded
+background work and returns; foreground admission never waits for another
+message, DNS, connection, TLS, or peer receipt. A remote outcome is recorded
+asynchronously and remains distinct from local admission under ADR-041.
 
 After a delivery failure, the coordinator schedules the same host no earlier
 than 60 seconds, then with exponential backoff capped at 15 minutes while
 eligible records remain. Restart waits the same minimum before an eligible
-attempt. Explicit one-shot sync uses the same lease and connection. There is no
-ping, empty-peer monitor, batch endpoint, or recovery-specific router.
+attempt. Explicit one-shot sync uses the same scheduler and ordinary endpoint.
+There is no ping, empty-peer monitor, batch endpoint, or recovery-specific
+router.
 
 The storage trait—not the daemon or transport—owns the backend-neutral query.
 There is no outbox, replay store, retry queue, background monitor, cursor,

--- a/docs/adr/ADR-038-bounded-peer-reconciliation.md
+++ b/docs/adr/ADR-038-bounded-peer-reconciliation.md
@@ -5,7 +5,7 @@
 | ID | ADR-038 |
 | Status | Proposed |
 | Scope | Repository-wide |
-| Relates to | ADR-034, ADR-035, ADR-036, ADR-041, Phase AI.28 |
+| Relates to | ADR-034, ADR-035, ADR-036, ADR-041, Phase AI.28, AI.31--AI.33 |
 
 ## Decision
 
@@ -28,7 +28,8 @@ peer and newer than `now - max_message_age`, then submits unchanged records to
 `PeerHttpTransport` as independent jobs.
 
 Each scheduler scan pages eligible records through the storage trait and
-enqueues ordinary `WriteRequest` jobs. Global and per-host bounds limit
+enqueues ordinary `WriteRequest` jobs. The queue has a depth of 256, with at
+most 64 active jobs globally and 8 per host; global and per-host bounds limit
 concurrent jobs; an in-flight ULID may be coalesced. The scheduler makes no
 delivery-order promise across independent messages, does not require a stream,
 and does not define a durable cursor. It holds only transient host/message-ID
@@ -44,7 +45,9 @@ background work and returns; foreground admission never waits for another
 message, DNS, connection, TLS, or peer receipt. A remote outcome is recorded
 asynchronously and remains distinct from local admission under ADR-041.
 
-After a delivery failure, the coordinator schedules the same host no earlier
+Each job has the one absolute 10-second worker deadline from
+`REQ-CORE-TRANSPORT-005`, spanning DNS through response. After a delivery
+failure, the coordinator schedules the same host no earlier
 than 60 seconds, then with exponential backoff capped at 15 minutes while
 eligible records remain. Restart waits the same minimum before an eligible
 attempt. Explicit one-shot sync uses the same scheduler and ordinary endpoint.
@@ -64,4 +67,6 @@ age. It provides a small recovery window after Wi-Fi/VPN connectivity returns wi
 creating a second write path or transport state machine. It never changes the
 message ID or immutable payload, and it cannot synthesize delivery success.
 Its retained events distinguish a scheduled/attempted scan from peer HTTP
-acceptance.
+acceptance. A record that remains unconfirmed until it ages beyond the enabled
+window emits the terminal typed `peer_delivery_expired` event; this is an
+observability outcome, never a receipt or delivery-state record.

--- a/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
+++ b/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
@@ -11,8 +11,8 @@
 
 Every daemon request owns one absolute `RequestDeadline` for local admission.
 The SQLite transaction that persists the immutable origin record is the only
-synchronous operation before the local response. Background delivery has a
-separate bounded worker budget: signalling, peer DNS, connection, TLS, and
+synchronous operation before the local response. Background delivery has one
+separate absolute 10-second worker budget: signalling, peer DNS, connection, TLS, and
 remote receipt cannot delay or be cancelled by the completed local response.
 The immutable origin record is the worker's only durable input.
 
@@ -36,6 +36,10 @@ Observability names outcomes precisely:
 - `peer_delivery_confirmed` requires the peer HTTP acceptance response; and
 - `peer_delivery_unconfirmed` records deadline/disconnect/failure with the
   message ULID and typed error code.
+- `peer_delivery_expired` records that an unconfirmed immutable record aged
+  out of the explicitly enabled reconciliation window. It is a terminal
+  observability outcome, not a delivery receipt or a change to the earlier
+  local admission response.
 
 No event may label local persistence as `sent` or remote delivery.
 

--- a/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
+++ b/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
@@ -9,12 +9,12 @@
 
 ## Decision
 
-Every daemon request owns one absolute `RequestDeadline`. The local HTTP
-adapter, router, dispatcher, post-write router, and HTTPS adapter consume the
-same remaining budget; no layer creates a longer independent peer deadline.
-Tracked work is cancelled when that budget expires or the local connection is
-closed, except that a remote peer may already have accepted bytes before a
-cancellation race completes.
+Every daemon request owns one absolute `RequestDeadline` for local admission.
+The SQLite transaction that persists the immutable origin record is the only
+synchronous operation before the local response. Background delivery has a
+separate bounded worker budget: signalling, peer DNS, connection, TLS, and
+remote receipt cannot delay or be cancelled by the completed local response.
+The immutable origin record is the worker's only durable input.
 
 For a remote write, local persistence is not delivery success. The only
 successful remote result is a verified HTTP response from the peer after its
@@ -26,8 +26,9 @@ immutable ULID is safe through ordinary idempotent write handling.
 
 `ATM_DAEMON_UNAVAILABLE` is reserved for an unavailable local daemon. A local
 response-read timeout must never map to that code when the daemon accepted the
-request. Daemon connection handler failures, terminal route errors, and
-response-write failures are structured retained events.
+request. In particular, peer work must not hold the local response open after
+local admission. Daemon connection handler failures, terminal route errors,
+and response-write failures are structured retained events.
 
 Observability names outcomes precisely:
 

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -538,6 +538,9 @@ Accepted daemon-private partitions:
 - `request_runtime`
   - owns per-connection request execution, request-work tracking, request
     deadlines, and response emission
+  - performs only request validation, one canonical storage transaction, one
+    post-commit work signal, and response emission; it must not scan peer
+    records, wait on peer work, or perform DNS/socket/TLS/HTTP/hook/nudge work
 - `runtime_status`
   - owns the live status cache, cache-cap semantics, roster hydration,
     reload-time runtime-view assembly, and doctor-health projection into
@@ -548,9 +551,10 @@ Accepted daemon-private partitions:
   - owns HTTP(S) socket/TLS adaptation only; it cannot persist, queue, retry,
     route, or nudge
 - `peer_recovery`
-  - owns ADR-038's one non-durable per-host coordinator lease, bounded
+  - owns ADR-038's bounded non-durable independent peer jobs,
     canonical-record query handoff, backoff, and status-event emission; it
-    cannot own a message, payload, cursor, receipt, or storage implementation
+    cannot own a message payload, cursor, receipt, attempt history, or storage
+    implementation, and it makes no same-peer FIFO/stream promise
 
 Historical-only retired partitions:
 - `watch_runtime`
@@ -690,6 +694,10 @@ Required caps:
 - max concurrent accepted connections: `64`
 - max per-connection inflight requests: `32`
 - ingest queue depth: `1024`
+- post-commit work queue depth: `256`
+- active peer jobs: `64` globally and `8` per host
+- peer job deadline: one absolute `10s` DNS-through-response budget; no
+  independent per-leg deadline
 - SQLite handle/pool budget: min `1`, max `4`
 - live status-cache cap: `4096` entries
 

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -151,6 +151,27 @@ Current implementation:
   but neither adapter nor coordinator can own a replay store, outbox, retry
   queue, receipt, message payload, or persistence implementation.
 
+## Phase AI post-commit admission boundary
+
+AI.31--AI.33 tighten the split between canonical admission and peer work:
+
+- `runtime_health` and `PostWriteRouter` may persist one canonical request,
+  choose exactly one local-nudge or peer-delivery work key, and signal the
+  daemon-private bounded queue. They must not perform peer-store scans, DNS,
+  socket/TLS, HTTP delivery, hooks, or nudge execution before the local
+  response.
+- `peer_drain_coordinator` is the sole daemon-private owner of post-commit
+  peer jobs. Its visible seam is crate-private and returns typed
+  `PeerDeliveryOutcome`, not HTTP status integers or concrete transport types.
+- the coordinator accesses canonical records only through `atm-storage`
+  traits and receives an immutable runtime-view snapshot from composition; it
+  must not introduce daemon-specific persistence traits or concrete SQLite
+  values.
+- `crates/atm-architecture/tests/boundary_enforcement.rs` and the relevant
+  `boundaries/atm-daemon/*.toml` records must fail closed if the first boundary
+  grows direct peer transport/store work or the second boundary grows durable
+  queue/receipt/retry state.
+
 ## LifecycleControlSourceAdapter
 
 Canonical machine-readable boundary source:

--- a/docs/plans/phase-ai/plan-phase-ai-crosshost-smoke-gaps.md
+++ b/docs/plans/phase-ai/plan-phase-ai-crosshost-smoke-gaps.md
@@ -32,6 +32,9 @@ solely to diagnose connectivity and proves no production security property.
 | Wi-Fi/VPN loss leaves recent persisted writes without recovery | AI.28 | bounded per-peer reconciliation schedule with backoff |
 | smoke treated local `outcome sent` as receipt | AI.29 | receiver-side ULID evidence and physical rerun |
 | product releases block compatible CLI/daemon pairs | AI.30 | explicit schema and HTTP SemVer compatibility contract |
+| foreground peer delivery blocks local daemon response | AI.31 | SQLite-only local admission followed by non-durable peer-job signalling |
+| recovery assumes an ordered peer stream | AI.32 | bounded independent ULID jobs with no cross-command ordering promise |
+| no isolated 1,000/s proof or comprehensible two-host ladder | AI.33 | disposable-db capacity harness and ten-run local/cross-host HTML evidence |
 
 The TLS trust-snapshot/restart observation is closed by AI.25's daemon-owned
 atomic configuration refresh. The five Windows sends in the first smoke remain
@@ -44,7 +47,7 @@ AI.21-pre evidence harness ─> AI.22 self-send guard ─> AI.23 shared write en
                                                                                        ├─> AI.25 peer authority ────────────┐
                                                                                        └─> AI.26 deadline/error contract ─> AI.27 outcome truth ─> AI.28 recovery
 AI.30 schema/HTTP compatibility ───────────────────────────────────────────────┘
-AI.24 + AI.25–AI.28 + AI.30 ─> AI.29 physical rerun
+AI.24 + AI.25–AI.28 + AI.30 ─> AI.29 physical rerun ─> AI.31 local admission ─> AI.32 independent jobs ─> AI.33 capacity/smoke evidence
 ```
 
 AI.21-pre closes the retained smoke harness/security-profile adoption before
@@ -68,8 +71,11 @@ so tested CLI/daemon builds are not artificially blocked by release-label drift.
 - A single absolute request deadline governs every local and remote leg.
 - A remote write is successful only after peer HTTP acceptance; local
   persistence is separately observable, never proof of receiver receipt.
-- A failed peer write may schedule bounded reconciliation of existing immutable
-  records, but it may not create a per-message queue, receipt, or retry state.
+- A failed peer write may schedule bounded non-durable work over existing
+  immutable records. Its transient queue may reference a hostname/ULID but may
+  not retain payload, receipt, retry history, or durable delivery state.
+- Independent CLI/API writes have no cross-command delivery-order guarantee;
+  acknowledgement correlation is by immutable ULID.
 - Every repeated immutable ULID follows the same write path and remains
   idempotent. No finding authorizes an outbox, replay queue, receipt, retry
   worker, or parallel acknowledgement workflow.
@@ -81,8 +87,9 @@ so tested CLI/daemon builds are not artificially blocked by release-label drift.
   changes the HTTP resource, `WriteRequest`, router, persistence, post-write,
   or production TLS/allowlist evidence contract.
 - Each sprint's first commit sets matching workspace CLI/daemon release
-  metadata to `1.3.2-beta-<sprint-number>` and verifies it with
-  `atm doctor --json` before runtime evidence.
+  metadata to the current Phase AI prerelease plus its sprint number (for
+  example, AI.31 is `1.4.0-beta-ai.31`) and verifies it with `atm doctor
+  --json` before runtime evidence.
 
 ## Required validation
 

--- a/docs/plans/phase-ai/plan-phase-ai.md
+++ b/docs/plans/phase-ai/plan-phase-ai.md
@@ -189,16 +189,20 @@ integration; they do not alter it.
 | AI.28 | `feature/pAI-s28-bounded-peer-recovery` | Backed-off bounded reconciliation after connectivity loss |
 | AI.29 | `feature/pAI-s29-crosshost-smoke-rerun` | Receiver-proven Mac↔Windows physical smoke evidence |
 | AI.30 | `feature/pAI-s30-semver-http-compatibility` | Schema/HTTP compatibility admission and opt-in SemVer prerelease distribution |
+| AI.31 | `feature/pAI-s31-async-local-admission` | SQLite-only local admission response; host-qualified peer work is signalled after response |
+| AI.32 | `feature/pAI-s32-independent-peer-jobs` | Bounded non-durable per-ULID peer jobs; no cross-command delivery-order promise or stream abstraction |
+| AI.33 | `feature/pAI-s33-admission-capacity-smoke` | Isolated 1,000/s admission proof and ten-run, endpoint-explicit local/cross-host smoke report |
 
 AI.17–AI.21 scope, dependencies, and parallel-execution rules are
 authoritative in [plan-ai17-21-hermes-graft.md](plan-ai17-21-hermes-graft.md).
 Findings are fixed on their owning sprint before forward merge.
 
 For every remaining Phase AI implementation sprint, the first commit sets the
-workspace release for every releasable ATM assembly to
-`1.3.2-beta-<sprint-number>` (for example, AI.22 is `1.3.2-beta-22`). Runtime
-evidence starts only after `atm doctor --json` reports matching CLI and daemon
-release values; release labels are diagnostic, not protocol admission.
+workspace release for every releasable ATM assembly to the current Phase AI
+prerelease plus the sprint number (for example, AI.31 is
+`1.4.0-beta-ai.31`). Runtime evidence starts only after `atm doctor --json`
+reports matching CLI and daemon release values; release labels are diagnostic,
+not protocol admission.
 
 ## Verification matrix
 

--- a/docs/plans/phase-ai/sprint-ai-28-bounded-peer-recovery.md
+++ b/docs/plans/phase-ai/sprint-ai-28-bounded-peer-recovery.md
@@ -8,6 +8,12 @@ depends_on: AI.21-pre, AI.26, AI.27
 
 # AI.28 — bounded peer recovery after connectivity loss
 
+> **Superseded operating rules:** AI.31 and AI.32 replace this sprint's
+> foreground-wait, oldest-first, one-socket delivery mechanics. The durable
+> recovery intent remains: immutable SQLite records are the sole recovery
+> input; no outbox or durable delivery state is permitted. Current work must
+> follow AI.31/AI.32 and `REQ-CORE-TRANSPORT-005B`.
+
 ## Release candidate
 
 - First commit: set every releasable ATM assembly to `1.3.2-beta-28`; record

--- a/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
+++ b/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
@@ -62,10 +62,16 @@ smaller request path, not a more patient client.
    `crates/atm-daemon/src/peer_drain_coordinator.rs`:
 
    ```rust
-   trait PeerDeliveryCoordinator: Send + Sync {
+   pub(crate) trait PeerDeliveryCoordinator: Send + Sync {
        fn signal_after_persist(&self, peer: HostName);
        fn sync_peer(&self, peer: &HostName, deadline: RequestDeadline)
-           -> Result<u16, AtmError>;
+           -> Result<PeerSyncOutcome, AtmError>;
+   }
+
+   enum PeerSyncOutcome {
+       Confirmed,
+       Unconfirmed { code: PeerDeliveryErrorCode },
+       Expired { code: PeerDeliveryErrorCode },
    }
    ```
 
@@ -92,8 +98,9 @@ smaller request path, not a more patient client.
 4. In `runtime_health/peer_delivery_router.rs`, replace
    `deliver_to_peer(..., deadline, ...)` with one post-commit
    `signal_after_persist(peer)` call for every host-qualified origin write.
-   Local/no-host nudge handling stays unchanged. No special localhost or
-   self-IP route is permitted.
+   Empty-host routing likewise emits only `LocalNudge(message_id)` work; the
+   worker performs its existing nudge/hook behavior after the response. No
+   special localhost or self-IP route is permitted.
 5. Move `ResolvedAcknowledgement::finish` into the same SQLite transaction as
    the acknowledgement record. An ACK admission response therefore proves both
    writes committed; peer delivery of the reply remains post-commit work.
@@ -109,6 +116,12 @@ smaller request path, not a more patient client.
 7. Update `ADR-038`, `ADR-041`, and the requirements to state that the local
    request deadline ends at admission response and never owns background peer
    work.
+8. Extend the daemon boundary TOML record and
+   `crates/atm-architecture/tests/boundary_enforcement.rs`: the admission
+   files may signal `PostCommitWorkQueue` but must reject direct
+   `PeerHttpTransport`/delivery, peer-store scans, DNS/socket/TLS, hooks, and
+   nudge calls. The scheduler must reject concrete SQLite imports and durable
+   payload/receipt/retry state.
 
 ## Paths to delete
 

--- a/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
+++ b/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
@@ -23,15 +23,41 @@ appear unavailable when its client response deadline expires. Persisting the
 message first already gives the system its recovery source; peer work belongs
 after the response, not inside it.
 
+## Current root cause and required simplification
+
+The current path is slow because `DaemonRequestDispatcher::route_write` calls
+`PostWriteRouter::dispatch` before `PreparedWrite::finish`. For a
+host-qualified write, that call currently performs all of the following before
+the local IPC handler can write response headers:
+
+| Current site | Foreground work today | Required change |
+| --- | --- | --- |
+| `atm-core/src/send/mod.rs::prepare_send_context` | Config/hook lookup and recipient/delivery snapshot resolution | Read only daemon-owned, reloadable in-memory runtime view on admission. Move hook/nudge configuration use to post-commit work. No filesystem or SQLite read per admitted write. |
+| `atm-core/src/ack/mod.rs::{resolve_acknowledgement_write,resolve_received_acknowledgement_write}` | Loads source and source record before persistence, then defers mutation | Replace with one storage transaction that resolves source data, inserts the immutable ACK reply, and conditionally marks source acknowledged. No application-layer source read before transaction. |
+| `runtime_health/peer_delivery_router.rs::dispatch` | `list_trusted_peers`, authority resolution, delivery-event setup, then direct delivery | Validate syntax and authority from the in-memory runtime view; emit `write_persisted`; signal work by immutable message ID and return. |
+| `peer_drain_coordinator.rs::acquire` | Slot creation, generation bookkeeping, mutex/condition-variable wait behind another request | Delete it from admission entirely. Admission never waits for another message. |
+| `peer_drain_coordinator.rs::{drain,deliver_current}` | Policy/store reads, outbound page scan, JSON decode, DNS, TCP connect, TLS, HTTP write/read | Run only in post-commit worker jobs. None may execute before the local response. |
+| `atm-core/src/send/mod.rs::PreparedWrite::finish` / `ack::ResolvedAcknowledgement::finish` | ACK source mutation occurs after peer delivery | Move ACK record plus source-state mutation into the one SQLite admission transaction. |
+| `PreparedWrite::emit_local_post_write` | Nudge/hook emission runs in the request handler | Queue only the immutable message ID; worker loads/uses the committed record after response. |
+
+The client currently gives local IPC roughly its request deadline plus a
+250-ms response grace. That is where the observed `os error 35` originates;
+raising that deadline is forbidden as a remediation. The accepted design is a
+smaller request path, not a more patient client.
+
 ## Deliverables
 
 1. First commit sets every releasable assembly to `1.4.0-beta-ai.31` and
    records matching CLI/daemon values from `atm doctor --json`.
-2. In `crates/atm-daemon/src/runtime_health.rs`, keep
-   `MessageWriter::write(...)` as the only synchronous write-path operation.
-   It prepares/persists the canonical record, calls the post-write router, and
-   immediately builds the existing `SendResponseEnvelope::{Sent,Acknowledged}`
-   admission response. Do not add a remote-success response variant.
+2. In `crates/atm-daemon/src/runtime_health.rs`, reduce the request path to
+   admission validation from an in-memory runtime view, one SQLite transaction,
+   one `write_persisted` event, one non-blocking work signal, and the existing
+   `SendResponseEnvelope::{Sent,Acknowledged}` response. Do not add a
+   remote-success response variant.
+   `crates/atm-daemon/src/composition.rs` constructs one immutable
+   `AdmissionRuntimeView` from existing configuration/roster/trust data; the
+   existing runtime-reload path atomically swaps that view. The view is a
+   lookup cache, not another persistence store or delivery state machine.
 3. Replace the foreground coordinator trait method with a signal-only seam in
    `crates/atm-daemon/src/peer_drain_coordinator.rs`:
 
@@ -43,24 +69,74 @@ after the response, not inside it.
    }
    ```
 
-   `signal_after_persist` is non-blocking, cannot perform network I/O, and
-   cannot make a successfully committed local write fail. It records only a
-   bounded non-durable scheduling signal; no `WriteRequest`, payload, receipt,
-   or per-message retry record is retained there.
+   `signal_after_persist` is non-blocking, cannot perform network I/O or a
+   store read, and cannot make a successfully committed local write fail. It
+   records only a bounded non-durable scheduling signal; no `WriteRequest`,
+   payload, receipt, or per-message retry record is retained there.
+
+   ```rust
+   enum PostCommitWorkKey {
+       LocalNudge(AtmMessageId),
+       PeerDelivery { peer: HostName, message_id: AtmMessageId },
+   }
+
+   trait PostCommitWorkQueue: Send + Sync {
+       fn signal(&self, work: PostCommitWorkKey);
+   }
+   ```
+
+   The queue holds identifiers only. On bounded-queue pressure it coalesces a
+   peer rescan signal rather than blocking, dropping a durable message, or
+   retaining its payload. It has no state transitions beyond queued/in-flight
+   coalescing.
 4. In `runtime_health/peer_delivery_router.rs`, replace
    `deliver_to_peer(..., deadline, ...)` with one post-commit
    `signal_after_persist(peer)` call for every host-qualified origin write.
    Local/no-host nudge handling stays unchanged. No special localhost or
    self-IP route is permitted.
-5. Retain AI.27 events, but make their meanings precise: `write_persisted` is
+5. Move `ResolvedAcknowledgement::finish` into the same SQLite transaction as
+   the acknowledgement record. An ACK admission response therefore proves both
+   writes committed; peer delivery of the reply remains post-commit work.
+   Replace `resolve_acknowledgement_write` and
+   `resolve_received_acknowledgement_write` with one sealed storage/runtime
+   operation whose transaction returns the reply target and typed
+   already-acknowledged/not-found outcome. Do not perform a source lookup in
+   `atm-core` before calling that operation.
+6. Retain AI.27 events, but make their meanings precise: `write_persisted` is
    emitted before response; later worker outcomes produce
    `peer_delivery_confirmed` or `peer_delivery_unconfirmed`. No admission
    response, event, or CLI prose may call local persistence “remote sent.”
-6. Update `ADR-038`, `ADR-041`, and the requirements to state that the local
+7. Update `ADR-038`, `ADR-041`, and the requirements to state that the local
    request deadline ends at admission response and never owns background peer
    work.
 
-## Required tests
+## Paths to delete
+
+- `PeerDeliveryCoordinator::deliver_after_persist(...)` and every foreground
+  call site.
+- `PostWriteRouter::deliver_to_peer(..., RequestDeadline, ...)`; its peer
+  transport/error classification belongs to the worker, not local admission.
+- `PreparedWrite::finish` as a deferred ACK mutation boundary; acknowledgement
+  source mutation becomes part of the admission transaction.
+- Application-layer `load_ack_source` and `load_ack_source_record` calls on
+  the admission path.
+- Foreground post-send hook/config lookup from `prepare_send_context` and
+  `PreparedWrite::emit_local_post_write`.
+
+## Implementation map
+
+- `crates/atm-daemon/src/composition.rs`: construct/swap the immutable
+  admission runtime view and one post-commit queue.
+- `crates/atm-daemon/src/runtime_health.rs`: use that view and return the
+  admission response immediately after the transaction and work signal.
+- `crates/atm-daemon/src/runtime_health/peer_delivery_router.rs`: classify
+  local-nudge versus host-qualified work and signal only `PostCommitWorkKey`.
+- `crates/atm-core/src/send/mod.rs`: remove deferred completion semantics;
+  retain only data needed for the admission transaction and post-commit key.
+- `crates/atm-core/src/ack/mod.rs` and the sealed storage/runtime boundary:
+  replace source-read/finish with the atomic acknowledgement transaction.
+
+## Required validation
 
 - A real local IPC integration test installs a peer transport that deliberately
   blocks beyond the old response grace period. The same host-qualified send and
@@ -75,16 +151,25 @@ after the response, not inside it.
   `ATM_DAEMON_UNAVAILABLE`.
 - Bare same-agent/no-host self-send remains rejected; host-qualified localhost
   and self-IP remain admitted through the ordinary host route.
+- Runtime-view tests prove one admission performs no peer-config store read,
+  policy read, outbound-page read, DNS call, socket open, TLS operation, or
+  hook/nudge execution before its response is written.
+- ACK tests prove source resolution, reply insertion, and source transition are
+  atomic: a typed pending/source error leaves no reply row; a successful ACK
+  has both rows committed before response; no test double observes an
+  application-layer source read before the storage transaction.
+- `just lint`, `just test`, and branch-daemon `just smoke localhost` pass.
 
 ## Acceptance criteria
 
 - SQLite commit is the sole synchronous post-validation operation before a
   local send/ack response.
+- An ACK admission transaction persists both the immutable reply and its source
+  acknowledgement state before response; it never waits for reply delivery.
 - A slow or unavailable peer cannot delay, cancel, or relabel a committed local
   admission response.
 - No outbox, durable queue, receipt, delivery state, or extra public endpoint
   is introduced.
-- `just lint`, `just test`, and branch-daemon `just smoke localhost` pass.
 
 ## Non-goals
 

--- a/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
+++ b/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
@@ -1,0 +1,92 @@
+---
+title: AI.31 asynchronous durable local admission
+status: proposed
+branch: feature/pAI-s31-async-local-admission
+target: integrate/phase-AI
+depends_on: AI.23, AI.27, AI.28
+---
+
+# AI.31 — asynchronous durable local admission
+
+## Closure
+
+A host-qualified `atm send` or `atm ack` returns after its immutable origin
+record commits to SQLite. It does not wait for another message, peer DNS,
+connection, TLS, remote handler, receipt, or nudge. The response means
+**locally admitted**, never remotely delivered.
+
+## Why
+
+The current foreground `deliver_after_persist` call holds the local IPC
+response open while it performs peer work. A healthy local daemon can then
+appear unavailable when its client response deadline expires. Persisting the
+message first already gives the system its recovery source; peer work belongs
+after the response, not inside it.
+
+## Deliverables
+
+1. First commit sets every releasable assembly to `1.4.0-beta-ai.31` and
+   records matching CLI/daemon values from `atm doctor --json`.
+2. In `crates/atm-daemon/src/runtime_health.rs`, keep
+   `MessageWriter::write(...)` as the only synchronous write-path operation.
+   It prepares/persists the canonical record, calls the post-write router, and
+   immediately builds the existing `SendResponseEnvelope::{Sent,Acknowledged}`
+   admission response. Do not add a remote-success response variant.
+3. Replace the foreground coordinator trait method with a signal-only seam in
+   `crates/atm-daemon/src/peer_drain_coordinator.rs`:
+
+   ```rust
+   trait PeerDeliveryCoordinator: Send + Sync {
+       fn signal_after_persist(&self, peer: HostName);
+       fn sync_peer(&self, peer: &HostName, deadline: RequestDeadline)
+           -> Result<u16, AtmError>;
+   }
+   ```
+
+   `signal_after_persist` is non-blocking, cannot perform network I/O, and
+   cannot make a successfully committed local write fail. It records only a
+   bounded non-durable scheduling signal; no `WriteRequest`, payload, receipt,
+   or per-message retry record is retained there.
+4. In `runtime_health/peer_delivery_router.rs`, replace
+   `deliver_to_peer(..., deadline, ...)` with one post-commit
+   `signal_after_persist(peer)` call for every host-qualified origin write.
+   Local/no-host nudge handling stays unchanged. No special localhost or
+   self-IP route is permitted.
+5. Retain AI.27 events, but make their meanings precise: `write_persisted` is
+   emitted before response; later worker outcomes produce
+   `peer_delivery_confirmed` or `peer_delivery_unconfirmed`. No admission
+   response, event, or CLI prose may call local persistence “remote sent.”
+6. Update `ADR-038`, `ADR-041`, and the requirements to state that the local
+   request deadline ends at admission response and never owns background peer
+   work.
+
+## Required tests
+
+- A real local IPC integration test installs a peer transport that deliberately
+  blocks beyond the old response grace period. The same host-qualified send and
+  host-qualified ack must receive successful local admission before that peer
+  transport is released; the immutable record is present in SQLite.
+- The existing normal remote HTTP endpoint, dispatcher, persistence method, and
+  post-write router remain the only peer path for localhost, self-IP, and a
+  remote host. Add an AST/source boundary test that rejects a direct transport
+  call from `runtime_health.rs` or `peer_delivery_router.rs`.
+- Peer failure after admission creates exactly one retained unconfirmed event
+  with the original ULID and does not convert the local response to
+  `ATM_DAEMON_UNAVAILABLE`.
+- Bare same-agent/no-host self-send remains rejected; host-qualified localhost
+  and self-IP remain admitted through the ordinary host route.
+
+## Acceptance criteria
+
+- SQLite commit is the sole synchronous post-validation operation before a
+  local send/ack response.
+- A slow or unavailable peer cannot delay, cancel, or relabel a committed local
+  admission response.
+- No outbox, durable queue, receipt, delivery state, or extra public endpoint
+  is introduced.
+- `just lint`, `just test`, and branch-daemon `just smoke localhost` pass.
+
+## Non-goals
+
+This sprint does not define worker concurrency, delivery order, capacity, or
+cross-host evidence. Those belong to AI.32 and AI.33.

--- a/docs/plans/phase-ai/sprint-ai-32-independent-peer-jobs.md
+++ b/docs/plans/phase-ai/sprint-ai-32-independent-peer-jobs.md
@@ -43,13 +43,24 @@ requirement.
    Acknowledgements are ordinary independent write jobs with
    `acknowledges_message_id` set.
 5. A job completion clears its in-flight marker and emits the AI.27 confirmed
-   or unconfirmed event. A failure may schedule the existing bounded
-   reconciliation delay, but must not attach an attempt count or delivery state
-   to the message record.
-6. Define named constants for global and per-host limits in the coordinator;
-   document why they bound file descriptors and peer load. They are capacity
-   controls, not ordering controls. Different hosts must make progress
-   independently.
+   or unconfirmed event with a stable `PeerDeliveryErrorCode`. When an eligible
+   record ages beyond `PeerSyncPolicy.max_message_age`, emit terminal
+   `peer_delivery_expired` with that code and stop scheduling it until a new
+   persisted write or explicit policy change makes it eligible. The existing
+   retained-event sink idempotently records that terminal `(ULID, code)` event;
+   the scheduler retains no terminal marker. A failure may
+   schedule the existing bounded reconciliation delay, but must not attach an
+   attempt count or delivery state to the message record.
+6. Define `POST_COMMIT_QUEUE_DEPTH = 256`, `MAX_ACTIVE_PEER_JOBS = 64`,
+   `MAX_ACTIVE_PEER_JOBS_PER_HOST = 8`, and
+   `PEER_DELIVERY_WORKER_DEADLINE = 10s` in the coordinator. The deadline
+   spans the whole one job and cannot be extended per leg. Document why the
+   limits bound file descriptors and peer load. They are capacity controls,
+   not ordering controls. Different hosts must make progress independently.
+7. `sync_peer` is a crate-private explicit one-shot scheduler request. It
+   returns `PeerSyncOutcome`, uses the same queue and 10-second worker budget,
+   and cannot bypass the ordinary canonical endpoint or introduce a foreground
+   delivery path.
 
 ## Paths to delete
 
@@ -67,14 +78,21 @@ requirement.
   any completion order; all retain their original distinct ULIDs and produce
   exactly one recipient persistence/nudge each.
 - Two signals for the same ULID while its job is in-flight create one outbound
-  attempt; a signal after terminal completion may safely rediscover that ULID,
-  whose receiver duplicate remains idempotent.
+  attempt; a signal after a confirmed or unconfirmed job completes may safely
+  rediscover an eligible ULID, whose receiver duplicate remains idempotent.
 - Per-host and global limits block excess *worker* starts without blocking a
   new local SQLite admission response.
 - A source-boundary test rejects `PeerDrainSlot`, `Condvar`, generation fields,
   ordered cursor state, and fixed polling from the replacement scheduler.
+- The daemon boundary TOML record and
+  `crates/atm-architecture/tests/boundary_enforcement.rs` reject concrete
+  SQLite imports, payload/receipt/retry-history fields, and public exposure of
+  the scheduler or its outcome types.
 - One stalled host cannot prevent a second host job from starting within its
   own bound.
+- A peer that remains unavailable until its configured window expires emits one
+  terminal `peer_delivery_expired` event with a stable typed code; it creates
+  no receipt, attempt history, or caller-visible remote-success claim.
 - A send followed by its generated acknowledgement proves the ACK refers to
   the delivered message ULID; no test asserts incidental order between
   independently submitted sends.
@@ -87,6 +105,8 @@ requirement.
 - All peer work is bounded, non-durable, and rebuildable from immutable SQLite
   records after restart.
 - Ordinary localhost, self-IP, and cross-host traffic use the same HTTP route.
+- `PeerSyncOutcome` and `PeerDeliveryErrorCode` remain crate-private typed
+  seams; no raw HTTP status or transport implementation leaks into routing.
 
 ## Non-goals
 

--- a/docs/plans/phase-ai/sprint-ai-32-independent-peer-jobs.md
+++ b/docs/plans/phase-ai/sprint-ai-32-independent-peer-jobs.md
@@ -13,7 +13,7 @@ depends_on: AI.31
 The daemon schedules independent immutable-ULID peer-delivery jobs after
 local admission. It bounds work globally and per host, but does not promise
 delivery order between separate CLI/API writes and does not create a stream,
-outbox, or durable retry system.
+outbox, durable retry system, or delivery state machine.
 
 ## Why
 
@@ -27,12 +27,12 @@ requirement.
 
 1. First commit sets every releasable assembly to `1.4.0-beta-ai.32` and
    records matching branch CLI/daemon values through `atm doctor --json`.
-2. Refactor `crates/atm-daemon/src/peer_drain_coordinator.rs` into the only
-   owner of a bounded, non-durable scheduler. It may use a bounded channel,
-   work semaphore, and in-flight `HashSet<MessageId>`/host accounting. Its
-   state may contain only hostname, message ULID, timing/backoff, and
-   concurrency counters—never payload, receipt, remote result, checkpoint,
-   or retry history.
+2. Replace `crates/atm-daemon/src/peer_drain_coordinator.rs` with the only
+   owner of a small bounded, non-durable work queue. It may use a bounded
+   channel, work semaphore, and in-flight `HashSet<MessageId>`/host accounting.
+   Its state may contain only hostname, message ULID, one next-eligible time,
+   and concurrency counters—never a slot state machine, payload, receipt,
+   remote result, checkpoint, cursor, generation, or retry history.
 3. Replace AI.28's ordered `PeerDrainSlot`/cursor contract with storage paging
    that returns eligible immutable records for one exact hostname. Enqueue an
    independent job for each ULID, coalescing an already-in-flight ULID. Do not
@@ -51,7 +51,17 @@ requirement.
    controls, not ordering controls. Different hosts must make progress
    independently.
 
-## Required tests
+## Paths to delete
+
+- AI.28's `PeerDrainSlot` ordered cursor/lower-bound state and any
+  oldest-first or one-socket assertion.
+- `acquire`, `release`, generation comparison, `Condvar` waiting,
+  `run_scheduled_recovery`, and 250-ms polling from
+  `peer_drain_coordinator.rs`.
+- Any product contract or test that treats independent same-peer sends as a
+  FIFO stream rather than independent immutable ULID jobs.
+
+## Required validation
 
 - Three same-peer writes submitted concurrently can reach a controlled peer in
   any completion order; all retain their original distinct ULIDs and produce
@@ -61,11 +71,14 @@ requirement.
   whose receiver duplicate remains idempotent.
 - Per-host and global limits block excess *worker* starts without blocking a
   new local SQLite admission response.
+- A source-boundary test rejects `PeerDrainSlot`, `Condvar`, generation fields,
+  ordered cursor state, and fixed polling from the replacement scheduler.
 - One stalled host cannot prevent a second host job from starting within its
   own bound.
 - A send followed by its generated acknowledgement proves the ACK refers to
   the delivered message ULID; no test asserts incidental order between
   independently submitted sends.
+- `just lint`, `just test`, and branch-daemon `just smoke localhost` pass.
 
 ## Acceptance criteria
 
@@ -74,7 +87,6 @@ requirement.
 - All peer work is bounded, non-durable, and rebuildable from immutable SQLite
   records after restart.
 - Ordinary localhost, self-IP, and cross-host traffic use the same HTTP route.
-- `just lint`, `just test`, and branch-daemon `just smoke localhost` pass.
 
 ## Non-goals
 

--- a/docs/plans/phase-ai/sprint-ai-32-independent-peer-jobs.md
+++ b/docs/plans/phase-ai/sprint-ai-32-independent-peer-jobs.md
@@ -1,0 +1,82 @@
+---
+title: AI.32 bounded independent peer jobs
+status: proposed
+branch: feature/pAI-s32-independent-peer-jobs
+target: integrate/phase-AI
+depends_on: AI.31
+---
+
+# AI.32 — bounded independent peer jobs
+
+## Closure
+
+The daemon schedules independent immutable-ULID peer-delivery jobs after
+local admission. It bounds work globally and per host, but does not promise
+delivery order between separate CLI/API writes and does not create a stream,
+outbox, or durable retry system.
+
+## Why
+
+Two CLI invocations milliseconds apart are independent messages. The only
+ordering that matters is byte order within one HTTP exchange and the causal
+relationship between a message and an acknowledgement that names its ULID.
+Serializing unrelated messages adds latency and state without an agreed
+requirement.
+
+## Deliverables
+
+1. First commit sets every releasable assembly to `1.4.0-beta-ai.32` and
+   records matching branch CLI/daemon values through `atm doctor --json`.
+2. Refactor `crates/atm-daemon/src/peer_drain_coordinator.rs` into the only
+   owner of a bounded, non-durable scheduler. It may use a bounded channel,
+   work semaphore, and in-flight `HashSet<MessageId>`/host accounting. Its
+   state may contain only hostname, message ULID, timing/backoff, and
+   concurrency counters—never payload, receipt, remote result, checkpoint,
+   or retry history.
+3. Replace AI.28's ordered `PeerDrainSlot`/cursor contract with storage paging
+   that returns eligible immutable records for one exact hostname. Enqueue an
+   independent job for each ULID, coalescing an already-in-flight ULID. Do not
+   expose a batch endpoint or send a `Vec<WriteRequest>`.
+4. Each job invokes the existing `PeerHttpTransport` and ordinary canonical
+   `WriteRequest` endpoint. HTTP keep-alive is allowed as a transport
+   optimization but not as a message-stream abstraction or ordering contract.
+   Acknowledgements are ordinary independent write jobs with
+   `acknowledges_message_id` set.
+5. A job completion clears its in-flight marker and emits the AI.27 confirmed
+   or unconfirmed event. A failure may schedule the existing bounded
+   reconciliation delay, but must not attach an attempt count or delivery state
+   to the message record.
+6. Define named constants for global and per-host limits in the coordinator;
+   document why they bound file descriptors and peer load. They are capacity
+   controls, not ordering controls. Different hosts must make progress
+   independently.
+
+## Required tests
+
+- Three same-peer writes submitted concurrently can reach a controlled peer in
+  any completion order; all retain their original distinct ULIDs and produce
+  exactly one recipient persistence/nudge each.
+- Two signals for the same ULID while its job is in-flight create one outbound
+  attempt; a signal after terminal completion may safely rediscover that ULID,
+  whose receiver duplicate remains idempotent.
+- Per-host and global limits block excess *worker* starts without blocking a
+  new local SQLite admission response.
+- One stalled host cannot prevent a second host job from starting within its
+  own bound.
+- A send followed by its generated acknowledgement proves the ACK refers to
+  the delivered message ULID; no test asserts incidental order between
+  independently submitted sends.
+
+## Acceptance criteria
+
+- No global/per-peer FIFO delivery promise, cursor, ordered backlog, or stream
+  abstraction remains in product code or requirements.
+- All peer work is bounded, non-durable, and rebuildable from immutable SQLite
+  records after restart.
+- Ordinary localhost, self-IP, and cross-host traffic use the same HTTP route.
+- `just lint`, `just test`, and branch-daemon `just smoke localhost` pass.
+
+## Non-goals
+
+This sprint does not claim a throughput target or physical peer evidence. It
+creates the simple bounded worker model that AI.33 measures.

--- a/docs/plans/phase-ai/sprint-ai-33-admission-capacity-smoke.md
+++ b/docs/plans/phase-ai/sprint-ai-33-admission-capacity-smoke.md
@@ -1,0 +1,85 @@
+---
+title: AI.33 admission capacity and smoke evidence
+status: proposed
+branch: feature/pAI-s33-admission-capacity-smoke
+target: integrate/phase-AI
+depends_on: AI.31, AI.32
+---
+
+# AI.33 — admission capacity and smoke evidence
+
+## Closure
+
+Release-built ATM proves ten consecutive one-second intervals of at least
+1,000 local host-qualified admissions per second on a disposable SQLite
+database. The smoke runner also produces a compact, endpoint-explicit report
+for ten repetitions of each local and available cross-host check.
+
+## Deliverables
+
+1. First commit sets every releasable assembly to `1.4.0-beta-ai.33` and
+   records matching branch CLI/daemon values with `atm doctor --json`.
+2. Add `scripts/smoke/run_admission_capacity.py` plus unit tests. It creates a
+   temporary `ATM_HOME`, starts exactly one release-built branch daemon for
+   that directory, and deletes the directory only after evidence collection.
+   It must reject an unset/unsafe home path and never target `~/.atm` or a
+   team/shared database.
+3. Drive the public daemon client/API, not a direct dispatcher or mock. For ten
+   consecutive one-second intervals, submit and receive 1,000 host-qualified
+   `send` admissions. Run the same proof once with an accepting controlled peer
+   and once with an unavailable configured peer. Persist JSON evidence with
+   accepted count, response count, latency summary, failures, daemon PID,
+   `ATM_HOME`, and release/doctor data; report PASS only when every interval
+   meets the requirement.
+4. Extend the keeper smoke runner from PR #675,
+   `scripts/smoke/run_feature_smoke.py`, rather than creating another shell
+   runner. Default each positive ladder row to ten consecutive attempts. Its
+   generated combined HTML report has:
+   - one card per participating computer;
+   - a compact endpoint table for hostname, IP used, CLI version, daemon
+     version, and doctor PASS/FAIL for each endpoint;
+   - rows naming origin, destination, protocol/route, operation, and `n/10`
+     result; and
+   - a short failure summary plus bounded session logs.
+5. The ladder is explicit:
+   - one-computer: doctor, physical-interface self-IP send/read, `127.0.0.1`
+     send/read, and their required-ack round trips;
+   - two-computer: direct TLS curl doctor each direction, DNS TLS curl doctor
+     each direction, ordinary ATM send/read each direction, then required-ack
+     round trips each direction; and
+   - recovery: only after both ordinary cross-host levels pass, make the peer
+     unavailable, admit messages locally, restore it, and prove original ULID
+     delivery without false remote-success claims.
+6. Curl rows are transport diagnostics, not ATM delivery proof. ATM rows must
+   verify the same ULID in the receiver inbox and, for ack-required, verify
+   message delivery/read plus the reply acknowledgement's successful delivery.
+
+## Required tests
+
+- Unit tests reject production/shared `ATM_HOME`, retain all ten attempts in
+  JSON, and render a FAIL row with the first failing attempt rather than hiding
+  it behind a summary.
+- A controlled local daemon integration test proves the capacity harness uses
+  the public client and isolated SQLite database.
+- Renderer tests verify one card per endpoint and show both endpoints' IP,
+  version, and doctor state on a cross-host report.
+- A test proves a received acknowledgement is correlated by ULID, not arrival
+  order or a constant fixture value.
+
+## Acceptance criteria
+
+- Ten of ten one-second intervals each return at least 1,000 local admissions
+  and responses using a disposable database.
+- Every smoke row executes ten times by default; any failed attempt makes that
+  row FAIL and preserves evidence.
+- Cross-host report makes origin/destination and both endpoint identities
+  obvious without reading source or raw logs.
+- `just lint`, `just test`, `just smoke localhost`, and the isolated capacity
+  command pass on the branch daemon. Cross-host rows are run only when peers
+  are available; unavailable infrastructure is reported NOT-RUN, never PASS.
+
+## Non-goals
+
+This is not a production load benchmark, a multi-machine stress suite, or a
+replacement for CI. It is a deterministic release gate for the exact local
+admission and peer-delivery contracts introduced by AI.31–AI.32.

--- a/docs/plans/phase-ai/sprint-ai-33-admission-capacity-smoke.md
+++ b/docs/plans/phase-ai/sprint-ai-33-admission-capacity-smoke.md
@@ -4,6 +4,7 @@ status: proposed
 branch: feature/pAI-s33-admission-capacity-smoke
 target: integrate/phase-AI
 depends_on: AI.31, AI.32
+requires_merged_pr: PR #675 (keeper smoke runner on develop)
 ---
 
 # AI.33 — admission capacity and smoke evidence
@@ -21,7 +22,9 @@ The 1,000/s gate is a design-simplification gate, not a timeout-tuning
 exercise. Before raising a timeout, adding a retry, adding a queue depth, or
 adding a worker, implementation must remove work from the admission path:
 peer scans, DNS, socket/TLS work, remote response waits, duplicate delivery,
-acknowledgement, and nudge work belong after the SQLite response. If the gate
+peer acknowledgement delivery, and nudge work belong after the SQLite
+response. The ACK reply's source resolution, reply insertion, and source
+transition remain the one admission SQLite transaction. If the gate
 fails, record the measured path and remove or relocate the unnecessary
 foreground step; do not mask it with a longer deadline, retry loop, or larger
 buffer.
@@ -48,7 +51,7 @@ not a license to add profiling state to production delivery.
    accepted count, response count, latency summary, failures, daemon PID,
    `ATM_HOME`, and release/doctor data; report PASS only when every interval
    meets the requirement.
-4. Extend the keeper smoke runner from PR #675,
+4. **After PR #675 merges to `develop`,** extend its keeper smoke runner,
    `scripts/smoke/run_feature_smoke.py`, rather than creating another shell
    runner. Default each positive ladder row to ten consecutive attempts. Its
    generated combined HTML report has:

--- a/docs/plans/phase-ai/sprint-ai-33-admission-capacity-smoke.md
+++ b/docs/plans/phase-ai/sprint-ai-33-admission-capacity-smoke.md
@@ -15,6 +15,23 @@ Release-built ATM proves ten consecutive one-second intervals of at least
 database. The smoke runner also produces a compact, endpoint-explicit report
 for ten repetitions of each local and available cross-host check.
 
+## Throughput rule
+
+The 1,000/s gate is a design-simplification gate, not a timeout-tuning
+exercise. Before raising a timeout, adding a retry, adding a queue depth, or
+adding a worker, implementation must remove work from the admission path:
+peer scans, DNS, socket/TLS work, remote response waits, duplicate delivery,
+acknowledgement, and nudge work belong after the SQLite response. If the gate
+fails, record the measured path and remove or relocate the unnecessary
+foreground step; do not mask it with a longer deadline, retry loop, or larger
+buffer.
+
+The harness must emit per-stage admission timing—runtime-view validation,
+SQLite transaction, post-commit signal, and response write—so a failure names
+the expensive synchronous step. It must fail if any peer/store-read/network/
+hook stage appears before the response boundary. This is evidence for removal,
+not a license to add profiling state to production delivery.
+
 ## Deliverables
 
 1. First commit sets every releasable assembly to `1.4.0-beta-ai.33` and
@@ -54,7 +71,7 @@ for ten repetitions of each local and available cross-host check.
    verify the same ULID in the receiver inbox and, for ack-required, verify
    message delivery/read plus the reply acknowledgement's successful delivery.
 
-## Required tests
+## Required validation
 
 - Unit tests reject production/shared `ATM_HOME`, retain all ten attempts in
   JSON, and render a FAIL row with the first failing attempt rather than hiding
@@ -65,6 +82,9 @@ for ten repetitions of each local and available cross-host check.
   version, and doctor state on a cross-host report.
 - A test proves a received acknowledgement is correlated by ULID, not arrival
   order or a constant fixture value.
+- `just lint`, `just test`, `just smoke localhost`, and the isolated capacity
+  command pass on the branch daemon. Cross-host rows are run only when peers
+  are available; unavailable infrastructure is reported NOT-RUN, never PASS.
 
 ## Acceptance criteria
 
@@ -74,9 +94,6 @@ for ten repetitions of each local and available cross-host check.
   row FAIL and preserves evidence.
 - Cross-host report makes origin/destination and both endpoint identities
   obvious without reading source or raw logs.
-- `just lint`, `just test`, `just smoke localhost`, and the isolated capacity
-  command pass on the branch daemon. Cross-host rows are run only when peers
-  are available; unavailable infrastructure is reported NOT-RUN, never PASS.
 
 ## Non-goals
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3819,18 +3819,24 @@ mail correctness.
   Required behavior:
   - no replay store, outbox, retry queue, deferred receipt, remote
     acknowledgement state, or duplicate-delivery subsystem may exist
-  - an unavailable peer returns one normal transport error for the attempted
-    write; retry is an ordinary repeat of the immutable message identity
+  - after local admission, an unavailable peer records the typed asynchronous
+    `peer_delivery_unconfirmed` outcome for the attempted immutable write; it
+    does not relabel the already-returned local admission response as a
+    transport error. A later ordinary canonical attempt reuses that identity
   - duplicate arrival is idempotent at storage by the existing message ULID;
     an identical already-delivered remote duplicate has no side effect, while
     the narrow same-host retained-origin receipt defined by
     `REQ-CORE-TRANSPORT-002` logs its skipped write and continues the ordinary
     inbound recipient nudge without a second database write
-  - the only exception is REQ-CORE-TRANSPORT-003A's bounded, user-selected
-    reconciliation scan; it creates no delivery state
+  - the only exception is REQ-CORE-TRANSPORT-003B's bounded, user-selected
+    reconciliation scheduler; it creates no delivery state. Its transient work
+    keys are execution coordination, not a retry queue: they contain no
+    payload, result, receipt, attempt history, or durable checkpoint
 
-- `REQ-CORE-TRANSPORT-003A` Bounded peer reconciliation may re-send canonical
-  immutable records after a peer reconnects without adding delivery state.
+- `REQ-CORE-TRANSPORT-003A` **Historical; superseded by
+  `REQ-CORE-TRANSPORT-003B`.** It records the AI.28 ordered-coordinator
+  contract and is not an active implementation requirement. AI.31--AI.32
+  must implement only `REQ-CORE-TRANSPORT-003B`.
 
   Required behavior:
   - durable backend-neutral `PeerSyncPolicy.max_message_age` and
@@ -3883,16 +3889,23 @@ mail correctness.
   capacity limits for transport/store/health operations.
 
   Required behavior:
-  - every request has one absolute `RequestDeadline`; local HTTP, router,
-    dispatcher, post-write router, and HTTPS consume only its remaining budget
-  - no peer connect, TLS, request, or response leg may create a longer
-    independent deadline below dispatcher scope
+  - every local admission request has one absolute `RequestDeadline`; local
+    HTTP, router, dispatcher, validation, SQLite transaction, post-commit
+    signal, and response consume only its remaining budget
+  - after the admission response, a peer worker has one separate absolute
+    `PEER_DELIVERY_WORKER_DEADLINE = 10s` for its full DNS/connect/TLS/request/
+    response attempt. Neither admission nor worker code may create nested or
+    extended per-leg deadlines
   - SQLite `busy_timeout`: `5000ms`
   - ingest batch processing slice: `2s`
   - doctor health query deadline: `3s`
   - max concurrent accepts: `64`
   - max per-connection inflight requests: `32`
   - ingest queue depth: `1024`
+  - post-commit work queue depth: `256`; global active peer jobs: `64`; active
+    peer jobs per host: `8`. These are load/file-descriptor bounds, not FIFO
+    controls; saturation coalesces a host rescan signal and never blocks or
+    drops a committed admission
   - SQLite handle budget: `1..=4`
   - live status-cache cap: `4096`
   - saturation behavior must fail with typed errors or structured degradation,
@@ -3936,14 +3949,17 @@ mail correctness.
     is the only synchronous operation on the admission-response path. Once it
     commits, the daemon returns the typed local admission response; peer-job
     signalling, DNS, connection, TLS, remote receipt, duplicate handling,
-    acknowledgement, and nudge work run asynchronously
-  - admission validation uses request data plus the daemon-owned reloadable
-    runtime view. It performs no per-request config-file read, peer-config or
-    policy store read, outbound-page read, DNS lookup, socket/TLS operation,
-    hook, or nudge before responding. An acknowledgement resolves its source,
-    inserts its immutable reply, and conditionally marks the source
-    acknowledged within one SQLite transaction; it has no application-layer
-    source read before that transaction
+    acknowledgement source resolution/mutation and the acknowledgement reply
+    insertion are the one atomic SQLite transaction; peer delivery, duplicate
+    handling, nudge, and hook work run asynchronously
+  - pre-persistence admission validation uses only request syntax, provenance,
+    and identity rules. The sole post-persistence `PostWriteRouter` remains
+    the owner of local-versus-host-qualified routing and consults a
+    daemon-owned reloadable runtime view, never a per-request config-file,
+    peer-config/policy store, outbound-page, DNS, socket/TLS, hook, or nudge.
+    An acknowledgement resolves its source, inserts its immutable reply, and
+    conditionally marks the source acknowledged within one SQLite transaction;
+    it has no application-layer source read before that transaction
   - the response proves only local admission. Remote acceptance remains the
     separate asynchronous outcome defined by `REQ-CORE-TRANSPORT-005A`; a
     local admission response must never claim remote delivery
@@ -3988,12 +4004,21 @@ mail correctness.
     another message's delivery
   - first recovery attempt is no earlier than 60 seconds; later failures use
     exponential backoff capped at 15 minutes
+  - each individual peer job consumes the one
+    `PEER_DELIVERY_WORKER_DEADLINE = 10s` defined by
+    `REQ-CORE-TRANSPORT-005`; the scheduler never extends it with per-leg
+    timeouts
   - recovery submits original ULIDs through normal HTTPS; no ping, outbox,
     cursor, receipt, payload cache, per-message attempt state, or alternate
     write route is allowed
   - empty window, policy disable, or peer revoke stops scheduling
-  - retained events distinguish scheduled, attempted, confirmed, and
-    unconfirmed recovery without body or certificate material
+  - retained events use stable typed codes and distinguish
+    `peer_delivery_scheduled`, `peer_delivery_attempted`,
+    `peer_delivery_confirmed`, `peer_delivery_unconfirmed`, and terminal
+    `peer_delivery_expired` (eligible record aged beyond the configured
+    window), without body or certificate material. `peer_delivery_expired`
+    is observability only: it creates no durable delivery state and cannot
+    change the prior local admission result
   - doctor exposes a bounded, secret-free per-host link projection: quality,
     last success/failure, last typed error, next attempt, drain state, and
     bounded candidate count. It is observability only, not durable delivery

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3916,13 +3916,47 @@ mail correctness.
   - deadline, disconnect, or failed response after dispatch returns the typed
     `REMOTE_DELIVERY_UNCONFIRMED` error, never `DAEMON_UNAVAILABLE` when the
     local daemon accepted the request
-  - accepted work remains runtime-tracked and is cancelled on deadline expiry
-    or local disconnect; detached delivery is forbidden
+  - local admission completes at the SQLite response boundary. Later bounded
+    peer work is runtime-tracked independently of the closed local connection;
+    it is not detached, because the scheduler owns cancellation, concurrency,
+    and observability, but it is not cancelled by the completed admission
+    request
   - the possible remote side effect is resolved only by repeating the same
     immutable ULID through ordinary idempotent write handling
   - daemon logs record `write_persisted`, `peer_delivery_confirmed`, or
     `peer_delivery_unconfirmed`; terminal handler/response-write failures are
     retained structured events
+
+- `REQ-CORE-TRANSPORT-005B` The local daemon must admit and respond to at
+  least 1,000 host-qualified `send` requests per second through the public ATM
+  API.
+
+  Required behavior:
+  - the SQLite transaction that durably persists the immutable origin record
+    is the only synchronous operation on the admission-response path. Once it
+    commits, the daemon returns the typed local admission response; peer-job
+    signalling, DNS, connection, TLS, remote receipt, duplicate handling,
+    acknowledgement, and nudge work run asynchronously
+  - the response proves only local admission. Remote acceptance remains the
+    separate asynchronous outcome defined by `REQ-CORE-TRANSPORT-005A`; a
+    local admission response must never claim remote delivery
+  - distinct CLI/API write requests are independent. ATM makes no ordering
+    promise between their delivery attempts, even when they target the same
+    peer. Byte ordering is required only within one HTTP request/response
+    exchange, and an acknowledgement is correlated solely by its immutable
+    message ULID
+  - post-commit work uses a bounded, non-durable scheduler. It may hold
+    transient `HostName`/message-ULID jobs and in-flight coalescing markers,
+    but no payload, receipt, retry history, delivery result, or durable
+    checkpoint. A restart drops that work and rebuilds eligibility from the
+    immutable SQLite records and enabled peer policy
+  - the throughput requirement applies while the destination peer is
+    unavailable as well as healthy. Release evidence runs ten consecutive
+    one-second admission intervals against one release-built daemon using a
+    disposable isolated `ATM_HOME` and SQLite database; it must never run
+    against a shared or production ATM store. Each interval has at least 1,000
+    accepted requests and responses. Mock routers, direct dispatcher calls,
+    and disabled peer delivery do not satisfy this evidence
 
 - `REQ-CORE-TRANSPORT-003B` An enabled peer reconciliation policy may recover
   recent immutable outbound writes after connectivity loss without delivery
@@ -3930,24 +3964,21 @@ mail correctness.
 
   Required behavior:
   - policy selects a bounded send window and batch; zero window disables it
-  - exactly one non-durable drain lease exists per canonical peer hostname;
-    it owns storage paging, one connection, ordered sends, and final rescan,
-    but contains no message ID, payload, cursor, receipt, or attempt history
-  - every drain advances a transient exclusive `(created_at, message_ulid)`
-    lower bound through pages of at most `max_batch_messages`, ordered
-    oldest-first, until an empty page, transport failure, or cancellation. It
-    sends ordinary canonical writes sequentially on one HTTP(S) connection;
-    no batch request shape or recovery-only endpoint is allowed. The lower
-    bound is dropped with the in-memory lease and is never durable state
-  - every newly persisted outbound write signals a per-host generation. The
-    drain must re-scan before lease release if that generation changes, and a
-    post-release signal starts the next lease; no write may be lost in the
-    final-scan/release race
-  - the post-write router has one `PeerDeliveryCoordinator::deliver_after_persist`
-    handoff for host-qualified writes. It serializes a foreground write behind
-    the same host lease and existing older backlog; it must not open a second
-    socket or bypass ordered canonical records. A request-local wait ends at
-    its existing deadline and is never durable or per-message delivery state
+  - the non-durable scheduler bounds global and per-host in-flight delivery
+    jobs. It may coalesce duplicate in-flight ULIDs, but it makes no ordering
+    promise across distinct messages and owns no durable delivery state
+  - a scheduler scan pages eligible exact-peer records through the storage
+    trait and enqueues ordinary canonical writes. It has no batch request
+    shape, recovery-only endpoint, or durable cursor; restart/next signal may
+    safely rediscover an immutable ULID through idempotent recipient storage
+  - every newly persisted outbound write signals scheduling. A signal arriving
+    during a scan or active work must cause a further eligibility scan before
+    the host is considered idle; no write may be lost between scan completion
+    and idle transition
+  - the post-write router has one `PeerDeliveryCoordinator::signal_after_persist`
+    handoff for host-qualified writes. It signals bounded background work after
+    local admission and never waits for DNS, a socket, TLS, remote receipt, or
+    another message's delivery
   - first recovery attempt is no earlier than 60 seconds; later failures use
     exponential backoff capped at 15 minutes
   - recovery submits original ULIDs through normal HTTPS; no ping, outbox,

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3937,6 +3937,13 @@ mail correctness.
     commits, the daemon returns the typed local admission response; peer-job
     signalling, DNS, connection, TLS, remote receipt, duplicate handling,
     acknowledgement, and nudge work run asynchronously
+  - admission validation uses request data plus the daemon-owned reloadable
+    runtime view. It performs no per-request config-file read, peer-config or
+    policy store read, outbound-page read, DNS lookup, socket/TLS operation,
+    hook, or nudge before responding. An acknowledgement resolves its source,
+    inserts its immutable reply, and conditionally marks the source
+    acknowledged within one SQLite transaction; it has no application-layer
+    source read before that transaction
   - the response proves only local admission. Remote acceptance remains the
     separate asynchronous outcome defined by `REQ-CORE-TRANSPORT-005A`; a
     local admission response must never claim remote delivery


### PR DESCRIPTION
## Scope
- formalize SQLite-only local admission and remote-outcome separation
- define AI.31 async admission, AI.32 bounded independent peer jobs, and AI.33 isolated 1,000/s evidence
- remove the former foreground wait / ordered-peer-stream requirement

## Guardrails
- no durable outbox, receipt, retry history, or delivery state
- no cross-command delivery-order promise
- capacity evidence must use disposable isolated ATM_HOME/SQLite
- approved remove-member work is untouched

## Validation
- `just lint` — all 22 checks passed
- `git diff --check` passed