### PR TITLE
fix(ci): pin cargo-modules to 0.26.0 for rustc 1.94.1 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         uses: taiki-e/install-action@cargo-binstall
 
       - name: Install cargo-modules
-        run: cargo binstall cargo-modules --no-confirm
+        run: cargo binstall cargo-modules@0.26.0 --no-confirm
 
       - name: Install Python lint dependencies
         run: python -m pip install codespell 'pydantic>=2.12,<3'

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -67,7 +67,7 @@ jobs:
         uses: taiki-e/install-action@cargo-binstall
 
       - name: Install cargo-modules
-        run: cargo binstall cargo-modules --no-confirm
+        run: cargo binstall cargo-modules@0.26.0 --no-confirm
 
       - name: Install codespell
         run: python -m pip install codespell


### PR DESCRIPTION
## Summary
- Every Just-lint job (develop, PR #726, PR #727) was failing at the "Install cargo-modules" step: `cargo binstall cargo-modules` was resolving 0.27.0, which requires rustc 1.95.0+, but the repo pins rustc 1.94.1.
- Pins cargo-modules to 0.26.0 (last version compatible with rustc 1.91.0+) in `ci.yml` and `release-preflight.yml`.

## Test plan
- [ ] CI green on all 3 OS legs (Just lint should now pass)