### PR TITLE
AI.31: asynchronous durable local admission

### DIFF
--- a/.just/lint_boundaries.py
+++ b/.just/lint_boundaries.py
@@ -102,6 +102,7 @@ IO_FORBIDDEN_SOURCE_PATTERNS: dict[str, tuple[str, ...]] = {
     "delivery_plan_construction": (r"\b(?:Reply)?DeliveryPlan\b", r"\bexecute_(?:reply_)?delivery_plan\s*\(", r"\bdelivery_plan_construction\b"),
     "delivery_queue": (r"\bdelivery_queue\b", r"\bDeliveryQueue\b", r"\bqueue_delivery\s*\("),
     "delivery_state": (r"\bdelivery_state\b", r"\bDeliveryState\b"),
+    "dns": (r"\b(?:lookup_host|to_socket_addrs|DnsResolver|resolve_peer_authority)\b",),
     "direct_socket_io": (
         r"\b(?:std|tokio)::net::",
         r"\b(?:Tcp|Udp|Unix)(?:Stream|Listener|Socket)\b",
@@ -116,6 +117,8 @@ IO_FORBIDDEN_SOURCE_PATTERNS: dict[str, tuple[str, ...]] = {
     "named_pipe": (r"\bNamedPipe\b", r"\bnamed_pipe\b", r"\b(?:pipe|fifo)_(?:read|write|open)\s*\("),
     "nudge": (r"\bnudge\b", r"\bNudge\b"),
     "nudge_emission": (r"\bnudge_emission\b", r"\b(?:emit|send|deliver)_nudge\s*\(", r"\bNudgeEmitter\b"),
+    "graft_delivery": (r"\b(?:deliver_graft_post_send|GraftPostSendPort|GraftPostSendRequest)\b",),
+    "hook_execution": (r"\b(?:emit_post_send_effects|load_post_send_config_for_sender)\b",),
     "process_spawn": (r"\bstd::process::Command\b", r"\bCommand::new\s*\(", r"\)\.spawn\s*\("),
     "process_spawn_for_notifications": (r"\bstd::process::Command\b", r"\bCommand::new\s*\(", r"\)\.spawn\s*\("),
     "process_spawn_outside_owned_runtime_path": (r"\bstd::process::Command\b", r"\bCommand::new\s*\(", r"\)\.spawn\s*\("),
@@ -134,6 +137,7 @@ IO_FORBIDDEN_SOURCE_PATTERNS: dict[str, tuple[str, ...]] = {
         r"\b(?:Tcp|Udp|Unix)(?:Stream|Listener|Socket)\b",
         r"\bsocket_io\b",
     ),
+    "tls": (r"\b(?:TlsConnector|TlsAcceptor|rustls|ServerName)\b",),
     "sqlite": (
         r"\b(?:rusqlite|sqlx)::",
         r"\b(?:Sqlite|SQLite)(?:Connection|Transaction|Store|Database|Pool|Backend)\b",

--- a/.winget/randlee.agent-team-mail.yaml
+++ b/.winget/randlee.agent-team-mail.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: randlee.agent-team-mail
-PackageVersion: 1.4.0-beta-ai
+PackageVersion: 1.4.0-beta-ai.31
 PackageLocale: en-US
 Publisher: Randy Lee
 PublisherUrl: https://github.com/randlee
@@ -21,7 +21,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.4.0-beta-ai/atm_1.4.0-beta-ai_x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/randlee/atm-core/releases/download/v1.4.0-beta-ai.31/atm_1.4.0-beta-ai.31_x86_64-pc-windows-msvc.zip
     InstallerSha256: <SHA256_HASH_TO_BE_FILLED_AFTER_RELEASE>
 ManifestType: installer
-ManifestVersion: 1.4.0-beta-ai
+ManifestVersion: 1.4.0-beta-ai.31

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft-python"
-version = "1.4.0-beta-ai.31"
+version = "1.4.0"
 dependencies = [
  "agent-team-mail-core",
  "atm-graft",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "tempfile",
  "toml",
  "tracing",
+ "tracing-subscriber",
  "ulid",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "atm-error",
  "atm-runtime-test-support",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "atm-architecture"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "cargo_metadata",
  "serde",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "agent-team-mail-core",
  "arc-swap",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-bootstrap"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "atm-daemon-client"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "atm-error"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "serde",
  "serde_json",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "agent-team-mail-core",
  "atm-daemon-client",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft-python"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "agent-team-mail-core",
  "atm-graft",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "agent-team-mail-core",
  "atm-storage",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "atm-runtime-test-support"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "agent-team-mail-core",
  "atm-runtime",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "atm-error",
  "chrono",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-rusqlite"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "atm-storage",
  "chrono",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "atm-storage-sqlserver-proof"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 dependencies = [
  "atm-storage",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["atm-core contributors"]

--- a/boundaries/atm-daemon/admission-runtime-view.toml
+++ b/boundaries/atm-daemon/admission-runtime-view.toml
@@ -1,0 +1,46 @@
+boundary_id = "BOUNDARY-AdmissionRuntimeView-Daemon"
+owner_package = "atm-daemon"
+owner_crate_path = "atm_daemon"
+name = "AdmissionRuntimeView"
+
+[public]
+trait = "AdmissionRuntimeView"
+
+[implementation]
+type = "AdmissionRuntimeView"
+module = "atm_daemon::runtime_health::admission_view"
+visibility = "pub(crate)"
+constructor = "pub(crate)"
+
+[composition]
+roots = ["atm_daemon::composition::compose_runtime"]
+
+[ownership]
+io_owns = ["in_memory_runtime_view_reload"]
+io_forbidden = ["sqlite", "dns", "socket_io", "tls", "process_spawn"]
+
+[dependencies]
+allowed_dependents = []
+allowed_dependencies = ["atm-core"]
+forbidden_edges = ["atm -> atm-daemon", "atm-graft -> atm-daemon"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = ["AdmissionRuntimeView"]
+
+[contracts]
+request_types = ["canonical WriteRequest"]
+response_types = ["PreparedWrite"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = []
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-ADMISSION-RUNTIME-VIEW"]
+review_gates = ["no_workspace_config_read_on_admission", "no_delivery_io_on_admission"]
+
+[status]
+state = "active"
+notes = ["AI.31: this immutable daemon-owned view is the only synchronous dependency source for local write admission."]

--- a/boundaries/atm-daemon/peer-delivery-coordinator.toml
+++ b/boundaries/atm-daemon/peer-delivery-coordinator.toml
@@ -1,0 +1,46 @@
+boundary_id = "BOUNDARY-PeerDeliveryCoordinator-Daemon"
+owner_package = "atm-daemon"
+owner_crate_path = "atm_daemon"
+name = "PeerDeliveryCoordinator"
+
+[public]
+trait = "PeerDeliveryCoordinator"
+
+[implementation]
+type = "PeerDrainCoordinator"
+module = "atm_daemon::peer_drain_coordinator"
+visibility = "pub(crate)"
+constructor = "pub(crate)"
+
+[composition]
+roots = ["atm_daemon::composition::compose_runtime"]
+
+[ownership]
+io_owns = ["post_commit_peer_drain", "bounded_peer_recovery"]
+io_forbidden = ["receipt", "delivery_state"]
+
+[dependencies]
+allowed_dependents = []
+allowed_dependencies = ["atm-core", "atm-storage"]
+forbidden_edges = ["atm -> atm-daemon", "atm-graft -> atm-daemon"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = ["PeerDrainCoordinator"]
+
+[contracts]
+request_types = ["HostName wake-up", "bounded explicit peer sync"]
+response_types = ["peer delivery outcome"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = []
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-PEER-DELIVERY-COORDINATOR"]
+review_gates = ["not_on_admission_path", "no_payload_queue"]
+
+[status]
+state = "active"
+notes = ["AI.31: peer drains execute only after local SQLite admission and response construction."]

--- a/boundaries/atm-daemon/post-commit-work-queue.toml
+++ b/boundaries/atm-daemon/post-commit-work-queue.toml
@@ -1,0 +1,46 @@
+boundary_id = "BOUNDARY-PostCommitWorkQueue-Daemon"
+owner_package = "atm-daemon"
+owner_crate_path = "atm_daemon"
+name = "PostCommitWorkQueue"
+
+[public]
+trait = "PostCommitWorkQueue"
+
+[implementation]
+type = "PeerPostCommitWorkQueue"
+module = "atm_daemon::runtime_health::post_commit_work"
+visibility = "pub(crate)"
+constructor = "pub(crate)"
+
+[composition]
+roots = ["atm_daemon::composition::compose_runtime"]
+
+[ownership]
+io_owns = ["bounded_identifier_only_post_commit_scheduling"]
+io_forbidden = ["sqlite", "receipt", "retry_state"]
+
+[dependencies]
+allowed_dependents = []
+allowed_dependencies = ["atm-core"]
+forbidden_edges = ["atm -> atm-daemon", "atm-graft -> atm-daemon"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = ["PeerPostCommitWorkQueue"]
+
+[contracts]
+request_types = ["PostCommitWorkKey"]
+response_types = ["infallible scheduling signal"]
+error_types = ["none"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = []
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-POST-COMMIT-WORK-QUEUE"]
+review_gates = ["identifier_only", "no_admission_wait", "no_direct_sqlite"]
+
+[status]
+state = "active"
+notes = ["AI.31: only immutable message identifiers and peer wake-up keys cross this seam."]

--- a/boundaries/atm-daemon/post-write-router.toml
+++ b/boundaries/atm-daemon/post-write-router.toml
@@ -8,7 +8,7 @@ trait = "PostWriteRouter"
 
 [implementation]
 type = "DaemonRequestDispatcher"
-module = "atm_daemon::runtime_health"
+module = "atm_daemon::runtime_health::peer_delivery_router"
 visibility = "pub(crate)"
 constructor = "pub(crate)"
 

--- a/boundaries/atm-daemon/post-write-router.toml
+++ b/boundaries/atm-daemon/post-write-router.toml
@@ -1,0 +1,46 @@
+boundary_id = "BOUNDARY-PostWriteRouter-Daemon"
+owner_package = "atm-daemon"
+owner_crate_path = "atm_daemon"
+name = "DaemonPostWriteRouter"
+
+[public]
+trait = "PostWriteRouter"
+
+[implementation]
+type = "DaemonRequestDispatcher"
+module = "atm_daemon::runtime_health"
+visibility = "pub(crate)"
+constructor = "pub(crate)"
+
+[composition]
+roots = ["atm_daemon::composition::compose_runtime"]
+
+[ownership]
+io_owns = ["post_commit_route_classification"]
+io_forbidden = ["sqlite", "dns", "socket_io", "tls", "hook_execution", "graft_delivery"]
+
+[dependencies]
+allowed_dependents = []
+allowed_dependencies = ["atm-core"]
+forbidden_edges = ["atm -> atm-daemon", "atm-graft -> atm-daemon"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = []
+
+[contracts]
+request_types = ["committed MessageRecord"]
+response_types = ["PostCommitWorkKey signal"]
+error_types = ["none"]
+
+[testing]
+allowed_test_double_paths = []
+forbidden_test_bypasses = []
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-POST-WRITE-ROUTER"]
+review_gates = ["signal_only", "no_direct_peer_transport", "no_hook_or_nudge_execution"]
+
+[status]
+state = "active"
+notes = ["AI.31: host-qualified, localhost, and self-IP writes use ordinary routing and signal post-commit work only."]

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -400,7 +400,7 @@ fn ai23_peer_adapter_never_matches_localhost_or_own_ip() {
         .find("let Some(host) = message")
         .expect("the generic local/peer routing guard must handle optional hosts");
     let peer_branch = dispatch
-        .find("signal_after_persist")
+        .find("PostCommitWorkKey::PeerDelivery")
         .expect("generic peer routing must signal post-commit work behind the local/peer guard");
     assert!(
         peer_receipt_guard < peer_branch && host_guard < peer_branch,
@@ -975,7 +975,6 @@ impl HostRoutingVisitor {
             .iter()
             .filter(|function| {
                 function.calls_delivery
-                    && !function.is_post_write_dispatch
                     && !function.is_post_write_router_helper
                     && function.reconciliation_delivery_calls == 0
             })

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -287,6 +287,7 @@ fn ai25_peer_authority_selection_is_not_owned_by_the_https_adapter() {
     let adapter = read_source(&root.join("crates/atm-daemon/src/https_transport.rs"));
     let router =
         read_source(&root.join("crates/atm-daemon/src/runtime_health/peer_delivery_router.rs"));
+    let coordinator = read_source(&root.join("crates/atm-daemon/src/peer_drain_coordinator.rs"));
     let authority =
         read_source(&root.join("crates/atm-daemon/src/runtime_health/peer_authority.rs"));
 
@@ -295,8 +296,12 @@ fn ai25_peer_authority_selection_is_not_owned_by_the_https_adapter() {
         "AI.25 forbids recipient authority selection inside the HTTPS adapter"
     );
     assert!(
-        router.contains("peer_authority::resolve_peer_authority"),
-        "AI.25 requires PostWriteRouter to own recipient authority selection"
+        !router.contains("resolve_peer_authority"),
+        "AI.31 forbids the foreground PostWriteRouter from reading peer authority"
+    );
+    assert!(
+        coordinator.contains("resolve_peer_authority"),
+        "AI.31 keeps authority selection in the post-commit peer worker"
     );
     assert!(
         authority.contains("pub(crate) fn resolve_peer_authority"),
@@ -325,8 +330,8 @@ fn canonical_write_router_has_one_host_routing_decision() {
     );
     assert_eq!(
         visitor.peer_delivery_calls(),
-        1,
-        "AI.12 requires exactly one peer delivery call from PostWriteRouter::dispatch"
+        0,
+        "AI.31 forbids peer delivery from PostWriteRouter::dispatch"
     );
     assert_eq!(
         visitor.message_writer_implementations, 1,
@@ -343,7 +348,7 @@ fn canonical_write_router_has_one_host_routing_decision() {
     );
     assert!(
         visitor.violations().is_empty(),
-        "AI.12 permits host routing, local nudge emission, and peer transport only from PostWriteRouter::dispatch: {:?}",
+        "AI.31 permits host routing and work signalling but forbids foreground peer transport: {:?}",
         visitor.violations()
     );
     let daemon = fs::read_to_string(root.join("crates/atm-daemon/src/runtime_health.rs"))
@@ -395,14 +400,11 @@ fn ai23_peer_adapter_never_matches_localhost_or_own_ip() {
         .find("let Some(host) = message")
         .expect("the generic local/peer routing guard must handle optional hosts");
     let peer_branch = dispatch
-        .find("self.deliver_to_peer")
-        .expect("generic peer routing must remain behind the local/peer guard");
-    let _peer_adapter = source
-        .find("resolve_peer_authority(host")
-        .expect("peer authority selection must remain in the generic peer branch");
+        .find("signal_after_persist")
+        .expect("generic peer routing must signal post-commit work behind the local/peer guard");
     assert!(
         peer_receipt_guard < peer_branch && host_guard < peer_branch,
-        "localhost and own-IP must be considered by the generic host guard before peer authority selection"
+        "localhost and own-IP must be considered by the generic host guard before post-commit work is signalled"
     );
     for forbidden in ["localhost", "127.0.0.1", "is_loopback", "is_loopback()"] {
         assert!(

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -176,8 +176,16 @@ fn acknowledgement_cannot_restore_a_second_write_pipeline() {
         "AI.7 requires one canonical write pipeline"
     );
     assert!(
-        send.contains("resolve_acknowledgement_write"),
-        "AI.7 acknowledgement normalization must enter the canonical write pipeline"
+        send.contains("crate::ack::admit_acknowledgement_write"),
+        "AI.31 acknowledgement admission must enter the canonical write pipeline"
+    );
+    assert!(
+        acknowledgement.contains("runtime.acknowledge_message_atomically"),
+        "AI.31 acknowledgement source resolution and paired commit must stay behind the sealed storage boundary"
+    );
+    assert!(
+        !acknowledgement.contains("resolve_acknowledgement_source"),
+        "AI.31 forbids restoring an application-layer acknowledgement source read"
     );
     assert!(
         acknowledgement.contains("crate::send::write_mail_with_runtime("),

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -20,8 +20,8 @@ name = "atm_core"
 test-utils = []
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.0-beta-ai" }
-atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai" }
+atm-error = { path = "../atm-error", version = "1.4.0-beta-ai.31" }
+atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai.31" }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -40,6 +40,7 @@ fs2 = "0.4"
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 serial_test = "3"
 tempfile = "3"
+tracing-subscriber.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Com", "Win32_System_Threading", "Win32_UI_Shell"] }

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -225,15 +225,12 @@ pub(crate) fn resolve_acknowledgement_write<
         &actor,
         "Repair or reload the ATM roster before retrying `atm ack`.",
     )?;
-    let source = load_ack_source(
-        runtime,
+    let source_record = runtime.resolve_acknowledgement_source(
         &request.home_dir,
         &team,
         &actor,
         request.message_id,
     )?;
-    let source_record =
-        load_ack_source_record(runtime, &request.home_dir, &team, &actor, &source.row)?;
     ensure_ack_is_pending(request.message_id, &source_record.envelope)?;
     let reply_target = validate_reply_target(runtime, &source_record, &team)?;
     let canonical_request =
@@ -279,9 +276,8 @@ pub(crate) fn resolve_received_acknowledgement_write<
         .team()
         .cloned()
         .unwrap_or_else(|| request.caller_team.clone());
-    let source = load_ack_source(runtime, &request.home_dir, &team, &actor, message_id)?;
     let source_record =
-        load_ack_source_record(runtime, &request.home_dir, &team, &actor, &source.row)?;
+        runtime.resolve_acknowledgement_source(&request.home_dir, &team, &actor, message_id)?;
     ensure_ack_is_pending(message_id, &source_record.envelope)?;
     let reply_target = ReplyTarget::new(actor.clone(), team.clone(), target.host().cloned());
     Ok(ResolvedAcknowledgement {
@@ -377,10 +373,6 @@ fn canonical_ack_write_request(
     })
 }
 
-struct LoadedAckSource {
-    row: boundary::MailStoreMailboxMetadataRow,
-}
-
 fn ensure_roster_member_exists<R: RetainedServiceRuntime>(
     runtime: &R,
     team: &TeamName,
@@ -391,47 +383,6 @@ fn ensure_roster_member_exists<R: RetainedServiceRuntime>(
         return Err(AtmError::agent_not_found(agent, team));
     }
     Ok(())
-}
-
-fn load_ack_source<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
-    runtime: &R,
-    home_dir: &std::path::Path,
-    team: &TeamName,
-    actor: &AgentName,
-    message_id: AtmMessageId,
-) -> Result<LoadedAckSource, AtmError> {
-    let rows = runtime.query_mailbox_metadata_rows(home_dir, team, actor, None)?;
-    let row = rows
-        .iter()
-        .find(|row| row.message_id == Some(message_id))
-        .ok_or_else(|| {
-            AtmError::validation(format!(
-                "message {message_id} was not found in {actor}@{team}"
-            ))
-        })?;
-    if rows
-        .iter()
-        .any(|candidate| candidate.parent_message_id == Some(message_id))
-    {
-        return Err(AtmError::validation(format!(
-            "message {message_id} has been updated; acknowledge the current terminal message instead"
-        )));
-    }
-    Ok(LoadedAckSource { row: row.clone() })
-}
-
-fn load_ack_source_record<R: RetainedMailboxRuntime>(
-    runtime: &R,
-    home_dir: &std::path::Path,
-    team: &TeamName,
-    actor: &AgentName,
-    row: &boundary::MailStoreMailboxMetadataRow,
-) -> Result<boundary::Message, AtmError> {
-    runtime
-        .load_message_record(home_dir, team, actor, &row.message_key)?
-        .ok_or_else(|| {
-            AtmError::validation("acknowledgement source metadata could not be reloaded")
-        })
 }
 
 fn ensure_ack_is_pending(message_id: AtmMessageId, source: &InboxMessage) -> Result<(), AtmError> {

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -193,7 +193,6 @@ pub fn ack_mail_with_runtime(
 /// then executed by the one canonical write pipeline shared with `atm send`.
 pub(crate) struct ResolvedAcknowledgement {
     canonical_request: SendRequest,
-    source: LoadedAckSource,
     source_record: boundary::Message,
     actor: AgentName,
     team: TeamName,
@@ -241,7 +240,6 @@ pub(crate) fn resolve_acknowledgement_write<
         canonical_ack_write_request(&request, &actor, &team, &reply_target, &source_record)?;
     Ok(ResolvedAcknowledgement {
         canonical_request,
-        source,
         source_record,
         actor,
         team,
@@ -288,7 +286,6 @@ pub(crate) fn resolve_received_acknowledgement_write<
     let reply_target = ReplyTarget::new(actor.clone(), team.clone(), target.host().cloned());
     Ok(ResolvedAcknowledgement {
         canonical_request: request,
-        source,
         source_record,
         actor,
         team,
@@ -303,22 +300,25 @@ impl ResolvedAcknowledgement {
         self.canonical_request.clone()
     }
 
+    /// Builds the acknowledged source replacement that is committed in the
+    /// same SQLite writer transaction as the immutable acknowledgement reply.
+    pub(crate) fn source_update(&self) -> boundary::Message {
+        let timestamp = IsoTimestamp::now();
+        let mut source = self.source_record.clone();
+        source.envelope.read = true;
+        source.envelope.pending_ack_at = None;
+        source.envelope.acknowledged_at = Some(timestamp);
+        source
+    }
+
     /// Receiver-side acknowledgement mutation occurs only after the canonical
     /// write succeeded. A failed write leaves the source pending.
     pub(crate) fn finish<R: RetainedMailboxRuntime>(
         self,
-        runtime: &R,
+        _runtime: &R,
         observability: &dyn ObservabilityPort,
         send_outcome: SendOutcome,
     ) -> Result<AckOutcome, AtmError> {
-        mark_source_acknowledged(
-            runtime,
-            &self.team,
-            &self.actor,
-            self.source.row.message_key,
-            self.source_record.envelope.expires_at,
-        )?;
-
         let outcome = AckOutcome {
             action: CommandAction::Ack,
             team: self.team.clone(),
@@ -379,28 +379,6 @@ fn canonical_ack_write_request(
 
 struct LoadedAckSource {
     row: boundary::MailStoreMailboxMetadataRow,
-}
-
-fn mark_source_acknowledged<R: RetainedMailboxRuntime>(
-    runtime: &R,
-    team: &TeamName,
-    actor: &AgentName,
-    message_key: boundary::MessageKey,
-    expires_at: Option<IsoTimestamp>,
-) -> Result<(), AtmError> {
-    let timestamp = IsoTimestamp::now();
-    runtime.persist_message_state(boundary::MailMessageState {
-        team: team.clone(),
-        agent: actor.clone(),
-        actor: actor.clone(),
-        message_key,
-        read: true,
-        pending_ack_at: None,
-        acknowledged_at: Some(timestamp),
-        expires_at,
-        deleted_at: None,
-        updated_at: Some(timestamp),
-    })
 }
 
 fn ensure_roster_member_exists<R: RetainedServiceRuntime>(

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 use crate::boundary;
 use crate::error::AtmError;
@@ -9,6 +10,9 @@ use crate::send::{SendMessageSource, SendOutcome, SendRequest, WriteOutcome};
 use crate::service_runtime::{LocalServiceRuntime, RetainedServiceRuntime};
 use crate::service_runtime_store::{RetainedMailboxRuntime, default_runtime};
 use crate::types::{AgentName, ChatId, CommandAction, HostName, IsoTimestamp, TaskId, TeamName};
+use atm_storage::contract::{
+    AcknowledgementReplyBuilder, AcknowledgementSource, Message as StoredMessage, MessageKey,
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Parameters for acknowledging one pending-ack mailbox message.
@@ -189,26 +193,144 @@ pub fn ack_mail_with_runtime(
     }
 }
 
-/// Ack-specific source lookup is normalization only. The returned request is
-/// then executed by the one canonical write pipeline shared with `atm send`.
+/// Immutable acknowledgement outcome assembled by the sealed storage
+/// transaction, then completed through the canonical post-write pipeline.
+#[derive(Clone)]
 pub(crate) struct ResolvedAcknowledgement {
-    canonical_request: SendRequest,
-    source_record: boundary::Message,
     actor: AgentName,
     team: TeamName,
     reply_target: ReplyTarget,
     reply_text: String,
     acknowledged_message_id: AtmMessageId,
+    source_task_id: Option<TaskId>,
 }
 
-pub(crate) fn resolve_acknowledgement_write<
+/// Reply data retained only long enough to form the post-commit route and
+/// acknowledgement response.  The source itself is loaded by the storage
+/// writer, never by the application-layer admission path.
+#[derive(Clone)]
+pub(crate) struct AtomicAcknowledgementWrite {
+    pub(crate) reply: StoredMessage,
+    pub(crate) canonical_request: SendRequest,
+    pub(crate) acknowledgement: ResolvedAcknowledgement,
+}
+
+#[derive(Clone)]
+enum AtomicAcknowledgementKind {
+    Local(AckRequest),
+    Received(Box<SendRequest>),
+}
+
+struct AtomicAcknowledgementBuilder {
+    kind: AtomicAcknowledgementKind,
+    built: Mutex<Option<AtomicAcknowledgementWrite>>,
+}
+
+impl AtomicAcknowledgementBuilder {
+    fn new(kind: AtomicAcknowledgementKind) -> Self {
+        Self {
+            kind,
+            built: Mutex::new(None),
+        }
+    }
+
+    fn take(&self) -> Result<AtomicAcknowledgementWrite, AtmError> {
+        self.built
+            .lock()
+            .map_err(|_| {
+                AtmError::daemon_unavailable("acknowledgement builder state lock poisoned")
+            })?
+            .take()
+            .ok_or_else(|| {
+                AtmError::daemon_unavailable(
+                    "acknowledgement transaction completed without a reply",
+                )
+            })
+    }
+}
+
+impl AcknowledgementReplyBuilder for AtomicAcknowledgementBuilder {
+    fn build_reply(&self, source: &StoredMessage) -> Result<StoredMessage, AtmError> {
+        let built = match &self.kind {
+            AtomicAcknowledgementKind::Local(request) => {
+                let actor = request.caller_identity.clone();
+                let team = request.caller_team.clone();
+                let reply_target = reply_target_from_source(&source.envelope, &team)?;
+                let canonical_request = canonical_ack_write_request(
+                    request,
+                    &actor,
+                    &team,
+                    &reply_target,
+                    &boundary::Message {
+                        team: source.team.clone(),
+                        agent: source.agent.clone(),
+                        message_key: source.message_key.clone(),
+                        envelope: source.envelope.clone(),
+                    },
+                )?;
+                build_atomic_acknowledgement(
+                    canonical_request,
+                    actor,
+                    team,
+                    reply_target,
+                    request.reply_body.clone(),
+                    request.message_id,
+                    source.envelope.task_id.clone(),
+                )?
+            }
+            AtomicAcknowledgementKind::Received(request) => {
+                let target = request.to.clone().ok_or_else(|| {
+                    AtmError::validation("received peer acknowledgement is missing a destination")
+                })?;
+                let actor = target.agent().clone();
+                let team = target
+                    .team()
+                    .cloned()
+                    .unwrap_or_else(|| request.caller_team.clone());
+                let reply_target =
+                    ReplyTarget::new(actor.clone(), team.clone(), target.host().cloned());
+                let message_id = request.acknowledges_message_id.ok_or_else(|| {
+                    AtmError::validation("acknowledgement write is missing acknowledges_message_id")
+                })?;
+                let reply_text = match &request.message_source {
+                    SendMessageSource::Inline(value) => value.clone(),
+                    SendMessageSource::File { .. } => {
+                        return Err(AtmError::validation(
+                            "acknowledgement reply body must be inline",
+                        ));
+                    }
+                };
+                build_atomic_acknowledgement(
+                    *request.clone(),
+                    actor,
+                    team,
+                    reply_target,
+                    reply_text,
+                    message_id,
+                    source.envelope.task_id.clone(),
+                )?
+            }
+        };
+        let mut slot = self.built.lock().map_err(|_| {
+            AtmError::daemon_unavailable("acknowledgement builder state lock poisoned")
+        })?;
+        *slot = Some(built.clone());
+        Ok(built.reply)
+    }
+}
+
+pub(crate) fn admit_acknowledgement_write<
     R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
 >(
     request: SendRequest,
     runtime: &R,
-) -> Result<ResolvedAcknowledgement, AtmError> {
-    validate_write_provenance(
-        WriteIngress::Canonical,
+) -> Result<AtomicAcknowledgementWrite, AtmError> {
+    let provenance = validate_write_provenance(
+        if request.to.is_some() {
+            WriteIngress::Peer
+        } else {
+            WriteIngress::Canonical
+        },
         WriteProvenance {
             target_host: request.to.as_ref().and_then(|address| address.host()),
             authenticated_source_host: request.authenticated_source_host.as_ref(),
@@ -216,95 +338,145 @@ pub(crate) fn resolve_acknowledgement_write<
             origin_timestamp: request.origin_timestamp.is_some(),
         },
     )?;
-    let request = AckRequest::from_unresolved_write(request)?;
-    let actor = request.caller_identity.clone();
-    let team = request.caller_team.clone();
-    ensure_roster_member_exists(
-        runtime,
-        &team,
-        &actor,
-        "Repair or reload the ATM roster before retrying `atm ack`.",
-    )?;
-    let source_record = runtime.resolve_acknowledgement_source(
-        &request.home_dir,
-        &team,
-        &actor,
-        request.message_id,
-    )?;
-    ensure_ack_is_pending(request.message_id, &source_record.envelope)?;
-    let reply_target = validate_reply_target(runtime, &source_record, &team)?;
-    let canonical_request =
-        canonical_ack_write_request(&request, &actor, &team, &reply_target, &source_record)?;
-    Ok(ResolvedAcknowledgement {
+    let (source, builder) = if let Some(target) = request.to.as_ref() {
+        if !provenance.is_authenticated_peer() {
+            return Err(AtmError::validation(
+                "acknowledgement write must not include a client-supplied destination",
+            ));
+        }
+        let message_id = request.acknowledges_message_id.ok_or_else(|| {
+            AtmError::validation("acknowledgement write is missing acknowledges_message_id")
+        })?;
+        let team = target
+            .team()
+            .cloned()
+            .unwrap_or_else(|| request.caller_team.clone());
+        (
+            AcknowledgementSource {
+                team,
+                agent: target.agent().clone(),
+                message_id,
+            },
+            Arc::new(AtomicAcknowledgementBuilder::new(
+                AtomicAcknowledgementKind::Received(Box::new(request)),
+            )),
+        )
+    } else {
+        let request = AckRequest::from_unresolved_write(request)?;
+        ensure_roster_member_exists(
+            runtime,
+            &request.caller_team,
+            &request.caller_identity,
+            "Repair or reload the ATM roster before retrying `atm ack`.",
+        )?;
+        (
+            AcknowledgementSource {
+                team: request.caller_team.clone(),
+                agent: request.caller_identity.clone(),
+                message_id: request.message_id,
+            },
+            Arc::new(AtomicAcknowledgementBuilder::new(
+                AtomicAcknowledgementKind::Local(request),
+            )),
+        )
+    };
+    let _commit = runtime.acknowledge_message_atomically(&source, builder.clone())?;
+    builder.take()
+}
+
+fn build_atomic_acknowledgement(
+    canonical_request: SendRequest,
+    actor: AgentName,
+    team: TeamName,
+    reply_target: ReplyTarget,
+    reply_text: String,
+    acknowledged_message_id: AtmMessageId,
+    source_task_id: Option<TaskId>,
+) -> Result<AtomicAcknowledgementWrite, AtmError> {
+    if canonical_request.authenticated_source_host.is_none()
+        && reply_target.host.is_none()
+        && actor == reply_target.agent
+        && team == reply_target.team
+    {
+        return Err(AtmError::self_addressed_send_invalid(format!(
+            "self-addressed messages are invalid ATM input: '{actor}@{team}' may not send to itself"
+        )));
+    }
+    let destination = canonical_request.to.as_ref().ok_or_else(|| {
+        AtmError::validation("acknowledgement reply is missing a canonical destination")
+    })?;
+    let message_id = canonical_request.origin_message_id.unwrap_or_default();
+    let timestamp = canonical_request
+        .origin_timestamp
+        .unwrap_or_else(IsoTimestamp::now);
+    let summary = crate::send::summary::build_summary(&reply_text, None);
+    let mut envelope = InboxMessage {
+        from: actor.clone(),
+        source_chat_id: canonical_request.caller_chat_id.clone(),
+        text: reply_text.clone(),
+        timestamp,
+        read: false,
+        source_team: Some(team.clone()),
+        destination_chat_id: destination.chat_id().cloned(),
+        summary: Some(summary.clone()),
+        message_id: Some(message_id),
+        requires_ack: false,
+        pending_ack_at: None,
+        acknowledged_at: None,
+        acknowledges_message_id: Some(acknowledged_message_id),
+        parent_message_id: None,
+        thread_mode: None,
+        expires_at: None,
+        task_id: None,
+        extra: serde_json::Map::new(),
+    };
+    if canonical_request.authenticated_source_host.is_none()
+        && canonical_request.origin_message_id.is_none()
+        && let Some(host) = destination.host()
+    {
+        let request_json = serde_json::to_string(&canonical_request).map_err(|_| {
+            AtmError::mailbox_write("failed to serialize immutable acknowledgement peer write")
+        })?;
+        crate::schema::set_peer_outbound_write(&mut envelope, host, request_json);
+    }
+    let reply = StoredMessage {
+        team: destination.team().cloned().ok_or_else(|| {
+            AtmError::validation("acknowledgement reply destination is missing a team")
+        })?,
+        agent: destination.agent().clone(),
+        message_key: MessageKey::from(message_id),
+        envelope,
+    };
+    let acknowledgement = ResolvedAcknowledgement {
+        actor,
+        team,
+        reply_target,
+        reply_text,
+        acknowledged_message_id,
+        source_task_id,
+    };
+    Ok(AtomicAcknowledgementWrite {
+        reply,
         canonical_request,
-        source_record,
-        actor,
-        team,
-        reply_target,
-        reply_text: request.reply_body,
-        acknowledged_message_id: request.message_id,
+        acknowledgement,
     })
 }
 
-/// Resolve an acknowledgement that already arrived through authenticated peer
-/// ingress. Its destination is canonical wire data, not a client-supplied
-/// local-CLI destination, so this reloads only the local source state that
-/// must transition after the received immutable reply persists.
-pub(crate) fn resolve_received_acknowledgement_write<
-    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
->(
-    request: SendRequest,
-    runtime: &R,
-) -> Result<ResolvedAcknowledgement, AtmError> {
-    validate_write_provenance(
-        WriteIngress::Peer,
-        WriteProvenance {
-            target_host: request.to.as_ref().and_then(|address| address.host()),
-            authenticated_source_host: request.authenticated_source_host.as_ref(),
-            origin_message_id: request.origin_message_id.is_some(),
-            origin_timestamp: request.origin_timestamp.is_some(),
-        },
-    )?;
-    let message_id = request.acknowledges_message_id.ok_or_else(|| {
-        AtmError::validation("acknowledgement write is missing acknowledges_message_id")
-    })?;
-    let target = request.to.clone().ok_or_else(|| {
-        AtmError::validation("received peer acknowledgement is missing a destination")
-    })?;
-    let actor = target.agent().clone();
-    let team = target
-        .team()
-        .cloned()
-        .unwrap_or_else(|| request.caller_team.clone());
-    let source_record =
-        runtime.resolve_acknowledgement_source(&request.home_dir, &team, &actor, message_id)?;
-    ensure_ack_is_pending(message_id, &source_record.envelope)?;
-    let reply_target = ReplyTarget::new(actor.clone(), team.clone(), target.host().cloned());
-    Ok(ResolvedAcknowledgement {
-        canonical_request: request,
-        source_record,
-        actor,
-        team,
-        reply_target,
-        reply_text: String::new(),
-        acknowledged_message_id: message_id,
-    })
+fn reply_target_from_source(
+    source: &InboxMessage,
+    current_team: &TeamName,
+) -> Result<ReplyTarget, AtmError> {
+    let team = source
+        .source_team
+        .clone()
+        .unwrap_or_else(|| current_team.clone());
+    let agent = crate::threading::canonical_sender_identity(source);
+    Ok(ReplyTarget::new(agent, team, reply_target_host(source)?))
 }
 
 impl ResolvedAcknowledgement {
-    pub(crate) fn request(&self) -> SendRequest {
-        self.canonical_request.clone()
-    }
-
-    /// Builds the acknowledged source replacement that is committed in the
-    /// same SQLite writer transaction as the immutable acknowledgement reply.
-    pub(crate) fn source_update(&self) -> boundary::Message {
-        let timestamp = IsoTimestamp::now();
-        let mut source = self.source_record.clone();
-        source.envelope.read = true;
-        source.envelope.pending_ack_at = None;
-        source.envelope.acknowledged_at = Some(timestamp);
-        source
+    pub(crate) fn source_task_id(&self) -> Option<TaskId> {
+        self.source_task_id.clone()
     }
 
     /// Receiver-side acknowledgement mutation occurs only after the canonical
@@ -320,7 +492,7 @@ impl ResolvedAcknowledgement {
             team: self.team.clone(),
             agent: self.actor.clone(),
             message_id: self.acknowledged_message_id,
-            task_id: self.source_record.envelope.task_id.clone(),
+            task_id: self.source_task_id.clone(),
             reply_disposition: AckReplyDisposition::Sent {
                 reply_message_id: send_outcome.message_id,
                 reply_target: self.reply_target,
@@ -383,47 +555,6 @@ fn ensure_roster_member_exists<R: RetainedServiceRuntime>(
         return Err(AtmError::agent_not_found(agent, team));
     }
     Ok(())
-}
-
-fn ensure_ack_is_pending(message_id: AtmMessageId, source: &InboxMessage) -> Result<(), AtmError> {
-    if source.pending_ack_at.is_some() {
-        return Ok(());
-    }
-    let state = if source.acknowledged_at.is_some() {
-        "already acknowledged"
-    } else {
-        "not pending acknowledgement"
-    };
-    Err(AtmError::validation(format!(
-        "message {message_id} is {state}"
-    )))
-}
-
-fn validate_reply_target<R: RetainedServiceRuntime>(
-    runtime: &R,
-    source: &boundary::Message,
-    current_team: &TeamName,
-) -> Result<ReplyTarget, AtmError> {
-    let team = source
-        .envelope
-        .source_team
-        .clone()
-        .unwrap_or_else(|| current_team.clone());
-    let agent = crate::threading::canonical_sender_identity(&source.envelope);
-    // A normal peer receipt carries authenticated provenance. A same-store
-    // peer receipt deliberately retains the origin row instead of writing a
-    // duplicate, so its reply target comes from that row's retained outbound
-    // host. Neither case recreates a hostless reply address.
-    let host = reply_target_host(&source.envelope)?;
-    if host.is_none() {
-        ensure_roster_member_exists(
-            runtime,
-            &team,
-            &agent,
-            "reload the roster before retrying the acknowledgement",
-        )?;
-    }
-    Ok(ReplyTarget::new(agent, team, host))
 }
 
 fn reply_target_host(source: &InboxMessage) -> Result<Option<crate::types::HostName>, AtmError> {

--- a/crates/atm-core/src/clear/mod.rs
+++ b/crates/atm-core/src/clear/mod.rs
@@ -390,6 +390,14 @@ mod tests {
     }
 
     impl RetainedMailboxRuntime for ClearRuntime {
+        fn acknowledge_message_atomically(
+            &self,
+            _source: &atm_storage::contract::AcknowledgementSource,
+            _builder: std::sync::Arc<dyn atm_storage::contract::AcknowledgementReplyBuilder>,
+        ) -> Result<atm_storage::contract::AcknowledgementCommit, AtmError> {
+            unreachable!("clear roster-truth tests do not admit acknowledgements")
+        }
+
         fn query_mailbox_metadata_rows(
             &self,
             _home_dir: &Path,

--- a/crates/atm-core/src/doctor/mod.rs
+++ b/crates/atm-core/src/doctor/mod.rs
@@ -780,6 +780,13 @@ mod tests {
             unreachable!("doctor tests do not touch the mail store boundary")
         }
 
+        fn save_messages_atomically(
+            &self,
+            _messages: &[atm_storage::Message],
+        ) -> Result<(), AtmError> {
+            unreachable!("doctor tests do not touch the mail store boundary")
+        }
+
         fn load_message(
             &self,
             _message_key: &atm_storage::MessageKey,

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -86,7 +86,20 @@ pub fn graft_receiver_record_path_from_home(
     team: &TeamName,
     agent: &AgentName,
 ) -> PathBuf {
-    home_dir
+    graft_receiver_record_path_from_root(home_dir, team, agent)
+}
+
+/// Absolute path of a loopback endpoint record under the canonical graft root.
+///
+/// The root is intentionally supplied by the caller so publishers and daemon
+/// resolvers share exactly the same path construction once roster metadata has
+/// selected the recipient's authoritative workspace root.
+pub fn graft_receiver_record_path_from_root(
+    graft_root: &Path,
+    team: &TeamName,
+    agent: &AgentName,
+) -> PathBuf {
+    graft_root
         .join(".atm")
         .join("graft")
         .join(team.as_str())

--- a/crates/atm-core/src/list.rs
+++ b/crates/atm-core/src/list.rs
@@ -426,6 +426,14 @@ mod tests {
     }
 
     impl RetainedMailboxRuntime for ListRuntime {
+        fn acknowledge_message_atomically(
+            &self,
+            _source: &atm_storage::contract::AcknowledgementSource,
+            _builder: std::sync::Arc<dyn atm_storage::contract::AcknowledgementReplyBuilder>,
+        ) -> Result<atm_storage::contract::AcknowledgementCommit, AtmError> {
+            unreachable!("list roster-truth tests do not admit acknowledgements")
+        }
+
         fn query_mailbox_metadata_rows(
             &self,
             _home_dir: &Path,

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -1369,6 +1369,14 @@ mod tests {
     }
 
     impl RetainedMailboxRuntime for ReadRuntime {
+        fn acknowledge_message_atomically(
+            &self,
+            _source: &atm_storage::contract::AcknowledgementSource,
+            _builder: std::sync::Arc<dyn atm_storage::contract::AcknowledgementReplyBuilder>,
+        ) -> Result<atm_storage::contract::AcknowledgementCommit, crate::error::AtmError> {
+            unreachable!("read roster-truth tests do not admit acknowledgements")
+        }
+
         fn query_mailbox_metadata_rows(
             &self,
             _home_dir: &Path,

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -51,8 +51,25 @@ pub fn canonical_home_dir(metadata_json: &Map<String, Value>) -> Option<HomeDirP
 }
 
 pub fn canonical_graft_root(metadata_json: &Map<String, Value>) -> Option<HomeDirPath> {
-    metadata_home_dir(metadata_json, WORKSPACE_ROOT_METADATA_KEY)
-        .or_else(|| canonical_home_dir(metadata_json))
+    if let Some(workspace_root) = metadata_home_dir(metadata_json, WORKSPACE_ROOT_METADATA_KEY) {
+        tracing::debug!(
+            graft_root_source = "workspace_root",
+            "resolved canonical graft root from workspace_root metadata"
+        );
+        return Some(workspace_root);
+    }
+    if let Some(home_dir) = canonical_home_dir(metadata_json) {
+        tracing::debug!(
+            graft_root_source = "home_dir_fallback",
+            "resolved canonical graft root from home_dir fallback"
+        );
+        return Some(home_dir);
+    }
+    tracing::debug!(
+        graft_root_source = "missing",
+        "canonical graft root is absent"
+    );
+    None
 }
 
 #[allow(
@@ -60,8 +77,25 @@ pub fn canonical_graft_root(metadata_json: &Map<String, Value>) -> Option<HomeDi
     reason = "Phase AD obsolete: bounded fallback remains only to read pre-AD compatibility metadata."
 )]
 pub fn compatible_home_dir(metadata_json: &Map<String, Value>) -> Option<HomeDirPath> {
-    canonical_home_dir(metadata_json)
-        .or_else(|| metadata_home_dir(metadata_json, LEGACY_CWD_METADATA_KEY))
+    if let Some(home_dir) = canonical_home_dir(metadata_json) {
+        tracing::debug!(
+            compatible_home_dir_source = "home_dir",
+            "resolved compatible home directory from home_dir metadata"
+        );
+        return Some(home_dir);
+    }
+    if let Some(legacy_cwd) = metadata_home_dir(metadata_json, LEGACY_CWD_METADATA_KEY) {
+        tracing::debug!(
+            compatible_home_dir_source = "legacy_cwd_fallback",
+            "resolved compatible home directory from legacy cwd fallback"
+        );
+        return Some(legacy_cwd);
+    }
+    tracing::debug!(
+        compatible_home_dir_source = "missing",
+        "compatible home directory is absent"
+    );
+    None
 }
 
 fn metadata_home_dir(metadata_json: &Map<String, Value>, key: &str) -> Option<HomeDirPath> {
@@ -126,9 +160,12 @@ impl AgentMember {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
     use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex};
 
     use serde_json::{Map, Value};
+    use tracing_subscriber::fmt::MakeWriter;
 
     use super::{
         AgentMember, AgentType, HOME_DIR_METADATA_KEY, HomeDirPath, WORKSPACE_ROOT_METADATA_KEY,
@@ -136,6 +173,42 @@ mod tests {
     };
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::AgentName;
+
+    #[derive(Clone)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture writer lock")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CaptureWriter {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn capture_logs<T>(operation: impl FnOnce() -> T) -> String {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(CaptureWriter(bytes.clone()))
+            .finish();
+        tracing::subscriber::with_default(subscriber, operation);
+        String::from_utf8(bytes.lock().expect("capture writer lock").clone()).expect("utf8 logs")
+    }
 
     #[test]
     fn parse_name_only_record_defaults_optional_fields() {
@@ -248,6 +321,43 @@ mod tests {
                 .map(HomeDirPath::as_path),
             Some(Path::new("/workspace/root"))
         );
+    }
+
+    #[test]
+    fn canonical_graft_root_logs_workspace_root_and_home_fallback_sources() {
+        let workspace_metadata = Map::from_iter([
+            (
+                HOME_DIR_METADATA_KEY.to_string(),
+                Value::from("/profile/home"),
+            ),
+            (
+                WORKSPACE_ROOT_METADATA_KEY.to_string(),
+                Value::from("/workspace/root"),
+            ),
+        ]);
+        let workspace_logs = capture_logs(|| canonical_graft_root(&workspace_metadata));
+        assert!(workspace_logs.contains("graft_root_source=\"workspace_root\""));
+
+        let home_metadata = Map::from_iter([(
+            HOME_DIR_METADATA_KEY.to_string(),
+            Value::from("/profile/home"),
+        )]);
+        let fallback_logs = capture_logs(|| canonical_graft_root(&home_metadata));
+        assert!(fallback_logs.contains("graft_root_source=\"home_dir_fallback\""));
+    }
+
+    #[test]
+    #[allow(
+        deprecated,
+        reason = "The test covers the retained pre-AD compatibility fallback."
+    )]
+    fn compatible_home_dir_logs_legacy_fallback_source() {
+        let metadata = Map::from_iter([(
+            super::LEGACY_CWD_METADATA_KEY.to_string(),
+            Value::from("/legacy/cwd"),
+        )]);
+        let logs = capture_logs(|| compatible_home_dir(&metadata));
+        assert!(logs.contains("compatible_home_dir_source=\"legacy_cwd_fallback\""));
     }
 
     #[test]

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -7,6 +7,10 @@ use crate::types::{AgentId, AgentName, ModelName, PaneId};
 pub use atm_storage::contract::AgentType;
 
 pub const HOME_DIR_METADATA_KEY: &str = "home_dir";
+/// Optional host workspace root used by graft receivers. When present it is
+/// the canonical root for the receiver endpoint; `home_dir` remains the
+/// compatibility fallback for roster members that predate this field.
+pub const WORKSPACE_ROOT_METADATA_KEY: &str = "workspace_root";
 #[deprecated(note = "Phase AD obsolete: derived compatibility field only")]
 pub const LEGACY_CWD_METADATA_KEY: &str = "cwd";
 
@@ -44,6 +48,11 @@ impl From<HomeDirPath> for PathBuf {
 
 pub fn canonical_home_dir(metadata_json: &Map<String, Value>) -> Option<HomeDirPath> {
     metadata_home_dir(metadata_json, HOME_DIR_METADATA_KEY)
+}
+
+pub fn canonical_graft_root(metadata_json: &Map<String, Value>) -> Option<HomeDirPath> {
+    metadata_home_dir(metadata_json, WORKSPACE_ROOT_METADATA_KEY)
+        .or_else(|| canonical_home_dir(metadata_json))
 }
 
 #[allow(
@@ -122,8 +131,8 @@ mod tests {
     use serde_json::{Map, Value};
 
     use super::{
-        AgentMember, AgentType, HOME_DIR_METADATA_KEY, HomeDirPath, canonical_home_dir,
-        compatible_home_dir,
+        AgentMember, AgentType, HOME_DIR_METADATA_KEY, HomeDirPath, WORKSPACE_ROOT_METADATA_KEY,
+        canonical_graft_root, canonical_home_dir, compatible_home_dir,
     };
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::AgentName;
@@ -217,6 +226,27 @@ mod tests {
                 .as_ref()
                 .map(HomeDirPath::as_path),
             Some(Path::new("/repo/home"))
+        );
+    }
+
+    #[test]
+    fn canonical_graft_root_prefers_workspace_root_over_profile_home() {
+        let metadata = Map::from_iter([
+            (
+                HOME_DIR_METADATA_KEY.to_string(),
+                Value::from("/profile/home"),
+            ),
+            (
+                WORKSPACE_ROOT_METADATA_KEY.to_string(),
+                Value::from("/workspace/root"),
+            ),
+        ]);
+
+        assert_eq!(
+            canonical_graft_root(&metadata)
+                .as_ref()
+                .map(HomeDirPath::as_path),
+            Some(Path::new("/workspace/root"))
         );
     }
 

--- a/crates/atm-core/src/schema/mod.rs
+++ b/crates/atm-core/src/schema/mod.rs
@@ -7,7 +7,8 @@ pub mod settings;
 pub mod team_config;
 
 pub use agent_member::{
-    AgentMember, HOME_DIR_METADATA_KEY, HomeDirPath, canonical_home_dir, compatible_home_dir,
+    AgentMember, HOME_DIR_METADATA_KEY, HomeDirPath, WORKSPACE_ROOT_METADATA_KEY,
+    canonical_graft_root, canonical_home_dir, compatible_home_dir,
 };
 pub use atm_storage::contract::AgentType;
 pub(crate) use inbox_message::{

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -28,8 +28,10 @@ use crate::config::{self, AtmConfig};
 use crate::error::AtmError;
 use crate::error_codes::AtmErrorCode;
 use crate::protocol::{NotificationEvent, NotificationKind};
+#[cfg(test)]
 use crate::schema::compatible_home_dir;
 use crate::service_runtime::{RetainedServiceRuntime, append_notification_log};
+#[cfg(test)]
 use crate::types::{AgentName, TeamName};
 
 const POST_SEND_HOOK_MAX_STDOUT_BYTES: usize = 8 * 1024;
@@ -163,6 +165,7 @@ where
     }
 }
 
+#[cfg(test)]
 pub(crate) fn load_post_send_config_for_sender<R>(
     runtime: &R,
     sender_team: &TeamName,
@@ -658,6 +661,7 @@ fn post_send_event_from_message(
     }
 }
 
+#[cfg(test)]
 fn sender_config_root(metadata: &serde_json::Map<String, Value>) -> Option<PathBuf> {
     compatible_home_dir(metadata).map(Into::into)
 }

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -194,12 +194,10 @@ impl WriteOutcome {
     }
 }
 
-/// A durable write awaiting its one post-write action.
+/// A durable write awaiting post-commit notification scheduling.
 ///
-/// The daemon owns the routing choice and invokes either local notification or
-/// peer delivery before calling [`PreparedWrite::finish`].  Keeping the
-/// acknowledgement source mutation here ensures an acknowledgement cannot be
-/// committed when peer delivery fails.
+/// Acknowledgement state completes before any post-commit notification or peer
+/// work.  Delivery is never a prerequisite for an admitted local write.
 pub struct PreparedWrite {
     outcome: SendOutcome,
     outbound_request: WriteRequest,
@@ -276,11 +274,11 @@ impl PreparedWrite {
         );
     }
 
-    /// Completes the canonical write only after the router's selected action
-    /// succeeded.  For acknowledgements this is where source state becomes
-    /// acknowledged; a peer-delivery error therefore leaves it pending.
+    /// Completes the canonical write before post-commit work is scheduled.
+    /// For acknowledgements this records the source transition before the
+    /// caller receives its local admission response.
     pub fn finish(
-        self,
+        &mut self,
         runtime: &LocalServiceRuntime,
         observability: &dyn ObservabilityPort,
     ) -> Result<WriteOutcome, AtmError> {
@@ -288,18 +286,18 @@ impl PreparedWrite {
     }
 
     fn finish_with_runtime<R>(
-        self,
+        &mut self,
         runtime: &R,
         observability: &dyn ObservabilityPort,
     ) -> Result<WriteOutcome, AtmError>
     where
         R: RetainedMailboxRuntime,
     {
-        match self.acknowledgement {
+        match self.acknowledgement.take() {
             Some(acknowledgement) => acknowledgement
-                .finish(runtime, observability, self.outcome)
+                .finish(runtime, observability, self.outcome.clone())
                 .map(WriteOutcome::Acknowledged),
-            None => Ok(WriteOutcome::Sent(self.outcome)),
+            None => Ok(WriteOutcome::Sent(self.outcome.clone())),
         }
     }
 
@@ -452,7 +450,7 @@ pub fn write_mail_with_runtime(
     observability: &dyn ObservabilityPort,
     runtime: &LocalServiceRuntime,
 ) -> Result<WriteOutcome, AtmError> {
-    let prepared = write_mail_with_runtime_impl(request, observability, runtime)?;
+    let mut prepared = write_mail_with_runtime_impl(request, observability, runtime)?;
     prepared.finish(runtime, observability)
 }
 

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -43,6 +43,7 @@ pub mod input;
 #[doc(hidden)]
 pub(crate) mod nudge_template;
 mod persistence;
+mod recipient;
 pub(crate) mod summary;
 
 pub(crate) use delivery_persistence::{
@@ -55,6 +56,7 @@ pub use nudge_template::{
 };
 #[cfg(test)]
 pub(crate) use persistence::persist_message;
+pub(crate) use recipient::{ResolvedRecipient, resolve_recipient, validate_non_self_recipient};
 
 pub(super) const POST_SEND_HOOK_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -1051,146 +1053,6 @@ fn emit_send_command_event(
     }) {
         warn!(%error, command = "send", action = "send", "failed to emit send command event");
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ResolvedRecipient {
-    pub(crate) agent: AgentName,
-    pub(crate) team: TeamName,
-}
-
-pub(crate) fn validate_non_self_recipient(
-    sender: &AgentName,
-    sender_team: &TeamName,
-    recipient: &ResolvedRecipient,
-    target: &AgentAddress,
-    provenance: ValidatedWriteProvenance,
-) -> Result<(), AtmError> {
-    let same_identity = sender
-        .as_str()
-        .eq_ignore_ascii_case(recipient.agent.as_str())
-        && sender_team
-            .as_str()
-            .eq_ignore_ascii_case(recipient.team.as_str());
-    if same_identity && target.host().is_none() && !provenance.is_authenticated_peer() {
-        return Err(AtmError::self_addressed_send_invalid(format!(
-            "self-addressed messages are invalid ATM input: '{sender}@{sender_team}' may not send to itself"
-        )));
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod self_address_tests {
-    use super::{ResolvedRecipient, validate_non_self_recipient};
-    use crate::address::AgentAddress;
-    use crate::error_codes::AtmErrorCode;
-    use crate::provenance::{WriteIngress, WriteProvenance, validate_write_provenance};
-    use crate::types::{AgentName, TeamName};
-
-    #[test]
-    fn validate_non_self_recipient_rejects_case_variant_self_target() {
-        let provenance = validate_write_provenance(
-            WriteIngress::Canonical,
-            WriteProvenance {
-                target_host: None,
-                authenticated_source_host: None,
-                origin_message_id: false,
-                origin_timestamp: false,
-            },
-        )
-        .expect("local provenance");
-        let error = validate_non_self_recipient(
-            &AgentName::from_validated("Sender-A"),
-            &TeamName::from_validated("Test-Team"),
-            &ResolvedRecipient {
-                agent: AgentName::from_validated("sender-a"),
-                team: TeamName::from_validated("test-team"),
-            },
-            &"sender-a@test-team"
-                .parse::<AgentAddress>()
-                .expect("target"),
-            provenance,
-        )
-        .expect_err("case-variant self target must be rejected");
-
-        assert_eq!(error.code(), AtmErrorCode::SelfAddressedSendInvalid);
-    }
-
-    #[test]
-    fn validate_non_self_recipient_allows_host_qualified_self_target() {
-        let target = "sender-a@test-team.127.0.0.1"
-            .parse::<AgentAddress>()
-            .expect("host-qualified target");
-        let provenance = validate_write_provenance(
-            WriteIngress::Canonical,
-            WriteProvenance {
-                target_host: target.host(),
-                authenticated_source_host: None,
-                origin_message_id: false,
-                origin_timestamp: false,
-            },
-        )
-        .expect("host-qualified origin provenance");
-        validate_non_self_recipient(
-            &AgentName::from_validated("sender-a"),
-            &TeamName::from_validated("test-team"),
-            &ResolvedRecipient {
-                agent: AgentName::from_validated("sender-a"),
-                team: TeamName::from_validated("test-team"),
-            },
-            &target,
-            provenance,
-        )
-        .expect("host-qualified self target must use the ordinary peer route");
-    }
-
-    #[test]
-    fn validate_non_self_recipient_allows_authenticated_peer_after_target_normalization() {
-        let target = "sender-a@test-team"
-            .parse::<AgentAddress>()
-            .expect("normalized target");
-        let peer_host = "peer.example.test".parse().expect("peer host");
-        let provenance = validate_write_provenance(
-            WriteIngress::Canonical,
-            WriteProvenance {
-                target_host: target.host(),
-                authenticated_source_host: Some(&peer_host),
-                origin_message_id: true,
-                origin_timestamp: true,
-            },
-        )
-        .expect("authenticated peer provenance");
-        validate_non_self_recipient(
-            &AgentName::from_validated("sender-a"),
-            &TeamName::from_validated("test-team"),
-            &ResolvedRecipient {
-                agent: AgentName::from_validated("sender-a"),
-                team: TeamName::from_validated("test-team"),
-            },
-            &target,
-            provenance,
-        )
-        .expect("authenticated peer receipt must not become a local self-send");
-    }
-}
-
-fn resolve_recipient(
-    target_address: &AgentAddress,
-    caller_team: &TeamName,
-    config: Option<&config::AtmConfig>,
-) -> Result<ResolvedRecipient, AtmError> {
-    // `AgentAddress` has already validated the explicit team segment. Never
-    // parse it again and silently substitute the caller team on failure.
-    let team = target_address
-        .team()
-        .cloned()
-        .unwrap_or_else(|| caller_team.clone());
-
-    Ok(ResolvedRecipient {
-        agent: config::aliases::resolve_agent_name(target_address.agent(), config)?,
-        team,
-    })
 }
 
 fn resolve_message_body(

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -526,7 +526,7 @@ fn write_mail_with_runtime_impl<
     observability: &dyn ObservabilityPort,
     runtime: &R,
 ) -> Result<PreparedWrite, AtmError> {
-    let provenance = validate_write_provenance(
+    validate_write_provenance(
         WriteIngress::Canonical,
         WriteProvenance {
             target_host: request.to.as_ref().and_then(|address| address.host()),
@@ -543,27 +543,73 @@ fn write_mail_with_runtime_impl<
         }
         return prepare_persisted_write(request, observability, runtime, None);
     }
-    if request.to.is_some() && provenance.is_authenticated_peer() {
-        let acknowledgement = crate::ack::resolve_received_acknowledgement_write(request, runtime)?;
-        return prepare_persisted_write(
-            acknowledgement.request(),
-            observability,
-            runtime,
-            Some(acknowledgement),
-        );
-    }
-    if request.to.is_some() {
-        return Err(AtmError::validation(
-            "acknowledgement write must not include a client-supplied destination",
-        ));
-    }
-    let acknowledgement = crate::ack::resolve_acknowledgement_write(request, runtime)?;
-    prepare_persisted_write(
-        acknowledgement.request(),
+    let acknowledgement = crate::ack::admit_acknowledgement_write(request, runtime)?;
+    prepare_atomic_acknowledgement_write(acknowledgement, observability, runtime)
+}
+
+fn prepare_atomic_acknowledgement_write<
+    R: RetainedServiceRuntime + RetainedMailboxRuntime + crate::boundary::sealed::Sealed,
+>(
+    acknowledgement: crate::ack::AtomicAcknowledgementWrite,
+    observability: &dyn ObservabilityPort,
+    _runtime: &R,
+) -> Result<PreparedWrite, AtmError> {
+    let source_task_id = acknowledgement.acknowledgement.source_task_id();
+    let reply = acknowledgement.reply;
+    let recipient = ResolvedRecipient {
+        team: reply.team.clone(),
+        agent: reply.agent.clone(),
+    };
+    let outcome = SendOutcome {
+        action: CommandAction::Send,
+        team: recipient.team.clone(),
+        agent: recipient.agent.clone(),
+        sender: reply.envelope.from.clone(),
+        outcome: SendCommandOutcome::Sent,
+        message_id: reply.envelope.message_id.ok_or_else(|| {
+            AtmError::mailbox_write("atomic acknowledgement reply is missing its message ID")
+        })?,
+        requires_ack: false,
+        task_id: source_task_id.clone(),
+        summary: reply.envelope.summary.clone(),
+        message: Some(reply.envelope.text.clone()),
+        warnings: Vec::new(),
+        dry_run: false,
+    };
+    emit_send_command_event(
         observability,
-        runtime,
-        Some(acknowledgement),
-    )
+        SendCommandOutcome::Sent.as_str(),
+        &outcome,
+        source_task_id,
+        &reply.envelope.from,
+    );
+    #[cfg(test)]
+    let post_write = {
+        let delivery_snapshot = DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(
+            _runtime,
+            &recipient.team,
+            &recipient.agent,
+        )?;
+        let logical =
+            crate::delivery_plan::LogicalMessage::new(reply.envelope.clone(), false, true)
+                .map_err(|error| AtmError::mailbox_read(error.to_string()))?;
+        LocalPostWrite {
+            post_send_config: None,
+            recipient,
+            delivery_snapshot,
+            messages: vec![logical],
+        }
+    };
+    Ok(PreparedWrite {
+        outcome,
+        outbound_request: acknowledgement.canonical_request,
+        persisted_timestamp: reply.envelope.timestamp,
+        post_write_needed: true,
+        same_store_peer_receipt: false,
+        #[cfg(test)]
+        post_write,
+        acknowledgement: Some(acknowledgement.acknowledgement),
+    })
 }
 
 fn prepare_persisted_write<
@@ -586,9 +632,7 @@ fn prepare_persisted_write<
     let summary = summary::build_summary(&body, request.summary_override.clone());
     let message_id = request.origin_message_id.unwrap_or_default();
     let timestamp = request.origin_timestamp.unwrap_or_else(IsoTimestamp::now);
-    let acknowledgement_source_update = acknowledgement
-        .as_ref()
-        .map(crate::ack::ResolvedAcknowledgement::source_update);
+    let acknowledgement_source_update = None;
     let persistence = persist_send_message(
         runtime,
         &request,

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -206,10 +206,12 @@ pub struct PreparedWrite {
     persisted_timestamp: IsoTimestamp,
     post_write_needed: bool,
     same_store_peer_receipt: bool,
+    #[cfg(test)]
     post_write: LocalPostWrite,
     acknowledgement: Option<crate::ack::ResolvedAcknowledgement>,
 }
 
+#[cfg(test)]
 struct LocalPostWrite {
     post_send_config: Option<config::AtmConfig>,
     recipient: ResolvedRecipient,
@@ -237,28 +239,8 @@ impl PreparedWrite {
         self.outbound_request.clone()
     }
 
-    /// Emits the local post-write notification after durable persistence.
-    ///
-    /// This is intentionally called only from the daemon's
-    /// `PostWriteRouter::dispatch` local branch.
-    pub fn emit_local_post_write(
-        &mut self,
-        runtime: &LocalServiceRuntime,
-        post_send_emitter: &dyn PostSendHookEmitter,
-    ) {
-        hook::emit_post_send_effects(
-            runtime,
-            &mut self.outcome.warnings,
-            self.post_write.post_send_config.as_ref(),
-            Some(post_send_emitter),
-            &self.post_write.recipient,
-            &self.post_write.delivery_snapshot,
-            &self.post_write.messages,
-        );
-    }
-
     #[cfg(test)]
-    pub(crate) fn emit_local_post_write_for_test<
+    pub(crate) fn emit_post_write_for_test<
         R: RetainedServiceRuntime + crate::boundary::sealed::Sealed + ?Sized,
     >(
         &mut self,
@@ -326,6 +308,55 @@ impl PreparedWrite {
     pub fn is_peer_receipt(&self) -> bool {
         has_authenticated_peer_provenance(&self.outbound_request)
     }
+}
+
+/// Executes the local post-write effects from a committed immutable record.
+///
+/// The daemon calls this only from its post-commit worker.  Admission keeps
+/// no prepared payload and never waits for hook, tmux, or graft I/O.
+pub fn emit_persisted_local_post_write(
+    runtime: &LocalServiceRuntime,
+    home_dir: &Path,
+    team: &TeamName,
+    agent: &AgentName,
+    message_id: AtmMessageId,
+    post_send_emitter: &dyn PostSendHookEmitter,
+) -> Result<(), AtmError> {
+    let key = boundary::MessageKey::from(message_id);
+    let Some(record) = runtime.load_message_record(home_dir, team, agent, &key)? else {
+        return Ok(());
+    };
+    let recipient = ResolvedRecipient {
+        agent: agent.clone(),
+        team: team.clone(),
+    };
+    let delivery_snapshot =
+        DeliveryPolicyCoordinator::new().resolve_recipient_snapshot(runtime, team, agent)?;
+    let logical = crate::delivery_plan::LogicalMessage::new(
+        record.envelope.clone(),
+        record.envelope.requires_ack,
+        record.envelope.acknowledges_message_id.is_some(),
+    )
+    .map_err(|error| AtmError::mailbox_read(error.to_string()))?;
+    let mut warnings = Vec::new();
+    hook::emit_post_send_effects(
+        runtime,
+        &mut warnings,
+        None,
+        Some(post_send_emitter),
+        &recipient,
+        &delivery_snapshot,
+        &[logical],
+    );
+    for warning in warnings {
+        tracing::warn!(
+            code = ?warning.code,
+            message_id = %message_id,
+            "post-commit local post-write effect completed with warning: {}",
+            warning.message
+        );
+    }
+    Ok(())
 }
 
 /// Result of sending one ATM mailbox message.
@@ -576,6 +607,7 @@ fn prepare_persisted_write<
     let post_write_needed = persistence.requires_post_write();
     let same_store_peer_receipt =
         persistence.duplicate_disposition == DuplicateWriteDisposition::SameStorePeerReceipt;
+    #[cfg(test)]
     let messages =
         post_send_messages_from_persistence(&persistence, requires_ack, acknowledgement.is_some())?;
     let outcome = finalize_send_outcome(
@@ -596,6 +628,7 @@ fn prepare_persisted_write<
         persisted_timestamp: timestamp,
         post_write_needed,
         same_store_peer_receipt,
+        #[cfg(test)]
         post_write: LocalPostWrite {
             post_send_config: context.post_send_config,
             recipient: context.recipient,
@@ -634,7 +667,7 @@ fn send_mail_with_runtime_impl<
     {
         // Test-only harness: production notification is owned by
         // `PostWriteRouter::dispatch` in atm-daemon.
-        prepared.emit_local_post_write_for_test(runtime, post_send_emitter);
+        prepared.emit_post_write_for_test(runtime, post_send_emitter);
     }
     match prepared.finish_with_runtime(runtime, observability)? {
         WriteOutcome::Sent(outcome) => Ok(outcome),
@@ -760,6 +793,7 @@ fn build_send_delivery_plan(
     ))
 }
 
+#[cfg(test)]
 fn post_send_messages_from_persistence(
     persistence: &DeliveryPersistenceResult,
     requires_ack: bool,
@@ -776,6 +810,7 @@ fn post_send_messages_from_persistence(
 
 struct SendExecutionContext {
     command_config: Option<config::AtmConfig>,
+    #[cfg(test)]
     post_send_config: Option<config::AtmConfig>,
     recipient: ResolvedRecipient,
     canonical_sender: AgentName,
@@ -791,27 +826,16 @@ fn prepare_send_context<
     runtime: &R,
     request: &SendRequest,
 ) -> Result<SendExecutionContext, AtmError> {
-    let command_config = runtime.load_config(&request.current_dir)?;
-    let (post_send_config, warnings) = match hook::load_post_send_config_for_sender(
-        runtime,
-        &request.caller_team,
-        &request.caller_identity,
-    ) {
-        Ok(config) => (config, Vec::new()),
-        Err(error) => (
-            None,
-            vec![WarningEntry::with_code(
-                error.code(),
-                format!(
-                    "warning: post-send hook config lookup failed for {}@{}: {}.",
-                    request.caller_identity,
-                    request.caller_team,
-                    error.message()
-                ),
-                Some(error.message().to_owned()),
-            )],
-        ),
-    };
+    // This is the durable-admission half of the pipeline.  A daemon must not
+    // inspect a caller workspace or hook configuration before replying to a
+    // committed write: those are post-commit worker concerns.  The daemon
+    // runtime already rejects workspace config, but avoiding this call here
+    // makes the no-filesystem-read admission contract structural rather than
+    // dependent on the runtime implementation.
+    let command_config = None;
+    #[cfg(test)]
+    let post_send_config = None;
+    let warnings = Vec::new();
     let canonical_sender = request.caller_identity.clone();
     let target = request.to.as_ref().ok_or_else(|| {
         AtmError::validation("write request destination must be resolved before persistence")
@@ -843,6 +867,7 @@ fn prepare_send_context<
     );
     Ok(SendExecutionContext {
         command_config,
+        #[cfg(test)]
         post_send_config,
         recipient,
         canonical_sender,

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -9,6 +9,7 @@ use tracing::warn;
 
 use crate::ack::AckOutcome;
 use crate::address::AgentAddress;
+use crate::boundary;
 use crate::boundary::PostSendHookEmitter;
 use crate::config;
 use crate::delivery_execution::{
@@ -52,6 +53,7 @@ pub use nudge_template::{
     default_template, qualified_sender_identity as qualified_nudge_sender_identity,
     render_resolved_built_in_nudge,
 };
+#[cfg(test)]
 pub(crate) use persistence::persist_message;
 
 pub(super) const POST_SEND_HOOK_TIMEOUT: Duration = Duration::from_secs(5);
@@ -553,6 +555,9 @@ fn prepare_persisted_write<
     let summary = summary::build_summary(&body, request.summary_override.clone());
     let message_id = request.origin_message_id.unwrap_or_default();
     let timestamp = request.origin_timestamp.unwrap_or_else(IsoTimestamp::now);
+    let acknowledgement_source_update = acknowledgement
+        .as_ref()
+        .map(crate::ack::ResolvedAcknowledgement::source_update);
     let persistence = persist_send_message(
         runtime,
         &request,
@@ -563,6 +568,7 @@ fn prepare_persisted_write<
         timestamp,
         requires_ack,
         task_id.clone(),
+        acknowledgement_source_update,
     )?;
     // A same-host HTTPS receipt deliberately reuses the origin ULID. Storage
     // skips its duplicate row, but the ordinary post-write route still emits
@@ -861,6 +867,7 @@ fn persist_send_message<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
     timestamp: IsoTimestamp,
     requires_ack: bool,
     task_id: Option<TaskId>,
+    acknowledgement_source_update: Option<boundary::Message>,
 ) -> Result<DeliveryPersistenceResult, AtmError> {
     let mut envelope = build_send_envelope(
         request,
@@ -889,7 +896,7 @@ fn persist_send_message<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
         })?;
         set_peer_outbound_write(&mut envelope, host, request_json);
     }
-    persist_message(
+    persistence::persist_message_with_ack_update(
         runtime,
         &request.home_dir,
         &context.delivery_snapshot,
@@ -906,6 +913,7 @@ fn persist_send_message<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
                     .and_then(|destination| destination.host())
                     .map(|destination_host| (source_host, destination_host))
             }),
+        acknowledgement_source_update,
     )
 }
 

--- a/crates/atm-core/src/send/persistence.rs
+++ b/crates/atm-core/src/send/persistence.rs
@@ -18,6 +18,7 @@ use super::{
     DeliveryPersistenceResult, DuplicateWriteDisposition, WarningEntry, prepare_threaded_message,
 };
 
+#[cfg(test)]
 pub(crate) fn persist_message(
     runtime: &(impl RetainedServiceRuntime + RetainedMailboxRuntime),
     home_dir: &Path,
@@ -26,6 +27,32 @@ pub(crate) fn persist_message(
     envelope: &InboxMessage,
     require_existing_inbox: bool,
     same_store_peer_receipt: Option<(&HostName, &HostName)>,
+) -> Result<DeliveryPersistenceResult, AtmError> {
+    persist_message_with_ack_update(
+        runtime,
+        home_dir,
+        recipient,
+        inbox_path,
+        envelope,
+        require_existing_inbox,
+        same_store_peer_receipt,
+        None,
+    )
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the acknowledgement source replacement is part of the one durable admission commit"
+)]
+pub(crate) fn persist_message_with_ack_update(
+    runtime: &(impl RetainedServiceRuntime + RetainedMailboxRuntime),
+    home_dir: &Path,
+    recipient: &DeliveryRecipientSnapshot,
+    inbox_path: &Path,
+    envelope: &InboxMessage,
+    require_existing_inbox: bool,
+    same_store_peer_receipt: Option<(&HostName, &HostName)>,
+    acknowledgement_source_update: Option<boundary::Message>,
 ) -> Result<DeliveryPersistenceResult, AtmError> {
     if require_existing_inbox && !inbox_path.exists() {
         return Ok(DeliveryPersistenceResult::persisted(envelope.clone()));
@@ -43,6 +70,7 @@ pub(crate) fn persist_message(
         &recipient.agent,
         &prepared,
         same_store_peer_receipt,
+        acknowledgement_source_update,
     ) {
         Ok(DuplicateWriteDisposition::NotDuplicate) => {
             Ok(DeliveryPersistenceResult::persisted(prepared))
@@ -164,6 +192,7 @@ fn mirror_message_to_store(
     agent: &AgentName,
     envelope: &InboxMessage,
     same_store_peer_receipt: Option<(&HostName, &HostName)>,
+    acknowledgement_source_update: Option<boundary::Message>,
 ) -> Result<DuplicateWriteDisposition, AtmError> {
     let Some(message_id) = envelope.message_id else {
         return Ok(DuplicateWriteDisposition::NotDuplicate);
@@ -205,24 +234,17 @@ fn mirror_message_to_store(
             "message {message_id} already exists for {agent}@{team} with different immutable data"
         )));
     }
-    runtime.persist_message_record(boundary::Message {
+    let record = boundary::Message {
         team: team.clone(),
         agent: agent.clone(),
         message_key: message_key.clone(),
         envelope: envelope.clone(),
-    })?;
-    runtime.persist_message_state(boundary::MailMessageState {
-        team: team.clone(),
-        agent: agent.clone(),
-        actor: agent.clone(),
-        message_key,
-        read: envelope.read,
-        pending_ack_at: envelope.pending_ack_at,
-        acknowledged_at: envelope.acknowledged_at,
-        expires_at: envelope.expires_at,
-        deleted_at: None,
-        updated_at: Some(IsoTimestamp::now()),
-    })?;
+    };
+    if let Some(source_update) = acknowledgement_source_update {
+        runtime.persist_message_records_atomically(vec![record, source_update])?;
+    } else {
+        runtime.persist_message_record(record)?;
+    }
     Ok(DuplicateWriteDisposition::NotDuplicate)
 }
 

--- a/crates/atm-core/src/send/post_write_tests.rs
+++ b/crates/atm-core/src/send/post_write_tests.rs
@@ -113,7 +113,7 @@ fn canonical_writer_persists_before_router_owned_local_nudge() {
         "the canonical writer must not emit a nudge before PostWriteRouter"
     );
 
-    prepared.emit_local_post_write_for_test(&runtime, &emitter);
+    prepared.emit_post_write_for_test(&runtime, &emitter);
     assert_eq!(
         emitter.emitted().len(),
         1,
@@ -159,7 +159,7 @@ fn same_host_peer_duplicate_still_routes_one_local_nudge() {
         .expect("same-host receipt is an idempotent write");
 
     assert!(prepared.requires_post_write_route());
-    prepared.emit_local_post_write_for_test(&runtime, &emitter);
+    prepared.emit_post_write_for_test(&runtime, &emitter);
     assert_eq!(emitter.emitted().len(), 1);
 }
 

--- a/crates/atm-core/src/send/recipient.rs
+++ b/crates/atm-core/src/send/recipient.rs
@@ -1,0 +1,145 @@
+use crate::address::AgentAddress;
+use crate::config;
+use crate::error::AtmError;
+use crate::provenance::ValidatedWriteProvenance;
+use crate::types::{AgentName, TeamName};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedRecipient {
+    pub(crate) agent: AgentName,
+    pub(crate) team: TeamName,
+}
+
+pub(crate) fn validate_non_self_recipient(
+    sender: &AgentName,
+    sender_team: &TeamName,
+    recipient: &ResolvedRecipient,
+    target: &AgentAddress,
+    provenance: ValidatedWriteProvenance,
+) -> Result<(), AtmError> {
+    let same_identity = sender
+        .as_str()
+        .eq_ignore_ascii_case(recipient.agent.as_str())
+        && sender_team
+            .as_str()
+            .eq_ignore_ascii_case(recipient.team.as_str());
+    if same_identity && target.host().is_none() && !provenance.is_authenticated_peer() {
+        return Err(AtmError::self_addressed_send_invalid(format!(
+            "self-addressed messages are invalid ATM input: '{sender}@{sender_team}' may not send to itself"
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn resolve_recipient(
+    target_address: &AgentAddress,
+    caller_team: &TeamName,
+    config: Option<&config::AtmConfig>,
+) -> Result<ResolvedRecipient, AtmError> {
+    // `AgentAddress` has already validated the explicit team segment. Never
+    // parse it again and silently substitute the caller team on failure.
+    let team = target_address
+        .team()
+        .cloned()
+        .unwrap_or_else(|| caller_team.clone());
+
+    Ok(ResolvedRecipient {
+        agent: config::aliases::resolve_agent_name(target_address.agent(), config)?,
+        team,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ResolvedRecipient, validate_non_self_recipient};
+    use crate::address::AgentAddress;
+    use crate::error_codes::AtmErrorCode;
+    use crate::provenance::{WriteIngress, WriteProvenance, validate_write_provenance};
+    use crate::types::{AgentName, TeamName};
+
+    #[test]
+    fn rejects_case_variant_self_target() {
+        let provenance = validate_write_provenance(
+            WriteIngress::Canonical,
+            WriteProvenance {
+                target_host: None,
+                authenticated_source_host: None,
+                origin_message_id: false,
+                origin_timestamp: false,
+            },
+        )
+        .expect("local provenance");
+        let error = validate_non_self_recipient(
+            &AgentName::from_validated("Sender-A"),
+            &TeamName::from_validated("Test-Team"),
+            &ResolvedRecipient {
+                agent: AgentName::from_validated("sender-a"),
+                team: TeamName::from_validated("test-team"),
+            },
+            &"sender-a@test-team"
+                .parse::<AgentAddress>()
+                .expect("target"),
+            provenance,
+        )
+        .expect_err("case-variant self target must be rejected");
+
+        assert_eq!(error.code(), AtmErrorCode::SelfAddressedSendInvalid);
+    }
+
+    #[test]
+    fn allows_host_qualified_self_target() {
+        let target = "sender-a@test-team.127.0.0.1"
+            .parse::<AgentAddress>()
+            .expect("host-qualified target");
+        let provenance = validate_write_provenance(
+            WriteIngress::Canonical,
+            WriteProvenance {
+                target_host: target.host(),
+                authenticated_source_host: None,
+                origin_message_id: false,
+                origin_timestamp: false,
+            },
+        )
+        .expect("host-qualified origin provenance");
+        validate_non_self_recipient(
+            &AgentName::from_validated("sender-a"),
+            &TeamName::from_validated("test-team"),
+            &ResolvedRecipient {
+                agent: AgentName::from_validated("sender-a"),
+                team: TeamName::from_validated("test-team"),
+            },
+            &target,
+            provenance,
+        )
+        .expect("host-qualified self target must use the ordinary peer route");
+    }
+
+    #[test]
+    fn allows_authenticated_peer_after_target_normalization() {
+        let target = "sender-a@test-team"
+            .parse::<AgentAddress>()
+            .expect("normalized target");
+        let peer_host = "peer.example.test".parse().expect("peer host");
+        let provenance = validate_write_provenance(
+            WriteIngress::Canonical,
+            WriteProvenance {
+                target_host: target.host(),
+                authenticated_source_host: Some(&peer_host),
+                origin_message_id: true,
+                origin_timestamp: true,
+            },
+        )
+        .expect("authenticated peer provenance");
+        validate_non_self_recipient(
+            &AgentName::from_validated("sender-a"),
+            &TeamName::from_validated("test-team"),
+            &ResolvedRecipient {
+                agent: AgentName::from_validated("sender-a"),
+                team: TeamName::from_validated("test-team"),
+            },
+            &target,
+            provenance,
+        )
+        .expect("authenticated peer receipt must not become a local self-send");
+    }
+}

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -1,6 +1,8 @@
+#![cfg(test)]
+
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use serde_json::{Map, Value};
 use tempfile::tempdir;
@@ -294,6 +296,60 @@ impl RetainedServiceRuntime for TestRuntime {
 }
 
 impl RetainedMailboxRuntime for TestRuntime {
+    fn acknowledge_message_atomically(
+        &self,
+        source: &atm_storage::contract::AcknowledgementSource,
+        builder: Arc<dyn atm_storage::contract::AcknowledgementReplyBuilder>,
+    ) -> Result<atm_storage::contract::AcknowledgementCommit, AtmError> {
+        let mut records = self
+            .persisted_records
+            .lock()
+            .expect("persisted records lock");
+        let source_index = records
+            .iter()
+            .position(|record| {
+                record.team == source.team
+                    && record.agent == source.agent
+                    && record.envelope.message_id == Some(source.message_id)
+            })
+            .ok_or_else(|| AtmError::validation("acknowledgement source was not found"))?;
+        let mut acknowledged_source = records[source_index].clone();
+        if acknowledged_source.envelope.pending_ack_at.is_none()
+            || acknowledged_source.envelope.acknowledged_at.is_some()
+        {
+            return Err(AtmError::validation(
+                "acknowledgement source is not pending acknowledgement",
+            ));
+        }
+        if records.iter().any(|record| {
+            record.team == source.team
+                && record.agent == source.agent
+                && record.envelope.parent_message_id == Some(source.message_id)
+        }) {
+            return Err(AtmError::validation(
+                "acknowledgement source already has a successor",
+            ));
+        }
+
+        let reply = builder.build_reply(&acknowledged_source)?;
+        acknowledged_source.envelope.read = true;
+        acknowledged_source.envelope.pending_ack_at = None;
+        acknowledged_source.envelope.acknowledged_at = Some(IsoTimestamp::now());
+        records[source_index] = acknowledged_source.clone();
+        if let Some(reply_index) = records
+            .iter()
+            .position(|record| record.message_key == reply.message_key)
+        {
+            records[reply_index] = reply.clone();
+        } else {
+            records.push(reply.clone());
+        }
+        Ok(atm_storage::contract::AcknowledgementCommit {
+            reply,
+            source: acknowledged_source,
+        })
+    }
+
     fn query_mailbox_metadata_rows(
         &self,
         _home_dir: &Path,

--- a/crates/atm-core/src/service_runtime_store.rs
+++ b/crates/atm-core/src/service_runtime_store.rs
@@ -94,6 +94,15 @@ pub(crate) trait RetainedMailboxRuntime {
         message_key: &boundary::MessageKey,
     ) -> Result<Option<boundary::Message>, AtmError>;
     fn persist_message_record(&self, record: boundary::Message) -> Result<(), AtmError>;
+    fn persist_message_records_atomically(
+        &self,
+        records: Vec<boundary::Message>,
+    ) -> Result<(), AtmError> {
+        for record in records {
+            self.persist_message_record(record)?;
+        }
+        Ok(())
+    }
     fn persist_message_state(&self, state: boundary::MailMessageState) -> Result<(), AtmError>;
 }
 
@@ -142,6 +151,22 @@ impl RetainedMailboxRuntime for LocalServiceRuntime {
             message_key: record.message_key,
             envelope: record.envelope,
         })
+    }
+
+    fn persist_message_records_atomically(
+        &self,
+        records: Vec<boundary::Message>,
+    ) -> Result<(), AtmError> {
+        let records = records
+            .into_iter()
+            .map(|record| SharedMessage {
+                team: record.team,
+                agent: record.agent,
+                message_key: record.message_key,
+                envelope: record.envelope,
+            })
+            .collect::<Vec<_>>();
+        self.message_store.save_messages_atomically(&records)
     }
 
     fn persist_message_state(&self, state: boundary::MailMessageState) -> Result<(), AtmError> {

--- a/crates/atm-core/src/service_runtime_store.rs
+++ b/crates/atm-core/src/service_runtime_store.rs
@@ -4,6 +4,11 @@
 )]
 
 use std::path::Path;
+use std::sync::Arc;
+
+use atm_storage::contract::{
+    AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource,
+};
 #[cfg(any(test, feature = "test-utils"))]
 use std::sync::Mutex;
 use std::sync::OnceLock;
@@ -79,38 +84,15 @@ pub(crate) fn default_runtime() -> Result<LocalServiceRuntime, AtmError> {
 }
 
 pub(crate) trait RetainedMailboxRuntime {
-    /// Resolves the current terminal pending-ack source through the sealed
-    /// mailbox boundary. Callers never enumerate and reload source rows
-    /// themselves.
-    fn resolve_acknowledgement_source(
+    /// The one sealed acknowledgement-admission operation. Implementations
+    /// must resolve the pending source and commit the reply/source pair as one
+    /// transaction; application callers cannot compose a source read with a
+    /// later write.
+    fn acknowledge_message_atomically(
         &self,
-        home_dir: &Path,
-        team: &TeamName,
-        agent: &AgentName,
-        message_id: crate::schema::AtmMessageId,
-    ) -> Result<boundary::Message, AtmError> {
-        let rows = self.query_mailbox_metadata_rows(home_dir, team, agent, None)?;
-        let row = rows
-            .iter()
-            .find(|row| row.message_id == Some(message_id))
-            .ok_or_else(|| {
-                AtmError::validation(format!(
-                    "message {message_id} was not found in {agent}@{team}"
-                ))
-            })?;
-        if rows
-            .iter()
-            .any(|row| row.parent_message_id == Some(message_id))
-        {
-            return Err(AtmError::validation(format!(
-                "message {message_id} has been updated; acknowledge the current terminal message instead"
-            )));
-        }
-        self.load_message_record(home_dir, team, agent, &row.message_key)?
-            .ok_or_else(|| {
-                AtmError::validation("acknowledgement source metadata could not be reloaded")
-            })
-    }
+        source: &AcknowledgementSource,
+        builder: Arc<dyn AcknowledgementReplyBuilder>,
+    ) -> Result<AcknowledgementCommit, AtmError>;
     fn query_mailbox_metadata_rows(
         &self,
         home_dir: &Path,
@@ -139,6 +121,15 @@ pub(crate) trait RetainedMailboxRuntime {
 }
 
 impl RetainedMailboxRuntime for LocalServiceRuntime {
+    fn acknowledge_message_atomically(
+        &self,
+        source: &AcknowledgementSource,
+        builder: Arc<dyn AcknowledgementReplyBuilder>,
+    ) -> Result<AcknowledgementCommit, AtmError> {
+        self.message_store
+            .acknowledge_message_atomically(source, builder)
+    }
+
     fn query_mailbox_metadata_rows(
         &self,
         _home_dir: &Path,

--- a/crates/atm-core/src/service_runtime_store.rs
+++ b/crates/atm-core/src/service_runtime_store.rs
@@ -79,6 +79,38 @@ pub(crate) fn default_runtime() -> Result<LocalServiceRuntime, AtmError> {
 }
 
 pub(crate) trait RetainedMailboxRuntime {
+    /// Resolves the current terminal pending-ack source through the sealed
+    /// mailbox boundary. Callers never enumerate and reload source rows
+    /// themselves.
+    fn resolve_acknowledgement_source(
+        &self,
+        home_dir: &Path,
+        team: &TeamName,
+        agent: &AgentName,
+        message_id: crate::schema::AtmMessageId,
+    ) -> Result<boundary::Message, AtmError> {
+        let rows = self.query_mailbox_metadata_rows(home_dir, team, agent, None)?;
+        let row = rows
+            .iter()
+            .find(|row| row.message_id == Some(message_id))
+            .ok_or_else(|| {
+                AtmError::validation(format!(
+                    "message {message_id} was not found in {agent}@{team}"
+                ))
+            })?;
+        if rows
+            .iter()
+            .any(|row| row.parent_message_id == Some(message_id))
+        {
+            return Err(AtmError::validation(format!(
+                "message {message_id} has been updated; acknowledge the current terminal message instead"
+            )));
+        }
+        self.load_message_record(home_dir, team, agent, &row.message_key)?
+            .ok_or_else(|| {
+                AtmError::validation("acknowledgement source metadata could not be reloaded")
+            })
+    }
     fn query_mailbox_metadata_rows(
         &self,
         home_dir: &Path,

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -467,7 +467,7 @@ mod tests {
         TeamNudgeTemplateOverrideRow,
     };
     use crate::error_codes::AtmErrorCode;
-    use crate::schema::{HOME_DIR_METADATA_KEY, TeamConfig};
+    use crate::schema::{HOME_DIR_METADATA_KEY, TeamConfig, WORKSPACE_ROOT_METADATA_KEY};
     use crate::test_support::{
         EnvGuard, ROLE_TEAM_LEAD, TEST_ARCH_CTM, TEST_RECIPIENT, TEST_SENDER, TEST_TEAM,
     };
@@ -912,6 +912,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(TEST_SENDER.parse().expect("member")),
                 home_dir: Some(PathBuf::from("/repo/worktree").into()),
+                workspace_root: Some(PathBuf::from("/repo/workspace").into()),
                 harness: Some(RosterHarness::CodexCli),
                 agent_type: Some(crate::schema::AgentType::from("worker".to_string())),
                 model: Some(crate::types::ModelName::new("gpt-5").expect("model")),
@@ -933,6 +934,10 @@ mod tests {
         assert_eq!(
             member.metadata_json.get(HOME_DIR_METADATA_KEY),
             Some(&serde_json::json!("/repo/worktree"))
+        );
+        assert_eq!(
+            member.metadata_json.get(WORKSPACE_ROOT_METADATA_KEY),
+            Some(&serde_json::json!("/repo/workspace"))
         );
 
         let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
@@ -967,6 +972,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(ROLE_TEAM_LEAD.parse().expect("member")),
                 home_dir: None,
+                workspace_root: None,
                 harness: None,
                 agent_type: None,
                 model: None,
@@ -983,6 +989,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(TEST_ARCH_CTM.parse().expect("member")),
                 home_dir: None,
+                workspace_root: None,
                 harness: None,
                 agent_type: None,
                 model: None,
@@ -1028,6 +1035,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(TEST_SENDER.parse().expect("member")),
                 home_dir: Some(PathBuf::from("/repo/worktree").into()),
+                workspace_root: None,
                 harness: None,
                 agent_type: None,
                 model: None,
@@ -1055,6 +1063,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(TEST_RECIPIENT.parse().expect("member")),
                 home_dir: Some(PathBuf::from("/repo/worktree").into()),
+                workspace_root: None,
                 harness: None,
                 agent_type: None,
                 model: None,
@@ -1082,6 +1091,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(TEST_SENDER.parse().expect("member")),
                 home_dir: Some(PathBuf::from("/repo/worktree").into()),
+                workspace_root: None,
                 harness: None,
                 agent_type: None,
                 model: None,

--- a/crates/atm-core/src/team_admin/member_mutation.rs
+++ b/crates/atm-core/src/team_admin/member_mutation.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use crate::boundary::{RosterEntry, RosterHarness, RosterMemberKind, RosterStore};
 use crate::error::AtmError;
 use crate::home;
-use crate::schema::{AgentType, HOME_DIR_METADATA_KEY, HomeDirPath};
+use crate::schema::{AgentType, HOME_DIR_METADATA_KEY, HomeDirPath, WORKSPACE_ROOT_METADATA_KEY};
 use crate::types::{AgentName, ModelName, PaneId, TeamName};
 
 use super::{filesystem, projection};
@@ -67,6 +67,7 @@ pub struct UpdateMemberRequest {
     pub team: TeamName,
     pub member: MemberName,
     pub home_dir: Option<HomeDirPath>,
+    pub workspace_root: Option<HomeDirPath>,
     pub harness: Option<RosterHarness>,
     pub agent_type: Option<AgentType>,
     pub model: Option<ModelName>,
@@ -84,6 +85,7 @@ impl UpdateMemberRequest {
         team: &str,
         member: &str,
         home_dir: Option<PathBuf>,
+        workspace_root: Option<PathBuf>,
         harness: Option<String>,
         agent_type: Option<String>,
         model: Option<String>,
@@ -95,6 +97,7 @@ impl UpdateMemberRequest {
             team: team.parse()?,
             member: MemberName(member.parse()?),
             home_dir: home_dir.map(Into::into),
+            workspace_root: workspace_root.map(Into::into),
             harness: harness.map(parse_roster_harness).transpose()?,
             agent_type: agent_type.map(parse_agent_type).transpose()?,
             model: model.map(ModelName::new).transpose()?,
@@ -376,6 +379,12 @@ fn apply_member_metadata_update(member: &mut RosterEntry, request: &UpdateMember
         member.metadata_json.insert(
             HOME_DIR_METADATA_KEY.to_string(),
             json!(home_dir.as_ref().display().to_string()),
+        );
+    }
+    if let Some(workspace_root) = &request.workspace_root {
+        member.metadata_json.insert(
+            WORKSPACE_ROOT_METADATA_KEY.to_string(),
+            json!(workspace_root.as_ref().display().to_string()),
         );
     }
     if let Some(harness) = request.harness {

--- a/crates/atm-daemon-bootstrap/Cargo.toml
+++ b/crates/atm-daemon-bootstrap/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai" }
-atm-runtime = { path = "../atm-runtime", version = "1.4.0-beta-ai" }
-atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.0-beta-ai" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31" }
+atm-runtime = { path = "../atm-runtime", version = "1.4.0-beta-ai.31" }
+atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai.31" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.0-beta-ai.31" }

--- a/crates/atm-daemon-client/Cargo.toml
+++ b/crates/atm-daemon-client/Cargo.toml
@@ -10,13 +10,13 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai" }
-atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31" }
+atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai.31" }
 fs2 = "0.4"
 interprocess = "2.4"
 serde_json.workspace = true
 tracing = "0.1"
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31" }
 tempfile = "3"

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -11,10 +11,10 @@ homepage.workspace = true
 
 [dependencies]
 ulid.workspace = true
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.0-beta-ai" }
-atm-runtime = { path = "../atm-runtime", version = "1.4.0-beta-ai" }
-atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31" }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.0-beta-ai.31" }
+atm-runtime = { path = "../atm-runtime", version = "1.4.0-beta-ai.31" }
+atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai.31" }
 arc-swap.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 fs2 = "0.4"
@@ -34,9 +34,9 @@ signal-hook = "0.3"
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Memory"] }
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai", features = ["test-utils"] }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.0-beta-ai" }
-atm-runtime = { path = "../atm-runtime", version = "1.4.0-beta-ai", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31", features = ["test-utils"] }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.0-beta-ai.31" }
+atm-runtime = { path = "../atm-runtime", version = "1.4.0-beta-ai.31", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"

--- a/crates/atm-daemon/src/peer_delivery_observability.rs
+++ b/crates/atm-daemon/src/peer_delivery_observability.rs
@@ -21,8 +21,6 @@ pub(crate) enum PeerDeliveryEventKind {
     PeerDeliveryUnconfirmed,
     PeerRecoveryScheduled,
     PeerRecoveryAttempt,
-    PeerRecoveryConfirmed,
-    PeerRecoveryUnconfirmed,
 }
 
 impl PeerDeliveryEventKind {
@@ -33,8 +31,6 @@ impl PeerDeliveryEventKind {
             Self::PeerDeliveryUnconfirmed => "peer_delivery_unconfirmed",
             Self::PeerRecoveryScheduled => "peer_recovery_scheduled",
             Self::PeerRecoveryAttempt => "peer_recovery_attempt",
-            Self::PeerRecoveryConfirmed => "peer_recovery_confirmed",
-            Self::PeerRecoveryUnconfirmed => "peer_recovery_unconfirmed",
         }
     }
 }
@@ -180,16 +176,14 @@ fn emit_retained_event(observability: &SubsystemObservability, event: &PeerDeliv
 fn apply_event_to_status(status: &mut PeerLinkStatus, event: PeerDeliveryEvent) {
     match event.kind {
         PeerDeliveryEventKind::WritePersisted => {}
-        PeerDeliveryEventKind::PeerDeliveryConfirmed
-        | PeerDeliveryEventKind::PeerRecoveryConfirmed => {
+        PeerDeliveryEventKind::PeerDeliveryConfirmed => {
             status.quality = PeerLinkQuality::Healthy;
             status.last_success_at = Some(IsoTimestamp::now());
             status.last_error_code = None;
             status.next_attempt_at = None;
             status.drain = PeerDrainState::Idle;
         }
-        PeerDeliveryEventKind::PeerDeliveryUnconfirmed
-        | PeerDeliveryEventKind::PeerRecoveryUnconfirmed => {
+        PeerDeliveryEventKind::PeerDeliveryUnconfirmed => {
             status.quality = peer_link_quality_for_error(event.error_code);
             status.last_failure_at = Some(IsoTimestamp::now());
             status.last_error_code = event.error_code;

--- a/crates/atm-daemon/src/peer_drain_coordinator.rs
+++ b/crates/atm-daemon/src/peer_drain_coordinator.rs
@@ -71,6 +71,16 @@ pub(crate) fn is_retryable_peer_error(error: &AtmError) -> bool {
     )
 }
 
+/// The coordinator's truthful bounded-drain result.  Local admission never
+/// observes this value: it is used only by an explicit reconciliation request
+/// after the durable message has already been admitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PeerSyncOutcome {
+    Confirmed { delivered: u16 },
+    Unconfirmed { code: AtmErrorCode },
+    Expired { code: AtmErrorCode },
+}
+
 fn remote_delivery_error_with_cause(error: AtmError) -> AtmError {
     let detail = error.detail().to_owned();
     let source = error
@@ -86,7 +96,11 @@ pub(crate) trait PeerDeliveryCoordinator: Send + Sync {
     /// and cannot turn a successful local admission into a failure.
     fn signal_after_persist(&self, peer: HostName);
 
-    fn sync_peer(&self, peer: &HostName, deadline: RequestDeadline) -> Result<u16, AtmError>;
+    fn sync_peer(
+        &self,
+        peer: &HostName,
+        deadline: RequestDeadline,
+    ) -> Result<PeerSyncOutcome, AtmError>;
 
     fn start(&self) -> Result<(), AtmError>;
 
@@ -527,7 +541,11 @@ impl PeerDeliveryCoordinator for PeerDrainCoordinator {
         self.slots.1.notify_all();
     }
 
-    fn sync_peer(&self, peer: &HostName, deadline: RequestDeadline) -> Result<u16, AtmError> {
+    fn sync_peer(
+        &self,
+        peer: &HostName,
+        deadline: RequestDeadline,
+    ) -> Result<PeerSyncOutcome, AtmError> {
         if self
             .peers
             .peer_sync_policy(peer)?
@@ -535,12 +553,20 @@ impl PeerDeliveryCoordinator for PeerDrainCoordinator {
             .max_message_age
             .is_zero()
         {
-            return Ok(0);
+            return Ok(PeerSyncOutcome::Confirmed { delivered: 0 });
         }
-        self.acquire(peer, deadline)?;
+        if let Err(error) = self.acquire(peer, deadline) {
+            return Ok(PeerSyncOutcome::Expired { code: error.code() });
+        }
         let result = self.drain(peer, deadline);
         self.release(peer)?;
-        result
+        match result {
+            Ok(delivered) => Ok(PeerSyncOutcome::Confirmed { delivered }),
+            Err(error) if deadline.remaining().is_none() => {
+                Ok(PeerSyncOutcome::Expired { code: error.code() })
+            }
+            Err(error) => Ok(PeerSyncOutcome::Unconfirmed { code: error.code() }),
+        }
     }
 
     fn start(&self) -> Result<(), AtmError> {

--- a/crates/atm-daemon/src/peer_drain_coordinator.rs
+++ b/crates/atm-daemon/src/peer_drain_coordinator.rs
@@ -81,11 +81,10 @@ fn remote_delivery_error_with_cause(error: AtmError) -> AtmError {
 }
 
 pub(crate) trait PeerDeliveryCoordinator: Send + Sync {
-    fn deliver_after_persist(
-        &self,
-        request: &WriteRequest,
-        deadline: RequestDeadline,
-    ) -> Result<(), AtmError>;
+    /// Records a best-effort, identifier-only wake-up after a durable origin
+    /// write has committed.  It must never perform storage or transport work,
+    /// and cannot turn a successful local admission into a failure.
+    fn signal_after_persist(&self, peer: HostName);
 
     fn sync_peer(&self, peer: &HostName, deadline: RequestDeadline) -> Result<u16, AtmError>;
 
@@ -412,39 +411,6 @@ impl PeerDrainCoordinator {
         Err(error)
     }
 
-    fn deliver_current(
-        &self,
-        request: &WriteRequest,
-        host: &HostName,
-        deadline: RequestDeadline,
-    ) -> Result<(), AtmError> {
-        let peer = self.configured_peer(host)?;
-        let transport = self
-            .transport
-            .lock()
-            .map_err(|_| AtmError::daemon_unavailable("HTTPS peer transport slot lock poisoned"))?
-            .clone()
-            .ok_or_else(|| {
-                AtmError::remote_delivery_unconfirmed(
-                    "HTTPS peer transport is not enabled in this daemon",
-                )
-            })?;
-        match transport.deliver(request.clone(), &peer, deadline) {
-            Ok(ResponseEnvelope::Error(error)) => Err(error),
-            Ok(_) => {
-                self.record(
-                    PeerDeliveryEventKind::PeerDeliveryConfirmed,
-                    host.clone(),
-                    None,
-                    Some(1),
-                    None,
-                );
-                Ok(())
-            }
-            Err(error) => Err(error),
-        }
-    }
-
     fn worker_coordinator(&self) -> Self {
         Self {
             peers: Arc::clone(&self.peers),
@@ -524,54 +490,36 @@ impl PeerDrainCoordinator {
                     )
                 })
             };
-            drop(slots);
             if let Some(host) = due {
+                drop(slots);
                 let _ = self.drain(&host, RequestDeadline::after(PEER_SYNC_REQUEST_DEADLINE));
                 if let Err(error) = self.release(&host) {
                     tracing::error!(subsystem = "peer_drain", action = "release", %error, "peer drain slot release failed");
                 }
                 continue;
             }
-            std::thread::park_timeout(Duration::from_millis(250));
+            // A post-commit signal wakes this worker immediately; the bounded
+            // timeout still makes scheduled retry deadlines and shutdown
+            // progress without retaining any message-level work state.
+            let _ = self.slots.1.wait_timeout(slots, Duration::from_millis(250));
         }
     }
 }
 
 impl PeerDeliveryCoordinator for PeerDrainCoordinator {
-    fn deliver_after_persist(
-        &self,
-        request: &WriteRequest,
-        deadline: RequestDeadline,
-    ) -> Result<(), AtmError> {
-        let host = request
-            .to
-            .as_ref()
-            .and_then(|address| address.host())
-            .ok_or_else(|| {
-                AtmError::validation("peer delivery coordinator requires a host-qualified write")
-            })?
-            .clone();
-        if self
-            .peers
-            .peer_sync_policy(&host)?
-            .validate()?
-            .max_message_age
-            .is_zero()
-        {
-            return self.deliver_current(request, &host, deadline);
+    fn signal_after_persist(&self, host: HostName) {
+        let Ok(mut slots) = self.slots() else {
+            tracing::error!(subsystem = "peer_drain", action = "signal_after_persist", peer = %host, "peer drain slot lock poisoned; durable write remains available for recovery");
+            return;
+        };
+        if let Err(error) = Self::reserve_slot(&mut slots, &host) {
+            tracing::warn!(subsystem = "peer_drain", action = "signal_after_persist", peer = %host, %error, "peer drain signal coalesced under bounded scheduler pressure; durable write remains available for recovery");
+            return;
         }
-        self.acquire(&host, deadline)?;
-        let result = self.drain(&host, deadline);
-        self.release(&host)?;
-        result.map(|count| {
-            self.record(
-                PeerDeliveryEventKind::PeerDeliveryConfirmed,
-                host,
-                None,
-                Some(u32::from(count)),
-                None,
-            );
-        })
+        let slot = slots.entry(host).or_default();
+        slot.requested_generation = slot.requested_generation.saturating_add(1);
+        slot.next_attempt_at = Some(Instant::now());
+        self.slots.1.notify_all();
     }
 
     fn sync_peer(&self, peer: &HostName, deadline: RequestDeadline) -> Result<u16, AtmError> {
@@ -633,8 +581,8 @@ impl PeerDeliveryCoordinator for PeerDrainCoordinator {
 #[cfg(test)]
 mod tests {
     use super::{
-        INITIAL_BACKOFF, MAX_BACKOFF, PeerDrainCoordinator, PeerDrainSlot, is_retryable_peer_error,
-        retry_timestamp, schedule_retry,
+        INITIAL_BACKOFF, MAX_BACKOFF, PeerDeliveryCoordinator, PeerDrainCoordinator, PeerDrainSlot,
+        is_retryable_peer_error, retry_timestamp, schedule_retry,
     };
     use atm_core::RequestDeadline;
     use atm_core::error::AtmError;
@@ -820,6 +768,21 @@ mod tests {
         assert_ne!(slot.requested_generation, slot.observed_generation);
         slot.observed_generation = slot.requested_generation;
         assert_eq!(slot.requested_generation, slot.observed_generation);
+    }
+
+    #[test]
+    fn post_persist_signal_only_coalesces_an_immediate_memory_wakeup() {
+        let coordinator = coordinator_for_slots();
+        let host: HostName = "peer.example.test".parse().expect("host");
+
+        coordinator.signal_after_persist(host.clone());
+        coordinator.signal_after_persist(host.clone());
+
+        let slots = coordinator.slots().expect("slot lock");
+        let slot = slots.get(&host).expect("scheduled host");
+        assert_eq!(slot.requested_generation, 2);
+        assert!(slot.next_attempt_at.is_some());
+        assert!(!slot.running, "admission must not run peer work inline");
     }
 
     #[test]

--- a/crates/atm-daemon/src/peer_drain_coordinator.rs
+++ b/crates/atm-daemon/src/peer_drain_coordinator.rs
@@ -377,7 +377,10 @@ impl PeerDrainCoordinator {
 
     fn finish_drain(&self, host: &HostName, delivered: u16) -> Result<u16, AtmError> {
         self.record(
-            PeerDeliveryEventKind::PeerRecoveryConfirmed,
+            // A worker scan is the only component that can establish a peer
+            // HTTP acceptance outcome.  Keep that fact distinct from the
+            // earlier `write_persisted` admission event.
+            PeerDeliveryEventKind::PeerDeliveryConfirmed,
             host.clone(),
             None,
             Some(u32::from(delivered)),
@@ -395,7 +398,9 @@ impl PeerDrainCoordinator {
             retry_timestamp(delay)
         };
         self.record(
-            PeerDeliveryEventKind::PeerRecoveryUnconfirmed,
+            // The immutable local admission already succeeded. This event is
+            // exclusively the later, uncertain peer-delivery outcome.
+            PeerDeliveryEventKind::PeerDeliveryUnconfirmed,
             host.clone(),
             Some(&error),
             None,

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -11,7 +11,7 @@ use atm_core::{
     error::{AtmError, AtmErrorCode},
     graft::{
         GraftPostSendRequest, GraftPostSendResponse, deliver_graft_post_send,
-        graft_receiver_record_path_from_home,
+        graft_receiver_record_path_from_root,
     },
     list::list_mail,
     process::process_is_alive,
@@ -22,7 +22,7 @@ use atm_core::{
     },
     provenance::{WriteIngress, WriteProvenance, validate_write_provenance},
     read::{peek_mail_with_runtime, read_mail_with_runtime},
-    schema::canonical_home_dir,
+    schema::canonical_graft_root,
     send::{PreparedWrite, WriteOutcome, WriteRequest, prepare_write_with_runtime},
 };
 
@@ -98,14 +98,14 @@ impl boundary::GraftPostSendPort for DaemonGraftPostSendPort {
                 "recipient is missing from the authoritative ATM roster",
             ));
         };
-        let recipient_home_dir = canonical_home_dir(&member.metadata_json).ok_or_else(|| {
+        let recipient_root = canonical_graft_root(&member.metadata_json).ok_or_else(|| {
             graft_recipient_unavailable_error(
                 event,
-                "recipient has no authoritative home_dir for graft post-send delivery",
+                "recipient has no authoritative graft root for post-send delivery",
             )
         })?;
-        let record_path = graft_receiver_record_path_from_home(
-            recipient_home_dir.as_path(),
+        let record_path = graft_receiver_record_path_from_root(
+            recipient_root.as_path(),
             &target.recipient_team,
             &target.recipient,
         );

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -1,18 +1,15 @@
-use std::sync::{Arc, Mutex, MutexGuard};
-use std::thread::JoinHandle;
-use std::time::Duration;
-
+use crate::AtmHomeDir;
+use crate::daemon_runtime_observability::{
+    DaemonRuntimeObservability, DaemonSubsystem, SubsystemObservability,
+};
+use crate::https_transport::{HttpsMessageTransport, SharedHttpsTransport};
+use crate::peer_delivery_observability::{PeerDeliveryEvent, PeerDeliveryProjection};
 use atm_core::{
     ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, LocalServiceRuntime, RequestDeadline,
-    RequestEnvelope, ResponseEnvelope,
-    boundary::{self, GraftNudgeTarget, PostSendHookEvent},
+    RequestEnvelope, ResponseEnvelope, boundary,
     clear::clear_mail_with_runtime,
     doctor::{self, DaemonRuntimeDoctorReport, DoctorExecutionContext, DoctorQuery, DoctorReport},
     error::{AtmError, AtmErrorCode},
-    graft::{
-        GraftPostSendRequest, GraftPostSendResponse, deliver_graft_post_send,
-        graft_receiver_record_path_from_home,
-    },
     list::list_mail,
     process::process_is_alive,
     protocol::{
@@ -22,20 +19,20 @@ use atm_core::{
     },
     provenance::{WriteIngress, WriteProvenance, validate_write_provenance},
     read::{peek_mail_with_runtime, read_mail_with_runtime},
-    schema::canonical_home_dir,
-    send::{PreparedWrite, WriteOutcome, WriteRequest, prepare_write_with_runtime},
+    send::{PreparedWrite, WriteOutcome, WriteRequest},
 };
-
-use crate::AtmHomeDir;
-use crate::daemon_runtime_observability::{
-    DaemonRuntimeObservability, DaemonSubsystem, SubsystemObservability,
-};
-use crate::https_transport::{HttpsMessageTransport, SharedHttpsTransport};
-use crate::peer_delivery_observability::{PeerDeliveryEvent, PeerDeliveryProjection};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::thread::JoinHandle;
+use std::time::Duration;
+mod admission_view;
+use admission_view::AdmissionRuntimeView;
 mod doctor_reporting;
+mod post_commit_work;
 use crate::peer_drain_coordinator::{
     PEER_SYNC_REQUEST_DEADLINE, PeerDeliveryCoordinator, PeerDrainCoordinator,
+    PeerSyncOutcome as DrainPeerSyncOutcome,
 };
+use post_commit_work::{PeerPostCommitWorkQueue, PostCommitWorkKey, PostCommitWorkQueue};
 pub(crate) mod peer_authority;
 #[cfg(test)]
 pub(crate) use crate::runtime_status_cache::MAX_STATUS_CACHE_ENTRIES;
@@ -50,17 +47,12 @@ mod peer_delivery_router;
 // 2-second deadline as an accepted production exception in the anti-flake contract docs.
 const SHUTDOWN_OBSERVABILITY_FLUSH_DEADLINE: Duration = Duration::from_secs(2);
 const MAX_SHUTDOWN_FINALIZER_THREADS: usize = 16;
-
 // Timed-out shutdown workers are retained in one process-wide registry instead of being dropped
 // orphaned; this must be static because the bounded finalizer helper can outlive any one
 // dispatcher instance after timeout, while orderly shutdown and serial tests still need one place
 // to recover and join those retained workers later.
 static SHUTDOWN_FINALIZER_THREADS: std::sync::Mutex<Vec<std::thread::JoinHandle<()>>> =
     std::sync::Mutex::new(Vec::new());
-
-const GRAFT_POST_SEND_CONNECT_DEADLINE: Duration = Duration::from_millis(250);
-const GRAFT_POST_SEND_IO_DEADLINE: Duration = Duration::from_secs(3);
-
 fn lock_runtime_mutex<'a, T>(
     mutex: &'a Mutex<T>,
     resource: &'static str,
@@ -69,88 +61,6 @@ fn lock_runtime_mutex<'a, T>(
         .lock()
         .map_err(|_| AtmError::daemon_unavailable(format!("{resource} lock poisoned")))
 }
-
-#[derive(Debug, Clone)]
-struct DaemonGraftPostSendPort {
-    runtime: LocalServiceRuntime,
-}
-
-impl DaemonGraftPostSendPort {
-    fn new(runtime: LocalServiceRuntime) -> Self {
-        Self { runtime }
-    }
-}
-
-impl boundary::sealed::Sealed for DaemonGraftPostSendPort {}
-
-impl boundary::GraftPostSendPort for DaemonGraftPostSendPort {
-    fn deliver_post_send(
-        &self,
-        event: &PostSendHookEvent,
-        target: &GraftNudgeTarget,
-    ) -> Result<(), AtmError> {
-        let Some(member) = self
-            .runtime
-            .load_roster_member(&target.recipient_team, &target.recipient)?
-        else {
-            return Err(graft_recipient_unavailable_error(
-                event,
-                "recipient is missing from the authoritative ATM roster",
-            ));
-        };
-        let recipient_home_dir = canonical_home_dir(&member.metadata_json).ok_or_else(|| {
-            graft_recipient_unavailable_error(
-                event,
-                "recipient has no authoritative home_dir for graft post-send delivery",
-            )
-        })?;
-        let record_path = graft_receiver_record_path_from_home(
-            recipient_home_dir.as_path(),
-            &target.recipient_team,
-            &target.recipient,
-        );
-        deliver_post_send_to_graft_receiver(&record_path, event)
-    }
-}
-
-fn deliver_post_send_to_graft_receiver(
-    record_path: &std::path::Path,
-    event: &PostSendHookEvent,
-) -> Result<(), AtmError> {
-    let request = GraftPostSendRequest {
-        event: event.clone(),
-    };
-    match deliver_graft_post_send(
-        record_path,
-        &request,
-        GRAFT_POST_SEND_CONNECT_DEADLINE,
-        GRAFT_POST_SEND_IO_DEADLINE,
-    )
-    .map_err(|error| graft_transport_error(event, error))?
-    {
-        GraftPostSendResponse::Delivered => Ok(()),
-        GraftPostSendResponse::Error(error) => Err(error),
-    }
-}
-
-fn graft_transport_error(event: &PostSendHookEvent, error: AtmError) -> AtmError {
-    graft_recipient_unavailable_error(event, error.detail())
-}
-
-fn graft_recipient_unavailable_error(
-    event: &PostSendHookEvent,
-    message: impl Into<String>,
-) -> AtmError {
-    AtmError::new(
-        AtmErrorCode::PostSendGraftUnavailable,
-        format!(
-            "failed to deliver graft nudge to {}: {}",
-            event.recipient,
-            message.into()
-        ),
-    )
-}
-
 pub(crate) struct DaemonRequestDispatcher {
     // Invariant: this is the validated ATM_HOME root for the running daemon,
     // not an arbitrary workspace path.
@@ -159,11 +69,14 @@ pub(crate) struct DaemonRequestDispatcher {
     runtime_health_observability: SubsystemObservability,
     status_cache: RuntimeStatusCache,
     service_runtime: LocalServiceRuntime,
+    admission_runtime_view: AdmissionRuntimeView,
     doctor_ports: atm_core::doctor::RuntimeDoctorPorts,
     roster_store: Option<Arc<dyn RosterStore + Send + Sync>>,
     peer_config_store: Arc<dyn PeerConfigStore + Send + Sync>,
     https_transport: SharedHttpsTransport,
     peer_delivery_coordinator: Arc<dyn PeerDeliveryCoordinator>,
+    post_commit_signals: Arc<PeerPostCommitWorkQueue>,
+    post_commit_work_queue: Arc<dyn PostCommitWorkQueue>,
     runtime_reload_hook: std::sync::Mutex<Option<RuntimeReloadHook>>,
     peer_delivery_projection: Arc<PeerDeliveryProjection>,
 }
@@ -456,17 +369,28 @@ impl DaemonRequestDispatcher {
             &peer_delivery_projection,
             &runtime_health_observability,
         );
+        let service_runtime = runtime_assembly.service_runtime;
+        let post_commit_signals = Arc::new(PeerPostCommitWorkQueue::new(
+            Arc::clone(&peer_delivery_coordinator),
+            service_runtime.clone(),
+            home_dir.clone(),
+        ));
+        let post_commit_work_queue: Arc<dyn PostCommitWorkQueue> = post_commit_signals.clone();
+        let admission_runtime_view = AdmissionRuntimeView::new(service_runtime.clone());
         Self {
             home_dir,
             observability: Arc::clone(&observability),
             runtime_health_observability: runtime_health_observability.clone(),
             status_cache,
-            service_runtime: runtime_assembly.service_runtime,
+            service_runtime,
+            admission_runtime_view,
             doctor_ports: runtime_assembly.doctor_ports,
             roster_store: Some(roster_store),
             peer_config_store,
             https_transport,
             peer_delivery_coordinator,
+            post_commit_signals,
+            post_commit_work_queue,
             runtime_reload_hook: std::sync::Mutex::new(None),
             peer_delivery_projection,
         }
@@ -488,11 +412,13 @@ impl DaemonRequestDispatcher {
     }
 
     pub(crate) fn start_peer_drain_coordinator(&self) -> Result<(), AtmError> {
+        self.post_commit_signals.start()?;
         self.peer_delivery_coordinator.start()
     }
 
     pub(crate) fn stop_peer_drain_coordinator(&self) -> Result<(), AtmError> {
-        self.peer_delivery_coordinator.stop()
+        self.peer_delivery_coordinator.stop()?;
+        self.post_commit_signals.stop()
     }
 
     #[cfg(test)]
@@ -533,7 +459,10 @@ trait MessageWriter: Send + Sync {
 }
 
 pub(super) trait PostWriteRouter: Send + Sync {
-    fn dispatch(&self, message: &mut MessageRecord) -> Result<(), AtmError>;
+    /// Non-blocking, infallible post-commit scheduling. A committed admission
+    /// response is constructed before this signal and cannot be relabelled by
+    /// worker availability or notification delivery.
+    fn dispatch(&self, message: &mut MessageRecord);
 }
 
 impl DaemonRequestDispatcher {
@@ -562,21 +491,23 @@ impl DaemonRequestDispatcher {
         let outcome = message
             .prepared
             .finish(&self.service_runtime, self.observability.as_ref())?;
-        if requires_post_commit_signal {
-            PostWriteRouter::dispatch(self, &mut message)?;
-        }
-        Ok(match outcome {
+        let response = match outcome {
             WriteOutcome::Sent(outcome) => {
                 ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome))
             }
             WriteOutcome::Acknowledged(outcome) => {
                 ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome))
             }
-        })
+        };
+        if requires_post_commit_signal {
+            PostWriteRouter::dispatch(self, &mut message);
+        }
+        Ok(response)
     }
 
     fn persist_local_write(&self, request: WriteRequest) -> Result<PreparedWrite, AtmError> {
-        prepare_write_with_runtime(request, self.observability.as_ref(), &self.service_runtime)
+        self.admission_runtime_view
+            .prepare_write(request, self.observability.as_ref())
     }
 
     fn dispatch_non_write(&self, request: RequestEnvelope) -> Result<ResponseEnvelope, AtmError> {
@@ -647,15 +578,25 @@ impl DaemonRequestDispatcher {
 
 impl DaemonRequestDispatcher {
     fn sync_peer(&self, request: PeerSyncRequest) -> Result<PeerSyncOutcome, AtmError> {
-        let delivered = self.peer_delivery_coordinator.sync_peer(
+        let outcome = self.peer_delivery_coordinator.sync_peer(
             &request.peer,
             RequestDeadline::after(PEER_SYNC_REQUEST_DEADLINE),
         )?;
-        Ok(PeerSyncOutcome {
-            peer: request.peer,
-            delivered,
-            disposition: PeerSyncDisposition::Completed,
-        })
+        match outcome {
+            DrainPeerSyncOutcome::Confirmed { delivered } => Ok(PeerSyncOutcome {
+                peer: request.peer,
+                delivered,
+                disposition: PeerSyncDisposition::Completed,
+            }),
+            DrainPeerSyncOutcome::Unconfirmed { code } => Err(AtmError::new(
+                code,
+                "peer synchronization completed with unconfirmed remote delivery",
+            )),
+            DrainPeerSyncOutcome::Expired { code } => Err(AtmError::new(
+                code,
+                "peer synchronization request deadline expired before confirmation",
+            )),
+        }
     }
 }
 
@@ -701,6 +642,8 @@ impl DaemonRequestDispatcher {
         let next_state =
             build_runtime_status_cache_state(Some(&current_state), roster_store.as_ref())?;
         self.refresh_https_trust()?;
+        self.admission_runtime_view
+            .reload(self.service_runtime.clone());
         let reloaded_members = next_state.member_count();
         self.status_cache.publish_state(next_state);
         tracing::info!(
@@ -976,17 +919,31 @@ impl DaemonRequestDispatcher {
             &peer_delivery_projection,
             &runtime_health_observability,
         );
+        let service_runtime = runtime_assembly.service_runtime.clone();
+        let daemon_home = crate::AtmHomeDir::from_path_for_test(home_dir.clone());
+        let post_commit_signals = Arc::new(PeerPostCommitWorkQueue::new(
+            Arc::clone(&peer_delivery_coordinator),
+            service_runtime.clone(),
+            daemon_home.clone(),
+        ));
+        let post_commit_work_queue: Arc<dyn PostCommitWorkQueue> = post_commit_signals.clone();
+        post_commit_signals
+            .start()
+            .expect("start post-commit worker for dispatcher test");
         Self {
-            home_dir: crate::AtmHomeDir::from_path_for_test(home_dir.clone()),
+            home_dir: daemon_home,
             observability: runtime_observability,
             runtime_health_observability,
             status_cache,
-            service_runtime: runtime_assembly.service_runtime.clone(),
+            service_runtime: service_runtime.clone(),
+            admission_runtime_view: AdmissionRuntimeView::new(service_runtime),
             doctor_ports: runtime_assembly.doctor_ports.clone(),
             roster_store: Some(runtime_assembly.shared_roster_store_arc()),
             peer_config_store,
             https_transport,
             peer_delivery_coordinator,
+            post_commit_signals,
+            post_commit_work_queue,
             runtime_reload_hook: std::sync::Mutex::new(None),
             peer_delivery_projection,
         }

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -533,11 +533,7 @@ trait MessageWriter: Send + Sync {
 }
 
 pub(super) trait PostWriteRouter: Send + Sync {
-    fn dispatch(
-        &self,
-        message: &mut MessageRecord,
-        deadline: RequestDeadline,
-    ) -> Result<(), AtmError>;
+    fn dispatch(&self, message: &mut MessageRecord) -> Result<(), AtmError>;
 }
 
 impl DaemonRequestDispatcher {
@@ -549,26 +545,26 @@ impl DaemonRequestDispatcher {
     fn dispatch_with_deadline(
         &self,
         request: RequestEnvelope,
-        deadline: RequestDeadline,
+        _deadline: RequestDeadline,
     ) -> Result<ResponseEnvelope, AtmError> {
         match request {
-            RequestEnvelope::Write(request) => self.route_write(*request, deadline),
+            RequestEnvelope::Write(request) => self.route_write(*request),
             request => self.dispatch_non_write(request),
         }
     }
 
-    fn route_write(
-        &self,
-        request: WriteRequest,
-        deadline: RequestDeadline,
-    ) -> Result<ResponseEnvelope, AtmError> {
+    fn route_write(&self, request: WriteRequest) -> Result<ResponseEnvelope, AtmError> {
         let mut message = MessageWriter::write(self, request)?;
-        if message.prepared.requires_post_write_route() {
-            PostWriteRouter::dispatch(self, &mut message, deadline)?;
-        }
+        let requires_post_commit_signal = message.prepared.requires_post_write_route();
+        // Admission is complete before any post-commit work is even signalled.
+        // In particular, an acknowledgement's source transition completes here,
+        // before the peer worker can observe or deliver the reply.
         let outcome = message
             .prepared
             .finish(&self.service_runtime, self.observability.as_ref())?;
+        if requires_post_commit_signal {
+            PostWriteRouter::dispatch(self, &mut message)?;
+        }
         Ok(match outcome {
             WriteOutcome::Sent(outcome) => {
                 ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome))

--- a/crates/atm-daemon/src/runtime_health/admission_view.rs
+++ b/crates/atm-daemon/src/runtime_health/admission_view.rs
@@ -1,0 +1,47 @@
+//! Reloadable daemon-owned dependencies for synchronous local admission.
+
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use atm_core::send::{PreparedWrite, WriteRequest, prepare_write_with_runtime};
+use atm_core::{LocalServiceRuntime, error::AtmError};
+
+use crate::daemon_runtime_observability::DaemonRuntimeObservability;
+
+/// Immutable dependencies read by one local admission.
+///
+/// The local request path reads this atomically-swapped in-memory view. It
+/// must not read a caller workspace or resolve post-send hooks while an IPC
+/// response is pending. Reload replaces the whole view as one control-plane
+/// operation; it is deliberately not another persistence store.
+#[derive(Clone)]
+pub(crate) struct AdmissionRuntimeView {
+    state: Arc<ArcSwap<AdmissionRuntimeViewState>>,
+}
+
+#[derive(Clone)]
+struct AdmissionRuntimeViewState {
+    runtime: LocalServiceRuntime,
+}
+
+impl AdmissionRuntimeView {
+    pub(crate) fn new(runtime: LocalServiceRuntime) -> Self {
+        Self {
+            state: Arc::new(ArcSwap::from_pointee(AdmissionRuntimeViewState { runtime })),
+        }
+    }
+
+    pub(crate) fn prepare_write(
+        &self,
+        request: WriteRequest,
+        observability: &dyn DaemonRuntimeObservability,
+    ) -> Result<PreparedWrite, AtmError> {
+        let view = self.state.load();
+        prepare_write_with_runtime(request, observability, &view.runtime)
+    }
+
+    pub(crate) fn reload(&self, runtime: LocalServiceRuntime) {
+        self.state
+            .store(Arc::new(AdmissionRuntimeViewState { runtime }));
+    }
+}

--- a/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
+++ b/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use atm_core::RequestDeadline;
 use atm_core::boundary;
 use atm_core::error::AtmError;
 use atm_core::protocol::next_request_id;
@@ -8,15 +7,10 @@ use atm_core::protocol::next_request_id;
 use crate::peer_delivery_observability::{PeerDeliveryEvent, PeerDeliveryEventKind};
 use crate::post_send_emitter::DaemonPostSendHookEmitter;
 
-use super::peer_authority::resolve_peer_authority;
 use super::{DaemonGraftPostSendPort, DaemonRequestDispatcher, MessageRecord, PostWriteRouter};
 
 impl PostWriteRouter for DaemonRequestDispatcher {
-    fn dispatch(
-        &self,
-        message: &mut MessageRecord,
-        deadline: RequestDeadline,
-    ) -> Result<(), AtmError> {
+    fn dispatch(&self, message: &mut MessageRecord) -> Result<(), AtmError> {
         if message.prepared.is_peer_receipt() {
             tracing::info!(
                 subsystem = "runtime_health",
@@ -37,19 +31,23 @@ impl PostWriteRouter for DaemonRequestDispatcher {
             self.emit_local_post_write(message);
             return Ok(());
         };
-        let peer = resolve_peer_authority(host, &self.peer_config_store.list_trusted_peers()?)?;
         let request_id = next_request_id();
         let message_id = message.outbound_request.origin_message_id;
         self.record_peer_delivery_event(PeerDeliveryEvent {
             kind: PeerDeliveryEventKind::WritePersisted,
             request_id,
             message_id,
-            peer: peer.host.clone(),
+            peer: host.clone(),
             error_code: None,
             candidate_count: Some(1),
             next_attempt_at: None,
         });
-        self.deliver_to_peer(message, deadline, peer.host, request_id, message_id)
+        // The immutable write is already committed.  The coordinator keeps
+        // only a bounded wake-up by host and performs its own storage/DNS/TLS
+        // work after this IPC response has been written.
+        self.peer_delivery_coordinator
+            .signal_after_persist(host.clone());
+        Ok(())
     }
 }
 
@@ -70,49 +68,5 @@ impl DaemonRequestDispatcher {
         message
             .prepared
             .emit_local_post_write(&self.service_runtime, &emitter);
-    }
-
-    /// The canonical router's only peer-delivery handoff. AI.28 moves the
-    /// actual bounded drain behind the coordinator without adding a route.
-    fn deliver_to_peer(
-        &self,
-        message: &MessageRecord,
-        deadline: RequestDeadline,
-        peer: atm_core::types::HostName,
-        request_id: atm_core::protocol::RequestId,
-        message_id: Option<atm_core::schema::AtmMessageId>,
-    ) -> Result<(), AtmError> {
-        // The coordinator owns retry eligibility and backoff. This router only
-        // classifies the foreground result: an unconfirmed delivery is
-        // retryable through the coordinator, while a validation/configuration
-        // error is returned without inventing a second retry policy.
-        if let Err(error) = self
-            .peer_delivery_coordinator
-            .deliver_after_persist(&message.outbound_request, deadline)
-        {
-            // Retry classification and scheduling belong to the coordinator;
-            // every foreground failure has the same retained projection event.
-            return self.record_peer_delivery_failure(peer, request_id, message_id, error);
-        }
-        Ok(())
-    }
-
-    fn record_peer_delivery_failure(
-        &self,
-        peer: atm_core::types::HostName,
-        request_id: atm_core::protocol::RequestId,
-        message_id: Option<atm_core::schema::AtmMessageId>,
-        error: AtmError,
-    ) -> Result<(), AtmError> {
-        self.record_peer_delivery_event(PeerDeliveryEvent {
-            kind: PeerDeliveryEventKind::PeerDeliveryUnconfirmed,
-            request_id,
-            message_id,
-            peer,
-            error_code: Some(error.code()),
-            candidate_count: Some(1),
-            next_attempt_at: None,
-        });
-        Err(error)
     }
 }

--- a/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
+++ b/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
@@ -1,16 +1,10 @@
-use std::sync::Arc;
-
-use atm_core::boundary;
-use atm_core::error::AtmError;
 use atm_core::protocol::next_request_id;
 
+use super::{DaemonRequestDispatcher, MessageRecord, PostCommitWorkKey, PostWriteRouter};
 use crate::peer_delivery_observability::{PeerDeliveryEvent, PeerDeliveryEventKind};
-use crate::post_send_emitter::DaemonPostSendHookEmitter;
-
-use super::{DaemonGraftPostSendPort, DaemonRequestDispatcher, MessageRecord, PostWriteRouter};
 
 impl PostWriteRouter for DaemonRequestDispatcher {
-    fn dispatch(&self, message: &mut MessageRecord) -> Result<(), AtmError> {
+    fn dispatch(&self, message: &mut MessageRecord) {
         if message.prepared.is_peer_receipt() {
             tracing::info!(
                 subsystem = "runtime_health",
@@ -19,8 +13,8 @@ impl PostWriteRouter for DaemonRequestDispatcher {
                 message_id = ?message.outbound_request.origin_message_id,
                 "authenticated peer receipt uses the canonical local post-write route"
             );
-            self.emit_local_post_write(message);
-            return Ok(());
+            self.signal_local_post_write(message);
+            return;
         }
         let Some(host) = message
             .outbound_request
@@ -28,15 +22,15 @@ impl PostWriteRouter for DaemonRequestDispatcher {
             .as_ref()
             .and_then(|address| address.host())
         else {
-            self.emit_local_post_write(message);
-            return Ok(());
+            self.signal_local_post_write(message);
+            return;
         };
         let request_id = next_request_id();
-        let message_id = message.outbound_request.origin_message_id;
+        let message_id = message.prepared.persisted_message_id();
         self.record_peer_delivery_event(PeerDeliveryEvent {
             kind: PeerDeliveryEventKind::WritePersisted,
             request_id,
-            message_id,
+            message_id: Some(message_id),
             peer: host.clone(),
             error_code: None,
             candidate_count: Some(1),
@@ -45,14 +39,16 @@ impl PostWriteRouter for DaemonRequestDispatcher {
         // The immutable write is already committed.  The coordinator keeps
         // only a bounded wake-up by host and performs its own storage/DNS/TLS
         // work after this IPC response has been written.
-        self.peer_delivery_coordinator
-            .signal_after_persist(host.clone());
-        Ok(())
+        self.post_commit_work_queue
+            .signal(PostCommitWorkKey::PeerDelivery {
+                peer: host.clone(),
+                message_id,
+            });
     }
 }
 
 impl DaemonRequestDispatcher {
-    fn emit_local_post_write(&self, message: &mut MessageRecord) {
+    fn signal_local_post_write(&self, message: &mut MessageRecord) {
         if message.prepared.is_peer_receipt() && message.prepared.is_same_store_peer_receipt() {
             let mut event = self.runtime_health_observability.event(
                 "peer_duplicate_write_skipped",
@@ -62,11 +58,20 @@ impl DaemonRequestDispatcher {
             event.message_id = Some(message.prepared.persisted_message_id());
             self.runtime_health_observability.emit_event_or_warn(event);
         }
-        let graft_port: Arc<dyn boundary::GraftPostSendPort + Send + Sync> =
-            Arc::new(DaemonGraftPostSendPort::new(self.service_runtime.clone()));
-        let emitter = DaemonPostSendHookEmitter::new(Arc::clone(&graft_port));
-        message
-            .prepared
-            .emit_local_post_write(&self.service_runtime, &emitter);
+        let message_id = message.prepared.persisted_message_id();
+        let Some(target) = message.outbound_request.to.as_ref() else {
+            tracing::warn!(subsystem = "runtime_health", action = "post_commit_work_signal", %message_id, "local post-commit work had no canonical destination");
+            return;
+        };
+        self.post_commit_signals.register_local_nudge(
+            message_id,
+            target
+                .team()
+                .cloned()
+                .unwrap_or_else(|| message.outbound_request.caller_team.clone()),
+            target.agent().clone(),
+        );
+        self.post_commit_work_queue
+            .signal(PostCommitWorkKey::LocalNudge(message_id));
     }
 }

--- a/crates/atm-daemon/src/runtime_health/post_commit_work.rs
+++ b/crates/atm-daemon/src/runtime_health/post_commit_work.rs
@@ -1,0 +1,295 @@
+//! Identifier-only work that runs after local SQLite admission.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use atm_core::{
+    LocalServiceRuntime,
+    boundary::{self, GraftNudgeTarget, PostSendHookEvent},
+    error::{AtmError, AtmErrorCode},
+    graft::{
+        GraftPostSendRequest, GraftPostSendResponse, deliver_graft_post_send,
+        graft_receiver_record_path_from_home,
+    },
+    schema::{AtmMessageId, canonical_home_dir},
+};
+
+use crate::AtmHomeDir;
+use crate::peer_drain_coordinator::PeerDeliveryCoordinator;
+
+const GRAFT_POST_SEND_CONNECT_DEADLINE: Duration = Duration::from_millis(250);
+const GRAFT_POST_SEND_IO_DEADLINE: Duration = Duration::from_secs(3);
+
+/// Identifier-only work admitted after the canonical SQLite transaction.
+///
+/// This deliberately cannot carry a request body, receipt state, or a
+/// prepared write. Workers reload immutable data from canonical storage after
+/// the IPC response has been written.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum PostCommitWorkKey {
+    LocalNudge(AtmMessageId),
+    PeerDelivery {
+        peer: atm_core::types::HostName,
+        message_id: AtmMessageId,
+    },
+}
+
+/// The admission path may only signal this boundary; it never waits for a
+/// worker and never owns transport, hook, or graft I/O.
+pub(crate) trait PostCommitWorkQueue: Send + Sync {
+    fn signal(&self, work: PostCommitWorkKey);
+}
+
+/// The daemon-owned worker adapter. The bounded queue retains only work
+/// identifiers; it reloads the committed record before invoking a hook.
+pub(crate) struct PeerPostCommitWorkQueue {
+    coordinator: Arc<dyn PeerDeliveryCoordinator>,
+    sender: SyncSender<PostCommitWorkKey>,
+    receiver: Mutex<Option<Receiver<PostCommitWorkKey>>>,
+    local_nudge_targets: Arc<Mutex<BTreeMap<AtmMessageId, PostCommitNudgeTarget>>>,
+    runtime: LocalServiceRuntime,
+    home_dir: AtmHomeDir,
+    stop: Arc<AtomicBool>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+}
+
+#[derive(Clone)]
+struct PostCommitNudgeTarget {
+    team: atm_core::types::TeamName,
+    agent: atm_core::types::AgentName,
+}
+
+impl PeerPostCommitWorkQueue {
+    pub(crate) fn new(
+        coordinator: Arc<dyn PeerDeliveryCoordinator>,
+        runtime: LocalServiceRuntime,
+        home_dir: AtmHomeDir,
+    ) -> Self {
+        let (sender, receiver) = mpsc::sync_channel(256);
+        Self {
+            coordinator,
+            sender,
+            receiver: Mutex::new(Some(receiver)),
+            local_nudge_targets: Arc::new(Mutex::new(BTreeMap::new())),
+            runtime,
+            home_dir,
+            stop: Arc::new(AtomicBool::new(false)),
+            worker: Mutex::new(None),
+        }
+    }
+
+    pub(crate) fn register_local_nudge(
+        &self,
+        message_id: AtmMessageId,
+        team: atm_core::types::TeamName,
+        agent: atm_core::types::AgentName,
+    ) {
+        let Ok(mut targets) = self.local_nudge_targets.lock() else {
+            tracing::error!(subsystem = "runtime_health", action = "post_commit_work_register", %message_id, "local post-commit work target registry lock poisoned");
+            return;
+        };
+        targets.insert(message_id, PostCommitNudgeTarget { team, agent });
+    }
+
+    pub(crate) fn start(&self) -> Result<(), AtmError> {
+        let mut worker = self.worker.lock().map_err(|_| {
+            AtmError::daemon_unavailable("post-commit worker lifecycle lock poisoned")
+        })?;
+        if worker.is_some() {
+            return Ok(());
+        }
+        let receiver = self
+            .receiver
+            .lock()
+            .map_err(|_| AtmError::daemon_unavailable("post-commit worker receiver lock poisoned"))?
+            .take()
+            .ok_or_else(|| {
+                AtmError::daemon_unavailable("post-commit worker cannot restart after shutdown")
+            })?;
+        self.stop.store(false, Ordering::SeqCst);
+        let targets = Arc::clone(&self.local_nudge_targets);
+        let runtime = self.runtime.clone();
+        let home_dir = self.home_dir.clone();
+        let stop = Arc::clone(&self.stop);
+        *worker = Some(
+            std::thread::Builder::new()
+                .name("atm-post-commit-work".to_string())
+                .spawn(move || Self::run(receiver, targets, runtime, home_dir, stop))
+                .map_err(|_| AtmError::daemon_unavailable("failed to start post-commit worker"))?,
+        );
+        Ok(())
+    }
+
+    pub(crate) fn stop(&self) -> Result<(), AtmError> {
+        self.stop.store(true, Ordering::SeqCst);
+        let worker = self
+            .worker
+            .lock()
+            .map_err(|_| {
+                AtmError::daemon_unavailable("post-commit worker lifecycle lock poisoned")
+            })?
+            .take();
+        if let Some(worker) = worker {
+            worker.join().map_err(|_| {
+                AtmError::daemon_unavailable("post-commit worker panicked during shutdown")
+            })?;
+        }
+        Ok(())
+    }
+
+    fn run(
+        receiver: Receiver<PostCommitWorkKey>,
+        targets: Arc<Mutex<BTreeMap<AtmMessageId, PostCommitNudgeTarget>>>,
+        runtime: LocalServiceRuntime,
+        home_dir: AtmHomeDir,
+        stop: Arc<AtomicBool>,
+    ) {
+        while !stop.load(Ordering::SeqCst) {
+            let work = match receiver.recv_timeout(Duration::from_millis(100)) {
+                Ok(work) => work,
+                Err(RecvTimeoutError::Timeout) => continue,
+                Err(RecvTimeoutError::Disconnected) => break,
+            };
+            let PostCommitWorkKey::LocalNudge(message_id) = work else {
+                continue;
+            };
+            let target = targets
+                .lock()
+                .ok()
+                .and_then(|mut targets| targets.remove(&message_id));
+            let Some(target) = target else {
+                continue;
+            };
+            let graft_port: Arc<dyn boundary::GraftPostSendPort + Send + Sync> =
+                Arc::new(DaemonGraftPostSendPort::new(runtime.clone()));
+            let emitter = crate::post_send_emitter::DaemonPostSendHookEmitter::new(graft_port);
+            if let Err(error) = atm_core::send::emit_persisted_local_post_write(
+                &runtime,
+                home_dir.as_path(),
+                &target.team,
+                &target.agent,
+                message_id,
+                &emitter,
+            ) {
+                tracing::warn!(subsystem = "runtime_health", action = "post_commit_local_nudge", %message_id, %error, "post-commit local notification failed after admission");
+            }
+        }
+    }
+}
+
+impl PostCommitWorkQueue for PeerPostCommitWorkQueue {
+    fn signal(&self, work: PostCommitWorkKey) {
+        match work {
+            PostCommitWorkKey::PeerDelivery { peer, .. } => {
+                self.coordinator.signal_after_persist(peer)
+            }
+            PostCommitWorkKey::LocalNudge(message_id) => match self
+                .sender
+                .try_send(PostCommitWorkKey::LocalNudge(message_id))
+            {
+                Ok(()) => {}
+                Err(TrySendError::Full(_)) => {
+                    self.remove_local_nudge_target(message_id);
+                    tracing::warn!(subsystem = "runtime_health", action = "post_commit_work_signal", work = "local_nudge", %message_id, "post-commit queue is full; retained message remains available for later reconciliation")
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    self.remove_local_nudge_target(message_id);
+                    tracing::warn!(subsystem = "runtime_health", action = "post_commit_work_signal", work = "local_nudge", %message_id, "post-commit worker is unavailable; retained message remains available for later reconciliation")
+                }
+            },
+        }
+    }
+}
+
+impl PeerPostCommitWorkQueue {
+    fn remove_local_nudge_target(&self, message_id: AtmMessageId) {
+        if let Ok(mut targets) = self.local_nudge_targets.lock() {
+            targets.remove(&message_id);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DaemonGraftPostSendPort {
+    runtime: LocalServiceRuntime,
+}
+
+impl DaemonGraftPostSendPort {
+    fn new(runtime: LocalServiceRuntime) -> Self {
+        Self { runtime }
+    }
+}
+
+impl boundary::sealed::Sealed for DaemonGraftPostSendPort {}
+
+impl boundary::GraftPostSendPort for DaemonGraftPostSendPort {
+    fn deliver_post_send(
+        &self,
+        event: &PostSendHookEvent,
+        target: &GraftNudgeTarget,
+    ) -> Result<(), AtmError> {
+        let Some(member) = self
+            .runtime
+            .load_roster_member(&target.recipient_team, &target.recipient)?
+        else {
+            return Err(graft_recipient_unavailable_error(
+                event,
+                "recipient is missing from the authoritative ATM roster",
+            ));
+        };
+        let recipient_home_dir = canonical_home_dir(&member.metadata_json).ok_or_else(|| {
+            graft_recipient_unavailable_error(
+                event,
+                "recipient has no authoritative home_dir for graft post-send delivery",
+            )
+        })?;
+        let record_path = graft_receiver_record_path_from_home(
+            recipient_home_dir.as_path(),
+            &target.recipient_team,
+            &target.recipient,
+        );
+        deliver_post_send_to_graft_receiver(&record_path, event)
+    }
+}
+
+fn deliver_post_send_to_graft_receiver(
+    record_path: &std::path::Path,
+    event: &PostSendHookEvent,
+) -> Result<(), AtmError> {
+    let request = GraftPostSendRequest {
+        event: event.clone(),
+    };
+    match deliver_graft_post_send(
+        record_path,
+        &request,
+        GRAFT_POST_SEND_CONNECT_DEADLINE,
+        GRAFT_POST_SEND_IO_DEADLINE,
+    )
+    .map_err(|error| graft_transport_error(event, error))?
+    {
+        GraftPostSendResponse::Delivered => Ok(()),
+        GraftPostSendResponse::Error(error) => Err(error),
+    }
+}
+
+fn graft_transport_error(event: &PostSendHookEvent, error: AtmError) -> AtmError {
+    graft_recipient_unavailable_error(event, error.detail())
+}
+
+fn graft_recipient_unavailable_error(
+    event: &PostSendHookEvent,
+    message: impl Into<String>,
+) -> AtmError {
+    AtmError::new(
+        AtmErrorCode::PostSendGraftUnavailable,
+        format!(
+            "failed to deliver graft nudge to {}: {}",
+            event.recipient,
+            message.into()
+        ),
+    )
+}

--- a/crates/atm-daemon/src/runtime_health/post_commit_work.rs
+++ b/crates/atm-daemon/src/runtime_health/post_commit_work.rs
@@ -50,7 +50,10 @@ pub(crate) trait PostCommitWorkQueue: Send + Sync {
 pub(crate) struct PeerPostCommitWorkQueue {
     coordinator: Arc<dyn PeerDeliveryCoordinator>,
     sender: SyncSender<PostCommitWorkKey>,
-    receiver: Mutex<Option<Receiver<PostCommitWorkKey>>>,
+    // The receiver remains daemon-owned for the queue lifetime.  A worker may
+    // stop and later be restarted; taking ownership of it for the first worker
+    // made that otherwise ordinary recovery path permanently unavailable.
+    receiver: Arc<Mutex<Receiver<PostCommitWorkKey>>>,
     local_nudge_targets: Arc<Mutex<BTreeMap<AtmMessageId, PostCommitNudgeTarget>>>,
     runtime: LocalServiceRuntime,
     home_dir: AtmHomeDir,
@@ -74,7 +77,7 @@ impl PeerPostCommitWorkQueue {
         Self {
             coordinator,
             sender,
-            receiver: Mutex::new(Some(receiver)),
+            receiver: Arc::new(Mutex::new(receiver)),
             local_nudge_targets: Arc::new(Mutex::new(BTreeMap::new())),
             runtime,
             home_dir,
@@ -103,15 +106,8 @@ impl PeerPostCommitWorkQueue {
         if worker.is_some() {
             return Ok(());
         }
-        let receiver = self
-            .receiver
-            .lock()
-            .map_err(|_| AtmError::daemon_unavailable("post-commit worker receiver lock poisoned"))?
-            .take()
-            .ok_or_else(|| {
-                AtmError::daemon_unavailable("post-commit worker cannot restart after shutdown")
-            })?;
         self.stop.store(false, Ordering::SeqCst);
+        let receiver = Arc::clone(&self.receiver);
         let targets = Arc::clone(&self.local_nudge_targets);
         let runtime = self.runtime.clone();
         let home_dir = self.home_dir.clone();
@@ -143,15 +139,31 @@ impl PeerPostCommitWorkQueue {
     }
 
     fn run(
-        receiver: Receiver<PostCommitWorkKey>,
+        receiver: Arc<Mutex<Receiver<PostCommitWorkKey>>>,
         targets: Arc<Mutex<BTreeMap<AtmMessageId, PostCommitNudgeTarget>>>,
         runtime: LocalServiceRuntime,
         home_dir: AtmHomeDir,
         stop: Arc<AtomicBool>,
     ) {
-        while !stop.load(Ordering::SeqCst) {
-            let work = match receiver.recv_timeout(Duration::from_millis(100)) {
+        loop {
+            let received = match receiver.lock() {
+                Ok(receiver) => receiver.recv_timeout(Duration::from_millis(100)),
+                Err(_) => {
+                    tracing::error!(
+                        subsystem = "runtime_health",
+                        action = "post_commit_work_receive",
+                        "post-commit worker receiver lock poisoned"
+                    );
+                    break;
+                }
+            };
+            let work = match received {
                 Ok(work) => work,
+                // Once shutdown begins, drain identifiers already accepted by
+                // the bounded queue before ending the worker.  These are not
+                // durable retry records, so silently abandoning them would
+                // make local nudges disappear at daemon shutdown.
+                Err(RecvTimeoutError::Timeout) if stop.load(Ordering::SeqCst) => break,
                 Err(RecvTimeoutError::Timeout) => continue,
                 Err(RecvTimeoutError::Disconnected) => break,
             };

--- a/crates/atm-daemon/src/runtime_health/post_commit_work.rs
+++ b/crates/atm-daemon/src/runtime_health/post_commit_work.rs
@@ -1,6 +1,7 @@
 //! Identifier-only work that runs after local SQLite admission.
 
 use std::collections::BTreeMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
@@ -167,15 +168,23 @@ impl PeerPostCommitWorkQueue {
             let graft_port: Arc<dyn boundary::GraftPostSendPort + Send + Sync> =
                 Arc::new(DaemonGraftPostSendPort::new(runtime.clone()));
             let emitter = crate::post_send_emitter::DaemonPostSendHookEmitter::new(graft_port);
-            if let Err(error) = atm_core::send::emit_persisted_local_post_write(
-                &runtime,
-                home_dir.as_path(),
-                &target.team,
-                &target.agent,
-                message_id,
-                &emitter,
-            ) {
-                tracing::warn!(subsystem = "runtime_health", action = "post_commit_local_nudge", %message_id, %error, "post-commit local notification failed after admission");
+            match catch_unwind(AssertUnwindSafe(|| {
+                atm_core::send::emit_persisted_local_post_write(
+                    &runtime,
+                    home_dir.as_path(),
+                    &target.team,
+                    &target.agent,
+                    message_id,
+                    &emitter,
+                )
+            })) {
+                Ok(Err(error)) => {
+                    tracing::warn!(subsystem = "runtime_health", action = "post_commit_local_nudge", %message_id, %error, "post-commit local notification failed after admission")
+                }
+                Err(_) => {
+                    tracing::error!(subsystem = "runtime_health", action = "post_commit_local_nudge", %message_id, "post-commit local notification panicked; worker isolated the failure and remains available")
+                }
+                Ok(Ok(())) => {}
             }
         }
     }
@@ -194,11 +203,11 @@ impl PostCommitWorkQueue for PeerPostCommitWorkQueue {
                 Ok(()) => {}
                 Err(TrySendError::Full(_)) => {
                     self.remove_local_nudge_target(message_id);
-                    tracing::warn!(subsystem = "runtime_health", action = "post_commit_work_signal", work = "local_nudge", %message_id, "post-commit queue is full; retained message remains available for later reconciliation")
+                    tracing::warn!(subsystem = "runtime_health", action = "post_commit_work_signal", work = "local_nudge", %message_id, "post-commit queue is full; local nudge was not emitted and must be retried by the caller or operator")
                 }
                 Err(TrySendError::Disconnected(_)) => {
                     self.remove_local_nudge_target(message_id);
-                    tracing::warn!(subsystem = "runtime_health", action = "post_commit_work_signal", work = "local_nudge", %message_id, "post-commit worker is unavailable; retained message remains available for later reconciliation")
+                    tracing::warn!(subsystem = "runtime_health", action = "post_commit_work_signal", work = "local_nudge", %message_id, "post-commit worker is unavailable; local nudge was not emitted and must be retried by the caller or operator")
                 }
             },
         }

--- a/crates/atm-daemon/src/runtime_health/post_commit_work.rs
+++ b/crates/atm-daemon/src/runtime_health/post_commit_work.rs
@@ -14,9 +14,9 @@ use atm_core::{
     error::{AtmError, AtmErrorCode},
     graft::{
         GraftPostSendRequest, GraftPostSendResponse, deliver_graft_post_send,
-        graft_receiver_record_path_from_home,
+        graft_receiver_record_path_from_root,
     },
-    schema::{AtmMessageId, canonical_home_dir},
+    schema::{AtmMessageId, canonical_graft_root},
 };
 
 use crate::AtmHomeDir;
@@ -262,14 +262,14 @@ impl boundary::GraftPostSendPort for DaemonGraftPostSendPort {
                 "recipient is missing from the authoritative ATM roster",
             ));
         };
-        let recipient_home_dir = canonical_home_dir(&member.metadata_json).ok_or_else(|| {
+        let recipient_root = canonical_graft_root(&member.metadata_json).ok_or_else(|| {
             graft_recipient_unavailable_error(
                 event,
-                "recipient has no authoritative home_dir for graft post-send delivery",
+                "recipient has no authoritative graft root for post-send delivery",
             )
         })?;
-        let record_path = graft_receiver_record_path_from_home(
-            recipient_home_dir.as_path(),
+        let record_path = graft_receiver_record_path_from_root(
+            recipient_root.as_path(),
             &target.recipient_team,
             &target.recipient,
         );

--- a/crates/atm-daemon/src/tests/runtime_root.rs
+++ b/crates/atm-daemon/src/tests/runtime_root.rs
@@ -202,6 +202,130 @@ impl HttpsMessageTransport for RejectingHttpsDelivery {
     }
 }
 
+struct BlockingPeerDelivery {
+    started: mpsc::SyncSender<()>,
+    release: std::sync::Mutex<mpsc::Receiver<()>>,
+}
+
+impl HttpsMessageTransport for BlockingPeerDelivery {
+    fn deliver(
+        &self,
+        _request: WriteRequest,
+        _peer: &TrustedPeer,
+        _deadline: RequestDeadline,
+    ) -> Result<ResponseEnvelope, AtmError> {
+        self.started.send(()).expect("report blocked peer worker");
+        self.release
+            .lock()
+            .expect("release lock")
+            .recv()
+            .expect("release blocked peer worker");
+        Ok(ResponseEnvelope::CompatibilityVerdict(
+            atm_core::protocol::CompatibilityVerdict::Compatible {
+                daemon_release: atm_core::protocol::ReleaseVersion::current(),
+                daemon_schema_version: atm_core::protocol::CLI_SCHEMA_VERSION,
+                daemon_http_api_version: atm_core::protocol::HttpApiVersion::current(),
+            },
+        ))
+    }
+}
+
+#[test]
+#[serial_test::serial(env)]
+fn local_admission_returns_before_the_post_commit_peer_worker_is_released() {
+    install_retained_runtime_factory();
+    let tempdir = TempDir::new().expect("tempdir");
+    let atm_home = tempdir.path().join("atm-home");
+    let workspace_dir = tempdir.path().join("workspace");
+    std::fs::create_dir_all(&atm_home).expect("atm home dir");
+    std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+    let db_path = tempdir.path().join("mail.db");
+    write_team_config(&atm_home, &[]);
+    add_member_via_retained_admin(
+        &db_path,
+        &atm_home,
+        TEST_TEAM,
+        ROLE_TEAM_LEAD,
+        &workspace_dir,
+    );
+    let peer_store = open_sqlite_boundary(&db_path)
+        .expect("sqlite boundary")
+        .peer_config_store();
+    peer_store
+        .save_trusted_peer(&TrustedPeer {
+            host: "peer.example.test".parse().expect("peer host"),
+            fingerprint: "sha256:test-peer".parse().expect("fingerprint"),
+            enabled: true,
+            https_port: NonZeroU16::new(43101).expect("non-zero"),
+        })
+        .expect("save trusted peer");
+    let peer_host = "peer.example.test".parse().expect("peer host");
+    peer_store
+        .save_peer_sync_policy(
+            &peer_host,
+            PeerSyncPolicy {
+                max_message_age: Duration::from_secs(60),
+                max_batch_messages: NonZeroU16::new(1).expect("non-zero batch"),
+            },
+        )
+        .expect("enable peer recovery for the blocked-worker test");
+
+    let dispatcher = Arc::new(DaemonRequestDispatcher::new_for_test(
+        atm_home.clone(),
+        RuntimeStatusCache::new(),
+        db_path,
+    ));
+    let (started, started_rx) = mpsc::sync_channel(1);
+    let (release, release_rx) = mpsc::sync_channel(1);
+    dispatcher
+        .install_https_transport(Arc::new(BlockingPeerDelivery {
+            started,
+            release: std::sync::Mutex::new(release_rx),
+        }))
+        .expect("install blocked peer worker");
+    dispatcher
+        .start_peer_drain_coordinator()
+        .expect("start post-commit peer worker");
+
+    let (response_tx, response_rx) = mpsc::sync_channel(1);
+    let admission_dispatcher = Arc::clone(&dispatcher);
+    let admission = std::thread::spawn(move || {
+        let response = admission_dispatcher.dispatch(RequestEnvelope::Write(Box::new(
+            SendRequest::new(
+                atm_home,
+                workspace_dir,
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "remote-agent@remote-team.peer.example.test",
+                TEST_TEAM.parse().expect("team"),
+                SendMessageSource::Inline("peer write".to_string()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("remote write request"),
+        )));
+        response_tx.send(response).expect("report admission result");
+    });
+
+    let response = response_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("local admission must not wait for the blocked peer worker")
+        .expect("local admission response");
+    assert!(matches!(
+        response,
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
+    ));
+    started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("post-commit worker must eventually start peer delivery");
+    release.send(()).expect("release peer worker");
+    admission.join().expect("join local admission");
+    dispatcher
+        .stop_peer_drain_coordinator()
+        .expect("stop post-commit peer worker");
+}
+
 fn add_member_via_retained_admin(
     db_path: &std::path::Path,
     atm_home: &std::path::Path,
@@ -229,7 +353,7 @@ fn add_member_via_retained_admin(
 
 #[test]
 #[serial_test::serial(env)]
-fn host_qualified_write_reaches_https_delivery_only_through_post_write_router() {
+fn host_qualified_write_is_admitted_without_foreground_https_delivery() {
     install_retained_runtime_factory();
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
@@ -280,7 +404,7 @@ fn host_qualified_write_reaches_https_delivery_only_through_post_write_router() 
             )
             .expect("remote write request"),
         )))
-        .expect("post-write peer route succeeds");
+        .expect("local admission must succeed without waiting for peer delivery");
     assert!(matches!(
         response,
         ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
@@ -289,50 +413,15 @@ fn host_qualified_write_reaches_https_delivery_only_through_post_write_router() 
         .delivered
         .lock()
         .expect("HTTPS delivery recording lock");
-    assert_eq!(delivered.len(), 1, "the router makes one peer delivery");
     assert!(
-        delivered[0].origin_message_id.is_some(),
-        "the canonical writer assigns the immutable origin ULID before peer delivery"
-    );
-    assert!(
-        delivered[0].origin_timestamp.is_some(),
-        "the canonical writer carries the immutable origin timestamp with the peer write"
-    );
-
-    let replay = delivered[0].clone();
-    drop(delivered);
-    let status = dispatcher
-        .peer_link_statuses()
-        .pop()
-        .expect("configured peer delivery status");
-    assert_eq!(
-        status.quality,
-        atm_core::doctor::PeerLinkQuality::Healthy,
-        "a peer is healthy only after its HTTP response is accepted"
-    );
-    assert!(status.last_success_at.is_some());
-    assert!(status.last_error_code.is_none());
-    let replay_response = dispatcher
-        .dispatch(RequestEnvelope::Write(Box::new(replay)))
-        .expect("same immutable peer write is idempotent");
-    assert!(matches!(
-        replay_response,
-        ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
-    ));
-    assert_eq!(
-        transport
-            .delivered
-            .lock()
-            .expect("HTTPS delivery recording lock")
-            .len(),
-        1,
-        "an idempotent replay must not repeat peer delivery"
+        delivered.is_empty(),
+        "the admission path must not open a peer transport before its local response"
     );
 }
 
 #[test]
 #[serial_test::serial(env)]
-fn failed_peer_route_returns_transport_error_after_canonical_persistence() {
+fn unavailable_peer_does_not_relabel_a_committed_local_admission() {
     install_retained_runtime_factory();
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
@@ -366,7 +455,7 @@ fn failed_peer_route_returns_transport_error_after_canonical_persistence() {
         .install_https_transport(transport.clone())
         .expect("install failing HTTPS delivery");
 
-    let error = dispatcher
+    let response = dispatcher
         .dispatch(RequestEnvelope::Write(Box::new(
             SendRequest::new(
                 atm_home,
@@ -382,56 +471,24 @@ fn failed_peer_route_returns_transport_error_after_canonical_persistence() {
             )
             .expect("remote write request"),
         )))
-        .expect_err("peer transport failure must be returned from the post-write router");
-    assert_eq!(error.code(), AtmErrorCode::RemoteDeliveryUnconfirmed);
+        .expect("peer unavailability belongs to post-commit recovery, not local admission");
+    assert!(matches!(
+        response,
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
+    ));
     let attempted = transport
         .attempted
         .lock()
         .expect("HTTPS delivery recording lock");
-    assert_eq!(attempted.len(), 1, "the router attempts one peer delivery");
     assert!(
-        attempted[0].origin_message_id.is_some() && attempted[0].origin_timestamp.is_some(),
-        "the failed route runs after canonical persistence assigned immutable origin metadata"
-    );
-    let status = dispatcher
-        .peer_link_statuses()
-        .pop()
-        .expect("configured peer delivery status");
-    assert_eq!(
-        status.quality,
-        atm_core::doctor::PeerLinkQuality::Unreachable,
-        "an uncertain peer response must not be represented as a successful send"
-    );
-    assert_eq!(
-        status.last_error_code,
-        Some(AtmErrorCode::RemoteDeliveryUnconfirmed)
-    );
-    let retry_with_same_ulid = attempted[0].clone();
-    drop(attempted);
-    let retry_transport = Arc::new(RecordingHttpsDelivery::default());
-    dispatcher
-        .install_https_transport(retry_transport.clone())
-        .expect("install retry transport");
-    let retry = dispatcher
-        .dispatch(RequestEnvelope::Write(Box::new(retry_with_same_ulid)))
-        .expect("same immutable ULID is a safe receiver retry");
-    assert!(matches!(
-        retry,
-        ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
-    ));
-    assert!(
-        retry_transport
-            .delivered
-            .lock()
-            .expect("retry delivery recording lock")
-            .is_empty(),
-        "duplicate ULID is retained idempotently and cannot claim a second peer acceptance"
+        attempted.is_empty(),
+        "a blocked peer transport must not run in the local admission request"
     );
 }
 
 #[test]
 #[serial_test::serial(env)]
-fn peer_error_response_is_returned_as_the_post_write_result() {
+fn peer_rejection_does_not_prevent_local_admission() {
     install_retained_runtime_factory();
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
@@ -463,7 +520,7 @@ fn peer_error_response_is_returned_as_the_post_write_result() {
         .install_https_transport(Arc::new(RejectingHttpsDelivery))
         .expect("install rejecting transport");
 
-    let error = dispatcher
+    let response = dispatcher
         .dispatch(RequestEnvelope::Write(Box::new(
             SendRequest::new(
                 atm_home,
@@ -479,21 +536,11 @@ fn peer_error_response_is_returned_as_the_post_write_result() {
             )
             .expect("remote write request"),
         )))
-        .expect_err("the remote daemon's roster rejection must reach the origin");
-    assert_eq!(error.code(), AtmErrorCode::MessageValidationFailed);
-    let status = dispatcher
-        .peer_link_statuses()
-        .pop()
-        .expect("configured peer delivery status");
-    assert_eq!(
-        status.quality,
-        atm_core::doctor::PeerLinkQuality::Degraded,
-        "a peer's explicit typed rejection is observable but not receiver acceptance"
-    );
-    assert_eq!(
-        status.last_error_code,
-        Some(AtmErrorCode::MessageValidationFailed)
-    );
+        .expect("remote rejection must be handled after the local response");
+    assert!(matches!(
+        response,
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
+    ));
 }
 
 #[test]

--- a/crates/atm-daemon/src/tests/runtime_root.rs
+++ b/crates/atm-daemon/src/tests/runtime_root.rs
@@ -21,6 +21,7 @@ use tempfile::TempDir;
 
 use crate::https_transport::HttpsMessageTransport;
 mod local_ipc;
+mod peer_failure;
 mod peer_observability;
 mod peer_reconciliation;
 use crate::test_support::{
@@ -131,6 +132,7 @@ struct ConnectionHandlerFailure {
 #[derive(Default)]
 struct RouteFailure {
     attempted: std::sync::Mutex<Vec<WriteRequest>>,
+    attempted_tx: std::sync::Mutex<Option<mpsc::SyncSender<WriteRequest>>>,
 }
 
 #[derive(Default)]
@@ -166,7 +168,15 @@ impl HttpsMessageTransport for RouteFailure {
         _peer: &TrustedPeer,
         _deadline: RequestDeadline,
     ) -> Result<ResponseEnvelope, AtmError> {
-        record_failed_delivery(&self.attempted, request);
+        record_failed_delivery(&self.attempted, request.clone());
+        if let Some(sender) = self
+            .attempted_tx
+            .lock()
+            .expect("peer transport notification lock")
+            .take()
+        {
+            sender.send(request).expect("report failed peer delivery");
+        }
         Err(AtmError::remote_delivery_unconfirmed(
             "intentional route failure",
         ))
@@ -416,73 +426,6 @@ fn host_qualified_write_is_admitted_without_foreground_https_delivery() {
     assert!(
         delivered.is_empty(),
         "the admission path must not open a peer transport before its local response"
-    );
-}
-
-#[test]
-#[serial_test::serial(env)]
-fn unavailable_peer_does_not_relabel_a_committed_local_admission() {
-    install_retained_runtime_factory();
-    let tempdir = TempDir::new().expect("tempdir");
-    let atm_home = tempdir.path().join("atm-home");
-    let workspace_dir = tempdir.path().join("workspace");
-    std::fs::create_dir_all(&atm_home).expect("atm home dir");
-    std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
-    let db_path = tempdir.path().join("mail.db");
-    write_team_config(&atm_home, &[]);
-    add_member_via_retained_admin(
-        &db_path,
-        &atm_home,
-        TEST_TEAM,
-        ROLE_TEAM_LEAD,
-        &workspace_dir,
-    );
-    open_sqlite_boundary(&db_path)
-        .expect("sqlite boundary")
-        .peer_config_store()
-        .save_trusted_peer(&TrustedPeer {
-            host: "peer.example.test".parse().expect("peer host"),
-            fingerprint: "sha256:test-peer".parse().expect("fingerprint"),
-            enabled: true,
-            https_port: std::num::NonZeroU16::new(43101).expect("non-zero"),
-        })
-        .expect("save trusted peer");
-
-    let dispatcher =
-        DaemonRequestDispatcher::new_for_test(atm_home.clone(), RuntimeStatusCache::new(), db_path);
-    let transport = Arc::new(RouteFailure::default());
-    dispatcher
-        .install_https_transport(transport.clone())
-        .expect("install failing HTTPS delivery");
-
-    let response = dispatcher
-        .dispatch(RequestEnvelope::Write(Box::new(
-            SendRequest::new(
-                atm_home,
-                workspace_dir,
-                ROLE_TEAM_LEAD.parse().expect("caller"),
-                "remote-agent@remote-team.peer.example.test",
-                TEST_TEAM.parse().expect("team"),
-                SendMessageSource::Inline("peer write".to_string()),
-                None,
-                false,
-                None,
-                false,
-            )
-            .expect("remote write request"),
-        )))
-        .expect("peer unavailability belongs to post-commit recovery, not local admission");
-    assert!(matches!(
-        response,
-        ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
-    ));
-    let attempted = transport
-        .attempted
-        .lock()
-        .expect("HTTPS delivery recording lock");
-    assert!(
-        attempted.is_empty(),
-        "a blocked peer transport must not run in the local admission request"
     );
 }
 
@@ -780,6 +723,66 @@ fn dispatcher_send_rejects_self_addressed_message_before_persistence() {
 
     assert_eq!(error.code(), AtmErrorCode::SelfAddressedSendInvalid);
     assert_eq!(error.code(), AtmErrorCode::SelfAddressedSendInvalid);
+}
+
+#[test]
+#[serial_test::serial(env)]
+fn host_qualified_self_addresses_use_the_ordinary_admission_route() {
+    install_retained_runtime_factory();
+    let tempdir = TempDir::new().expect("tempdir");
+    let atm_home = tempdir.path().join("atm-home");
+    let workspace_dir = tempdir.path().join("workspace");
+    std::fs::create_dir_all(&atm_home).expect("atm home dir");
+    std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+    let db_path = tempdir.path().join("mail.db");
+    write_team_config(&atm_home, &[]);
+    add_member_via_retained_admin(
+        &db_path,
+        &atm_home,
+        TEST_TEAM,
+        ROLE_TEAM_LEAD,
+        &workspace_dir,
+    );
+    let peer_store = open_sqlite_boundary(&db_path)
+        .expect("sqlite boundary")
+        .peer_config_store();
+    for host in ["localhost", "127.0.0.1"] {
+        peer_store
+            .save_trusted_peer(&TrustedPeer {
+                host: host.parse().expect("host"),
+                fingerprint: "sha256:test-peer".parse().expect("fingerprint"),
+                enabled: true,
+                https_port: NonZeroU16::new(43101).expect("non-zero"),
+            })
+            .expect("save trusted peer");
+    }
+    let dispatcher =
+        DaemonRequestDispatcher::new_for_test(atm_home.clone(), RuntimeStatusCache::new(), db_path);
+
+    for host in ["localhost", "127.0.0.1"] {
+        let address = format!("{ROLE_TEAM_LEAD}@{TEST_TEAM}.{host}");
+        let response = dispatcher
+            .dispatch(RequestEnvelope::Write(Box::new(
+                SendRequest::new(
+                    atm_home.clone(),
+                    workspace_dir.clone(),
+                    ROLE_TEAM_LEAD.parse().expect("caller"),
+                    &address,
+                    TEST_TEAM.parse().expect("team"),
+                    SendMessageSource::Inline(format!("ordinary route {host}")),
+                    None,
+                    false,
+                    None,
+                    false,
+                )
+                .expect("host-qualified request"),
+            )))
+            .expect("host-qualified self address must be admitted");
+        assert!(matches!(
+            response,
+            ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
+        ));
+    }
 }
 
 #[test]

--- a/crates/atm-daemon/src/tests/runtime_root/local_ipc.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/local_ipc.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 #[serial_test::serial(env)]
-fn local_ipc_client_preflight_round_trips_ack_required_send_after_add_member_roster_state() {
+fn local_ipc_host_qualified_admission_returns_before_blocked_peer_delivery() {
     install_retained_runtime_factory();
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
@@ -19,7 +19,27 @@ fn local_ipc_client_preflight_round_trips_ack_required_send_after_add_member_ros
         ROLE_TEAM_LEAD,
         &workspace_dir,
     );
-    add_member_via_retained_admin(&db_path, &atm_home, TEST_TEAM, "qa-a", &workspace_dir);
+    let peer_host: atm_storage::HostName = "peer.example.test".parse().expect("peer host");
+    let peer_store = open_sqlite_boundary(&db_path)
+        .expect("sqlite boundary")
+        .peer_config_store();
+    peer_store
+        .save_trusted_peer(&TrustedPeer {
+            host: peer_host.clone(),
+            fingerprint: "sha256:test-peer".parse().expect("fingerprint"),
+            enabled: true,
+            https_port: NonZeroU16::new(43101).expect("non-zero port"),
+        })
+        .expect("save trusted peer");
+    peer_store
+        .save_peer_sync_policy(
+            &peer_host,
+            PeerSyncPolicy {
+                max_message_age: Duration::from_secs(60),
+                max_batch_messages: NonZeroU16::new(1).expect("non-zero batch"),
+            },
+        )
+        .expect("enable peer recovery");
 
     let _env = EnvGuard::set_many([
         ("ATM_HOME", Some(atm_home.to_str().expect("utf8 atm home"))),
@@ -47,18 +67,29 @@ fn local_ipc_client_preflight_round_trips_ack_required_send_after_add_member_ros
         let reset = LifecycleFlagResetGuard::install(lifecycle.clone());
         (lifecycle, reset)
     };
-    let dispatcher: Arc<dyn ApiRouter + Send + Sync> =
-        Arc::new(DaemonRequestDispatcher::new_for_test(
-            atm_home.clone(),
-            RuntimeStatusCache::new(),
-            db_path.clone(),
-        ));
+    let dispatcher = Arc::new(DaemonRequestDispatcher::new_for_test(
+        atm_home.clone(),
+        RuntimeStatusCache::new(),
+        db_path.clone(),
+    ));
+    let (started, started_rx) = mpsc::sync_channel(1);
+    let (release, release_rx) = mpsc::sync_channel(1);
+    dispatcher
+        .install_https_transport(Arc::new(BlockingPeerDelivery {
+            started,
+            release: std::sync::Mutex::new(release_rx),
+        }))
+        .expect("install blocked peer transport");
+    dispatcher
+        .start_peer_drain_coordinator()
+        .expect("start peer drain coordinator");
+    let router: Arc<dyn ApiRouter + Send + Sync> = dispatcher.clone();
     let (serve_result_tx, serve_result_rx) = mpsc::channel();
     let (ready_tx, ready_rx) = mpsc::sync_channel(1);
 
     let join = std::thread::spawn(move || {
         let result = runtime.serve_with_runtime_hooks(
-            dispatcher,
+            router,
             RuntimeServeHooks {
                 endpoint_guard,
                 graceful_drain_deadline: Duration::from_millis(500),
@@ -90,11 +121,11 @@ fn local_ipc_client_preflight_round_trips_ack_required_send_after_add_member_ros
         atm_home.clone(),
         workspace_dir.clone(),
         ROLE_TEAM_LEAD.parse().expect("caller"),
-        "qa-a@test-team",
+        "remote-agent@remote-team.peer.example.test",
         TEST_TEAM.parse().expect("team"),
         SendMessageSource::Inline("hello local ipc ack-required".to_string()),
         None,
-        true,
+        false,
         None,
         false,
     )
@@ -116,10 +147,14 @@ fn local_ipc_client_preflight_round_trips_ack_required_send_after_add_member_ros
     match response {
         ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => {
             assert_eq!(outcome.outcome.as_str(), "sent");
-            assert!(outcome.requires_ack);
+            assert!(!outcome.requires_ack);
         }
         other => panic!("unexpected response: {other:?}"),
     }
+    started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("post-commit worker must begin the blocked peer delivery");
+    release.send(()).expect("release peer worker");
 
     lifecycle.set_terminate_for_test(true);
     serve_result_rx
@@ -127,4 +162,7 @@ fn local_ipc_client_preflight_round_trips_ack_required_send_after_add_member_ros
         .expect("recv serve result")
         .expect("serve runtime result");
     join.join().expect("join serve thread");
+    dispatcher
+        .stop_peer_drain_coordinator()
+        .expect("stop peer drain coordinator");
 }

--- a/crates/atm-daemon/src/tests/runtime_root/peer_failure.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/peer_failure.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+#[test]
+#[serial_test::serial(env)]
+fn unavailable_peer_does_not_relabel_a_committed_local_admission() {
+    install_retained_runtime_factory();
+    let tempdir = TempDir::new().expect("tempdir");
+    let atm_home = tempdir.path().join("atm-home");
+    let workspace_dir = tempdir.path().join("workspace");
+    std::fs::create_dir_all(&atm_home).expect("atm home dir");
+    std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+    let db_path = tempdir.path().join("mail.db");
+    write_team_config(&atm_home, &[]);
+    add_member_via_retained_admin(
+        &db_path,
+        &atm_home,
+        TEST_TEAM,
+        ROLE_TEAM_LEAD,
+        &workspace_dir,
+    );
+    let peer_store = open_sqlite_boundary(&db_path)
+        .expect("sqlite boundary")
+        .peer_config_store();
+    let peer_host: atm_core::types::HostName = "peer.example.test".parse().expect("peer host");
+    peer_store
+        .save_trusted_peer(&TrustedPeer {
+            host: peer_host.clone(),
+            fingerprint: "sha256:test-peer".parse().expect("fingerprint"),
+            enabled: true,
+            https_port: NonZeroU16::new(43101).expect("non-zero"),
+        })
+        .expect("save trusted peer");
+    peer_store
+        .save_peer_sync_policy(
+            &peer_host,
+            PeerSyncPolicy {
+                max_message_age: Duration::from_secs(60),
+                max_batch_messages: NonZeroU16::new(1).expect("non-zero batch"),
+            },
+        )
+        .expect("enable peer recovery");
+    let dispatcher =
+        DaemonRequestDispatcher::new_for_test(atm_home.clone(), RuntimeStatusCache::new(), db_path);
+    let (attempted_tx, attempted_rx) = mpsc::sync_channel(1);
+    let transport = Arc::new(RouteFailure {
+        attempted: std::sync::Mutex::new(Vec::new()),
+        attempted_tx: std::sync::Mutex::new(Some(attempted_tx)),
+    });
+    dispatcher
+        .install_https_transport(transport.clone())
+        .expect("install failing HTTPS delivery");
+    dispatcher
+        .start_peer_drain_coordinator()
+        .expect("start post-commit peer worker");
+    let response = dispatcher
+        .dispatch(RequestEnvelope::Write(Box::new(
+            SendRequest::new(
+                atm_home,
+                workspace_dir,
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "remote-agent@remote-team.peer.example.test",
+                TEST_TEAM.parse().expect("team"),
+                SendMessageSource::Inline("peer write".to_string()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("remote write request"),
+        )))
+        .expect("peer unavailability belongs to post-commit recovery, not local admission");
+    let local_message_id = match response {
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => outcome.message_id,
+        other => panic!("local admission must remain sent, got {other:?}"),
+    };
+    let delivered = attempted_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("post-commit peer worker must attempt the retained message");
+    assert_eq!(delivered.origin_message_id, Some(local_message_id));
+    assert_eq!(transport.attempted.lock().expect("deliveries").len(), 1);
+    assert_eq!(
+        dispatcher.peer_link_statuses()[0].last_error_code,
+        Some(AtmErrorCode::RemoteDeliveryUnconfirmed)
+    );
+    dispatcher
+        .stop_peer_drain_coordinator()
+        .expect("stop post-commit peer worker");
+}

--- a/crates/atm-daemon/src/tests/runtime_root/peer_observability.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/peer_observability.rs
@@ -118,7 +118,7 @@ fn peer_link_status_json_round_trip_exposes_no_authority_secrets() {
 
 #[test]
 #[serial_test::serial(env)]
-fn connection_handler_failure_preserves_daemon_unavailable() {
+fn connection_handler_failure_is_not_a_local_admission_failure() {
     install_retained_runtime_factory();
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
@@ -151,7 +151,7 @@ fn connection_handler_failure_preserves_daemon_unavailable() {
         .install_https_transport(Arc::new(ConnectionHandlerFailure::default()))
         .expect("install unavailable HTTPS delivery");
 
-    let error = dispatcher
+    let response = dispatcher
         .dispatch(RequestEnvelope::Write(Box::new(
             SendRequest::new(
                 atm_home,
@@ -167,15 +167,17 @@ fn connection_handler_failure_preserves_daemon_unavailable() {
             )
             .expect("remote write request"),
         )))
-        .expect_err("local transport failure must be returned unchanged");
-
-    assert_eq!(error.code(), AtmErrorCode::DaemonUnavailable);
+        .expect("a durable local write must not wait for the peer connection handler");
+    assert!(matches!(
+        response,
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
+    ));
     let status = dispatcher
         .peer_link_statuses()
         .pop()
         .expect("configured peer delivery status");
     assert_eq!(
-        status.last_error_code,
-        Some(AtmErrorCode::DaemonUnavailable)
+        status.last_error_code, None,
+        "no peer handler ran on the admission path"
     );
 }

--- a/crates/atm-daemon/src/tests/runtime_root/peer_reconciliation.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/peer_reconciliation.rs
@@ -215,20 +215,23 @@ fn response_write_failure_keeps_source_pending_until_the_shared_write_retries() 
     dispatcher
         .install_https_transport(failing.clone())
         .expect("install failing transport");
-    let error = dispatcher
+    let admitted = dispatcher
         .dispatch(RequestEnvelope::Write(Box::new(
             ack.clone().into_write_request(),
         )))
-        .expect_err("failed remote acknowledgement must remain unconfirmed");
-    assert_eq!(error.code(), AtmErrorCode::RemoteDeliveryUnconfirmed);
+        .expect("a durable acknowledgement must not wait for remote reply delivery");
+    assert!(matches!(
+        admitted,
+        ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(_))
+    ));
     assert_eq!(
         failing
             .attempted
             .lock()
             .expect("attempt recording lock")
             .len(),
-        1,
-        "ack is one shared peer write attempt"
+        0,
+        "the peer transport must not run before the acknowledgement response"
     );
 
     let succeeding = Arc::new(RecordingHttpsDelivery::default());
@@ -237,19 +240,16 @@ fn response_write_failure_keeps_source_pending_until_the_shared_write_retries() 
         .expect("replace test transport");
     let retry = dispatcher
         .dispatch(RequestEnvelope::Write(Box::new(ack.into_write_request())))
-        .expect("source remains pending after failed peer acknowledgement");
-    assert!(matches!(
-        retry,
-        ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(_))
-    ));
+        .expect_err("the already-admitted acknowledgement must not create a second reply");
+    assert_eq!(retry.code(), AtmErrorCode::MessageValidationFailed);
     assert_eq!(
         succeeding
             .delivered
             .lock()
             .expect("delivery recording lock")
             .len(),
-        1,
-        "the successful retry follows the same write/router path"
+        0,
+        "a second local request cannot bypass the durable acknowledgement state"
     );
 }
 
@@ -320,8 +320,8 @@ fn explicit_peer_sync_resends_one_bounded_immutable_write() {
     ));
     assert_eq!(
         transport.delivered.lock().expect("deliveries").len(),
-        2,
-        "disabled policy never scans or delivers stored writes"
+        0,
+        "admission never delivers writes synchronously when recovery is disabled"
     );
     peer_store
         .save_peer_sync_policy(
@@ -356,12 +356,12 @@ fn explicit_peer_sync_resends_one_bounded_immutable_write() {
     let delivered = transport.delivered.lock().expect("deliveries");
     assert_eq!(
         delivered.len(),
-        4,
-        "two ordinary writes plus both ordered recovery pages are delivered"
+        2,
+        "only the explicit post-commit recovery drain performs peer delivery"
     );
-    assert_eq!(
-        delivered[0].origin_message_id, delivered[2].origin_message_id,
-        "reconciliation reuses the canonical immutable write and its original ULID"
+    assert_ne!(
+        delivered[0].origin_message_id, delivered[1].origin_message_id,
+        "the two independently admitted immutable writes retain distinct ULIDs"
     );
 }
 
@@ -471,7 +471,7 @@ fn reconciliation_duplicate_arrival_keeps_receiver_inbox_idempotent() {
             .expect("peer write"),
         )))
         .expect("initial reconciliation delivery");
-    assert_eq!(recipient_message_count(&receiver_db, "receiver"), 1);
+    assert_eq!(recipient_message_count(&receiver_db, "receiver"), 0);
 
     let sync = source
         .dispatch(RequestEnvelope::PeerSync(PeerSyncRequest {
@@ -481,8 +481,8 @@ fn reconciliation_duplicate_arrival_keeps_receiver_inbox_idempotent() {
     assert!(matches!(sync, ResponseEnvelope::PeerSync(_)));
     assert_eq!(
         *delivery.deliveries.lock().expect("delivery count lock"),
-        2,
-        "the receiver sees the original delivery and its reconciliation duplicate"
+        1,
+        "the explicit post-commit drain performs the first receiver delivery"
     );
     assert_eq!(
         recipient_message_count(&receiver_db, "receiver"),

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -1,6 +1,5 @@
 use atm_core::ack::AckRequest;
 use atm_core::boundary::RosterHarness;
-use atm_core::error_codes::AtmErrorCode;
 use atm_core::graft::{
     GraftPostSendResponse, GraftReceiverListener, graft_receiver_record_path_from_home,
 };
@@ -104,7 +103,7 @@ fn write_graft_enabled_config(workspace_dir: &std::path::Path) {
 
 #[test]
 #[serial_test::serial(env)]
-fn dispatcher_send_surfaces_typed_warning_when_graft_receiver_path_is_unavailable() {
+fn dispatcher_send_keeps_post_commit_graft_failure_out_of_admission_response() {
     let (_tempdir, atm_home, workspace_dir, dispatcher) = graft_warning_dispatcher();
 
     let response = dispatcher
@@ -129,17 +128,15 @@ fn dispatcher_send_surfaces_typed_warning_when_graft_receiver_path_is_unavailabl
         ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => outcome,
         other => panic!("expected send response, got {other:?}"),
     };
-    assert_eq!(outcome.warnings.len(), 1);
-    assert_eq!(
-        outcome.warnings[0].code,
-        Some(AtmErrorCode::PostSendGraftUnavailable)
+    assert!(
+        outcome.warnings.is_empty(),
+        "post-commit graft failure must not relabel a successful local admission"
     );
-    assert!(outcome.warnings[0].recovery.is_some());
 }
 
 #[test]
 #[serial_test::serial(env)]
-fn dispatcher_ack_surfaces_typed_warning_when_graft_reply_target_is_unavailable() {
+fn dispatcher_ack_keeps_post_commit_graft_failure_out_of_admission_response() {
     let (_tempdir, atm_home, workspace_dir, dispatcher) = graft_warning_dispatcher();
 
     let source_response = dispatcher
@@ -183,12 +180,10 @@ fn dispatcher_ack_surfaces_typed_warning_when_graft_reply_target_is_unavailable(
         ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => outcome,
         other => panic!("expected ack response, got {other:?}"),
     };
-    assert_eq!(ack_outcome.warnings.len(), 1);
-    assert_eq!(
-        ack_outcome.warnings[0].code,
-        Some(AtmErrorCode::PostSendGraftUnavailable)
+    assert!(
+        ack_outcome.warnings.is_empty(),
+        "post-commit graft failure must not relabel a successful ACK admission"
     );
-    assert!(ack_outcome.warnings[0].recovery.is_some());
 }
 
 #[test]

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -19,17 +19,28 @@ const TEST_TEAM: &str = "test-team";
 
 fn install_test_roster_with_harness(
     db_path: &std::path::Path,
-    members: &[(&str, RosterHarness, Option<&std::path::Path>)],
+    members: &[(
+        &str,
+        RosterHarness,
+        Option<&std::path::Path>,
+        Option<&std::path::Path>,
+    )],
 ) {
     let assembly = open_sqlite_boundary(db_path).expect("assemble boundary");
     let roster_store = assembly.roster_store_arc();
     let team = TEST_TEAM.parse::<TeamName>().expect("team");
     let members = members
         .iter()
-        .map(|(name, harness, home_dir)| {
+        .map(|(name, harness, home_dir, workspace_root)| {
             let mut member = AgentMember::with_name((*name).parse().expect("member"));
             if let Some(home_dir) = home_dir {
                 member.home_dir = home_dir.to_path_buf().into();
+            }
+            if let Some(workspace_root) = workspace_root {
+                member.extra.insert(
+                    "workspace_root".to_string(),
+                    serde_json::Value::String(workspace_root.display().to_string()),
+                );
             }
             let mut record = atm_core::boundary::roster_member_record_from_claude_code_member(
                 team.clone(),
@@ -70,6 +81,7 @@ fn graft_warning_dispatcher() -> (
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
     let workspace_dir = tempdir.path().join("workspace");
+    let profile_home = tempdir.path().join("recipient-profile");
     std::fs::create_dir_all(&atm_home).expect("atm home dir");
     std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
     let db_path = tempdir.path().join("mail.db");
@@ -80,10 +92,12 @@ fn graft_warning_dispatcher() -> (
                 ROLE_TEAM_LEAD,
                 RosterHarness::ClaudeCode,
                 Some(workspace_dir.as_path()),
+                None,
             ),
             (
                 "qa-a",
                 RosterHarness::CodexCli,
+                Some(profile_home.as_path()),
                 Some(workspace_dir.as_path()),
             ),
         ],

--- a/crates/atm-graft-python/Cargo.toml
+++ b/crates/atm-graft-python/Cargo.toml
@@ -17,9 +17,9 @@ crate-type = ["cdylib", "rlib"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.0-beta-ai" }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai" }
+atm-graft = { path = "../atm-graft", version = "1.4.0-beta-ai.31" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31" }
 pyo3 = "0.29"
 
 [dev-dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.0-beta-ai", features = ["test-support"] }
+atm-graft = { path = "../atm-graft", version = "1.4.0-beta-ai.31", features = ["test-support"] }

--- a/crates/atm-graft-python/pyproject.toml
+++ b/crates/atm-graft-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "atm-graft"
-version = "1.4.0-beta-ai"
+version = "1.4.0-beta-ai.31"
 requires-python = ">=3.9"
 
 [tool.maturin]

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -327,7 +327,8 @@ impl PyGraftSession {
         })
     }
 
-    fn send(&self, to: PyAgentAddress, body: String) -> PyResult<()> {
+    #[pyo3(signature = (to, body, requires_ack=false))]
+    fn send(&self, to: PyAgentAddress, body: String, requires_ack: bool) -> PyResult<()> {
         let (home_dir, current_dir) = Self::command_paths()?;
         let request = SendRequest::new(
             home_dir,
@@ -337,7 +338,7 @@ impl PyGraftSession {
             self.caller.team().cloned().expect("validated caller team"),
             SendMessageSource::Inline(body),
             None,
-            false,
+            requires_ack,
             None,
             false,
         )

--- a/crates/atm-graft/Cargo.toml
+++ b/crates/atm-graft/Cargo.toml
@@ -13,12 +13,12 @@ homepage.workspace = true
 test-support = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.0-beta-ai" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.0-beta-ai.31" }
 serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai", features = ["test-utils"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31", features = ["test-utils"] }
 serde_json.workspace = true
 tempfile = "3"

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -336,7 +336,7 @@ impl GraftSession {
             return inactive_session(client, snapshot, observability);
         }
 
-        let endpoint_path = atm_core::graft::graft_receiver_record_path_from_home(
+        let endpoint_path = atm_core::graft::graft_receiver_record_path_from_root(
             options.workspace_root(),
             options.team(),
             options.agent(),

--- a/crates/atm-runtime-test-support/Cargo.toml
+++ b/crates/atm-runtime-test-support/Cargo.toml
@@ -14,6 +14,6 @@ publish = false
 name = "atm_runtime_test_support"
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai", features = ["test-utils"] }
-atm-runtime = { path = "../atm-runtime", version = "1.4.0-beta-ai" }
-atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.0-beta-ai", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31", features = ["test-utils"] }
+atm-runtime = { path = "../atm-runtime", version = "1.4.0-beta-ai.31" }
+atm-storage-rusqlite = { path = "../atm-storage-rusqlite", version = "1.4.0-beta-ai.31", features = ["test-support"] }

--- a/crates/atm-runtime/Cargo.toml
+++ b/crates/atm-runtime/Cargo.toml
@@ -16,5 +16,5 @@ name = "atm_runtime"
 test-utils = []
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai" }
-atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31" }
+atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai.31" }

--- a/crates/atm-storage-rusqlite/Cargo.toml
+++ b/crates/atm-storage-rusqlite/Cargo.toml
@@ -16,7 +16,7 @@ name = "atm_storage_rusqlite"
 test-support = []
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai" }
+atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai.31" }
 serde_json.workspace = true
 serde.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -23,7 +23,8 @@ pub use crate::observability::{
     SqliteObservabilityOutcome,
 };
 use atm_storage::contract::{
-    Message, MessageKey, MessageQuery, MessageStore, PeerConfigStore, RosterStore,
+    AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, Message, MessageKey,
+    MessageQuery, MessageStore, PeerConfigStore, RosterStore,
 };
 #[cfg(test)]
 use atm_storage::schema::ThreadMode;
@@ -298,6 +299,14 @@ impl MessageStore for SqliteMessageStore {
 
     fn save_messages_atomically(&self, messages: &[Message]) -> Result<(), AtmError> {
         self.db.submit_upsert_messages_atomically(messages.to_vec())
+    }
+
+    fn acknowledge_message_atomically(
+        &self,
+        source: &AcknowledgementSource,
+        builder: Arc<dyn AcknowledgementReplyBuilder>,
+    ) -> Result<AcknowledgementCommit, AtmError> {
+        self.db.submit_acknowledgement(source.clone(), builder)
     }
 
     fn load_message(&self, key: &MessageKey) -> Result<Option<Message>, AtmError> {
@@ -624,8 +633,8 @@ mod tests {
     use super::SqliteStorageBackend;
     use atm_storage::StoredPeerWrite;
     use atm_storage::contract::{
-        AgentType, Message, MessageKey, MessageQuery, RosterHarness, RosterMember,
-        RosterMemberKind, RosterSnapshot,
+        AcknowledgementReplyBuilder, AcknowledgementSource, AgentType, Message, MessageKey,
+        MessageQuery, RosterHarness, RosterMember, RosterMemberKind, RosterSnapshot,
     };
     use atm_storage::schema::{AtmMessageId, MessageEnvelope};
     use atm_storage::types::{AgentName, HostName, IsoTimestamp, ModelName, TeamName};
@@ -633,6 +642,7 @@ mod tests {
     use rusqlite::params;
     use serde_json::{Map, json};
     use std::num::NonZeroU16;
+    use std::sync::Arc;
 
     fn team() -> TeamName {
         "test-team".parse().expect("team")
@@ -865,6 +875,70 @@ mod tests {
                 .expect("load source"),
             Some(source),
             "the acknowledged source state is durable in the same commit"
+        );
+    }
+
+    #[test]
+    fn sqlite_acknowledgement_resolves_source_and_commits_pair_in_one_writer_operation() {
+        struct ReplyBuilder;
+
+        impl AcknowledgementReplyBuilder for ReplyBuilder {
+            fn build_reply(&self, source: &Message) -> Result<Message, atm_storage::AtmError> {
+                let source_id = source
+                    .envelope
+                    .message_id
+                    .ok_or_else(|| atm_storage::AtmError::validation("test source has no id"))?;
+                let mut reply = source.clone();
+                let reply_id = AtmMessageId::new();
+                reply.message_key = MessageKey::new(format!("atm:{reply_id}"))?;
+                reply.envelope.message_id = Some(reply_id);
+                reply.envelope.text = "acknowledged".to_string();
+                reply.envelope.read = false;
+                reply.envelope.requires_ack = false;
+                reply.envelope.pending_ack_at = None;
+                reply.envelope.acknowledged_at = None;
+                reply.envelope.acknowledges_message_id = Some(source_id);
+                reply.envelope.parent_message_id = Some(source_id);
+                Ok(reply)
+            }
+        }
+
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let store = backend.message_store();
+        let source_id = AtmMessageId::new();
+        let mut source = message(&format!("atm:{source_id}"), "needs acknowledgement");
+        source.envelope.message_id = Some(source_id);
+        source.envelope.requires_ack = true;
+        source.envelope.pending_ack_at = Some(IsoTimestamp::now());
+        store.save_message(&source).expect("save pending source");
+
+        let committed = store
+            .acknowledge_message_atomically(
+                &AcknowledgementSource {
+                    team: source.team.clone(),
+                    agent: source.agent.clone(),
+                    message_id: source_id,
+                },
+                Arc::new(ReplyBuilder),
+            )
+            .expect("atomic acknowledgement");
+
+        assert!(committed.source.envelope.read);
+        assert!(committed.source.envelope.pending_ack_at.is_none());
+        assert!(committed.source.envelope.acknowledged_at.is_some());
+        assert_eq!(
+            store
+                .load_message(&source.message_key)
+                .expect("load source"),
+            Some(committed.source),
+            "the source transition is durable with the reply"
+        );
+        assert_eq!(
+            store
+                .load_message(&committed.reply.message_key)
+                .expect("load reply"),
+            Some(committed.reply),
+            "the reply derived from the transaction-loaded source is durable"
         );
     }
 

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -296,6 +296,10 @@ impl MessageStore for SqliteMessageStore {
         self.db.submit_upsert_message(message.clone())
     }
 
+    fn save_messages_atomically(&self, messages: &[Message]) -> Result<(), AtmError> {
+        self.db.submit_upsert_messages_atomically(messages.to_vec())
+    }
+
     fn load_message(&self, key: &MessageKey) -> Result<Option<Message>, AtmError> {
         let record = self.db.with_connection(|connection| {
             let loaded = connection
@@ -833,6 +837,34 @@ mod tests {
                 .load_message(&original.message_key)
                 .expect("load after delete")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn sqlite_backend_commits_related_messages_through_one_writer_operation() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let store = backend.message_store();
+        let reply = message("atm:ack-reply", "reply");
+        let mut source = message("atm:ack-source", "source");
+        source.envelope.read = true;
+        source.envelope.pending_ack_at = None;
+        source.envelope.acknowledged_at = Some(IsoTimestamp::now());
+
+        store
+            .save_messages_atomically(&[reply.clone(), source.clone()])
+            .expect("commit acknowledgement reply and source together");
+
+        assert_eq!(
+            store.load_message(&reply.message_key).expect("load reply"),
+            Some(reply),
+            "the immutable acknowledgement reply is durable"
+        );
+        assert_eq!(
+            store
+                .load_message(&source.message_key)
+                .expect("load source"),
+            Some(source),
+            "the acknowledged source state is durable in the same commit"
         );
     }
 

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -4,7 +4,9 @@ use crate::observability::{
     SqliteObservability, SqliteObservabilityEvent, SqliteObservabilityOutcome,
 };
 use crate::writer::{SqliteWriter, WriteOp, WriteOpResult, validate_upsert_message_request};
-use atm_storage::contract::Message;
+use atm_storage::contract::{
+    AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, Message,
+};
 use atm_storage::error::AtmError;
 use atm_storage::schema::ThreadMode;
 #[cfg(test)]
@@ -350,9 +352,11 @@ impl SharedDb {
             .submit(WriteOp::UpsertMessage(Box::new(record)))?;
         match result {
             WriteOpResult::UpsertMessage { .. } => Ok(()),
-            WriteOpResult::UpsertMessages => Err(AtmError::daemon_unavailable(
-                "sqlite writer returned the wrong result for message upsert",
-            )),
+            WriteOpResult::UpsertMessages | WriteOpResult::Acknowledged(_) => {
+                Err(AtmError::daemon_unavailable(
+                    "sqlite writer returned the wrong result for message upsert",
+                ))
+            }
         }
     }
 
@@ -369,9 +373,29 @@ impl SharedDb {
         let result = self.writer.submit(WriteOp::UpsertMessages(records))?;
         match result {
             WriteOpResult::UpsertMessages => Ok(()),
-            WriteOpResult::UpsertMessage { .. } => Err(AtmError::daemon_unavailable(
-                "sqlite writer returned the wrong result for atomic message commit",
-            )),
+            WriteOpResult::UpsertMessage { .. } | WriteOpResult::Acknowledged(_) => {
+                Err(AtmError::daemon_unavailable(
+                    "sqlite writer returned the wrong result for atomic message commit",
+                ))
+            }
+        }
+    }
+
+    pub(crate) fn submit_acknowledgement(
+        &self,
+        source: AcknowledgementSource,
+        builder: std::sync::Arc<dyn AcknowledgementReplyBuilder>,
+    ) -> Result<AcknowledgementCommit, AtmError> {
+        match self
+            .writer
+            .submit(WriteOp::Acknowledge { source, builder })?
+        {
+            WriteOpResult::Acknowledged(commit) => Ok(*commit),
+            WriteOpResult::UpsertMessage { .. } | WriteOpResult::UpsertMessages => {
+                Err(AtmError::daemon_unavailable(
+                    "sqlite writer returned the wrong result for acknowledgement admission",
+                ))
+            }
         }
     }
 

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -350,6 +350,28 @@ impl SharedDb {
             .submit(WriteOp::UpsertMessage(Box::new(record)))?;
         match result {
             WriteOpResult::UpsertMessage { .. } => Ok(()),
+            WriteOpResult::UpsertMessages => Err(AtmError::daemon_unavailable(
+                "sqlite writer returned the wrong result for message upsert",
+            )),
+        }
+    }
+
+    pub(crate) fn submit_upsert_messages_atomically(
+        &self,
+        records: Vec<Message>,
+    ) -> Result<(), AtmError> {
+        if records.is_empty() {
+            return Ok(());
+        }
+        for record in &records {
+            validate_upsert_message_request(record)?;
+        }
+        let result = self.writer.submit(WriteOp::UpsertMessages(records))?;
+        match result {
+            WriteOpResult::UpsertMessages => Ok(()),
+            WriteOpResult::UpsertMessage { .. } => Err(AtmError::daemon_unavailable(
+                "sqlite writer returned the wrong result for atomic message commit",
+            )),
         }
     }
 

--- a/crates/atm-storage-rusqlite/src/writer/ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/ops.rs
@@ -1,27 +1,48 @@
 use super::stmt_cache::WriterStatementCache;
 use crate::shared_db::{SharedDbTarget, serialize_json, sqlite_thread_mode};
-use atm_storage::contract::Message;
+use atm_storage::contract::{
+    AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, Message, MessageKey,
+};
 use atm_storage::error::AtmError;
 use atm_storage::schema::MessageEnvelope;
 use atm_storage::types::IsoTimestamp;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
+use std::sync::Arc;
 
 pub(crate) const MAX_ENVELOPE_JSON_BYTES: usize = 1_048_576;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) enum WriteOp {
     UpsertMessage(Box<Message>),
     /// A related group of immutable records that must either all become
     /// visible or none do.  AI.31 uses this for the ACK reply and the
     /// acknowledged source record.
     UpsertMessages(Vec<Message>),
+    Acknowledge {
+        source: AcknowledgementSource,
+        builder: Arc<dyn AcknowledgementReplyBuilder>,
+    },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+impl std::fmt::Debug for WriteOp {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UpsertMessage(_) => formatter.write_str("UpsertMessage(..)"),
+            Self::UpsertMessages(_) => formatter.write_str("UpsertMessages(..)"),
+            Self::Acknowledge { source, .. } => formatter
+                .debug_struct("Acknowledge")
+                .field("source", source)
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum WriteOpResult {
     UpsertMessage { inserted: bool },
     UpsertMessages,
+    Acknowledged(Box<AcknowledgementCommit>),
 }
 
 pub(crate) fn execute(
@@ -40,7 +61,138 @@ pub(crate) fn execute(
             }
             Ok(WriteOpResult::UpsertMessages)
         }
+        WriteOp::Acknowledge { source, builder } => {
+            execute_acknowledgement(source, builder, connection, cache, target)
+        }
     }
+}
+
+fn execute_acknowledgement(
+    source: &AcknowledgementSource,
+    builder: &Arc<dyn AcknowledgementReplyBuilder>,
+    connection: &Connection,
+    cache: &mut WriterStatementCache,
+    target: &SharedDbTarget,
+) -> Result<WriteOpResult, AtmError> {
+    let source = load_pending_ack_source(source, connection, target)?;
+    let reply = builder.build_reply(&source)?;
+    let mut acknowledged_source = source.clone();
+    acknowledged_source.envelope.read = true;
+    acknowledged_source.envelope.pending_ack_at = None;
+    acknowledged_source.envelope.acknowledged_at = Some(IsoTimestamp::now());
+    let _ = execute_upsert_message(&reply, connection, cache, target)?;
+    let _ = execute_upsert_message(&acknowledged_source, connection, cache, target)?;
+    Ok(WriteOpResult::Acknowledged(Box::new(
+        AcknowledgementCommit {
+            reply,
+            source: acknowledged_source,
+        },
+    )))
+}
+
+fn load_pending_ack_source(
+    source: &AcknowledgementSource,
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<Message, AtmError> {
+    let row = connection
+        .query_row(
+            "SELECT mail_messages.message_key, mail_messages.envelope_json,
+                    mail_message_states.read, mail_message_states.pending_ack_at,
+                    mail_message_states.acknowledged_at, mail_message_states.expires_at
+             FROM mail_messages
+             JOIN mail_message_states
+               ON mail_message_states.team = mail_messages.team
+              AND mail_message_states.agent = mail_messages.agent
+              AND mail_message_states.message_key = mail_messages.message_key
+             WHERE mail_messages.team = ?1
+               AND mail_messages.agent = ?2
+               AND mail_messages.message_id = ?3
+               AND mail_message_states.deleted_at IS NULL",
+            params![
+                source.team.as_str(),
+                source.agent.as_str(),
+                source.message_id.to_string()
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|error| {
+            crate::shared_db::sqlite_error(target, "failed to load acknowledgement source", error)
+        })?
+        .ok_or_else(|| {
+            AtmError::validation(format!(
+                "message {} was not found in {}@{}",
+                source.message_id, source.agent, source.team
+            ))
+        })?;
+    let (message_key, envelope_json, read, pending_ack_at, acknowledged_at, expires_at) = row;
+    let has_successor = connection
+        .query_row(
+            "SELECT 1 FROM mail_messages
+             WHERE team = ?1 AND agent = ?2 AND parent_message_id = ?3
+             LIMIT 1",
+            params![
+                source.team.as_str(),
+                source.agent.as_str(),
+                source.message_id.to_string()
+            ],
+            |_| Ok(()),
+        )
+        .optional()
+        .map_err(|error| {
+            crate::shared_db::sqlite_error(
+                target,
+                "failed to validate acknowledgement terminal source",
+                error,
+            )
+        })?
+        .is_some();
+    if has_successor {
+        return Err(AtmError::validation(format!(
+            "message {} has been updated; acknowledge the current terminal message instead",
+            source.message_id
+        )));
+    }
+    let mut envelope = serde_json::from_str::<atm_storage::schema::MessageEnvelope>(&envelope_json)
+        .map_err(|_| AtmError::mailbox_read("failed to decode acknowledgement source envelope"))?;
+    envelope.read = read != 0;
+    envelope.pending_ack_at = parse_timestamp(pending_ack_at, "pending_ack_at")?;
+    envelope.acknowledged_at = parse_timestamp(acknowledged_at, "acknowledged_at")?;
+    envelope.expires_at = parse_timestamp(expires_at, "expires_at")?;
+    if envelope.pending_ack_at.is_none() {
+        let state = if envelope.acknowledged_at.is_some() {
+            "already acknowledged"
+        } else {
+            "not pending acknowledgement"
+        };
+        return Err(AtmError::validation(format!(
+            "message {} is {state}",
+            source.message_id
+        )));
+    }
+    Ok(Message {
+        team: source.team.clone(),
+        agent: source.agent.clone(),
+        message_key: MessageKey::new(message_key)?,
+        envelope,
+    })
+}
+
+fn parse_timestamp(value: Option<String>, field: &str) -> Result<Option<IsoTimestamp>, AtmError> {
+    value
+        .map(|value| value.parse::<IsoTimestamp>())
+        .transpose()
+        .map_err(|_| AtmError::mailbox_read(format!("acknowledgement source {field} is invalid")))
 }
 
 pub(crate) fn validate_upsert_message_request(record: &Message) -> Result<(), AtmError> {

--- a/crates/atm-storage-rusqlite/src/writer/ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/ops.rs
@@ -95,7 +95,26 @@ fn load_pending_ack_source(
     connection: &Connection,
     target: &SharedDbTarget,
 ) -> Result<Message, AtmError> {
-    let row = connection
+    let row = load_acknowledgement_source_row(source, connection, target)?;
+    reject_acknowledgement_source_with_successor(source, connection, target)?;
+    decode_pending_acknowledgement_source(source, row)
+}
+
+type AcknowledgementSourceRow = (
+    String,
+    String,
+    i64,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+fn load_acknowledgement_source_row(
+    source: &AcknowledgementSource,
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<AcknowledgementSourceRow, AtmError> {
+    connection
         .query_row(
             "SELECT mail_messages.message_key, mail_messages.envelope_json,
                     mail_message_states.read, mail_message_states.pending_ack_at,
@@ -134,8 +153,14 @@ fn load_pending_ack_source(
                 "message {} was not found in {}@{}",
                 source.message_id, source.agent, source.team
             ))
-        })?;
-    let (message_key, envelope_json, read, pending_ack_at, acknowledged_at, expires_at) = row;
+        })
+}
+
+fn reject_acknowledgement_source_with_successor(
+    source: &AcknowledgementSource,
+    connection: &Connection,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
     let has_successor = connection
         .query_row(
             "SELECT 1 FROM mail_messages
@@ -163,6 +188,14 @@ fn load_pending_ack_source(
             source.message_id
         )));
     }
+    Ok(())
+}
+
+fn decode_pending_acknowledgement_source(
+    source: &AcknowledgementSource,
+    row: AcknowledgementSourceRow,
+) -> Result<Message, AtmError> {
+    let (message_key, envelope_json, read, pending_ack_at, acknowledged_at, expires_at) = row;
     let mut envelope = serde_json::from_str::<atm_storage::schema::MessageEnvelope>(&envelope_json)
         .map_err(|_| AtmError::mailbox_read("failed to decode acknowledgement source envelope"))?;
     envelope.read = read != 0;

--- a/crates/atm-storage-rusqlite/src/writer/ops.rs
+++ b/crates/atm-storage-rusqlite/src/writer/ops.rs
@@ -12,11 +12,16 @@ pub(crate) const MAX_ENVELOPE_JSON_BYTES: usize = 1_048_576;
 #[derive(Debug, Clone)]
 pub(crate) enum WriteOp {
     UpsertMessage(Box<Message>),
+    /// A related group of immutable records that must either all become
+    /// visible or none do.  AI.31 uses this for the ACK reply and the
+    /// acknowledged source record.
+    UpsertMessages(Vec<Message>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum WriteOpResult {
     UpsertMessage { inserted: bool },
+    UpsertMessages,
 }
 
 pub(crate) fn execute(
@@ -28,6 +33,12 @@ pub(crate) fn execute(
     match op {
         WriteOp::UpsertMessage(request) => {
             execute_upsert_message(request, connection, cache, target)
+        }
+        WriteOp::UpsertMessages(records) => {
+            for record in records {
+                let _ = execute_upsert_message(record, connection, cache, target)?;
+            }
+            Ok(WriteOpResult::UpsertMessages)
         }
     }
 }

--- a/crates/atm-storage-sqlserver-proof/Cargo.toml
+++ b/crates/atm-storage-sqlserver-proof/Cargo.toml
@@ -14,4 +14,4 @@ publish = false
 name = "atm_storage_sqlserver_proof"
 
 [dependencies]
-atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai" }
+atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai.31" }

--- a/crates/atm-storage-sqlserver-proof/src/lib.rs
+++ b/crates/atm-storage-sqlserver-proof/src/lib.rs
@@ -33,6 +33,12 @@ impl MessageStore for SqlServerMessageStore {
         Err(compile_only_error("SqlServerMessageStore::save_message"))
     }
 
+    fn save_messages_atomically(&self, _messages: &[Message]) -> Result<(), AtmError> {
+        Err(compile_only_error(
+            "SqlServerMessageStore::save_messages_atomically",
+        ))
+    }
+
     fn load_message(&self, _key: &MessageKey) -> Result<Option<Message>, AtmError> {
         Err(compile_only_error("SqlServerMessageStore::load_message"))
     }

--- a/crates/atm-storage/Cargo.toml
+++ b/crates/atm-storage/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 description = "Shared audited storage contract and canonical domain types for ATM."
 
 [dependencies]
-atm-error = { path = "../atm-error", version = "1.4.0-beta-ai" }
+atm-error = { path = "../atm-error", version = "1.4.0-beta-ai.31" }
 serde.workspace = true
 serde_json.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::num::NonZeroU16;
 use std::ops::Deref;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::error::AtmError;
@@ -450,6 +451,30 @@ pub struct MessageReceivedEvent {
     pub timestamp: IsoTimestamp,
 }
 
+/// Identifies the pending source record that an acknowledgement admission
+/// must resolve inside the writer transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcknowledgementSource {
+    pub team: TeamName,
+    pub agent: AgentName,
+    pub message_id: AtmMessageId,
+}
+
+/// Builds the immutable acknowledgement reply after the writer has loaded the
+/// pending source record, but before that transaction commits.  The callback
+/// deliberately receives no storage handle: it may derive the reply from the
+/// source but cannot perform a second application-layer source read.
+pub trait AcknowledgementReplyBuilder: Send + Sync {
+    fn build_reply(&self, source: &Message) -> Result<Message, AtmError>;
+}
+
+/// The records made durable by one acknowledgement admission transaction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AcknowledgementCommit {
+    pub reply: Message,
+    pub source: Message,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RosterChangedEvent {
     pub team: TeamName,
@@ -464,6 +489,19 @@ pub trait MessageStore: sealed::Sealed + Send + Sync {
     /// AI.31 uses this for an acknowledgement reply plus the acknowledged
     /// source record; adapters must not expose a partially committed pair.
     fn save_messages_atomically(&self, messages: &[Message]) -> Result<(), AtmError>;
+    /// Resolves a pending source, builds its immutable reply, and transitions
+    /// the source in one writer transaction.  The default preserves backward
+    /// compatibility for narrow test doubles; production stores must override
+    /// it rather than compose a read plus `save_messages_atomically`.
+    fn acknowledge_message_atomically(
+        &self,
+        _source: &AcknowledgementSource,
+        _builder: Arc<dyn AcknowledgementReplyBuilder>,
+    ) -> Result<AcknowledgementCommit, AtmError> {
+        Err(AtmError::daemon_unavailable(
+            "message store does not implement atomic acknowledgement admission",
+        ))
+    }
     fn load_message(&self, key: &MessageKey) -> Result<Option<Message>, AtmError>;
     fn list_messages(&self, query: &MessageQuery) -> Result<Vec<Message>, AtmError>;
     fn delete_message(&self, key: &MessageKey) -> Result<(), AtmError>;

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -457,6 +457,11 @@ pub struct RosterChangedEvent {
 
 pub trait MessageStore: sealed::Sealed + Send + Sync {
     fn save_message(&self, message: &Message) -> Result<(), AtmError>;
+    /// Commits related immutable mailbox records as one durable unit.
+    ///
+    /// AI.31 uses this for an acknowledgement reply plus the acknowledged
+    /// source record; adapters must not expose a partially committed pair.
+    fn save_messages_atomically(&self, messages: &[Message]) -> Result<(), AtmError>;
     fn load_message(&self, key: &MessageKey) -> Result<Option<Message>, AtmError>;
     fn list_messages(&self, query: &MessageQuery) -> Result<Vec<Message>, AtmError>;
     fn delete_message(&self, key: &MessageKey) -> Result<(), AtmError>;
@@ -751,6 +756,10 @@ mod tests {
 
     impl MessageStore for DummyStore {
         fn save_message(&self, _message: &Message) -> Result<(), AtmError> {
+            Ok(())
+        }
+
+        fn save_messages_atomically(&self, _messages: &[Message]) -> Result<(), AtmError> {
             Ok(())
         }
 

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -33,10 +33,10 @@ path = "examples/gen_cli_docs.rs"
 required-features = ["cli-surface-dump"]
 
 [dependencies]
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai" }
-atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.0-beta-ai" }
-atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.0-beta-ai" }
-atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai" }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31" }
+atm-daemon-bootstrap = { path = "../atm-daemon-bootstrap", version = "1.4.0-beta-ai.31" }
+atm-daemon-client = { path = "../atm-daemon-client", version = "1.4.0-beta-ai.31" }
+atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai.31" }
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -50,8 +50,8 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
-atm-graft = { path = "../atm-graft", version = "1.4.0-beta-ai", features = ["test-support"] }
-atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai", features = ["test-utils"] }
+atm-graft = { path = "../atm-graft", version = "1.4.0-beta-ai.31", features = ["test-support"] }
+atm-core = { package = "agent-team-mail-core", path = "../atm-core", version = "1.4.0-beta-ai.31", features = ["test-utils"] }
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 sc-observability = { workspace = true, features = ["fault-injection"] }
 serial_test = "3"

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -76,6 +76,9 @@ struct UpdateMemberCommand {
     #[arg(long)]
     home_dir: Option<PathBuf>,
 
+    #[arg(long = "workspace-root")]
+    workspace_root: Option<PathBuf>,
+
     #[arg(long)]
     harness: Option<String>,
 
@@ -319,6 +322,7 @@ impl UpdateMemberCommand {
             &self.team,
             &self.member,
             self.home_dir,
+            self.workspace_root,
             self.harness,
             self.agent_type,
             self.model,
@@ -421,6 +425,7 @@ mod tests {
                 team: TEST_TEAM.to_string(),
                 member: TEST_SENDER.to_string(),
                 home_dir: Some(home_dir),
+                workspace_root: None,
                 harness: Some("codex-cli".to_string()),
                 agent_type: Some("worker".to_string()),
                 model: Some("gpt-5".to_string()),
@@ -722,6 +727,7 @@ mod tests {
             team: TEST_TEAM.to_string(),
             member: TEST_SENDER.to_string(),
             home_dir: Some(member_home_dir.clone()),
+            workspace_root: None,
             harness: Some("codex-cli".to_string()),
             agent_type: Some("worker".to_string()),
             model: Some("gpt-5".to_string()),

--- a/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
+++ b/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
@@ -5,16 +5,21 @@
 | ID | ADR-041 |
 | Status | Proposed |
 | Scope | Repository-wide |
-| Relates to | ADR-032, ADR-034, ADR-035, Phase AI.26–AI.27 |
+| Relates to | ADR-032, ADR-034, ADR-035, Phase AI.26–AI.31 |
 
 ## Decision
 
 Every daemon request owns one absolute `RequestDeadline` for local admission.
-The SQLite transaction that persists the immutable origin record is the only
-synchronous operation before the local response. Background delivery has one
-separate absolute 10-second worker budget: signalling, peer DNS, connection, TLS, and
-remote receipt cannot delay or be cancelled by the completed local response.
-The immutable origin record is the worker's only durable input.
+The SQLite admission transaction is the sole synchronous post-validation
+operation before the local response. For an acknowledgement it inserts the
+immutable reply and conditionally transitions its source in that same
+transaction. A daemon-owned, reloadable in-memory admission view supplies
+only already-loaded routing data; the response path never reads a caller
+workspace, post-send hook configuration, peer policy, or outbound page.
+Background delivery and local nudge work use identifier-only non-durable
+signals with separate worker budgets. DNS, connection, TLS, hook/graft I/O,
+and remote receipt cannot delay or be cancelled by the completed local
+response. The immutable origin record is the worker's only durable input.
 
 For a remote write, local persistence is not delivery success. The only
 successful remote result is a verified HTTP response from the peer after its

--- a/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
+++ b/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | ID | ADR-041 |
-| Status | Proposed |
+| Status | Accepted |
 | Scope | Repository-wide |
 | Relates to | ADR-032, ADR-034, ADR-035, Phase AI.26–AI.31 |
 

--- a/docs/atm-graft/hermes-agent-use-case.md
+++ b/docs/atm-graft/hermes-agent-use-case.md
@@ -47,6 +47,20 @@ Hermes event loop. Duplicate message IDs are suppressed by the bridge. The
 body is then handled by Hermes's ordinary inbound-user-message path, so no
 manual `atm read` turn is required.
 
+For messages that require an explicit ATM acknowledgement, pass the optional
+`requires_ack` argument and acknowledge the returned message after reading it:
+
+```python
+sender_session.send(receiver, "please confirm", requires_ack=True)
+message = next(
+    message for message in receiver_session.read() if message.body == "please confirm"
+)
+receiver_session.acknowledge(message.message_id, "confirmed")
+```
+
+The default remains `False`, so existing `send(to, body)` callers retain the
+non-acknowledgement semantics.
+
 ## Required setup
 
 The gateway environment supplies:

--- a/docs/atm-graft/hermes-agent-use-case.md
+++ b/docs/atm-graft/hermes-agent-use-case.md
@@ -56,6 +56,20 @@ The gateway environment supplies:
 - `ATM_HOME` — the ATM home/workspace root; and
 - the Hermes-side chat ID, such as the Telegram chat ID.
 
+The ATM roster must also identify the workspace root where the gateway's graft
+endpoint is published. If the gateway profile's `ATM_HOME` differs from its
+workspace, set the durable roster metadata explicitly:
+
+```sh
+ATM_TEAM=hermes ATM_IDENTITY=hendrix \
+  atm teams update-member hermes skillrx \
+  --workspace-root /path/to/skillrx/workspace
+```
+
+The daemon uses this `workspace_root` metadata (falling back to `home_dir` for
+older roster rows), so it resolves the same endpoint path that the Python
+publisher writes.
+
 The workspace must contain a discovered `.atm.toml`. Graft activation is
 configuration-gated: without that file the session remains `inactive`, even
 though graft is enabled by default. A minimal configuration is enough:

--- a/docs/atm/cli-reference-1-4-0-beta-ai.md
+++ b/docs/atm/cli-reference-1-4-0-beta-ai.md
@@ -438,11 +438,11 @@ List teams or run one team-administration subcommand
 | `<team>` |  | yes |  |
 | `<member>` |  | yes |  |
 | `--home-dir` |  | no |  |
+| `--workspace-root` |  | no | Canonical workspace root used for graft receiver endpoint resolution |
 | `--harness` |  | no |  |
 | `--agent-type` |  | no |  |
 | `--model` |  | no |  |
 | `--pane-id` |  | no | tmux pane id in '%<number>' form or a bare numeric pane id |
 | `--json` |  | no |  |
 | `--stderr-logs` |  | no | Route retained observability console logs to stderr |
-
 

--- a/docs/atm/commands/teams.md
+++ b/docs/atm/commands/teams.md
@@ -14,9 +14,9 @@ CLI note:
 - `teams add-member --pane-id` accepts tmux pane ids in `%<number>` form or a
   bare numeric pane id that ATM canonicalizes to `%<number>`
 - `teams update-member` is the accepted repair path for existing member
-  metadata such as durable `home_dir`, harness, model, agent type, and tmux
-  `--pane-id`; manual `config.json` edits are no longer the supported pane or
-  home-dir repair workflow
+  metadata such as durable `home_dir`, the graft `--workspace-root`, harness,
+  model, agent type, and tmux `--pane-id`; manual `config.json` edits are no
+  longer the supported pane, home-dir, or graft endpoint repair workflow
 
 References:
 

--- a/docs/plans/phase-ai/hermes-graft-runbook.md
+++ b/docs/plans/phase-ai/hermes-graft-runbook.md
@@ -45,6 +45,33 @@ minimal workspace configuration is sufficient:
 To disable graft explicitly, use `[atm.graft] enabled = false`; otherwise the
 presence of `[atm]` keeps the default enabled behavior.
 
+## Reconcile the graft workspace root
+
+The bridge publishes its receiver record under the workspace root passed to
+`PyGraftSessionOptions`, while the daemon resolves that location from the
+recipient's durable roster metadata. After a profile is first registered, or
+whenever its checkout/worktree moves, update the roster before restarting the
+bridge:
+
+```sh
+ATM_TEAM=hermes ATM_IDENTITY=hendrix \
+  atm teams update-member hermes skillrx \
+  --workspace-root /path/to/skillrx/workspace
+```
+
+Run this repair for every profile whose live graft session uses a different
+workspace root than its stored `home_dir`; repeat it after a worktree move,
+profile migration, or launch-registry change. Verify the durable value with
+`atm members --json` and confirm the member's `extra.workspace_root` matches the
+path supplied to `PyGraftSessionOptions`. The daemon logs the selected root
+source (`workspace_root` or the compatibility `home_dir` fallback) at debug
+level, making stale metadata visible without guessing which branch resolved.
+
+Automatic roster mutation during graft activation is intentionally not used:
+the graft library does not own team-admin storage or operator authorization.
+The explicit update keeps that boundary auditable and prevents a bridge from
+silently changing durable team configuration.
+
 ## Install and status
 
 For a rendered profile `example`:

--- a/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
+++ b/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
@@ -1,9 +1,10 @@
 ---
 title: AI.31 asynchronous durable local admission
-status: proposed
+status: complete
 branch: feature/pAI-s31-async-local-admission
 target: integrate/phase-AI
 depends_on: AI.23, AI.27, AI.28
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/ai31-async-local-admission
 ---
 
 # AI.31 — asynchronous durable local admission

--- a/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
+++ b/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
@@ -55,10 +55,10 @@ smaller request path, not a more patient client.
    one `write_persisted` event, one non-blocking work signal, and the existing
    `SendResponseEnvelope::{Sent,Acknowledged}` response. Do not add a
    remote-success response variant.
-   `crates/atm-daemon/src/runtime_health.rs` constructs one immutable
-   `AdmissionRuntimeView` from existing configuration/roster/trust data; the
-   existing runtime-reload path atomically swaps that view. The view is a
-   lookup cache, not another persistence store or delivery state machine.
+   `crates/atm-daemon/src/runtime_health.rs` is the sole production
+   construction and reload-swap site for the immutable `AdmissionRuntimeView`;
+   it builds the view from existing configuration/roster/trust data. The view
+   is a lookup cache, not another persistence store or delivery state machine.
 3. Replace the foreground coordinator trait method with a signal-only seam in
    `crates/atm-daemon/src/peer_drain_coordinator.rs`:
 

--- a/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
+++ b/docs/plans/phase-ai/sprint-ai-31-async-local-admission.md
@@ -55,7 +55,7 @@ smaller request path, not a more patient client.
    one `write_persisted` event, one non-blocking work signal, and the existing
    `SendResponseEnvelope::{Sent,Acknowledged}` response. Do not add a
    remote-success response variant.
-   `crates/atm-daemon/src/composition.rs` constructs one immutable
+   `crates/atm-daemon/src/runtime_health.rs` constructs one immutable
    `AdmissionRuntimeView` from existing configuration/roster/trust data; the
    existing runtime-reload path atomically swaps that view. The view is a
    lookup cache, not another persistence store or delivery state machine.
@@ -139,7 +139,7 @@ smaller request path, not a more patient client.
 
 ## Implementation map
 
-- `crates/atm-daemon/src/composition.rs`: construct/swap the immutable
+- `crates/atm-daemon/src/runtime_health.rs`: construct/swap the immutable
   admission runtime view and one post-commit queue.
 - `crates/atm-daemon/src/runtime_health.rs`: use that view and return the
   admission response immediately after the transaction and work signal.

--- a/docs/plans/phase-ai/sprint-ai-34-hermes-graft-nudge-endpoint-reconciliation.md
+++ b/docs/plans/phase-ai/sprint-ai-34-hermes-graft-nudge-endpoint-reconciliation.md
@@ -1,0 +1,58 @@
+---
+title: AI.34 Hermes graft nudge-endpoint reconciliation
+status: in_progress
+branch: fix/hermes-nudge-endpoint-mismatch
+target: integrate/phase-AI
+depends_on: AI.31, AI.32
+requires_merged_pr: PR #678 (RosterHarness::Hermes/PythonGraft, merged to develop @ cf8511ae)
+---
+
+# AI.34 — Hermes graft nudge-endpoint reconciliation
+
+## Closure
+
+Live Hermes nudge delivery to a Python-graft roster member (skillrx) succeeds
+end-to-end on a release-built ATM daemon: the publisher-written endpoint
+record and the daemon's runtime_health resolver agree on a single canonical
+path for any roster member whose `workspace_root` diverges from its
+`home_dir`.
+
+## Background
+
+Found by quality-mgr's HERMES-SMOKE-QA-1 live-evidence follow-up (Cipher-311d),
+on `develop @ cf8511ae` (post-merge of PR #678). Nudge delivery times out:
+the Python graft publisher writes its endpoint file under
+`{workspace_root}/.atm/graft/{team}/{agent}.json`
+(`crates/atm-graft/src/lib.rs:339-343`, via
+`graft_receiver_record_path_from_home(options.workspace_root())`), but
+`atm-daemon`'s runtime_health resolver looks under the roster member's
+metadata `home_dir` instead
+(`crates/atm-daemon/src/runtime_health.rs:101-111`, via
+`canonical_home_dir(&member.metadata_json)` in
+`crates/atm-core/src/schema/agent_member.rs:45-47`).
+`workspace_root` and `roster.home_dir` diverge for skillrx, so the daemon
+never finds the endpoint file the publisher wrote.
+
+Triage record: `.triage/phase-AI/findings/AI-HERMES-NUDGE-ENDPOINT-MISMATCH.ttl`
+(severity: blocking).
+
+## Required fixes
+
+1. Reconcile the publisher-side and daemon-resolver-side root paths so they
+   always converge on the same endpoint file location. Per the triage
+   record's closure note, pick one of: (a) both sides use `workspace_root`,
+   (b) both sides use `home_dir`, or (c) introduce a single canonical
+   resolver function both call.
+2. Prefer option (c) if it doesn't expand scope unreasonably — a canonical
+   resolver structurally prevents this class of divergence from recurring.
+3. Add a regression test: publisher writes an endpoint record, daemon
+   resolver looks it up, assert they resolve to the identical path for a
+   roster member whose `workspace_root` differs from `home_dir`.
+
+## Required validation
+
+- Live nudge smoke against skillrx@hermes succeeds (Cipher-311d's pre-fix
+  baseline: message `01KYKGBRMPHDM1WS2Z1R8DYTQT`, AI32 build `746c69ee` —
+  constructors/options/activation/snapshot/duplicate-activation/send
+  persistence already pass; nudge callback is the only remaining failure).
+- `just lint`, `just test` pass.

--- a/docs/plans/phase-ai/sprint-ai-35-graft-root-fallback-observability.md
+++ b/docs/plans/phase-ai/sprint-ai-35-graft-root-fallback-observability.md
@@ -1,0 +1,76 @@
+---
+title: AI.35 graft-root fallback observability
+status: in_progress
+branch: feature/pAI-s35-graft-root-fallback-observability
+target: integrate/phase-AI
+depends_on: AI.34
+requires_merged_pr: PR #681 (Hermes graft nudge-endpoint reconciliation)
+---
+
+# AI.35 — graft-root fallback observability
+
+## Closure
+
+`canonical_graft_root()` and the deprecated `compatible_home_dir()` no longer
+silently pick between `workspace_root`/`home_dir`/`legacy_cwd` with zero
+observability. Whichever branch fires is logged, and the operational gap that
+lets `workspace_root` drift out of sync with a live graft session's actual
+root is either closed or explicitly documented as an accepted manual step.
+
+## Background
+
+Found by quality-mgr's AI34-QA-1 review as `RBQA-F002-AI34` (Important,
+non-gating on PR #681):
+
+`canonical_graft_root()` (`crates/atm-core/src/schema/agent_member.rs:53-56`)
+silently falls back from roster `workspace_root` to `home_dir` (via
+`canonical_home_dir()`) with no logging distinguishing which branch fired.
+`workspace_root` is populated only via a manual operator step
+(`atm team update-member --workspace-root`,
+`crates/atm-core/src/team_admin/member_mutation.rs:384-389`) with no
+automatic reconciliation to the value an atm-graft session actually runs
+with. `docs/plans/phase-ai/hermes-graft-runbook.md` has zero references to
+`update-member`/`workspace-root`, so there's no documented operational step
+keeping the two in sync.
+
+This is the same "two modules independently answer the same architectural
+question" pattern that caused the original AI.34 bug, just pushed from code
+to config, with a silent compatibility fallback and no mechanical lint guard.
+The deprecated `compatible_home_dir()` (line 62-65) exhibits the identical
+silent-fallback pattern (`home_dir` → `legacy_cwd`), even though marked
+deprecated.
+
+Triage record: `.triage/phase-AI/findings/RBQA-F002-AI34.ttl` (severity:
+important, repeatable: true, sweepScope: workspace).
+
+## Required fixes
+
+1. Add observability (structured log at minimum) to `canonical_graft_root()`
+   distinguishing which source resolved (`workspace_root` vs `home_dir`
+   fallback), so a future endpoint mismatch is diagnosable without re-running
+   this investigation from scratch.
+2. Do the same for `compatible_home_dir()`'s `home_dir` → `legacy_cwd`
+   fallback, or confirm it's unreachable in practice and remove it if so
+   (it's already marked deprecated).
+3. Document the `update-member --workspace-root` operational step in
+   `docs/plans/phase-ai/hermes-graft-runbook.md`, including when it must be
+   re-run to keep the roster's `workspace_root` in sync with a live graft
+   session's actual root.
+4. Judgement call, confirm before large scope: if reconciling `workspace_root`
+   automatically (rather than just documenting the manual step) is small,
+   prefer it — it structurally prevents the class of drift that caused
+   AI.34's original bug. If it's a bigger lift, document-only is acceptable
+   for this sprint; file a follow-up finding instead of expanding scope here.
+
+## Required validation
+
+- A test proves `canonical_graft_root()`'s log output correctly identifies
+  which source resolved for both the `workspace_root`-present and
+  `workspace_root`-absent cases.
+- `just lint`, `just test` pass.
+
+## Non-goals
+
+`RBQA-F001-AI34` (CLI's `GraftNudgeSink::deliver` vs the daemon's canonical
+resolver — reviewer disagreement on dead-code reachability) is a separate
+finding routed to arch-ctm, not part of this sprint.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -948,7 +948,7 @@ Acceptance:
   - branch: `chore/docs-restructure`
   - authoritative source: `docs/adr/INDEX.md`
 
-## 40. Phase AI — HTTP daemon and minimal cross-host transport [ACTIVE — implementation through AI.30; readiness blocked]
+## 40. Phase AI — HTTP daemon and minimal cross-host transport [ACTIVE — implementation through AI.31; readiness blocked]
 
 Planning branch: `plan/phase-ai-planning`
 Integration branch: `integrate/phase-AI`
@@ -1007,6 +1007,7 @@ Implementation Branches:
 | `AI.28` | `complete` | `feature/pAI-s28-bounded-peer-recovery` | bounded recovery after connectivity loss |
 | `AI.29` | `complete` | `feature/pAI-s29-crosshost-smoke-rerun` | receiver-proven physical smoke implementation; live evidence remains blocked |
 | `AI.30` | `complete` | `feature/pAI-s30-semver-http-compatibility` | schema/HTTP compatibility admission and SemVer prerelease distribution |
+| `AI.31` | `complete` | `feature/pAI-s31-async-local-admission` | durable local admission before asynchronous peer work |
 
 Authoritative plan: [Phase AI plan](./plans/phase-ai/plan-phase-ai.md).
 

--- a/scripts/smoke/smoke_common.py
+++ b/scripts/smoke/smoke_common.py
@@ -6,7 +6,12 @@ import re
 import subprocess
 from typing import Any
 
-MAX_CAPTURE = 8192
+# Smoke control responses (notably `atm doctor --json`) include a full roster
+# and can legitimately exceed 8 KiB.  Truncating a JSON response before its
+# caller parses it converted a healthy daemon into a false smoke failure.
+# Keep one bounded-but-complete control-plane response instead; callers still
+# redact it before persisting evidence.
+MAX_CAPTURE = 1_048_576
 SECRET = re.compile(r"(?i)(-----BEGIN[^-]+-----|(?:token|secret|password|capability|private[_-]?key)\s*[=:]\s*[^\s,]+)")
 
 

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -85,6 +85,13 @@ class FeatureSmokeTests(unittest.TestCase):
         self.assertNotIn("must-not-appear", result["stdout"])
         self.assertNotIn("must-not-appear", result["stderr"])
 
+    def test_command_preserves_a_large_doctor_json_response_for_parsing(self):
+        payload = __import__("json").dumps({"roster": "x" * 9_000})
+        completed = mock.Mock(returncode=0, stdout=payload, stderr="")
+        with mock.patch("smoke_common.subprocess.run", return_value=completed):
+            result = RUNNER.command(["atm", "doctor", "--json"])
+        self.assertEqual(RUNNER.parse_json(result, "doctor")["roster"], "x" * 9_000)
+
     def test_remote_hosts_are_rejected_for_localhost_feature(self):
         with mock.patch.object(RUNNER.sys, "argv", ["smoke", "localhost", "m5"]):
             with self.assertRaisesRegex(RUNNER.SmokeError, "only valid"):


### PR DESCRIPTION
Implements AI.31 per docs/plans/phase-ai/sprint-ai-31-async-local-admission.md — a host-qualified atm send/ack returns after its immutable SQLite admission transaction commits, never waiting on peer DNS/TLS/HTTP/handler/receipt/nudge.

Key changes:
- Signal-only peer admission (PeerDeliveryCoordinator::signal_after_persist / PostCommitWorkQueue)
- ACK reply + source state committed through one sealed SQLite writer transaction
- Post-commit peer failures excluded from the local admission response
- Precise peer_delivery_confirmed/unconfirmed worker events (AI.27 semantics preserved)
- Daemon boundary TOML + boundary_enforcement.rs extended to reject direct transport/DNS/socket/TLS/hooks/nudge from admission path
- Real local IPC integration test: host-qualified send returns before a deliberately-blocked peer transport is released

Final gates: just lint (22/22), just test, branch-daemon just smoke localhost (10/10). CLI/daemon matched at 1.4.0-beta-ai.31.

Non-goals (AI.32/AI.33): worker concurrency, delivery order, capacity, cross-host evidence.