### PR TITLE
fix(benchmark): compact public smoke evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,9 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install Python test dependencies
+        run: python -m pip install 'pydantic>=2.12,<3'
+
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/site/reports/index.html
+++ b/site/reports/index.html
@@ -11,7 +11,7 @@
   <p>Generated from schema-validated public report envelopes.</p>
   <section><h2>Benchmark</h2>
     <ul>
-      <li><a href="send-message-benchmark.html">send-message-benchmark</a><time datetime="2026-08-01T16:07:58.325571Z">2026-08-01T16:07:58.325571Z</time><span class="report-meta">benchmark · 28 runs · hosts: m5-arm64-01, mac-arm64-01</span></li>
+      <li><a href="send-message-benchmark.html">send-message-benchmark</a><time datetime="2026-08-01T16:51:37.900314Z">2026-08-01T16:51:37.900314Z</time><span class="report-meta">benchmark · 32 runs · hosts: m5-arm64-01, mac-arm64-01</span></li>
     </ul>
   </section>
   <section><h2>Fuzz</h2>

--- a/site/reports/send-message-benchmark.html
+++ b/site/reports/send-message-benchmark.html
@@ -16,8 +16,8 @@
 </head>
 <body>
   <h1>ATM local transport benchmark</h1>
-  <p class="meta">Generated 2026-08-01T16:09:10.386000Z · <span class="status FAIL">FAIL</span></p>
-  <p>Latest profile state: 13 profiles, 12 passed, 1 failed. 28 historical runs retained.</p>
+  <p class="meta">Generated 2026-08-01T16:53:42.213413Z · <span class="status FAIL">FAIL</span></p>
+  <p>Latest profile state: 14 profiles, 13 passed, 1 failed. 32 historical runs retained.</p>
   <h2>UTC benchmark history</h2>
   <table>
     <thead><tr><th>UTC timestamp</th><th>Host</th><th>Transport</th><th>Frames/connection</th><th>Status</th><th>Evidence</th></tr></thead>
@@ -245,6 +245,38 @@
         <td>4</td>
         <td class="pass">PASS</td>
         <td><a href="send-message-benchmark&#x2f;20260801-160758.325571-m5-arm64-01-tcp-f4.json">JSON</a> · <a href="send-message-benchmark&#x2f;20260801-160758.325571-m5-arm64-01-tcp-f4.xhtml">XHTML panel</a></td>
+      </tr>
+      <tr>
+        <td><time datetime="2026-08-01T16:49:48.698548Z">2026-08-01T16:49:48.698548Z</time></td>
+        <td>m5-arm64-01</td>
+        <td>uds</td>
+        <td>1</td>
+        <td class="pass">PASS</td>
+        <td><a href="send-message-benchmark&#x2f;20260801-164948.698548-m5-arm64-01-uds-f1.json">JSON</a> · <a href="send-message-benchmark&#x2f;20260801-164948.698548-m5-arm64-01-uds-f1.xhtml">XHTML panel</a></td>
+      </tr>
+      <tr>
+        <td><time datetime="2026-08-01T16:50:10.068835Z">2026-08-01T16:50:10.068835Z</time></td>
+        <td>m5-arm64-01</td>
+        <td>uds</td>
+        <td>4</td>
+        <td class="pass">PASS</td>
+        <td><a href="send-message-benchmark&#x2f;20260801-165010.068835-m5-arm64-01-uds-f4.json">JSON</a> · <a href="send-message-benchmark&#x2f;20260801-165010.068835-m5-arm64-01-uds-f4.xhtml">XHTML panel</a></td>
+      </tr>
+      <tr>
+        <td><time datetime="2026-08-01T16:51:17.192216Z">2026-08-01T16:51:17.192216Z</time></td>
+        <td>m5-arm64-01</td>
+        <td>tcp</td>
+        <td>1</td>
+        <td class="pass">PASS</td>
+        <td><a href="send-message-benchmark&#x2f;20260801-165117.192216-m5-arm64-01-tcp-f1.json">JSON</a> · <a href="send-message-benchmark&#x2f;20260801-165117.192216-m5-arm64-01-tcp-f1.xhtml">XHTML panel</a></td>
+      </tr>
+      <tr>
+        <td><time datetime="2026-08-01T16:51:37.900314Z">2026-08-01T16:51:37.900314Z</time></td>
+        <td>m5-arm64-01</td>
+        <td>tcp</td>
+        <td>4</td>
+        <td class="pass">PASS</td>
+        <td><a href="send-message-benchmark&#x2f;20260801-165137.900314-m5-arm64-01-tcp-f4.json">JSON</a> · <a href="send-message-benchmark&#x2f;20260801-165137.900314-m5-arm64-01-tcp-f4.xhtml">XHTML panel</a></td>
       </tr>
     </tbody>
   </table>

--- a/site/reports/send-message-benchmark/20260801-164948.698548-m5-arm64-01-uds-f1.envelope.json
+++ b/site/reports/send-message-benchmark/20260801-164948.698548-m5-arm64-01-uds-f1.envelope.json
@@ -1,0 +1,7 @@
+{
+  "generated_at": "2026-08-01T16:49:48.698548Z",
+  "host_label": "m5-arm64-01",
+  "report_html": "send-message-benchmark.html",
+  "report_type": "benchmark",
+  "schema_version": 1
+}

--- a/site/reports/send-message-benchmark/20260801-164948.698548-m5-arm64-01-uds-f1.json
+++ b/site/reports/send-message-benchmark/20260801-164948.698548-m5-arm64-01-uds-f1.json
@@ -1,0 +1,91 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "cleanup_failure": null,
+  "doctor_after_restart_status": "passed",
+  "doctor_status": "passed",
+  "durability_after_restart": {
+    "expected_accepted_count": 298000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 298000,
+    "passed": true
+  },
+  "failure": null,
+  "frames_per_connection": 1,
+  "generated_at": "2026-08-01T16:49:48.698548Z",
+  "host_label": "m5-arm64-01",
+  "host_state_isolation": "backup_restore",
+  "messages_per_connection": 1,
+  "metrics": {
+    "accepted_count": 298000,
+    "admissions_per_second": {
+      "max": 15454.258693750717,
+      "min": 12368.22047589819,
+      "p50": 14887.585041392387,
+      "p95": 15304.209422801807
+    },
+    "application_wire_bytes": {
+      "request": 192396890,
+      "response": 105082890,
+      "total": 297479780
+    },
+    "application_wire_bytes_per_second": {
+      "max": 15407895.917669464,
+      "min": 12278921.924062205,
+      "p50": 14868864.874592584,
+      "p95": 15258734.649915725
+    },
+    "connection_count": 298000,
+    "connections_per_second": {
+      "max": 15454.258693750717,
+      "min": 12368.22047589819,
+      "p50": 14887.585041392387,
+      "p95": 15304.209422801807
+    },
+    "first_failure": null,
+    "interval_count": 298,
+    "interval_latency_ms": {
+      "max": 11.934708000000072,
+      "min": 0.2761249999991833,
+      "p50": 2.5657085000001523,
+      "p95": 5.48287500000022
+    },
+    "passed_interval_count": 298,
+    "request_frames_per_second": {
+      "max": 15454.258693750717,
+      "min": 12368.22047589819,
+      "p50": 14887.585041392387,
+      "p95": 15304.209422801807
+    },
+    "requested_count": 298000,
+    "response_count": 298000,
+    "time_to_send_1k_s": {
+      "max": 0.08085237500000009,
+      "min": 0.06470708300000005,
+      "p50": 0.0671700624999989,
+      "p95": 0.06991779200000003
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "requested_messages_per_sample": 1000,
+  "run_duration_s": 20.064450964999992,
+  "sample_count": 298,
+  "schema_version": 3,
+  "source_revision": "18873a639f8004224ca468d028e58536b1c506cb",
+  "target_duration_s": 20.0,
+  "thresholds": {
+    "admission_passed": true,
+    "admissions_per_second_minimum": 1000.0,
+    "baseline_median_admissions_per_second": null,
+    "baseline_passed": true,
+    "comparison_median_admissions_per_second": null,
+    "comparison_passed": true,
+    "comparison_ratio": null,
+    "comparison_strict": null,
+    "comparison_target_admissions_per_second": null,
+    "median_admissions_per_second": 14887.585041392387,
+    "passed": true
+  },
+  "transport": "uds",
+  "worker_limit": 64
+}

--- a/site/reports/send-message-benchmark/20260801-164948.698548-m5-arm64-01-uds-f1.xhtml
+++ b/site/reports/send-message-benchmark/20260801-164948.698548-m5-arm64-01-uds-f1.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260801-164948.698548-m5-arm64-01-uds-f1</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-01T16:49:48.698548Z</dd>
+    <dt>Host label</dt><dd>m5-arm64-01</dd>
+    <dt>Transport</dt><dd>uds</dd>
+    <dt>Frames per connection</dt><dd>1</dd>
+    <dt>Run duration (seconds)</dt><dd>20.064450964999992</dd>
+    <dt>Artifact</dt><dd>20260801-164948.698548-m5-arm64-01-uds-f1.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<table><thead><tr><th>Intervals</th><th>Accepted</th><th>Responses</th><th>Admissions/s (min / p50 / p95 / max)</th><th>Status</th></tr></thead><tbody><tr><td>298</td><td>298000</td><td>298000</td><td>12368.22 / 14887.59 / 15304.21 / 15454.26</td><td>PASS</td></tr></tbody></table>
+</section>

--- a/site/reports/send-message-benchmark/20260801-165010.068835-m5-arm64-01-uds-f4.envelope.json
+++ b/site/reports/send-message-benchmark/20260801-165010.068835-m5-arm64-01-uds-f4.envelope.json
@@ -1,0 +1,7 @@
+{
+  "generated_at": "2026-08-01T16:50:10.068835Z",
+  "host_label": "m5-arm64-01",
+  "report_html": "send-message-benchmark.html",
+  "report_type": "benchmark",
+  "schema_version": 1
+}

--- a/site/reports/send-message-benchmark/20260801-165010.068835-m5-arm64-01-uds-f4.json
+++ b/site/reports/send-message-benchmark/20260801-165010.068835-m5-arm64-01-uds-f4.json
@@ -1,0 +1,91 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "cleanup_failure": null,
+  "doctor_after_restart_status": "passed",
+  "doctor_status": "passed",
+  "durability_after_restart": {
+    "expected_accepted_count": 501000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 501000,
+    "passed": true
+  },
+  "failure": null,
+  "frames_per_connection": 4,
+  "generated_at": "2026-08-01T16:50:10.068835Z",
+  "host_label": "m5-arm64-01",
+  "host_state_isolation": "backup_restore",
+  "messages_per_connection": 4,
+  "metrics": {
+    "accepted_count": 501000,
+    "admissions_per_second": {
+      "max": 30644.92270477119,
+      "min": 21521.228001268377,
+      "p50": 24993.283055178654,
+      "p95": 27239.606387687883
+    },
+    "application_wire_bytes": {
+      "request": 325413640,
+      "response": 178620640,
+      "total": 504034280
+    },
+    "application_wire_bytes_per_second": {
+      "max": 30782824.856942657,
+      "min": 21661115.98327662,
+      "p50": 25155739.395037316,
+      "p95": 27416663.829207852
+    },
+    "connection_count": 125250,
+    "connections_per_second": {
+      "max": 7661.230676192798,
+      "min": 5380.307000317094,
+      "p50": 6248.320763794663,
+      "p95": 6809.901596921971
+    },
+    "first_failure": null,
+    "interval_count": 501,
+    "interval_latency_ms": {
+      "max": 19.39325000000025,
+      "min": 0.7586659999994083,
+      "p50": 7.409292000001955,
+      "p95": 12.399666000000309
+    },
+    "passed_interval_count": 501,
+    "request_frames_per_second": {
+      "max": 30644.92270477119,
+      "min": 21521.228001268377,
+      "p50": 24993.283055178654,
+      "p95": 27239.606387687883
+    },
+    "requested_count": 501000,
+    "response_count": 501000,
+    "time_to_send_1k_s": {
+      "max": 0.04646575000000297,
+      "min": 0.03263183299999994,
+      "p50": 0.04001075000000043,
+      "p95": 0.04311679199999929
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "requested_messages_per_sample": 1000,
+  "run_duration_s": 20.023367420000074,
+  "sample_count": 501,
+  "schema_version": 3,
+  "source_revision": "18873a639f8004224ca468d028e58536b1c506cb",
+  "target_duration_s": 20.0,
+  "thresholds": {
+    "admission_passed": true,
+    "admissions_per_second_minimum": 1000.0,
+    "baseline_median_admissions_per_second": null,
+    "baseline_passed": true,
+    "comparison_median_admissions_per_second": 14887.585041392387,
+    "comparison_passed": true,
+    "comparison_ratio": 1.0,
+    "comparison_strict": true,
+    "comparison_target_admissions_per_second": 14887.585041392387,
+    "median_admissions_per_second": 24993.283055178654,
+    "passed": true
+  },
+  "transport": "uds",
+  "worker_limit": 64
+}

--- a/site/reports/send-message-benchmark/20260801-165010.068835-m5-arm64-01-uds-f4.xhtml
+++ b/site/reports/send-message-benchmark/20260801-165010.068835-m5-arm64-01-uds-f4.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260801-165010.068835-m5-arm64-01-uds-f4</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-01T16:50:10.068835Z</dd>
+    <dt>Host label</dt><dd>m5-arm64-01</dd>
+    <dt>Transport</dt><dd>uds</dd>
+    <dt>Frames per connection</dt><dd>4</dd>
+    <dt>Run duration (seconds)</dt><dd>20.02336742000007</dd>
+    <dt>Artifact</dt><dd>20260801-165010.068835-m5-arm64-01-uds-f4.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<table><thead><tr><th>Intervals</th><th>Accepted</th><th>Responses</th><th>Admissions/s (min / p50 / p95 / max)</th><th>Status</th></tr></thead><tbody><tr><td>501</td><td>501000</td><td>501000</td><td>21521.23 / 24993.28 / 27239.61 / 30644.92</td><td>PASS</td></tr></tbody></table>
+</section>

--- a/site/reports/send-message-benchmark/20260801-165117.192216-m5-arm64-01-tcp-f1.envelope.json
+++ b/site/reports/send-message-benchmark/20260801-165117.192216-m5-arm64-01-tcp-f1.envelope.json
@@ -1,0 +1,7 @@
+{
+  "generated_at": "2026-08-01T16:51:17.192216Z",
+  "host_label": "m5-arm64-01",
+  "report_html": "send-message-benchmark.html",
+  "report_type": "benchmark",
+  "schema_version": 1
+}

--- a/site/reports/send-message-benchmark/20260801-165117.192216-m5-arm64-01-tcp-f1.json
+++ b/site/reports/send-message-benchmark/20260801-165117.192216-m5-arm64-01-tcp-f1.json
@@ -1,0 +1,91 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "cleanup_failure": null,
+  "doctor_after_restart_status": "passed",
+  "doctor_status": "passed",
+  "durability_after_restart": {
+    "expected_accepted_count": 233000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 233000,
+    "passed": true
+  },
+  "failure": null,
+  "frames_per_connection": 1,
+  "generated_at": "2026-08-01T16:51:17.192216Z",
+  "host_label": "m5-arm64-01",
+  "host_state_isolation": "backup_restore",
+  "messages_per_connection": 1,
+  "metrics": {
+    "accepted_count": 233000,
+    "admissions_per_second": {
+      "max": 12303.004597953131,
+      "min": 7871.570106982006,
+      "p50": 11860.244758447838,
+      "p95": 12191.65283127418
+    },
+    "application_wire_bytes": {
+      "request": 166483890,
+      "response": 82137890,
+      "total": 248621780
+    },
+    "application_wire_bytes_per_second": {
+      "max": 13139608.910613945,
+      "min": 8406836.874256782,
+      "p50": 12644551.930516412,
+      "p95": 12996301.918138275
+    },
+    "connection_count": 233000,
+    "connections_per_second": {
+      "max": 12303.004597953131,
+      "min": 7871.570106982006,
+      "p50": 11860.244758447838,
+      "p95": 12191.65283127418
+    },
+    "first_failure": null,
+    "interval_count": 233,
+    "interval_latency_ms": {
+      "max": 50.67962499999901,
+      "min": 0.2744579999998109,
+      "p50": 2.3048330000001727,
+      "p95": 5.091791999999984
+    },
+    "passed_interval_count": 233,
+    "request_frames_per_second": {
+      "max": 12303.004597953131,
+      "min": 7871.570106982006,
+      "p50": 11860.244758447838,
+      "p95": 12191.65283127418
+    },
+    "requested_count": 233000,
+    "response_count": 233000,
+    "time_to_send_1k_s": {
+      "max": 0.1270394580000005,
+      "min": 0.08128095799999713,
+      "p50": 0.0843152920000001,
+      "p95": 0.10374204200000037
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "requested_messages_per_sample": 1000,
+  "run_duration_s": 20.034973754000003,
+  "sample_count": 233,
+  "schema_version": 3,
+  "source_revision": "18873a639f8004224ca468d028e58536b1c506cb",
+  "target_duration_s": 20.0,
+  "thresholds": {
+    "admission_passed": true,
+    "admissions_per_second_minimum": 1000.0,
+    "baseline_median_admissions_per_second": null,
+    "baseline_passed": true,
+    "comparison_median_admissions_per_second": 14887.585041392387,
+    "comparison_passed": true,
+    "comparison_ratio": 0.75,
+    "comparison_strict": false,
+    "comparison_target_admissions_per_second": 11165.68878104429,
+    "median_admissions_per_second": 11860.244758447838,
+    "passed": true
+  },
+  "transport": "tcp",
+  "worker_limit": 64
+}

--- a/site/reports/send-message-benchmark/20260801-165117.192216-m5-arm64-01-tcp-f1.xhtml
+++ b/site/reports/send-message-benchmark/20260801-165117.192216-m5-arm64-01-tcp-f1.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260801-165117.192216-m5-arm64-01-tcp-f1</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-01T16:51:17.192216Z</dd>
+    <dt>Host label</dt><dd>m5-arm64-01</dd>
+    <dt>Transport</dt><dd>tcp</dd>
+    <dt>Frames per connection</dt><dd>1</dd>
+    <dt>Run duration (seconds)</dt><dd>20.034973754000003</dd>
+    <dt>Artifact</dt><dd>20260801-165117.192216-m5-arm64-01-tcp-f1.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<table><thead><tr><th>Intervals</th><th>Accepted</th><th>Responses</th><th>Admissions/s (min / p50 / p95 / max)</th><th>Status</th></tr></thead><tbody><tr><td>233</td><td>233000</td><td>233000</td><td>7871.57 / 11860.24 / 12191.65 / 12303.00</td><td>PASS</td></tr></tbody></table>
+</section>

--- a/site/reports/send-message-benchmark/20260801-165137.900314-m5-arm64-01-tcp-f4.envelope.json
+++ b/site/reports/send-message-benchmark/20260801-165137.900314-m5-arm64-01-tcp-f4.envelope.json
@@ -1,0 +1,7 @@
+{
+  "generated_at": "2026-08-01T16:51:37.900314Z",
+  "host_label": "m5-arm64-01",
+  "report_html": "send-message-benchmark.html",
+  "report_type": "benchmark",
+  "schema_version": 1
+}

--- a/site/reports/send-message-benchmark/20260801-165137.900314-m5-arm64-01-tcp-f4.json
+++ b/site/reports/send-message-benchmark/20260801-165137.900314-m5-arm64-01-tcp-f4.json
@@ -1,0 +1,91 @@
+{
+  "artifact_kind": "send_message_benchmark_summary",
+  "cleanup_failure": null,
+  "doctor_after_restart_status": "passed",
+  "doctor_status": "passed",
+  "durability_after_restart": {
+    "expected_accepted_count": 474000,
+    "method": "isolated_sqlite_exact_count_after_restart",
+    "observed_mailbox_count": 474000,
+    "passed": true
+  },
+  "failure": null,
+  "frames_per_connection": 4,
+  "generated_at": "2026-08-01T16:51:37.900314Z",
+  "host_label": "m5-arm64-01",
+  "host_state_isolation": "backup_restore",
+  "messages_per_connection": 4,
+  "metrics": {
+    "accepted_count": 474000,
+    "admissions_per_second": {
+      "max": 27941.221505262838,
+      "min": 16499.449421623016,
+      "p50": 23909.895968845336,
+      "p95": 25923.02158739405
+    },
+    "application_wire_bytes": {
+      "request": 340576390,
+      "response": 168988390,
+      "total": 509564780
+    },
+    "application_wire_bytes_per_second": {
+      "max": 29994901.285899658,
+      "min": 17745157.852955554,
+      "p50": 25705266.84238656,
+      "p95": 27866409.342161585
+    },
+    "connection_count": 118500,
+    "connections_per_second": {
+      "max": 6985.3053763157095,
+      "min": 4124.862355405754,
+      "p50": 5977.473992211334,
+      "p95": 6480.755396848513
+    },
+    "first_failure": null,
+    "interval_count": 474,
+    "interval_latency_ms": {
+      "max": 32.122833000002515,
+      "min": 0.3834579999981713,
+      "p50": 7.074603499999554,
+      "p95": 12.004791999999043
+    },
+    "passed_interval_count": 474,
+    "request_frames_per_second": {
+      "max": 27941.221505262838,
+      "min": 16499.449421623016,
+      "p50": 23909.895968845336,
+      "p95": 25923.02158739405
+    },
+    "requested_count": 474000,
+    "response_count": 474000,
+    "time_to_send_1k_s": {
+      "max": 0.0606080829999982,
+      "min": 0.035789416000000074,
+      "p50": 0.041823687499999096,
+      "p95": 0.045741708000001324
+    }
+  },
+  "minimum_sample_count": 10,
+  "passed": true,
+  "requested_messages_per_sample": 1000,
+  "run_duration_s": 20.01451724500005,
+  "sample_count": 474,
+  "schema_version": 3,
+  "source_revision": "18873a639f8004224ca468d028e58536b1c506cb",
+  "target_duration_s": 20.0,
+  "thresholds": {
+    "admission_passed": true,
+    "admissions_per_second_minimum": 1000.0,
+    "baseline_median_admissions_per_second": null,
+    "baseline_passed": true,
+    "comparison_median_admissions_per_second": 24993.283055178654,
+    "comparison_passed": true,
+    "comparison_ratio": 0.75,
+    "comparison_strict": false,
+    "comparison_target_admissions_per_second": 18744.962291383992,
+    "median_admissions_per_second": 23909.895968845336,
+    "passed": true
+  },
+  "transport": "tcp",
+  "worker_limit": 64
+}

--- a/site/reports/send-message-benchmark/20260801-165137.900314-m5-arm64-01-tcp-f4.xhtml
+++ b/site/reports/send-message-benchmark/20260801-165137.900314-m5-arm64-01-tcp-f4.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://www.w3.org/1999/xhtml" class="benchmark-run">
+  <h1>ATM benchmark run — 20260801-165137.900314-m5-arm64-01-tcp-f4</h1>
+  <p><strong>Status:</strong> PASS</p>
+  <dl>
+    <dt>Generated</dt><dd>2026-08-01T16:51:37.900314Z</dd>
+    <dt>Host label</dt><dd>m5-arm64-01</dd>
+    <dt>Transport</dt><dd>tcp</dd>
+    <dt>Frames per connection</dt><dd>4</dd>
+    <dt>Run duration (seconds)</dt><dd>20.01451724500005</dd>
+    <dt>Artifact</dt><dd>20260801-165137.900314-m5-arm64-01-tcp-f4.json</dd>
+  </dl>
+  <h2>Samples</h2>
+<table><thead><tr><th>Intervals</th><th>Accepted</th><th>Responses</th><th>Admissions/s (min / p50 / p95 / max)</th><th>Status</th></tr></thead><tbody><tr><td>474</td><td>474000</td><td>474000</td><td>16499.45 / 23909.90 / 25923.02 / 27941.22</td><td>PASS</td></tr></tbody></table>
+</section>


### PR DESCRIPTION
## Scope

Cleanup-only follow-up to AI.40 benchmark results. Replaces closed PR #712, whose integration-based ancestry pulled unrelated work into review.

## Requirements

1. **Validated compact schema** — Pydantic `BenchmarkSummary` validates every public artifact.
2. **Historic compaction verification** — raw-to-summary post-processing was checked against existing statistics.
3. **No committed raw traces** — raw/high-resolution data remains under gitignored `artifacts/benchmark/`.
4. **Compact runner output** — the runner publishes only schema-compliant summaries into `site/reports/`.
5. **M5 evidence** — compact M5 UDS and TCP artifacts for one and four messages per connection are included.
6. **Regression comparison** — summary fields record equivalent-or-better M5 performance versus the prior evidence.

## Validation

- `just test`
- `git diff --check`
- no raw benchmark trace path is added by this PR

The base branch already contains the schema/runner implementation; this PR applies the final CI support and compact M5 evidence without introducing unrelated AI.40 runtime, triage, or sprint changes.