### PR TITLE
AI.50: Fuzz report rendering

### DIFF
--- a/.claude/lib/sc_compose_dependency.py
+++ b/.claude/lib/sc_compose_dependency.py
@@ -5,9 +5,19 @@ from __future__ import annotations
 import re
 
 
-MIN_SC_COMPOSE = (1, 2, 0)
-MIN_SC_COMPOSE_TEXT = ">= 1.2.0"
+SC_COMPOSE_SOURCE_REV = "113729e60e3409ad8c651a74956ffa5c167dd1b6"
+MIN_SC_COMPOSE = (1, 3, 0)
+MIN_SC_COMPOSE_TEXT = (
+    ">= 1.3.0 (unreleased source revision "
+    f"{SC_COMPOSE_SOURCE_REV})"
+)
+MIN_SC_COMPOSE_BINDING = (1, 2, 0)
+MIN_SC_COMPOSE_BINDING_TEXT = ">= 1.2.0"
 SC_COMPOSE_INSTALL = (
+    "cargo install --git https://github.com/randlee/sc-compose.git "
+    f"--rev {SC_COMPOSE_SOURCE_REV} --locked --bin sc-compose"
+)
+SC_COMPOSE_BINDING_INSTALL = (
     "python3 -m pip install --user --break-system-packages "
     "'sc-compose>=1.2.0'"
 )

--- a/.claude/skills/graph-orchestration/SKILL.md
+++ b/.claude/skills/graph-orchestration/SKILL.md
@@ -6,7 +6,7 @@ repo: atm-core
 requires:
   cli:
     - name: sc-compose
-      minimum_version: 1.2.0
+      minimum_version: 1.3.0
     - name: jq
   python:
     - package: rdflib
@@ -45,7 +45,7 @@ the phase, invoking an agent, reading the cursor, or appending a TTL event:
 .claude/skills/graph-orchestration/scripts/preflight
 ```
 
-It checks the `sc-compose >= 1.2.0` CLI, the matching `sc_compose >= 1.2.0`
+It checks the pinned unreleased `sc-compose` CLI, the matching `sc_compose >= 1.2.0`
 Python/maturin binding, `jq`, and a `python3` interpreter that can import
 `rdflib`. The command always emits a structured JSON result and exits `0`
 only when all runtime checks pass; exit `2` is an operational dependency error
@@ -445,7 +445,7 @@ All scripts live in `.claude/skills/graph-orchestration/scripts/`:
 | Script | Purpose |
 |---|---|
 | `next-dev-task` | Entry point: cursor resolution, returns JSON |
-| `preflight` | First-step dependency gate; requires CLI + Python binding `sc-compose >= 1.2.0`, `jq`, and `python3` + `rdflib` |
+| `preflight` | First-step dependency gate; requires the pinned CLI + Python binding `sc_compose >= 1.2.0`, `jq`, and `python3` + `rdflib` |
 | `validate-findings.py` | Mandatory raw findings/provenance gate invoked before query resolution |
 | `query_runner.py` | Python SPARQL runner (rdflib) |
 | `cursor.sparql` | Returns cursor sprint (lowest-ordered sprint without a truly in-flight Assignment or valid Completion); parameter: `$PHASE` |

--- a/.claude/skills/graph-orchestration/references/installation-and-troubleshooting.md
+++ b/.claude/skills/graph-orchestration/references/installation-and-troubleshooting.md
@@ -27,7 +27,7 @@ The required runtime dependencies are:
 
 | Dependency | Minimum | Used for |
 |---|---:|---|
-| `sc-compose` CLI | **1.2.0** | Rendering fenced Jinja templates and agent prompts |
+| `sc-compose` CLI | **unreleased source revision `113729e` (1.3.0-compatible)** | Rendering fenced Jinja templates and agent prompts |
 | `sc_compose` Python binding | **1.2.0** | Python/maturin rendering integrations and wrappers |
 | Python + `rdflib` | **3.11+** | RDF/Turtle parsing and SPARQL queries |
 | `jq` | any current release | Reading the JSON cursor contract |
@@ -71,10 +71,11 @@ The executable and Python binding are separate artifacts.  Installing the
 PyPI wheel does **not** guarantee that a `sc-compose` executable is on `PATH`.
 Install both and keep them at the same minimum version.
 
-For the CLI (Homebrew tap):
+For the CLI, use the pinned source revision required by the report templates:
 
 ```bash
-brew install randlee/tap/sc-compose
+cargo install --git https://github.com/randlee/sc-compose.git \
+  --rev 113729e60e3409ad8c651a74956ffa5c167dd1b6 --locked --bin sc-compose
 ```
 
 For the Python/maturin binding (a one-time per-machine setup; no activation
@@ -87,9 +88,9 @@ brew install jq
 
 The `--user` target keeps the wheel out of Homebrew-managed site-packages;
 `--break-system-packages` is the explicit Python override for this trusted,
-user-owned install.  The wheel is published on PyPI and provides the
-`sc_compose` binding (Python 3.11+; prebuilt platform wheels).  It does not install the standalone CLI, so keep the
-Homebrew CLI install above as a separate step.  This is done once per machine;
+user-owned install. The wheel is published on PyPI and provides the
+`sc_compose` binding (Python 3.11+; prebuilt platform wheels). It does not install the standalone CLI, so keep the
+source-pinned CLI install above as a separate step. This is done once per machine;
 callers only perform a guarded `import sc_compose` on each invocation.
 
 ### Linux
@@ -100,13 +101,11 @@ sudo apt-get install jq                 # Debian/Ubuntu; use the native package 
 ```
 
 The PyPI package supplies the `sc_compose` Python binding, not the standalone
-CLI. Install the CLI from the v1.2.0 release or from a source checkout with
-the upstream `cargo install --path crates/sc-compose` procedure, then rerun
+CLI. Install the CLI from the pinned source revision above, then rerun
 preflight.
 
-Install the `sc-compose` CLI from the project release channel for the
-platform (Homebrew tap, package manager, or a release binary); the pip wheel
-above is the Python binding and is not a CLI installation.
+The pip wheel above is the Python binding and is not a CLI installation; use
+the source-pinned CLI command above on every platform.
 If the invoking Python is not `python3`, substitute that interpreter in the
 one-time install command and in the preflight.
 
@@ -114,7 +113,7 @@ one-time install command and in the preflight.
 
 ```powershell
 py -m pip install --user --break-system-packages "sc-compose>=1.2.0"
-winget install randlee.sc-compose
+cargo install --git https://github.com/randlee/sc-compose.git --rev 113729e60e3409ad8c651a74956ffa5c167dd1b6 --locked --bin sc-compose
 winget install jqlang.jq
 ```
 
@@ -130,14 +129,14 @@ python3 -m pytest .claude/skills/graph-orchestration/scripts/test_validate_findi
 ```
 
 The first command must return `"success": true` and report
-`sc-compose` version `1.2.0` or newer.  A test pass does not override a failed
+the pinned unreleased 1.3.0-compatible `sc-compose` build. A test pass does not override a failed
 preflight: dependency errors are distinct from expected validation failures.
 
 ## Known issues
 
-- **`sc-compose 1.0.x` is rejected.** Upgrade it; do not lower the requirement.
-  Version 1.2.0 supplies the bindings and rendering behavior used by these
-  skills.
+- **The v1.2.0 CLI is rejected for current templates.** Install the pinned
+  source revision above; the Python binding remains a separate `>=1.2.0`
+  artifact.
 - **`rdflib` import fails although it was installed.** `pip` and `python3`
   often point at different interpreters.  Compare `command -v python3` with
   `python3 -m pip --version`, then use the same interpreter for installation or

--- a/.claude/skills/graph-orchestration/scripts/preflight.py
+++ b/.claude/skills/graph-orchestration/scripts/preflight.py
@@ -25,8 +25,10 @@ if str(_CLAUDE_DIR) not in sys.path:
 
 from lib.sc_compose_dependency import (  # noqa: E402
     MIN_SC_COMPOSE,
+    MIN_SC_COMPOSE_BINDING,
+    MIN_SC_COMPOSE_BINDING_TEXT,
     MIN_SC_COMPOSE_TEXT,
-    SC_COMPOSE_INSTALL,
+    SC_COMPOSE_BINDING_INSTALL,
     parse_version as _version,
 )
 
@@ -163,9 +165,9 @@ def check_rdflib() -> Check:
 def check_sc_compose_binding() -> Check:
     """Verify the maturin/PyO3 binding is installed beside the chosen Python.
 
-    The CLI and Python wheel are separate artifacts.  Keeping this check here
-    catches a split environment where the CLI is 1.2.x but ``sc_compose`` is
-    an older wheel (or belongs to another interpreter).
+    The CLI and Python wheel are separate artifacts. Keeping this check here
+    catches a split environment where ``sc_compose`` is an older wheel (or
+    belongs to another interpreter).
     """
 
     candidates = _python_candidates()
@@ -173,7 +175,7 @@ def check_sc_compose_binding() -> Check:
         return Check(
             "python3/sc_compose",
             False,
-            "python3 not found; install the binding with: " + SC_COMPOSE_INSTALL,
+            "python3 not found; install the binding with: " + SC_COMPOSE_BINDING_INSTALL,
         )
     failures: list[str] = []
     probe = (
@@ -185,12 +187,12 @@ def check_sc_compose_binding() -> Check:
         rc, stdout, stderr = _run([path, "-c", probe])
         parsed = _version(stdout)
         if rc == 0 and parsed is not None:
-            if parsed < MIN_SC_COMPOSE:
+            if parsed < MIN_SC_COMPOSE_BINDING:
                 return Check(
                     "python3/sc_compose",
                     False,
-                    f"{path} has sc-compose {stdout}; required >= 1.2.0; "
-                    "reinstall with: " + SC_COMPOSE_INSTALL,
+                    f"{path} has sc-compose {stdout}; required {MIN_SC_COMPOSE_BINDING_TEXT}; "
+                    "reinstall with: " + SC_COMPOSE_BINDING_INSTALL,
                     path,
                 )
             return Check("python3/sc_compose", True, f"{path} binding {stdout}", path)
@@ -200,7 +202,7 @@ def check_sc_compose_binding() -> Check:
         False,
         "sc_compose binding is unavailable to the selected python3 interpreter; "
         "install it with: "
-        + SC_COMPOSE_INSTALL
+        + SC_COMPOSE_BINDING_INSTALL
         + ". Details: "
         + "; ".join(failures),
     )
@@ -229,7 +231,7 @@ def run_preflight(*, for_tests: bool = False, checks: Iterable[Callable[[], Chec
     failures = [result for result in results if not result["ok"]]
     return {
         "success": not failures,
-        "data": {"checks": results, "required_sc_compose": ">=1.2.0", "for_tests": for_tests},
+        "data": {"checks": results, "required_sc_compose": MIN_SC_COMPOSE_TEXT, "for_tests": for_tests},
         "error": None
         if not failures
         else {

--- a/.claude/skills/graph-orchestration/scripts/test_preflight.py
+++ b/.claude/skills/graph-orchestration/scripts/test_preflight.py
@@ -28,8 +28,8 @@ def _module():
 def test_version_floor_is_semver_and_inclusive():
     preflight = _module()
     assert preflight._version("sc-compose 1.2.0") == (1, 2, 0)
-    assert preflight._version("sc-compose 1.2.9") > preflight.MIN_SC_COMPOSE
-    assert preflight._version("sc-compose 1.1.99") < preflight.MIN_SC_COMPOSE
+    assert preflight._version("sc-compose 1.3.9") > preflight.MIN_SC_COMPOSE
+    assert preflight._version("sc-compose 1.2.9") < preflight.MIN_SC_COMPOSE
     assert preflight._version("unknown") is None
 
 
@@ -43,7 +43,7 @@ def test_sc_compose_rejects_old_cli(monkeypatch):
     )
     result = preflight.check_sc_compose()
     assert not result.ok
-    assert "required >= 1.2.0" in result.detail
+    assert f"required {preflight.MIN_SC_COMPOSE_TEXT}" in result.detail
 
 
 def test_binding_rejects_old_python_wheel(monkeypatch):
@@ -98,7 +98,7 @@ def test_run_preflight_success_and_failure_envelopes():
     failure = preflight.run_preflight(checks=[bad])
     assert success == {
         "success": True,
-        "data": {"checks": [{"name": "fake", "ok": True, "detail": "ok"}], "required_sc_compose": ">=1.2.0", "for_tests": False},
+        "data": {"checks": [{"name": "fake", "ok": True, "detail": "ok"}], "required_sc_compose": preflight.MIN_SC_COMPOSE_TEXT, "for_tests": False},
         "error": None,
     }
     assert failure["success"] is False

--- a/.claude/skills/html-report/fuzz-run-agent-contract.md
+++ b/.claude/skills/html-report/fuzz-run-agent-contract.md
@@ -1,0 +1,108 @@
+# Fuzz-session report contract
+
+This contract extends the generic `html-report` package contract. A fuzz
+session is a coordinated run of multiple workers. Each worker receives one
+distinct fuzz task, executes one bounded fuzz test, and returns one structured
+JSON result. Each worker produces exactly one XHTML panel. The report package
+contains one HTML page, one JSON sidecar, and one XHTML companion per worker.
+
+## Session package
+
+The top-level report data uses the generic fields `output_path`,
+`json_output_path`, `title`, `status`, `summary_html`, and `sections[]`.
+`summary_html` must contain a table with one row per worker and these columns:
+
+| Column | Meaning |
+| --- | --- |
+| Fuzz run description | The distinct task assigned to the worker |
+| Iterations | Number of bounded test inputs exercised |
+| Pass | Fraction in `passed/iterations` form |
+| Result | Simple `PASS` or `FAIL` verdict |
+
+Each `sections[]` entry is one worker panel. It must include `id`, `title`,
+`status`, `body_html`, `context_text`, `json_payload`, and `xhtml_path`, with
+`fragment_source: "auto-generated"`. The panel XHTML must be generated from
+`templates/fuzz-run-agent.xhtml.j2`; do not concatenate multiple workers into
+one fragment.
+
+## Two-template rendering
+
+The report package uses two checked-in templates:
+
+1. `templates/fuzz-run-agent.xhtml.j2` renders one worker panel per worker.
+2. `templates/fuzz-run-report.html.j2` renders the complete top-level HTML
+   shell through `sc-compose render --file ... --var-file ... --output ...`.
+
+The shell receives top-level arrays only. `rows` and `metadata_rows` are
+arrays of objects; `sections` is an array of already-rendered worker-panel
+strings inserted into the shell. Pre-render nested worker data into those
+strings before shell rendering rather than relying on nested array-of-object
+traversal. This keeps the shell deterministic and makes the two-template
+boundary explicit; the generator must not hand-assemble the HTML document.
+
+## Worker panel fields
+
+| Field | Required | Source / meaning |
+| --- | --- | --- |
+| `session_id` | yes | Durable fuzz-session identifier |
+| `agent_id` | yes | Stable worker/task identifier |
+| `fuzz_run_description` | yes | Human-readable task the worker exercised |
+| `worker_correlation_id` | yes | Worker identity from the evidence envelope |
+| `classification` | yes | `pass`, `confirmed_bug`, `intentional_boundary`, or `inconclusive` |
+| `iterations` | yes | Bounded number of test inputs exercised |
+| `passed` | yes | Number of inputs satisfying the worker oracle |
+| `failed` | yes | Number of inputs not satisfying the oracle |
+| `result` | yes | `PASS` only when `failed` is zero; otherwise `FAIL` |
+| `summary` | yes | What this worker tested and what happened |
+| `test_inputs` | yes | Rows containing `case_id`, a prose `description`, literal `minimal_template`/frontmatter, literal `minimal_input`, boolean `passed`, and `outcome` |
+| `json_payload` | yes | Full worker evidence envelope used by copy-JSON |
+| `copy_json` | yes | Deterministic escaped JSON serialization |
+| `context_text` | yes | Human-readable worker context used by copy-context |
+
+The worker payload may include the original `cases[]`, `findings[]`, command,
+minimal template, minimal input, and recommended test fields from the E.3
+evidence contract. Preserve those names in `json_payload`; do not invent a
+parallel finding schema.
+
+## Primary-agent failure investigation
+
+The primary coordinator owns triage after workers return. For every candidate
+failure it may deploy background explore agents to identify the applicable
+requirement, ADR, or NFR; establish the evidence-backed root cause; and
+propose recommended changes. The primary coordinator merges those conclusions
+into the worker's structured JSON before rendering the panel. A worker panel
+must therefore show the exact frontmatter/template and input that caused each
+failure, not only a prose verdict.
+
+## Failed worker findings
+
+When `classification` is not a successful alias, `findings[]` is required.
+Each finding must expose the original finding fields plus:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `requirement_trace` | yes | Requirement/ADR/NFR citation, or the explicit text `No requirement or ADR currently covers this behavior.` |
+| `requirement_follow_up` | yes when no existing reference | Recommend creating/updating a requirement or ADR only when the behavior is supported and the gap is genuine; otherwise record the rationale for no new document or name the owner of the product decision |
+| `root_cause` | yes | Current evidence-backed cause, or an honest unresolved note |
+| `recommended_fix` | yes | Next test, design, or implementation action |
+
+A missing requirement reference is not by itself a reason to create an ADR or
+requirement.
+
+## Output naming and placement
+
+Real session artifacts are written under `site/reports/` after the
+`adversarial-fuzzing` skill completes. The main HTML stays at the top level;
+its supporting artifacts use a directory named for the shared session stem:
+
+`YYYYMMDD-N-fuzz-report.html`
+
+The JSON sidecar is written to
+`site/reports/YYYYMMDD-N-fuzz-report/YYYYMMDD-N-fuzz-report.json`. Each
+companion panel uses the same designated stem plus the deterministic worker
+suffix inside that directory, for example:
+
+`site/reports/20260729-1-fuzz-report/20260729-1-fuzz-report-shape-probe.xhtml`
+
+Review mocks remain under `docs/examples/fuzz-run-report/` and are not session
+output.

--- a/.claude/skills/html-report/templates/fuzz-run-agent.xhtml.j2
+++ b/.claude/skills/html-report/templates/fuzz-run-agent.xhtml.j2
@@ -1,0 +1,91 @@
+---
+metadata:
+  name: fuzz-run-agent
+  description: One adversarial-fuzz worker's copyable XHTML panel.
+required_variables:
+  - agent.session_id
+  - agent.agent_id
+  - agent.fuzz_run_description
+  - agent.worker_correlation_id
+  - agent.classification
+  - agent.copy_json
+  - agent.iterations
+  - agent.passed
+  - agent.result
+  - agent.test_inputs
+  - agent.context_text
+  - agent.findings
+---
+<section xmlns="http://www.w3.org/1999/xhtml" class="fuzz-agent fuzz-agent-{{ agent.classification | lower | e }}">
+{% set agent_is_pass = agent.classification in ["pass", "success", "successful", "ok"] %}
+  <header class="agent-header fuzz-agent-header">
+    <div>
+      <p class="eyebrow">Adversarial fuzz worker</p>
+      <h2>{{ agent.agent_id | e }}</h2>
+      <p class="agent-meta">Session {{ agent.session_id | e }} · Worker {{ agent.worker_correlation_id | e }}</p>
+    </div>
+    <div class="agent-actions" role="group" aria-label="Copy worker data">
+      <button type="button" class="icon-button" title="Copy JSON" data-copy-text="{{ agent.copy_json | e }}">{}</button>
+      <button type="button" class="icon-button" title="Copy Context" data-copy-text="{{ agent.context_text | e }}">⎘</button>
+    </div>
+  </header>
+
+  <p class="status">
+{% if agent_is_pass %}
+    <span class="status status-pass">PASS</span>
+{% else %}
+    <span class="status status-error">FAIL</span>
+{% endif %}
+  </p>
+
+  <table class="agent-results">
+    <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+    <tbody>
+      <tr>
+        <th scope="row">{{ agent.fuzz_run_description | e }}</th>
+        <td>{{ agent.iterations | e }}</td>
+        <td>{{ agent.passed | e }}/{{ agent.iterations | e }}</td>
+        <td>
+{% if agent_is_pass %}
+          <span class="status status-pass">{{ agent.result | e }}</span>
+{% else %}
+          <span class="status status-error">{{ agent.result | e }}</span>
+{% endif %}
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <section class="test-inputs">
+    <h3>Inputs exercised</h3>
+    <table>
+      <thead><tr><th scope="col">Case</th><th scope="col">Template / input</th><th scope="col">Outcome</th></tr></thead>
+      <tbody>
+{% for item in agent.test_inputs %}
+        <tr><th scope="row">{{ item.case_id | e }}</th><td><code>{{ item.description | e }}</code></td><td>{{ item.outcome | e }}</td></tr>
+{% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+{% if not agent_is_pass %}
+  <section class="findings">
+    <h3>Findings</h3>
+{% for finding in agent.findings %}
+    <article class="finding">
+      <h4>{{ finding.finding_id | e }}</h4>
+      <dl>
+        <dt>Minimal template / frontmatter</dt><dd><code>{{ finding.minimal_template | e }}</code></dd>
+        <dt>Input</dt><dd><code>{{ finding.minimal_input | e }}</code></dd>
+        <dt>Expected</dt><dd>{{ finding.expected_oracle | e }}</dd>
+        <dt>Observed</dt><dd>{{ finding.observed_result | e }}</dd>
+        <dt>Requirement / ADR</dt><dd>{{ finding.requirement_trace | e }}</dd>
+        <dt>Requirement / ADR follow-up</dt><dd>{{ finding.requirement_follow_up | e }}</dd>
+        <dt>Root cause</dt><dd>{{ finding.root_cause | e }}</dd>
+        <dt>Recommended fix</dt><dd>{{ finding.recommended_fix | e }}</dd>
+      </dl>
+    </article>
+{% endfor %}
+  </section>
+{% endif %}
+</section>

--- a/.claude/skills/html-report/templates/fuzz-run-report.html.j2
+++ b/.claude/skills/html-report/templates/fuzz-run-report.html.j2
@@ -1,0 +1,173 @@
+---
+metadata:
+  name: fuzz-run-report
+  description: Top-level shell for a multi-worker adversarial fuzz report.
+required_variables:
+  - title
+  - status
+  - summary_intro_html
+  - rows
+  - sections
+  - metadata_rows
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title | e }}</title>
+  <style type="text/css">
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 24px; color: #1f2937; background: #ffffff; line-height: 1.5; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1220; color: #e5e7eb; }
+      .section { background: #111827; border-color: #1f2937; }
+      table { background: #0f172a; }
+      th, td { border-color: #1f2937 !important; }
+      .icon-button { background: #1f2937; color: #cbd5e1; border-color: #374151; }
+      code { background: #1f2937; color: #e5e7eb; }
+      a { color: #93c5fd; }
+    }
+    :root[data-theme="dark"] body { background: #0b1220; color: #e5e7eb; }
+    :root[data-theme="dark"] .section { background: #111827; border-color: #1f2937; }
+    :root[data-theme="light"] body { background: #ffffff; color: #1f2937; }
+    header { border-bottom: 1px solid #e5e7eb; padding-bottom: 16px; margin-bottom: 20px; }
+    h1 { margin: 0 0 6px 0; font-size: 1.6rem; }
+    .subtitle { margin: 0 0 4px 0; color: #6b7280; }
+    .generated-at, .source-label { margin: 2px 0; font-size: 0.85rem; color: #6b7280; }
+    .status { font-weight: 700; padding: 4px 10px; border-radius: 999px; display: inline-block; font-size: 0.85em; border: 1px solid transparent; }
+    .status-pass { color: #065f46; background: #d1fae5; border-color: #6ee7b7; }
+    .status-drift { color: #92400e; background: #fef3c7; border-color: #f59e0b; }
+    .status-error { color: #991b1b; background: #fee2e2; border-color: #ef4444; }
+    .status-info { color: #1e40af; background: #dbeafe; border-color: #3b82f6; }
+    .top-status { margin-top: 8px; }
+    nav.toc { margin: 16px 0; padding: 12px 16px; border: 1px solid #e5e7eb; border-radius: 10px; }
+    nav.toc ul { margin: 8px 0 0 0; padding-left: 20px; }
+    .summary-block { border: 1px solid #e5e7eb; border-radius: 10px; padding: 16px; margin: 16px 0; }
+    .section { border: 1px solid #e5e7eb; border-radius: 10px; padding: 16px; margin-top: 16px; }
+    .section-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; flex-wrap: wrap; }
+    .section-head h2 { margin: 0; font-size: 1.15rem; display: flex; align-items: center; gap: 10px; }
+    .section-actions { display: flex; gap: 8px; flex-shrink: 0; }
+    .icon-button { width: 30px; height: 30px; border-radius: 999px; border: 1px solid #cbd5e1; background: #ffffff; color: #334155; font-size: 14px; cursor: pointer; }
+    .icon-button:hover { filter: brightness(0.95); }
+    .section-summary { color: #374151; font-style: italic; }
+    .fragment-link { font-size: 0.9rem; }
+    .fragment-source { color: #6b7280; }
+    table { border-collapse: collapse; width: 100%; margin: 10px 0; }
+    th, td { border: 1px solid #e5e7eb; padding: 6px 10px; text-align: left; vertical-align: top; font-size: 0.9rem; }
+    thead th { background: #f3f4f6; }
+    :root[data-theme="dark"] thead th { background: #1f2937; }
+    @media (prefers-color-scheme: dark) { thead th { background: #1f2937; } }
+    code { background: #f3f4f6; padding: 1px 4px; border-radius: 4px; font-size: 0.9em; white-space: pre-wrap; word-break: break-word; }
+    .finding { border-top: 1px dashed #e5e7eb; padding-top: 10px; margin-top: 10px; }
+    dl { display: grid; grid-template-columns: max-content 1fr; gap: 4px 12px; margin: 8px 0; }
+    dt { font-weight: 600; }
+    dd { margin: 0; }
+    .scratchpad { background: #f9fafb; border-left: 4px solid #3b82f6; padding: 12px; margin-top: 12px; border-radius: 4px; }
+    :root[data-theme="dark"] .scratchpad { background: #0f172a; }
+    .recommendations ul { padding-left: 20px; }
+    .metadata-table th { width: 260px; }
+    footer { margin-top: 24px; padding-top: 12px; border-top: 1px solid #e5e7eb; font-size: 0.85rem; color: #6b7280; }
+    table { display: block; overflow-x: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{{ title | e }}</h1>
+{% if subtitle %}
+    <p class="subtitle">{{ subtitle | e }}</p>
+{% endif %}
+{% if generated_at %}
+    <p class="generated-at">Generated: {{ generated_at | e }}</p>
+{% endif %}
+{% if source_label %}
+    <p class="source-label">Source: {{ source_label | e }}</p>
+{% endif %}
+    <div class="top-status"><span class="status status-{{ status | lower | e }}">{{ status | e }}</span></div>
+  </header>
+
+  <section class="summary-block">
+    <div class="section-head">
+      <h2>Summary</h2>
+{% if summary_copy_json or summary_copy_context %}
+      <div class="section-actions" role="group" aria-label="Copy summary data">
+{% if summary_copy_json %}
+        <button class="icon-button" type="button" title="Copy JSON" data-copy-text="{{ summary_copy_json | e }}">{}</button>
+{% endif %}
+{% if summary_copy_context %}
+        <button class="icon-button" type="button" title="Copy Context" data-copy-text="{{ summary_copy_context | e }}">⎘</button>
+{% endif %}
+      </div>
+{% endif %}
+    </div>
+    {{ summary_intro_html | safe }}
+    <table class="session-summary">
+      <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+      <tbody>
+{% for row in rows %}
+        <tr>
+          <th scope="row">{{ row.label | e }}</th>
+          <td>{{ row.iterations | e }}</td>
+          <td>{{ row.pass | e }}</td>
+          <td><span class="status status-{{ row.result | lower | e }}">{{ row.result | e }}</span></td>
+        </tr>
+{% endfor %}
+      </tbody>
+    </table>
+{% if summary_trailer_html %}
+    {{ summary_trailer_html | safe }}
+{% endif %}
+  </section>
+
+{% if toc_rows %}
+  <nav class="toc">
+    <strong>Worker Sections</strong>
+    <ul>
+{% for row in toc_rows %}
+      <li><a href="#{{ row.id | e }}">{{ row.title | e }}</a> <span class="status status-{{ row.status | lower | e }}">{{ row.status | e }}</span></li>
+{% endfor %}
+    </ul>
+  </nav>
+{% endif %}
+
+{% for section in sections %}
+{{ section | safe }}
+{% endfor %}
+
+{% if recommendations_html %}
+  <section class="section recommendations">
+    <h2>Recommendations</h2>
+    {{ recommendations_html | safe }}
+  </section>
+{% endif %}
+
+{% if metadata_rows %}
+  <section class="section metadata">
+    <h2>Metadata</h2>
+    <table class="metadata-table"><tbody>
+{% for row in metadata_rows %}
+      <tr><th scope="row">{{ row.label | e }}</th><td>{{ row.value | e }}</td></tr>
+{% endfor %}
+    </tbody></table>
+  </section>
+{% endif %}
+
+  <footer>
+{% if footer_html %}
+    {{ footer_html | safe }}
+{% endif %}
+  </footer>
+
+  <script>
+    document.addEventListener("click", async function (event) {
+      var button = event.target.closest("[data-copy-text]");
+      if (!button) return;
+      var text = button.getAttribute("data-copy-text") || "";
+      try {
+        await navigator.clipboard.writeText(text);
+        button.setAttribute("title", "Copied");
+      } catch (err) {
+        button.setAttribute("title", "Copy failed");
+      }
+    });
+  </script>
+</body>
+</html>

--- a/.claude/skills/triaging-findings/SKILL.md
+++ b/.claude/skills/triaging-findings/SKILL.md
@@ -5,7 +5,7 @@ description: Orchestrate pre-dispatch QA finding triage as team-lead. Launch one
 requires:
   cli:
     - name: sc-compose
-      minimum_version: 1.2.0
+      minimum_version: 1.3.0
     - name: oxigraph
     - name: rg
   python:
@@ -34,8 +34,8 @@ record:
 python3 .claude/skills/triaging-findings/scripts/check_dependencies.py
 ```
 
-The preflight requires the `sc-compose` CLI and Python `sc_compose` binding at
-`>= 1.2.0`, plus `oxigraph`, `rg`, and Python `rdflib`. It checks PATH plus
+The preflight requires the `sc-compose` CLI at the unreleased source pin and
+the Python `sc_compose` binding at `>= 1.2.0`, plus `oxigraph`, `rg`, and Python `rdflib`. It checks PATH plus
 common Homebrew/Cargo/user-install locations and returns a structured result.
 A non-zero result is a hard stop; read
 `references/installation-and-troubleshooting.md`, fix the environment, and
@@ -54,7 +54,7 @@ Before using this workflow:
 2. The target phase has an explicit `phase_id` such as `phase-R`.
 3. The ordered worktree list is known in promotion order.
 4. QA findings exist in a structured form with stable finding ids.
-5. The Step 1 preflight passes: `sc-compose >= 1.2.0` CLI and Python binding,
+5. The Step 1 preflight passes: the pinned `sc-compose` CLI and `sc_compose >= 1.2.0` Python binding,
    `oxigraph`, `rg`, and Python `rdflib` are available.
 
 ## Ownership Model

--- a/.claude/skills/triaging-findings/references/installation-and-troubleshooting.md
+++ b/.claude/skills/triaging-findings/references/installation-and-troubleshooting.md
@@ -5,7 +5,7 @@ requires:
 
 | Dependency | Minimum | Purpose |
 |---|---:|---|
-| `sc-compose` CLI | **1.2.0** | Render canonical Turtle records |
+| `sc-compose` CLI | **unreleased source revision `113729e` (1.3.0-compatible)** | Render canonical Turtle records |
 | Python `sc_compose` binding | **1.2.0** | Native Python rendering/API tests |
 | `oxigraph` | supported installed release | Parse/validate rendered Turtle |
 | `rg` | installed | Sweep source worktrees |
@@ -27,8 +27,10 @@ locations. If it reports success, do not reinstall anything.
 macOS (one-time per-machine setup):
 
 ```bash
-brew install randlee/tap/sc-compose
 python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'
+# The CLI pin below is required for the current report/template contract.
+cargo install --git https://github.com/randlee/sc-compose.git \
+  --rev 113729e60e3409ad8c651a74956ffa5c167dd1b6 --locked --bin sc-compose
 cargo install oxigraph-cli
 ```
 
@@ -36,17 +38,17 @@ The `--user` target avoids Homebrew-managed site-packages and
 `--break-system-packages` is Python's sanctioned override for this trusted
 user-owned wheel. Do not create or activate a venv for this setup. The PyPI
 package supplies the `sc_compose` Python binding (Python 3.11+; prebuilt
-platform wheels); it does not replace
-the standalone `sc-compose` CLI. On Linux without Homebrew, install the CLI
-from the v1.2.0 release or from a source checkout with the upstream
-`cargo install --path crates/sc-compose` procedure.
+platform wheels); it does not replace the standalone `sc-compose` CLI. On
+Linux without Homebrew, install the CLI from the pinned source revision
+shown above.
 
 Linux:
 
 ```bash
 python3 -m pip install --user --break-system-packages 'sc-compose>=1.2.0'
-# Install the standalone CLI from the v1.2.0 release, or from source:
-# cargo install --path crates/sc-compose
+# Install the standalone CLI from the pinned source revision:
+cargo install --git https://github.com/randlee/sc-compose.git \
+  --rev 113729e60e3409ad8c651a74956ffa5c167dd1b6 --locked --bin sc-compose
 cargo install oxigraph-cli
 ```
 
@@ -94,7 +96,7 @@ host-specific absolute checkout path in a canonical Turtle record.
 ## Validate after setup
 
 ```bash
-sc-compose --version       # CLI must be 1.2.0 or newer
+sc-compose --version       # CLI must be the pinned unreleased 1.3.0-compatible build
 oxigraph --version
 rg --version
 python3 -c 'import rdflib; print(rdflib.__version__)'
@@ -104,8 +106,9 @@ python3 .claude/skills/triaging-findings/scripts/check_dependencies.py
 
 ## Known issues
 
-- `sc-compose 1.0.x` is insufficient; upgrade rather than suppressing the
-  version failure.
+- The v1.2.0 CLI is insufficient for the current templates. Install the pinned
+  source revision above; do not lower the requirement or substitute a release
+  binary.
 - Installing with one Python and invoking the skill with another leaves
   `rdflib` unavailable. Compare `python3 -c 'import sys; print(sys.executable)'`
   with the interpreter used for installation.

--- a/.claude/skills/triaging-findings/scripts/check_dependencies.py
+++ b/.claude/skills/triaging-findings/scripts/check_dependencies.py
@@ -18,7 +18,10 @@ if str(_CLAUDE_DIR) not in sys.path:
 
 from lib.sc_compose_dependency import (  # noqa: E402
     MIN_SC_COMPOSE,
-    SC_COMPOSE_INSTALL,
+    MIN_SC_COMPOSE_BINDING,
+    MIN_SC_COMPOSE_BINDING_TEXT,
+    MIN_SC_COMPOSE_TEXT,
+    SC_COMPOSE_BINDING_INSTALL,
     parse_version as _version,
 )
 
@@ -84,29 +87,29 @@ def _python_binding_entry() -> dict[str, Any]:
     except (ImportError, importlib.metadata.PackageNotFoundError):
         return {
             "name": "sc_compose",
-            "required": "Python binding >=1.2.0",
+            "required": f"Python binding {MIN_SC_COMPOSE_BINDING_TEXT}",
             "path": sys.executable,
             "ok": False,
             "error": (
                 "sc-compose Python bindings not installed. Run: "
-                + SC_COMPOSE_INSTALL
+                + SC_COMPOSE_BINDING_INSTALL
             ),
         }
-    if installed is None or installed < MIN_SC_COMPOSE:
+    if installed is None or installed < MIN_SC_COMPOSE_BINDING:
         return {
             "name": "sc_compose",
-            "required": "Python binding >=1.2.0",
+            "required": f"Python binding {MIN_SC_COMPOSE_BINDING_TEXT}",
             "path": sys.executable,
             "version": version_text,
             "ok": False,
-            "error": "requires >= 1.2.0; reinstall with: " + SC_COMPOSE_INSTALL,
+            "error": "requires " + MIN_SC_COMPOSE_BINDING_TEXT + "; reinstall with: " + SC_COMPOSE_BINDING_INSTALL,
         }
-    return {"name": "sc_compose", "required": "Python binding >=1.2.0", "path": sys.executable, "version": version_text, "ok": True}
+    return {"name": "sc_compose", "required": f"Python binding {MIN_SC_COMPOSE_BINDING_TEXT}", "path": sys.executable, "version": version_text, "ok": True}
 
 
 def run() -> dict[str, Any]:
     checks = [
-        _entry("sc-compose", ">=1.2.0", minimum=MIN_SC_COMPOSE),
+        _entry("sc-compose", MIN_SC_COMPOSE_TEXT, minimum=MIN_SC_COMPOSE),
         _entry("oxigraph", "installed"),
         _entry("rg", "installed"),
     ]

--- a/.claude/skills/triaging-findings/tests/test_check_dependencies.py
+++ b/.claude/skills/triaging-findings/tests/test_check_dependencies.py
@@ -20,7 +20,7 @@ def test_version_parser():
 
 def test_preflight_passes_in_current_environment(monkeypatch):
     monkeypatch.setattr(check_dependencies, "_find", lambda name: Path("/bin/true"))
-    monkeypatch.setattr(check_dependencies, "_run_version", lambda path: ("tool 1.2.0", "tool 1.2.0"))
+    monkeypatch.setattr(check_dependencies, "_run_version", lambda path: ("tool 1.3.0", "tool 1.3.0"))
     monkeypatch.setattr(check_dependencies, "_python_binding_entry", lambda: {"name": "sc_compose", "ok": True})
     result = check_dependencies.run()
     assert result["success"] is True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Install sc-compose CLI
         # AI.50's copied fuzz templates require nested arrays-of-objects,
-        # which shipped after the v1.2.0 release. Pin the source revision
-        # that provides the established 1.3.0 report renderer.
+        # supported by this unreleased source revision but not by v1.2.0.
+        # Keep this pin aligned with .claude/lib/sc_compose_dependency.py.
         run: cargo install --git https://github.com/randlee/sc-compose.git --rev 113729e60e3409ad8c651a74956ffa5c167dd1b6 --locked --bin sc-compose
 
       - name: Expose Cargo binaries on PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,10 @@ jobs:
           python-version: "3.x"
 
       - name: Install sc-compose CLI
-        run: cargo install --git https://github.com/randlee/sc-compose.git --tag v1.2.0 --locked --bin sc-compose
+        # AI.50's copied fuzz templates require nested arrays-of-objects,
+        # which shipped after the v1.2.0 release. Pin the source revision
+        # that provides the established 1.3.0 report renderer.
+        run: cargo install --git https://github.com/randlee/sc-compose.git --rev 113729e60e3409ad8c651a74956ffa5c167dd1b6 --locked --bin sc-compose
 
       - name: Expose Cargo binaries on PATH
         run: python -c "import os; cargo_bin = os.path.expanduser('~/.cargo/bin'); open(os.environ['GITHUB_PATH'], 'a', encoding='utf-8').write(cargo_bin + os.linesep)"

--- a/.just/fixtures/fuzz/ai48-report-mixed.json
+++ b/.just/fixtures/fuzz/ai48-report-mixed.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "adversarial-fuzzing/v1",
+  "generated_at": "2026-08-01T03:30:00Z",
+  "host_label": "mac-arm64",
+  "execution_mode": "contract-only",
+  "campaign": {
+    "worktree_path": "/Users/example/atm-core-worktrees/feature/pAI-s48-fuzz-tooling-port",
+    "target": "full",
+    "baseline_ref": "develop",
+    "seed": 157,
+    "max_workers": 4,
+    "cases_per_worker": 12,
+    "per_worker_timeout_s": 120,
+    "promote_regressions": true,
+    "notes": "AI.48 fixture covering pass, confirmed bug, timeout, and incomplete worker states."
+  },
+  "workers": [
+    {
+      "correlation_id": "shape-probe",
+      "target": "full",
+      "status": "success",
+      "cases_run": 12,
+      "passed": 12,
+      "failed": 0,
+      "finding_ids": [],
+      "error": null
+    },
+    {
+      "correlation_id": "template-probe",
+      "target": "full",
+      "status": "failed",
+      "cases_run": 12,
+      "passed": 9,
+      "failed": 3,
+      "finding_ids": ["template-probe-001"],
+      "error": {"code": "confirmed_bug", "message": "three deterministic output mismatches"},
+      "classification": "confirmed_bug",
+      "findings": [
+        {
+          "finding_id": "template-probe-001",
+          "minimal_template": "---\n---\n{{ value }}",
+          "minimal_input": "value=<literal>",
+          "expected_oracle": "literal input is escaped in the XHTML panel",
+          "observed_result": "worker observed an unescaped output mismatch",
+          "requirement_trace": "No requirement or ADR currently covers this behavior.",
+          "requirement_follow_up": "Confirm the public escaping contract before changing the renderer.",
+          "root_cause": "The probe found a deterministic renderer mismatch.",
+          "recommended_fix": "Add a minimized regression fixture and rerun the bounded campaign."
+        }
+      ]
+    },
+    {
+      "correlation_id": "boundary-probe",
+      "target": "full",
+      "status": "timed_out",
+      "cases_run": 4,
+      "passed": 0,
+      "failed": 4,
+      "finding_ids": [],
+      "error": {"code": "worker_timeout", "message": "worker exceeded per-worker timeout"}
+    }
+  ]
+}

--- a/.just/fixtures/fuzz/redaction-paths.json
+++ b/.just/fixtures/fuzz/redaction-paths.json
@@ -1,0 +1,8 @@
+{
+  "mac_home": "/Users/example/atm-core",
+  "linux_home": "/home/runner/work/atm-core",
+  "mac_process_tmp": "/private/var/folders/zz/tmp/atm-report",
+  "mac_shared_tmp": "/private/tmp/atm-report",
+  "linux_tmp": "/tmp/atm-report",
+  "windows_home": "C:\\Users\\runneradmin\\atm-report"
+}

--- a/.just/tests/test_fuzz_report.py
+++ b/.just/tests/test_fuzz_report.py
@@ -33,7 +33,7 @@ class FuzzReportTests(unittest.TestCase):
         self.assertEqual([worker["classification"] for worker in session["workers"]], [
             "pass", "confirmed_bug", "inconclusive", "inconclusive"
         ])
-        self.assertEqual(session["campaign"]["worktree_path"], "<redacted-path>")
+        self.assertNotIn("worktree_path", session["campaign"])
 
     def test_rejects_invalid_worker_envelope(self) -> None:
         payload = self.fixture()

--- a/.just/tests/test_fuzz_report.py
+++ b/.just/tests/test_fuzz_report.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+import xml.etree.ElementTree as ET
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.fuzz.render_report import FuzzReportError
+from scripts.fuzz.render_report import normalize_campaign
+from scripts.fuzz.render_report import render_campaign
+
+
+FIXTURE = ROOT / ".just/fixtures/fuzz/ai48-report-mixed.json"
+
+
+class FuzzReportTests(unittest.TestCase):
+    def fixture(self) -> dict:
+        return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    def test_normalizes_success_failure_timeout_and_incomplete_workers(self) -> None:
+        session = normalize_campaign(self.fixture())
+        self.assertEqual([worker["agent_id"] for worker in session["workers"]], [
+            "shape-probe", "template-probe", "boundary-probe", "differential-probe"
+        ])
+        self.assertEqual([worker["classification"] for worker in session["workers"]], [
+            "pass", "confirmed_bug", "inconclusive", "inconclusive"
+        ])
+        self.assertEqual(session["campaign"]["worktree_path"], "<redacted-path>")
+
+    def test_rejects_invalid_worker_envelope(self) -> None:
+        payload = self.fixture()
+        payload["workers"][0]["status"] = "unknown"
+        with self.assertRaisesRegex(FuzzReportError, "invalid status"):
+            normalize_campaign(payload)
+
+    def test_renders_all_worker_outcomes_and_relative_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            report_root = Path(tempdir)
+            report = render_campaign(self.fixture(), "20260801-1-fuzz-report", report_root, invoke_index=False)
+            report_path = report_root / "20260801-1-fuzz-report.html"
+            evidence_dir = report_root / "20260801-1-fuzz-report"
+            self.assertTrue(report_path.is_file())
+            self.assertEqual(len(report["sections"]), 4)
+            self.assertNotIn("/Users/example", (evidence_dir / "20260801-1-fuzz-report.json").read_text())
+            for section in report["sections"]:
+                panel = report_root / section["xhtml_path"]
+                self.assertTrue(panel.is_file())
+                ET.parse(panel)
+            self.assertIn("confirmed_bug", (evidence_dir / "20260801-1-fuzz-report.json").read_text())
+
+    def test_reports_index_is_invoked_after_artifacts_are_written(self) -> None:
+        real_run = subprocess.run
+
+        def run_with_index_mock(*args, **kwargs):
+            command = args[0]
+            if command[:2] == ["just", "reports-index"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            return real_run(*args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as tempdir, mock.patch(
+            "scripts.fuzz.render_report.subprocess.run", side_effect=run_with_index_mock
+        ) as run:
+            render_campaign(self.fixture(), "20260801-2-fuzz-report", Path(tempdir), invoke_index=True)
+            self.assertEqual(run.call_args.args[0], ["just", "reports-index"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.just/tests/test_public_redaction.py
+++ b/.just/tests/test_public_redaction.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.public_redaction import public_string
+from scripts.public_redaction import public_value
+
+
+class PublicRedactionTests(unittest.TestCase):
+    def test_redacts_all_supported_ci_path_roots(self) -> None:
+        fixture = json.loads((ROOT / ".just/fixtures/fuzz/redaction-paths.json").read_text())
+        for value in fixture.values():
+            redacted = public_string(value)
+            self.assertEqual(redacted, "<redacted-path>", value)
+
+    def test_drops_sensitive_keys_and_redacts_nested_free_text(self) -> None:
+        value = public_value(
+            {
+                "peer_host": "runner.internal",
+                "worktree_path": "/home/runner/work/atm-core",
+                "message": "temporary output at /private/var/folders/zz/tmp/report",
+            }
+        )
+        self.assertNotIn("peer_host", value)
+        self.assertNotIn("worktree_path", value)
+        self.assertEqual(value["message"], "temporary output at <redacted-path>")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/fuzz/render_report.py
+++ b/scripts/fuzz/render_report.py
@@ -31,6 +31,8 @@ STATUSES = {"success", "failed", "timed_out"}
 CLASSIFICATIONS = {"pass", "confirmed_bug", "intentional_boundary", "inconclusive"}
 SAFE_STEM = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 SAFE_HOST = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+ABSOLUTE_PATH = re.compile(r"(?:/Users/[^\s,;]+|/private/tmp/[^\s,;]+|/tmp/[^\s,;]+|[A-Za-z]:\\[^\s,;]+)")
+SENSITIVE_KEYS = frozenset({"atm_home", "current_dir", "daemon_pid", "endpoint", "home_dir", "path", "worktree_path"})
 
 
 class FuzzReportError(ValueError):
@@ -50,6 +52,22 @@ def safe_stem(value: str) -> str:
 def safe_host(value: Any) -> str:
     if not isinstance(value, str) or not SAFE_HOST.fullmatch(value):
         raise FuzzReportError("host_label must be a safe opaque label")
+    return value
+
+
+def public_text(value: Any) -> str:
+    return ABSOLUTE_PATH.sub("<redacted-path>", str(value))[:4000]
+
+
+def public_value(value: Any, key: str | None = None) -> Any:
+    if key in SENSITIVE_KEYS:
+        return "<redacted-path>"
+    if isinstance(value, str):
+        return public_text(value)
+    if isinstance(value, list):
+        return [public_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(item_key): public_value(item, str(item_key)) for item_key, item in value.items()}
     return value
 
 
@@ -124,15 +142,16 @@ def normalize_worker(raw: Any, session_id: str, target: str) -> dict[str, Any]:
             raise FuzzReportError(f"worker {worker_id}: test input text fields must be strings")
         if not isinstance(item["passed"], bool):
             raise FuzzReportError(f"worker {worker_id}: test input passed must be boolean")
-        normalized_inputs.append({field: item[field] for field in required})
+        normalized_inputs.append({field: public_value(item[field]) for field in required})
     findings = raw.get("findings", [])
     if not isinstance(findings, list) or any(not isinstance(item, dict) for item in findings):
         raise FuzzReportError(f"worker {worker_id}: findings must be an array of objects")
     if classification != "pass" and not findings:
         findings = [_default_finding(worker_id, status)]
-    payload = dict(raw)
+    findings = public_value(findings)
+    payload = public_value(dict(raw))
     payload.update({"correlation_id": worker_id, "target": target, "status": status, "cases_run": cases_run})
-    description = raw.get("fuzz_run_description", f"AI.48 {target} {worker_id} bounded campaign")
+    description = public_text(raw.get("fuzz_run_description", f"AI.48 {target} {worker_id} bounded campaign"))
     result = "PASS" if failed == 0 else "FAIL"
     return {
         "session_id": session_id,
@@ -144,12 +163,12 @@ def normalize_worker(raw: Any, session_id: str, target: str) -> dict[str, Any]:
         "passed": passed,
         "failed": failed,
         "result": result,
-        "summary": raw.get("summary", f"{worker_id} returned {status} after {cases_run} bounded cases."),
+        "summary": public_text(raw.get("summary", f"{worker_id} returned {status} after {cases_run} bounded cases.")),
         "test_inputs": normalized_inputs,
         "findings": findings,
         "json_payload": payload,
         "copy_json": json.dumps(payload, sort_keys=True),
-        "context_text": raw.get("context_text", f"{worker_id}: {status}; {passed}/{cases_run} cases passed."),
+        "context_text": public_text(raw.get("context_text", f"{worker_id}: {status}; {passed}/{cases_run} cases passed.")),
     }
 
 
@@ -176,10 +195,7 @@ def normalize_campaign(payload: Any, session_id: str | None = None) -> dict[str,
     missing = [worker for worker in expected if worker not in present]
     for worker_id in missing:
         workers.append(normalize_worker({"correlation_id": worker_id, "status": "timed_out", "cases_run": 0}, sid, target))
-    public_campaign = {
-        key: ("<redacted-path>" if key == "worktree_path" else value)
-        for key, value in campaign.items()
-    }
+    public_campaign = public_value(campaign)
     return {
         "schema_version": SCHEMA_VERSION,
         "session_id": sid,

--- a/scripts/fuzz/render_report.py
+++ b/scripts/fuzz/render_report.py
@@ -22,6 +22,13 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.public_redaction import public_string
+from scripts.public_redaction import public_value
+
+
 REPORTS_ROOT = ROOT / "site" / "reports"
 REPORT_TEMPLATE = ROOT / ".claude/skills/html-report/templates/fuzz-run-report.html.j2"
 PANEL_TEMPLATE = ROOT / ".claude/skills/html-report/templates/fuzz-run-agent.xhtml.j2"
@@ -31,8 +38,6 @@ STATUSES = {"success", "failed", "timed_out"}
 CLASSIFICATIONS = {"pass", "confirmed_bug", "intentional_boundary", "inconclusive"}
 SAFE_STEM = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 SAFE_HOST = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
-ABSOLUTE_PATH = re.compile(r"(?:/Users/[^\s,;]+|/private/tmp/[^\s,;]+|/tmp/[^\s,;]+|[A-Za-z]:\\[^\s,;]+)")
-SENSITIVE_KEYS = frozenset({"atm_home", "current_dir", "daemon_pid", "endpoint", "home_dir", "path", "worktree_path"})
 
 
 class FuzzReportError(ValueError):
@@ -52,22 +57,6 @@ def safe_stem(value: str) -> str:
 def safe_host(value: Any) -> str:
     if not isinstance(value, str) or not SAFE_HOST.fullmatch(value):
         raise FuzzReportError("host_label must be a safe opaque label")
-    return value
-
-
-def public_text(value: Any) -> str:
-    return ABSOLUTE_PATH.sub("<redacted-path>", str(value))[:4000]
-
-
-def public_value(value: Any, key: str | None = None) -> Any:
-    if key in SENSITIVE_KEYS:
-        return "<redacted-path>"
-    if isinstance(value, str):
-        return public_text(value)
-    if isinstance(value, list):
-        return [public_value(item) for item in value]
-    if isinstance(value, dict):
-        return {str(item_key): public_value(item, str(item_key)) for item_key, item in value.items()}
     return value
 
 
@@ -151,7 +140,7 @@ def normalize_worker(raw: Any, session_id: str, target: str) -> dict[str, Any]:
     findings = public_value(findings)
     payload = public_value(dict(raw))
     payload.update({"correlation_id": worker_id, "target": target, "status": status, "cases_run": cases_run})
-    description = public_text(raw.get("fuzz_run_description", f"AI.48 {target} {worker_id} bounded campaign"))
+    description = public_string(raw.get("fuzz_run_description", f"AI.48 {target} {worker_id} bounded campaign"))
     result = "PASS" if failed == 0 else "FAIL"
     return {
         "session_id": session_id,
@@ -163,12 +152,12 @@ def normalize_worker(raw: Any, session_id: str, target: str) -> dict[str, Any]:
         "passed": passed,
         "failed": failed,
         "result": result,
-        "summary": public_text(raw.get("summary", f"{worker_id} returned {status} after {cases_run} bounded cases.")),
+        "summary": public_string(raw.get("summary", f"{worker_id} returned {status} after {cases_run} bounded cases.")),
         "test_inputs": normalized_inputs,
         "findings": findings,
         "json_payload": payload,
         "copy_json": json.dumps(payload, sort_keys=True),
-        "context_text": public_text(raw.get("context_text", f"{worker_id}: {status}; {passed}/{cases_run} cases passed.")),
+        "context_text": public_string(raw.get("context_text", f"{worker_id}: {status}; {passed}/{cases_run} cases passed.")),
     }
 
 

--- a/scripts/fuzz/render_report.py
+++ b/scripts/fuzz/render_report.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Render AI.48 fuzz-session evidence through the copied sc-compose templates.
+
+The coordinator/probe contract is intentionally kept separate from the report
+contract.  This module adapts each bounded worker result into the fields
+required by ``fuzz-run-agent.xhtml.j2`` and lets sc-compose render both the
+worker panels and the top-level HTML shell.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from html import escape
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORTS_ROOT = ROOT / "site" / "reports"
+REPORT_TEMPLATE = ROOT / ".claude/skills/html-report/templates/fuzz-run-report.html.j2"
+PANEL_TEMPLATE = ROOT / ".claude/skills/html-report/templates/fuzz-run-agent.xhtml.j2"
+SCHEMA_VERSION = "adversarial-fuzzing/v1"
+WORKERS = ("shape-probe", "template-probe", "boundary-probe", "differential-probe")
+STATUSES = {"success", "failed", "timed_out"}
+CLASSIFICATIONS = {"pass", "confirmed_bug", "intentional_boundary", "inconclusive"}
+SAFE_STEM = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+SAFE_HOST = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class FuzzReportError(ValueError):
+    """The campaign or one of its public artifacts is invalid."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def safe_stem(value: str) -> str:
+    if not isinstance(value, str) or not SAFE_STEM.fullmatch(value):
+        raise FuzzReportError(f"unsafe report stem: {value!r}")
+    return value
+
+
+def safe_host(value: Any) -> str:
+    if not isinstance(value, str) or not SAFE_HOST.fullmatch(value):
+        raise FuzzReportError("host_label must be a safe opaque label")
+    return value
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise FuzzReportError(f"unable to read JSON artifact: {path}") from error
+
+
+def _bounded_count(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0 or value > 1000:
+        raise FuzzReportError(f"{field} must be an integer between 0 and 1000")
+    return value
+
+
+def _default_input(worker_id: str, status: str, cases_run: int) -> dict[str, Any]:
+    return {
+        "case_id": f"{worker_id}-campaign",
+        "description": f"AI.48 bounded {worker_id} campaign",
+        "minimal_template": "---\n---\n{{ value }}",
+        "minimal_input": f"status={status}; cases_run={cases_run}",
+        "passed": status == "success",
+        "outcome": "all bounded cases completed" if status == "success" else f"worker ended with {status}",
+    }
+
+
+def _default_finding(worker_id: str, status: str) -> dict[str, str]:
+    return {
+        "finding_id": f"{worker_id}-{status}",
+        "minimal_template": "---\n---\n{{ value }}",
+        "minimal_input": f"worker status={status}",
+        "expected_oracle": "worker completes its bounded campaign",
+        "observed_result": f"worker returned {status}",
+        "requirement_trace": "No requirement or ADR currently covers this behavior.",
+        "requirement_follow_up": "Record the owner and evidence before changing a product contract.",
+        "root_cause": "Worker did not provide an evidence-backed root cause.",
+        "recommended_fix": "Review the worker evidence and rerun the bounded campaign.",
+    }
+
+
+def normalize_worker(raw: Any, session_id: str, target: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise FuzzReportError("worker result must be an object")
+    worker_id = raw.get("correlation_id")
+    if worker_id not in WORKERS:
+        raise FuzzReportError(f"unknown worker correlation_id: {worker_id!r}")
+    status = raw.get("status")
+    if status not in STATUSES:
+        raise FuzzReportError(f"worker {worker_id}: invalid status {status!r}")
+    cases_run = _bounded_count(raw.get("cases_run"), f"{worker_id}.cases_run")
+    passed = _bounded_count(raw.get("passed", cases_run if status == "success" else 0), f"{worker_id}.passed")
+    if passed > cases_run:
+        raise FuzzReportError(f"worker {worker_id}: passed exceeds cases_run")
+    failed = _bounded_count(raw.get("failed", cases_run - passed), f"{worker_id}.failed")
+    if failed != cases_run - passed:
+        raise FuzzReportError(f"worker {worker_id}: failed does not equal cases_run - passed")
+    classification = raw.get("classification")
+    if classification is None:
+        classification = {"success": "pass", "failed": "confirmed_bug", "timed_out": "inconclusive"}[status]
+    if classification not in CLASSIFICATIONS:
+        raise FuzzReportError(f"worker {worker_id}: invalid classification {classification!r}")
+    test_inputs = raw.get("test_inputs", [_default_input(worker_id, status, cases_run)])
+    if not isinstance(test_inputs, list) or any(not isinstance(item, dict) for item in test_inputs):
+        raise FuzzReportError(f"worker {worker_id}: test_inputs must be an array of objects")
+    normalized_inputs: list[dict[str, Any]] = []
+    for item in test_inputs:
+        required = {"case_id", "description", "minimal_template", "minimal_input", "passed", "outcome"}
+        if required - item.keys():
+            raise FuzzReportError(f"worker {worker_id}: test input is missing required fields")
+        if not all(isinstance(item[field], str) for field in required - {"passed"}):
+            raise FuzzReportError(f"worker {worker_id}: test input text fields must be strings")
+        if not isinstance(item["passed"], bool):
+            raise FuzzReportError(f"worker {worker_id}: test input passed must be boolean")
+        normalized_inputs.append({field: item[field] for field in required})
+    findings = raw.get("findings", [])
+    if not isinstance(findings, list) or any(not isinstance(item, dict) for item in findings):
+        raise FuzzReportError(f"worker {worker_id}: findings must be an array of objects")
+    if classification != "pass" and not findings:
+        findings = [_default_finding(worker_id, status)]
+    payload = dict(raw)
+    payload.update({"correlation_id": worker_id, "target": target, "status": status, "cases_run": cases_run})
+    description = raw.get("fuzz_run_description", f"AI.48 {target} {worker_id} bounded campaign")
+    result = "PASS" if failed == 0 else "FAIL"
+    return {
+        "session_id": session_id,
+        "agent_id": worker_id,
+        "fuzz_run_description": description,
+        "worker_correlation_id": worker_id,
+        "classification": classification,
+        "iterations": cases_run,
+        "passed": passed,
+        "failed": failed,
+        "result": result,
+        "summary": raw.get("summary", f"{worker_id} returned {status} after {cases_run} bounded cases."),
+        "test_inputs": normalized_inputs,
+        "findings": findings,
+        "json_payload": payload,
+        "copy_json": json.dumps(payload, sort_keys=True),
+        "context_text": raw.get("context_text", f"{worker_id}: {status}; {passed}/{cases_run} cases passed."),
+    }
+
+
+def normalize_campaign(payload: Any, session_id: str | None = None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise FuzzReportError("campaign result must be a JSON object")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise FuzzReportError(f"expected schema_version {SCHEMA_VERSION}")
+    campaign = payload.get("campaign")
+    if not isinstance(campaign, dict):
+        raise FuzzReportError("campaign result must contain a campaign object")
+    target = campaign.get("target")
+    if not isinstance(target, str) or not target:
+        raise FuzzReportError("campaign.target must be a non-empty string")
+    workers_raw = payload.get("workers")
+    if not isinstance(workers_raw, list):
+        raise FuzzReportError("campaign result workers must be an array")
+    sid = session_id or str(payload.get("session_id") or campaign.get("session_id") or "ai48-fuzz-session")
+    workers = [normalize_worker(item, sid, target) for item in workers_raw]
+    if len({worker["agent_id"] for worker in workers}) != len(workers):
+        raise FuzzReportError("worker correlation_id values must be unique")
+    expected = WORKERS if target == "full" else tuple(worker["agent_id"] for worker in workers)
+    present = {worker["agent_id"] for worker in workers}
+    missing = [worker for worker in expected if worker not in present]
+    for worker_id in missing:
+        workers.append(normalize_worker({"correlation_id": worker_id, "status": "timed_out", "cases_run": 0}, sid, target))
+    public_campaign = {
+        key: ("<redacted-path>" if key == "worktree_path" else value)
+        for key, value in campaign.items()
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "session_id": sid,
+        "generated_at": payload.get("generated_at", utc_now()),
+        "host_label": safe_host(payload.get("host_label", "local")),
+        "campaign": public_campaign,
+        "workers": workers,
+        "execution_mode": payload.get("execution_mode", "contract-only"),
+    }
+
+
+def compose(template: Path, variables: dict[str, Any], output: Path, root: Path = ROOT) -> None:
+    variables_path: Path | None = None
+    output.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", encoding="utf-8", delete=False) as handle:
+            json.dump(variables, handle, sort_keys=True)
+            variables_path = Path(handle.name)
+        result = subprocess.run(
+            ["sc-compose", "render", "--root", str(root), "--file", str(template), "--var-file", str(variables_path), "--output", str(output)],
+            cwd=root, capture_output=True, text=True, check=False,
+        )
+        if result.returncode != 0:
+            raise FuzzReportError(f"sc-compose render failed: {result.stderr.strip() or result.stdout.strip()}")
+    finally:
+        if variables_path is not None:
+            variables_path.unlink(missing_ok=True)
+
+
+def _summary_intro(session: dict[str, Any]) -> str:
+    return (
+        "<p>AI.48 coordinator/probe evidence rendered through the copied sc-compose fuzz-report contract. "
+        f"Session <code>{escape(session['session_id'])}</code> contains one bounded panel per worker.</p>"
+    )
+
+
+def render_campaign(payload: Any, stem: str, reports_root: Path = REPORTS_ROOT, invoke_index: bool = True) -> dict[str, Any]:
+    stem = safe_stem(stem)
+    session = normalize_campaign(payload)
+    report_dir = reports_root / stem
+    report_html = reports_root / f"{stem}.html"
+    sidecar = report_dir / f"{stem}.json"
+    workers = session["workers"]
+    sections: list[str] = []
+    section_records: list[dict[str, Any]] = []
+    for worker in workers:
+        panel_path = report_dir / f"{stem}-{worker['agent_id']}.xhtml"
+        compose(PANEL_TEMPLATE, {"agent": worker}, panel_path)
+        sections.append(panel_path.read_text(encoding="utf-8"))
+        section_records.append({
+            "id": worker["agent_id"],
+            "title": worker["agent_id"],
+            "status": worker["result"],
+            "body_html": sections[-1],
+            "context_text": worker["context_text"],
+            "json_payload": worker["json_payload"],
+            "xhtml_path": f"{stem}/{panel_path.name}",
+            "fragment_source": "auto-generated",
+        })
+    failed = any(worker["failed"] for worker in workers)
+    incomplete = any(worker["classification"] == "inconclusive" for worker in workers)
+    status = "ERROR" if failed else "INFO" if incomplete else "PASS"
+    rows = [
+        {"label": worker["fuzz_run_description"], "iterations": worker["iterations"], "pass": f"{worker['passed']}/{worker['iterations']}", "result": worker["result"]}
+        for worker in workers
+    ]
+    report_data: dict[str, Any] = {
+        "output_path": f"site/reports/{stem}.html",
+        "json_output_path": f"site/reports/{stem}/{stem}.json",
+        "title": f"Adversarial fuzz session: {session['session_id']}",
+        "subtitle": "AI.48 coordinator/probe evidence",
+        "status": status,
+        "generated_at": session["generated_at"],
+        "campaign": session["campaign"],
+        "source_label": "AI.48 fuzz coordinator contract",
+        "summary_intro_html": _summary_intro(session),
+        "rows": rows,
+        "sections": sections,
+        "toc_rows": [{"id": worker["agent_id"], "title": worker["agent_id"], "status": worker["result"]} for worker in workers],
+        "metadata_rows": [
+            {"label": "Session", "value": session["session_id"]},
+            {"label": "Execution mode", "value": session["execution_mode"]},
+            {"label": "Worker count", "value": len(workers)},
+        ],
+        "summary_copy_json": json.dumps({"session_id": session["session_id"], "status": status, "workers": len(workers)}, sort_keys=True),
+        "summary_copy_context": f"{session['session_id']}: {status}; {len(workers)} worker panels.",
+        "footer_html": "<p>Generated from AI.48 coordinator evidence through sc-compose.</p>",
+    }
+    compose(REPORT_TEMPLATE, report_data, report_html)
+    report_data["sections"] = section_records
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(json.dumps(report_data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    envelope = {
+        "schema_version": 1,
+        "report_type": "fuzz",
+        "generated_at": session["generated_at"],
+        "host_label": session["host_label"],
+        "report_html": f"{stem}.html",
+    }
+    (report_dir / f"{stem}.envelope.json").write_text(json.dumps(envelope, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if invoke_index:
+        result = subprocess.run(["just", "reports-index"], cwd=ROOT, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            raise FuzzReportError(f"reports-index failed: {result.stderr.strip() or result.stdout.strip()}")
+    return report_data
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Render an AI.48 fuzz campaign through sc-compose templates.")
+    parser.add_argument("campaign", type=Path, help="AI.48 campaign result JSON")
+    parser.add_argument("--stem", required=True, help="safe report stem, e.g. 20260801-1-fuzz-report")
+    args = parser.parse_args(argv[1:])
+    try:
+        render_campaign(load_json(args.campaign), args.stem)
+    except FuzzReportError as error:
+        print(f"fuzz-report: error: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/public_redaction.py
+++ b/scripts/public_redaction.py
@@ -1,0 +1,49 @@
+"""Shared public-evidence redaction policy for report producers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+# Keep this intentionally broad: macOS may expose per-process temporary paths
+# below /private/var, while Linux CI commonly uses /home and /tmp roots.
+ABSOLUTE_PATH = re.compile(
+    r"(?:/Users/[^\s,;]+|/home/[^\s,;]+|/private/tmp/[^\s,;]+|/private/var/[^\s,;]+|/tmp/[^\s,;]+|[A-Za-z]:\\[^\s,;]+)"
+)
+SENSITIVE_KEYS = frozenset(
+    {
+        "atm_home",
+        "current_dir",
+        "daemon_pid",
+        "doctor",
+        "endpoint",
+        "home_dir",
+        "path",
+        "peer_host",
+        "release",
+        "worktree_path",
+    }
+)
+
+
+def public_string(value: Any, max_length: int = 2000) -> str:
+    """Redact absolute paths and bound free-text evidence."""
+    return ABSOLUTE_PATH.sub("<redacted-path>", str(value))[:max_length]
+
+
+def public_value(value: Any) -> Any:
+    """Return JSON-compatible evidence with sensitive keys omitted."""
+    if isinstance(value, str):
+        return public_string(value)
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return [public_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key): public_value(item)
+            for key, item in value.items()
+            if str(key) not in SENSITIVE_KEYS
+        }
+    return public_string(value)

--- a/scripts/smoke/benchmark_report.py
+++ b/scripts/smoke/benchmark_report.py
@@ -15,6 +15,13 @@ from typing import Any, Iterable
 
 
 ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.public_redaction import public_string
+from scripts.public_redaction import public_value
+
+
 REPORTS_ROOT = ROOT / "site" / "reports"
 REPORT_NAME = "send-message-benchmark"
 REPORT_HTML = f"{REPORT_NAME}.html"
@@ -25,8 +32,6 @@ SUPPORTED_TRANSPORTS = frozenset({"uds", "tcp"})
 SUPPORTED_FRAMES = frozenset({1, 2, 8, 16, 64})
 SAFE_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
-ABSOLUTE_PATH = re.compile(r"(?:/Users/[^\s,;]+|/private/tmp/[^\s,;]+|/tmp/[^\s,;]+|[A-Za-z]:\\[^\s,;]+)")
-SENSITIVE_KEYS = frozenset({"atm_home", "daemon_pid", "doctor", "endpoint", "release", "peer_host", "current_dir", "home_dir", "path"})
 RUN_KEYS = frozenset({
     "interval", "accepted_count", "requested_count", "response_count", "elapsed_seconds",
     "admissions_per_second", "connections_per_second", "request_frames_per_second",
@@ -67,22 +72,6 @@ def safe_artifact_id(value: str) -> str:
     if not candidate or not SAFE_ID.fullmatch(candidate):
         raise BenchmarkReportError(f"unsafe benchmark artifact id: {value!r}")
     return candidate
-
-
-def public_string(value: str) -> str:
-    return ABSOLUTE_PATH.sub("<redacted-path>", value)[:2000]
-
-
-def public_value(value: Any) -> Any:
-    if isinstance(value, str):
-        return public_string(value)
-    if isinstance(value, (int, float, bool)) or value is None:
-        return value
-    if isinstance(value, list):
-        return [public_value(item) for item in value]
-    if isinstance(value, dict):
-        return {str(key): public_value(item) for key, item in value.items() if str(key) not in SENSITIVE_KEYS}
-    return public_string(str(value))
 
 
 def migrate_result(payload: dict[str, Any], source: Path) -> dict[str, Any]:

--- a/site/reports/20260801-1-fuzz-report.html
+++ b/site/reports/20260801-1-fuzz-report.html
@@ -1,0 +1,370 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Adversarial fuzz session: ai48-fuzz-session</title>
+  <style type="text/css">
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 24px; color: #1f2937; background: #ffffff; line-height: 1.5; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0b1220; color: #e5e7eb; }
+      .section { background: #111827; border-color: #1f2937; }
+      table { background: #0f172a; }
+      th, td { border-color: #1f2937 !important; }
+      .icon-button { background: #1f2937; color: #cbd5e1; border-color: #374151; }
+      code { background: #1f2937; color: #e5e7eb; }
+      a { color: #93c5fd; }
+    }
+    :root[data-theme="dark"] body { background: #0b1220; color: #e5e7eb; }
+    :root[data-theme="dark"] .section { background: #111827; border-color: #1f2937; }
+    :root[data-theme="light"] body { background: #ffffff; color: #1f2937; }
+    header { border-bottom: 1px solid #e5e7eb; padding-bottom: 16px; margin-bottom: 20px; }
+    h1 { margin: 0 0 6px 0; font-size: 1.6rem; }
+    .subtitle { margin: 0 0 4px 0; color: #6b7280; }
+    .generated-at, .source-label { margin: 2px 0; font-size: 0.85rem; color: #6b7280; }
+    .status { font-weight: 700; padding: 4px 10px; border-radius: 999px; display: inline-block; font-size: 0.85em; border: 1px solid transparent; }
+    .status-pass { color: #065f46; background: #d1fae5; border-color: #6ee7b7; }
+    .status-drift { color: #92400e; background: #fef3c7; border-color: #f59e0b; }
+    .status-error { color: #991b1b; background: #fee2e2; border-color: #ef4444; }
+    .status-info { color: #1e40af; background: #dbeafe; border-color: #3b82f6; }
+    .top-status { margin-top: 8px; }
+    nav.toc { margin: 16px 0; padding: 12px 16px; border: 1px solid #e5e7eb; border-radius: 10px; }
+    nav.toc ul { margin: 8px 0 0 0; padding-left: 20px; }
+    .summary-block { border: 1px solid #e5e7eb; border-radius: 10px; padding: 16px; margin: 16px 0; }
+    .section { border: 1px solid #e5e7eb; border-radius: 10px; padding: 16px; margin-top: 16px; }
+    .section-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; flex-wrap: wrap; }
+    .section-head h2 { margin: 0; font-size: 1.15rem; display: flex; align-items: center; gap: 10px; }
+    .section-actions { display: flex; gap: 8px; flex-shrink: 0; }
+    .icon-button { width: 30px; height: 30px; border-radius: 999px; border: 1px solid #cbd5e1; background: #ffffff; color: #334155; font-size: 14px; cursor: pointer; }
+    .icon-button:hover { filter: brightness(0.95); }
+    .section-summary { color: #374151; font-style: italic; }
+    .fragment-link { font-size: 0.9rem; }
+    .fragment-source { color: #6b7280; }
+    table { border-collapse: collapse; width: 100%; margin: 10px 0; }
+    th, td { border: 1px solid #e5e7eb; padding: 6px 10px; text-align: left; vertical-align: top; font-size: 0.9rem; }
+    thead th { background: #f3f4f6; }
+    :root[data-theme="dark"] thead th { background: #1f2937; }
+    @media (prefers-color-scheme: dark) { thead th { background: #1f2937; } }
+    code { background: #f3f4f6; padding: 1px 4px; border-radius: 4px; font-size: 0.9em; white-space: pre-wrap; word-break: break-word; }
+    .finding { border-top: 1px dashed #e5e7eb; padding-top: 10px; margin-top: 10px; }
+    dl { display: grid; grid-template-columns: max-content 1fr; gap: 4px 12px; margin: 8px 0; }
+    dt { font-weight: 600; }
+    dd { margin: 0; }
+    .scratchpad { background: #f9fafb; border-left: 4px solid #3b82f6; padding: 12px; margin-top: 12px; border-radius: 4px; }
+    :root[data-theme="dark"] .scratchpad { background: #0f172a; }
+    .recommendations ul { padding-left: 20px; }
+    .metadata-table th { width: 260px; }
+    footer { margin-top: 24px; padding-top: 12px; border-top: 1px solid #e5e7eb; font-size: 0.85rem; color: #6b7280; }
+    table { display: block; overflow-x: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Adversarial fuzz session: ai48-fuzz-session</h1>
+    <p class="subtitle">AI.48 coordinator&#x2f;probe evidence</p>
+    <p class="generated-at">Generated: 2026-08-01T03:30:00Z</p>
+    <p class="source-label">Source: AI.48 fuzz coordinator contract</p>
+    <div class="top-status"><span class="status status-error">ERROR</span></div>
+  </header>
+
+  <section class="summary-block">
+    <div class="section-head">
+      <h2>Summary</h2>
+      <div class="section-actions" role="group" aria-label="Copy summary data">
+        <button class="icon-button" type="button" title="Copy JSON" data-copy-text="{&quot;session_id&quot;: &quot;ai48-fuzz-session&quot;, &quot;status&quot;: &quot;ERROR&quot;, &quot;workers&quot;: 4}">{}</button>
+        <button class="icon-button" type="button" title="Copy Context" data-copy-text="ai48-fuzz-session: ERROR; 4 worker panels.">⎘</button>
+      </div>
+    </div>
+    <p>AI.48 coordinator/probe evidence rendered through the copied sc-compose fuzz-report contract. Session <code>ai48-fuzz-session</code> contains one bounded panel per worker.</p>
+    <table class="session-summary">
+      <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+      <tbody>
+        <tr>
+          <th scope="row">AI.48 full shape-probe bounded campaign</th>
+          <td>12</td>
+          <td>12&#x2f;12</td>
+          <td><span class="status status-pass">PASS</span></td>
+        </tr>
+        <tr>
+          <th scope="row">AI.48 full template-probe bounded campaign</th>
+          <td>12</td>
+          <td>9&#x2f;12</td>
+          <td><span class="status status-fail">FAIL</span></td>
+        </tr>
+        <tr>
+          <th scope="row">AI.48 full boundary-probe bounded campaign</th>
+          <td>4</td>
+          <td>0&#x2f;4</td>
+          <td><span class="status status-fail">FAIL</span></td>
+        </tr>
+        <tr>
+          <th scope="row">AI.48 full differential-probe bounded campaign</th>
+          <td>0</td>
+          <td>0&#x2f;0</td>
+          <td><span class="status status-pass">PASS</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <nav class="toc">
+    <strong>Worker Sections</strong>
+    <ul>
+      <li><a href="#shape-probe">shape-probe</a> <span class="status status-pass">PASS</span></li>
+      <li><a href="#template-probe">template-probe</a> <span class="status status-fail">FAIL</span></li>
+      <li><a href="#boundary-probe">boundary-probe</a> <span class="status status-fail">FAIL</span></li>
+      <li><a href="#differential-probe">differential-probe</a> <span class="status status-pass">PASS</span></li>
+    </ul>
+  </nav>
+
+<section xmlns="http://www.w3.org/1999/xhtml" class="fuzz-agent fuzz-agent-pass">
+  <header class="agent-header fuzz-agent-header">
+    <div>
+      <p class="eyebrow">Adversarial fuzz worker</p>
+      <h2>shape-probe</h2>
+      <p class="agent-meta">Session ai48-fuzz-session · Worker shape-probe</p>
+    </div>
+    <div class="agent-actions" role="group" aria-label="Copy worker data">
+      <button type="button" class="icon-button" title="Copy JSON" data-copy-text="{&quot;cases_run&quot;: 12, &quot;correlation_id&quot;: &quot;shape-probe&quot;, &quot;error&quot;: null, &quot;failed&quot;: 0, &quot;finding_ids&quot;: [], &quot;passed&quot;: 12, &quot;status&quot;: &quot;success&quot;, &quot;target&quot;: &quot;full&quot;}">{}</button>
+      <button type="button" class="icon-button" title="Copy Context" data-copy-text="shape-probe: success; 12&#x2f;12 cases passed.">⎘</button>
+    </div>
+  </header>
+
+  <p class="status">
+    <span class="status status-pass">PASS</span>
+  </p>
+
+  <table class="agent-results">
+    <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+    <tbody>
+      <tr>
+        <th scope="row">AI.48 full shape-probe bounded campaign</th>
+        <td>12</td>
+        <td>12/12</td>
+        <td>
+          <span class="status status-pass">PASS</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <section class="test-inputs">
+    <h3>Inputs exercised</h3>
+    <table>
+      <thead><tr><th scope="col">Case</th><th scope="col">Template / input</th><th scope="col">Outcome</th></tr></thead>
+      <tbody>
+        <tr><th scope="row">shape-probe-campaign</th><td><code>AI.48 bounded shape-probe campaign</code></td><td>all bounded cases completed</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+</section>
+<section xmlns="http://www.w3.org/1999/xhtml" class="fuzz-agent fuzz-agent-confirmed_bug">
+  <header class="agent-header fuzz-agent-header">
+    <div>
+      <p class="eyebrow">Adversarial fuzz worker</p>
+      <h2>template-probe</h2>
+      <p class="agent-meta">Session ai48-fuzz-session · Worker template-probe</p>
+    </div>
+    <div class="agent-actions" role="group" aria-label="Copy worker data">
+      <button type="button" class="icon-button" title="Copy JSON" data-copy-text="{&quot;cases_run&quot;: 12, &quot;classification&quot;: &quot;confirmed_bug&quot;, &quot;correlation_id&quot;: &quot;template-probe&quot;, &quot;error&quot;: {&quot;code&quot;: &quot;confirmed_bug&quot;, &quot;message&quot;: &quot;three deterministic output mismatches&quot;}, &quot;failed&quot;: 3, &quot;finding_ids&quot;: [&quot;template-probe-001&quot;], &quot;findings&quot;: [{&quot;expected_oracle&quot;: &quot;literal input is escaped in the XHTML panel&quot;, &quot;finding_id&quot;: &quot;template-probe-001&quot;, &quot;minimal_input&quot;: &quot;value=&lt;literal&gt;&quot;, &quot;minimal_template&quot;: &quot;---\n---\n{{ value }}&quot;, &quot;observed_result&quot;: &quot;worker observed an unescaped output mismatch&quot;, &quot;recommended_fix&quot;: &quot;Add a minimized regression fixture and rerun the bounded campaign.&quot;, &quot;requirement_follow_up&quot;: &quot;Confirm the public escaping contract before changing the renderer.&quot;, &quot;requirement_trace&quot;: &quot;No requirement or ADR currently covers this behavior.&quot;, &quot;root_cause&quot;: &quot;The probe found a deterministic renderer mismatch.&quot;}], &quot;passed&quot;: 9, &quot;status&quot;: &quot;failed&quot;, &quot;target&quot;: &quot;full&quot;}">{}</button>
+      <button type="button" class="icon-button" title="Copy Context" data-copy-text="template-probe: failed; 9&#x2f;12 cases passed.">⎘</button>
+    </div>
+  </header>
+
+  <p class="status">
+    <span class="status status-error">FAIL</span>
+  </p>
+
+  <table class="agent-results">
+    <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+    <tbody>
+      <tr>
+        <th scope="row">AI.48 full template-probe bounded campaign</th>
+        <td>12</td>
+        <td>9/12</td>
+        <td>
+          <span class="status status-error">FAIL</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <section class="test-inputs">
+    <h3>Inputs exercised</h3>
+    <table>
+      <thead><tr><th scope="col">Case</th><th scope="col">Template / input</th><th scope="col">Outcome</th></tr></thead>
+      <tbody>
+        <tr><th scope="row">template-probe-campaign</th><td><code>AI.48 bounded template-probe campaign</code></td><td>worker ended with failed</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="findings">
+    <h3>Findings</h3>
+    <article class="finding">
+      <h4>template-probe-001</h4>
+      <dl>
+        <dt>Minimal template / frontmatter</dt><dd><code>---
+---
+{{ value }}</code></dd>
+        <dt>Input</dt><dd><code>value=&lt;literal&gt;</code></dd>
+        <dt>Expected</dt><dd>literal input is escaped in the XHTML panel</dd>
+        <dt>Observed</dt><dd>worker observed an unescaped output mismatch</dd>
+        <dt>Requirement / ADR</dt><dd>No requirement or ADR currently covers this behavior.</dd>
+        <dt>Requirement / ADR follow-up</dt><dd>Confirm the public escaping contract before changing the renderer.</dd>
+        <dt>Root cause</dt><dd>The probe found a deterministic renderer mismatch.</dd>
+        <dt>Recommended fix</dt><dd>Add a minimized regression fixture and rerun the bounded campaign.</dd>
+      </dl>
+    </article>
+  </section>
+</section>
+<section xmlns="http://www.w3.org/1999/xhtml" class="fuzz-agent fuzz-agent-inconclusive">
+  <header class="agent-header fuzz-agent-header">
+    <div>
+      <p class="eyebrow">Adversarial fuzz worker</p>
+      <h2>boundary-probe</h2>
+      <p class="agent-meta">Session ai48-fuzz-session · Worker boundary-probe</p>
+    </div>
+    <div class="agent-actions" role="group" aria-label="Copy worker data">
+      <button type="button" class="icon-button" title="Copy JSON" data-copy-text="{&quot;cases_run&quot;: 4, &quot;correlation_id&quot;: &quot;boundary-probe&quot;, &quot;error&quot;: {&quot;code&quot;: &quot;worker_timeout&quot;, &quot;message&quot;: &quot;worker exceeded per-worker timeout&quot;}, &quot;failed&quot;: 4, &quot;finding_ids&quot;: [], &quot;passed&quot;: 0, &quot;status&quot;: &quot;timed_out&quot;, &quot;target&quot;: &quot;full&quot;}">{}</button>
+      <button type="button" class="icon-button" title="Copy Context" data-copy-text="boundary-probe: timed_out; 0&#x2f;4 cases passed.">⎘</button>
+    </div>
+  </header>
+
+  <p class="status">
+    <span class="status status-error">FAIL</span>
+  </p>
+
+  <table class="agent-results">
+    <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+    <tbody>
+      <tr>
+        <th scope="row">AI.48 full boundary-probe bounded campaign</th>
+        <td>4</td>
+        <td>0/4</td>
+        <td>
+          <span class="status status-error">FAIL</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <section class="test-inputs">
+    <h3>Inputs exercised</h3>
+    <table>
+      <thead><tr><th scope="col">Case</th><th scope="col">Template / input</th><th scope="col">Outcome</th></tr></thead>
+      <tbody>
+        <tr><th scope="row">boundary-probe-campaign</th><td><code>AI.48 bounded boundary-probe campaign</code></td><td>worker ended with timed_out</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="findings">
+    <h3>Findings</h3>
+    <article class="finding">
+      <h4>boundary-probe-timed_out</h4>
+      <dl>
+        <dt>Minimal template / frontmatter</dt><dd><code>---
+---
+{{ value }}</code></dd>
+        <dt>Input</dt><dd><code>worker status=timed_out</code></dd>
+        <dt>Expected</dt><dd>worker completes its bounded campaign</dd>
+        <dt>Observed</dt><dd>worker returned timed_out</dd>
+        <dt>Requirement / ADR</dt><dd>No requirement or ADR currently covers this behavior.</dd>
+        <dt>Requirement / ADR follow-up</dt><dd>Record the owner and evidence before changing a product contract.</dd>
+        <dt>Root cause</dt><dd>Worker did not provide an evidence-backed root cause.</dd>
+        <dt>Recommended fix</dt><dd>Review the worker evidence and rerun the bounded campaign.</dd>
+      </dl>
+    </article>
+  </section>
+</section>
+<section xmlns="http://www.w3.org/1999/xhtml" class="fuzz-agent fuzz-agent-inconclusive">
+  <header class="agent-header fuzz-agent-header">
+    <div>
+      <p class="eyebrow">Adversarial fuzz worker</p>
+      <h2>differential-probe</h2>
+      <p class="agent-meta">Session ai48-fuzz-session · Worker differential-probe</p>
+    </div>
+    <div class="agent-actions" role="group" aria-label="Copy worker data">
+      <button type="button" class="icon-button" title="Copy JSON" data-copy-text="{&quot;cases_run&quot;: 0, &quot;correlation_id&quot;: &quot;differential-probe&quot;, &quot;status&quot;: &quot;timed_out&quot;, &quot;target&quot;: &quot;full&quot;}">{}</button>
+      <button type="button" class="icon-button" title="Copy Context" data-copy-text="differential-probe: timed_out; 0&#x2f;0 cases passed.">⎘</button>
+    </div>
+  </header>
+
+  <p class="status">
+    <span class="status status-error">FAIL</span>
+  </p>
+
+  <table class="agent-results">
+    <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+    <tbody>
+      <tr>
+        <th scope="row">AI.48 full differential-probe bounded campaign</th>
+        <td>0</td>
+        <td>0/0</td>
+        <td>
+          <span class="status status-error">PASS</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <section class="test-inputs">
+    <h3>Inputs exercised</h3>
+    <table>
+      <thead><tr><th scope="col">Case</th><th scope="col">Template / input</th><th scope="col">Outcome</th></tr></thead>
+      <tbody>
+        <tr><th scope="row">differential-probe-campaign</th><td><code>AI.48 bounded differential-probe campaign</code></td><td>worker ended with timed_out</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="findings">
+    <h3>Findings</h3>
+    <article class="finding">
+      <h4>differential-probe-timed_out</h4>
+      <dl>
+        <dt>Minimal template / frontmatter</dt><dd><code>---
+---
+{{ value }}</code></dd>
+        <dt>Input</dt><dd><code>worker status=timed_out</code></dd>
+        <dt>Expected</dt><dd>worker completes its bounded campaign</dd>
+        <dt>Observed</dt><dd>worker returned timed_out</dd>
+        <dt>Requirement / ADR</dt><dd>No requirement or ADR currently covers this behavior.</dd>
+        <dt>Requirement / ADR follow-up</dt><dd>Record the owner and evidence before changing a product contract.</dd>
+        <dt>Root cause</dt><dd>Worker did not provide an evidence-backed root cause.</dd>
+        <dt>Recommended fix</dt><dd>Review the worker evidence and rerun the bounded campaign.</dd>
+      </dl>
+    </article>
+  </section>
+</section>
+
+
+  <section class="section metadata">
+    <h2>Metadata</h2>
+    <table class="metadata-table"><tbody>
+      <tr><th scope="row">Session</th><td>ai48-fuzz-session</td></tr>
+      <tr><th scope="row">Execution mode</th><td>contract-only</td></tr>
+      <tr><th scope="row">Worker count</th><td>4</td></tr>
+    </tbody></table>
+  </section>
+
+  <footer>
+    <p>Generated from AI.48 coordinator evidence through sc-compose.</p>
+  </footer>
+
+  <script>
+    document.addEventListener("click", async function (event) {
+      var button = event.target.closest("[data-copy-text]");
+      if (!button) return;
+      var text = button.getAttribute("data-copy-text") || "";
+      try {
+        await navigator.clipboard.writeText(text);
+        button.setAttribute("title", "Copied");
+      } catch (err) {
+        button.setAttribute("title", "Copy failed");
+      }
+    });
+  </script>
+</body>
+</html>

--- a/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report-boundary-probe.xhtml
+++ b/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report-boundary-probe.xhtml
@@ -1,0 +1,60 @@
+<section xmlns="http://www.w3.org/1999/xhtml" class="fuzz-agent fuzz-agent-inconclusive">
+  <header class="agent-header fuzz-agent-header">
+    <div>
+      <p class="eyebrow">Adversarial fuzz worker</p>
+      <h2>boundary-probe</h2>
+      <p class="agent-meta">Session ai48-fuzz-session · Worker boundary-probe</p>
+    </div>
+    <div class="agent-actions" role="group" aria-label="Copy worker data">
+      <button type="button" class="icon-button" title="Copy JSON" data-copy-text="{&quot;cases_run&quot;: 4, &quot;correlation_id&quot;: &quot;boundary-probe&quot;, &quot;error&quot;: {&quot;code&quot;: &quot;worker_timeout&quot;, &quot;message&quot;: &quot;worker exceeded per-worker timeout&quot;}, &quot;failed&quot;: 4, &quot;finding_ids&quot;: [], &quot;passed&quot;: 0, &quot;status&quot;: &quot;timed_out&quot;, &quot;target&quot;: &quot;full&quot;}">{}</button>
+      <button type="button" class="icon-button" title="Copy Context" data-copy-text="boundary-probe: timed_out; 0&#x2f;4 cases passed.">⎘</button>
+    </div>
+  </header>
+
+  <p class="status">
+    <span class="status status-error">FAIL</span>
+  </p>
+
+  <table class="agent-results">
+    <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+    <tbody>
+      <tr>
+        <th scope="row">AI.48 full boundary-probe bounded campaign</th>
+        <td>4</td>
+        <td>0/4</td>
+        <td>
+          <span class="status status-error">FAIL</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <section class="test-inputs">
+    <h3>Inputs exercised</h3>
+    <table>
+      <thead><tr><th scope="col">Case</th><th scope="col">Template / input</th><th scope="col">Outcome</th></tr></thead>
+      <tbody>
+        <tr><th scope="row">boundary-probe-campaign</th><td><code>AI.48 bounded boundary-probe campaign</code></td><td>worker ended with timed_out</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="findings">
+    <h3>Findings</h3>
+    <article class="finding">
+      <h4>boundary-probe-timed_out</h4>
+      <dl>
+        <dt>Minimal template / frontmatter</dt><dd><code>---
+---
+{{ value }}</code></dd>
+        <dt>Input</dt><dd><code>worker status=timed_out</code></dd>
+        <dt>Expected</dt><dd>worker completes its bounded campaign</dd>
+        <dt>Observed</dt><dd>worker returned timed_out</dd>
+        <dt>Requirement / ADR</dt><dd>No requirement or ADR currently covers this behavior.</dd>
+        <dt>Requirement / ADR follow-up</dt><dd>Record the owner and evidence before changing a product contract.</dd>
+        <dt>Root cause</dt><dd>Worker did not provide an evidence-backed root cause.</dd>
+        <dt>Recommended fix</dt><dd>Review the worker evidence and rerun the bounded campaign.</dd>
+      </dl>
+    </article>
+  </section>
+</section>

--- a/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report-differential-probe.xhtml
+++ b/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report-differential-probe.xhtml
@@ -1,0 +1,60 @@
+<section xmlns="http://www.w3.org/1999/xhtml" class="fuzz-agent fuzz-agent-inconclusive">
+  <header class="agent-header fuzz-agent-header">
+    <div>
+      <p class="eyebrow">Adversarial fuzz worker</p>
+      <h2>differential-probe</h2>
+      <p class="agent-meta">Session ai48-fuzz-session · Worker differential-probe</p>
+    </div>
+    <div class="agent-actions" role="group" aria-label="Copy worker data">
+      <button type="button" class="icon-button" title="Copy JSON" data-copy-text="{&quot;cases_run&quot;: 0, &quot;correlation_id&quot;: &quot;differential-probe&quot;, &quot;status&quot;: &quot;timed_out&quot;, &quot;target&quot;: &quot;full&quot;}">{}</button>
+      <button type="button" class="icon-button" title="Copy Context" data-copy-text="differential-probe: timed_out; 0&#x2f;0 cases passed.">⎘</button>
+    </div>
+  </header>
+
+  <p class="status">
+    <span class="status status-error">FAIL</span>
+  </p>
+
+  <table class="agent-results">
+    <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+    <tbody>
+      <tr>
+        <th scope="row">AI.48 full differential-probe bounded campaign</th>
+        <td>0</td>
+        <td>0/0</td>
+        <td>
+          <span class="status status-error">PASS</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <section class="test-inputs">
+    <h3>Inputs exercised</h3>
+    <table>
+      <thead><tr><th scope="col">Case</th><th scope="col">Template / input</th><th scope="col">Outcome</th></tr></thead>
+      <tbody>
+        <tr><th scope="row">differential-probe-campaign</th><td><code>AI.48 bounded differential-probe campaign</code></td><td>worker ended with timed_out</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="findings">
+    <h3>Findings</h3>
+    <article class="finding">
+      <h4>differential-probe-timed_out</h4>
+      <dl>
+        <dt>Minimal template / frontmatter</dt><dd><code>---
+---
+{{ value }}</code></dd>
+        <dt>Input</dt><dd><code>worker status=timed_out</code></dd>
+        <dt>Expected</dt><dd>worker completes its bounded campaign</dd>
+        <dt>Observed</dt><dd>worker returned timed_out</dd>
+        <dt>Requirement / ADR</dt><dd>No requirement or ADR currently covers this behavior.</dd>
+        <dt>Requirement / ADR follow-up</dt><dd>Record the owner and evidence before changing a product contract.</dd>
+        <dt>Root cause</dt><dd>Worker did not provide an evidence-backed root cause.</dd>
+        <dt>Recommended fix</dt><dd>Review the worker evidence and rerun the bounded campaign.</dd>
+      </dl>
+    </article>
+  </section>
+</section>

--- a/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report-shape-probe.xhtml
+++ b/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report-shape-probe.xhtml
@@ -1,0 +1,42 @@
+<section xmlns="http://www.w3.org/1999/xhtml" class="fuzz-agent fuzz-agent-pass">
+  <header class="agent-header fuzz-agent-header">
+    <div>
+      <p class="eyebrow">Adversarial fuzz worker</p>
+      <h2>shape-probe</h2>
+      <p class="agent-meta">Session ai48-fuzz-session · Worker shape-probe</p>
+    </div>
+    <div class="agent-actions" role="group" aria-label="Copy worker data">
+      <button type="button" class="icon-button" title="Copy JSON" data-copy-text="{&quot;cases_run&quot;: 12, &quot;correlation_id&quot;: &quot;shape-probe&quot;, &quot;error&quot;: null, &quot;failed&quot;: 0, &quot;finding_ids&quot;: [], &quot;passed&quot;: 12, &quot;status&quot;: &quot;success&quot;, &quot;target&quot;: &quot;full&quot;}">{}</button>
+      <button type="button" class="icon-button" title="Copy Context" data-copy-text="shape-probe: success; 12&#x2f;12 cases passed.">⎘</button>
+    </div>
+  </header>
+
+  <p class="status">
+    <span class="status status-pass">PASS</span>
+  </p>
+
+  <table class="agent-results">
+    <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+    <tbody>
+      <tr>
+        <th scope="row">AI.48 full shape-probe bounded campaign</th>
+        <td>12</td>
+        <td>12/12</td>
+        <td>
+          <span class="status status-pass">PASS</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <section class="test-inputs">
+    <h3>Inputs exercised</h3>
+    <table>
+      <thead><tr><th scope="col">Case</th><th scope="col">Template / input</th><th scope="col">Outcome</th></tr></thead>
+      <tbody>
+        <tr><th scope="row">shape-probe-campaign</th><td><code>AI.48 bounded shape-probe campaign</code></td><td>all bounded cases completed</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+</section>

--- a/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report-template-probe.xhtml
+++ b/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report-template-probe.xhtml
@@ -1,0 +1,60 @@
+<section xmlns="http://www.w3.org/1999/xhtml" class="fuzz-agent fuzz-agent-confirmed_bug">
+  <header class="agent-header fuzz-agent-header">
+    <div>
+      <p class="eyebrow">Adversarial fuzz worker</p>
+      <h2>template-probe</h2>
+      <p class="agent-meta">Session ai48-fuzz-session · Worker template-probe</p>
+    </div>
+    <div class="agent-actions" role="group" aria-label="Copy worker data">
+      <button type="button" class="icon-button" title="Copy JSON" data-copy-text="{&quot;cases_run&quot;: 12, &quot;classification&quot;: &quot;confirmed_bug&quot;, &quot;correlation_id&quot;: &quot;template-probe&quot;, &quot;error&quot;: {&quot;code&quot;: &quot;confirmed_bug&quot;, &quot;message&quot;: &quot;three deterministic output mismatches&quot;}, &quot;failed&quot;: 3, &quot;finding_ids&quot;: [&quot;template-probe-001&quot;], &quot;findings&quot;: [{&quot;expected_oracle&quot;: &quot;literal input is escaped in the XHTML panel&quot;, &quot;finding_id&quot;: &quot;template-probe-001&quot;, &quot;minimal_input&quot;: &quot;value=&lt;literal&gt;&quot;, &quot;minimal_template&quot;: &quot;---\n---\n{{ value }}&quot;, &quot;observed_result&quot;: &quot;worker observed an unescaped output mismatch&quot;, &quot;recommended_fix&quot;: &quot;Add a minimized regression fixture and rerun the bounded campaign.&quot;, &quot;requirement_follow_up&quot;: &quot;Confirm the public escaping contract before changing the renderer.&quot;, &quot;requirement_trace&quot;: &quot;No requirement or ADR currently covers this behavior.&quot;, &quot;root_cause&quot;: &quot;The probe found a deterministic renderer mismatch.&quot;}], &quot;passed&quot;: 9, &quot;status&quot;: &quot;failed&quot;, &quot;target&quot;: &quot;full&quot;}">{}</button>
+      <button type="button" class="icon-button" title="Copy Context" data-copy-text="template-probe: failed; 9&#x2f;12 cases passed.">⎘</button>
+    </div>
+  </header>
+
+  <p class="status">
+    <span class="status status-error">FAIL</span>
+  </p>
+
+  <table class="agent-results">
+    <thead><tr><th scope="col">Fuzz run description</th><th scope="col">Iterations</th><th scope="col">Pass</th><th scope="col">Result</th></tr></thead>
+    <tbody>
+      <tr>
+        <th scope="row">AI.48 full template-probe bounded campaign</th>
+        <td>12</td>
+        <td>9/12</td>
+        <td>
+          <span class="status status-error">FAIL</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <section class="test-inputs">
+    <h3>Inputs exercised</h3>
+    <table>
+      <thead><tr><th scope="col">Case</th><th scope="col">Template / input</th><th scope="col">Outcome</th></tr></thead>
+      <tbody>
+        <tr><th scope="row">template-probe-campaign</th><td><code>AI.48 bounded template-probe campaign</code></td><td>worker ended with failed</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="findings">
+    <h3>Findings</h3>
+    <article class="finding">
+      <h4>template-probe-001</h4>
+      <dl>
+        <dt>Minimal template / frontmatter</dt><dd><code>---
+---
+{{ value }}</code></dd>
+        <dt>Input</dt><dd><code>value=&lt;literal&gt;</code></dd>
+        <dt>Expected</dt><dd>literal input is escaped in the XHTML panel</dd>
+        <dt>Observed</dt><dd>worker observed an unescaped output mismatch</dd>
+        <dt>Requirement / ADR</dt><dd>No requirement or ADR currently covers this behavior.</dd>
+        <dt>Requirement / ADR follow-up</dt><dd>Confirm the public escaping contract before changing the renderer.</dd>
+        <dt>Root cause</dt><dd>The probe found a deterministic renderer mismatch.</dd>
+        <dt>Recommended fix</dt><dd>Add a minimized regression fixture and rerun the bounded campaign.</dd>
+      </dl>
+    </article>
+  </section>
+</section>

--- a/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report.envelope.json
+++ b/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report.envelope.json
@@ -1,0 +1,7 @@
+{
+  "generated_at": "2026-08-01T03:30:00Z",
+  "host_label": "mac-arm64",
+  "report_html": "20260801-1-fuzz-report.html",
+  "report_type": "fuzz",
+  "schema_version": 1
+}

--- a/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report.json
+++ b/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report.json
@@ -7,8 +7,7 @@
     "per_worker_timeout_s": 120,
     "promote_regressions": true,
     "seed": 157,
-    "target": "full",
-    "worktree_path": "<redacted-path>"
+    "target": "full"
   },
   "footer_html": "<p>Generated from AI.48 coordinator evidence through sc-compose.</p>",
   "generated_at": "2026-08-01T03:30:00Z",

--- a/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report.json
+++ b/site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report.json
@@ -1,0 +1,182 @@
+{
+  "campaign": {
+    "baseline_ref": "develop",
+    "cases_per_worker": 12,
+    "max_workers": 4,
+    "notes": "AI.48 fixture covering pass, confirmed bug, timeout, and incomplete worker states.",
+    "per_worker_timeout_s": 120,
+    "promote_regressions": true,
+    "seed": 157,
+    "target": "full",
+    "worktree_path": "<redacted-path>"
+  },
+  "footer_html": "<p>Generated from AI.48 coordinator evidence through sc-compose.</p>",
+  "generated_at": "2026-08-01T03:30:00Z",
+  "json_output_path": "site/reports/20260801-1-fuzz-report/20260801-1-fuzz-report.json",
+  "metadata_rows": [
+    {
+      "label": "Session",
+      "value": "ai48-fuzz-session"
+    },
+    {
+      "label": "Execution mode",
+      "value": "contract-only"
+    },
+    {
+      "label": "Worker count",
+      "value": 4
+    }
+  ],
+  "output_path": "site/reports/20260801-1-fuzz-report.html",
+  "rows": [
+    {
+      "iterations": 12,
+      "label": "AI.48 full shape-probe bounded campaign",
+      "pass": "12/12",
+      "result": "PASS"
+    },
+    {
+      "iterations": 12,
+      "label": "AI.48 full template-probe bounded campaign",
+      "pass": "9/12",
+      "result": "FAIL"
+    },
+    {
+      "iterations": 4,
+      "label": "AI.48 full boundary-probe bounded campaign",
+      "pass": "0/4",
+      "result": "FAIL"
+    },
+    {
+      "iterations": 0,
+      "label": "AI.48 full differential-probe bounded campaign",
+      "pass": "0/0",
+      "result": "PASS"
+    }
+  ],
+  "sections": [
+    {
+      "body_html": "<section xmlns=\"http://www.w3.org/1999/xhtml\" class=\"fuzz-agent fuzz-agent-pass\">\n  <header class=\"agent-header fuzz-agent-header\">\n    <div>\n      <p class=\"eyebrow\">Adversarial fuzz worker</p>\n      <h2>shape-probe</h2>\n      <p class=\"agent-meta\">Session ai48-fuzz-session \u00b7 Worker shape-probe</p>\n    </div>\n    <div class=\"agent-actions\" role=\"group\" aria-label=\"Copy worker data\">\n      <button type=\"button\" class=\"icon-button\" title=\"Copy JSON\" data-copy-text=\"{&quot;cases_run&quot;: 12, &quot;correlation_id&quot;: &quot;shape-probe&quot;, &quot;error&quot;: null, &quot;failed&quot;: 0, &quot;finding_ids&quot;: [], &quot;passed&quot;: 12, &quot;status&quot;: &quot;success&quot;, &quot;target&quot;: &quot;full&quot;}\">{}</button>\n      <button type=\"button\" class=\"icon-button\" title=\"Copy Context\" data-copy-text=\"shape-probe: success; 12&#x2f;12 cases passed.\">\u2398</button>\n    </div>\n  </header>\n\n  <p class=\"status\">\n    <span class=\"status status-pass\">PASS</span>\n  </p>\n\n  <table class=\"agent-results\">\n    <thead><tr><th scope=\"col\">Fuzz run description</th><th scope=\"col\">Iterations</th><th scope=\"col\">Pass</th><th scope=\"col\">Result</th></tr></thead>\n    <tbody>\n      <tr>\n        <th scope=\"row\">AI.48 full shape-probe bounded campaign</th>\n        <td>12</td>\n        <td>12/12</td>\n        <td>\n          <span class=\"status status-pass\">PASS</span>\n        </td>\n      </tr>\n    </tbody>\n  </table>\n\n  <section class=\"test-inputs\">\n    <h3>Inputs exercised</h3>\n    <table>\n      <thead><tr><th scope=\"col\">Case</th><th scope=\"col\">Template / input</th><th scope=\"col\">Outcome</th></tr></thead>\n      <tbody>\n        <tr><th scope=\"row\">shape-probe-campaign</th><td><code>AI.48 bounded shape-probe campaign</code></td><td>all bounded cases completed</td></tr>\n      </tbody>\n    </table>\n  </section>\n\n</section>",
+      "context_text": "shape-probe: success; 12/12 cases passed.",
+      "fragment_source": "auto-generated",
+      "id": "shape-probe",
+      "json_payload": {
+        "cases_run": 12,
+        "correlation_id": "shape-probe",
+        "error": null,
+        "failed": 0,
+        "finding_ids": [],
+        "passed": 12,
+        "status": "success",
+        "target": "full"
+      },
+      "status": "PASS",
+      "title": "shape-probe",
+      "xhtml_path": "20260801-1-fuzz-report/20260801-1-fuzz-report-shape-probe.xhtml"
+    },
+    {
+      "body_html": "<section xmlns=\"http://www.w3.org/1999/xhtml\" class=\"fuzz-agent fuzz-agent-confirmed_bug\">\n  <header class=\"agent-header fuzz-agent-header\">\n    <div>\n      <p class=\"eyebrow\">Adversarial fuzz worker</p>\n      <h2>template-probe</h2>\n      <p class=\"agent-meta\">Session ai48-fuzz-session \u00b7 Worker template-probe</p>\n    </div>\n    <div class=\"agent-actions\" role=\"group\" aria-label=\"Copy worker data\">\n      <button type=\"button\" class=\"icon-button\" title=\"Copy JSON\" data-copy-text=\"{&quot;cases_run&quot;: 12, &quot;classification&quot;: &quot;confirmed_bug&quot;, &quot;correlation_id&quot;: &quot;template-probe&quot;, &quot;error&quot;: {&quot;code&quot;: &quot;confirmed_bug&quot;, &quot;message&quot;: &quot;three deterministic output mismatches&quot;}, &quot;failed&quot;: 3, &quot;finding_ids&quot;: [&quot;template-probe-001&quot;], &quot;findings&quot;: [{&quot;expected_oracle&quot;: &quot;literal input is escaped in the XHTML panel&quot;, &quot;finding_id&quot;: &quot;template-probe-001&quot;, &quot;minimal_input&quot;: &quot;value=&lt;literal&gt;&quot;, &quot;minimal_template&quot;: &quot;---\\n---\\n{{ value }}&quot;, &quot;observed_result&quot;: &quot;worker observed an unescaped output mismatch&quot;, &quot;recommended_fix&quot;: &quot;Add a minimized regression fixture and rerun the bounded campaign.&quot;, &quot;requirement_follow_up&quot;: &quot;Confirm the public escaping contract before changing the renderer.&quot;, &quot;requirement_trace&quot;: &quot;No requirement or ADR currently covers this behavior.&quot;, &quot;root_cause&quot;: &quot;The probe found a deterministic renderer mismatch.&quot;}], &quot;passed&quot;: 9, &quot;status&quot;: &quot;failed&quot;, &quot;target&quot;: &quot;full&quot;}\">{}</button>\n      <button type=\"button\" class=\"icon-button\" title=\"Copy Context\" data-copy-text=\"template-probe: failed; 9&#x2f;12 cases passed.\">\u2398</button>\n    </div>\n  </header>\n\n  <p class=\"status\">\n    <span class=\"status status-error\">FAIL</span>\n  </p>\n\n  <table class=\"agent-results\">\n    <thead><tr><th scope=\"col\">Fuzz run description</th><th scope=\"col\">Iterations</th><th scope=\"col\">Pass</th><th scope=\"col\">Result</th></tr></thead>\n    <tbody>\n      <tr>\n        <th scope=\"row\">AI.48 full template-probe bounded campaign</th>\n        <td>12</td>\n        <td>9/12</td>\n        <td>\n          <span class=\"status status-error\">FAIL</span>\n        </td>\n      </tr>\n    </tbody>\n  </table>\n\n  <section class=\"test-inputs\">\n    <h3>Inputs exercised</h3>\n    <table>\n      <thead><tr><th scope=\"col\">Case</th><th scope=\"col\">Template / input</th><th scope=\"col\">Outcome</th></tr></thead>\n      <tbody>\n        <tr><th scope=\"row\">template-probe-campaign</th><td><code>AI.48 bounded template-probe campaign</code></td><td>worker ended with failed</td></tr>\n      </tbody>\n    </table>\n  </section>\n\n  <section class=\"findings\">\n    <h3>Findings</h3>\n    <article class=\"finding\">\n      <h4>template-probe-001</h4>\n      <dl>\n        <dt>Minimal template / frontmatter</dt><dd><code>---\n---\n{{ value }}</code></dd>\n        <dt>Input</dt><dd><code>value=&lt;literal&gt;</code></dd>\n        <dt>Expected</dt><dd>literal input is escaped in the XHTML panel</dd>\n        <dt>Observed</dt><dd>worker observed an unescaped output mismatch</dd>\n        <dt>Requirement / ADR</dt><dd>No requirement or ADR currently covers this behavior.</dd>\n        <dt>Requirement / ADR follow-up</dt><dd>Confirm the public escaping contract before changing the renderer.</dd>\n        <dt>Root cause</dt><dd>The probe found a deterministic renderer mismatch.</dd>\n        <dt>Recommended fix</dt><dd>Add a minimized regression fixture and rerun the bounded campaign.</dd>\n      </dl>\n    </article>\n  </section>\n</section>",
+      "context_text": "template-probe: failed; 9/12 cases passed.",
+      "fragment_source": "auto-generated",
+      "id": "template-probe",
+      "json_payload": {
+        "cases_run": 12,
+        "classification": "confirmed_bug",
+        "correlation_id": "template-probe",
+        "error": {
+          "code": "confirmed_bug",
+          "message": "three deterministic output mismatches"
+        },
+        "failed": 3,
+        "finding_ids": [
+          "template-probe-001"
+        ],
+        "findings": [
+          {
+            "expected_oracle": "literal input is escaped in the XHTML panel",
+            "finding_id": "template-probe-001",
+            "minimal_input": "value=<literal>",
+            "minimal_template": "---\n---\n{{ value }}",
+            "observed_result": "worker observed an unescaped output mismatch",
+            "recommended_fix": "Add a minimized regression fixture and rerun the bounded campaign.",
+            "requirement_follow_up": "Confirm the public escaping contract before changing the renderer.",
+            "requirement_trace": "No requirement or ADR currently covers this behavior.",
+            "root_cause": "The probe found a deterministic renderer mismatch."
+          }
+        ],
+        "passed": 9,
+        "status": "failed",
+        "target": "full"
+      },
+      "status": "FAIL",
+      "title": "template-probe",
+      "xhtml_path": "20260801-1-fuzz-report/20260801-1-fuzz-report-template-probe.xhtml"
+    },
+    {
+      "body_html": "<section xmlns=\"http://www.w3.org/1999/xhtml\" class=\"fuzz-agent fuzz-agent-inconclusive\">\n  <header class=\"agent-header fuzz-agent-header\">\n    <div>\n      <p class=\"eyebrow\">Adversarial fuzz worker</p>\n      <h2>boundary-probe</h2>\n      <p class=\"agent-meta\">Session ai48-fuzz-session \u00b7 Worker boundary-probe</p>\n    </div>\n    <div class=\"agent-actions\" role=\"group\" aria-label=\"Copy worker data\">\n      <button type=\"button\" class=\"icon-button\" title=\"Copy JSON\" data-copy-text=\"{&quot;cases_run&quot;: 4, &quot;correlation_id&quot;: &quot;boundary-probe&quot;, &quot;error&quot;: {&quot;code&quot;: &quot;worker_timeout&quot;, &quot;message&quot;: &quot;worker exceeded per-worker timeout&quot;}, &quot;failed&quot;: 4, &quot;finding_ids&quot;: [], &quot;passed&quot;: 0, &quot;status&quot;: &quot;timed_out&quot;, &quot;target&quot;: &quot;full&quot;}\">{}</button>\n      <button type=\"button\" class=\"icon-button\" title=\"Copy Context\" data-copy-text=\"boundary-probe: timed_out; 0&#x2f;4 cases passed.\">\u2398</button>\n    </div>\n  </header>\n\n  <p class=\"status\">\n    <span class=\"status status-error\">FAIL</span>\n  </p>\n\n  <table class=\"agent-results\">\n    <thead><tr><th scope=\"col\">Fuzz run description</th><th scope=\"col\">Iterations</th><th scope=\"col\">Pass</th><th scope=\"col\">Result</th></tr></thead>\n    <tbody>\n      <tr>\n        <th scope=\"row\">AI.48 full boundary-probe bounded campaign</th>\n        <td>4</td>\n        <td>0/4</td>\n        <td>\n          <span class=\"status status-error\">FAIL</span>\n        </td>\n      </tr>\n    </tbody>\n  </table>\n\n  <section class=\"test-inputs\">\n    <h3>Inputs exercised</h3>\n    <table>\n      <thead><tr><th scope=\"col\">Case</th><th scope=\"col\">Template / input</th><th scope=\"col\">Outcome</th></tr></thead>\n      <tbody>\n        <tr><th scope=\"row\">boundary-probe-campaign</th><td><code>AI.48 bounded boundary-probe campaign</code></td><td>worker ended with timed_out</td></tr>\n      </tbody>\n    </table>\n  </section>\n\n  <section class=\"findings\">\n    <h3>Findings</h3>\n    <article class=\"finding\">\n      <h4>boundary-probe-timed_out</h4>\n      <dl>\n        <dt>Minimal template / frontmatter</dt><dd><code>---\n---\n{{ value }}</code></dd>\n        <dt>Input</dt><dd><code>worker status=timed_out</code></dd>\n        <dt>Expected</dt><dd>worker completes its bounded campaign</dd>\n        <dt>Observed</dt><dd>worker returned timed_out</dd>\n        <dt>Requirement / ADR</dt><dd>No requirement or ADR currently covers this behavior.</dd>\n        <dt>Requirement / ADR follow-up</dt><dd>Record the owner and evidence before changing a product contract.</dd>\n        <dt>Root cause</dt><dd>Worker did not provide an evidence-backed root cause.</dd>\n        <dt>Recommended fix</dt><dd>Review the worker evidence and rerun the bounded campaign.</dd>\n      </dl>\n    </article>\n  </section>\n</section>",
+      "context_text": "boundary-probe: timed_out; 0/4 cases passed.",
+      "fragment_source": "auto-generated",
+      "id": "boundary-probe",
+      "json_payload": {
+        "cases_run": 4,
+        "correlation_id": "boundary-probe",
+        "error": {
+          "code": "worker_timeout",
+          "message": "worker exceeded per-worker timeout"
+        },
+        "failed": 4,
+        "finding_ids": [],
+        "passed": 0,
+        "status": "timed_out",
+        "target": "full"
+      },
+      "status": "FAIL",
+      "title": "boundary-probe",
+      "xhtml_path": "20260801-1-fuzz-report/20260801-1-fuzz-report-boundary-probe.xhtml"
+    },
+    {
+      "body_html": "<section xmlns=\"http://www.w3.org/1999/xhtml\" class=\"fuzz-agent fuzz-agent-inconclusive\">\n  <header class=\"agent-header fuzz-agent-header\">\n    <div>\n      <p class=\"eyebrow\">Adversarial fuzz worker</p>\n      <h2>differential-probe</h2>\n      <p class=\"agent-meta\">Session ai48-fuzz-session \u00b7 Worker differential-probe</p>\n    </div>\n    <div class=\"agent-actions\" role=\"group\" aria-label=\"Copy worker data\">\n      <button type=\"button\" class=\"icon-button\" title=\"Copy JSON\" data-copy-text=\"{&quot;cases_run&quot;: 0, &quot;correlation_id&quot;: &quot;differential-probe&quot;, &quot;status&quot;: &quot;timed_out&quot;, &quot;target&quot;: &quot;full&quot;}\">{}</button>\n      <button type=\"button\" class=\"icon-button\" title=\"Copy Context\" data-copy-text=\"differential-probe: timed_out; 0&#x2f;0 cases passed.\">\u2398</button>\n    </div>\n  </header>\n\n  <p class=\"status\">\n    <span class=\"status status-error\">FAIL</span>\n  </p>\n\n  <table class=\"agent-results\">\n    <thead><tr><th scope=\"col\">Fuzz run description</th><th scope=\"col\">Iterations</th><th scope=\"col\">Pass</th><th scope=\"col\">Result</th></tr></thead>\n    <tbody>\n      <tr>\n        <th scope=\"row\">AI.48 full differential-probe bounded campaign</th>\n        <td>0</td>\n        <td>0/0</td>\n        <td>\n          <span class=\"status status-error\">PASS</span>\n        </td>\n      </tr>\n    </tbody>\n  </table>\n\n  <section class=\"test-inputs\">\n    <h3>Inputs exercised</h3>\n    <table>\n      <thead><tr><th scope=\"col\">Case</th><th scope=\"col\">Template / input</th><th scope=\"col\">Outcome</th></tr></thead>\n      <tbody>\n        <tr><th scope=\"row\">differential-probe-campaign</th><td><code>AI.48 bounded differential-probe campaign</code></td><td>worker ended with timed_out</td></tr>\n      </tbody>\n    </table>\n  </section>\n\n  <section class=\"findings\">\n    <h3>Findings</h3>\n    <article class=\"finding\">\n      <h4>differential-probe-timed_out</h4>\n      <dl>\n        <dt>Minimal template / frontmatter</dt><dd><code>---\n---\n{{ value }}</code></dd>\n        <dt>Input</dt><dd><code>worker status=timed_out</code></dd>\n        <dt>Expected</dt><dd>worker completes its bounded campaign</dd>\n        <dt>Observed</dt><dd>worker returned timed_out</dd>\n        <dt>Requirement / ADR</dt><dd>No requirement or ADR currently covers this behavior.</dd>\n        <dt>Requirement / ADR follow-up</dt><dd>Record the owner and evidence before changing a product contract.</dd>\n        <dt>Root cause</dt><dd>Worker did not provide an evidence-backed root cause.</dd>\n        <dt>Recommended fix</dt><dd>Review the worker evidence and rerun the bounded campaign.</dd>\n      </dl>\n    </article>\n  </section>\n</section>",
+      "context_text": "differential-probe: timed_out; 0/0 cases passed.",
+      "fragment_source": "auto-generated",
+      "id": "differential-probe",
+      "json_payload": {
+        "cases_run": 0,
+        "correlation_id": "differential-probe",
+        "status": "timed_out",
+        "target": "full"
+      },
+      "status": "PASS",
+      "title": "differential-probe",
+      "xhtml_path": "20260801-1-fuzz-report/20260801-1-fuzz-report-differential-probe.xhtml"
+    }
+  ],
+  "source_label": "AI.48 fuzz coordinator contract",
+  "status": "ERROR",
+  "subtitle": "AI.48 coordinator/probe evidence",
+  "summary_copy_context": "ai48-fuzz-session: ERROR; 4 worker panels.",
+  "summary_copy_json": "{\"session_id\": \"ai48-fuzz-session\", \"status\": \"ERROR\", \"workers\": 4}",
+  "summary_intro_html": "<p>AI.48 coordinator/probe evidence rendered through the copied sc-compose fuzz-report contract. Session <code>ai48-fuzz-session</code> contains one bounded panel per worker.</p>",
+  "title": "Adversarial fuzz session: ai48-fuzz-session",
+  "toc_rows": [
+    {
+      "id": "shape-probe",
+      "status": "PASS",
+      "title": "shape-probe"
+    },
+    {
+      "id": "template-probe",
+      "status": "FAIL",
+      "title": "template-probe"
+    },
+    {
+      "id": "boundary-probe",
+      "status": "FAIL",
+      "title": "boundary-probe"
+    },
+    {
+      "id": "differential-probe",
+      "status": "PASS",
+      "title": "differential-probe"
+    }
+  ]
+}

--- a/site/reports/index.html
+++ b/site/reports/index.html
@@ -15,7 +15,9 @@
     </ul>
   </section>
   <section><h2>Fuzz</h2>
-    <p class="empty">No reports available.</p>
+    <ul>
+      <li><a href="20260801-1-fuzz-report.html">20260801-1-fuzz-report</a><time datetime="2026-08-01T03:30:00Z">2026-08-01T03:30:00Z</time><span class="report-meta">fuzz · hosts: mac-arm64</span></li>
+    </ul>
   </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Copies verbatim sc-compose fuzz-run-report/agent templates and contract
- Renders AI.48 fuzz results (success/confirmed_bug/timeout/incomplete states) into top-level HTML report, JSON sidecar, and per-probe XHTML panels
- Invokes `just reports-index` after each campaign artifact write
- Pins sc-compose to source rev 113729e (1.3.0) — v1.2.0 rejects nested arrays required by the copied panel contract

## Test plan
- 337 Python tests
- `just lint` (23/23)
- `just reports-index --check`
- `xmllint` on all rendered panels
- `npx html-validate` on the report

Sprint doc: docs/plans/phase-ai/sprint-ai-50-fuzz-report.md