### PR TITLE
fix(lint): guard Hermes adapter ingress regressions locally (AI3138-HERMES-LINT-GUARD-GAP)

### DIFF
--- a/.just/lint_hermes_adapter.py
+++ b/.just/lint_hermes_adapter.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Guard the Hermes adapter against retired normal-message ingress symbols."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+from lint_common import build_report
+from lint_common import discover_repo_root
+from lint_common import monotonic_now
+from lint_common import print_report
+
+
+LINT_NAME = "hermes-adapter"
+ADAPTER_SOURCE_ROOT = Path("crates/atm-graft-python/python")
+RETIRED_NORMAL_INGRESS_SYMBOLS = (
+    "MessageEvent",
+    "SessionSource",
+    "internal=False",
+    "inject_user_message",
+    "BasePlatformAdapter",
+    "register_platform",
+)
+
+
+@dataclass(frozen=True)
+class HermesAdapterViolation:
+    path: str
+    line_number: int
+    symbol: str
+    line: str
+
+    def render(self) -> str:
+        return f"{self.path}:{self.line_number}: retired symbol {self.symbol!r}: {self.line}"
+
+
+def collect_violations(
+    repo_root: Path,
+    *,
+    retired_symbols: tuple[str, ...] = RETIRED_NORMAL_INGRESS_SYMBOLS,
+) -> list[HermesAdapterViolation]:
+    source_root = repo_root / ADAPTER_SOURCE_ROOT
+    violations: list[HermesAdapterViolation] = []
+    for source_path in sorted(source_root.glob("*.py")):
+        relative_path = source_path.relative_to(repo_root).as_posix()
+        for line_number, line in enumerate(source_path.read_text(encoding="utf-8").splitlines(), start=1):
+            for symbol in retired_symbols:
+                if symbol in line:
+                    violations.append(
+                        HermesAdapterViolation(
+                            path=relative_path,
+                            line_number=line_number,
+                            symbol=symbol,
+                            line=line.strip(),
+                        )
+                    )
+    return violations
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reject retired normal-message ingress symbols in the Hermes adapter source."
+    )
+    parser.add_argument("--root", help="Repo root to inspect.")
+    return parser.parse_args(argv[1:])
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = discover_repo_root(args.root)
+    started_at = datetime.now(timezone.utc)
+    start_time = monotonic_now()
+    violations = collect_violations(repo_root)
+    duration_seconds = monotonic_now() - start_time
+    findings = [violation.render() for violation in violations]
+    passed = not violations
+    summary = (
+        "retired normal-message ingress symbols found in Hermes adapter source"
+        if violations
+        else "Hermes adapter uses the steer boundary without retired normal-message ingress symbols"
+    )
+    report = build_report(
+        lint_name=LINT_NAME,
+        repo_root=repo_root,
+        passed=passed,
+        summary=summary,
+        findings=findings,
+        transcript_lines=["findings:", *(findings or ["none"])],
+        started_at=started_at,
+        duration_seconds=duration_seconds,
+    )
+    print_report(report, repo_root=repo_root, preview_limit=0, direct_threshold=0)
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/run_lint.py
+++ b/.just/run_lint.py
@@ -36,6 +36,7 @@ PYTHON_LINT_ORDER = (
     "ttl-triage",
     "lines",
     "spell",
+    "hermes-adapter",
     "daemon-singleton",
     "pytests",
 )
@@ -52,6 +53,7 @@ FAST_LINT_ORDER = (
     "legacy-mailbox-paths",
     "capability-degradation",
     "spell",
+    "hermes-adapter",
     "pytests",
 )
 HIGH_VOLUME_LINTS = {"identities", "lines"}
@@ -130,6 +132,9 @@ def build_tasks(repo_root: Path) -> dict[str, LintTask]:
             [*python_command, str(repo_root / "scripts/check-capability-degradation.py")],
         ),
         "spell": LintTask("spell", [*python_command, str(repo_root / ".just/lint_codespell.py")]),
+        "hermes-adapter": LintTask(
+            "hermes-adapter", [*python_command, str(repo_root / ".just/lint_hermes_adapter.py")]
+        ),
         "fixed-sleep": LintTask(
             "fixed-sleep", [*python_command, str(repo_root / ".just/check_fixed_sleep_hygiene.py")]
         ),

--- a/.just/tests/test_lint_hermes_adapter.py
+++ b/.just/tests/test_lint_hermes_adapter.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from lint_hermes_adapter import collect_violations
+
+
+class HermesAdapterLintTests(unittest.TestCase):
+    def write_adapter_source(self, root: Path, text: str) -> None:
+        source_dir = root / "crates/atm-graft-python/python"
+        source_dir.mkdir(parents=True)
+        (source_dir / "atm_graft_hermes_adapter.py").write_text(text, encoding="utf-8")
+
+    def test_clean_steer_adapter_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            self.write_adapter_source(root, "async def steer(text):\n    return text\n")
+
+            self.assertEqual(collect_violations(root), [])
+
+    def test_retired_normal_ingress_symbols_are_reported_with_locations(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            self.write_adapter_source(
+                root,
+                "from gateway import MessageEvent\n\n    return MessageEvent(internal=False)\n",
+            )
+
+            violations = collect_violations(root)
+
+            self.assertEqual(
+                [(item.symbol, item.line_number) for item in violations],
+                [("MessageEvent", 1), ("MessageEvent", 3), ("internal=False", 3)],
+            )
+            self.assertIn("crates/atm-graft-python/python/atm_graft_hermes_adapter.py:3", violations[-1].render())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_run_lint.py
+++ b/.just/tests/test_run_lint.py
@@ -46,6 +46,7 @@ resolver = "2"
         self.assertIn("ttl-triage", names)
         self.assertIn("spell", names)
         self.assertIn("daemon-singleton", names)
+        self.assertIn("hermes-adapter", names)
         self.assertIn("pytests", names)
         self.assertNotIn("sc-boundary", names)
         self.assertNotIn("sc-portability", names)
@@ -157,6 +158,10 @@ resolver = "2"
             )
             self.assertEqual(tasks["spell"].command[-1], str(repo_root / ".just/lint_codespell.py"))
             self.assertEqual(
+                tasks["hermes-adapter"].command[-1],
+                str(repo_root / ".just/lint_hermes_adapter.py"),
+            )
+            self.assertEqual(
                 tasks["daemon-singleton"].command[-1],
                 str(repo_root / "scripts/lint_daemon_singleton.py"),
             )
@@ -176,6 +181,7 @@ resolver = "2"
                 "legacy-mailbox-paths",
                 "capability-degradation",
                 "spell",
+                "hermes-adapter",
                 "pytests",
             ],
         )


### PR DESCRIPTION
## Summary
- Phase-end critical review (arch-qa ARCH-001 + ruthless-boundary-qa RBQA-F001) found the Hermes-adapter forbidden-symbol regression guard test runs in CI but was not reachable from `just lint`/`just ci` locally.
- Adds a local hermes-adapter lint target scanning `crates/atm-graft-python/python/*.py` for retired normal-ingress symbols, with unit coverage, registered in `just lint`/`just fast`/`just ci`.
- CI workflow (`.github/workflows/ci.yml:182-183`) left unchanged — this adds a second, local-first layer, not a replacement.

## Triage record
- .triage/phase-AI/findings/AI3138-HERMES-LINT-GUARD-GAP.ttl

## Test plan
- [ ] quality-mgr QA round
- [ ] CI green