### PR TITLE
feat(hermes): graft-root fallback observability (AI.35)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "tempfile",
  "toml",
  "tracing",
+ "tracing-subscriber",
  "ulid",
  "windows-sys 0.59.0",
 ]

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -40,6 +40,7 @@ fs2 = "0.4"
 atm-runtime-test-support = { path = "../atm-runtime-test-support" }
 serial_test = "3"
 tempfile = "3"
+tracing-subscriber.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Com", "Win32_System_Threading", "Win32_UI_Shell"] }

--- a/crates/atm-core/src/graft.rs
+++ b/crates/atm-core/src/graft.rs
@@ -86,7 +86,20 @@ pub fn graft_receiver_record_path_from_home(
     team: &TeamName,
     agent: &AgentName,
 ) -> PathBuf {
-    home_dir
+    graft_receiver_record_path_from_root(home_dir, team, agent)
+}
+
+/// Absolute path of a loopback endpoint record under the canonical graft root.
+///
+/// The root is intentionally supplied by the caller so publishers and daemon
+/// resolvers share exactly the same path construction once roster metadata has
+/// selected the recipient's authoritative workspace root.
+pub fn graft_receiver_record_path_from_root(
+    graft_root: &Path,
+    team: &TeamName,
+    agent: &AgentName,
+) -> PathBuf {
+    graft_root
         .join(".atm")
         .join("graft")
         .join(team.as_str())

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -51,8 +51,25 @@ pub fn canonical_home_dir(metadata_json: &Map<String, Value>) -> Option<HomeDirP
 }
 
 pub fn canonical_graft_root(metadata_json: &Map<String, Value>) -> Option<HomeDirPath> {
-    metadata_home_dir(metadata_json, WORKSPACE_ROOT_METADATA_KEY)
-        .or_else(|| canonical_home_dir(metadata_json))
+    if let Some(workspace_root) = metadata_home_dir(metadata_json, WORKSPACE_ROOT_METADATA_KEY) {
+        tracing::debug!(
+            graft_root_source = "workspace_root",
+            "resolved canonical graft root from workspace_root metadata"
+        );
+        return Some(workspace_root);
+    }
+    if let Some(home_dir) = canonical_home_dir(metadata_json) {
+        tracing::debug!(
+            graft_root_source = "home_dir_fallback",
+            "resolved canonical graft root from home_dir fallback"
+        );
+        return Some(home_dir);
+    }
+    tracing::debug!(
+        graft_root_source = "missing",
+        "canonical graft root is absent"
+    );
+    None
 }
 
 #[allow(
@@ -60,8 +77,25 @@ pub fn canonical_graft_root(metadata_json: &Map<String, Value>) -> Option<HomeDi
     reason = "Phase AD obsolete: bounded fallback remains only to read pre-AD compatibility metadata."
 )]
 pub fn compatible_home_dir(metadata_json: &Map<String, Value>) -> Option<HomeDirPath> {
-    canonical_home_dir(metadata_json)
-        .or_else(|| metadata_home_dir(metadata_json, LEGACY_CWD_METADATA_KEY))
+    if let Some(home_dir) = canonical_home_dir(metadata_json) {
+        tracing::debug!(
+            compatible_home_dir_source = "home_dir",
+            "resolved compatible home directory from home_dir metadata"
+        );
+        return Some(home_dir);
+    }
+    if let Some(legacy_cwd) = metadata_home_dir(metadata_json, LEGACY_CWD_METADATA_KEY) {
+        tracing::debug!(
+            compatible_home_dir_source = "legacy_cwd_fallback",
+            "resolved compatible home directory from legacy cwd fallback"
+        );
+        return Some(legacy_cwd);
+    }
+    tracing::debug!(
+        compatible_home_dir_source = "missing",
+        "compatible home directory is absent"
+    );
+    None
 }
 
 fn metadata_home_dir(metadata_json: &Map<String, Value>, key: &str) -> Option<HomeDirPath> {
@@ -126,9 +160,12 @@ impl AgentMember {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
     use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex};
 
     use serde_json::{Map, Value};
+    use tracing_subscriber::fmt::MakeWriter;
 
     use super::{
         AgentMember, AgentType, HOME_DIR_METADATA_KEY, HomeDirPath, WORKSPACE_ROOT_METADATA_KEY,
@@ -136,6 +173,42 @@ mod tests {
     };
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::AgentName;
+
+    #[derive(Clone)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture writer lock")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CaptureWriter {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn capture_logs<T>(operation: impl FnOnce() -> T) -> String {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(CaptureWriter(bytes.clone()))
+            .finish();
+        tracing::subscriber::with_default(subscriber, operation);
+        String::from_utf8(bytes.lock().expect("capture writer lock").clone()).expect("utf8 logs")
+    }
 
     #[test]
     fn parse_name_only_record_defaults_optional_fields() {
@@ -248,6 +321,43 @@ mod tests {
                 .map(HomeDirPath::as_path),
             Some(Path::new("/workspace/root"))
         );
+    }
+
+    #[test]
+    fn canonical_graft_root_logs_workspace_root_and_home_fallback_sources() {
+        let workspace_metadata = Map::from_iter([
+            (
+                HOME_DIR_METADATA_KEY.to_string(),
+                Value::from("/profile/home"),
+            ),
+            (
+                WORKSPACE_ROOT_METADATA_KEY.to_string(),
+                Value::from("/workspace/root"),
+            ),
+        ]);
+        let workspace_logs = capture_logs(|| canonical_graft_root(&workspace_metadata));
+        assert!(workspace_logs.contains("graft_root_source=\"workspace_root\""));
+
+        let home_metadata = Map::from_iter([(
+            HOME_DIR_METADATA_KEY.to_string(),
+            Value::from("/profile/home"),
+        )]);
+        let fallback_logs = capture_logs(|| canonical_graft_root(&home_metadata));
+        assert!(fallback_logs.contains("graft_root_source=\"home_dir_fallback\""));
+    }
+
+    #[test]
+    #[allow(
+        deprecated,
+        reason = "The test covers the retained pre-AD compatibility fallback."
+    )]
+    fn compatible_home_dir_logs_legacy_fallback_source() {
+        let metadata = Map::from_iter([(
+            super::LEGACY_CWD_METADATA_KEY.to_string(),
+            Value::from("/legacy/cwd"),
+        )]);
+        let logs = capture_logs(|| compatible_home_dir(&metadata));
+        assert!(logs.contains("compatible_home_dir_source=\"legacy_cwd_fallback\""));
     }
 
     #[test]

--- a/crates/atm-core/src/schema/agent_member.rs
+++ b/crates/atm-core/src/schema/agent_member.rs
@@ -7,6 +7,10 @@ use crate::types::{AgentId, AgentName, ModelName, PaneId};
 pub use atm_storage::contract::AgentType;
 
 pub const HOME_DIR_METADATA_KEY: &str = "home_dir";
+/// Optional host workspace root used by graft receivers. When present it is
+/// the canonical root for the receiver endpoint; `home_dir` remains the
+/// compatibility fallback for roster members that predate this field.
+pub const WORKSPACE_ROOT_METADATA_KEY: &str = "workspace_root";
 #[deprecated(note = "Phase AD obsolete: derived compatibility field only")]
 pub const LEGACY_CWD_METADATA_KEY: &str = "cwd";
 
@@ -44,6 +48,11 @@ impl From<HomeDirPath> for PathBuf {
 
 pub fn canonical_home_dir(metadata_json: &Map<String, Value>) -> Option<HomeDirPath> {
     metadata_home_dir(metadata_json, HOME_DIR_METADATA_KEY)
+}
+
+pub fn canonical_graft_root(metadata_json: &Map<String, Value>) -> Option<HomeDirPath> {
+    metadata_home_dir(metadata_json, WORKSPACE_ROOT_METADATA_KEY)
+        .or_else(|| canonical_home_dir(metadata_json))
 }
 
 #[allow(
@@ -122,8 +131,8 @@ mod tests {
     use serde_json::{Map, Value};
 
     use super::{
-        AgentMember, AgentType, HOME_DIR_METADATA_KEY, HomeDirPath, canonical_home_dir,
-        compatible_home_dir,
+        AgentMember, AgentType, HOME_DIR_METADATA_KEY, HomeDirPath, WORKSPACE_ROOT_METADATA_KEY,
+        canonical_graft_root, canonical_home_dir, compatible_home_dir,
     };
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::AgentName;
@@ -217,6 +226,27 @@ mod tests {
                 .as_ref()
                 .map(HomeDirPath::as_path),
             Some(Path::new("/repo/home"))
+        );
+    }
+
+    #[test]
+    fn canonical_graft_root_prefers_workspace_root_over_profile_home() {
+        let metadata = Map::from_iter([
+            (
+                HOME_DIR_METADATA_KEY.to_string(),
+                Value::from("/profile/home"),
+            ),
+            (
+                WORKSPACE_ROOT_METADATA_KEY.to_string(),
+                Value::from("/workspace/root"),
+            ),
+        ]);
+
+        assert_eq!(
+            canonical_graft_root(&metadata)
+                .as_ref()
+                .map(HomeDirPath::as_path),
+            Some(Path::new("/workspace/root"))
         );
     }
 

--- a/crates/atm-core/src/schema/mod.rs
+++ b/crates/atm-core/src/schema/mod.rs
@@ -7,7 +7,8 @@ pub mod settings;
 pub mod team_config;
 
 pub use agent_member::{
-    AgentMember, HOME_DIR_METADATA_KEY, HomeDirPath, canonical_home_dir, compatible_home_dir,
+    AgentMember, HOME_DIR_METADATA_KEY, HomeDirPath, WORKSPACE_ROOT_METADATA_KEY,
+    canonical_graft_root, canonical_home_dir, compatible_home_dir,
 };
 pub use atm_storage::contract::AgentType;
 pub(crate) use inbox_message::{

--- a/crates/atm-core/src/team_admin.rs
+++ b/crates/atm-core/src/team_admin.rs
@@ -467,7 +467,7 @@ mod tests {
         TeamNudgeTemplateOverrideRow,
     };
     use crate::error_codes::AtmErrorCode;
-    use crate::schema::{HOME_DIR_METADATA_KEY, TeamConfig};
+    use crate::schema::{HOME_DIR_METADATA_KEY, TeamConfig, WORKSPACE_ROOT_METADATA_KEY};
     use crate::test_support::{
         EnvGuard, ROLE_TEAM_LEAD, TEST_ARCH_CTM, TEST_RECIPIENT, TEST_SENDER, TEST_TEAM,
     };
@@ -912,6 +912,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(TEST_SENDER.parse().expect("member")),
                 home_dir: Some(PathBuf::from("/repo/worktree").into()),
+                workspace_root: Some(PathBuf::from("/repo/workspace").into()),
                 harness: Some(RosterHarness::CodexCli),
                 agent_type: Some(crate::schema::AgentType::from("worker".to_string())),
                 model: Some(crate::types::ModelName::new("gpt-5").expect("model")),
@@ -933,6 +934,10 @@ mod tests {
         assert_eq!(
             member.metadata_json.get(HOME_DIR_METADATA_KEY),
             Some(&serde_json::json!("/repo/worktree"))
+        );
+        assert_eq!(
+            member.metadata_json.get(WORKSPACE_ROOT_METADATA_KEY),
+            Some(&serde_json::json!("/repo/workspace"))
         );
 
         let team_dir = tempdir.path().join(".claude").join("teams").join(TEST_TEAM);
@@ -967,6 +972,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(ROLE_TEAM_LEAD.parse().expect("member")),
                 home_dir: None,
+                workspace_root: None,
                 harness: None,
                 agent_type: None,
                 model: None,
@@ -983,6 +989,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(TEST_ARCH_CTM.parse().expect("member")),
                 home_dir: None,
+                workspace_root: None,
                 harness: None,
                 agent_type: None,
                 model: None,
@@ -1028,6 +1035,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(TEST_SENDER.parse().expect("member")),
                 home_dir: Some(PathBuf::from("/repo/worktree").into()),
+                workspace_root: None,
                 harness: None,
                 agent_type: None,
                 model: None,
@@ -1055,6 +1063,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(TEST_RECIPIENT.parse().expect("member")),
                 home_dir: Some(PathBuf::from("/repo/worktree").into()),
+                workspace_root: None,
                 harness: None,
                 agent_type: None,
                 model: None,
@@ -1082,6 +1091,7 @@ mod tests {
                 team: TEST_TEAM.parse().expect("team"),
                 member: MemberName(TEST_SENDER.parse().expect("member")),
                 home_dir: Some(PathBuf::from("/repo/worktree").into()),
+                workspace_root: None,
                 harness: None,
                 agent_type: None,
                 model: None,

--- a/crates/atm-core/src/team_admin/member_mutation.rs
+++ b/crates/atm-core/src/team_admin/member_mutation.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use crate::boundary::{RosterEntry, RosterHarness, RosterMemberKind, RosterStore};
 use crate::error::AtmError;
 use crate::home;
-use crate::schema::{AgentType, HOME_DIR_METADATA_KEY, HomeDirPath};
+use crate::schema::{AgentType, HOME_DIR_METADATA_KEY, HomeDirPath, WORKSPACE_ROOT_METADATA_KEY};
 use crate::types::{AgentName, ModelName, PaneId, TeamName};
 
 use super::{filesystem, projection};
@@ -67,6 +67,7 @@ pub struct UpdateMemberRequest {
     pub team: TeamName,
     pub member: MemberName,
     pub home_dir: Option<HomeDirPath>,
+    pub workspace_root: Option<HomeDirPath>,
     pub harness: Option<RosterHarness>,
     pub agent_type: Option<AgentType>,
     pub model: Option<ModelName>,
@@ -84,6 +85,7 @@ impl UpdateMemberRequest {
         team: &str,
         member: &str,
         home_dir: Option<PathBuf>,
+        workspace_root: Option<PathBuf>,
         harness: Option<String>,
         agent_type: Option<String>,
         model: Option<String>,
@@ -95,6 +97,7 @@ impl UpdateMemberRequest {
             team: team.parse()?,
             member: MemberName(member.parse()?),
             home_dir: home_dir.map(Into::into),
+            workspace_root: workspace_root.map(Into::into),
             harness: harness.map(parse_roster_harness).transpose()?,
             agent_type: agent_type.map(parse_agent_type).transpose()?,
             model: model.map(ModelName::new).transpose()?,
@@ -376,6 +379,12 @@ fn apply_member_metadata_update(member: &mut RosterEntry, request: &UpdateMember
         member.metadata_json.insert(
             HOME_DIR_METADATA_KEY.to_string(),
             json!(home_dir.as_ref().display().to_string()),
+        );
+    }
+    if let Some(workspace_root) = &request.workspace_root {
+        member.metadata_json.insert(
+            WORKSPACE_ROOT_METADATA_KEY.to_string(),
+            json!(workspace_root.as_ref().display().to_string()),
         );
     }
     if let Some(harness) = request.harness {

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -11,7 +11,7 @@ use atm_core::{
     error::{AtmError, AtmErrorCode},
     graft::{
         GraftPostSendRequest, GraftPostSendResponse, deliver_graft_post_send,
-        graft_receiver_record_path_from_home,
+        graft_receiver_record_path_from_root,
     },
     list::list_mail,
     process::process_is_alive,
@@ -22,7 +22,7 @@ use atm_core::{
     },
     provenance::{WriteIngress, WriteProvenance, validate_write_provenance},
     read::{peek_mail_with_runtime, read_mail_with_runtime},
-    schema::canonical_home_dir,
+    schema::canonical_graft_root,
     send::{PreparedWrite, WriteOutcome, WriteRequest, prepare_write_with_runtime},
 };
 
@@ -98,14 +98,14 @@ impl boundary::GraftPostSendPort for DaemonGraftPostSendPort {
                 "recipient is missing from the authoritative ATM roster",
             ));
         };
-        let recipient_home_dir = canonical_home_dir(&member.metadata_json).ok_or_else(|| {
+        let recipient_root = canonical_graft_root(&member.metadata_json).ok_or_else(|| {
             graft_recipient_unavailable_error(
                 event,
-                "recipient has no authoritative home_dir for graft post-send delivery",
+                "recipient has no authoritative graft root for post-send delivery",
             )
         })?;
-        let record_path = graft_receiver_record_path_from_home(
-            recipient_home_dir.as_path(),
+        let record_path = graft_receiver_record_path_from_root(
+            recipient_root.as_path(),
             &target.recipient_team,
             &target.recipient,
         );

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -19,17 +19,28 @@ const TEST_TEAM: &str = "test-team";
 
 fn install_test_roster_with_harness(
     db_path: &std::path::Path,
-    members: &[(&str, RosterHarness, Option<&std::path::Path>)],
+    members: &[(
+        &str,
+        RosterHarness,
+        Option<&std::path::Path>,
+        Option<&std::path::Path>,
+    )],
 ) {
     let assembly = open_sqlite_boundary(db_path).expect("assemble boundary");
     let roster_store = assembly.roster_store_arc();
     let team = TEST_TEAM.parse::<TeamName>().expect("team");
     let members = members
         .iter()
-        .map(|(name, harness, home_dir)| {
+        .map(|(name, harness, home_dir, workspace_root)| {
             let mut member = AgentMember::with_name((*name).parse().expect("member"));
             if let Some(home_dir) = home_dir {
                 member.home_dir = home_dir.to_path_buf().into();
+            }
+            if let Some(workspace_root) = workspace_root {
+                member.extra.insert(
+                    "workspace_root".to_string(),
+                    serde_json::Value::String(workspace_root.display().to_string()),
+                );
             }
             let mut record = atm_core::boundary::roster_member_record_from_claude_code_member(
                 team.clone(),
@@ -70,6 +81,7 @@ fn graft_warning_dispatcher() -> (
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
     let workspace_dir = tempdir.path().join("workspace");
+    let profile_home = tempdir.path().join("recipient-profile");
     std::fs::create_dir_all(&atm_home).expect("atm home dir");
     std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
     let db_path = tempdir.path().join("mail.db");
@@ -80,10 +92,12 @@ fn graft_warning_dispatcher() -> (
                 ROLE_TEAM_LEAD,
                 RosterHarness::ClaudeCode,
                 Some(workspace_dir.as_path()),
+                None,
             ),
             (
                 "qa-a",
                 RosterHarness::CodexCli,
+                Some(profile_home.as_path()),
                 Some(workspace_dir.as_path()),
             ),
         ],

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -327,7 +327,8 @@ impl PyGraftSession {
         })
     }
 
-    fn send(&self, to: PyAgentAddress, body: String) -> PyResult<()> {
+    #[pyo3(signature = (to, body, requires_ack=false))]
+    fn send(&self, to: PyAgentAddress, body: String, requires_ack: bool) -> PyResult<()> {
         let (home_dir, current_dir) = Self::command_paths()?;
         let request = SendRequest::new(
             home_dir,
@@ -337,7 +338,7 @@ impl PyGraftSession {
             self.caller.team().cloned().expect("validated caller team"),
             SendMessageSource::Inline(body),
             None,
-            false,
+            requires_ack,
             None,
             false,
         )

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -336,7 +336,7 @@ impl GraftSession {
             return inactive_session(client, snapshot, observability);
         }
 
-        let endpoint_path = atm_core::graft::graft_receiver_record_path_from_home(
+        let endpoint_path = atm_core::graft::graft_receiver_record_path_from_root(
             options.workspace_root(),
             options.team(),
             options.agent(),

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -76,6 +76,9 @@ struct UpdateMemberCommand {
     #[arg(long)]
     home_dir: Option<PathBuf>,
 
+    #[arg(long = "workspace-root")]
+    workspace_root: Option<PathBuf>,
+
     #[arg(long)]
     harness: Option<String>,
 
@@ -319,6 +322,7 @@ impl UpdateMemberCommand {
             &self.team,
             &self.member,
             self.home_dir,
+            self.workspace_root,
             self.harness,
             self.agent_type,
             self.model,
@@ -421,6 +425,7 @@ mod tests {
                 team: TEST_TEAM.to_string(),
                 member: TEST_SENDER.to_string(),
                 home_dir: Some(home_dir),
+                workspace_root: None,
                 harness: Some("codex-cli".to_string()),
                 agent_type: Some("worker".to_string()),
                 model: Some("gpt-5".to_string()),
@@ -722,6 +727,7 @@ mod tests {
             team: TEST_TEAM.to_string(),
             member: TEST_SENDER.to_string(),
             home_dir: Some(member_home_dir.clone()),
+            workspace_root: None,
             harness: Some("codex-cli".to_string()),
             agent_type: Some("worker".to_string()),
             model: Some("gpt-5".to_string()),

--- a/docs/atm-graft/hermes-agent-use-case.md
+++ b/docs/atm-graft/hermes-agent-use-case.md
@@ -47,6 +47,20 @@ Hermes event loop. Duplicate message IDs are suppressed by the bridge. The
 body is then handled by Hermes's ordinary inbound-user-message path, so no
 manual `atm read` turn is required.
 
+For messages that require an explicit ATM acknowledgement, pass the optional
+`requires_ack` argument and acknowledge the returned message after reading it:
+
+```python
+sender_session.send(receiver, "please confirm", requires_ack=True)
+message = next(
+    message for message in receiver_session.read() if message.body == "please confirm"
+)
+receiver_session.acknowledge(message.message_id, "confirmed")
+```
+
+The default remains `False`, so existing `send(to, body)` callers retain the
+non-acknowledgement semantics.
+
 ## Required setup
 
 The gateway environment supplies:

--- a/docs/atm-graft/hermes-agent-use-case.md
+++ b/docs/atm-graft/hermes-agent-use-case.md
@@ -56,6 +56,20 @@ The gateway environment supplies:
 - `ATM_HOME` — the ATM home/workspace root; and
 - the Hermes-side chat ID, such as the Telegram chat ID.
 
+The ATM roster must also identify the workspace root where the gateway's graft
+endpoint is published. If the gateway profile's `ATM_HOME` differs from its
+workspace, set the durable roster metadata explicitly:
+
+```sh
+ATM_TEAM=hermes ATM_IDENTITY=hendrix \
+  atm teams update-member hermes skillrx \
+  --workspace-root /path/to/skillrx/workspace
+```
+
+The daemon uses this `workspace_root` metadata (falling back to `home_dir` for
+older roster rows), so it resolves the same endpoint path that the Python
+publisher writes.
+
 The workspace must contain a discovered `.atm.toml`. Graft activation is
 configuration-gated: without that file the session remains `inactive`, even
 though graft is enabled by default. A minimal configuration is enough:

--- a/docs/atm/cli-reference-1-4-0-beta-ai.md
+++ b/docs/atm/cli-reference-1-4-0-beta-ai.md
@@ -438,11 +438,11 @@ List teams or run one team-administration subcommand
 | `<team>` |  | yes |  |
 | `<member>` |  | yes |  |
 | `--home-dir` |  | no |  |
+| `--workspace-root` |  | no | Canonical workspace root used for graft receiver endpoint resolution |
 | `--harness` |  | no |  |
 | `--agent-type` |  | no |  |
 | `--model` |  | no |  |
 | `--pane-id` |  | no | tmux pane id in '%<number>' form or a bare numeric pane id |
 | `--json` |  | no |  |
 | `--stderr-logs` |  | no | Route retained observability console logs to stderr |
-
 

--- a/docs/atm/commands/teams.md
+++ b/docs/atm/commands/teams.md
@@ -14,9 +14,9 @@ CLI note:
 - `teams add-member --pane-id` accepts tmux pane ids in `%<number>` form or a
   bare numeric pane id that ATM canonicalizes to `%<number>`
 - `teams update-member` is the accepted repair path for existing member
-  metadata such as durable `home_dir`, harness, model, agent type, and tmux
-  `--pane-id`; manual `config.json` edits are no longer the supported pane or
-  home-dir repair workflow
+  metadata such as durable `home_dir`, the graft `--workspace-root`, harness,
+  model, agent type, and tmux `--pane-id`; manual `config.json` edits are no
+  longer the supported pane, home-dir, or graft endpoint repair workflow
 
 References:
 

--- a/docs/plans/phase-ai/hermes-graft-runbook.md
+++ b/docs/plans/phase-ai/hermes-graft-runbook.md
@@ -45,6 +45,33 @@ minimal workspace configuration is sufficient:
 To disable graft explicitly, use `[atm.graft] enabled = false`; otherwise the
 presence of `[atm]` keeps the default enabled behavior.
 
+## Reconcile the graft workspace root
+
+The bridge publishes its receiver record under the workspace root passed to
+`PyGraftSessionOptions`, while the daemon resolves that location from the
+recipient's durable roster metadata. After a profile is first registered, or
+whenever its checkout/worktree moves, update the roster before restarting the
+bridge:
+
+```sh
+ATM_TEAM=hermes ATM_IDENTITY=hendrix \
+  atm teams update-member hermes skillrx \
+  --workspace-root /path/to/skillrx/workspace
+```
+
+Run this repair for every profile whose live graft session uses a different
+workspace root than its stored `home_dir`; repeat it after a worktree move,
+profile migration, or launch-registry change. Verify the durable value with
+`atm members --json` and confirm the member's `extra.workspace_root` matches the
+path supplied to `PyGraftSessionOptions`. The daemon logs the selected root
+source (`workspace_root` or the compatibility `home_dir` fallback) at debug
+level, making stale metadata visible without guessing which branch resolved.
+
+Automatic roster mutation during graft activation is intentionally not used:
+the graft library does not own team-admin storage or operator authorization.
+The explicit update keeps that boundary auditable and prevents a bridge from
+silently changing durable team configuration.
+
 ## Install and status
 
 For a rendered profile `example`:

--- a/docs/plans/phase-ai/sprint-ai-34-hermes-graft-nudge-endpoint-reconciliation.md
+++ b/docs/plans/phase-ai/sprint-ai-34-hermes-graft-nudge-endpoint-reconciliation.md
@@ -1,0 +1,58 @@
+---
+title: AI.34 Hermes graft nudge-endpoint reconciliation
+status: in_progress
+branch: fix/hermes-nudge-endpoint-mismatch
+target: integrate/phase-AI
+depends_on: AI.31, AI.32
+requires_merged_pr: PR #678 (RosterHarness::Hermes/PythonGraft, merged to develop @ cf8511ae)
+---
+
+# AI.34 — Hermes graft nudge-endpoint reconciliation
+
+## Closure
+
+Live Hermes nudge delivery to a Python-graft roster member (skillrx) succeeds
+end-to-end on a release-built ATM daemon: the publisher-written endpoint
+record and the daemon's runtime_health resolver agree on a single canonical
+path for any roster member whose `workspace_root` diverges from its
+`home_dir`.
+
+## Background
+
+Found by quality-mgr's HERMES-SMOKE-QA-1 live-evidence follow-up (Cipher-311d),
+on `develop @ cf8511ae` (post-merge of PR #678). Nudge delivery times out:
+the Python graft publisher writes its endpoint file under
+`{workspace_root}/.atm/graft/{team}/{agent}.json`
+(`crates/atm-graft/src/lib.rs:339-343`, via
+`graft_receiver_record_path_from_home(options.workspace_root())`), but
+`atm-daemon`'s runtime_health resolver looks under the roster member's
+metadata `home_dir` instead
+(`crates/atm-daemon/src/runtime_health.rs:101-111`, via
+`canonical_home_dir(&member.metadata_json)` in
+`crates/atm-core/src/schema/agent_member.rs:45-47`).
+`workspace_root` and `roster.home_dir` diverge for skillrx, so the daemon
+never finds the endpoint file the publisher wrote.
+
+Triage record: `.triage/phase-AI/findings/AI-HERMES-NUDGE-ENDPOINT-MISMATCH.ttl`
+(severity: blocking).
+
+## Required fixes
+
+1. Reconcile the publisher-side and daemon-resolver-side root paths so they
+   always converge on the same endpoint file location. Per the triage
+   record's closure note, pick one of: (a) both sides use `workspace_root`,
+   (b) both sides use `home_dir`, or (c) introduce a single canonical
+   resolver function both call.
+2. Prefer option (c) if it doesn't expand scope unreasonably — a canonical
+   resolver structurally prevents this class of divergence from recurring.
+3. Add a regression test: publisher writes an endpoint record, daemon
+   resolver looks it up, assert they resolve to the identical path for a
+   roster member whose `workspace_root` differs from `home_dir`.
+
+## Required validation
+
+- Live nudge smoke against skillrx@hermes succeeds (Cipher-311d's pre-fix
+  baseline: message `01KYKGBRMPHDM1WS2Z1R8DYTQT`, AI32 build `746c69ee` —
+  constructors/options/activation/snapshot/duplicate-activation/send
+  persistence already pass; nudge callback is the only remaining failure).
+- `just lint`, `just test` pass.

--- a/docs/plans/phase-ai/sprint-ai-35-graft-root-fallback-observability.md
+++ b/docs/plans/phase-ai/sprint-ai-35-graft-root-fallback-observability.md
@@ -1,0 +1,76 @@
+---
+title: AI.35 graft-root fallback observability
+status: in_progress
+branch: feature/pAI-s35-graft-root-fallback-observability
+target: integrate/phase-AI
+depends_on: AI.34
+requires_merged_pr: PR #681 (Hermes graft nudge-endpoint reconciliation)
+---
+
+# AI.35 — graft-root fallback observability
+
+## Closure
+
+`canonical_graft_root()` and the deprecated `compatible_home_dir()` no longer
+silently pick between `workspace_root`/`home_dir`/`legacy_cwd` with zero
+observability. Whichever branch fires is logged, and the operational gap that
+lets `workspace_root` drift out of sync with a live graft session's actual
+root is either closed or explicitly documented as an accepted manual step.
+
+## Background
+
+Found by quality-mgr's AI34-QA-1 review as `RBQA-F002-AI34` (Important,
+non-gating on PR #681):
+
+`canonical_graft_root()` (`crates/atm-core/src/schema/agent_member.rs:53-56`)
+silently falls back from roster `workspace_root` to `home_dir` (via
+`canonical_home_dir()`) with no logging distinguishing which branch fired.
+`workspace_root` is populated only via a manual operator step
+(`atm team update-member --workspace-root`,
+`crates/atm-core/src/team_admin/member_mutation.rs:384-389`) with no
+automatic reconciliation to the value an atm-graft session actually runs
+with. `docs/plans/phase-ai/hermes-graft-runbook.md` has zero references to
+`update-member`/`workspace-root`, so there's no documented operational step
+keeping the two in sync.
+
+This is the same "two modules independently answer the same architectural
+question" pattern that caused the original AI.34 bug, just pushed from code
+to config, with a silent compatibility fallback and no mechanical lint guard.
+The deprecated `compatible_home_dir()` (line 62-65) exhibits the identical
+silent-fallback pattern (`home_dir` → `legacy_cwd`), even though marked
+deprecated.
+
+Triage record: `.triage/phase-AI/findings/RBQA-F002-AI34.ttl` (severity:
+important, repeatable: true, sweepScope: workspace).
+
+## Required fixes
+
+1. Add observability (structured log at minimum) to `canonical_graft_root()`
+   distinguishing which source resolved (`workspace_root` vs `home_dir`
+   fallback), so a future endpoint mismatch is diagnosable without re-running
+   this investigation from scratch.
+2. Do the same for `compatible_home_dir()`'s `home_dir` → `legacy_cwd`
+   fallback, or confirm it's unreachable in practice and remove it if so
+   (it's already marked deprecated).
+3. Document the `update-member --workspace-root` operational step in
+   `docs/plans/phase-ai/hermes-graft-runbook.md`, including when it must be
+   re-run to keep the roster's `workspace_root` in sync with a live graft
+   session's actual root.
+4. Judgement call, confirm before large scope: if reconciling `workspace_root`
+   automatically (rather than just documenting the manual step) is small,
+   prefer it — it structurally prevents the class of drift that caused
+   AI.34's original bug. If it's a bigger lift, document-only is acceptable
+   for this sprint; file a follow-up finding instead of expanding scope here.
+
+## Required validation
+
+- A test proves `canonical_graft_root()`'s log output correctly identifies
+  which source resolved for both the `workspace_root`-present and
+  `workspace_root`-absent cases.
+- `just lint`, `just test` pass.
+
+## Non-goals
+
+`RBQA-F001-AI34` (CLI's `GraftNudgeSink::deliver` vs the daemon's canonical
+resolver — reviewer disagreement on dead-code reachability) is a separate
+finding routed to arch-ctm, not part of this sprint.


### PR DESCRIPTION
## Summary
- Sprint AI.35 — fixes RBQA-F002-AI34 (Important, non-gating on PR #681): `canonical_graft_root()` and deprecated `compatible_home_dir()` silently picked between `workspace_root`/`home_dir`/`legacy_cwd` with no observability into which branch fired.
- `canonical_graft_root()` now logs a structured source: `workspace_root` / `home_dir_fallback` / `missing`.
- `compatible_home_dir()` now logs `home_dir` / `legacy_cwd_fallback` / `missing`.
- Capture tests verify both the primary and fallback branches for each resolver.
- Documents the `update-member --workspace-root` operational step in the Hermes graft runbook, including an explicit boundary decision against automatic roster mutation (reconciliation stays a documented manual step, not automated, for this sprint).

Sprint doc: docs/plans/phase-ai/sprint-ai-35-graft-root-fallback-observability.md
Triage record: .triage/phase-AI/findings/RBQA-F002-AI34.ttl

## Test plan
- [x] `just lint` PASS
- [x] `just test` PASS (full workspace)
- [ ] quality-mgr QA-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)