### PR TITLE
fix(send): require ack for file task envelopes

### DIFF
--- a/crates/atm-core/src/send/file_policy.rs
+++ b/crates/atm-core/src/send/file_policy.rs
@@ -1,10 +1,43 @@
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use crate::error::{AtmError, AtmErrorCode};
 use crate::types::TeamName;
 
 const MAX_FILE_REFERENCE_BYTES: u64 = 10 * 1024 * 1024;
+const TASK_ENVELOPE_INSPECTION_BYTES: u64 = 8 * 1024;
+
+/// Return whether a referenced file is an ATM task envelope.
+///
+/// This is deliberately a narrow recognition rule: only an XML document whose
+/// root tag is `atm-task` changes durable acknowledgement semantics. Other
+/// files remain ordinary references, including files that merely mention the
+/// string in prose.
+pub fn is_task_envelope(file_path: &Path) -> bool {
+    let Ok(file) = fs::File::open(file_path) else {
+        return false;
+    };
+    let mut prefix = Vec::with_capacity(TASK_ENVELOPE_INSPECTION_BYTES as usize);
+    let Ok(_) = file
+        .take(TASK_ENVELOPE_INSPECTION_BYTES)
+        .read_to_end(&mut prefix)
+    else {
+        return false;
+    };
+    std::str::from_utf8(&prefix).is_ok_and(is_task_envelope_body)
+}
+
+fn is_task_envelope_body(body: &str) -> bool {
+    let body = body.trim_start_matches('\u{feff}').trim_start();
+    let Some(after_name) = body.strip_prefix("<atm-task") else {
+        return false;
+    };
+    after_name
+        .chars()
+        .next()
+        .is_some_and(|character| character == '>' || character == '/' || character.is_whitespace())
+}
 
 /// Process a send `--file` reference under the ATM file-policy rules.
 ///
@@ -118,7 +151,7 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::{MAX_FILE_REFERENCE_BYTES, process_file_reference};
+    use super::{MAX_FILE_REFERENCE_BYTES, is_task_envelope, process_file_reference};
     use crate::test_support::TEST_TEAM;
 
     #[test]
@@ -154,5 +187,20 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn recognizes_only_an_atm_task_root_element() {
+        let directory = tempdir().expect("tempdir");
+        let task = directory.path().join("task.xml");
+        let prose = directory.path().join("prose.txt");
+        let similarly_named = directory.path().join("similarly-named.xml");
+        fs::write(&task, "\u{feff}\n <atm-task id=\"TASK-1\"></atm-task>").expect("task fixture");
+        fs::write(&prose, "please review <atm-task id=\"TASK-1\">").expect("prose fixture");
+        fs::write(&similarly_named, "<atm-task-note />").expect("similarly named fixture");
+
+        assert!(is_task_envelope(&task));
+        assert!(!is_task_envelope(&prose));
+        assert!(!is_task_envelope(&similarly_named));
     }
 }

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -624,7 +624,15 @@ fn prepare_persisted_write<
 ) -> Result<PreparedWrite, AtmError> {
     let context = prepare_send_context(runtime, &request)?;
     let task_id = request.task_id.clone();
-    let requires_ack = request.requires_ack || task_id.is_some();
+    // Team-lead dispatches XML task envelopes through `atm send --file`.
+    // Those messages render an immediate-ack instruction, so admission must
+    // create the matching durable pending-ack state even without --task-id.
+    let requires_ack = request.requires_ack
+        || task_id.is_some()
+        || matches!(
+            &request.message_source,
+            SendMessageSource::File { path, .. } if file_policy::is_task_envelope(path)
+        );
     let body = resolve_message_body(
         &request.message_source,
         &request.current_dir,

--- a/crates/atm-core/src/send/tests.rs
+++ b/crates/atm-core/src/send/tests.rs
@@ -1018,6 +1018,43 @@ fn self_addressed_task_send_is_rejected_before_persistence() {
 
 #[test]
 #[serial_test::serial(env)]
+fn plain_file_task_envelope_requires_ack_without_explicit_task_id() {
+    let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
+    let observability = RecordingObservability::default();
+    let tempdir = tempdir().expect("tempdir");
+    let task_file = tempdir.path().join("task-envelope.xml");
+    fs::write(
+        &task_file,
+        "<atm-task id=\"AI-ACK-1\"><description>ack immediately</description></atm-task>",
+    )
+    .expect("task envelope fixture");
+    let mut request = send_request(tempdir.path());
+    request.message_source = SendMessageSource::File {
+        path: task_file,
+        message: None,
+    };
+    request.requires_ack = false;
+    request.task_id = None;
+
+    let outcome = super::send_mail_with_runtime_impl(request, &observability, &runtime, None)
+        .expect("plain file task envelope send succeeds");
+
+    assert!(outcome.requires_ack);
+    assert!(outcome.task_id.is_none());
+    let records = runtime
+        .persisted_records
+        .lock()
+        .expect("records lock")
+        .clone();
+    assert_eq!(records.len(), 1);
+    let record = &records[0];
+    assert!(record.envelope.requires_ack);
+    assert!(record.envelope.pending_ack_at.is_some());
+    assert!(record.envelope.task_id.is_none());
+}
+
+#[test]
+#[serial_test::serial(env)]
 fn self_addressed_dry_run_is_rejected_before_reporting_success() {
     let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
     let observability = RecordingObservability::default();

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -831,6 +831,77 @@ fn ack_persists_read_state_and_acknowledged_timestamp() {
 
 #[test]
 #[serial_test::serial(env)]
+fn cross_team_ack_closes_the_recipient_pending_row_and_delivers_reply_to_source_team() {
+    const RECEIVER_TEAM: &str = "receiver-team";
+    const RECEIVER: &str = "receiver";
+
+    let fixture = Fixture::new();
+    let observability = NullObservability;
+    let message_id = AtmMessageId::new();
+    create_team_with_config(
+        fixture.tempdir.path(),
+        fixture.sqlite_db_path().as_path(),
+        RECEIVER_TEAM,
+        &[RECEIVER],
+    );
+    fixture.write_primary_inbox_for_team(
+        RECEIVER_TEAM,
+        RECEIVER,
+        &[pending_ack_message(
+            PRIMARY_AGENT,
+            "cross-team acknowledgement requested",
+            message_id,
+            PRIMARY_TEAM,
+        )],
+    );
+
+    let outcome = ack_mail(
+        AckRequest {
+            home_dir: fixture.tempdir.path().to_path_buf(),
+            current_dir: fixture.tempdir.path().to_path_buf(),
+            caller_identity: RECEIVER.parse().expect("receiver identity"),
+            caller_chat_id: None,
+            caller_team: RECEIVER_TEAM.parse().expect("receiver team"),
+            message_id,
+            reply_body: "cross-team acknowledgement delivered".to_string(),
+        },
+        &observability,
+    )
+    .expect("cross-team ack succeeds");
+
+    assert_eq!(outcome.team.as_str(), RECEIVER_TEAM);
+    assert_eq!(outcome.agent.as_str(), RECEIVER);
+    assert!(matches!(
+        &outcome.reply_disposition,
+        atm_core::ack::AckReplyDisposition::Sent { reply_target, .. }
+            if reply_target.to_string() == format!("{PRIMARY_AGENT}@{PRIMARY_TEAM}")
+    ));
+
+    let receiver_message = fixture
+        .inbox_contents_for_team(RECEIVER_TEAM, RECEIVER)
+        .into_iter()
+        .find(|message| message.message_id == Some(message_id))
+        .expect("receiver retains acknowledged source");
+    assert!(receiver_message.read);
+    assert!(receiver_message.pending_ack_at.is_none());
+    assert!(receiver_message.acknowledged_at.is_some());
+
+    let reply = fixture
+        .inbox_contents(PRIMARY_AGENT)
+        .into_iter()
+        .find(|message| message.acknowledges_message_id == Some(message_id))
+        .expect("reply is delivered to the source-team mailbox");
+    assert_eq!(reply.from.as_str(), RECEIVER);
+    assert_eq!(
+        reply.source_team.as_ref().map(TeamName::as_str),
+        Some(RECEIVER_TEAM)
+    );
+    assert_eq!(reply.text, "cross-team acknowledgement delivered");
+    assert!(reply.pending_ack_at.is_none());
+}
+
+#[test]
+#[serial_test::serial(env)]
 fn ack_self_addressed_empty_host_target_rejects_without_mutating_source() {
     let fixture = Fixture::new();
     let observability = NullObservability;


### PR DESCRIPTION
## Summary
- Root-caused a real ACK protocol gap: `atm send --file <task.xml>` silently set `requires_ack=false` for hand-composed task envelopes lacking `--task-id`/`--requires-ack`, so recipients following team ack-protocol convention could never successfully `atm ack` the message.
- Fix narrowly detects an `<atm-task>` XML root element (first 8KiB of the referenced file) and infers `requires_ack=true` for those files only — plain prose mentioning the string, or similarly-named tags (`<atm-task-note/>`), are explicitly excluded by test.
- Supersedes commit `4911bb46`, which only re-proved the already-working explicit `requires_ack=true` path and did not reproduce the actual failure.

## Test plan
- [x] New regression test `plain_file_task_envelope_requires_ack_without_explicit_task_id` reproduces the original failure: sends a plain-file task envelope with no explicit ack flag, confirms `requires_ack=true` and durable `pending_ack_at` is set.
- [x] New unit test `recognizes_only_an_atm_task_root_element` confirms narrow recognition (task envelope matches; prose mentioning the tag and similarly-named tags do not).
- [x] `just lint`, `just test` (author-reported, pending independent quality-mgr re-verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)