### PR TITLE
test: add full Hermes graft smoke runner

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -145,6 +145,10 @@ test-graft-python:
 test-hermes-graft-bridge:
     {{python_cmd}} .just/run_hermes_graft_bridge_tests.py
 
+# Run the live Hermes smoke test across the complete PyO3 graft surface.
+test-hermes-graft-smoke:
+    {{python_cmd}} scripts/phase-ai/run-hermes-graft-smoke.py
+
 # Validate a Hermes bridge registry; append --active only for real operator profiles.
 verify-hermes-bridge-deployment profile_registry *args:
     scripts/phase-ai/run-hermes-bridge-probes.sh {{profile_registry}} {{args}}

--- a/docs/atm-graft/hermes-agent-use-case.md
+++ b/docs/atm-graft/hermes-agent-use-case.md
@@ -110,3 +110,39 @@ linked above, not by the live receive path.
 
 This is an integration reference, not a sprint status record or AI.21 evidence
 claim.
+
+## Full smoke test
+
+The bridge unit tests validate source-to-chat mapping and duplicate suppression.
+For a live end-to-end check of every PyO3 session operation, first build the
+binding in the Hermes Python environment:
+
+```sh
+maturin develop --manifest-path crates/atm-graft-python/Cargo.toml
+```
+
+Then run the smoke test as the receiving Hermes profile. It uses the registered
+`hendrix` member as the sender, so both identities must be present in the same
+team roster:
+
+```sh
+ATM_IDENTITY=skillrx ATM_TEAM=hermes \
+  python scripts/phase-ai/run-hermes-graft-smoke.py \
+  --sender hendrix \
+  --workspace-root /Users/randlee/Documents/github/synaptic-canvas-dolt \
+  --chat-id 8991600178
+```
+
+The test covers:
+
+- `PyAgentAddress` and `PyGraftSessionOptions` construction and validation;
+- `PyGraftSession` activation, duplicate activation rejection, snapshot, and
+  close lifecycle;
+- daemon-backed `send`, `read`, and `acknowledge` operations;
+- typed `PyNudge` callback delivery with source, body, and message ID checks;
+- typed `PyMessage` read projections and acknowledgement reply; and
+- post-close fail-closed behavior.
+
+The receiver endpoint must be published while the test runs. If the test
+reports `ATM_POST_SEND_GRAFT_UNAVAILABLE`, inspect the gateway hook and the
+profile's `.atm/graft/<team>/<agent>.json` endpoint before rerunning QA.

--- a/scripts/phase-ai/run-hermes-graft-smoke.py
+++ b/scripts/phase-ai/run-hermes-graft-smoke.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Run an end-to-end smoke test for the Hermes PyO3 graft surface.
+
+The test uses two registered Hermes identities: ``sender`` writes to the
+receiver mailbox, while the receiver exercises read, acknowledge, and graft
+nudging.  Run it from the active Hermes gateway environment after building
+the binding with Maturin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import threading
+import time
+import uuid
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sender", default="hendrix")
+    parser.add_argument("--agent", default=os.environ.get("ATM_IDENTITY", "skillrx"))
+    parser.add_argument("--team", default=os.environ.get("ATM_TEAM", "hermes"))
+    parser.add_argument("--chat-id", default=None)
+    parser.add_argument(
+        "--workspace-root",
+        default=os.environ.get("ATM_WORKSPACE_ROOT", str(Path.cwd())),
+    )
+    parser.add_argument("--timeout", type=float, default=15.0)
+    return parser.parse_args()
+
+
+def expect_error(label: str, operation: object) -> None:
+    try:
+        operation()  # type: ignore[operator]
+    except Exception as error:  # noqa: BLE001 - smoke test records the boundary error
+        print(f"PASS {label}: {type(error).__name__}: {error}")
+        return
+    raise AssertionError(f"{label} unexpectedly succeeded")
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        import atm_graft
+    except ImportError as error:
+        raise SystemExit(
+            "atm_graft is not installed; run maturin develop for "
+            "crates/atm-graft-python first"
+        ) from error
+    if args.agent == args.sender:
+        raise SystemExit("--agent and --sender must identify different registered agents")
+    if args.timeout <= 0:
+        raise SystemExit("--timeout must be positive")
+
+    sender = atm_graft.PyAgentAddress(args.sender, args.team, None)
+    receiver = atm_graft.PyAgentAddress(args.agent, args.team, args.chat_id)
+    options = atm_graft.PyGraftSessionOptions(args.workspace_root, args.agent, args.team)
+    print(f"PASS address: {sender} -> {receiver}")
+    print(
+        "PASS options: "
+        f"workspace_root={options.workspace_root} agent={options.agent} team={options.team}"
+    )
+
+    expect_error(
+        "blank workspace validation",
+        lambda: atm_graft.PyGraftSessionOptions("   ", args.agent, args.team),
+    )
+    expect_error(
+        "invalid nudge validation",
+        lambda: atm_graft.PyNudge("not-a-message-id", receiver, "body"),
+    )
+
+    receiver_session = atm_graft.PyGraftSession(receiver)
+    sender_session = atm_graft.PyGraftSession(sender)
+    nudges: list[atm_graft.PyNudge] = []
+    nudge_ready = threading.Event()
+
+    def on_nudge(nudge: atm_graft.PyNudge) -> None:
+        nudges.append(nudge)
+        nudge_ready.set()
+
+    try:
+        expect_error("snapshot before activation", receiver_session.snapshot)
+        receiver_session.activate_receiver(options, on_nudge)
+        snapshot = receiver_session.snapshot()
+        assert snapshot.agent == args.agent, snapshot.agent
+        assert snapshot.team == args.team, snapshot.team
+        assert snapshot.state == "listening", snapshot.state
+        print(f"PASS receiver activation: state={snapshot.state}")
+        expect_error(
+            "duplicate receiver activation",
+            lambda: receiver_session.activate_receiver(options, on_nudge),
+        )
+
+        marker = f"hermes-graft-smoke-{uuid.uuid4()}"
+        sender_session.send(receiver, marker)
+        print(f"PASS send: marker={marker}")
+
+        if not nudge_ready.wait(args.timeout):
+            raise TimeoutError(f"no graft nudge arrived within {args.timeout:.1f}s")
+        assert len(nudges) == 1, f"expected one nudge, got {len(nudges)}"
+        nudge = nudges[0]
+        assert nudge.source.agent == args.sender, nudge.source.agent
+        assert nudge.source.team == args.team, nudge.source.team
+        assert marker in nudge.body, nudge.body
+        print(
+            "PASS nudge callback: "
+            f"message_id={nudge.message_id} source={nudge.source} body={nudge.body!r}"
+        )
+
+        deadline = time.monotonic() + args.timeout
+        messages: list[atm_graft.PyMessage] = []
+        while time.monotonic() < deadline:
+            messages = receiver_session.read()
+            if any(message.body == marker for message in messages):
+                break
+        message = next((message for message in messages if message.body == marker), None)
+        if message is None or message.message_id is None:
+            raise AssertionError("read did not return the sent message with an ATM id")
+        assert message.source.agent == args.sender, message.source.agent
+        assert message.source.team == args.team, message.source.team
+        print(
+            "PASS read: "
+            f"message_id={message.message_id} source={message.source} body={message.body!r}"
+        )
+
+        receiver_session.acknowledge(message.message_id, f"ack-{marker}")
+        print(f"PASS acknowledge: message_id={message.message_id}")
+    finally:
+        sender_session.close()
+        receiver_session.close()
+
+    expect_error("snapshot after close", receiver_session.snapshot)
+    print("PASS close: sender and receiver sessions closed")
+    print("Hermes graft smoke test: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Follow-up to #678 (already merged) — adds run-hermes-graft-smoke.py, a smoke runner exercising the full documented Hermes atm_graft PyO3 surface (activation, duplicate-activation rejection, send/nudge-callback/read/ack, clean close, fail-closed post-close snapshot).

## QA
HERMES-SMOKE-QA-1: PASS. req-qa/arch-qa/ruthless-boundary-qa clean, 0 Blocking/Important. Confirmed no socket/storage bypass, no second delivery path. One non-blocking doc nit noted (hardcoded path in hermes-agent-use-case.md:132), not fixed here.
Report: https://github.com/randlee/atm-core/pull/678#issuecomment-5099932100

🤖 Generated with [Claude Code](https://claude.com/claude-code)