### PR TITLE
docs(plan): Phase AK MVP simplification — hardened plan

### DIFF
--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -30,7 +30,7 @@ boundary text; it defines no resend replacement semantics. AK.3 exclusively
 owns the alias/configuration subclauses of `REQ-CORE-TRANSPORT-002A/-002D`,
 ADR-040, and the corresponding admission language in ADR-035. AK.4 owns the
 active direct-delivery subclauses (`REQ-CORE-TRANSPORT-002`, `-002B`, `-002B1`,
-`-002C`, `-003`, `-004`, and `-005A`) and creates ADR-045; it must not revise
+`-002C`, `-004`, and `-005A`) and creates ADR-047; it must not revise
 AK.3's alias semantics. AK.5 creates ADR-046 and exclusively defines the new
 resend-cache semantics for `REQ-CORE-TRANSPORT-003/-003B`. AK.6 finalizes
 supersession markers and removes obsolete wording without changing AK.3's
@@ -156,7 +156,7 @@ AK.1 records and implements the surviving cross-host provenance fixes. AK.2
 marks only the worker/replay portion of `REQ-CORE-TRANSPORT-003B` and ADR-038
 superseded, then updates project/architecture/boundary text to retire
 worker-specific AI.28/AI.31/AI.32 claims; AK.5 later owns the replacement
-resend-cache semantics. AK.6 completes ADR-045's supersession of
+resend-cache semantics. AK.6 completes ADR-047's supersession of
 ADR-034/040/041 and the corresponding requirements/boundary rules: peer host
 alias configuration remains; custom TLS/pinning, inferred literal-IP authority
 discovery, and daemon worker delivery do not. ADR-035 remains the canonical

--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -143,12 +143,18 @@ substitute for the production-sender proof.
 | AK.3 | Normalize configured aliases to full hostnames before persistence, with no outbound delivery behavior change; prove canonical ingress/nudge with curl. | Must follow AK.2 development push and merge-forward. AK.2 PR must merge before AK.3 PR completion. | arch-ctm |
 | AK.4 | Prove direct full-host HTTP delivery with no retry, including one production sender/receiver/nudge chain. | Must follow AK.3 development push and merge-forward. AK.3 PR must merge before AK.4 PR completion. | arch-ctm |
 | AK.5 | Add optional default-on resend caching through AK.4's proven HTTP function, including restart recovery and disabled-cache behavior. | Must follow AK.4 development push and merge-forward. AK.4 PR must merge before AK.5 PR completion. | arch-ctm |
-| AK.6 | Delete now-dead peer scans, inferred literal-IP discovery, DNS threads, and active custom TLS; isolate provisioning/receiver curl interop. | Must follow AK.5 development push and merge-forward. AK.5 PR must merge before AK.6 PR completion. | Cipher-311d |
+| AK.6 | Delete now-dead peer scans, inferred literal-IP discovery, DNS threads, and active custom TLS; isolate provisioning/receiver curl interop. | May develop in parallel after the Phase AI→`develop` entry gate. Before final validation or PR completion, merge-forward AK.5; AK.5 PR must merge before AK.6 PR completion. | Cipher-311d |
 
 Each dependent sprint begins immediately after its predecessor development is
 pushed and merge-forwarded; it does **not** wait for predecessor QA approval.
 Every dependent development or fix round first merges its predecessor. A
 dependent PR cannot complete before its predecessor PR merges.
+
+AK.6 is the explicit parallel exception: Cipher may start its isolated
+interop-fixture and deletion-ledger work immediately after the Phase AI entry
+gate, without waiting for AK.5. It must not merge an active-transport deletion
+until AK.5 is merged forward, and it must merge AK.5 before its final
+validation, any final fix round, and PR completion.
 
 ## Governing changes
 

--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -1,0 +1,120 @@
+---
+title: Phase AK Plan — direct peer HTTP delivery
+status: proposed
+branch: plan/mvp-simplification
+worktree: ../atm-core-worktrees/plan/mvp-simplification
+target: integrate/phase-ak
+---
+
+# Phase AK — direct peer HTTP delivery
+
+## Goal
+
+Replace daemon-owned peer workers, custom DNS, and custom mTLS transport with
+one direct HTTP request function. A host-qualified write uses the same request
+shape as local HTTP. The receiving daemon persists it and emits the ordinary
+nudge.
+
+Phase AK starts only after Phase AI merges to `develop`, on
+`integrate/phase-ak`. It does not alter the already-planned Phase AJ
+runtime-observation work. AK.2's temporary no-delivery state must never merge
+to `develop`; AK.4 restores and proves direct delivery on this phase branch.
+
+## MVP contract
+
+| Concern | Decision |
+| --- | --- |
+| Peer configuration | Canonical full hostname plus explicit aliases and port. Configuration changes populate a small alias index. SQLite stores the full hostname, never a resolved IP. |
+| Wire | HTTP/1.1 `POST /v1/atm/messages`, JSON `WriteRequest`, JSON `SendResponseEnvelope`. `send_peer_http` accepts an array but issues this one existing request shape per immutable write; AK adds no batch route or second receiver handler. |
+| Security | Explicit trusted-LAN MVP: no mTLS, certificate pinning, or claimed-source authentication. The sender-host header is display provenance only. Internet exposure is prohibited. |
+| Receiver | The existing HTTP decoder, canonical write handler, SQLite transaction, ACK semantics, and post-write nudge remain the only ingress path. |
+| Sender | CLI and graft use their existing local daemon HTTP call. After canonical SQLite persistence, the daemon makes one private `send_peer_http(endpoint, &[write])` call with the in-memory write and returns the ordinary response. |
+| AK.4 baseline | No automatic retry. A failed direct send returns an ordinary delivery error and leaves the admitted SQLite record undelivered. |
+| AK.5 resend cache | Adds optional per-endpoint `Connected`/`Disconnected`/`Queued` state, one aggregate, and one timer. `peer_resend_cache = true` is the default; `false` preserves AK.4's no-retry behavior. |
+| Failure | Ordinary typed send failure; no receipt synthesis, remote mailbox mutation, or local nudge fallback. |
+
+The plan intentionally does not invent a second cross-host protocol, a curl
+subprocess, client-side SQLite ownership, a client-only payload, or a
+local/cross-host inbound branch. `curl` is the executable proof for this
+ordinary HTTP request; the production call uses the same HTTP request/response
+contract in-process.
+
+## Required removal
+
+Delete, not adapt:
+
+- `crates/atm-daemon/src/peer_drain_coordinator.rs` and its composition,
+  shutdown, tests, `PeerDeliveryCoordinator`, per-message threads, job state,
+  and peer delivery post-commit queue key.
+- `crates/atm-daemon/src/peer_resolution.rs` and literal-IP authority
+  discovery in `runtime_health/peer_authority.rs`.
+- Active `HttpsTransport`, `PinnedClientVerifier`, `TlsIdentity`, custom
+  rustls client/server handshake code, and certificate/fingerprint peer
+  transport configuration once the plain HTTP listener is live. AK.6 preserves
+  verified TLS provisioning/configuration and curl-interoperable receiver
+  support only in an isolated, unused TLS crate. That crate is not a native
+  peer transport: no native ATM TLS sender is known to work. It does not
+  preserve the failing native outbound client in active code.
+- Worker-only peer recovery/replay observability, policies, and documentation.
+
+The existing simple-send path is intentionally reduced in explicit steps:
+
+| Current step | AK owner | Result |
+| --- | --- | --- |
+| Save the immutable write locally. | Retain | Canonical SQLite admission remains first. The origin record retains its immutable write plus destination host; this is durable message data, not worker state. |
+| Queue only `{ hostname, message_id }`. | AK.2 | Delete. |
+| Start a coordinator thread. | AK.2 | Delete. |
+| Start a per-message thread. | AK.2 | Delete. |
+| Re-scan SQLite for the write just saved. | AK.2 | Delete. AK.4 uses the in-memory `WriteRequest` for an immediate send. |
+| Read every trusted-peer row. | AK.3/AK.6 | AK.3 creates the O(1) alias-to-full-host index; AK.6 deletes the old broad scan. |
+| Resolve every peer hostname for literal-IP alias discovery. | AK.3/AK.6 | AK.3 permits only explicit configured IP aliases; AK.6 deletes inferred discovery. |
+| Start a DNS thread for the selected peer. | AK.6 | Delete. Resolve the persisted full hostname only when connecting; never in an ATM DNS thread. |
+| Open custom TCP/rustls HTTP. | AK.4/AK.6 | AK.4 creates its replacement; AK.6 deletes the unused legacy stack. |
+
+Retain unchanged unless a direct compile consumer proves otherwise:
+
+- `WriteRequest`, origin ULID idempotency, `ResponseEnvelope`, HTTP framing,
+  body limits, canonical persistence, receiver ACK transition, and ordinary
+  post-write nudge.
+- Host-qualified address parsing and the exact host/port peer alias row.
+
+## Non-negotiable checks
+
+1. A host-qualified message delivered by `curl` and by the production direct
+   call reaches the same receiver handler, persists the same ULID, renders the
+   claimed source host, and produces the same nudge.
+2. A source gate rejects `peer_drain_coordinator`, `PeerDeliveryCoordinator`,
+   `PeerWork`, `PeerJob`, `PinnedClientVerifier`, `TlsIdentity`, `rustls`,
+   `peer_resolution`, custom peer DNS threads, and per-message peer threads.
+3. No production route makes a local-host/same-IP exception after ingress.
+4. AK.5's only batch path calls the same `send_peer_http` function as AK.4's
+   immediate path. It adds no second serializer, parser, delivery protocol, or
+   nudge route.
+5. With `peer_resend_cache = false`, a failed direct send creates no automatic
+   resend aggregate or timer and returns a delivery error.
+6. `just lint` and `just test` pass. Cross-host evidence includes M4→M5 and
+   M5→M4 curl and production-call send, receive, and nudge.
+
+## Sprint order
+
+| Sprint | Closure | Dependencies | Recommended agent |
+| --- | --- | --- | --- |
+| AK.1 | Recover cross-host ACK/provenance from `fix/crosshost-ack-provenance`: audit, retain the useful fixes, and prove remote curl message/ACK/nudge behavior. | Must follow Phase AI merge to `develop`; lands only on `integrate/phase-ak`. | arch-ctm |
+| AK.2 | Delete the daemon peer worker and all worker-only state. | Must follow AK.1 development push and merge-forward. AK.1 PR must merge before AK.2 PR completion. | arch-ctm |
+| AK.3 | Normalize configured aliases to full hostnames before persistence, with no delivery behavior change. | Must follow AK.2 development push and merge-forward. AK.2 PR must merge before AK.3 PR completion. | arch-ctm |
+| AK.4 | Prove direct full-host HTTP delivery with no retry. | Must follow AK.3 development push and merge-forward. AK.3 PR must merge before AK.4 PR completion. | arch-ctm |
+| AK.5 | Add optional default-on resend caching through AK.4's proven HTTP function. | Must follow AK.4 development push and merge-forward. AK.4 PR must merge before AK.5 PR completion. | arch-ctm |
+| AK.6 | Delete now-dead peer scans, literal-IP discovery, DNS threads, and active custom TLS; isolate provisioning/receiver curl interop. | Must follow AK.5 development push and merge-forward. AK.5 PR must merge before AK.6 PR completion. | arch-ctm |
+
+Each dependent sprint begins immediately after its predecessor development is
+pushed and merge-forwarded; it does **not** wait for predecessor QA approval.
+Every dependent development or fix round first merges its predecessor. A
+dependent PR cannot complete before its predecessor PR merges.
+
+## Governing changes
+
+AK.1 records and implements the surviving cross-host provenance fixes. AK.2 updates the
+project plan and retires worker-specific AI.28/AI.31/AI.32 claims. AK.6
+replaces ADR-034/ADR-035 transport text and the corresponding
+requirements/boundary rules: peer host alias configuration remains; custom
+TLS/pinning, literal-IP authority discovery, and daemon worker delivery do not.

--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -20,18 +20,35 @@ Phase AK starts only after Phase AI merges to `develop`, on
 runtime-observation work. AK.2's temporary no-delivery state must never merge
 to `develop`; AK.4 restores and proves direct delivery on this phase branch.
 
+## Documentation transition
+
+The current requirements and ADRs describe the superseded HTTPS worker design;
+they must not be silently contradicted by implementation. AK.3 revises the
+alias/configuration portions of `REQ-CORE-TRANSPORT-002A/-002D`, ADR-040, and
+ADR-035. AK.4 creates ADR-045, superseding ADR-034/040/041 for the active
+direct trusted-LAN HTTP path and revising the listed `REQ-CORE-TRANSPORT-002*`,
+`-003`, `-004`, and `-005A` requirements in the same PR. AK.5 creates ADR-046
+and revises `REQ-CORE-TRANSPORT-003/-003B` for its non-durable aggregate. AK.6
+finishes the physical TLS deletion and marks the superseded ADRs/index/docs
+accordingly. No sprint may claim a code/doc mismatch as an acceptable interim
+state after its own PR completes.
+
 ## MVP contract
 
 | Concern | Decision |
 | --- | --- |
 | Peer configuration | Canonical full hostname plus explicit aliases and port. Configuration changes populate a small alias index. SQLite stores the full hostname, never a resolved IP. |
-| Wire | HTTP/1.1 `POST /v1/atm/messages`, JSON `WriteRequest`, JSON `SendResponseEnvelope`. `send_peer_http` accepts an array but issues this one existing request shape per immutable write; AK adds no batch route or second receiver handler. |
+| Wire | HTTP/1.1 `POST /v1/atm/messages`, JSON `WriteRequest`, JSON `SendResponseEnvelope`. `send_peer_http_frames` accepts an array but issues this one existing request shape per immutable write; AK adds no batch route or second receiver handler. |
 | Security | Explicit trusted-LAN MVP: no mTLS, certificate pinning, or claimed-source authentication. The sender-host header is display provenance only. Internet exposure is prohibited. |
-| Receiver | The existing HTTP decoder, canonical write handler, SQLite transaction, ACK semantics, and post-write nudge remain the only ingress path. |
-| Sender | CLI and graft use their existing local daemon HTTP call. After canonical SQLite persistence, the daemon makes one private `send_peer_http(endpoint, &[write])` call with the in-memory write and returns the ordinary response. |
+| Receiver | AK.4 renames the retained plain half of `HttpsListenerSet` to `PeerHttpListenerSet`. Its bounded accept/request execution, HTTP decoder, canonical write handler, SQLite transaction, ACK semantics, and post-write nudge remain the only ingress path. |
+| Sender | CLI and graft use their existing local daemon HTTP call. After canonical SQLite persistence, the daemon makes one private `send_peer_http_frames(config, endpoint, &[write], deadline)` call with the in-memory write and returns the ordinary response. `config` is the immutable configured source-host snapshot, never CLI input or a per-send peer scan. |
 | AK.4 baseline | No automatic retry. A failed direct send returns an ordinary delivery error and leaves the admitted SQLite record undelivered. |
 | AK.5 resend cache | Adds optional per-endpoint `Connected`/`Disconnected`/`Queued` state, one aggregate, and one timer. `peer_resend_cache = true` is the default; `false` preserves AK.4's no-retry behavior. |
 | Failure | Ordinary typed send failure; no receipt synthesis, remote mailbox mutation, or local nudge fallback. |
+
+Every sprint inventories its important structs, enums, traits, and execution
+boundaries. An unlisted new type, trait, thread, task, worker, channel,
+listener, persistence table, or route requires a plan amendment before code.
 
 The plan intentionally does not invent a second cross-host protocol, a curl
 subprocess, client-side SQLite ownership, a client-only payload, or a
@@ -50,7 +67,7 @@ Delete, not adapt:
   discovery in `runtime_health/peer_authority.rs`.
 - Active `HttpsTransport`, `PinnedClientVerifier`, `TlsIdentity`, custom
   rustls client/server handshake code, and certificate/fingerprint peer
-  transport configuration once the plain HTTP listener is live. AK.6 preserves
+  transport configuration once the plain `PeerHttpListenerSet` is live. AK.6 preserves
   verified TLS provisioning/configuration and curl-interoperable receiver
   support only in `crates/atm-peer-tls-interop`, an isolated, unused TLS crate.
   No daemon, CLI, graft, or active send-path crate may depend on it. It is not a native
@@ -71,6 +88,7 @@ The existing simple-send path is intentionally reduced in explicit steps:
 | Resolve every peer hostname for literal-IP alias discovery. | AK.3/AK.6 | AK.3 permits only explicit configured IP aliases; AK.6 deletes inferred discovery. |
 | Start a DNS thread for the selected peer. | AK.6 | Delete. Resolve the persisted full hostname only when connecting; never in an ATM DNS thread. |
 | Open custom TCP/rustls HTTP. | AK.4/AK.6 | AK.4 creates its replacement; AK.6 deletes the unused legacy stack. |
+| Receive a successful peer response. | AK.4 | One idempotent `MessageStore::confirm_peer_delivery(PeerDeliveryConfirmation)` mutation removes only matching `peerOutbound`; accepted writes do not re-enter AK.5's backlog. |
 
 Retain unchanged unless a direct compile consumer proves otherwise:
 
@@ -88,7 +106,7 @@ Retain unchanged unless a direct compile consumer proves otherwise:
    `PeerWork`, `PeerJob`, `PinnedClientVerifier`, `TlsIdentity`, `rustls`,
    `peer_resolution`, custom peer DNS threads, and per-message peer threads.
 3. No production route makes a local-host/same-IP exception after ingress.
-4. AK.5's only batch path calls the same `send_peer_http` function as AK.4's
+4. AK.5's only batch path calls the same `send_peer_http_frames` function as AK.4's
    immediate path. It adds no second serializer, parser, delivery protocol, or
    nudge route.
 5. With `peer_resend_cache = false`, a failed direct send creates no automatic
@@ -101,16 +119,30 @@ it may contain provisioning/configuration value objects and a curl-mTLS
 receiver interoperability fixture. It exposes no daemon listener, outbound
 sender, routing API, background work, or production dependency edge.
 
+## Verification sequence
+
+Every sprint runs `just lint`, `just test`, `just smoke localhost`, and
+`just smoke local-ip` against an isolated test home/database. AK.3 also runs
+the bidirectional current-configured `crosshost-curl-tls` receiver/nudge proof,
+because it intentionally has no production sender after AK.2. AK.4 converts
+the standard `crosshost-curl-plain` lane to its configured production listener;
+AK.4, AK.5, and AK.6 each then run it with bidirectional `crosshost-send` and
+`crosshost-ack` on M4/M5. Every successful receiver case must prove one remote
+read, exact ULID/body, host-qualified rendering where applicable, and exactly
+one nudge; every rejected/truncated/failed case must prove no false
+confirmation or nudge. Curl remains independent protocol evidence, never a
+substitute for the production-sender proof.
+
 ## Sprint order
 
 | Sprint | Closure | Dependencies | Recommended agent |
 | --- | --- | --- | --- |
 | AK.1 | Recover cross-host ACK/provenance from `fix/crosshost-ack-provenance`: audit, retain the useful fixes, and prove remote curl message/ACK/nudge behavior. | Must follow Phase AI merge to `develop`; lands only on `integrate/phase-ak`. | arch-ctm |
 | AK.2 | Delete the daemon peer worker and all worker-only state. | Must follow AK.1 development push and merge-forward. AK.1 PR must merge before AK.2 PR completion. | arch-ctm |
-| AK.3 | Normalize configured aliases to full hostnames before persistence, with no delivery behavior change. | Must follow AK.2 development push and merge-forward. AK.2 PR must merge before AK.3 PR completion. | arch-ctm |
-| AK.4 | Prove direct full-host HTTP delivery with no retry. | Must follow AK.3 development push and merge-forward. AK.3 PR must merge before AK.4 PR completion. | arch-ctm |
-| AK.5 | Add optional default-on resend caching through AK.4's proven HTTP function. | Must follow AK.4 development push and merge-forward. AK.4 PR must merge before AK.5 PR completion. | arch-ctm |
-| AK.6 | Delete now-dead peer scans, literal-IP discovery, DNS threads, and active custom TLS; isolate provisioning/receiver curl interop. | Must follow AK.5 development push and merge-forward. AK.5 PR must merge before AK.6 PR completion. | Cipher-311d |
+| AK.3 | Normalize configured aliases to full hostnames before persistence, with no outbound delivery behavior change; prove canonical ingress/nudge with curl. | Must follow AK.2 development push and merge-forward. AK.2 PR must merge before AK.3 PR completion. | arch-ctm |
+| AK.4 | Prove direct full-host HTTP delivery with no retry, including one production sender/receiver/nudge chain. | Must follow AK.3 development push and merge-forward. AK.3 PR must merge before AK.4 PR completion. | arch-ctm |
+| AK.5 | Add optional default-on resend caching through AK.4's proven HTTP function, including restart recovery and disabled-cache behavior. | Must follow AK.4 development push and merge-forward. AK.4 PR must merge before AK.5 PR completion. | arch-ctm |
+| AK.6 | Delete now-dead peer scans, inferred literal-IP discovery, DNS threads, and active custom TLS; isolate provisioning/receiver curl interop. | Must follow AK.5 development push and merge-forward. AK.5 PR must merge before AK.6 PR completion. | Cipher-311d |
 
 Each dependent sprint begins immediately after its predecessor development is
 pushed and merge-forwarded; it does **not** wait for predecessor QA approval.
@@ -121,6 +153,7 @@ dependent PR cannot complete before its predecessor PR merges.
 
 AK.1 records and implements the surviving cross-host provenance fixes. AK.2 updates the
 project plan and retires worker-specific AI.28/AI.31/AI.32 claims. AK.6
-replaces ADR-034/ADR-035 transport text and the corresponding
+completes ADR-045's supersession of ADR-034/040/041 and the corresponding
 requirements/boundary rules: peer host alias configuration remains; custom
-TLS/pinning, literal-IP authority discovery, and daemon worker delivery do not.
+TLS/pinning, inferred literal-IP authority discovery, and daemon worker
+delivery do not. ADR-035 remains the canonical single-ingress/nudge rule.

--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -23,15 +23,16 @@ to `develop`; AK.4 restores and proves direct delivery on this phase branch.
 ## Documentation transition
 
 The current requirements and ADRs describe the superseded HTTPS worker design;
-they must not be silently contradicted by implementation. AK.3 revises the
-alias/configuration portions of `REQ-CORE-TRANSPORT-002A/-002D`, ADR-040, and
-ADR-035. AK.4 creates ADR-045, superseding ADR-034/040/041 for the active
-direct trusted-LAN HTTP path and revising the listed `REQ-CORE-TRANSPORT-002*`,
-`-003`, `-004`, and `-005A` requirements in the same PR. AK.5 creates ADR-046
-and revises `REQ-CORE-TRANSPORT-003/-003B` for its non-durable aggregate. AK.6
-finishes the physical TLS deletion and marks the superseded ADRs/index/docs
-accordingly. No sprint may claim a code/doc mismatch as an acceptable interim
-state after its own PR completes.
+they must not be silently contradicted by implementation. AK.3 exclusively
+owns the alias/configuration subclauses of `REQ-CORE-TRANSPORT-002A/-002D`,
+ADR-040, and the corresponding admission language in ADR-035. AK.4 owns the
+active direct-delivery subclauses (`REQ-CORE-TRANSPORT-002`, `-002B`, `-002B1`,
+`-002C`, `-003`, `-004`, and `-005A`) and creates ADR-045; it must not revise
+AK.3's alias semantics. AK.5 creates ADR-046 and revises
+`REQ-CORE-TRANSPORT-003/-003B` for its non-durable aggregate. AK.6 finalizes
+supersession markers and removes obsolete wording without changing AK.3's
+alias contract or AK.4/AK.5 active semantics. No sprint may claim a code/doc
+mismatch as an acceptable interim state after its own PR completes.
 
 ## MVP contract
 
@@ -39,7 +40,7 @@ state after its own PR completes.
 | --- | --- |
 | Peer configuration | Canonical full hostname plus explicit aliases and port. Configuration changes populate a small alias index. SQLite stores the full hostname, never a resolved IP. |
 | Wire | HTTP/1.1 `POST /v1/atm/messages`, JSON `WriteRequest`, JSON `SendResponseEnvelope`. `send_peer_http_frames` accepts an array but issues this one existing request shape per immutable write; AK adds no batch route or second receiver handler. |
-| Security | Explicit trusted-LAN MVP: no mTLS, certificate pinning, or claimed-source authentication. The sender-host header is display provenance only. Internet exposure is prohibited. |
+| Security | Explicit trusted-LAN MVP: no mTLS, certificate pinning, or claimed-source authentication. The sender-host header is display provenance only. AK.4 refuses wildcard or multicast peer-listener binds and binds only configured local interface addresses; network isolation beyond that explicit bind allowlist remains a deployment/firewall responsibility, not an ATM-enforced Internet-exposure guarantee. |
 | Receiver | AK.4 renames the retained plain half of `HttpsListenerSet` to `PeerHttpListenerSet`. Its bounded accept/request execution, HTTP decoder, canonical write handler, SQLite transaction, ACK semantics, and post-write nudge remain the only ingress path. |
 | Sender | CLI and graft use their existing local daemon HTTP call. After canonical SQLite persistence, the daemon makes one private `send_peer_http_frames(config, endpoint, &[write], deadline)` call with the in-memory write and returns the ordinary response. `config` is the immutable configured source-host snapshot, never CLI input or a per-send peer scan. |
 | AK.4 baseline | No automatic retry. A failed direct send returns an ordinary delivery error and leaves the admitted SQLite record undelivered. |
@@ -97,22 +98,19 @@ Retain unchanged unless a direct compile consumer proves otherwise:
   post-write nudge.
 - Host-qualified address parsing and the exact host/port peer alias row.
 
-## Non-negotiable checks
+## Sprint validation index
 
-1. A host-qualified message delivered by `curl` and by the production direct
-   call reaches the same receiver handler, persists the same ULID, renders the
-   claimed source host, and produces the same nudge.
-2. A source gate rejects `peer_drain_coordinator`, `PeerDeliveryCoordinator`,
-   `PeerWork`, `PeerJob`, `PinnedClientVerifier`, `TlsIdentity`, `rustls`,
-   `peer_resolution`, custom peer DNS threads, and per-message peer threads.
-3. No production route makes a local-host/same-IP exception after ingress.
-4. AK.5's only batch path calls the same `send_peer_http_frames` function as AK.4's
-   immediate path. It adds no second serializer, parser, delivery protocol, or
-   nudge route.
-5. With `peer_resend_cache = false`, a failed direct send creates no automatic
-   resend aggregate or timer and returns a delivery error.
-6. `just lint` and `just test` pass. Cross-host evidence includes M4→M5 and
-   M5→M4 curl and production-call send, receive, and nudge.
+This is a navigation aid, not a second acceptance-criteria source. Each
+sprint's `Explicit prohibitions` and `Required validation` sections are
+authoritative:
+
+- AK.1: salvage ledger and curl provenance/ACK/nudge proof.
+- AK.2: deletion ledger and compiler-attributed worker removal proof.
+- AK.3: alias persistence and staged curl receiver/nudge proof.
+- AK.4: direct production send/receiver/nudge chain and bind control.
+- AK.5: cache-disabled, immediate, due-batch, restart, and nudge proofs.
+- AK.6: active-transport deletion, isolated curl-mTLS fixture, and final
+  bidirectional production evidence.
 
 `atm-peer-tls-interop` is a preservation boundary, not a service component:
 it may contain provisioning/configuration value objects and a curl-mTLS

--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -23,13 +23,16 @@ to `develop`; AK.4 restores and proves direct delivery on this phase branch.
 ## Documentation transition
 
 The current requirements and ADRs describe the superseded HTTPS worker design;
-they must not be silently contradicted by implementation. AK.3 exclusively
+they must not be silently contradicted by implementation. AK.2 exclusively
+marks the worker/replay portion of `REQ-CORE-TRANSPORT-003B` and ADR-038
+superseded, and retires only Phase AI worker claims in project/architecture/
+boundary text; it defines no resend replacement semantics. AK.3 exclusively
 owns the alias/configuration subclauses of `REQ-CORE-TRANSPORT-002A/-002D`,
 ADR-040, and the corresponding admission language in ADR-035. AK.4 owns the
 active direct-delivery subclauses (`REQ-CORE-TRANSPORT-002`, `-002B`, `-002B1`,
 `-002C`, `-003`, `-004`, and `-005A`) and creates ADR-045; it must not revise
-AK.3's alias semantics. AK.5 creates ADR-046 and revises
-`REQ-CORE-TRANSPORT-003/-003B` for its non-durable aggregate. AK.6 finalizes
+AK.3's alias semantics. AK.5 creates ADR-046 and exclusively defines the new
+resend-cache semantics for `REQ-CORE-TRANSPORT-003/-003B`. AK.6 finalizes
 supersession markers and removes obsolete wording without changing AK.3's
 alias contract or AK.4/AK.5 active semantics. No sprint may claim a code/doc
 mismatch as an acceptable interim state after its own PR completes.
@@ -149,9 +152,12 @@ dependent PR cannot complete before its predecessor PR merges.
 
 ## Governing changes
 
-AK.1 records and implements the surviving cross-host provenance fixes. AK.2 updates the
-project plan and retires worker-specific AI.28/AI.31/AI.32 claims. AK.6
-completes ADR-045's supersession of ADR-034/040/041 and the corresponding
-requirements/boundary rules: peer host alias configuration remains; custom
-TLS/pinning, inferred literal-IP authority discovery, and daemon worker
-delivery do not. ADR-035 remains the canonical single-ingress/nudge rule.
+AK.1 records and implements the surviving cross-host provenance fixes. AK.2
+marks only the worker/replay portion of `REQ-CORE-TRANSPORT-003B` and ADR-038
+superseded, then updates project/architecture/boundary text to retire
+worker-specific AI.28/AI.31/AI.32 claims; AK.5 later owns the replacement
+resend-cache semantics. AK.6 completes ADR-045's supersession of
+ADR-034/040/041 and the corresponding requirements/boundary rules: peer host
+alias configuration remains; custom TLS/pinning, inferred literal-IP authority
+discovery, and daemon worker delivery do not. ADR-035 remains the canonical
+single-ingress/nudge rule.

--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -52,7 +52,8 @@ Delete, not adapt:
   rustls client/server handshake code, and certificate/fingerprint peer
   transport configuration once the plain HTTP listener is live. AK.6 preserves
   verified TLS provisioning/configuration and curl-interoperable receiver
-  support only in an isolated, unused TLS crate. That crate is not a native
+  support only in `crates/atm-peer-tls-interop`, an isolated, unused TLS crate.
+  No daemon, CLI, graft, or active send-path crate may depend on it. It is not a native
   peer transport: no native ATM TLS sender is known to work. It does not
   preserve the failing native outbound client in active code.
 - Worker-only peer recovery/replay observability, policies, and documentation.
@@ -95,6 +96,11 @@ Retain unchanged unless a direct compile consumer proves otherwise:
 6. `just lint` and `just test` pass. Cross-host evidence includes M4→M5 and
    M5→M4 curl and production-call send, receive, and nudge.
 
+`atm-peer-tls-interop` is a preservation boundary, not a service component:
+it may contain provisioning/configuration value objects and a curl-mTLS
+receiver interoperability fixture. It exposes no daemon listener, outbound
+sender, routing API, background work, or production dependency edge.
+
 ## Sprint order
 
 | Sprint | Closure | Dependencies | Recommended agent |
@@ -104,7 +110,7 @@ Retain unchanged unless a direct compile consumer proves otherwise:
 | AK.3 | Normalize configured aliases to full hostnames before persistence, with no delivery behavior change. | Must follow AK.2 development push and merge-forward. AK.2 PR must merge before AK.3 PR completion. | arch-ctm |
 | AK.4 | Prove direct full-host HTTP delivery with no retry. | Must follow AK.3 development push and merge-forward. AK.3 PR must merge before AK.4 PR completion. | arch-ctm |
 | AK.5 | Add optional default-on resend caching through AK.4's proven HTTP function. | Must follow AK.4 development push and merge-forward. AK.4 PR must merge before AK.5 PR completion. | arch-ctm |
-| AK.6 | Delete now-dead peer scans, literal-IP discovery, DNS threads, and active custom TLS; isolate provisioning/receiver curl interop. | Must follow AK.5 development push and merge-forward. AK.5 PR must merge before AK.6 PR completion. | arch-ctm |
+| AK.6 | Delete now-dead peer scans, literal-IP discovery, DNS threads, and active custom TLS; isolate provisioning/receiver curl interop. | Must follow AK.5 development push and merge-forward. AK.5 PR must merge before AK.6 PR completion. | Cipher-311d |
 
 Each dependent sprint begins immediately after its predecessor development is
 pushed and merge-forwarded; it does **not** wait for predecessor QA approval.

--- a/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
+++ b/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
@@ -1,6 +1,8 @@
 ---
 title: AK.1 Cross-host ACK and provenance recovery
 status: in_progress
+branch: feature/pak-s1-crosshost-ack-provenance-recovery
+worktree: ../atm-core-worktrees/feature/pak-s1-crosshost-ack-provenance-recovery
 target: integrate/phase-ak
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning

--- a/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
+++ b/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
@@ -71,6 +71,9 @@ AK.1. The keep/discard ledger below is the full change authority.
   a host-qualified ACK retains its origin ULID/provenance.
 - Live smoke: curl M4→M5 and M5→M4 each prove exact message ULID/body, host
   rendering, receiver nudge, and ordinary ACK reply receipt.
+- Smoke: run `just smoke localhost` and `just smoke local-ip` against an
+  isolated test home/database; each preserves the same canonical receiver,
+  provenance rendering, and ordinary nudge path.
 - `git diff --check`, `just lint`, and `just test` pass.
 
 ## Dependencies

--- a/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
+++ b/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
@@ -1,0 +1,84 @@
+---
+title: AK.1 Cross-host ACK and provenance recovery
+status: in_progress
+target: integrate/phase-ak
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+must_follow: Phase AI merge to develop
+parallel_safe: false
+---
+
+# AK.1 — cross-host ACK and provenance recovery
+
+## Closure
+
+Recover the useful cross-host ACK/provenance behavior from
+`fix/crosshost-ack-provenance` onto `integrate/phase-ak`. This is the focused
+Phase AK baseline, not an audit-only sprint: retain only independent
+provenance or local-IPC fixes; discard legacy peer transport, ad-hoc handoff,
+version, and unrelated branch changes.
+
+The observed remote `curl` success proves this branch's receiver path:
+certificate provisioning, TLS listener, shared HTTP decode/route, canonical
+persistence, host rendering, and nudge. It does **not** prove the branch's
+native sender: curl bypasses `HttpsTransport`, `peer_resolution`, the delivery
+coordinator, and its per-message thread.
+
+## Deliverables
+
+1. Publish a keep/discard ledger in this sprint doc, with commit, affected
+   paths, decision, and rationale. It is authoritative for the branch.
+2. Retain and test the cross-host provenance behavior from `3d83a68d`,
+   `05834a4a`, and `8b91eb92`: a receiver-authenticated source hostname
+   survives inbound persistence, mailbox rendering, nudge rendering, and a
+   host-qualified ACK reply. Keep the current durable immutable outbound write
+   only as the delivery record; do not retain worker/recovery control flow.
+   AK.4 changes this host to claimed
+   trusted-LAN display provenance; it must never authorize routing.
+3. Independently assess `9b8c1003` macOS UDS timeout handling. Retain it only
+   if its focused regression test proves a real capability-boundary fix; it is
+   not cross-host delivery scope.
+4. Reimplement/cherry-pick only the retained changes as small focused commits
+   on `feature/pak-s1-crosshost-ack-provenance-recovery`; do not merge or
+   cherry-pick the branch wholesale.
+5. Prove M4→M5 and M5→M4 curl message delivery, receiver host rendering,
+   ordinary nudge, host-qualified ACK reply, and reply receipt. This proves the
+   preserved receiver/provenance behavior only; it does not claim native peer
+   sender success.
+6. Discard `d4681010` address-fallback/DNS-thread changes, `8fc886df` handoff
+   prose, `c808547e` version normalization, and any merge/CI bookkeeping not
+   needed by the retained changes. Do not cherry-pick the branch wholesale.
+7. Do not retain `ListenerSecurity::PlaintextTest`/`UntrustedSmoke` as AK.4's
+   production mode. It is a separate test ingress classification. AK.4 must
+   route its plain trusted-LAN HTTP write through the same canonical receiver
+   path as every other write, with host data used only for display provenance.
+
+## Required validation
+
+- Test: inbound authenticated host renders compactly in mailbox and nudge, and
+  a host-qualified ACK retains its origin ULID/provenance.
+- Live smoke: curl M4→M5 and M5→M4 each prove exact message ULID/body, host
+  rendering, receiver nudge, and ordinary ACK reply receipt.
+- `git diff --check`, `just lint`, and `just test` pass.
+
+## Dependencies
+
+Start after Phase AI merges to `develop`, on `integrate/phase-ak`. Push AK.1,
+then start AK.2 immediately with an AK.1→AK.2 merge-forward; do not wait for
+QA. AK.1 PR must merge before AK.2 PR completion. `must_follow` is required
+because AK.1 defines the retained provenance baseline. It is not parallel-safe:
+AK.2 deletes the same router/peer behavior that AK.1 audits.
+
+## Keep/discard ledger
+
+| Commit | Decision | Rationale |
+| --- | --- | --- |
+| `3d83a68d` | keep/adapt | ACK origin ULID/destination metadata is needed; discard its recovery-worker coupling. |
+| `05834a4a` | keep/adapt | Keep host-aware ordinary nudge rendering; decouple it from TLS-only authentication. |
+| `8b91eb92` | keep/adapt | Keep compact full-host mailbox rendering; decouple it from TLS-only authentication. |
+| `9b8c1003` | keep | macOS AF_UNIX reports unsupported timeout setup as `EINVAL`; focused regression test proves deadline fallback remains active. |
+| `d4681010` | discard | Legacy custom TLS/DNS address fallback. |
+| `8fc886df` | discard | Superseded handoff prose. |
+| `c808547e` | discard | Unrelated version change. |
+| `a398a151` | discard as a commit | Mixed release-version rollback and refactors; extract only a separately justified compile/test fix. |
+| merge/CI commits | discard as history | Reproduce only a verified still-required CI configuration change. |

--- a/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
+++ b/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
@@ -24,6 +24,18 @@ persistence, host rendering, and nudge. It does **not** prove the branch's
 native sender: curl bypasses `HttpsTransport`, `peer_resolution`, the delivery
 coordinator, and its per-message thread.
 
+## Type and boundary inventory
+
+| Item | AK.1 role |
+| --- | --- |
+| `HostName`, `WriteRequest`, `ResponseEnvelope` | Existing canonical provenance, immutable-write, and response values; AK.1 adds no peer-specific DTO. |
+| `HttpsListenerSet`, `ListenerSecurity::MutualTls`, `PinnedClientVerifier` | Existing receiver-only TLS boundary proven by curl. AK.1 does not expand it; AK.4 separates the retained plain receiver and AK.6 retires TLS. |
+| `AuthenticatedIngress::Peer`, `WriteIngress::Peer`, `validate_write_provenance` | Existing authenticated receiver path, source-host validation, and canonical persistence boundary. |
+| `PostCommitWorkKey::LocalNudge`, `PostCommitWorkQueue` | Existing ordinary post-write nudge boundary. AK.1 keeps it as the one receiver notification path. |
+
+No new struct, enum, trait, worker, or transport abstraction is authorized in
+AK.1. The keep/discard ledger below is the full change authority.
+
 ## Deliverables
 
 1. Publish a keep/discard ledger in this sprint doc, with commit, affected

--- a/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
+++ b/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
@@ -32,8 +32,12 @@ Host-qualified writes are not delivered until AK.4.
    host. It starts no work, owns no retry state, and is the sole durable input
    for AK.3 canonicalization and AK.5's later timer backlog. Do not create a
    second outbox table or duplicate payload representation.
-5. Update Phase AI status text, requirements, ADRs, architecture, boundaries,
-   and project plan so none promise daemon worker delivery or replay.
+5. Mark only the worker/replay portion of `REQ-CORE-TRANSPORT-003B` and
+   ADR-038 superseded by AK.2. Update Phase AI status text, architecture,
+   boundaries, and project plan so none promise daemon worker delivery or
+   replay. Do not define resend-cache semantics (AK.5 owns them), revise
+   alias semantics (AK.3 owns them), or revise active direct delivery (AK.4
+   owns it).
 
 ## Literal deletion ledger
 
@@ -168,7 +172,7 @@ delivery health.
 | `local_ipc_transport/request_worker.rs`, `atm-core/src/transport/testing.rs` | Delete `PeerSync` request arms and tests. |
 | `docs/atm-daemon/openapi.yaml`, `crates/atm/tests/openapi_surface_baseline.json` | Delete peer-sync route/schema/baseline entries and regenerate the accepted API surface. |
 | `crates/atm-architecture/tests/boundary_enforcement.rs` | Delete tests requiring `peer_drain_coordinator.rs` or `PostCommitWorkKey::PeerDelivery`; replace with gates proving those identifiers are absent and host-qualified admission has no post-commit peer signal. Keep unrelated host-loopback guards. |
-| `REQ-CORE-TRANSPORT-003B`, ADR-038, Phase AI worker wording in requirements/boundaries/project plan | Mark superseded by AK.2; do not rewrite historical sprint evidence as though it never existed. |
+| Worker/replay portion of `REQ-CORE-TRANSPORT-003B`, ADR-038, Phase AI worker wording in requirements/boundaries/project plan | Mark superseded by AK.2; do not rewrite historical sprint evidence as though it never existed. AK.5 exclusively defines later resend-cache semantics for `-003B`. |
 
 ### 7. Explicitly deferred from AK.2
 
@@ -198,11 +202,15 @@ delivery health.
 - OpenAPI baseline regeneration and `git diff --check` pass.
 - Post-delete: no AK.2 deprecation marker or warning remains; `just lint` and
   `just test` pass.
+- Smoke: run `just smoke localhost` and `just smoke local-ip` against an
+  isolated test home/database; each host-qualified admission remains persisted
+  and unnudgeted at the origin while the ordinary receiver path remains intact.
 
 ## Dependencies
 
 Before every AK.2 development/fix round, merge AK.1 into AK.2. Start AK.2 as
 soon as AK.1 is pushed; do not wait for QA. AK.2 must not merge to `develop`:
 AK.4 restores delivery. Push AK.2, then start AK.3 with AK.2→AK.3 merge-forward.
+AK.1 PR must merge before AK.2 PR completion.
 `must_follow` is required because AK.2 applies AK.1's keep/discard decision;
 it is not parallel-safe because both touch cross-host routing/provenance.

--- a/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
+++ b/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
@@ -1,0 +1,52 @@
+---
+title: AK.2 Delete daemon peer worker
+status: proposed
+target: integrate/phase-ak
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+must_follow: AK.1
+parallel_safe: false
+---
+
+# AK.2 — delete daemon peer worker
+
+## Closure
+
+Delete the daemon-owned host-qualified delivery worker before its replacement.
+This sprint deletes queue/thread/reload machinery only. A host-qualified
+origin record retains exactly one immutable outbound write and destination host
+(`peerOutbound`) as durable message data; it is not a queue or worker state.
+Host-qualified writes are not delivered until AK.4.
+
+## Deliverables
+
+1. Delete `peer_drain_coordinator.rs`, `PeerDeliveryCoordinator`, worker
+   creation/join/shutdown, `PeerJob`, `PeerWork`, channels, per-message
+   threads, and worker-only tests.
+2. Delete `PostCommitWorkKey::PeerDelivery` and its router signal. Retain the
+   existing local post-write nudge path.
+3. Delete worker-only retry/recovery policy and observability. Do not replace
+   them with renamed queues, task handles, threads, background scans, or an
+   immediate SQLite reload.
+4. Retain `peerOutbound` only as the immutable persisted write plus destination
+   host. It starts no work, owns no retry state, and is the sole durable input
+   for AK.3 canonicalization and AK.5's later timer backlog. Do not create a
+   second outbox table or duplicate payload representation.
+5. Update Phase AI status text, requirements, ADRs, architecture, boundaries,
+   and project plan so none promise daemon worker delivery or replay.
+
+## Required validation
+
+- Source gate rejects deleted worker symbols in production code.
+- Unit: host-qualified admission persists its origin ULID once and starts no
+  queue, thread, reload, socket, DNS, or nudge.
+- Unit: local write retains its ordinary local nudge.
+- `just lint` and `just test` pass.
+
+## Dependencies
+
+Before every AK.2 development/fix round, merge AK.1 into AK.2. Start AK.2 as
+soon as AK.1 is pushed; do not wait for QA. AK.2 must not merge to `develop`:
+AK.4 restores delivery. Push AK.2, then start AK.3 with AK.2→AK.3 merge-forward.
+`must_follow` is required because AK.2 applies AK.1's keep/discard decision;
+it is not parallel-safe because both touch cross-host routing/provenance.

--- a/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
+++ b/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
@@ -35,12 +35,133 @@ Host-qualified writes are not delivered until AK.4.
 5. Update Phase AI status text, requirements, ADRs, architecture, boundaries,
    and project plan so none promise daemon worker delivery or replay.
 
+## Literal deletion ledger
+
+This ledger is the AK.2 implementation scope. `Delete` means remove the named
+item and all tests that prove its retired behavior. `Rewrite` means retain only
+the listed local-nudge or durable-data responsibility. `Defer` means AK.2 does
+not change it.
+
+### 1. Delete the peer delivery worker module
+
+Delete `crates/atm-daemon/src/peer_drain_coordinator.rs` in full. It owns the
+old state machine and no item in it survives:
+
+| Item | Action | Why |
+| --- | --- | --- |
+| `POST_COMMIT_QUEUE_DEPTH`, `MAX_ACTIVE_PEER_JOBS`, `MAX_ACTIVE_PEER_JOBS_PER_HOST`, `PEER_DELIVERY_WORKER_DEADLINE`, `PEER_SYNC_REQUEST_DEADLINE`, `PEER_DRAIN_JOIN_POLICY`, `PEER_JOB_JOIN_POLICY` | Delete | Capacity, deadline, and join policy exist only for the retired worker. |
+| `PeerSyncOutcome` | Delete | Its only consumer is the explicit worker reconciliation API. |
+| `PeerDeliveryCoordinator` and `signal_after_persist`, `sync_peer`, `start`, `stop` | Delete | This trait is the coordinator boundary AK.2 removes. |
+| `PeerJob`, `EligiblePeerWrite`, `PeerWork`, `JobDeliveryResult`, `JobState` | Delete | Per-message job, queue, eligibility, and in-flight state are the prohibited state machine. |
+| `JobState::{try_take, release}` | Delete | Per-host/global job admission disappears with `PeerJob`. |
+| `PeerDrainCoordinator` | Delete | The coordinator has no replacement in AK.2. |
+| `PeerDrainCoordinator::{new, record, take_job, release_job, run_job, eligible_request, deliver_one, run, reap_finished_workers}` | Delete | These methods respectively construct, observe, admit, recover, reload, deliver, dispatch, and reap the prohibited peer work. |
+| `impl PeerDeliveryCoordinator for PeerDrainCoordinator::{signal_after_persist, sync_peer, start, stop}` | Delete | No peer scheduler remains. |
+| `decode_request` | Delete | AK.2 never reloads a persisted request. AK.5 will decode its durable backlog through a new, explicitly scoped reader if it still needs one. |
+| Test helper `job` and every coordinator unit test | Delete | They assert coalescing, caps, isolated threads, and worker reaping—the retired behavior. |
+
+### 2. Delete only the peer half of post-commit work
+
+`crates/atm-daemon/src/runtime_health/post_commit_work.rs` is **not** deleted:
+it remains the bounded local nudge executor. Rename
+`PeerPostCommitWorkQueue` to `LocalPostCommitWorkQueue` to prevent the old
+role from surviving in the name.
+
+| Item | Action | Why |
+| --- | --- | --- |
+| `PostCommitWorkKey::PeerDelivery { peer, message_id }` | Delete | It is the sole post-commit handoff into the peer coordinator. |
+| `PostCommitWorkKey::LocalNudge` | Retain | It drives the ordinary local/received-message nudge path. |
+| `PostCommitWorkQueue::signal` | Retain | It remains the local-nudge boundary only. |
+| `PeerPostCommitWorkQueue` | Rewrite/rename | Become `LocalPostCommitWorkQueue`; delete its `coordinator` field. |
+| `LocalPostCommitWorkQueue::new` | Rewrite | Remove the coordinator parameter and all peer construction. |
+| `register_local_nudge`, `start`, `stop`, `run`, `signal`, `remove_local_nudge_target` | Retain/rewrite | Preserve local nudge work; `signal` accepts only `LocalNudge`; `run` has no peer arm. |
+| `PostCommitNudgeTarget`, `DaemonGraftPostSendPort`, `DaemonGraftPostSendPort::new`, `deliver_post_send`, `deliver_post_send_to_graft_receiver`, `graft_transport_error`, `graft_recipient_unavailable_error` | Retain | These implement the one ordinary receiver/local nudge path, not peer delivery. |
+
+The remaining local-nudge thread is not a peer coordinator, retry worker, DNS
+worker, or per-message sender. It is unchanged post-write notification work.
+
+### 3. Rewrite dispatcher routing; delete worker composition
+
+| Location/item | Action | Exact AK.2 result |
+| --- | --- | --- |
+| `runtime_health/peer_delivery_router.rs::PostWriteRouter::dispatch` | Rewrite | Peer receipts and hostless writes call `signal_local_post_write`. A host-qualified origin write returns after persistence: no event, queue signal, SQLite reload, DNS, socket, TLS, or local nudge. |
+| `signal_local_post_write` | Retain | It is the common ordinary nudge path for local writes and received peer writes. |
+| `DaemonRequestDispatcher::peer_delivery_coordinator`, `post_commit_work_queue`, `peer_delivery_projection` fields | Delete | All are worker/projection ownership. |
+| `build_peer_delivery_coordinator` | Delete | Constructs the retired state machine. |
+| dispatcher construction in `new` and `new_for_test` | Rewrite | Construct one `LocalPostCommitWorkQueue`; do not request `outbound_message_query` or build peer state. |
+| `start_peer_drain_coordinator`, `stop_peer_drain_coordinator` | Delete | Lifecycle belongs to the deleted worker. |
+| `record_peer_delivery_event`, `peer_link_statuses`, `sync_peer` | Delete | All expose worker/projection behavior. |
+| `RequestEnvelope::PeerSync` dispatch arm | Delete | There is no explicit worker reconciliation in AK.2. |
+| `composition::{start_https_listeners, stop_https_listeners}` peer-coordinator calls | Delete | HTTPS receiver lifecycle remains until AK.6; it no longer starts/stops delivery work. |
+| `atm-daemon/src/lib.rs` modules `peer_drain_coordinator`, `peer_delivery_observability` | Delete | Both modules disappear. `peer_resolution` and `https_transport` are deferred to AK.6. |
+
+### 4. Delete peer reconciliation API and policy, retain durable writes
+
+| Item | Action | Why |
+| --- | --- | --- |
+| `RequestEnvelope::PeerSync`, `ResponseEnvelope::PeerSync`, `PeerSyncRequest`, `PeerSyncOutcome`, `PeerSyncDisposition` | Delete | Public protocol only triggers the retired worker. |
+| `api.rs` `PEER_SYNC_PREFIX`, `HttpRouteKind::PeerSync`, route spec, encode/decode arms, `peer_sync_path_host`, `ApiRequest::PeerSync`, peer-sync API tests | Delete | Remove the worker-only HTTP resource; do not replace it in AK.2. |
+| `atm/src/composition.rs::peer_sync` and request classification | Delete | CLI no longer invokes a daemon worker. |
+| `atm/src/commands/peer.rs` `PeerSubcommand::Sync`, `SyncPolicyCommand`, `SyncPolicySubcommand`, `run_sync`, `parse_whole_seconds`, sync-policy dispatch/tests | Delete | CLI controls only the retired reconciliation policy. Interface/certificate/trust commands are deferred to AK.6. |
+| `PeerSyncPolicy`, `MAX_PEER_SYNC_BATCH_MESSAGES`, `MAX_PEER_SYNC_MESSAGE_AGE`, `PeerSyncPolicy::{validate, default}`, `duration_seconds` | Delete | Configuration exists only for worker scanning. |
+| `PeerConfigStore::{peer_sync_policy, save_peer_sync_policy}` and re-export | Delete | No durable recovery policy remains. |
+| SQLite policy methods/tests/imports | Delete | Remove the dead persistence adapter surface. |
+| `peer_sync_policies` table and `idx_peer_sync_policies_host` | Delete | AK.2 explicitly drops this obsolete configuration from existing databases; do not leave unused durable state. |
+| `OutboundMessageQuery::find_for_peer` and its SQLite implementation/test | Delete | It exists only for a coordinator's immediate post-persist reload. |
+| `StoredPeerWrite`, `OutboundMessageQuery::page_for_peer`, SQLite page query | Retain | These are durable immutable message data and the future AK.5 backlog reader; AK.2 does not schedule or read them. |
+| `peerOutbound` envelope value and helpers | Retain | One canonical immutable write plus destination host. It is data, never a queue, retry record, or worker signal. |
+
+### 5. Delete worker-only doctor projection
+
+Delete `crates/atm-daemon/src/peer_delivery_observability.rs` in full:
+`PeerDeliveryEventKind`, `PeerDeliveryEvent`, `PeerDeliveryProjection`,
+`PeerDeliveryProjectionState`, `ProjectedPeerLinkStatus`,
+`PeerDeliveryProjection::{record, statuses, project}`, `emit_retained_event`,
+`apply_event_to_status`, `peer_link_quality_for_error`, and their tests.
+
+Delete the corresponding doctor model, because it reports a worker state that
+will no longer exist: `PeerLinkQuality`, `PeerDrainState`, `PeerLinkStatus`,
+`PeerLinkStatus::misconfigured`, and `DaemonRuntimeDoctorReport::peer_links`.
+Delete `atm::commands::doctor::configured_peer_links` and its tests. Retain
+`peer_config` reporting only; it reports configured data rather than invented
+delivery health.
+
+### 6. Remove tests, contracts, and historical promises
+
+| Surface | Action |
+| --- | --- |
+| `crates/atm-daemon/src/tests/runtime_root/peer_reconciliation.rs` | Delete whole file: every assertion is peer scan/replay behavior. |
+| `crates/atm-daemon/src/tests/runtime_root/peer_observability.rs` | Delete whole file: every assertion is the deleted projection. |
+| `runtime_root/local_ipc.rs`, `runtime_root.rs`, `peer_failure.rs` | Rewrite the blocked-worker/recovery tests into host-qualified admission proofs: one persisted immutable record, no peer attempt, no local nudge, prompt local response. Delete `BlockingPeerDelivery`, `RouteFailure`, worker start/stop, and policy setup. |
+| `local_ipc_transport/request_worker.rs`, `atm-core/src/transport/testing.rs` | Delete `PeerSync` request arms and tests. |
+| `docs/atm-daemon/openapi.yaml`, `crates/atm/tests/openapi_surface_baseline.json` | Delete peer-sync route/schema/baseline entries and regenerate the accepted API surface. |
+| `crates/atm-architecture/tests/boundary_enforcement.rs` | Delete tests requiring `peer_drain_coordinator.rs` or `PostCommitWorkKey::PeerDelivery`; replace with gates proving those identifiers are absent and host-qualified admission has no post-commit peer signal. Keep unrelated host-loopback guards. |
+| `REQ-CORE-TRANSPORT-003B`, ADR-038, Phase AI worker wording in requirements/boundaries/project plan | Mark superseded by AK.2; do not rewrite historical sprint evidence as though it never existed. |
+
+### 7. Explicitly deferred from AK.2
+
+- `peer_resolution.rs`, `runtime_health/peer_authority.rs`, `HttpsTransport`,
+  rustls listener/client code, certificate/fingerprint configuration, and
+  `PeerWireSecurity`: AK.6 owns their removal/isolation.
+- Alias index, `PeerEndpoint`, and canonical IP-alias substitution: AK.3.
+- Any native peer HTTP call: AK.4.
+- Any endpoint state, timer, aggregate, or retry: AK.5.
+- No replacement worker, task handle, per-message thread, broad peer scan, or
+  immediate SQLite reload may enter AK.2.
+
 ## Required validation
 
-- Source gate rejects deleted worker symbols in production code.
-- Unit: host-qualified admission persists its origin ULID once and starts no
-  queue, thread, reload, socket, DNS, or nudge.
+- Source gate rejects every deleted coordinator, PeerSync, policy, projection,
+  and peer post-commit identifier named above from production code.
+- Unit: host-qualified admission persists its origin ULID and immutable record
+  once and starts no peer queue, peer thread, reload, socket, DNS, or nudge.
 - Unit: local write retains its ordinary local nudge.
+- Regression: a received peer write still takes the same `signal_local_post_write`
+  nudge path as a local received HTTP write; no inbound local-host/same-IP
+  branch exists.
+- Migration: an existing SQLite database containing `peer_sync_policies`
+  opens successfully and the obsolete table/index are absent afterward.
+- OpenAPI baseline regeneration and `git diff --check` pass.
 - `just lint` and `just test` pass.
 
 ## Dependencies

--- a/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
+++ b/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
@@ -1,6 +1,8 @@
 ---
 title: AK.2 Delete daemon peer worker
 status: proposed
+branch: feature/pak-s2-delete-peer-worker
+worktree: ../atm-core-worktrees/feature/pak-s2-delete-peer-worker
 target: integrate/phase-ak
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning

--- a/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
+++ b/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
@@ -42,6 +42,37 @@ item and all tests that prove its retired behavior. `Rewrite` means retain only
 the listed local-nudge or durable-data responsibility. `Defer` means AK.2 does
 not change it.
 
+The literal ledger is also AK.2's complete inventory of important structs,
+enums, traits, constants, storage methods, routes, and worker boundaries.
+AK.2 may not introduce a replacement type or execution mechanism unless the
+ledger names it explicitly.
+
+### Compiler-attributed pre-delete map
+
+The listed production identifiers are already marked `#[deprecated(note =
+"AK.2 …")]` in the AK.2 branch. The markers are intentional discovery tools,
+not a compatibility policy and not a suppression: `atm-daemon` has no blanket
+`allow(deprecated)`. The pre-delete `cargo check --workspace` result is a
+complete compiler map of the marked target references, with no errors. Every
+warning belongs to one of the rows below. AK.2 deletes the marked surfaces and
+must finish with no AK.2 deprecation warnings.
+
+| Compiler-attributed caller | AK.2 action | Replacement, if any |
+| --- | --- | --- |
+| `peer_drain_coordinator.rs`, `peer_delivery_observability.rs` | Delete whole modules | None. |
+| `runtime_health.rs` coordinator fields/build/start/stop, projection, PeerSync dispatch | Delete | `start_local_post_write_executor` / `stop_local_post_write_executor` start and stop only the retained local nudge executor. |
+| `runtime_health/peer_delivery_router.rs` peer event and `PeerDelivery` signal | Rewrite | Host-qualified origin returns after persistence; peer receipts and hostless writes use `signal_local_post_write`. |
+| `runtime_health/post_commit_work.rs::PeerPostCommitWorkQueue` | Rename and rewrite | `LocalPostCommitWorkQueue`; no coordinator field or peer arm. |
+| `composition.rs` outbound `https_transport` slot and dispatcher installation/clearing | Delete | Retain only `HttpsListenerSet` lifecycle. The listener does not require the retired outbound sender slot. |
+| `atm-core::api`, `protocol`, local-IPC request classification, transport test adapter | Delete PeerSync route/envelopes/arms/tests | None. |
+| `atm::commands::peer::{sync,sync-policy}` and `CliComposition::peer_sync` | Delete | None. Trust/interface/certificate configuration survives unchanged until AK.6. |
+| `PeerSyncPolicy`, `PeerConfigStore` policy methods, SQLite adapter/table/index | Delete | None. AK.5 creates a distinct resend-cache setting only after AK.4 works. |
+| doctor `PeerLink*` projection and CLI `configured_peer_links` | Delete | Retain configured-peer report only; it must not invent delivery health. |
+
+No marker is placed on the retained `peerOutbound` record,
+`OutboundMessageQuery::page_for_peer`, `PostCommitWorkQueue`, local nudge
+delivery, peer configuration, or HTTPS receiver. They are not worker state.
+
 ### 1. Delete the peer delivery worker module
 
 Delete `crates/atm-daemon/src/peer_drain_coordinator.rs` in full. It owns the
@@ -72,7 +103,7 @@ role from surviving in the name.
 | `PostCommitWorkKey::PeerDelivery { peer, message_id }` | Delete | It is the sole post-commit handoff into the peer coordinator. |
 | `PostCommitWorkKey::LocalNudge` | Retain | It drives the ordinary local/received-message nudge path. |
 | `PostCommitWorkQueue::signal` | Retain | It remains the local-nudge boundary only. |
-| `PeerPostCommitWorkQueue` | Rewrite/rename | Become `LocalPostCommitWorkQueue`; delete its `coordinator` field. |
+| `PeerPostCommitWorkQueue` | Rewrite/rename | It is already marked deprecated as a rename target. Become `LocalPostCommitWorkQueue`; delete its `coordinator` field. |
 | `LocalPostCommitWorkQueue::new` | Rewrite | Remove the coordinator parameter and all peer construction. |
 | `register_local_nudge`, `start`, `stop`, `run`, `signal`, `remove_local_nudge_target` | Retain/rewrite | Preserve local nudge work; `signal` accepts only `LocalNudge`; `run` has no peer arm. |
 | `PostCommitNudgeTarget`, `DaemonGraftPostSendPort`, `DaemonGraftPostSendPort::new`, `deliver_post_send`, `deliver_post_send_to_graft_receiver`, `graft_transport_error`, `graft_recipient_unavailable_error` | Retain | These implement the one ordinary receiver/local nudge path, not peer delivery. |
@@ -86,13 +117,14 @@ worker, or per-message sender. It is unchanged post-write notification work.
 | --- | --- | --- |
 | `runtime_health/peer_delivery_router.rs::PostWriteRouter::dispatch` | Rewrite | Peer receipts and hostless writes call `signal_local_post_write`. A host-qualified origin write returns after persistence: no event, queue signal, SQLite reload, DNS, socket, TLS, or local nudge. |
 | `signal_local_post_write` | Retain | It is the common ordinary nudge path for local writes and received peer writes. |
-| `DaemonRequestDispatcher::peer_delivery_coordinator`, `post_commit_work_queue`, `peer_delivery_projection` fields | Delete | All are worker/projection ownership. |
+| `DaemonRequestDispatcher::peer_delivery_coordinator`, `post_commit_work_queue`, `peer_delivery_projection` fields | Delete | All are worker/projection ownership. Replace the peer lifecycle methods with `start_local_post_write_executor` / `stop_local_post_write_executor`, each delegating only to `LocalPostCommitWorkQueue`. |
 | `build_peer_delivery_coordinator` | Delete | Constructs the retired state machine. |
 | dispatcher construction in `new` and `new_for_test` | Rewrite | Construct one `LocalPostCommitWorkQueue`; do not request `outbound_message_query` or build peer state. |
 | `start_peer_drain_coordinator`, `stop_peer_drain_coordinator` | Delete | Lifecycle belongs to the deleted worker. |
 | `record_peer_delivery_event`, `peer_link_statuses`, `sync_peer` | Delete | All expose worker/projection behavior. |
 | `RequestEnvelope::PeerSync` dispatch arm | Delete | There is no explicit worker reconciliation in AK.2. |
 | `composition::{start_https_listeners, stop_https_listeners}` peer-coordinator calls | Delete | HTTPS receiver lifecycle remains until AK.6; it no longer starts/stops delivery work. |
+| `DaemonRequestDispatcher::{https_transport, install_https_transport, clear_https_transport}` and `RuntimeComposition::https_transport` | Delete | These marked slots exist only to hand an outbound custom sender to the worker. Keep `HttpsListenerSet`, listener bind/stop, and trust-refresh receiver lifecycle; they have no outbound-slot replacement. |
 | `atm-daemon/src/lib.rs` modules `peer_drain_coordinator`, `peer_delivery_observability` | Delete | Both modules disappear. `peer_resolution` and `https_transport` are deferred to AK.6. |
 
 ### 4. Delete peer reconciliation API and policy, retain durable writes
@@ -151,6 +183,8 @@ delivery health.
 
 ## Required validation
 
+- Pre-delete discovery: `cargo check --workspace` reports only the attributed
+  AK.2 deprecation set. Do not add an `allow(deprecated)` to hide callers.
 - Source gate rejects every deleted coordinator, PeerSync, policy, projection,
   and peer post-commit identifier named above from production code.
 - Unit: host-qualified admission persists its origin ULID and immutable record
@@ -162,7 +196,8 @@ delivery health.
 - Migration: an existing SQLite database containing `peer_sync_policies`
   opens successfully and the obsolete table/index are absent afterward.
 - OpenAPI baseline regeneration and `git diff --check` pass.
-- `just lint` and `just test` pass.
+- Post-delete: no AK.2 deprecation marker or warning remains; `just lint` and
+  `just test` pass.
 
 ## Dependencies
 

--- a/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
+++ b/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
@@ -38,6 +38,10 @@ Host-qualified writes are not delivered until AK.4.
    replay. Do not define resend-cache semantics (AK.5 owns them), revise
    alias semantics (AK.3 owns them), or revise active direct delivery (AK.4
    owns it).
+6. Update `boundaries/atm-storage/peer-config-store.toml` in this same PR:
+   remove `PeerSyncPolicy` from its ownership and contract request/response
+   types, and remove worker-policy wording. Retain only configuration that
+   survives AK.2; do not add an AK.5 resend-cache contract early.
 
 ## Literal deletion ledger
 

--- a/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
+++ b/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
@@ -1,6 +1,8 @@
 ---
 title: AK.3 Canonical peer alias persistence
 status: proposed
+branch: feature/pak-s3-canonical-peer-aliases
+worktree: ../atm-core-worktrees/feature/pak-s3-canonical-peer-aliases
 target: integrate/phase-ak
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning

--- a/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
+++ b/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
@@ -1,0 +1,60 @@
+---
+title: AK.3 Canonical peer alias persistence
+status: proposed
+target: integrate/phase-ak
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+must_follow: AK.2
+parallel_safe: false
+---
+
+# AK.3 — canonical peer alias persistence
+
+## Closure
+
+Normalize configured peer aliases before persistence. This changes only the
+stored destination representation; AK.3 adds no outbound delivery.
+
+## Fixed contract
+
+```rust
+struct PeerEndpoint {
+    host: HostName,
+    port: NonZeroU16,
+}
+
+fn normalize_peer_alias(alias: &HostName) -> Result<PeerEndpoint, AtmError>;
+```
+
+The configuration-owned alias index makes an O(1) local substitution: `m5`,
+`rand-m5.local`, and an explicit configured IP alias can each normalize to
+`rand-m5.local`. SQLite stores only that full hostname, never a resolved IP.
+A configured host is admitted offline; no live DNS, peer scan, or thread is
+needed for normalization.
+
+## Deliverables
+
+1. Add the configuration-owned alias index and canonical full-host endpoint
+   type. Keep IP aliases explicit configuration, not inferred DNS results.
+2. Normalize every host-qualified recipient before canonical persistence,
+   including the destination host retained in the origin record's immutable
+   `peerOutbound` delivery record.
+3. Preserve the full hostname through send, mailbox, ACK, and nudge data;
+   preserve the current no-delivery behavior from AK.2.
+4. Update peer configuration requirements and schema/boundary documentation.
+
+## Required validation
+
+- Unit: aliases for one peer normalize to one full hostname without SQLite,
+  live DNS, a peer scan, or a new thread.
+- Unit: unknown alias fails before persistence; configured unreachable peer
+  persists the canonical hostname while remaining undelivered.
+- `just lint` and `just test` pass.
+
+## Dependencies
+
+Before every AK.3 development/fix round, merge AK.2 into AK.3. Start AK.3 as
+soon as AK.2 is pushed; do not wait for QA. AK.3 PR completion waits for AK.2
+merge. Push AK.3, then start AK.4 with AK.3→AK.4 merge-forward.
+`must_follow` is required because AK.4 sends AK.3's persisted canonical host;
+it is not parallel-safe because both change host-qualified admission/routing.

--- a/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
+++ b/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
@@ -36,6 +36,7 @@ struct PeerDirectory {
 
 impl PeerDirectory {
     fn normalize(&self, alias: &PeerAliasKey) -> Result<PeerEndpoint, AtmError>;
+    fn endpoint_for_canonical_host(&self, host: &HostName) -> Option<PeerEndpoint>;
 }
 
 trait PeerConfigStore {
@@ -68,7 +69,7 @@ database read occurs during normalization.
 | `PeerAliasKey` | New exact alias input: host label/full host or literal `IpAddr`; it prevents conflating an IP with `HostName`. |
 | `PeerEndpoint` | New canonical destination: full hostname plus port. This is the only peer destination passed beyond admission. |
 | `PeerDirectory` | New immutable expected-O(1) alias index. It is built at configuration load/reload and has no background refresh. |
-| `PeerDirectory::normalize` | The one admission-time lookup. It returns a copied `PeerEndpoint` or one typed unknown-alias error; it cannot query SQLite or the network. |
+| `PeerDirectory::{normalize, endpoint_for_canonical_host}` | `normalize` is the one admission-time alias lookup. `endpoint_for_canonical_host` is AK.5's bootstrap-only canonical-host lookup; it returns the configured port with the host or `None`. Neither can query SQLite or the network. |
 | `PeerConfigStore::{peer_directory, list_peer_aliases, save_peer_alias, remove_peer_alias}` | Additive configuration boundary. It returns/saves configuration data only; it performs no DNS or delivery. |
 | `PeerAliasCommand` | New CLI command model for `list`, `add`, and `remove`. It accepts a validated `PeerAliasKey`; it never accepts a resolved address or triggers delivery. |
 | `TrustedPeer` | Existing canonical peer configuration. Its host/port source `PeerEndpoint`; no second peer model. |
@@ -104,7 +105,7 @@ plan amendment.
    delivery table, or per-send lookup query.
 5. Preserve the canonical full hostname through send, mailbox, ACK, and nudge
    data; preserve AK.2's no-delivery behavior.
-6. Update the future-facing configuration contract in
+6. Exclusively own the alias/configuration edits to
    `docs/requirements.md` (`REQ-CORE-TRANSPORT-002A` and `-002D`),
    `docs/adr/ADR-040-peer-authority-resolution.md`,
    `docs/adr/ADR-035-canonical-write-ingress-and-host-routing.md`,
@@ -112,7 +113,8 @@ plan amendment.
    `docs/atm/{architecture,requirements}.md`, CLI help, and
    `docs/peer-pair-smoke.md`. The edits must say explicit aliases are
    configuration, canonical hosts are durable routing selectors, and no
-   discovery occurs at admission.
+   discovery occurs at admission. AK.4 may reference their resulting
+   `PeerEndpoint`, but must not edit these alias subclauses.
 
 ## Explicit prohibitions
 

--- a/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
+++ b/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
@@ -18,37 +18,131 @@ stored destination representation; AK.3 adds no outbound delivery.
 ## Fixed contract
 
 ```rust
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum PeerAliasKey {
+    Host(HostName),
+    Ip(std::net::IpAddr),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
 struct PeerEndpoint {
-    host: HostName,
+    canonical_host: HostName,
     port: NonZeroU16,
 }
 
-fn normalize_peer_alias(alias: &HostName) -> Result<PeerEndpoint, AtmError>;
+struct PeerDirectory {
+    by_alias: HashMap<PeerAliasKey, PeerEndpoint>,
+}
+
+impl PeerDirectory {
+    fn normalize(&self, alias: &PeerAliasKey) -> Result<PeerEndpoint, AtmError>;
+}
+
+trait PeerConfigStore {
+    fn peer_directory(&self) -> Result<PeerDirectory, AtmError>;
+    fn list_peer_aliases(&self) -> Result<Vec<(PeerAliasKey, HostName)>, AtmError>;
+    fn save_peer_alias(&self, alias: PeerAliasKey, canonical_host: HostName) -> Result<(), AtmError>;
+    fn remove_peer_alias(&self, alias: &PeerAliasKey) -> Result<bool, AtmError>;
+}
+
+enum PeerAliasCommand {
+    List,
+    Add { alias: PeerAliasKey, canonical_host: HostName },
+    Remove { alias: PeerAliasKey },
+}
 ```
 
-The configuration-owned alias index makes an O(1) local substitution: `m5`,
-`rand-m5.local`, and an explicit configured IP alias can each normalize to
-`rand-m5.local`. SQLite stores only that full hostname, never a resolved IP.
-A configured host is admitted offline; no live DNS, peer scan, or thread is
-needed for normalization.
+`PeerDirectory` is one immutable configuration snapshot, built at configuration
+load/reload and passed to admission. Its expected-O(1) local substitution maps `m5`,
+`rand-m5.local`, or an explicitly configured `IpAddr` alias to exactly one
+canonical full hostname such as `rand-m5.local`. SQLite stores only
+`PeerEndpoint::canonical_host` in `peerOutbound.host`, never a resolved IP.
+The canonical host is also a self-alias. A configured endpoint is admitted
+offline; no live DNS, peer scan, thread, process-wide mutable cache, or
+database read occurs during normalization.
+
+## Type and boundary inventory
+
+| Item | AK.3 role |
+| --- | --- |
+| `PeerAliasKey` | New exact alias input: host label/full host or literal `IpAddr`; it prevents conflating an IP with `HostName`. |
+| `PeerEndpoint` | New canonical destination: full hostname plus port. This is the only peer destination passed beyond admission. |
+| `PeerDirectory` | New immutable expected-O(1) alias index. It is built at configuration load/reload and has no background refresh. |
+| `PeerDirectory::normalize` | The one admission-time lookup. It returns a copied `PeerEndpoint` or one typed unknown-alias error; it cannot query SQLite or the network. |
+| `PeerConfigStore::{peer_directory, list_peer_aliases, save_peer_alias, remove_peer_alias}` | Additive configuration boundary. It returns/saves configuration data only; it performs no DNS or delivery. |
+| `PeerAliasCommand` | New CLI command model for `list`, `add`, and `remove`. It accepts a validated `PeerAliasKey`; it never accepts a resolved address or triggers delivery. |
+| `TrustedPeer` | Existing canonical peer configuration. Its host/port source `PeerEndpoint`; no second peer model. |
+| `peer_aliases` | New configuration table, not an outbox/retry/delivery table. |
+
+No other AK.3 struct, enum, trait, executor, or cache is authorized without a
+plan amendment.
 
 ## Deliverables
 
-1. Add the configuration-owned alias index and canonical full-host endpoint
-   type. Keep IP aliases explicit configuration, not inferred DNS results.
-2. Normalize every host-qualified recipient before canonical persistence,
-   including the destination host retained in the origin record's immutable
-   `peerOutbound` delivery record.
-3. Preserve the full hostname through send, mailbox, ACK, and nudge data;
-   preserve the current no-delivery behavior from AK.2.
-4. Update peer configuration requirements and schema/boundary documentation.
+1. Add `PeerAliasKey`, `PeerEndpoint`, and immutable `PeerDirectory`; keep the
+   type at the configuration/admission boundary, not in message, nudge,
+   roster, or agent/session state.
+2. Add `peer_aliases(alias_kind TEXT NOT NULL CHECK (alias_kind IN ('host',
+   'ip')), alias_value TEXT NOT NULL, canonical_host TEXT NOT NULL REFERENCES
+   peer_trusted_peers(host) ON DELETE CASCADE, UNIQUE(alias_kind,
+   alias_value))`. Host aliases use the existing canonical `HostName` spelling;
+   IP aliases use `IpAddr::to_string()`. Migration validates that every
+   canonical host exists and is enabled. Canonical-host self-aliases are
+   synthesized in the snapshot, not duplicated in SQLite.
+3. Add `atm peer alias {list,add <host-or-ip> <canonical-host>,remove
+   <host-or-ip>}` through `PeerAliasCommand`, explicit peer-alias CRUD, and
+   tests. Parse a literal IP as `PeerAliasKey::Ip` before treating the input as
+   `PeerAliasKey::Host`. Alias creation rejects an unknown/disabled canonical
+   host, a duplicate normalized key, and `alias_kind='host'` when its
+   `alias_value` parses as an `IpAddr`. It never calls DNS or discovers
+   aliases.
+4. Build/swap one `PeerDirectory` only at daemon configuration load/reload;
+   parse the optional recipient host as either `HostName` or literal `IpAddr`,
+   construct one `PeerAliasKey`, and normalize every host-qualified recipient
+   before its one canonical
+   persistence, including `peerOutbound.host`. Do not add a second outbox,
+   delivery table, or per-send lookup query.
+5. Preserve the canonical full hostname through send, mailbox, ACK, and nudge
+   data; preserve AK.2's no-delivery behavior.
+6. Update the future-facing configuration contract in
+   `docs/requirements.md` (`REQ-CORE-TRANSPORT-002A` and `-002D`),
+   `docs/adr/ADR-040-peer-authority-resolution.md`,
+   `docs/adr/ADR-035-canonical-write-ingress-and-host-routing.md`,
+   `docs/atm-daemon/{architecture,boundaries,http-api}.md`,
+   `docs/atm/{architecture,requirements}.md`, CLI help, and
+   `docs/peer-pair-smoke.md`. The edits must say explicit aliases are
+   configuration, canonical hosts are durable routing selectors, and no
+   discovery occurs at admission.
+
+## Explicit prohibitions
+
+- No DNS lookup, reverse lookup, full peer-row scan, socket, network I/O,
+  retry, timer, task, worker, channel, or thread.
+- No dynamic IP discovery or persistence of a resolved IP in `peerOutbound`.
+- No state derived from agent/session/roster/nudge data.
 
 ## Required validation
 
-- Unit: aliases for one peer normalize to one full hostname without SQLite,
-  live DNS, a peer scan, or a new thread.
-- Unit: unknown alias fails before persistence; configured unreachable peer
-  persists the canonical hostname while remaining undelivered.
+- Unit: host and `IpAddr` aliases resolve O(1) to one full hostname without
+  SQLite, live DNS, a peer scan, network I/O, or a new thread.
+- Unit: duplicate/unknown/disabled aliases fail at configuration mutation;
+  canonical self-aliases are synthesized, not stored twice.
+- Integration: host-qualified recipient input persists only the canonical host
+  in `peerOutbound`; configured unreachable peer remains undelivered.
+- Integration: after the AK.2 intentional no-delivery admission, a real curl
+  frame to the configured peer listener still reaches canonical persistence and
+  emits exactly one ordinary nudge for loopback, same-IP, and cross-host input;
+  no test may add a local-host ingress branch to make this pass.
+- Migration: existing peer configuration opens with an empty alias table;
+  aliases are cascade-deleted with their canonical trusted peer; an attempted
+  alias mutation for a disabled or deleted peer returns a typed error.
+- Smoke: run `just smoke localhost`, `just smoke local-ip`, and the current
+  configured `crosshost-curl-tls` receiver lane in both M4→M5 and M5→M4
+  directions, using isolated test homes/databases. The staged curl proof is
+  required here because AK.3 deliberately has no production outbound sender;
+  it must not use `UntrustedSmoke`. AK.4 is the first sprint that may claim a
+  complete production send/read/ACK/nudge chain and replaces this lane with
+  the production plain-HTTP proof.
 - `just lint` and `just test` pass.
 
 ## Dependencies

--- a/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
+++ b/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
@@ -1,0 +1,58 @@
+---
+title: AK.4 Direct peer HTTP without retry
+status: proposed
+target: integrate/phase-ak
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+must_follow: AK.3
+parallel_safe: false
+---
+
+# AK.4 — direct peer HTTP without retry
+
+## Closure
+
+Prove the smallest production peer-delivery path before resend caching: use
+AK.3's persisted full hostname, send ordinary HTTP once, and let the existing
+receiver persist and nudge. Failure returns an error and remains undelivered.
+
+## Fixed contract
+
+```rust
+fn send_peer_http(
+    endpoint: &PeerEndpoint,
+    write: &WriteRequest,
+) -> Result<ResponseEnvelope, AtmError>;
+```
+
+The normal HTTP connect resolves the full hostname to its current IP address.
+ATM creates no DNS thread. There is no queue, timer, retry state, worker,
+thread, channel, scan, or alternate receiver route.
+
+## Deliverables
+
+1. Add one direct plain trusted-LAN HTTP sender using the existing JSON
+   `WriteRequest`/`ResponseEnvelope` contract and receiver handler.
+2. Route host-qualified admission directly to it with the in-memory write; do
+   not reload SQLite.
+3. On failure, leave the admitted record explicitly undelivered and return a
+   delivery error. Do not add retry behavior.
+4. Update requirements, ADRs, architecture/boundaries, OpenAPI if affected,
+   and smoke documentation for the proven no-retry baseline.
+
+## Required validation
+
+- Integration: production send and curl submit the same JSON and receive the
+  same response shape.
+- Smoke: M4→M5 and M5→M4 each prove production send, remote read, acknowledged
+  reply, full-host rendering, and one receiver nudge; curl is the independent
+  request-path proof.
+- `just lint` and `just test` pass.
+
+## Dependencies
+
+Before every AK.4 development/fix round, merge AK.3 into AK.4. Start AK.4 as
+soon as AK.3 is pushed; do not wait for QA. AK.4 PR completion waits for AK.3
+merge. Push AK.4, then start AK.5 with AK.4→AK.5 merge-forward.
+`must_follow` is required because AK.5 retries AK.4's one verified function;
+it is not parallel-safe because both own the active peer send path.

--- a/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
+++ b/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
@@ -1,6 +1,8 @@
 ---
 title: AK.4 Direct peer HTTP without retry
 status: proposed
+branch: feature/pak-s4-direct-peer-http-no-retry
+worktree: ../atm-core-worktrees/feature/pak-s4-direct-peer-http-no-retry
 target: integrate/phase-ak
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
@@ -179,7 +181,7 @@ worker, queue, or test transport abstraction is authorized.
    one receiver/nudge path. Update `docs/adr/INDEX.md`,
    `docs/requirements.md` (`REQ-CORE-TRANSPORT-002`, `-002B`, `-002B1`,
    `-002C`, `-004`, and `-005A`),
-   `docs/{architecture,boundaries}.md`,
+   `docs/architecture.md`, `docs/atm-storage/boundaries.md`,
    `docs/atm-daemon/{architecture,boundaries,http-api,requirements}.md`,
    `docs/atm/{architecture,requirements}.md`, and
    `docs/peer-pair-smoke.md`. The documentation must describe the active

--- a/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
+++ b/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
@@ -90,7 +90,7 @@ daemon accept loop or unrelated workers. The call receives the request's
 existing absolute `RequestDeadline`; it does not create a second deadline and
 must use at most `PEER_HTTP_LOCAL_RESPONSE_BUDGET` (three seconds) of local
 response time. Expiry returns the ordinary persisted-but-undelivered delivery
-error. ADR-045 and `REQ-CORE-TRANSPORT-002` record this bounded
+error. ADR-047 and `REQ-CORE-TRANSPORT-002` record this bounded
 local-responsiveness tradeoff explicitly.
 
 The current `HttpsListenerSet` contains two separable responsibilities. AK.4
@@ -172,13 +172,13 @@ worker, queue, or test transport abstraction is authorized.
    successful confirmation removes the message from
    `OutboundMessageQuery::page_for_peer`; failed/partial responses leave only
    their corresponding `peerOutbound` metadata.
-7. In this same change, create `ADR-045` for the direct trusted-LAN HTTP
+7. In this same change, create `ADR-047` for the direct trusted-LAN HTTP
    delivery decision. It supersedes the active transport decisions in
    ADR-034, ADR-040, and ADR-041; ADR-035 remains the canonical ingress ADR
    but is amended to say local, loopback, same-IP, and cross-host ingress have
    one receiver/nudge path. Update `docs/adr/INDEX.md`,
    `docs/requirements.md` (`REQ-CORE-TRANSPORT-002`, `-002B`, `-002B1`,
-   `-002C`, `-003`, `-004`, and `-005A`),
+   `-002C`, `-004`, and `-005A`),
    `docs/{architecture,boundaries}.md`,
    `docs/atm-daemon/{architecture,boundaries,http-api,requirements}.md`,
    `docs/atm/{architecture,requirements}.md`, and
@@ -188,6 +188,13 @@ worker, queue, or test transport abstraction is authorized.
    `crosshost-curl-plain` runner so it starts the configured production
    `PeerHttpListenerSet` without `plaintext-test`/`UntrustedSmoke`; retain a
    separately named interop-only mTLS fixture lane for AK.6.
+8. Update governed boundary records in this same PR:
+   `boundaries/atm-daemon/peer-http-adapter.toml` replaces
+   `HttpsListenerSet` with `PeerHttpListenerSet` while preserving the legacy
+   outbound TLS entries until AK.6, and
+   `boundaries/atm-storage/message-store.toml` adds
+   `PeerDeliveryConfirmation` to `contracts.request_types` for
+   `MessageStore::confirm_peer_delivery`.
 
 ## Explicit prohibitions
 

--- a/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
+++ b/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
@@ -26,6 +26,16 @@ fn send_peer_http_frames(
     deadline: RequestDeadline,
 ) -> Result<Vec<ResponseEnvelope>, AtmError>;
 
+const PEER_HTTP_LOCAL_RESPONSE_BUDGET: Duration = Duration::from_secs(3);
+
+struct PeerHttpBindConfig {
+    bind_addrs: Vec<SocketAddr>,
+}
+
+impl PeerHttpBindConfig {
+    fn validate_at_startup(&self) -> Result<(), AtmError>;
+}
+
 struct PeerDeliveryConfirmation {
     message_id: AtmMessageId,
     canonical_host: HostName,
@@ -65,6 +75,24 @@ resolved address. There is no outbound queue, timer, retry state, worker,
 channel, peer scan, `HttpsMessageTransport` trait/mock, or alternate receiver
 route.
 
+`PeerHttpBindConfig` is the finite configured peer-listener bind allowlist.
+`validate_at_startup` rejects an empty list, duplicate address, unspecified
+(`0.0.0.0`/`::`), multicast, or non-local bind address before any listener is
+created. It enumerates local interface addresses once at startup, without DNS,
+only to validate the explicitly configured list. `PeerHttpListenerSet` binds
+exactly this validated list; it does not silently widen it or infer an
+interface. This prevents accidental wildcard exposure, but it does not claim
+that ATM can enforce a site's firewall or Internet reachability policy.
+
+AK.4 deliberately performs one synchronous direct send after local SQLite
+admission. It blocks only the initiating local request worker, never the
+daemon accept loop or unrelated workers. The call receives the request's
+existing absolute `RequestDeadline`; it does not create a second deadline and
+must use at most `PEER_HTTP_LOCAL_RESPONSE_BUDGET` (three seconds) of local
+response time. Expiry returns the ordinary persisted-but-undelivered delivery
+error. ADR-045 and `REQ-CORE-TRANSPORT-002` record this bounded
+local-responsiveness tradeoff explicitly.
+
 The current `HttpsListenerSet` contains two separable responsibilities. AK.4
 keeps its existing bounded inbound HTTP execution and renames the plaintext
 part `PeerHttpListenerSet`; AK.6 later deletes only its TLS security half.
@@ -81,8 +109,9 @@ admission, and the ordinary post-write nudge exactly once.
 | --- | --- |
 | `send_peer_http_frames` | New sole peer-sender function. It accepts singleton and batch slices; it is not a trait object, service, worker, or pool. |
 | `PeerHttpRuntimeConfig` | New immutable local source-host snapshot built at daemon configuration load/reload. It supplies only the display-provenance header; it has no peer lookup, socket, retry, or state. |
+| `PeerHttpBindConfig::validate_at_startup` | New exact finite local bind allowlist and startup validator. It rejects wildcard, multicast, duplicate, empty, and non-local addresses before `PeerHttpListenerSet` binds; it is neither peer discovery nor source authentication. |
 | `PeerEndpoint` | AK.3 canonical hostname/port input; AK.4 neither resolves aliases nor stores an address. |
-| `WriteRequest`, `RequestEnvelope::Write`, `ResponseEnvelope::Send`, `SendResponseEnvelope`, `RequestDeadline` | Existing canonical wire/request types. Acceptance is only the matching `ResponseEnvelope::Send` outcome for that write ULID; every other response, including `ResponseEnvelope::Error`, is a delivery failure. |
+| `WriteRequest`, `RequestEnvelope::Write`, `ResponseEnvelope::Send`, `SendResponseEnvelope`, `RequestDeadline`, `PEER_HTTP_LOCAL_RESPONSE_BUDGET` | Existing canonical wire/request types plus one AK.4 three-second local-response cap. The sender uses the caller's existing absolute deadline, never a fresh one. Acceptance is only the matching `ResponseEnvelope::Send` outcome for that write ULID; every other response, including `ResponseEnvelope::Error`, is a delivery failure. |
 | `TcpStream`, `SocketAddr` | Existing standard-library connection/address values. The OS resolver produces one ephemeral address for one direct call; neither enters ATM storage or state. |
 | `HttpFrameReader` and shared HTTP writer helpers | Existing framing boundary. Both production and real-loopback tests use it. |
 | `PeerHttpListenerSet`, `PeerHttpListener`, `PeerConnectionAdmission` | Renamed retained inbound HTTP listener lifecycle and its exact accept decision. It is the only production peer receiver; no second handler is created. |
@@ -101,14 +130,20 @@ worker, queue, or test transport abstraction is authorized.
    framing implementation. It owns one bounded connection/deadline and emits
    one write frame/response per input in order; do not add a transport trait,
    connection pool, background connection lifecycle, or test-only delivery
-   substitute. A response count/order mismatch, malformed frame, unexpected
+   substitute. It consumes the initiating local request's remaining
+   `RequestDeadline`, capped at the exact three-second
+   `PEER_HTTP_LOCAL_RESPONSE_BUDGET`; it must not create a fresh peer deadline.
+   A response count/order mismatch, malformed frame, unexpected
    response variant, error response, connect refusal, write failure, and
    read timeout are all typed delivery failures; none may confirm a write.
    Build one immutable `PeerHttpRuntimeConfig` from configured interface data
    at configuration load/reload; do not query peer configuration per send.
-2. Extract/rename the plaintext branch of `HttpsListenerSet` to
-   `PeerHttpListenerSet` and make it the configured production trusted-LAN
-   listener. Retain its listed bounded accept/request execution unchanged;
+2. Add and validate `PeerHttpBindConfig` at daemon startup, then extract/rename
+   the plaintext branch of `HttpsListenerSet` to `PeerHttpListenerSet` and
+   make it the configured production trusted-LAN listener. It binds only the
+   finite validated addresses; wildcard, multicast, empty, duplicate, or
+   non-local lists fail startup. Retain its listed bounded accept/request
+   execution unchanged;
    delete the `PlaintextTest`/`UntrustedSmoke` production distinction. A write
    with the configured source-host header is admitted as `WriteIngress::Peer`
    after the existing provenance validation. Do not authenticate or route from
@@ -142,8 +177,8 @@ worker, queue, or test transport abstraction is authorized.
    ADR-034, ADR-040, and ADR-041; ADR-035 remains the canonical ingress ADR
    but is amended to say local, loopback, same-IP, and cross-host ingress have
    one receiver/nudge path. Update `docs/adr/INDEX.md`,
-   `docs/requirements.md` (`REQ-CORE-TRANSPORT-002`, `-002A`, `-002B`,
-   `-002B1`, `-002C`, `-002D`, `-003`, `-004`, and `-005A`),
+   `docs/requirements.md` (`REQ-CORE-TRANSPORT-002`, `-002B`, `-002B1`,
+   `-002C`, `-003`, `-004`, and `-005A`),
    `docs/{architecture,boundaries}.md`,
    `docs/atm-daemon/{architecture,boundaries,http-api,requirements}.md`,
    `docs/atm/{architecture,requirements}.md`, and
@@ -163,6 +198,8 @@ worker, queue, or test transport abstraction is authorized.
 - No source-host value from user input, and no local-host/same-IP incoming
   branch. Local, loopback, same-IP, and cross-host frames use the same
   receiver/nudge path.
+- No wildcard, multicast, inferred, or unvalidated peer-listener bind. Network
+  firewall policy is not inferred as an ATM routing or authentication rule.
 
 ## Required validation
 
@@ -173,6 +210,12 @@ worker, queue, or test transport abstraction is authorized.
 - Integration: the configured production `PeerHttpListenerSet` admits a
   header-bearing plain HTTP write as `WriteIngress::Peer`; loopback, same-IP,
   and cross-host use this exact receiver/nudge path.
+- Unit/integration: startup rejects every invalid `PeerHttpBindConfig`; a
+  valid explicit local-interface list is the exact list handed to the
+  production listener, with no wildcard fallback.
+- Integration: a stalled peer consumes at most the initiating request's
+  three-second response budget, returns the ordinary persisted-but-undelivered
+  error, and does not prevent an unrelated local request worker from completing.
 - Integration: a one-element immediate call and a multi-frame call use the
   same function and preserve the original ULID/timestamp per write.
 - Integration: DNS resolution failure, connect refusal, receiver `4xx/5xx`,

--- a/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
+++ b/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
@@ -19,34 +19,176 @@ receiver persist and nudge. Failure returns an error and remains undelivered.
 ## Fixed contract
 
 ```rust
-fn send_peer_http(
+fn send_peer_http_frames(
+    config: &PeerHttpRuntimeConfig,
     endpoint: &PeerEndpoint,
-    write: &WriteRequest,
-) -> Result<ResponseEnvelope, AtmError>;
+    writes: &[WriteRequest],
+    deadline: RequestDeadline,
+) -> Result<Vec<ResponseEnvelope>, AtmError>;
+
+struct PeerDeliveryConfirmation {
+    message_id: AtmMessageId,
+    canonical_host: HostName,
+}
+
+struct PeerHttpRuntimeConfig {
+    source_host: HostName,
+}
+
+trait MessageStore {
+    fn confirm_peer_delivery(
+        &self,
+        confirmation: PeerDeliveryConfirmation,
+    ) -> Result<bool, AtmError>;
+}
 ```
 
-The normal HTTP connect resolves the full hostname to its current IP address.
-ATM creates no DNS thread. There is no queue, timer, retry state, worker,
-thread, channel, scan, or alternate receiver route.
+The function is the only peer sender. `PeerHttpRuntimeConfig::source_host` is
+the configured local interface advertisement, captured at daemon
+configuration load/reload; it is never obtained from CLI input or a per-send
+configuration query. Immediate delivery calls the function with a
+one-element slice; AK.5 passes an oldest-first durable batch to this exact
+function. It uses the shared `RequestEnvelope::Write` HTTP framing helpers
+(`write_http_request_with_headers` and `read_http_response_with_frame_reader`)
+and the normal configured peer receiver. The source-host header comes from
+configured daemon interface data, never a CLI argument. On the trusted-LAN
+MVP receiver it is display provenance, not authentication: the receiver
+normalizes it into the existing peer provenance fields, then calls
+`validate_write_provenance(WriteIngress::Peer, ...)`. Direct send must not use
+`UntrustedSmoke` or an alternate nudge path.
+
+The connect is exactly one bounded `TcpStream::connect` call using
+`PeerEndpoint::canonical_host` and `endpoint.port`; the operating system
+performs ordinary hostname resolution. ATM does not enumerate candidate
+addresses, perform a literal-IP fallback, create a DNS thread, or save a
+resolved address. There is no outbound queue, timer, retry state, worker,
+channel, peer scan, `HttpsMessageTransport` trait/mock, or alternate receiver
+route.
+
+The current `HttpsListenerSet` contains two separable responsibilities. AK.4
+keeps its existing bounded inbound HTTP execution and renames the plaintext
+part `PeerHttpListenerSet`; AK.6 later deletes only its TLS security half.
+`PeerHttpListenerSet` owns one existing accept thread per enabled interface and
+uses the existing `ActiveConnectionRegistry` to bound existing request threads
+at `MAX_PEER_HTTP_CONNECTIONS`. AK.4 creates no outbound thread and no new
+listener/request execution model. Every accepted frame—loopback, same-IP, and
+cross-host—runs `route_peer_http_request`, the canonical router, SQLite
+admission, and the ordinary post-write nudge exactly once.
+
+## Type and boundary inventory
+
+| Item | AK.4 role |
+| --- | --- |
+| `send_peer_http_frames` | New sole peer-sender function. It accepts singleton and batch slices; it is not a trait object, service, worker, or pool. |
+| `PeerHttpRuntimeConfig` | New immutable local source-host snapshot built at daemon configuration load/reload. It supplies only the display-provenance header; it has no peer lookup, socket, retry, or state. |
+| `PeerEndpoint` | AK.3 canonical hostname/port input; AK.4 neither resolves aliases nor stores an address. |
+| `WriteRequest`, `RequestEnvelope::Write`, `ResponseEnvelope::Send`, `SendResponseEnvelope`, `RequestDeadline` | Existing canonical wire/request types. Acceptance is only the matching `ResponseEnvelope::Send` outcome for that write ULID; every other response, including `ResponseEnvelope::Error`, is a delivery failure. |
+| `TcpStream`, `SocketAddr` | Existing standard-library connection/address values. The OS resolver produces one ephemeral address for one direct call; neither enters ATM storage or state. |
+| `HttpFrameReader` and shared HTTP writer helpers | Existing framing boundary. Both production and real-loopback tests use it. |
+| `PeerHttpListenerSet`, `PeerHttpListener`, `PeerConnectionAdmission` | Renamed retained inbound HTTP listener lifecycle and its exact accept decision. It is the only production peer receiver; no second handler is created. |
+| `ListenerSecurity::PlaintextTest`, `AuthenticatedIngress::UntrustedSmoke` | Existing temporary smoke-only classification deleted from production peer-write handling. AK.4 has no replacement enum: configured trusted-LAN peer writes use the existing `Peer` ingress value. |
+| `ActiveConnectionRegistry`, `ActiveConnectionGuard`, `TrackedDispatchHandle`, `MAX_PEER_HTTP_CONNECTIONS` | Existing bounded inbound request execution retained unchanged. These apply only after a peer socket is accepted; they are not outbound delivery state. |
+| `route_peer_http_request`, `WriteIngress::Peer`, `validate_write_provenance` | Existing common ingress boundary. AK.4 changes the former plaintext-test provenance classification to trusted-LAN `Peer`; it does not create local/cross-host branches. |
+| `PeerDeliveryConfirmation`, `MessageStore::confirm_peer_delivery` | New exact confirmation value and one sealed-storage mutation. `true` removes only matching `peerOutbound` metadata after a successful peer response; `false` is an idempotent already-confirmed no-op, so only undelivered writes appear in a later batch. |
+| `AtmError` | Existing delivery-failure type; no new retry/result enum is introduced. |
+
+No `PeerHttpTransport`, `PeerHttpSender` trait, connection manager, pool,
+worker, queue, or test transport abstraction is authorized.
 
 ## Deliverables
 
-1. Add one direct plain trusted-LAN HTTP sender using the existing JSON
-   `WriteRequest`/`ResponseEnvelope` contract and receiver handler.
-2. Route host-qualified admission directly to it with the in-memory write; do
-   not reload SQLite.
-3. On failure, leave the admitted record explicitly undelivered and return a
-   delivery error. Do not add retry behavior.
-4. Update requirements, ADRs, architecture/boundaries, OpenAPI if affected,
-   and smoke documentation for the proven no-retry baseline.
+1. Add only `send_peer_http_frames`, using one real bounded socket and the shared HTTP
+   framing implementation. It owns one bounded connection/deadline and emits
+   one write frame/response per input in order; do not add a transport trait,
+   connection pool, background connection lifecycle, or test-only delivery
+   substitute. A response count/order mismatch, malformed frame, unexpected
+   response variant, error response, connect refusal, write failure, and
+   read timeout are all typed delivery failures; none may confirm a write.
+   Build one immutable `PeerHttpRuntimeConfig` from configured interface data
+   at configuration load/reload; do not query peer configuration per send.
+2. Extract/rename the plaintext branch of `HttpsListenerSet` to
+   `PeerHttpListenerSet` and make it the configured production trusted-LAN
+   listener. Retain its listed bounded accept/request execution unchanged;
+   delete the `PlaintextTest`/`UntrustedSmoke` production distinction. A write
+   with the configured source-host header is admitted as `WriteIngress::Peer`
+   after the existing provenance validation. Do not authenticate or route from
+   that header in AK.4.
+3. Route a host-qualified admission directly to that function with its
+   in-memory immutable write after the canonical SQLite commit; do not reload
+   SQLite, read all peers, resolve aliases, or look up a literal address.
+4. On any connect/write/read/response failure, leave every admitted origin
+   record undelivered and return one delivery error that states persistence
+   succeeded. Do not add retry behavior, retry state, an outbox, or nudge at
+   the origin. A receiver that accepts a frame uses its ordinary post-write
+   nudge path.
+5. For every matching `ResponseEnvelope::Send` response, call the one atomic
+   `MessageStore::confirm_peer_delivery(PeerDeliveryConfirmation { message_id,
+   canonical_host })` mutation. It verifies the matching canonical host and
+   removes only `peerOutbound`; it never changes the immutable body, ULID,
+   timestamp, read/ACK state, mailbox history, or remote record. A repeated
+   confirmation is a harmless no-op. A mismatched ULID, wrong response variant,
+   or `ResponseEnvelope::Error` is a delivery failure and retains
+   `peerOutbound`. This is not an outbox, receipt table, or delivery-state
+   enum.
+6. Add real-loopback integration tests using the production sender and
+   receiver, including a split response frame and multiple frames on one
+   connection. Mocks may observe the receiver only after the real HTTP frame
+   parser; they may not replace the sender or receiver transport. Also prove
+   successful confirmation removes the message from
+   `OutboundMessageQuery::page_for_peer`; failed/partial responses leave only
+   their corresponding `peerOutbound` metadata.
+7. In this same change, create `ADR-045` for the direct trusted-LAN HTTP
+   delivery decision. It supersedes the active transport decisions in
+   ADR-034, ADR-040, and ADR-041; ADR-035 remains the canonical ingress ADR
+   but is amended to say local, loopback, same-IP, and cross-host ingress have
+   one receiver/nudge path. Update `docs/adr/INDEX.md`,
+   `docs/requirements.md` (`REQ-CORE-TRANSPORT-002`, `-002A`, `-002B`,
+   `-002B1`, `-002C`, `-002D`, `-003`, `-004`, and `-005A`),
+   `docs/{architecture,boundaries}.md`,
+   `docs/atm-daemon/{architecture,boundaries,http-api,requirements}.md`,
+   `docs/atm/{architecture,requirements}.md`, and
+   `docs/peer-pair-smoke.md`. The documentation must describe the active
+   plain-HTTP trusted-LAN MVP and its no-retry baseline without claiming that
+   AK.6 has already deleted legacy TLS code. Update the repository
+   `crosshost-curl-plain` runner so it starts the configured production
+   `PeerHttpListenerSet` without `plaintext-test`/`UntrustedSmoke`; retain a
+   separately named interop-only mTLS fixture lane for AK.6.
+
+## Explicit prohibitions
+
+- No coordinator, outbound per-message thread, DNS thread, outbound worker,
+  queue, channel, scan, retry, timer, `peer_sync`, or immediate
+  durable-request reload. The explicitly inventoried bounded receiver threads
+  are retained, not expanded.
+- No source-host value from user input, and no local-host/same-IP incoming
+  branch. Local, loopback, same-IP, and cross-host frames use the same
+  receiver/nudge path.
 
 ## Required validation
 
-- Integration: production send and curl submit the same JSON and receive the
-  same response shape.
+- Integration: production send and curl submit the same JSON/provenance and
+  receive the same response shape through the configured production
+  `PeerHttpListenerSet`; neither test may enable `plaintext-test` or use
+  `UntrustedSmoke`.
+- Integration: the configured production `PeerHttpListenerSet` admits a
+  header-bearing plain HTTP write as `WriteIngress::Peer`; loopback, same-IP,
+  and cross-host use this exact receiver/nudge path.
+- Integration: a one-element immediate call and a multi-frame call use the
+  same function and preserve the original ULID/timestamp per write.
+- Integration: DNS resolution failure, connect refusal, receiver `4xx/5xx`,
+  truncated/split/malformed response frames, mismatched response count, and a
+  response for the wrong ULID retain `peerOutbound`, emit no origin nudge, and
+  leave the receiver mailbox unchanged unless that receiver accepted its exact
+  frame.
+- Integration: only matching `ResponseEnvelope::Send` responses retire exactly their matching
+  `peerOutbound`; a later oldest-first query cannot select accepted writes,
+  while a failed write remains selectable.
 - Smoke: M4→M5 and M5→M4 each prove production send, remote read, acknowledged
-  reply, full-host rendering, and one receiver nudge; curl is the independent
-  request-path proof.
+  reply, full-host rendering, and one receiver nudge. Run the standard
+  `just smoke localhost`, `just smoke local-ip`, `just smoke crosshost-send`,
+  `just smoke crosshost-ack`, and `just smoke crosshost-curl-plain` lanes in
+  both directions using isolated test homes/databases. Curl is the independent
+  request-path proof, not a substitute for production sender evidence.
 - `just lint` and `just test` pass.
 
 ## Dependencies

--- a/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
+++ b/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
@@ -1,0 +1,57 @@
+---
+title: AK.5 Direct peer resend cache and timer aggregate
+status: proposed
+target: integrate/phase-ak
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+must_follow: AK.4
+parallel_safe: false
+---
+
+# AK.5 — direct peer resend cache and timer aggregate
+
+## Closure
+
+Add optional default-on resend caching to AK.4's proven direct HTTP function.
+It adds one endpoint aggregate and one timer, never a worker or alternate path.
+
+## Fixed contract
+
+```rust
+enum PeerConnectionState { Connected, Disconnected, Queued }
+```
+
+`peer_resend_cache` defaults to `true`. Connected sends call AK.4 directly;
+transient failure queues one endpoint aggregate and arms one timer; queued
+sends only append identities. The timer fires no sooner than 60 seconds, loads
+the oldest-first immutable origin records for that endpoint once, and calls
+AK.4's same HTTP function. Full
+success sets `Connected`; failure retains and re-arms. Disabled caching is
+exactly AK.4: failed messages remain undelivered and return an error.
+
+## Deliverables
+
+1. Add the three-value endpoint state, one timer-backed aggregate, and the
+   default-on `peer_resend_cache` daemon setting.
+2. Route immediate and timer sends exclusively through AK.4's HTTP function.
+3. Keep this transport state separate from agent/session/roster/nudge state.
+4. Update requirements/architecture/ADR language for optional resend caching;
+   state that AK.6 deletes obsolete legacy support.
+
+## Required validation
+
+- Unit: connected direct send, disconnected no-connect, and queued two-ULID
+  oldest-first timer resend.
+- Unit: disabled caching leaves no aggregate/timer and returns an error.
+- Unit: no coordinator, worker, per-message thread, channel, or immediate
+  SQLite reload exists.
+- Integration: immediate and timer resend use the same receiver/nudge path.
+- `just lint` and `just test` pass.
+
+## Dependencies
+
+Before every AK.5 development/fix round, merge AK.4 into AK.5. Start AK.5 as
+soon as AK.4 is pushed; do not wait for QA. AK.5 PR completion waits for AK.4
+merge. Push AK.5, then start AK.6 with AK.5→AK.6 merge-forward.
+`must_follow` is required because AK.6 removes only code superseded by the
+AK.4/AK.5 path; it is not parallel-safe because both touch peer transport.

--- a/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
+++ b/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
@@ -34,6 +34,17 @@ struct PeerResendState {
 }
 
 const PEER_RESEND_BATCH_LIMIT: u16 = 64;
+const PEER_RESEND_DUE_CALLBACK_BUDGET: Duration = Duration::from_millis(250);
+
+enum LocalIpcWaitOutcome {
+    Accepted(LocalSocketStream),
+    DeadlineElapsed,
+}
+
+fn accept_until(
+    listener: &LocalSocketListener,
+    deadline: Option<Instant>,
+) -> Result<LocalIpcWaitOutcome, AtmError>;
 
 struct PeerResendCacheSetting {
     enabled: bool,
@@ -78,23 +89,49 @@ do not connect. Full success sets `Connected`; any failure returns it to
 `Queued` with a new due time. `Disconnected` is only this in-progress guard,
 not a health claim and not a fourth state.
 
+With caching enabled, a first `Connected`-state attempt that fails queues the
+endpoint **and returns the exact ordinary AK.4 delivery `AtmError`** to the
+initiating caller. It is never converted to success or to a masked
+"accepted for retry" result. A later admission while already `Queued` makes
+no connection attempt, persists its immutable write, and returns a typed
+pending-delivery error. Both errors state that local persistence succeeded;
+neither emits an origin nudge.
+
 There is no general timer service today. AK.5 extends the existing local IPC
-accept loop with the scheduler's one `earliest_due` deadline. Before that
-deadline, the loop does not scan resend state or SQLite; at the deadline it
-calls `poll_due_peer_resends(now)`. It creates no timer thread, worker, task,
-channel, or periodic resend polling loop. The callback chooses at most one due
-endpoint per due event, reads one bounded oldest-first page from
-`OutboundMessageQuery::page_for_peer`, and calls AK.4's same slice sender.
+serve loop with the scheduler's one `earliest_due` deadline because that loop
+already owns daemon lifetime, shutdown, and runtime-view reload. The peer HTTP
+listener remains inbound-only and must not initiate outbound delivery.
+`accept_until` replaces an unbounded accept wait in that existing loop: it
+returns `DeadlineElapsed` no earlier than its monotonic deadline or
+`Accepted` when a local client arrives. It is a deadline-aware wait in the
+existing loop, not a timer thread, worker, task, channel, or polling loop.
+
+At each loop turn, `poll_due_peer_resends(now)` selects at most one due
+endpoint by `(due_at, canonical_host, port)`, reads one bounded oldest-first
+page from `OutboundMessageQuery::page_for_peer`, and calls AK.4's same slice
+sender with a fresh internal `PEER_RESEND_DUE_CALLBACK_BUDGET` of 250 ms.
+This is the only bounded work permitted in the serve loop after a deadline;
+the normal immediate AK.4 path retains its originating request deadline.
+After every callback the scheduler recomputes `earliest_due`. If another
+endpoint is already due, the next loop turn has a zero-duration wait and
+drains that endpoint before a later wait; otherwise the loop accepts normally.
+This one-endpoint-per-turn order prevents a failing endpoint from starving
+other due endpoints or local admissions, without creating a coordinator.
 `PEER_RESEND_BATCH_LIMIT` is exactly `64`; its one conversion to `NonZeroU16`
 for `page_for_peer` is checked. It bounds one direct batch, not the durable
 backlog. An endpoint absent from
 the map is optimistically `Connected`; no health state is persisted. On runtime
 construction when caching is enabled, `bootstrap_pending_peer_resends` performs
 one read-only `SELECT DISTINCT peerOutbound.host` query of already-undelivered
-records. Its result has at most one row per configured canonical peer, not one
-row per message; it creates `Queued` aggregates due no earlier than 60 seconds
-later. It reads no payload and opens no connection. This is the only restart
-recovery: it is not a worker, peer-config scan, or recurring database poll.
+records. For each returned canonical `HostName`, it calls
+`PeerDirectory::endpoint_for_canonical_host`; only `Some(PeerEndpoint)` creates
+one `Queued` aggregate due no earlier than 60 seconds later. `None` means the
+host is no longer configured: retain its durable record untouched, log the
+configuration mismatch, and create no aggregate, guessed port, DNS lookup, or
+connection. A later configuration reload builds a fresh scheduler and performs
+the same one bootstrap query, allowing a restored configured endpoint to queue
+normally. This is the only restart recovery: it is not a worker, peer-config
+scan, or recurring database poll.
 Disabled caching is exactly AK.4: failed messages remain undelivered and return
 an error with no aggregate or due event.
 
@@ -105,14 +142,16 @@ an error with no aggregate or due event.
 | `PeerConnectionState` | New three-value enum only: `Connected`, `Disconnected`, `Queued { due_at }`. It is endpoint transport state, never agent health. |
 | `PeerResendAggregate` | New per-endpoint in-memory state: only `state`; `Queued` owns `due_at`, so connected/disconnected values cannot carry a meaningless deadline. It has no payload, ULID list, receipt, or peer scan result. |
 | `PeerResendState` | New private mutex-protected aggregate map plus `earliest_due`. It is the sole atomic state owner; no separate lock or atomics may mirror its deadline. |
-| `PeerResendScheduler::{deliver_or_queue, bootstrap_pending_peer_resends, poll_due_peer_resends, next_due}` | New owner of the one mutex-protected state, immutable AK.3 directory/AK.4 HTTP config, and existing sealed storage ports. These direct dependencies let both singleton and batch calls use AK.4's exact sender/confirmation without a new trait/service. `next_due` exposes the coalesced earliest deadline; `poll_due_peer_resends(now)` runs only at/after it and owns no thread/task/channel. |
+| `PeerResendScheduler::{deliver_or_queue, bootstrap_pending_peer_resends, poll_due_peer_resends, next_due}` | New owner of the one mutex-protected state, immutable AK.3 directory/AK.4 HTTP config, and existing sealed storage ports. These direct dependencies let both singleton and batch calls use AK.4's exact sender/confirmation without a new trait/service. `next_due` exposes the coalesced earliest deadline; `poll_due_peer_resends(now)` chooses one due endpoint deterministically and owns no thread/task/channel. |
 | `Instant` | Existing monotonic clock value. It exists only inside `Queued { due_at }`; no wall-clock timestamp or transport health is persisted. |
 | `PeerResendCacheSetting`, `peer_delivery_settings` | New persisted one-bit default-on setting and its exact one-row table. It replaces no old policy and has no per-peer override in this sprint. |
 | `PeerConfigStore::{peer_resend_cache_setting, save_peer_resend_cache_setting}` | New sealed configuration accessors for the one setting. Saving uses the existing runtime-view reload; it does not start a worker or mutate a live endpoint map directly. |
 | `PeerSubcommand::ResendCache`, `ResendCacheCommand` | New explicit CLI configuration surface for showing or setting the one Boolean. It owns no send/retry operation and has no per-peer form. |
-| `PEER_RESEND_BATCH_LIMIT` | New exact `u16` bound of 64 for one oldest-first due batch; the sole `NonZeroU16` conversion occurs at `page_for_peer`. It is not an admission, connection, or retry-attempt cap. |
-| `RuntimeServeHooks::{next_peer_resend_due, poll_due_peer_resends}` | Two new closure fields used by the existing local-IPC wait path: it caps the wait at the coalesced deadline and invokes the due callback only when due. They are not a new trait, thread, task, channel, or loop. |
-| `OutboundMessageQuery::{pending_peer_endpoints, page_for_peer}` | Read-only immutable backlog readers. The former is one startup-only distinct-host query; the latter is the only payload read in a due batch. |
+| `PEER_RESEND_BATCH_LIMIT`, `PEER_RESEND_DUE_CALLBACK_BUDGET` | New exact bounds: 64 writes for one oldest-first due batch and 250 ms for one due callback. The sole `NonZeroU16` conversion occurs at `page_for_peer`. Neither is an admission, connection, or retry-attempt cap. |
+| `LocalIpcWaitOutcome`, `accept_until` | New deadline-aware operation inside the existing local IPC serve loop. It returns one accepted local stream or one elapsed monotonic deadline; it adds no thread, timer service, channel, or second event loop. |
+| `RuntimeServeHooks::{next_peer_resend_due, poll_due_peer_resends}` | Two new closure fields used by the existing local-IPC wait path: `next_peer_resend_due` supplies `accept_until`'s cap and `poll_due_peer_resends` runs one due endpoint after `DeadlineElapsed`. They are not a new trait, thread, task, channel, or loop. |
+| `PeerDirectory::endpoint_for_canonical_host` | AK.3 bootstrap-only lookup from durable canonical host to its current `PeerEndpoint`, including port. It returns `None` for a deleted/disabled host and never guesses a port or uses DNS. |
+| `OutboundMessageQuery::{pending_peer_hosts, page_for_peer}` | Read-only immutable backlog readers. `pending_peer_hosts` is the one startup-only `SELECT DISTINCT peerOutbound.host` query; `page_for_peer` is the only payload read in a due batch. |
 | `MessageStore::confirm_peer_delivery` | AK.4's existing sealed confirmation port, held only to retire each confirmed durable record after the shared sender returns its matching response. |
 | `send_peer_http_frames` | AK.4 sender reused unchanged for singleton and batch delivery. |
 
@@ -131,18 +170,25 @@ connection pool, or health model is authorized without a plan amendment.
    HTTP config, and setting: `false` drops all transient aggregates, while
    `true` performs the one bootstrap query. It does not mutate old scheduler
    state in place.
-2. Add only the existing-accept-loop due callback described above. It must
-   perform no DNS, peer-config scan, or resend work before `due_at`; one due
-   callback may select only one endpoint and one bounded oldest-first page.
-   Coalesce deadlines in `earliest_due`; do not call a resend callback on each
-   1 ms `WouldBlock` pass.
+2. Add only the deadline-aware existing-accept-loop callback described above.
+   `accept_until` waits for a local connection or the one coalesced monotonic
+   deadline; it must perform no DNS, peer-config scan, or resend work before
+   `due_at`. One due callback selects only one deterministic endpoint and one
+   bounded oldest-first page, with the exact 250 ms callback budget. Recompute
+   `earliest_due` after it so already-due peers drain one per loop turn; do not
+   call a resend callback on each 1 ms `WouldBlock` pass.
 3. Route immediate singleton and timer batch delivery exclusively through
    AK.4's `send_peer_http_frames`. A timer batch is a slice into that function,
    not a second transport or receiver path.
 4. Keep resend state separate from agent/session/roster/nudge state. A
    receiver's nudge remains normal post-write behavior and is never used as a
    resend signal.
-5. Update requirements/architecture/ADR language for optional resend caching;
+5. Bootstrap only through `pending_peer_hosts` followed by
+   `PeerDirectory::endpoint_for_canonical_host`. A durable host absent from
+   the current directory remains untouched and unqueued; it is retried only
+   if a later configuration reload restores a matching configured endpoint.
+   Never infer its port, scan peers, or consult DNS.
+6. Update requirements/architecture/ADR language for optional resend caching;
    state that AK.6 deletes obsolete legacy support. Create `ADR-046` for the
    three-state, in-memory endpoint aggregate and one startup recovery query;
    revise `REQ-CORE-TRANSPORT-003` and `-003B` so immutable `peerOutbound`
@@ -160,16 +206,20 @@ connection pool, or health model is authorized without a plan amendment.
 
 ## Required validation
 
-- Unit: `Connected` immediate singleton success; failure queues exactly one
-  endpoint deadline; `Queued` adds no connection attempt; `Disconnected`
-  prevents a concurrent attempt.
+- Unit: `Connected` immediate singleton success; its first failure queues
+  exactly one endpoint deadline and returns the same AK.4 delivery error;
+  `Queued` adds no connection attempt and returns typed pending-delivery;
+  `Disconnected` prevents a concurrent attempt.
 - Unit: due callback reads one oldest-first page and passes its ordered writes
   of at most `PEER_RESEND_BATCH_LIMIT` to AK.4's exact slice sender;
   partial/failure re-arms without duplicating durable records.
 - Unit: a daemon restart with enabled caching performs one distinct-pending-host
-  bootstrap, schedules no payload or connection before 60 seconds, and later
-  uses the same due callback. With caching disabled, it performs no bootstrap,
-  creates no aggregate, and does not retry a retained record.
+  bootstrap, derives every queued endpoint and port only through
+  `endpoint_for_canonical_host`, schedules no payload or connection before 60
+  seconds, and later uses the same due callback. An absent configured host
+  stays durable-but-unqueued with no guessed port or DNS lookup. With caching
+  disabled, it performs no bootstrap, creates no aggregate, and does not retry
+  a retained record.
 - Migration: an existing database receives the one default-on settings row;
   an explicit `false` survives restart and creates no aggregate.
 - CLI/integration: `atm peer resend-cache set false` persists the setting and
@@ -178,6 +228,11 @@ connection pool, or health model is authorized without a plan amendment.
   with no duplicate endpoint aggregate.
 - Unit: disabled caching leaves no aggregate/due event and returns the AK.4
   delivery error.
+- Unit/integration: `accept_until` never invokes resend before `due_at`, emits
+  `DeadlineElapsed` at the coalesced monotonic deadline, and processes due
+  endpoint ties by `(due_at, canonical_host, port)` one per loop turn. A
+  250-ms stalled due callback neither creates a thread nor prevents the next
+  local accepted connection from being dispatched.
 - Source gate: no coordinator, worker, timer thread, per-message thread,
   channel, immediate SQLite reload, DNS thread, or peer scan exists.
 - Integration: immediate and timer resend use the same receiver/nudge path.

--- a/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
+++ b/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
@@ -259,6 +259,8 @@ connection pool, or health model is authorized without a plan amendment.
 
 Before every AK.5 development/fix round, merge AK.4 into AK.5. Start AK.5 as
 soon as AK.4 is pushed; do not wait for QA. AK.5 PR completion waits for AK.4
-merge. Push AK.5, then start AK.6 with AK.5→AK.6 merge-forward.
-`must_follow` is required because AK.6 removes only code superseded by the
-AK.4/AK.5 path; it is not parallel-safe because both touch peer transport.
+merge. AK.6 may already be developing its isolated fixture work after the
+Phase AI entry gate; after AK.5 is pushed, it must merge AK.5 before its final
+validation, final fix round, or PR completion.
+`must_follow` is required because AK.5 retries AK.4's one verified function;
+AK.6 deletes code superseded by the AK.4/AK.5 path only after that merge gate.

--- a/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
+++ b/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
@@ -18,34 +18,183 @@ It adds one endpoint aggregate and one timer, never a worker or alternate path.
 ## Fixed contract
 
 ```rust
-enum PeerConnectionState { Connected, Disconnected, Queued }
+enum PeerConnectionState {
+    Connected,
+    Disconnected,
+    Queued { due_at: Instant },
+}
+
+struct PeerResendAggregate {
+    state: PeerConnectionState,
+}
+
+struct PeerResendState {
+    aggregates: HashMap<PeerEndpoint, PeerResendAggregate>,
+    earliest_due: Option<Instant>,
+}
+
+const PEER_RESEND_BATCH_LIMIT: u16 = 64;
+
+struct PeerResendCacheSetting {
+    enabled: bool,
+}
+
+struct PeerResendScheduler {
+    state: Mutex<PeerResendState>,
+    setting: PeerResendCacheSetting,
+    http: PeerHttpRuntimeConfig,
+    directory: PeerDirectory,
+    outbound: Arc<dyn OutboundMessageQuery + Send + Sync>,
+    messages: Arc<dyn MessageStore + Send + Sync>,
+}
+
+impl PeerResendScheduler {
+    fn deliver_or_queue(
+        &self,
+        endpoint: PeerEndpoint,
+        write: WriteRequest,
+        deadline: RequestDeadline,
+    ) -> Result<(), AtmError>;
+    fn bootstrap_pending_peer_resends(&self) -> Result<(), AtmError>;
+    fn next_due(&self) -> Option<Instant>;
+    fn poll_due_peer_resends(&self, now: Instant) -> Result<(), AtmError>;
+}
 ```
 
-`peer_resend_cache` defaults to `true`. Connected sends call AK.4 directly;
-transient failure queues one endpoint aggregate and arms one timer; queued
-sends only append identities. The timer fires no sooner than 60 seconds, loads
-the oldest-first immutable origin records for that endpoint once, and calls
-AK.4's same HTTP function. Full
-success sets `Connected`; failure retains and re-arms. Disabled caching is
-exactly AK.4: failed messages remain undelivered and return an error.
+`peer_resend_cache` defaults to `true`; it is stored in the one-row
+`peer_delivery_settings(singleton PRIMARY KEY CHECK (singleton = 1),
+resend_cache_enabled INTEGER NOT NULL DEFAULT 1)` table. The scheduler owns one
+`PeerResendState` under one mutex; it stores no payload, request copy, ULID
+list, agent/session state, or delivery result. The immutable `peerOutbound`
+records remain the sole backlog. The mutex makes the admission transition,
+`Disconnected` in-progress guard, and earliest-deadline update one atomic
+state transition.
+
+`Connected` performs AK.4's `send_peer_http_frames` immediately. A failure
+sets `Queued { due_at >= now + 60s }`; new sends for a queued endpoint only
+persist and return a pending-delivery error. When the due event begins its one
+oldest-first batch, the endpoint is `Disconnected` so concurrent admissions
+do not connect. Full success sets `Connected`; any failure returns it to
+`Queued` with a new due time. `Disconnected` is only this in-progress guard,
+not a health claim and not a fourth state.
+
+There is no general timer service today. AK.5 extends the existing local IPC
+accept loop with the scheduler's one `earliest_due` deadline. Before that
+deadline, the loop does not scan resend state or SQLite; at the deadline it
+calls `poll_due_peer_resends(now)`. It creates no timer thread, worker, task,
+channel, or periodic resend polling loop. The callback chooses at most one due
+endpoint per due event, reads one bounded oldest-first page from
+`OutboundMessageQuery::page_for_peer`, and calls AK.4's same slice sender.
+`PEER_RESEND_BATCH_LIMIT` is exactly `64`; its one conversion to `NonZeroU16`
+for `page_for_peer` is checked. It bounds one direct batch, not the durable
+backlog. An endpoint absent from
+the map is optimistically `Connected`; no health state is persisted. On runtime
+construction when caching is enabled, `bootstrap_pending_peer_resends` performs
+one read-only `SELECT DISTINCT peerOutbound.host` query of already-undelivered
+records. Its result has at most one row per configured canonical peer, not one
+row per message; it creates `Queued` aggregates due no earlier than 60 seconds
+later. It reads no payload and opens no connection. This is the only restart
+recovery: it is not a worker, peer-config scan, or recurring database poll.
+Disabled caching is exactly AK.4: failed messages remain undelivered and return
+an error with no aggregate or due event.
+
+## Type and boundary inventory
+
+| Item | AK.5 role |
+| --- | --- |
+| `PeerConnectionState` | New three-value enum only: `Connected`, `Disconnected`, `Queued { due_at }`. It is endpoint transport state, never agent health. |
+| `PeerResendAggregate` | New per-endpoint in-memory state: only `state`; `Queued` owns `due_at`, so connected/disconnected values cannot carry a meaningless deadline. It has no payload, ULID list, receipt, or peer scan result. |
+| `PeerResendState` | New private mutex-protected aggregate map plus `earliest_due`. It is the sole atomic state owner; no separate lock or atomics may mirror its deadline. |
+| `PeerResendScheduler::{deliver_or_queue, bootstrap_pending_peer_resends, poll_due_peer_resends, next_due}` | New owner of the one mutex-protected state, immutable AK.3 directory/AK.4 HTTP config, and existing sealed storage ports. These direct dependencies let both singleton and batch calls use AK.4's exact sender/confirmation without a new trait/service. `next_due` exposes the coalesced earliest deadline; `poll_due_peer_resends(now)` runs only at/after it and owns no thread/task/channel. |
+| `Instant` | Existing monotonic clock value. It exists only inside `Queued { due_at }`; no wall-clock timestamp or transport health is persisted. |
+| `PeerResendCacheSetting`, `peer_delivery_settings` | New persisted one-bit default-on setting and its exact one-row table. It replaces no old policy and has no per-peer override in this sprint. |
+| `PeerConfigStore::{peer_resend_cache_setting, save_peer_resend_cache_setting}` | New sealed configuration accessors for the one setting. Saving uses the existing runtime-view reload; it does not start a worker or mutate a live endpoint map directly. |
+| `PeerSubcommand::ResendCache`, `ResendCacheCommand` | New explicit CLI configuration surface for showing or setting the one Boolean. It owns no send/retry operation and has no per-peer form. |
+| `PEER_RESEND_BATCH_LIMIT` | New exact `u16` bound of 64 for one oldest-first due batch; the sole `NonZeroU16` conversion occurs at `page_for_peer`. It is not an admission, connection, or retry-attempt cap. |
+| `RuntimeServeHooks::{next_peer_resend_due, poll_due_peer_resends}` | Two new closure fields used by the existing local-IPC wait path: it caps the wait at the coalesced deadline and invokes the due callback only when due. They are not a new trait, thread, task, channel, or loop. |
+| `OutboundMessageQuery::{pending_peer_endpoints, page_for_peer}` | Read-only immutable backlog readers. The former is one startup-only distinct-host query; the latter is the only payload read in a due batch. |
+| `MessageStore::confirm_peer_delivery` | AK.4's existing sealed confirmation port, held only to retire each confirmed durable record after the shared sender returns its matching response. |
+| `send_peer_http_frames` | AK.4 sender reused unchanged for singleton and batch delivery. |
+
+No other retry struct, enum, trait, timer service, executor, worker, queue,
+connection pool, or health model is authorized without a plan amendment.
 
 ## Deliverables
 
-1. Add the three-value endpoint state, one timer-backed aggregate, and the
-   default-on `peer_resend_cache` daemon setting.
-2. Route immediate and timer sends exclusively through AK.4's HTTP function.
-3. Keep this transport state separate from agent/session/roster/nudge state.
-4. Update requirements/architecture/ADR language for optional resend caching;
-   state that AK.6 deletes obsolete legacy support.
+1. Add the exact three-value state and one aggregate per canonical endpoint;
+   persist only the default-on `peer_resend_cache` setting. Do not reuse
+   `PeerSyncPolicy`, add a per-message retry table, or store a second request.
+   `Session`/agent/roster data is neither read nor written.
+   Add only the listed peer-config accessors and `atm peer resend-cache
+   {show,set <true|false>}`; a save uses the existing runtime-view reload. A
+   reload builds one fresh scheduler from the current immutable directory,
+   HTTP config, and setting: `false` drops all transient aggregates, while
+   `true` performs the one bootstrap query. It does not mutate old scheduler
+   state in place.
+2. Add only the existing-accept-loop due callback described above. It must
+   perform no DNS, peer-config scan, or resend work before `due_at`; one due
+   callback may select only one endpoint and one bounded oldest-first page.
+   Coalesce deadlines in `earliest_due`; do not call a resend callback on each
+   1 ms `WouldBlock` pass.
+3. Route immediate singleton and timer batch delivery exclusively through
+   AK.4's `send_peer_http_frames`. A timer batch is a slice into that function,
+   not a second transport or receiver path.
+4. Keep resend state separate from agent/session/roster/nudge state. A
+   receiver's nudge remains normal post-write behavior and is never used as a
+   resend signal.
+5. Update requirements/architecture/ADR language for optional resend caching;
+   state that AK.6 deletes obsolete legacy support. Create `ADR-046` for the
+   three-state, in-memory endpoint aggregate and one startup recovery query;
+   revise `REQ-CORE-TRANSPORT-003` and `-003B` so immutable `peerOutbound`
+   data remains the sole durable backlog while the aggregate is explicitly
+   non-durable. Update `docs/adr/INDEX.md`, `docs/architecture.md`,
+   `docs/boundaries.md`, `docs/atm-daemon/{architecture,boundaries,requirements}.md`,
+   `docs/atm/{architecture,requirements}.md`, and `docs/peer-pair-smoke.md`.
+
+## Explicit prohibitions
+
+- No coordinator, timer thread, worker, task, per-message thread, channel,
+  connection pool, global background scan, DNS thread, or peer-row scan.
+- No retry when caching is disabled; no hidden automatic retry in AK.4.
+- No decision based on agent state, session ID, roster state, or a nudge.
 
 ## Required validation
 
-- Unit: connected direct send, disconnected no-connect, and queued two-ULID
-  oldest-first timer resend.
-- Unit: disabled caching leaves no aggregate/timer and returns an error.
-- Unit: no coordinator, worker, per-message thread, channel, or immediate
-  SQLite reload exists.
+- Unit: `Connected` immediate singleton success; failure queues exactly one
+  endpoint deadline; `Queued` adds no connection attempt; `Disconnected`
+  prevents a concurrent attempt.
+- Unit: due callback reads one oldest-first page and passes its ordered writes
+  of at most `PEER_RESEND_BATCH_LIMIT` to AK.4's exact slice sender;
+  partial/failure re-arms without duplicating durable records.
+- Unit: a daemon restart with enabled caching performs one distinct-pending-host
+  bootstrap, schedules no payload or connection before 60 seconds, and later
+  uses the same due callback. With caching disabled, it performs no bootstrap,
+  creates no aggregate, and does not retry a retained record.
+- Migration: an existing database receives the one default-on settings row;
+  an explicit `false` survives restart and creates no aggregate.
+- CLI/integration: `atm peer resend-cache set false` persists the setting and
+  the reloaded scheduler takes the no-retry path without daemon restart or new
+  background work; toggling it back to `true` creates one fresh bootstrap map
+  with no duplicate endpoint aggregate.
+- Unit: disabled caching leaves no aggregate/due event and returns the AK.4
+  delivery error.
+- Source gate: no coordinator, worker, timer thread, per-message thread,
+  channel, immediate SQLite reload, DNS thread, or peer scan exists.
 - Integration: immediate and timer resend use the same receiver/nudge path.
+- Integration: each non-error batch response invokes AK.4's exact
+  `confirm_peer_delivery`; a partial response leaves only unconfirmed writes
+  eligible for the next oldest-first batch.
+- Integration: successful immediate delivery, failed-then-recovered delivery,
+  and a restarted queued backlog all use the same receiver persistence and
+  post-write nudge path exactly once per accepted ULID. A timeout, malformed
+  response, duplicate response, or nudge emission failure never becomes a
+  resend-success signal.
+- Smoke: after local `just smoke localhost` and `just smoke local-ip`, run
+  isolated M4→M5 and M5→M4 `crosshost-send`, `crosshost-ack`, and
+  `crosshost-curl-plain` lanes. For enabled caching, induce one connection
+  failure, wait for the documented due event, and prove one recovered remote
+  read plus one receiver nudge; for disabled caching, prove the record remains
+  undelivered and no automatic resend occurs.
 - `just lint` and `just test` pass.
 
 ## Dependencies

--- a/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
+++ b/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
@@ -1,6 +1,8 @@
 ---
 title: AK.5 Direct peer resend cache and timer aggregate
 status: proposed
+branch: feature/pak-s5-direct-peer-timer-state
+worktree: ../atm-core-worktrees/feature/pak-s5-direct-peer-timer-state
 target: integrate/phase-ak
 recommended_agent: arch-ctm
 recommended_model: deep-reasoning
@@ -194,7 +196,8 @@ connection pool, or health model is authorized without a plan amendment.
    revise `REQ-CORE-TRANSPORT-003` and `-003B` so immutable `peerOutbound`
    data remains the sole durable backlog while the aggregate is explicitly
    non-durable. Update `docs/adr/INDEX.md`, `docs/architecture.md`,
-   `docs/boundaries.md`, `docs/atm-daemon/{architecture,boundaries,requirements}.md`,
+   `docs/atm-storage/boundaries.md`,
+   `docs/atm-daemon/{architecture,boundaries,requirements}.md`,
    `docs/atm/{architecture,requirements}.md`, and `docs/peer-pair-smoke.md`.
 
 ## Explicit prohibitions

--- a/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
+++ b/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
@@ -18,30 +18,95 @@ receiver interoperability in `crates/atm-peer-tls-interop`; it is not a native
 ATM TLS sender and no active daemon, CLI, graft, or send-path crate may depend
 on it.
 
+The current deletion boundary is explicit: remove
+`peer_resolution.rs`, `runtime_health/peer_authority.rs`,
+`HttpsMessageTransport`, `SharedHttpsTransport`, `HttpsTransport`, `TlsIdentity`,
+`PinnedClientVerifier`, TLS client connection/open/deliver helpers, and the
+daemon composition outbound transport slot. Remove all literal-IP fallback and
+every DNS/thread helper. Retain the AK.4 `PeerHttpListenerSet` plain receiver;
+it is not TLS machinery. Retain only the data/provisioning APIs needed to construct
+the separate interop crate and a curl mTLS receiver fixture there. That crate
+is an isolated verification/provisioning utility, not an active transport
+dependency.
+
+## Type and boundary inventory
+
+| Item | AK.6 role |
+| --- | --- |
+| `TlsInteropConfig` | New interop-only value object containing the existing `LocalCertificate` and `TrustedPeer` provisioning data needed by curl verification. It has no routing or send method. |
+| `CurlMtlsReceiverFixture` | New interop-only, synchronous one-shot receiver fixture for curl proof. It has no production caller, background thread, worker, or daemon lifecycle ownership. |
+| `LocalCertificate`, `CertificateFingerprint`, `TrustedPeer` | Existing durable provisioning/configuration values retained only for the interop fixture and configuration display. They do not select a production route. |
+| `PeerHttpListenerSet`, `PeerHttpListener`, `PeerConnectionAdmission`, `route_peer_http_request`, `ActiveConnectionRegistry` | AK.4's retained production plain receiver. AK.6 must neither delete it nor add a replacement receiver/thread model. |
+| `PeerHttpRuntimeConfig` | AK.4's retained immutable source-host snapshot. AK.6 must retain it without adding a TLS, resolver, or delivery capability. |
+| `PeerWireSecurity`, `HttpsMessageTransport`, `SharedHttpsTransport`, `HttpsTransport`, `TlsIdentity`, `PinnedClientVerifier`, TLS `ListenerSecurity::MutualTls`, TLS handshake helpers | Existing TLS transport types to delete from active code. `HttpsListenerSet` has already been renamed to `PeerHttpListenerSet` in AK.4; its plain receiver survives. |
+| `peer_resolution` / `peer_authority` helpers | Existing legacy resolver/authority surfaces to delete; AK.3 `PeerDirectory` is the sole alias mechanism. |
+
+No other interop trait, service, executor, listener, sender, thread, task,
+channel, or production dependency is authorized without a plan amendment.
+
 ## Deliverables
 
 1. Create `crates/atm-peer-tls-interop`. Move verified TLS provisioning,
    certificate/fingerprint configuration/data access, and curl receiver
-   interoperability into it. It exposes no native sender, listener, route,
-   background task, or routing API; active daemon/CLI/graft/send-path crates
-   have no dependency edge to it.
+   interoperability into it. Its public surface is only configuration fixtures
+   and a bounded test receiver; it exposes no native sender, listener used by
+   production, route, background task, thread, DNS resolver, or routing API.
+   Active daemon/CLI/graft/send-path crates have no dependency edge to it.
+   Before moving code, capture a passing curl mTLS fixture proof using the
+   existing certificate/fingerprint records; after the move, the identical
+   fixture must pass from the new crate. This preserves verified provisioning
+   evidence without preserving a native sender.
 2. Delete `peer_resolution.rs`, literal-IP authority discovery, full peer-row
    scans, custom DNS threads, active `HttpsTransport`,
    `PinnedClientVerifier`, `TlsIdentity`, rustls composition, and the failing
    native TLS sender.
-3. Retain AK.3 alias normalization, full-host persistence, and ordinary HTTP
-   hostname resolution at connect time.
-4. Update ADR-034/035, requirements, architecture/boundaries, OpenAPI if
-   affected, and smoke documentation.
+3. Retain AK.3 alias normalization, full-host persistence, and AK.4/AK.5's
+   ordinary HTTP hostname resolution at connect time. Do not move any old
+   sender/retry code into the interop crate merely to preserve it.
+4. Delete obsolete TLS listener lifecycle/config validation from active daemon
+   composition only after AK.4/AK.5 smoke has demonstrated the replacement.
+   Retain the AK.4 `PeerHttpListenerSet` lifecycle unchanged. Preserve durable
+   certificate/fingerprint rows only as interop provisioning data; do not let
+   them influence active routing or retry decisions.
+5. Finalize the active-transport documentation started in AK.4: mark ADR-034,
+   ADR-040, and ADR-041 superseded by ADR-045; retain ADR-035 as the one
+   ingress/router decision and amend only its obsolete TLS/worker language.
+   Update `docs/adr/INDEX.md`, `docs/requirements.md`
+   (`REQ-CORE-TRANSPORT-002`, `-002A`, `-002B`, `-002B1`, `-002C`, `-002D`,
+   `-003`, `-003B`, `-004`, and `-005A`),
+   `docs/{architecture,boundaries}.md`,
+   `docs/atm-daemon/{architecture,boundaries,http-api,requirements}.md`,
+   `docs/atm/{architecture,requirements}.md`, and
+   `docs/peer-pair-smoke.md`. Documentation must distinguish the inactive
+   `atm-peer-tls-interop` curl fixture from active production delivery.
+
+## Explicit prohibitions
+
+- No thread, worker, task, channel, DNS resolver, broad peer scan, native TLS
+  sender, custom connection pool, or fallback transport may move into the new
+  crate. The explicitly inventoried retained plain receiver is the only active
+  listener execution.
+- No active crate may depend on the interop crate, and curl evidence must not
+  be represented as production native-send coverage.
 
 ## Required validation
 
 - Source gate rejects legacy worker, scan, DNS-thread, and TLS symbols from
   active daemon/CLI/graft/send-path crates; `atm-peer-tls-interop` is the sole
   TLS owner.
-- TLS crate: provisioning/configuration round trip and curl mTLS receiver
-  interop pass; no test claims native ATM TLS send works.
-- M4↔M5 smoke proves curl and production send/read/ACK/nudge.
+- Dependency-graph check proves no active crate depends on
+  `atm-peer-tls-interop`.
+- TLS crate: provisioning/configuration round trip, accepted configured curl
+  mTLS peer, and rejected unknown/mismatched client certificate pass; no test
+  claims native ATM TLS send works.
+- Integration: a legacy TLS configuration record cannot select a sender,
+  listener, retry path, alias, or fallback after AK.6; an explicit configured
+  IP alias still canonicalizes through AK.3 and reaches AK.4 HTTP only.
+- Smoke: run `just smoke localhost`, `just smoke local-ip`, and isolated
+  M4→M5 and M5→M4 `crosshost-send`, `crosshost-ack`, and
+  `crosshost-curl-plain` lanes. Each direction proves remote read, ACK reply,
+  full-host provenance, and exactly one receiver nudge. Curl mTLS fixture
+  evidence is recorded separately and never substitutes for production send.
 - `just lint` and `just test` pass.
 
 ## Dependencies

--- a/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
+++ b/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
@@ -99,6 +99,18 @@ channel, or production dependency is authorized without a plan amendment.
    and a bounded test receiver; it exposes no native sender, listener used by
    production, route, background task, thread, DNS resolver, or routing API.
    Active daemon/CLI/graft/send-path crates have no dependency edge to it.
+   Create `boundaries/atm-peer-tls-interop/tls-interop.toml` in this same PR
+   with this minimum isolation contract:
+   ```toml
+   owner_package = "atm-peer-tls-interop"
+   forbidden_edges = [
+     "atm-daemon -> atm-peer-tls-interop",
+     "atm -> atm-peer-tls-interop",
+     "atm-graft -> atm-peer-tls-interop",
+     "atm-runtime -> atm-peer-tls-interop",
+     "atm-daemon-bootstrap -> atm-peer-tls-interop",
+   ]
+   ```
    Before moving code, capture a passing curl mTLS fixture proof using the
    existing certificate/fingerprint records; after the move, the identical
    fixture must pass from the new crate. This preserves verified provisioning
@@ -116,8 +128,12 @@ channel, or production dependency is authorized without a plan amendment.
    Retain the AK.4 `PeerHttpListenerSet` lifecycle unchanged. Preserve durable
    certificate/fingerprint rows only as interop provisioning data; do not let
    them influence active routing or retry decisions.
+   In this same PR, update `boundaries/atm-daemon/peer-http-adapter.toml`:
+   remove the deleted `HttpsTransport`/`HttpsMessageTransport` ownership and
+   references, retain the AK.4 `PeerHttpListenerSet` receiver boundary, and
+   do not leave a concrete record describing removed TLS code.
 5. Finalize the active-transport documentation started in AK.4: mark ADR-034,
-   ADR-040, and ADR-041 superseded by ADR-045; retain ADR-035 as the one
+   ADR-040, and ADR-041 superseded by ADR-047; retain ADR-035 as the one
    ingress/router decision and amend only its obsolete TLS/worker language.
    Update `docs/adr/INDEX.md`, `docs/requirements.md`
    (`REQ-CORE-TRANSPORT-002`, `-002A`, `-002B`, `-002B1`, `-002C`, `-002D`,
@@ -134,6 +150,12 @@ channel, or production dependency is authorized without a plan amendment.
    `-002B1`, `-002C`, `-004`, and `-005A`, AK.6 likewise updates only
    supersession/status cross-references; AK.4 remains the exclusive owner of
    active direct-delivery semantics.
+   For ADR-040, AK.6 updates only the supersession/status banner; AK.3
+   remains the exclusive owner of alias/configuration content. For ADR-035,
+   AK.6 updates only obsolete TLS/worker status wording; AK.3 owns its
+   alias/admission language and AK.4 owns its one-receiver direct-delivery
+   amendment. For ADR-034 and ADR-041, AK.6 updates only their
+   supersession/status banners; ADR-047 is AK.4's direct-delivery decision.
 
 ## Explicit prohibitions
 
@@ -149,7 +171,9 @@ channel, or production dependency is authorized without a plan amendment.
 - Source gate rejects legacy worker, scan, DNS-thread, and TLS symbols from
   active daemon/CLI/graft/send-path crates; `atm-peer-tls-interop` is the sole
   TLS owner.
-- Dependency-graph check proves no active crate depends on
+- Dependency-graph check validates
+  `boundaries/atm-peer-tls-interop/tls-interop.toml`, including all five
+  active-crate `forbidden_edges`, and proves no active crate depends on
   `atm-peer-tls-interop`.
 - TLS crate: provisioning/configuration round trip, accepted configured curl
   mTLS peer, and rejected unknown/mismatched client certificate pass; no test

--- a/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
+++ b/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
@@ -18,6 +18,14 @@ receiver interoperability in `crates/atm-peer-tls-interop`; it is not a native
 ATM TLS sender and no active daemon, CLI, graft, or send-path crate may depend
 on it.
 
+AK.6 deliberately keeps interop preservation and legacy deletion in one
+sprint. The curl-mTLS fixture must be captured and moved before the last active
+TLS configuration/data paths are deleted; splitting them would require either
+a temporary active dependency on the preservation crate or a PR that deletes
+the only reproducible fixture before its replacement is qualified. The work is
+sequenced inside this one sprint—capture proof, create/move fixture, prove it,
+then delete active transport and finalize docs—but has one atomic PR boundary.
+
 The current deletion boundary is explicit: remove
 `peer_resolution.rs`, `runtime_health/peer_authority.rs`,
 `HttpsMessageTransport`, `SharedHttpsTransport`, `HttpsTransport`, `TlsIdentity`,
@@ -29,12 +37,50 @@ the separate interop crate and a curl mTLS receiver fixture there. That crate
 is an isolated verification/provisioning utility, not an active transport
 dependency.
 
+## Fixed contract
+
+```rust
+struct TlsInteropConfig {
+    local_certificate: LocalCertificate,
+    trusted_peers: Vec<TrustedPeer>,
+}
+
+impl TlsInteropConfig {
+    fn from_provisioning(
+        local_certificate: LocalCertificate,
+        trusted_peers: Vec<TrustedPeer>,
+    ) -> Result<Self, AtmError>;
+}
+
+struct CurlMtlsReceiverFixture {
+    bind_addr: SocketAddr,
+    config: TlsInteropConfig,
+}
+
+enum CurlMtlsFixtureOutcome {
+    Accepted,
+    RejectedClientCertificate,
+}
+
+impl CurlMtlsReceiverFixture {
+    fn serve_one(
+        &self,
+        deadline: RequestDeadline,
+    ) -> Result<CurlMtlsFixtureOutcome, AtmError>;
+}
+```
+
+`CurlMtlsReceiverFixture::serve_one` is a test/interop-only bounded one-shot
+operation. Its `bind_addr` is supplied by the fixture harness, never daemon
+composition; it has no production caller or lifecycle registration. Neither
+type has a send, route, resolver, or background-work method.
+
 ## Type and boundary inventory
 
 | Item | AK.6 role |
 | --- | --- |
 | `TlsInteropConfig` | New interop-only value object containing the existing `LocalCertificate` and `TrustedPeer` provisioning data needed by curl verification. It has no routing or send method. |
-| `CurlMtlsReceiverFixture` | New interop-only, synchronous one-shot receiver fixture for curl proof. It has no production caller, background thread, worker, or daemon lifecycle ownership. |
+| `CurlMtlsReceiverFixture`, `CurlMtlsFixtureOutcome` | New interop-only, synchronous one-shot receiver fixture and its accepted/rejected result for curl proof. It has no production caller, background thread, worker, or daemon lifecycle ownership. |
 | `LocalCertificate`, `CertificateFingerprint`, `TrustedPeer` | Existing durable provisioning/configuration values retained only for the interop fixture and configuration display. They do not select a production route. |
 | `PeerHttpListenerSet`, `PeerHttpListener`, `PeerConnectionAdmission`, `route_peer_http_request`, `ActiveConnectionRegistry` | AK.4's retained production plain receiver. AK.6 must neither delete it nor add a replacement receiver/thread model. |
 | `PeerHttpRuntimeConfig` | AK.4's retained immutable source-host snapshot. AK.6 must retain it without adding a TLS, resolver, or delivery capability. |
@@ -46,7 +92,8 @@ channel, or production dependency is authorized without a plan amendment.
 
 ## Deliverables
 
-1. Create `crates/atm-peer-tls-interop`. Move verified TLS provisioning,
+1. Create `crates/atm-peer-tls-interop` with exactly the fixed contract above.
+   Capture the existing fixture proof, then move verified TLS provisioning,
    certificate/fingerprint configuration/data access, and curl receiver
    interoperability into it. Its public surface is only configuration fixtures
    and a bounded test receiver; it exposes no native sender, listener used by
@@ -55,7 +102,8 @@ channel, or production dependency is authorized without a plan amendment.
    Before moving code, capture a passing curl mTLS fixture proof using the
    existing certificate/fingerprint records; after the move, the identical
    fixture must pass from the new crate. This preserves verified provisioning
-   evidence without preserving a native sender.
+   evidence without preserving a native sender. Only after this before/after
+   proof passes may active TLS code be deleted.
 2. Delete `peer_resolution.rs`, literal-IP authority discovery, full peer-row
    scans, custom DNS threads, active `HttpsTransport`,
    `PinnedClientVerifier`, `TlsIdentity`, rustls composition, and the failing
@@ -78,7 +126,9 @@ channel, or production dependency is authorized without a plan amendment.
    `docs/atm-daemon/{architecture,boundaries,http-api,requirements}.md`,
    `docs/atm/{architecture,requirements}.md`, and
    `docs/peer-pair-smoke.md`. Documentation must distinguish the inactive
-   `atm-peer-tls-interop` curl fixture from active production delivery.
+   `atm-peer-tls-interop` curl fixture from active production delivery. For
+   `-002A/-002D`, AK.6 may update only supersession/status cross-references;
+   AK.3 remains the exclusive owner of their alias semantics.
 
 ## Explicit prohibitions
 

--- a/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
+++ b/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
@@ -1,6 +1,8 @@
 ---
 title: AK.6 Remove legacy peer transport machinery
 status: proposed
+branch: feature/pak-s6-remove-legacy-peer-transport
+worktree: ../atm-core-worktrees/feature/pak-s6-remove-legacy-peer-transport
 target: integrate/phase-ak
 recommended_agent: Cipher-311d
 recommended_model: deep-reasoning
@@ -100,9 +102,32 @@ channel, or production dependency is authorized without a plan amendment.
    production, route, background task, thread, DNS resolver, or routing API.
    Active daemon/CLI/graft/send-path crates have no dependency edge to it.
    Create `boundaries/atm-peer-tls-interop/tls-interop.toml` in this same PR
-   with this minimum isolation contract:
+   with this complete `.just/lint_boundaries.py` contract:
    ```toml
+   boundary_id = "BOUNDARY-PeerTlsInterop"
    owner_package = "atm-peer-tls-interop"
+   owner_crate_path = "atm_peer_tls_interop"
+   name = "PeerTlsInterop"
+
+   [public]
+   facade = "TlsInteropConfig"
+
+   [implementation]
+   type = "CurlMtlsReceiverFixture"
+   module = "atm_peer_tls_interop"
+   visibility = "public"
+   constructor = "pub(crate)"
+
+   [composition]
+   roots = []
+
+   [ownership]
+   io_owns = ["tls_provisioning_configuration", "curl_mtls_fixture"]
+   io_forbidden = ["production_delivery", "recipient_routing", "retry_state", "background_work"]
+
+   [dependencies]
+   allowed_dependents = []
+   allowed_dependencies = ["atm-core", "atm-storage"]
    forbidden_edges = [
      "atm-daemon -> atm-peer-tls-interop",
      "atm -> atm-peer-tls-interop",
@@ -110,6 +135,27 @@ channel, or production dependency is authorized without a plan amendment.
      "atm-runtime -> atm-peer-tls-interop",
      "atm-daemon-bootstrap -> atm-peer-tls-interop",
    ]
+
+   [references]
+   scope = "outside_owner_crate"
+   forbidden = []
+
+   [contracts]
+   request_types = ["LocalCertificate", "TrustedPeer"]
+   response_types = ["TlsInteropConfig", "CurlMtlsFixtureOutcome"]
+   error_types = ["AtmError"]
+
+   [testing]
+   allowed_test_double_paths = []
+   forbidden_test_bypasses = ["native_tls_sender", "production_listener"]
+
+   [enforcement]
+   lint_rules = ["LINT-BOUNDARY-PEER-TLS-INTEROP-EDGES"]
+   review_gates = ["no_active_dependent", "no_native_sender", "no_production_listener"]
+
+   [status]
+   state = "planned"
+   notes = ["Curl mTLS interop and provisioning preservation only."]
    ```
    Before moving code, capture a passing curl mTLS fixture proof using the
    existing certificate/fingerprint records; after the move, the identical
@@ -138,7 +184,7 @@ channel, or production dependency is authorized without a plan amendment.
    Update `docs/adr/INDEX.md`, `docs/requirements.md`
    (`REQ-CORE-TRANSPORT-002`, `-002A`, `-002B`, `-002B1`, `-002C`, `-002D`,
    `-003`, `-003B`, `-004`, and `-005A`),
-   `docs/{architecture,boundaries}.md`,
+   `docs/architecture.md`, `docs/atm-storage/boundaries.md`,
    `docs/atm-daemon/{architecture,boundaries,http-api,requirements}.md`,
    `docs/atm/{architecture,requirements}.md`, and
    `docs/peer-pair-smoke.md`. Documentation must distinguish the inactive

--- a/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
+++ b/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
@@ -1,0 +1,50 @@
+---
+title: AK.6 Remove legacy peer transport machinery
+status: proposed
+target: integrate/phase-ak
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+must_follow: AK.5
+parallel_safe: false
+---
+
+# AK.6 — remove legacy peer transport machinery
+
+## Closure
+
+After AK.4/AK.5 prove the replacement path, delete legacy scans, DNS threads,
+and active custom TLS. Preserve only provisioning/configuration and curl
+receiver interoperability in an isolated unused TLS crate; it is not a native
+ATM TLS sender.
+
+## Deliverables
+
+1. Move verified TLS provisioning, certificate/fingerprint configuration/data
+   access, and curl receiver interoperability into an isolated crate with no
+   dependency from active daemon/CLI/graft paths. It exposes no native sender.
+2. Delete `peer_resolution.rs`, literal-IP authority discovery, full peer-row
+   scans, custom DNS threads, active `HttpsTransport`,
+   `PinnedClientVerifier`, `TlsIdentity`, rustls composition, and the failing
+   native TLS sender.
+3. Retain AK.3 alias normalization, full-host persistence, and ordinary HTTP
+   hostname resolution at connect time.
+4. Update ADR-034/035, requirements, architecture/boundaries, OpenAPI if
+   affected, and smoke documentation.
+
+## Required validation
+
+- Source gate rejects legacy worker, scan, DNS-thread, and TLS symbols from
+  active daemon/CLI/graft crates; the isolated TLS crate is the sole TLS owner.
+- TLS crate: provisioning/configuration round trip and curl mTLS receiver
+  interop pass; no test claims native ATM TLS send works.
+- M4↔M5 smoke proves curl and production send/read/ACK/nudge.
+- `just lint` and `just test` pass.
+
+## Dependencies
+
+Before every AK.6 development/fix round, merge AK.5 into AK.6. Start AK.6 as
+soon as AK.5 is pushed; do not wait for QA. AK.6 PR completion waits for AK.5
+merge.
+`must_follow` is required because deletion is safe only after AK.5's resend
+path is proven. It is not parallel-safe because it removes its transport
+dependencies.

--- a/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
+++ b/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
@@ -2,7 +2,7 @@
 title: AK.6 Remove legacy peer transport machinery
 status: proposed
 target: integrate/phase-ak
-recommended_agent: arch-ctm
+recommended_agent: Cipher-311d
 recommended_model: deep-reasoning
 must_follow: AK.5
 parallel_safe: false
@@ -14,14 +14,17 @@ parallel_safe: false
 
 After AK.4/AK.5 prove the replacement path, delete legacy scans, DNS threads,
 and active custom TLS. Preserve only provisioning/configuration and curl
-receiver interoperability in an isolated unused TLS crate; it is not a native
-ATM TLS sender.
+receiver interoperability in `crates/atm-peer-tls-interop`; it is not a native
+ATM TLS sender and no active daemon, CLI, graft, or send-path crate may depend
+on it.
 
 ## Deliverables
 
-1. Move verified TLS provisioning, certificate/fingerprint configuration/data
-   access, and curl receiver interoperability into an isolated crate with no
-   dependency from active daemon/CLI/graft paths. It exposes no native sender.
+1. Create `crates/atm-peer-tls-interop`. Move verified TLS provisioning,
+   certificate/fingerprint configuration/data access, and curl receiver
+   interoperability into it. It exposes no native sender, listener, route,
+   background task, or routing API; active daemon/CLI/graft/send-path crates
+   have no dependency edge to it.
 2. Delete `peer_resolution.rs`, literal-IP authority discovery, full peer-row
    scans, custom DNS threads, active `HttpsTransport`,
    `PinnedClientVerifier`, `TlsIdentity`, rustls composition, and the failing
@@ -34,7 +37,8 @@ ATM TLS sender.
 ## Required validation
 
 - Source gate rejects legacy worker, scan, DNS-thread, and TLS symbols from
-  active daemon/CLI/graft crates; the isolated TLS crate is the sole TLS owner.
+  active daemon/CLI/graft/send-path crates; `atm-peer-tls-interop` is the sole
+  TLS owner.
 - TLS crate: provisioning/configuration round trip and curl mTLS receiver
   interop pass; no test claims native ATM TLS send works.
 - M4↔M5 smoke proves curl and production send/read/ACK/nudge.

--- a/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
+++ b/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
@@ -128,7 +128,12 @@ channel, or production dependency is authorized without a plan amendment.
    `docs/peer-pair-smoke.md`. Documentation must distinguish the inactive
    `atm-peer-tls-interop` curl fixture from active production delivery. For
    `-002A/-002D`, AK.6 may update only supersession/status cross-references;
-   AK.3 remains the exclusive owner of their alias semantics.
+   AK.3 remains the exclusive owner of their alias semantics. For `-003/-003B`,
+   AK.6 may update only supersession/status cross-references; AK.5 remains the
+   exclusive owner of their resend-cache semantics. For `-002`, `-002B`,
+   `-002B1`, `-002C`, `-004`, and `-005A`, AK.6 likewise updates only
+   supersession/status cross-references; AK.4 remains the exclusive owner of
+   active direct-delivery semantics.
 
 ## Explicit prohibitions
 

--- a/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
+++ b/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
@@ -6,8 +6,9 @@ worktree: ../atm-core-worktrees/feature/pak-s6-remove-legacy-peer-transport
 target: integrate/phase-ak
 recommended_agent: Cipher-311d
 recommended_model: deep-reasoning
-must_follow: AK.5
-parallel_safe: false
+must_follow: Phase AI merge to develop
+merge_gate: AK.5
+parallel_safe: true
 ---
 
 # AK.6 — remove legacy peer transport machinery
@@ -27,6 +28,11 @@ a temporary active dependency on the preservation crate or a PR that deletes
 the only reproducible fixture before its replacement is qualified. The work is
 sequenced inside this one sprint—capture proof, create/move fixture, prove it,
 then delete active transport and finalize docs—but has one atomic PR boundary.
+
+Cipher may start the isolated fixture, boundary record, and deletion ledger in
+parallel after the Phase AI entry gate. Active-transport deletion, final smoke,
+and final documentation reconciliation wait for the AK.5 merge-forward; the
+AK.6 PR cannot complete before the AK.5 PR merges.
 
 The current deletion boundary is explicit: remove
 `peer_resolution.rs`, `runtime_health/peer_authority.rs`,
@@ -236,9 +242,10 @@ channel, or production dependency is authorized without a plan amendment.
 
 ## Dependencies
 
-Before every AK.6 development/fix round, merge AK.5 into AK.6. Start AK.6 as
-soon as AK.5 is pushed; do not wait for QA. AK.6 PR completion waits for AK.5
-merge.
-`must_follow` is required because deletion is safe only after AK.5's resend
-path is proven. It is not parallel-safe because it removes its transport
-dependencies.
+AK.6 may start immediately after Phase AI merges to `develop`; it develops its
+isolated fixture, boundary record, and deletion ledger in a separate worktree
+without waiting for AK.5. Before active-transport deletion, final validation,
+any final fix round, or PR completion, merge AK.5 into AK.6. AK.6 PR completion
+waits for the AK.5 PR merge. `merge_gate` exists because deletion is safe only
+after AK.5's resend path is proven; it does not block the parallel preparation
+work above.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1031,6 +1031,43 @@ Authoritative plan: [Phase AI plan](./plans/phase-ai/plan-phase-ai.md).
 AI.3 (`feature/pAI-s3-error-contract-foundation`) completes the two-field
 serializable error contract and removes the retired protocol error envelope.
 
+## 41. Phase AK — Direct peer HTTP delivery [PROPOSED]
+
+Status summary:
+- Phase AK is the planned simplification line for replacing the Phase AI peer
+  worker and custom TLS sender with one direct HTTP delivery function.
+- Planning branch: `plan/mvp-simplification`.
+- Integration branch: `integrate/phase-ak`.
+- Entry gate: Phase AI must merge to `develop` before AK implementation starts.
+- The authoritative plan is
+  [Phase AK plan](./plans/phase-ak/plan-phase-ak.md).
+
+Goal:
+- preserve immutable local admission and the one ordinary inbound
+  persistence/nudge path while removing peer worker, per-message-thread,
+  broad-scan, DNS-thread, and native custom-TLS delivery complexity
+- prove direct configured-host HTTP delivery before adding the small optional
+  resend cache
+
+Deliverables:
+- direct host-alias normalization, one direct no-retry HTTP sender, optional
+  timer-driven resend cache, and isolated curl-mTLS provisioning evidence
+- deletion of obsolete worker/replay/TLS transport state with governed
+  boundary-record updates
+
+Sprint line:
+- `AK.1` `feature/pak-s1-crosshost-ack-provenance-recovery`
+- `AK.2` `feature/pak-s2-delete-peer-worker`
+- `AK.3` `feature/pak-s3-canonical-peer-aliases`
+- `AK.4` `feature/pak-s4-direct-peer-http-no-retry`
+- `AK.5` `feature/pak-s5-direct-peer-timer-state`
+- `AK.6` `feature/pak-s6-remove-legacy-peer-transport`
+
+Acceptance:
+- Phase AK acceptance is defined by the authoritative plan's sprint
+  validations and its required bidirectional production send/read/ACK/nudge
+  proof on the accepted `integrate/phase-ak` line.
+
 ## Publishing Improvements
 
 Implementation Branches:


### PR DESCRIPTION
## Summary
Hardened Phase AK plan docs (plan-phase-ak.md + sprint-AK1..6) through two rounds of parallel plan-scope-reviewer + critical-plan-reviewer passes, with arch-ctm fixing all findings after each round.

- Round 1: 9 findings (4 scope + 5 critical) fixed at 55628f6b
- Round 2 (final, 2-round cap): all 9 round-1 findings confirmed fixed; 4 new Important findings (PLAN-SCOPE-006, PLAN-CRIT-AK-006/007/008) fixed at e71c4c6c
- arch-ctm self-review: dependency rules, local smoke requirements, ownership boundaries, docs-only scope all consistent; no known open plan item remains

Docs-only change. Ready for quality-mgr plan QA (`review_mode: plan`).

## Test plan
- [ ] quality-mgr plan QA (req-qa, arch-qa, ruthless-boundary-qa, rust-best-practices-agent, rust-service-hardening-agent)