### PR TITLE
docs(phase-ai): plan Hermes graft wake-recovery follow-up (AI.36-AI.38)

### DIFF
--- a/docs/adr/ADR-039-python-graft-host-binding.md
+++ b/docs/adr/ADR-039-python-graft-host-binding.md
@@ -27,11 +27,11 @@ retry queue, or second delivery path. The binding calls the existing sealed
 accesses storage directly.
 
 Any session/chat-based host may map a validated `ATM_CHAT_ID` to ADR-037
-`ChatId` before caller address construction. Hermes is the first host adapter;
-AI.19 maps a received canonical source address to a Hermes-local `atm:` chat
-and injects the nudge body through Hermes's ordinary inbound-user-message
-mechanism. No `session_id`, custom session header, webhook-specific address
-grammar, or alternate send/ack path exists.
+`ChatId` before caller address construction. Hermes is the first host adapter.
+Its current profile/session binding and non-interrupting nudge handoff are
+governed by ADR-043: an ATM wake-up is not an ordinary inbound user message.
+No `session_id`, custom session header, webhook-specific address grammar, or
+alternate send/ack path exists.
 
 The atm-core deliverable is an in-repository reference adapter and contract.
 It does not edit or validate an external Hermes checkout; Hermes maintainers

--- a/docs/adr/ADR-043-hermes-graft-wake-up-ownership.md
+++ b/docs/adr/ADR-043-hermes-graft-wake-up-ownership.md
@@ -46,6 +46,12 @@ to make the one-profile path reliable.
    profile's `ChatId` for validation/observability but does not add multi-chat
    routing, fan-out, or a second endpoint namespace. A future multi-channel
    feature must explicitly revise this ADR.
+6. A live steer injection failure while the receiver remains listening is
+   logged and surfaced to the host, but has no in-session retry, periodic
+   poll, normal-message fallback, or graft queue. The accepted recovery path
+   for this first release is a subsequent profile restart/reconnect, which
+   produces the one ten-second durable-mail summary. This residual is explicit
+   rather than hidden by an unbounded background mechanism.
 
 ## Consequences
 
@@ -55,6 +61,8 @@ to make the one-profile path reliable.
   its normal ATM skills to inspect/ack durable mail.
 - The implementation adds a small count projection over the existing daemon
   read contract; it adds no daemon session, mailbox table, queue, or protocol.
+- An in-session steer failure remains operator-observable residual risk until a
+  separately approved bounded recovery design exists.
 
 ## Alternatives considered
 

--- a/docs/adr/ADR-043-hermes-graft-wake-up-ownership.md
+++ b/docs/adr/ADR-043-hermes-graft-wake-up-ownership.md
@@ -1,0 +1,74 @@
+# ADR-043 — Hermes Graft Wake-up Ownership and Recovery
+
+| Field | Value |
+| --- | --- |
+| ID | ADR-043 |
+| Status | Proposed |
+| Scope | `atm-graft`, Python binding, and Hermes reference adapter |
+| Relates to | ADR-037, ADR-039, ADR-033 |
+
+## Context
+
+ATM mail is durable in the daemon-owned mailbox. Graft exists to provide a
+thin embedded daemon client and to push bounded wake-up notifications into a
+host agent. The existing receiver record has one pathname per root/team/agent
+but no ownership generation or safe hand-off rule. The reference Hermes
+adapter also converts graft nudges into normal Telegram-style user messages,
+which can interrupt a running agent.
+
+Hermes runs one long-lived profile for each ATM team member. Profiles can
+restart independently; a restart must discover durable work without making
+graft a second mailbox. A profile's `ATM_CHAT_ID` identifies its actual host
+session today. Future multi-channel support is desirable but is not required
+to make the one-profile path reliable.
+
+## Decision
+
+1. A graft receiver endpoint is singly owned by `(canonical graft root, team,
+   agent)`. Activation acquires an OS-backed ownership guard and publishes a
+   fresh random generation in the endpoint record. Concurrent activation fails
+   without mutating the active record. Close removes a record only when its
+   generation matches the owner; process death releases the ownership guard so
+   the next profile can reclaim it.
+2. Graft's only persistent state is none. Its temporary state is bounded
+   nudge-handoff work. The daemon mailbox and ordinary daemon API remain the
+   sole authority for mail, unread state, and acknowledgement state.
+3. A Hermes profile carries one configured `ChatId`. Live graft nudges and the
+   one restart summary invoke Hermes's non-interrupting steer seam for that
+   exact profile session. They must not use normal inbound-user-message
+   dispatch and must not create a Hermes conversation manager.
+4. Exactly ten seconds after a successful receiver activation, the Python
+   adapter queries ordinary daemon `ReadOutcome.bucket_counts`. If `unread` or
+   `pending_ack` is non-zero, it emits one advisory steer: `ATM: <u> unread
+   messages; <p> acknowledgements pending.` It makes no individual message
+   replay, read, ack, retry loop, or persistence write.
+5. The endpoint record remains one receiver per agent for now. It stores the
+   profile's `ChatId` for validation/observability but does not add multi-chat
+   routing, fan-out, or a second endpoint namespace. A future multi-channel
+   feature must explicitly revise this ADR.
+
+## Consequences
+
+- A profile restart becomes recoverable even when a prior live nudge was lost.
+- A second live gateway cannot silently steal another profile's wake-ups.
+- The host agent sees concise ATM work prompts in its safe steer flow and uses
+  its normal ATM skills to inspect/ack durable mail.
+- The implementation adds a small count projection over the existing daemon
+  read contract; it adds no daemon session, mailbox table, queue, or protocol.
+
+## Alternatives considered
+
+- **Normal Telegram-style `MessageEvent` injection:** rejected because it can
+  disrupt a running agent and has different scheduling semantics than steer.
+- **A graft-owned durable queue/retry store:** rejected because it duplicates
+  daemon mailbox authority and creates reconciliation/state ownership.
+- **Last writer wins endpoint publication:** rejected because it loses a live
+  profile's wake-ups and permits an old close to delete a successor record.
+- **Multi-chat endpoint registry now:** deferred; it adds policy/fan-out work
+  before the required one-profile reliability path is proven.
+
+## Follow-up work
+
+- AI.36: singleton receiver ownership and generation-safe endpoint removal.
+- AI.37: one delayed durable-work summary after profile recovery.
+- AI.38: Hermes steer injection and end-to-end non-interruption evidence.

--- a/docs/atm-graft/boundaries.md
+++ b/docs/atm-graft/boundaries.md
@@ -39,6 +39,12 @@ Rules:
 - automatic between-tool-call nudge injection belongs to this consumer layer
 - reconnect and shutdown behavior are owned here rather than in daemon-private
   runtime code
+- one active receiver must own each canonical `(graft root, team, agent)`
+  endpoint record. Ownership acquisition is explicit and a second live owner
+  fails without replacing the published endpoint; stale owner recovery is
+  process-death-safe.
+- receiver-local state may be a bounded transient nudge handoff only. It must
+  not persist mail, retain acknowledgement state, or implement reconciliation.
 - receiver-private task/thread/callback choices stay inside this consumer layer
 - `atm-graft` must not require shared daemon session registration, daemon-owned
   per-session queues, or a dedicated shared advisory-stream packet family
@@ -52,6 +58,8 @@ Purpose:
 Rules:
 - the host executable owns the final insertion point
 - `atm-graft` must drive that path automatically once nudges arrive
+- a Hermes adapter must use the host's non-interrupting steer insertion path,
+  not normal user-message ingress; the latter may interrupt a running agent
 - external terminal automation is not an accepted production delivery path
 - a language binding may translate the existing `HostNudgeInjector` callback
   into its host language, but may not add another receiver, transport, retry,
@@ -71,3 +79,6 @@ Rules:
   well. Unix UDS support is permitted only transitively through the approved
   `atm-daemon-client` facade.
 - it must not dispatch daemon requests or access SQLite/storage directly
+- endpoint records carry the receiver generation needed to make close
+  compare-and-remove safe; they remain one receiver endpoint per current
+  `(root, team, agent)`, not a multi-chat session registry

--- a/docs/atm-graft/hermes-agent-use-case.md
+++ b/docs/atm-graft/hermes-agent-use-case.md
@@ -23,7 +23,7 @@ options = atm_graft.PyGraftSessionOptions(
     os.environ["ATM_IDENTITY"],
     os.environ["ATM_TEAM"],
 )
-bridge = HermesGraftBridge(caller, options, inject_user_message)
+bridge = HermesGraftBridge(caller, options, inject_steer)
 bridge.start()
 ```
 
@@ -33,19 +33,21 @@ for client operations; it is not a separate receiver endpoint. Keep the bridge
 alive for the gateway lifetime and call `bridge.close()` during shutdown.
 
 The receiver callback runs from the graft receiver thread. The Hermes adapter
-maps the canonical source address to an isolated ATM chat key and schedules a
-native internal message on the gateway event loop:
+retains the canonical source address for attribution and schedules a
+non-interrupting steer to the configured profile session on the gateway event
+loop:
 
 ```text
 PyNudge(source=hendrix:1234@hermes, body=...) →
-atm:hendrix:1234@hermes → MessageEvent(internal=True) → gateway._handle_message()
+configured ATM_CHAT_ID → HermesSteerPort.steer(...)
 ```
 
 The callback uses `asyncio.run_coroutine_threadsafe()` (or the equivalent
 gateway-safe scheduling primitive) to cross from the receiver thread into the
 Hermes event loop. Duplicate message IDs are suppressed by the bridge. The
-body is then handled by Hermes's ordinary inbound-user-message path, so no
-manual `atm read` turn is required.
+steer wakes the host at its next safe tool-loop boundary; the agent's ATM
+skills then use normal daemon-backed `read`/`ack` operations. The bridge never
+stores or consumes mail itself.
 
 For messages that require an explicit ATM acknowledgement, pass the optional
 `requires_ack` argument and acknowledge the returned message after reading it:
@@ -68,7 +70,8 @@ The gateway environment supplies:
 - `ATM_IDENTITY` — the agent name;
 - `ATM_TEAM` — the ATM team name;
 - `ATM_HOME` — the ATM home/workspace root; and
-- the Hermes-side chat ID, such as the Telegram chat ID.
+  - the Hermes-side chat ID, such as the Telegram chat ID, which is the
+    profile's current host-session binding.
 
 The ATM roster must also identify the workspace root where the gateway's graft
 endpoint is published. If the gateway profile's `ATM_HOME` differs from its

--- a/docs/atm-graft/hermes-agent-use-case.md
+++ b/docs/atm-graft/hermes-agent-use-case.md
@@ -6,6 +6,17 @@ agent (Hermes) acts as a native ATM client through the PyO3 bindings in
 it does not shell out to the `atm` CLI and does not open a second daemon or
 storage path.
 
+## Status
+
+**Current validated flow (pre-AI.36–AI.38):** the checked-in generic bridge
+delivers its typed callback to a host-provided inbound callable. The retained
+Live validation section below documents that pre-AI.38 flow only.
+
+**Target flow (AI.36–AI.38, proposed):** one lease-safe receiver per profile
+identity, one ten-second durable-work summary after recovery, and an adapter
+that injects live/recovery wake-ups through the configured Hermes steer path.
+Those target artifacts are not yet shipped by this document's baseline.
+
 ## Integration shape
 
 Each Hermes gateway runs one background `HermesGraftBridge`. At gateway startup
@@ -23,7 +34,7 @@ options = atm_graft.PyGraftSessionOptions(
     os.environ["ATM_IDENTITY"],
     os.environ["ATM_TEAM"],
 )
-bridge = HermesGraftBridge(caller, options, inject_steer)
+bridge = HermesGraftBridge(caller, options, inject_user_message)
 bridge.start()
 ```
 
@@ -32,22 +43,21 @@ The optional caller `chat_id` supplies the Hermes/Telegram conversation context
 for client operations; it is not a separate receiver endpoint. Keep the bridge
 alive for the gateway lifetime and call `bridge.close()` during shutdown.
 
-The receiver callback runs from the graft receiver thread. The Hermes adapter
-retains the canonical source address for attribution and schedules a
-non-interrupting steer to the configured profile session on the gateway event
-loop:
+In the current validated flow, the receiver callback runs from the graft
+receiver thread. The host maps the canonical source address to an ATM chat key
+and schedules its configured inbound callback on the gateway event loop:
 
 ```text
 PyNudge(source=hendrix:1234@hermes, body=...) →
-configured ATM_CHAT_ID → HermesSteerPort.steer(...)
+atm:hendrix:1234@hermes → host-provided callback
 ```
 
 The callback uses `asyncio.run_coroutine_threadsafe()` (or the equivalent
 gateway-safe scheduling primitive) to cross from the receiver thread into the
-Hermes event loop. Duplicate message IDs are suppressed by the bridge. The
-steer wakes the host at its next safe tool-loop boundary; the agent's ATM
-skills then use normal daemon-backed `read`/`ack` operations. The bridge never
-stores or consumes mail itself.
+Hermes event loop. Duplicate message IDs are suppressed by the bridge. AI.38
+replaces this target host handoff with non-interrupting steer; this current
+flow does not itself prove steer semantics. The bridge never stores or
+consumes mail itself.
 
 For messages that require an explicit ATM acknowledgement, pass the optional
 `requires_ack` argument and acknowledge the returned message after reading it:

--- a/docs/atm-graft/requirements.md
+++ b/docs/atm-graft/requirements.md
@@ -81,6 +81,25 @@ Initial crate requirement IDs:
   must use structured `AgentAddress`, preserve the immutable message ID, and
   must not create a session header, daemon session, or transport-specific
   routing policy.
+- `REQ-GRAFT-RUNTIME-002` A graft receiver has exactly one active owner for a
+  `(canonical_graft_root, team, agent)` endpoint record. Activation must either
+  acquire that ownership or fail with a typed conflict; it must never silently
+  replace a live receiver. Close may remove a record only when it still owns
+  the published generation. A crashed owner must be reclaimable without an
+  operator deleting a stale file.
+- `REQ-GRAFT-NOTIFY-002` Graft nudges are bounded wake-up signals only. They
+  are never mail storage, a durable retry queue, a conversation manager, or a
+  second mailbox. The daemon mailbox remains the source of truth.
+- `REQ-GRAFT-HERMES-002` One Hermes profile binds one ATM identity and its
+  configured ADR-037 `ChatId` host session. Live and recovery wake-ups must
+  enter that host session through its non-interrupting steer path, not through
+  normal inbound-user-message dispatch. The full source address, including a
+  present chat-id, remains available for attribution and reply routing.
+- `REQ-GRAFT-HERMES-003` After a Hermes profile receiver becomes listening,
+  its Python adapter waits exactly ten seconds once, reads durable mailbox
+  bucket counts through the ordinary daemon API, and emits at most one concise
+  steer summary when unread or pending-ack counts are non-zero. The summary is
+  advisory; it neither reads, acknowledges, persists, nor replays mail.
 
 ## 4. Required References
 
@@ -155,10 +174,11 @@ Required rules:
   signaling before asserting injection success; acceptance must not depend on
   scheduler luck or on a shorter `#[cfg(test)]` delivery deadline than the
   accepted production path
-- if the host is idle when a nudge arrives, `atm-graft` must enqueue the
-  received nudge or retain equivalent receiver-local state until host
-  consumption and fire a host wake/event signal so the host takes follow-on
-  action promptly
+- if the host is idle when a nudge arrives, `atm-graft` must deliver one
+  bounded receiver-local wake-up through its host injection seam and fire the
+  host wake/event signal promptly. Any receiver-local buffer is transient,
+  bounded, and contains only nudge metadata; it must not become mail storage
+  or a durable retry queue.
 - the exact task/thread/callback mechanism used for that behavior is private to
   `atm-graft` and is not fixed by this requirement doc
 - production `atm-graft` acceptance must not depend on `tmux send-keys`,
@@ -259,8 +279,10 @@ Scope-simplification rule for the first implementation pass:
 - `REQ-GRAFT-NOTIFY-001`
   - daemon-originated nudge receipt is automatic in embedded mode
   - the host-facing nudge payload exposes at least `from` and `message_id`
-  - the client runtime queues nudges or retains equivalent receiver-local
-    state until host consumption and emits a host wake/event signal on arrival
+  - the client runtime delivers bounded transient nudges through the host
+    injection seam and emits a host wake/event signal on arrival; durable mail
+    recovery is supplied by the ordinary daemon read contract, not a graft
+    queue
   - no acceptance path relies on `tmux send-keys` or external terminal key
     injection as the delivery mechanism
 - `REQ-GRAFT-OBS-001`
@@ -268,3 +290,15 @@ Scope-simplification rule for the first implementation pass:
     injected ATM-owned observability boundary
   - the concrete exported observability/injection seams include
     `GraftObservability` and `HostNudgeInjector`
+- `REQ-GRAFT-RUNTIME-002`
+  - a second simultaneous activation for the same canonical root/team/agent
+    fails without changing the current endpoint record
+  - closing an old receiver cannot remove a successor's endpoint record
+  - an abandoned owner can be reclaimed after process death
+- `REQ-GRAFT-HERMES-002` and `REQ-GRAFT-HERMES-003`
+  - an adapter test proves live graft notification invokes the configured steer
+    seam and never ordinary user-message ingress
+  - a restart test proves exactly one summary steer after ten seconds when
+    durable `bucket_counts.unread` or `bucket_counts.pending_ack` is non-zero
+  - a zero-count restart emits no steer; a live nudge during the delay remains
+    a normal one-event wake-up

--- a/docs/plans/phase-ai/README.md
+++ b/docs/plans/phase-ai/README.md
@@ -37,6 +37,13 @@ graft nudge adapter; they are specified in
 [ai17-21-hermes-graft-overview.md](./ai17-21-hermes-graft-overview.md). They
 add no message schema, CLI grammar, HTTP resource, or alternate write path.
 
+AI.36–AI.38 close the resulting graft wake-up reliability gaps without adding
+mail storage or a conversation manager: [AI.36](sprint-ai-36-graft-receiver-ownership.md)
+makes receiver ownership safe, [AI.37](sprint-ai-37-hermes-recovery-summary.md)
+adds one durable-mail-derived restart summary, and
+[AI.38](sprint-ai-38-hermes-steer-nudge-delivery.md) routes live/recovery
+wake-ups through Hermes's non-interrupting steer path.
+
 The checked-in OpenAPI 3.1 description is a durable interface artifact. A
 browser UI is intentionally deferred to a later phase and consumes this API as
 a client.

--- a/docs/plans/phase-ai/README.md
+++ b/docs/plans/phase-ai/README.md
@@ -37,12 +37,15 @@ graft nudge adapter; they are specified in
 [ai17-21-hermes-graft-overview.md](./ai17-21-hermes-graft-overview.md). They
 add no message schema, CLI grammar, HTTP resource, or alternate write path.
 
-AI.36–AI.38 close the resulting graft wake-up reliability gaps without adding
-mail storage or a conversation manager: [AI.36](sprint-ai-36-graft-receiver-ownership.md)
+AI.36–AI.38 plan the first closure of identified graft wake-up reliability
+gaps without adding mail storage or a conversation manager:
+[AI.36](sprint-ai-36-graft-receiver-ownership.md)
 makes receiver ownership safe, [AI.37](sprint-ai-37-hermes-recovery-summary.md)
 adds one durable-mail-derived restart summary, and
 [AI.38](sprint-ai-38-hermes-steer-nudge-delivery.md) routes live/recovery
-wake-ups through Hermes's non-interrupting steer path.
+wake-ups through Hermes's non-interrupting steer path. A live steer failure
+while the receiver remains connected is an explicitly retained, logged
+residual; ADR-043 forbids masking it with an unbounded graft retry queue.
 
 The checked-in OpenAPI 3.1 description is a durable interface artifact. A
 browser UI is intentionally deferred to a later phase and consumes this API as

--- a/docs/plans/phase-ai/ai17-21-hermes-graft-overview.md
+++ b/docs/plans/phase-ai/ai17-21-hermes-graft-overview.md
@@ -39,6 +39,9 @@ AI.17–AI.21 consume these Phase AI decisions unchanged:
    and routes it to the corresponding isolated Hermes chat.
 3. Deliver graft nudges to Hermes as in-process events, using the canonical
    message identity in the payload rather than a custom `X-Session-ID` header.
+   AI.36–AI.38 amend the host handoff to use the configured profile's
+   non-interrupting steer path and add restart recovery; they do not alter the
+   ATM message identity or daemon API.
 4. Deploy one supervised bridge per Hermes profile and prove the documented
    multi-turn user stories.
 

--- a/docs/plans/phase-ai/hermes-graft-adapter-contract.md
+++ b/docs/plans/phase-ai/hermes-graft-adapter-contract.md
@@ -6,17 +6,15 @@
 
 ## Scope
 
-`atm_graft_hermes_bridge.HermesGraftBridge` is the ATM-core reference adapter
-for one Hermes profile. It creates one existing `PyGraftSession`, activates
-that session with one `PyGraftSessionOptions`, and gives the existing graft
-receiver one Python nudge callback.
-
-The adapter does not open a socket, write ATM data, retain mail, retry a
-delivery, or implement an alternate acknowledgement path. It forwards a
-canonical nudge body to the configured profile's non-interrupting steer
-callable exactly once for a message ID retained in its bounded in-memory
-duplicate set. ADR-043 and AI.36–AI.38 supersede the earlier ordinary
-inbound-user-message handoff.
+`atm_graft_hermes_bridge.HermesGraftBridge` stays the generic ATM-core bridge:
+it creates one `PyGraftSession`, activates one receiver, de-duplicates typed
+nudges by bounded message-ID memory, and invokes its supplied callback. It
+does not know Hermes steer semantics. AI.38 creates the separate
+`atm_graft_hermes_adapter.py` artifact and its `HermesSteerPort`; that adapter
+owns forwarding a live nudge or recovery notice to the configured profile's
+non-interrupting steer callable. Neither layer opens an ATM socket directly,
+writes/retains mail, retries delivery, or implements an alternate
+acknowledgement path.
 
 ## Typed callback
 

--- a/docs/plans/phase-ai/hermes-graft-adapter-contract.md
+++ b/docs/plans/phase-ai/hermes-graft-adapter-contract.md
@@ -7,10 +7,12 @@ for one Hermes profile. It creates one existing `PyGraftSession`, activates
 that session with one `PyGraftSessionOptions`, and gives the existing graft
 receiver one Python nudge callback.
 
-The adapter does not open a socket, write ATM data, retry a delivery, poll, or
-implement an alternate acknowledgement path. It forwards a canonical nudge
-body to the host's ordinary inbound-user-message callable exactly once for a
-message ID retained in its bounded in-memory duplicate set.
+The adapter does not open a socket, write ATM data, retain mail, retry a
+delivery, or implement an alternate acknowledgement path. It forwards a
+canonical nudge body to the configured profile's non-interrupting steer
+callable exactly once for a message ID retained in its bounded in-memory
+duplicate set. ADR-043 and AI.36–AI.38 supersede the earlier ordinary
+inbound-user-message handoff.
 
 ## Typed callback
 
@@ -19,26 +21,28 @@ The callback receives `PyNudge` from AI.18. It uses only these typed values:
 - `nudge.message_id` — immutable duplicate-suppression key;
 - `nudge.source` — a validated `PyAgentAddress` whose `__str__()` renders the
   canonical chat identity;
-- `nudge.body` — the body submitted to Hermes's normal inbound-user-message
-  path.
+- `nudge.body` — the concise text submitted to Hermes's configured steer path.
 
 `PyNudge(message_id, source, body)` is a validated Python value constructor
 for bridge/reference-adapter tests. It validates the immutable message ID and
 nonblank body; it does not write, route, or synthesize a nudge.
 
-It performs no address parsing, segment validation, or rendering. It prefixes
-the binding-rendered identity with `atm:`, yielding `atm:agent:chat-id@team`
-or `atm:agent@team`. The prefix keeps ATM state disjoint from Telegram,
-Discord, and every other host namespace.
+It performs no address parsing, segment validation, or rendering. The
+binding-rendered identity is retained as attribution (`atm:agent:chat-id@team`
+or `atm:agent@team`); it does not select a second Hermes conversation. The
+configured profile `ATM_CHAT_ID` selects the one current host session.
 
 The callback is emitted only after the canonical write is durable. A failed
 host injection propagates to the existing graft callback caller; the bridge
-does not retry or persist a delivery result.
+does not retry or persist a delivery result. After receiver activation, it may
+perform the single ADR-043 ten-second count check and submit one advisory
+recovery steer; this is derived from the ordinary daemon mailbox read contract
+and is not a nudge queue or replay.
 
 ## Downstream handoff
 
 Hermes maintainers copy or package this adapter in the Hermes repository,
-connect `inject_user_message(chat_key, body)` to Hermes's existing inbound
-user-message path, and validate it in that repository's normal review and
-test process. This ATM-core sprint changes no external checkout and does not
-make downstream Hermes merge status a closure gate.
+connect its narrow `HermesSteerPort` to Hermes's supported non-interrupting
+steer API, and validate it in that repository's normal review and test
+process. This ATM-core sprint changes no external checkout and does not make
+downstream Hermes merge status a closure gate.

--- a/docs/plans/phase-ai/hermes-graft-adapter-contract.md
+++ b/docs/plans/phase-ai/hermes-graft-adapter-contract.md
@@ -1,5 +1,9 @@
 # Hermes Graft Adapter Contract
 
+> **Status:** AI.38 target contract. The current checked-in bridge is generic
+> `inject_user_message` callback plumbing; it does not yet contain the new
+> `atm_graft_hermes_adapter.py` artifact or a Hermes steer implementation.
+
 ## Scope
 
 `atm_graft_hermes_bridge.HermesGraftBridge` is the ATM-core reference adapter
@@ -41,8 +45,9 @@ and is not a nudge queue or replay.
 
 ## Downstream handoff
 
-Hermes maintainers copy or package this adapter in the Hermes repository,
-connect its narrow `HermesSteerPort` to Hermes's supported non-interrupting
-steer API, and validate it in that repository's normal review and test
-process. This ATM-core sprint changes no external checkout and does not make
-downstream Hermes merge status a closure gate.
+AI.38 supplies a checked-in `HermesSteerFixture` and
+`scripts/phase-ai/run-hermes-steer-smoke.py` as its merge-gating reference
+proof. Hermes maintainers may additionally copy or package the adapter in the
+Hermes repository and connect its narrow `HermesSteerPort` to the supported
+steer API. That downstream production merge is useful operational evidence but
+is not a closure gate for the ATM-core sprint.

--- a/docs/plans/phase-ai/hermes-graft-runbook.md
+++ b/docs/plans/phase-ai/hermes-graft-runbook.md
@@ -27,8 +27,9 @@ unstarted and return its nonzero status to launchd, which may retry the same
 gate through `KeepAlive`. This is the required pre-activation readiness gate;
 the active probe below verifies an already-started job and does not replace it.
 `@BRIDGE_COMMAND@` is the profile-owned Hermes runner that imports
-`atm_graft_hermes_bridge`; it is not a daemon command. The runner uses its
-ordinary inbound-user-message hook.
+`atm_graft_hermes_bridge`; it is not a daemon command. The runner binds the
+bridge to the configured profile's non-interrupting steer hook, not ordinary
+inbound-user-message ingress.
 
 The bridge process is restartable by launchd. It does not start, stop, restart,
 or own `atm-daemon`.

--- a/docs/plans/phase-ai/plan-ai17-21-hermes-graft.md
+++ b/docs/plans/phase-ai/plan-ai17-21-hermes-graft.md
@@ -65,9 +65,10 @@ mapping is deterministic and never changes the persisted message address.
 The graft callback receives the canonical post-write nudge. The bridge passes
 the message ID and binding-rendered canonical source address into Hermes. It
 must not use a custom session-routing header, locally parse or re-render that
-address, or issue another ATM write. Hermes uses the `atm:`-prefixed canonical
-source identity to select the incoming chat, then submits the body to its
-ordinary inbound-user-message path.
+address, or issue another ATM write. This historical AI.17–AI.21 plan used an
+incoming-chat handoff; ADR-043 and AI.36–AI.38 supersede that handoff with the
+configured profile's non-interrupting steer path. The source remains
+attribution/reply identity, not a Hermes session selector.
 
 ### Boundaries
 

--- a/docs/plans/phase-ai/plan-phase-ai.md
+++ b/docs/plans/phase-ai/plan-phase-ai.md
@@ -192,6 +192,9 @@ integration; they do not alter it.
 | AI.31 | `feature/pAI-s31-async-local-admission` | SQLite-only local admission response; host-qualified peer work is signalled after response |
 | AI.32 | `feature/pAI-s32-independent-peer-jobs` | Bounded non-durable per-ULID peer jobs; no cross-command delivery-order promise or stream abstraction |
 | AI.33 | `feature/pAI-s33-admission-capacity-smoke` | Isolated 1,000/s admission proof and ten-run, endpoint-explicit local/cross-host smoke report |
+| AI.36 | `feature/pAI-s36-graft-receiver-ownership` | One lease-safe receiver owner per canonical graft root/team/agent; crash reclaim and generation-safe endpoint removal |
+| AI.37 | `feature/pAI-s37-hermes-recovery-summary` | One ten-second durable-mail-derived recovery summary; no graft mail queue or mailbox mutation |
+| AI.38 | `feature/pAI-s38-hermes-steer-nudge-delivery` | Live and recovery graft wake-ups enter the configured Hermes profile through non-interrupting steer, never normal user-message ingress |
 
 AI.17–AI.21 scope, dependencies, and parallel-execution rules are
 authoritative in [plan-ai17-21-hermes-graft.md](plan-ai17-21-hermes-graft.md).

--- a/docs/plans/phase-ai/plan-phase-ai.md
+++ b/docs/plans/phase-ai/plan-phase-ai.md
@@ -192,6 +192,8 @@ integration; they do not alter it.
 | AI.31 | `feature/pAI-s31-async-local-admission` | SQLite-only local admission response; host-qualified peer work is signalled after response |
 | AI.32 | `feature/pAI-s32-independent-peer-jobs` | Bounded non-durable per-ULID peer jobs; no cross-command delivery-order promise or stream abstraction |
 | AI.33 | `feature/pAI-s33-admission-capacity-smoke` | Isolated 1,000/s admission proof and ten-run, endpoint-explicit local/cross-host smoke report |
+| AI.34 | `fix/hermes-nudge-endpoint-mismatch` | Canonical roster workspace-root resolution for Python-graft post-send nudge endpoint delivery |
+| AI.35 | `feature/pAI-s35-graft-root-fallback-observability` | Graft-root fallback observability and operator runbook closure |
 | AI.36 | `feature/pAI-s36-graft-receiver-ownership` | One lease-safe receiver owner per canonical graft root/team/agent; crash reclaim and generation-safe endpoint removal |
 | AI.37 | `feature/pAI-s37-hermes-recovery-summary` | One ten-second durable-mail-derived recovery summary; no graft mail queue or mailbox mutation |
 | AI.38 | `feature/pAI-s38-hermes-steer-nudge-delivery` | Live and recovery graft wake-ups enter the configured Hermes profile through non-interrupting steer, never normal user-message ingress |

--- a/docs/plans/phase-ai/sprint-ai-19-hermes-graft-integration.md
+++ b/docs/plans/phase-ai/sprint-ai-19-hermes-graft-integration.md
@@ -11,7 +11,10 @@ target: integrate/phase-AI
 
 ## Goal
 
-Connect the AI.18 graft callback to Hermes’s normal inbound-user-message path.
+Historical AI.19 scope connected the AI.18 graft callback to Hermes’s normal
+inbound-user-message path. ADR-043 and AI.36–AI.38 supersede that wake-up
+handoff with the configured profile's non-interrupting steer path; this frozen
+sprint remains an implementation-history record, not the current requirement.
 The callback receives a canonical post-write nudge; Hermes uses its structured
 source address to select an isolated `atm:` chat and injects the message body.
 

--- a/docs/plans/phase-ai/sprint-ai-36-graft-receiver-ownership.md
+++ b/docs/plans/phase-ai/sprint-ai-36-graft-receiver-ownership.md
@@ -1,0 +1,187 @@
+---
+title: AI.36 graft receiver ownership
+status: proposed
+branch: feature/pAI-s36-graft-receiver-ownership
+target: integrate/phase-AI
+depends_on: AI.35
+---
+
+# AI.36 — Graft receiver ownership
+
+```yaml
+plan_type: sprint_plan
+phase: AI
+sprint: AI.36
+worktree: feature/pAI-s36-graft-receiver-ownership
+branch: feature/pAI-s36-graft-receiver-ownership
+status: proposed
+estimated_scope: small cross-platform Rust lifecycle change
+```
+
+## Goal
+
+Make one live graft receiver the unambiguous owner of each canonical
+`(graft_root, team, agent)` endpoint. A restart may reclaim a dead owner, but
+two live profiles must never overwrite or delete one another's endpoint.
+
+## Scope Summary
+
+This sprint changes receiver ownership only. It does not add a mailbox queue,
+retry delivery, multi-chat routing, or Hermes-specific steering. The current
+single endpoint path remains `.atm/graft/<team>/<agent>.json`; `ChatId` is
+recorded for validation/observability only and does not change that path.
+
+## Governing Requirements
+
+- `REQ-GRAFT-RUNTIME-002`
+- `REQ-GRAFT-NOTIFY-002`
+- `REQ-CORE-GRAFT-001`
+- ADR-037 address identity and `ChatId` preservation
+
+## Governing ADRs
+
+- ADR-039 — Python Graft Host Binding
+- ADR-043 — Hermes Graft Wake-up Ownership and Recovery
+
+## Governing Boundaries
+
+- `docs/atm-graft/boundaries.md`: Session Runtime Consumer and Post-Send
+  Notification Transport
+- `atm-core::graft::GraftReceiverListener` owns record format/publication;
+  `atm-graft::GraftSession` owns lifecycle.
+
+## Prerequisites
+
+- AI.34's canonical graft-root resolver is merged; publisher and daemon use
+  the same root.
+
+## Hard Dependencies
+
+- This sprint blocks AI.37 and AI.38 because recovery/steer cannot be reliable
+  while a second profile can steal or erase the receiver endpoint.
+
+## Non-Goals
+
+- No daemon-owned session registry, SQLite table, durable nudge queue, or
+  message retry state.
+- No endpoint fan-out or multiple active chat sessions for one agent.
+- No normal-message or steer injection behavior.
+
+## Sub-Tasks
+
+### 1. Version and record contract
+
+Development work:
+
+1. First commit sets all releasable assemblies to `1.4.0-beta-ai.36`.
+2. In `crates/atm-core/src/graft.rs`, extend the private endpoint-record
+   format with a random `owner_generation` and the optional owning `ChatId`.
+   Bump `GRAFT_RECEIVER_RECORD_SCHEMA_VERSION`; old records fail closed rather
+   than being guessed as live owners.
+3. Add a private ownership guard acquired before record publication. Its
+   cross-platform implementation must use an OS-released exclusive file lock
+   on a sibling lock path; do not use a create-only sentinel that survives a
+   crashed process.
+
+Required shape:
+
+```rust
+struct ReceiverOwnershipGuard { /* exclusive lock held for listener lifetime */ }
+
+struct GraftReceiverEndpointRecord {
+    schema_version: u8,
+    owner_generation: String,
+    owner_chat_id: Option<ChatId>,
+    loopback: SocketAddr,
+    capability_base64url: String,
+}
+```
+
+Required tests:
+
+- record decoding rejects the old schema and a malformed generation;
+- one owner publishes a record containing its generation and optional chat ID.
+
+### 2. Acquire, close, and reclaim lifecycle
+
+Development work:
+
+1. Change `GraftReceiverListener::bind` to acquire the guard before binding
+   and publishing. A conflicting live acquisition returns a typed
+   `GraftReceiverAlreadyActive` error naming root/team/agent; it must not bind
+   a replacement socket or write the record.
+2. Change `Drop`/close cleanup to read the current record and unlink only when
+   `owner_generation` equals the listener generation. Never blindly remove the
+   path.
+3. Thread the caller's optional `ChatId` from `GraftSessionOptions` into the
+   receiver record. A live owner with a different chat ID still conflicts; AI.36
+   does not choose a multi-session routing policy.
+
+Required tests:
+
+- two concurrent activations of the same identity: first remains reachable,
+  second fails, and record bytes are unchanged;
+- an old listener's cleanup cannot delete a manually published successor
+  generation;
+- a short-lived child process acquires then exits without close; a parent can
+  subsequently acquire the same guard on macOS, Linux, and Windows;
+- distinct agents or teams under the same root can listen concurrently.
+
+### 3. Boundary and observability closure
+
+Development work:
+
+1. Emit structured activation/conflict/reclaim/compare-remove outcomes through
+   existing graft observability; never log capability material.
+2. Update Python snapshot/error translation only as needed to surface the
+   typed conflict without parsing strings.
+3. Add a structural test/gate that the endpoint record is written only by
+   `GraftReceiverListener` and receiver ownership is not reimplemented in the
+   Python bridge.
+
+Required tests:
+
+- Python activation reports the typed conflict;
+- a source scan rejects a second record publisher or direct record unlink
+  outside the owner implementation.
+
+## Split Recommendation
+
+Do not combine this with recovery counts or Hermes injection. Receiver lease
+correctness is independently production-ready and its cross-platform failure
+model deserves its own closure.
+
+## Acceptance Criteria
+
+1. Exactly one live receiver owns a canonical root/team/agent endpoint.
+2. A second live activation changes neither socket nor endpoint record and
+   returns a typed error.
+3. A dead owner is reclaimable without manual filesystem cleanup.
+4. Old cleanup cannot remove a successor's record.
+5. `ChatId` is preserved as owner metadata without adding multi-session
+   routing.
+
+## Required Validation
+
+```text
+cargo test -p atm-core graft -- --nocapture
+cargo test -p atm-graft -- --nocapture
+cargo test -p atm-graft-python -- --nocapture
+just lint
+just test
+```
+
+Run the ownership subprocess tests on macOS, Linux, and Windows CI.
+
+## Required Document Updates
+
+- `docs/atm-graft/requirements.md`
+- `docs/atm-graft/boundaries.md`
+- ADR-043 status/evidence note
+
+## Risks And Watchouts
+
+- Do not treat an endpoint record's existence as ownership; only the held OS
+  lock is authoritative.
+- Do not make the owner generation a routing or daemon session token.
+- Keep the record capability secret and owner-readable as today.

--- a/docs/plans/phase-ai/sprint-ai-36-graft-receiver-ownership.md
+++ b/docs/plans/phase-ai/sprint-ai-36-graft-receiver-ownership.md
@@ -78,10 +78,11 @@ Development work:
    format with a random `owner_generation` and the optional owning `ChatId`.
    Bump `GRAFT_RECEIVER_RECORD_SCHEMA_VERSION`; old records fail closed rather
    than being guessed as live owners.
-3. Add a private ownership guard acquired before record publication. Its
-   cross-platform implementation must use an OS-released exclusive file lock
-   on a sibling lock path; do not use a create-only sentinel that survives a
-   crashed process.
+3. Add a private ownership guard acquired before record publication. Reuse the
+   repository's existing `fs2::FileExt::try_lock_exclusive()` precedent from
+   `crates/atm-daemon/src/host_ownership.rs`; `fs2` maps this to advisory file
+   locking on Unix and `LockFileEx` on Windows. Do not use a create-only
+   sentinel that survives a crashed process.
 
 Required shape:
 

--- a/docs/plans/phase-ai/sprint-ai-36-graft-receiver-ownership.md
+++ b/docs/plans/phase-ai/sprint-ai-36-graft-receiver-ownership.md
@@ -2,7 +2,7 @@
 title: AI.36 graft receiver ownership
 status: proposed
 branch: feature/pAI-s36-graft-receiver-ownership
-target: integrate/phase-AI
+target: integrate/phase-ai-31-33
 depends_on: AI.35
 ---
 

--- a/docs/plans/phase-ai/sprint-ai-37-hermes-recovery-summary.md
+++ b/docs/plans/phase-ai/sprint-ai-37-hermes-recovery-summary.md
@@ -1,0 +1,189 @@
+---
+title: AI.37 Hermes graft recovery summary
+status: proposed
+branch: feature/pAI-s37-hermes-recovery-summary
+target: integrate/phase-AI
+depends_on: AI.36
+---
+
+# AI.37 — Hermes graft recovery summary
+
+```yaml
+plan_type: sprint_plan
+phase: AI
+sprint: AI.37
+worktree: feature/pAI-s37-hermes-recovery-summary
+branch: feature/pAI-s37-hermes-recovery-summary
+status: proposed
+estimated_scope: small Rust/Python recovery contract
+```
+
+## Goal
+
+After a profile restart, use the durable daemon mailbox to generate one
+non-message recovery wake-up summary after exactly ten seconds when work is
+available. Graft must not store, replay, read, or acknowledge mail itself.
+
+## Scope Summary
+
+This sprint adds a count-only projection over the existing `ReadOutcome` and
+a one-shot Python recovery scheduler. It deliberately stops at an injected
+host-neutral recovery callback. AI.38 binds that callback and live nudges to
+Hermes's steer API.
+
+## Governing Requirements
+
+- `REQ-GRAFT-NOTIFY-002`
+- `REQ-GRAFT-HERMES-003`
+- `REQ-CORE-GRAFT-001`
+- `REQ-CORE-COMPAT-003` persistence precedes post-send behavior
+
+## Governing ADRs
+
+- ADR-033 — shared daemon client/API contract
+- ADR-037 — `ChatId` identity
+- ADR-043 — durable recovery is mailbox-derived, not graft-owned
+
+## Governing Boundaries
+
+- `DaemonApiClient` and existing `ReadQuery`/`ReadOutcome` own counts.
+- `atm-graft-python` only projects existing daemon results; it does not access
+  SQLite or create an HTTP resource.
+- The Python bridge owns one-shot scheduling but not host routing policy.
+
+## Prerequisites
+
+- AI.36 receiver ownership is merged and receiver activation has a reliable
+  listening transition.
+
+## Hard Dependencies
+
+- AI.38 consumes the host-neutral live/recovery callback introduced here.
+
+## Non-Goals
+
+- No durable graft queue, retries, polling loop, bulk message replay, or
+  automatic acknowledgement.
+- No additional daemon endpoint, database schema, or message state.
+- No configurable delay: the first supported recovery delay is exactly ten
+  seconds, hardcoded in the Python adapter.
+
+## Sub-Tasks
+
+### 1. Count-only daemon-client projection
+
+Development work:
+
+1. First commit sets all releasable assemblies to `1.4.0-beta-ai.37`.
+2. Reuse `ReadQuery` with its existing non-mutating classified read and
+   `ReadOutcome.bucket_counts`; do not add a new mailbox API or query source.
+3. Add an explicit graft method and Python projection that exposes only:
+
+```rust
+pub struct MailboxWorkCounts {
+    pub unread: usize,
+    pub pending_ack: usize,
+}
+
+fn mailbox_work_counts(&self) -> Result<MailboxWorkCounts, AtmError>;
+```
+
+4. `pending_ack` means inbound messages for this profile that require its ATM
+   acknowledgement and remain unacknowledged. It is not an outbound delivery
+   receipt count.
+
+Required tests:
+
+- returned values equal the existing `ReadOutcome.bucket_counts` for empty,
+  unread-only, pending-ack-only, and mixed mailboxes;
+- the method neither changes read state nor acknowledgement state;
+- Python binding preserves both values as integers without exposing stored
+  message bodies.
+
+### 2. One-shot recovery trigger
+
+Development work:
+
+1. Add a bridge-level recovery hook whose only payload is the immutable count
+   value, not message content:
+
+```python
+@dataclass(frozen=True)
+class MailboxRecoveryNotice:
+    unread: int
+    pending_ack: int
+
+    def render(self) -> str:
+        return f"ATM: {self.unread} unread messages; {self.pending_ack} acknowledgements pending."
+```
+
+2. After a receiver first reports `listening`, schedule exactly one callback
+   with `loop.call_later(10.0, ...)`. At callback time call
+   `mailbox_work_counts()` once. Invoke the recovery hook only when either
+   count is non-zero.
+3. Cancellation on `disconnect()` is mandatory. Reconnect creates one new
+   ten-second window only after the prior timer is cancelled/finished.
+4. A live nudge during the delay remains a live nudge. It does not cancel,
+   accelerate, or multiply the recovery summary.
+
+Required tests with a fake loop/clock (no wall-clock sleep):
+
+- no callback before 10.0 seconds and exactly one at 10.0 seconds;
+- mixed counts render the exact concise text; zero/zero invokes nothing;
+- disconnect before 10 seconds invokes nothing;
+- reconnect after cancellation has one new timer, never two;
+- a live-nudge callback plus a later recovery summary are distinct bounded
+  notifications, while no individual durable message is replayed.
+
+### 3. Observability and contract documentation
+
+Development work:
+
+1. Record structured recovery scheduled/cancelled/counts/summary-emitted
+   events without mail body or capability data.
+2. Update the Hermes adapter contract to state that the host must use its
+   normal ATM skills after a summary; graft never consumes the mail.
+
+Required tests:
+
+- emitted event names distinguish zero-work from summary-emitted;
+- source test rejects `read()`, `acknowledge()`, persistence, or retry-loop
+  calls from the recovery scheduler.
+
+## Split Recommendation
+
+Keep actual Hermes steer wiring out of this sprint. This produces a
+deterministic and host-neutral recovery contract that can be reviewed without
+depending on an external gateway API.
+
+## Acceptance Criteria
+
+1. One successful receiver activation schedules one fixed ten-second recovery
+   check.
+2. The check uses existing daemon mailbox counts and makes no mutation.
+3. Nonzero work emits one concise count summary; empty work emits nothing.
+4. Disconnect/reconnect cannot duplicate scheduled summaries.
+5. Graft contains no durable mail or conversation state.
+
+## Required Validation
+
+```text
+cargo test -p atm-graft -- --nocapture
+cargo test -p atm-graft-python -- --nocapture
+python3 -m unittest crates/atm-graft-python/tests/test_hermes_bridge.py
+just lint
+just test
+```
+
+## Required Document Updates
+
+- `docs/atm-graft/requirements.md`
+- `docs/plans/phase-ai/hermes-graft-adapter-contract.md`
+- ADR-043 status/evidence note
+
+## Risks And Watchouts
+
+- Counts must come from the daemon's normal mailbox view at timer execution,
+  not activation-time snapshots.
+- Do not turn the one-shot timer into a periodic poller or retry mechanism.
+- The scheduler must remain testable with an injected clock/loop.

--- a/docs/plans/phase-ai/sprint-ai-37-hermes-recovery-summary.md
+++ b/docs/plans/phase-ai/sprint-ai-37-hermes-recovery-summary.md
@@ -2,7 +2,7 @@
 title: AI.37 Hermes graft recovery summary
 status: proposed
 branch: feature/pAI-s37-hermes-recovery-summary
-target: integrate/phase-AI
+target: integrate/phase-ai-31-33
 depends_on: AI.36
 ---
 

--- a/docs/plans/phase-ai/sprint-ai-38-hermes-steer-nudge-delivery.md
+++ b/docs/plans/phase-ai/sprint-ai-38-hermes-steer-nudge-delivery.md
@@ -1,0 +1,196 @@
+---
+title: AI.38 Hermes steer nudge delivery
+status: proposed
+branch: feature/pAI-s38-hermes-steer-nudge-delivery
+target: integrate/phase-AI
+depends_on: AI.37
+---
+
+# AI.38 — Hermes steer nudge delivery
+
+```yaml
+plan_type: sprint_plan
+phase: AI
+sprint: AI.38
+worktree: feature/pAI-s38-hermes-steer-nudge-delivery
+branch: feature/pAI-s38-hermes-steer-nudge-delivery
+status: proposed
+estimated_scope: focused Python host-adapter replacement plus live evidence
+```
+
+## Goal
+
+Deliver live graft nudges and AI.37's one-shot recovery summary through the
+configured Hermes profile's non-interrupting steer path so an active agent sees
+ATM work at its next safe API/tool-loop boundary without normal user-message
+interruption.
+
+## Scope Summary
+
+This replaces the current `MessageEvent(..., internal=False)` normal inbound
+dispatch in `atm_graft_hermes_adapter.py`. It does not create a Hermes
+conversation manager, a multi-channel registry, another ATM transport, or an
+ATM message read/ack workflow.
+
+## Governing Requirements
+
+- `REQ-GRAFT-HERMES-002`
+- `REQ-GRAFT-HERMES-003`
+- `REQ-GRAFT-NOTIFY-002`
+- `REQ-CORE-GRAFT-001`
+
+## Governing ADRs
+
+- ADR-037 — configured `ChatId` remains the host session binding
+- ADR-039 — Python binding stays a translation over the graft client
+- ADR-043 — wake-ups use steer, not normal user-message ingress
+
+## Governing Boundaries
+
+- `atm_graft_hermes_adapter.py` owns the Hermes-specific adapter.
+- `atm_graft_hermes_bridge.py` owns typed nudge de-duplication and callbacks.
+- Hermes owns the final steer API and its agent scheduling semantics.
+- `atm-graft` remains host-neutral and owns neither Telegram nor Hermes state.
+
+## Prerequisites
+
+- AI.36 and AI.37 are merged.
+- Before coding, record the exact supported Hermes steer callable and its
+  result/error contract from the installed Hermes source; do not infer it from
+  a normal gateway message handler.
+
+## Hard Dependencies
+
+- This sprint is the closure point for non-interrupting Hermes wake-up
+  evidence.
+
+## Non-Goals
+
+- No multiple-channel/multiple-chat routing policy for one ATM agent.
+- No synthetic Telegram user event, `MessageEvent`, or normal inbound
+  authorization path for ATM nudges.
+- No direct ATM read/send/ack performed by the adapter after receiving a
+  nudge; the agent's existing ATM skills decide the follow-up work.
+
+## Sub-Tasks
+
+### 1. Introduce a narrow steer boundary
+
+Development work:
+
+1. First commit sets all releasable assemblies to `1.4.0-beta-ai.38`.
+2. Replace the adapter's normal `_message_handler` invocation with one
+   injected async steer port tied to the configured profile `ChatId`.
+3. Bind the port to Hermes's documented non-interrupting steer API. The
+   adapter must await/report its result but must never fall back to normal
+   user-message dispatch.
+
+Required shape:
+
+```python
+class HermesSteerPort(Protocol):
+    async def steer(self, *, chat_id: str, text: str) -> None: ...
+
+async def _inject_steer(self, text: str) -> None:
+    await self._steer_port.steer(chat_id=self._chat_id, text=text)
+```
+
+4. Use `_inject_steer` for both the typed live nudge body and AI.37 recovery
+   summary. The sender address/chat-id is retained in bounded attribution
+   metadata/logging; it does not become a second Hermes session key.
+
+Required tests:
+
+- fake steer port records configured `ATM_CHAT_ID` and exact text for a live
+  nudge and recovery notice;
+- fake normal message handler fails the test if called;
+- no fallback occurs when steer fails; the failure is structured and visible.
+
+### 2. Preserve one-profile identity without premature multi-channel work
+
+Development work:
+
+1. Validate the configured `ATM_CHAT_ID` once at adapter connection and pass
+   it unchanged to every steer call.
+2. Preserve `PyNudge.source` (including its chat-id) for attribution and any
+   ordinary ATM reply address; do not parse/rebuild it as a Hermes session.
+3. Make duplicate ULID suppression remain bounded and bridge-local. It only
+   prevents duplicated live pushes; it is not durable recovery state.
+
+Required tests:
+
+- sources `sender:telegram-chat@team` and `sender:future-chat@team` retain
+  different structured addresses but both steer only the current profile's
+  configured session;
+- a duplicate ULID generates one steer; distinct ULIDs generate two;
+- reconnect constructs one profile binding, not a session registry.
+
+### 3. End-to-end proof against a live Hermes profile
+
+Development work:
+
+1. Extend the Hermes smoke harness to run a real profile with a controlled
+   active tool turn and a real graft nudge.
+2. Capture evidence that the steer is accepted for the configured session and
+   becomes visible after the current safe tool boundary without interrupting
+   or replacing that task.
+3. Repeat for the AI.37 delayed recovery summary with durable unread and
+   pending-ack fixtures. The agent uses its normal ATM skill to read the mail;
+   the harness verifies the summary itself did not mutate mail state.
+
+Required evidence fields:
+
+```json
+{
+  "profile": "agent@team",
+  "chat_id": "configured-host-session",
+  "wake_kind": "live_nudge|recovery_summary",
+  "steer_accepted": true,
+  "normal_message_handler_called": false,
+  "current_task_interrupted": false,
+  "mailbox_mutated_by_wake": false
+}
+```
+
+## Split Recommendation
+
+Do not combine a later Discord/multi-channel capability into AI.38. It needs
+an explicit identity/ownership revision after the single configured session is
+reliable in production.
+
+## Acceptance Criteria
+
+1. Every live and recovery ATM wake-up uses the configured Hermes steer path.
+2. No ATM wake-up invokes normal inbound-user-message dispatch.
+3. A real active Hermes agent receives the wake-up at a safe boundary without
+   interruption, while durable ATM mail remains unchanged until its normal ATM
+   skills act.
+4. One configured profile/session works independently of other profiles.
+
+## Required Validation
+
+```text
+python3 -m unittest crates/atm-graft-python/tests/test_hermes_adapter.py
+python3 -m unittest crates/atm-graft-python/tests/test_hermes_bridge.py
+just test-hermes-graft-bridge
+just lint
+just test
+```
+
+Plus retained real-Hermes evidence for one live nudge and one recovery summary.
+
+## Required Document Updates
+
+- `docs/atm-graft/requirements.md`
+- `docs/plans/phase-ai/hermes-graft-adapter-contract.md`
+- `docs/plans/phase-ai/hermes-graft-runbook.md`
+- ADR-039 and ADR-043 evidence/status notes
+
+## Risks And Watchouts
+
+- `/steer` semantics must be verified from the installed Hermes contract, not
+  approximated by `MessageEvent(internal=False)`.
+- A steer failure is observable but must never trigger a normal-message
+  fallback or a graft retry queue.
+- Keep the adapter's scope to one configured host session; future multi-chat
+  routing is an explicit new feature.

--- a/docs/plans/phase-ai/sprint-ai-38-hermes-steer-nudge-delivery.md
+++ b/docs/plans/phase-ai/sprint-ai-38-hermes-steer-nudge-delivery.md
@@ -15,7 +15,7 @@ sprint: AI.38
 worktree: feature/pAI-s38-hermes-steer-nudge-delivery
 branch: feature/pAI-s38-hermes-steer-nudge-delivery
 status: proposed
-estimated_scope: focused Python host-adapter replacement plus live evidence
+estimated_scope: focused new Python host adapter plus checked-in reference evidence
 ```
 
 ## Goal
@@ -27,10 +27,14 @@ interruption.
 
 ## Scope Summary
 
-This replaces the current `MessageEvent(..., internal=False)` normal inbound
-dispatch in `atm_graft_hermes_adapter.py`. It does not create a Hermes
-conversation manager, a multi-channel registry, another ATM transport, or an
-ATM message read/ack workflow.
+This sprint creates the currently absent
+`crates/atm-graft-python/python/atm_graft_hermes_adapter.py` and the narrow
+`HermesSteerPort` dispatch it consumes. The existing checked-in
+`atm_graft_hermes_bridge.py` remains a generic typed callback bridge. The
+`MessageEvent` normal-ingress pattern is an external Hermes pattern that this
+new adapter must not adopt. This sprint does not create a Hermes conversation
+manager, a multi-channel registry, another ATM transport, or an ATM message
+read/ack workflow.
 
 ## Governing Requirements
 
@@ -79,9 +83,10 @@ ATM message read/ack workflow.
 Development work:
 
 1. First commit sets all releasable assemblies to `1.4.0-beta-ai.38`.
-2. Replace the adapter's normal `_message_handler` invocation with one
-   injected async steer port tied to the configured profile `ChatId`.
-3. Bind the port to Hermes's documented non-interrupting steer API. The
+2. Create `atm_graft_hermes_adapter.py` with one injected async steer port
+   tied to the configured profile `ChatId`; do not add a normal-message
+   adapter first.
+3. Bind that port to Hermes's documented non-interrupting steer API. The
    adapter must await/report its result but must never fall back to normal
    user-message dispatch.
 
@@ -103,7 +108,7 @@ Required tests:
 
 - fake steer port records configured `ATM_CHAT_ID` and exact text for a live
   nudge and recovery notice;
-- fake normal message handler fails the test if called;
+- a sentinel normal-message handler fails the test if called;
 - no fallback occurs when steer fails; the failure is structured and visible.
 
 ### 2. Preserve one-profile identity without premature multi-channel work
@@ -125,12 +130,16 @@ Required tests:
 - a duplicate ULID generates one steer; distinct ULIDs generate two;
 - reconnect constructs one profile binding, not a session registry.
 
-### 3. End-to-end proof against a live Hermes profile
+### 3. Reproducible active-profile reference proof
 
 Development work:
 
-1. Extend the Hermes smoke harness to run a real profile with a controlled
-   active tool turn and a real graft nudge.
+1. Create `crates/atm-graft-python/tests/hermes_steer_fixture.py`,
+   `scripts/phase-ai/run-hermes-steer-smoke.py`, and its unit test
+   `scripts/phase-ai/test_run_hermes_steer_smoke.py`. The script must use the
+   checked-in `HermesSteerFixture`: an ATM-controlled reference profile that
+   implements the documented steer-port contract and has a controlled active
+   tool turn. It is not a downstream production Hermes checkout.
 2. Capture evidence that the steer is accepted for the configured session and
    becomes visible after the current safe tool boundary without interrupting
    or replacing that task.
@@ -162,22 +171,27 @@ reliable in production.
 
 1. Every live and recovery ATM wake-up uses the configured Hermes steer path.
 2. No ATM wake-up invokes normal inbound-user-message dispatch.
-3. A real active Hermes agent receives the wake-up at a safe boundary without
-   interruption, while durable ATM mail remains unchanged until its normal ATM
-   skills act.
+3. The checked-in active-profile reference fixture receives the wake-up at a
+   safe boundary without interruption, while durable ATM mail remains
+   unchanged until normal ATM skills act. A separately retained downstream
+   Hermes smoke run is useful operational evidence but is not a merge gate.
 4. One configured profile/session works independently of other profiles.
 
 ## Required Validation
 
 ```text
-python3 -m unittest crates/atm-graft-python/tests/test_hermes_adapter.py
+python3 -m unittest crates/atm-graft-python/tests/test_hermes_adapter.py  # new in AI.38
 python3 -m unittest crates/atm-graft-python/tests/test_hermes_bridge.py
+python3 scripts/phase-ai/run-hermes-steer-smoke.py --fixture
 just test-hermes-graft-bridge
 just lint
 just test
 ```
 
-Plus retained real-Hermes evidence for one live nudge and one recovery summary.
+`run-hermes-steer-smoke.py --fixture` writes the Sub-Task 3 JSON evidence
+schema for one live nudge and one recovery summary. A real downstream Hermes
+run may be retained as operational evidence but cannot replace the checked-in
+fixture proof or block this sprint on an external merge.
 
 ## Required Document Updates
 

--- a/docs/plans/phase-ai/sprint-ai-38-hermes-steer-nudge-delivery.md
+++ b/docs/plans/phase-ai/sprint-ai-38-hermes-steer-nudge-delivery.md
@@ -2,7 +2,7 @@
 title: AI.38 Hermes steer nudge delivery
 status: proposed
 branch: feature/pAI-s38-hermes-steer-nudge-delivery
-target: integrate/phase-AI
+target: integrate/phase-ai-31-33
 depends_on: AI.37
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -4073,6 +4073,26 @@ mail correctness.
   - thin-client surfaces such as graft align to the shared daemon/API contract
     rather than to a mailbox-JSON transport
 
+- `REQ-CORE-GRAFT-001` Graft is a thin embedded daemon client and bounded
+  host-wake transport, not a second mailbox or host conversation subsystem.
+
+  Required behavior:
+  - graft `send`, `read`, and `ack` use the normal daemon API and durable ATM
+    mailbox; graft has no direct SQLite, mailbox-file, or durable nudge queue
+  - a graft receiver has one explicit live owner per canonical receiver
+    identity; competing live activation fails without replacing the current
+    endpoint, and process death permits safe reclaim
+  - a host session identifier such as ADR-037 `ChatId` is preserved as an
+    opaque profile/session binding, never parsed into a second ATM transport
+    or conversation manager
+  - a host integration must deliver a nudge through its documented safe
+    between-tool-call mechanism. A Hermes integration uses non-interrupting
+    steer delivery, not normal user-message ingress
+  - after host restart/reconnect, a host integration may issue one bounded
+    advisory wake-up derived from durable unread/pending-ack counts. It must
+    not replay mail, mutate mail, create a retry loop, or persist recovery
+    state outside the ATM mailbox
+
 - `REQ-CORE-COMPAT-003` Post-send behavior must use one direct post-persist
   emitter seam.
 


### PR DESCRIPTION
## Summary
Planning sprint(s) for the Hermes/AtmGraftAdapter follow-up scoped from arch-ctm's architecture review of integrate/phase-ai-31-33@21957012 (findings AI3133-HERMES-GRAFT-NO-DURABLE-QUEUE, AI3133-HERMES-GRAFT-SINGLE-CHAT-ROUTING, AI3133-HERMES-GRAFT-RECEIVER-SINGLETON-UNSAFE), plus the clarified requirement that live/recovery nudges use Hermes's non-interrupting `/steer` delivery path.

Adds ADR-043 (Hermes graft wake-up ownership), updated product/crate requirements, and three separated Phase-AI sprints:
- **AI.36** — lease-safe one-receiver ownership
- **AI.37** — one fixed-10-second durable mailbox count summary, no graft mail queue
- **AI.38** — non-interrupting Hermes steer delivery + live evidence

Existing remove-member planning is untouched.

## Validation
- `just lint` — PASS (22 checks), per arch-ctm self-report (not yet independently QA'd)

## Next
- plan-scope-reviewer + critical-plan-reviewer in parallel (this PR)
- fix round(s) with arch-ctm as needed
- quality-mgr <-> arch-ctm loop to finalize plan doc