### PR TITLE
Phase AJ: AJ.1 — SessionId type and protocol extensions

### DIFF
--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -456,11 +456,7 @@ mod tests {
             pid: 4242,
             observed_at,
             activity: HeartbeatActivity::ActiveToolUse,
-            session_id: Some(
-                SessionId::new("session-1")
-                    .expect("valid session id")
-                    .expect("non-blank session id"),
-            ),
+            session_id: Some(SessionId::new("session-1").expect("valid session id")),
         });
 
         let encoded = serde_json::to_vec(&request).expect("encode heartbeat request");

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -22,7 +22,9 @@ use crate::home;
 use crate::list::{ListOutcome, ListQuery};
 use crate::read::{PeekQuery, ReadOutcome, ReadQuery};
 use crate::send::{SendOutcome, WriteRequest};
-use crate::types::{AgentName, HostName, IsoTimestamp, TeamName};
+use crate::types::{
+    AgentName, HostName, IsoTimestamp, SessionId, TeamName, deserialize_optional_session_id,
+};
 
 const DAEMON_SOCKET_FILENAME: &str = "atm-daemon.sock";
 const MAX_VERSION_LENGTH: usize = 256;
@@ -348,6 +350,12 @@ pub struct TeamMemberHeartbeatRequest {
     pub pid: u32,
     pub observed_at: IsoTimestamp,
     pub activity: HeartbeatActivity,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_session_id"
+    )]
+    pub session_id: Option<SessionId>,
 }
 
 /// One daemon heartbeat response after runtime-state application.
@@ -361,6 +369,12 @@ pub struct TeamMemberHeartbeatResponse {
     pub state: RuntimeMemberState,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_active_at: Option<IsoTimestamp>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_session_id"
+    )]
+    pub session_id: Option<SessionId>,
 }
 
 /// Runtime-owned live-state projection for one known team member.
@@ -429,7 +443,7 @@ mod tests {
     use crate::list::ListQuery;
     use crate::send::{SendMessageSource, SendRequest};
     use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM};
-    use crate::types::{AgentName, IsoTimestamp, ReadSelection, TeamName};
+    use crate::types::{AgentName, IsoTimestamp, ReadSelection, SessionId, TeamName};
     use serial_test::serial;
     use tempfile::TempDir;
 
@@ -442,6 +456,11 @@ mod tests {
             pid: 4242,
             observed_at,
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: Some(
+                SessionId::new("session-1")
+                    .expect("valid session id")
+                    .expect("non-blank session id"),
+            ),
         });
 
         let encoded = serde_json::to_vec(&request).expect("encode heartbeat request");
@@ -455,6 +474,10 @@ mod tests {
                 assert_eq!(decoded.pid, 4242);
                 assert_eq!(decoded.observed_at, observed_at);
                 assert_eq!(decoded.activity, HeartbeatActivity::ActiveToolUse);
+                assert_eq!(
+                    decoded.session_id.as_ref().map(AsRef::as_ref),
+                    Some("session-1")
+                );
             }
             other => panic!("expected heartbeat request, got {other:?}"),
         }
@@ -470,6 +493,7 @@ mod tests {
             pid_changed: true,
             state: RuntimeMemberState::Active,
             last_active_at: Some(last_active_at),
+            session_id: None,
         });
 
         let encoded = serde_json::to_vec(&response).expect("encode heartbeat response");
@@ -484,9 +508,49 @@ mod tests {
                 assert!(decoded.pid_changed);
                 assert_eq!(decoded.state, RuntimeMemberState::Active);
                 assert_eq!(decoded.last_active_at, Some(last_active_at));
+                assert_eq!(decoded.session_id, None);
             }
             other => panic!("expected heartbeat response, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn heartbeat_session_id_is_additive_and_normalizes_legacy_blank_input() {
+        let observed_at = IsoTimestamp::now();
+        let request = TeamMemberHeartbeatRequest {
+            team: TeamName::from_validated("test-team"),
+            member: AgentName::from_validated("test-agent"),
+            pid: 4242,
+            observed_at,
+            activity: HeartbeatActivity::Idle,
+            session_id: None,
+        };
+
+        let encoded = serde_json::to_value(&request).expect("encode heartbeat request");
+        assert!(encoded.get("session_id").is_none());
+
+        let legacy_without_session = serde_json::json!({
+            "team": "test-team",
+            "member": "test-agent",
+            "pid": 4242,
+            "observed_at": observed_at,
+            "activity": "idle"
+        });
+        let decoded: TeamMemberHeartbeatRequest =
+            serde_json::from_value(legacy_without_session).expect("decode old heartbeat");
+        assert_eq!(decoded.session_id, None);
+
+        let legacy_blank_session = serde_json::json!({
+            "team": "test-team",
+            "member": "test-agent",
+            "pid": 4242,
+            "observed_at": observed_at,
+            "activity": "idle",
+            "session_id": " \t "
+        });
+        let decoded: TeamMemberHeartbeatRequest =
+            serde_json::from_value(legacy_blank_session).expect("decode blank session");
+        assert_eq!(decoded.session_id, None);
     }
 
     #[test]

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -4,7 +4,110 @@ pub use atm_storage::types::{
     TeamName,
 };
 
-use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fmt;
+
+use serde::de;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Maximum UTF-8 byte length for a session identifier retained in runtime state.
+pub const SESSION_ID_MAX_BYTES: usize = 256;
+
+/// Opaque, bounded identifier for one observed runtime session.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SessionId(String);
+
+/// Validation error returned when a session identifier exceeds its bounded size.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SessionIdError {
+    TooLong {
+        max_bytes: usize,
+        actual_bytes: usize,
+    },
+}
+
+impl fmt::Display for SessionIdError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooLong {
+                max_bytes,
+                actual_bytes,
+            } => write!(
+                formatter,
+                "session id is {actual_bytes} bytes; maximum is {max_bytes} bytes"
+            ),
+        }
+    }
+}
+
+impl Error for SessionIdError {}
+
+impl SessionId {
+    /// Construct a bounded session identifier, treating blank input as absent.
+    pub fn new(value: impl AsRef<str>) -> Result<Option<Self>, SessionIdError> {
+        let value = value.as_ref();
+        if value.trim().is_empty() {
+            return Ok(None);
+        }
+
+        let actual_bytes = value.len();
+        if actual_bytes > SESSION_ID_MAX_BYTES {
+            return Err(SessionIdError::TooLong {
+                max_bytes: SESSION_ID_MAX_BYTES,
+                actual_bytes,
+            });
+        }
+
+        Ok(Some(Self(value.to_owned())))
+    }
+}
+
+impl AsRef<str> for SessionId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl Serialize for SessionId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for SessionId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value)
+            .map_err(de::Error::custom)?
+            .ok_or_else(|| de::Error::custom("session id must not be blank"))
+    }
+}
+
+/// Deserialize an optional session identifier while accepting legacy blank input.
+pub fn deserialize_optional_session_id<'de, D>(
+    deserializer: D,
+) -> Result<Option<SessionId>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer)?
+        .map(SessionId::new)
+        .transpose()
+        .map_err(de::Error::custom)
+        .map(Option::flatten)
+}
 
 /// Index of one message within its source mailbox file.
 #[derive(
@@ -97,4 +200,38 @@ pub enum CommandAction {
     Peek,
     Read,
     Send,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SESSION_ID_MAX_BYTES, SessionId, SessionIdError};
+
+    #[test]
+    fn session_id_normalizes_blank_input_to_absent() {
+        assert_eq!(SessionId::new(" \t\n ").expect("blank is valid"), None);
+    }
+
+    #[test]
+    fn session_id_accepts_its_byte_limit() {
+        let value = "s".repeat(SESSION_ID_MAX_BYTES);
+        let session_id = SessionId::new(&value)
+            .expect("bounded session id")
+            .expect("non-blank session id");
+
+        assert_eq!(session_id.as_ref(), value);
+        assert_eq!(session_id.to_string(), value);
+    }
+
+    #[test]
+    fn session_id_rejects_values_over_its_byte_limit() {
+        let value = "s".repeat(SESSION_ID_MAX_BYTES + 1);
+
+        assert_eq!(
+            SessionId::new(value),
+            Err(SessionIdError::TooLong {
+                max_bytes: SESSION_ID_MAX_BYTES,
+                actual_bytes: SESSION_ID_MAX_BYTES + 1,
+            })
+        );
+    }
 }

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -20,6 +20,7 @@ pub struct SessionId(String);
 /// Validation error returned when a session identifier exceeds its bounded size.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SessionIdError {
+    Blank,
     TooLong {
         max_bytes: usize,
         actual_bytes: usize,
@@ -29,6 +30,7 @@ pub enum SessionIdError {
 impl fmt::Display for SessionIdError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Blank => formatter.write_str("session id must not be blank"),
             Self::TooLong {
                 max_bytes,
                 actual_bytes,
@@ -42,12 +44,18 @@ impl fmt::Display for SessionIdError {
 
 impl Error for SessionIdError {}
 
+impl SessionIdError {
+    pub const fn code(&self) -> crate::error_codes::AtmErrorCode {
+        crate::error_codes::AtmErrorCode::MessageValidationFailed
+    }
+}
+
 impl SessionId {
-    /// Construct a bounded session identifier, treating blank input as absent.
-    pub fn new(value: impl AsRef<str>) -> Result<Option<Self>, SessionIdError> {
+    /// Construct one non-blank bounded session identifier.
+    pub fn new(value: impl AsRef<str>) -> Result<Self, SessionIdError> {
         let value = value.as_ref();
         if value.trim().is_empty() {
-            return Ok(None);
+            return Err(SessionIdError::Blank);
         }
 
         let actual_bytes = value.len();
@@ -58,7 +66,15 @@ impl SessionId {
             });
         }
 
-        Ok(Some(Self(value.to_owned())))
+        Ok(Self(value.to_owned()))
+    }
+
+    /// Parse optional wire telemetry, normalizing legacy blank input to absent.
+    pub fn parse_optional(value: impl AsRef<str>) -> Result<Option<Self>, SessionIdError> {
+        let value = value.as_ref();
+        (!value.trim().is_empty())
+            .then(|| Self::new(value))
+            .transpose()
     }
 }
 
@@ -89,21 +105,19 @@ impl<'de> Deserialize<'de> for SessionId {
         D: Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        Self::new(value)
-            .map_err(de::Error::custom)?
-            .ok_or_else(|| de::Error::custom("session id must not be blank"))
+        Self::new(value).map_err(de::Error::custom)
     }
 }
 
 /// Deserialize an optional session identifier while accepting legacy blank input.
-pub fn deserialize_optional_session_id<'de, D>(
+pub(crate) fn deserialize_optional_session_id<'de, D>(
     deserializer: D,
 ) -> Result<Option<SessionId>, D::Error>
 where
     D: Deserializer<'de>,
 {
     Option::<String>::deserialize(deserializer)?
-        .map(SessionId::new)
+        .map(SessionId::parse_optional)
         .transpose()
         .map_err(de::Error::custom)
         .map(Option::flatten)
@@ -208,15 +222,16 @@ mod tests {
 
     #[test]
     fn session_id_normalizes_blank_input_to_absent() {
-        assert_eq!(SessionId::new(" \t\n ").expect("blank is valid"), None);
+        assert_eq!(
+            SessionId::parse_optional(" \t\n ").expect("blank is valid"),
+            None
+        );
     }
 
     #[test]
     fn session_id_accepts_its_byte_limit() {
         let value = "s".repeat(SESSION_ID_MAX_BYTES);
-        let session_id = SessionId::new(&value)
-            .expect("bounded session id")
-            .expect("non-blank session id");
+        let session_id = SessionId::new(&value).expect("bounded session id");
 
         assert_eq!(session_id.as_ref(), value);
         assert_eq!(session_id.to_string(), value);

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -1188,6 +1188,7 @@ mod tests {
                         base + ChronoDuration::seconds(index as i64),
                     ),
                     activity: HeartbeatActivity::Idle,
+                    session_id: None,
                 },
                 false,
             );
@@ -1200,6 +1201,7 @@ mod tests {
                 pid: std::process::id(),
                 observed_at: IsoTimestamp::from_datetime(base + ChronoDuration::hours(1)),
                 activity: HeartbeatActivity::ActiveToolUse,
+                session_id: None,
             },
             false,
         );

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -112,6 +112,7 @@ impl RuntimeStatusCache {
             pid_changed,
             state,
             last_active_at,
+            session_id: None,
         }
     }
 
@@ -502,6 +503,7 @@ mod tests {
                 pid: std::process::id(),
                 observed_at: IsoTimestamp::now(),
                 activity: HeartbeatActivity::ActiveToolUse,
+                session_id: None,
             },
             false,
         );

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -390,6 +390,7 @@ fn heartbeat_updates_status_cache_and_doctor_projection() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("heartbeat response");
     match response {
@@ -476,6 +477,7 @@ fn reload_runtime_view_applies_updated_team_config_and_preserves_live_state() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("initial heartbeat");
 
@@ -519,6 +521,7 @@ fn reload_runtime_view_ignores_invalid_config_and_preserves_last_known_good_stat
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("initial heartbeat");
 
@@ -559,6 +562,7 @@ fn heartbeat_rejects_live_pid_conflict() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("initial heartbeat");
 
@@ -569,6 +573,7 @@ fn heartbeat_rejects_live_pid_conflict() {
             pid: std::process::id().saturating_add(1),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::Idle,
+            session_id: None,
         }))
         .expect_err("live pid conflict");
 
@@ -613,6 +618,7 @@ fn heartbeat_accepts_pid_takeover_when_previous_pid_is_dead() {
             pid: u32::MAX,
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::Idle,
+            session_id: None,
         }))
         .expect("initial dead-pid heartbeat");
 
@@ -623,6 +629,7 @@ fn heartbeat_accepts_pid_takeover_when_previous_pid_is_dead() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("takeover heartbeat");
 
@@ -675,6 +682,7 @@ fn heartbeat_evicts_oldest_member_and_projects_missing_roster_entries_as_unknown
             pid: std::process::id(),
             observed_at: IsoTimestamp::from_datetime(base + ChronoDuration::hours(2)),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         },
         false,
     );
@@ -722,6 +730,7 @@ fn heartbeat_retries_identity_conflict_after_old_pid_dies() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("retry heartbeat");
 
@@ -766,6 +775,7 @@ fn identity_conflict_insert_evicts_oldest_conflict_when_cache_is_full() {
         pid: std::process::id(),
         observed_at: IsoTimestamp::from_datetime(base + ChronoDuration::hours(1)),
         activity: HeartbeatActivity::ActiveToolUse,
+        session_id: None,
     };
     status_cache.record_identity_conflict_for_test(&request, u32::MAX);
 
@@ -866,6 +876,7 @@ fn doctor_projects_unavailable_runtime_when_all_members_are_offline() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::SessionEnded,
+            session_id: None,
         }))
         .and_then(|_| {
             dispatcher.dispatch(RequestEnvelope::Doctor(atm_core::doctor::DoctorQuery {

--- a/docs/plans/phase-aj/sprint-AJ1.md
+++ b/docs/plans/phase-aj/sprint-AJ1.md
@@ -43,6 +43,9 @@ identity.
 
 - `crates/atm-core/src/types.rs`
 - `crates/atm-core/src/protocol.rs`
+- `crates/atm-daemon/src/runtime_health.rs` (mechanical `session_id: None` literals)
+- `crates/atm-daemon/src/runtime_status_cache.rs` (mechanical `session_id: None` literals)
+- `crates/atm-daemon/src/tests.rs` (mechanical `session_id: None` literals)
 
 ## Why `SessionId` Is A Newtype
 
@@ -66,9 +69,10 @@ value.
   ```
   It derives `Serialize`, `Deserialize`, `Clone`, `Debug`, `PartialEq`, `Eq`,
   and `Hash`; it implements `Display` and `AsRef<str>`. Its only public
-  construction API is `SessionId::new(value) -> Result<Option<SessionId>,
-  SessionIdError>`: whitespace-only input returns `Ok(None)` and a value over
-  256 UTF-8 bytes returns `SessionIdError::TooLong`.
+  construction API is `SessionId::new(value) -> Result<SessionId, SessionIdError>`;
+  `SessionId::parse_optional` and the optional wire deserializer normalize
+  whitespace-only input to absent, while a value over 256 UTF-8 bytes returns
+  `SessionIdError::TooLong`.
 - `TeamMemberHeartbeatRequest` gains
   `pub session_id: Option<SessionId>` with
   `#[serde(default, skip_serializing_if = "Option::is_none")]`
@@ -120,7 +124,7 @@ value.
 - New unit tests in `crates/atm-core/src/types.rs` and `protocol.rs`:
   - serde round-trip on `Some` and `None`
   - missing field deserializes to `None`
-  - `Display` and `From<&str>` produce identical strings
+  - `Display` preserves the validated string representation
 - `rg -n "session_id" crates/atm-core/src/protocol.rs` shows both new
   fields with the required serde attributes
 - `git diff --check`

--- a/docs/plans/phase-aj/sprint-AJ1.md
+++ b/docs/plans/phase-aj/sprint-AJ1.md
@@ -1,10 +1,10 @@
 ---
 id: AJ.1
 title: SessionId Type And Protocol Extensions
-status: planned
+status: complete
 branch: feature/pAJ-s1-session-id-and-protocol
 worktree: ../atm-core-worktrees/feature/pAJ-s1-session-id-and-protocol
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.1 — SessionId Type And Protocol Extensions
@@ -20,7 +20,7 @@ identity.
 - `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
 - Phase AI merged to `develop`; phase-entry reconciliation recorded the
   post-merge SHA and reviewed all AJ exact targets for baseline drift
-- `integrate/phase-AJ`, cut from that reconciled post-merge `develop` SHA
+- `integrate/phase-aj`, cut from that reconciled post-merge `develop` SHA
   before AJ.1 implementation dispatch
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`
@@ -114,9 +114,9 @@ value.
 
 ## Required Validation
 
-- `cargo build -p atm-core`
-- `cargo clippy -p atm-core --all-targets -- -D warnings`
-- `cargo test -p atm-core`
+- `cargo build -p agent-team-mail-core`
+- `cargo clippy -p agent-team-mail-core --all-targets -- -D warnings`
+- `cargo test -p agent-team-mail-core`
 - New unit tests in `crates/atm-core/src/types.rs` and `protocol.rs`:
   - serde round-trip on `Some` and `None`
   - missing field deserializes to `None`

--- a/docs/plans/phase-aj/sprint-AJ10.md
+++ b/docs/plans/phase-aj/sprint-AJ10.md
@@ -4,7 +4,7 @@ title: Runtime Observation Phase Closeout
 status: planned
 branch: feature/pAJ-s10-runtime-observation-phase-closeout
 worktree: ../atm-core-worktrees/feature/pAJ-s10-runtime-observation-phase-closeout
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.10 — Runtime Observation Phase Closeout

--- a/docs/plans/phase-aj/sprint-AJ2.md
+++ b/docs/plans/phase-aj/sprint-AJ2.md
@@ -4,7 +4,7 @@ title: CallerContext Env Resolution
 status: planned
 branch: feature/pAJ-s2-caller-context-env
 worktree: ../atm-core-worktrees/feature/pAJ-s2-caller-context-env
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.2 — CallerContext Env Resolution
@@ -19,7 +19,7 @@ command arguments as trusted telemetry.
 
 - AJ.1 merged forward into this branch
 - `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
-- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+- Completed Phase-AI reconciliation gate; `integrate/phase-aj` was cut from
   the recorded post-merge `develop` SHA before AJ.1 and AJ.2 begin
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`

--- a/docs/plans/phase-aj/sprint-AJ3.md
+++ b/docs/plans/phase-aj/sprint-AJ3.md
@@ -4,7 +4,7 @@ title: CLI Wire Payload Integration
 status: planned
 branch: feature/pAJ-s3-cli-wire-payload
 worktree: ../atm-core-worktrees/feature/pAJ-s3-cli-wire-payload
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.3 — CLI Wire Payload Integration
@@ -34,7 +34,7 @@ must not use that unscoped exclusion to absorb new observation wiring.
 
 - AJ.1 and AJ.2 merged forward into this branch
 - `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
-- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+- Completed Phase-AI reconciliation gate; `integrate/phase-aj` was cut from
   the recorded post-merge `develop` SHA before AJ.1 and AJ.3 begin
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`

--- a/docs/plans/phase-aj/sprint-AJ4.md
+++ b/docs/plans/phase-aj/sprint-AJ4.md
@@ -4,7 +4,7 @@ title: Daemon Cache Touch On Dispatch
 status: planned
 branch: feature/pAJ-s4-daemon-cache-touch
 worktree: ../atm-core-worktrees/feature/pAJ-s4-daemon-cache-touch
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.4 — Daemon Cache Touch On Dispatch
@@ -29,7 +29,7 @@ tests; do not add AJ surface to a file that would exceed the 1,000-line ceiling.
   unified HTTP-framed local transport, UDS in
   `local_ipc_transport/request_worker.rs` and TCP in
   `local_tcp_transport.rs`, both dispatching into `ApiRouter`
-- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+- Completed Phase-AI reconciliation gate; `integrate/phase-aj` was cut from
   the recorded post-merge `develop` SHA before AJ.1 and AJ.4 begin
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`

--- a/docs/plans/phase-aj/sprint-AJ5.md
+++ b/docs/plans/phase-aj/sprint-AJ5.md
@@ -4,7 +4,7 @@ title: HTTP Heartbeat Session State
 status: planned
 branch: feature/pAJ-s5-heartbeat-session
 worktree: ../atm-core-worktrees/feature/pAJ-s5-heartbeat-session
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.5 — HTTP Heartbeat Session State
@@ -25,7 +25,7 @@ never waive or exclude the line-count rule.
 
 - AJ.1 through AJ.4 merged forward into this branch
 - `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
-- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+- Completed Phase-AI reconciliation gate; `integrate/phase-aj` was cut from
   the recorded post-merge `develop` SHA before AJ.1 and AJ.5 begin
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`

--- a/docs/plans/phase-aj/sprint-AJ6.md
+++ b/docs/plans/phase-aj/sprint-AJ6.md
@@ -4,7 +4,7 @@ title: Runtime Observation Snapshot Projection
 status: planned
 branch: feature/pAJ-s6-runtime-observation-snapshot
 worktree: ../atm-core-worktrees/feature/pAJ-s6-runtime-observation-snapshot
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.6 — Runtime Observation Snapshot Projection
@@ -19,7 +19,7 @@ snapshot feature and its direct tests; AJ.7 owns the source-use guard.
 
 - AJ.1 through AJ.5 merged forward into this branch
 - `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
-- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+- Completed Phase-AI reconciliation gate; `integrate/phase-aj` was cut from
   the recorded post-merge `develop` SHA before AJ.1 and AJ.6 begin
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`

--- a/docs/plans/phase-aj/sprint-AJ7.md
+++ b/docs/plans/phase-aj/sprint-AJ7.md
@@ -4,7 +4,7 @@ title: Runtime Observation Source-Use Guard
 status: planned
 branch: feature/pAJ-s7-runtime-observation-source-guard
 worktree: ../atm-core-worktrees/feature/pAJ-s7-runtime-observation-source-guard
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.7 — Runtime Observation Source-Use Guard

--- a/docs/plans/phase-aj/sprint-AJ8.md
+++ b/docs/plans/phase-aj/sprint-AJ8.md
@@ -4,7 +4,7 @@ title: Runtime Observation Boundary Record
 status: planned
 branch: feature/pAJ-s8-runtime-observation-boundary-record
 worktree: ../atm-core-worktrees/feature/pAJ-s8-runtime-observation-boundary-record
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.8 — Runtime Observation Boundary Record

--- a/docs/plans/phase-aj/sprint-AJ9.md
+++ b/docs/plans/phase-aj/sprint-AJ9.md
@@ -4,7 +4,7 @@ title: Runtime Observation Governing Contract Reconciliation
 status: planned
 branch: feature/pAJ-s9-runtime-observation-contract-reconciliation
 worktree: ../atm-core-worktrees/feature/pAJ-s9-runtime-observation-contract-reconciliation
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.9 — Runtime Observation Governing Contract Reconciliation


### PR DESCRIPTION
## Sprint AJ.1 — SessionId Type And Protocol Extensions

Authoritative sprint doc: `docs/plans/phase-aj/sprint-AJ1.md`

### Delivered
- Bounded `SessionId` newtype: blank/whitespace normalizes to absent, 256-byte limit with structured `TooLong` error, no `From<String>`/`From<&str>` construction bypass
- Additive `session_id: Option<SessionId>` on `TeamMemberHeartbeatRequest`/`TeamMemberHeartbeatResponse`, omit-on-`None`, legacy blank-to-`None` decoding
- Updated daemon fixtures, focused type/protocol regression tests
- Normalized all AJ sprint doc references from mixed-case `integrate/phase-AJ` to the actual lowercase `integrate/phase-aj`

### Validation (commit `d55a5aec28be3ba079e501017e242b5147fd55b7`)
- `cargo build -p agent-team-mail-core`: PASS
- `cargo clippy -p agent-team-mail-core --all-targets -- -D warnings`: PASS
- `cargo test -p agent-team-mail-core`: PASS (418 tests)
- `cargo test -p atm-daemon`: PASS (150 tests)
- `git diff --check`: PASS

QA-1 (quality-mgr) to follow.