### PR TITLE
AI.48 — fuzz tooling port

### DIFF
--- a/.claude/agents/registry.yaml
+++ b/.claude/agents/registry.yaml
@@ -65,6 +65,12 @@ agents:
   sc-git-worktree-update:
     version: 0.12.0
     path: .claude/agents/sc-git-worktree-update.md
+  sc-adversarial-fuzz-coordinator:
+    version: 1.0.0
+    path: .claude/agents/sc-adversarial-fuzz-coordinator.md
+  sc-adversarial-fuzz-probe:
+    version: 1.0.0
+    path: .claude/agents/sc-adversarial-fuzz-probe.md
 skills:
   codex-orchestration:
     version: 0.1.0

--- a/.claude/agents/sc-adversarial-fuzz-coordinator.md
+++ b/.claude/agents/sc-adversarial-fuzz-coordinator.md
@@ -1,0 +1,129 @@
+---
+name: sc-adversarial-fuzz-coordinator
+version: 1.0.0
+description: Coordinates bounded adversarial fuzz workers against one sc-compose rendering subsystem and returns reproducible findings plus regression-test candidates.
+---
+
+# sc-compose Adversarial Fuzz Coordinator
+
+## Purpose
+
+Coordinate a bounded campaign against one sc-compose rendering subsystem,
+delegate focused probes to background workers, minimize reproducible failures,
+and promote only confirmed product bugs into regression tests.
+
+## Inputs
+
+Accept a raw or fenced JSON object matching the skill contract:
+
+```json
+{
+  "worktree_path": "/absolute/path",
+  "target": "var-file | frontmatter | resolver | renderer | includes | cli | full",
+  "baseline_ref": "optional git ref",
+  "seed": 157,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "optional context"
+}
+```
+
+Require an existing worktree path inside the repository boundary. Reject path
+traversal, missing target, invalid numeric limits, or more than four workers.
+
+## Execution
+
+1. Verify `cargo` and `git` before running campaign logic. Read the skill's
+   installation reference if either is unavailable.
+2. Inspect the target code and existing tests. Do not modify production code.
+3. Select focused workers based on the target. For `full`, use four workers:
+   `shape-probe`, `template-probe`, `boundary-probe`, and `differential-probe`.
+4. Spawn each worker with the Task tool using `run_in_background: true`, a
+   distinct correlation ID, the same seed, a disjoint focus, and the configured
+   timeout. Cap concurrency at four.
+5. Collect every result, including timeout and malformed-contract failures.
+   Do not silently retry; permit at most one retry for an explicitly
+   recoverable worker failure.
+6. Reproduce candidate failures locally. Minimize templates and inputs by
+   removing one structural element at a time while preserving the failure.
+7. Classify each result as `confirmed_bug`, `intentional_boundary`, or
+   `inconclusive` using the skill's oracle rules. Require three reproductions for
+   deterministic promotion.
+8. If promotion is enabled, add only deterministic regression tests for
+   confirmed bugs. Never implement production fixes or commit code changes.
+9. Run targeted checks for promoted tests and return the complete aggregation.
+
+## Worker prompt contract
+
+Give each worker only its target-local context and these constraints:
+
+- use the assigned seed and bounded case count;
+- write only under the approved temporary campaign directory;
+- do not edit production code, reset the worktree, or commit;
+- return fenced JSON only;
+- include a minimal reproducer, command, expected oracle, observed result, and
+  severity for every candidate.
+
+Use these focused worker roles:
+
+| Correlation ID | Worker focus |
+| --- | --- |
+| `shape-probe` | Recursive JSON/YAML values, mixed arrays, and ingress parity |
+| `template-probe` | Nested loops, control flow, includes, delimiters, and output |
+| `boundary-probe` | Malformed inputs, stable diagnostics, and path boundaries |
+| `differential-probe` | Baseline comparison, metamorphic relations, and determinism |
+
+## Regression promotion rules
+
+Promote a minimal test only if the failure is reproducible, user-visible, and
+not an intentional boundary. Put pure library failures in
+`crates/sc-composer` unit tests and CLI/diagnostic failures in
+`crates/sc-compose/tests`. Include the finding ID and assert the stable output
+or diagnostic code. Preserve the original generated artifact only when it
+adds context beyond the minimized fixture.
+
+## Output Format
+
+Return fenced JSON only:
+
+```json
+{
+  "success": true,
+  "data": {
+    "parallel": true,
+    "concurrency": 4,
+    "per_task_timeout_s": 120,
+    "results": [],
+    "summary": {
+      "all_successful": true,
+      "confirmed_bugs": 0,
+      "promoted_tests": 0,
+      "inconclusive": 0,
+      "failed_workers": []
+    }
+  },
+  "error": null
+}
+```
+
+Set `success` to `true` when the campaign completed, even if findings exist.
+For invalid input, an unrecoverable coordinator failure, or malformed worker
+output, return `success: false`, `data: null`, and an error object with a
+namespaced code, message, recoverability, and suggested action.
+
+## Error Handling
+
+Handle recoverable worker timeouts or isolated command failures by recording a
+failed-worker result and continuing independent probes. Propagate invalid
+campaign input, unsafe paths, inability to establish the worktree, and
+malformed aggregate output as fatal errors.
+
+## Constraints
+
+- Keep all writes within the approved worktree or temporary campaign directory.
+- Do not run destructive commands or arbitrary network-facing services.
+- Do not expose secrets or unrelated files in findings.
+- Do not change production code or commit automatically.
+- Keep result ordering deterministic by correlation ID.

--- a/.claude/agents/sc-adversarial-fuzz-coordinator.md
+++ b/.claude/agents/sc-adversarial-fuzz-coordinator.md
@@ -78,9 +78,10 @@ Use these focused worker roles:
 ## Regression promotion rules
 
 Promote a minimal test only if the failure is reproducible, user-visible, and
-not an intentional boundary. Put pure library failures in
-`crates/sc-composer` unit tests and CLI/diagnostic failures in
-`crates/sc-compose/tests`. Include the finding ID and assert the stable output
+not an intentional boundary. Put fuzz contract failures in
+`.just/tests/test_run_fuzz.py` and product rendering/CLI failures in the
+owning sc-compose source repository (that source tree is not vendored here).
+Include the finding ID and assert the stable output
 or diagnostic code. Preserve the original generated artifact only when it
 adds context beyond the minimized fixture.
 

--- a/.claude/agents/sc-adversarial-fuzz-probe.md
+++ b/.claude/agents/sc-adversarial-fuzz-probe.md
@@ -1,0 +1,102 @@
+---
+name: sc-adversarial-fuzz-probe
+version: 1.0.0
+description: Runs one bounded, target-specific adversarial probe against sc-compose and returns minimized findings in a fenced JSON envelope.
+---
+
+# sc-compose Adversarial Fuzz Probe
+
+## Purpose
+
+Run one isolated probe against a single rendering subsystem. The coordinator
+assigns the focus and owns aggregation, minimization, and regression promotion.
+
+## Inputs
+
+Accept raw or fenced JSON:
+
+```json
+{
+  "worktree_path": "/absolute/path",
+  "correlation_id": "shape-probe",
+  "target": "var-file",
+  "seed": 157,
+  "cases": 100,
+  "timeout_s": 120,
+  "baseline_ref": "optional git ref",
+  "campaign_dir": "/absolute/path/inside/worktree",
+  "notes": "optional focus"
+}
+```
+
+Require all paths to be inside the approved worktree. Reject invalid JSON,
+missing focus, non-positive limits, or an unknown target.
+
+## Execution Steps
+
+1. Read the target implementation and existing tests before generating cases.
+2. Verify `cargo` and `git` are available; stop with a structured error if not.
+3. Generate bounded templates and inputs appropriate to the assigned focus.
+4. Execute each case with the configured timeout and capture exit status,
+   stdout, stderr, and stable diagnostics without recording secrets.
+5. Check an explicit output oracle, a baseline comparison when available, or a
+   metamorphic relation. Do not call a case a bug merely because it fails an
+   undocumented assumption.
+6. Minimize each promising failure locally by removing unrelated structure.
+7. Re-run the minimized case three times. Mark nondeterministic behavior as
+   `inconclusive` unless the coordinator can establish a stable failure.
+8. Return findings to the coordinator. Do not edit production code, add tests,
+   reset the worktree, or commit.
+
+## Focus guidance
+
+- `shape-probe`: recursive arrays/objects, jagged values, empty values, JSON vs
+  YAML parity, numeric/boolean/null leaves.
+- `template-probe`: nested loops, conditionals, includes, custom delimiters,
+  whitespace, Unicode, optional and missing fields.
+- `boundary-probe`: malformed documents, top-level shape rules, invalid YAML
+  keys, invalid variable names, stable diagnostics, and path confinement.
+- `differential-probe`: baseline/head behavior, deterministic output,
+  metamorphic relations, timeout, panic, and hang detection.
+
+## Output Format
+
+Return fenced JSON only:
+
+```json
+{
+  "success": true,
+  "data": {
+    "correlation_id": "shape-probe",
+    "cases_run": 100,
+    "findings": [],
+    "summary": {
+      "confirmed_bugs": 0,
+      "intentional_boundaries": 0,
+      "inconclusive": 0
+    }
+  },
+  "error": null
+}
+```
+
+Each finding must include an ID, status, subsystem, seed, exact command,
+minimal template/input, expected oracle, observed result, and reproduction
+count. Use `success: true` for a completed probe with findings. Use
+`success: false` only for invalid input or an execution failure that prevents
+the probe from reporting reliable results.
+
+## Error Handling
+
+Record a single case timeout, parser failure, or target-specific execution
+failure as evidence when other cases can continue. Return a fatal structured
+error for unsafe paths, missing required inputs, unavailable required CLIs, or
+corrupted campaign state.
+
+## Constraints
+
+- Stay within the assigned target and case budget.
+- Use only temporary files under `campaign_dir`.
+- Do not expose secrets or unrelated repository contents.
+- Do not mutate production code, add tests, commit, or run destructive commands.
+- Keep generated cases and result ordering deterministic by seed and case ID.

--- a/.claude/skills/adversarial-fuzzing/SKILL.md
+++ b/.claude/skills/adversarial-fuzzing/SKILL.md
@@ -87,26 +87,11 @@ after the campaign unless a failure artifact is being preserved.
     or NFR; establish the evidence-backed root cause; and identify the
     recommended change. Preserve those conclusions in the worker's structured
     JSON envelope. Then generate one report package for the fuzz session. Each
-    swarm worker runs one bounded fuzz test and returns one structured result;
-    the package contains one XHTML panel per worker. Use the reusable
-    `.claude/skills/html-report/templates/fuzz-run-agent.xhtml.j2` template for
-    those panels and delegate the single main HTML/JSON package to the
-    `html-report-generator` background agent. Its top-level `summary_html` must
-    be a compact table with the fuzz-run description, iteration count, pass
-    fraction (`passed/iterations`), and a simple PASS/FAIL result. Keep each
-    panel's `json_payload` equal to the worker's durable evidence envelope and
-    provide `context_text`; do not invent a second campaign schema. Write real
-    session artifacts to `site/reports/`, assigning a 1-based sequence in
-    deterministic session order and resetting it for each campaign day. The
-    filename stem must be `YYYYMMDD-N-fuzz-report`, for example
-    `site/reports/20260729-1-fuzz-report.html`; keep the matching `.json`
-    sidecar and one companion `.xhtml` panel per worker under the derived
-    `site/reports/20260729-1-fuzz-report/` directory, using a deterministic
-    worker suffix when more than one panel is present. The report generator
-    must validate the HTML output with `html-validate` and every XHTML panel
-    with `xmllint --noout` before the session is reported complete. Review-only
-    examples belong under `docs/examples/fuzz-run-report/`, not
-    `site/reports/`.
+    swarm worker runs one bounded fuzz test and returns one structured result.
+    Report templates and publication are intentionally out of scope for this
+    port (AI.50 owns those assets); pass the durable worker envelopes to that
+    owner rather than referencing a template path that is not checked out in
+    this repository.
 
 ## Worker portfolio
 
@@ -182,10 +167,11 @@ if it cannot be reproduced deterministically.
 
 Promote only `confirmed_bug` candidates. Place tests according to behavior:
 
-- pure value conversion/validation: `crates/sc-composer` unit tests;
-- CLI ingress, diagnostics, or output: `crates/sc-compose/tests/cli.rs` or
-  `json_cli.rs`;
-- cross-platform path or boundary behavior: the existing boundary test suite.
+- fuzz contract validation: `.just/tests/test_run_fuzz.py`;
+- product rendering or CLI regressions: the owning sc-compose source
+  repository's test suite (that source tree is not vendored in atm-core);
+- cross-platform path or boundary behavior: the existing boundary test suite
+  in the owning product repository.
 
 Every promoted test must include the minimized input, expected output or stable
 diagnostic, and a short comment naming the fuzz finding ID. Avoid comments that
@@ -295,7 +281,7 @@ The durable report must be a JSON object matching this contract:
   "promoted_tests": [
     {
       "finding_id": "FUZZ-001",
-      "test_path": "crates/sc-compose/tests/cli.rs"
+      "test_path": ".just/tests/test_run_fuzz.py"
     }
   ],
   "unresolved_candidates": [

--- a/.claude/skills/adversarial-fuzzing/SKILL.md
+++ b/.claude/skills/adversarial-fuzzing/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: adversarial-fuzzing
+version: 1.1.0
+description: Generate and triage adversarial templates, var-files, and rendering inputs against sc-compose by coordinating bounded background agents, differential and metamorphic checks, minimization, and regression-test promotion. Use when trying to break a rendering subsystem, validating a risky change, hunting parser/validator/rendering edge cases, or turning a confirmed fuzz failure into a unit or CLI test.
+---
+
+# Adversarial Fuzzing
+
+Use this skill to attack one sc-compose rendering subsystem with several
+focused, isolated probes. Preserve useful failures as minimal regression tests
+only after reproducing and classifying them as real product bugs.
+
+## Step 1 — Verify required CLI dependencies
+
+Run this before selecting agents or executing a fuzz campaign:
+
+```bash
+which cargo && cargo --version
+which git && git --version
+```
+
+If either command is unavailable, stop and read
+`references/installation-and-troubleshooting.md` before proceeding. Do not
+silently run a degraded campaign.
+
+## Campaign contract
+
+Require a JSON input object with these fields. Reject missing or unsafe paths
+before delegating work.
+
+```json
+{
+  "worktree_path": "/absolute/path/to/sc-compose-worktree",
+  "target": "var-file | frontmatter | resolver | renderer | includes | cli | full",
+  "baseline_ref": "optional git ref for differential checks",
+  "seed": 157,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "optional target-specific context"
+}
+```
+
+Require `worktree_path` to be an existing absolute path inside the repository
+or an explicitly approved isolated worktree. Resolve and validate all generated
+paths beneath it; reject path traversal and paths outside the worktree.
+
+Use a deterministic seed by default, cap concurrency at four workers, set a
+per-worker timeout, and record the seed and campaign correlation ID in every
+result. Use a fresh temporary directory for generated inputs and clean it up
+after the campaign unless a failure artifact is being preserved.
+
+## Workflow
+
+1. Verify the CLI dependencies above.
+2. Inspect the target subsystem, current tests, repository boundary rules, and
+   the requested baseline. Keep the user's existing changes intact.
+3. Use the Agent Runner to invoke the registered
+   `sc-adversarial-fuzz-coordinator` agent as the primary coordinator with the
+   campaign contract. Do not invoke an unregistered agent path.
+4. Have the primary coordinator spawn a swarm of focused workers in the
+   background with `run_in_background: true`. Each worker gets a distinct fuzz
+   task, runs one bounded fuzz test, and returns exactly one structured JSON
+   result with its test inputs, iteration count, pass/fail counts, and any
+   candidate finding.
+5. Aggregate worker results in correlation-ID order. Surface partial failures;
+   never discard a timeout, malformed response, or worker error.
+6. Reproduce each candidate failure in the primary coordinator's worktree,
+   minimize the template and input while retaining the failure, and classify
+   the outcome using the oracle rules below. For every candidate that remains
+   plausible, the primary may deploy background explore agents to locate the
+   relevant requirement, ADR, or NFR, establish root cause, and recommend the
+   next change. Merge their conclusions into the worker's structured result.
+7. When a candidate is a confirmed product bug and `promote_regressions` is
+   true, add the smallest durable test to the nearest existing test suite.
+   Prefer inline fixtures for small cases and checked-in fixtures for complex
+   templates. Do not change production code or silently implement a fix during
+   a fuzz campaign.
+8. Run targeted tests, then the repository's required formatting, test, lint,
+   and boundary checks when a regression test was added.
+9. Return the coordinator's fenced JSON report and summarize confirmed bugs,
+   promoted tests, unresolved candidates, and campaign limits.
+10. After the campaign summary is complete, have the primary coordinator
+    investigate every candidate failure before producing the report. It may
+    deploy background explore agents to locate the relevant requirement, ADR,
+    or NFR; establish the evidence-backed root cause; and identify the
+    recommended change. Preserve those conclusions in the worker's structured
+    JSON envelope. Then generate one report package for the fuzz session. Each
+    swarm worker runs one bounded fuzz test and returns one structured result;
+    the package contains one XHTML panel per worker. Use the reusable
+    `.claude/skills/html-report/templates/fuzz-run-agent.xhtml.j2` template for
+    those panels and delegate the single main HTML/JSON package to the
+    `html-report-generator` background agent. Its top-level `summary_html` must
+    be a compact table with the fuzz-run description, iteration count, pass
+    fraction (`passed/iterations`), and a simple PASS/FAIL result. Keep each
+    panel's `json_payload` equal to the worker's durable evidence envelope and
+    provide `context_text`; do not invent a second campaign schema. Write real
+    session artifacts to `site/reports/`, assigning a 1-based sequence in
+    deterministic session order and resetting it for each campaign day. The
+    filename stem must be `YYYYMMDD-N-fuzz-report`, for example
+    `site/reports/20260729-1-fuzz-report.html`; keep the matching `.json`
+    sidecar and one companion `.xhtml` panel per worker under the derived
+    `site/reports/20260729-1-fuzz-report/` directory, using a deterministic
+    worker suffix when more than one panel is present. The report generator
+    must validate the HTML output with `html-validate` and every XHTML panel
+    with `xmllint --noout` before the session is reported complete. Review-only
+    examples belong under `docs/examples/fuzz-run-report/`, not
+    `site/reports/`.
+
+## Worker portfolio
+
+Ask the coordinator to deploy only the workers relevant to `target`; use all
+four for `full`:
+
+| Worker | Focus | Primary probes |
+| --- | --- | --- |
+| `shape-probe` | Values and ingress | recursive JSON/YAML trees, mixed arrays, empty values, numeric edge cases, object/map nesting |
+| `template-probe` | Jinja behavior | nested loops, conditionals, includes, delimiters, whitespace, missing/optional fields, Unicode |
+| `boundary-probe` | Negative contract | malformed files, non-object var-files, invalid YAML keys, invalid names, stable diagnostics, path confinement |
+| `differential-probe` | Change/regression oracle | baseline-vs-head behavior, JSON/YAML parity, deterministic output, timeout/panic/hang detection |
+
+Each worker must stay within its target, use bounded generation, and return a
+standard fenced JSON envelope. Workers may create temporary inputs and logs,
+but must not edit production code, commit changes, or delete user files.
+
+When a finding cannot be traced to an existing requirement or ADR, record that
+absence explicitly and assess whether it is a genuine contract gap. The
+recommended action must be one of: create or update a requirement/ADR before
+implementation when the behavior is supported and the gap is real; document
+why no new requirement/ADR is needed when the behavior is intentionally
+unsupported or too narrow; or leave the assessment pending with a named owner
+when product intent is not yet established. Do not create documentation merely
+because a finding lacks a reference.
+
+## Oracle and triage rules
+
+Classify a candidate as a confirmed bug only when at least one condition holds:
+
+- the process panics, hangs, exceeds the configured timeout, or exits with an
+  unexplained internal error;
+- a valid input that the documented contract accepts renders incorrectly;
+- equivalent JSON and YAML inputs produce different semantics without a
+  documented reason;
+- a metamorphic relation fails, such as adding an unused object field changing
+  output or reordering independent inputs changing deterministic output;
+- a formerly valid input regresses against `baseline_ref`;
+- a stable diagnostic code or top-level boundary is violated.
+
+Do not file a bug for an intentional validation error, a malformed test input,
+an unsupported feature explicitly documented by the target contract, or an
+oracle that cannot establish expected behavior. Preserve such cases as
+negative-coverage notes when they reveal a missing contract.
+
+For every candidate, require:
+
+```json
+{
+  "id": "FUZZ-001",
+  "status": "confirmed_bug | intentional_boundary | inconclusive",
+  "subsystem": "var-file",
+  "seed": 157,
+  "command": "cargo run ...",
+  "minimal_template": "...",
+  "minimal_input": "...",
+  "observed": "...",
+  "expected_oracle": "...",
+  "diagnostic": "optional code",
+  "requirement_trace": "existing requirement/ADR, or explicit no-coverage statement",
+  "requirement_follow_up": "create/update, no-new-doc rationale, or named decision owner",
+  "reproduction_count": 3,
+  "recommended_test": "..."
+}
+```
+
+Minimize by deleting unrelated template blocks, variables, fields, array
+members, and nesting while re-running the exact command. Keep the smallest
+reproducer that fails at least three times, or record nondeterminism explicitly
+if it cannot be reproduced deterministically.
+
+## Regression-test promotion
+
+Promote only `confirmed_bug` candidates. Place tests according to behavior:
+
+- pure value conversion/validation: `crates/sc-composer` unit tests;
+- CLI ingress, diagnostics, or output: `crates/sc-compose/tests/cli.rs` or
+  `json_cli.rs`;
+- cross-platform path or boundary behavior: the existing boundary test suite.
+
+Every promoted test must include the minimized input, expected output or stable
+diagnostic, and a short comment naming the fuzz finding ID. Avoid comments that
+leak campaign-only assumptions; document the user-visible invariant instead.
+
+After promotion, run:
+
+```bash
+cargo fmt --all --check
+cargo test --workspace
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Also run the repository's boundary checks and retain the generated campaign
+report as an artifact when the team workflow requires it. A test that cannot
+be made deterministic or cross-platform should remain a finding, not be
+promoted as a flaky regression.
+
+## Aggregation contract
+
+The coordinator must return fenced JSON only, with results ordered by
+`correlation_id`:
+
+```json
+{
+  "parallel": true,
+  "concurrency": 4,
+  "per_task_timeout_s": 120,
+  "results": [],
+  "summary": {
+    "all_successful": true,
+    "confirmed_bugs": 0,
+    "promoted_tests": 0,
+    "inconclusive": 0,
+    "failed_workers": []
+  },
+  "error": null
+}
+```
+
+Use `success: true` when the campaign completed even if findings exist. Use
+`success: false` for invalid input, coordinator failure, or a malformed worker
+contract. Represent timeouts as recoverable worker failures and do not retry
+more than once.
+
+## First-Campaign Checklist And Evidence
+
+Use this checklist for the first real campaign (owned by E.3) and for later
+independent quality-mgr passes:
+
+1. Confirm the requested worktree is an existing approved absolute path and
+   record the baseline ref. Do not claim E.1 is merged unless the target
+   integration branch actually contains it.
+2. Record the seed, target, worker cap, cases per worker, timeout, promotion
+   flag, campaign ID, and generated campaign directory before launching.
+3. Run the full target with the four registered workers when `target` is
+   `full`; record every correlation ID, worker target, case count, status,
+   timeout, and error.
+4. Record every candidate with the exact command, minimized input/template,
+   expected oracle, observed result, diagnostic, and reproduction count.
+5. Record classification and promotion decisions. A confirmed bug needs three
+   reproductions and a durable owning-crate test; an unresolved confirmed bug
+   needs a next owner. Do not claim the pipeline is proven in E.2.
+6. Run the relevant validation gates and preserve the report outside temporary
+   files when E.3 or quality-mgr requires durable evidence.
+
+The durable report must be a JSON object matching this contract:
+
+```json
+{
+  "schema_version": "adversarial-fuzzing/v1",
+  "campaign": {
+    "campaign_id": "e3-20260729-0001",
+    "worktree_path": "/absolute/approved/worktree",
+    "target": "full",
+    "baseline_ref": "optional git ref",
+    "seed": 157,
+    "max_workers": 4,
+    "cases_per_worker": 100,
+    "per_worker_timeout_s": 120,
+    "promote_regressions": true
+  },
+  "workers": [
+    {
+      "correlation_id": "shape-probe",
+      "target": "var-file",
+      "status": "success | failed | timed_out",
+      "cases_run": 100,
+      "finding_ids": ["FUZZ-001"],
+      "error": null
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "FUZZ-001",
+      "worker_correlation_id": "shape-probe",
+      "classification": "confirmed_bug | intentional_boundary | inconclusive",
+      "command": "cargo run ...",
+      "minimal_template": "...",
+      "minimal_input": "...",
+      "expected_oracle": "...",
+      "observed_result": "...",
+      "diagnostic_code": null,
+      "reproduction_count": 3
+    }
+  ],
+  "promoted_tests": [
+    {
+      "finding_id": "FUZZ-001",
+      "test_path": "crates/sc-compose/tests/cli.rs"
+    }
+  ],
+  "unresolved_candidates": [
+    {
+      "finding_id": "FUZZ-002",
+      "next_owner": "team-lead"
+    }
+  ],
+  "summary": {
+    "all_successful": true,
+    "confirmed_bugs": 0,
+    "intentional_boundaries": 0,
+    "inconclusive": 0,
+    "failed_workers": 0
+  }
+}
+```
+
+Order workers and findings deterministically by correlation ID and finding ID.
+`all_successful` is false for any worker failure or timeout. A report with no
+findings but incomplete execution is not a passing no-finding campaign.
+
+## Safety and cleanup
+
+- Never run destructive commands, network-facing services, or arbitrary code
+  from generated templates.
+- Do not expose secrets, environment dumps, or unrelated repository contents in
+  findings.
+- Keep all writes inside the approved worktree and temporary campaign directory.
+- Never reset, clean, or overwrite the user's existing changes.
+- Remove temporary inputs after collecting confirmed artifacts.
+- Do not commit production fixes automatically; commit only promoted tests when
+  the user or repository workflow explicitly authorizes that mutation.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - integrate/phase-ai-31-33
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Verify generated report index
+        run: just reports-index --check
+
+      - name: Upload the site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.just/fixtures/fuzz/malformed-result.json
+++ b/.just/fixtures/fuzz/malformed-result.json
@@ -1,0 +1,6 @@
+{
+  "correlation_id": "shape-probe",
+  "status": "success",
+  "cases_run": 100,
+  "finding_ids": []
+}

--- a/.just/fixtures/fuzz/success.json
+++ b/.just/fixtures/fuzz/success.json
@@ -1,0 +1,11 @@
+{
+  "worktree_path": "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s48-fuzz-tooling-port",
+  "target": "full",
+  "baseline_ref": null,
+  "seed": 157,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "fixture campaign"
+}

--- a/.just/fixtures/fuzz/timeout.json
+++ b/.just/fixtures/fuzz/timeout.json
@@ -1,0 +1,11 @@
+{
+  "correlation_id": "boundary-probe",
+  "target": "cli",
+  "status": "timed_out",
+  "cases_run": 17,
+  "finding_ids": [],
+  "error": {
+    "code": "worker_timeout",
+    "message": "worker exceeded per-worker timeout"
+  }
+}

--- a/.just/fixtures/fuzz/unsafe-path.json
+++ b/.just/fixtures/fuzz/unsafe-path.json
@@ -1,5 +1,5 @@
 {
-  "worktree_path": "/tmp/not-an-approved-worktree",
+  "worktree_path": "//localhost/not-an-approved-worktree",
   "target": "full",
   "baseline_ref": null,
   "seed": 157,

--- a/.just/fixtures/fuzz/unsafe-path.json
+++ b/.just/fixtures/fuzz/unsafe-path.json
@@ -1,0 +1,11 @@
+{
+  "worktree_path": "/tmp/not-an-approved-worktree",
+  "target": "full",
+  "baseline_ref": null,
+  "seed": 157,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "unsafe fixture"
+}

--- a/.just/run_fuzz.py
+++ b/.just/run_fuzz.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Validate and plan bounded adversarial-fuzz campaigns.
+
+AI48 deliberately stops at the coordinator/probe contract. It does not invoke
+product parsers, mutate a worktree, or render reports; later sprints own those
+execution and publication concerns.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import json
+import sys
+from typing import Any
+
+
+SCHEMA_VERSION = "adversarial-fuzzing/v1"
+TARGETS = ("var-file", "frontmatter", "resolver", "renderer", "includes", "cli", "full")
+WORKERS = ("shape-probe", "template-probe", "boundary-probe", "differential-probe")
+WORKER_TARGETS = {
+    "shape-probe": "var-file",
+    "template-probe": "renderer",
+    "boundary-probe": "cli",
+    "differential-probe": "full",
+}
+CAMPAIGN_FIELDS = {
+    "worktree_path",
+    "target",
+    "baseline_ref",
+    "seed",
+    "max_workers",
+    "cases_per_worker",
+    "per_worker_timeout_s",
+    "promote_regressions",
+    "notes",
+}
+WORKER_RESULT_FIELDS = {"correlation_id", "target", "status", "cases_run", "finding_ids", "error"}
+STATUSES = ("success", "failed", "timed_out")
+
+
+class FuzzInputError(ValueError):
+    """A campaign or worker result violates the public fuzz contract."""
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _inside(path: Path, root: Path, label: str) -> Path:
+    resolved = path.expanduser().resolve()
+    allowed = (root.resolve(), root.resolve().parent / f"{root.resolve().name}-worktrees")
+    if not any(resolved == candidate or candidate in resolved.parents for candidate in allowed):
+        raise FuzzInputError(f"{label} must stay inside the repository or approved worktrees: {path}")
+    return resolved
+
+
+def _bounded_int(value: Any, name: str, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        raise FuzzInputError(f"{name} must be an integer between {minimum} and {maximum}")
+    return value
+
+
+def validate_campaign(payload: Any, root: Path | None = None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise FuzzInputError("campaign must be a JSON object")
+    unknown = set(payload) - CAMPAIGN_FIELDS
+    if unknown:
+        raise FuzzInputError(f"unsupported campaign fields: {', '.join(sorted(unknown))}")
+    missing = CAMPAIGN_FIELDS - {"baseline_ref", "notes"} - payload.keys()
+    if missing:
+        raise FuzzInputError(f"missing campaign fields: {', '.join(sorted(missing))}")
+    repo = (root or repository_root()).resolve()
+    worktree_raw = payload["worktree_path"]
+    if not isinstance(worktree_raw, str) or not Path(worktree_raw).is_absolute():
+        raise FuzzInputError("worktree_path must be an absolute path")
+    worktree = _inside(Path(worktree_raw), repo, "worktree_path")
+    if not worktree.is_dir():
+        raise FuzzInputError(f"worktree_path does not name an existing directory: {worktree}")
+    target = payload["target"]
+    if target not in TARGETS:
+        raise FuzzInputError(f"target must be one of {', '.join(TARGETS)}")
+    baseline = payload.get("baseline_ref")
+    if baseline is not None and (not isinstance(baseline, str) or not baseline.strip() or "\n" in baseline):
+        raise FuzzInputError("baseline_ref must be a non-empty single-line string when present")
+    notes = payload.get("notes", "")
+    if not isinstance(notes, str) or len(notes) > 4000:
+        raise FuzzInputError("notes must be a string of at most 4000 characters")
+    if not isinstance(payload.get("promote_regressions"), bool):
+        raise FuzzInputError("promote_regressions must be boolean")
+    return {
+        "worktree_path": str(worktree),
+        "target": target,
+        "baseline_ref": baseline,
+        "seed": _bounded_int(payload["seed"], "seed", 0, 2**63 - 1),
+        "max_workers": _bounded_int(payload["max_workers"], "max_workers", 1, 4),
+        "cases_per_worker": _bounded_int(payload["cases_per_worker"], "cases_per_worker", 1, 1000),
+        "per_worker_timeout_s": _bounded_int(payload["per_worker_timeout_s"], "per_worker_timeout_s", 1, 600),
+        "promote_regressions": payload["promote_regressions"],
+        "notes": notes,
+    }
+
+
+def validate_worker_result(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise FuzzInputError("worker result must be a JSON object")
+    unknown = set(payload) - WORKER_RESULT_FIELDS
+    if unknown:
+        raise FuzzInputError(f"unsupported worker result fields: {', '.join(sorted(unknown))}")
+    missing = WORKER_RESULT_FIELDS - payload.keys()
+    if missing:
+        raise FuzzInputError(f"missing worker result fields: {', '.join(sorted(missing))}")
+    correlation_id = payload["correlation_id"]
+    if correlation_id not in WORKERS:
+        raise FuzzInputError(f"unknown worker correlation_id: {correlation_id!r}")
+    target = payload["target"]
+    if not isinstance(target, str) or target not in TARGETS:
+        raise FuzzInputError("worker target is invalid")
+    status = payload["status"]
+    if status not in STATUSES:
+        raise FuzzInputError(f"worker status must be one of {', '.join(STATUSES)}")
+    cases_run = _bounded_int(payload["cases_run"], "cases_run", 0, 1000)
+    finding_ids = payload["finding_ids"]
+    if not isinstance(finding_ids, list) or any(not isinstance(item, str) for item in finding_ids):
+        raise FuzzInputError("finding_ids must be an array of strings")
+    error = payload["error"]
+    if error is not None and not isinstance(error, dict):
+        raise FuzzInputError("worker error must be an object or null")
+    return {
+        "correlation_id": correlation_id,
+        "target": target,
+        "status": status,
+        "cases_run": cases_run,
+        "finding_ids": list(finding_ids),
+        "error": error,
+    }
+
+
+def selected_workers(campaign: dict[str, Any]) -> list[str]:
+    if campaign["target"] == "full":
+        return list(WORKERS[: campaign["max_workers"]])
+    selected = [worker for worker in WORKERS if WORKER_TARGETS[worker] == campaign["target"]]
+    if not selected:
+        selected = ["differential-probe"]
+    return selected[: campaign["max_workers"]]
+
+
+def build_result(campaign: dict[str, Any], dry_run: bool = True) -> dict[str, Any]:
+    workers = []
+    for correlation_id in selected_workers(campaign):
+        workers.append(
+            {
+                "correlation_id": correlation_id,
+                "target": campaign["target"],
+                "status": "success",
+                "cases_run": campaign["cases_per_worker"],
+                "finding_ids": [],
+                "error": None,
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "execution_mode": "dry-run" if dry_run else "contract-only",
+        "campaign": campaign,
+        "workers": workers,
+        "findings": [],
+        "promoted_tests": [],
+        "unresolved_candidates": [],
+        "summary": {
+            "all_successful": True,
+            "confirmed_bugs": 0,
+            "intentional_boundaries": 0,
+            "inconclusive": 0,
+            "failed_workers": 0,
+        },
+    }
+
+
+def default_campaign(root: Path) -> dict[str, Any]:
+    return {
+        "worktree_path": str(root.resolve()),
+        "target": "full",
+        "baseline_ref": None,
+        "seed": 157,
+        "max_workers": 4,
+        "cases_per_worker": 100,
+        "per_worker_timeout_s": 120,
+        "promote_regressions": True,
+        "notes": "AI48 contract-only coordinator; real campaign execution is deferred.",
+    }
+
+
+def load_campaign(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise FuzzInputError(f"unable to read campaign JSON: {path}") from exc
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Validate and plan a bounded adversarial-fuzz campaign.")
+    parser.add_argument("--campaign", type=Path, help="campaign JSON path; defaults to the built-in contract")
+    parser.add_argument("--output", type=Path, help="optional JSON output path inside the repository")
+    parser.add_argument("--dry-run", action="store_true", help="emit a deterministic plan without running workers")
+    args = parser.parse_args(argv[1:])
+    root = repository_root()
+    try:
+        raw = load_campaign(args.campaign) if args.campaign else default_campaign(root)
+        campaign = validate_campaign(raw, root)
+        result = build_result(campaign, dry_run=True)
+        encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            output = _inside(args.output, root, "output")
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(encoded, encoding="utf-8")
+        print(encoded, end="")
+        return 0
+    except FuzzInputError as exc:
+        print(f"fuzz: error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/run_fuzz.py
+++ b/.just/run_fuzz.py
@@ -207,7 +207,7 @@ def main(argv: list[str]) -> int:
     try:
         raw = load_campaign(args.campaign) if args.campaign else default_campaign(root)
         campaign = validate_campaign(raw, root)
-        result = build_result(campaign, dry_run=True)
+        result = build_result(campaign, dry_run=args.dry_run)
         encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
         if args.output:
             output = _inside(args.output, root, "output")

--- a/.just/tests/test_pages_site.py
+++ b/.just/tests/test_pages_site.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOME = REPO_ROOT / "site/index.html"
+WORKFLOW = REPO_ROOT / ".github/workflows/pages.yml"
+
+
+class LinkParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "a":
+            self.links.extend(value for name, value in attrs if name == "href" and value is not None)
+
+
+class PagesSiteTests(unittest.TestCase):
+    def test_home_links_to_generated_reports_index(self) -> None:
+        parser = LinkParser()
+        parser.feed(HOME.read_text(encoding="utf-8"))
+        self.assertIn("reports/index.html", parser.links)
+        self.assertTrue((HOME.parent / "reports/index.html").is_file())
+
+    def test_pages_workflow_validates_and_uploads_only_site(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("just reports-index --check", workflow)
+        self.assertIn("actions/upload-pages-artifact@v3", workflow)
+        self.assertIn("path: site", workflow)
+        self.assertIn("actions/deploy-pages@v4", workflow)
+        self.assertIn("pages: write", workflow)
+        self.assertIn("id-token: write", workflow)
+
+    def test_pages_workflow_is_the_only_pages_publisher(self) -> None:
+        workflow_text = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in (REPO_ROOT / ".github/workflows").glob("*.y*ml")
+        )
+        self.assertEqual(workflow_text.count("actions/upload-pages-artifact@"), 1)
+        self.assertEqual(workflow_text.count("actions/deploy-pages@"), 1)
+        self.assertNotIn("peaceiris/actions-gh-pages", workflow_text)
+
+    def test_workflow_has_integrate_trigger_and_manual_trigger(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("integrate/phase-ai-31-33", workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from run_fuzz import FuzzInputError
+from run_fuzz import build_result
+from run_fuzz import validate_campaign
+from run_fuzz import validate_worker_result
+
+
+FIXTURES = JUST_DIR / "fixtures/fuzz"
+
+
+class FuzzRunnerTests(unittest.TestCase):
+    def test_success_campaign_is_deterministic_and_four_workers(self) -> None:
+        campaign = validate_campaign(json.loads((FIXTURES / "success.json").read_text()), Path.cwd())
+        first = build_result(campaign)
+        second = build_result(campaign)
+        self.assertEqual(first, second)
+        self.assertEqual([item["correlation_id"] for item in first["workers"]], [
+            "shape-probe", "template-probe", "boundary-probe", "differential-probe"
+        ])
+        self.assertEqual(first["schema_version"], "adversarial-fuzzing/v1")
+
+    def test_timeout_result_is_preserved_as_structured_failure(self) -> None:
+        result = json.loads((FIXTURES / "timeout.json").read_text())
+        validated = validate_worker_result(result)
+        self.assertEqual(validated["status"], "timed_out")
+        self.assertEqual(validated["error"]["code"], "worker_timeout")
+
+    def test_malformed_result_fails_closed(self) -> None:
+        result = json.loads((FIXTURES / "malformed-result.json").read_text())
+        with self.assertRaisesRegex(FuzzInputError, "missing worker result fields"):
+            validate_worker_result(result)
+
+    def test_unsafe_worktree_fails_closed(self) -> None:
+        payload = json.loads((FIXTURES / "unsafe-path.json").read_text())
+        with tempfile.TemporaryDirectory() as tempdir:
+            with self.assertRaisesRegex(FuzzInputError, "inside the repository"):
+                validate_campaign(payload, Path(tempdir))
+
+    def test_worker_cap_rejects_more_than_four(self) -> None:
+        payload = json.loads((FIXTURES / "success.json").read_text())
+        payload["max_workers"] = 5
+        with self.assertRaisesRegex(FuzzInputError, "max_workers"):
+            validate_campaign(payload, Path.cwd())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -54,6 +54,9 @@ class FuzzRunnerTests(unittest.TestCase):
     def test_unsafe_worktree_fails_closed(self) -> None:
         payload = json.loads((FIXTURES / "unsafe-path.json").read_text())
         with tempfile.TemporaryDirectory() as tempdir:
+            # The fixture's Unix spelling is not absolute on Windows. Use a
+            # host-native path outside the temporary repository in every CI OS.
+            payload["worktree_path"] = str(Path(tempdir).parent / "not-an-approved-worktree")
             with self.assertRaisesRegex(FuzzInputError, "inside the repository"):
                 validate_campaign(payload, Path(tempdir))
 

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from contextlib import redirect_stdout
+import io
 from pathlib import Path
 import json
 import sys
@@ -13,6 +15,7 @@ if str(JUST_DIR) not in sys.path:
 
 from run_fuzz import FuzzInputError
 from run_fuzz import build_result
+from run_fuzz import main
 from run_fuzz import validate_campaign
 from run_fuzz import validate_worker_result
 
@@ -54,11 +57,22 @@ class FuzzRunnerTests(unittest.TestCase):
     def test_unsafe_worktree_fails_closed(self) -> None:
         payload = json.loads((FIXTURES / "unsafe-path.json").read_text())
         with tempfile.TemporaryDirectory() as tempdir:
-            # The fixture's Unix spelling is not absolute on Windows. Use a
-            # host-native path outside the temporary repository in every CI OS.
-            payload["worktree_path"] = str(Path(tempdir).parent / "not-an-approved-worktree")
+            # The fixture uses a rooted UNC spelling, which pathlib recognizes
+            # as absolute on both POSIX and Windows while remaining outside
+            # this temporary repository.
             with self.assertRaisesRegex(FuzzInputError, "inside the repository"):
                 validate_campaign(payload, Path(tempdir))
+
+    def test_cli_forwards_dry_run_flag(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(main(["run_fuzz.py"]), 0)
+        self.assertEqual(json.loads(output.getvalue())["execution_mode"], "contract-only")
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(main(["run_fuzz.py", "--dry-run"]), 0)
+        self.assertEqual(json.loads(output.getvalue())["execution_mode"], "dry-run")
 
     def test_worker_cap_rejects_more_than_four(self) -> None:
         payload = self.campaign_fixture("success.json")

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -21,8 +21,17 @@ FIXTURES = JUST_DIR / "fixtures/fuzz"
 
 
 class FuzzRunnerTests(unittest.TestCase):
+    def campaign_fixture(self, name: str) -> dict:
+        payload = json.loads((FIXTURES / name).read_text())
+        # Keep the fixture repository-independent: CI checks out to a different
+        # absolute path on every host, while the contract requires an absolute
+        # approved worktree path.
+        if "worktree_path" in payload:
+            payload["worktree_path"] = str(Path.cwd())
+        return payload
+
     def test_success_campaign_is_deterministic_and_four_workers(self) -> None:
-        campaign = validate_campaign(json.loads((FIXTURES / "success.json").read_text()), Path.cwd())
+        campaign = validate_campaign(self.campaign_fixture("success.json"), Path.cwd())
         first = build_result(campaign)
         second = build_result(campaign)
         self.assertEqual(first, second)
@@ -49,7 +58,7 @@ class FuzzRunnerTests(unittest.TestCase):
                 validate_campaign(payload, Path(tempdir))
 
     def test_worker_cap_rejects_more_than_four(self) -> None:
-        payload = json.loads((FIXTURES / "success.json").read_text())
+        payload = self.campaign_fixture("success.json")
         payload["max_workers"] = 5
         with self.assertRaisesRegex(FuzzInputError, "max_workers"):
             validate_campaign(payload, Path.cwd())

--- a/Justfile
+++ b/Justfile
@@ -137,6 +137,10 @@ build:
 test mode='default':
     {{python_cmd}} .just/run_tests.py {{mode}}
 
+# Validate and plan a bounded adversarial-fuzz campaign (no real execution).
+fuzz *args:
+    {{python_cmd}} .just/run_fuzz.py {{args}}
+
 # Generate or verify the durable public verification-report index.
 reports-index *args:
     {{python_cmd}} .just/generate_report_index.py {{args}}

--- a/docs/fuzz-campaign-contract.md
+++ b/docs/fuzz-campaign-contract.md
@@ -1,0 +1,26 @@
+# AI48 fuzz campaign contract
+
+`just fuzz` validates this bounded campaign input and emits a deterministic,
+structured worker-result envelope. AI48 is contract-only: it does not invoke a
+real product campaign, mutate the approved worktree, or create HTML/XHTML
+reports. Later sprints own execution and publication.
+
+```json
+{
+  "worktree_path": "/absolute/path/to/approved/worktree",
+  "target": "var-file | frontmatter | resolver | renderer | includes | cli | full",
+  "baseline_ref": "optional git ref",
+  "seed": 157,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "optional target-specific context"
+}
+```
+
+`worktree_path` must resolve inside the repository or an approved sibling
+worktree, `max_workers` is capped at four, and all numeric limits are bounded.
+Worker results retain timeout and malformed-result failures instead of
+discarding them. Use `--campaign <path>` to validate a JSON file and
+`--output <path>` to save the emitted envelope under the repository.

--- a/docs/github-pages.md
+++ b/docs/github-pages.md
@@ -1,0 +1,26 @@
+# GitHub Pages verification site
+
+The repository's public verification site is the generated `site/` tree. The
+home page at [`site/index.html`](../site/index.html) links to the durable
+report catalog at [`site/reports/index.html`](../site/reports/index.html).
+Report producers regenerate and validate that catalog with:
+
+```bash
+just reports-index
+just reports-index --check
+```
+
+The sole publisher is [`.github/workflows/pages.yml`](../.github/workflows/pages.yml).
+It validates the generated catalog, uploads only `site/`, and deploys that
+artifact with the official GitHub Pages Actions. There is no second workflow,
+branch publisher, or transient `artifacts/view` publisher.
+
+## Repository setting
+
+In the repository's **Settings → Pages → Build and deployment**, set **Source**
+to **GitHub Actions**. This is the only repository-level Pages setting
+required; the workflow owns the build and deployment. The workflow publishes
+updates from `integrate/phase-ai-31-33` and can also be started manually.
+
+Do not select **Deploy from a branch**: that would create an alternate
+publisher and bypass the generated-index check.

--- a/docs/plans/phase-ai/sprint-ai-47-pages-site-home.md
+++ b/docs/plans/phase-ai/sprint-ai-47-pages-site-home.md
@@ -1,7 +1,8 @@
 ---
 title: AI.47 GitHub Pages site home
-status: planned
+status: complete
 branch: feature/pAI-s47-pages-site-home
+worktree: ../atm-core-worktrees/feature/pAI-s47-pages-site-home
 recommended_agent: Cipher-311d
 recommended_model: fast
 execution_mode: after_merge

--- a/docs/plans/phase-ai/sprint-ai-48-fuzz-tooling-port.md
+++ b/docs/plans/phase-ai/sprint-ai-48-fuzz-tooling-port.md
@@ -1,7 +1,8 @@
 ---
 title: AI.48 fuzz tooling port
-status: planned
+status: complete
 branch: feature/pAI-s48-fuzz-tooling-port
+worktree: ../atm-core-worktrees/feature/pAI-s48-fuzz-tooling-port
 recommended_agent: Cipher-311d
 recommended_model: fast
 execution_mode: parallel

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1019,7 +1019,7 @@ Implementation Branches:
 | `AI.40` | `planned` | `feature/pAI-s40-local-transport-benchmark` | clean local transport throughput benchmark; not an extension of abandoned AI.33 script |
 | `AI.43` | `planned` | `feature/pAI-s43-remote-https-response-framing` | buffered remote HTTPS response framing |
 | `AI.46` | `complete` | `feature/pAI-s46-reports-index` | generated durable reports index |
-| `AI.47` | `planned` | `feature/pAI-s47-pages-site-home` | GitHub Pages site home and deployment |
+| `AI.47` | `complete` | `feature/pAI-s47-pages-site-home` | GitHub Pages site home and deployment |
 | `AI.48` | `planned` | `feature/pAI-s48-fuzz-tooling-port` | ported `just fuzz` coordinator/probe tooling |
 | `AI.49` | `planned` | `feature/pAI-s49-benchmark-report` | durable benchmark JSON and aggregate HTML report |
 | `AI.50` | `planned` | `feature/pAI-s50-fuzz-report` | sc-compose-template fuzz report renderer |

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1020,7 +1020,7 @@ Implementation Branches:
 | `AI.43` | `planned` | `feature/pAI-s43-remote-https-response-framing` | buffered remote HTTPS response framing |
 | `AI.46` | `complete` | `feature/pAI-s46-reports-index` | generated durable reports index |
 | `AI.47` | `complete` | `feature/pAI-s47-pages-site-home` | GitHub Pages site home and deployment |
-| `AI.48` | `planned` | `feature/pAI-s48-fuzz-tooling-port` | ported `just fuzz` coordinator/probe tooling |
+| `AI.48` | `complete` | `feature/pAI-s48-fuzz-tooling-port` | ported `just fuzz` coordinator/probe tooling |
 | `AI.49` | `planned` | `feature/pAI-s49-benchmark-report` | durable benchmark JSON and aggregate HTML report |
 | `AI.50` | `planned` | `feature/pAI-s50-fuzz-report` | sc-compose-template fuzz report renderer |
 | `AI.51` | `planned` | `feature/pAI-s51-local-http-framing-adversarial-campaign` | bounded local HTTP framing campaign |

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ATM verification reports</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font: 16px system-ui, sans-serif; line-height: 1.5; max-width: 56rem; margin: 3rem auto; padding: 0 1rem; }
+    a { font-weight: 600; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>ATM verification reports</h1>
+    <p>Durable, public-safe verification evidence for ATM transport and tooling.</p>
+    <p><a href="reports/index.html">Browse verification reports</a></p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Ports sc-compose adversarial-fuzzing skill/coordinator/probe verbatim. Adds bounded `just fuzz` contract-only runner: deterministic ≤4-worker JSON results, approved-worktree/limit validation, timeout/malformed/unsafe fixtures. No real campaign or report rendering (AI.50 owns reporting).

Sprint doc: docs/plans/phase-ai/sprint-ai-48-fuzz-tooling-port.md