### PR TITLE
AI.46 — generated reports index

### DIFF
--- a/.just/generate_report_index.py
+++ b/.just/generate_report_index.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Generate and validate the durable public verification-report index.
+
+Report producers may place one envelope at ``site/reports/<name>.json`` or
+store run envelopes inside the same-named evidence directory.  Every envelope
+points at a root-level ``<name>.html`` and its same-named evidence directory.
+Ordinary evidence JSON without envelope fields is not a discovery input.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import html
+import json
+from pathlib import Path, PurePosixPath
+import re
+import sys
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = 1
+REPORT_TYPES = ("benchmark", "fuzz")
+REPORTS_RELATIVE = Path("site/reports")
+INDEX_NAME = "index.html"
+HOST_LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+REPORT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+REQUIRED_FIELDS = frozenset(
+    {"schema_version", "report_type", "generated_at", "host_label", "report_html"}
+)
+
+
+class ReportIndexError(ValueError):
+    """A report input cannot be published as public verification evidence."""
+
+
+@dataclass(frozen=True)
+class Envelope:
+    schema_version: int
+    report_type: str
+    generated_at: datetime
+    generated_at_text: str
+    host_label: str
+    report_html: str
+    source: Path
+
+
+@dataclass(frozen=True)
+class ReportEntry:
+    report_type: str
+    report_html: str
+    generated_at: datetime
+    generated_at_text: str
+    host_labels: tuple[str, ...]
+    run_count: int
+
+
+def _utc_timestamp(value: Any, source: Path) -> tuple[datetime, str]:
+    if not isinstance(value, str) or not value:
+        raise ReportIndexError(f"{source}: generated_at must be a non-empty string")
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        timestamp = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ReportIndexError(f"{source}: generated_at is not ISO-8601: {value!r}") from exc
+    if timestamp.tzinfo is None or timestamp.utcoffset() != timezone.utc.utcoffset(timestamp):
+        raise ReportIndexError(f"{source}: generated_at must include UTC timezone")
+    timestamp = timestamp.astimezone(timezone.utc)
+    return timestamp, timestamp.isoformat().replace("+00:00", "Z")
+
+
+def _safe_relative_html(value: Any, source: Path) -> str:
+    if not isinstance(value, str) or not value:
+        raise ReportIndexError(f"{source}: report_html must be a non-empty relative path")
+    if "\\" in value or value.startswith("/") or "\x00" in value:
+        raise ReportIndexError(f"{source}: report_html is not a safe relative path: {value!r}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ReportIndexError(f"{source}: report_html is not a safe relative path: {value!r}")
+    if len(path.parts) != 1 or path.suffix.lower() != ".html":
+        raise ReportIndexError(f"{source}: report_html must be a root-level .html file")
+    name = path.name[:-5]
+    if not REPORT_NAME_RE.fullmatch(name):
+        raise ReportIndexError(f"{source}: report_html has an unsafe report name: {value!r}")
+    return path.as_posix()
+
+
+def _safe_host_label(value: Any, source: Path) -> str:
+    if not isinstance(value, str) or not HOST_LABEL_RE.fullmatch(value):
+        raise ReportIndexError(
+            f"{source}: host_label must be a 1-64 character opaque safe label"
+        )
+    return value
+
+
+def parse_envelope(source: Path, reports_root: Path) -> Envelope:
+    try:
+        payload = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ReportIndexError(f"{source}: malformed JSON envelope") from exc
+    if not isinstance(payload, dict):
+        raise ReportIndexError(f"{source}: envelope must be a JSON object")
+    missing = REQUIRED_FIELDS - payload.keys()
+    if missing:
+        raise ReportIndexError(f"{source}: missing envelope fields: {', '.join(sorted(missing))}")
+    unexpected_fields = set(payload) - REQUIRED_FIELDS
+    if unexpected_fields:
+        raise ReportIndexError(
+            f"{source}: unsupported public fields: {', '.join(sorted(unexpected_fields))}"
+        )
+    schema_version = payload["schema_version"]
+    if schema_version != SCHEMA_VERSION or isinstance(schema_version, bool):
+        raise ReportIndexError(
+            f"{source}: schema_version must be integer {SCHEMA_VERSION}"
+        )
+    report_type = payload["report_type"]
+    if report_type not in REPORT_TYPES:
+        raise ReportIndexError(
+            f"{source}: report_type must be one of {', '.join(REPORT_TYPES)}"
+        )
+    generated_at, generated_at_text = _utc_timestamp(payload["generated_at"], source)
+    host_label = _safe_host_label(payload["host_label"], source)
+    report_html = _safe_relative_html(payload["report_html"], source)
+    html_path = reports_root / report_html
+    evidence_dir = reports_root / Path(report_html).stem
+    if not html_path.is_file():
+        raise ReportIndexError(f"{source}: missing report HTML: {report_html}")
+    if not evidence_dir.is_dir():
+        raise ReportIndexError(
+            f"{source}: missing same-named evidence directory: {evidence_dir.name}/"
+        )
+    return Envelope(
+        schema_version=schema_version,
+        report_type=report_type,
+        generated_at=generated_at,
+        generated_at_text=generated_at_text,
+        host_label=host_label,
+        report_html=report_html,
+        source=source,
+    )
+
+
+def discover_envelopes(reports_root: Path) -> list[Envelope]:
+    if not reports_root.exists():
+        return []
+    if not reports_root.is_dir():
+        raise ReportIndexError(f"reports root is not a directory: {reports_root}")
+    envelopes: list[Envelope] = []
+    for source in sorted(reports_root.rglob("*.json")):
+        if source.name == "index.json":
+            continue
+        is_root_envelope = source.parent == reports_root
+        is_explicit_envelope = source.name.endswith(".envelope.json")
+        try:
+            payload = json.loads(source.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            if is_root_envelope or is_explicit_envelope:
+                envelopes.append(parse_envelope(source, reports_root))
+            continue
+        if not isinstance(payload, dict):
+            if is_root_envelope or is_explicit_envelope:
+                envelopes.append(parse_envelope(source, reports_root))
+            continue
+        if is_root_envelope or is_explicit_envelope or {"report_type", "report_html"} & payload.keys():
+            envelopes.append(parse_envelope(source, reports_root))
+    return envelopes
+
+
+def aggregate_entries(envelopes: Iterable[Envelope]) -> list[ReportEntry]:
+    grouped: dict[tuple[str, str], list[Envelope]] = {}
+    for envelope in envelopes:
+        grouped.setdefault((envelope.report_type, envelope.report_html), []).append(envelope)
+    entries: list[ReportEntry] = []
+    for (report_type, report_html), group in grouped.items():
+        newest = max(group, key=lambda item: (item.generated_at, item.source.name))
+        entries.append(
+            ReportEntry(
+                report_type=report_type,
+                report_html=report_html,
+                generated_at=newest.generated_at,
+                generated_at_text=newest.generated_at_text,
+                host_labels=tuple(sorted({item.host_label for item in group})),
+                run_count=len(group),
+            )
+        )
+    return sorted(
+        entries,
+        key=lambda item: (REPORT_TYPES.index(item.report_type), -item.generated_at.timestamp(), item.report_html),
+    )
+
+
+def _entry_html(entry: ReportEntry) -> str:
+    report_name = Path(entry.report_html).stem
+    details = [html.escape(entry.report_type)]
+    if entry.run_count != 1:
+        details.append(f"{entry.run_count} runs")
+    details.append("hosts: " + ", ".join(html.escape(label) for label in entry.host_labels))
+    return (
+        "      <li>"
+        f'<a href="{html.escape(entry.report_html, quote=True)}">{html.escape(report_name)}</a>'
+        f'<time datetime="{html.escape(entry.generated_at_text, quote=True)}">'
+        f"{html.escape(entry.generated_at_text)}</time>"
+        f'<span class="report-meta">{" · ".join(details)}</span>'
+        "</li>"
+    )
+
+
+def render_index(entries: Iterable[ReportEntry]) -> str:
+    entries_by_type = {report_type: [] for report_type in REPORT_TYPES}
+    for entry in entries:
+        entries_by_type[entry.report_type].append(entry)
+    sections: list[str] = []
+    for report_type in REPORT_TYPES:
+        title = report_type.capitalize()
+        report_entries = entries_by_type[report_type]
+        if report_entries:
+            rows = "\n".join(_entry_html(entry) for entry in report_entries)
+            body = f"\n    <ul>\n{rows}\n    </ul>"
+        else:
+            body = "\n    <p class=\"empty\">No reports available.</p>"
+        sections.append(f"  <section><h2>{title}</h2>{body}\n  </section>")
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '  <meta charset="utf-8">\n'
+        '  <meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "  <title>ATM verification reports</title>\n"
+        "  <style>body{font:16px system-ui,sans-serif;max-width:64rem;margin:2rem auto;padding:0 1rem;line-height:1.5}"
+        "h1{margin-bottom:.25rem}ul{padding:0;list-style:none}li{display:grid;grid-template-columns:minmax(12rem,2fr) auto 1fr;gap:1rem;padding:.55rem 0;border-bottom:1px solid #ddd}"
+        "time,.report-meta{color:#555;font-size:.9em}.empty{color:#666;font-style:italic}</style>\n"
+        "</head>\n"
+        "<body>\n"
+        "  <h1>ATM verification reports</h1>\n"
+        "  <p>Generated from schema-validated public report envelopes.</p>\n"
+        + "\n".join(sections)
+        + "\n</body>\n</html>\n"
+    )
+
+
+def build_index(reports_root: Path) -> str:
+    return render_index(aggregate_entries(discover_envelopes(reports_root)))
+
+
+def write_or_check(repo_root: Path, check: bool) -> int:
+    reports_root = repo_root / REPORTS_RELATIVE
+    expected = build_index(reports_root)
+    index_path = reports_root / INDEX_NAME
+    if check:
+        try:
+            actual = index_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise ReportIndexError(f"missing or unreadable generated index: {index_path}") from exc
+        if actual != expected:
+            raise ReportIndexError(f"stale generated index: {index_path}")
+        return 0
+    reports_root.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(expected, encoding="utf-8")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Generate or check the durable report index.")
+    parser.add_argument("--check", action="store_true", help="fail if the generated index is stale")
+    parser.add_argument("--root", type=Path, help="repository root (defaults to the parent of .just)")
+    args = parser.parse_args(argv[1:])
+    repo_root = args.root.resolve() if args.root else Path(__file__).resolve().parents[1]
+    try:
+        return write_or_check(repo_root, args.check)
+    except ReportIndexError as exc:
+        print(f"report-index: error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/generate_report_index.py
+++ b/.just/generate_report_index.py
@@ -56,6 +56,14 @@ class ReportEntry:
     run_count: int
 
 
+def _ensure_inside(path: Path, root: Path, description: str) -> None:
+    try:
+        resolved = path.resolve()
+        resolved.relative_to(root.resolve())
+    except ValueError as exc:
+        raise ReportIndexError(f"{description} escapes the reports root: {path}") from exc
+
+
 def _utc_timestamp(value: Any, source: Path) -> tuple[datetime, str]:
     if not isinstance(value, str) or not value:
         raise ReportIndexError(f"{source}: generated_at must be a non-empty string")
@@ -95,6 +103,7 @@ def _safe_host_label(value: Any, source: Path) -> str:
 
 
 def parse_envelope(source: Path, reports_root: Path) -> Envelope:
+    _ensure_inside(source, reports_root, "envelope")
     try:
         payload = json.loads(source.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
@@ -124,6 +133,8 @@ def parse_envelope(source: Path, reports_root: Path) -> Envelope:
     report_html = _safe_relative_html(payload["report_html"], source)
     html_path = reports_root / report_html
     evidence_dir = reports_root / Path(report_html).stem
+    _ensure_inside(html_path, reports_root, "report HTML")
+    _ensure_inside(evidence_dir, reports_root, "evidence directory")
     if not html_path.is_file():
         raise ReportIndexError(f"{source}: missing report HTML: {report_html}")
     if not evidence_dir.is_dir():

--- a/.just/tests/test_generate_report_index.py
+++ b/.just/tests/test_generate_report_index.py
@@ -155,6 +155,30 @@ class GenerateReportIndexTests(unittest.TestCase):
             with self.assertRaisesRegex(ReportIndexError, "stale"):
                 write_or_check(root, check=True)
 
+    def test_rejects_report_symlink_that_escapes_public_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir, tempfile.TemporaryDirectory() as outside:
+            root = Path(tempdir)
+            reports = root / "site/reports"
+            reports.mkdir(parents=True)
+            outside_path = Path(outside) / "private.html"
+            outside_path.write_text("private\n", encoding="utf-8")
+            (reports / "leak.html").symlink_to(outside_path)
+            (reports / "leak").mkdir()
+            (reports / "leak.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "report_type": "benchmark",
+                        "generated_at": "2026-07-01T00:00:00Z",
+                        "host_label": "mac-arm64",
+                        "report_html": "leak.html",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ReportIndexError, "escapes"):
+                build_index(reports)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.just/tests/test_generate_report_index.py
+++ b/.just/tests/test_generate_report_index.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from generate_report_index import ReportIndexError
+from generate_report_index import build_index
+from generate_report_index import write_or_check
+
+
+def write_envelope(root: Path, name: str, report_type: str, generated_at: str, host: str) -> None:
+    reports = root / "site/reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    (reports / f"{name}.html").write_text(f"<html>{name}</html>\n", encoding="utf-8")
+    (reports / name).mkdir(exist_ok=True)
+    (reports / name / "evidence.json").write_text("{}\n", encoding="utf-8")
+    (reports / f"{name}.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_type": report_type,
+                "generated_at": generated_at,
+                "host_label": host,
+                "report_html": f"{name}.html",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class GenerateReportIndexTests(unittest.TestCase):
+    def test_empty_input_has_both_groups(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            (root / "site/reports").mkdir(parents=True)
+            index = build_index(root / "site/reports")
+            self.assertIn("<h2>Benchmark</h2>", index)
+            self.assertIn("<h2>Fuzz</h2>", index)
+            self.assertEqual(index.count("No reports available."), 2)
+
+    def test_aggregates_benchmark_and_orders_entries_newest_first(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            # Two run envelopes intentionally point to the same aggregate HTML.
+            reports = root / "site/reports"
+            reports.mkdir(parents=True)
+            (reports / "benchmark.html").write_text("<html>benchmark</html>\n", encoding="utf-8")
+            (reports / "benchmark").mkdir()
+            for name, host, timestamp in (
+                ("benchmark", "mac-arm64", "2026-07-01T00:00:00Z"),
+                ("benchmark-run-2", "linux-x64", "2026-07-03T00:00:00Z"),
+            ):
+                source = reports / f"{name}.json"
+                source.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": 1,
+                            "report_type": "benchmark",
+                            "generated_at": timestamp,
+                            "host_label": host,
+                            "report_html": "benchmark.html",
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+            write_envelope(root, "campaign", "fuzz", "2026-07-02T00:00:00Z", "mac-arm64")
+            index = build_index(reports)
+            self.assertEqual(index.count('href="benchmark.html"'), 1)
+            self.assertIn("2 runs", index)
+            self.assertLess(index.index("benchmark.html"), index.index("campaign.html"))
+            self.assertIn("hosts: linux-x64, mac-arm64", index)
+
+    def test_rejects_unsafe_or_incomplete_envelope(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            reports = root / "site/reports"
+            reports.mkdir(parents=True)
+            (reports / "bad.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "report_type": "benchmark",
+                        "generated_at": "2026-07-01T00:00:00Z",
+                        "host_label": "machine name",
+                        "report_html": "bad.html",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ReportIndexError, "host_label"):
+                build_index(reports)
+
+    def test_rejects_missing_html_and_evidence_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            reports = root / "site/reports"
+            reports.mkdir(parents=True)
+            (reports / "missing.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "report_type": "fuzz",
+                        "generated_at": "2026-07-01T00:00:00Z",
+                        "host_label": "mac-arm64",
+                        "report_html": "missing.html",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ReportIndexError, "missing report HTML"):
+                build_index(reports)
+
+    def test_discovers_nested_run_envelope_without_treating_evidence_as_envelope(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            reports = root / "site/reports"
+            evidence = reports / "campaign"
+            evidence.mkdir(parents=True)
+            (reports / "campaign.html").write_text("<html>campaign</html>\n", encoding="utf-8")
+            (evidence / "run-001.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "report_type": "fuzz",
+                        "generated_at": "2026-07-01T00:00:00Z",
+                        "host_label": "mac-arm64",
+                        "report_html": "campaign.html",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (evidence / "metrics.json").write_text(
+                json.dumps({"schema_version": 2, "accepted": 10}), encoding="utf-8"
+            )
+            index = build_index(reports)
+            self.assertIn('href="campaign.html"', index)
+            self.assertNotIn("metrics", index)
+
+    def test_check_detects_stale_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            (root / "site/reports").mkdir(parents=True)
+            write_or_check(root, check=False)
+            self.assertEqual(write_or_check(root, check=True), 0)
+            index_path = root / "site/reports/index.html"
+            index_path.write_text(index_path.read_text(encoding="utf-8") + "<!-- stale -->\n", encoding="utf-8")
+            with self.assertRaisesRegex(ReportIndexError, "stale"):
+                write_or_check(root, check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Justfile
+++ b/Justfile
@@ -137,6 +137,10 @@ build:
 test mode='default':
     {{python_cmd}} .just/run_tests.py {{mode}}
 
+# Generate or verify the durable public verification-report index.
+reports-index *args:
+    {{python_cmd}} .just/generate_report_index.py {{args}}
+
 # Build the PyO3 extension with Maturin and prove Python can import it.
 test-graft-python:
     {{python_cmd}} scripts/test_atm_graft_python.py

--- a/docs/plans/phase-ai/sprint-ai-46-pages-report-index.md
+++ b/docs/plans/phase-ai/sprint-ai-46-pages-report-index.md
@@ -1,7 +1,8 @@
 ---
 title: AI.46 generated reports index
-status: planned
+status: complete
 branch: feature/pAI-s46-reports-index
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s46-reports-index
 recommended_agent: Cipher-311d
 recommended_model: fast
 execution_mode: parallel

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1018,7 +1018,7 @@ Implementation Branches:
 | `AI.39` | `planned` | `feature/pAI-s39-buffered-local-http-framing` | bounded buffered local HTTP request framing |
 | `AI.40` | `planned` | `feature/pAI-s40-local-transport-benchmark` | clean local transport throughput benchmark; not an extension of abandoned AI.33 script |
 | `AI.43` | `planned` | `feature/pAI-s43-remote-https-response-framing` | buffered remote HTTPS response framing |
-| `AI.46` | `planned` | `feature/pAI-s46-reports-index` | generated durable reports index |
+| `AI.46` | `complete` | `feature/pAI-s46-reports-index` | generated durable reports index |
 | `AI.47` | `planned` | `feature/pAI-s47-pages-site-home` | GitHub Pages site home and deployment |
 | `AI.48` | `planned` | `feature/pAI-s48-fuzz-tooling-port` | ported `just fuzz` coordinator/probe tooling |
 | `AI.49` | `planned` | `feature/pAI-s49-benchmark-report` | durable benchmark JSON and aggregate HTML report |

--- a/site/reports/index.html
+++ b/site/reports/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ATM verification reports</title>
+  <style>body{font:16px system-ui,sans-serif;max-width:64rem;margin:2rem auto;padding:0 1rem;line-height:1.5}h1{margin-bottom:.25rem}ul{padding:0;list-style:none}li{display:grid;grid-template-columns:minmax(12rem,2fr) auto 1fr;gap:1rem;padding:.55rem 0;border-bottom:1px solid #ddd}time,.report-meta{color:#555;font-size:.9em}.empty{color:#666;font-style:italic}</style>
+</head>
+<body>
+  <h1>ATM verification reports</h1>
+  <p>Generated from schema-validated public report envelopes.</p>
+  <section><h2>Benchmark</h2>
+    <p class="empty">No reports available.</p>
+  </section>
+  <section><h2>Fuzz</h2>
+    <p class="empty">No reports available.</p>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Public report envelope (schema_version, report_type, generated_at, host_label, report_html) for benchmark/fuzz report types
- `.just/generate_report_index.py` generates/checks `site/reports/index.html` grouped by type, newest-first
- `just reports-index` / `just reports-index --check` recipes

## Sprint doc
docs/plans/phase-ai/sprint-ai-46-pages-report-index.md

## Test plan
- [ ] just reports-index --check
- [ ] just lint
- [ ] just test
- [ ] QA (quality-mgr)