### PR TITLE
docs: Phase AJ planning — session/pid caching in daemon runtime (rebuild)

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -22,14 +22,18 @@ allowed_paths = ["crates/atm-core/tests/mailbox_locking.rs"]
 config_home_env = "ATM_CONFIG_HOME"
 
 [env_var_boundary]
-forbidden_env_vars = ["ATM_TEAM", "ATM_IDENTITY", "ATM_CHAT_ID"]
+forbidden_env_vars = ["ATM_TEAM", "ATM_IDENTITY", "ATM_CHAT_ID", "ATM_SESSION_ID", "ATM_PID"]
 restricted_crate_roots = ["crates/atm-core/src", "crates/atm-daemon/src"]
 # Seed boundary readers. The lint expands this set transitively to include
 # same-file wrappers (for example `*_or_warn`) that call these functions.
+# The session/PID readers are the sole atm-core exceptions: they construct
+# transient, environment-attested caller metadata; every other reader is denied.
 boundary_reader_functions = [
   "read_cli_identity_from_env",
   "read_cli_team_from_env",
   "read_cli_chat_id_from_env",
+  "read_cli_session_id_from_env",
+  "read_cli_pid_from_env",
 ]
 
 [line_counts]

--- a/.just/tests/test_check_env_var_boundary.py
+++ b/.just/tests/test_check_env_var_boundary.py
@@ -19,12 +19,14 @@ from check_env_var_boundary import load_restricted_crate_roots
 
 LINT_CONFIG = """\
 [env_var_boundary]
-forbidden_env_vars = ["ATM_TEAM", "ATM_IDENTITY", "ATM_CHAT_ID"]
+forbidden_env_vars = ["ATM_TEAM", "ATM_IDENTITY", "ATM_CHAT_ID", "ATM_SESSION_ID", "ATM_PID"]
 restricted_crate_roots = ["crates/atm-core/src", "crates/atm-daemon/src"]
 boundary_reader_functions = [
   "read_cli_identity_from_env",
   "read_cli_team_from_env",
   "read_cli_chat_id_from_env",
+  "read_cli_session_id_from_env",
+  "read_cli_pid_from_env",
 ]
 """
 
@@ -75,7 +77,7 @@ name = "{lib_name}"
 
             self.assertEqual(
                 load_forbidden_env_vars(repo_root),
-                ("ATM_TEAM", "ATM_IDENTITY", "ATM_CHAT_ID"),
+                ("ATM_TEAM", "ATM_IDENTITY", "ATM_CHAT_ID", "ATM_SESSION_ID", "ATM_PID"),
             )
             self.assertEqual(
                 load_restricted_crate_roots(repo_root),
@@ -87,6 +89,8 @@ name = "{lib_name}"
                     "read_cli_identity_from_env",
                     "read_cli_team_from_env",
                     "read_cli_chat_id_from_env",
+                    "read_cli_session_id_from_env",
+                    "read_cli_pid_from_env",
                 ),
             )
 

--- a/boundaries/atm-daemon/daemon-status-source.toml
+++ b/boundaries/atm-daemon/daemon-status-source.toml
@@ -43,4 +43,4 @@ review_gates = ["no_public_impl", "no_status_leakage_into_roster_store"]
 
 [status]
 state = "active"
-notes = ["crate-root daemon adapter is assembled through atm_daemon::composition", "runtime status is now served from the daemon-memory status cache rather than the atm_core::boundary_support placeholder helper"]
+notes = ["crate-root daemon adapter is assembled through atm_daemon::composition", "runtime status is now served from the daemon-memory status cache rather than the atm_core::boundary_support placeholder helper", "Phase AJ adds the runtime_observation_non_authoritative review gate only when its observation implementation lands"]

--- a/docs/adr/ADR-045-runtime-observation-attribution.md
+++ b/docs/adr/ADR-045-runtime-observation-attribution.md
@@ -1,0 +1,64 @@
+# ADR-045 — Runtime Observation Attribution
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Scope | Phase AJ runtime observation |
+| Relates to | `REQ-CORE-RUNTIME-002`, `REQ-CORE-RUNTIME-004`, ADR-015 |
+
+## Decision
+
+Session, pid, heartbeat activity, and derived agent state are in-memory,
+best-effort telemetry. They are forbidden inputs to routing, nudge,
+notification, retry, admission, delivery, and policy decisions because the
+state is neither complete nor proven current.
+
+A successful local command updates telemetry only if `ATM_IDENTITY` and
+`ATM_TEAM` are present and agree with any CLI identity/team arguments.
+Args-only or mismatched commands retain normal behavior but suppress telemetry;
+an info-level diagnostic is allowed. The existing heartbeat ingress remains a
+separate telemetry path. Graft may use only its environment-derived caller
+context. Roster reload, recovery, transport adapters, peer delivery, and nudge
+paths are not telemetry ingress.
+
+Local read/write DTOs carry one optional `ActivityObservation` containing the
+attested team/member and optional session/pid. It is transient, never mail
+data. The daemon accepts it only over the existing authenticated local
+UDS/loopback ingress; it does not read its own environment or prove the DTO's
+provenance. Remote HTTPS ingress clears it before shared dispatch.
+
+State and session retain separate last-change source/timestamp provenance.
+Absent/default data is a no-op and cannot overwrite a defined observation.
+Accepted-ingress order, not client-clock order, determines the current value. A
+trusted changed pid/session becomes the current observation and emits retained
+diagnostic evidence. Normal heartbeat, CLI, and graft ingestion cannot restore
+defaults; roster removal drops its runtime entry and a later re-add starts
+without observation.
+
+Every actual pid/session mutation emits one structured diagnostic audit event
+with prior/new value, member, source, and timestamp. No-op input emits none.
+The existing heartbeat `pid_changed` response field remains true only for
+replacement of a prior defined pid; an initial PID is audited but is not a
+replacement.
+
+`Unknown` means no trustworthy state observation; `Offline` requires an
+explicit heartbeat session-end event. They are never interchangeable.
+
+Successful environment-attested CLI/graft send, read, and ack are `Active`;
+heartbeat maps its explicit activity to `Active`, `Idle`, or `Offline`.
+`state_changed_at` records only a real lifecycle transition, not a metadata or
+same-state activity update.
+External hooks emit startup/active, idle, and stop through that existing
+heartbeat contract; hook-side implementation is outside this repository.
+
+Identity change and malformed/suppressed observation are retained anomaly
+events, not lifecycle states. They never reject ingress, emit
+`IdentityConflict`, degrade readiness, alter cache eviction, or change
+routing/nudge/delivery behavior. A future doctor phase may diagnose them.
+
+An exception requires an explicit requirement, ADR, boundary record, and test.
+
+The existing roster view may render defined state age, pid, and a shortened
+session for its matching member. JSON retains raw values; human output omits
+default `Unknown` / absent-session telemetry and never uses display state to
+make a workflow decision.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -52,6 +52,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-042 — SemVer Release And HTTP Compatibility](./ADR-042-semver-release-and-http-compatibility.md)
 - [ADR-043 — Hermes Graft Wake-up Ownership and Recovery](./ADR-043-hermes-graft-wake-up-ownership.md)
 - [ADR-044 — Public Verification Report Classification](./ADR-044-public-verification-report-classification.md)
+- [ADR-045 — Runtime Observation Attribution](./ADR-045-runtime-observation-attribution.md)
 
 ## Extracted Crate-Local ADRs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3049,6 +3049,15 @@ Architectural rules:
   - aggregate active/idle/offline/unknown member counts
 - CLI code must not inspect private daemon state directly to synthesize health
   answers
+- **Phase AJ planned target — not implemented on the current baseline:** runtime
+  observation (state, pid, session, and timestamps) will be daemon-memory
+  telemetry. Only heartbeat and successful environment-attested local CLI or
+  graft ingress may update it; it must never select routing, nudge, retry,
+  admission, delivery, notification, or policy behavior.
+- **Phase AJ planned target — not implemented on the current baseline:** a
+  changed trusted pid/session will replace the current observation and emit
+  retained diagnostic evidence. It must not reject ingress, create an
+  `IdentityConflict` lifecycle state, degrade readiness, or alter cache policy.
 
 Phase AA target doctor split:
 - daemon health remains a separate explicit request/response boundary for

--- a/docs/atm-core/boundaries.md
+++ b/docs/atm-core/boundaries.md
@@ -71,6 +71,10 @@ Purpose:
 Notes:
 - The public workflow surface above this boundary should stay centered on send
   and receive.
+- Optional runtime-observation DTOs are telemetry only. Args-only or
+  environment-conflicting identity/team produces no observation while retaining
+  normal command behavior; DTOs must not become authorization or delivery-policy
+  inputs.
 - Thin clients must use this shared boundary and must not take a dependency on
   `atm-daemon` internals.
 - `atm-graft` now lands as one such thin client crate and is expected to stay

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -54,6 +54,23 @@ even though they are not public cross-crate traits:
   - must remain separate from socket serving code
   - immutable snapshot publication is the accepted design for readers; no
     daemon-shared mutable cache lock is used
+  - **Phase AJ planned extension — not current implementation:** session, pid,
+    heartbeat activity, and derived state will be telemetry only. This boundary
+    may merge/publish them, but routing, nudge, notification, retry, admission,
+    and delivery code must not consume them without an explicit requirement,
+    ADR, boundary record, and test.
+  - **Phase AJ planned extension — not current implementation:** local
+    `ActivityObservation` will be transient request metadata. Only accepted
+    heartbeat and successful environment-attested local CLI/graft ingress may
+    reach this cache; HTTPS peer ingress must clear it before shared dispatch.
+    Changed session/PID values will be diagnostic evidence, never a liveness or
+    conflict decision.
+  - **Phase AJ planned extension — not current implementation:** removal of the
+    former conflict-driven `Degraded` readiness projection is intentional.
+    Downstream alerting must consume the retained
+    `runtime_observation_metadata_changed` diagnostic event as
+    non-authoritative evidence; AJ adds no replacement readiness signal or
+    doctor aggregate.
 
 ## Planned R.20 partition map
 

--- a/docs/plans/phase-aj/discussion-only-observation-history.md
+++ b/docs/plans/phase-aj/discussion-only-observation-history.md
@@ -1,0 +1,23 @@
+# Discussion Only: Observation History And Resume
+
+> Not a Phase AJ deliverable. Not an approved requirement, sprint, dependency,
+> or implementation authorization. Discard freely.
+
+## Question
+
+AJ retains the current trusted session/pid in memory and emits structured
+transition events. That makes the last session visible while the daemon lives,
+but does not promise a restart-surviving `/resume` or `/continue` lookup.
+
+## Candidate Follow-Up
+
+If restart-surviving session history becomes required, add one daemon-owned
+history model rather than storing pid/session on mail:
+
+- immutable observation-transition records keyed by team, member, observed-at;
+- raw session/pid and prior/new values for diagnostic history;
+- no read/write/ack mail-row changes and no message-payload fields;
+- explicit retention, privacy, doctor query, and roster projection contracts.
+
+This needs a separate requirement and ADR. It must not be slipped into AJ's
+hot dispatch path or used as lifecycle/routing/nudge policy input.

--- a/docs/plans/phase-aj/discussion-only-same-team-multi-checkout.md
+++ b/docs/plans/phase-aj/discussion-only-same-team-multi-checkout.md
@@ -1,0 +1,39 @@
+# Discussion Only: Same Team In Multiple Local Checkouts
+
+> Not a Phase AJ deliverable. Not an approved requirement, sprint, dependency,
+> or implementation authorization. Discard freely.
+
+## Scenario
+
+One computer runs two ATM checkouts — for example `atm-dev` from the internal
+disk and `atm-dev` from an external SSD — while both use the same daemon.
+
+## AJ Position
+
+AJ keeps one current observation keyed by `(team, member)`. Each trusted
+heartbeat or environment-attested CLI/graft event replaces that entry's current
+pid/session when supplied. A change is retained as diagnostic evidence only.
+No production decision distinguishes the two checkouts.
+
+This deliberately supports today's diagnostic simplicity, not concurrent
+instance identity. The roster may show the most recently observed session/pid;
+it must not claim that this proves one checkout is inactive or rogue.
+
+## Future Options To Evaluate
+
+1. **Keep single current observation.** Lowest complexity; retained events and
+   doctor diagnose frequent toggling. Appropriate until concurrent same-member
+   work needs independent delivery or notification.
+2. **Add an explicit instance key.** Define a stable, opt-in checkout/daemon
+   instance identity and key observations by `(team, member, instance)`.
+   Requires an ADR, wire contract, roster projection, migration strategy, and
+   explicit routing/nudge semantics before implementation.
+3. **Separate daemon namespaces.** Each checkout owns a distinct daemon and
+   database/socket namespace. This avoids identity collision but changes the
+   operational model and cross-daemon delivery story.
+
+## Non-Negotiable Boundary
+
+Neither pid, session id, checkout path, nor inferred agent state may decide
+routing, nudge, retry, admission, delivery, or access. Any future multi-instance
+design must preserve that boundary and prove it with tests.

--- a/docs/plans/phase-aj/phase-aj-research.md
+++ b/docs/plans/phase-aj/phase-aj-research.md
@@ -1,0 +1,198 @@
+# Phase AJ Research: Agent State & Heartbeat Extension
+
+**Date:** 2026-07-31  
+**Branch:** `plan/phase-aj`  
+**Status:** non-normative research. The authoritative planning baseline is
+`integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
+(unified HTTP over UDS/TCP). Before AJ.1 implementation, Phase AI merges to
+`develop`; `integrate/phase-AJ` is cut from the recorded post-merge SHA and
+AJ exact targets are reconciled against this planning baseline. Pre-merge plan
+review uses this baseline; post-merge reconciliation cites both SHAs.
+
+## Goal
+
+Maintain runtime state for every roster member in the daemon's `RuntimeStatusCache`.
+State is updated via two paths:
+
+1. **CLI/graft commands** (send/read/ack) — extend existing local payload with
+   optional environment-attested `ActivityObservation`. Daemon touches cache as
+   a side effect of successful local dispatch.
+2. **HTTP heartbeat endpoint** (`POST /v1/atm/heartbeat`) — extend
+   `TeamMemberHeartbeatRequest` with `session_id`. Hook-driven.
+
+Rule: absent optional fields do NOT overwrite existing cache values. A trusted
+new pid/session becomes the current observation and emits retained diagnostic
+evidence; it never changes routing, nudge, admission, retry, or lifecycle policy.
+
+The closure sequence is strictly serial: AJ.6 snapshot projection, AJ.7
+source-use guard, AJ.8 daemon boundary record, AJ.9 governing-contract
+reconciliation, then AJ.10 phase closeout. Each successor starts immediately
+after its parent development head is merged forward; QA approval is not a
+development gate. The successor repeats parent → child merge-forward before
+every dev/fix round and cannot complete its PR before the parent PR merges.
+
+---
+
+## Transport Architecture (to reverify at Phase AJ entry)
+
+Both UDS and TCP transports use unified HTTP framing:
+
+| Transport | File | Reader | Writer | Dispatcher |
+|---|---|---|---|---|
+| UDS | `crates/atm-daemon/src/local_ipc_transport/request_worker.rs` | `HttpFrameReader` | `write_local_http_response` | `ApiRouter` |
+| TCP | `crates/atm-daemon/src/local_tcp_transport.rs` | `HttpFrameReader` | `write_local_http_response` | `ApiRouter` |
+
+Supports keep-alive (`MAX_KEEP_ALIVE_REQUESTS`). On Unix, TCP runs as a secondary loopback HTTP listener for UDS/TCP parity. Both land in the same dispatcher; AJ.4 adds its one local-only `touch_member()` site there, so it covers both transports without transport-specific code.
+
+### Files to Analyze / Modify
+
+### 1. Protocol — Core Types
+**File:** `crates/atm-core/src/protocol.rs`
+
+| What | Change |
+|---|---|
+| `TeamMemberHeartbeatRequest` | Add `session_id: Option<SessionId>` |
+| `TeamMemberHeartbeatResponse` | Add `session_id: Option<SessionId>` |
+| `RuntimeMemberState` | AJ emits only Unknown, Offline, Idle, Active; `IdentityConflict` may remain only for compatibility deserialization |
+| `RuntimeObservationSource` | Add `Heartbeat` and `LocalCommand` provenance values; neither is an authority or behavior selector |
+| `RuntimeMemberObservation` | Add one public per-member snapshot DTO with state, optional session/pid, and state/session edge provenance |
+| `RuntimeStatusSnapshot` | Add `members: Vec<RuntimeMemberObservation>` with current optional `session_id`, `pid`, provenance, and timestamps |
+| `HeartbeatActivity` | No change (ActiveToolUse, Idle, SessionEnded) |
+
+### 2. Wire Payload — WriteRequest
+**File:** `crates/atm-core/src/send/mod.rs`
+
+| What | Change |
+|---|---|
+| `ActivityObservation` | Add one nested transient DTO: team, member, optional session_id/pid; only environment-attested callers construct it |
+| `WriteRequest` struct | Add `activity_observation: Option<ActivityObservation>` with additive serde; never persist it with mail |
+
+### 3. Read Query
+**File:** `crates/atm-core/src/read/mod.rs`
+
+| What | Change |
+|---|---|
+| `ReadQuery` struct | Add `activity_observation: Option<ActivityObservation>`; never persist it with mail |
+
+### 3a. Ack Conversion
+**File:** `crates/atm-core/src/ack/mod.rs`
+
+| What | Change |
+|---|---|
+| `AckRequest` | Add the same optional transient observation field |
+| conversion | Preserve the field through `into_write_request()` and `from_unresolved_write()` so acknowledgement dispatch has the same observation semantics as send |
+
+### 4. New Type — SessionId
+**File:** `crates/atm-core/src/types.rs`
+
+| What | Change |
+|---|---|
+| `SessionId` | Canonical `String` newtype; blank wire value normalizes to absent at cache merge |
+
+### 5. Caller Context — Env Var Resolution
+**File:** `crates/atm-core/src/caller_context.rs`
+
+| What | Change |
+|---|---|
+| `CallerContext` struct | Add `activity_observation: Option<ActivityObservation>` |
+| `read_cli_session_id_from_env()` | New function — reads `ATM_SESSION_ID` |
+| `read_cli_pid_from_env()` | New function — reads `ATM_PID`; no process-ID fallback |
+| `resolve_cli_*_caller_context()` | Construct observation only when environment team/identity attest resolved command identity |
+| `activity_observation_for_resolved_caller()` | Shared non-fallible environment-attestation helper for CLI and graft; it parses raw `var_os` metadata locally, so absent/non-Unicode/malformed/mismatched telemetry is `None`, not a command error |
+
+### 6. CLI Send Command
+**File:** `crates/atm/src/commands/send.rs`
+
+| What | Change |
+|---|---|
+| `SendCommand::build_request()` | Pass optional `activity_observation` from `CallerContext` into `WriteRequest` |
+
+### 7. CLI Read Command
+**File:** `crates/atm/src/commands/read.rs`
+
+| What | Change |
+|---|---|
+| Read command | Pass optional `activity_observation` into `ReadQuery` |
+
+### 8. CLI Ack Command
+**File:** `crates/atm/src/commands/ack.rs`
+
+| What | Change |
+|---|---|
+| Ack command | Pass optional `activity_observation` into `AckRequest`; the core acknowledgement conversion forwards it into the canonical write request |
+
+### 9. Daemon Dispatch — Cache Touch
+**File:** `crates/atm-daemon/src/runtime_health.rs`
+
+| What | Change |
+|---|---|
+| `route_write()` | After successful local dispatch, touch cache with `activity_observation` only for `AuthenticatedIngress::Local` |
+| `dispatch_non_write()` for `Receive` | Same — touch cache on successful local read only |
+| `record_heartbeat()` | Accept and store `session_id` from heartbeat request |
+
+### 10. Runtime Status Cache
+**File:** `crates/atm-daemon/src/runtime_status_cache.rs`
+
+| What | Change |
+|---|---|
+| Cache entry struct | Add current `session_id: Option<SessionId>`, `pid: Option<u32>`, provenance, and state-edge timestamp |
+| `record_heartbeat()` | Update `session_id` only if `Some(...)`; required heartbeat pid replaces current pid |
+| `merge_observation()` | One infallible cache merge helper; heartbeat and environment-attested local commands supply source/state, accepted-ingress order wins, `None` preserves |
+| `ObservationMergeOutcome` | Crate-private comparison result reused for audit and `pid_changed` response construction |
+| `touch_member()` | Thin local-command adapter around `merge_observation(ActivityObservation)` |
+| `cached_session_id()` | New accessor |
+| `snapshot()` | Include optional `session_id` and `pid` in `RuntimeStatusSnapshot` |
+
+### 11. HTTP API Route
+**File:** `crates/atm-core/src/api.rs`
+
+| What | Change |
+|---|---|
+| `HEARTBEAT_PATH` | Already `/v1/atm/heartbeat` — no change; HTTPS peer ingress clears `activity_observation` from both Write and Receive request variants before shared dispatch |
+| Serialization | `TeamMemberHeartbeatRequest` gains `session_id` — already derives Serialize/Deserialize |
+
+### 12. Database Schema (NO CHANGE)
+**File:** `crates/atm-storage-rusqlite/src/shared_db.rs`
+
+State is in-memory only. No SQLite persistence for session_id, pid, or runtime
+state, including no mail row/payload fields. The `team_roster` table already has
+`member_kind` and `agent_type` — those are durable. Structured retained logs are
+AJ's transition evidence; doctor aggregation and durable history are later work.
+
+---
+
+## Env Variables
+
+| Variable | Purpose | CLI? | Hook? |
+|---|---|---|---|
+| `ATM_IDENTITY` | Agent identity | Required | Required |
+| `ATM_TEAM` | Team name | Required | Required |
+| `ATM_SESSION_ID` | Session identifier | Optional | Optional |
+| `ATM_PID` | Process ID (or OS pid) | Optional | Required |
+
+---
+
+## Non-Overwrite Rule
+
+When `session_id` is `None` in the incoming request:
+- Do NOT clear the existing `session_id` in the cache
+- Do NOT set it to `None`
+- Leave the existing value untouched
+
+When a local `ActivityObservation.pid` is `None`:
+- Same rule — do not overwrite. Heartbeat pid is required and replaces current
+  observation.
+
+This applies to both the UDS dispatch path and the HTTP heartbeat path.
+
+---
+
+## Hard Constraint
+
+> It is expressly forbidden for any assumptions to be made in software based on
+> the presence/absence of these values.
+
+No code may branch on session, pid, heartbeat activity, or derived state to
+change behavior. The cache merge, audit, and snapshot projection are the only
+allowed consumers; routing, nudge, notification, retry, admission, delivery,
+and policy code are explicitly forbidden consumers.

--- a/docs/plans/phase-aj/plan-phase-aj.md
+++ b/docs/plans/phase-aj/plan-phase-aj.md
@@ -1,0 +1,422 @@
+---
+title: Phase AJ Plan
+status: planned
+branch: plan/phase-aj
+worktree: ../atm-core-worktrees/plan/phase-aj
+---
+
+# Phase AJ Plan
+
+## Phase-entry gate
+
+Phase AJ's planning and review baseline is
+`integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`, the
+line that contains the unified HTTP local transports over UDS and TCP.
+Plan review, acceptance review, and source references compare against that
+branch's recorded SHA. Before AJ.1 implementation begins, Phase AI must merge
+to `develop`; team-lead records the resulting `develop` SHA, creates
+`integrate/phase-AJ` from it, and completes the reconciliation gate below.
+`integrate/phase-AJ` is the AJ implementation target, not the planning
+baseline.
+
+**Planning-review rule.** Before Phase AI merges, a plan finding must compare
+an AJ contract to the pinned AI baseline, not an unrelated `develop` snapshot.
+After the Phase AI merge, a reconciliation finding is valid only when it names
+both the pinned AI SHA and post-merge `develop` SHA and identifies a changed AJ
+target. It is resolved before AJ.1 development, not ignored.
+
+**Phase-AI reconciliation gate.** Phase AI's PR merges to `develop` before any
+AJ implementation branch is created or any AJ dev/fix round begins. Team-lead
+then records the post-merge `develop` SHA, creates `integrate/phase-AJ` at that
+SHA, and diffs the pinned AI baseline against that SHA for every AJ exact target
+and required baseline dependency (including AJ.3 `ack/mod.rs` and AJ.5
+`api.rs`). Any drift updates the AJ plan
+or implementation target and is revalidated before AJ.1 starts. All AJ
+implementation branches inherit this recut target through their mandatory
+parent → child merge-forward chain. An accidentally pre-created AJ branch must
+first merge the recut target and re-run its sprint validation before any dev or
+fix; no AJ PR may merge to `develop` before Phase AI's merge is complete.
+
+## Goal
+
+Maintain runtime observational state for every roster member in the daemon's
+`RuntimeStatusCache`, fed by two independent update paths that converge on a
+single in-memory entry per roster member:
+
+1. **CLI/graft command path** — `atm send`, `atm read`, `atm ack`, and graft
+   carry an optional `ActivityObservation` on the existing local wire payload.
+   The DTO exists only when environment identity/team attest the caller; the
+   daemon touches the cache after successful dispatch via `touch_member()` in
+   `runtime_health.rs`.
+2. **HTTP heartbeat path** — `POST /v1/atm/heartbeat` carries an optional
+   `session_id`; the daemon records it through `record_heartbeat()` alongside
+   the existing heartbeat activity.
+
+State is in-memory only. No SQLite persistence. The fields are observational
+only — recorded, never acted upon, and never retained with mail.
+
+## Baseline
+
+- **Planning baseline: `integrate/phase-ai-31-33 @
+  150391ecdf2e003185bff7d78427cd21509a7981`**, recorded before plan review.
+  It is the source of truth for the existing HTTP/UDS/TCP transport
+  architecture and every AJ code-comparison finding.
+- **Implementation target: `integrate/phase-AJ`**, created from the accepted
+  post-Phase-AI-merge `develop` SHA after the reconciliation gate. All AJ work
+  merges forward from this line.
+- Research: `docs/plans/phase-aj/phase-aj-research.md`
+- Governing contracts: `REQ-CORE-RUNTIME-002`, `REQ-CORE-RUNTIME-004`,
+  `docs/adr/ADR-045-runtime-observation-attribution.md`, and
+  `docs/team-member-state.md`. AJ.6 implements snapshot projection; AJ.7
+  adds the source-use guard; AJ.8 records that guard at the daemon boundary;
+  AJ.9 reconciles governing documents; and AJ.10 performs evidence-backed
+  phase closeout.
+- Transport: UDS and TCP are unified under HTTP framing. Both read with
+  `HttpFrameReader` and write with `write_local_http_response`; both dispatch
+  into the same `ApiRouter`. Because the dispatcher is transport-agnostic, a
+  single `touch_member()` call inside the dispatch path covers UDS and TCP
+  with no transport-specific code.
+
+  | Transport | File | Reader | Writer |
+  |---|---|---|---|
+  | UDS | `crates/atm-daemon/src/local_ipc_transport/request_worker.rs` | `HttpFrameReader` | `write_local_http_response` |
+  | TCP | `crates/atm-daemon/src/local_tcp_transport.rs` | `HttpFrameReader` | `write_local_http_response` |
+
+- Dispatcher: `crates/atm-daemon/src/runtime_health.rs`
+- Cache: `crates/atm-daemon/src/runtime_status_cache.rs`
+- `RuntimeMemberState`, `RuntimeStatusSnapshot`, and `HeartbeatActivity`
+  already exist in `crates/atm-core/src/protocol.rs`; AJ removes the
+  `IdentityConflict` producer path and adds an additive member-observation
+  projection to the snapshot
+- `HEARTBEAT_PATH` (`/v1/atm/heartbeat`) already exists in
+  `crates/atm-core/src/api.rs`
+
+## Active Issues
+
+Phase AJ does not directly close any open GH issue. It is forward-looking
+observability groundwork that later tooling (status surfaces, doctor
+extensions, ATM overlays) will consume.
+
+| Bucket | Issues | Disposition |
+|---|---|---|
+| AD-addressed | (#421, #440) | Out of scope — owned by Phase AD line |
+| Missing features | (#423, #448) | Out of scope — separate CLI surfaces |
+| Release quality | (#435, #90) | Out of scope |
+| Integration | (#461) | Out of scope — AJ adds state, not harness emitters |
+| Bugs | — | None targeted |
+| Backlog | (#19, #36, #64, #100) | Unchanged |
+
+## Design Rules
+
+These rules bind every AJ sprint:
+
+- **Observational-only constraint.** It is expressly forbidden for any code
+  to branch on the presence or absence of `session_id` or `pid`. The fields
+  are recorded state, never behavior inputs. No `if session_id.is_some()`
+  style behavioral forks outside the "do we update the cache" write path
+  itself.
+- **Latest accepted trusted observation wins.** "Latest" means accepted ingress
+  order, not client-clock ordering. `None` leaves a cached optional value
+  untouched. A trusted `Some(session_id)` replaces the current session; a
+  heartbeat's required pid replaces the current pid and a trusted CLI/graft
+  `Some(pid)` does the same. A distinct value is retained diagnostic evidence,
+  not a rejection or lifecycle transition.
+- **In-memory only.** No new SQLite column, table, or migration. The
+  `team_roster` table already covers durable `member_kind`/`agent_type`;
+  session state is ephemeral by design.
+- **Wire compatibility.** All new wire fields use
+  `#[serde(default, skip_serializing_if = "Option::is_none")]`. New readers
+  accept older payloads with defaults; existing readers must accept and ignore
+  the additive fields. AJ does not promise lossless re-serialization through
+  an older binary that does not know those fields.
+- **Env var precedence.** CLI resolution reads `ATM_SESSION_ID` and
+  `ATM_PID` from the process environment as optional local metadata. The
+  heartbeat's existing pid remains required; a hook may omit its optional
+  session ID on `SessionEnded`, and CLI users may leave both environment values
+  unset.
+- **Trusted local observation.** CLI activity is recorded only when both
+  `ATM_IDENTITY` and `ATM_TEAM` are present and parseable. Args-only activity
+  produces no observation. If explicit identity/team differs from environment,
+  normal command semantics continue but observation is silently suppressed; a
+  concise `info!` event is permitted. Matching arguments and environment
+  produce a normal observation. Delegated use is neither an error nor warning.
+- **Transport trust boundary.** The daemon does not read its own environment
+  or cryptographically prove the DTO's provenance. It accepts
+  `ActivityObservation` only from existing authenticated local UDS/loopback
+  ingress, where the client performed environment attestation, and clears it
+  at remote HTTPS peer ingress before shared dispatch.
+- **Single-mechanism.** The cache is the only authoritative runtime state
+  surface. Because UDS and TCP share `ApiRouter`, a single `touch_member()`
+  call site inside the dispatcher is the only write path for the CLI side —
+  do not add per-transport touch sites in `request_worker.rs` or
+  `local_tcp_transport.rs`.
+- **No behavioral branching.** Restated: any conditional on
+  `session_id`/`pid` presence that alters routing, retry, notification, or
+  dispatch semantics is a defect.
+- **Hard policy boundary.** Session, pid, heartbeat activity, and derived
+  agent state are unproven best-effort telemetry. They are forbidden inputs to
+  routing, nudge, notification, retry, admission, delivery, or policy logic.
+  Only cache-merge and snapshot-projection code may inspect them. Any future
+  exception requires a named requirement, ADR, boundary record, and test. AJ
+  removes the existing live-pid conflict behavior: no heartbeat rejection,
+  `IdentityConflict` cache write, readiness degradation, or cache-eviction
+  special case may remain.
+- **Closed ingress set.** Runtime observation may be updated only by (1) the
+  existing heartbeat endpoint, (2) successful CLI `send`/`read`/`ack` with
+  trusted environment identity/team, or (3) graft through its existing
+  environment-derived caller context. Roster reload, daemon recovery,
+  transport adapters, peer delivery, nudge code, and all other paths must not
+  synthesize or mutate observation.
+- **Field-level provenance and no default overwrite.** Cache state records the
+  source and timestamp of the last state change and the last session change
+  independently. `None`, absent session, and default `Unknown` are no-ops for
+  existing state/session data. A trusted CLI/graft action sets `Active`; the
+  next heartbeat may set its explicit state. Roster output renders provenance
+  only with a defined state/session value.
+- **State-change timestamp.** Each cache member has
+  `state_changed_at: Option<IsoTimestamp>`. It is initialized only with a real
+  known state and changes only when the lifecycle value changes; activity time
+  may advance without rewriting it. The roster projection shows it only with a
+  defined non-`Unknown` state, rendering a human relative age (for example,
+  `Idle — 30m`) while retaining the absolute timestamp in structured output.
+  Repeated evidence of the current state is not an edge and never resets this
+  timestamp. Every lifecycle value follows the same rule: record the first
+  entry into that value, then retain its timestamp until a different-state edge.
+- **Change audit.** Every actual pid or session-ID mutation, including its
+  initial set, emits one structured retained `info!` event with team, member,
+  ingress source, timestamp, previous value, and new value. Raw values are
+  allowed in this diagnostic event. No-op/missing/default input emits no
+  mutation event. This audit event is diagnostic only.
+- **No ordinary reset.** AJ adds no reset API. Removing a roster member drops
+  its runtime entry; a later re-add starts `Unknown`. A roster metadata update
+  preserves observation. Normal heartbeat, CLI, and graft updates cannot clear
+  a known session or replace a known state with `Unknown`.
+- **State meaning.** `Unknown` means no trustworthy ingress has established a
+  runtime state. `Offline` means the
+  heartbeat path explicitly received `SessionEnded`. They are never aliases:
+  a normal update cannot convert either one into the other, and roster output
+  must preserve the distinction.
+- **Anomalies are not states.** AJ's roster lifecycle is only `Unknown`,
+  `Active`, `Idle`, and `Offline`. A changed pid/session or suppressed
+  observation emits retained structured evidence and then preserves the
+  lifecycle transition dictated by its ingress. AJ does not expose conflict as
+  roster state or make a decision from it. Existing `IdentityConflict` wire
+  support may remain only for backward deserialization; AJ adds no producer.
+  Doctor aggregation is future work; the retained log is sufficient in AJ.
+- **Known-state transitions.** A successful environment-attested CLI or graft
+  `send`, `read`, or `ack` transitions the member to `Active`. Heartbeat maps
+  explicit activity to `Active`, `Idle`, or `Offline` (`SessionEnded`). These
+  known transitions update field provenance. Missing optional metadata is a
+  no-op; it cannot manufacture `Unknown` or `Offline`.
+- **Hook transition contract.** The external activity hooks use the existing
+  heartbeat endpoint: startup/active → `ActiveToolUse`, idle → `Idle`, and
+  stop → `SessionEnded` (`Offline`). AJ consumes these values only; hook-side
+  installation and emission remain outside atm-core.
+
+### Pid Overwrite Policy
+
+`TeamMemberHeartbeatRequest.pid` is `u32` (required, always present), while
+`ActivityObservation.pid` on `WriteRequest` and `ReadQuery` is `Option<u32>`.
+This asymmetry is
+intentional:
+
+- **Heartbeat path: pid always overwrites.** Heartbeat has a required pid, so
+  every heartbeat replaces the cached current pid, including one previously
+  supplied by CLI dispatch. This records its newest observation; it does not
+  establish a liveness policy.
+- **CLI dispatch path: pid only sets when `Some`.** CLI-supplied pid is
+  best-effort observational metadata from the calling process; a `None`
+  must never erase state the heartbeat authority previously recorded.
+
+This policy is an explicit, deliberate exception to the `None`-preserves rule:
+heartbeat has no absent pid value, while local CLI/graft ingress does.
+
+## Architecture Decisions
+
+### AD-AJ-1: Session/pid state is in-memory only (no SQLite persistence)
+
+**Decision.** `RuntimeStatusCache` entries for `session_id` and `pid` live
+only in process memory. No new SQLite column, table, or migration is
+introduced in Phase AJ.
+
+**Rationale.**
+
+- The state is ephemeral: it is the daemon's current trusted observation, not
+  a durable liveness claim. A retained structured transition event supplies AJ
+  diagnostics without writing telemetry on every mail operation.
+- Avoiding the migration tax keeps Phase AJ scoped to observability
+  groundwork; the `team_roster` table already covers the durable
+  concerns (`member_kind`, `agent_type`).
+- In-memory reads are lock-cheap and keep the dispatch hot path free of
+  SQLite write contention.
+
+**Reconsideration triggers.** This decision should be revisited if any of
+the following become requirements:
+
+- Post-restart forensics ("which session was active before the daemon
+  died?") demanded by an operator surface.
+- Session history/auditing across daemon lifetimes.
+- Cross-host aggregation that outlives any single daemon process.
+
+**Future persistence decision.** A later requirement and ADR must choose the
+history model, retention, privacy, recovery semantics, and write budget before
+adding any durable table. It may reuse AJ's two ingress adapters, but Phase AJ
+does not pre-approve a schema or imply that the current observation should
+survive a daemon restart.
+
+### AD-AJ-2: Pid overwrite asymmetry (heartbeat required field)
+
+Captured under "Pid Overwrite Policy" in Design Rules above; recorded
+here as a decision so future readers find it in both places.
+
+### AD-AJ-3: Rust type and error shape
+
+- **Newtype.** `SessionId` is one transparent core newtype. PID stays
+  the existing `u32` protocol field: AJ adds no new semantic invariant beyond
+  rejecting an invalid optional local environment value, so a second wrapper
+  would add conversion churn without preventing a real class of error.
+- **Dynamic cache, not typestate.** Runtime observation is a dynamic, shared cache fed by
+  independent external events. It is intentionally one closed merge function,
+  not a typestate API; the values must coexist in snapshots and can legally
+  transition among `Active`, `Idle`, and `Offline` in accepted-ingress order.
+- **Infallible merge and preserved error contract.** AJ adds no user-facing failure path for observation.
+  The cache merge is infallible and cannot turn a successful command or
+  heartbeat into an error. Existing command and heartbeat errors retain their
+  current contracts; malformed or suppressed optional telemetry is an
+  informational diagnostic, not a new error result.
+
+## Scope Rules
+
+Phase AJ may:
+
+- add `SessionId` as a new core type
+- extend `TeamMemberHeartbeatRequest` / `TeamMemberHeartbeatResponse`
+- add transient `ActivityObservation` and carry it optionally on `WriteRequest`
+  and `ReadQuery`, preserving it through the `AckRequest` conversion into the
+  canonical `WriteRequest`
+- extend `CallerContext` and add env-var resolvers that construct an optional
+  environment-attested `ActivityObservation`
+- extend `RuntimeStatusCache` entries with `session_id` and `pid`, and add
+  the `touch_member` write path used by dispatch
+- extend `RuntimeStatusSnapshot` and `atm members` to surface current
+  state/session/pid/provenance only when defined; JSON uses raw values and
+  human output shortens the session identifier
+- extend CLI and graft read/send/ack callers to populate the optional
+  observation from their environment-derived context
+- add unit, integration, and narrow boundary tests proving latest-observation
+  merge semantics, the dual-path (UDS + TCP + HTTP heartbeat) update flow,
+  and that observation cannot enter policy code
+
+Phase AJ must not:
+
+- persist `session_id` or `pid` to SQLite, mail rows, or mail payloads
+- introduce behavior changes triggered by `session_id`/`pid` values
+- remove or rename any existing wire field, cache accessor, or heartbeat
+  field, except the deprecated live-pid-conflict accessors and heartbeat
+  error-path call site named for removal under the Design Rules and AJ.5:
+  `record_identity_conflict`, `record_identity_conflict_for_test`, and the
+  `AtmError::identity_conflict(...)` return inside `record_heartbeat` (the
+  shared constructor remains)
+- add a new IPC channel, socket, HTTP route, or transport — both update
+  paths reuse the existing unified HTTP-framed local transport and the
+  existing heartbeat endpoint
+- modify `local_ipc_transport/request_worker.rs` or `local_tcp_transport.rs`
+  framing logic — the touch happens inside `runtime_health.rs` dispatch
+- add a new operator surface or change routing/notification behavior from
+  runtime observation
+- produce or act on `RuntimeMemberState::IdentityConflict`; compatibility-only
+  deserialization is permitted
+
+## Scope Deferred
+
+- `atm doctor` / `atm status` surface changes that consume
+  `RuntimeStatusSnapshot.session_id`
+- Durable (SQLite) persistence of session history, if ever desired
+- Any pid-liveness probing, reaping, or process-tree tracking
+- Heartbeat TTL/expiry tuning beyond what already exists
+- ATM overlay consumption of session state (alpha-prime / overlay work)
+- Hook-side emitter changes (those land in their own repos)
+- Durable session/PID span history or post-restart session recovery
+
+## Execution Order
+
+Strict merge-forward: `AJ.1 → AJ.2 → AJ.3 → AJ.4 → AJ.5 → AJ.6 → AJ.7 → AJ.8 → AJ.9 → AJ.10`, all on top
+of `integrate/phase-AJ`.
+
+AJ.1 starts only after the Phase-AI reconciliation gate above. That gate is a
+phase-entry dependency, not parent-sprint QA: once it passes, AJ.1 and every
+successor follow the immediate merge-forward rule below without waiting for
+their parent QA outcome.
+
+| Sprint | Title | Purpose |
+|---|---|---|
+| AJ.1 | SessionId Type And Protocol Extensions | New `SessionId` type; heartbeat protocol structs gain `session_id` |
+| AJ.2 | CallerContext Env Resolution | `ATM_SESSION_ID` / `ATM_PID` env resolvers |
+| AJ.3 | CLI Wire Payload Integration | `send`/`read`/`ack` populate new fields; `WriteRequest`/`ReadQuery` extended |
+| AJ.4 | Daemon Cache Touch On Dispatch | `touch_member` write path; non-overwrite rule on the unified dispatch path |
+| AJ.5 | HTTP Heartbeat Session State | `record_heartbeat` accepts and stores `session_id` |
+| AJ.6 | Runtime Observation Snapshot Projection | Snapshot exposure and roster projection |
+| AJ.7 | Runtime Observation Source-Use Guard | Narrow static guard for non-authoritative observation use |
+| AJ.8 | Runtime Observation Boundary Record | Machine and human daemon boundary record |
+| AJ.9 | Runtime Observation Governing Contract Reconciliation | Requirements, ADR, architecture, and team-state reconciliation |
+| AJ.10 | Runtime Observation Phase Closeout | Evidence validation and phase/sprint/project closeout |
+
+No AJ pair is parallel-safe. The immediate successor starts as soon as its
+parent development head is available: merge parent → child, then begin child
+development. Parent QA approval is never a gate for child development. Before
+every child dev or fix round, merge the current parent head into the child
+branch. A child PR cannot complete or merge its target before its parent PR
+merges. Here, “parent merged” for a dev/fix round means this mandatory
+parent-branch → child-branch merge-forward, not parent PR completion.
+
+| Parent | Immediate successor | Merge-forward reason |
+|---|---|---|
+| AJ.1 | AJ.2 | `SessionId` protocol contract |
+| AJ.2 | AJ.3 | environment-attested observation DTO |
+| AJ.3 | AJ.4 | local-wire request fields |
+| AJ.4 | AJ.5 | sole cache-merge contract |
+| AJ.5 | AJ.6 | converged heartbeat/cache state |
+| AJ.6 | AJ.7 | implemented snapshot/roster targets |
+| AJ.7 | AJ.8 | passing source-use enforcement gate |
+| AJ.8 | AJ.9 | final boundary record |
+| AJ.9 | AJ.10 | reconciled governing contracts |
+
+## Phase Exit Criteria
+
+Phase AJ closes when all of the following hold:
+
+- [ ] `SessionId` exists as a single canonical core type
+- [ ] Phase AI merged to `develop`; the post-merge SHA and AJ planning-baseline
+  SHA were recorded, AJ target exact paths were reconciled, and
+  `integrate/phase-AJ` was cut from that post-merge SHA before AJ.1 began
+- [ ] `TeamMemberHeartbeatRequest` / `TeamMemberHeartbeatResponse` carry
+  `session_id` and round-trip on the wire
+- [ ] `ActivityObservation` is one optional, wire-compatible DTO on `WriteRequest`
+  and `ReadQuery`; it carries team/member plus optional session/pid only for
+  environment-attested local callers, and HTTPS peer ingress clears it before
+  shared dispatch
+- [ ] `CallerContext` resolves `ATM_SESSION_ID` and `ATM_PID` from env; CLI and
+  graft read/send/ack pass the optional observation through only when the
+  environment attests the resolved caller, including the `AckRequest` →
+  canonical `WriteRequest` conversion
+- [ ] `RuntimeStatusCache` stores the current `session_id` and `pid`, exposes both
+  on `RuntimeStatusSnapshot`, and applies latest-accepted-trusted-observation
+  semantics on local dispatch (UDS + TCP) and HTTP heartbeat paths
+- [ ] `atm members` displays defined observed state age, pid, and shortened session
+  for a roster member; it omits default `Unknown` / absent-session observation
+- [ ] A single `touch_member()` call site inside `runtime_health.rs` covers
+  both UDS and TCP — verified by an integration test that exercises both
+  transports against the same identity; it runs only after a successful local
+  write/read, never after a failed dispatch or through remote ingress
+- [ ] `cargo build --workspace`, `cargo clippy --workspace --all-targets
+  -- -D warnings`, and `cargo test --workspace` are green
+- [ ] Integration tests prove: (a) trusted latest values update cache and `None`
+  leaves it untouched, (b) UDS, TCP, and HTTP heartbeat paths converge on the
+  same cache entry, (c) a changed pid/session is retained evidence only, and
+  (d) no code branches behaviorally on observation state
+- [ ] The AJ.7 source-use guard has required-positive checks and rejects policy
+  consumers of runtime observation
+- [ ] AJ.8 daemon boundary records agree with the merged implementation
+- [ ] AJ.9 requirements, ADR, architecture, and team-member-state agree with
+  the merged implementation
+- [ ] All ten sprint docs are marked `complete` in their frontmatter

--- a/docs/plans/phase-aj/sprint-AJ1.md
+++ b/docs/plans/phase-aj/sprint-AJ1.md
@@ -1,0 +1,126 @@
+---
+id: AJ.1
+title: SessionId Type And Protocol Extensions
+status: planned
+branch: feature/pAJ-s1-session-id-and-protocol
+worktree: ../atm-core-worktrees/feature/pAJ-s1-session-id-and-protocol
+target: integrate/phase-AJ
+---
+
+# Sprint AJ.1 — SessionId Type And Protocol Extensions
+
+## Goal
+
+Introduce the canonical `SessionId` core type and extend the heartbeat
+protocol structs so every later sprint has one shared vocabulary for session
+identity.
+
+## Hard Dependencies
+
+- `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
+- Phase AI merged to `develop`; phase-entry reconciliation recorded the
+  post-merge SHA and reviewed all AJ exact targets for baseline drift
+- `integrate/phase-AJ`, cut from that reconciled post-merge `develop` SHA
+  before AJ.1 implementation dispatch
+- `docs/plans/phase-aj/plan-phase-aj.md`
+- `docs/plans/phase-aj/phase-aj-research.md`
+- `crates/atm-core/src/protocol.rs` at the recorded Phase AJ baseline
+
+## Dependency Relation
+
+- `must_follow` the recorded `integrate/phase-ai-31-33 @ 150391ec` planning baseline;
+  AJ.1 may begin only after the Phase-AI reconciliation gate creates its
+  post-merge-`develop` implementation target.
+- No AJ sprint is `parallel_safe`: AJ.2–AJ.10 consume this public `SessionId`
+  contract. AJ.2 begins immediately when AJ.1's development head is merged
+  forward into its branch; it does not wait for AJ.1 QA. AJ.2 must repeat that
+  merge-forward before every dev/fix round and cannot complete its PR first.
+- On AJ.1 development-head push, AJ.2 begins immediately by merging
+  AJ.1 → AJ.2; AJ.2 must complete that merge before any dev/fix round and does
+  not wait for AJ.1 QA.
+
+## Exact Targets
+
+- `crates/atm-core/src/types.rs`
+- `crates/atm-core/src/protocol.rs`
+
+## Why `SessionId` Is A Newtype
+
+`SessionId` is a newtype wrapper around `String` rather than a plain
+`String` for type safety and to prevent conflation with the other
+string-like identifiers already moving through the protocol
+(`TeamName`, `AgentName`, message bodies, identity strings). Function
+signatures that take `SessionId` cannot accidentally accept a member
+name or an arbitrary payload string. Its smart constructor centralizes AJ's
+content rules: blank/whitespace normalizes to absent, and a non-blank value is
+limited to 256 UTF-8 bytes before it can enter request, cache, or audit-log
+state. Serde retains the string wire representation; the optional field
+deserializer maps legacy blank values to `None` rather than creating an invalid
+value.
+
+## Interfaces To Add Or Modify
+
+- New transparent core type in `crates/atm-core/src/types.rs`:
+  ```rust
+  pub struct SessionId(String);
+  ```
+  It derives `Serialize`, `Deserialize`, `Clone`, `Debug`, `PartialEq`, `Eq`,
+  and `Hash`; it implements `Display` and `AsRef<str>`. Its only public
+  construction API is `SessionId::new(value) -> Result<Option<SessionId>,
+  SessionIdError>`: whitespace-only input returns `Ok(None)` and a value over
+  256 UTF-8 bytes returns `SessionIdError::TooLong`.
+- `TeamMemberHeartbeatRequest` gains
+  `pub session_id: Option<SessionId>` with
+  `#[serde(default, skip_serializing_if = "Option::is_none")]`
+- `TeamMemberHeartbeatResponse` gains
+  `pub session_id: Option<SessionId>` with the same serde attributes.
+- **Response semantics (authoritative).** Once AJ.5's cache merge exists, the
+  heartbeat response returns the post-update cached session value, not simply
+  the request value. AJ.1 defines that contract where it introduces the wire
+  field; AJ.5 implements it and does not redefine it.
+- `session_id` is transient observation metadata. AJ.1 must not add it to a
+  mail row, mail payload, or session-history table.
+- The optional request/response field uses
+  `deserialize_optional_session_id`, which maps legacy blank/whitespace wire
+  input to `None` before construction. It therefore neither clears a known
+  session nor appears in a roster projection.
+- The canonical import is `atm_core::types::SessionId`; AJ.1 does not add a
+  top-level or prelude re-export.
+
+## Deliverables
+
+- `SessionId` newtype exists, derives the listed traits, and round-trips
+  through `serde_json` without loss for valid values
+- Tests prove whitespace maps to absent, a 256-byte value succeeds, and a
+  257-byte value returns `SessionIdError::TooLong`; no direct `From<String>`
+  or `From<&str>` construction bypass remains
+- Heartbeat request/response structs serialize with `session_id` present
+  when `Some`, omit the field entirely when `None`
+- The response behavior is the authoritative post-update cached-value contract
+  defined in **Interfaces To Add Or Modify** above: a request containing `None`
+  may return the prior known `Some` value after AJ.5, while AJ.1 itself adds no
+  cache behavior.
+- Older payloads missing `session_id` deserialize with `session_id: None`
+  and an existing reader ignores the additive field. Lossless re-serialization
+  through an older reader is not required.
+- `RuntimeMemberState`, `RuntimeStatusSnapshot`, and `HeartbeatActivity`
+  are unchanged in this sprint
+
+## Acceptance Criteria
+
+- `SessionId` is the canonical opaque core newtype for session identity; old
+  payloads deserialize with `None` and no cache behavior exists yet.
+- AJ.1 must_follow Phase AI cutover; the dispatch records the phase target SHA.
+
+## Required Validation
+
+- `cargo build -p atm-core`
+- `cargo clippy -p atm-core --all-targets -- -D warnings`
+- `cargo test -p atm-core`
+- New unit tests in `crates/atm-core/src/types.rs` and `protocol.rs`:
+  - serde round-trip on `Some` and `None`
+  - missing field deserializes to `None`
+  - `Display` and `From<&str>` produce identical strings
+- `rg -n "session_id" crates/atm-core/src/protocol.rs` shows both new
+  fields with the required serde attributes
+- `git diff --check`

--- a/docs/plans/phase-aj/sprint-AJ10.md
+++ b/docs/plans/phase-aj/sprint-AJ10.md
@@ -1,0 +1,65 @@
+---
+id: AJ.10
+title: Runtime Observation Phase Closeout
+status: planned
+branch: feature/pAJ-s10-runtime-observation-phase-closeout
+worktree: ../atm-core-worktrees/feature/pAJ-s10-runtime-observation-phase-closeout
+target: integrate/phase-AJ
+---
+
+# Sprint AJ.10 — Runtime Observation Phase Closeout
+
+## Goal
+
+Verify final Phase AJ evidence, update phase/sprint/project status, and close
+the phase. AJ.10 adds no production behavior or governing contract.
+
+After AJ.6, `phase-aj-research.md` remains planning context rather than a hard
+dependency: AJ.10 verifies merged evidence and status.
+
+## Hard Dependencies
+
+- AJ.1 through AJ.9 development heads merged forward into this branch
+- AJ.9's reconciled governing contracts are present through the immediate
+  AJ.9 → AJ.10 merge-forward; AJ.9 QA/PR completion is not a dev-start gate
+- `docs/plans/phase-aj/plan-phase-aj.md`
+
+## Dependency Relation
+
+- `must_follow` AJ.9 because closeout is valid only after implementation,
+  enforcement, boundary records, and governing documents are complete.
+- AJ.10 begins immediately after AJ.9 → AJ.10 merge-forward; it does not wait
+  for AJ.9 QA. Repeat that merge before every AJ.10 dev/fix round. AJ.10's PR
+  completes only after AJ.9's PR merges. No AJ pair is `parallel_safe`.
+
+## Exact Targets
+
+- `docs/plans/phase-aj/plan-phase-aj.md` (exit checklist)
+- `docs/plans/phase-aj/sprint-AJ1.md` through `sprint-AJ10.md` (frontmatter)
+- `docs/project-plan.md` (AJ status table)
+
+## Interfaces To Add Or Modify
+
+None. AJ.10 does not change production code, requirements, ADRs, boundary
+records, tests, or runtime behavior.
+
+## Deliverables
+
+- Re-run final validation against the AJ.1–AJ.9 line merged forward into AJ.10.
+- Mark every Phase AJ exit criterion checked and AJ.1–AJ.10 complete only when
+  the validation and all parent PR merge gates pass.
+- Update the project-plan AJ table in the same closeout commit.
+
+## Required Validation
+
+- `just lint`
+- `just test`
+- Confirm AJ.7 source-use guard and AJ.8 boundary gate are present and passing.
+- Confirm the four AJ.9 governing documents agree with implemented source.
+- `git diff --check`
+
+## Acceptance Criteria
+
+- Phase/sprint/project status is evidence-backed and changes only in this
+  closeout sprint.
+- AJ.10 must_follow AJ.9 under the merge-forward and PR-completion rule above.

--- a/docs/plans/phase-aj/sprint-AJ2.md
+++ b/docs/plans/phase-aj/sprint-AJ2.md
@@ -1,0 +1,145 @@
+---
+id: AJ.2
+title: CallerContext Env Resolution
+status: planned
+branch: feature/pAJ-s2-caller-context-env
+worktree: ../atm-core-worktrees/feature/pAJ-s2-caller-context-env
+target: integrate/phase-AJ
+---
+
+# Sprint AJ.2 — CallerContext Env Resolution
+
+## Goal
+
+Add one optional environment-attested `ActivityObservation` to
+`CallerContext` so AJ.3 can carry caller-side observation without treating
+command arguments as trusted telemetry.
+
+## Hard Dependencies
+
+- AJ.1 merged forward into this branch
+- `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
+- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+  the recorded post-merge `develop` SHA before AJ.1 and AJ.2 begin
+- `docs/plans/phase-aj/plan-phase-aj.md`
+- `docs/plans/phase-aj/phase-aj-research.md`
+- `crates/atm-core/src/caller_context.rs` baseline
+
+## Dependency Relation
+
+- `must_follow` AJ.1 because `ActivityObservation` uses its `SessionId` type.
+- No AJ sprint is `parallel_safe`: AJ.3 consumes this caller contract and later
+  sprints consume its wire result. AJ.2 begins immediately after AJ.1 → AJ.2
+  merge-forward; it does not wait for AJ.1 QA. Repeat that merge before every
+  AJ.2 dev/fix round; AJ.2's PR completes after AJ.1's PR merges.
+- On AJ.2 development-head push, AJ.3 begins immediately by merging
+  AJ.2 → AJ.3; AJ.3 must complete that merge before any dev/fix round and does
+  not wait for AJ.2 QA.
+
+## Exact Targets
+
+- `crates/atm-core/src/caller_context.rs`
+- `crates/atm-core/src/protocol.rs`
+- `.just/lint-config.toml` (the environment-reader boundary allowlist)
+
+## Interfaces To Add Or Modify
+
+- Add `ActivityObservation`, deriving `Debug`, `Clone`, `Serialize`,
+  `Deserialize`, `PartialEq`, and `Eq`:
+  ```rust
+  pub struct ActivityObservation {
+      pub team: TeamName,
+      pub member: AgentName,
+      #[serde(default, skip_serializing_if = "Option::is_none")]
+      pub session_id: Option<SessionId>,
+      #[serde(default, skip_serializing_if = "Option::is_none")]
+      pub pid: Option<u32>,
+  }
+  ```
+  It is transient observation metadata, not command identity and not mail
+  persistence data.
+- `CallerContext` gains `pub activity_observation: Option<ActivityObservation>`.
+- New public function
+  `pub fn read_cli_session_id_from_env() -> Option<SessionId>` — reads
+  `ATM_SESSION_ID` via `std::env::var_os`; missing, non-Unicode, blank, or
+  over-256-byte input is `None`. It calls `SessionId::new` and emits only the
+  permitted informational suppression diagnostic for invalid optional
+  telemetry.
+- New public function
+  `pub fn read_cli_pid_from_env() -> Option<u32>` — reads `ATM_PID`;
+  missing, non-Unicode, parse failure, or empty input yields `None`. Validation rules: zero
+  and negative values are rejected (yield `None`); the valid range is
+  `1..=u32::MAX`. (`pid: 0` is a real PID on some systems but is never
+  a legitimate caller-supplied observational value here.) If tighter
+  platform-specific validation is ever needed (e.g. checking the
+  process actually exists), it belongs in a later phase, not in this
+  resolver.
+- Add `ATM_SESSION_ID` and `ATM_PID` to
+  `.just/lint-config.toml`'s `env_var_boundary.forbidden_env_vars`, and add
+  only `read_cli_session_id_from_env` and `read_cli_pid_from_env` to the
+  boundary-reader allowlist. The comment must state that these are the sole
+  `atm-core` readers because they construct transient, environment-attested
+  caller metadata; all other reads remain lint violations.
+- `ActivityObservation.pid` is optional local caller metadata only. Its
+  required-heartbeat counterpart remains `TeamMemberHeartbeatRequest.pid` in
+  `crates/atm-core/src/protocol.rs`; the overwrite asymmetry is implemented
+  only by AJ.4's `merge_observation`, never by either env resolver.
+- Add one shared, non-fallible
+  `activity_observation_for_resolved_caller(&AgentName, &TeamName) -> Option<ActivityObservation>`.
+  It reads raw environment identity/team with `var_os`, parses them locally,
+  compares them to the already resolved caller, and returns `None` for absent,
+  non-Unicode, malformed, args-only, or mismatched identity/team. It must not
+  call a fallible caller resolver or turn optional telemetry into an `AtmError`.
+  When identity/team match, it returns `Some` even if session and pid are both
+  absent: the attested command still establishes `Active` later.
+- `resolve_cli_inspection_caller_context()` constructs the optional observation
+  from the shared resolver; mutation resolution inherits it through its
+  existing delegation to inspection resolution. AJ.3's CLI callers copy that
+  field; graft calls the same helper once against `PyGraftSession`'s resolved
+  caller. Neither adds a per-command identity override.
+
+## Deliverables
+
+- `CallerContext` carries one `Some(ActivityObservation)` only when parsed
+  `ATM_IDENTITY` and `ATM_TEAM` match the resolved command identity/team.
+  Args-only and mismatched invocations retain command behavior and yield `None`;
+  an `info!` anomaly is allowed.
+- Env resolvers are pure — no process-state probing, no `/proc` reads, and no
+  fallback to `std::process::id()` in any AJ caller path.
+- Unit tests cover: env unset → `None`; env empty → `None`; env set to a
+  valid value → `Some(...)`; `ATM_PID` set to non-numeric → `None`; matching
+  command/environment creates one observation; args-only and mismatch create
+  none while preserving the command's existing result/error contract.
+- Unit tests also prove matching identity/team with no session/pid produces
+  `Some(ActivityObservation { session_id: None, pid: None, .. })`; absence of
+  metadata must not suppress the state observation.
+- A resolver test sets malformed/non-Unicode metadata where the platform test
+  helper permits it and proves telemetry becomes `None` without adding a new
+  caller-resolution error.
+- No behavioral branching on the presence of this DTO anywhere in
+  `atm-core`
+- The environment-boundary lint has positive tests for both new approved
+  readers and a negative test proving a direct `ATM_SESSION_ID` or `ATM_PID`
+  read outside those functions fails.
+
+## Acceptance Criteria
+
+- observation is present only when environment identity/team are present and
+  match the resolved command identity/team; args-only or mismatch is `None`
+  without altering command behavior. The comparison is write-side telemetry
+  attestation only; it does not replace existing command validation.
+- AJ.2 must_follow AJ.1: begin immediately after AJ.1 → AJ.2 merge-forward,
+  repeat it before every dev/fix round, do not wait for AJ.1 QA, and complete
+  AJ.2's PR only after AJ.1's PR merges.
+
+## Required Validation
+
+- `cargo build -p atm-core`
+- `cargo clippy -p atm-core --all-targets -- -D warnings`
+- `cargo test -p atm-core caller_context`
+- New unit tests use `temp-env` (or an equivalent per-command environment
+  fixture) and never mutate process-global environment through
+  `std::env::set_var`, avoiding parallel-test pollution
+- `rg -n "ATM_SESSION_ID|ATM_PID" crates/atm-core/src/caller_context.rs`
+  shows both readers
+- `git diff --check`

--- a/docs/plans/phase-aj/sprint-AJ3.md
+++ b/docs/plans/phase-aj/sprint-AJ3.md
@@ -1,0 +1,160 @@
+---
+id: AJ.3
+title: CLI Wire Payload Integration
+status: planned
+branch: feature/pAJ-s3-cli-wire-payload
+worktree: ../atm-core-worktrees/feature/pAJ-s3-cli-wire-payload
+target: integrate/phase-AJ
+---
+
+# Sprint AJ.3 — CLI Wire Payload Integration
+
+## Goal
+
+Carry optional `ActivityObservation` on `WriteRequest` and `ReadQuery`, then
+have `atm send`, `atm read`, `atm ack`, and graft populate it from their
+environment-derived context so the daemon sees caller observational state on every
+local dispatch (UDS or TCP — both share the same wire structs).
+
+Before attaching the new field, decompose `send/mod.rs` below the repository's
+1,000 non-test-line ceiling. This is an implementation precondition, not a
+post-hoc cleanup: move the existing request-construction/dispatch helpers into
+`crates/atm-core/src/send/request.rs` (and update `send/mod.rs` re-exports)
+without behavior change, then add `activity_observation` at the resulting
+stable seam.
+
+Apply the same precondition to `read/mod.rs`: before adding
+`ReadQuery.activity_observation`, extract existing query-construction helpers
+into `crates/atm-core/src/read/request.rs` and reduce `read/mod.rs` to at most
+1,000 non-test lines. Remove its current `Q.6 split pending` line-count
+exclusion from `.just/lint-config.toml` in the same decomposition commit; AJ.3
+must not use that unscoped exclusion to absorb new observation wiring.
+
+## Hard Dependencies
+
+- AJ.1 and AJ.2 merged forward into this branch
+- `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
+- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+  the recorded post-merge `develop` SHA before AJ.1 and AJ.3 begin
+- `docs/plans/phase-aj/plan-phase-aj.md`
+- `docs/plans/phase-aj/phase-aj-research.md`
+- `crates/atm-core/src/send/mod.rs` baseline
+- `crates/atm-core/src/read/mod.rs` baseline
+
+## Dependency Relation
+
+- `must_follow` AJ.2 because CLI and graft transmit its attestation DTO.
+- No AJ sprint is `parallel_safe`: AJ.4 consumes these wire fields. AJ.3 begins
+  immediately after AJ.2 → AJ.3 merge-forward; it does not wait for AJ.2 QA.
+  Repeat that merge before every AJ.3 dev/fix round; AJ.3's PR completes after
+  AJ.2's PR merges.
+- On AJ.3 development-head push, AJ.4 begins immediately by merging
+  AJ.3 → AJ.4; AJ.4 must complete that merge before any dev/fix round and does
+  not wait for AJ.3 QA.
+
+## Exact Targets
+
+- `crates/atm-core/src/send/mod.rs`
+- `crates/atm-core/src/send/request.rs` (new decomposition module)
+- `crates/atm-core/src/read/mod.rs`
+- `crates/atm-core/src/read/request.rs` (new decomposition module)
+- `.just/lint-config.toml` (remove the `read/mod.rs` exclusion after the split)
+- `crates/atm-core/src/ack/mod.rs`
+- `crates/atm/src/commands/send.rs`
+- `crates/atm/src/commands/read.rs`
+- `crates/atm/src/commands/ack.rs`
+- `crates/atm-graft-python/src/lib.rs`
+- `crates/atm-daemon/src/https_transport.rs` (remote-ingress stripping only)
+
+No changes to `crates/atm-daemon/src/local_ipc_transport/request_worker.rs`
+or `crates/atm-daemon/src/local_tcp_transport.rs` — the unified HTTP
+framing passes the JSON body through unchanged.
+
+## Interfaces To Add Or Modify
+
+- `WriteRequest` and `ReadQuery` gain
+  `pub activity_observation: Option<ActivityObservation>` with
+  `#[serde(default, skip_serializing_if = "Option::is_none")]`.
+  It is transient request metadata, consumed only by the trusted observation
+  merge after successful local dispatch; it must not enter a `mail_messages`
+  row or message payload.
+- `WriteRequest::with_activity_observation(Option<ActivityObservation>) -> Self`
+  and `ReadQuery::with_activity_observation(Option<ActivityObservation>) -> Self`
+  are the sole builder-style setters. They only attach the additive DTO; they
+  do not validate it, persist it, or affect command behavior.
+- `SendCommand::build_request()` and the `read` command call the respective
+  setter with the optional observation from `CallerContext`.
+- `AckRequest` gains the same optional field. `atm ack` copies it from
+  `CallerContext`; both `AckRequest::into_write_request()` and
+  `AckRequest::from_unresolved_write()` preserve it. This is required because
+  acknowledgements become the canonical `WriteRequest` only through that
+  conversion.
+- `PyGraftSession` retains its existing caller argument for normal graft
+  behavior, but read/send/ack obtain observation only through AJ.2's shared
+  resolver against that resolved caller. Args-only graft sessions and an
+  environment mismatch serialize no observation; the Python address is never
+  copied directly into telemetry.
+- HTTPS peer ingress uses one explicit
+  `clear_remote_activity_observation(&mut ApiRequest)` helper before the
+  shared router. It clears the DTO from both `ApiRequest::Write` and
+  `ApiRequest::Messages(MessageCollectionRequest::Receive)`; remote peer
+  traffic can never update local observation.
+
+## Deliverables
+
+- `send/mod.rs` is at or below 1,000 non-test lines before the observation
+  field/builder is added; its extracted request helpers retain existing public
+  API behavior and tests. AJ.3 must not waive the line-count lint or add an
+  exclusion for this module.
+- `read/mod.rs` is at or below 1,000 non-test lines before the `ReadQuery`
+  observation field/builder is added; its extracted request helpers retain
+  existing public API behavior and tests, and its `Q.6 split pending`
+  line-count exclusion is removed rather than extended or re-justified.
+- CLI and graft transmit `activity_observation` only when a trusted environment
+  identity/team attests the caller; otherwise the field is omitted entirely
+  (no `null` literals, no empty strings)
+- Wire payloads remain readable by older daemon builds — the new fields
+  are strictly additive
+- Payloads flow identically over UDS and TCP because both transports use
+  `HttpFrameReader` and dispatch through the same `ApiRouter`
+- No CLI flag is added in this sprint; values come from env only
+- No code path inspects observation telemetry to alter CLI/graft behavior
+
+## Required Validation
+
+- `cargo build --workspace`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test -p atm-core -p atm -p atm-graft-python -p atm-daemon`
+- `just lint` proves `send/mod.rs` remains under the production-line ceiling
+- `just lint` proves `read/mod.rs` remains under the production-line ceiling
+  after its exclusion is removed
+- New integration test: serialize `WriteRequest`/`ReadQuery` with observation
+  `None` → JSON contains no `activity_observation`; with `Some(...)` → JSON
+  contains the nested team/member/session/pid values
+- Manual smoke over UDS: `ATM_SESSION_ID=smoke-1 ATM_PID=$$ atm send ...`
+  against a dev daemon and confirm receipt in daemon trace log
+- Manual smoke over TCP loopback: same env against a daemon started with
+  TCP enabled; confirm identical receipt in trace log (UDS/TCP parity)
+- Regression test: an inbound HTTPS `WriteRequest` with a forged observation
+  reaches normal write handling with the DTO stripped. The matching forged
+  remote `Receive(ReadQuery)` case also reaches normal handling with the DTO
+  stripped. AJ.4 proves neither ingress can update `RuntimeStatusCache`.
+- Ack conversion test: an environment-attested `AckRequest` becomes one
+  `WriteRequest` with identical `activity_observation`; converting that write
+  back through `from_unresolved_write()` preserves the same DTO.
+- Storage regression test: serializing the durable mail row/payload after a
+  local write proves it contains no `activity_observation`, session id, or pid
+  telemetry from the request DTO.
+- `rg -n "activity_observation" crates/atm-core/src/send/mod.rs crates/atm-core/src/read/mod.rs crates/atm-core/src/ack/mod.rs crates/atm-daemon/src/https_transport.rs`
+  shows the additive field, acknowledgement conversion, and remote-ingress
+  clearing boundary
+- `git diff --check`
+
+## Acceptance Criteria
+
+- request-capture tests prove CLI and graft send/read/ack only transmit
+  telemetry when env identity/team match any corresponding arguments; UDS/TCP
+  use identical DTOs, both remote Write and Receive ingress strip it, and
+  remote HTTPS cannot carry observation into the cache.
+- AJ.3 must_follow AJ.2 under the merge-forward and PR-completion rule in the
+  phase plan.

--- a/docs/plans/phase-aj/sprint-AJ4.md
+++ b/docs/plans/phase-aj/sprint-AJ4.md
@@ -1,0 +1,247 @@
+---
+id: AJ.4
+title: Daemon Cache Touch On Dispatch
+status: planned
+branch: feature/pAJ-s4-daemon-cache-touch
+worktree: ../atm-core-worktrees/feature/pAJ-s4-daemon-cache-touch
+target: integrate/phase-AJ
+---
+
+# Sprint AJ.4 — Daemon Cache Touch On Dispatch
+
+## Goal
+
+Teach the daemon to update `RuntimeStatusCache` as a side effect of every
+send/read/ack dispatch, honoring the non-overwrite rule for absent
+optional fields — with a single touch site in the shared dispatcher so
+UDS and TCP both update the same cache entry.
+
+Before extending dispatcher behavior, run the production-line checkpoint for
+`runtime_health.rs`. If it is above 900 non-test lines, first extract the
+existing observation-free route helpers into
+`crates/atm-daemon/src/runtime_health/dispatch.rs`, preserving behavior and
+tests; do not add AJ surface to a file that would exceed the 1,000-line ceiling.
+
+## Hard Dependencies
+
+- AJ.1, AJ.2, and AJ.3 merged forward into this branch
+- `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`:
+  unified HTTP-framed local transport, UDS in
+  `local_ipc_transport/request_worker.rs` and TCP in
+  `local_tcp_transport.rs`, both dispatching into `ApiRouter`
+- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+  the recorded post-merge `develop` SHA before AJ.1 and AJ.4 begin
+- `docs/plans/phase-aj/plan-phase-aj.md`
+- `docs/plans/phase-aj/phase-aj-research.md`
+- `crates/atm-daemon/src/runtime_health.rs` baseline
+- `crates/atm-daemon/src/runtime_status_cache.rs` baseline
+
+## Dependency Relation
+
+- `must_follow` AJ.3 because cache touch consumes its optional wire DTO.
+- No AJ sprint is `parallel_safe`: AJ.5 reuses this merge contract and AJ.6
+  projects its cache fields. AJ.4 begins immediately after AJ.3 → AJ.4
+  merge-forward; it does not wait for AJ.3 QA. Repeat that merge before every
+  AJ.4 dev/fix round; AJ.4's PR completes after AJ.3's PR merges.
+- On AJ.4 development-head push, AJ.5 begins immediately by merging
+  AJ.4 → AJ.5; AJ.5 must complete that merge before any dev/fix round and does
+  not wait for AJ.4 QA.
+
+## Exact Targets
+
+- `crates/atm-core/src/protocol.rs`
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/runtime_health/dispatch.rs` (split contingency when
+  the checkpoint requires it)
+- `crates/atm-daemon/src/https_transport.rs` (remote ingress stripping test
+  coverage only; AJ.3 owns the stripping helper)
+
+Explicitly NOT touched (framing is transport-agnostic and stays that way):
+
+- `crates/atm-daemon/src/local_ipc_transport/request_worker.rs`
+- `crates/atm-daemon/src/local_tcp_transport.rs`
+
+## Interfaces To Add Or Modify
+
+- Add public protocol:
+  ```rust
+  pub enum RuntimeObservationSource {
+      Heartbeat,
+      LocalCommand,
+  }
+  ```
+  It derives `Debug`, `Clone`, `Copy`, `Serialize`, `Deserialize`,
+  `PartialEq`, and `Eq`.
+  It identifies ingress provenance; it is not an authority or behavior
+  selector. Graft's environment-attested read/send/ack uses `LocalCommand`;
+  AJ does not add a graft-specific request field merely for provenance.
+- `RuntimeMemberRecord` gains `session_id: Option<SessionId>`, `pid: Option<u32>`,
+  `state_changed_by: Option<RuntimeObservationSource>`,
+  `state_changed_at: Option<IsoTimestamp>`,
+  `session_changed_by: Option<RuntimeObservationSource>`, and
+  `session_changed_at: Option<IsoTimestamp>`, while retaining its existing
+  `last_active_at`. State provenance changes only on a lifecycle edge; session
+  provenance changes only on a session edge.
+- `RuntimeMemberRecord.state_changed_at: Option<IsoTimestamp>` updates only
+  for a real lifecycle transition, never for a metadata-only or same-state
+  activity touch.
+  `Active → Active`, `Idle → Idle`, and `Offline → Offline` are not edges.
+  Every lifecycle value records its first entry and retains that timestamp until
+  a different-state edge.
+- `last_active_at` advances on each trusted `Active` observation but is not a
+  state-edge timestamp and is never shown as the roster's state age.
+- Every actual session/pid mutation emits one structured info event with id
+  `runtime_observation_metadata_changed`, previous/new value, team/member,
+  source, and timestamp; no-op input emits no change event.
+- Add one crate-private, infallible merge helper:
+  ```rust
+  fn merge_observation(
+      &self,
+      key: &RuntimeMemberKey,
+      source: RuntimeObservationSource,
+      state: RuntimeMemberState,
+      session_id: Option<&SessionId>,
+      pid: Option<u32>,
+      observed_at: IsoTimestamp,
+  ) -> ObservationMergeOutcome
+  ```
+  It is the only AJ mutation point for `RuntimeMemberRecord` observation fields.
+  `touch_member` and `record_heartbeat` are thin ingress adapters; no trait or
+  transport-specific implementation is introduced.
+- Add crate-private, copyable `ObservationMergeOutcome` with at least
+  `pid_changed`, `session_changed`, and `state_changed`. It is returned by the
+  merge helper so heartbeat response construction and audit emission share one
+  comparison result. `pid_changed` is true only for replacement of one defined
+  pid by a different defined pid; initial `None -> Some(pid)` is an audited
+  mutation but reports `false` for compatibility with the existing response
+  field's replacement meaning.
+  ```rust
+  struct ObservationMergeOutcome {
+      pid_changed: bool,
+      session_changed: bool,
+      state_changed: bool,
+  }
+  ```
+- Add daemon-private `TrustedActivityObservation(ActivityObservation)`. Only
+  `ApiRouter`'s successful local `AuthenticatedIngress` dispatch path may
+  construct it, through a private constructor that consumes the local-ingress
+  proof and an optional request DTO. `touch_member` accepts this capability,
+  never raw `ActivityObservation`; peer, anonymous, and HTTPS-stripped paths
+  cannot type-check a cache mutation call.
+- New crate-private method on the cache:
+  `pub(crate) fn touch_member(&self, observation: &ActivityObservation,
+  observed_at: IsoTimestamp)`
+  implementing latest-trusted-observation semantics:
+  - if `observation.session_id` is `Some`, replace the cached current value
+  - if it is `None`, leave the cached current value untouched
+  - blank/whitespace session values normalize to absent before these rules
+  - same for `observation.pid`; heartbeat's required pid overwrites through the
+    shared helper
+  - a different pid/session emits one retained change event but never rejects
+    ingress, changes lifecycle state, or selects behavior
+- AJ adds no reset API. Roster removal drops the entry; a future re-add starts
+  with no observation. `touch_member` must not write `Unknown` or clear a
+  defined session.
+- New crate-private accessor
+  `pub(crate) fn cached_session_id(&self, team: &TeamName, member: &AgentName) -> Option<SessionId>`
+  — returns the currently cached `session_id` for the identity, or
+  `None` if the member has no cache entry or no `Some` value has ever
+  been written. Infallible: `cached_session_id` reads through the existing
+  ArcSwap snapshot-load pattern (no `Mutex`/`RwLock`, no poisoning possible);
+  it never errors.
+- Thread `AuthenticatedIngress` from `ApiRouter::route()` through
+  `dispatch_with_deadline()`, `route_write()`, and `dispatch_non_write()`.
+  These functions use it only to enforce the local-observation trust boundary;
+  it is not session/pid/state policy.
+- `route_write()` calls `touch_member` exactly once, after `finish()` reports a
+  successful write, only when ingress is `Local`, and with the pre-write
+  `WriteRequest.activity_observation`. A failed persistence or post-write
+  route never touches the cache.
+- The shared `dispatch_with_deadline()` guard remains outside the observation
+  merge. An expiry before route dispatch produces no observation. If an
+  already-admitted local write/read has completed its normal dispatch work and
+  the guard subsequently returns the existing retry-safe
+  `ATM_DAEMON_MAY_HAVE_EXECUTED` outcome, the accepted local observation is
+  retained: it describes the daemon-side event, not a client-visible success.
+  Observation must never relabel that timeout outcome or add a retry decision.
+- `dispatch_non_write()` for the `Receive` path calls `touch_member` exactly
+  once after a successful read, only when ingress is `Local`, and with
+  `ReadQuery.activity_observation`. A failed read never touches the cache.
+- Local ingress supplies `IsoTimestamp::now()` at successful daemon dispatch;
+  heartbeat supplies its accepted `request.observed_at`, matching the existing
+  heartbeat contract. Merge order is accepted-ingress order: AJ adds no
+  stale-event rejection, clock-skew policy, or state-based retry behavior.
+
+Because UDS (`request_worker.rs`) and TCP (`local_tcp_transport.rs`) both
+land in `ApiRouter` and both go through `route_write()` /
+`dispatch_non_write()`, these two call sites cover both transports with
+no per-transport code.
+
+## Deliverables
+
+- Cache entries retain `session_id` and `pid` for the daemon process lifetime
+- A dispatch carrying `Some(ActivityObservation { .. })` updates the cache
+- A dispatch carrying `None` leaves the existing cached values
+  untouched (covered by dedicated tests — one `Some` followed by one
+  `None` followed by an accessor read must return the original `Some`)
+- A local CLI/graft touch after a heartbeat-derived state transitions it to
+  `Active` with `LocalCommand` provenance and preserves absent session metadata.
+- The same test runs once over UDS and once over TCP loopback and
+  produces identical cache state (transport parity)
+- Touching the cache is a side effect only; dispatch behavior is
+  unchanged regardless of whether the fields are present
+- Cache merging is an infallible side effect; it never changes a successful
+  dispatch result.
+
+## Required Validation
+
+- `cargo build --workspace`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test -p atm-daemon`
+- `just lint` proves `runtime_health.rs` remains at or below the production
+  line ceiling after the checkpoint/split
+- New unit tests in `runtime_status_cache.rs`:
+  - `touch_member_some_then_none_preserves_value`
+  - `touch_member_none_on_empty_cache_stays_none`
+  - `touch_member_some_overwrites_some`
+  - `blank_session_normalizes_to_absent_without_clearing_known_session`
+  - same trio for `pid`
+  - `normal_updates_never_regress_known_state_or_session_to_default`
+  - `roster_removal_drops_observation_and_readd_starts_unknown`
+  - `unknown_and_offline_are_distinct_states_with_distinct_provenance`
+  - `trusted_cli_activity_transitions_offline_or_idle_to_active`
+  - `state_changed_at_updates_only_on_real_state_transition`
+  - `state_changed_by_updates_only_on_real_state_transition`
+  - `session_changed_by_and_at_update_only_on_session_edge`
+  - `session_and_pid_mutations_emit_exactly_one_audit_event`
+  - `pid_changed_response_is_false_for_initial_set_and_true_for_replacement`
+  - `changed_pid_or_session_is_retained_evidence_not_identity_conflict`
+  - `no_op_metadata_updates_emit_no_audit_event`
+- New integration test in `runtime_health.rs` exercises send → read → ack and
+  asserts the cache reflects the latest attested observation
+- Regression tests prove a failed local send/read, and peer, untrusted-smoke,
+  and anonymous ingress carrying a forged observation, cannot mutate the
+  cache. This remains true if an HTTPS stripping regression is introduced:
+  dispatcher ingress gating is defense in depth, not a behavior policy.
+- Compile-time coverage proves only the private local-dispatch constructor can
+  produce `TrustedActivityObservation`; `touch_member` has no raw
+  `ActivityObservation` overload.
+- Regression tests prove an expired pre-dispatch deadline leaves the cache
+  untouched, while a post-side-effect deadline result retains the already
+  accepted local observation and returns the existing retry-safe uncertainty
+  unchanged.
+- New transport-parity integration test: same dispatch sequence issued
+  once via the UDS path and once via the TCP loopback path against the
+  same daemon; assert identical `RuntimeStatusCache` contents afterwards
+- `rg -n "touch_member|merge_observation|cached_session_id" crates/atm-daemon/src/`
+  shows the new surface in `runtime_health.rs` and `runtime_status_cache.rs`
+  only — never in `local_ipc_transport/` or `local_tcp_transport.rs`
+- `git diff --check`
+
+## Acceptance Criteria
+
+- cache touch occurs exactly once only after successful send/read/ack and only
+  for a trusted observation; it never changes state-machine behavior.
+- AJ.4 must_follow AJ.3 under the merge-forward and PR-completion rule in the
+  phase plan.

--- a/docs/plans/phase-aj/sprint-AJ5.md
+++ b/docs/plans/phase-aj/sprint-AJ5.md
@@ -1,0 +1,177 @@
+---
+id: AJ.5
+title: HTTP Heartbeat Session State
+status: planned
+branch: feature/pAJ-s5-heartbeat-session
+worktree: ../atm-core-worktrees/feature/pAJ-s5-heartbeat-session
+target: integrate/phase-AJ
+---
+
+# Sprint AJ.5 — HTTP Heartbeat Session State
+
+## Goal
+
+Extend the heartbeat ingestion path so `POST /v1/atm/heartbeat` records
+`session_id` into `RuntimeStatusCache` under the same non-overwrite rule
+used by the local dispatch path.
+
+Re-run AJ.4's `runtime_health.rs` production-line checkpoint after merge. If
+the heartbeat addition would exceed the 1,000-line ceiling, extract the
+existing heartbeat adapter into
+`crates/atm-daemon/src/runtime_health/heartbeat.rs` before adding behavior;
+never waive or exclude the line-count rule.
+
+## Hard Dependencies
+
+- AJ.1 through AJ.4 merged forward into this branch
+- `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
+- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+  the recorded post-merge `develop` SHA before AJ.1 and AJ.5 begin
+- `docs/plans/phase-aj/plan-phase-aj.md`
+- `docs/plans/phase-aj/phase-aj-research.md`
+- `crates/atm-core/src/api.rs` baseline (`HEARTBEAT_PATH` unchanged)
+- `crates/atm-daemon/src/runtime_health.rs` baseline (`record_heartbeat`)
+
+## Dependency Relation
+
+- `must_follow` AJ.4 because heartbeat calls its only cache merge function and
+  consumes its merge outcome.
+- No AJ sprint is `parallel_safe`: AJ.6 exposes this converged heartbeat/cache
+  result. AJ.5 begins immediately after AJ.4 → AJ.5 merge-forward; it does not
+  wait for AJ.4 QA. Repeat that merge before every AJ.5 dev/fix round; AJ.5's
+  PR completes after AJ.4's PR merges.
+- On AJ.5 development-head push, AJ.6 begins immediately by merging
+  AJ.5 → AJ.6; AJ.6 must complete that merge before any dev/fix round and does
+  not wait for AJ.5 QA.
+
+## Exact Targets
+
+- `crates/atm-daemon/src/runtime_health.rs`
+- `crates/atm-daemon/src/runtime_health/heartbeat.rs` (split contingency when
+  the LOC checkpoint requires it)
+- `crates/atm-daemon/src/runtime_status_cache.rs`
+- `crates/atm-daemon/src/tests.rs`
+- `docs/atm-daemon/boundaries.md`
+
+## Interfaces To Add Or Modify
+
+- `record_heartbeat()` accepts `session_id` from
+  `TeamMemberHeartbeatRequest` and calls AJ.4's shared
+  `merge_observation(..., RuntimeObservationSource::Heartbeat, ...)`. The
+  helper owns `Some`/`None` merge rules; `record_heartbeat` only maps the
+  heartbeat activity to its lifecycle state. Its required pid becomes the
+  current pid — see "Pid Overwrite Policy" in `plan-phase-aj.md`.
+- `TeamMemberHeartbeatResponse.pid_changed` retains its existing wire field
+  and means only replacement of a prior defined pid by a different defined
+  pid. Initial pid observation is recorded and audited but is not a
+  replacement. The value comes from AJ.4's `ObservationMergeOutcome`, never
+  from a process-liveness guard.
+- `HeartbeatActivity` semantics are unchanged
+- `TeamMemberHeartbeatResponse` echoes the post-update cached
+  `session_id` per the authoritative response-semantics contract stated
+  in `sprint-AJ1.md` (Interfaces To Add Or Modify). AJ.5 implements
+  that contract; it does not redefine it.
+- No new HTTP route, no new handler — this sprint extends the existing
+  heartbeat handler only
+
+## Deliverables
+
+- A heartbeat with `session_id: Some(...)` updates the cached value
+- A heartbeat with `session_id: None` leaves the cached value untouched
+- A heartbeat with `session_id: None` against an empty cache leaves the
+  cached value as `None`
+- Missing optional heartbeat telemetry must not reset known state/session or
+  their provenance.
+- Only a `SessionEnded` heartbeat may set `Offline`; missing telemetry and
+  any default/absent value never mean `Offline`.
+- Heartbeat activity transitions `ActiveToolUse` → `Active`, `Idle` → `Idle`,
+  and `SessionEnded` → `Offline`; each transition records heartbeat provenance.
+  `SessionEnded` retains the last known session id when its request omits one.
+- Contract test fixtures represent hook emission exactly: startup/active uses
+  `ActiveToolUse`, idle uses `Idle`, and stop uses `SessionEnded`. This sprint
+  does not modify hook-side code.
+- A changed heartbeat pid/session emits retained structured evidence, updates
+  the current observation, and does not reject the heartbeat, change lifecycle
+  state, degrade readiness, or trigger a cache policy. Doctor aggregation is
+  explicitly future scope.
+- The heartbeat response carries the post-update cached `session_id`
+- A local dispatch (UDS or TCP) carrying `Some` followed by a heartbeat
+  carrying `None` leaves the dispatch-supplied value visible in
+  subsequent heartbeats (proves convergence on one cache entry per
+  roster member across all three ingestion paths)
+- No behavioral branching on `session_id` anywhere in the heartbeat path
+- A heartbeat state/session change records `Heartbeat` provenance; `None`
+  session input preserves both prior value and prior provenance.
+- A heartbeat session/pid mutation uses the same required one-event audit
+  contract as local ingress.
+- Update `docs/atm-daemon/boundaries.md` for downstream alerting consumers:
+  removing conflict-driven `Degraded` readiness is intentional because it was
+  policy, not health; the replacement is the non-authoritative retained
+  `runtime_observation_metadata_changed` event, not a new readiness signal or
+  doctor aggregate.
+
+## Paths To Delete
+
+- In `crates/atm-daemon/src/runtime_health.rs`, delete `record_heartbeat`'s
+  `process_is_alive` guard, `record_identity_conflict` call, and only its
+  `return Err(AtmError::identity_conflict(...))` statement. The shared
+  `AtmError::identity_conflict()` constructor remains for unrelated
+  identity-resolution callers outside this sprint.
+- In `crates/atm-daemon/src/runtime_status_cache.rs`, delete
+  `RuntimeStatusCache::record_identity_conflict` and
+  `record_identity_conflict_for_test`.
+- In `runtime_status_cache.rs`, remove the `IdentityConflict` projection
+  special case and its `conflict_count`-driven `Degraded` readiness branch and
+  detail string `admin takeover or dead-pid retry` from
+  `finish_runtime_snapshot`; remove `IdentityConflict` eviction prioritization
+  from `evict_status_cache_entry_if_needed`; and remove its special projection
+  handling from `build_runtime_snapshot_all` and
+  `build_runtime_snapshot_scoped`. Keep an exhaustive match arm that buckets a
+  deserialized-only `IdentityConflict` as `unknown_members`, preserving wire
+  backwards compatibility.
+- Remove or adapt the retired-behavior tests: the live-pid conflict rejection
+  test, `heartbeat_retries_identity_conflict_after_old_pid_dies`,
+  `identity_conflict_insert_evicts_oldest_conflict_when_cache_is_full`, and
+  `doctor_projects_degraded_runtime_when_member_identity_conflicts_exist`.
+
+The replacement is the ordinary `merge_observation` result and retained audit
+evidence; no ATM routing, retry, admission, delivery, nudge, or
+session-rejection behavior may consume a PID/session conflict.
+
+## Required Validation
+
+- `cargo build --workspace`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test -p atm-daemon`
+- `just lint` proves `runtime_health.rs` remains at or below the production
+  line ceiling after the checkpoint/split
+- New integration test `heartbeat_session_id_round_trip`:
+  - POST heartbeat with `session_id: Some("s-1")` → response shows
+    `Some("s-1")`
+  - POST heartbeat with `session_id: None` → response still shows
+    `Some("s-1")`
+  - POST heartbeat with `session_id: Some("s-2")` → response shows
+    `Some("s-2")`
+- New regression test `session_ended_preserves_last_known_session`:
+  `ActiveToolUse` with `Some("s-1")`, then `SessionEnded` with `None`, yields
+  `Offline` plus `Some("s-1")`.
+- New integration test `heartbeat_and_local_dispatch_converge_on_cache`
+  exercises a UDS send followed by an HTTP heartbeat against the same
+  identity; repeat with TCP send to confirm parity
+- Regression test: a prior pid plus a heartbeat with a different pid
+  succeeds, updates the current pid, retains one change event, and never emits
+  `IdentityConflict`.
+- `rg -n "merge_observation|record_identity_conflict|process_is_alive" crates/atm-daemon/src/runtime_health.rs crates/atm-daemon/src/runtime_status_cache.rs`
+  shows the shared merge flow and no live-pid conflict producer or guard
+- `rg -n "record_identity_conflict_for_test|AtmErrorCode::IdentityConflict" crates/atm-daemon/src/tests.rs`
+  returns no matches
+- `rg -n "conflict_count|admin takeover or dead-pid retry" crates/atm-daemon/src/runtime_status_cache.rs`
+  returns no matches
+- `git diff --check`
+
+## Acceptance Criteria
+
+- heartbeat merges telemetry without adding a business decision; its response
+  returns the post-update cached session while preserving existing fields.
+- AJ.5 must_follow AJ.4 under the merge-forward and PR-completion rule in the
+  phase plan.

--- a/docs/plans/phase-aj/sprint-AJ6.md
+++ b/docs/plans/phase-aj/sprint-AJ6.md
@@ -1,0 +1,105 @@
+---
+id: AJ.6
+title: Runtime Observation Snapshot Projection
+status: planned
+branch: feature/pAJ-s6-runtime-observation-snapshot
+worktree: ../atm-core-worktrees/feature/pAJ-s6-runtime-observation-snapshot
+target: integrate/phase-AJ
+---
+
+# Sprint AJ.6 — Runtime Observation Snapshot Projection
+
+## Goal
+
+Implement the production `RuntimeStatusSnapshot` and `atm members` projection
+for current runtime observation. This sprint owns only the user-visible
+snapshot feature and its direct tests; AJ.7 owns the source-use guard.
+
+## Hard Dependencies
+
+- AJ.1 through AJ.5 merged forward into this branch
+- `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
+- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+  the recorded post-merge `develop` SHA before AJ.1 and AJ.6 begin
+- `docs/plans/phase-aj/plan-phase-aj.md`
+- `docs/plans/phase-aj/phase-aj-research.md`
+
+## Dependency Relation
+
+- `must_follow` AJ.5 because this sprint exposes AJ.5's converged cache and
+  heartbeat semantics.
+- AJ.7 `must_follow`s AJ.6 because its static guard inspects this implemented
+  snapshot and roster projection.
+- AJ.6 begins immediately after AJ.5 → AJ.6 merge-forward; it does not wait
+  for AJ.5 QA. Repeat that merge before every AJ.6 dev/fix round. AJ.6's PR
+  completes only after AJ.5's PR merges. No AJ pair is `parallel_safe`.
+- On AJ.6 development-head push, AJ.7 begins immediately by merging
+  AJ.6 → AJ.7; AJ.7 must complete that merge before any dev/fix round and does
+  not wait for AJ.6 QA.
+
+## Exact Targets
+
+- `crates/atm-core/src/protocol.rs` (`RuntimeMemberObservation` and additive
+  `RuntimeStatusSnapshot.members`)
+- `crates/atm-daemon/src/runtime_status_cache.rs` (`snapshot_for_members()`)
+- `crates/atm/src/commands/members.rs` (human/JSON projection)
+
+## Interfaces To Add Or Modify
+
+- Add public `RuntimeMemberObservation`, deriving `Debug`, `Clone`,
+  `Serialize`, `Deserialize`, `PartialEq`, and `Eq`:
+  ```rust
+  pub struct RuntimeMemberObservation {
+      pub team: TeamName,
+      pub member: AgentName,
+      pub state: RuntimeMemberState,
+      pub session_id: Option<SessionId>,
+      pub pid: Option<u32>,
+      pub last_active_at: Option<IsoTimestamp>,
+      pub state_changed_by: Option<RuntimeObservationSource>,
+      pub state_changed_at: Option<IsoTimestamp>,
+      pub session_changed_by: Option<RuntimeObservationSource>,
+      pub session_changed_at: Option<IsoTimestamp>,
+  }
+  ```
+  Optional fields use `#[serde(default, skip_serializing_if =
+  "Option::is_none")]`; structured output contains raw session id and pid.
+- `RuntimeStatusSnapshot` gains `members: Vec<RuntimeMemberObservation>` with
+  `#[serde(default, skip_serializing_if = "Vec::is_empty")]`.
+- `RuntimeStatusCache::snapshot_for_members()` returns one observation for each
+  roster member, retaining `Unknown` in structured output. `atm members`
+  omits default observation from human output.
+- `crates/atm/src/commands/members.rs` owns one private
+  `short_session_id_for_human(&SessionId)` helper. Human output renders state
+  age only from `state_changed_at`, then pid and that helper's first 12 Unicode
+  scalar values plus `…` only when longer; JSON retains raw values and absolute
+  timestamps. Fixtures use a fixed clock.
+
+## Deliverables
+
+- Optional current session/pid are projected in snapshot members; existing
+  snapshot fields, `member_counts`, and `CLI_SCHEMA_VERSION` remain intact.
+- A UDS send/read, heartbeat-without-session, and TCP-loopback ack integration
+  test proves the same member retains its known session when a later trusted
+  command omits session metadata.
+- Roster fixtures prove raw JSON, short human session display, state age, and
+  omission of default `Unknown` observation.
+- Compatibility fixtures prove a new reader accepts a pre-AJ snapshot without
+  `members`; an older reader ignores the additive field.
+
+## Required Validation
+
+- `cargo build -p atm-core -p atm-daemon -p atm`
+- `cargo clippy -p atm-core -p atm-daemon -p atm --all-targets -- -D warnings`
+- `cargo test -p atm-core -p atm-daemon -p atm`
+- Run the UDS/TCP/heartbeat integration test on macOS and Linux CI.
+- `git diff --check`
+
+## Acceptance Criteria
+
+- `atm members` fixture tests prove the defined observation renders for the
+  correct member and default observation renders nowhere in the human table.
+- AJ.6 is production-ready only for its snapshot/roster feature; it does not
+  claim source-use enforcement, boundary-record reclassification, governing
+  document reconciliation, or phase closeout.
+- AJ.6 must_follow AJ.5 under the merge-forward and PR-completion rule above.

--- a/docs/plans/phase-aj/sprint-AJ7.md
+++ b/docs/plans/phase-aj/sprint-AJ7.md
@@ -1,0 +1,103 @@
+---
+id: AJ.7
+title: Runtime Observation Source-Use Guard
+status: planned
+branch: feature/pAJ-s7-runtime-observation-source-guard
+worktree: ../atm-core-worktrees/feature/pAJ-s7-runtime-observation-source-guard
+target: integrate/phase-AJ
+---
+
+# Sprint AJ.7 — Runtime Observation Source-Use Guard
+
+## Goal
+
+Add the narrow static source-use guard that prevents runtime observation from
+escaping its non-authoritative cache/snapshot boundary. AJ.7 owns only this
+enforcement test and its lint registration; AJ.8 owns boundary-record wording.
+
+After AJ.6, `phase-aj-research.md` remains planning context rather than a hard
+dependency: AJ.7 validates the merged implementation and its enforcement
+shape.
+
+## Hard Dependencies
+
+- AJ.1 through AJ.6 development heads merged forward into this branch
+- AJ.6's snapshot and roster projection are present through the immediate
+  AJ.6 → AJ.7 merge-forward; AJ.6 QA/PR completion is not a dev-start gate
+- `docs/plans/phase-aj/plan-phase-aj.md`
+
+## Dependency Relation
+
+- `must_follow` AJ.6 because the guard requires the implemented DTO, cache
+  merge, HTTPS stripping, snapshot, and roster projection targets.
+- AJ.8 `must_follow`s AJ.7 because a boundary record may name this enforcement
+  gate only after it is real and passing.
+- AJ.7 begins immediately after AJ.6 → AJ.7 merge-forward; it does not wait
+  for AJ.6 QA. Repeat that merge before every AJ.7 dev/fix round. AJ.7's PR
+  completes only after AJ.6's PR merges. No AJ pair is `parallel_safe`.
+- On AJ.7 development-head push, AJ.8 begins immediately by merging
+  AJ.7 → AJ.8; AJ.8 must complete that merge before any dev/fix round and does
+  not wait for AJ.7 QA.
+
+## Exact Targets
+
+- `.just/tests/test_runtime_observation_boundary.py`
+- `.just/check_runtime_observation_boundary.py`
+- `.just/run_lint.py` only if explicit registration is required by the existing
+  test collector; do not alter unrelated lint execution.
+
+## Interfaces To Add Or Modify
+
+AJ.7 adds no production Rust type, wire field, transport behavior, or boundary
+record. `.just/check_runtime_observation_boundary.py` is the production lint
+checker; its test file verifies the checker. The checker is default-deny: it
+scans all Rust sources under `crates/` for observation identifiers, permits
+them only at an explicit file/symbol allowlist, and fails any unlisted use.
+Its tests must follow the existing environment-boundary guard configuration
+pattern with explicit required-positive file/symbol checks. The forbidden
+consumer regression fixtures include these concrete paths:
+
+- `crates/atm-daemon/src/runtime_health/peer_delivery_router.rs`
+- `crates/atm-daemon/src/runtime_health/peer_authority.rs`
+- `crates/atm-daemon/src/peer_drain_coordinator.rs`
+- `crates/atm-daemon/src/post_send_emitter.rs`
+- `crates/atm-core/src/delivery_policy.rs` (`DeliveryPolicyCoordinator`,
+  `DeliveryEventFamily`)
+- `crates/atm/src/commands/internal_nudge.rs`
+
+The positive list must require these concrete files and symbols, rather than
+merely allowing their directories:
+
+- `crates/atm-core/src/caller_context.rs` — `ActivityObservation`
+- `crates/atm-core/src/send/mod.rs` — `WriteRequest` observation field
+- `crates/atm-core/src/read/mod.rs` — `ReadQuery` observation field
+- `crates/atm-core/src/ack/mod.rs` — `AckRequest` conversion into `WriteRequest`
+- `crates/atm-daemon/src/https_transport.rs` — HTTPS Write/Receive stripping
+- `crates/atm-daemon/src/runtime_health.rs` — local dispatcher forwarding
+- `crates/atm-daemon/src/runtime_status_cache.rs` — merge and snapshot projection
+
+## Deliverables
+
+- The guard permits observation references only at the enumerated positive
+  file/symbol targets, plus the roster projection target explicitly named by
+  the test. Its default-deny scan rejects every other use; the listed consumer
+  paths are mandatory regression fixtures, not a hand-maintained complete
+  denylist.
+- The required-positive configuration must fail at the Phase AJ entry baseline,
+  preventing shape-only closure.
+
+## Required Validation
+
+- Run the new test through its normal `just lint` collection path.
+- Add a fixture or source-copy test proving one forbidden policy reference
+  fails and one listed required-positive target is mandatory.
+- `just lint`
+- `git diff --check`
+
+## Acceptance Criteria
+
+- The guard is narrow, deterministic, and cannot pass merely because AJ code
+  is absent.
+- AJ.7 is production-ready only for static enforcement; it does not alter
+  boundary records, governing documents, or phase status.
+- AJ.7 must_follow AJ.6 under the merge-forward and PR-completion rule above.

--- a/docs/plans/phase-aj/sprint-AJ8.md
+++ b/docs/plans/phase-aj/sprint-AJ8.md
@@ -1,0 +1,73 @@
+---
+id: AJ.8
+title: Runtime Observation Boundary Record
+status: planned
+branch: feature/pAJ-s8-runtime-observation-boundary-record
+worktree: ../atm-core-worktrees/feature/pAJ-s8-runtime-observation-boundary-record
+target: integrate/phase-AJ
+---
+
+# Sprint AJ.8 — Runtime Observation Boundary Record
+
+## Goal
+
+Reclassify the daemon boundary record from the explicit pre-AJ planned target
+to the implemented non-authoritative runtime-observation contract. AJ.8 owns
+only the machine-readable and matching human boundary records.
+
+After AJ.6, `phase-aj-research.md` remains planning context rather than a hard
+dependency: AJ.8 validates merged implementation and contracts.
+
+## Hard Dependencies
+
+- AJ.1 through AJ.7 development heads merged forward into this branch
+- AJ.7's passing source-use guard is present through the immediate AJ.7 → AJ.8
+  merge-forward; AJ.7 QA/PR completion is not a dev-start gate
+- `docs/plans/phase-aj/plan-phase-aj.md`
+
+## Dependency Relation
+
+- `must_follow` AJ.7 because this sprint names its real enforcement gate in
+  the machine-readable boundary contract.
+- AJ.9 `must_follow`s AJ.8 because governing documents must cite the final
+  boundary contract rather than a planned placeholder.
+- AJ.8 begins immediately after AJ.7 → AJ.8 merge-forward; it does not wait
+  for AJ.7 QA. Repeat that merge before every AJ.8 dev/fix round. AJ.8's PR
+  completes only after AJ.7's PR merges. No AJ pair is `parallel_safe`.
+- On AJ.8 development-head push, AJ.9 begins immediately by merging
+  AJ.8 → AJ.9; AJ.9 must complete that merge before any dev/fix round and does
+  not wait for AJ.8 QA.
+
+## Exact Targets
+
+- `boundaries/atm-daemon/daemon-status-source.toml`
+- `docs/atm-daemon/boundaries.md`
+
+## Interfaces To Add Or Modify
+
+None. AJ.8 changes no Rust API, I/O ownership, dependency edge, or runtime
+behavior.
+
+## Deliverables
+
+- Replace the explicit pre-AJ planned labels with the implemented contract only
+  after the AJ.7 source-use guard passes on the merged-forward child branch.
+- Add `runtime_observation_non_authoritative` to
+  `BOUNDARY-StatusSource-Daemon.review_gates`.
+- State that cache merge/snapshot projection may inspect observation while
+  routing, nudge, notification, retry, admission, delivery, and policy may
+  not. Do not broaden `io_owns`, `io_forbidden`, or dependencies.
+
+## Required Validation
+
+- Parse the TOML through the repository boundary-lint path.
+- `just lint`
+- `git diff --check`
+
+## Acceptance Criteria
+
+- Human and machine-readable boundary records agree exactly on the named guard
+  and non-authoritative observation rule.
+- AJ.8 is production-ready only for boundary record reclassification; it does
+  not reconcile governing requirements/ADR/architecture or close the phase.
+- AJ.8 must_follow AJ.7 under the merge-forward and PR-completion rule above.

--- a/docs/plans/phase-aj/sprint-AJ9.md
+++ b/docs/plans/phase-aj/sprint-AJ9.md
@@ -1,0 +1,78 @@
+---
+id: AJ.9
+title: Runtime Observation Governing Contract Reconciliation
+status: planned
+branch: feature/pAJ-s9-runtime-observation-contract-reconciliation
+worktree: ../atm-core-worktrees/feature/pAJ-s9-runtime-observation-contract-reconciliation
+target: integrate/phase-AJ
+---
+
+# Sprint AJ.9 — Runtime Observation Governing Contract Reconciliation
+
+## Goal
+
+Reconcile the governing requirements, ADR, architecture, and team-member-state
+contract against the merged AJ.1–AJ.8 implementation. AJ.9 changes only those
+documents; AJ.10 owns phase status and closure.
+
+After AJ.6, `phase-aj-research.md` remains planning context rather than a hard
+dependency: AJ.9 reconciles merged implementation and contracts.
+
+## Hard Dependencies
+
+- AJ.1 through AJ.8 development heads merged forward into this branch
+- AJ.8's final boundary record is present through the immediate AJ.8 → AJ.9
+  merge-forward; AJ.8 QA/PR completion is not a dev-start gate
+- `docs/plans/phase-aj/plan-phase-aj.md`
+
+## Dependency Relation
+
+- `must_follow` AJ.8 because governing contracts must agree with the final
+  named boundary gate and implemented behavior.
+- AJ.10 `must_follow`s AJ.9 because phase status may change only after these
+  governing documents agree with implementation.
+- AJ.9 begins immediately after AJ.8 → AJ.9 merge-forward; it does not wait
+  for AJ.8 QA. Repeat that merge before every AJ.9 dev/fix round. AJ.9's PR
+  completes only after AJ.8's PR merges. No AJ pair is `parallel_safe`.
+- On AJ.9 development-head push, AJ.10 begins immediately by merging
+  AJ.9 → AJ.10; AJ.10 must complete that merge before any dev/fix round and
+  does not wait for AJ.9 QA.
+
+## Exact Targets
+
+- `docs/requirements.md` (`REQ-CORE-RUNTIME-002` / `-004`)
+- `docs/adr/ADR-045-runtime-observation-attribution.md`
+- `docs/architecture.md` (runtime-health observation boundary)
+- `docs/team-member-state.md`
+
+## Interfaces To Add Or Modify
+
+None. AJ.9 adds no production code, DTO, persistence, transport, or static
+test behavior.
+
+## Deliverables
+
+- The four documents agree with actual code on the closed ingress set,
+  accepted-ingress order, no-default-overwrite behavior, lifecycle meanings,
+  retained audit evidence, raw JSON/short human projection, and no durable/mail
+  telemetry.
+- They prohibit observation-driven routing, nudge, notification, retry,
+  admission, delivery, and policy logic, without reintroducing live-pid
+  rejection, durable PID ownership, or an admin-assume-identity path.
+
+## Required Validation
+
+- Perform a clause-by-clause diff of every governing-document claim against
+  merged AJ.1–AJ.8 source and the named tests that prove it. Record a source
+  symbol and test name for each clause; any clause without both remains marked
+  as a planned target rather than being reviewed through as prose.
+- `just lint`
+- `git diff --check`
+
+## Acceptance Criteria
+
+- All four governing documents agree with the final AJ boundary record and
+  implementation without ambiguous planned/current wording.
+- AJ.9 is production-ready only for governing contract reconciliation; it does
+  not flip phase/sprint status or claim phase closure.
+- AJ.9 must_follow AJ.8 under the merge-forward and PR-completion rule above.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1069,6 +1069,39 @@ Acceptance:
   validations and its required bidirectional production send/read/ACK/nudge
   proof on the accepted `integrate/phase-ak` line.
 
+## 42. Phase AJ — Runtime observation [PLANNED — gated by Phase AI closeout]
+
+Phase AJ plans and reviews against `integrate/phase-ai-31-33 @
+150391ecdf2e003185bff7d78427cd21509a7981`, the HTTP local transport line for
+UDS and TCP. This is a planning baseline, not permission to start AJ
+implementation before Phase AI closes: Phase AI must merge to `develop`, then
+team-lead records that post-merge SHA, cuts `integrate/phase-AJ` from it, diffs
+every AJ exact target against the pinned planning baseline, and revalidates
+drift before AJ.1 starts. A pre-merge plan finding cites the pinned baseline;
+a post-merge reconciliation finding cites both SHAs and the changed target.
+
+AJ keeps roster runtime observation in daemon memory: successful
+environment-attested CLI/graft activity and heartbeat converge on one current
+entry. Session, pid, and state are diagnostic telemetry, not inputs to routing,
+nudge, retry, admission, delivery, notification, or policy.
+
+| Sprint | Status | Branch | Purpose |
+| --- | --- | --- | --- |
+| `AJ.1` | `planned` | `feature/pAJ-s1-session-id-and-protocol` | canonical `SessionId` and additive heartbeat fields |
+| `AJ.2` | `planned` | `feature/pAJ-s2-caller-context-env` | environment-attested observation resolver |
+| `AJ.3` | `planned` | `feature/pAJ-s3-cli-wire-payload` | transient local CLI/graft request metadata |
+| `AJ.4` | `planned` | `feature/pAJ-s4-daemon-cache-touch` | shared daemon cache merge after successful local dispatch |
+| `AJ.5` | `planned` | `feature/pAJ-s5-heartbeat-session` | heartbeat session observation convergence |
+| `AJ.6` | `planned` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
+| `AJ.7` | `planned` | `feature/pAJ-s7-runtime-observation-source-guard` | non-authoritative source-use guard |
+| `AJ.8` | `planned` | `feature/pAJ-s8-runtime-observation-boundary-record` | machine and human daemon boundary record |
+| `AJ.9` | `planned` | `feature/pAJ-s9-runtime-observation-contract-reconciliation` | requirements, ADR, architecture, and team-state reconciliation |
+| `AJ.10` | `planned` | `feature/pAJ-s10-runtime-observation-phase-closeout` | evidence-backed phase and status closeout |
+
+Each AJ successor begins immediately when its parent's development head is
+merged forward into it; do not wait for parent QA approval. Merge the current
+parent branch into the child before every child dev/fix round. A child PR may
+
 ## Publishing Improvements
 
 Implementation Branches:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3509,16 +3509,80 @@ mail correctness.
   - live status is runtime-owned daemon state
   - SQLite stores canonical roster membership and optional routing metadata,
     but not the current process `pid`
-  - daemon memory caches the current `pid` as the primary liveness field
+  - daemon memory caches the current `pid` as observational metadata, not a
+    liveness-policy input
   - daemon runtime state must include `last_active_at` for each known active
     agent/member entry
   - the shared protocol must expose typed heartbeat request/response DTOs for
-    runtime state updates and PID continuity handling
+    runtime state updates and observational pid continuity
   - SQLite must not own live `last_active_at`; it remains daemon-memory-only
     runtime state
   - roster truth and live-status truth must remain distinct
 - `pid` is transient daemon-owned runtime state rather than durable roster
   truth and must not be persisted in SQLite
+
+> **Phase AJ planned target — not implemented on the current baseline.** The
+> following runtime-observation clauses become current only after AJ.9 compares
+> each claim with the merged AJ.1–AJ.8 source symbols and named tests.
+
+- `REQ-CORE-RUNTIME-004` Runtime observation is best-effort telemetry, not a
+  business-policy input.
+
+  Required behavior:
+  - successful heartbeat and successful local `send`, `read`, or `ack` may
+    update in-memory observation only
+  - graft may update observation only through its environment-derived caller
+    context; no other ingress or daemon side effect may synthesize an update
+  - each defined state/session value retains independent source and timestamp;
+    absent/default values are no-ops and cannot overwrite prior valid data;
+    accepted ingress order, not client-clock ordering, determines the current
+    observation; a trusted changed pid/session becomes the current observation
+    and is retained as diagnostic evidence only
+  - every actual pid/session mutation, including initial set, emits one
+    structured info audit event with prior/new value, member, source, and time;
+    no-op input emits no mutation event
+  - the existing heartbeat `pid_changed` response field remains additive
+    observation metadata: it is true only when a prior defined pid is replaced
+    by a different defined pid; initial pid observation is audited but is not a
+    replacement
+  - normal heartbeat, CLI, and graft updates may not restore `Unknown` or clear
+    a defined session; roster removal drops its runtime entry and a later re-add
+    starts without observation
+  - `Unknown` means no trustworthy state observation; `Offline` means an
+    explicit heartbeat session-end observation. They are distinct values and
+    must not be substituted for one another
+  - trusted environment-attested CLI/graft `send`, `read`, and `ack` transition
+    state to `Active`; heartbeat activity transitions to `Active`, `Idle`, or
+    `Offline` only from its explicit activity value
+  - each cache member carries `state_changed_at`; it changes only on a real
+    lifecycle-state transition and is shown only for defined non-default state;
+    human roster output renders its relative age while structured output keeps
+    the absolute timestamp; repeated same-state evidence never resets it
+  - external hook heartbeat mapping is startup/active → `ActiveToolUse`, idle
+    → `Idle`, and stop → `SessionEnded`; ATM consumes, but does not install or
+    emit, those hooks
+  - identity change and malformed/suppressed observation are retained
+    anomalies, not roster lifecycle state. They must not reject ingress, emit
+    `IdentityConflict`, degrade readiness, alter cache eviction, or alter
+    routing, notification, or delivery behavior. A future doctor phase may
+    diagnose them.
+  - local observation requires matching, parseable `ATM_IDENTITY` and
+    `ATM_TEAM`; args-only or mismatched invocation leaves normal command
+    behavior unchanged and suppresses observation
+  - local read/write request DTOs carry one optional `ActivityObservation`
+    (team, member, optional session/pid), constructed only by that
+    environment-attestation step; the daemon accepts it only on existing
+    authenticated local UDS/loopback ingress, and remote HTTPS ingress clears
+    it before shared dispatch
+  - session, pid, heartbeat activity, and derived state must not drive routing,
+    nudge, notification, retry, admission, delivery, or policy logic
+  - any exception requires an explicit requirement, ADR, boundary record, and
+    test; telemetry never enters SQLite, durable roster state, mail rows, or
+    message payloads
+  - the existing roster-view command may display a member's non-default state
+    age, defined pid, and shortened session identifier as an observational
+    projection; JSON preserves raw values. Default `Unknown` state with no
+    session/pid is omitted from human output
 
 ### 22.2 Singleton Daemon Runtime
 

--- a/docs/team-member-state.md
+++ b/docs/team-member-state.md
@@ -1,385 +1,146 @@
 # Team Member State
 
-This document is the authoritative current reference for how every team-member
-field is populated and updated.
+This document is the authoritative contract for roster truth and the daemon's
+runtime observation after Phase AJ.
 
-Goals:
-- one auditable update path per field
-- no fallback chains that silently rewrite ownership
-- no ambiguous "best effort" state derivation
-- minimal state machines only; no extra substates unless they remove a real
-  ambiguity
-- one place to answer:
-  - how is `pid` set?
-  - how is `last_active_at` set?
-  - how is `state` set?
-  - which component owns each update?
+> **Phase AJ planned target — not implemented on the current baseline.** The
+> rules and Rust shapes below describe the planned AJ end state. AJ.9 must
+> reconcile each clause with merged implementation source and named tests before
+> this marker is removed.
 
-## Ownership Split
+## Ownership
 
-- SQLite owns durable roster truth.
-- SQLite also owns the current durable `pid` for each team member.
-- `atm-daemon` owns runtime liveness truth.
-- hook/runtime layers report runtime facts to `atm-daemon`; they do not become
-  the source of truth themselves.
+- SQLite owns durable roster membership and routing metadata. It does not own
+  live state, pid, session ID, timestamps, or observation history.
+- `atm-daemon` owns one in-memory current observation keyed by `(team, member)`.
+- Structured observability owns retained diagnostic events. AJ adds no database
+  history, ring buffer, or doctor aggregation.
 
-## Durable Roster Fields
+Durable roster changes never synthesize a runtime observation. Removing a
+member drops its runtime entry; re-adding it starts without observation.
+Updating roster metadata preserves any existing runtime entry.
+
+## Current Observation
 
 ```rust
-pub struct TeamMateRecord {
-    pub team: TeamName,
-    pub name: AgentName,
-    pub provider: ProviderName,
-    pub model: ModelName,
-    pub transport_kind: Option<TransportKind>,
-    pub host_name: Option<HostName>,
-    pub tmux: Option<TmuxLocator>,
-    pub recipient_pane_id: Option<PaneId>,
-    pub pid: Option<u32>,
-    pub metadata_json: Option<String>,
-}
-
-pub struct TmuxLocator {
-    pub session_name: Option<String>,
-    pub window_name: Option<String>,
-    pub pane_id: Option<PaneId>,
-}
-```
-
-### Durable Field Update Rules
-
-| Field | Owner | Allowed update paths | Forbidden update paths |
-|---|---|---|---|
-| `team` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | hook events; daemon liveness probes |
-| `name` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | hook events; daemon liveness probes |
-| `provider` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | inferred from pid; inferred from recent activity |
-| `model` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | inferred from pid; inferred from recent activity |
-| `transport_kind` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | transport handshake side effects |
-| `host_name` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | inferred from socket peer state |
-| `tmux.session_name` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | hook events; runtime liveness logic |
-| `tmux.window_name` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | hook events; runtime liveness logic |
-| `tmux.pane_id` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | hook events; runtime liveness logic |
-| `recipient_pane_id` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | post-send hook side effects; runtime liveness logic |
-| `pid` | SQLite roster store | documented heartbeat handler writes only | ad hoc runtime cache writes; roster ingest guesses |
-| `metadata_json` | SQLite roster store | roster bootstrap; config/roster ingest; explicit roster repair/admin path | runtime liveness logic |
-
-Rule:
-- runtime activity must not mutate durable roster fields unless the update
-  comes through one explicit roster-write path.
-
-## Runtime State Fields
-
-```rust
-pub struct TeamMateRuntime {
-    pub last_active_at: Option<IsoTimestamp>,
-    pub state: AgentState,
-}
-
-pub enum AgentState {
+pub enum RuntimeMemberState {
     Unknown,
-    IdentityConflict,
     Offline,
     Idle,
     Active,
+    // IdentityConflict remains deserializable only for wire compatibility.
 }
 
-pub struct TeamMateView {
+pub enum RuntimeObservationSource {
+    Heartbeat,
+    LocalCommand,
+}
+
+pub struct RuntimeMemberObservation {
     pub team: TeamName,
-    pub name: AgentName,
-    pub provider: ProviderName,
-    pub model: ModelName,
-    pub transport_kind: Option<TransportKind>,
-    pub host_name: Option<HostName>,
-    pub tmux: Option<TmuxLocator>,
-    pub recipient_pane_id: Option<PaneId>,
+    pub member: AgentName,
+    pub state: RuntimeMemberState,
+    pub session_id: Option<SessionId>,
     pub pid: Option<u32>,
     pub last_active_at: Option<IsoTimestamp>,
-    pub state: AgentState,
+    pub state_changed_by: Option<RuntimeObservationSource>,
+    pub state_changed_at: Option<IsoTimestamp>,
+    pub session_changed_by: Option<RuntimeObservationSource>,
+    pub session_changed_at: Option<IsoTimestamp>,
 }
 ```
 
-## Runtime Field Update Rules
+`RuntimeMemberObservation` is a snapshot projection. The cache's internal
+record may use a separate private type, but it has the same observation fields
+and one crate-private, infallible merge owner.
 
-All daemon-managed team-member fields must update through one daemon socket
-handler:
+## Closed Ingress Set
+
+Only these accepted events can update current observation:
+
+| Ingress | State | Metadata | Source |
+| --- | --- | --- | --- |
+| `POST /v1/atm/heartbeat` | `ActiveToolUse -> Active`, `Idle -> Idle`, `SessionEnded -> Offline` | required pid; optional session ID | `Heartbeat` |
+| Successful environment-attested local `send`, `read`, or `ack` | `Active` | optional pid/session ID | `LocalCommand` |
+| Graft read/send/ack with the same environment-derived caller context | `Active` | optional pid/session ID | `LocalCommand` |
+
+Local request metadata uses one transient `ActivityObservation`:
 
 ```rust
-pub struct TeamMemberHeartbeatRequest {
+pub struct ActivityObservation {
     pub team: TeamName,
     pub member: AgentName,
-    pub pid: u32,
-    pub observed_at: IsoTimestamp,
-    pub activity: HeartbeatActivity,
-}
-
-pub enum HeartbeatActivity {
-    ActiveToolUse,
-    Idle,
-    SessionEnded,
+    pub session_id: Option<SessionId>,
+    pub pid: Option<u32>,
 }
 ```
 
-Allowed producers:
-- ATM CLI
-- hook/runtime layer
+It exists only when parseable `ATM_IDENTITY` and `ATM_TEAM` attest the resolved
+caller. Arguments alone create no observation. An argument/environment mismatch
+keeps the command's existing behavior, suppresses observation, and may emit an
+info diagnostic. HTTPS peer ingress clears this transient field before shared
+dispatch. The daemon accepts it only over existing authenticated local
+UDS/loopback ingress; it never reads its own environment to infer provenance.
+It never enters a mail row, message payload, or SQLite table.
 
-Forbidden producers:
-- direct SQLite writes
-- ad hoc liveness polling that bypasses the socket handler
-- transport adapters performing inline state mutation outside the heartbeat
-  handler
+Roster reload, daemon recovery, transport adapters, peer delivery, nudge,
+notification, routing, retry, admission, and mailbox import are not ingress.
 
-The documented response DTO is:
+## Merge And Lifecycle Rules
 
-```rust
-pub struct TeamMemberHeartbeatResponse {
-    pub team: TeamName,
-    pub member: AgentName,
-    pub pid: u32,
-    pub pid_changed: bool,
-    pub state: RuntimeMemberState,
-    pub last_active_at: Option<IsoTimestamp>,
-}
-```
+- Merge order is accepted-ingress order, not client-clock order. AJ adds no
+  stale-event rejection,
+  timeout inference, PID liveness probe, or process-tree policy.
+- `Some(session_id)` or `Some(pid)` replaces that field's current value. `None`
+  and blank session IDs preserve the prior value. Heartbeat pid is required, so
+  it always replaces the current pid.
+- A changed pid/session is normal diagnostic evidence: retain it, audit it,
+  and continue the ingress's lifecycle transition. Do not reject the request,
+  set `IdentityConflict`, degrade readiness, alter eviction, or select a code
+  path.
+- Each actual initial or changed pid/session value emits one retained `info!`
+  event with team, member, source, timestamp, and raw previous/new values.
+  No-op or absent metadata emits no mutation event.
+- `Unknown` means no trustworthy state observation. `Offline` means an
+  explicit `SessionEnded` heartbeat. They are distinct and never inferred from
+  timeout, missing data, a dead PID, roster data, or inbox state.
+- A trusted local command moves the member to `Active`. A later heartbeat may
+  move it to `Idle` or `Offline`. `state_changed_at` and its source update only
+  on a real state edge; repeated evidence of the same state does not reset the
+  edge time. `last_active_at` may advance on every trusted `Active` event.
+- No ordinary reset API exists. Normal ingress cannot clear a known session or
+  set a known state back to `Unknown`.
 
-## Required State Machines
+## Non-Authoritative Boundary
 
-These state machines are the complete current transition model for team-member
-runtime state. No additional state machines or hidden fallback transitions are
-permitted unless this document is updated first.
+Session ID, PID, heartbeat activity, and derived state are telemetry only. No
+routing, nudge, notification, retry, admission, delivery, access, or policy
+decision may inspect them. Cache merge and snapshot projection are the only
+allowed consumers. A future exception requires a named requirement, ADR,
+boundary record, and regression test.
 
-Implementation rule:
-- per `RBP-002 Typestate`, illegal transitions should be made impossible at
-  compile time where practical
-- at minimum, transition logic must live in one closed module with one explicit
-  transition API rather than being reimplemented across handlers
+This deliberately permits a member's latest session/PID to toggle when two
+legitimate checkouts or a rogue process share a member name. AJ records the
+evidence; it does not attempt to decide which process is legitimate.
 
-### Runtime Activity State Machine
+## Roster Projection
 
-States:
-- `Unknown`
-- `Active`
-- `Idle`
-- `Offline`
-
-Allowed transitions:
-
-```text
-Unknown --heartbeat(active)--> Active
-Unknown --heartbeat(idle)----> Idle
-Unknown --session-ended------> Offline
-
-Active --heartbeat(active)---> Active
-Active --heartbeat(idle)-----> Idle
-Active --session-ended-------> Offline
-Active --pid-dead-----------> Offline
-
-Idle ----heartbeat(active)---> Active
-Idle ----heartbeat(idle)-----> Idle
-Idle ----session-ended-------> Offline
-Idle ----pid-dead-----------> Offline
-
-Offline -heartbeat(active)---> Active
-Offline -heartbeat(idle)-----> Idle
-Offline -session-ended-------> Offline
-```
-
-Forbidden transitions:
-
-```text
-Unknown -> Offline by timeout/guess alone
-Any -> Active without a documented heartbeat
-Any -> Idle without a documented heartbeat
-Any -> Offline from roster-only or inbox-only inference
-```
-
-### PID Ownership State Machine
-
-States:
-- `UnregisteredPid`
-- `RegisteredPid(pid)`
-- `Conflict(old_pid, new_pid)`
-
-Allowed transitions:
-
-```text
-UnregisteredPid --heartbeat(pid=P)----------------------> RegisteredPid(P)
-RegisteredPid(P) --heartbeat(pid=P)---------------------> RegisteredPid(P)
-RegisteredPid(P_old) --heartbeat(pid=P_new), old dead --> RegisteredPid(P_new) + AgentPidChanged
-RegisteredPid(P_old) --heartbeat(pid=P_new), old live --> Conflict(P_old, P_new)
-Conflict(P_old, P_new) --admin-assume-identity---------> RegisteredPid(P_new) + AgentPidChanged
-```
-
-Forbidden transitions:
-
-```text
-RegisteredPid(P_old) --heartbeat(pid=P_new), old live --> RegisteredPid(P_new)
-Conflict(...) -> RegisteredPid(...) without explicit admin path
-Any pid change by roster ingest or direct SQLite write
-```
-
-### Identity Conflict State Machine
-
-States:
-- `NoConflict`
-- `IdentityConflict`
-
-Allowed transitions:
-
-```text
-NoConflict --live-old-pid + new-pid heartbeat--> IdentityConflict
-IdentityConflict --admin-assume-identity-------> NoConflict
-IdentityConflict --old-pid dead + retry--------> NoConflict
-```
-
-Required behavior in `IdentityConflict`:
-- reject the calling heartbeat/CLI action
-- return `ATM_IDENTITY_CONFLICT`
-- return the exact caller-facing stop message:
-  - `ATM_IDENTITY_CONFLICT: stop and report to user immediately`
-- do not overwrite durable pid
-- do not mutate runtime `state` to accommodate the new pid
-
-Admin-only exit path:
-- explicit admin command such as
-  `atm admin assume-identity --team <team> --agent <name> --pid <new_pid>`
-- this command may mark the old pid/session as rogue or superseded
-- this command must update durable pid, emit `AgentPidChanged`, and emit an
-  audit event
-
-### `pid`
-
-Owner:
-- SQLite durable roster/runtime identity field
-- cached by `atm-daemon` for runtime liveness checks
-
-Authoritative update path:
-1. `TeamMateHeartbeat` accepted by `atm-daemon`.
-   (`TeamMemberHeartbeatRequest` in the shared protocol)
-   - Claude-compatible hook producer supplies the stable parent session pid
-   - Codex/native producer supplies the agent process pid itself
-
-Forbidden update paths:
-- inferred from roster file
-- inferred from tmux pane only
-- inferred from previous cached pid without a fresh confirming event
-
-Rules:
-- `pid` is the primary liveness field
-- replacing `pid` is allowed only through the documented heartbeat handler,
-  which updates SQLite and then refreshes daemon runtime state
-- if a new event reports a different pid for the same member and the old pid is
-  dead, the daemon updates SQLite, refreshes runtime state, and emits
-  `AgentPidChanged`
-- if a new event reports a different pid for the same member and the old pid is
-  still alive, the daemon must reject the new heartbeat as an identity conflict
-  unless the explicit admin takeover path below is active
-- a live-old-pid plus new-pid conflict is a security event, not a normal
-  respawn path
-- daemon startup hydrates configured roster members as `Unknown` and consults
-  durable SQLite pid continuity only as startup fallback; after the first live
-  heartbeat, cache-first pid checks become the primary conflict detector
-
-### `last_active_at`
-
-Owner:
-- `atm-daemon` runtime state
-
-Authoritative update path:
-1. `TeamMateHeartbeat { activity: ActiveToolUse | Idle | SessionEnded }`
-   accepted by `atm-daemon`
-
-Forbidden update paths:
-- background polling with no attributable agent event
-- read-only roster inspection
-- mailbox import of unrelated inbound messages
-
-Rules:
-- update only when a concrete attributable activity event occurs
-- do not synthesize activity timestamps from daemon startup time
-- do not backfill from durable roster metadata
-
-### `state`
-
-Owner:
-- `atm-daemon` runtime state
-
-Authoritative update paths:
-1. `Unknown`
-   - daemon startup before the member has emitted any authoritative runtime
-     event in the current daemon lifetime
-   - bounded status-cache eviction demotes the member back to `Unknown`
-2. `IdentityConflict`
-   - daemon records a live-old-pid/new-pid collision without rewriting the
-     durable pid until an admin takeover or dead-pid retry clears the conflict
-3. `Active`
-   - `TeamMateHeartbeat { activity: ActiveToolUse }`
-4. `Idle`
-   - `TeamMateHeartbeat { activity: Idle }`
-5. `Offline`
-   - liveness check proves tracked `pid` is dead
-   - `TeamMateHeartbeat { activity: SessionEnded }`
-
-Forbidden update paths:
-- inferred from roster-only data
-- inferred from "has inbox messages"
-- inferred from stale `last_active_at` without the documented idle/offline rule
-
-Rules:
-- `state` changes only from one of the five update classes above
-- no undocumented fallback chain may map missing data directly to `Offline`
-- missing runtime data yields `Unknown`, not `Offline`
-
-## PID Capture Contract
-
-### Claude-Compatible Sessions
-
-- the hook/runtime layer must capture the stable parent session pid
-- the hook subprocess pid is never valid as the member `pid`
-- the hook/runtime layer must send that pid to the daemon through the
-  `TeamMemberHeartbeatRequest` socket path
-
-Current interim source:
-- the already-installed Python hooks from `../agent-team-mail`
-
-Future source:
-- `schooks 1.0`
-
-### Codex Sessions
-
-- Codex does not rely on Claude hook semantics
-- the ATM CLI/runtime must send the Codex process pid to the daemon through the
-  same `TeamMemberHeartbeatRequest` socket path
-- that pid is the authoritative runtime pid until superseded by a new explicit
-  heartbeat/session event
-
-## No Fallback-Soup Rule
-
-The following are prohibited:
-- multi-step undocumented fallback chains for `state`
-- multi-step undocumented fallback chains for `pid`
-- mutating roster settings as a side effect of liveness tracking
-- mutating runtime liveness fields as a side effect of roster ingest
-- silent ownership transfer between store, daemon, and hook layers
-- adding a second runtime state mutation path besides the heartbeat socket
-  handler without updating this document
-
-If a field has more than one allowed update path, every path must be listed in
-this document.
+Structured output preserves raw session ID, pid, state, source, and absolute
+timestamps. Human `atm members` output omits a default `Unknown` observation
+with no session/pid. For a defined observation it may show state age, pid, and
+the first 12 Unicode scalar values of session ID followed by `…` when longer.
 
 ## Required Tests
 
-- roster field writes occur only through documented roster-write paths
-- runtime events update `pid` only from documented authoritative sources
-- pid changes with a still-live old pid are rejected unless an explicit
-  admin takeover path is active
-- runtime events update `last_active_at` only from attributable activity events
-- both CLI-originated and hook-originated activity go through the same
-  heartbeat socket handler
-- state transitions are limited to the documented `Unknown/Offline/Idle/Active`
-  transition causes
-- a dead tracked pid transitions the member to `Offline`
-- missing runtime data leaves the member `Unknown`, not `Offline`
-- daemon restart resets runtime-only state to `Unknown` until fresh events
-- projected `TeamMateView` combines durable and runtime fields without
-  cross-layer mutation
+- heartbeat and environment-attested local/graft ingress are the only cache
+  mutation paths;
+- args-only and mismatched command identity produce no observation without
+  changing existing command behavior;
+- UDS, TCP, and heartbeat converge on one cache entry;
+- absent/blank optional telemetry preserves known values;
+- changed pid/session is logged and retained without conflict/rejection;
+- `Unknown` and `Offline` remain distinct; only explicit heartbeat
+  `SessionEnded` sets `Offline`;
+- state-edge timestamps update only on a real transition;
+- raw JSON and shortened human roster projections have the documented shape;
+- a narrow source-use gate rejects observation references in policy modules.


### PR DESCRIPTION
## Phase AJ Planning (clean rebuild)

Replaces PR #717, whose branch history was polluted by an accidental full-`develop` merge and its revert (making the PR diff show 667 unrelated files instead of the real ~25). This branch carries identical content, rebuilt fresh on top of current `develop`.

### Contents
- **10 sprint plans** (AJ1–AJ10): session_id/pid caching, heartbeat propagation, CLI/graft dispatch integration, runtime observation source guard, boundary record, contract reconciliation, phase closeout
- **Master plan**: Design rules, ADRs (AD-AJ-1 in-memory-only rationale, AD-AJ-2 pid overwrite policy, AD-AJ-3 Rust type/error shape), Phase-AI reconciliation gate
- **ADR-045**: runtime observation attribution
- Shared-doc updates: `docs/architecture.md`, `docs/requirements.md`, `docs/team-member-state.md`, `docs/atm-core/boundaries.md`, `docs/atm-daemon/boundaries.md`, `.just/lint-config.toml`, `.just/tests/test_check_env_var_boundary.py`
- `docs/project-plan.md` Phase AJ entry (renumbered to §42; develop's Phase AK, merged via PR #730, holds §41)

### Review
Full `/plan-hardening` process complete:
- Step 1 (arch-ctm guidelines pass): 2 rounds, converged
- Steps 2 & 4 (plan-scope-reviewer + critical-plan-reviewer, run concurrently): round 2 clean PASS on both, 0 blocking/important/minor
- Step 6 (quality-mgr QA): QA-1 FAIL (1 blocking + 5 important + 5 minor) → all fixed → QA-2 PASS 12/12 (100%), plus one follow-up finding (ARCH-003) folded in and verified

Content verified byte-identical to the QA-2-passed commit, file by file. `just lint`: 24/24 checks pass on this branch.

Per `plan-phase-aj.md`'s own Phase-AI reconciliation gate, this is a **planning-only** PR — no AJ implementation code. AJ.1 implementation itself still requires Phase AI's full closeout and the documented reconciliation diff before it starts.