### PR TITLE
AI.39 — buffered local HTTP framing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "getrandom 0.3.4",
  "interprocess",
  "libc",
+ "memchr",
  "parking_lot",
  "semver",
  "serde",

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -1435,12 +1435,11 @@ fn ai11_deletion_gate_rejects_retired_windows_transport_ast_and_dependencies() {
         local_tcp_source.contains("pub(crate) struct LocalIpcServerTransportAdapter"),
         "the Windows local HTTP adapter must remain implemented by loopback TCP"
     );
-    for http_primitive in ["read_http_request", "write_http_response"] {
-        assert!(
-            local_tcp_source.contains(http_primitive) && local_ipc_source.contains(http_primitive),
-            "Unix UDS and loopback TCP must use the same HTTP primitive `{http_primitive}`"
-        );
-    }
+    assert!(
+        local_tcp_source.contains("HttpFrameReader")
+            && local_ipc_source.contains("HttpFrameReader"),
+        "Unix UDS and loopback TCP must use the shared HTTP frame reader"
+    );
     let non_loopback_binds = local_tcp_source
         .lines()
         .filter(|line| line.contains("TcpListener::bind"))

--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -20,6 +20,7 @@ name = "atm_core"
 test-utils = []
 
 [dependencies]
+memchr = "2.7"
 atm-error = { path = "../atm-error", version = "1.4.0-beta-ai.38" }
 atm-storage = { path = "../atm-storage", version = "1.4.0-beta-ai.38" }
 serde.workspace = true

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -962,6 +962,18 @@ mod tests {
     }
 
     #[test]
+    fn http_frame_reader_rejects_duplicate_content_length() {
+        let wire =
+            b"POST /v1/atm/messages HTTP/1.1\r\nContent-Length: 2\r\nContent-Length: 2\r\n\r\n{}";
+        let error = HttpFrameReader::new()
+            .read_request(&mut wire.as_slice())
+            .expect_err("duplicate Content-Length must be rejected");
+
+        assert!(error.is_validation());
+        assert!(error.message().contains("duplicate Content-Length"));
+    }
+
+    #[test]
     fn http_wire_body_is_route_schema_not_request_envelope() {
         let request = RequestEnvelope::Doctor(DoctorQuery::default());
         let mut bytes = Vec::new();

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -249,7 +249,28 @@ pub fn write_http_request_with_headers(
 }
 
 pub fn read_http_request(reader: &mut impl Read) -> Result<Option<HttpRequest>, AtmError> {
-    HttpFrameReader::new().read_request(reader)
+    let Some((start_line, headers)) = read_http_headers(reader)? else {
+        return Ok(None);
+    };
+    let mut parts = start_line.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| AtmError::validation("malformed daemon HTTP request method"))?;
+    let path = parts
+        .next()
+        .ok_or_else(|| AtmError::validation("malformed daemon HTTP request path"))?;
+    if parts.next().is_none() {
+        return Err(AtmError::validation(
+            "malformed daemon HTTP request version",
+        ));
+    }
+    let body = read_http_body(reader, &headers)?;
+    Ok(Some(HttpRequest {
+        method: method.to_string(),
+        path: path.to_string(),
+        headers,
+        body,
+    }))
 }
 
 /// Writes an HTTP response with the supplied local connection policy.
@@ -871,16 +892,19 @@ mod tests {
         let request = RequestEnvelope::Doctor(DoctorQuery::default());
         let mut wire = Vec::new();
         write_http_request(&mut wire, &request).expect("write HTTP request");
-        let mut fragmented = FragmentedReader::new(wire, 1);
 
-        let decoded = decode_request(
-            read_http_request(&mut fragmented)
-                .expect("read fragmented HTTP request")
-                .expect("request"),
-        )
-        .expect("decode fragmented HTTP request");
+        for mut frames in [HttpFrameReader::new(), HttpFrameReader::scalar_for_test()] {
+            let mut fragmented = FragmentedReader::new(wire.clone(), 1);
+            let decoded = decode_request(
+                frames
+                    .read_request(&mut fragmented)
+                    .expect("read fragmented HTTP request")
+                    .expect("request"),
+            )
+            .expect("decode fragmented HTTP request");
 
-        assert!(matches!(decoded, ApiRequest::Doctor(_)));
+            assert!(matches!(decoded, ApiRequest::Doctor(_)));
+        }
     }
 
     #[test]
@@ -892,49 +916,49 @@ mod tests {
             for _ in 0..frame_count {
                 write_http_request(&mut wire, &request).expect("write coalesced HTTP request");
             }
-            let mut coalesced = wire.as_slice();
-            let mut frames = HttpFrameReader::new();
-
-            for frame_index in 0..frame_count {
-                let decoded = decode_request(
-                    frames
-                        .read_request(&mut coalesced)
-                        .expect("read coalesced HTTP request")
-                        .unwrap_or_else(|| {
-                            panic!(
-                                "coalesced run of {frame_count} frames ended before frame {}",
-                                frame_index + 1
-                            )
-                        }),
-                )
-                .expect("decode coalesced request");
-                assert!(matches!(decoded, ApiRequest::Doctor(_)));
+            for mut frames in [HttpFrameReader::new(), HttpFrameReader::scalar_for_test()] {
+                let mut coalesced = wire.as_slice();
+                for frame_index in 0..frame_count {
+                    let decoded = decode_request(
+                        frames
+                            .read_request(&mut coalesced)
+                            .expect("read coalesced HTTP request")
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "coalesced run of {frame_count} frames ended before frame {}",
+                                    frame_index + 1
+                                )
+                            }),
+                    )
+                    .expect("decode coalesced request");
+                    assert!(matches!(decoded, ApiRequest::Doctor(_)));
+                }
+                assert!(
+                    coalesced.is_empty(),
+                    "coalesced run of {frame_count} complete frames left trailing bytes"
+                );
             }
-            assert!(
-                coalesced.is_empty(),
-                "coalesced run of {frame_count} complete frames left trailing bytes"
-            );
         }
     }
 
     #[test]
     fn http_frame_reader_retains_bytes_after_a_body_boundary() {
         let wire = b"POST /v1/atm/messages HTTP/1.1\r\nContent-Length: 2\r\n\r\n{}GET /v1/atm/doctor HTTP/1.1\r\nContent-Length: 0\r\n\r\n";
-        let mut source = FragmentedReader::new(wire.to_vec(), wire.len());
-        let mut frames = HttpFrameReader::new();
+        for mut frames in [HttpFrameReader::new(), HttpFrameReader::scalar_for_test()] {
+            let mut source = FragmentedReader::new(wire.to_vec(), wire.len());
+            let first = frames
+                .read_request(&mut source)
+                .expect("read first frame")
+                .expect("first frame");
+            let second = frames
+                .read_request(&mut source)
+                .expect("read second frame")
+                .expect("second frame");
 
-        let first = frames
-            .read_request(&mut source)
-            .expect("read first frame")
-            .expect("first frame");
-        let second = frames
-            .read_request(&mut source)
-            .expect("read second frame")
-            .expect("second frame");
-
-        assert_eq!(first.body, b"{}");
-        assert_eq!(second.method, "GET");
-        assert_eq!(second.path, "/v1/atm/doctor");
+            assert_eq!(first.body, b"{}");
+            assert_eq!(second.method, "GET");
+            assert_eq!(second.path, "/v1/atm/doctor");
+        }
     }
 
     #[test]

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -19,6 +19,9 @@ use crate::send::WriteRequest;
 use crate::types::HostName;
 use base64::Engine as _;
 
+mod http_frame_reader;
+pub use http_frame_reader::HttpFrameReader;
+
 pub const MAX_HTTP_REQUEST_BODY_BYTES: usize = 1_048_576;
 /// Version of the daemon's HTTP request contract.
 pub const HTTP_API_VERSION: &str = crate::protocol::HTTP_API_VERSION;
@@ -246,28 +249,24 @@ pub fn write_http_request_with_headers(
 }
 
 pub fn read_http_request(reader: &mut impl Read) -> Result<Option<HttpRequest>, AtmError> {
-    let Some((start_line, headers)) = read_http_headers(reader)? else {
-        return Ok(None);
-    };
-    let mut parts = start_line.split_whitespace();
-    let method = parts
-        .next()
-        .ok_or_else(|| AtmError::validation("malformed daemon HTTP request method"))?;
-    let path = parts
-        .next()
-        .ok_or_else(|| AtmError::validation("malformed daemon HTTP request path"))?;
-    if parts.next().is_none() {
-        return Err(AtmError::validation(
-            "malformed daemon HTTP request version",
-        ));
+    HttpFrameReader::new().read_request(reader)
+}
+
+/// Writes an HTTP response with the supplied local connection policy.
+///
+/// Local adapters use this for their opt-in bounded keep-alive loop; the
+/// public default remains [`write_http_response`], which closes the connection.
+pub fn write_local_http_response(
+    writer: &mut impl Write,
+    response: &ResponseEnvelope,
+    keep_alive: bool,
+) -> Result<(), AtmError> {
+    match response {
+        ResponseEnvelope::Clear(outcome) => {
+            write_no_content_response_with_connection(writer, outcome, keep_alive)
+        }
+        _ => write_http_response_body_with_connection(writer, response, keep_alive),
     }
-    let body = read_http_body(reader, &headers)?;
-    Ok(Some(HttpRequest {
-        method: method.to_string(),
-        path: path.to_string(),
-        headers,
-        body,
-    }))
 }
 
 pub fn decode_request(request: HttpRequest) -> Result<ApiRequest, AtmError> {
@@ -297,6 +296,14 @@ fn write_http_response_body(
     writer: &mut impl Write,
     response: &ResponseEnvelope,
 ) -> Result<(), AtmError> {
+    write_http_response_body_with_connection(writer, response, false)
+}
+
+fn write_http_response_body_with_connection(
+    writer: &mut impl Write,
+    response: &ResponseEnvelope,
+    keep_alive: bool,
+) -> Result<(), AtmError> {
     let (status, reason, body, location) = encode_response(response)?;
     let location = location
         .as_deref()
@@ -304,8 +311,9 @@ fn write_http_response_body(
         .unwrap_or_default();
     write!(
         writer,
-        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\n{location}Content-Length: {}\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\n{location}Content-Length: {}\r\nConnection: {}\r\n\r\n",
         body.len(),
+        if keep_alive { "keep-alive" } else { "close" },
     )
     .map_err(|source| {
         AtmError::daemon_unavailable(format!("failed to write daemon HTTP response headers: {source}"))
@@ -351,11 +359,20 @@ fn write_no_content_response(
     writer: &mut impl Write,
     outcome: &crate::clear::ClearOutcome,
 ) -> Result<(), AtmError> {
+    write_no_content_response_with_connection(writer, outcome, false)
+}
+
+fn write_no_content_response_with_connection(
+    writer: &mut impl Write,
+    outcome: &crate::clear::ClearOutcome,
+    keep_alive: bool,
+) -> Result<(), AtmError> {
     let outcome = serde_json::to_vec(outcome).map_err(AtmError::from)?;
     let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(outcome);
     write!(
         writer,
-        "HTTP/1.1 204 No Content\r\n{CLEAR_OUTCOME_HEADER}: {encoded}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        "HTTP/1.1 204 No Content\r\n{CLEAR_OUTCOME_HEADER}: {encoded}\r\nContent-Length: 0\r\nConnection: {}\r\n\r\n",
+        if keep_alive { "keep-alive" } else { "close" },
     )
     .map_err(|source| {
         AtmError::daemon_unavailable(format!(
@@ -783,9 +800,11 @@ pub trait DaemonApiClient: crate::boundary::sealed::Sealed + Send + Sync {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{self, Read};
+
     use super::{
-        ApiRequest, MAX_HTTP_REQUEST_BODY_BYTES, decode_request, read_http_request,
-        read_http_response, write_http_request, write_http_response,
+        ApiRequest, HttpFrameReader, MAX_HTTP_REQUEST_BODY_BYTES, decode_request,
+        read_http_request, read_http_response, write_http_request, write_http_response,
     };
     use crate::ack::AckRequest;
     use crate::clear::{ClearOutcome, ClearQuery, RemovedByClass};
@@ -796,6 +815,40 @@ mod tests {
     use crate::send::{SendMessageSource, SendRequest};
     use crate::test_support::{TEST_SENDER, TEST_TEAM};
     use crate::types::CommandAction;
+
+    /// A reader that presents a valid HTTP stream in deliberately small reads.
+    ///
+    /// TCP may split one HTTP frame at any byte boundary; adapters must rely on
+    /// HTTP framing rather than a single socket read.
+    struct FragmentedReader {
+        bytes: Vec<u8>,
+        position: usize,
+        maximum_chunk: usize,
+    }
+
+    impl FragmentedReader {
+        fn new(bytes: Vec<u8>, maximum_chunk: usize) -> Self {
+            Self {
+                bytes,
+                position: 0,
+                maximum_chunk,
+            }
+        }
+    }
+
+    impl Read for FragmentedReader {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            if self.position == self.bytes.len() {
+                return Ok(0);
+            }
+            let count = (self.bytes.len() - self.position)
+                .min(self.maximum_chunk)
+                .min(buffer.len());
+            buffer[..count].copy_from_slice(&self.bytes[self.position..self.position + count]);
+            self.position += count;
+            Ok(count)
+        }
+    }
 
     #[test]
     fn http_uds_request_round_trip_preserves_the_canonical_envelope() {
@@ -811,6 +864,77 @@ mod tests {
         .expect("decode HTTP request");
 
         assert!(matches!(decoded, ApiRequest::Doctor(_)));
+    }
+
+    #[test]
+    fn http_request_parser_accepts_a_request_fragmented_at_every_transport_read() {
+        let request = RequestEnvelope::Doctor(DoctorQuery::default());
+        let mut wire = Vec::new();
+        write_http_request(&mut wire, &request).expect("write HTTP request");
+        let mut fragmented = FragmentedReader::new(wire, 1);
+
+        let decoded = decode_request(
+            read_http_request(&mut fragmented)
+                .expect("read fragmented HTTP request")
+                .expect("request"),
+        )
+        .expect("decode fragmented HTTP request");
+
+        assert!(matches!(decoded, ApiRequest::Doctor(_)));
+    }
+
+    #[test]
+    fn http_request_parser_handles_coalesced_runs_of_consecutive_frames() {
+        let request = RequestEnvelope::Doctor(DoctorQuery::default());
+
+        for frame_count in [1_usize, 2, 4, 8, 16, 32, 64] {
+            let mut wire = Vec::new();
+            for _ in 0..frame_count {
+                write_http_request(&mut wire, &request).expect("write coalesced HTTP request");
+            }
+            let mut coalesced = wire.as_slice();
+            let mut frames = HttpFrameReader::new();
+
+            for frame_index in 0..frame_count {
+                let decoded = decode_request(
+                    frames
+                        .read_request(&mut coalesced)
+                        .expect("read coalesced HTTP request")
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "coalesced run of {frame_count} frames ended before frame {}",
+                                frame_index + 1
+                            )
+                        }),
+                )
+                .expect("decode coalesced request");
+                assert!(matches!(decoded, ApiRequest::Doctor(_)));
+            }
+            assert!(
+                coalesced.is_empty(),
+                "coalesced run of {frame_count} complete frames left trailing bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn http_frame_reader_retains_bytes_after_a_body_boundary() {
+        let wire = b"POST /v1/atm/messages HTTP/1.1\r\nContent-Length: 2\r\n\r\n{}GET /v1/atm/doctor HTTP/1.1\r\nContent-Length: 0\r\n\r\n";
+        let mut source = FragmentedReader::new(wire.to_vec(), wire.len());
+        let mut frames = HttpFrameReader::new();
+
+        let first = frames
+            .read_request(&mut source)
+            .expect("read first frame")
+            .expect("first frame");
+        let second = frames
+            .read_request(&mut source)
+            .expect("read second frame")
+            .expect("second frame");
+
+        assert_eq!(first.body, b"{}");
+        assert_eq!(second.method, "GET");
+        assert_eq!(second.path, "/v1/atm/doctor");
     }
 
     #[test]
@@ -842,6 +966,28 @@ mod tests {
         assert!(!text.contains("Error\":{") && !text.contains("Error\""));
         let response = read_http_response(&mut bytes.as_slice(), &request).expect("read error");
         assert!(matches!(response, ResponseEnvelope::Error(error) if error.is_validation()));
+    }
+
+    #[test]
+    fn http_response_remains_explicitly_connection_close_until_keep_alive_is_introduced() {
+        let mut bytes = Vec::new();
+
+        write_http_response(
+            &mut bytes,
+            &ResponseEnvelope::Error(AtmError::validation("bad")),
+        )
+        .expect("write HTTP error");
+
+        let headers = std::str::from_utf8(&bytes)
+            .expect("HTTP response is UTF-8")
+            .split("\r\n\r\n")
+            .next()
+            .expect("response headers");
+        assert!(
+            headers
+                .lines()
+                .any(|line| line.eq_ignore_ascii_case("Connection: close"))
+        );
     }
 
     #[test]

--- a/crates/atm-core/src/api/http_frame_reader.rs
+++ b/crates/atm-core/src/api/http_frame_reader.rs
@@ -64,19 +64,32 @@ impl HttpFrameReader {
     ///
     /// EOF before a frame is not an error. EOF inside a header or declared body
     /// remains a typed daemon-unavailable error, matching the legacy parser.
+    ///
+    /// Callers must configure a transport read deadline before calling this
+    /// method: a generic [`Read`] cannot cancel a blocking read itself. Both
+    /// production local transports enforce their three-second request deadline
+    /// at their socket/worker boundary.
     pub fn read_request(
         &mut self,
         reader: &mut impl Read,
     ) -> Result<Option<HttpRequest>, AtmError> {
+        // Only the delimiter overlap can become newly matchable after a read;
+        // resuming there prevents repeatedly scanning an unbounded prefix.
+        let mut search_from = 0;
         let header_end = loop {
-            if let Some(index) = self.delimiter.find(&self.unread) {
-                break index + HEADER_DELIMITER.len();
+            if let Some(index) = self.delimiter.find(&self.unread[search_from..]) {
+                break search_from + index + HEADER_DELIMITER.len();
             }
             if self.unread.len() > MAX_HTTP_HEADER_BYTES {
-                return Err(AtmError::validation(
-                    "daemon HTTP headers exceed 16384 bytes",
+                return Err(AtmError::validation_with_recovery(
+                    format!("daemon HTTP headers exceed {MAX_HTTP_HEADER_BYTES} bytes"),
+                    "send a smaller HTTP request header",
                 ));
             }
+            search_from = self
+                .unread
+                .len()
+                .saturating_sub(HEADER_DELIMITER.len().saturating_sub(1));
             if !self.read_more(reader)? {
                 return if self.unread.is_empty() {
                     Ok(None)
@@ -88,16 +101,18 @@ impl HttpFrameReader {
             }
         };
         if header_end > MAX_HTTP_HEADER_BYTES {
-            return Err(AtmError::validation(
-                "daemon HTTP headers exceed 16384 bytes",
+            return Err(AtmError::validation_with_recovery(
+                format!("daemon HTTP headers exceed {MAX_HTTP_HEADER_BYTES} bytes"),
+                "send a smaller HTTP request header",
             ));
         }
 
         let (method, path, headers) = parse_headers(&self.unread[..header_end])?;
         let body_length = content_length(&headers)?;
         if body_length > MAX_HTTP_REQUEST_BODY_BYTES {
-            return Err(AtmError::validation(
-                "daemon HTTP body exceeds 1048576 bytes",
+            return Err(AtmError::validation_with_recovery(
+                format!("daemon HTTP body exceeds {MAX_HTTP_REQUEST_BODY_BYTES} bytes"),
+                "send a smaller HTTP request body",
             ));
         }
         let frame_end = header_end + body_length;
@@ -127,28 +142,40 @@ impl HttpFrameReader {
                 self.unread.extend_from_slice(&chunk[..count]);
                 Ok(true)
             }
-            Err(source) => Err(AtmError::daemon_unavailable(format!(
-                "failed to read daemon HTTP headers: {source}",
-            ))),
+            Err(source) => Err(AtmError::daemon_unavailable_with_cause(
+                "failed to read daemon HTTP headers",
+                source,
+            )),
         }
     }
 }
 
 fn parse_headers(bytes: &[u8]) -> Result<(String, String, Vec<String>), AtmError> {
-    let text = std::str::from_utf8(bytes)
-        .map_err(|_source| AtmError::validation("daemon HTTP headers are not UTF-8"))?;
+    let text = std::str::from_utf8(bytes).map_err(|_source| {
+        AtmError::validation_with_recovery(
+            "daemon HTTP headers are not UTF-8",
+            "send an HTTP/1.1 request encoded as UTF-8",
+        )
+    })?;
     let mut lines = text.split("\r\n");
     let start_line = lines.next().unwrap_or_default();
     let mut parts = start_line.split_whitespace();
-    let method = parts
-        .next()
-        .ok_or_else(|| AtmError::validation("malformed daemon HTTP request method"))?;
-    let path = parts
-        .next()
-        .ok_or_else(|| AtmError::validation("malformed daemon HTTP request path"))?;
+    let method = parts.next().ok_or_else(|| {
+        AtmError::validation_with_recovery(
+            "malformed daemon HTTP request method",
+            "send an HTTP/1.1 request line with method, path, and version",
+        )
+    })?;
+    let path = parts.next().ok_or_else(|| {
+        AtmError::validation_with_recovery(
+            "malformed daemon HTTP request path",
+            "send an HTTP/1.1 request line with method, path, and version",
+        )
+    })?;
     if parts.next().is_none() {
-        return Err(AtmError::validation(
+        return Err(AtmError::validation_with_recovery(
             "malformed daemon HTTP request version",
+            "send an HTTP/1.1 request line with method, path, and version",
         ));
     }
     Ok((
@@ -162,15 +189,25 @@ fn parse_headers(bytes: &[u8]) -> Result<(String, String, Vec<String>), AtmError
 }
 
 fn content_length(headers: &[String]) -> Result<usize, AtmError> {
-    headers
-        .iter()
-        .find_map(|header| {
-            header
-                .split_once(':')
-                .filter(|(name, _)| name.eq_ignore_ascii_case("content-length"))
-        })
-        .map(|(_, value)| value.trim().parse::<usize>())
-        .transpose()
-        .map_err(|_source| AtmError::validation("daemon HTTP Content-Length is invalid"))
-        .map(|length| length.unwrap_or(0))
+    let mut values = headers.iter().filter_map(|header| {
+        header
+            .split_once(':')
+            .filter(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+            .map(|(_, value)| value.trim())
+    });
+    let Some(value) = values.next() else {
+        return Ok(0);
+    };
+    if values.next().is_some() {
+        return Err(AtmError::validation_with_recovery(
+            "daemon HTTP request contains duplicate Content-Length headers",
+            "send exactly one Content-Length header",
+        ));
+    }
+    value.parse().map_err(|_source| {
+        AtmError::validation_with_recovery(
+            "daemon HTTP Content-Length is invalid",
+            "send one non-negative decimal Content-Length value",
+        )
+    })
 }

--- a/crates/atm-core/src/api/http_frame_reader.rs
+++ b/crates/atm-core/src/api/http_frame_reader.rs
@@ -1,0 +1,149 @@
+use std::io::Read;
+
+use memchr::memmem::Finder;
+
+use super::{HttpRequest, MAX_HTTP_HEADER_BYTES, MAX_HTTP_REQUEST_BODY_BYTES};
+use crate::error::AtmError;
+
+const HEADER_DELIMITER: &[u8] = b"\r\n\r\n";
+const READ_CHUNK_BYTES: usize = 8 * 1024;
+
+/// Bounded request-frame reader for local HTTP transports.
+///
+/// A stream read can include more than one request. The reader retains the
+/// exact bytes after the current request for the next call.
+#[derive(Debug)]
+pub struct HttpFrameReader {
+    unread: Vec<u8>,
+    delimiter: Finder<'static>,
+}
+
+impl Default for HttpFrameReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HttpFrameReader {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            unread: Vec::with_capacity(READ_CHUNK_BYTES),
+            delimiter: Finder::new(HEADER_DELIMITER),
+        }
+    }
+
+    /// Reads one complete local HTTP request frame.
+    ///
+    /// EOF before a frame is not an error. EOF inside a header or declared body
+    /// remains a typed daemon-unavailable error, matching the legacy parser.
+    pub fn read_request(
+        &mut self,
+        reader: &mut impl Read,
+    ) -> Result<Option<HttpRequest>, AtmError> {
+        let header_end = loop {
+            if let Some(index) = self.delimiter.find(&self.unread) {
+                break index + HEADER_DELIMITER.len();
+            }
+            if self.unread.len() > MAX_HTTP_HEADER_BYTES {
+                return Err(AtmError::validation(
+                    "daemon HTTP headers exceed 16384 bytes",
+                ));
+            }
+            if !self.read_more(reader)? {
+                return if self.unread.is_empty() {
+                    Ok(None)
+                } else {
+                    Err(AtmError::daemon_unavailable(
+                        "daemon HTTP headers ended unexpectedly",
+                    ))
+                };
+            }
+        };
+        if header_end > MAX_HTTP_HEADER_BYTES {
+            return Err(AtmError::validation(
+                "daemon HTTP headers exceed 16384 bytes",
+            ));
+        }
+
+        let (method, path, headers) = parse_headers(&self.unread[..header_end])?;
+        let body_length = content_length(&headers)?;
+        if body_length > MAX_HTTP_REQUEST_BODY_BYTES {
+            return Err(AtmError::validation(
+                "daemon HTTP body exceeds 1048576 bytes",
+            ));
+        }
+        let frame_end = header_end + body_length;
+        while self.unread.len() < frame_end {
+            if !self.read_more(reader)? {
+                return Err(AtmError::daemon_unavailable(
+                    "failed to read daemon HTTP body: unexpected end of file",
+                ));
+            }
+        }
+
+        let body = self.unread[header_end..frame_end].to_vec();
+        self.unread.drain(..frame_end);
+        Ok(Some(HttpRequest {
+            method,
+            path,
+            headers,
+            body,
+        }))
+    }
+
+    fn read_more(&mut self, reader: &mut impl Read) -> Result<bool, AtmError> {
+        let mut chunk = [0_u8; READ_CHUNK_BYTES];
+        match reader.read(&mut chunk) {
+            Ok(0) => Ok(false),
+            Ok(count) => {
+                self.unread.extend_from_slice(&chunk[..count]);
+                Ok(true)
+            }
+            Err(source) => Err(AtmError::daemon_unavailable(format!(
+                "failed to read daemon HTTP headers: {source}",
+            ))),
+        }
+    }
+}
+
+fn parse_headers(bytes: &[u8]) -> Result<(String, String, Vec<String>), AtmError> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|_source| AtmError::validation("daemon HTTP headers are not UTF-8"))?;
+    let mut lines = text.split("\r\n");
+    let start_line = lines.next().unwrap_or_default();
+    let mut parts = start_line.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| AtmError::validation("malformed daemon HTTP request method"))?;
+    let path = parts
+        .next()
+        .ok_or_else(|| AtmError::validation("malformed daemon HTTP request path"))?;
+    if parts.next().is_none() {
+        return Err(AtmError::validation(
+            "malformed daemon HTTP request version",
+        ));
+    }
+    Ok((
+        method.to_string(),
+        path.to_string(),
+        lines
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+            .collect(),
+    ))
+}
+
+fn content_length(headers: &[String]) -> Result<usize, AtmError> {
+    headers
+        .iter()
+        .find_map(|header| {
+            header
+                .split_once(':')
+                .filter(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        })
+        .map(|(_, value)| value.trim().parse::<usize>())
+        .transpose()
+        .map_err(|_source| AtmError::validation("daemon HTTP Content-Length is invalid"))
+        .map(|length| length.unwrap_or(0))
+}

--- a/crates/atm-core/src/api/http_frame_reader.rs
+++ b/crates/atm-core/src/api/http_frame_reader.rs
@@ -15,7 +15,26 @@ const READ_CHUNK_BYTES: usize = 8 * 1024;
 #[derive(Debug)]
 pub struct HttpFrameReader {
     unread: Vec<u8>,
-    delimiter: Finder<'static>,
+    delimiter: DelimiterFinder,
+}
+
+#[derive(Debug)]
+enum DelimiterFinder {
+    Optimized(Finder<'static>),
+    #[cfg(test)]
+    Scalar,
+}
+
+impl DelimiterFinder {
+    fn find(&self, haystack: &[u8]) -> Option<usize> {
+        match self {
+            Self::Optimized(finder) => finder.find(haystack),
+            #[cfg(test)]
+            Self::Scalar => haystack
+                .windows(HEADER_DELIMITER.len())
+                .position(|window| window == HEADER_DELIMITER),
+        }
+    }
 }
 
 impl Default for HttpFrameReader {
@@ -29,7 +48,15 @@ impl HttpFrameReader {
     pub fn new() -> Self {
         Self {
             unread: Vec::with_capacity(READ_CHUNK_BYTES),
-            delimiter: Finder::new(HEADER_DELIMITER),
+            delimiter: DelimiterFinder::Optimized(Finder::new(HEADER_DELIMITER)),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn scalar_for_test() -> Self {
+        Self {
+            unread: Vec::with_capacity(READ_CHUNK_BYTES),
+            delimiter: DelimiterFinder::Scalar,
         }
     }
 

--- a/crates/atm-core/src/api/http_frame_reader.rs
+++ b/crates/atm-core/src/api/http_frame_reader.rs
@@ -20,7 +20,7 @@ pub struct HttpFrameReader {
 
 #[derive(Debug)]
 enum DelimiterFinder {
-    Optimized(Finder<'static>),
+    Optimized(Box<Finder<'static>>),
     #[cfg(test)]
     Scalar,
 }
@@ -48,7 +48,7 @@ impl HttpFrameReader {
     pub fn new() -> Self {
         Self {
             unread: Vec::with_capacity(READ_CHUNK_BYTES),
-            delimiter: DelimiterFinder::Optimized(Finder::new(HEADER_DELIMITER)),
+            delimiter: DelimiterFinder::Optimized(Box::new(Finder::new(HEADER_DELIMITER))),
         }
     }
 

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -71,6 +71,8 @@ pub(crate) use local_tcp_transport::LocalIpcServerTransportAdapter;
 
 pub(crate) const GRACEFUL_DRAIN_DEADLINE: Duration = Duration::from_secs(2);
 pub(crate) const FORCE_CANCEL_DEADLINE: Duration = Duration::from_secs(3);
+/// Shared local HTTP connection bound for both Unix UDS and loopback TCP.
+pub(crate) const MAX_KEEP_ALIVE_REQUESTS: usize = 64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DaemonExitCode {

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -49,6 +49,7 @@ use shutdown::{
 // comfortably exceed realistic single-host caller fan-out while still bounding
 // per-connection worker threads and shutdown drain pressure.
 pub(crate) const MAX_CONCURRENT_CONNECTIONS: usize = 64;
+pub(crate) const MAX_KEEP_ALIVE_REQUESTS: usize = 64;
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 const TRACKED_DISPATCH_JOIN_DEADLINE: Duration = Duration::from_millis(250);
 // Give terminate/reload a brief grace window to deliver a typed rejection

--- a/crates/atm-daemon/src/local_ipc_transport.rs
+++ b/crates/atm-daemon/src/local_ipc_transport.rs
@@ -49,7 +49,6 @@ use shutdown::{
 // comfortably exceed realistic single-host caller fan-out while still bounding
 // per-connection worker threads and shutdown drain pressure.
 pub(crate) const MAX_CONCURRENT_CONNECTIONS: usize = 64;
-pub(crate) const MAX_KEEP_ALIVE_REQUESTS: usize = 64;
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 const TRACKED_DISPATCH_JOIN_DEADLINE: Duration = Duration::from_millis(250);
 // Give terminate/reload a brief grace window to deliver a typed rejection

--- a/crates/atm-daemon/src/local_ipc_transport/accept_loop.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/accept_loop.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::AtomicBool;
 use std::thread;
 
 use atm_core::api::ApiRouter;
-use atm_core::api::{read_http_request, write_http_response};
+use atm_core::api::{HttpFrameReader, write_http_response};
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::observability::{ConnectionFailureClassification, DaemonConnectionFailureFields};
@@ -104,7 +104,7 @@ pub(super) fn reject_connection_when_capped(
     ));
     let _ = stream.set_recv_timeout(Some(REQUEST_DEADLINE));
     let _ = stream.set_send_timeout(Some(REQUEST_DEADLINE));
-    let has_request = match read_http_request(stream) {
+    let has_request = match HttpFrameReader::new().read_request(stream) {
         Ok(Some(_)) => true,
         Ok(None) => false,
         Err(error) => {

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -22,9 +22,10 @@ use crate::active_connection_registry::{
 #[cfg(test)]
 use super::PreparedRuntimeServer;
 use super::{
-    DISPATCH_PANIC_RECOVERED_MESSAGE, MAX_CONCURRENT_CONNECTIONS, MAX_KEEP_ALIVE_REQUESTS,
-    REQUEST_DEADLINE, write_shutdown_response,
+    DISPATCH_PANIC_RECOVERED_MESSAGE, MAX_CONCURRENT_CONNECTIONS, REQUEST_DEADLINE,
+    write_shutdown_response,
 };
+use crate::MAX_KEEP_ALIVE_REQUESTS;
 
 type DispatchResultRx = std::sync::mpsc::Receiver<Result<ResponseEnvelope, AtmError>>;
 type DispatchCompletionRx = std::sync::mpsc::Receiver<()>;
@@ -356,9 +357,8 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::active_connection_registry::ActiveConnectionRegistry;
-    use crate::local_ipc_transport::MAX_KEEP_ALIVE_REQUESTS;
     use crate::test_support::{DoctorOnlyDispatcher, connect_local_ipc_with_timeout};
-    use crate::{DaemonSubsystem, SubsystemObservability};
+    use crate::{DaemonSubsystem, MAX_KEEP_ALIVE_REQUESTS, SubsystemObservability};
 
     #[test]
     fn side_effecting_timeout_returns_may_have_executed_code() {

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -3,8 +3,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use atm_core::api::{
-    ApiRequest, ApiRouter, AuthenticatedIngress, RequestDeadline, decode_request,
-    read_http_request, write_http_response,
+    ApiRequest, ApiRouter, AuthenticatedIngress, HttpFrameReader, RequestDeadline, decode_request,
+    write_local_http_response,
 };
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
@@ -30,6 +30,7 @@ type DispatchResultRx = std::sync::mpsc::Receiver<Result<ResponseEnvelope, AtmEr
 type DispatchCompletionRx = std::sync::mpsc::Receiver<()>;
 type DispatchWorkerHandle = std::thread::JoinHandle<()>;
 type DispatchWorker = (DispatchResultRx, DispatchCompletionRx, DispatchWorkerHandle);
+const MAX_KEEP_ALIVE_REQUESTS: usize = 64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RequestExecutionRisk {
@@ -44,53 +45,67 @@ pub(super) fn handle_connection(
     registry: Arc<ActiveConnectionRegistry>,
     observability: &SubsystemObservability,
 ) -> Result<(), AtmError> {
-    // The deadline starts at local HTTP admission, not when a later dispatch
-    // worker happens to run. It is propagated unchanged through peer delivery.
-    let deadline = RequestDeadline::after(REQUEST_DEADLINE);
     apply_primary_request_deadline(&mut stream);
-    if force_shutdown.load(Ordering::SeqCst) {
-        return write_shutdown_response(&mut stream).map(|_| ());
-    }
-    let request = match read_bounded_http_request(&mut stream)? {
-        Some(request) => decode_request(request)?,
-        None => return Ok(()),
-    };
-    tracing::debug!(
-        max_http_request_body_bytes = atm_core::MAX_HTTP_REQUEST_BODY_BYTES,
-        "daemon HTTP request accepted under configured size cap"
-    );
-    let request_id = atm_core::protocol::next_request_id();
-    let response = dispatch_request(
-        request_id,
-        request,
-        deadline,
-        dispatcher,
-        &registry,
-        observability,
-    )?;
-    if let Err(error) = write_http_response(&mut stream, &response) {
-        let classification = classify_connection_failure(&error);
-        if classification == ConnectionFailureClassification::ExpectedPeerDisconnect {
-            observability.emit_event_or_warn(
-                observability
-                    .event(
-                        "connection_worker",
-                        classification.as_str(),
-                        "same-host peer disconnected before the daemon HTTP response completed",
-                    )
-                    .with_connection_failure(DaemonConnectionFailureFields {
-                        code: error.code(),
-                        request_id: Some(request_id),
-                        classification,
-                    })
-                    .with_transport_context("response_write"),
+    let mut frames = HttpFrameReader::new();
+    for request_count in 1..=MAX_KEEP_ALIVE_REQUESTS {
+        if force_shutdown.load(Ordering::SeqCst) {
+            return write_shutdown_response(&mut stream).map(|_| ());
+        }
+        let Some(raw_request) = read_bounded_http_request(&mut frames, &mut stream)? else {
+            return Ok(());
+        };
+        let keep_alive = raw_request
+            .header("connection")
+            .is_some_and(|value| value.eq_ignore_ascii_case("keep-alive"))
+            && request_count < MAX_KEEP_ALIVE_REQUESTS;
+        let request = decode_request(raw_request)?;
+        tracing::debug!(
+            max_http_request_body_bytes = atm_core::MAX_HTTP_REQUEST_BODY_BYTES,
+            "daemon HTTP request accepted under configured size cap"
+        );
+        let request_id = atm_core::protocol::next_request_id();
+        // The deadline starts at local HTTP admission, not when a later dispatch
+        // worker happens to run. It is propagated unchanged through peer delivery.
+        let response = dispatch_request(
+            request_id,
+            request,
+            RequestDeadline::after(REQUEST_DEADLINE),
+            dispatcher.clone(),
+            &registry,
+            observability,
+        )?;
+        if let Err(error) = write_local_http_response(&mut stream, &response, keep_alive) {
+            let classification = classify_connection_failure(&error);
+            if classification == ConnectionFailureClassification::ExpectedPeerDisconnect {
+                observability.emit_event_or_warn(
+                    observability
+                        .event(
+                            "connection_worker",
+                            classification.as_str(),
+                            "same-host peer disconnected before the daemon HTTP response completed",
+                        )
+                        .with_connection_failure(DaemonConnectionFailureFields {
+                            code: error.code(),
+                            request_id: Some(request_id),
+                            classification,
+                        })
+                        .with_transport_context("response_write"),
+                );
+                return Ok(());
+            }
+            emit_connection_failure_event(
+                observability,
+                &error,
+                Some(request_id),
+                "response_write",
             );
+            return Err(error);
+        }
+        emit_dispatch_panic_recovery(observability, registry.reap_finished_dispatches()?);
+        if !keep_alive {
             return Ok(());
         }
-        emit_connection_failure_event(observability, &error, Some(request_id), "response_write");
-        return Err(error);
     }
-    emit_dispatch_panic_recovery(observability, registry.reap_finished_dispatches()?);
     Ok(())
 }
 
@@ -223,22 +238,28 @@ fn apply_primary_request_deadline(stream: &mut LocalSocketStream) {
 }
 
 fn read_bounded_http_request(
+    frames: &mut HttpFrameReader,
     stream: &mut LocalSocketStream,
 ) -> Result<Option<atm_core::api::HttpRequest>, AtmError> {
     let mut read_stream = stream.try_clone().map_err(|_source| {
         AtmError::daemon_unavailable("failed to clone daemon local IPC stream for bounded read")
     })?;
     let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    let mut reader = std::mem::take(frames);
     std::thread::Builder::new()
         .name("local-ipc-request-read".to_string())
         .spawn(move || {
-            let _ = result_tx.send(read_http_request(&mut read_stream));
+            let request = reader.read_request(&mut read_stream);
+            let _ = result_tx.send((reader, request));
         })
         .map_err(|_source| {
             AtmError::daemon_unavailable("failed to spawn daemon local IPC request read worker")
         })?;
     match result_rx.recv_timeout(REQUEST_DEADLINE) {
-        Ok(result) => result,
+        Ok((reader, result)) => {
+            *frames = reader;
+            result
+        }
         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(AtmError::daemon_unavailable(
             "daemon local IPC request read exceeded the 3s deadline",
         )),

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -22,15 +22,14 @@ use crate::active_connection_registry::{
 #[cfg(test)]
 use super::PreparedRuntimeServer;
 use super::{
-    DISPATCH_PANIC_RECOVERED_MESSAGE, MAX_CONCURRENT_CONNECTIONS, REQUEST_DEADLINE,
-    write_shutdown_response,
+    DISPATCH_PANIC_RECOVERED_MESSAGE, MAX_CONCURRENT_CONNECTIONS, MAX_KEEP_ALIVE_REQUESTS,
+    REQUEST_DEADLINE, write_shutdown_response,
 };
 
 type DispatchResultRx = std::sync::mpsc::Receiver<Result<ResponseEnvelope, AtmError>>;
 type DispatchCompletionRx = std::sync::mpsc::Receiver<()>;
 type DispatchWorkerHandle = std::thread::JoinHandle<()>;
 type DispatchWorker = (DispatchResultRx, DispatchCompletionRx, DispatchWorkerHandle);
-const MAX_KEEP_ALIVE_REQUESTS: usize = 64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RequestExecutionRisk {
@@ -260,6 +259,9 @@ fn read_bounded_http_request(
             *frames = reader;
             result
         }
+        // The worker retains `reader` in these branches.  `handle_connection`
+        // returns the error immediately, which drops this connection, so the
+        // caller can never reuse the moved frame state on another request.
         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(AtmError::daemon_unavailable(
             "daemon local IPC request read exceeded the 3s deadline",
         )),

--- a/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/request_worker.rs
@@ -340,7 +340,7 @@ mod tests {
         RequestExecutionRisk, classify_connection_failure, dispatch_timeout_response,
         handle_connection, request_execution_risk,
     };
-    use atm_core::api::ApiRequest;
+    use atm_core::api::{ApiRequest, read_http_response, write_http_request};
     use atm_core::clear::ClearQuery;
     use atm_core::doctor::DoctorQuery;
     use atm_core::error::AtmError;
@@ -349,12 +349,14 @@ mod tests {
     use atm_core::protocol::{PeerSyncRequest, RequestEnvelope, ResponseEnvelope};
     use interprocess::local_socket::ListenerOptions;
     use interprocess::local_socket::traits::Listener as _;
+    use std::io::{Read as _, Write as _};
     use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
     use std::time::{Duration, Instant};
     use tempfile::TempDir;
 
     use crate::active_connection_registry::ActiveConnectionRegistry;
+    use crate::local_ipc_transport::MAX_KEEP_ALIVE_REQUESTS;
     use crate::test_support::{DoctorOnlyDispatcher, connect_local_ipc_with_timeout};
     use crate::{DaemonSubsystem, SubsystemObservability};
 
@@ -508,5 +510,67 @@ mod tests {
         );
         let _ = release_client_tx.send(());
         client.join().expect("join wedged peer");
+    }
+
+    #[test]
+    fn uds_keep_alive_serves_configured_counts_and_closes_at_bound() {
+        let request = RequestEnvelope::Doctor(DoctorQuery::default());
+        for count in [1_usize, 2, 8, 16, MAX_KEEP_ALIVE_REQUESTS] {
+            let tempdir = TempDir::new().expect("tempdir");
+            let socket_path = tempdir.path().join("keep-alive.sock");
+            let socket_name = atm_core::protocol::daemon_local_ipc_name_from_path(&socket_path)
+                .expect("socket name")
+                .into_owned();
+            let listener = ListenerOptions::new()
+                .name(socket_name.clone())
+                .create_sync()
+                .expect("bind listener");
+            let server = std::thread::spawn(move || {
+                let stream = listener.accept().expect("accept client");
+                handle_connection(
+                    stream,
+                    Arc::new(DoctorOnlyDispatcher),
+                    &AtomicBool::new(false),
+                    Arc::new(ActiveConnectionRegistry::default()),
+                    &SubsystemObservability::disabled(DaemonSubsystem::LocalIpcTransport),
+                )
+                .expect("serve keep-alive requests");
+            });
+            let mut stream = connect_local_ipc_with_timeout(socket_name, Duration::from_secs(5))
+                .expect("connect local IPC");
+
+            for request_count in 1..=count {
+                let mut wire = Vec::new();
+                write_http_request(&mut wire, &request).expect("encode request");
+                let connection = if request_count == count && count < MAX_KEEP_ALIVE_REQUESTS {
+                    "close"
+                } else {
+                    "keep-alive"
+                };
+                let wire = String::from_utf8(wire)
+                    .expect("request is UTF-8")
+                    .replace("Connection: close", &format!("Connection: {connection}"));
+                stream.write_all(wire.as_bytes()).expect("write request");
+                stream.flush().expect("flush request");
+                let response = read_http_response(&mut stream, &request).expect("read response");
+                assert!(
+                    matches!(response, ResponseEnvelope::Doctor(_)),
+                    "keep-alive request {request_count} of {count} returned {response:?}"
+                );
+            }
+            if count == MAX_KEEP_ALIVE_REQUESTS {
+                server.join().expect("server join at keep-alive bound");
+                let mut trailing = [0_u8; 1];
+                assert_eq!(
+                    stream
+                        .read(&mut trailing)
+                        .expect("read capped socket closure"),
+                    0,
+                    "the server must close after the configured keep-alive request bound"
+                );
+            } else {
+                server.join().expect("server join");
+            }
+        }
     }
 }

--- a/crates/atm-daemon/src/local_ipc_transport/shutdown.rs
+++ b/crates/atm-daemon/src/local_ipc_transport/shutdown.rs
@@ -141,7 +141,10 @@ pub(super) fn write_shutdown_response(
 ) -> Result<ShutdownResponseOutcome, AtmError> {
     let _ = stream.set_recv_timeout(Some(REQUEST_DEADLINE));
     let _ = stream.set_send_timeout(Some(REQUEST_DEADLINE));
-    if atm_core::api::read_http_request(stream)?.is_none() {
+    if atm_core::api::HttpFrameReader::new()
+        .read_request(stream)?
+        .is_none()
+    {
         return Ok(ShutdownResponseOutcome::NoFrame);
     }
     let response = ResponseEnvelope::Error(AtmError::daemon_unavailable(

--- a/crates/atm-daemon/src/local_tcp_transport.rs
+++ b/crates/atm-daemon/src/local_tcp_transport.rs
@@ -698,43 +698,52 @@ mod tests {
 
     #[test]
     fn loopback_tcp_keep_alive_serves_multiple_requests_before_client_close() {
-        let capability = LocalCapability::generate().expect("capability");
-        let header = capability.to_base64url();
-        let (address, server) = serve_one(capability);
         let request = RequestEnvelope::Doctor(DoctorQuery::default());
-        let mut stream = TcpStream::connect(address).expect("connect");
+        for count in [1_usize, 2, 8, 16, MAX_KEEP_ALIVE_REQUESTS] {
+            let capability = LocalCapability::generate().expect("capability");
+            let header = capability.to_base64url();
+            let (address, server) = serve_one(capability);
+            let mut stream = TcpStream::connect(address).expect("connect");
 
-        for request_count in 1..=MAX_KEEP_ALIVE_REQUESTS {
-            let mut wire = Vec::new();
-            write_http_request_with_headers(
-                &mut wire,
-                &request,
-                &[(LOCAL_CAPABILITY_HEADER, header.as_str())],
-            )
-            .expect("write request");
-            let wire = String::from_utf8(wire)
-                .expect("request is UTF-8")
-                .replace("Connection: close", "Connection: keep-alive");
-            stream.write_all(wire.as_bytes()).expect("write request");
-            stream.flush().expect("flush request");
-            let response = read_http_response(&mut stream, &request).expect("read response");
-            assert!(
-                matches!(response, ResponseEnvelope::Doctor(_)),
-                "keep-alive request {request_count} returned {response:?}"
-            );
+            for request_count in 1..=count {
+                let mut wire = Vec::new();
+                write_http_request_with_headers(
+                    &mut wire,
+                    &request,
+                    &[(LOCAL_CAPABILITY_HEADER, header.as_str())],
+                )
+                .expect("write request");
+                let connection = if request_count == count && count < MAX_KEEP_ALIVE_REQUESTS {
+                    "close"
+                } else {
+                    "keep-alive"
+                };
+                let wire = String::from_utf8(wire)
+                    .expect("request is UTF-8")
+                    .replace("Connection: close", &format!("Connection: {connection}"));
+                stream.write_all(wire.as_bytes()).expect("write request");
+                stream.flush().expect("flush request");
+                let response = read_http_response(&mut stream, &request).expect("read response");
+                assert!(
+                    matches!(response, ResponseEnvelope::Doctor(_)),
+                    "keep-alive request {request_count} of {count} returned {response:?}"
+                );
+            }
+            if count == MAX_KEEP_ALIVE_REQUESTS {
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(1)))
+                    .expect("set close-read deadline");
+                let mut trailing = [0_u8; 1];
+                assert_eq!(
+                    stream
+                        .read(&mut trailing)
+                        .expect("read capped socket closure"),
+                    0,
+                    "the server must close after the configured keep-alive request bound"
+                );
+            }
+            server.join().expect("server join");
         }
-        stream
-            .set_read_timeout(Some(Duration::from_secs(1)))
-            .expect("set close-read deadline");
-        let mut trailing = [0_u8; 1];
-        assert_eq!(
-            stream
-                .read(&mut trailing)
-                .expect("read capped socket closure"),
-            0,
-            "the server must close after the configured keep-alive request bound"
-        );
-        server.join().expect("server join");
     }
 
     #[test]

--- a/crates/atm-daemon/src/local_tcp_transport.rs
+++ b/crates/atm-daemon/src/local_tcp_transport.rs
@@ -42,7 +42,6 @@ use crate::host_ownership::{HostOwnershipAdapter, HostOwnershipGuard};
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
 #[cfg(windows)]
 use crate::local_ipc_connection::drain_active_connections_for_shutdown;
-#[cfg(unix)]
 use crate::local_ipc_transport::MAX_KEEP_ALIVE_REQUESTS;
 
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
@@ -587,18 +586,51 @@ mod tests {
     use std::io::{Read as _, Write as _};
     use std::net::{Ipv4Addr, TcpListener, TcpStream};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread;
     use std::time::Duration;
 
-    use atm_core::api::{read_http_response, write_http_request_with_headers};
+    use atm_core::api::{
+        ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, RequestDeadline,
+        read_http_response, write_http_request_with_headers,
+    };
     use atm_core::doctor::DoctorQuery;
+    use atm_core::error::AtmError;
     use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
+    use atm_core::send::{SendMessageSource, SendRequest};
+    use atm_core::test_support::{ROLE_TEAM_LEAD, TEST_TEAM};
     use ulid::Ulid;
 
     use super::{
         LOCAL_CAPABILITY_HEADER, LocalCapability, MAX_KEEP_ALIVE_REQUESTS, handle_connection,
     };
     use crate::test_support::DoctorOnlyDispatcher;
+
+    #[derive(Default)]
+    struct WriteRecordingDispatcher {
+        writes: AtomicUsize,
+    }
+
+    impl atm_core::boundary::sealed::Sealed for WriteRecordingDispatcher {}
+
+    impl ApiRouter for WriteRecordingDispatcher {
+        fn route(
+            &self,
+            request: ApiRequest,
+            _ingress: AuthenticatedIngress,
+            _deadline: RequestDeadline,
+        ) -> Result<ApiResponse, AtmError> {
+            match request.into_inner() {
+                RequestEnvelope::Write(_) => {
+                    self.writes.fetch_add(1, Ordering::SeqCst);
+                    Ok(ApiResponse::new(ResponseEnvelope::Error(
+                        AtmError::validation("recorded local TCP message write"),
+                    )))
+                }
+                other => panic!("expected a message write, got {other:?}"),
+            }
+        }
+    }
 
     fn serve_one(capability: LocalCapability) -> (std::net::SocketAddr, thread::JoinHandle<()>) {
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind loopback");
@@ -663,6 +695,59 @@ mod tests {
         let response = read_http_response(&mut stream, &request).expect("read response");
 
         assert!(matches!(response, ResponseEnvelope::Doctor(_)));
+        server.join().expect("server join");
+    }
+
+    #[test]
+    fn loopback_tcp_routes_message_write_through_post_endpoint() {
+        let capability = LocalCapability::generate().expect("capability");
+        let header = capability.to_base64url();
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind loopback");
+        let address = listener.local_addr().expect("address");
+        let dispatcher = Arc::new(WriteRecordingDispatcher::default());
+        let server_dispatcher = Arc::clone(&dispatcher);
+        let server = thread::spawn(move || {
+            let (stream, peer) = listener.accept().expect("accept client");
+            assert!(peer.ip().is_loopback());
+            handle_connection(
+                stream,
+                server_dispatcher,
+                &capability,
+                &std::sync::atomic::AtomicBool::new(false),
+            )
+            .expect("serve local message write");
+        });
+        let request = RequestEnvelope::Write(Box::new(
+            SendRequest::new(
+                std::env::temp_dir(),
+                std::env::temp_dir(),
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "recipient@test-team",
+                TEST_TEAM.parse().expect("team"),
+                SendMessageSource::Inline("TCP route parity".to_string()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("message write request"),
+        ));
+        let mut stream = TcpStream::connect(address).expect("connect");
+        write_http_request_with_headers(
+            &mut stream,
+            &request,
+            &[(LOCAL_CAPABILITY_HEADER, header.as_str())],
+        )
+        .expect("write POST /v1/atm/messages request");
+        stream.flush().expect("flush request");
+        let response = read_http_response(&mut stream, &request).expect("read response");
+
+        assert!(matches!(response, ResponseEnvelope::Error(_)));
+        assert_eq!(
+            dispatcher.writes.load(Ordering::SeqCst),
+            1,
+            "the TCP POST endpoint must route exactly one message write"
+        );
         server.join().expect("server join");
     }
 

--- a/crates/atm-daemon/src/local_tcp_transport.rs
+++ b/crates/atm-daemon/src/local_tcp_transport.rs
@@ -617,6 +617,34 @@ mod tests {
         (address, server)
     }
 
+    fn serve_two_after_disconnect(
+        capability: LocalCapability,
+    ) -> (std::net::SocketAddr, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind loopback");
+        let address = listener.local_addr().expect("address");
+        let server = thread::spawn(move || {
+            for request_number in 1..=2 {
+                let (stream, peer) = listener.accept().expect("accept client");
+                assert!(peer.ip().is_loopback());
+                let result = handle_connection(
+                    stream,
+                    Arc::new(DoctorOnlyDispatcher),
+                    &capability,
+                    &std::sync::atomic::AtomicBool::new(false),
+                );
+                if request_number == 1 {
+                    assert!(
+                        result.is_err(),
+                        "abandoned request must fail its worker only"
+                    );
+                } else {
+                    result.expect("serve independent request after disconnect");
+                }
+            }
+        });
+        (address, server)
+    }
+
     #[test]
     fn loopback_tcp_capability_reaches_shared_router() {
         let capability = LocalCapability::generate().expect("capability");
@@ -706,6 +734,36 @@ mod tests {
             0,
             "the server must close after the configured keep-alive request bound"
         );
+        server.join().expect("server join");
+    }
+
+    #[test]
+    fn loopback_tcp_listener_serves_next_client_after_mid_request_disconnect() {
+        let capability = LocalCapability::generate().expect("capability");
+        let header = capability.to_base64url();
+        let (address, server) = serve_two_after_disconnect(capability);
+
+        let mut abandoned = TcpStream::connect(address).expect("connect abandoned client");
+        abandoned
+            .write_all(b"GET /v1/atm/doctor HTTP/1.1\r\n")
+            .expect("write partial request");
+        abandoned
+            .shutdown(std::net::Shutdown::Both)
+            .expect("drop client");
+        drop(abandoned);
+
+        let request = RequestEnvelope::Doctor(DoctorQuery::default());
+        let mut healthy = TcpStream::connect(address).expect("connect independent client");
+        write_http_request_with_headers(
+            &mut healthy,
+            &request,
+            &[(LOCAL_CAPABILITY_HEADER, header.as_str())],
+        )
+        .expect("write independent request");
+        healthy.flush().expect("flush independent request");
+        let response =
+            read_http_response(&mut healthy, &request).expect("read independent response");
+        assert!(matches!(response, ResponseEnvelope::Doctor(_)));
         server.join().expect("server join");
     }
 

--- a/crates/atm-daemon/src/local_tcp_transport.rs
+++ b/crates/atm-daemon/src/local_tcp_transport.rs
@@ -25,7 +25,7 @@ use std::os::windows::ffi::OsStrExt as _;
 use std::os::unix::fs::PermissionsExt as _;
 
 use atm_core::api::{
-    ApiRouter, AuthenticatedIngress, RequestDeadline, read_http_request, write_http_response,
+    ApiRouter, AuthenticatedIngress, HttpFrameReader, RequestDeadline, write_local_http_response,
 };
 use atm_core::error::AtmError;
 use atm_core::local_http::{LOCAL_CAPABILITY_HEADER, LocalCapability, LocalHttpEndpointRecord};
@@ -45,6 +45,7 @@ use crate::local_ipc_connection::drain_active_connections_for_shutdown;
 
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const MAX_KEEP_ALIVE_REQUESTS: usize = 64;
 #[cfg(windows)]
 pub(crate) const MAX_CONCURRENT_CONNECTIONS: usize = 64;
 
@@ -315,7 +316,6 @@ fn handle_connection(
     capability: &LocalCapability,
     force_shutdown: &AtomicBool,
 ) -> Result<(), AtmError> {
-    let deadline = RequestDeadline::after(REQUEST_DEADLINE);
     stream
         .set_read_timeout(Some(REQUEST_DEADLINE))
         .map_err(|source| {
@@ -330,30 +330,45 @@ fn handle_connection(
                 "failed to set local HTTP write deadline: {source}"
             ))
         })?;
-    let Some(request) = read_http_request(&mut stream)? else {
-        return Ok(());
-    };
-    let response = if force_shutdown.load(Ordering::SeqCst) {
-        atm_core::ResponseEnvelope::Error(AtmError::daemon_unavailable(
-            "daemon is shutting down and not accepting new requests",
-        ))
-    } else if !request
-        .header(LOCAL_CAPABILITY_HEADER)
-        .is_some_and(|value| capability.matches_header(value))
-    {
-        atm_core::ResponseEnvelope::Error(AtmError::validation(
-            "local HTTP capability is missing, invalid, stale, or revoked",
-        ))
-    } else {
-        match atm_core::api::decode_request(request) {
-            Ok(request) => router
-                .route(request, AuthenticatedIngress::Local, deadline)
-                .map(|response| response.into_inner())
-                .unwrap_or_else(atm_core::ResponseEnvelope::Error),
-            Err(error) => atm_core::ResponseEnvelope::Error(error),
+    let mut frames = HttpFrameReader::new();
+    for request_count in 1..=MAX_KEEP_ALIVE_REQUESTS {
+        let Some(request) = frames.read_request(&mut stream)? else {
+            return Ok(());
+        };
+        let keep_alive = request
+            .header("connection")
+            .is_some_and(|value| value.eq_ignore_ascii_case("keep-alive"))
+            && request_count < MAX_KEEP_ALIVE_REQUESTS;
+        let response = if force_shutdown.load(Ordering::SeqCst) {
+            atm_core::ResponseEnvelope::Error(AtmError::daemon_unavailable(
+                "daemon is shutting down and not accepting new requests",
+            ))
+        } else if !request
+            .header(LOCAL_CAPABILITY_HEADER)
+            .is_some_and(|value| capability.matches_header(value))
+        {
+            atm_core::ResponseEnvelope::Error(AtmError::validation(
+                "local HTTP capability is missing, invalid, stale, or revoked",
+            ))
+        } else {
+            match atm_core::api::decode_request(request) {
+                Ok(request) => router
+                    .route(
+                        request,
+                        AuthenticatedIngress::Local,
+                        RequestDeadline::after(REQUEST_DEADLINE),
+                    )
+                    .map(|response| response.into_inner())
+                    .unwrap_or_else(atm_core::ResponseEnvelope::Error),
+                Err(error) => atm_core::ResponseEnvelope::Error(error),
+            }
+        };
+        write_local_http_response(&mut stream, &response, keep_alive)?;
+        if !keep_alive {
+            return Ok(());
         }
-    };
-    write_http_response(&mut stream, &response)
+    }
+    Ok(())
 }
 
 fn publish_record(
@@ -568,7 +583,7 @@ impl LocalIpcServerTransportAdapter {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write as _;
+    use std::io::{Read as _, Write as _};
     use std::net::{Ipv4Addr, TcpListener, TcpStream};
     use std::sync::Arc;
     use std::thread;
@@ -617,6 +632,66 @@ mod tests {
         let response = read_http_response(&mut stream, &request).expect("read response");
 
         assert!(matches!(response, ResponseEnvelope::Doctor(_)));
+        server.join().expect("server join");
+    }
+
+    #[test]
+    fn loopback_tcp_connection_closes_after_its_single_response() {
+        let capability = LocalCapability::generate().expect("capability");
+        let header = capability.to_base64url();
+        let (address, server) = serve_one(capability);
+        let request = RequestEnvelope::Doctor(DoctorQuery::default());
+        let mut stream = TcpStream::connect(address).expect("connect");
+
+        write_http_request_with_headers(
+            &mut stream,
+            &request,
+            &[(LOCAL_CAPABILITY_HEADER, header.as_str())],
+        )
+        .expect("write request");
+        stream.flush().expect("flush request");
+        let response = read_http_response(&mut stream, &request).expect("read response");
+
+        assert!(matches!(response, ResponseEnvelope::Doctor(_)));
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("set close-read deadline");
+        let mut trailing = [0_u8; 1];
+        assert_eq!(
+            stream.read(&mut trailing).expect("read socket closure"),
+            0,
+            "the current one-request local TCP contract must close after its response"
+        );
+        server.join().expect("server join");
+    }
+
+    #[test]
+    fn loopback_tcp_keep_alive_serves_multiple_requests_before_client_close() {
+        let capability = LocalCapability::generate().expect("capability");
+        let header = capability.to_base64url();
+        let (address, server) = serve_one(capability);
+        let request = RequestEnvelope::Doctor(DoctorQuery::default());
+        let mut stream = TcpStream::connect(address).expect("connect");
+
+        for connection in ["keep-alive", "close"] {
+            let mut wire = Vec::new();
+            write_http_request_with_headers(
+                &mut wire,
+                &request,
+                &[(LOCAL_CAPABILITY_HEADER, header.as_str())],
+            )
+            .expect("write request");
+            let wire = String::from_utf8(wire)
+                .expect("request is UTF-8")
+                .replace("Connection: close", &format!("Connection: {connection}"));
+            stream.write_all(wire.as_bytes()).expect("write request");
+            stream.flush().expect("flush request");
+            let response = read_http_response(&mut stream, &request).expect("read response");
+            assert!(
+                matches!(response, ResponseEnvelope::Doctor(_)),
+                "keep-alive request returned {response:?}"
+            );
+        }
         server.join().expect("server join");
     }
 

--- a/crates/atm-daemon/src/local_tcp_transport.rs
+++ b/crates/atm-daemon/src/local_tcp_transport.rs
@@ -42,10 +42,11 @@ use crate::host_ownership::{HostOwnershipAdapter, HostOwnershipGuard};
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
 #[cfg(windows)]
 use crate::local_ipc_connection::drain_active_connections_for_shutdown;
+#[cfg(unix)]
+use crate::local_ipc_transport::MAX_KEEP_ALIVE_REQUESTS;
 
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(25);
-const MAX_KEEP_ALIVE_REQUESTS: usize = 64;
 #[cfg(windows)]
 pub(crate) const MAX_CONCURRENT_CONNECTIONS: usize = 64;
 
@@ -594,7 +595,9 @@ mod tests {
     use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
     use ulid::Ulid;
 
-    use super::{LOCAL_CAPABILITY_HEADER, LocalCapability, handle_connection};
+    use super::{
+        LOCAL_CAPABILITY_HEADER, LocalCapability, MAX_KEEP_ALIVE_REQUESTS, handle_connection,
+    };
     use crate::test_support::DoctorOnlyDispatcher;
 
     fn serve_one(capability: LocalCapability) -> (std::net::SocketAddr, thread::JoinHandle<()>) {
@@ -673,7 +676,7 @@ mod tests {
         let request = RequestEnvelope::Doctor(DoctorQuery::default());
         let mut stream = TcpStream::connect(address).expect("connect");
 
-        for connection in ["keep-alive", "close"] {
+        for request_count in 1..=MAX_KEEP_ALIVE_REQUESTS {
             let mut wire = Vec::new();
             write_http_request_with_headers(
                 &mut wire,
@@ -683,15 +686,26 @@ mod tests {
             .expect("write request");
             let wire = String::from_utf8(wire)
                 .expect("request is UTF-8")
-                .replace("Connection: close", &format!("Connection: {connection}"));
+                .replace("Connection: close", "Connection: keep-alive");
             stream.write_all(wire.as_bytes()).expect("write request");
             stream.flush().expect("flush request");
             let response = read_http_response(&mut stream, &request).expect("read response");
             assert!(
                 matches!(response, ResponseEnvelope::Doctor(_)),
-                "keep-alive request returned {response:?}"
+                "keep-alive request {request_count} returned {response:?}"
             );
         }
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("set close-read deadline");
+        let mut trailing = [0_u8; 1];
+        assert_eq!(
+            stream
+                .read(&mut trailing)
+                .expect("read capped socket closure"),
+            0,
+            "the server must close after the configured keep-alive request bound"
+        );
         server.join().expect("server join");
     }
 

--- a/crates/atm-daemon/src/local_tcp_transport.rs
+++ b/crates/atm-daemon/src/local_tcp_transport.rs
@@ -31,6 +31,7 @@ use atm_core::error::AtmError;
 use atm_core::local_http::{LOCAL_CAPABILITY_HEADER, LocalCapability, LocalHttpEndpointRecord};
 use ulid::Ulid;
 
+use crate::MAX_KEEP_ALIVE_REQUESTS;
 #[cfg(windows)]
 use crate::SubsystemObservability;
 #[cfg(windows)]
@@ -42,7 +43,6 @@ use crate::host_ownership::{HostOwnershipAdapter, HostOwnershipGuard};
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
 #[cfg(windows)]
 use crate::local_ipc_connection::drain_active_connections_for_shutdown;
-use crate::local_ipc_transport::MAX_KEEP_ALIVE_REQUESTS;
 
 const REQUEST_DEADLINE: Duration = Duration::from_secs(3);
 const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(25);

--- a/docs/plans/phase-ai/sprint-ai-39-buffered-local-http-framing.md
+++ b/docs/plans/phase-ai/sprint-ai-39-buffered-local-http-framing.md
@@ -1,18 +1,10 @@
 ---
 title: AI.39 buffered local HTTP framing
-status: proposed
+status: complete
 branch: feature/pAI-s39-buffered-local-http-framing
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
-execution_mode: after_merge
-execution_dependencies:
-  - AI.33
-dependencies_relation:
-  - sprint: AI.33
-    relation: must_follow
-    rationale: Shares the local admission/framing path that AI.33 establishes.
 target: integrate/phase-ai-31-33
-depends_on: AI.33
 ---
 
 # AI.39 — Buffered local HTTP framing
@@ -25,16 +17,8 @@ planning-time recommendation, not a binding assignment.
 
 ## Execution Dependencies
 
-AI.39 `must_follow`s AI.33. Merge-forward trigger: AI.33 development is
-pushed, not QA; before every round merge AI.33 into this branch. PR-completion
-trigger: AI.33's PR merges into `integrate/phase-ai-31-33` first. Both touch
-the local admission/framing path.
-
-## Dependency Relations
-
-| Sprint | Relation | Rationale |
-| --- | --- | --- |
-| AI.33 | must_follow | It owns the local admission baseline in the same framing path. |
+None. AI.33 is abandoned/superseded and was not merged; AI.39 proceeds from
+`integrate/phase-ai-31-33` independently.
 
 ```yaml
 plan_type: sprint_plan
@@ -42,7 +26,7 @@ phase: AI
 sprint: AI.39
 worktree: feature/pAI-s39-buffered-local-http-framing
 branch: feature/pAI-s39-buffered-local-http-framing
-status: proposed
+status: complete
 estimated_scope: one shared framing primitive and two local adapters
 ```
 

--- a/docs/plans/phase-ai/sprint-ai-39-buffered-local-http-framing.md
+++ b/docs/plans/phase-ai/sprint-ai-39-buffered-local-http-framing.md
@@ -2,6 +2,7 @@
 title: AI.39 buffered local HTTP framing
 status: complete
 branch: feature/pAI-s39-buffered-local-http-framing
+worktree: feature/pAI-s39-buffered-local-http-framing
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
 target: integrate/phase-ai-31-33

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1015,7 +1015,7 @@ Implementation Branches:
 | `AI.36` | `complete` | `feature/pAI-s36-graft-receiver-ownership` | lease-safe receiver ownership per canonical graft root/team/agent |
 | `AI.37` | `complete` | `feature/pAI-s37-hermes-recovery-summary` | ten-second durable-mail-derived recovery summary |
 | `AI.38` | `complete` | `feature/pAI-s38-hermes-steer-nudge-delivery` | live and recovery graft wake-ups via non-interrupting steer |
-| `AI.39` | `planned` | `feature/pAI-s39-buffered-local-http-framing` | bounded buffered local HTTP request framing |
+| `AI.39` | `complete` | `feature/pAI-s39-buffered-local-http-framing` | bounded buffered local HTTP request framing |
 | `AI.40` | `planned` | `feature/pAI-s40-local-transport-benchmark` | clean local transport throughput benchmark; not an extension of abandoned AI.33 script |
 | `AI.43` | `planned` | `feature/pAI-s43-remote-https-response-framing` | buffered remote HTTPS response framing |
 | `AI.46` | `planned` | `feature/pAI-s46-reports-index` | generated durable reports index |


### PR DESCRIPTION
## Summary
- New HttpFrameReader shared across local UDS/TCP admission framing
- Corrected peer-HTTPS scope leak; local IPC one-shot parsing moved onto HttpFrameReader
- Scalar-forced parity coverage added
- AI.39's stale must_follow AI.33 dependency removed (AI.33 abandoned/superseded, PR #695 never merged)

## Sprint doc
docs/plans/phase-ai/sprint-ai-39-buffered-local-http-framing.md

## Test plan
- [x] just lint (arch-ctm)
- [x] just test (arch-ctm)
- [ ] QA (quality-mgr)