### PR TITLE
fix(list): bounded list_mail read via SQLite bucket-count aggregation

### DIFF
--- a/crates/atm-core/src/list.rs
+++ b/crates/atm-core/src/list.rs
@@ -150,7 +150,14 @@ fn list_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
     };
 
     let storage_bucket_counts = runtime.query_mailbox_bucket_counts(&target.team, &target.agent)?;
-    let metadata_limit = metadata_limit_for_list(&query);
+    // A backend aggregate lets the ordinary list view retain its bounded
+    // metadata window. Backends which do not implement that optional
+    // aggregate must instead provide the complete metadata set so the
+    // in-process fallback reports truthful mailbox bucket counts.
+    let metadata_limit = storage_bucket_counts
+        .is_some()
+        .then(|| metadata_limit_for_list(&query))
+        .flatten();
     let metadata_rows = runtime.query_mailbox_metadata_rows(
         &query.home_dir,
         &target.team,
@@ -272,8 +279,8 @@ fn list_row_from_message(message: &ClassifiedMessage) -> ListRow {
 mod tests {
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     use serde_json::Map;
     use tempfile::tempdir;
@@ -374,9 +381,30 @@ mod tests {
 
     struct ListRuntime {
         roster_present: bool,
-        metadata_rows: Vec<boundary::MailStoreMailboxMetadataRow>,
+        metadata_rows: TestMetadataRows,
         message_records: HashMap<MessageKey, boundary::Message>,
         load_message_record_count: Arc<AtomicUsize>,
+        metadata_query_limits: Arc<Mutex<Vec<Option<usize>>>>,
+    }
+
+    enum TestMetadataRows {
+        Static(Vec<boundary::MailStoreMailboxMetadataRow>),
+        Generated(usize),
+    }
+
+    impl TestMetadataRows {
+        fn query(&self, limit: Option<usize>) -> Vec<boundary::MailStoreMailboxMetadataRow> {
+            match self {
+                Self::Static(rows) => rows
+                    .iter()
+                    .take(limit.unwrap_or(usize::MAX))
+                    .cloned()
+                    .collect(),
+                Self::Generated(count) => (0..limit.unwrap_or(*count).min(*count))
+                    .map(generated_metadata_row)
+                    .collect(),
+            }
+        }
     }
 
     impl crate::boundary::sealed::Sealed for ListRuntime {}
@@ -464,9 +492,13 @@ mod tests {
             _home_dir: &Path,
             _team: &TeamName,
             _agent: &AgentName,
-            _limit: Option<usize>,
+            limit: Option<usize>,
         ) -> Result<Vec<boundary::MailStoreMailboxMetadataRow>, AtmError> {
-            Ok(self.metadata_rows.clone())
+            self.metadata_query_limits
+                .lock()
+                .expect("metadata query limits lock")
+                .push(limit);
+            Ok(self.metadata_rows.query(limit))
         }
 
         fn load_message_record(
@@ -566,6 +598,31 @@ mod tests {
         )
     }
 
+    const LARGE_MAILBOX_ROW_COUNT: usize = 500_000;
+
+    fn generated_metadata_row(index: usize) -> boundary::MailStoreMailboxMetadataRow {
+        let pending_ack =
+            (LARGE_MAILBOX_ROW_COUNT - 4..LARGE_MAILBOX_ROW_COUNT - 2).contains(&index);
+        let read = index >= LARGE_MAILBOX_ROW_COUNT - 2;
+        boundary::MailStoreMailboxMetadataRow {
+            message_key: MessageKey::new(format!("atm:scale-{index}")).expect("message key"),
+            message_id: None,
+            parent_message_id: None,
+            thread_mode: None,
+            from_agent: AgentName::from_validated(TEST_SENDER),
+            source_chat_id: None,
+            destination_chat_id: None,
+            summary: None,
+            message_at: IsoTimestamp::now(),
+            read,
+            requires_ack: pending_ack,
+            pending_ack,
+            acknowledged_at: None,
+            expires_at: None,
+            task_id: None,
+        }
+    }
+
     fn runtime_with_messages(
         _tempdir: &tempfile::TempDir,
         rows_and_messages: Vec<(boundary::MailStoreMailboxMetadataRow, boundary::Message)>,
@@ -582,9 +639,10 @@ mod tests {
         (
             ListRuntime {
                 roster_present,
-                metadata_rows,
+                metadata_rows: TestMetadataRows::Static(metadata_rows),
                 message_records: message_records.into_iter().collect(),
                 load_message_record_count: load_message_record_count.clone(),
+                metadata_query_limits: Arc::new(Mutex::new(Vec::new())),
             },
             load_message_record_count,
         )
@@ -595,9 +653,10 @@ mod tests {
         let tempdir = tempdir().expect("tempdir");
         let runtime = ListRuntime {
             roster_present: true,
-            metadata_rows: Vec::new(),
+            metadata_rows: TestMetadataRows::Static(Vec::new()),
             message_records: HashMap::new(),
             load_message_record_count: Arc::new(AtomicUsize::new(0)),
+            metadata_query_limits: Arc::new(Mutex::new(Vec::new())),
         };
 
         let outcome = list_mail_with_runtime_impl(
@@ -617,9 +676,10 @@ mod tests {
         let tempdir = tempdir().expect("tempdir");
         let runtime = ListRuntime {
             roster_present: false,
-            metadata_rows: Vec::new(),
+            metadata_rows: TestMetadataRows::Static(Vec::new()),
             message_records: HashMap::new(),
             load_message_record_count: Arc::new(AtomicUsize::new(0)),
+            metadata_query_limits: Arc::new(Mutex::new(Vec::new())),
         };
 
         let error = list_mail_with_runtime_impl(
@@ -632,6 +692,52 @@ mod tests {
         assert!(
             error.code() == crate::error_codes::AtmErrorCode::AgentNotFound,
             "{error:?}"
+        );
+    }
+
+    #[test]
+    fn list_mail_counts_a_500k_mailbox_correctly_without_backend_aggregate() {
+        let tempdir = tempdir().expect("tempdir");
+        let query_limits = Arc::new(Mutex::new(Vec::new()));
+        let runtime = ListRuntime {
+            roster_present: true,
+            metadata_rows: TestMetadataRows::Generated(LARGE_MAILBOX_ROW_COUNT),
+            message_records: HashMap::new(),
+            load_message_record_count: Arc::new(AtomicUsize::new(0)),
+            metadata_query_limits: query_limits.clone(),
+        };
+        let target = format!("recipient@{TEST_TEAM}");
+        let query = ListQuery::new(
+            tempdir.path().to_path_buf(),
+            tempdir.path().to_path_buf(),
+            TEST_SENDER.parse().expect("caller"),
+            Some(&target),
+            TEST_TEAM.parse().expect("team"),
+            ReadSelection::PendingAck,
+            false,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("list query");
+
+        let outcome = list_mail_with_runtime_impl(query, &NullObservability, &runtime)
+            .expect("large fallback list outcome");
+
+        assert_eq!(outcome.count, 1);
+        assert_eq!(outcome.bucket_counts.unread, LARGE_MAILBOX_ROW_COUNT - 4);
+        assert_eq!(outcome.bucket_counts.pending_ack, 2);
+        assert_eq!(outcome.bucket_counts.history, 2);
+        assert!(outcome.history_collapsed);
+        assert_eq!(
+            query_limits
+                .lock()
+                .expect("metadata query limits lock")
+                .as_slice(),
+            &[None],
+            "the no-aggregate fallback must read full metadata before counting"
         );
     }
 

--- a/crates/atm-core/src/list.rs
+++ b/crates/atm-core/src/list.rs
@@ -150,14 +150,7 @@ fn list_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
     };
 
     let storage_bucket_counts = runtime.query_mailbox_bucket_counts(&target.team, &target.agent)?;
-    // A backend aggregate lets the ordinary list view retain its bounded
-    // metadata window. Backends which do not implement that optional
-    // aggregate must instead provide the complete metadata set so the
-    // in-process fallback reports truthful mailbox bucket counts.
-    let metadata_limit = storage_bucket_counts
-        .is_some()
-        .then(|| metadata_limit_for_list(&query))
-        .flatten();
+    let metadata_limit = metadata_limit_for_list(&query, storage_bucket_counts.is_some());
     let metadata_rows = runtime.query_mailbox_metadata_rows(
         &query.home_dir,
         &target.team,
@@ -209,17 +202,20 @@ fn list_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
     })
 }
 
-fn metadata_limit_for_list(query: &ListQuery) -> Option<usize> {
+fn metadata_limit_for_list(query: &ListQuery, storage_counts_available: bool) -> Option<usize> {
     // The normal list view has no metadata predicates. Its bounded display
-    // window can therefore be fetched directly; bucket counts come from the
-    // backend aggregate above. Predicate/contains views retain the complete
-    // candidate set so their existing filtering semantics remain exact.
-    (query.sender_filter.is_none()
-        && query.timestamp_filter.is_none()
-        && query.task_filter.is_none()
-        && query.contains_filter.is_none())
-    .then_some(query.limit)
-    .flatten()
+    // window requires a backend aggregate; otherwise fallback counting needs
+    // full metadata. Predicate/contains views always retain full candidates.
+    storage_counts_available
+        .then(|| {
+            (query.sender_filter.is_none()
+                && query.timestamp_filter.is_none()
+                && query.task_filter.is_none()
+                && query.contains_filter.is_none())
+            .then_some(query.limit)
+            .flatten()
+        })
+        .flatten()
 }
 
 fn validate_target_member_in_roster<R: RetainedServiceRuntime>(

--- a/crates/atm-core/src/list.rs
+++ b/crates/atm-core/src/list.rs
@@ -149,11 +149,23 @@ fn list_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
         None
     };
 
-    let metadata_rows =
-        runtime.query_mailbox_metadata_rows(&query.home_dir, &target.team, &target.agent, None)?;
+    let storage_bucket_counts = runtime.query_mailbox_bucket_counts(&target.team, &target.agent)?;
+    let metadata_limit = metadata_limit_for_list(&query);
+    let metadata_rows = runtime.query_mailbox_metadata_rows(
+        &query.home_dir,
+        &target.team,
+        &target.agent,
+        metadata_limit,
+    )?;
     let classified_all = classify_mailbox_metadata_rows(&metadata_rows);
     let logical_current = logical_current_messages(classified_all);
-    let bucket_counts = bucket_counts_for(&logical_current);
+    let bucket_counts = storage_bucket_counts
+        .map(|counts| BucketCounts {
+            unread: counts.unread,
+            pending_ack: counts.pending_ack,
+            history: counts.history,
+        })
+        .unwrap_or_else(|| bucket_counts_for(&logical_current));
     let filtered = apply_list_filters(
         logical_current,
         query.sender_filter.as_ref(),
@@ -188,6 +200,19 @@ fn list_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
         rows,
         bucket_counts,
     })
+}
+
+fn metadata_limit_for_list(query: &ListQuery) -> Option<usize> {
+    // The normal list view has no metadata predicates. Its bounded display
+    // window can therefore be fetched directly; bucket counts come from the
+    // backend aggregate above. Predicate/contains views retain the complete
+    // candidate set so their existing filtering semantics remain exact.
+    (query.sender_filter.is_none()
+        && query.timestamp_filter.is_none()
+        && query.task_filter.is_none()
+        && query.contains_filter.is_none())
+    .then_some(query.limit)
+    .flatten()
 }
 
 fn validate_target_member_in_roster<R: RetainedServiceRuntime>(

--- a/crates/atm-core/src/service_runtime_store.rs
+++ b/crates/atm-core/src/service_runtime_store.rs
@@ -14,7 +14,8 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 
 use atm_storage::{
-    AckRequirementState, Message as SharedMessage, MessageQuery, derive_ack_requirement,
+    AckRequirementState, MailboxBucketCounts, Message as SharedMessage, MessageQuery,
+    derive_ack_requirement,
 };
 
 use crate::boundary;
@@ -100,6 +101,13 @@ pub(crate) trait RetainedMailboxRuntime {
         agent: &AgentName,
         limit: Option<usize>,
     ) -> Result<Vec<boundary::MailStoreMailboxMetadataRow>, AtmError>;
+    fn query_mailbox_bucket_counts(
+        &self,
+        _team: &TeamName,
+        _agent: &AgentName,
+    ) -> Result<Option<MailboxBucketCounts>, AtmError> {
+        Ok(None)
+    }
     fn load_message_record(
         &self,
         home_dir: &Path,
@@ -151,6 +159,14 @@ impl RetainedMailboxRuntime for LocalServiceRuntime {
                     .map(shared_message_to_metadata_row)
                     .collect()
             })
+    }
+
+    fn query_mailbox_bucket_counts(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+    ) -> Result<Option<MailboxBucketCounts>, AtmError> {
+        self.message_store.mailbox_bucket_counts(team, agent)
     }
 
     fn load_message_record(

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -23,8 +23,8 @@ pub use crate::observability::{
     SqliteObservabilityOutcome,
 };
 use atm_storage::contract::{
-    AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, Message, MessageKey,
-    MessageQuery, MessageStore, PeerConfigStore, RosterStore,
+    AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, MailboxBucketCounts,
+    Message, MessageKey, MessageQuery, MessageStore, PeerConfigStore, RosterStore,
 };
 #[cfg(test)]
 use atm_storage::schema::ThreadMode;
@@ -465,6 +465,82 @@ impl MessageStore for SqliteMessageStore {
         })
     }
 
+    fn mailbox_bucket_counts(
+        &self,
+        team: &TeamName,
+        agent: &AgentName,
+    ) -> Result<Option<MailboxBucketCounts>, AtmError> {
+        self.db.with_connection(|connection| {
+            let sql = "WITH visible AS (
+                    SELECT
+                        mail_messages.message_id,
+                        mail_messages.parent_message_id,
+                        COALESCE(
+                            mail_message_states.read,
+                            json_extract(mail_messages.envelope_json, '$.read'),
+                            0
+                        ) AS is_read,
+                        mail_message_states.pending_ack_at,
+                        mail_message_states.acknowledged_at,
+                        mail_message_states.expires_at
+                    FROM mail_messages
+                    LEFT JOIN mail_message_states
+                      ON mail_message_states.team = mail_messages.team
+                     AND mail_message_states.agent = mail_messages.agent
+                     AND mail_message_states.message_key = mail_messages.message_key
+                    WHERE mail_messages.team = ?1
+                      AND mail_messages.agent = ?2
+                      AND mail_message_states.deleted_at IS NULL
+                      AND (
+                           mail_message_states.expires_at IS NULL
+                           OR mail_message_states.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                      )
+                 ), terminal AS (
+                    SELECT visible.*
+                    FROM visible
+                    WHERE visible.message_id IS NULL
+                       OR NOT EXISTS (
+                            SELECT 1
+                            FROM visible AS successor
+                            WHERE successor.parent_message_id = visible.message_id
+                       )
+                 ), displayable AS (
+                    SELECT *
+                    FROM terminal
+                    WHERE expires_at IS NULL OR is_read = 0
+                 )
+                 SELECT
+                    COALESCE(SUM(CASE
+                        WHEN pending_ack_at IS NOT NULL AND acknowledged_at IS NULL THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(CASE
+                        WHEN NOT (pending_ack_at IS NOT NULL AND acknowledged_at IS NULL)
+                         AND is_read = 0 THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(CASE
+                        WHEN NOT (pending_ack_at IS NOT NULL AND acknowledged_at IS NULL)
+                         AND is_read != 0 THEN 1 ELSE 0 END), 0)
+                 FROM displayable";
+            let (pending_ack, unread, history): (i64, i64, i64) = connection
+                .query_row(sql, params![team.as_str(), agent.as_str()], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                })
+                .map_err(|error| {
+                    self.db
+                        .error("failed to aggregate sqlite mailbox bucket counts", error)
+                })?;
+            Ok(Some(MailboxBucketCounts {
+                unread: usize::try_from(unread).map_err(|_| {
+                    AtmError::validation("sqlite unread mailbox count exceeds usize range")
+                })?,
+                pending_ack: usize::try_from(pending_ack).map_err(|_| {
+                    AtmError::validation("sqlite pending-ack mailbox count exceeds usize range")
+                })?,
+                history: usize::try_from(history).map_err(|_| {
+                    AtmError::validation("sqlite history mailbox count exceeds usize range")
+                })?,
+            }))
+        })
+    }
+
     fn delete_message(&self, key: &MessageKey) -> Result<(), AtmError> {
         self.db.with_transaction(|transaction| {
             transaction
@@ -787,6 +863,30 @@ mod tests {
             }],
             "only recent immutable writes for the requested peer are eligible"
         );
+    }
+
+    #[test]
+    fn mailbox_bucket_counts_aggregate_without_loading_message_bodies() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let store = backend.message_store();
+        let mut unread = message("atm:unread", "unread");
+        let mut pending_ack = message("atm:pending", "pending");
+        let mut history = message("atm:history", "history");
+        pending_ack.envelope.requires_ack = true;
+        pending_ack.envelope.pending_ack_at = Some(IsoTimestamp::from_datetime(Utc::now()));
+        history.envelope.read = true;
+        for record in [&mut unread, &mut pending_ack, &mut history] {
+            store.save_message(record).expect("save message");
+        }
+
+        let counts = store
+            .mailbox_bucket_counts(&team(), &agent())
+            .expect("aggregate counts")
+            .expect("sqlite aggregate is available");
+
+        assert_eq!(counts.unread, 1);
+        assert_eq!(counts.pending_ack, 1);
+        assert_eq!(counts.history, 1);
     }
 
     #[test]

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -264,6 +264,14 @@ pub struct Message {
     pub envelope: MessageEnvelope,
 }
 
+/// Aggregate display counts for one mailbox without materializing its messages.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MailboxBucketCounts {
+    pub unread: usize,
+    pub pending_ack: usize,
+    pub history: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MailMessageState {
     pub team: TeamName,
@@ -524,6 +532,15 @@ pub trait MessageStore: sealed::Sealed + Send + Sync {
     }
     fn load_message(&self, key: &MessageKey) -> Result<Option<Message>, AtmError>;
     fn list_messages(&self, query: &MessageQuery) -> Result<Vec<Message>, AtmError>;
+    /// Returns mailbox display counts when the backend can aggregate them
+    /// without materializing every immutable message record.
+    fn mailbox_bucket_counts(
+        &self,
+        _team: &TeamName,
+        _agent: &AgentName,
+    ) -> Result<Option<MailboxBucketCounts>, AtmError> {
+        Ok(None)
+    }
     fn delete_message(&self, key: &MessageKey) -> Result<(), AtmError>;
 }
 

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -15,8 +15,8 @@ pub const ROLE_WORKER: &str = "worker";
 pub use contract::{
     AckRequirementState, AckTransition, AgentType, BuiltInNudgeTemplateKind,
     CertificateFingerprint, HttpsInterface, LocalCertificate, MAX_PEER_SYNC_BATCH_MESSAGES,
-    MAX_PEER_SYNC_MESSAGE_AGE, MailMessageState, Message, MessageFingerprint, MessageKey,
-    MessageQuery, MessageReceivedEvent, MessageStore, NudgeTemplateOverrideStore,
+    MAX_PEER_SYNC_MESSAGE_AGE, MailMessageState, MailboxBucketCounts, Message, MessageFingerprint,
+    MessageKey, MessageQuery, MessageReceivedEvent, MessageStore, NudgeTemplateOverrideStore,
     OutboundMessageQuery, PeerConfigStore, PeerSyncPolicy, PrivateKeyRef, RosterChangedEvent,
     RosterHarness, RosterMember, RosterMemberKind, RosterSnapshot, RosterStore, StorageNotifier,
     StoredPeerWrite, TaskState, TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow,


### PR DESCRIPTION
## Summary
- Fixes the ATM-QA-40-LISTMAIL-TIMEOUT product defect: `list_mail` loaded and classified the entire mailbox in-process before returning `bucket_counts`, causing the post-restart public durability-count/read path to exceed the daemon's fixed 3s deadline once an isolated mailbox holds ~500k rows.
- Aggregates mailbox bucket counts directly in SQLite instead of loading/classifying every row in-process.

## Test plan
- [ ] just lint
- [ ] just test
- [ ] Confirm the 500k-row sustained-scale scenario no longer times out at the 3s deadline
- [ ] quality-mgr QA pass

Related: `.triage/phase-AI/findings/ATM-QA-40-LISTMAIL-TIMEOUT.ttl`