### PR TITLE
fix(benchmark): centralize p50 calculation

### DIFF
--- a/.triage/phase-AI/findings/RBQA-AI40-F002-P50-TRIPLICATE.ttl
+++ b/.triage/phase-AI/findings/RBQA-AI40-F002-P50-TRIPLICATE.ttl
@@ -12,11 +12,13 @@
   triage:severity "important" ;
   triage:repeatable false ;
   triage:sweepScope "file_only" ;
-  triage:status "open" ;
+  triage:status "fixed" ;
   triage:dispatchReady true ;
   triage:foundIn triage:AI40-MATHTEST-QA-1 ;
   triage:foundAt "2026-08-01T00:00:00Z"^^xsd:dateTime ;
   triage:triagedAt "2026-08-01T00:00:00Z"^^xsd:dateTime ;
+  triage:closedAt "2026-08-01T00:00:00Z"^^xsd:dateTime ;
+  triage:closedBy "quality-mgr" ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-AI40-F002-P50-TRIPLICATE/1> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-AI40-F002-P50-TRIPLICATE/2> ;
   triage:hasOccurrence <urn:atm:triage:occurrence/RBQA-AI40-F002-P50-TRIPLICATE/3> ;
@@ -27,9 +29,9 @@
   a triage:Occurrence ;
   triage:file "scripts/smoke/run_admission_capacity.py" ;
   triage:line 477 ;
-  triage:snippet "run_interval() latency p50 via latencies[len(latencies) // 2] -- pure nearest-rank, no averaging" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:snippet "Fixed on fix/ai40-p50-median-consolidation @ 25a2487a: run_interval() now computes latency_distribution = distribution(latencies), no longer nearest-rank." ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ai-31-33" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-ai-31-33/1> .
 
@@ -37,9 +39,9 @@
   a triage:Occurrence ;
   triage:file "scripts/smoke/benchmark_schema.py" ;
   triage:line 178 ;
-  triage:snippet "distribution() p50 averages the middle pair for even-length input" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:snippet "distribution() remains the single canonical p50 implementation; both call sites now delegate to it." ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ai-31-33" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-ai-31-33/1> .
 
@@ -47,9 +49,9 @@
   a triage:Occurrence ;
   triage:file "scripts/smoke/run_admission_capacity.py" ;
   triage:line 582 ;
-  triage:snippet "profile_median_admissions_per_second() re-implements distribution()'s averaging logic independently instead of calling it" ;
-  triage:status "open" ;
-  triage:closed false ;
+  triage:snippet "Fixed on fix/ai40-p50-median-consolidation @ 25a2487a: profile_median_admissions_per_second() now returns distribution(rates)[\"p50\"] instead of re-implementing the averaging logic." ;
+  triage:status "fixed" ;
+  triage:closed true ;
   triage:branch "integrate/phase-ai-31-33" ;
   triage:occursIn <urn:atm:triage:worktree/integrate-phase-ai-31-33/1> .
 

--- a/scripts/smoke/run_admission_capacity.py
+++ b/scripts/smoke/run_admission_capacity.py
@@ -35,7 +35,7 @@ DEFAULT_RAW_EVIDENCE_DIR = ROOT / "artifacts" / "benchmark" / "send-message-benc
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts.smoke.benchmark_schema import BenchmarkSchemaError, compact_evidence
+from scripts.smoke.benchmark_schema import BenchmarkSchemaError, compact_evidence, distribution
 
 if os.name != "nt":
     import pwd
@@ -465,7 +465,13 @@ def run_interval(
     elapsed_seconds = time.perf_counter() - started
     accepted = sum(result.status == 201 for result in results)
     failures = [result.failure or f"HTTP {result.status}" for result in results if result.status != 201]
-    latencies = sorted(result.elapsed_ms for result in results)
+    latencies = [result.elapsed_ms for result in results]
+    latency_distribution = distribution(latencies) if latencies else {
+        "min": 0.0,
+        "p50": 0.0,
+        "p95": 0.0,
+        "max": 0.0,
+    }
     request_bytes = sum(result.request_bytes for result in results)
     response_bytes = sum(result.response_bytes for result in results)
     return {
@@ -474,12 +480,7 @@ def run_interval(
         "response_count": len(results),
         "elapsed_seconds": elapsed_seconds,
         "admissions_per_second": accepted / elapsed_seconds if elapsed_seconds else 0.0,
-        "latency_ms": {
-            "min": latencies[0] if latencies else 0.0,
-            "p50": latencies[len(latencies) // 2] if latencies else 0.0,
-            "p95": latencies[min(len(latencies) - 1, int(len(latencies) * 0.95))] if latencies else 0.0,
-            "max": latencies[-1] if latencies else 0.0,
-        },
+        "latency_ms": latency_distribution,
         "connections": connections,
         "request_frames_per_second": len(results) / elapsed_seconds if elapsed_seconds else 0.0,
         "connections_per_second": connections / elapsed_seconds if elapsed_seconds else 0.0,
@@ -581,13 +582,8 @@ def write_evidence(directory: Path, evidence: dict[str, Any]) -> Path:
 
 def profile_median_admissions_per_second(profile: dict[str, Any]) -> float:
     """Return the midpoint rate retained by a complete profile."""
-    rates = sorted(float(item["admissions_per_second"]) for item in profile["intervals"])
-    if not rates:
-        return 0.0
-    middle = len(rates) // 2
-    if len(rates) % 2:
-        return rates[middle]
-    return (rates[middle - 1] + rates[middle]) / 2
+    rates = [float(item["admissions_per_second"]) for item in profile["intervals"]]
+    return distribution(rates)["p50"] if rates else 0.0
 
 
 def evaluate_profile_thresholds(

--- a/scripts/smoke/test_run_admission_capacity.py
+++ b/scripts/smoke/test_run_admission_capacity.py
@@ -488,6 +488,24 @@ class AdmissionCapacityTests(unittest.TestCase):
         self.assertNotIn("http_request_frames_per_second", result)
         self.assertNotIn("wire_bytes", result)
 
+    def test_interval_latency_p50_uses_schema_distribution_for_even_samples(self):
+        latencies = iter((1.0, 2.0, 3.0, 4.0))
+
+        def submit(_sequence, _message_count):
+            return [RUNNER.AdmissionResult(201, next(latencies))]
+
+        result = RUNNER.run_interval(submit, 0, 1, 1, 4)
+        self.assertEqual(result["latency_ms"]["p50"], 2.5)
+
+    def test_profile_median_uses_schema_distribution_for_even_samples(self):
+        profile = {
+            "intervals": [
+                {"admissions_per_second": value}
+                for value in (1.0, 2.0, 3.0, 4.0)
+            ]
+        }
+        self.assertEqual(RUNNER.profile_median_admissions_per_second(profile), 2.5)
+
     def test_interval_metrics_are_retained_by_the_benchmark_report_schema(self):
         import benchmark_report
 


### PR DESCRIPTION
Fixes RBQA-AI40-F002-P50-TRIPLICATE.

- delegates interval latency p50 and profile admission median to `benchmark_schema.distribution()`
- preserves schema-of-record even-length averaging semantics
- adds even-length regression coverage

Validation: `just lint`; `just test`.