### PR TITLE
fix(ai31-33): peer-drain scan-cap fallback, joinhandle reaping, hermes smoke ack verify

### DIFF
--- a/crates/atm-daemon/src/peer_drain_coordinator.rs
+++ b/crates/atm-daemon/src/peer_drain_coordinator.rs
@@ -229,7 +229,21 @@ impl PeerDrainCoordinator {
             .into_iter()
             .find(|stored| stored.message_id == job.message_id)
         else {
-            return Ok(EligiblePeerWrite::Missing);
+            let budget = deadline.remaining().ok_or_else(|| {
+                AtmError::remote_delivery_unconfirmed(
+                    "peer delivery deadline elapsed before direct storage lookup",
+                )
+            })?;
+            let Some(stored) = self
+                .outbound
+                .find_for_peer(&job.peer, job.message_id, budget)?
+            else {
+                return Ok(EligiblePeerWrite::Missing);
+            };
+            if stored.created_at < not_before {
+                return Ok(EligiblePeerWrite::Expired);
+            }
+            return Ok(EligiblePeerWrite::Ready(Box::new(decode_request(stored)?)));
         };
         if stored.created_at < not_before {
             return Ok(EligiblePeerWrite::Expired);
@@ -276,6 +290,7 @@ impl PeerDrainCoordinator {
 
     fn run(self: Arc<Self>, receiver: Receiver<PeerWork>) {
         while let Ok(work) = receiver.recv() {
+            Self::reap_finished_workers(&self.job_workers);
             let PeerWork::Job(job) = work else { break };
             let coordinator = Arc::clone(&self);
             let handle = std::thread::spawn(move || {
@@ -303,6 +318,41 @@ impl PeerDrainCoordinator {
         }
         while let Ok(PeerWork::Job(job)) = receiver.try_recv() {
             Self::release_job(&self.state, &job);
+        }
+    }
+
+    fn reap_finished_workers(job_workers: &Mutex<Vec<JoinHandle<()>>>) {
+        let finished = {
+            let Ok(mut workers) = job_workers.lock() else {
+                tracing::warn!(
+                    subsystem = "peer_drain",
+                    action = "reap_workers",
+                    outcome = "lock_poisoned",
+                    "peer delivery worker reaping skipped because worker list is poisoned"
+                );
+                return;
+            };
+            let mut active = Vec::with_capacity(workers.len());
+            let mut finished = Vec::new();
+            for handle in std::mem::take(&mut *workers) {
+                if handle.is_finished() {
+                    finished.push(handle);
+                } else {
+                    active.push(handle);
+                }
+            }
+            *workers = active;
+            finished
+        };
+        for handle in finished {
+            if handle.join().is_err() {
+                tracing::error!(
+                    subsystem = "peer_drain",
+                    action = "reap_workers",
+                    outcome = "worker_panicked",
+                    "peer delivery job panicked after its cleanup wrapper"
+                );
+            }
         }
     }
 }
@@ -455,7 +505,7 @@ fn decode_request(stored: StoredPeerWrite) -> Result<WriteRequest, AtmError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Barrier};
+    use std::sync::{Arc, Barrier, Mutex, mpsc};
 
     fn job(peer: &str) -> PeerJob {
         PeerJob {
@@ -582,6 +632,29 @@ mod tests {
         assert!(
             state.try_take(&acknowledgement),
             "an acknowledgement reply has a distinct ULID and must not be coalesced with its send"
+        );
+    }
+
+    #[test]
+    fn reaps_finished_job_workers_during_normal_dispatch() {
+        let (completed_tx, completed_rx) = mpsc::channel();
+        let workers = Mutex::new(vec![std::thread::spawn(move || {
+            completed_tx.send(()).expect("report completion");
+        })]);
+        completed_rx.recv().expect("worker completed");
+        for _ in 0..100 {
+            if workers.lock().expect("workers lock")[0].is_finished() {
+                break;
+            }
+            std::thread::yield_now();
+        }
+        assert!(workers.lock().expect("workers lock")[0].is_finished());
+
+        PeerDrainCoordinator::reap_finished_workers(&workers);
+
+        assert!(
+            workers.lock().expect("workers lock").is_empty(),
+            "completed worker handles must not accumulate until daemon shutdown"
         );
     }
 }

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -114,7 +114,43 @@ impl OutboundMessageQuery for SqliteOutboundMessageQuery {
                     })
                     .map_err(|error| self.db.error("failed to read outbound peer message", error))?
                 })
-                .collect()
+            .collect()
+        })
+    }
+
+    fn find_for_peer(
+        &self,
+        peer: &HostName,
+        message_id: AtmMessageId,
+        budget: std::time::Duration,
+    ) -> Result<Option<StoredPeerWrite>, AtmError> {
+        self.db.with_connection_budget(budget, |connection| {
+            connection
+                .query_row(
+                    "SELECT message_at, json_extract(envelope_json, '$.peerOutbound.request')
+                     FROM mail_messages
+                     WHERE json_extract(envelope_json, '$.peerOutbound.host') = ?1
+                       AND message_key = ?2",
+                    params![peer.as_str(), format!("atm:{message_id}")],
+                    |row| {
+                        Ok(StoredPeerWrite {
+                            created_at: row.get::<_, String>(0)?.parse().map_err(|_source| {
+                                rusqlite::Error::FromSqlConversionFailure(
+                                    0,
+                                    rusqlite::types::Type::Text,
+                                    "stored peer write timestamp is invalid".into(),
+                                )
+                            })?,
+                            message_id,
+                            request_json: row.get(1)?,
+                        })
+                    },
+                )
+                .optional()
+                .map_err(|error| {
+                    self.db
+                        .error("failed to load outbound peer message by identity", error)
+                })
         })
     }
 }
@@ -798,6 +834,56 @@ mod tests {
             "exclusive cursor returns the next write"
         );
         assert_ne!(first_page[0].message_id, next_page[0].message_id);
+    }
+
+    #[test]
+    fn find_for_peer_returns_a_write_outside_a_bounded_reconciliation_page() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let target: HostName = "peer.example.test".parse().expect("target host");
+        let timestamp = IsoTimestamp::now();
+        let first = AtmMessageId::new();
+        let target_id = AtmMessageId::new();
+        let store = backend.message_store();
+        for (message_id, request, created_at) in [
+            (
+                first,
+                "first",
+                IsoTimestamp::from_datetime(timestamp.into_inner() - Duration::seconds(1)),
+            ),
+            (target_id, "target", timestamp),
+        ] {
+            store
+                .save_message(&peer_outbound_message(
+                    &format!("atm:{message_id}"),
+                    target.as_str(),
+                    request,
+                    created_at,
+                ))
+                .expect("save peer write");
+        }
+
+        let first_page = backend
+            .outbound_message_query()
+            .page_for_peer(
+                &target,
+                IsoTimestamp::from_datetime(timestamp.into_inner() - Duration::seconds(2)),
+                None,
+                NonZeroU16::new(1).expect("nonzero limit"),
+                std::time::Duration::from_secs(1),
+            )
+            .expect("bounded first page");
+        assert_eq!(first_page.len(), 1);
+        assert_ne!(
+            first_page[0].message_id, target_id,
+            "the direct lookup must cover a write omitted by the bounded page"
+        );
+        let stored = backend
+            .outbound_message_query()
+            .find_for_peer(&target, target_id, std::time::Duration::from_secs(1))
+            .expect("direct lookup")
+            .expect("target remains discoverable outside the first page");
+        assert_eq!(stored.message_id, target_id);
+        assert_eq!(stored.request_json, "target");
     }
 
     #[test]

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -713,6 +713,18 @@ pub trait OutboundMessageQuery: sealed::Sealed + Send + Sync {
         limit: NonZeroU16,
         budget: std::time::Duration,
     ) -> Result<Vec<StoredPeerWrite>, AtmError>;
+
+    /// Load one immutable peer-directed write by its canonical identity.
+    ///
+    /// The peer-drain coordinator uses this only after its bounded
+    /// reconciliation page does not contain a newly persisted job. It is a
+    /// direct eligibility lookup, not a cursor or delivery-state mutation.
+    fn find_for_peer(
+        &self,
+        peer: &HostName,
+        message_id: AtmMessageId,
+        budget: std::time::Duration,
+    ) -> Result<Option<StoredPeerWrite>, AtmError>;
 }
 
 mod duration_seconds {

--- a/scripts/phase-ai/run-hermes-graft-smoke.py
+++ b/scripts/phase-ai/run-hermes-graft-smoke.py
@@ -125,8 +125,21 @@ def main() -> None:
             f"message_id={message.message_id} source={message.source} body={message.body!r}"
         )
 
-        receiver_session.acknowledge(message.message_id, f"ack-{marker}")
-        print(f"PASS acknowledge: message_id={message.message_id}")
+        acknowledgement = f"ack-{marker}"
+        receiver_session.acknowledge(message.message_id, acknowledgement)
+        deadline = time.monotonic() + args.timeout
+        while time.monotonic() < deadline:
+            replies = sender_session.read()
+            if any(
+                reply.body == acknowledgement
+                and reply.source.agent == args.agent
+                and reply.source.team == args.team
+                for reply in replies
+            ):
+                break
+        else:
+            raise AssertionError("acknowledgement reply was not delivered to the sender")
+        print(f"PASS acknowledge round trip: message_id={message.message_id}")
     finally:
         sender_session.close()
         receiver_session.close()


### PR DESCRIPTION
## Summary
Fixes 3 findings from arch-ctm's own critical review of integrate/phase-ai-31-33:
- **AI3133-PEERDRAIN-SCAN-CAP**: `eligible_request`'s bounded scan (MAX_PEER_SYNC_BATCH_MESSAGES=100) could silently drop delivery for backlogged peers whose message fell outside the bounded page. Added a deadline-bounded direct immutable lookup by peer+ULID as a fallback when the bounded page misses.
- **AI3133-PEERDRAIN-JOINHANDLE-LEAK**: `job_workers: Arc<Mutex<Vec<JoinHandle<()>>>>` grew unbounded for daemon uptime, only drained at shutdown. Completed handles are now reaped during dispatcher work.
- **AI3133-HERMES-SMOKE-NO-ACK-VERIFY**: `run-hermes-graft-smoke.py`'s poll loop declared PASS without confirming the fire-and-forget `acknowledge()` round-tripped. Smoke now verifies the receiver's ACK reply reaches the original sender before PASS.

## Test plan
- [x] Regression tests for bounded-page omission + direct lookup fallback
- [x] Regression test for worker reaping
- [x] Targeted Rust tests, Python compile, `just test`, `just lint` (author-reported, pending independent quality-mgr re-verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)