### PR TITLE
docs(plan): AK.2 deprecation-map corrections ahead of AK.6 parallel start

### DIFF
--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -44,7 +44,7 @@ mismatch as an acceptable interim state after its own PR completes.
 | Peer configuration | Canonical full hostname plus explicit aliases and port. Configuration changes populate a small alias index. SQLite stores the full hostname, never a resolved IP. |
 | Wire | HTTP/1.1 `POST /v1/atm/messages`, JSON `WriteRequest`, JSON `SendResponseEnvelope`. `send_peer_http_frames` accepts an array but issues this one existing request shape per immutable write; AK adds no batch route or second receiver handler. |
 | Security | Explicit trusted-LAN MVP: no mTLS, certificate pinning, or claimed-source authentication. The sender-host header is display provenance only. AK.4 refuses wildcard or multicast peer-listener binds and binds only configured local interface addresses; network isolation beyond that explicit bind allowlist remains a deployment/firewall responsibility, not an ATM-enforced Internet-exposure guarantee. |
-| Receiver | AK.4 renames the retained plain half of `HttpsListenerSet` to `PeerHttpListenerSet`. Its bounded accept/request execution, HTTP decoder, canonical write handler, SQLite transaction, ACK semantics, and post-write nudge remain the only ingress path. |
+| Receiver | AK.4 creates the minimal plain `PeerHttpListenerSet` after AK.2 removes `HttpsListenerSet`. Its bounded accept/request execution, HTTP decoder, canonical write handler, SQLite transaction, ACK semantics, and post-write nudge remain the only ingress path. |
 | Sender | CLI and graft use their existing local daemon HTTP call. After canonical SQLite persistence, the daemon makes one private `send_peer_http_frames(config, endpoint, &[write], deadline)` call with the in-memory write and returns the ordinary response. `config` is the immutable configured source-host snapshot, never CLI input or a per-send peer scan. |
 | AK.4 baseline | No automatic retry. A failed direct send returns an ordinary delivery error and leaves the admitted SQLite record undelivered. |
 | AK.5 resend cache | Adds optional per-endpoint `Connected`/`Disconnected`/`Queued` state, one aggregate, and one timer. `peer_resend_cache = true` is the default; `false` preserves AK.4's no-retry behavior. |
@@ -69,11 +69,10 @@ Delete, not adapt:
   and peer delivery post-commit queue key.
 - `crates/atm-daemon/src/peer_resolution.rs` and literal-IP authority
   discovery in `runtime_health/peer_authority.rs`.
-- Active `HttpsTransport`, `PinnedClientVerifier`, `TlsIdentity`, custom
-  rustls client/server handshake code, and certificate/fingerprint peer
-  transport configuration once the plain `PeerHttpListenerSet` is live. AK.6 preserves
-  verified TLS provisioning/configuration and curl-interoperable receiver
-  support only in `crates/atm-peer-tls-interop`, an isolated, unused TLS crate.
+- The legacy custom TLS module in AK.2. AK.6 begins independently from the
+  pre-AK.2 Phase AK baseline and preserves verified TLS provisioning/
+  configuration and curl-interoperable receiver support only in
+  `crates/atm-peer-tls-interop`, an isolated, unused TLS crate.
   No daemon, CLI, graft, or active send-path crate may depend on it. It is not a native
   peer transport: no native ATM TLS sender is known to work. It does not
   preserve the failing native outbound client in active code.
@@ -88,10 +87,10 @@ The existing simple-send path is intentionally reduced in explicit steps:
 | Start a coordinator thread. | AK.2 | Delete. |
 | Start a per-message thread. | AK.2 | Delete. |
 | Re-scan SQLite for the write just saved. | AK.2 | Delete. AK.4 uses the in-memory `WriteRequest` for an immediate send. |
-| Read every trusted-peer row. | AK.3/AK.6 | AK.3 creates the O(1) alias-to-full-host index; AK.6 deletes the old broad scan. |
-| Resolve every peer hostname for literal-IP alias discovery. | AK.3/AK.6 | AK.3 permits only explicit configured IP aliases; AK.6 deletes inferred discovery. |
-| Start a DNS thread for the selected peer. | AK.6 | Delete. Resolve the persisted full hostname only when connecting; never in an ATM DNS thread. |
-| Open custom TCP/rustls HTTP. | AK.4/AK.6 | AK.4 creates its replacement; AK.6 deletes the unused legacy stack. |
+| Read every trusted-peer row. | AK.3 | Replace with the O(1) immutable alias-to-full-host index; delete the old broad scan. |
+| Resolve every peer hostname for literal-IP alias discovery. | AK.3 | Replace with explicit configured IP aliases; delete inferred discovery. |
+| Start a DNS thread for the selected peer. | AK.3 | Delete. Resolve the persisted full hostname only when connecting; never in an ATM DNS thread. |
+| Open custom TCP/rustls HTTP. | AK.2/AK.4 | AK.2 deletes the legacy stack; AK.4 creates the plain direct-HTTP replacement. |
 | Receive a successful peer response. | AK.4 | One idempotent `MessageStore::confirm_peer_delivery(PeerDeliveryConfirmation)` mutation removes only matching `peerOutbound`; accepted writes do not re-enter AK.5's backlog. |
 
 Retain unchanged unless a direct compile consumer proves otherwise:
@@ -112,8 +111,7 @@ authoritative:
 - AK.3: alias persistence and staged curl receiver/nudge proof.
 - AK.4: direct production send/receiver/nudge chain and bind control.
 - AK.5: cache-disabled, immediate, due-batch, restart, and nudge proofs.
-- AK.6: active-transport deletion, isolated curl-mTLS fixture, and final
-  bidirectional production evidence.
+- AK.6: isolated pre-AK.2 curl-mTLS fixture and final documentation evidence.
 
 `atm-peer-tls-interop` is a preservation boundary, not a service component:
 it may contain provisioning/configuration value objects and a curl-mTLS
@@ -143,7 +141,7 @@ substitute for the production-sender proof.
 | AK.3 | Normalize configured aliases to full hostnames before persistence, with no outbound delivery behavior change; prove canonical ingress/nudge with curl. | Must follow AK.2 development push and merge-forward. AK.2 PR must merge before AK.3 PR completion. | arch-ctm |
 | AK.4 | Prove direct full-host HTTP delivery with no retry, including one production sender/receiver/nudge chain. | Must follow AK.3 development push and merge-forward. AK.3 PR must merge before AK.4 PR completion. | arch-ctm |
 | AK.5 | Add optional default-on resend caching through AK.4's proven HTTP function, including restart recovery and disabled-cache behavior. | Must follow AK.4 development push and merge-forward. AK.4 PR must merge before AK.5 PR completion. | arch-ctm |
-| AK.6 | Delete now-dead peer scans, inferred literal-IP discovery, DNS threads, and active custom TLS; isolate provisioning/receiver curl interop. | May develop in parallel after the Phase AI→`develop` entry gate. Before final validation or PR completion, merge-forward AK.5; AK.5 PR must merge before AK.6 PR completion. | Cipher-311d |
+| AK.6 | Independently preserve provisioning/receiver curl-mTLS interop from the pre-AK.2 baseline in an inactive crate. | May develop in parallel from the pre-AK.2 `integrate/phase-ak` baseline after the Phase AI→`develop` entry gate. Before final validation or PR completion, merge-forward AK.5; AK.5 PR must merge before AK.6 PR completion. | Cipher-311d |
 
 Each dependent sprint begins immediately after its predecessor development is
 pushed and merge-forwarded; it does **not** wait for predecessor QA approval.
@@ -151,10 +149,10 @@ Every dependent development or fix round first merges its predecessor. A
 dependent PR cannot complete before its predecessor PR merges.
 
 AK.6 is the explicit parallel exception: Cipher may start its isolated
-interop-fixture and deletion-ledger work immediately after the Phase AI entry
-gate, without waiting for AK.5. It must not merge an active-transport deletion
-until AK.5 is merged forward, and it must merge AK.5 before its final
-validation, any final fix round, and PR completion.
+pre-AK.2-baseline interop fixture immediately after
+the Phase AI entry gate, without waiting for AK.5. It must merge AK.5 before
+its final validation, any final fix round, and PR completion; it must never
+restore active legacy TLS code to the post-AK.2 line.
 
 ## Governing changes
 

--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -186,7 +186,7 @@ discovery, and daemon worker delivery do not. ADR-035 remains the canonical
 single-ingress/nudge rule.
 
 AK.7 implements and makes testable `REQ-P-RUNTIME-006` plus the existing
-daemon-ambient-identity prohibition in `REQ-P-RUNTIME-002`. It updates
+daemon-ambient-identity prohibition in `REQ-CORE-CONFIG-001`. It updates
 `docs/atm-daemon-client/boundaries.md`, `docs/atm-daemon/requirements.md`, and
 the daemon startup documentation to make the shared CLI/graft auto-start
 boundary explicit. No new ADR is needed: this is enforcement of the accepted

--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -19,6 +19,9 @@ Phase AK starts only after Phase AI merges to `develop`, on
 `integrate/phase-ak`. It does not alter the already-planned Phase AJ
 runtime-observation work. AK.2's temporary no-delivery state must never merge
 to `develop`; AK.4 restores and proves direct delivery on this phase branch.
+AK.7 is an independent daemon-launch hardening sprint: it has no peer-routing,
+transport, retry, or lifecycle-state dependency and may merge on its own QA
+result.
 
 ## Documentation transition
 
@@ -36,6 +39,13 @@ resend-cache semantics for `REQ-CORE-TRANSPORT-003/-003B`. AK.6 finalizes
 supersession markers and removes obsolete wording without changing AK.3's
 alias contract or AK.4/AK.5 active semantics. No sprint may claim a code/doc
 mismatch as an acceptable interim state after its own PR completes.
+
+AK.7 implements the existing `REQ-P-RUNTIME-006` launch-environment boundary:
+every standard daemon launcher strips `ATM_TEAM`, `ATM_IDENTITY`, and
+`ATM_ENVIRONMENT` before `atm-daemon` starts, and daemon production code has
+no ambient caller-context fallback. It updates only daemon-launch/
+daemon-boundary documentation; it neither changes Phase AJ caller-context
+semantics nor adds agent-state behavior.
 
 ## MVP contract
 
@@ -112,6 +122,8 @@ authoritative:
 - AK.4: direct production send/receiver/nudge chain and bind control.
 - AK.5: cache-disabled, immediate, due-batch, restart, and nudge proofs.
 - AK.6: isolated pre-AK.2 curl-mTLS fixture and final documentation evidence.
+- AK.7: daemon launch-environment sanitation and ambient-context boundary
+  proof.
 
 `atm-peer-tls-interop` is a preservation boundary, not a service component:
 it may contain provisioning/configuration value objects and a curl-mTLS
@@ -142,6 +154,7 @@ substitute for the production-sender proof.
 | AK.4 | Prove direct full-host HTTP delivery with no retry, including one production sender/receiver/nudge chain. | Must follow AK.3 development push and merge-forward. AK.3 PR must merge before AK.4 PR completion. | arch-ctm |
 | AK.5 | Add optional default-on resend caching through AK.4's proven HTTP function, including restart recovery and disabled-cache behavior. | Must follow AK.4 development push and merge-forward. AK.4 PR must merge before AK.5 PR completion. | arch-ctm |
 | AK.6 | Independently preserve provisioning/receiver curl-mTLS interop from the pre-AK.2 baseline in an inactive crate. | May develop in parallel from the pre-AK.2 `integrate/phase-ak` baseline after the Phase AI→`develop` entry gate. Before final validation or PR completion, merge-forward AK.5; AK.5 PR must merge before AK.6 PR completion. | Cipher-311d |
+| AK.7 | Strip caller identity/team/environment from every daemon launch and remove daemon ambient-caller reads. | May develop and merge independently after the Phase AI→`develop` entry gate. Its owned launch/boundary paths do not overlap AK.1–AK.6. | Cipher-311d |
 
 Each dependent sprint begins immediately after its predecessor development is
 pushed and merge-forwarded; it does **not** wait for predecessor QA approval.
@@ -154,6 +167,12 @@ the Phase AI entry gate, without waiting for AK.5. It must merge AK.5 before
 its final validation, any final fix round, and PR completion; it must never
 restore active legacy TLS code to the post-AK.2 line.
 
+AK.7 is also parallel-safe: Cipher may start from the `integrate/phase-ak`
+baseline immediately after the Phase AI entry gate and merge as soon as AK.7
+QA passes. It does not wait for, merge-forward, or modify AK.1–AK.6. If the
+shared baseline advances before an AK.7 fix round, merge it first; resolve only
+the AK.7-owned launch/boundary files.
+
 ## Governing changes
 
 AK.1 records and implements the surviving cross-host provenance fixes. AK.2
@@ -165,3 +184,10 @@ ADR-034/040/041 and the corresponding requirements/boundary rules: peer host
 alias configuration remains; custom TLS/pinning, inferred literal-IP authority
 discovery, and daemon worker delivery do not. ADR-035 remains the canonical
 single-ingress/nudge rule.
+
+AK.7 implements and makes testable `REQ-P-RUNTIME-006` plus the existing
+daemon-ambient-identity prohibition in `REQ-P-RUNTIME-002`. It updates
+`docs/atm-daemon-client/boundaries.md`, `docs/atm-daemon/requirements.md`, and
+the daemon startup documentation to make the shared CLI/graft auto-start
+boundary explicit. No new ADR is needed: this is enforcement of the accepted
+runtime requirement, not a new architectural option.

--- a/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
+++ b/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
@@ -31,7 +31,7 @@ coordinator, and its per-message thread.
 | Item | AK.1 role |
 | --- | --- |
 | `HostName`, `WriteRequest`, `ResponseEnvelope` | Existing canonical provenance, immutable-write, and response values; AK.1 adds no peer-specific DTO. |
-| `HttpsListenerSet`, `ListenerSecurity::MutualTls`, `PinnedClientVerifier` | Existing receiver-only TLS boundary proven by curl. AK.1 does not expand it; AK.4 separates the retained plain receiver and AK.6 retires TLS. |
+| `HttpsListenerSet`, `ListenerSecurity::MutualTls`, `PinnedClientVerifier` | Existing receiver-only TLS boundary proven by curl. AK.1 does not expand it; AK.2 deletes it, AK.4 creates the plain receiver, and AK.6 preserves only baseline interop evidence. |
 | `AuthenticatedIngress::Peer`, `WriteIngress::Peer`, `validate_write_provenance` | Existing authenticated receiver path, source-host validation, and canonical persistence boundary. |
 | `PostCommitWorkKey::LocalNudge`, `PostCommitWorkQueue` | Existing ordinary post-write nudge boundary. AK.1 keeps it as the one receiver notification path. |
 

--- a/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
+++ b/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
@@ -62,8 +62,9 @@ ledger names it explicitly.
 AK.2 begins with a marker-only commit: apply `#[deprecated(note = "AK.2 …")]`
 to every listed production deletion/rename target before deleting any of them.
 The markers are intentional discovery tools, not a compatibility policy or
-suppression: `atm-daemon` has no blanket `allow(deprecated)`. Record the
-marker-only `cargo check --workspace` output as the complete compiler map of
+suppression: remove blanket `allow(deprecated)` from `atm-daemon` and
+`atm-storage-rusqlite` for this checkpoint. Record the marker-only
+`cargo check --workspace --all-targets` output as the complete compiler map of
 target references; every warning must belong to a row below. Then delete or
 rewrite the marked surfaces and finish with no AK.2 deprecation warnings.
 

--- a/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
+++ b/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
@@ -59,13 +59,13 @@ ledger names it explicitly.
 
 ### Compiler-attributed pre-delete map
 
-The listed production identifiers are already marked `#[deprecated(note =
-"AK.2 …")]` in the AK.2 branch. The markers are intentional discovery tools,
-not a compatibility policy and not a suppression: `atm-daemon` has no blanket
-`allow(deprecated)`. The pre-delete `cargo check --workspace` result is a
-complete compiler map of the marked target references, with no errors. Every
-warning belongs to one of the rows below. AK.2 deletes the marked surfaces and
-must finish with no AK.2 deprecation warnings.
+AK.2 begins with a marker-only commit: apply `#[deprecated(note = "AK.2 …")]`
+to every listed production deletion/rename target before deleting any of them.
+The markers are intentional discovery tools, not a compatibility policy or
+suppression: `atm-daemon` has no blanket `allow(deprecated)`. Record the
+marker-only `cargo check --workspace` output as the complete compiler map of
+target references; every warning must belong to a row below. Then delete or
+rewrite the marked surfaces and finish with no AK.2 deprecation warnings.
 
 | Compiler-attributed caller | AK.2 action | Replacement, if any |
 | --- | --- | --- |
@@ -113,7 +113,7 @@ role from surviving in the name.
 | `PostCommitWorkKey::PeerDelivery { peer, message_id }` | Delete | It is the sole post-commit handoff into the peer coordinator. |
 | `PostCommitWorkKey::LocalNudge` | Retain | It drives the ordinary local/received-message nudge path. |
 | `PostCommitWorkQueue::signal` | Retain | It remains the local-nudge boundary only. |
-| `PeerPostCommitWorkQueue` | Rewrite/rename | It is already marked deprecated as a rename target. Become `LocalPostCommitWorkQueue`; delete its `coordinator` field. |
+| `PeerPostCommitWorkQueue` | Rewrite/rename | Mark as an AK.2 rename target in the marker-only commit. Become `LocalPostCommitWorkQueue`; delete its `coordinator` field. |
 | `LocalPostCommitWorkQueue::new` | Rewrite | Remove the coordinator parameter and all peer construction. |
 | `register_local_nudge`, `start`, `stop`, `run`, `signal`, `remove_local_nudge_target` | Retain/rewrite | Preserve local nudge work; `signal` accepts only `LocalNudge`; `run` has no peer arm. |
 | `PostCommitNudgeTarget`, `DaemonGraftPostSendPort`, `DaemonGraftPostSendPort::new`, `deliver_post_send`, `deliver_post_send_to_graft_receiver`, `graft_transport_error`, `graft_recipient_unavailable_error` | Retain | These implement the one ordinary receiver/local nudge path, not peer delivery. |
@@ -193,8 +193,9 @@ delivery health.
 
 ## Required validation
 
-- Pre-delete discovery: `cargo check --workspace` reports only the attributed
-  AK.2 deprecation set. Do not add an `allow(deprecated)` to hide callers.
+- Pre-delete discovery: the marker-only commit applies the listed AK.2
+  deprecations, then `cargo check --workspace` reports only the attributed
+  AK.2 warning set. Do not add an `allow(deprecated)` to hide callers.
 - Source gate rejects every deleted coordinator, PeerSync, policy, projection,
   and peer post-commit identifier named above from production code.
 - Unit: host-qualified admission persists its origin ULID and immutable record

--- a/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
+++ b/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
@@ -65,10 +65,13 @@ AK.2 begins with a marker-only commit: apply `#[deprecated(note = "AK.2 …")]`
 to every listed production deletion/rename target before deleting any of them.
 The markers are intentional discovery tools, not a compatibility policy or
 suppression: remove blanket `allow(deprecated)` from `atm-daemon` and
-`atm-storage-rusqlite` for this checkpoint. Record the marker-only
-`cargo check --workspace --all-targets` output as the complete compiler map of
-target references; every warning must belong to a row below. Then delete or
-rewrite the marked surfaces and finish with no AK.2 deprecation warnings.
+`atm-storage-rusqlite` for this checkpoint. First record the unmarked baseline
+`cargo check --workspace --all-targets`; then record the marker-only output
+and its warning delta as the complete compiler map of target references. Every
+**new** warning must belong to a row below. Preserve and name any pre-existing
+unrelated warning in the evidence; do not suppress it to falsify the delta.
+Then delete or rewrite the marked surfaces and finish with no AK.2 deprecation
+warnings.
 
 | Compiler-attributed caller | AK.2 action | Replacement, if any |
 | --- | --- | --- |
@@ -197,9 +200,11 @@ delivery health.
 
 ## Required validation
 
-- Pre-delete discovery: the marker-only commit applies the listed AK.2
-  deprecations, then `cargo check --workspace` reports only the attributed
-  AK.2 warning set. Do not add an `allow(deprecated)` to hide callers.
+- Pre-delete discovery: record the unmarked compiler baseline, then apply the
+  listed AK.2 deprecations and record the `cargo check --workspace --all-targets`
+  warning delta. Every new warning is attributable to this ledger; explicitly
+  retain rather than suppress any unrelated pre-existing deprecation warning.
+  Do not add an `allow(deprecated)` to hide callers.
 - Source gate rejects every deleted coordinator, PeerSync, policy, projection,
   and peer post-commit identifier named above from production code.
 - Unit: host-qualified admission persists its origin ULID and immutable record

--- a/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
+++ b/docs/plans/phase-ak/sprint-AK2-delete-peer-worker.md
@@ -15,7 +15,9 @@ parallel_safe: false
 ## Closure
 
 Delete the daemon-owned host-qualified delivery worker before its replacement.
-This sprint deletes queue/thread/reload machinery only. A host-qualified
+This sprint deletes queue/thread/reload machinery and the legacy custom TLS
+module only. AK.6 preserves its interop-only subset from the pre-AK.2 baseline.
+A host-qualified
 origin record retains exactly one immutable outbound write and destination host
 (`peerOutbound`) as durable message data; it is not a queue or worker state.
 Host-qualified writes are not delivered until AK.4.
@@ -24,7 +26,7 @@ Host-qualified writes are not delivered until AK.4.
 
 1. Delete `peer_drain_coordinator.rs`, `PeerDeliveryCoordinator`, worker
    creation/join/shutdown, `PeerJob`, `PeerWork`, channels, per-message
-   threads, and worker-only tests.
+   threads, `https_transport.rs`, and worker-only tests.
 2. Delete `PostCommitWorkKey::PeerDelivery` and its router signal. Retain the
    existing local post-write nudge path.
 3. Delete worker-only retry/recovery policy and observability. Do not replace
@@ -74,9 +76,9 @@ rewrite the marked surfaces and finish with no AK.2 deprecation warnings.
 | `runtime_health.rs` coordinator fields/build/start/stop, projection, PeerSync dispatch | Delete | `start_local_post_write_executor` / `stop_local_post_write_executor` start and stop only the retained local nudge executor. |
 | `runtime_health/peer_delivery_router.rs` peer event and `PeerDelivery` signal | Rewrite | Host-qualified origin returns after persistence; peer receipts and hostless writes use `signal_local_post_write`. |
 | `runtime_health/post_commit_work.rs::PeerPostCommitWorkQueue` | Rename and rewrite | `LocalPostCommitWorkQueue`; no coordinator field or peer arm. |
-| `composition.rs` outbound `https_transport` slot and dispatcher installation/clearing | Delete | Retain only `HttpsListenerSet` lifecycle. The listener does not require the retired outbound sender slot. |
+| `composition.rs` custom TLS listener/client lifecycle and outbound `https_transport` slot | Delete | AK.2 leaves no legacy transport lifecycle. AK.4 creates the minimal plain receiver; AK.6 preserves only its baseline interop fixture. |
 | `atm-core::api`, `protocol`, local-IPC request classification, transport test adapter | Delete PeerSync route/envelopes/arms/tests | None. |
-| `atm::commands::peer::{sync,sync-policy}` and `CliComposition::peer_sync` | Delete | None. Trust/interface/certificate configuration survives unchanged until AK.6. |
+| `atm::commands::peer::{sync,sync-policy}` and `CliComposition::peer_sync` | Delete | None. Provisioning records and configuration display remain only as AK.6 interop-fixture input; they must not install or select an active transport after AK.2. |
 | `PeerSyncPolicy`, `PeerConfigStore` policy methods, SQLite adapter/table/index | Delete | None. AK.5 creates a distinct resend-cache setting only after AK.4 works. |
 | doctor `PeerLink*` projection and CLI `configured_peer_links` | Delete | Retain configured-peer report only; it must not invent delivery health. |
 
@@ -134,9 +136,9 @@ worker, or per-message sender. It is unchanged post-write notification work.
 | `start_peer_drain_coordinator`, `stop_peer_drain_coordinator` | Delete | Lifecycle belongs to the deleted worker. |
 | `record_peer_delivery_event`, `peer_link_statuses`, `sync_peer` | Delete | All expose worker/projection behavior. |
 | `RequestEnvelope::PeerSync` dispatch arm | Delete | There is no explicit worker reconciliation in AK.2. |
-| `composition::{start_https_listeners, stop_https_listeners}` peer-coordinator calls | Delete | HTTPS receiver lifecycle remains until AK.6; it no longer starts/stops delivery work. |
-| `DaemonRequestDispatcher::{https_transport, install_https_transport, clear_https_transport}` and `RuntimeComposition::https_transport` | Delete | These marked slots exist only to hand an outbound custom sender to the worker. Keep `HttpsListenerSet`, listener bind/stop, and trust-refresh receiver lifecycle; they have no outbound-slot replacement. |
-| `atm-daemon/src/lib.rs` modules `peer_drain_coordinator`, `peer_delivery_observability` | Delete | Both modules disappear. `peer_resolution` and `https_transport` are deferred to AK.6. |
+| `composition::{start_https_listeners, stop_https_listeners}` and their worker calls | Delete | The entire legacy custom transport lifecycle disappears; AK.4 owns the replacement plain receiver. |
+| `DaemonRequestDispatcher::{https_transport, install_https_transport, clear_https_transport}` and `RuntimeComposition::https_transport` | Delete | These slots exist only for the legacy custom transport; they have no AK.2 replacement. |
+| `atm-daemon/src/lib.rs` modules `peer_drain_coordinator`, `peer_delivery_observability`, `https_transport` | Delete | All three modules disappear. `peer_resolution` remains only until AK.3 replaces it with configured alias normalization. |
 
 ### 4. Delete peer reconciliation API and policy, retain durable writes
 
@@ -145,7 +147,7 @@ worker, or per-message sender. It is unchanged post-write notification work.
 | `RequestEnvelope::PeerSync`, `ResponseEnvelope::PeerSync`, `PeerSyncRequest`, `PeerSyncOutcome`, `PeerSyncDisposition` | Delete | Public protocol only triggers the retired worker. |
 | `api.rs` `PEER_SYNC_PREFIX`, `HttpRouteKind::PeerSync`, route spec, encode/decode arms, `peer_sync_path_host`, `ApiRequest::PeerSync`, peer-sync API tests | Delete | Remove the worker-only HTTP resource; do not replace it in AK.2. |
 | `atm/src/composition.rs::peer_sync` and request classification | Delete | CLI no longer invokes a daemon worker. |
-| `atm/src/commands/peer.rs` `PeerSubcommand::Sync`, `SyncPolicyCommand`, `SyncPolicySubcommand`, `run_sync`, `parse_whole_seconds`, sync-policy dispatch/tests | Delete | CLI controls only the retired reconciliation policy. Interface/certificate/trust commands are deferred to AK.6. |
+| `atm/src/commands/peer.rs` `PeerSubcommand::Sync`, `SyncPolicyCommand`, `SyncPolicySubcommand`, `run_sync`, `parse_whole_seconds`, sync-policy dispatch/tests | Delete | CLI controls only the retired reconciliation policy. Provisioning/configuration commands may remain solely for AK.6's isolated fixture, never active daemon transport. |
 | `PeerSyncPolicy`, `MAX_PEER_SYNC_BATCH_MESSAGES`, `MAX_PEER_SYNC_MESSAGE_AGE`, `PeerSyncPolicy::{validate, default}`, `duration_seconds` | Delete | Configuration exists only for worker scanning. |
 | `PeerConfigStore::{peer_sync_policy, save_peer_sync_policy}` and re-export | Delete | No durable recovery policy remains. |
 | SQLite policy methods/tests/imports | Delete | Remove the dead persistence adapter surface. |
@@ -183,9 +185,10 @@ delivery health.
 
 ### 7. Explicitly deferred from AK.2
 
-- `peer_resolution.rs`, `runtime_health/peer_authority.rs`, `HttpsTransport`,
-  rustls listener/client code, certificate/fingerprint configuration, and
-  `PeerWireSecurity`: AK.6 owns their removal/isolation.
+- `peer_resolution.rs` and `runtime_health/peer_authority.rs`: AK.3 owns their
+  separate alias/resolver cleanup. AK.6 independently preserves the
+  TLS interop subset from the pre-AK.2 baseline; AK.2 deletes all active custom
+  TLS code instead of retaining it in the daemon.
 - Alias index, `PeerEndpoint`, and canonical IP-alias substitution: AK.3.
 - Any native peer HTTP call: AK.4.
 - Any endpoint state, timer, aggregate, or retry: AK.5.

--- a/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
+++ b/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
@@ -99,15 +99,21 @@ plan amendment.
    host, a duplicate normalized key, and `alias_kind='host'` when its
    `alias_value` parses as an `IpAddr`. It never calls DNS or discovers
    aliases.
-4. Build/swap one `PeerDirectory` only at daemon configuration load/reload;
+4. Delete the legacy `runtime_health/peer_authority.rs::{resolve_peer_authority,
+   MAX_LITERAL_IP_AUTHORITY_CANDIDATES}` and `peer_resolution.rs::resolve_peer_socket_addresses`
+   modules, including their DNS/fan-out tests and `lib.rs`/runtime module declarations.
+   `PeerDirectory::normalize` is their sole replacement for recipient
+   canonicalization; it performs configured-alias substitution only. It must
+   not retain a compatibility wrapper, scan peer rows, or resolve an address.
+5. Build/swap one `PeerDirectory` only at daemon configuration load/reload;
    parse the optional recipient host as either `HostName` or literal `IpAddr`,
    construct one `PeerAliasKey`, and normalize every host-qualified recipient
    before its one canonical
    persistence, including `peerOutbound.host`. Do not add a second outbox,
    delivery table, or per-send lookup query.
-5. Preserve the canonical full hostname through send, mailbox, ACK, and nudge
+6. Preserve the canonical full hostname through send, mailbox, ACK, and nudge
    data; preserve AK.2's no-delivery behavior.
-6. Exclusively own the alias/configuration edits to
+7. Exclusively own the alias/configuration edits to
    `docs/requirements.md` (`REQ-CORE-TRANSPORT-002A` and `-002D`),
    `docs/adr/ADR-040-peer-authority-resolution.md`,
    `docs/adr/ADR-035-canonical-write-ingress-and-host-routing.md`,
@@ -127,6 +133,10 @@ plan amendment.
 
 ## Required validation
 
+- Source gate: the legacy `resolve_peer_authority`,
+  `resolve_peer_socket_addresses`, `MAX_LITERAL_IP_AUTHORITY_CANDIDATES`, and
+  their module declarations are absent; no compatibility wrapper or DNS path
+  remains at admission.
 - Unit: host and `IpAddr` aliases resolve O(1) to one full hostname without
   SQLite, live DNS, a peer scan, network I/O, or a new thread.
 - Unit: duplicate/unknown/disabled aliases fail at configuration mutation;

--- a/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
+++ b/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
@@ -47,6 +47,9 @@ struct PeerHttpRuntimeConfig {
     source_host: HostName,
 }
 
+const MAX_PEER_HTTP_CONNECTIONS: usize = 64;
+const PLAINTEXT_PEER_SOURCE_HOST_HEADER: &str = "X-ATM-Peer-Source-Host";
+
 trait MessageStore {
     fn confirm_peer_delivery(
         &self,
@@ -95,15 +98,22 @@ response time. Expiry returns the ordinary persisted-but-undelivered delivery
 error. ADR-047 and `REQ-CORE-TRANSPORT-002` record this bounded
 local-responsiveness tradeoff explicitly.
 
-The current `HttpsListenerSet` contains two separable responsibilities. AK.4
-keeps its existing bounded inbound HTTP execution and renames the plaintext
-part `PeerHttpListenerSet`; AK.6 later deletes only its TLS security half.
-`PeerHttpListenerSet` owns one existing accept thread per enabled interface and
-uses the existing `ActiveConnectionRegistry` to bound existing request threads
-at `MAX_PEER_HTTP_CONNECTIONS`. AK.4 creates no outbound thread and no new
-listener/request execution model. Every accepted frame—loopback, same-IP, and
-cross-host—runs `route_peer_http_request`, the canonical router, SQLite
-admission, and the ordinary post-write nudge exactly once.
+AK.2 deletes the legacy `HttpsListenerSet` module. AK.4 builds the replacement
+`PeerHttpListenerSet`: a minimal configured plain-HTTP receiver that retains
+the existing bounded HTTP framing, `ActiveConnectionRegistry`, canonical
+`route_peer_http_request`, SQLite admission, and ordinary post-write nudge.
+It owns one bounded accept thread per enabled interface and no outbound thread,
+pool, worker, or second receiver. Every accepted frame—loopback, same-IP, and
+cross-host—uses that one receiver/nudge path exactly once.
+
+`crates/atm-daemon/src/peer_http_listener.rs` is a new module, not a rename or
+partial extraction of `https_transport.rs`. It owns the explicit listener
+types below plus `peer_connection_admission`, `spawn_request_worker`,
+`track_request_worker`, `route_peer_http_request`, and the source-host header
+writer. The legacy equivalents disappear with AK.2. The replacement may reuse
+only the existing shared framing and active-connection primitives; it may not
+carry TLS mode, certificate, verifier, resolver, smoke-ingress, or outbound
+transport state forward.
 
 ## Type and boundary inventory
 
@@ -116,9 +126,10 @@ admission, and the ordinary post-write nudge exactly once.
 | `WriteRequest`, `RequestEnvelope::Write`, `ResponseEnvelope::Send`, `SendResponseEnvelope`, `RequestDeadline`, `PEER_HTTP_LOCAL_RESPONSE_BUDGET` | Existing canonical wire/request types plus one AK.4 three-second local-response cap. The sender uses the caller's existing absolute deadline, never a fresh one. Acceptance is only the matching `ResponseEnvelope::Send` outcome for that write ULID; every other response, including `ResponseEnvelope::Error`, is a delivery failure. |
 | `TcpStream`, `SocketAddr` | Existing standard-library connection/address values. The OS resolver produces one ephemeral address for one direct call; neither enters ATM storage or state. |
 | `HttpFrameReader` and shared HTTP writer helpers | Existing framing boundary. Both production and real-loopback tests use it. |
-| `PeerHttpListenerSet`, `PeerHttpListener`, `PeerConnectionAdmission` | Renamed retained inbound HTTP listener lifecycle and its exact accept decision. It is the only production peer receiver; no second handler is created. |
+| `PeerHttpListenerSet`, `PeerHttpListener`, `PeerConnectionAdmission` | New `peer_http_listener.rs` minimal plain-HTTP listener lifecycle and exact accept decision. It is the only production peer receiver; no second handler is created. |
+| `MAX_PEER_HTTP_CONNECTIONS`, `PLAINTEXT_PEER_SOURCE_HOST_HEADER`, `peer_connection_admission`, `spawn_request_worker`, `track_request_worker`, `route_peer_http_request` | New `peer_http_listener.rs` receiver-only constants/helpers. `64` is the exact concurrent inbound connection cap. They reuse bounded framing/dispatch and write the one configured provenance header; none has TLS, DNS, peer lookup, retry, or outbound state. |
 | `ListenerSecurity::PlaintextTest`, `AuthenticatedIngress::UntrustedSmoke` | Existing temporary smoke-only classification deleted from production peer-write handling. AK.4 has no replacement enum: configured trusted-LAN peer writes use the existing `Peer` ingress value. |
-| `ActiveConnectionRegistry`, `ActiveConnectionGuard`, `TrackedDispatchHandle`, `MAX_PEER_HTTP_CONNECTIONS` | Existing bounded inbound request execution retained unchanged. These apply only after a peer socket is accepted; they are not outbound delivery state. |
+| `ActiveConnectionRegistry`, `ActiveConnectionGuard`, `TrackedDispatchHandle`, `MAX_PEER_HTTP_CONNECTIONS` | Existing bounded inbound request primitives reused by the new listener. These apply only after a peer socket is accepted; they are not outbound delivery state. |
 | `route_peer_http_request`, `WriteIngress::Peer`, `validate_write_provenance` | Existing common ingress boundary. AK.4 changes the former plaintext-test provenance classification to trusted-LAN `Peer`; it does not create local/cross-host branches. |
 | `PeerDeliveryConfirmation`, `MessageStore::confirm_peer_delivery` | New exact confirmation value and one sealed-storage mutation. `true` removes only matching `peerOutbound` metadata after a successful peer response; `false` is an idempotent already-confirmed no-op, so only undelivered writes appear in a later batch. |
 | `AtmError` | Existing delivery-failure type; no new retry/result enum is introduced. |
@@ -140,12 +151,17 @@ worker, queue, or test transport abstraction is authorized.
    read timeout are all typed delivery failures; none may confirm a write.
    Build one immutable `PeerHttpRuntimeConfig` from configured interface data
    at configuration load/reload; do not query peer configuration per send.
-2. Add and validate `PeerHttpBindConfig` at daemon startup, then extract/rename
-   the plaintext branch of `HttpsListenerSet` to `PeerHttpListenerSet` and
-   make it the configured production trusted-LAN listener. It binds only the
+2. Add and validate `PeerHttpBindConfig` at daemon startup, then implement a
+   new `peer_http_listener.rs` with `PeerHttpListenerSet`,
+   `PeerHttpListener`, `PeerConnectionAdmission`, the exact `64` connection
+   cap, source-host header writer, and listed bounded request helpers. Do not
+   extract or rename any part of `https_transport.rs`; AK.2 deleted that
+   module. Implement `PeerHttpListenerSet` as the configured production
+   trusted-LAN listener.
+   It binds only the
    finite validated addresses; wildcard, multicast, empty, duplicate, or
    non-local lists fail startup. Retain its listed bounded accept/request
-   execution unchanged;
+   execution primitives without reviving the deleted TLS module;
    delete the `PlaintextTest`/`UntrustedSmoke` production distinction. A write
    with the configured source-host header is admitted as `WriteIngress::Peer`
    after the existing provenance validation. Do not authenticate or route from
@@ -185,15 +201,15 @@ worker, queue, or test transport abstraction is authorized.
    `docs/atm-daemon/{architecture,boundaries,http-api,requirements}.md`,
    `docs/atm/{architecture,requirements}.md`, and
    `docs/peer-pair-smoke.md`. The documentation must describe the active
-   plain-HTTP trusted-LAN MVP and its no-retry baseline without claiming that
-   AK.6 has already deleted legacy TLS code. Update the repository
+   plain-HTTP trusted-LAN MVP and its no-retry baseline after AK.2 removed the
+   legacy TLS module. Update the repository
    `crosshost-curl-plain` runner so it starts the configured production
    `PeerHttpListenerSet` without `plaintext-test`/`UntrustedSmoke`; retain a
    separately named interop-only mTLS fixture lane for AK.6.
 8. Update governed boundary records in this same PR:
    `boundaries/atm-daemon/peer-http-adapter.toml` replaces
-   `HttpsListenerSet` with `PeerHttpListenerSet` while preserving the legacy
-   outbound TLS entries until AK.6, and
+   legacy `HttpsListenerSet` with `PeerHttpListenerSet` and no legacy TLS
+   entries, and
    `boundaries/atm-storage/message-store.toml` adds
    `PeerDeliveryConfirmation` to `contracts.request_types` for
    `MessageStore::confirm_peer_delivery`.

--- a/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
+++ b/docs/plans/phase-ak/sprint-AK5-direct-peer-timer-state.md
@@ -37,6 +37,7 @@ struct PeerResendState {
 
 const PEER_RESEND_BATCH_LIMIT: u16 = 64;
 const PEER_RESEND_DUE_CALLBACK_BUDGET: Duration = Duration::from_millis(250);
+const PEER_RESEND_RETRY_DELAY: Duration = Duration::from_secs(60);
 
 enum LocalIpcWaitOutcome {
     Accepted(LocalSocketStream),
@@ -72,6 +73,17 @@ impl PeerResendScheduler {
     fn next_due(&self) -> Option<Instant>;
     fn poll_due_peer_resends(&self, now: Instant) -> Result<(), AtmError>;
 }
+
+trait OutboundMessageQuery {
+    fn pending_peer_hosts(&self, budget: Duration) -> Result<Vec<HostName>, AtmError>;
+    fn page_for_peer(
+        &self,
+        peer: &HostName,
+        after: Option<(IsoTimestamp, AtmMessageId)>,
+        limit: NonZeroU16,
+        budget: Duration,
+    ) -> Result<Vec<StoredPeerWrite>, AtmError>;
+}
 ```
 
 `peer_resend_cache` defaults to `true`; it is stored in the one-row
@@ -84,7 +96,7 @@ records remain the sole backlog. The mutex makes the admission transition,
 state transition.
 
 `Connected` performs AK.4's `send_peer_http_frames` immediately. A failure
-sets `Queued { due_at >= now + 60s }`; new sends for a queued endpoint only
+sets `Queued { due_at = now + PEER_RESEND_RETRY_DELAY }`; new sends for a queued endpoint only
 persist and return a pending-delivery error. When the due event begins its one
 oldest-first batch, the endpoint is `Disconnected` so concurrent admissions
 do not connect. Full success sets `Connected`; any failure returns it to
@@ -149,11 +161,11 @@ an error with no aggregate or due event.
 | `PeerResendCacheSetting`, `peer_delivery_settings` | New persisted one-bit default-on setting and its exact one-row table. It replaces no old policy and has no per-peer override in this sprint. |
 | `PeerConfigStore::{peer_resend_cache_setting, save_peer_resend_cache_setting}` | New sealed configuration accessors for the one setting. Saving uses the existing runtime-view reload; it does not start a worker or mutate a live endpoint map directly. |
 | `PeerSubcommand::ResendCache`, `ResendCacheCommand` | New explicit CLI configuration surface for showing or setting the one Boolean. It owns no send/retry operation and has no per-peer form. |
-| `PEER_RESEND_BATCH_LIMIT`, `PEER_RESEND_DUE_CALLBACK_BUDGET` | New exact bounds: 64 writes for one oldest-first due batch and 250 ms for one due callback. The sole `NonZeroU16` conversion occurs at `page_for_peer`. Neither is an admission, connection, or retry-attempt cap. |
+| `PEER_RESEND_BATCH_LIMIT`, `PEER_RESEND_DUE_CALLBACK_BUDGET`, `PEER_RESEND_RETRY_DELAY` | New exact bounds: 64 writes for one oldest-first due batch, 250 ms for one due callback, and 60 s from delivery failure to the next eligible attempt. The sole `NonZeroU16` conversion occurs at `page_for_peer`. Neither is an admission, connection, or retry-attempt cap. |
 | `LocalIpcWaitOutcome`, `accept_until` | New deadline-aware operation inside the existing local IPC serve loop. It returns one accepted local stream or one elapsed monotonic deadline; it adds no thread, timer service, channel, or second event loop. |
 | `RuntimeServeHooks::{next_peer_resend_due, poll_due_peer_resends}` | Two new closure fields used by the existing local-IPC wait path: `next_peer_resend_due` supplies `accept_until`'s cap and `poll_due_peer_resends` runs one due endpoint after `DeadlineElapsed`. They are not a new trait, thread, task, channel, or loop. |
 | `PeerDirectory::endpoint_for_canonical_host` | AK.3 bootstrap-only lookup from durable canonical host to its current `PeerEndpoint`, including port. It returns `None` for a deleted/disabled host and never guesses a port or uses DNS. |
-| `OutboundMessageQuery::{pending_peer_hosts, page_for_peer}` | Read-only immutable backlog readers. `pending_peer_hosts` is the one startup-only `SELECT DISTINCT peerOutbound.host` query; `page_for_peer` is the only payload read in a due batch. |
+| `OutboundMessageQuery::{pending_peer_hosts, page_for_peer}` | Read-only immutable backlog readers. `pending_peer_hosts` is the one startup-only `SELECT DISTINCT peerOutbound.host` query. AK.5 changes `page_for_peer` to remove the retired `not_before` age filter: it pages every still-undelivered record for one canonical host in `(message_at, message_id)` order. It is the only payload read in a due batch. |
 | `MessageStore::confirm_peer_delivery` | AK.4's existing sealed confirmation port, held only to retire each confirmed durable record after the shared sender returns its matching response. |
 | `send_peer_http_frames` | AK.4 sender reused unchanged for singleton and batch delivery. |
 
@@ -179,19 +191,24 @@ connection pool, or health model is authorized without a plan amendment.
    bounded oldest-first page, with the exact 250 ms callback budget. Recompute
    `earliest_due` after it so already-due peers drain one per loop turn; do not
    call a resend callback on each 1 ms `WouldBlock` pass.
-3. Route immediate singleton and timer batch delivery exclusively through
+3. Replace `OutboundMessageQuery::page_for_peer`'s retired `not_before`
+   parameter and SQLite `message_at >=` predicate with the exact cursor-only
+   contract above; add the exact `pending_peer_hosts` distinct-host reader.
+   This query change is solely AK.5 durable backlog selection: no age policy,
+   peer scan, delivery mutation, or new table is allowed.
+4. Route immediate singleton and timer batch delivery exclusively through
    AK.4's `send_peer_http_frames`. A timer batch is a slice into that function,
    not a second transport or receiver path.
-4. Keep resend state separate from agent/session/roster/nudge state. A
+5. Keep resend state separate from agent/session/roster/nudge state. A
    receiver's nudge remains normal post-write behavior and is never used as a
    resend signal.
-5. Bootstrap only through `pending_peer_hosts` followed by
+6. Bootstrap only through `pending_peer_hosts` followed by
    `PeerDirectory::endpoint_for_canonical_host`. A durable host absent from
    the current directory remains untouched and unqueued; it is retried only
    if a later configuration reload restores a matching configured endpoint.
    Never infer its port, scan peers, or consult DNS.
-6. Update requirements/architecture/ADR language for optional resend caching;
-   state that AK.6 deletes obsolete legacy support. Create `ADR-046` for the
+7. Update requirements/architecture/ADR language for optional resend caching;
+   state that AK.6 preserves only an isolated inactive interop fixture. Create `ADR-046` for the
    three-state, in-memory endpoint aggregate and one startup recovery query;
    revise `REQ-CORE-TRANSPORT-003` and `-003B` so immutable `peerOutbound`
    data remains the sole durable backlog while the aggregate is explicitly
@@ -216,6 +233,11 @@ connection pool, or health model is authorized without a plan amendment.
 - Unit: due callback reads one oldest-first page and passes its ordered writes
   of at most `PEER_RESEND_BATCH_LIMIT` to AK.4's exact slice sender;
   partial/failure re-arms without duplicating durable records.
+- Storage integration: `page_for_peer` selects a canonical host's complete
+  undelivered backlog in `(message_at, message_id)` order, including records
+  older than the retired worker's former age window; cursor continuation has
+  no duplicate or gap. `pending_peer_hosts` is distinct, deterministic, and
+  read-only.
 - Unit: a daemon restart with enabled caching performs one distinct-pending-host
   bootstrap, derives every queued endpoint and port only through
   `endpoint_for_canonical_host`, schedules no payload or connection before 60
@@ -263,4 +285,4 @@ merge. AK.6 may already be developing its isolated fixture work after the
 Phase AI entry gate; after AK.5 is pushed, it must merge AK.5 before its final
 validation, final fix round, or PR completion.
 `must_follow` is required because AK.5 retries AK.4's one verified function;
-AK.6 deletes code superseded by the AK.4/AK.5 path only after that merge gate.
+AK.6 finalizes its isolated inactive interop fixture only after that merge gate.

--- a/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
+++ b/docs/plans/phase-ak/sprint-AK6-remove-legacy-peer-transport.md
@@ -1,5 +1,5 @@
 ---
-title: AK.6 Remove legacy peer transport machinery
+title: AK.6 Preserve legacy TLS interop evidence
 status: proposed
 branch: feature/pak-s6-remove-legacy-peer-transport
 worktree: ../atm-core-worktrees/feature/pak-s6-remove-legacy-peer-transport
@@ -11,39 +11,34 @@ merge_gate: AK.5
 parallel_safe: true
 ---
 
-# AK.6 — remove legacy peer transport machinery
+# AK.6 — preserve legacy TLS interop evidence
 
 ## Closure
 
-After AK.4/AK.5 prove the replacement path, delete legacy scans, DNS threads,
-and active custom TLS. Preserve only provisioning/configuration and curl
+AK.6 begins from the pre-AK.2 `integrate/phase-ak` baseline, not from AK.2's
+deletion branch. It preserves only TLS provisioning/configuration and curl
 receiver interoperability in `crates/atm-peer-tls-interop`; it is not a native
 ATM TLS sender and no active daemon, CLI, graft, or send-path crate may depend
-on it.
+on it. AK.2 owns deletion of all active custom TLS code.
 
-AK.6 deliberately keeps interop preservation and legacy deletion in one
-sprint. The curl-mTLS fixture must be captured and moved before the last active
-TLS configuration/data paths are deleted; splitting them would require either
-a temporary active dependency on the preservation crate or a PR that deletes
-the only reproducible fixture before its replacement is qualified. The work is
-sequenced inside this one sprint—capture proof, create/move fixture, prove it,
-then delete active transport and finalize docs—but has one atomic PR boundary.
+AK.6 deliberately keeps baseline interop capture and its isolated fixture in
+one sprint. Its pre-AK.2 baseline contains the source independently of AK.2's
+deletion. The AK.6 branch must not merge active legacy TLS code back into the
+post-AK.2 line; its only mergeable output is the isolated crate and its
+interop-only documentation.
 
-Cipher may start the isolated fixture, boundary record, and deletion ledger in
-parallel after the Phase AI entry gate. Active-transport deletion, final smoke,
-and final documentation reconciliation wait for the AK.5 merge-forward; the
+Cipher may start the isolated fixture and boundary record in parallel from the
+pre-AK.2 baseline after the Phase AI entry gate. Final smoke and documentation
+reconciliation wait for the AK.5 merge-forward; the
 AK.6 PR cannot complete before the AK.5 PR merges.
 
-The current deletion boundary is explicit: remove
-`peer_resolution.rs`, `runtime_health/peer_authority.rs`,
-`HttpsMessageTransport`, `SharedHttpsTransport`, `HttpsTransport`, `TlsIdentity`,
-`PinnedClientVerifier`, TLS client connection/open/deliver helpers, and the
-daemon composition outbound transport slot. Remove all literal-IP fallback and
-every DNS/thread helper. Retain the AK.4 `PeerHttpListenerSet` plain receiver;
-it is not TLS machinery. Retain only the data/provisioning APIs needed to construct
-the separate interop crate and a curl mTLS receiver fixture there. That crate
-is an isolated verification/provisioning utility, not an active transport
-dependency.
+The baseline capture boundary is explicit: copy only the verified provisioning
+data and curl-mTLS receiver fixture inputs required by `TlsInteropConfig` and
+`CurlMtlsReceiverFixture`. Do not copy `HttpsMessageTransport`,
+`SharedHttpsTransport`, `HttpsTransport`, `TlsIdentity`, `PinnedClientVerifier`,
+TLS client connection/open/deliver helpers, daemon composition slots, literal-IP
+fallback, or DNS/thread helpers into the mergeable crate. AK.2 deletes those
+active transport symbols; AK.3 separately removes resolver/authority code.
 
 ## Fixed contract
 
@@ -90,10 +85,9 @@ type has a send, route, resolver, or background-work method.
 | `TlsInteropConfig` | New interop-only value object containing the existing `LocalCertificate` and `TrustedPeer` provisioning data needed by curl verification. It has no routing or send method. |
 | `CurlMtlsReceiverFixture`, `CurlMtlsFixtureOutcome` | New interop-only, synchronous one-shot receiver fixture and its accepted/rejected result for curl proof. It has no production caller, background thread, worker, or daemon lifecycle ownership. |
 | `LocalCertificate`, `CertificateFingerprint`, `TrustedPeer` | Existing durable provisioning/configuration values retained only for the interop fixture and configuration display. They do not select a production route. |
-| `PeerHttpListenerSet`, `PeerHttpListener`, `PeerConnectionAdmission`, `route_peer_http_request`, `ActiveConnectionRegistry` | AK.4's retained production plain receiver. AK.6 must neither delete it nor add a replacement receiver/thread model. |
+| `PeerHttpListenerSet`, `PeerHttpListener`, `PeerConnectionAdmission`, `route_peer_http_request`, `ActiveConnectionRegistry` | AK.4's new minimal production plain receiver. AK.6 must neither delete it nor add a replacement receiver/thread model. |
 | `PeerHttpRuntimeConfig` | AK.4's retained immutable source-host snapshot. AK.6 must retain it without adding a TLS, resolver, or delivery capability. |
-| `PeerWireSecurity`, `HttpsMessageTransport`, `SharedHttpsTransport`, `HttpsTransport`, `TlsIdentity`, `PinnedClientVerifier`, TLS `ListenerSecurity::MutualTls`, TLS handshake helpers | Existing TLS transport types to delete from active code. `HttpsListenerSet` has already been renamed to `PeerHttpListenerSet` in AK.4; its plain receiver survives. |
-| `peer_resolution` / `peer_authority` helpers | Existing legacy resolver/authority surfaces to delete; AK.3 `PeerDirectory` is the sole alias mechanism. |
+| `PeerWireSecurity`, `HttpsMessageTransport`, `SharedHttpsTransport`, `HttpsTransport`, `TlsIdentity`, `PinnedClientVerifier`, TLS handshake helpers | Pre-AK.2 baseline source. AK.2 deletes it from active code; AK.6 extracts only the fixed interop values/fixture. |
 
 No other interop trait, service, executor, listener, sender, thread, task,
 channel, or production dependency is authorized without a plan amendment.
@@ -164,27 +158,22 @@ channel, or production dependency is authorized without a plan amendment.
    notes = ["Curl mTLS interop and provisioning preservation only."]
    ```
    Before moving code, capture a passing curl mTLS fixture proof using the
-   existing certificate/fingerprint records; after the move, the identical
+   baseline certificate/fingerprint records; after the move, the identical
    fixture must pass from the new crate. This preserves verified provisioning
-   evidence without preserving a native sender. Only after this before/after
-   proof passes may active TLS code be deleted.
-2. Delete `peer_resolution.rs`, literal-IP authority discovery, full peer-row
-   scans, custom DNS threads, active `HttpsTransport`,
-   `PinnedClientVerifier`, `TlsIdentity`, rustls composition, and the failing
-   native TLS sender.
-3. Retain AK.3 alias normalization, full-host persistence, and AK.4/AK.5's
+   evidence without preserving a native sender or restoring active TLS code.
+2. Retain AK.3 alias normalization, full-host persistence, and AK.4/AK.5's
    ordinary HTTP hostname resolution at connect time. Do not move any old
    sender/retry code into the interop crate merely to preserve it.
-4. Delete obsolete TLS listener lifecycle/config validation from active daemon
-   composition only after AK.4/AK.5 smoke has demonstrated the replacement.
-   Retain the AK.4 `PeerHttpListenerSet` lifecycle unchanged. Preserve durable
+3. Do not restore obsolete TLS listener lifecycle/config validation to active
+   daemon composition. Retain the AK.4 `PeerHttpListenerSet` lifecycle
+   unchanged. Preserve durable
    certificate/fingerprint rows only as interop provisioning data; do not let
    them influence active routing or retry decisions.
    In this same PR, update `boundaries/atm-daemon/peer-http-adapter.toml`:
    remove the deleted `HttpsTransport`/`HttpsMessageTransport` ownership and
    references, retain the AK.4 `PeerHttpListenerSet` receiver boundary, and
    do not leave a concrete record describing removed TLS code.
-5. Finalize the active-transport documentation started in AK.4: mark ADR-034,
+4. Finalize the inactive-interop documentation started in AK.4: mark ADR-034,
    ADR-040, and ADR-041 superseded by ADR-047; retain ADR-035 as the one
    ingress/router decision and amend only its obsolete TLS/worker language.
    Update `docs/adr/INDEX.md`, `docs/requirements.md`
@@ -242,10 +231,15 @@ channel, or production dependency is authorized without a plan amendment.
 
 ## Dependencies
 
-AK.6 may start immediately after Phase AI merges to `develop`; it develops its
-isolated fixture, boundary record, and deletion ledger in a separate worktree
-without waiting for AK.5. Before active-transport deletion, final validation,
-any final fix round, or PR completion, merge AK.5 into AK.6. AK.6 PR completion
-waits for the AK.5 PR merge. `merge_gate` exists because deletion is safe only
-after AK.5's resend path is proven; it does not block the parallel preparation
-work above.
+AK.6 may start immediately from the pre-AK.2 `integrate/phase-ak` baseline
+after Phase AI merges to `develop`; it develops its isolated fixture, boundary
+record, and resolver-cleanup ledger in a separate worktree without waiting for
+AK.5. Before final validation, any final fix round, or PR completion, merge
+AK.5 into AK.6. AK.6 PR completion waits for the AK.5 PR merge. `merge_gate`
+exists because resolver cleanup is safe only after AK.5's resend path is
+proven; it does not block the parallel preparation work above.
+
+The AK.6 worktree records the exact pre-AK.2 base commit at creation. It does
+not merge AK.2 before capturing the interop fixture. Its required AK.5
+merge-forward happens only for final validation and PR completion; resolve that
+merge by retaining the isolated crate, never by restoring active TLS code.

--- a/docs/plans/phase-ak/sprint-AK7-daemon-environment-neutrality.md
+++ b/docs/plans/phase-ak/sprint-AK7-daemon-environment-neutrality.md
@@ -88,8 +88,9 @@ state machine, or diagnostic data model is authorized.
    `crates/atm-daemon-bootstrap/src`. The gate must permit its own test fixture
    and the client-side stripping helper, but must reject a new daemon ambient
    fallback before review.
-5. Update `docs/requirements.md`'s `REQ-P-RUNTIME-006` implementation/evidence
-   text if needed to name the shared auto-start boundary, then update
+5. Implement `docs/requirements.md`'s `REQ-P-RUNTIME-006` as the governing
+   requirement and keep its shared auto-start boundary/evidence text current;
+   then update
    `docs/atm-daemon-client/boundaries.md`, `docs/atm-daemon/requirements.md`,
    and `docs/atm-daemon/startup-state-machine.md`. State that daemon
    environment sanitation is pre-exec defense in depth and not a replacement

--- a/docs/plans/phase-ak/sprint-AK7-daemon-environment-neutrality.md
+++ b/docs/plans/phase-ak/sprint-AK7-daemon-environment-neutrality.md
@@ -1,0 +1,141 @@
+---
+title: AK.7 Daemon environment neutrality
+status: proposed
+branch: feature/pak-s7-daemon-environment-neutrality
+worktree: ../atm-core-worktrees/feature/pak-s7-daemon-environment-neutrality
+target: integrate/phase-ak
+recommended_agent: Cipher-311d
+recommended_model: deep-reasoning
+must_follow: Phase AI merge to develop
+parallel_safe: true
+---
+
+# AK.7 — daemon environment neutrality
+
+## Closure
+
+Make the daemon team-neutral at process launch and in production source. Every
+standard launcher strips `ATM_TEAM`, `ATM_IDENTITY`, and `ATM_ENVIRONMENT`
+before `atm-daemon` executes. The shared CLI/graft auto-start path is the
+primary required case. The daemon never reads those variables as caller
+context, diagnostic scope, configuration, routing input, or fallback.
+
+This is a narrow runtime hardening sprint. It does not modify the caller-owned
+CLI environment contract, request DTOs, peer delivery, nudge, state/session
+tracking, worker topology, or any AK.1–AK.6 path.
+
+## Fixed contract
+
+```rust
+const DAEMON_STRIPPED_ENVIRONMENT: [&str; 3] = [
+    "ATM_TEAM",
+    "ATM_IDENTITY",
+    "ATM_ENVIRONMENT",
+];
+
+fn sanitize_daemon_child_environment(command: &mut std::process::Command);
+```
+
+`sanitize_daemon_child_environment` is private to `atm-daemon-client`'s
+shared daemon auto-start composition, immediately before `Command::spawn`.
+It calls `Command::env_remove` for exactly the listed variables. It neither
+reads their values nor alters the invoking CLI process environment.
+
+The only daemon start boundary used by `atm` and `atm-graft` is
+`DaemonAutoStarter::spawn_daemon` in `crates/atm-daemon-client/src/lib.rs`.
+It must invoke this helper. OS-native launch templates/scripts must perform
+the equivalent removal before their daemon `exec`; do not rely on a daemon
+self-check after process start.
+
+`atm-daemon` may read its documented daemon settings (for example `ATM_HOME`
+and test-only readiness controls), but production daemon source must not read,
+default from, or report `ATM_TEAM`, `ATM_IDENTITY`, or `ATM_ENVIRONMENT`.
+Caller identity/team continue to arrive only in typed daemon request DTOs
+resolved by the invoking CLI/graft process.
+
+## Type and boundary inventory
+
+| Item | AK.7 role |
+| --- | --- |
+| `DAEMON_STRIPPED_ENVIRONMENT` | New private `atm-daemon-client` constant. The sole listed set of caller-context variables removed from daemon child processes. |
+| `sanitize_daemon_child_environment` | New private `atm-daemon-client` helper. It owns the three `env_remove` calls and has no I/O, thread, state, or retry behavior. |
+| `DaemonAutoStarter::spawn_daemon` | Existing shared auto-start boundary. It calls the helper once immediately before spawn; `atm` and graft retain the same bootstrap path. |
+| OS-native daemon launch template/script | Existing managed launcher boundary. It removes the same three names before `atm-daemon` exec, rather than forwarding a session environment. |
+| daemon request DTO caller fields | Existing authoritative caller context. AK.7 retains these fields unchanged and never synthesizes them from daemon process environment. |
+
+No new trait, service, worker, thread, timer, queue, persistence table, route,
+state machine, or diagnostic data model is authorized.
+
+## Deliverables
+
+1. In `crates/atm-daemon-client/src/lib.rs`, add the fixed private constant and
+   helper, then call it from `DaemonAutoStarter::spawn_daemon` after standard
+   stdio setup and before `spawn`. Preserve the existing launch gate, child
+   cleanup, deadline, trace, and error semantics exactly.
+2. Inventory every repository-owned standard daemon launcher: the shared
+   CLI/graft auto-start path and every managed OS-native service template,
+   launch script, installer, or generated plist. Each must strip exactly the
+   three fixed variables before daemon exec. If this repository has no
+   OS-native daemon-launch template, document that absence in the closure
+   evidence; do not invent a second daemon launcher merely to satisfy this
+   sprint.
+3. Delete/replace every production daemon read of `ATM_TEAM`, `ATM_IDENTITY`,
+   or `ATM_ENVIRONMENT`, including doctor/runtime-context fallback. Preserve
+   caller information already carried by typed request data. Test fixtures may
+   set hostile parent variables solely to prove they do not reach the child.
+4. Add a repository source gate that rejects the three variable names in
+   non-test production source below `crates/atm-daemon/src` and
+   `crates/atm-daemon-bootstrap/src`. The gate must permit its own test fixture
+   and the client-side stripping helper, but must reject a new daemon ambient
+   fallback before review.
+5. Update `docs/requirements.md`'s `REQ-P-RUNTIME-006` implementation/evidence
+   text if needed to name the shared auto-start boundary, then update
+   `docs/atm-daemon-client/boundaries.md`, `docs/atm-daemon/requirements.md`,
+   and `docs/atm-daemon/startup-state-machine.md`. State that daemon
+   environment sanitation is pre-exec defense in depth and not a replacement
+   for typed caller context. Do not create an ADR.
+
+## Explicit prohibitions
+
+- Do not inspect a stripped value to select team, identity, doctor scope,
+  config, routing, peer, nudge, retry, session, state, or persistence behavior.
+- Do not mutate the parent CLI/graft environment, add a daemon runtime
+  self-sanitizer, or add a second auto-start/LaunchAgent path.
+- Do not change caller environment precedence, user-facing CLI behavior,
+  request DTO shape, agent lifecycle, or cross-host delivery.
+
+## Required validation
+
+- Unit: construct the `DaemonAutoStarter` child command under hostile parent
+  values for all three variables and assert its command environment contains
+  an explicit removal for each; unrelated environment entries remain intact.
+- Process integration: a disposable daemon-child fixture launched through the
+  shared auto-start path records its inherited environment. With all three
+  hostile variables set in the parent, the fixture records none of them. This
+  test uses no real daemon/database and does not create an alternate production
+  launch path.
+- Launcher audit: render/inspect every repository-owned OS-native daemon
+  launcher and prove each pre-exec command removes all three names. If none is
+  repository-owned, the evidence states that fact and proves the shared
+  auto-start path instead.
+- Source gate: production code under `atm-daemon` and `atm-daemon-bootstrap`
+  cannot add `ATM_TEAM`, `ATM_IDENTITY`, or `ATM_ENVIRONMENT` access; the gate
+  runs in `just lint` or an existing mandatory local check.
+- Regression: environment-attested CLI `send`, `read`, and `ack` still resolve
+  caller identity/team before daemon dispatch and succeed against an isolated
+  daemon. `just smoke localhost` and `just smoke local-ip` each prove normal
+  receiver persistence and exactly one nudge.
+- `just lint` and `just test` pass.
+
+## Dependencies
+
+AK.7 may start immediately after Phase AI merges to `develop`, from the
+`integrate/phase-ak` baseline. It is parallel-safe with AK.1–AK.6: its owned
+files are the shared daemon child launcher, repository-owned launcher
+templates/scripts, source gate, and daemon-launch documentation; it does not
+touch peer routing, TLS preservation, aliases, sender, receiver, or resend
+code. Start immediately; do not wait for any AK.1–AK.6 QA result.
+
+AK.7 has no AK predecessor merge-forward. Its PR may merge immediately after
+its own QA approval. Before any AK.7 fix round, merge the current
+`integrate/phase-ak` baseline and retain the fixed pre-exec sanitation boundary.

--- a/docs/plans/phase-ak/sprint-AK7-daemon-environment-neutrality.md
+++ b/docs/plans/phase-ak/sprint-AK7-daemon-environment-neutrality.md
@@ -42,7 +42,7 @@ It calls `Command::env_remove` for exactly the listed variables. It neither
 reads their values nor alters the invoking CLI process environment.
 
 The only daemon start boundary used by `atm` and `atm-graft` is
-`DaemonAutoStarter::spawn_daemon` in `crates/atm-daemon-client/src/lib.rs`.
+`DaemonSupervisor::spawn_daemon` in `crates/atm-daemon-client/src/lib.rs`.
 It must invoke this helper. OS-native launch templates/scripts must perform
 the equivalent removal before their daemon `exec`; do not rely on a daemon
 self-check after process start.
@@ -59,7 +59,7 @@ resolved by the invoking CLI/graft process.
 | --- | --- |
 | `DAEMON_STRIPPED_ENVIRONMENT` | New private `atm-daemon-client` constant. The sole listed set of caller-context variables removed from daemon child processes. |
 | `sanitize_daemon_child_environment` | New private `atm-daemon-client` helper. It owns the three `env_remove` calls and has no I/O, thread, state, or retry behavior. |
-| `DaemonAutoStarter::spawn_daemon` | Existing shared auto-start boundary. It calls the helper once immediately before spawn; `atm` and graft retain the same bootstrap path. |
+| `DaemonSupervisor::spawn_daemon` | Existing shared auto-start boundary. It calls the helper once immediately before spawn; `atm` and graft retain the same bootstrap path. |
 | OS-native daemon launch template/script | Existing managed launcher boundary. It removes the same three names before `atm-daemon` exec, rather than forwarding a session environment. |
 | daemon request DTO caller fields | Existing authoritative caller context. AK.7 retains these fields unchanged and never synthesizes them from daemon process environment. |
 
@@ -69,7 +69,7 @@ state machine, or diagnostic data model is authorized.
 ## Deliverables
 
 1. In `crates/atm-daemon-client/src/lib.rs`, add the fixed private constant and
-   helper, then call it from `DaemonAutoStarter::spawn_daemon` after standard
+   helper, then call it from `DaemonSupervisor::spawn_daemon` after standard
    stdio setup and before `spawn`. Preserve the existing launch gate, child
    cleanup, deadline, trace, and error semantics exactly.
 2. Inventory every repository-owned standard daemon launcher: the shared
@@ -79,15 +79,18 @@ state machine, or diagnostic data model is authorized.
    OS-native daemon-launch template, document that absence in the closure
    evidence; do not invent a second daemon launcher merely to satisfy this
    sprint.
-3. Delete/replace every production daemon read of `ATM_TEAM`, `ATM_IDENTITY`,
-   or `ATM_ENVIRONMENT`, including doctor/runtime-context fallback. Preserve
-   caller information already carried by typed request data. Test fixtures may
-   set hostile parent variables solely to prove they do not reach the child.
-4. Add a repository source gate that rejects the three variable names in
-   non-test production source below `crates/atm-daemon/src` and
-   `crates/atm-daemon-bootstrap/src`. The gate must permit its own test fixture
-   and the client-side stripping helper, but must reject a new daemon ambient
-   fallback before review.
+3. Prove that no production read of `ATM_TEAM`, `ATM_IDENTITY`, or
+   `ATM_ENVIRONMENT` exists below `crates/atm-daemon/src` or
+   `crates/atm-daemon-bootstrap/src`; retain and extend
+   `doctor_client_context_reflects_caller_over_daemon_launch_environment` as
+   the regression proof. Preserve caller information already carried by typed
+   request data. Test fixtures may set hostile parent variables solely to
+   prove they do not reach the child.
+4. Extend the existing `.just/lint-config.toml` `[env_var_boundary]` contract:
+   add `ATM_ENVIRONMENT` to `forbidden_env_vars` and
+   `crates/atm-daemon-bootstrap/src` to `restricted_crate_roots`. The existing
+   `.just/check_env_var_boundary.py` gate, already run by `just lint`, then
+   rejects daemon ambient-context reads. Do not add a second gate or tooling.
 5. Implement `docs/requirements.md`'s `REQ-P-RUNTIME-006` as the governing
    requirement and keep its shared auto-start boundary/evidence text current;
    then update
@@ -107,9 +110,10 @@ state machine, or diagnostic data model is authorized.
 
 ## Required validation
 
-- Unit: construct the `DaemonAutoStarter` child command under hostile parent
-  values for all three variables and assert its command environment contains
-  an explicit removal for each; unrelated environment entries remain intact.
+- Unit: use `DaemonSupervisor`'s private `spawn_daemon` test seam under hostile
+  parent values for all three variables and assert its child command
+  environment contains an explicit removal for each; unrelated environment
+  entries remain intact.
 - Process integration: a disposable daemon-child fixture launched through the
   shared auto-start path records its inherited environment. With all three
   hostile variables set in the parent, the fixture records none of them. This
@@ -119,9 +123,10 @@ state machine, or diagnostic data model is authorized.
   launcher and prove each pre-exec command removes all three names. If none is
   repository-owned, the evidence states that fact and proves the shared
   auto-start path instead.
-- Source gate: production code under `atm-daemon` and `atm-daemon-bootstrap`
-  cannot add `ATM_TEAM`, `ATM_IDENTITY`, or `ATM_ENVIRONMENT` access; the gate
-  runs in `just lint` or an existing mandatory local check.
+- Source gate: the existing `env_var_boundary` lint configuration covers
+  production `atm-daemon` and `atm-daemon-bootstrap` code and rejects
+  `ATM_TEAM`, `ATM_IDENTITY`, `ATM_CHAT_ID`, or `ATM_ENVIRONMENT` reads; it
+  runs in `just lint`.
 - Regression: environment-attested CLI `send`, `read`, and `ack` still resolve
   caller identity/team before daemon dispatch and succeed against an isolated
   daemon. `just smoke localhost` and `just smoke local-ip` each prove normal

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1062,6 +1062,7 @@ Sprint line:
 - `AK.4` `feature/pak-s4-direct-peer-http-no-retry`
 - `AK.5` `feature/pak-s5-direct-peer-timer-state`
 - `AK.6` `feature/pak-s6-remove-legacy-peer-transport`
+- `AK.7` `feature/pak-s7-daemon-environment-neutrality`
 
 Acceptance:
 - Phase AK acceptance is defined by the authoritative plan's sprint

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -253,6 +253,24 @@ Satisfied by:
   - recovery guidance for that distinct timeout must tell callers to inspect
     mailbox or service-side effects before retrying
 
+- `REQ-P-RUNTIME-006` Every standard `atm-daemon` launch path—including the
+  shared CLI/graft auto-start path, LaunchAgent/launchd plists, and equivalent
+  OS-native service launchers—must sanitize its inherited environment before
+  `atm-daemon` starts. It must strip `ATM_TEAM`, `ATM_IDENTITY`, and
+  `ATM_ENVIRONMENT` before exec (for example, `/usr/bin/env -u` on supported
+  Unix launchers or the platform equivalent), so the daemon never receives
+  ambient caller-identity variables at process start.
+
+  Required behavior:
+  - every standard launch entry point applies the same three removals before
+    daemon exec; the CLI/graft auto-start path is not exempt
+  - sanitation is pre-exec defense in depth, not a daemon runtime self-check
+    and not a replacement for `REQ-P-RUNTIME-002`'s prohibition on daemon
+    ambient identity/team fallback
+  - daemon production code must not read, default from, or report these three
+    values as caller context; resolved caller identity/team arrive only in
+    typed request data from the invoking CLI/graft process
+
 - `REQ-P-DAEMON-PARTITION-001` Phase R daemon cleanup work must use one
   explicit daemon-private partition map so ownership, review scope, and later
   lint enforcement do not depend on ad hoc file boundaries.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -265,7 +265,7 @@ Satisfied by:
   - every standard launch entry point applies the same three removals before
     daemon exec; the CLI/graft auto-start path is not exempt
   - sanitation is pre-exec defense in depth, not a daemon runtime self-check
-    and not a replacement for `REQ-P-RUNTIME-002`'s prohibition on daemon
+    and not a replacement for `REQ-CORE-CONFIG-001`'s prohibition on daemon
     ambient identity/team fallback
   - daemon production code must not read, default from, or report these three
     values as caller context; resolved caller identity/team arrive only in


### PR DESCRIPTION
## Summary
- Follow-on to #730: corrects/completes the AK.2 peer-worker deletion map (3a9455e7, e0ad1c47) based on findings from the AK.2 worktree, done in advance of starting AK.6 in parallel.
- Needed before AK.2 deletion proceeds, since AK.6 (Cipher) must preserve overlapping code and run in parallel with AK.2, merging only after AK.5.

## Test plan
- [ ] quality-mgr plan-doc QA
- [ ] AK.2 deletion scope re-checked against corrected map

🤖 Generated with [Claude Code](https://claude.com/claude-code)