### PR TITLE
AI.49 benchmark report + AI.48 merge-forward

### DIFF
--- a/.claude/agents/registry.yaml
+++ b/.claude/agents/registry.yaml
@@ -65,6 +65,12 @@ agents:
   sc-git-worktree-update:
     version: 0.12.0
     path: .claude/agents/sc-git-worktree-update.md
+  sc-adversarial-fuzz-coordinator:
+    version: 1.0.0
+    path: .claude/agents/sc-adversarial-fuzz-coordinator.md
+  sc-adversarial-fuzz-probe:
+    version: 1.0.0
+    path: .claude/agents/sc-adversarial-fuzz-probe.md
 skills:
   codex-orchestration:
     version: 0.1.0

--- a/.claude/agents/sc-adversarial-fuzz-coordinator.md
+++ b/.claude/agents/sc-adversarial-fuzz-coordinator.md
@@ -1,0 +1,129 @@
+---
+name: sc-adversarial-fuzz-coordinator
+version: 1.0.0
+description: Coordinates bounded adversarial fuzz workers against one sc-compose rendering subsystem and returns reproducible findings plus regression-test candidates.
+---
+
+# sc-compose Adversarial Fuzz Coordinator
+
+## Purpose
+
+Coordinate a bounded campaign against one sc-compose rendering subsystem,
+delegate focused probes to background workers, minimize reproducible failures,
+and promote only confirmed product bugs into regression tests.
+
+## Inputs
+
+Accept a raw or fenced JSON object matching the skill contract:
+
+```json
+{
+  "worktree_path": "/absolute/path",
+  "target": "var-file | frontmatter | resolver | renderer | includes | cli | full",
+  "baseline_ref": "optional git ref",
+  "seed": 157,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "optional context"
+}
+```
+
+Require an existing worktree path inside the repository boundary. Reject path
+traversal, missing target, invalid numeric limits, or more than four workers.
+
+## Execution
+
+1. Verify `cargo` and `git` before running campaign logic. Read the skill's
+   installation reference if either is unavailable.
+2. Inspect the target code and existing tests. Do not modify production code.
+3. Select focused workers based on the target. For `full`, use four workers:
+   `shape-probe`, `template-probe`, `boundary-probe`, and `differential-probe`.
+4. Spawn each worker with the Task tool using `run_in_background: true`, a
+   distinct correlation ID, the same seed, a disjoint focus, and the configured
+   timeout. Cap concurrency at four.
+5. Collect every result, including timeout and malformed-contract failures.
+   Do not silently retry; permit at most one retry for an explicitly
+   recoverable worker failure.
+6. Reproduce candidate failures locally. Minimize templates and inputs by
+   removing one structural element at a time while preserving the failure.
+7. Classify each result as `confirmed_bug`, `intentional_boundary`, or
+   `inconclusive` using the skill's oracle rules. Require three reproductions for
+   deterministic promotion.
+8. If promotion is enabled, add only deterministic regression tests for
+   confirmed bugs. Never implement production fixes or commit code changes.
+9. Run targeted checks for promoted tests and return the complete aggregation.
+
+## Worker prompt contract
+
+Give each worker only its target-local context and these constraints:
+
+- use the assigned seed and bounded case count;
+- write only under the approved temporary campaign directory;
+- do not edit production code, reset the worktree, or commit;
+- return fenced JSON only;
+- include a minimal reproducer, command, expected oracle, observed result, and
+  severity for every candidate.
+
+Use these focused worker roles:
+
+| Correlation ID | Worker focus |
+| --- | --- |
+| `shape-probe` | Recursive JSON/YAML values, mixed arrays, and ingress parity |
+| `template-probe` | Nested loops, control flow, includes, delimiters, and output |
+| `boundary-probe` | Malformed inputs, stable diagnostics, and path boundaries |
+| `differential-probe` | Baseline comparison, metamorphic relations, and determinism |
+
+## Regression promotion rules
+
+Promote a minimal test only if the failure is reproducible, user-visible, and
+not an intentional boundary. Put pure library failures in
+`crates/sc-composer` unit tests and CLI/diagnostic failures in
+`crates/sc-compose/tests`. Include the finding ID and assert the stable output
+or diagnostic code. Preserve the original generated artifact only when it
+adds context beyond the minimized fixture.
+
+## Output Format
+
+Return fenced JSON only:
+
+```json
+{
+  "success": true,
+  "data": {
+    "parallel": true,
+    "concurrency": 4,
+    "per_task_timeout_s": 120,
+    "results": [],
+    "summary": {
+      "all_successful": true,
+      "confirmed_bugs": 0,
+      "promoted_tests": 0,
+      "inconclusive": 0,
+      "failed_workers": []
+    }
+  },
+  "error": null
+}
+```
+
+Set `success` to `true` when the campaign completed, even if findings exist.
+For invalid input, an unrecoverable coordinator failure, or malformed worker
+output, return `success: false`, `data: null`, and an error object with a
+namespaced code, message, recoverability, and suggested action.
+
+## Error Handling
+
+Handle recoverable worker timeouts or isolated command failures by recording a
+failed-worker result and continuing independent probes. Propagate invalid
+campaign input, unsafe paths, inability to establish the worktree, and
+malformed aggregate output as fatal errors.
+
+## Constraints
+
+- Keep all writes within the approved worktree or temporary campaign directory.
+- Do not run destructive commands or arbitrary network-facing services.
+- Do not expose secrets or unrelated files in findings.
+- Do not change production code or commit automatically.
+- Keep result ordering deterministic by correlation ID.

--- a/.claude/agents/sc-adversarial-fuzz-coordinator.md
+++ b/.claude/agents/sc-adversarial-fuzz-coordinator.md
@@ -78,9 +78,10 @@ Use these focused worker roles:
 ## Regression promotion rules
 
 Promote a minimal test only if the failure is reproducible, user-visible, and
-not an intentional boundary. Put pure library failures in
-`crates/sc-composer` unit tests and CLI/diagnostic failures in
-`crates/sc-compose/tests`. Include the finding ID and assert the stable output
+not an intentional boundary. Put fuzz contract failures in
+`.just/tests/test_run_fuzz.py` and product rendering/CLI failures in the
+owning sc-compose source repository (that source tree is not vendored here).
+Include the finding ID and assert the stable output
 or diagnostic code. Preserve the original generated artifact only when it
 adds context beyond the minimized fixture.
 

--- a/.claude/agents/sc-adversarial-fuzz-probe.md
+++ b/.claude/agents/sc-adversarial-fuzz-probe.md
@@ -1,0 +1,102 @@
+---
+name: sc-adversarial-fuzz-probe
+version: 1.0.0
+description: Runs one bounded, target-specific adversarial probe against sc-compose and returns minimized findings in a fenced JSON envelope.
+---
+
+# sc-compose Adversarial Fuzz Probe
+
+## Purpose
+
+Run one isolated probe against a single rendering subsystem. The coordinator
+assigns the focus and owns aggregation, minimization, and regression promotion.
+
+## Inputs
+
+Accept raw or fenced JSON:
+
+```json
+{
+  "worktree_path": "/absolute/path",
+  "correlation_id": "shape-probe",
+  "target": "var-file",
+  "seed": 157,
+  "cases": 100,
+  "timeout_s": 120,
+  "baseline_ref": "optional git ref",
+  "campaign_dir": "/absolute/path/inside/worktree",
+  "notes": "optional focus"
+}
+```
+
+Require all paths to be inside the approved worktree. Reject invalid JSON,
+missing focus, non-positive limits, or an unknown target.
+
+## Execution Steps
+
+1. Read the target implementation and existing tests before generating cases.
+2. Verify `cargo` and `git` are available; stop with a structured error if not.
+3. Generate bounded templates and inputs appropriate to the assigned focus.
+4. Execute each case with the configured timeout and capture exit status,
+   stdout, stderr, and stable diagnostics without recording secrets.
+5. Check an explicit output oracle, a baseline comparison when available, or a
+   metamorphic relation. Do not call a case a bug merely because it fails an
+   undocumented assumption.
+6. Minimize each promising failure locally by removing unrelated structure.
+7. Re-run the minimized case three times. Mark nondeterministic behavior as
+   `inconclusive` unless the coordinator can establish a stable failure.
+8. Return findings to the coordinator. Do not edit production code, add tests,
+   reset the worktree, or commit.
+
+## Focus guidance
+
+- `shape-probe`: recursive arrays/objects, jagged values, empty values, JSON vs
+  YAML parity, numeric/boolean/null leaves.
+- `template-probe`: nested loops, conditionals, includes, custom delimiters,
+  whitespace, Unicode, optional and missing fields.
+- `boundary-probe`: malformed documents, top-level shape rules, invalid YAML
+  keys, invalid variable names, stable diagnostics, and path confinement.
+- `differential-probe`: baseline/head behavior, deterministic output,
+  metamorphic relations, timeout, panic, and hang detection.
+
+## Output Format
+
+Return fenced JSON only:
+
+```json
+{
+  "success": true,
+  "data": {
+    "correlation_id": "shape-probe",
+    "cases_run": 100,
+    "findings": [],
+    "summary": {
+      "confirmed_bugs": 0,
+      "intentional_boundaries": 0,
+      "inconclusive": 0
+    }
+  },
+  "error": null
+}
+```
+
+Each finding must include an ID, status, subsystem, seed, exact command,
+minimal template/input, expected oracle, observed result, and reproduction
+count. Use `success: true` for a completed probe with findings. Use
+`success: false` only for invalid input or an execution failure that prevents
+the probe from reporting reliable results.
+
+## Error Handling
+
+Record a single case timeout, parser failure, or target-specific execution
+failure as evidence when other cases can continue. Return a fatal structured
+error for unsafe paths, missing required inputs, unavailable required CLIs, or
+corrupted campaign state.
+
+## Constraints
+
+- Stay within the assigned target and case budget.
+- Use only temporary files under `campaign_dir`.
+- Do not expose secrets or unrelated repository contents.
+- Do not mutate production code, add tests, commit, or run destructive commands.
+- Keep generated cases and result ordering deterministic by seed and case ID.

--- a/.claude/skills/adversarial-fuzzing/SKILL.md
+++ b/.claude/skills/adversarial-fuzzing/SKILL.md
@@ -87,26 +87,11 @@ after the campaign unless a failure artifact is being preserved.
     or NFR; establish the evidence-backed root cause; and identify the
     recommended change. Preserve those conclusions in the worker's structured
     JSON envelope. Then generate one report package for the fuzz session. Each
-    swarm worker runs one bounded fuzz test and returns one structured result;
-    the package contains one XHTML panel per worker. Use the reusable
-    `.claude/skills/html-report/templates/fuzz-run-agent.xhtml.j2` template for
-    those panels and delegate the single main HTML/JSON package to the
-    `html-report-generator` background agent. Its top-level `summary_html` must
-    be a compact table with the fuzz-run description, iteration count, pass
-    fraction (`passed/iterations`), and a simple PASS/FAIL result. Keep each
-    panel's `json_payload` equal to the worker's durable evidence envelope and
-    provide `context_text`; do not invent a second campaign schema. Write real
-    session artifacts to `site/reports/`, assigning a 1-based sequence in
-    deterministic session order and resetting it for each campaign day. The
-    filename stem must be `YYYYMMDD-N-fuzz-report`, for example
-    `site/reports/20260729-1-fuzz-report.html`; keep the matching `.json`
-    sidecar and one companion `.xhtml` panel per worker under the derived
-    `site/reports/20260729-1-fuzz-report/` directory, using a deterministic
-    worker suffix when more than one panel is present. The report generator
-    must validate the HTML output with `html-validate` and every XHTML panel
-    with `xmllint --noout` before the session is reported complete. Review-only
-    examples belong under `docs/examples/fuzz-run-report/`, not
-    `site/reports/`.
+    swarm worker runs one bounded fuzz test and returns one structured result.
+    Report templates and publication are intentionally out of scope for this
+    port (AI.50 owns those assets); pass the durable worker envelopes to that
+    owner rather than referencing a template path that is not checked out in
+    this repository.
 
 ## Worker portfolio
 
@@ -182,10 +167,11 @@ if it cannot be reproduced deterministically.
 
 Promote only `confirmed_bug` candidates. Place tests according to behavior:
 
-- pure value conversion/validation: `crates/sc-composer` unit tests;
-- CLI ingress, diagnostics, or output: `crates/sc-compose/tests/cli.rs` or
-  `json_cli.rs`;
-- cross-platform path or boundary behavior: the existing boundary test suite.
+- fuzz contract validation: `.just/tests/test_run_fuzz.py`;
+- product rendering or CLI regressions: the owning sc-compose source
+  repository's test suite (that source tree is not vendored in atm-core);
+- cross-platform path or boundary behavior: the existing boundary test suite
+  in the owning product repository.
 
 Every promoted test must include the minimized input, expected output or stable
 diagnostic, and a short comment naming the fuzz finding ID. Avoid comments that
@@ -295,7 +281,7 @@ The durable report must be a JSON object matching this contract:
   "promoted_tests": [
     {
       "finding_id": "FUZZ-001",
-      "test_path": "crates/sc-compose/tests/cli.rs"
+      "test_path": ".just/tests/test_run_fuzz.py"
     }
   ],
   "unresolved_candidates": [

--- a/.claude/skills/adversarial-fuzzing/SKILL.md
+++ b/.claude/skills/adversarial-fuzzing/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: adversarial-fuzzing
+version: 1.1.0
+description: Generate and triage adversarial templates, var-files, and rendering inputs against sc-compose by coordinating bounded background agents, differential and metamorphic checks, minimization, and regression-test promotion. Use when trying to break a rendering subsystem, validating a risky change, hunting parser/validator/rendering edge cases, or turning a confirmed fuzz failure into a unit or CLI test.
+---
+
+# Adversarial Fuzzing
+
+Use this skill to attack one sc-compose rendering subsystem with several
+focused, isolated probes. Preserve useful failures as minimal regression tests
+only after reproducing and classifying them as real product bugs.
+
+## Step 1 — Verify required CLI dependencies
+
+Run this before selecting agents or executing a fuzz campaign:
+
+```bash
+which cargo && cargo --version
+which git && git --version
+```
+
+If either command is unavailable, stop and read
+`references/installation-and-troubleshooting.md` before proceeding. Do not
+silently run a degraded campaign.
+
+## Campaign contract
+
+Require a JSON input object with these fields. Reject missing or unsafe paths
+before delegating work.
+
+```json
+{
+  "worktree_path": "/absolute/path/to/sc-compose-worktree",
+  "target": "var-file | frontmatter | resolver | renderer | includes | cli | full",
+  "baseline_ref": "optional git ref for differential checks",
+  "seed": 157,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "optional target-specific context"
+}
+```
+
+Require `worktree_path` to be an existing absolute path inside the repository
+or an explicitly approved isolated worktree. Resolve and validate all generated
+paths beneath it; reject path traversal and paths outside the worktree.
+
+Use a deterministic seed by default, cap concurrency at four workers, set a
+per-worker timeout, and record the seed and campaign correlation ID in every
+result. Use a fresh temporary directory for generated inputs and clean it up
+after the campaign unless a failure artifact is being preserved.
+
+## Workflow
+
+1. Verify the CLI dependencies above.
+2. Inspect the target subsystem, current tests, repository boundary rules, and
+   the requested baseline. Keep the user's existing changes intact.
+3. Use the Agent Runner to invoke the registered
+   `sc-adversarial-fuzz-coordinator` agent as the primary coordinator with the
+   campaign contract. Do not invoke an unregistered agent path.
+4. Have the primary coordinator spawn a swarm of focused workers in the
+   background with `run_in_background: true`. Each worker gets a distinct fuzz
+   task, runs one bounded fuzz test, and returns exactly one structured JSON
+   result with its test inputs, iteration count, pass/fail counts, and any
+   candidate finding.
+5. Aggregate worker results in correlation-ID order. Surface partial failures;
+   never discard a timeout, malformed response, or worker error.
+6. Reproduce each candidate failure in the primary coordinator's worktree,
+   minimize the template and input while retaining the failure, and classify
+   the outcome using the oracle rules below. For every candidate that remains
+   plausible, the primary may deploy background explore agents to locate the
+   relevant requirement, ADR, or NFR, establish root cause, and recommend the
+   next change. Merge their conclusions into the worker's structured result.
+7. When a candidate is a confirmed product bug and `promote_regressions` is
+   true, add the smallest durable test to the nearest existing test suite.
+   Prefer inline fixtures for small cases and checked-in fixtures for complex
+   templates. Do not change production code or silently implement a fix during
+   a fuzz campaign.
+8. Run targeted tests, then the repository's required formatting, test, lint,
+   and boundary checks when a regression test was added.
+9. Return the coordinator's fenced JSON report and summarize confirmed bugs,
+   promoted tests, unresolved candidates, and campaign limits.
+10. After the campaign summary is complete, have the primary coordinator
+    investigate every candidate failure before producing the report. It may
+    deploy background explore agents to locate the relevant requirement, ADR,
+    or NFR; establish the evidence-backed root cause; and identify the
+    recommended change. Preserve those conclusions in the worker's structured
+    JSON envelope. Then generate one report package for the fuzz session. Each
+    swarm worker runs one bounded fuzz test and returns one structured result;
+    the package contains one XHTML panel per worker. Use the reusable
+    `.claude/skills/html-report/templates/fuzz-run-agent.xhtml.j2` template for
+    those panels and delegate the single main HTML/JSON package to the
+    `html-report-generator` background agent. Its top-level `summary_html` must
+    be a compact table with the fuzz-run description, iteration count, pass
+    fraction (`passed/iterations`), and a simple PASS/FAIL result. Keep each
+    panel's `json_payload` equal to the worker's durable evidence envelope and
+    provide `context_text`; do not invent a second campaign schema. Write real
+    session artifacts to `site/reports/`, assigning a 1-based sequence in
+    deterministic session order and resetting it for each campaign day. The
+    filename stem must be `YYYYMMDD-N-fuzz-report`, for example
+    `site/reports/20260729-1-fuzz-report.html`; keep the matching `.json`
+    sidecar and one companion `.xhtml` panel per worker under the derived
+    `site/reports/20260729-1-fuzz-report/` directory, using a deterministic
+    worker suffix when more than one panel is present. The report generator
+    must validate the HTML output with `html-validate` and every XHTML panel
+    with `xmllint --noout` before the session is reported complete. Review-only
+    examples belong under `docs/examples/fuzz-run-report/`, not
+    `site/reports/`.
+
+## Worker portfolio
+
+Ask the coordinator to deploy only the workers relevant to `target`; use all
+four for `full`:
+
+| Worker | Focus | Primary probes |
+| --- | --- | --- |
+| `shape-probe` | Values and ingress | recursive JSON/YAML trees, mixed arrays, empty values, numeric edge cases, object/map nesting |
+| `template-probe` | Jinja behavior | nested loops, conditionals, includes, delimiters, whitespace, missing/optional fields, Unicode |
+| `boundary-probe` | Negative contract | malformed files, non-object var-files, invalid YAML keys, invalid names, stable diagnostics, path confinement |
+| `differential-probe` | Change/regression oracle | baseline-vs-head behavior, JSON/YAML parity, deterministic output, timeout/panic/hang detection |
+
+Each worker must stay within its target, use bounded generation, and return a
+standard fenced JSON envelope. Workers may create temporary inputs and logs,
+but must not edit production code, commit changes, or delete user files.
+
+When a finding cannot be traced to an existing requirement or ADR, record that
+absence explicitly and assess whether it is a genuine contract gap. The
+recommended action must be one of: create or update a requirement/ADR before
+implementation when the behavior is supported and the gap is real; document
+why no new requirement/ADR is needed when the behavior is intentionally
+unsupported or too narrow; or leave the assessment pending with a named owner
+when product intent is not yet established. Do not create documentation merely
+because a finding lacks a reference.
+
+## Oracle and triage rules
+
+Classify a candidate as a confirmed bug only when at least one condition holds:
+
+- the process panics, hangs, exceeds the configured timeout, or exits with an
+  unexplained internal error;
+- a valid input that the documented contract accepts renders incorrectly;
+- equivalent JSON and YAML inputs produce different semantics without a
+  documented reason;
+- a metamorphic relation fails, such as adding an unused object field changing
+  output or reordering independent inputs changing deterministic output;
+- a formerly valid input regresses against `baseline_ref`;
+- a stable diagnostic code or top-level boundary is violated.
+
+Do not file a bug for an intentional validation error, a malformed test input,
+an unsupported feature explicitly documented by the target contract, or an
+oracle that cannot establish expected behavior. Preserve such cases as
+negative-coverage notes when they reveal a missing contract.
+
+For every candidate, require:
+
+```json
+{
+  "id": "FUZZ-001",
+  "status": "confirmed_bug | intentional_boundary | inconclusive",
+  "subsystem": "var-file",
+  "seed": 157,
+  "command": "cargo run ...",
+  "minimal_template": "...",
+  "minimal_input": "...",
+  "observed": "...",
+  "expected_oracle": "...",
+  "diagnostic": "optional code",
+  "requirement_trace": "existing requirement/ADR, or explicit no-coverage statement",
+  "requirement_follow_up": "create/update, no-new-doc rationale, or named decision owner",
+  "reproduction_count": 3,
+  "recommended_test": "..."
+}
+```
+
+Minimize by deleting unrelated template blocks, variables, fields, array
+members, and nesting while re-running the exact command. Keep the smallest
+reproducer that fails at least three times, or record nondeterminism explicitly
+if it cannot be reproduced deterministically.
+
+## Regression-test promotion
+
+Promote only `confirmed_bug` candidates. Place tests according to behavior:
+
+- pure value conversion/validation: `crates/sc-composer` unit tests;
+- CLI ingress, diagnostics, or output: `crates/sc-compose/tests/cli.rs` or
+  `json_cli.rs`;
+- cross-platform path or boundary behavior: the existing boundary test suite.
+
+Every promoted test must include the minimized input, expected output or stable
+diagnostic, and a short comment naming the fuzz finding ID. Avoid comments that
+leak campaign-only assumptions; document the user-visible invariant instead.
+
+After promotion, run:
+
+```bash
+cargo fmt --all --check
+cargo test --workspace
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Also run the repository's boundary checks and retain the generated campaign
+report as an artifact when the team workflow requires it. A test that cannot
+be made deterministic or cross-platform should remain a finding, not be
+promoted as a flaky regression.
+
+## Aggregation contract
+
+The coordinator must return fenced JSON only, with results ordered by
+`correlation_id`:
+
+```json
+{
+  "parallel": true,
+  "concurrency": 4,
+  "per_task_timeout_s": 120,
+  "results": [],
+  "summary": {
+    "all_successful": true,
+    "confirmed_bugs": 0,
+    "promoted_tests": 0,
+    "inconclusive": 0,
+    "failed_workers": []
+  },
+  "error": null
+}
+```
+
+Use `success: true` when the campaign completed even if findings exist. Use
+`success: false` for invalid input, coordinator failure, or a malformed worker
+contract. Represent timeouts as recoverable worker failures and do not retry
+more than once.
+
+## First-Campaign Checklist And Evidence
+
+Use this checklist for the first real campaign (owned by E.3) and for later
+independent quality-mgr passes:
+
+1. Confirm the requested worktree is an existing approved absolute path and
+   record the baseline ref. Do not claim E.1 is merged unless the target
+   integration branch actually contains it.
+2. Record the seed, target, worker cap, cases per worker, timeout, promotion
+   flag, campaign ID, and generated campaign directory before launching.
+3. Run the full target with the four registered workers when `target` is
+   `full`; record every correlation ID, worker target, case count, status,
+   timeout, and error.
+4. Record every candidate with the exact command, minimized input/template,
+   expected oracle, observed result, diagnostic, and reproduction count.
+5. Record classification and promotion decisions. A confirmed bug needs three
+   reproductions and a durable owning-crate test; an unresolved confirmed bug
+   needs a next owner. Do not claim the pipeline is proven in E.2.
+6. Run the relevant validation gates and preserve the report outside temporary
+   files when E.3 or quality-mgr requires durable evidence.
+
+The durable report must be a JSON object matching this contract:
+
+```json
+{
+  "schema_version": "adversarial-fuzzing/v1",
+  "campaign": {
+    "campaign_id": "e3-20260729-0001",
+    "worktree_path": "/absolute/approved/worktree",
+    "target": "full",
+    "baseline_ref": "optional git ref",
+    "seed": 157,
+    "max_workers": 4,
+    "cases_per_worker": 100,
+    "per_worker_timeout_s": 120,
+    "promote_regressions": true
+  },
+  "workers": [
+    {
+      "correlation_id": "shape-probe",
+      "target": "var-file",
+      "status": "success | failed | timed_out",
+      "cases_run": 100,
+      "finding_ids": ["FUZZ-001"],
+      "error": null
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "FUZZ-001",
+      "worker_correlation_id": "shape-probe",
+      "classification": "confirmed_bug | intentional_boundary | inconclusive",
+      "command": "cargo run ...",
+      "minimal_template": "...",
+      "minimal_input": "...",
+      "expected_oracle": "...",
+      "observed_result": "...",
+      "diagnostic_code": null,
+      "reproduction_count": 3
+    }
+  ],
+  "promoted_tests": [
+    {
+      "finding_id": "FUZZ-001",
+      "test_path": "crates/sc-compose/tests/cli.rs"
+    }
+  ],
+  "unresolved_candidates": [
+    {
+      "finding_id": "FUZZ-002",
+      "next_owner": "team-lead"
+    }
+  ],
+  "summary": {
+    "all_successful": true,
+    "confirmed_bugs": 0,
+    "intentional_boundaries": 0,
+    "inconclusive": 0,
+    "failed_workers": 0
+  }
+}
+```
+
+Order workers and findings deterministically by correlation ID and finding ID.
+`all_successful` is false for any worker failure or timeout. A report with no
+findings but incomplete execution is not a passing no-finding campaign.
+
+## Safety and cleanup
+
+- Never run destructive commands, network-facing services, or arbitrary code
+  from generated templates.
+- Do not expose secrets, environment dumps, or unrelated repository contents in
+  findings.
+- Keep all writes inside the approved worktree and temporary campaign directory.
+- Never reset, clean, or overwrite the user's existing changes.
+- Remove temporary inputs after collecting confirmed artifacts.
+- Do not commit production fixes automatically; commit only promoted tests when
+  the user or repository workflow explicitly authorizes that mutation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install sc-compose
-        run: python -m pip install "sc-compose>=1.2.0"
+      - name: Install sc-compose CLI
+        run: cargo install --git https://github.com/randlee/sc-compose.git --tag v1.2.0 --locked --bin sc-compose
 
-      - name: Expose Python scripts on PATH
-        run: python -c "import os, sysconfig; scripts = sysconfig.get_path('scripts'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(scripts + os.linesep)"
+      - name: Expose Cargo binaries on PATH
+        run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"
 
       - name: Install just
         uses: taiki-e/install-action@just

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install sc-compose
         run: python -m pip install "sc-compose>=1.2.0"
 
+      - name: Expose Python scripts on PATH
+        run: python -c "import os, sysconfig; scripts = sysconfig.get_path('scripts'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(scripts + os.linesep)"
+
       - name: Install just
         uses: taiki-e/install-action@just
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install sc-compose
+        run: python -m pip install "sc-compose>=1.2.0"
+
       - name: Install just
         uses: taiki-e/install-action@just
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - integrate/phase-ai-31-33
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Verify generated report index
+        run: just reports-index --check
+
+      - name: Upload the site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.just/fixtures/benchmark/failed-tcp-f8.json
+++ b/.just/fixtures/benchmark/failed-tcp-f8.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "generated_at": "2026-08-01T01:01:00Z",
+  "host_label": "mac-arm64-01",
+  "transport": "tcp",
+  "frames_per_connection": 8,
+  "run_duration_s": 20,
+  "runs": [
+    {
+      "label": "accepting-configured-peer",
+      "intervals": [
+        {"interval": 1, "accepted_count": 999, "response_count": 1000, "elapsed_seconds": 2.0, "admissions_per_second": 499.5, "first_failure": "HTTP 503", "passed": false}
+      ]
+    }
+  ],
+  "passed": false,
+  "failure": "one admission failed",
+  "cleanup_failure": "cleanup completed"
+}

--- a/.just/fixtures/benchmark/legacy-v1.json
+++ b/.just/fixtures/benchmark/legacy-v1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-01T00:59:00Z",
+  "host_label": "linux-x64-01",
+  "transport": "uds",
+  "frames_per_connection": 2,
+  "duration_seconds": 20,
+  "samples": [
+    {"interval": 1, "accepted_count": 1000, "response_count": 1000, "elapsed_seconds": 0.9, "admissions_per_second": 1111.0, "passed": true}
+  ],
+  "passed": true
+}

--- a/.just/fixtures/benchmark/success-uds-f1.json
+++ b/.just/fixtures/benchmark/success-uds-f1.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 2,
+  "generated_at": "2026-08-01T01:00:00Z",
+  "host_label": "mac-arm64-01",
+  "transport": "uds",
+  "frames_per_connection": 1,
+  "run_duration_s": 20,
+  "messages_per_connection": 1,
+  "runs": [
+    {
+      "label": "accepting-configured-peer",
+      "peer_host": "10.0.0.4",
+      "intervals": [
+        {"interval": 1, "accepted_count": 1000, "response_count": 1000, "elapsed_seconds": 0.8, "admissions_per_second": 1250.0, "passed": true}
+      ]
+    }
+  ],
+  "passed": true,
+  "atm_home": "/Users/randlee/.atm",
+  "release": {"atm": "/Users/randlee/Documents/github/atm-core/target/release/atm"}
+}

--- a/.just/fixtures/fuzz/malformed-result.json
+++ b/.just/fixtures/fuzz/malformed-result.json
@@ -1,0 +1,6 @@
+{
+  "correlation_id": "shape-probe",
+  "status": "success",
+  "cases_run": 100,
+  "finding_ids": []
+}

--- a/.just/fixtures/fuzz/success.json
+++ b/.just/fixtures/fuzz/success.json
@@ -1,0 +1,11 @@
+{
+  "worktree_path": "/Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s48-fuzz-tooling-port",
+  "target": "full",
+  "baseline_ref": null,
+  "seed": 157,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "fixture campaign"
+}

--- a/.just/fixtures/fuzz/timeout.json
+++ b/.just/fixtures/fuzz/timeout.json
@@ -1,0 +1,11 @@
+{
+  "correlation_id": "boundary-probe",
+  "target": "cli",
+  "status": "timed_out",
+  "cases_run": 17,
+  "finding_ids": [],
+  "error": {
+    "code": "worker_timeout",
+    "message": "worker exceeded per-worker timeout"
+  }
+}

--- a/.just/fixtures/fuzz/unsafe-path.json
+++ b/.just/fixtures/fuzz/unsafe-path.json
@@ -1,5 +1,5 @@
 {
-  "worktree_path": "/tmp/not-an-approved-worktree",
+  "worktree_path": "//localhost/not-an-approved-worktree",
   "target": "full",
   "baseline_ref": null,
   "seed": 157,

--- a/.just/fixtures/fuzz/unsafe-path.json
+++ b/.just/fixtures/fuzz/unsafe-path.json
@@ -1,0 +1,11 @@
+{
+  "worktree_path": "/tmp/not-an-approved-worktree",
+  "target": "full",
+  "baseline_ref": null,
+  "seed": 157,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "unsafe fixture"
+}

--- a/.just/run_fuzz.py
+++ b/.just/run_fuzz.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Validate and plan bounded adversarial-fuzz campaigns.
+
+AI48 deliberately stops at the coordinator/probe contract. It does not invoke
+product parsers, mutate a worktree, or render reports; later sprints own those
+execution and publication concerns.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import json
+import sys
+from typing import Any
+
+
+SCHEMA_VERSION = "adversarial-fuzzing/v1"
+TARGETS = ("var-file", "frontmatter", "resolver", "renderer", "includes", "cli", "full")
+WORKERS = ("shape-probe", "template-probe", "boundary-probe", "differential-probe")
+WORKER_TARGETS = {
+    "shape-probe": "var-file",
+    "template-probe": "renderer",
+    "boundary-probe": "cli",
+    "differential-probe": "full",
+}
+CAMPAIGN_FIELDS = {
+    "worktree_path",
+    "target",
+    "baseline_ref",
+    "seed",
+    "max_workers",
+    "cases_per_worker",
+    "per_worker_timeout_s",
+    "promote_regressions",
+    "notes",
+}
+WORKER_RESULT_FIELDS = {"correlation_id", "target", "status", "cases_run", "finding_ids", "error"}
+STATUSES = ("success", "failed", "timed_out")
+
+
+class FuzzInputError(ValueError):
+    """A campaign or worker result violates the public fuzz contract."""
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _inside(path: Path, root: Path, label: str) -> Path:
+    resolved = path.expanduser().resolve()
+    allowed = (root.resolve(), root.resolve().parent / f"{root.resolve().name}-worktrees")
+    if not any(resolved == candidate or candidate in resolved.parents for candidate in allowed):
+        raise FuzzInputError(f"{label} must stay inside the repository or approved worktrees: {path}")
+    return resolved
+
+
+def _bounded_int(value: Any, name: str, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        raise FuzzInputError(f"{name} must be an integer between {minimum} and {maximum}")
+    return value
+
+
+def validate_campaign(payload: Any, root: Path | None = None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise FuzzInputError("campaign must be a JSON object")
+    unknown = set(payload) - CAMPAIGN_FIELDS
+    if unknown:
+        raise FuzzInputError(f"unsupported campaign fields: {', '.join(sorted(unknown))}")
+    missing = CAMPAIGN_FIELDS - {"baseline_ref", "notes"} - payload.keys()
+    if missing:
+        raise FuzzInputError(f"missing campaign fields: {', '.join(sorted(missing))}")
+    repo = (root or repository_root()).resolve()
+    worktree_raw = payload["worktree_path"]
+    if not isinstance(worktree_raw, str) or not Path(worktree_raw).is_absolute():
+        raise FuzzInputError("worktree_path must be an absolute path")
+    worktree = _inside(Path(worktree_raw), repo, "worktree_path")
+    if not worktree.is_dir():
+        raise FuzzInputError(f"worktree_path does not name an existing directory: {worktree}")
+    target = payload["target"]
+    if target not in TARGETS:
+        raise FuzzInputError(f"target must be one of {', '.join(TARGETS)}")
+    baseline = payload.get("baseline_ref")
+    if baseline is not None and (not isinstance(baseline, str) or not baseline.strip() or "\n" in baseline):
+        raise FuzzInputError("baseline_ref must be a non-empty single-line string when present")
+    notes = payload.get("notes", "")
+    if not isinstance(notes, str) or len(notes) > 4000:
+        raise FuzzInputError("notes must be a string of at most 4000 characters")
+    if not isinstance(payload.get("promote_regressions"), bool):
+        raise FuzzInputError("promote_regressions must be boolean")
+    return {
+        "worktree_path": str(worktree),
+        "target": target,
+        "baseline_ref": baseline,
+        "seed": _bounded_int(payload["seed"], "seed", 0, 2**63 - 1),
+        "max_workers": _bounded_int(payload["max_workers"], "max_workers", 1, 4),
+        "cases_per_worker": _bounded_int(payload["cases_per_worker"], "cases_per_worker", 1, 1000),
+        "per_worker_timeout_s": _bounded_int(payload["per_worker_timeout_s"], "per_worker_timeout_s", 1, 600),
+        "promote_regressions": payload["promote_regressions"],
+        "notes": notes,
+    }
+
+
+def validate_worker_result(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise FuzzInputError("worker result must be a JSON object")
+    unknown = set(payload) - WORKER_RESULT_FIELDS
+    if unknown:
+        raise FuzzInputError(f"unsupported worker result fields: {', '.join(sorted(unknown))}")
+    missing = WORKER_RESULT_FIELDS - payload.keys()
+    if missing:
+        raise FuzzInputError(f"missing worker result fields: {', '.join(sorted(missing))}")
+    correlation_id = payload["correlation_id"]
+    if correlation_id not in WORKERS:
+        raise FuzzInputError(f"unknown worker correlation_id: {correlation_id!r}")
+    target = payload["target"]
+    if not isinstance(target, str) or target not in TARGETS:
+        raise FuzzInputError("worker target is invalid")
+    status = payload["status"]
+    if status not in STATUSES:
+        raise FuzzInputError(f"worker status must be one of {', '.join(STATUSES)}")
+    cases_run = _bounded_int(payload["cases_run"], "cases_run", 0, 1000)
+    finding_ids = payload["finding_ids"]
+    if not isinstance(finding_ids, list) or any(not isinstance(item, str) for item in finding_ids):
+        raise FuzzInputError("finding_ids must be an array of strings")
+    error = payload["error"]
+    if error is not None and not isinstance(error, dict):
+        raise FuzzInputError("worker error must be an object or null")
+    return {
+        "correlation_id": correlation_id,
+        "target": target,
+        "status": status,
+        "cases_run": cases_run,
+        "finding_ids": list(finding_ids),
+        "error": error,
+    }
+
+
+def selected_workers(campaign: dict[str, Any]) -> list[str]:
+    if campaign["target"] == "full":
+        return list(WORKERS[: campaign["max_workers"]])
+    selected = [worker for worker in WORKERS if WORKER_TARGETS[worker] == campaign["target"]]
+    if not selected:
+        selected = ["differential-probe"]
+    return selected[: campaign["max_workers"]]
+
+
+def build_result(campaign: dict[str, Any], dry_run: bool = True) -> dict[str, Any]:
+    workers = []
+    for correlation_id in selected_workers(campaign):
+        workers.append(
+            {
+                "correlation_id": correlation_id,
+                "target": campaign["target"],
+                "status": "success",
+                "cases_run": campaign["cases_per_worker"],
+                "finding_ids": [],
+                "error": None,
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "execution_mode": "dry-run" if dry_run else "contract-only",
+        "campaign": campaign,
+        "workers": workers,
+        "findings": [],
+        "promoted_tests": [],
+        "unresolved_candidates": [],
+        "summary": {
+            "all_successful": True,
+            "confirmed_bugs": 0,
+            "intentional_boundaries": 0,
+            "inconclusive": 0,
+            "failed_workers": 0,
+        },
+    }
+
+
+def default_campaign(root: Path) -> dict[str, Any]:
+    return {
+        "worktree_path": str(root.resolve()),
+        "target": "full",
+        "baseline_ref": None,
+        "seed": 157,
+        "max_workers": 4,
+        "cases_per_worker": 100,
+        "per_worker_timeout_s": 120,
+        "promote_regressions": True,
+        "notes": "AI48 contract-only coordinator; real campaign execution is deferred.",
+    }
+
+
+def load_campaign(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise FuzzInputError(f"unable to read campaign JSON: {path}") from exc
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Validate and plan a bounded adversarial-fuzz campaign.")
+    parser.add_argument("--campaign", type=Path, help="campaign JSON path; defaults to the built-in contract")
+    parser.add_argument("--output", type=Path, help="optional JSON output path inside the repository")
+    parser.add_argument("--dry-run", action="store_true", help="emit a deterministic plan without running workers")
+    args = parser.parse_args(argv[1:])
+    root = repository_root()
+    try:
+        raw = load_campaign(args.campaign) if args.campaign else default_campaign(root)
+        campaign = validate_campaign(raw, root)
+        result = build_result(campaign, dry_run=True)
+        encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            output = _inside(args.output, root, "output")
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(encoded, encoding="utf-8")
+        print(encoded, end="")
+        return 0
+    except FuzzInputError as exc:
+        print(f"fuzz: error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.just/run_fuzz.py
+++ b/.just/run_fuzz.py
@@ -207,7 +207,7 @@ def main(argv: list[str]) -> int:
     try:
         raw = load_campaign(args.campaign) if args.campaign else default_campaign(root)
         campaign = validate_campaign(raw, root)
-        result = build_result(campaign, dry_run=True)
+        result = build_result(campaign, dry_run=args.dry_run)
         encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
         if args.output:
             output = _inside(args.output, root, "output")

--- a/.just/tests/test_benchmark_report.py
+++ b/.just/tests/test_benchmark_report.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/smoke/benchmark_report.py"
+spec = importlib.util.spec_from_file_location("benchmark_report", SCRIPT)
+assert spec and spec.loader
+REPORT = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(REPORT)
+
+
+class BenchmarkReportTests(unittest.TestCase):
+    def fixture(self, name: str) -> Path:
+        return ROOT / ".just/fixtures/benchmark" / name
+
+    def test_migrates_v1_and_strips_private_fields(self) -> None:
+        result = REPORT.load_result(self.fixture("legacy-v1.json"))
+        self.assertEqual(result["migration"], {"from_schema_version": 1})
+        self.assertEqual(result["runs"][0]["label"], "legacy")
+        encoded = json.dumps(REPORT.load_result(self.fixture("success-uds-f1.json")))
+        self.assertNotIn("/Users/", encoded)
+        self.assertNotIn("peer_host", encoded)
+
+    def test_transport_and_profile_are_preserved(self) -> None:
+        uds = REPORT.load_result(self.fixture("success-uds-f1.json"))
+        tcp = REPORT.load_result(self.fixture("failed-tcp-f8.json"))
+        self.assertEqual((uds["transport"], uds["frames_per_connection"]), ("uds", 1))
+        self.assertEqual((tcp["transport"], tcp["frames_per_connection"]), ("tcp", 8))
+
+    def test_failed_run_is_retained(self) -> None:
+        result = REPORT.load_result(self.fixture("failed-tcp-f8.json"))
+        self.assertFalse(result["passed"])
+        self.assertEqual(result["runs"][0]["intervals"][0]["accepted_count"], 999)
+        self.assertEqual(result["failure"], "one admission failed")
+
+    def test_immutable_write_rejects_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "artifact.json"
+            self.assertTrue(REPORT.immutable_write(path, "one\n"))
+            self.assertFalse(REPORT.immutable_write(path, "one\n"))
+            with self.assertRaisesRegex(REPORT.BenchmarkReportError, "immutable"):
+                REPORT.immutable_write(path, "two\n")
+
+    def test_persist_writes_ai46_envelope_sidecar(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report_dir = Path(directory) / "report"
+            with mock.patch.object(REPORT, "REPORT_DIR", report_dir):
+                result, artifact_id = REPORT.persist(self.fixture("success-uds-f1.json"))
+            artifact = json.loads((report_dir / f"{artifact_id}.json").read_text())
+            envelope = json.loads((report_dir / f"{artifact_id}.envelope.json").read_text())
+            self.assertEqual(artifact["host_label"], "mac-arm64-01")
+            self.assertEqual(set(envelope), {"schema_version", "report_type", "generated_at", "host_label", "report_html"})
+            self.assertEqual(envelope["report_type"], "benchmark")
+
+    def test_aggregate_orders_utc_history_and_separates_transports(self) -> None:
+        records = [
+            REPORT.load_result(self.fixture("success-uds-f1.json")),
+            REPORT.load_result(self.fixture("failed-tcp-f8.json")),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with mock.patch.object(REPORT, "ROOT", ROOT):
+                output = REPORT.render_aggregate(records, root)
+            text = output.read_text(encoding="utf-8")
+            self.assertIn("mac-arm64-01", text)
+            self.assertIn("uds", text)
+            self.assertIn("tcp", text)
+            self.assertLess(text.index("2026-08-01T01:00:00Z"), text.index("2026-08-01T01:01:00Z"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_pages_site.py
+++ b/.just/tests/test_pages_site.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOME = REPO_ROOT / "site/index.html"
+WORKFLOW = REPO_ROOT / ".github/workflows/pages.yml"
+
+
+class LinkParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "a":
+            self.links.extend(value for name, value in attrs if name == "href" and value is not None)
+
+
+class PagesSiteTests(unittest.TestCase):
+    def test_home_links_to_generated_reports_index(self) -> None:
+        parser = LinkParser()
+        parser.feed(HOME.read_text(encoding="utf-8"))
+        self.assertIn("reports/index.html", parser.links)
+        self.assertTrue((HOME.parent / "reports/index.html").is_file())
+
+    def test_pages_workflow_validates_and_uploads_only_site(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("just reports-index --check", workflow)
+        self.assertIn("actions/upload-pages-artifact@v3", workflow)
+        self.assertIn("path: site", workflow)
+        self.assertIn("actions/deploy-pages@v4", workflow)
+        self.assertIn("pages: write", workflow)
+        self.assertIn("id-token: write", workflow)
+
+    def test_pages_workflow_is_the_only_pages_publisher(self) -> None:
+        workflow_text = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in (REPO_ROOT / ".github/workflows").glob("*.y*ml")
+        )
+        self.assertEqual(workflow_text.count("actions/upload-pages-artifact@"), 1)
+        self.assertEqual(workflow_text.count("actions/deploy-pages@"), 1)
+        self.assertNotIn("peaceiris/actions-gh-pages", workflow_text)
+
+    def test_workflow_has_integrate_trigger_and_manual_trigger(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("integrate/phase-ai-31-33", workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+import tempfile
+import unittest
+
+
+JUST_DIR = Path(__file__).resolve().parents[1]
+if str(JUST_DIR) not in sys.path:
+    sys.path.insert(0, str(JUST_DIR))
+
+from run_fuzz import FuzzInputError
+from run_fuzz import build_result
+from run_fuzz import validate_campaign
+from run_fuzz import validate_worker_result
+
+
+FIXTURES = JUST_DIR / "fixtures/fuzz"
+
+
+class FuzzRunnerTests(unittest.TestCase):
+    def test_success_campaign_is_deterministic_and_four_workers(self) -> None:
+        campaign = validate_campaign(json.loads((FIXTURES / "success.json").read_text()), Path.cwd())
+        first = build_result(campaign)
+        second = build_result(campaign)
+        self.assertEqual(first, second)
+        self.assertEqual([item["correlation_id"] for item in first["workers"]], [
+            "shape-probe", "template-probe", "boundary-probe", "differential-probe"
+        ])
+        self.assertEqual(first["schema_version"], "adversarial-fuzzing/v1")
+
+    def test_timeout_result_is_preserved_as_structured_failure(self) -> None:
+        result = json.loads((FIXTURES / "timeout.json").read_text())
+        validated = validate_worker_result(result)
+        self.assertEqual(validated["status"], "timed_out")
+        self.assertEqual(validated["error"]["code"], "worker_timeout")
+
+    def test_malformed_result_fails_closed(self) -> None:
+        result = json.loads((FIXTURES / "malformed-result.json").read_text())
+        with self.assertRaisesRegex(FuzzInputError, "missing worker result fields"):
+            validate_worker_result(result)
+
+    def test_unsafe_worktree_fails_closed(self) -> None:
+        payload = json.loads((FIXTURES / "unsafe-path.json").read_text())
+        with tempfile.TemporaryDirectory() as tempdir:
+            with self.assertRaisesRegex(FuzzInputError, "inside the repository"):
+                validate_campaign(payload, Path(tempdir))
+
+    def test_worker_cap_rejects_more_than_four(self) -> None:
+        payload = json.loads((FIXTURES / "success.json").read_text())
+        payload["max_workers"] = 5
+        with self.assertRaisesRegex(FuzzInputError, "max_workers"):
+            validate_campaign(payload, Path.cwd())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -54,6 +54,9 @@ class FuzzRunnerTests(unittest.TestCase):
     def test_unsafe_worktree_fails_closed(self) -> None:
         payload = json.loads((FIXTURES / "unsafe-path.json").read_text())
         with tempfile.TemporaryDirectory() as tempdir:
+            # The fixture's Unix spelling is not absolute on Windows. Use a
+            # host-native path outside the temporary repository in every CI OS.
+            payload["worktree_path"] = str(Path(tempdir).parent / "not-an-approved-worktree")
             with self.assertRaisesRegex(FuzzInputError, "inside the repository"):
                 validate_campaign(payload, Path(tempdir))
 

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from contextlib import redirect_stdout
+import io
 from pathlib import Path
 import json
 import sys
@@ -13,6 +15,7 @@ if str(JUST_DIR) not in sys.path:
 
 from run_fuzz import FuzzInputError
 from run_fuzz import build_result
+from run_fuzz import main
 from run_fuzz import validate_campaign
 from run_fuzz import validate_worker_result
 
@@ -54,11 +57,22 @@ class FuzzRunnerTests(unittest.TestCase):
     def test_unsafe_worktree_fails_closed(self) -> None:
         payload = json.loads((FIXTURES / "unsafe-path.json").read_text())
         with tempfile.TemporaryDirectory() as tempdir:
-            # The fixture's Unix spelling is not absolute on Windows. Use a
-            # host-native path outside the temporary repository in every CI OS.
-            payload["worktree_path"] = str(Path(tempdir).parent / "not-an-approved-worktree")
+            # The fixture uses a rooted UNC spelling, which pathlib recognizes
+            # as absolute on both POSIX and Windows while remaining outside
+            # this temporary repository.
             with self.assertRaisesRegex(FuzzInputError, "inside the repository"):
                 validate_campaign(payload, Path(tempdir))
+
+    def test_cli_forwards_dry_run_flag(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(main(["run_fuzz.py"]), 0)
+        self.assertEqual(json.loads(output.getvalue())["execution_mode"], "contract-only")
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(main(["run_fuzz.py", "--dry-run"]), 0)
+        self.assertEqual(json.loads(output.getvalue())["execution_mode"], "dry-run")
 
     def test_worker_cap_rejects_more_than_four(self) -> None:
         payload = self.campaign_fixture("success.json")

--- a/.just/tests/test_run_fuzz.py
+++ b/.just/tests/test_run_fuzz.py
@@ -21,8 +21,17 @@ FIXTURES = JUST_DIR / "fixtures/fuzz"
 
 
 class FuzzRunnerTests(unittest.TestCase):
+    def campaign_fixture(self, name: str) -> dict:
+        payload = json.loads((FIXTURES / name).read_text())
+        # Keep the fixture repository-independent: CI checks out to a different
+        # absolute path on every host, while the contract requires an absolute
+        # approved worktree path.
+        if "worktree_path" in payload:
+            payload["worktree_path"] = str(Path.cwd())
+        return payload
+
     def test_success_campaign_is_deterministic_and_four_workers(self) -> None:
-        campaign = validate_campaign(json.loads((FIXTURES / "success.json").read_text()), Path.cwd())
+        campaign = validate_campaign(self.campaign_fixture("success.json"), Path.cwd())
         first = build_result(campaign)
         second = build_result(campaign)
         self.assertEqual(first, second)
@@ -49,7 +58,7 @@ class FuzzRunnerTests(unittest.TestCase):
                 validate_campaign(payload, Path(tempdir))
 
     def test_worker_cap_rejects_more_than_four(self) -> None:
-        payload = json.loads((FIXTURES / "success.json").read_text())
+        payload = self.campaign_fixture("success.json")
         payload["max_workers"] = 5
         with self.assertRaisesRegex(FuzzInputError, "max_workers"):
             validate_campaign(payload, Path.cwd())

--- a/.triage/phase-AI/findings/AI49-BENCHMARK-ARTIFACT-MISSING.ttl
+++ b/.triage/phase-AI/findings/AI49-BENCHMARK-ARTIFACT-MISSING.ttl
@@ -15,29 +15,33 @@
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-31T00:00:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "2026-07-31 (quality-mgr, AI49-QA-2): independently re-verified at feature/pAI-s49-benchmark-report@6fcbf3ea -- site/reports/send-message-benchmark.html and site/reports/send-message-benchmark/ (uds-f1, tcp-f8 profiles with .json/.envelope.json/.xhtml) are present and git-tracked with a real rendered history table, not a stub. Confirmed via direct file read plus independent req-qa/arch-qa/ruthless-boundary-qa/rust-qa-agent dispositions, not self-report." ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-07-31T23:15:00Z"^^xsd:dateTime ;
   triage:foundIn triage:AI49 ;
   triage:foundAt "2026-07-31T22:00:00Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI49-BENCHMARK-ARTIFACT-MISSING/AI49-1> ;
-  triage:triageRecordVersion "1" .
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/AI49-BENCHMARK-ARTIFACT-MISSING/AI49-1>
   a triage:Occurrence ;
   triage:file "site/reports/send-message-benchmark.html" ;
   triage:line 0 ;
   triage:snippet "[missing benchmark report HTML]" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAI-s49-benchmark-report" ;
-  triage:headSha "bedcb4b8" ;
-  triage:occursIn <urn:atm:triage:worktree/s49/bedcb4b8> .
+  triage:headSha "6fcbf3ea" ;
+  triage:occursIn <urn:atm:triage:worktree/s49/6fcbf3ea> .
 
-<urn:atm:triage:worktree/s49/bedcb4b8>
+<urn:atm:triage:worktree/s49/6fcbf3ea>
   a triage:WorktreeSnapshot ;
   triage:path "feature/pAI-s49-benchmark-report" ;
   triage:branch "feature/pAI-s49-benchmark-report" ;
-  triage:headSha "bedcb4b8" ;
+  triage:headSha "6fcbf3ea" ;
   triage:orderIndex 0 ;
-  triage:status "open" .
+  triage:status "fixed" .

--- a/.triage/phase-AI/findings/AI49-BENCHMARK-ARTIFACT-MISSING.ttl
+++ b/.triage/phase-AI/findings/AI49-BENCHMARK-ARTIFACT-MISSING.ttl
@@ -1,0 +1,43 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/AI49-BENCHMARK-ARTIFACT-MISSING>
+  a triage:Finding ;
+  triage:findingId "AI49-BENCHMARK-ARTIFACT-MISSING" ;
+  triage:title "Named Exact Target benchmark artifact never persisted" ;
+  triage:description "AI.49 sprint doc's Exact Targets list site/reports/send-message-benchmark.html plus its containing directory. quality-mgr confirmed via direct find that neither the file nor directory exists anywhere in the repo at PR #707 head (feature/pAI-s49-benchmark-report @ bedcb4b8). No real benchmark artifact was ever generated/committed." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "deliverable-missing" ;
+  triage:severity "blocking" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-31T23:15:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AI49 ;
+  triage:foundAt "2026-07-31T22:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI49-BENCHMARK-ARTIFACT-MISSING/AI49-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/AI49-BENCHMARK-ARTIFACT-MISSING/AI49-1>
+  a triage:Occurrence ;
+  triage:file "site/reports/send-message-benchmark.html" ;
+  triage:line 0 ;
+  triage:snippet "[missing benchmark report HTML]" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s49-benchmark-report" ;
+  triage:headSha "bedcb4b8" ;
+  triage:occursIn <urn:atm:triage:worktree/s49/bedcb4b8> .
+
+<urn:atm:triage:worktree/s49/bedcb4b8>
+  a triage:WorktreeSnapshot ;
+  triage:path "feature/pAI-s49-benchmark-report" ;
+  triage:branch "feature/pAI-s49-benchmark-report" ;
+  triage:headSha "bedcb4b8" ;
+  triage:orderIndex 0 ;
+  triage:status "open" .

--- a/.triage/phase-AI/findings/AI49-CI-SCCOMPOSE-LINT.ttl
+++ b/.triage/phase-AI/findings/AI49-CI-SCCOMPOSE-LINT.ttl
@@ -14,28 +14,33 @@
   triage:severity "blocking" ;
   triage:repeatable true ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedAt "2026-07-31T00:00:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
+  triage:closureNote "2026-07-31 (quality-mgr, AI49-QA-2): independently re-verified at feature/pAI-s49-benchmark-report@6fcbf3ea -- .github/workflows/ci.yml now installs sc-compose (cargo install --git https://github.com/randlee/sc-compose.git --tag v1.2.0 --locked --bin sc-compose) and exposes ~/.cargo/bin on PATH before `just lint` on all 3 matrix OSes. Confirmed via gh pr checks 707: Just lint (ubuntu-latest) and Just lint (macos-latest) pass on 6fcbf3ea; sc-compose install step itself succeeds on windows-latest too (that leg's residual failure is unrelated -- see AI49-WINDOWS-PATH-ASSERTION-REGRESSION). Confirmed via direct file read plus independent req-qa/arch-qa/ruthless-boundary-qa/rust-qa-agent dispositions, not self-report." ;
   triage:dispatchReady true ;
   triage:triagedAt "2026-08-01T01:18:23Z"^^xsd:dateTime ;
   triage:hasOccurrence <urn:atm:triage:occurrence/AI49-CI-SCCOMPOSE-LINT/s49/1> ;
-  triage:openOn <urn:atm:triage:worktree/s49/bedcb4b8> ;
-  triage:promoteTo <urn:atm:triage:worktree/s49/bedcb4b8> .
+  triage:openOn <urn:atm:triage:worktree/s49/6fcbf3ea> ;
+  triage:promoteTo <urn:atm:triage:worktree/s49/6fcbf3ea> ;
+  triage:triageRecordVersion "2" .
 
 <urn:atm:triage:occurrence/AI49-CI-SCCOMPOSE-LINT/s49/1>
   a triage:Occurrence ;
   triage:file ".just/tests/test_benchmark_report.py" ;
   triage:line 1 ;
   triage:snippet "test_aggregate_orders_utc_history_and_separates_transports invokes sc-compose via benchmark_report.py" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "feature/pAI-s49-benchmark-report" ;
-  triage:headSha "bedcb4b8" ;
-  triage:occursIn <urn:atm:triage:worktree/s49/bedcb4b8> .
+  triage:headSha "6fcbf3ea" ;
+  triage:occursIn <urn:atm:triage:worktree/s49/6fcbf3ea> .
 
-<urn:atm:triage:worktree/s49/bedcb4b8>
+<urn:atm:triage:worktree/s49/6fcbf3ea>
   a triage:WorktreeSnapshot ;
   triage:branch "feature/pAI-s49-benchmark-report" ;
   triage:path "feature/pAI-s49-benchmark-report" ;
-  triage:headSha "bedcb4b8" ;
+  triage:headSha "6fcbf3ea" ;
   triage:orderIndex 0 ;
-  triage:status "open" .
+  triage:status "fixed" .

--- a/.triage/phase-AI/findings/AI49-CI-SCCOMPOSE-LINT.ttl
+++ b/.triage/phase-AI/findings/AI49-CI-SCCOMPOSE-LINT.ttl
@@ -1,0 +1,41 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:atm:triage:finding/AI49-CI-SCCOMPOSE-LINT>
+  a triage:Finding ;
+  triage:findingId "AI49-CI-SCCOMPOSE-LINT" ;
+  triage:foundIn triage:AI49 ;
+  triage:foundAt "2026-07-31T22:00:00Z"^^xsd:dateTime ;
+  triage:title "`just lint` fails on all CI platforms (sc-compose not in PATH)" ;
+  triage:description "The pytest suite invoked by `just lint` runs `.just/tests/test_benchmark_report.py::BenchmarkReportTests::test_aggregate_orders_utc_history_and_separates_transports`, which shells out to the `sc-compose` binary (used by `scripts/smoke/benchmark_report.py` to render templates). The `Just lint` GitHub Actions job never installs or exposes `sc-compose` on PATH, so the test fails identically on all three CI platforms (ubuntu-latest, macos-latest, windows-latest) with `FileNotFoundError: [Errno 2] No such file or directory: 'sc-compose'`. Root cause confirmed via `gh run view --log` on run 30677243303. Affects PR #707, branch feature/pAI-s49-benchmark-report @ bedcb4b8." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "ci-environment-gap" ;
+  triage:severity "blocking" ;
+  triage:repeatable true ;
+  triage:sweepScope "file_only" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-08-01T01:18:23Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/AI49-CI-SCCOMPOSE-LINT/s49/1> ;
+  triage:openOn <urn:atm:triage:worktree/s49/bedcb4b8> ;
+  triage:promoteTo <urn:atm:triage:worktree/s49/bedcb4b8> .
+
+<urn:atm:triage:occurrence/AI49-CI-SCCOMPOSE-LINT/s49/1>
+  a triage:Occurrence ;
+  triage:file ".just/tests/test_benchmark_report.py" ;
+  triage:line 1 ;
+  triage:snippet "test_aggregate_orders_utc_history_and_separates_transports invokes sc-compose via benchmark_report.py" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s49-benchmark-report" ;
+  triage:headSha "bedcb4b8" ;
+  triage:occursIn <urn:atm:triage:worktree/s49/bedcb4b8> .
+
+<urn:atm:triage:worktree/s49/bedcb4b8>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s49-benchmark-report" ;
+  triage:path "feature/pAI-s49-benchmark-report" ;
+  triage:headSha "bedcb4b8" ;
+  triage:orderIndex 0 ;
+  triage:status "open" .

--- a/.triage/phase-AI/findings/ATM-QA-001.ttl
+++ b/.triage/phase-AI/findings/ATM-QA-001.ttl
@@ -1,42 +1,63 @@
 @prefix triage: <urn:atm:triage:> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-# Persisted file/path values are repository-relative. Runtime checkout paths
-# belong in the agent input only and must not be copied into this record.
-
 <urn:atm:triage:finding/ATM-QA-001>
   a triage:Finding ;
   triage:findingId "ATM-QA-001" ;
-  triage:title "Named Exact Target benchmark artifact never persisted" ;
-  triage:description "AI.49 sprint doc's Exact Targets list site/reports/send-message-benchmark.html plus its containing directory. quality-mgr confirmed via direct find that neither the file nor directory exists anywhere in the repo at PR #707 head (feature/pAI-s49-benchmark-report @ bedcb4b8). No real benchmark artifact was ever generated/committed." ;
+  triage:foundIn triage:AICH-Legacy ;
+  triage:foundAt "2026-07-20T00:00:00Z"^^xsd:dateTime ;
+  triage:title "Sprint-doc status gate: sprint-ai-2.md still reads status: proposed on the authoritative planning branch" ;
+  triage:description "AI2-QA-1 (req-qa) on PR #597: authoritative sprint doc plan/phase-ai-planning/docs/plans/phase-ai/sprint-ai-2.md:3 still reads 'status: proposed'. Standing policy requires status: complete before QA can PASS. Confirmed by direct inspection: plan/phase-ai-planning copy still 'proposed', while feature/pAI-s2-storage-topology's own copy of the same file was hand-edited to 'complete' (see ATM-QA-002 for the divergence this created)." ;
   triage:phaseId "phase-AI" ;
   triage:triageMode "initial_pass" ;
-  triage:category "deliverable-missing" ;
+  triage:category "QA" ;
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
-  triage:dispatchReady true ;
-  triage:triagedAt "2026-07-31T23:15:00Z"^^xsd:dateTime ;
-  triage:foundIn triage:AI49 ;
-  triage:foundAt "2026-07-31T22:00:00Z"^^xsd:dateTime ;
-  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-001/AI49-1> ;
-  triage:triageRecordVersion "1" .
+  triage:status "fixed" ;
+  triage:dispatchReady false ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-001/pAI-2/1> ;
+  triage:openOn <urn:atm:triage:worktree/pAI-2/770dd8ed> ;
+  triage:promoteTo <urn:atm:triage:worktree/pAI-2/770dd8ed> ;
+  triage:highestOpenBranch "feature/pAI-s2-storage-topology" ;
+  triage:resolution "Fixed on feature/pAI-s2-storage-topology closure round; see PR #597 Windows validation notes." ;
+  triage:triagedAt "2026-07-20T00:00:00Z"^^xsd:dateTime .
 
-<urn:atm:triage:occurrence/ATM-QA-001/AI49-1>
+<urn:atm:triage:occurrence/ATM-QA-001/pAI-2/1>
   a triage:Occurrence ;
-  triage:file "site/reports/send-message-benchmark.html" ;
-  triage:line 0 ;
-  triage:snippet "[missing benchmark report HTML]" ;
-  triage:status "open" ;
-  triage:closed false ;
-  triage:branch "feature/pAI-s49-benchmark-report" ;
-  triage:headSha "bedcb4b8" ;
-  triage:occursIn <urn:atm:triage:worktree/s49/bedcb4b8> .
+  triage:file "docs/plans/phase-ai/sprint-ai-2.md" ;
+  triage:line 3 ;
+  triage:snippet "status: proposed (on plan/phase-ai-planning canonical copy; feature/pAI-s2-storage-topology's own copy independently reads status: complete)" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "feature/pAI-s2-storage-topology" ;
+  triage:headSha "770dd8ed" ;
+  triage:occursIn <urn:atm:triage:worktree/pAI-2/770dd8ed> .
 
-<urn:atm:triage:worktree/s49/bedcb4b8>
+<urn:atm:triage:worktree/pAI-1/c479452e>
   a triage:WorktreeSnapshot ;
-  triage:path "feature/pAI-s49-benchmark-report" ;
-  triage:branch "feature/pAI-s49-benchmark-report" ;
-  triage:headSha "bedcb4b8" ;
+  triage:branch "feature/pAI-1-daemon-preag-reset" ;
+  triage:path "feature/pAI-1-daemon-preag-reset" ;
+  triage:headSha "c479452e" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/pAI-2/770dd8ed>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s2-storage-topology" ;
+  triage:path "feature/pAI-s2-storage-topology" ;
+  triage:headSha "770dd8ed" ;
+  triage:orderIndex 2 .
+
+<urn:atm:triage:worktree/pAI-3/c9d62ff6>
+  a triage:WorktreeSnapshot ;
+  triage:branch "feature/pAI-s3-error-contract-foundation" ;
+  triage:path "feature/pAI-s3-error-contract-foundation" ;
+  triage:headSha "c9d62ff6" ;
+  triage:orderIndex 3 .
+
+<urn:atm:triage:worktree/integrate-phase-AI/00fe6608>
+  a triage:WorktreeSnapshot ;
+  triage:branch "integrate/phase-AI" ;
+  triage:path "integrate/phase-AI" ;
+  triage:headSha "00fe6608" ;
   triage:orderIndex 0 .

--- a/.triage/phase-AI/findings/ATM-QA-001.ttl
+++ b/.triage/phase-AI/findings/ATM-QA-001.ttl
@@ -1,63 +1,42 @@
 @prefix triage: <urn:atm:triage:> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
 <urn:atm:triage:finding/ATM-QA-001>
   a triage:Finding ;
   triage:findingId "ATM-QA-001" ;
-  triage:foundIn triage:AICH-Legacy ;
-  triage:foundAt "2026-07-20T00:00:00Z"^^xsd:dateTime ;
-  triage:title "Sprint-doc status gate: sprint-ai-2.md still reads status: proposed on the authoritative planning branch" ;
-  triage:description "AI2-QA-1 (req-qa) on PR #597: authoritative sprint doc plan/phase-ai-planning/docs/plans/phase-ai/sprint-ai-2.md:3 still reads 'status: proposed'. Standing policy requires status: complete before QA can PASS. Confirmed by direct inspection: plan/phase-ai-planning copy still 'proposed', while feature/pAI-s2-storage-topology's own copy of the same file was hand-edited to 'complete' (see ATM-QA-002 for the divergence this created)." ;
+  triage:title "Named Exact Target benchmark artifact never persisted" ;
+  triage:description "AI.49 sprint doc's Exact Targets list site/reports/send-message-benchmark.html plus its containing directory. quality-mgr confirmed via direct find that neither the file nor directory exists anywhere in the repo at PR #707 head (feature/pAI-s49-benchmark-report @ bedcb4b8). No real benchmark artifact was ever generated/committed." ;
   triage:phaseId "phase-AI" ;
   triage:triageMode "initial_pass" ;
-  triage:category "QA" ;
+  triage:category "deliverable-missing" ;
   triage:severity "blocking" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "fixed" ;
-  triage:dispatchReady false ;
-  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-001/pAI-2/1> ;
-  triage:openOn <urn:atm:triage:worktree/pAI-2/770dd8ed> ;
-  triage:promoteTo <urn:atm:triage:worktree/pAI-2/770dd8ed> ;
-  triage:highestOpenBranch "feature/pAI-s2-storage-topology" ;
-  triage:resolution "Fixed on feature/pAI-s2-storage-topology closure round; see PR #597 Windows validation notes." ;
-  triage:triagedAt "2026-07-20T00:00:00Z"^^xsd:dateTime .
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-31T23:15:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AI49 ;
+  triage:foundAt "2026-07-31T22:00:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-001/AI49-1> ;
+  triage:triageRecordVersion "1" .
 
-<urn:atm:triage:occurrence/ATM-QA-001/pAI-2/1>
+<urn:atm:triage:occurrence/ATM-QA-001/AI49-1>
   a triage:Occurrence ;
-  triage:file "docs/plans/phase-ai/sprint-ai-2.md" ;
-  triage:line 3 ;
-  triage:snippet "status: proposed (on plan/phase-ai-planning canonical copy; feature/pAI-s2-storage-topology's own copy independently reads status: complete)" ;
-  triage:status "fixed" ;
-  triage:closed true ;
-  triage:branch "feature/pAI-s2-storage-topology" ;
-  triage:headSha "770dd8ed" ;
-  triage:occursIn <urn:atm:triage:worktree/pAI-2/770dd8ed> .
+  triage:file "site/reports/send-message-benchmark.html" ;
+  triage:line 0 ;
+  triage:snippet "[missing benchmark report HTML]" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "feature/pAI-s49-benchmark-report" ;
+  triage:headSha "bedcb4b8" ;
+  triage:occursIn <urn:atm:triage:worktree/s49/bedcb4b8> .
 
-<urn:atm:triage:worktree/pAI-1/c479452e>
+<urn:atm:triage:worktree/s49/bedcb4b8>
   a triage:WorktreeSnapshot ;
-  triage:branch "feature/pAI-1-daemon-preag-reset" ;
-  triage:path "feature/pAI-1-daemon-preag-reset" ;
-  triage:headSha "c479452e" ;
-  triage:orderIndex 1 .
-
-<urn:atm:triage:worktree/pAI-2/770dd8ed>
-  a triage:WorktreeSnapshot ;
-  triage:branch "feature/pAI-s2-storage-topology" ;
-  triage:path "feature/pAI-s2-storage-topology" ;
-  triage:headSha "770dd8ed" ;
-  triage:orderIndex 2 .
-
-<urn:atm:triage:worktree/pAI-3/c9d62ff6>
-  a triage:WorktreeSnapshot ;
-  triage:branch "feature/pAI-s3-error-contract-foundation" ;
-  triage:path "feature/pAI-s3-error-contract-foundation" ;
-  triage:headSha "c9d62ff6" ;
-  triage:orderIndex 3 .
-
-<urn:atm:triage:worktree/integrate-phase-AI/00fe6608>
-  a triage:WorktreeSnapshot ;
-  triage:branch "integrate/phase-AI" ;
-  triage:path "integrate/phase-AI" ;
-  triage:headSha "00fe6608" ;
+  triage:path "feature/pAI-s49-benchmark-report" ;
+  triage:branch "feature/pAI-s49-benchmark-report" ;
+  triage:headSha "bedcb4b8" ;
   triage:orderIndex 0 .

--- a/.triage/phase-AI/findings/ATM-QA-681-R2-001.ttl
+++ b/.triage/phase-AI/findings/ATM-QA-681-R2-001.ttl
@@ -1,0 +1,49 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/ATM-QA-681-R2-001>
+  a triage:Finding ;
+  triage:findingId "ATM-QA-681-R2-001" ;
+  triage:title "Missing automated test for PyGraftSession.send(requires_ack=True)" ;
+  triage:description "Commit 106044e3 adds an optional requires_ack parameter to PyGraftSession.send(to, body, requires_ack=False) in crates/atm-graft-python/src/lib.rs:330-349, correctly wired into the canonical ack mechanism (SendRequest::new at lib.rs:333-344, flows into AckIntentFields::from_requires_ack at crates/atm-core/src/send/mod.rs:928, same path used by CLI/composition sends). No automated test exists for the requires_ack=True path: crates/atm-graft-python/tests/python_api.rs is only a crate-linkable smoke assertion; crates/atm-graft-python/tests/test_hermes_bridge.py has zero references to requires_ack or .send( on PyGraftSession. Only Cipher-311d's self-reported live smoke test (send requires_ack=True -> read pending ACK -> acknowledge against skillrx@hermes) covers this behavior, which does not substitute for a committed, repeatable test. Required correction: add a Rust or pytest case exercising send(..., requires_ack=True) -> resulting message pending-ack -> acknowledge() clears it, so behavior is CI-enforced." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "missing-test-coverage" ;
+  triage:severity "important" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "open" ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-28T05:32:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AICH-Legacy ;
+  triage:foundAt "2026-07-28T05:30:00Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/ATM-QA-681-R2-001/FHE-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/ATM-QA-681-R2-001/FHE-1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-graft-python/src/lib.rs" ;
+  triage:line 330 ;
+  triage:snippet "fn send(&self, to: PyAgentAddress, body: String, requires_ack: bool) -> PyResult<()> { ... } -- requires_ack=True path has no automated test coverage" ;
+  triage:status "open" ;
+  triage:closed false ;
+  triage:branch "fix/hermes-nudge-endpoint-mismatch" ;
+  triage:headSha "106044e3" ;
+  triage:occursIn <urn:atm:triage:worktree/FHE/106044e3> .
+
+<urn:atm:triage:worktree/FHE/106044e3>
+  a triage:WorktreeSnapshot ;
+  triage:path ".worktrees/fix/hermes-nudge-endpoint-mismatch" ;
+  triage:branch "fix/hermes-nudge-endpoint-mismatch" ;
+  triage:headSha "106044e3" ;
+  triage:orderIndex 1 .
+
+<urn:atm:triage:worktree/IAI/1d82ad9f>
+  a triage:WorktreeSnapshot ;
+  triage:path ".worktrees/integrate/phase-AI" ;
+  triage:branch "integrate/phase-AI" ;
+  triage:headSha "1d82ad9f" ;
+  triage:orderIndex 2 .

--- a/.triage/phase-AI/findings/QA-LINT-002.ttl
+++ b/.triage/phase-AI/findings/QA-LINT-002.ttl
@@ -1,0 +1,48 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/QA-LINT-002>
+  a triage:Finding ;
+  triage:findingId "QA-LINT-002" ;
+  triage:title "RULE-002 hard function-length violation in load_pending_ack_source" ;
+  triage:description "Function load_pending_ack_source in crates/atm-storage-rusqlite/src/writer/ops.rs (lines 93-189) is 97 lines, exceeding the 80-line hard limit enforced by scripts/check-function-length.py (part of just lint). This function was newly added in AI.31 fix round as part of sealing the ack-source read inside the atomic transaction. CI on feature/ai31-async-local-admission confirms this blocks just lint on all platforms (ubuntu-latest, macos-latest, windows-latest)." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "CI-LINT" ;
+  triage:severity "blocking" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedBy "quality-mgr" ;
+  triage:closedAt "2026-07-28T05:40:00Z"^^xsd:dateTime ;
+  triage:fixCommit "0ff0112ddcebdac8bd80ffe0200141fb42abda0" ;
+  triage:fixPr 677 ;
+  triage:closureNote "Fixed by splitting the 97-line load_pending_ack_source (crates/atm-storage-rusqlite/src/writer/ops.rs) into 4 functions, each under 80 lines: load_pending_ack_source (93-101), load_acknowledgement_source_row (112-157), reject_acknowledgement_source_with_successor (159-192), decode_pending_acknowledgement_source (194-222). Verified via scripts/check-function-length.py and direct file read by AI31-QA-4." ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-28T05:11:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AICH-S11 ;
+  triage:foundAt "2026-07-28T05:10:07Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/QA-LINT-002/ai31-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/QA-LINT-002/ai31-1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-storage-rusqlite/src/writer/ops.rs" ;
+  triage:line 93 ;
+  triage:snippet "fn load_pending_ack_source(source: &AcknowledgementSource, connection: &Connection, target: &SharedDbTarget) -> Result<Message, AtmError>" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "feature/ai31-async-local-admission" ;
+  triage:headSha "7188ca99" ;
+  triage:occursIn <urn:atm:triage:worktree/ai31/7188ca99> .
+
+<urn:atm:triage:worktree/ai31/7188ca99>
+  a triage:WorktreeSnapshot ;
+  triage:path ".worktrees/ai31" ;
+  triage:branch "feature/ai31-async-local-admission" ;
+  triage:headSha "7188ca99" ;
+  triage:orderIndex 1 .

--- a/.triage/phase-AI/findings/QA-LINT-003.ttl
+++ b/.triage/phase-AI/findings/QA-LINT-003.ttl
@@ -1,0 +1,48 @@
+@prefix triage: <urn:atm:triage:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Persisted file/path values are repository-relative. Runtime checkout paths
+# belong in the agent input only and must not be copied into this record.
+
+<urn:atm:triage:finding/QA-LINT-003>
+  a triage:Finding ;
+  triage:findingId "QA-LINT-003" ;
+  triage:title "RULE-003 file-size gate violation in send/mod.rs" ;
+  triage:description "File crates/atm-core/src/send/mod.rs now has 1002 production lines, exceeding the 1000-line hard limit enforced by .just/check_line_counts.py (part of just lint). This file was modified in AI.31 fix round (+92 lines net per git show --stat HEAD). CI on feature/ai31-async-local-admission confirms this blocks just lint on all platforms (ubuntu-latest, macos-latest, windows-latest)." ;
+  triage:phaseId "phase-AI" ;
+  triage:triageMode "initial_pass" ;
+  triage:category "CI-LINT" ;
+  triage:severity "blocking" ;
+  triage:repeatable false ;
+  triage:sweepScope "file_only" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:closedBy "quality-mgr" ;
+  triage:closedAt "2026-07-28T05:40:00Z"^^xsd:dateTime ;
+  triage:fixCommit "0ff0112ddcebdac8bd80ffe0200141fb42abda0" ;
+  triage:fixPr 677 ;
+  triage:closureNote "Fixed by extracting recipient-resolution logic and its tests out of crates/atm-core/src/send/mod.rs, now 965 production lines (under 1000-line RULE-003 limit). Verified via .just/check_line_counts.py by AI31-QA-4." ;
+  triage:dispatchReady true ;
+  triage:triagedAt "2026-07-28T05:11:00Z"^^xsd:dateTime ;
+  triage:foundIn triage:AICH-S11 ;
+  triage:foundAt "2026-07-28T05:10:07Z"^^xsd:dateTime ;
+  triage:hasOccurrence <urn:atm:triage:occurrence/QA-LINT-003/ai31-1> ;
+  triage:triageRecordVersion "1" .
+
+<urn:atm:triage:occurrence/QA-LINT-003/ai31-1>
+  a triage:Occurrence ;
+  triage:file "crates/atm-core/src/send/mod.rs" ;
+  triage:line 1 ;
+  triage:snippet "File exceeds 1000-line production limit (1002 lines total)" ;
+  triage:status "fixed" ;
+  triage:closed true ;
+  triage:branch "feature/ai31-async-local-admission" ;
+  triage:headSha "7188ca99" ;
+  triage:occursIn <urn:atm:triage:worktree/ai31/7188ca99> .
+
+<urn:atm:triage:worktree/ai31/7188ca99>
+  a triage:WorktreeSnapshot ;
+  triage:path ".worktrees/ai31" ;
+  triage:branch "feature/ai31-async-local-admission" ;
+  triage:headSha "7188ca99" ;
+  triage:orderIndex 1 .

--- a/Justfile
+++ b/Justfile
@@ -137,6 +137,10 @@ build:
 test mode='default':
     {{python_cmd}} .just/run_tests.py {{mode}}
 
+# Validate and plan a bounded adversarial-fuzz campaign (no real execution).
+fuzz *args:
+    {{python_cmd}} .just/run_fuzz.py {{args}}
+
 # Generate or verify the durable public verification-report index.
 reports-index *args:
     {{python_cmd}} .just/generate_report_index.py {{args}}

--- a/Justfile
+++ b/Justfile
@@ -187,6 +187,10 @@ smoke feature='normal' *hosts:
 benchmark *args:
     {{python_cmd}} scripts/smoke/run_admission_capacity.py {{args}}
 
+# Persist AI.40 benchmark JSON and render the aggregate public report.
+benchmark-report *args:
+    {{python_cmd}} scripts/smoke/benchmark_report.py {{args}}
+
 # Generate architecture visualization artifacts.
 view target='all':
     {{python_cmd}} .just/run_view.py {{target}}

--- a/Justfile
+++ b/Justfile
@@ -173,6 +173,12 @@ validate target='all':
 smoke feature='normal' *hosts:
     {{python_cmd}} scripts/smoke/run_feature_smoke.py {{feature}} {{hosts}}
 
+# Run one isolated, release-built local admission benchmark. On Unix choose
+# UDS or loopback TCP; Windows accepts TCP only. The runner rejects ambient
+# daemon/database state and returns JSON to AI.49 rather than writing site/.
+benchmark *args:
+    {{python_cmd}} scripts/smoke/run_admission_capacity.py {{args}}
+
 # Generate architecture visualization artifacts.
 view target='all':
     {{python_cmd}} .just/run_view.py {{target}}

--- a/docs/fuzz-campaign-contract.md
+++ b/docs/fuzz-campaign-contract.md
@@ -1,0 +1,26 @@
+# AI48 fuzz campaign contract
+
+`just fuzz` validates this bounded campaign input and emits a deterministic,
+structured worker-result envelope. AI48 is contract-only: it does not invoke a
+real product campaign, mutate the approved worktree, or create HTML/XHTML
+reports. Later sprints own execution and publication.
+
+```json
+{
+  "worktree_path": "/absolute/path/to/approved/worktree",
+  "target": "var-file | frontmatter | resolver | renderer | includes | cli | full",
+  "baseline_ref": "optional git ref",
+  "seed": 157,
+  "max_workers": 4,
+  "cases_per_worker": 100,
+  "per_worker_timeout_s": 120,
+  "promote_regressions": true,
+  "notes": "optional target-specific context"
+}
+```
+
+`worktree_path` must resolve inside the repository or an approved sibling
+worktree, `max_workers` is capped at four, and all numeric limits are bounded.
+Worker results retain timeout and malformed-result failures instead of
+discarding them. Use `--campaign <path>` to validate a JSON file and
+`--output <path>` to save the emitted envelope under the repository.

--- a/docs/github-pages.md
+++ b/docs/github-pages.md
@@ -1,0 +1,26 @@
+# GitHub Pages verification site
+
+The repository's public verification site is the generated `site/` tree. The
+home page at [`site/index.html`](../site/index.html) links to the durable
+report catalog at [`site/reports/index.html`](../site/reports/index.html).
+Report producers regenerate and validate that catalog with:
+
+```bash
+just reports-index
+just reports-index --check
+```
+
+The sole publisher is [`.github/workflows/pages.yml`](../.github/workflows/pages.yml).
+It validates the generated catalog, uploads only `site/`, and deploys that
+artifact with the official GitHub Pages Actions. There is no second workflow,
+branch publisher, or transient `artifacts/view` publisher.
+
+## Repository setting
+
+In the repository's **Settings → Pages → Build and deployment**, set **Source**
+to **GitHub Actions**. This is the only repository-level Pages setting
+required; the workflow owns the build and deployment. The workflow publishes
+updates from `integrate/phase-ai-31-33` and can also be started manually.
+
+Do not select **Deploy from a branch**: that would create an alternate
+publisher and bypass the generated-index check.

--- a/docs/plans/phase-ai/sprint-ai-33-admission-capacity-smoke.md
+++ b/docs/plans/phase-ai/sprint-ai-33-admission-capacity-smoke.md
@@ -5,6 +5,7 @@ branch: feature/pAI-s33-admission-capacity-smoke
 target: integrate/phase-ai-31-33
 depends_on: AI.31, AI.32
 requires_merged_pr: PR #675 (keeper smoke runner on develop)
+worktree: /Users/randlee/Documents/github/atm-core-worktrees/feature/pAI-s33-admission-capacity-smoke
 ---
 
 # AI.33 — admission capacity and smoke evidence
@@ -47,11 +48,15 @@ not a license to add profiling state to production delivery.
 
 ## Deliverables
 
-1. First commit sets every releasable assembly to `1.4.0-beta-ai.33` and
-   records matching branch CLI/daemon values with `atm doctor --json`.
+1. Record matching branch CLI/daemon values with `atm doctor --json`. The
+   current integration line may already carry a later prerelease; a capacity
+   sprint never downgrades releasable assemblies solely to restore its old
+   sprint-number label.
 2. Add `scripts/smoke/run_admission_capacity.py` plus unit tests. It creates a
-   temporary `ATM_HOME`, starts exactly one release-built branch daemon for
-   that directory, and deletes the directory only after evidence collection.
+   temporary `ATM_HOME`, starts exactly one release-built branch daemon, and
+   deletes the directory only after evidence collection. Under ADR-026 it
+   additionally requires a dedicated clean OS-user environment: `ATM_HOME`
+   selects only config while the daemon and SQLite state remain host-owned.
    It must reject an unset/unsafe home path and never target `~/.atm` or a
    team/shared database.
 3. Drive the public daemon client/API, not a direct dispatcher or mock. For ten

--- a/docs/plans/phase-ai/sprint-ai-47-pages-site-home.md
+++ b/docs/plans/phase-ai/sprint-ai-47-pages-site-home.md
@@ -1,7 +1,8 @@
 ---
 title: AI.47 GitHub Pages site home
-status: planned
+status: complete
 branch: feature/pAI-s47-pages-site-home
+worktree: ../atm-core-worktrees/feature/pAI-s47-pages-site-home
 recommended_agent: Cipher-311d
 recommended_model: fast
 execution_mode: after_merge

--- a/docs/plans/phase-ai/sprint-ai-48-fuzz-tooling-port.md
+++ b/docs/plans/phase-ai/sprint-ai-48-fuzz-tooling-port.md
@@ -1,7 +1,8 @@
 ---
 title: AI.48 fuzz tooling port
-status: planned
+status: complete
 branch: feature/pAI-s48-fuzz-tooling-port
+worktree: ../atm-core-worktrees/feature/pAI-s48-fuzz-tooling-port
 recommended_agent: Cipher-311d
 recommended_model: fast
 execution_mode: parallel

--- a/docs/plans/phase-ai/sprint-ai-49-benchmark-report.md
+++ b/docs/plans/phase-ai/sprint-ai-49-benchmark-report.md
@@ -1,7 +1,8 @@
 ---
 title: AI.49 benchmark report
-status: planned
+status: complete
 branch: feature/pAI-s49-benchmark-report
+worktree: ../atm-core-worktrees/feature/pAI-s49-benchmark-report
 recommended_agent: Cipher-311d
 recommended_model: fast
 execution_mode: after_merge

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1019,7 +1019,7 @@ Implementation Branches:
 | `AI.40` | `planned` | `feature/pAI-s40-local-transport-benchmark` | clean local transport throughput benchmark; not an extension of abandoned AI.33 script |
 | `AI.43` | `planned` | `feature/pAI-s43-remote-https-response-framing` | buffered remote HTTPS response framing |
 | `AI.46` | `complete` | `feature/pAI-s46-reports-index` | generated durable reports index |
-| `AI.47` | `planned` | `feature/pAI-s47-pages-site-home` | GitHub Pages site home and deployment |
+| `AI.47` | `complete` | `feature/pAI-s47-pages-site-home` | GitHub Pages site home and deployment |
 | `AI.48` | `planned` | `feature/pAI-s48-fuzz-tooling-port` | ported `just fuzz` coordinator/probe tooling |
 | `AI.49` | `planned` | `feature/pAI-s49-benchmark-report` | durable benchmark JSON and aggregate HTML report |
 | `AI.50` | `planned` | `feature/pAI-s50-fuzz-report` | sc-compose-template fuzz report renderer |

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1021,7 +1021,7 @@ Implementation Branches:
 | `AI.46` | `complete` | `feature/pAI-s46-reports-index` | generated durable reports index |
 | `AI.47` | `complete` | `feature/pAI-s47-pages-site-home` | GitHub Pages site home and deployment |
 | `AI.48` | `complete` | `feature/pAI-s48-fuzz-tooling-port` | ported `just fuzz` coordinator/probe tooling |
-| `AI.49` | `planned` | `feature/pAI-s49-benchmark-report` | durable benchmark JSON and aggregate HTML report |
+| `AI.49` | `complete` | `feature/pAI-s49-benchmark-report` | durable benchmark JSON and aggregate HTML report |
 | `AI.50` | `planned` | `feature/pAI-s50-fuzz-report` | sc-compose-template fuzz report renderer |
 | `AI.51` | `planned` | `feature/pAI-s51-local-http-framing-adversarial-campaign` | bounded local HTTP framing campaign |
 | `AI.52` | `planned` | `feature/pAI-s52-windows-transport-benchmark` | cwin Windows TCP confirmation after accepted M5 performance evidence |

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1020,7 +1020,7 @@ Implementation Branches:
 | `AI.43` | `planned` | `feature/pAI-s43-remote-https-response-framing` | buffered remote HTTPS response framing |
 | `AI.46` | `complete` | `feature/pAI-s46-reports-index` | generated durable reports index |
 | `AI.47` | `complete` | `feature/pAI-s47-pages-site-home` | GitHub Pages site home and deployment |
-| `AI.48` | `planned` | `feature/pAI-s48-fuzz-tooling-port` | ported `just fuzz` coordinator/probe tooling |
+| `AI.48` | `complete` | `feature/pAI-s48-fuzz-tooling-port` | ported `just fuzz` coordinator/probe tooling |
 | `AI.49` | `planned` | `feature/pAI-s49-benchmark-report` | durable benchmark JSON and aggregate HTML report |
 | `AI.50` | `planned` | `feature/pAI-s50-fuzz-report` | sc-compose-template fuzz report renderer |
 | `AI.51` | `planned` | `feature/pAI-s51-local-http-framing-adversarial-campaign` | bounded local HTTP framing campaign |

--- a/scripts/smoke/benchmark_report.py
+++ b/scripts/smoke/benchmark_report.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Persist and render public-safe AI.40 local-transport benchmark evidence."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from html import escape
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any, Iterable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORTS_ROOT = ROOT / "site" / "reports"
+REPORT_NAME = "send-message-benchmark"
+REPORT_HTML = f"{REPORT_NAME}.html"
+REPORT_DIR = REPORTS_ROOT / REPORT_NAME
+ENVELOPE_SCHEMA_VERSION = 1
+AI40_SCHEMA_VERSION = 2
+SUPPORTED_TRANSPORTS = frozenset({"uds", "tcp"})
+SUPPORTED_FRAMES = frozenset({1, 2, 8, 16, 64})
+SAFE_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+ABSOLUTE_PATH = re.compile(r"(?:/Users/[^\s,;]+|/private/tmp/[^\s,;]+|/tmp/[^\s,;]+|[A-Za-z]:\\[^\s,;]+)")
+SENSITIVE_KEYS = frozenset({"atm_home", "daemon_pid", "doctor", "endpoint", "release", "peer_host", "current_dir", "home_dir", "path"})
+RUN_KEYS = frozenset({
+    "interval", "accepted_count", "requested_count", "response_count", "elapsed_seconds",
+    "admissions_per_second", "connections_per_second", "request_frames_per_second",
+    "application_wire_bytes", "application_wire_bytes_per_second", "bytes_per_second",
+    "latency_ms", "first_failure", "passed",
+})
+
+
+class BenchmarkReportError(ValueError):
+    """The benchmark result cannot be published as public evidence."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_utc(value: Any, source: Path) -> str:
+    if not isinstance(value, str) or not value:
+        raise BenchmarkReportError(f"{source}: generated_at must be a non-empty UTC timestamp")
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as error:
+        raise BenchmarkReportError(f"{source}: generated_at is not ISO-8601") from error
+    if parsed.tzinfo is None or parsed.utcoffset() != timezone.utc.utcoffset(parsed):
+        raise BenchmarkReportError(f"{source}: generated_at must include UTC timezone")
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def safe_label(value: Any, field: str, source: Path) -> str:
+    if not isinstance(value, str) or not SAFE_LABEL.fullmatch(value):
+        raise BenchmarkReportError(f"{source}: {field} is not a safe opaque label")
+    return value
+
+
+def safe_artifact_id(value: str) -> str:
+    candidate = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")[:128]
+    if not candidate or not SAFE_ID.fullmatch(candidate):
+        raise BenchmarkReportError(f"unsafe benchmark artifact id: {value!r}")
+    return candidate
+
+
+def public_string(value: str) -> str:
+    return ABSOLUTE_PATH.sub("<redacted-path>", value)[:2000]
+
+
+def public_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return public_string(value)
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return [public_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): public_value(item) for key, item in value.items() if str(key) not in SENSITIVE_KEYS}
+    return public_string(str(value))
+
+
+def migrate_result(payload: dict[str, Any], source: Path) -> dict[str, Any]:
+    """Migrate the short-lived AI.40 v1 fixture shape into schema v2."""
+    if payload.get("schema_version") == 1:
+        samples = payload.get("samples", payload.get("runs", []))
+        if not isinstance(samples, list):
+            raise BenchmarkReportError(f"{source}: legacy samples must be a list")
+        payload = {
+            **payload,
+            "schema_version": AI40_SCHEMA_VERSION,
+            "run_duration_s": payload.get("run_duration_s", payload.get("duration_seconds", 0)),
+            "runs": samples if samples and isinstance(samples[0], dict) and "intervals" in samples[0] else [{"label": "legacy", "intervals": samples}],
+            "migration": {"from_schema_version": 1},
+        }
+    if payload.get("schema_version") != AI40_SCHEMA_VERSION or isinstance(payload.get("schema_version"), bool):
+        raise BenchmarkReportError(f"{source}: expected AI.40 schema_version {AI40_SCHEMA_VERSION}")
+    return payload
+
+
+def validate_result(payload: dict[str, Any], source: Path) -> dict[str, Any]:
+    payload = migrate_result(payload, source)
+    generated_at = parse_utc(payload.get("generated_at", utc_now()), source)
+    host_label = safe_label(payload.get("host_label"), "host_label", source)
+    transport = payload.get("transport")
+    if transport not in SUPPORTED_TRANSPORTS:
+        raise BenchmarkReportError(f"{source}: transport must be uds or tcp")
+    frames = payload.get("frames_per_connection")
+    if isinstance(frames, bool) or frames not in SUPPORTED_FRAMES:
+        raise BenchmarkReportError(f"{source}: frames_per_connection must be one of 1, 2, 8, 16, 64")
+    duration = payload.get("run_duration_s")
+    if isinstance(duration, bool) or not isinstance(duration, (int, float)) or duration <= 0:
+        raise BenchmarkReportError(f"{source}: run_duration_s must be positive")
+    runs = payload.get("runs")
+    if not isinstance(runs, list) or not runs:
+        raise BenchmarkReportError(f"{source}: runs must be a non-empty list")
+    public_runs: list[dict[str, Any]] = []
+    for index, run in enumerate(runs):
+        if not isinstance(run, dict):
+            raise BenchmarkReportError(f"{source}: run {index} must be an object")
+        intervals = run.get("intervals")
+        if intervals is not None and not isinstance(intervals, list):
+            raise BenchmarkReportError(f"{source}: run {index} intervals must be a list")
+        retained = {key: public_value(value) for key, value in run.items() if key in RUN_KEYS}
+        if intervals is not None:
+            retained["intervals"] = [public_value(item) for item in intervals]
+        if "label" in run:
+            retained["label"] = public_string(str(run["label"]))
+        public_runs.append(retained)
+    result: dict[str, Any] = {
+        "schema_version": AI40_SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "host_label": host_label,
+        "transport": transport,
+        "frames_per_connection": frames,
+        "run_duration_s": duration,
+        "messages_per_connection": payload.get("messages_per_connection", frames),
+        "runs": public_runs,
+        "passed": bool(payload.get("passed", False)),
+    }
+    if "migration" in payload:
+        result["migration"] = public_value(payload["migration"])
+    for key in ("failure", "cleanup_failure"):
+        if payload.get(key):
+            result[key] = public_string(str(payload[key]))
+    return result
+
+
+def load_result(source: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise BenchmarkReportError(f"{source}: invalid JSON") from error
+    if not isinstance(payload, dict):
+        raise BenchmarkReportError(f"{source}: result must be a JSON object")
+    return validate_result(payload, source)
+
+
+def immutable_write(path: Path, content: str) -> bool:
+    """Write once; repeated identical writes are idempotent, mutations fail."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if path.read_text(encoding="utf-8") != content:
+            raise BenchmarkReportError(f"immutable artifact already exists with different content: {path}")
+        return False
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def result_id(result: dict[str, Any], _source: Path | None = None) -> str:
+    stamp = result["generated_at"].replace("-", "").replace(":", "").replace("T", "-").replace("Z", "")
+    return safe_artifact_id(f"{stamp}-{result['host_label']}-{result['transport']}-f{result['frames_per_connection']}")
+
+
+def compose(template: Path, variables: dict[str, Any], output: Path) -> None:
+    variables_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", encoding="utf-8", delete=False) as handle:
+            json.dump(variables, handle, sort_keys=True)
+            variables_path = Path(handle.name)
+        completed = subprocess.run(
+            ["sc-compose", "render", "--root", str(ROOT), "--file", str(template), "--var-file", str(variables_path), "--output", str(output)],
+            cwd=ROOT, capture_output=True, text=True, check=False,
+        )
+        if completed.returncode != 0:
+            raise BenchmarkReportError(f"sc-compose render failed: {completed.stderr.strip() or completed.stdout.strip()}")
+    finally:
+        if variables_path is not None:
+            variables_path.unlink(missing_ok=True)
+
+
+def evidence_records(report_dir: Path = REPORT_DIR) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    if not report_dir.is_dir():
+        return records
+    for path in sorted(report_dir.glob("*.json")):
+        if path.name.endswith(".envelope.json"):
+            continue
+        try:
+            records.append(load_result(path))
+        except BenchmarkReportError:
+            continue
+    return sorted(records, key=lambda item: (item["generated_at"], item["host_label"], item["transport"], item["frames_per_connection"]))
+
+
+def render_run(result: dict[str, Any], artifact_id: str, report_dir: Path = REPORT_DIR) -> Path:
+    output = report_dir / f"{artifact_id}.xhtml"
+    template = ROOT / "templates" / "benchmark-report" / "benchmark-run.xhtml.j2"
+    sample_html = []
+    for run in result["runs"]:
+        rows = []
+        for interval in run.get("intervals", []):
+            rows.append(
+                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>".format(
+                    escape(str(interval.get("interval", "—"))),
+                    escape(str(interval.get("accepted_count", "—"))),
+                    escape(str(interval.get("response_count", "—"))),
+                    escape(str(interval.get("elapsed_seconds", "—"))),
+                    escape(str(interval.get("admissions_per_second", "—"))),
+                    "PASS" if interval.get("passed") else "FAIL",
+                )
+            )
+        sample_html.append(
+            "<article class=\"benchmark-sample\"><h3>{}</h3><table><thead><tr>"
+            "<th>Interval</th><th>Accepted</th><th>Responses</th><th>Elapsed s</th>"
+            "<th>Admissions/s</th><th>Status</th></tr></thead><tbody>{}</tbody></table></article>".format(
+                escape(str(run.get("label", "sample"))), "".join(rows)
+            )
+        )
+    compose(
+        template,
+        {
+            "title": f"ATM benchmark run — {artifact_id}",
+            "artifact_id": artifact_id,
+            "generated_at": result["generated_at"],
+            "host_label": result["host_label"],
+            "transport": result["transport"],
+            "frames_per_connection": result["frames_per_connection"],
+            "run_duration_s": result["run_duration_s"],
+            "passed": result["passed"],
+            "failure": result.get("failure", ""),
+            "cleanup_failure": result.get("cleanup_failure", ""),
+            "sample_html": "".join(sample_html),
+        },
+        output,
+    )
+    return output
+
+
+def render_aggregate(records: Iterable[dict[str, Any]], report_root: Path = REPORTS_ROOT) -> Path:
+    rows = []
+    for result in records:
+        artifact_id = result_id(result)
+        rows.append({
+            "artifact_id": artifact_id,
+            "generated_at": result["generated_at"],
+            "host_label": result["host_label"],
+            "transport": result["transport"],
+            "frames_per_connection": result["frames_per_connection"],
+            "passed": result["passed"],
+            "json_href": f"{REPORT_NAME}/{artifact_id}.json",
+            "xhtml_href": f"{REPORT_NAME}/{artifact_id}.xhtml",
+        })
+    output = report_root / REPORT_HTML
+    template = ROOT / "templates" / "benchmark-report" / "benchmark-report.html.j2"
+    compose(template, {
+        "title": "ATM local transport benchmark", "generated_at": utc_now(),
+        "status": "PASS" if rows and all(row["passed"] for row in rows) else "FAIL" if rows else "INFO",
+        "rows": rows, "profile_count": len(rows),
+        "passed_count": sum(row["passed"] for row in rows),
+        "failed_count": sum(not row["passed"] for row in rows),
+    }, output)
+    return output
+
+
+def regenerate_index() -> None:
+    completed = subprocess.run(["just", "reports-index"], cwd=ROOT, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise BenchmarkReportError(f"reports-index failed: {completed.stderr.strip() or completed.stdout.strip()}")
+
+
+def persist(source: Path) -> tuple[dict[str, Any], str]:
+    result = load_result(source)
+    artifact_id = result_id(result, source)
+    artifact = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    envelope = json.dumps({
+        "schema_version": ENVELOPE_SCHEMA_VERSION, "report_type": "benchmark",
+        "generated_at": result["generated_at"], "host_label": result["host_label"],
+        "report_html": REPORT_HTML,
+    }, indent=2, sort_keys=True) + "\n"
+    immutable_write(REPORT_DIR / f"{artifact_id}.json", artifact)
+    immutable_write(REPORT_DIR / f"{artifact_id}.envelope.json", envelope)
+    return result, artifact_id
+
+
+def process(inputs: list[Path]) -> int:
+    errors: list[str] = []
+    if not inputs:
+        try:
+            render_aggregate(evidence_records())
+            regenerate_index()
+        except (BenchmarkReportError, OSError) as error:
+            errors.append(str(error))
+    for source in inputs:
+        try:
+            result, artifact_id = persist(source)
+            render_run(result, artifact_id)
+            render_aggregate(evidence_records())
+        except (BenchmarkReportError, OSError) as error:
+            errors.append(str(error))
+        finally:
+            try:
+                regenerate_index()
+            except BenchmarkReportError as error:
+                errors.append(str(error))
+    for error in errors:
+        print(f"benchmark-report: {error}", file=sys.stderr)
+    return 1 if errors else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, action="append", default=[], help="AI.40 result JSON (repeatable)")
+    parser.add_argument("--rebuild", action="store_true", help="re-render existing evidence without adding input")
+    args = parser.parse_args(argv)
+    if not args.input and not args.rebuild:
+        parser.error("provide --input PATH or --rebuild")
+    return process(args.input)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -44,6 +44,7 @@ ADMISSIONS_PER_INTERVAL = 1_000
 WORKERS = 64
 READY_TIMEOUT_SECONDS = 30.0
 CAPACITY_ROOT_PREFIX = "atm-capacity-"
+SPARSE_FRAMES_PER_CONNECTION = (1, 2, 8, 16, 64)
 
 
 @dataclass(frozen=True)
@@ -196,10 +197,19 @@ def http_request_body(home: Path, sequence: int, peer_host: str) -> bytes:
     return json.dumps(payload, separators=(",", ":")).encode("utf-8")
 
 
-def local_endpoint() -> LocalEndpoint:
+def validate_transport(transport: str) -> str:
+    """Keep platform transport selection explicit and comparable."""
+    if transport not in {"uds", "tcp"}:
+        raise SmokeError("capacity transport must be `uds` or `tcp`")
+    if os.name == "nt" and transport != "tcp":
+        raise SmokeError("Windows capacity benchmarking supports only `tcp`")
+    return transport
+
+
+def local_endpoint(transport: str) -> LocalEndpoint:
     """Resolve the documented UDS/TCP public API without a dispatcher seam."""
     runtime = os_account_home() / ".atm" / "daemon"
-    if os.name != "nt":
+    if transport == "uds":
         return LocalEndpoint("uds", str(runtime / "atm-daemon.sock"))
     try:
         record = json.loads((runtime / "local-http.json").read_text(encoding="utf-8"))
@@ -302,8 +312,18 @@ def write_evidence(directory: Path, evidence: dict[str, Any]) -> Path:
     return path
 
 
-def run_capacity(atm_home: Path, evidence_directory: Path, accepting_host: str, unavailable_host: str) -> tuple[int, Path]:
+def run_capacity(
+    atm_home: Path,
+    evidence_directory: Path,
+    accepting_host: str,
+    unavailable_host: str,
+    transport: str,
+    frames_per_connection: int,
+) -> tuple[int, Path]:
     """Start one branch daemon, exercise public UDS API, retain evidence, then clean up."""
+    transport = validate_transport(transport)
+    if frames_per_connection not in SPARSE_FRAMES_PER_CONNECTION:
+        raise SmokeError(f"frames per connection must be one of {SPARSE_FRAMES_PER_CONNECTION}")
     require_isolated_os_user()
     home = validate_capacity_home(atm_home)
     require_clean_host_daemon_state(smoke_label="admission-capacity smoke")
@@ -314,6 +334,12 @@ def run_capacity(atm_home: Path, evidence_directory: Path, accepting_host: str, 
     env = runtime_environment(home)
     process: subprocess.Popen[str] | None = None
     evidence: dict[str, Any] = {
+        "schema_version": 2,
+        "host_label": os.environ.get("ATM_CAPACITY_HOST_LABEL", "local"),
+        "transport": transport,
+        "frames_per_connection": frames_per_connection,
+        "run_duration_s": INTERVALS,
+        "messages_per_connection": frames_per_connection,
         "release": {"atm": str(atm), "atm_daemon": str(daemon)},
         "atm_home": str(home),
         "runs": [],
@@ -335,7 +361,7 @@ def run_capacity(atm_home: Path, evidence_directory: Path, accepting_host: str, 
         evidence["doctor"] = json.loads(doctor["stdout"])
         configure_controlled_peer(atm, env, accepting_host, "capacity-accepting-peer")
         configure_controlled_peer(atm, env, unavailable_host, "capacity-unavailable-peer")
-        endpoint = local_endpoint()
+        endpoint = local_endpoint(transport)
         if endpoint.kind == "uds" and not Path(str(endpoint.address)).exists():
             raise SmokeError(f"daemon did not publish public local socket {endpoint.address}")
         evidence["runs"] = [
@@ -379,13 +405,21 @@ def main() -> int:
     parser.add_argument("--evidence-dir", type=Path, default=ROOT / "artifacts" / "smoke" / "admission-capacity")
     parser.add_argument("--accepting-host", default="127.0.0.1")
     parser.add_argument("--unavailable-host", default="192.0.2.1")
+    parser.add_argument("--transport", default="uds" if os.name != "nt" else "tcp")
+    parser.add_argument("--frames-per-connection", type=int, default=1)
     args = parser.parse_args()
     if args.atm_home is None:
         with tempfile.TemporaryDirectory(prefix="atm-capacity-parent-") as temp:
             home = Path(temp) / f"{CAPACITY_ROOT_PREFIX}home"
-            code, evidence = run_capacity(home, args.evidence_dir, args.accepting_host, args.unavailable_host)
+            code, evidence = run_capacity(
+                home, args.evidence_dir, args.accepting_host, args.unavailable_host,
+                args.transport, args.frames_per_connection,
+            )
     else:
-        code, evidence = run_capacity(args.atm_home, args.evidence_dir, args.accepting_host, args.unavailable_host)
+        code, evidence = run_capacity(
+            args.atm_home, args.evidence_dir, args.accepting_host, args.unavailable_host,
+            args.transport, args.frames_per_connection,
+        )
     print(f"{'PASS' if code == 0 else 'FAIL'} admission-capacity evidence: {evidence}")
     return code
 

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Prove the public local ATM admission boundary accepts 1,000 writes/second.
+
+This runner is deliberately a *clean-user* smoke gate.  ADR-026 makes the
+daemon and its SQLite store OS-user-owned, not ``ATM_HOME``-owned.  Therefore
+it refuses to run beside an ambient daemon and requires an explicit isolated
+OS-user acknowledgement; changing ``ATM_HOME`` alone would not isolate a
+developer's real mail database.
+"""
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+from queue import Empty, Queue
+import socket
+import subprocess
+import sys
+import tempfile
+from threading import Thread
+import time
+from typing import Any, Callable
+
+if os.name != "nt":
+    import pwd
+
+from daemon_lifecycle import (
+    assert_no_process_leak,
+    count_atm_daemon_processes,
+    require_clean_host_daemon_state,
+    terminate_process,
+    wait_for_process_exit,
+)
+from smoke_common import SmokeError, command_result
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INTERVALS = 10
+ADMISSIONS_PER_INTERVAL = 1_000
+WORKERS = 64
+READY_TIMEOUT_SECONDS = 30.0
+CAPACITY_ROOT_PREFIX = "atm-capacity-"
+
+
+@dataclass(frozen=True)
+class AdmissionResult:
+    status: int
+    elapsed_ms: float
+    failure: str | None = None
+
+
+@dataclass(frozen=True)
+class LocalEndpoint:
+    """One authenticated public local daemon endpoint."""
+
+    kind: str
+    address: str | tuple[str, int]
+    capability: str | None = None
+
+
+def require_isolated_os_user() -> None:
+    """Reject a developer's ordinary account before any daemon can start."""
+    if os.environ.get("ATM_CAPACITY_ISOLATED_OS_USER") != "1":
+        raise SmokeError(
+            "set ATM_CAPACITY_ISOLATED_OS_USER=1 only in a dedicated clean OS-user environment; "
+            "ADR-026 forbids treating ATM_HOME as an isolated database"
+        )
+
+
+def os_account_home() -> Path:
+    """Match ADR-026's OS-account root instead of trusting a shell HOME override."""
+    if os.name == "nt":
+        profile = os.environ.get("USERPROFILE", "").strip()
+        if not profile:
+            raise SmokeError("could not resolve the Windows OS-user profile for capacity smoke")
+        return Path(profile)
+    return Path(pwd.getpwuid(os.geteuid()).pw_dir)
+
+
+def validate_capacity_home(path: Path) -> Path:
+    """Accept only a fresh, clearly disposable temporary config directory."""
+    if not path.is_absolute():
+        raise SmokeError("capacity ATM_HOME must be an absolute path")
+    resolved = path.resolve()
+    temporary = Path(tempfile.gettempdir()).resolve()
+    try:
+        resolved.relative_to(temporary)
+    except ValueError as error:
+        raise SmokeError("capacity ATM_HOME must be below the OS temporary directory") from error
+    if not resolved.name.startswith(CAPACITY_ROOT_PREFIX):
+        raise SmokeError(f"capacity ATM_HOME basename must start with {CAPACITY_ROOT_PREFIX!r}")
+    if resolved == os_account_home().resolve() / ".atm":
+        raise SmokeError("capacity runner must never target the production ~/.atm directory")
+    return resolved
+
+
+def release_binary(name: str) -> Path:
+    """Locate an already-built branch release executable without using PATH."""
+    suffix = ".exe" if os.name == "nt" else ""
+    path = ROOT / "target" / "release" / f"{name}{suffix}"
+    if not path.is_file():
+        raise SmokeError(f"release-built {name} is required at {path}; run cargo build --release first")
+    return path
+
+
+def runtime_environment(atm_home: Path) -> dict[str, str]:
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "ATM_HOME": str(atm_home),
+            "ATM_IDENTITY": "capacity-agent",
+            "ATM_TEAM": "capacity-team",
+            "ATM_DAEMON_READY_STDOUT": "1",
+        }
+    )
+    return environment
+
+
+def await_daemon_ready(process: subprocess.Popen[str]) -> None:
+    """Wait only for the daemon's explicit readiness signal."""
+    if process.stdout is None:
+        raise SmokeError("capacity daemon stdout was not captured")
+    lines: Queue[str | None] = Queue()
+
+    def read_stdout() -> None:
+        try:
+            for line in process.stdout:
+                lines.put(line)
+        finally:
+            lines.put(None)
+
+    Thread(target=read_stdout, name="atm-capacity-ready", daemon=True).start()
+    deadline = time.monotonic() + READY_TIMEOUT_SECONDS
+    last_line = ""
+    while time.monotonic() < deadline:
+        try:
+            line = lines.get(timeout=min(0.1, max(0.0, deadline - time.monotonic())))
+        except Empty:
+            if process.poll() is not None:
+                raise SmokeError(f"capacity daemon exited before ready: {last_line.strip()}")
+            continue
+        if line is None:
+            raise SmokeError(f"capacity daemon exited before ready: {last_line.strip()}")
+        last_line = line
+        if line.strip() == "ATM_DAEMON_READY":
+            return
+    raise SmokeError("capacity daemon did not publish ATM_DAEMON_READY within 30 seconds")
+
+
+def prepare_capacity_roster(atm: Path, env: dict[str, str], home: Path) -> None:
+    """Create the sole local recipient through the public CLI boundary."""
+    result = command_result(
+        [str(atm), "teams", "add-member", "capacity-team", "capacity-agent", "--home-dir", str(home), "--json"],
+        timeout=15.0,
+        env=env,
+    )
+    if result["exit_code"] != 0:
+        raise SmokeError(f"could not create capacity recipient: {result['stderr'].strip()}")
+
+
+def configure_controlled_peer(atm: Path, env: dict[str, str], host: str, fingerprint: str) -> None:
+    """Install one test-only trusted peer through the public CLI and reload path."""
+    result = command_result(
+        [
+            str(atm), "peer", "trust", "add", "--host", host,
+            "--fingerprint", fingerprint, "--yes",
+        ],
+        timeout=15.0,
+        env=env,
+    )
+    if result["exit_code"] != 0:
+        raise SmokeError(f"could not configure controlled peer {host}: {result['stderr'].strip()}")
+
+
+def http_request_body(home: Path, sequence: int, peer_host: str) -> bytes:
+    """Build the documented /v1/atm/messages request; no dispatcher shortcut."""
+    payload = {
+        "home_dir": str(home),
+        "current_dir": str(home),
+        "caller_identity": "capacity-agent",
+        "caller_team": "capacity-team",
+        "to": {"agent": "capacity-agent", "team": "capacity-team", "host": peer_host},
+        "message_source": {"Inline": f"capacity-{sequence}"},
+        "summary_override": None,
+        "requires_ack": False,
+        "task_id": None,
+        "parent_message_id": None,
+        "thread_mode": None,
+        "expires_at": None,
+        "dry_run": False,
+    }
+    return json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+
+def local_endpoint() -> LocalEndpoint:
+    """Resolve the documented UDS/TCP public API without a dispatcher seam."""
+    runtime = os_account_home() / ".atm" / "daemon"
+    if os.name != "nt":
+        return LocalEndpoint("uds", str(runtime / "atm-daemon.sock"))
+    try:
+        record = json.loads((runtime / "local-http.json").read_text(encoding="utf-8"))
+        address = record["ipv4_loopback"]
+        capability = record["capability_base64url"]
+        if not isinstance(address, str) or not isinstance(capability, str):
+            raise ValueError("missing loopback endpoint or capability")
+        host, port = address.rsplit(":", 1)
+        return LocalEndpoint("tcp", (host, int(port)), capability)
+    except (OSError, ValueError, json.JSONDecodeError, KeyError) as error:
+        raise SmokeError(f"could not read daemon local HTTP endpoint record: {error}") from error
+
+
+def read_http_status(stream: socket.socket) -> int:
+    """Read just enough of one close-delimited HTTP response to classify admission."""
+    data = bytearray()
+    while b"\r\n" not in data:
+        chunk = stream.recv(4096)
+        if not chunk:
+            raise SmokeError("daemon closed the local HTTP connection before a status line")
+        data.extend(chunk)
+        if len(data) > 8_192:
+            raise SmokeError("daemon local HTTP status line exceeded the safety bound")
+    status_line = bytes(data).split(b"\r\n", 1)[0].decode("ascii", "replace")
+    fields = status_line.split()
+    if len(fields) < 2 or not fields[1].isdigit():
+        raise SmokeError(f"daemon returned malformed HTTP status line: {status_line}")
+    return int(fields[1])
+
+
+def submit_admission(endpoint: LocalEndpoint, body: bytes) -> AdmissionResult:
+    """Submit one real same-host API request over the daemon's public local transport."""
+    started = time.perf_counter()
+    capability = (
+        f"X-ATM-Local-Capability: {endpoint.capability}\r\n".encode("ascii")
+        if endpoint.capability is not None
+        else b""
+    )
+    request = (
+        b"POST /v1/atm/messages HTTP/1.1\r\n"
+        b"Content-Type: application/json\r\n"
+        + capability
+        + f"Content-Length: {len(body)}\r\nConnection: close\r\n\r\n".encode("ascii")
+        + body
+    )
+    try:
+        family = socket.AF_UNIX if endpoint.kind == "uds" else socket.AF_INET
+        with socket.socket(family, socket.SOCK_STREAM) as stream:
+            stream.settimeout(3.5)
+            stream.connect(endpoint.address)
+            stream.sendall(request)
+            status = read_http_status(stream)
+        elapsed_ms = (time.perf_counter() - started) * 1_000
+        return AdmissionResult(status=status, elapsed_ms=elapsed_ms, failure=None if status == 201 else f"HTTP {status}")
+    except (OSError, SmokeError) as error:
+        return AdmissionResult(status=0, elapsed_ms=(time.perf_counter() - started) * 1_000, failure=str(error))
+
+
+def run_interval(submit: Callable[[int], AdmissionResult], interval: int) -> dict[str, Any]:
+    """Run one exactly-sized admission interval without retrying failed writes."""
+    started = time.perf_counter()
+    results: list[AdmissionResult] = []
+    with ThreadPoolExecutor(max_workers=WORKERS, thread_name_prefix="atm-capacity") as executor:
+        futures = [executor.submit(submit, interval * ADMISSIONS_PER_INTERVAL + sequence) for sequence in range(ADMISSIONS_PER_INTERVAL)]
+        for future in as_completed(futures):
+            results.append(future.result())
+    elapsed_seconds = time.perf_counter() - started
+    accepted = sum(result.status == 201 for result in results)
+    failures = [result.failure or f"HTTP {result.status}" for result in results if result.status != 201]
+    latencies = sorted(result.elapsed_ms for result in results)
+    return {
+        "interval": interval + 1,
+        "accepted_count": accepted,
+        "response_count": len(results),
+        "elapsed_seconds": elapsed_seconds,
+        "admissions_per_second": accepted / elapsed_seconds if elapsed_seconds else 0.0,
+        "latency_ms": {
+            "min": latencies[0] if latencies else 0.0,
+            "p50": latencies[len(latencies) // 2] if latencies else 0.0,
+            "max": latencies[-1] if latencies else 0.0,
+        },
+        "first_failure": failures[0] if failures else None,
+        "passed": accepted == ADMISSIONS_PER_INTERVAL and elapsed_seconds <= 1.0,
+    }
+
+
+def run_peer_case(endpoint: LocalEndpoint, home: Path, peer_host: str, label: str) -> dict[str, Any]:
+    """Collect all ten intervals for one configured peer state."""
+    def submit(sequence: int) -> AdmissionResult:
+        return submit_admission(endpoint, http_request_body(home, sequence, peer_host))
+
+    intervals = [run_interval(submit, interval) for interval in range(INTERVALS)]
+    return {"label": label, "peer_host": peer_host, "intervals": intervals, "passed": all(item["passed"] for item in intervals)}
+
+
+def write_evidence(directory: Path, evidence: dict[str, Any]) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"admission-capacity-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def run_capacity(atm_home: Path, evidence_directory: Path, accepting_host: str, unavailable_host: str) -> tuple[int, Path]:
+    """Start one branch daemon, exercise public UDS API, retain evidence, then clean up."""
+    require_isolated_os_user()
+    home = validate_capacity_home(atm_home)
+    require_clean_host_daemon_state(smoke_label="admission-capacity smoke")
+    before = count_atm_daemon_processes()
+    atm = release_binary("atm")
+    daemon = release_binary("atm-daemon")
+    home.mkdir(parents=True, exist_ok=False)
+    env = runtime_environment(home)
+    process: subprocess.Popen[str] | None = None
+    evidence: dict[str, Any] = {
+        "release": {"atm": str(atm), "atm_daemon": str(daemon)},
+        "atm_home": str(home),
+        "runs": [],
+        "stages": {
+            "runtime_view_validation": "daemon-owned; no peer/store/network work is requested by this client before response",
+            "sqlite_transaction": "measured by each public admission response latency",
+            "post_commit_signal": "not awaited by this runner",
+            "response_write": "included in each public admission response latency",
+        },
+    }
+    try:
+        prepare_capacity_roster(atm, env, home)
+        process = subprocess.Popen([str(daemon)], cwd=home, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        await_daemon_ready(process)
+        doctor = command_result([str(atm), "doctor", "--json"], timeout=10.0, env=env)
+        if doctor["exit_code"] != 0:
+            raise SmokeError(f"capacity doctor failed: {doctor['stderr'].strip()}")
+        evidence["daemon_pid"] = process.pid
+        evidence["doctor"] = json.loads(doctor["stdout"])
+        configure_controlled_peer(atm, env, accepting_host, "capacity-accepting-peer")
+        configure_controlled_peer(atm, env, unavailable_host, "capacity-unavailable-peer")
+        endpoint = local_endpoint()
+        if endpoint.kind == "uds" and not Path(str(endpoint.address)).exists():
+            raise SmokeError(f"daemon did not publish public local socket {endpoint.address}")
+        evidence["runs"] = [
+            run_peer_case(endpoint, home, accepting_host, "accepting-configured-peer"),
+            run_peer_case(endpoint, home, unavailable_host, "unavailable-configured-peer"),
+        ]
+        evidence["passed"] = all(run["passed"] for run in evidence["runs"])
+    except (OSError, ValueError, SmokeError) as error:
+        evidence["passed"] = False
+        evidence["failure"] = str(error)
+    finally:
+        if process is not None:
+            terminate_process(process.pid)
+            try:
+                wait_for_process_exit(process.pid, process_label="admission-capacity daemon")
+            except RuntimeError as error:
+                evidence["passed"] = False
+                evidence["cleanup_failure"] = str(error)
+        try:
+            assert_no_process_leak(before, count_atm_daemon_processes(), smoke_label="admission-capacity smoke")
+        except RuntimeError as error:
+            evidence["passed"] = False
+            evidence["cleanup_failure"] = str(error)
+        evidence_path = write_evidence(evidence_directory, evidence)
+        try:
+            if home.exists():
+                for child in sorted(home.rglob("*"), reverse=True):
+                    if child.is_file() or child.is_symlink():
+                        child.unlink()
+                    elif child.is_dir():
+                        child.rmdir()
+                home.rmdir()
+        except OSError as error:
+            raise SmokeError(f"could not remove temporary capacity ATM_HOME {home}: {error}") from error
+    return (0 if evidence.get("passed") else 1), evidence_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--atm-home", type=Path)
+    parser.add_argument("--evidence-dir", type=Path, default=ROOT / "artifacts" / "smoke" / "admission-capacity")
+    parser.add_argument("--accepting-host", default="127.0.0.1")
+    parser.add_argument("--unavailable-host", default="192.0.2.1")
+    args = parser.parse_args()
+    if args.atm_home is None:
+        with tempfile.TemporaryDirectory(prefix="atm-capacity-parent-") as temp:
+            home = Path(temp) / f"{CAPACITY_ROOT_PREFIX}home"
+            code, evidence = run_capacity(home, args.evidence_dir, args.accepting_host, args.unavailable_host)
+    else:
+        code, evidence = run_capacity(args.atm_home, args.evidence_dir, args.accepting_host, args.unavailable_host)
+    print(f"{'PASS' if code == 0 else 'FAIL'} admission-capacity evidence: {evidence}")
+    return code
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SmokeError as error:
+        print(f"capacity smoke error: {error}", file=sys.stderr)
+        raise SystemExit(2)

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -51,6 +51,7 @@ CROSSHOST_SEND = "crosshost-send"
 CROSSHOST_ACK = "crosshost-ack"
 CROSSHOST_CURL_PLAINTEXT = "crosshost-curl-plain"
 CROSSHOST_CURL_MTLS = "crosshost-curl-tls"
+ADMISSION_CAPACITY = "admission-capacity"
 DOCTOR_BODY = '{"home_dir":"","current_dir":"","team_override":null,"caller_team":null,"caller_identity":null}'
 DEFAULT_LIVE_REPETITIONS = 10
 
@@ -79,8 +80,13 @@ def branch_version() -> str:
         "cargo metadata",
     )
     packages = metadata.get("packages", []) if isinstance(metadata, dict) else []
-    versions = {package.get("version") for package in packages if package.get("name") in {"atm", "atm-daemon"}}
-    if len(versions) != 1 or not isinstance(next(iter(versions)), str):
+    selected = {
+        package.get("name"): package.get("version")
+        for package in packages
+        if package.get("name") in {"agent-team-mail", "atm-daemon"}
+    }
+    versions = set(selected.values())
+    if set(selected) != {"agent-team-mail", "atm-daemon"} or len(versions) != 1 or not isinstance(next(iter(versions)), str):
         raise SmokeError("cargo metadata did not expose one shared atm/atm-daemon version")
     return next(iter(versions))
 
@@ -834,6 +840,13 @@ def main() -> int:
     parser.add_argument("feature", nargs="?", default="normal")
     parser.add_argument("peers", nargs="*")
     args = parser.parse_args()
+    if args.feature == ADMISSION_CAPACITY:
+        if args.peers:
+            raise SmokeError("admission-capacity does not accept peer hostnames")
+        return subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "smoke" / "run_admission_capacity.py")],
+            check=False,
+        ).returncode
     if args.feature in FIXTURE_FEATURES:
         if args.peers:
             raise SmokeError(f"fixture smoke `{args.feature}` does not accept hostnames")
@@ -853,7 +866,7 @@ def main() -> int:
         raise SmokeError(
             "supported smoke features: fast, normal, thorough, localhost, local-ip, "
             "peer-preflight, crosshost-curl-plain, crosshost-curl-tls, "
-            "crosshost-send, crosshost-ack"
+            "crosshost-send, crosshost-ack, admission-capacity"
         )
     if args.peers and feature not in crosshost_features:
         raise SmokeError("hostnames are only valid with a cross-host smoke feature")

--- a/scripts/smoke/smoke_common.py
+++ b/scripts/smoke/smoke_common.py
@@ -23,12 +23,14 @@ def sanitize(value: str) -> str:
     return SECRET.sub("<redacted>", value)[-MAX_CAPTURE:]
 
 
-def command_result(command: list[str], timeout: float = 15.0) -> dict[str, Any]:
+def command_result(
+    command: list[str], timeout: float = 15.0, *, env: dict[str, str] | None = None
+) -> dict[str, Any]:
     """Run one command and retain only bounded, redacted evidence."""
     try:
         completed = subprocess.run(
             command, capture_output=True, text=True, encoding="utf-8",
-            errors="replace", timeout=timeout, check=False,
+            errors="replace", timeout=timeout, check=False, env=env,
         )
         return {
             "command": command,

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -41,6 +41,18 @@ class AdmissionCapacityTests(unittest.TestCase):
             with self.assertRaisesRegex(RUNNER.SmokeError, "dedicated clean OS-user"):
                 RUNNER.require_isolated_os_user()
 
+    def test_transport_is_platform_explicit(self):
+        self.assertEqual(RUNNER.validate_transport("tcp"), "tcp")
+        self.assertEqual(RUNNER.validate_transport("uds"), "uds")
+        with self.assertRaisesRegex(RUNNER.SmokeError, "must be"):
+            RUNNER.validate_transport("https")
+        with mock.patch.object(RUNNER.os, "name", "nt"):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "Windows"):
+                RUNNER.validate_transport("uds")
+
+    def test_sparse_profiles_and_schema_fields_are_declared(self):
+        self.assertEqual(RUNNER.SPARSE_FRAMES_PER_CONNECTION, (1, 2, 8, 16, 64))
+
     def test_public_request_is_host_qualified_and_never_a_dispatch_envelope(self):
         body = __import__("json").loads(RUNNER.http_request_body(Path("/tmp/atm-capacity-test"), 42, "192.0.2.10"))
         self.assertEqual(body["to"], {"agent": "capacity-agent", "team": "capacity-team", "host": "192.0.2.10"})

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -26,9 +26,10 @@ RUNNER = load_runner()
 
 class AdmissionCapacityTests(unittest.TestCase):
     def test_home_rejects_production_or_non_temporary_paths(self):
-        with mock.patch.object(RUNNER, "os_account_home", return_value=Path("/Users/capacity")):
+        production_home = Path(tempfile.gettempdir()).resolve().parent / "atm-production-home"
+        with mock.patch.object(RUNNER, "os_account_home", return_value=production_home):
             with self.assertRaisesRegex(RUNNER.SmokeError, "temporary"):
-                RUNNER.validate_capacity_home(Path("/Users/capacity/.atm"))
+                RUNNER.validate_capacity_home(production_home / ".atm")
         with self.assertRaisesRegex(RUNNER.SmokeError, "basename"):
             RUNNER.validate_capacity_home(Path(tempfile.gettempdir()) / "shared-atm")
 
@@ -68,7 +69,7 @@ class AdmissionCapacityTests(unittest.TestCase):
         self.assertEqual(
             command.call_args.args[0],
             [
-                "/tmp/atm", "peer", "trust", "add", "--host", "192.0.2.10",
+                str(Path("/tmp/atm")), "peer", "trust", "add", "--host", "192.0.2.10",
                 "--fingerprint", "fingerprint", "--yes",
             ],
         )

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -44,7 +44,8 @@ class AdmissionCapacityTests(unittest.TestCase):
 
     def test_transport_is_platform_explicit(self):
         self.assertEqual(RUNNER.validate_transport("tcp"), "tcp")
-        self.assertEqual(RUNNER.validate_transport("uds"), "uds")
+        with mock.patch.object(RUNNER.os, "name", "posix"):
+            self.assertEqual(RUNNER.validate_transport("uds"), "uds")
         with self.assertRaisesRegex(RUNNER.SmokeError, "must be"):
             RUNNER.validate_transport("https")
         with mock.patch.object(RUNNER.os, "name", "nt"):

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -1,0 +1,92 @@
+"""Focused unit tests for the AI.33 public admission-capacity runner."""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+def load_runner():
+    path = Path(__file__).with_name("run_admission_capacity.py")
+    sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location("run_admission_capacity", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+RUNNER = load_runner()
+
+
+class AdmissionCapacityTests(unittest.TestCase):
+    def test_home_rejects_production_or_non_temporary_paths(self):
+        with mock.patch.object(RUNNER, "os_account_home", return_value=Path("/Users/capacity")):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "temporary"):
+                RUNNER.validate_capacity_home(Path("/Users/capacity/.atm"))
+        with self.assertRaisesRegex(RUNNER.SmokeError, "basename"):
+            RUNNER.validate_capacity_home(Path(tempfile.gettempdir()) / "shared-atm")
+
+    def test_home_accepts_only_a_marked_temporary_directory(self):
+        path = Path(tempfile.gettempdir()) / "atm-capacity-unit-home"
+        self.assertEqual(RUNNER.validate_capacity_home(path), path.resolve())
+
+    def test_requires_explicit_clean_os_user_guard(self):
+        with mock.patch.dict(os.environ, {"ATM_CAPACITY_ISOLATED_OS_USER": ""}, clear=False):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "dedicated clean OS-user"):
+                RUNNER.require_isolated_os_user()
+
+    def test_public_request_is_host_qualified_and_never_a_dispatch_envelope(self):
+        body = __import__("json").loads(RUNNER.http_request_body(Path("/tmp/atm-capacity-test"), 42, "192.0.2.10"))
+        self.assertEqual(body["to"], {"agent": "capacity-agent", "team": "capacity-team", "host": "192.0.2.10"})
+        self.assertEqual(body["message_source"], {"Inline": "capacity-42"})
+        self.assertNotIn("RequestEnvelope", body)
+
+    def test_controlled_peer_configuration_uses_the_public_cli_reload_path(self):
+        result = {"exit_code": 0, "stdout": "", "stderr": ""}
+        with mock.patch.object(RUNNER, "command_result", return_value=result) as command:
+            RUNNER.configure_controlled_peer(
+                Path("/tmp/atm"), {"ATM_HOME": "/tmp/atm-capacity-test"}, "192.0.2.10", "fingerprint"
+            )
+        self.assertEqual(
+            command.call_args.args[0],
+            [
+                "/tmp/atm", "peer", "trust", "add", "--host", "192.0.2.10",
+                "--fingerprint", "fingerprint", "--yes",
+            ],
+        )
+
+    def test_interval_preserves_the_first_failure_and_requires_all_1000_responses(self):
+        calls = 0
+
+        def submit(_sequence):
+            nonlocal calls
+            calls += 1
+            return RUNNER.AdmissionResult(201 if calls != 7 else 503, 0.1, None if calls != 7 else "HTTP 503")
+
+        with mock.patch.object(RUNNER, "ADMISSIONS_PER_INTERVAL", 10), mock.patch.object(RUNNER, "WORKERS", 2):
+            result = RUNNER.run_interval(submit, 0)
+        self.assertEqual(result["accepted_count"], 9)
+        self.assertEqual(result["response_count"], 10)
+        self.assertEqual(result["first_failure"], "HTTP 503")
+        self.assertFalse(result["passed"])
+
+    def test_peer_case_retains_each_interval_in_evidence(self):
+        with mock.patch.object(RUNNER, "INTERVALS", 3), mock.patch.object(
+            RUNNER, "run_interval", return_value={"passed": True}
+        ) as interval:
+            result = RUNNER.run_peer_case(
+                RUNNER.LocalEndpoint("uds", "/tmp/socket"), Path("/tmp/atm-capacity-test"), "peer.example", "peer"
+            )
+        self.assertEqual(len(result["intervals"]), 3)
+        self.assertTrue(result["passed"])
+        self.assertEqual(interval.call_count, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -62,18 +62,31 @@ class FeatureSmokeTests(unittest.TestCase):
                 self.assertEqual(RUNNER.main(), 0)
         self.assertEqual(Path(run.call_args.args[0][1]).name, "run.py")
 
+    def test_admission_capacity_reuses_the_feature_smoke_dispatcher(self):
+        completed = mock.Mock(returncode=0)
+        with mock.patch.object(RUNNER.subprocess, "run", return_value=completed) as run:
+            with mock.patch.object(RUNNER.sys, "argv", ["smoke", "admission-capacity"]):
+                self.assertEqual(RUNNER.main(), 0)
+        self.assertEqual(Path(run.call_args.args[0][1]).name, "run_admission_capacity.py")
+
     def test_missing_identity_is_a_hard_failure(self):
         with mock.patch.dict(os.environ, {"ATM_IDENTITY": "", "ATM_TEAM": ""}, clear=False):
             with self.assertRaisesRegex(RUNNER.SmokeError, "ATM_IDENTITY"):
                 RUNNER.require_environment()
 
     def test_branch_version_requires_one_shared_cli_daemon_version(self):
-        metadata = {"packages": [{"name": "atm", "version": "1.3.2-beta.27"}, {"name": "atm-daemon", "version": "1.3.2-beta.27"}]}
+        metadata = {"packages": [{"name": "agent-team-mail", "version": "1.3.2-beta.27"}, {"name": "atm-daemon", "version": "1.3.2-beta.27"}]}
         with mock.patch.object(RUNNER, "command", return_value={"exit_code": 0, "stdout": __import__("json").dumps(metadata), "stderr": ""}):
             self.assertEqual(RUNNER.branch_version(), "1.3.2-beta.27")
 
     def test_branch_version_rejects_divergent_cli_daemon_versions(self):
-        metadata = {"packages": [{"name": "atm", "version": "1.3.2-beta.27"}, {"name": "atm-daemon", "version": "1.3.2-beta.28"}]}
+        metadata = {"packages": [{"name": "agent-team-mail", "version": "1.3.2-beta.27"}, {"name": "atm-daemon", "version": "1.3.2-beta.28"}]}
+        with mock.patch.object(RUNNER, "command", return_value={"exit_code": 0, "stdout": __import__("json").dumps(metadata), "stderr": ""}):
+            with self.assertRaisesRegex(RUNNER.SmokeError, "shared"):
+                RUNNER.branch_version()
+
+    def test_branch_version_rejects_metadata_without_the_real_cli_package(self):
+        metadata = {"packages": [{"name": "atm", "version": "1.3.2-beta.27"}, {"name": "atm-daemon", "version": "1.3.2-beta.27"}]}
         with mock.patch.object(RUNNER, "command", return_value={"exit_code": 0, "stdout": __import__("json").dumps(metadata), "stderr": ""}):
             with self.assertRaisesRegex(RUNNER.SmokeError, "shared"):
                 RUNNER.branch_version()

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ATM verification reports</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font: 16px system-ui, sans-serif; line-height: 1.5; max-width: 56rem; margin: 3rem auto; padding: 0 1rem; }
+    a { font-weight: 600; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>ATM verification reports</h1>
+    <p>Durable, public-safe verification evidence for ATM transport and tooling.</p>
+    <p><a href="reports/index.html">Browse verification reports</a></p>
+  </main>
+</body>
+</html>

--- a/site/reports/index.html
+++ b/site/reports/index.html
@@ -10,7 +10,9 @@
   <h1>ATM verification reports</h1>
   <p>Generated from schema-validated public report envelopes.</p>
   <section><h2>Benchmark</h2>
-    <p class="empty">No reports available.</p>
+    <ul>
+      <li><a href="send-message-benchmark.html">send-message-benchmark</a><time datetime="2026-08-01T01:01:00Z">2026-08-01T01:01:00Z</time><span class="report-meta">benchmark · 2 runs · hosts: mac-arm64-01</span></li>
+    </ul>
   </section>
   <section><h2>Fuzz</h2>
     <p class="empty">No reports available.</p>

--- a/site/reports/send-message-benchmark.html
+++ b/site/reports/send-message-benchmark.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ATM local transport benchmark</title>
+  <style>
+    body { font: 16px system-ui, sans-serif; max-width: 80rem; margin: 2rem auto; padding: 0 1rem; color: #1f2937; }
+    h1 { margin-bottom: .25rem; } .meta { color: #64748b; }
+    .status { display: inline-block; padding: .2rem .6rem; border-radius: 999px; font-weight: 700; }
+    .PASS { color: #065f46; background: #d1fae5; } .FAIL { color: #991b1b; background: #fee2e2; } .INFO { color: #1e40af; background: #dbeafe; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { border: 1px solid #d1d5db; padding: .55rem; text-align: left; } th { background: #f3f4f6; }
+    .pass { color: #065f46; } .fail { color: #991b1b; }
+  </style>
+</head>
+<body>
+  <h1>ATM local transport benchmark</h1>
+  <p class="meta">Generated 2026-08-01T01:26:49.281377Z · <span class="status FAIL">FAIL</span></p>
+  <p>2 profiles: 1 passed, 1 failed. Failed profiles remain retained for diagnosis.</p>
+  <h2>UTC benchmark history</h2>
+  <table>
+    <thead><tr><th>UTC timestamp</th><th>Host</th><th>Transport</th><th>Frames/connection</th><th>Status</th><th>Evidence</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><time datetime="2026-08-01T01:00:00Z">2026-08-01T01:00:00Z</time></td>
+        <td>mac-arm64-01</td>
+        <td>uds</td>
+        <td>1</td>
+        <td class="pass">PASS</td>
+        <td><a href="send-message-benchmark&#x2f;20260801-010000-mac-arm64-01-uds-f1.json">JSON</a> · <a href="send-message-benchmark&#x2f;20260801-010000-mac-arm64-01-uds-f1.xhtml">XHTML panel</a></td>
+      </tr>
+      <tr>
+        <td><time datetime="2026-08-01T01:01:00Z">2026-08-01T01:01:00Z</time></td>
+        <td>mac-arm64-01</td>
+        <td>tcp</td>
+        <td>8</td>
+        <td class="fail">FAIL</td>
+        <td><a href="send-message-benchmark&#x2f;20260801-010100-mac-arm64-01-tcp-f8.json">JSON</a> · <a href="send-message-benchmark&#x2f;20260801-010100-mac-arm64-01-tcp-f8.xhtml">XHTML panel</a></td>
+      </tr>
+    </tbody>
+  </table>
+</body>
+</html>

--- a/site/reports/send-message-benchmark/20260801-010000-mac-arm64-01-uds-f1.envelope.json
+++ b/site/reports/send-message-benchmark/20260801-010000-mac-arm64-01-uds-f1.envelope.json
@@ -1,0 +1,7 @@
+{
+  "generated_at": "2026-08-01T01:00:00Z",
+  "host_label": "mac-arm64-01",
+  "report_html": "send-message-benchmark.html",
+  "report_type": "benchmark",
+  "schema_version": 1
+}

--- a/site/reports/send-message-benchmark/20260801-010000-mac-arm64-01-uds-f1.json
+++ b/site/reports/send-message-benchmark/20260801-010000-mac-arm64-01-uds-f1.json
@@ -1,0 +1,25 @@
+{
+  "frames_per_connection": 1,
+  "generated_at": "2026-08-01T01:00:00Z",
+  "host_label": "mac-arm64-01",
+  "messages_per_connection": 1,
+  "passed": true,
+  "run_duration_s": 20,
+  "runs": [
+    {
+      "intervals": [
+        {
+          "accepted_count": 1000,
+          "admissions_per_second": 1250.0,
+          "elapsed_seconds": 0.8,
+          "interval": 1,
+          "passed": true,
+          "response_count": 1000
+        }
+      ],
+      "label": "accepting-configured-peer"
+    }
+  ],
+  "schema_version": 2,
+  "transport": "uds"
+}

--- a/site/reports/send-message-benchmark/20260801-010000-mac-arm64-01-uds-f1.xhtml
+++ b/site/reports/send-message-benchmark/20260801-010000-mac-arm64-01-uds-f1.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260801-010000-mac-arm64-01-uds-f1</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-01T01:00:00Z</dd>
+    <dt>Host label</dt><dd>mac-arm64-01</dd>
+    <dt>Transport</dt><dd>uds</dd>
+    <dt>Frames per connection</dt><dd>1</dd>
+    <dt>Run duration (seconds)</dt><dd>20</dd>
+    <dt>Artifact</dt><dd>20260801-010000-mac-arm64-01-uds-f1.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<article class="benchmark-sample"><h3>accepting-configured-peer</h3><table><thead><tr><th>Interval</th><th>Accepted</th><th>Responses</th><th>Elapsed s</th><th>Admissions/s</th><th>Status</th></tr></thead><tbody><tr><td>1</td><td>1000</td><td>1000</td><td>0.8</td><td>1250.0</td><td>PASS</td></tr></tbody></table></article>
+</section>

--- a/site/reports/send-message-benchmark/20260801-010100-mac-arm64-01-tcp-f8.envelope.json
+++ b/site/reports/send-message-benchmark/20260801-010100-mac-arm64-01-tcp-f8.envelope.json
@@ -1,0 +1,7 @@
+{
+  "generated_at": "2026-08-01T01:01:00Z",
+  "host_label": "mac-arm64-01",
+  "report_html": "send-message-benchmark.html",
+  "report_type": "benchmark",
+  "schema_version": 1
+}

--- a/site/reports/send-message-benchmark/20260801-010100-mac-arm64-01-tcp-f8.json
+++ b/site/reports/send-message-benchmark/20260801-010100-mac-arm64-01-tcp-f8.json
@@ -1,0 +1,28 @@
+{
+  "cleanup_failure": "cleanup completed",
+  "failure": "one admission failed",
+  "frames_per_connection": 8,
+  "generated_at": "2026-08-01T01:01:00Z",
+  "host_label": "mac-arm64-01",
+  "messages_per_connection": 8,
+  "passed": false,
+  "run_duration_s": 20,
+  "runs": [
+    {
+      "intervals": [
+        {
+          "accepted_count": 999,
+          "admissions_per_second": 499.5,
+          "elapsed_seconds": 2.0,
+          "first_failure": "HTTP 503",
+          "interval": 1,
+          "passed": false,
+          "response_count": 1000
+        }
+      ],
+      "label": "accepting-configured-peer"
+    }
+  ],
+  "schema_version": 2,
+  "transport": "tcp"
+}

--- a/site/reports/send-message-benchmark/20260801-010100-mac-arm64-01-tcp-f8.xhtml
+++ b/site/reports/send-message-benchmark/20260801-010100-mac-arm64-01-tcp-f8.xhtml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260801-010100-mac-arm64-01-tcp-f8</h1>
+  <p><strong>Status:</strong> FAIL</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-01T01:01:00Z</dd>
+    <dt>Host label</dt><dd>mac-arm64-01</dd>
+    <dt>Transport</dt><dd>tcp</dd>
+    <dt>Frames per connection</dt><dd>8</dd>
+    <dt>Run duration (seconds)</dt><dd>20</dd>
+    <dt>Artifact</dt><dd>20260801-010100-mac-arm64-01-tcp-f8.json</dd>
+  </dl>
+  <h2>Failure diagnostics</h2><pre>one admission failed</pre>
+  <h2>Cleanup diagnostics</h2><pre>cleanup completed</pre>
+  <h2>Samples</h2>
+<article class="benchmark-sample"><h3>accepting-configured-peer</h3><table><thead><tr><th>Interval</th><th>Accepted</th><th>Responses</th><th>Elapsed s</th><th>Admissions/s</th><th>Status</th></tr></thead><tbody><tr><td>1</td><td>999</td><td>1000</td><td>2.0</td><td>499.5</td><td>FAIL</td></tr></tbody></table></article>
+</section>

--- a/templates/benchmark-report/benchmark-report.html.j2
+++ b/templates/benchmark-report/benchmark-report.html.j2
@@ -1,0 +1,51 @@
+---
+metadata:
+  name: benchmark-report
+  description: Aggregate ATM local transport benchmark report
+required_variables:
+  - title
+  - generated_at
+  - status
+  - rows
+  - profile_count
+  - passed_count
+  - failed_count
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ title | e }}</title>
+  <style>
+    body { font: 16px system-ui, sans-serif; max-width: 80rem; margin: 2rem auto; padding: 0 1rem; color: #1f2937; }
+    h1 { margin-bottom: .25rem; } .meta { color: #64748b; }
+    .status { display: inline-block; padding: .2rem .6rem; border-radius: 999px; font-weight: 700; }
+    .PASS { color: #065f46; background: #d1fae5; } .FAIL { color: #991b1b; background: #fee2e2; } .INFO { color: #1e40af; background: #dbeafe; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { border: 1px solid #d1d5db; padding: .55rem; text-align: left; } th { background: #f3f4f6; }
+    .pass { color: #065f46; } .fail { color: #991b1b; }
+  </style>
+</head>
+<body>
+  <h1>{{ title | e }}</h1>
+  <p class="meta">Generated {{ generated_at | e }} · <span class="status {{ status | e }}">{{ status | e }}</span></p>
+  <p>{{ profile_count }} profiles: {{ passed_count }} passed, {{ failed_count }} failed. Failed profiles remain retained for diagnosis.</p>
+  <h2>UTC benchmark history</h2>
+  <table>
+    <thead><tr><th>UTC timestamp</th><th>Host</th><th>Transport</th><th>Frames/connection</th><th>Status</th><th>Evidence</th></tr></thead>
+    <tbody>
+{% for row in rows %}
+      <tr>
+        <td><time datetime="{{ row.generated_at | e }}">{{ row.generated_at | e }}</time></td>
+        <td>{{ row.host_label | e }}</td>
+        <td>{{ row.transport | e }}</td>
+        <td>{{ row.frames_per_connection }}</td>
+        <td class="{{ 'pass' if row.passed else 'fail' }}">{{ 'PASS' if row.passed else 'FAIL' }}</td>
+        <td><a href="{{ row.json_href | e }}">JSON</a> · <a href="{{ row.xhtml_href | e }}">XHTML panel</a></td>
+      </tr>
+{% endfor %}
+    </tbody>
+  </table>
+</body>
+</html>

--- a/templates/benchmark-report/benchmark-run.xhtml.j2
+++ b/templates/benchmark-report/benchmark-run.xhtml.j2
@@ -1,0 +1,38 @@
+---
+metadata:
+  name: benchmark-run
+  description: One ATM local transport benchmark evidence panel
+required_variables:
+  - title
+  - artifact_id
+  - generated_at
+  - host_label
+  - transport
+  - frames_per_connection
+  - run_duration_s
+  - passed
+  - failure
+  - cleanup_failure
+  - sample_html
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>{{ title | e }}</h1>
+  <p><strong>Status:</strong> {{ 'PASS' if passed else 'FAIL' }}</p>
+  <dl>
+    <dt>Generated</dt><dd>{{ generated_at | e }}</dd>
+    <dt>Host label</dt><dd>{{ host_label | e }}</dd>
+    <dt>Transport</dt><dd>{{ transport | e }}</dd>
+    <dt>Frames per connection</dt><dd>{{ frames_per_connection }}</dd>
+    <dt>Run duration (seconds)</dt><dd>{{ run_duration_s }}</dd>
+    <dt>Artifact</dt><dd>{{ artifact_id | e }}.json</dd>
+  </dl>
+{% if failure %}
+  <h2>Failure diagnostics</h2><pre>{{ failure | e }}</pre>
+{% endif %}
+{% if cleanup_failure %}
+  <h2>Cleanup diagnostics</h2><pre>{{ cleanup_failure | e }}</pre>
+{% endif %}
+  <h2>Samples</h2>
+{{ sample_html | safe }}
+</section>


### PR DESCRIPTION
AI.49 benchmark-report implementation, dev-reported at bedcb4b8.

Includes:
- AI48 merge-forward (00a504fc, CI portability fix)
- Public-safe AI40 result migration/persistence with AI46 envelope sidecars
- Immutable per-profile JSON
- sc-compose aggregate HTML + XHTML panels
- Failed-run retention
- Transport/profile separation
- Fixtures/tests, benchmark-report Just recipe
- Sprint/project-plan completion metadata

Validation (dev-reported):
- Focused benchmark tests 6/6
- just reports-index --check PASS
- just lint PASS (23 checks)
- Full just test PASS: 332 Python fixture tests (51 fixtures) + full Rust workspace/doc suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)