### PR TITLE
docs(plan): AI.33 abandonment follow-up — AI.39/AI.40 doc corrections

### DIFF
--- a/docs/plans/phase-ai/plan-phase-ai.md
+++ b/docs/plans/phase-ai/plan-phase-ai.md
@@ -198,7 +198,7 @@ integration; they do not alter it.
 | AI.30 | `feature/pAI-s30-semver-http-compatibility` | Schema/HTTP compatibility admission and opt-in SemVer prerelease distribution |
 | AI.31 | `feature/pAI-s31-async-local-admission` | SQLite-only local admission response; host-qualified peer work is signalled after response |
 | AI.32 | `feature/pAI-s32-independent-peer-jobs` | Bounded non-durable per-ULID peer jobs; no cross-command delivery-order promise or stream abstraction |
-| AI.33 | `feature/pAI-s33-admission-capacity-smoke` | Isolated 1,000/s admission proof and ten-run, endpoint-explicit local/cross-host smoke report |
+| AI.33 | `feature/pAI-s33-admission-capacity-smoke` | **Abandoned/superseded.** Isolated 1,000/s admission proof and ten-run, endpoint-explicit local/cross-host smoke report; PR #695 closed after real M5 evidence retained a blocking HTTP 503 throughput failure. AI.40 is the active owner of the benchmark runner/evidence path. |
 | AI.34 | `fix/hermes-nudge-endpoint-mismatch` | Canonical roster workspace-root resolution for Python-graft post-send nudge endpoint delivery |
 | AI.35 | `feature/pAI-s35-graft-root-fallback-observability` | Graft-root fallback observability and operator runbook closure |
 | AI.36 | `feature/pAI-s36-graft-receiver-ownership` | One lease-safe receiver owner per canonical graft root/team/agent; crash reclaim and generation-safe endpoint removal |

--- a/docs/plans/phase-ai/sprint-ai-39-buffered-local-http-framing.md
+++ b/docs/plans/phase-ai/sprint-ai-39-buffered-local-http-framing.md
@@ -4,15 +4,8 @@ status: proposed
 branch: feature/pAI-s39-buffered-local-http-framing
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
-execution_mode: after_merge
-execution_dependencies:
-  - AI.33
-dependencies_relation:
-  - sprint: AI.33
-    relation: must_follow
-    rationale: Shares the local admission/framing path that AI.33 establishes.
+execution_mode: standard
 target: integrate/phase-ai-31-33
-depends_on: AI.33
 ---
 
 # AI.39 — Buffered local HTTP framing
@@ -25,16 +18,16 @@ planning-time recommendation, not a binding assignment.
 
 ## Execution Dependencies
 
-AI.39 `must_follow`s AI.33. Merge-forward trigger: AI.33 development is
-pushed, not QA; before every round merge AI.33 into this branch. PR-completion
-trigger: AI.33's PR merges into `integrate/phase-ai-31-33` first. Both touch
-the local admission/framing path.
+None. AI.33 (admission capacity and smoke evidence) is abandoned/superseded —
+PR #695 closed, not merged, after real M5 evidence retained a blocking HTTP
+503 throughput failure. AI.39 no longer depends on AI.33; AI.40 (local
+transport benchmark) is the active owner of a clean benchmark runner/evidence
+path in this line.
 
 ## Dependency Relations
 
-| Sprint | Relation | Rationale |
-| --- | --- | --- |
-| AI.33 | must_follow | It owns the local admission baseline in the same framing path. |
+None. Previously `must_follow`d AI.33; that dependency is removed because
+AI.33 is abandoned/superseded (see sprint-ai-33-admission-capacity-smoke.md).
 
 ```yaml
 plan_type: sprint_plan

--- a/docs/plans/phase-ai/sprint-ai-40-local-transport-benchmark.md
+++ b/docs/plans/phase-ai/sprint-ai-40-local-transport-benchmark.md
@@ -64,10 +64,15 @@ the public report artifact.
 
 ## Deliverables
 
-1. Extend AI.33's `scripts/smoke/run_admission_capacity.py`; do not create a
-   second admission gate. `just benchmark` selects its profiles and reports,
-   accepts explicit `--transport uds|tcp` on Unix and `--transport tcp` on
-   Windows. The same public authenticated
+1. AI.33 (`feature/pAI-s33-admission-capacity-smoke`, PR #695) is
+   abandoned/superseded and never merged; `scripts/smoke/run_admission_capacity.py`
+   does not exist on `integrate/phase-ai-31-33`. AI.40 owns a clean, minimal
+   `scripts/smoke/run_admission_capacity.py` benchmark runner from scratch —
+   selective salvage of AI.33's closed-branch logic is allowed where it is
+   directly useful, but AI.40 does not depend on or extend any unmerged AI.33
+   artifact. `just benchmark` selects its profiles and reports, accepts
+   explicit `--transport uds|tcp` on Unix and `--transport tcp` on Windows. The
+   same public authenticated
    `POST /v1/atm/messages` request, response handling, message count, worker
    limit, timeout policy, and disposable daemon/database lifecycle apply to
    every selected transport.


### PR DESCRIPTION
## Summary
- Marks AI.33 abandoned/superseded in the plan-phase-ai.md status table (PR #695 closed, not merged)
- Removes AI.39's `must_follow` dependency on AI.33
- Rewrites AI.40 deliverable 1: it owns a clean minimal `run_admission_capacity.py` from scratch (AI.33's script never merged), not an extension of it — selective salvage from the closed branch is allowed but not a hard dependency

Follow-up to PR #699, which merged before these 2 commits landed on the branch. arch-ctm caught the AI.40 contradiction in post-merge verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)