### PR TITLE
fix(ai52): pipeline local TCP admissions on Windows (bounded 8-frame dispatch)

### DIFF
--- a/crates/atm-daemon/src/local_tcp_transport.rs
+++ b/crates/atm-daemon/src/local_tcp_transport.rs
@@ -27,7 +27,9 @@ use std::os::windows::ffi::OsStrExt as _;
 use std::os::unix::fs::PermissionsExt as _;
 
 #[cfg(any(test, windows))]
-use atm_core::api::{ApiRouter, AuthenticatedIngress, RequestDeadline};
+use atm_core::api::ApiRouter;
+#[cfg(test)]
+use atm_core::api::{AuthenticatedIngress, RequestDeadline};
 use atm_core::api::{HttpFrameReader, write_local_http_response};
 use atm_core::error::AtmError;
 use atm_core::local_http::{LOCAL_CAPABILITY_HEADER, LocalCapability, LocalHttpEndpointRecord};
@@ -44,7 +46,7 @@ use crate::host_ownership::{HostOwnershipAdapter, HostOwnershipGuard};
 use crate::lifecycle_control::LifecycleControlSourceAdapter;
 #[cfg(windows)]
 use crate::local_ipc_connection::drain_active_connections_for_shutdown;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use crate::local_ipc_transport::request_worker::{
     DispatchWorkerPool, MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS, enqueue_request,
 };
@@ -277,6 +279,7 @@ pub(crate) struct PreparedRuntimeServer {
     listener: TcpListener,
     capability: LocalCapability,
     lifecycle: LifecycleControlSourceAdapter,
+    observability: SubsystemObservability,
     endpoint_guard: Option<SocketEndpointGuard>,
 }
 
@@ -330,6 +333,7 @@ impl PreparedRuntimeServer {
             listener,
             capability,
             lifecycle,
+            observability,
             endpoint_guard: Some(SocketEndpointGuard::new(record_path)),
         })
     }
@@ -355,71 +359,108 @@ impl PreparedRuntimeServer {
             listener,
             capability,
             lifecycle,
+            observability,
             endpoint_guard: _,
         } = self;
         (hooks.publish_ready)()?;
         let registry = Arc::new(ActiveConnectionRegistry::default());
         let force_shutdown = Arc::new(AtomicBool::new(false));
-        loop {
-            if lifecycle.terminate_requested() {
-                (hooks.begin_shutdown)()?;
-                drain_active_connections_for_shutdown(
-                    registry.as_ref(),
-                    force_shutdown.as_ref(),
-                    hooks.graceful_drain_deadline,
-                    hooks.force_cancel_deadline,
-                    Instant::now(),
-                    REQUEST_DEADLINE,
-                )?;
-                drop(hooks.endpoint_guard);
-                return Ok(());
-            }
-            if lifecycle.take_reload_requested() {
-                (hooks.reload_runtime_view)()?;
-            }
-            match listener.accept() {
-                Ok((stream, peer)) => {
-                    if !peer.ip().is_loopback() {
-                        continue;
-                    }
-                    registry.reap_finished_dispatches()?;
-                    let Some(active_connection) = registry.try_register(MAX_CONCURRENT_CONNECTIONS)
-                    else {
-                        continue;
-                    };
-                    let router = Arc::clone(&router);
-                    let capability = capability.clone();
-                    let force_shutdown = Arc::clone(&force_shutdown);
-                    let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
-                    let join_handle = thread::spawn(move || {
-                        let _active = active_connection;
-                        let _ =
-                            handle_connection(stream, router, &capability, force_shutdown.as_ref());
-                        let _ = completion_tx.send(());
-                    });
-                    registry.push_dispatch_handle(
-                        TrackedDispatchHandle {
-                            completion_rx,
-                            join_handle,
-                        },
-                        MAX_CONCURRENT_CONNECTIONS,
+        let dispatch_workers = DispatchWorkerPool::start(
+            Arc::clone(&router),
+            Arc::clone(&registry),
+            observability.clone(),
+            MAX_CONCURRENT_CONNECTIONS,
+        )?;
+        // Windows retains its nonblocking lifecycle loop, while every accepted
+        // connection shares the bounded pipelined dispatcher used by Unix.
+        let serve_result = (|| {
+            loop {
+                if lifecycle.terminate_requested() {
+                    (hooks.begin_shutdown)()?;
+                    drain_active_connections_for_shutdown(
+                        registry.as_ref(),
+                        force_shutdown.as_ref(),
+                        hooks.graceful_drain_deadline,
+                        hooks.force_cancel_deadline,
+                        Instant::now(),
+                        REQUEST_DEADLINE,
                     )?;
+                    return Ok(());
                 }
-                Err(source) if source.kind() == std::io::ErrorKind::WouldBlock => {
-                    registry.reap_finished_dispatches()?;
-                    thread::sleep(ACCEPT_POLL_INTERVAL);
+                if lifecycle.take_reload_requested() {
+                    (hooks.reload_runtime_view)()?;
                 }
-                Err(source) => {
-                    return Err(AtmError::daemon_unavailable(format!(
-                        "local loopback HTTP listener accept failed: {source}"
-                    )));
+                match listener.accept() {
+                    Ok((stream, peer)) => {
+                        if !peer.ip().is_loopback() {
+                            continue;
+                        }
+                        spawn_windows_connection(
+                            stream,
+                            &registry,
+                            &capability,
+                            &force_shutdown,
+                            &dispatch_workers,
+                            &observability,
+                        )?;
+                    }
+                    Err(source) if source.kind() == std::io::ErrorKind::WouldBlock => {
+                        registry.reap_finished_dispatches()?;
+                        thread::sleep(ACCEPT_POLL_INTERVAL);
+                    }
+                    Err(source) => {
+                        return Err(AtmError::daemon_unavailable(format!(
+                            "local loopback HTTP listener accept failed: {source}"
+                        )));
+                    }
                 }
             }
-        }
+        })();
+        let worker_shutdown_result = dispatch_workers.shutdown();
+        drop(hooks.endpoint_guard);
+        serve_result.and(worker_shutdown_result)
     }
 }
 
-#[cfg(unix)]
+#[cfg(windows)]
+fn spawn_windows_connection(
+    stream: TcpStream,
+    registry: &Arc<ActiveConnectionRegistry>,
+    capability: &LocalCapability,
+    force_shutdown: &Arc<AtomicBool>,
+    dispatch_workers: &Arc<DispatchWorkerPool>,
+    observability: &SubsystemObservability,
+) -> Result<(), AtmError> {
+    registry.reap_finished_dispatches()?;
+    let Some(active_connection) = registry.try_register(MAX_CONCURRENT_CONNECTIONS) else {
+        return Ok(());
+    };
+    let capability = capability.clone();
+    let force_shutdown = Arc::clone(force_shutdown);
+    let dispatch_workers = Arc::clone(dispatch_workers);
+    let observability = observability.clone();
+    let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
+    let join_handle = thread::spawn(move || {
+        let _active = active_connection;
+        let _ = handle_connection_with_dispatch_workers(
+            stream,
+            &capability,
+            force_shutdown.as_ref(),
+            dispatch_workers.as_ref(),
+            &observability,
+        );
+        let _ = completion_tx.send(());
+    });
+    registry.push_dispatch_handle(
+        TrackedDispatchHandle {
+            completion_rx,
+            join_handle,
+        },
+        MAX_CONCURRENT_CONNECTIONS,
+    )
+}
+
+#[cfg(any(unix, windows))]
 fn handle_connection_with_dispatch_workers(
     mut stream: TcpStream,
     capability: &LocalCapability,
@@ -475,7 +516,7 @@ fn handle_connection_with_dispatch_workers(
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 enum TcpPendingResponse {
     Dispatched(crate::local_ipc_transport::request_worker::PendingRequest),
     Immediate {
@@ -484,7 +525,7 @@ enum TcpPendingResponse {
     },
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 impl TcpPendingResponse {
     fn keep_alive(&self) -> bool {
         match self {
@@ -527,7 +568,7 @@ fn configure_connection(stream: &TcpStream) -> Result<(), AtmError> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn enqueue_tcp_request(
     raw_request: atm_core::api::HttpRequest,
     request_count: usize,
@@ -562,7 +603,7 @@ fn enqueue_tcp_request(
     Ok(())
 }
 
-#[cfg(any(test, windows))]
+#[cfg(test)]
 fn handle_connection(
     mut stream: TcpStream,
     router: Arc<dyn ApiRouter + Send + Sync>,
@@ -841,7 +882,7 @@ mod tests {
     use atm_core::test_support::{ROLE_TEAM_LEAD, TEST_TEAM};
     use ulid::Ulid;
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     use super::{
         DispatchWorkerPool, MAX_IN_FLIGHT_KEEP_ALIVE_REQUESTS,
         handle_connection_with_dispatch_workers,
@@ -849,10 +890,10 @@ mod tests {
     use super::{
         LOCAL_CAPABILITY_HEADER, LocalCapability, MAX_KEEP_ALIVE_REQUESTS, handle_connection,
     };
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     use crate::active_connection_registry::ActiveConnectionRegistry;
     use crate::test_support::DoctorOnlyDispatcher;
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     use crate::{DaemonSubsystem, SubsystemObservability};
 
     #[derive(Default)]
@@ -928,7 +969,7 @@ mod tests {
         (address, server)
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn serve_one_with_dispatch_workers(
         capability: LocalCapability,
     ) -> (std::net::SocketAddr, thread::JoinHandle<()>) {
@@ -1011,7 +1052,7 @@ mod tests {
         server.join().expect("server join");
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[test]
     fn loopback_tcp_dispatch_workers_serve_a_pipelined_run_in_response_order() {
         let capability = LocalCapability::generate().expect("capability");

--- a/docs/plans/phase-ai/ai52-windows-tcp-pipeline-handoff.md
+++ b/docs/plans/phase-ai/ai52-windows-tcp-pipeline-handoff.md
@@ -1,0 +1,34 @@
+# AI.52 Windows TCP pipeline handoff
+
+## Purpose
+
+This fix makes Windows loopback TCP use the same bounded eight-frame
+keep-alive dispatch path as Unix. It does not change HTTP framing: the shared
+`HttpFrameReader` continues to use `memchr`'s optimized delimiter finder.
+
+## Cwin procedure
+
+1. In `F:\github\atm-core`, use `/sc-git-checkout` to update the AI.52
+   worktree and merge or cherry-pick the Windows TCP pipeline fix commit.
+2. Run `just test` first. Do not benchmark a failing tree.
+3. If `just test` fails, Cwin is authorized to root-cause and fix the failure
+   on the AI.52 branch: add a focused regression test, run `just test` again,
+   and commit/push the fix. Do not wait for another assignment.
+4. Under the dedicated `atm` Windows account, stop/reset the designated
+   disposable benchmark daemon and database as needed. Do not use a shared or
+   production ATM home/database.
+5. Run `just smoke`, `just smoke localhost`, `just smoke local-ip`, and
+   `atm doctor --json`. Root-cause, fix, and re-run any failed smoke stage
+   before benchmarking.
+6. Set `ATM_CAPACITY_HOST_LABEL=windows-x64-01`, then run the release-daemon
+   TCP benchmark at frames per connection `1`, `2`, `8`, `16`, and `64`.
+   Preserve every run, including failures, through `just benchmark-report`;
+   run `just reports-index --check` before committing generated artifacts.
+
+## Result to report
+
+For each profile report accepted/responses, errors, p50 admissions/s, bytes/s,
+and the committed `site/reports/send-message-benchmark/` artifact. A failed
+or sub-threshold run is diagnostic work, not closure: Cwin must remove
+straightforward defects and rerun until the remaining limit requires a
+deliberate redesign.


### PR DESCRIPTION
## Summary
- Applies Unix's bounded 8-frame local TCP dispatch worker pattern to Windows, replacing the serial per-admission path suspected to explain AI.52's 3-15% Windows-vs-Mac-M5 throughput ratio.
- Based on AI.52 @ `deb9196e` (feature/pAI-s52-windows-transport-benchmark).

## Validation reported by arch-ctm
- Focused `local_tcp_transport` tests pass
- `just lint` passes

## Status
- Awaiting cwin's next Windows benchmark re-run against this branch to confirm the throughput fix before QA.
- PR targets `feature/pAI-s52-windows-transport-benchmark` (not integrate directly) since it's a fix on top of that in-flight sprint branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)