### PR TITLE
test(hermes): cover non-internal graft nudges

### DIFF
--- a/crates/atm-graft-python/tests/test_hermes_adapter.py
+++ b/crates/atm-graft-python/tests/test_hermes_adapter.py
@@ -72,7 +72,14 @@ class HermesAdapterContractTests(unittest.TestCase):
         observed = []
 
         async def handle(event) -> None:
-            observed.append((event.source.chat_id, event.source.user_id, event.text))
+            observed.append(
+                (
+                    event.source.chat_id,
+                    event.source.user_id,
+                    event.text,
+                    event.internal,
+                )
+            )
 
         adapter = AtmGraftAdapter(None)
         adapter._chat_id = "8991600178"
@@ -85,7 +92,7 @@ class HermesAdapterContractTests(unittest.TestCase):
         asyncio.run(adapter._dispatch_nudge(chat_key, "reply-route-check"))
         self.assertEqual(
             observed,
-            [("8991600178", "8991600178", "reply-route-check")],
+            [("8991600178", "8991600178", "reply-route-check", False)],
         )
 
 


### PR DESCRIPTION
## Summary
- Closes AI3133-HERMES-NUDGE-INTERNAL-FLAG-UNTESTED (filed during quality-mgr's HERMES-NUDGE-ROUTING-QA-2 review of PR #688): adds an explicit assertion that MessageEvent.internal == False on graft-nudge dispatch, guarding the security-relevant authorization behavior introduced in 61e65d31 (previously the internal flag had zero test coverage — reverting it alone left all tests green).

## Test plan
- [ ] quality-mgr independent re-verify
- [x] Focused adapter tests 5/5 pass
- [x] just test-hermes-graft-bridge 12/12 pass

Follow-up (separate, untouched by this PR): AI3133-GRAFT-SUCCESS-OBSERVABILITY-GAP (daemon-side graft success logging).