### PR TITLE
docs: document Hermes atm-graft client use case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "atm-graft-python"
-version = "1.4.0-beta-ai"
+version = "1.4.0"
 dependencies = [
  "agent-team-mail-core",
  "atm-graft",

--- a/crates/atm-core/src/boundary/store.rs
+++ b/crates/atm-core/src/boundary/store.rs
@@ -119,6 +119,8 @@ fn roster_harness_from_metadata(value: &str) -> Option<RosterHarness> {
         "codex-cli" => Some(RosterHarness::CodexCli),
         "gemini-cli" => Some(RosterHarness::GeminiCli),
         "opencode" => Some(RosterHarness::Opencode),
+        "hermes" => Some(RosterHarness::Hermes),
+        "python-graft" => Some(RosterHarness::PythonGraft),
         _ => None,
     }
 }

--- a/crates/atm-core/src/delivery_policy.rs
+++ b/crates/atm-core/src/delivery_policy.rs
@@ -41,9 +41,11 @@ impl DeliveryHarnessPath {
     pub(crate) fn from_roster_harness(harness: RosterHarness) -> Self {
         match harness {
             RosterHarness::ClaudeCode => Self::ClaudeCode,
-            RosterHarness::CodexCli | RosterHarness::GeminiCli | RosterHarness::Opencode => {
-                Self::NonClaude
-            }
+            RosterHarness::CodexCli
+            | RosterHarness::GeminiCli
+            | RosterHarness::Opencode
+            | RosterHarness::Hermes
+            | RosterHarness::PythonGraft => Self::NonClaude,
         }
     }
 }
@@ -81,7 +83,11 @@ impl DeliveryRecipientSnapshot {
                 == Some("tmux");
         let graft_post_send = matches!(
             member.harness,
-            RosterHarness::CodexCli | RosterHarness::GeminiCli | RosterHarness::Opencode
+            RosterHarness::CodexCli
+                | RosterHarness::GeminiCli
+                | RosterHarness::Opencode
+                | RosterHarness::Hermes
+                | RosterHarness::PythonGraft
         ) && !local_tmux_post_send;
         Self {
             agent: member.agent_name,
@@ -627,7 +633,12 @@ mod tests {
     use crate::schema::ThreadMode;
     use crate::service_runtime::RetainedServiceRuntime;
     use crate::types::{AgentName, IsoTimestamp, TeamName};
-    use crate::{boundary::RosterEntry, config::AtmConfig};
+    use crate::{
+        boundary::{RosterEntry, RosterHarness, RosterMemberKind},
+        config::AtmConfig,
+    };
+    use atm_storage::contract::AgentType;
+    use serde_json::Map;
     use std::path::{Path, PathBuf};
 
     struct MissingRosterRuntime;
@@ -735,6 +746,25 @@ mod tests {
                 "delivery_policy.new_message.delivered",
             ]
         );
+    }
+
+    #[test]
+    fn python_graft_harnesses_use_graft_delivery_without_tmux() {
+        for harness in [RosterHarness::Hermes, RosterHarness::PythonGraft] {
+            let entry = RosterEntry {
+                team_name: "team-a".parse().expect("team"),
+                agent_name: "python-agent".parse().expect("agent"),
+                member_kind: RosterMemberKind::Permanent,
+                harness,
+                agent_type: AgentType::Worker,
+                model: crate::types::ModelName::default(),
+                recipient_pane_id: None,
+                metadata_json: Map::new(),
+            };
+            let snapshot = DeliveryRecipientSnapshot::from_roster(entry);
+            assert_eq!(snapshot.harness, DeliveryHarnessPath::NonClaude);
+            assert!(snapshot.graft_post_send);
+        }
     }
 
     #[test]

--- a/crates/atm-core/src/team_admin/member_mutation.rs
+++ b/crates/atm-core/src/team_admin/member_mutation.rs
@@ -418,8 +418,11 @@ fn parse_roster_harness(value: String) -> Result<RosterHarness, AtmError> {
         "codex-cli" => Ok(RosterHarness::CodexCli),
         "gemini-cli" => Ok(RosterHarness::GeminiCli),
         "opencode" => Ok(RosterHarness::Opencode),
+        "hermes" => Ok(RosterHarness::Hermes),
+        "python-graft" => Ok(RosterHarness::PythonGraft),
         _ => Err(AtmError::validation(
-            "harness must be one of: claude-code, codex-cli, gemini-cli, opencode".to_string(),
+            "harness must be one of: claude-code, codex-cli, gemini-cli, opencode, hermes, python-graft"
+                .to_string(),
         )),
     }
 }

--- a/crates/atm-graft-python/Cargo.toml
+++ b/crates/atm-graft-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm-graft-python"
-version.workspace = true
+version = "1.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/atm-graft-python/pyproject.toml
+++ b/crates/atm-graft-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "atm-graft"
-version = "1.4.0-beta-ai"
+version = "1.4.0"
 requires-python = ">=3.9"
 
 [tool.maturin]

--- a/crates/atm-storage-rusqlite/src/roster_store.rs
+++ b/crates/atm-storage-rusqlite/src/roster_store.rs
@@ -243,6 +243,8 @@ fn parse_harness(raw: &str) -> Result<RosterHarness, AtmError> {
         "codex-cli" => Ok(RosterHarness::CodexCli),
         "gemini-cli" => Ok(RosterHarness::GeminiCli),
         "opencode" => Ok(RosterHarness::Opencode),
+        "hermes" => Ok(RosterHarness::Hermes),
+        "python-graft" => Ok(RosterHarness::PythonGraft),
         other => Err(AtmError::validation(format!(
             "failed to parse canonical team-roster harness `{other}`"
         ))),
@@ -262,6 +264,8 @@ fn roster_harness_value(harness: RosterHarness) -> &'static str {
         RosterHarness::CodexCli => "codex-cli",
         RosterHarness::GeminiCli => "gemini-cli",
         RosterHarness::Opencode => "opencode",
+        RosterHarness::Hermes => "hermes",
+        RosterHarness::PythonGraft => "python-graft",
     }
 }
 
@@ -272,6 +276,51 @@ mod tests {
     use atm_storage::IsoTimestamp;
 
     const TEST_WORKER: &str = "worker";
+
+    #[test]
+    fn save_and_load_support_python_graft_harnesses() {
+        let store = SqliteStorageBackend::in_memory_for_test()
+            .expect("backend")
+            .roster_store;
+        let team: TeamName = "team-a".parse().expect("team");
+        let roster = RosterSnapshot {
+            team_name: team.clone(),
+            members: vec![
+                RosterMember {
+                    team_name: team.clone(),
+                    agent_name: "hermes-agent".parse().expect("agent"),
+                    member_kind: RosterMemberKind::Permanent,
+                    harness: RosterHarness::Hermes,
+                    agent_type: AgentType::Worker,
+                    model: ModelName::default(),
+                    recipient_pane_id: None,
+                    metadata_json: Map::new(),
+                },
+                RosterMember {
+                    team_name: team.clone(),
+                    agent_name: "python-agent".parse().expect("agent"),
+                    member_kind: RosterMemberKind::Permanent,
+                    harness: RosterHarness::PythonGraft,
+                    agent_type: AgentType::Worker,
+                    model: ModelName::default(),
+                    recipient_pane_id: None,
+                    metadata_json: Map::new(),
+                },
+            ],
+            refreshed_at: None,
+        };
+
+        store.save_roster(&roster).expect("save roster");
+        let loaded = store.load_roster(&team).expect("load roster");
+        assert_eq!(
+            loaded
+                .members
+                .iter()
+                .map(|member| member.harness)
+                .collect::<Vec<_>>(),
+            vec![RosterHarness::Hermes, RosterHarness::PythonGraft]
+        );
+    }
 
     #[test]
     fn save_roster_rejects_mismatched_team_names() {

--- a/crates/atm-storage-rusqlite/src/shared_db.rs
+++ b/crates/atm-storage-rusqlite/src/shared_db.rs
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS team_roster (
     team_name TEXT NOT NULL,
     agent_name TEXT NOT NULL,
     member_kind TEXT NOT NULL CHECK(member_kind IN ('permanent', 'ephemeral')),
-    harness TEXT NOT NULL CHECK(harness IN ('claude-code', 'codex-cli', 'gemini-cli', 'opencode')),
+    harness TEXT NOT NULL CHECK(harness IN ('claude-code', 'codex-cli', 'gemini-cli', 'opencode', 'hermes', 'python-graft')),
     agent_type TEXT NOT NULL DEFAULT '',
     model TEXT NOT NULL DEFAULT '',
     metadata_json TEXT NOT NULL DEFAULT '{}',
@@ -519,6 +519,7 @@ pub(crate) fn ensure_schema(
         .map_err(|error| sqlite_error(target, "failed to initialize sqlite schema", error))?;
     ensure_mail_message_columns(connection, target)?;
     ensure_team_roster_columns(connection, target)?;
+    ensure_team_roster_harness_values(connection, target)?;
     ensure_team_nudge_template_override_columns(connection, target)?;
     ensure_column(
         connection,
@@ -624,6 +625,80 @@ fn ensure_team_roster_columns(
         "metadata_json",
         "ALTER TABLE team_roster ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}';",
     )
+}
+
+fn ensure_team_roster_harness_values(
+    connection: &mut Connection,
+    target: &SharedDbTarget,
+) -> Result<(), AtmError> {
+    let table_sql = connection
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'team_roster';",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to inspect team_roster harness constraint",
+                error,
+            )
+        })?;
+    if table_sql.contains("'hermes'") && table_sql.contains("'python-graft'") {
+        return Ok(());
+    }
+
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to start team_roster harness migration",
+                error,
+            )
+        })?;
+    transaction
+        .execute_batch(
+            "DROP INDEX IF EXISTS idx_team_roster_team_name;
+             ALTER TABLE team_roster RENAME TO team_roster_legacy_harness;
+             CREATE TABLE team_roster (
+                 team_name TEXT NOT NULL,
+                 agent_name TEXT NOT NULL,
+                 member_kind TEXT NOT NULL CHECK(member_kind IN ('permanent', 'ephemeral')),
+                 harness TEXT NOT NULL CHECK(harness IN ('claude-code', 'codex-cli', 'gemini-cli', 'opencode', 'hermes', 'python-graft')),
+                 agent_type TEXT NOT NULL DEFAULT '',
+                 model TEXT NOT NULL DEFAULT '',
+                 metadata_json TEXT NOT NULL DEFAULT '{}',
+                 source TEXT,
+                 recipient_pane_id TEXT NULL,
+                 updated_at TEXT NOT NULL,
+                 PRIMARY KEY (team_name, agent_name)
+             );
+             INSERT INTO team_roster(
+                 team_name, agent_name, member_kind, harness, agent_type, model,
+                 metadata_json, source, recipient_pane_id, updated_at
+             )
+             SELECT
+                 team_name, agent_name, member_kind, harness, agent_type, model,
+                 metadata_json, source, recipient_pane_id, updated_at
+             FROM team_roster_legacy_harness;
+             DROP TABLE team_roster_legacy_harness;
+             CREATE INDEX idx_team_roster_team_name ON team_roster(team_name);",
+        )
+        .map_err(|error| {
+            sqlite_error(
+                target,
+                "failed to migrate team_roster harness constraint",
+                error,
+            )
+        })?;
+    transaction.commit().map_err(|error| {
+        sqlite_error(
+            target,
+            "failed to commit team_roster harness migration",
+            error,
+        )
+    })
 }
 
 fn ensure_team_nudge_template_override_columns(
@@ -819,6 +894,59 @@ pub(crate) fn sqlite_thread_mode(mode: Option<ThreadMode>) -> Option<&'static st
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ensure_team_roster_harness_values_migrates_legacy_check_constraint() {
+        let target = SharedDbTarget::InMemory {
+            uri: format!(
+                "file:atm-storage-rusqlite-roster-harness-test-{}?mode=memory&cache=shared",
+                NEXT_IN_MEMORY_DB_ID.fetch_add(1, Ordering::Relaxed)
+            ),
+        };
+        let mut connection = open_connection_for_target(&target).expect("open connection");
+        connection
+            .execute_batch(
+                "CREATE TABLE team_roster (
+                    team_name TEXT NOT NULL,
+                    agent_name TEXT NOT NULL,
+                    member_kind TEXT NOT NULL CHECK(member_kind IN ('permanent', 'ephemeral')),
+                    harness TEXT NOT NULL CHECK(harness IN ('claude-code', 'codex-cli', 'gemini-cli', 'opencode')),
+                    agent_type TEXT NOT NULL DEFAULT '',
+                    model TEXT NOT NULL DEFAULT '',
+                    metadata_json TEXT NOT NULL DEFAULT '{}',
+                    source TEXT,
+                    recipient_pane_id TEXT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (team_name, agent_name)
+                );
+                CREATE INDEX idx_team_roster_team_name ON team_roster(team_name);
+                INSERT INTO team_roster(
+                    team_name, agent_name, member_kind, harness, updated_at
+                ) VALUES ('hermes', 'skillrx', 'permanent', 'claude-code', 'now');",
+            )
+            .expect("create legacy roster table");
+
+        ensure_team_roster_harness_values(&mut connection, &target).expect("migrate roster");
+        connection
+            .execute(
+                "INSERT INTO team_roster(
+                    team_name, agent_name, member_kind, harness, updated_at
+                ) VALUES ('hermes', 'python-worker', 'permanent', 'python-graft', 'now');",
+                [],
+            )
+            .expect("new harness should satisfy migrated check constraint");
+        let harnesses: Vec<String> = connection
+            .prepare(
+                "SELECT harness FROM team_roster
+                 WHERE team_name = 'hermes' ORDER BY agent_name;",
+            )
+            .expect("prepare harness query")
+            .query_map([], |row| row.get(0))
+            .expect("query harnesses")
+            .collect::<Result<_, _>>()
+            .expect("decode harnesses");
+        assert_eq!(harnesses, vec!["python-graft", "claude-code"]);
+    }
 
     #[test]
     fn ensure_team_nudge_template_override_columns_migrates_legacy_empty_rows_to_disabled() {

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -342,6 +342,8 @@ pub enum RosterHarness {
     CodexCli,
     GeminiCli,
     Opencode,
+    Hermes,
+    PythonGraft,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/docs/adr/ADR-039-python-graft-host-binding.md
+++ b/docs/adr/ADR-039-python-graft-host-binding.md
@@ -47,5 +47,10 @@ personal-machine profiles.
   a nudge for a message unavailable to a normal read.
 - Hermes remains an external host integration. Its process supervision and
   chat namespace are not daemon responsibilities.
+- The canonical roster distinguishes `hermes` from `python-graft`: the former
+  names the Hermes gateway adapter, while the latter is available to any
+  Python host built on the `atm-graft` interface. Both values select the
+  non-Claude graft delivery path and allow post-send nudges without a tmux
+  pane.
 - AI.19 consumes the complete AI.18 Python host surface and remains a
   Python-only adapter; it does not add Rust wrapper code.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2570,6 +2570,12 @@ Minimum canonical roster-member durable fields:
 - `recipient_pane_id TEXT NULL`
   - authoritative post-send-hook pane mapping when known
 
+The canonical harness values are `claude-code`, `codex-cli`, `gemini-cli`,
+`opencode`, `hermes`, and `python-graft`. `hermes` is the named Hermes Python
+gateway integration; `python-graft` is the generic value for any Python host
+that receives messages through the `atm-graft` interface. Both Python graft
+harnesses use the non-Claude delivery path and do not require a tmux pane.
+
 `pid` is not part of the canonical roster-member durable schema. It remains
 transient daemon-owned runtime state only.
 

--- a/docs/atm-core/architecture.md
+++ b/docs/atm-core/architecture.md
@@ -512,7 +512,11 @@ Approved canonical roster-member schema direction:
 - `team_name`
 - `agent_name`
 - `member_kind` — `permanent` or `ephemeral`
-- `harness` — behavioral enum; approved values: `claude-code`, `codex-cli`, `gemini-cli`, `opencode`
+- `harness` — behavioral enum; approved values: `claude-code`, `codex-cli`,
+  `gemini-cli`, `opencode`, `hermes`, `python-graft`
+  - `hermes` identifies the Hermes Python gateway integration
+  - `python-graft` identifies any other Python host using the `atm-graft`
+    interface
 - `agent_type`
 - `model`
 - `metadata_json`

--- a/docs/atm-graft/hermes-agent-use-case.md
+++ b/docs/atm-graft/hermes-agent-use-case.md
@@ -1,0 +1,112 @@
+# Hermes as an ATM client
+
+This document describes the supported exploratory use case in which a Python
+agent (Hermes) acts as a native ATM client through the PyO3 bindings in
+`crates/atm-graft-python`. Hermes uses the typed `atm-graft` client in-process;
+it does not shell out to the `atm` CLI and does not open a second daemon or
+storage path.
+
+## Integration shape
+
+Each Hermes gateway runs one background `HermesGraftBridge`. At gateway startup
+it constructs a `PyGraftSession` through `PyGraftSessionOptions`, scoped to the
+gateway's agent and team, then activates the receiver:
+
+```python
+caller = atm_graft.PyAgentAddress(
+    os.environ["ATM_IDENTITY"],
+    os.environ["ATM_TEAM"],
+    hermes_chat_id,
+)
+options = atm_graft.PyGraftSessionOptions(
+    os.environ["ATM_HOME"],
+    os.environ["ATM_IDENTITY"],
+    os.environ["ATM_TEAM"],
+)
+bridge = HermesGraftBridge(caller, options, inject_user_message)
+bridge.start()
+```
+
+The receiver is registered by agent/team (`skillrx@hermes`, for example).
+The optional caller `chat_id` supplies the Hermes/Telegram conversation context
+for client operations; it is not a separate receiver endpoint. Keep the bridge
+alive for the gateway lifetime and call `bridge.close()` during shutdown.
+
+The receiver callback runs from the graft receiver thread. The Hermes adapter
+maps the canonical source address to an isolated ATM chat key and schedules a
+native internal message on the gateway event loop:
+
+```text
+PyNudge(source=hendrix:1234@hermes, body=...) →
+atm:hendrix:1234@hermes → MessageEvent(internal=True) → gateway._handle_message()
+```
+
+The callback uses `asyncio.run_coroutine_threadsafe()` (or the equivalent
+gateway-safe scheduling primitive) to cross from the receiver thread into the
+Hermes event loop. Duplicate message IDs are suppressed by the bridge. The
+body is then handled by Hermes's ordinary inbound-user-message path, so no
+manual `atm read` turn is required.
+
+## Required setup
+
+The gateway environment supplies:
+
+- `ATM_IDENTITY` — the agent name;
+- `ATM_TEAM` — the ATM team name;
+- `ATM_HOME` — the ATM home/workspace root; and
+- the Hermes-side chat ID, such as the Telegram chat ID.
+
+The workspace must contain a discovered `.atm.toml`. Graft activation is
+configuration-gated: without that file the session remains `inactive`, even
+though graft is enabled by default. A minimal configuration is enough:
+
+```toml
+[atm]
+```
+
+Use `[atm.graft] enabled = false` only when the receiver should be disabled.
+The daemon must be available through the normal same-host bootstrap path; the
+Hermes bridge does not start or own `atm-daemon`.
+
+## Build and packaging
+
+Build the Python binding with Maturin from the repository root:
+
+```sh
+maturin develop --manifest-path crates/atm-graft-python/Cargo.toml
+```
+
+Maturin requires the Python project version to be valid PEP 440. Hyphenated
+Cargo prerelease strings such as `1.4.0-beta-ai` cannot be used as the Python
+package version. The tested package metadata uses `1.4.0`, while the daemon
+workspace may retain its own release string; runtime compatibility is based on
+the HTTP API/schema contract rather than crate-version equality.
+
+See the open findings [AI18-GRAFT-PYTHON-NOT-BUILDABLE](../../.triage/phase-AI/findings/AI18-GRAFT-PYTHON-NOT-BUILDABLE.ttl)
+and [AI18-GRAFT-PYTHON-BINDING-CONTRACT](../../.triage/phase-AI/findings/AI18-GRAFT-PYTHON-BINDING-CONTRACT.ttl)
+for the packaging and exception-contract details. This use-case document does
+not close either finding.
+
+## Live validation
+
+The live partner test was run by `skillrx@hermes` against
+`testing/hermes-atm-graft` (version fix `b97ab1f3`; the current branch also
+contains the runbook note in `5f9db51b`). The observed flow was:
+
+1. Construct the Python session and activate the receiver; the snapshot reached
+   `listening`.
+2. Perform the daemon-backed ATM write/read flow. A nudge from
+   `hendrix:1234@hermes` to the skillrx gateway reached the callback as
+   `atm:hendrix:1234@hermes` with the expected body.
+3. Delivering the same message ID again produced no second Hermes turn.
+4. Close the bridge; receiver shutdown completed cleanly.
+
+Maturin built the `atm_graft-1.4.0` wheel successfully. The focused reference
+tests exercised the bridge behavior; six of seven passed. The remaining test
+is a known contract mismatch: it expects Python `RuntimeError` for malformed
+`hendrix:bad`, while the binding intentionally exposes the structured
+`atm_graft.AtmGraftError`. That is tracked by the binding-contract finding
+linked above, not by the live receive path.
+
+This is an integration reference, not a sprint status record or AI.21 evidence
+claim.

--- a/docs/plans/phase-U/sprint-U7.md
+++ b/docs/plans/phase-U/sprint-U7.md
@@ -123,6 +123,8 @@ Required shape for every sub-task:
      - `codex-cli`
      - `gemini-cli`
      - `opencode`
+     - `hermes`
+     - `python-graft`
    Required tests:
    - roster lifecycle tests for ephemeral-member removal consequences
    - harness serialization/validation tests

--- a/docs/plans/phase-ai/hermes-graft-runbook.md
+++ b/docs/plans/phase-ai/hermes-graft-runbook.md
@@ -33,6 +33,18 @@ ordinary inbound-user-message hook.
 The bridge process is restartable by launchd. It does not start, stop, restart,
 or own `atm-daemon`.
 
+Before starting the bridge, ensure the Hermes workspace contains a discovered
+`.atm.toml`. Graft activation is configuration-gated: when no file is found,
+the session remains `inactive` even though graft is enabled by default. A
+minimal workspace configuration is sufficient:
+
+```toml
+[atm]
+```
+
+To disable graft explicitly, use `[atm.graft] enabled = false`; otherwise the
+presence of `[atm]` keeps the default enabled behavior.
+
 ## Install and status
 
 For a rendered profile `example`:


### PR DESCRIPTION
## Summary
- document Hermes as a native Python atm-graft client
- capture live receiver wiring, chat mapping, and `.atm.toml` activation prerequisite
- record Maturin/PEP 440 packaging guidance and live harness evidence

## Validation
- `cargo check -p atm-graft-python`
- direct `maturin build`
- live skillrx@hermes harness: receiver listening, nudge injection, deduplication, clean close

The focused bridge suite has the known malformed-address exception-contract mismatch (6/7 pass): the test expects `RuntimeError`, while the binding raises structured `AtmGraftError`.
