### PR TITLE
Phase AJ: AJ.2 — CallerContext env resolution

### DIFF
--- a/.just/allowlists/env_var_boundary_allowlist.toml
+++ b/.just/allowlists/env_var_boundary_allowlist.toml
@@ -46,6 +46,22 @@ sunset_sprint = "follow-up: push caller_context env reads to the atm CLI / atm-g
 
 [[allow]]
 rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/caller_context.rs"
+symbol = "read_cli_session_id_from_env"
+line = 'let value = env::var_os("ATM_SESSION_ID")?.into_string().ok()?;'
+why = "sole atm-core reader for optional session telemetry; it constructs transient environment-attested caller metadata and suppresses invalid values rather than affecting caller resolution."
+sunset_sprint = "follow-up: have CLI and atm-graft pass an already-attested activity observation into atm-core"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/caller_context.rs"
+symbol = "read_cli_pid_from_env"
+line = 'env::var_os("ATM_PID")?'
+why = "sole atm-core reader for optional process telemetry; it constructs transient environment-attested caller metadata and never probes process state."
+sunset_sprint = "follow-up: have CLI and atm-graft pass an already-attested activity observation into atm-core"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
 path = "crates/atm-core/src/config/mod.rs"
 symbol = "resolve_team"
 line = ".or_else(|| read_cli_team_from_env().ok().flatten())"

--- a/.just/tests/test_check_env_var_boundary.py
+++ b/.just/tests/test_check_env_var_boundary.py
@@ -99,7 +99,7 @@ name = "{lib_name}"
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
             (repo_root / "crates/atm-core/src/example.rs").write_text(
-                """\\
+                """\
 use std::env;
 
 pub fn resolve_team_from_env() -> Option<String> {
@@ -141,7 +141,7 @@ pub fn resolve_identity_from_env() -> Option<std::ffi::OsString> {
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
             (repo_root / "crates/atm-core/src/example.rs").write_text(
-                """\
+                """\\
 use std::env;
 
 pub fn bypass_activity_reader() -> Option<std::ffi::OsString> {

--- a/.just/tests/test_check_env_var_boundary.py
+++ b/.just/tests/test_check_env_var_boundary.py
@@ -141,7 +141,7 @@ pub fn resolve_identity_from_env() -> Option<std::ffi::OsString> {
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
             (repo_root / "crates/atm-core/src/example.rs").write_text(
-                """\\
+                """\
 use std::env;
 
 pub fn bypass_activity_reader() -> Option<std::ffi::OsString> {
@@ -157,6 +157,56 @@ pub fn bypass_activity_reader() -> Option<std::ffi::OsString> {
             self.assertEqual(
                 {violation.kind for violation in violations}, {"direct_literal_env_read"}
             )
+
+    def test_allows_the_two_approved_activity_metadata_readers(self) -> None:
+        """The session and PID readers are independently exercised positives.
+
+        This mirrors the real caller-context choke points, including their
+        exact reviewed allowlist lines, so adding either reader to the config
+        without keeping its reviewed implementation would not satisfy the
+        boundary suite.
+        """
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            caller_context = repo_root / "crates/atm-core/src/caller_context.rs"
+            caller_context.write_text(
+                """\
+pub fn read_cli_session_id_from_env() -> Option<std::ffi::OsString> {
+    let value = std::env::var_os("ATM_SESSION_ID")?;
+    Some(value)
+}
+
+pub fn read_cli_pid_from_env() -> Option<std::ffi::OsString> {
+    std::env::var_os("ATM_PID")
+}
+""",
+                encoding="utf-8",
+            )
+            allowlist_dir = repo_root / ".just/allowlists"
+            allowlist_dir.mkdir(parents=True)
+            (allowlist_dir / "env_var_boundary_allowlist.toml").write_text(
+                """\
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/caller_context.rs"
+symbol = "read_cli_session_id_from_env"
+line = 'let value = std::env::var_os("ATM_SESSION_ID")?;'
+why = "approved session telemetry reader"
+sunset_sprint = "n/a"
+
+[[allow]]
+rule = "ATM-ENV-BOUNDARY-001"
+path = "crates/atm-core/src/caller_context.rs"
+symbol = "read_cli_pid_from_env"
+line = 'std::env::var_os("ATM_PID")'
+why = "approved PID telemetry reader"
+sunset_sprint = "n/a"
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(self.collect(repo_root), [])
 
     def test_flags_literal_forwarded_through_same_file_helper(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/.just/tests/test_check_env_var_boundary.py
+++ b/.just/tests/test_check_env_var_boundary.py
@@ -99,7 +99,7 @@ name = "{lib_name}"
             repo_root = Path(tempdir)
             self.write_repo(repo_root)
             (repo_root / "crates/atm-core/src/example.rs").write_text(
-                """\
+                """\\
 use std::env;
 
 pub fn resolve_team_from_env() -> Option<String> {

--- a/.just/tests/test_check_env_var_boundary.py
+++ b/.just/tests/test_check_env_var_boundary.py
@@ -136,6 +136,28 @@ pub fn resolve_identity_from_env() -> Option<std::ffi::OsString> {
             self.assertEqual(violations[0].symbol, "resolve_identity_from_env")
             self.assertEqual(violations[0].kind, "direct_literal_env_read")
 
+    def test_flags_direct_activity_metadata_env_reads_outside_approved_readers(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            self.write_repo(repo_root)
+            (repo_root / "crates/atm-core/src/example.rs").write_text(
+                """\\
+use std::env;
+
+pub fn bypass_activity_reader() -> Option<std::ffi::OsString> {
+    env::var_os("ATM_SESSION_ID").or_else(|| env::var_os("ATM_PID"))
+}
+""",
+                encoding="utf-8",
+            )
+
+            violations = self.collect(repo_root)
+
+            self.assertEqual(len(violations), 2)
+            self.assertEqual(
+                {violation.kind for violation in violations}, {"direct_literal_env_read"}
+            )
+
     def test_flags_literal_forwarded_through_same_file_helper(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo_root = Path(tempdir)

--- a/crates/atm-core/src/caller_context.rs
+++ b/crates/atm-core/src/caller_context.rs
@@ -1,13 +1,30 @@
 use std::env;
 
+use serde::{Deserialize, Serialize};
+
 use crate::error::AtmError;
-use crate::types::{AgentIdentity, AgentName, ChatId, TeamName};
+use crate::types::{AgentIdentity, AgentName, ChatId, SessionId, TeamName};
+
+/// Environment-attested, transient metadata about the caller's local activity.
+///
+/// This is deliberately distinct from command identity: it is present only
+/// when the ambient identity and team attest to the resolved caller.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivityObservation {
+    pub team: TeamName,
+    pub member: AgentName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<SessionId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallerContext {
     pub caller_identity: AgentName,
     pub caller_chat_id: Option<ChatId>,
     pub caller_team: TeamName,
+    pub activity_observation: Option<ActivityObservation>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -47,10 +64,13 @@ pub fn resolve_cli_inspection_caller_context(
         &caller_identity,
     )?;
     let caller_team = resolve_team_component(overrides.team_override.map(|value| value.0))?;
+    let activity_observation =
+        activity_observation_for_resolved_caller(&caller_identity.agent, &caller_team);
     Ok(CallerContext {
         caller_identity: caller_identity.agent,
         caller_chat_id,
         caller_team,
+        activity_observation,
     })
 }
 
@@ -122,6 +142,52 @@ pub fn read_cli_agent_name_from_env() -> Result<Option<AgentName>, AtmError> {
 
 pub fn read_cli_team_from_env() -> Result<Option<TeamName>, AtmError> {
     read_env_raw("ATM_TEAM")?.map(parse_team).transpose()
+}
+
+/// Reads optional, environment-attested session telemetry for the CLI caller.
+pub fn read_cli_session_id_from_env() -> Option<SessionId> {
+    let value = env::var_os("ATM_SESSION_ID")?.into_string().ok()?;
+    match SessionId::new(value) {
+        Ok(session_id) => session_id,
+        Err(error) => {
+            tracing::info!(
+                %error,
+                env_var = "ATM_SESSION_ID",
+                "suppressing invalid optional caller session telemetry"
+            );
+            None
+        }
+    }
+}
+
+/// Reads optional, environment-attested process telemetry for the CLI caller.
+pub fn read_cli_pid_from_env() -> Option<u32> {
+    env::var_os("ATM_PID")?
+        .into_string()
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+        .filter(|pid| *pid != 0)
+}
+
+/// Build transient telemetry only when the environment attests to this caller.
+pub fn activity_observation_for_resolved_caller(
+    member: &AgentName,
+    team: &TeamName,
+) -> Option<ActivityObservation> {
+    let env_identity = read_cli_identity_from_env().ok().flatten()?;
+    let env_team = read_cli_team_from_env().ok().flatten()?;
+    if env_identity.agent != *member || env_team != *team {
+        return None;
+    }
+
+    Some(ActivityObservation {
+        team: team.clone(),
+        member: member.clone(),
+        session_id: read_cli_session_id_from_env(),
+        pid: read_cli_pid_from_env(),
+    })
 }
 
 fn read_cli_chat_id_from_env() -> Result<Option<String>, AtmError> {
@@ -230,13 +296,14 @@ fn parse_team(raw: String) -> Result<TeamName, AtmError> {
 mod tests {
     use crate::error_codes::AtmErrorCode;
     use crate::roles::ROLE_TEAM_LEAD;
-    use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM};
-    use crate::types::{AgentIdentity, ChatId};
+    use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM, set_env_var};
+    use crate::types::{AgentIdentity, ChatId, SESSION_ID_MAX_BYTES};
 
     use super::{
         CallerChatIdOverride, CallerContextOverrides, CallerIdentityOverride, CallerTeamOverride,
-        read_cli_agent_name_from_env, read_cli_identity_from_env_or_warn, read_cli_team_from_env,
-        read_cli_team_from_env_or_warn, resolve_caller_chat_id,
+        activity_observation_for_resolved_caller, read_cli_agent_name_from_env,
+        read_cli_identity_from_env_or_warn, read_cli_pid_from_env, read_cli_session_id_from_env,
+        read_cli_team_from_env, read_cli_team_from_env_or_warn, resolve_caller_chat_id,
         resolve_cli_inspection_caller_context, resolve_cli_mutation_caller_context,
     };
 
@@ -258,6 +325,7 @@ mod tests {
 
         assert_eq!(context.caller_identity.as_str(), TEST_SENDER);
         assert_eq!(context.caller_team.as_str(), override_team);
+        assert_eq!(context.activity_observation, None);
     }
 
     #[test]
@@ -273,6 +341,15 @@ mod tests {
 
         assert_eq!(context.caller_identity.as_str(), TEST_SENDER);
         assert_eq!(context.caller_team.as_str(), TEST_TEAM);
+        assert_eq!(
+            context.activity_observation,
+            Some(super::ActivityObservation {
+                team: TEST_TEAM.parse().expect("team"),
+                member: TEST_SENDER.parse().expect("member"),
+                session_id: None,
+                pid: None,
+            })
+        );
     }
 
     #[test]
@@ -294,6 +371,7 @@ mod tests {
         assert_eq!(context.caller_identity.as_str(), TEST_SENDER);
         assert_eq!(context.caller_team.as_str(), TEST_TEAM);
         assert_eq!(context.caller_chat_id, None);
+        assert_eq!(context.activity_observation, None);
     }
 
     #[test]
@@ -343,10 +421,104 @@ mod tests {
     #[test]
     #[serial_test::serial(env)]
     fn optional_env_reads_return_none_when_missing() {
-        let _env = EnvGuard::set_many([("ATM_IDENTITY", None), ("ATM_TEAM", None)]);
+        let _env = EnvGuard::set_many([
+            ("ATM_IDENTITY", None),
+            ("ATM_TEAM", None),
+            ("ATM_SESSION_ID", None),
+            ("ATM_PID", None),
+        ]);
 
         assert_eq!(read_cli_agent_name_from_env().expect("identity"), None);
         assert_eq!(read_cli_team_from_env().expect("team"), None);
+        assert_eq!(read_cli_session_id_from_env(), None);
+        assert_eq!(read_cli_pid_from_env(), None);
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn optional_activity_metadata_readers_normalize_invalid_values() {
+        let oversized = "s".repeat(SESSION_ID_MAX_BYTES + 1);
+        let _env = EnvGuard::set_many([("ATM_SESSION_ID", Some("  ")), ("ATM_PID", Some("0"))]);
+
+        assert_eq!(read_cli_session_id_from_env(), None);
+        assert_eq!(read_cli_pid_from_env(), None);
+
+        drop(_env);
+        let _env = EnvGuard::set_many([
+            ("ATM_SESSION_ID", Some(oversized.as_str())),
+            ("ATM_PID", Some("not-a-pid")),
+        ]);
+
+        assert_eq!(read_cli_session_id_from_env(), None);
+        assert_eq!(read_cli_pid_from_env(), None);
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn matching_environment_attests_activity_observation() {
+        let _env = EnvGuard::set_many([
+            ("ATM_IDENTITY", Some(TEST_SENDER)),
+            ("ATM_TEAM", Some(TEST_TEAM)),
+            ("ATM_SESSION_ID", Some("session-17")),
+            ("ATM_PID", Some("17")),
+        ]);
+
+        let context = resolve_cli_inspection_caller_context(CallerContextOverrides::default())
+            .expect("caller context");
+        let observation = context.activity_observation.expect("attested observation");
+
+        assert_eq!(observation.member.as_str(), TEST_SENDER);
+        assert_eq!(observation.team.as_str(), TEST_TEAM);
+        assert_eq!(
+            observation.session_id.as_ref().map(AsRef::as_ref),
+            Some("session-17")
+        );
+        assert_eq!(observation.pid, Some(17));
+    }
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn malformed_ambient_identity_suppresses_telemetry_without_breaking_overrides() {
+        let _env = EnvGuard::set_many([
+            ("ATM_IDENTITY", Some("   ")),
+            ("ATM_TEAM", Some(TEST_TEAM)),
+            ("ATM_SESSION_ID", Some("session-17")),
+            ("ATM_PID", Some("17")),
+        ]);
+
+        let context = resolve_cli_inspection_caller_context(CallerContextOverrides {
+            identity_override: Some(CallerIdentityOverride(TEST_SENDER)),
+            chat_id_override: None,
+            team_override: Some(CallerTeamOverride(TEST_TEAM)),
+        })
+        .expect("overrides remain valid");
+
+        assert_eq!(context.activity_observation, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(env)]
+    fn non_unicode_activity_metadata_is_suppressed() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let _env = EnvGuard::set_many([
+            ("ATM_IDENTITY", Some(TEST_SENDER)),
+            ("ATM_TEAM", Some(TEST_TEAM)),
+            ("ATM_SESSION_ID", None),
+            ("ATM_PID", None),
+        ]);
+        set_env_var("ATM_SESSION_ID", OsString::from_vec(vec![0xff]));
+        set_env_var("ATM_PID", OsString::from_vec(vec![0xff]));
+
+        let member = TEST_SENDER.parse().expect("member");
+        let team = TEST_TEAM.parse().expect("team");
+        let observation = activity_observation_for_resolved_caller(&member, &team)
+            .expect("identity and team attest");
+
+        assert_eq!(observation.session_id, None);
+        assert_eq!(observation.pid, None);
     }
 
     #[test]

--- a/crates/atm-core/src/caller_context.rs
+++ b/crates/atm-core/src/caller_context.rs
@@ -3,7 +3,9 @@ use std::env;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AtmError;
-use crate::types::{AgentIdentity, AgentName, ChatId, SessionId, TeamName};
+use crate::types::{
+    AgentIdentity, AgentName, ChatId, SessionId, TeamName, deserialize_optional_session_id,
+};
 
 /// Environment-attested, transient metadata about the caller's local activity.
 ///
@@ -13,7 +15,11 @@ use crate::types::{AgentIdentity, AgentName, ChatId, SessionId, TeamName};
 pub struct ActivityObservation {
     pub team: TeamName,
     pub member: AgentName,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_session_id"
+    )]
     pub session_id: Option<SessionId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
@@ -115,9 +121,10 @@ pub fn resolve_cli_mutation_caller_context_with_overrides(
     let ambient = read_cli_identity_from_env()?.ok_or_else(AtmError::identity_unavailable)?;
     let caller = resolve_cli_inspection_caller_context(overrides)?;
     if overrides.identity_override.is_some() && caller.caller_identity != ambient.agent {
-        return Err(AtmError::caller_context_request_invalid(
-            "--as must use the same base agent as ATM_IDENTITY for mutating commands",
-        ));
+        return Err(AtmError::caller_context_request_invalid(format!(
+            "--as ({}) must use the same base agent as ATM_IDENTITY ({}) for mutating commands",
+            caller.caller_identity, ambient.agent
+        )));
     }
     Ok(caller)
 }
@@ -147,7 +154,7 @@ pub fn read_cli_team_from_env() -> Result<Option<TeamName>, AtmError> {
 /// Reads optional, environment-attested session telemetry for the CLI caller.
 pub fn read_cli_session_id_from_env() -> Option<SessionId> {
     let value = env::var_os("ATM_SESSION_ID")?.into_string().ok()?;
-    match SessionId::new(value) {
+    match SessionId::parse_optional(value) {
         Ok(session_id) => session_id,
         Err(error) => {
             tracing::info!(
@@ -519,6 +526,18 @@ mod tests {
 
         assert_eq!(observation.session_id, None);
         assert_eq!(observation.pid, None);
+    }
+
+    #[test]
+    fn activity_observation_deserializes_blank_session_id_as_absent() {
+        let observation: super::ActivityObservation = serde_json::from_value(serde_json::json!({
+            "team": TEST_TEAM,
+            "member": TEST_SENDER,
+            "session_id": "   "
+        }))
+        .expect("legacy blank session id is accepted");
+
+        assert_eq!(observation.session_id, None);
     }
 
     #[test]

--- a/crates/atm-core/src/caller_context.rs
+++ b/crates/atm-core/src/caller_context.rs
@@ -303,15 +303,15 @@ fn parse_team(raw: String) -> Result<TeamName, AtmError> {
 mod tests {
     use crate::error_codes::AtmErrorCode;
     use crate::roles::ROLE_TEAM_LEAD;
-    use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM, set_env_var};
+    use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM};
     use crate::types::{AgentIdentity, ChatId, SESSION_ID_MAX_BYTES};
 
     use super::{
         CallerChatIdOverride, CallerContextOverrides, CallerIdentityOverride, CallerTeamOverride,
-        activity_observation_for_resolved_caller, read_cli_agent_name_from_env,
-        read_cli_identity_from_env_or_warn, read_cli_pid_from_env, read_cli_session_id_from_env,
-        read_cli_team_from_env, read_cli_team_from_env_or_warn, resolve_caller_chat_id,
-        resolve_cli_inspection_caller_context, resolve_cli_mutation_caller_context,
+        read_cli_agent_name_from_env, read_cli_identity_from_env_or_warn, read_cli_pid_from_env,
+        read_cli_session_id_from_env, read_cli_team_from_env, read_cli_team_from_env_or_warn,
+        resolve_caller_chat_id, resolve_cli_inspection_caller_context,
+        resolve_cli_mutation_caller_context,
     };
 
     #[test]
@@ -509,6 +509,10 @@ mod tests {
     fn non_unicode_activity_metadata_is_suppressed() {
         use std::ffi::OsString;
         use std::os::unix::ffi::OsStringExt;
+
+        use crate::test_support::set_env_var;
+
+        use super::activity_observation_for_resolved_caller;
 
         let _env = EnvGuard::set_many([
             ("ATM_IDENTITY", Some(TEST_SENDER)),

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -456,11 +456,7 @@ mod tests {
             pid: 4242,
             observed_at,
             activity: HeartbeatActivity::ActiveToolUse,
-            session_id: Some(
-                SessionId::new("session-1")
-                    .expect("valid session id")
-                    .expect("non-blank session id"),
-            ),
+            session_id: Some(SessionId::new("session-1").expect("valid session id")),
         });
 
         let encoded = serde_json::to_vec(&request).expect("encode heartbeat request");

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -22,7 +22,9 @@ use crate::home;
 use crate::list::{ListOutcome, ListQuery};
 use crate::read::{PeekQuery, ReadOutcome, ReadQuery};
 use crate::send::{SendOutcome, WriteRequest};
-use crate::types::{AgentName, HostName, IsoTimestamp, TeamName};
+use crate::types::{
+    AgentName, HostName, IsoTimestamp, SessionId, TeamName, deserialize_optional_session_id,
+};
 
 const DAEMON_SOCKET_FILENAME: &str = "atm-daemon.sock";
 const MAX_VERSION_LENGTH: usize = 256;
@@ -348,6 +350,12 @@ pub struct TeamMemberHeartbeatRequest {
     pub pid: u32,
     pub observed_at: IsoTimestamp,
     pub activity: HeartbeatActivity,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_session_id"
+    )]
+    pub session_id: Option<SessionId>,
 }
 
 /// One daemon heartbeat response after runtime-state application.
@@ -361,6 +369,12 @@ pub struct TeamMemberHeartbeatResponse {
     pub state: RuntimeMemberState,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_active_at: Option<IsoTimestamp>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_session_id"
+    )]
+    pub session_id: Option<SessionId>,
 }
 
 /// Runtime-owned live-state projection for one known team member.
@@ -429,7 +443,7 @@ mod tests {
     use crate::list::ListQuery;
     use crate::send::{SendMessageSource, SendRequest};
     use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM};
-    use crate::types::{AgentName, IsoTimestamp, ReadSelection, TeamName};
+    use crate::types::{AgentName, IsoTimestamp, ReadSelection, SessionId, TeamName};
     use serial_test::serial;
     use tempfile::TempDir;
 
@@ -442,6 +456,11 @@ mod tests {
             pid: 4242,
             observed_at,
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: Some(
+                SessionId::new("session-1")
+                    .expect("valid session id")
+                    .expect("non-blank session id"),
+            ),
         });
 
         let encoded = serde_json::to_vec(&request).expect("encode heartbeat request");
@@ -455,6 +474,10 @@ mod tests {
                 assert_eq!(decoded.pid, 4242);
                 assert_eq!(decoded.observed_at, observed_at);
                 assert_eq!(decoded.activity, HeartbeatActivity::ActiveToolUse);
+                assert_eq!(
+                    decoded.session_id.as_ref().map(AsRef::as_ref),
+                    Some("session-1")
+                );
             }
             other => panic!("expected heartbeat request, got {other:?}"),
         }
@@ -470,6 +493,7 @@ mod tests {
             pid_changed: true,
             state: RuntimeMemberState::Active,
             last_active_at: Some(last_active_at),
+            session_id: None,
         });
 
         let encoded = serde_json::to_vec(&response).expect("encode heartbeat response");
@@ -484,9 +508,49 @@ mod tests {
                 assert!(decoded.pid_changed);
                 assert_eq!(decoded.state, RuntimeMemberState::Active);
                 assert_eq!(decoded.last_active_at, Some(last_active_at));
+                assert_eq!(decoded.session_id, None);
             }
             other => panic!("expected heartbeat response, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn heartbeat_session_id_is_additive_and_normalizes_legacy_blank_input() {
+        let observed_at = IsoTimestamp::now();
+        let request = TeamMemberHeartbeatRequest {
+            team: TeamName::from_validated("test-team"),
+            member: AgentName::from_validated("test-agent"),
+            pid: 4242,
+            observed_at,
+            activity: HeartbeatActivity::Idle,
+            session_id: None,
+        };
+
+        let encoded = serde_json::to_value(&request).expect("encode heartbeat request");
+        assert!(encoded.get("session_id").is_none());
+
+        let legacy_without_session = serde_json::json!({
+            "team": "test-team",
+            "member": "test-agent",
+            "pid": 4242,
+            "observed_at": observed_at,
+            "activity": "idle"
+        });
+        let decoded: TeamMemberHeartbeatRequest =
+            serde_json::from_value(legacy_without_session).expect("decode old heartbeat");
+        assert_eq!(decoded.session_id, None);
+
+        let legacy_blank_session = serde_json::json!({
+            "team": "test-team",
+            "member": "test-agent",
+            "pid": 4242,
+            "observed_at": observed_at,
+            "activity": "idle",
+            "session_id": " \t "
+        });
+        let decoded: TeamMemberHeartbeatRequest =
+            serde_json::from_value(legacy_blank_session).expect("decode blank session");
+        assert_eq!(decoded.session_id, None);
     }
 
     #[test]

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -4,7 +4,110 @@ pub use atm_storage::types::{
     TeamName,
 };
 
-use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fmt;
+
+use serde::de;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Maximum UTF-8 byte length for a session identifier retained in runtime state.
+pub const SESSION_ID_MAX_BYTES: usize = 256;
+
+/// Opaque, bounded identifier for one observed runtime session.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SessionId(String);
+
+/// Validation error returned when a session identifier exceeds its bounded size.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SessionIdError {
+    TooLong {
+        max_bytes: usize,
+        actual_bytes: usize,
+    },
+}
+
+impl fmt::Display for SessionIdError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooLong {
+                max_bytes,
+                actual_bytes,
+            } => write!(
+                formatter,
+                "session id is {actual_bytes} bytes; maximum is {max_bytes} bytes"
+            ),
+        }
+    }
+}
+
+impl Error for SessionIdError {}
+
+impl SessionId {
+    /// Construct a bounded session identifier, treating blank input as absent.
+    pub fn new(value: impl AsRef<str>) -> Result<Option<Self>, SessionIdError> {
+        let value = value.as_ref();
+        if value.trim().is_empty() {
+            return Ok(None);
+        }
+
+        let actual_bytes = value.len();
+        if actual_bytes > SESSION_ID_MAX_BYTES {
+            return Err(SessionIdError::TooLong {
+                max_bytes: SESSION_ID_MAX_BYTES,
+                actual_bytes,
+            });
+        }
+
+        Ok(Some(Self(value.to_owned())))
+    }
+}
+
+impl AsRef<str> for SessionId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl Serialize for SessionId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for SessionId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value)
+            .map_err(de::Error::custom)?
+            .ok_or_else(|| de::Error::custom("session id must not be blank"))
+    }
+}
+
+/// Deserialize an optional session identifier while accepting legacy blank input.
+pub fn deserialize_optional_session_id<'de, D>(
+    deserializer: D,
+) -> Result<Option<SessionId>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer)?
+        .map(SessionId::new)
+        .transpose()
+        .map_err(de::Error::custom)
+        .map(Option::flatten)
+}
 
 /// Index of one message within its source mailbox file.
 #[derive(
@@ -97,4 +200,38 @@ pub enum CommandAction {
     Peek,
     Read,
     Send,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SESSION_ID_MAX_BYTES, SessionId, SessionIdError};
+
+    #[test]
+    fn session_id_normalizes_blank_input_to_absent() {
+        assert_eq!(SessionId::new(" \t\n ").expect("blank is valid"), None);
+    }
+
+    #[test]
+    fn session_id_accepts_its_byte_limit() {
+        let value = "s".repeat(SESSION_ID_MAX_BYTES);
+        let session_id = SessionId::new(&value)
+            .expect("bounded session id")
+            .expect("non-blank session id");
+
+        assert_eq!(session_id.as_ref(), value);
+        assert_eq!(session_id.to_string(), value);
+    }
+
+    #[test]
+    fn session_id_rejects_values_over_its_byte_limit() {
+        let value = "s".repeat(SESSION_ID_MAX_BYTES + 1);
+
+        assert_eq!(
+            SessionId::new(value),
+            Err(SessionIdError::TooLong {
+                max_bytes: SESSION_ID_MAX_BYTES,
+                actual_bytes: SESSION_ID_MAX_BYTES + 1,
+            })
+        );
+    }
 }

--- a/crates/atm-core/src/types.rs
+++ b/crates/atm-core/src/types.rs
@@ -20,6 +20,7 @@ pub struct SessionId(String);
 /// Validation error returned when a session identifier exceeds its bounded size.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SessionIdError {
+    Blank,
     TooLong {
         max_bytes: usize,
         actual_bytes: usize,
@@ -29,6 +30,7 @@ pub enum SessionIdError {
 impl fmt::Display for SessionIdError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Blank => formatter.write_str("session id must not be blank"),
             Self::TooLong {
                 max_bytes,
                 actual_bytes,
@@ -42,12 +44,18 @@ impl fmt::Display for SessionIdError {
 
 impl Error for SessionIdError {}
 
+impl SessionIdError {
+    pub const fn code(&self) -> crate::error_codes::AtmErrorCode {
+        crate::error_codes::AtmErrorCode::MessageValidationFailed
+    }
+}
+
 impl SessionId {
-    /// Construct a bounded session identifier, treating blank input as absent.
-    pub fn new(value: impl AsRef<str>) -> Result<Option<Self>, SessionIdError> {
+    /// Construct one non-blank bounded session identifier.
+    pub fn new(value: impl AsRef<str>) -> Result<Self, SessionIdError> {
         let value = value.as_ref();
         if value.trim().is_empty() {
-            return Ok(None);
+            return Err(SessionIdError::Blank);
         }
 
         let actual_bytes = value.len();
@@ -58,7 +66,15 @@ impl SessionId {
             });
         }
 
-        Ok(Some(Self(value.to_owned())))
+        Ok(Self(value.to_owned()))
+    }
+
+    /// Parse optional wire telemetry, normalizing legacy blank input to absent.
+    pub fn parse_optional(value: impl AsRef<str>) -> Result<Option<Self>, SessionIdError> {
+        let value = value.as_ref();
+        (!value.trim().is_empty())
+            .then(|| Self::new(value))
+            .transpose()
     }
 }
 
@@ -89,21 +105,19 @@ impl<'de> Deserialize<'de> for SessionId {
         D: Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        Self::new(value)
-            .map_err(de::Error::custom)?
-            .ok_or_else(|| de::Error::custom("session id must not be blank"))
+        Self::new(value).map_err(de::Error::custom)
     }
 }
 
 /// Deserialize an optional session identifier while accepting legacy blank input.
-pub fn deserialize_optional_session_id<'de, D>(
+pub(crate) fn deserialize_optional_session_id<'de, D>(
     deserializer: D,
 ) -> Result<Option<SessionId>, D::Error>
 where
     D: Deserializer<'de>,
 {
     Option::<String>::deserialize(deserializer)?
-        .map(SessionId::new)
+        .map(SessionId::parse_optional)
         .transpose()
         .map_err(de::Error::custom)
         .map(Option::flatten)
@@ -208,15 +222,16 @@ mod tests {
 
     #[test]
     fn session_id_normalizes_blank_input_to_absent() {
-        assert_eq!(SessionId::new(" \t\n ").expect("blank is valid"), None);
+        assert_eq!(
+            SessionId::parse_optional(" \t\n ").expect("blank is valid"),
+            None
+        );
     }
 
     #[test]
     fn session_id_accepts_its_byte_limit() {
         let value = "s".repeat(SESSION_ID_MAX_BYTES);
-        let session_id = SessionId::new(&value)
-            .expect("bounded session id")
-            .expect("non-blank session id");
+        let session_id = SessionId::new(&value).expect("bounded session id");
 
         assert_eq!(session_id.as_ref(), value);
         assert_eq!(session_id.to_string(), value);

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -1188,6 +1188,7 @@ mod tests {
                         base + ChronoDuration::seconds(index as i64),
                     ),
                     activity: HeartbeatActivity::Idle,
+                    session_id: None,
                 },
                 false,
             );
@@ -1200,6 +1201,7 @@ mod tests {
                 pid: std::process::id(),
                 observed_at: IsoTimestamp::from_datetime(base + ChronoDuration::hours(1)),
                 activity: HeartbeatActivity::ActiveToolUse,
+                session_id: None,
             },
             false,
         );

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -112,6 +112,7 @@ impl RuntimeStatusCache {
             pid_changed,
             state,
             last_active_at,
+            session_id: None,
         }
     }
 
@@ -502,6 +503,7 @@ mod tests {
                 pid: std::process::id(),
                 observed_at: IsoTimestamp::now(),
                 activity: HeartbeatActivity::ActiveToolUse,
+                session_id: None,
             },
             false,
         );

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -390,6 +390,7 @@ fn heartbeat_updates_status_cache_and_doctor_projection() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("heartbeat response");
     match response {
@@ -476,6 +477,7 @@ fn reload_runtime_view_applies_updated_team_config_and_preserves_live_state() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("initial heartbeat");
 
@@ -519,6 +521,7 @@ fn reload_runtime_view_ignores_invalid_config_and_preserves_last_known_good_stat
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("initial heartbeat");
 
@@ -559,6 +562,7 @@ fn heartbeat_rejects_live_pid_conflict() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("initial heartbeat");
 
@@ -569,6 +573,7 @@ fn heartbeat_rejects_live_pid_conflict() {
             pid: std::process::id().saturating_add(1),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::Idle,
+            session_id: None,
         }))
         .expect_err("live pid conflict");
 
@@ -613,6 +618,7 @@ fn heartbeat_accepts_pid_takeover_when_previous_pid_is_dead() {
             pid: u32::MAX,
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::Idle,
+            session_id: None,
         }))
         .expect("initial dead-pid heartbeat");
 
@@ -623,6 +629,7 @@ fn heartbeat_accepts_pid_takeover_when_previous_pid_is_dead() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("takeover heartbeat");
 
@@ -675,6 +682,7 @@ fn heartbeat_evicts_oldest_member_and_projects_missing_roster_entries_as_unknown
             pid: std::process::id(),
             observed_at: IsoTimestamp::from_datetime(base + ChronoDuration::hours(2)),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         },
         false,
     );
@@ -722,6 +730,7 @@ fn heartbeat_retries_identity_conflict_after_old_pid_dies() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
         }))
         .expect("retry heartbeat");
 
@@ -766,6 +775,7 @@ fn identity_conflict_insert_evicts_oldest_conflict_when_cache_is_full() {
         pid: std::process::id(),
         observed_at: IsoTimestamp::from_datetime(base + ChronoDuration::hours(1)),
         activity: HeartbeatActivity::ActiveToolUse,
+        session_id: None,
     };
     status_cache.record_identity_conflict_for_test(&request, u32::MAX);
 
@@ -866,6 +876,7 @@ fn doctor_projects_unavailable_runtime_when_all_members_are_offline() {
             pid: std::process::id(),
             observed_at: IsoTimestamp::now(),
             activity: HeartbeatActivity::SessionEnded,
+            session_id: None,
         }))
         .and_then(|_| {
             dispatcher.dispatch(RequestEnvelope::Doctor(atm_core::doctor::DoctorQuery {

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -647,6 +647,7 @@ mod tests {
                 caller_identity: TEST_SENDER.parse().expect("caller"),
                 caller_chat_id: None,
                 caller_team: TEST_TEAM.parse().expect("team"),
+                activity_observation: None,
             })
             .expect_err("invalid kind");
 
@@ -668,6 +669,7 @@ mod tests {
                 caller_identity: TEST_SENDER.parse().expect("caller"),
                 caller_chat_id: None,
                 caller_team: TEST_TEAM.parse().expect("team"),
+                activity_observation: None,
             })
             .expect_err("empty body");
 
@@ -754,6 +756,7 @@ mod tests {
                 caller_identity: TEST_SENDER.parse().expect("caller"),
                 caller_chat_id: None,
                 caller_team: TEST_TEAM.parse().expect("team"),
+                activity_observation: None,
             })
             .expect("request");
 
@@ -781,6 +784,7 @@ mod tests {
                 caller_identity: TEST_SENDER.parse().expect("caller"),
                 caller_chat_id: None,
                 caller_team: TEST_TEAM.parse().expect("team"),
+                activity_observation: None,
             })
             .expect("request");
 
@@ -806,6 +810,7 @@ mod tests {
                     caller_identity: TEST_SENDER.parse().expect("caller"),
                     caller_chat_id: None,
                     caller_team: "other-team".parse().expect("team"),
+                    activity_observation: None,
                 })
                 .expect_err("cross-team caller");
             let atm_error = error.downcast_ref::<AtmError>().expect("AtmError");

--- a/docs/plans/phase-aj/sprint-AJ1.md
+++ b/docs/plans/phase-aj/sprint-AJ1.md
@@ -43,6 +43,9 @@ identity.
 
 - `crates/atm-core/src/types.rs`
 - `crates/atm-core/src/protocol.rs`
+- `crates/atm-daemon/src/runtime_health.rs` (mechanical `session_id: None` literals)
+- `crates/atm-daemon/src/runtime_status_cache.rs` (mechanical `session_id: None` literals)
+- `crates/atm-daemon/src/tests.rs` (mechanical `session_id: None` literals)
 
 ## Why `SessionId` Is A Newtype
 
@@ -66,9 +69,10 @@ value.
   ```
   It derives `Serialize`, `Deserialize`, `Clone`, `Debug`, `PartialEq`, `Eq`,
   and `Hash`; it implements `Display` and `AsRef<str>`. Its only public
-  construction API is `SessionId::new(value) -> Result<Option<SessionId>,
-  SessionIdError>`: whitespace-only input returns `Ok(None)` and a value over
-  256 UTF-8 bytes returns `SessionIdError::TooLong`.
+  construction API is `SessionId::new(value) -> Result<SessionId, SessionIdError>`;
+  `SessionId::parse_optional` and the optional wire deserializer normalize
+  whitespace-only input to absent, while a value over 256 UTF-8 bytes returns
+  `SessionIdError::TooLong`.
 - `TeamMemberHeartbeatRequest` gains
   `pub session_id: Option<SessionId>` with
   `#[serde(default, skip_serializing_if = "Option::is_none")]`
@@ -120,7 +124,7 @@ value.
 - New unit tests in `crates/atm-core/src/types.rs` and `protocol.rs`:
   - serde round-trip on `Some` and `None`
   - missing field deserializes to `None`
-  - `Display` and `From<&str>` produce identical strings
+  - `Display` preserves the validated string representation
 - `rg -n "session_id" crates/atm-core/src/protocol.rs` shows both new
   fields with the required serde attributes
 - `git diff --check`

--- a/docs/plans/phase-aj/sprint-AJ1.md
+++ b/docs/plans/phase-aj/sprint-AJ1.md
@@ -1,10 +1,10 @@
 ---
 id: AJ.1
 title: SessionId Type And Protocol Extensions
-status: planned
+status: complete
 branch: feature/pAJ-s1-session-id-and-protocol
 worktree: ../atm-core-worktrees/feature/pAJ-s1-session-id-and-protocol
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.1 — SessionId Type And Protocol Extensions
@@ -20,7 +20,7 @@ identity.
 - `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
 - Phase AI merged to `develop`; phase-entry reconciliation recorded the
   post-merge SHA and reviewed all AJ exact targets for baseline drift
-- `integrate/phase-AJ`, cut from that reconciled post-merge `develop` SHA
+- `integrate/phase-aj`, cut from that reconciled post-merge `develop` SHA
   before AJ.1 implementation dispatch
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`
@@ -114,9 +114,9 @@ value.
 
 ## Required Validation
 
-- `cargo build -p atm-core`
-- `cargo clippy -p atm-core --all-targets -- -D warnings`
-- `cargo test -p atm-core`
+- `cargo build -p agent-team-mail-core`
+- `cargo clippy -p agent-team-mail-core --all-targets -- -D warnings`
+- `cargo test -p agent-team-mail-core`
 - New unit tests in `crates/atm-core/src/types.rs` and `protocol.rs`:
   - serde round-trip on `Some` and `None`
   - missing field deserializes to `None`

--- a/docs/plans/phase-aj/sprint-AJ10.md
+++ b/docs/plans/phase-aj/sprint-AJ10.md
@@ -4,7 +4,7 @@ title: Runtime Observation Phase Closeout
 status: planned
 branch: feature/pAJ-s10-runtime-observation-phase-closeout
 worktree: ../atm-core-worktrees/feature/pAJ-s10-runtime-observation-phase-closeout
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.10 — Runtime Observation Phase Closeout

--- a/docs/plans/phase-aj/sprint-AJ2.md
+++ b/docs/plans/phase-aj/sprint-AJ2.md
@@ -4,7 +4,7 @@ title: CallerContext Env Resolution
 status: planned
 branch: feature/pAJ-s2-caller-context-env
 worktree: ../atm-core-worktrees/feature/pAJ-s2-caller-context-env
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.2 — CallerContext Env Resolution
@@ -19,7 +19,7 @@ command arguments as trusted telemetry.
 
 - AJ.1 merged forward into this branch
 - `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
-- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+- Completed Phase-AI reconciliation gate; `integrate/phase-aj` was cut from
   the recorded post-merge `develop` SHA before AJ.1 and AJ.2 begin
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`

--- a/docs/plans/phase-aj/sprint-AJ2.md
+++ b/docs/plans/phase-aj/sprint-AJ2.md
@@ -1,7 +1,7 @@
 ---
 id: AJ.2
 title: CallerContext Env Resolution
-status: planned
+status: complete
 branch: feature/pAJ-s2-caller-context-env
 worktree: ../atm-core-worktrees/feature/pAJ-s2-caller-context-env
 target: integrate/phase-aj
@@ -134,9 +134,9 @@ command arguments as trusted telemetry.
 
 ## Required Validation
 
-- `cargo build -p atm-core`
-- `cargo clippy -p atm-core --all-targets -- -D warnings`
-- `cargo test -p atm-core caller_context`
+- `cargo build -p agent-team-mail-core`
+- `cargo clippy -p agent-team-mail-core --all-targets -- -D warnings`
+- `cargo test -p agent-team-mail-core caller_context`
 - New unit tests use `temp-env` (or an equivalent per-command environment
   fixture) and never mutate process-global environment through
   `std::env::set_var`, avoiding parallel-test pollution

--- a/docs/plans/phase-aj/sprint-AJ2.md
+++ b/docs/plans/phase-aj/sprint-AJ2.md
@@ -50,7 +50,7 @@ command arguments as trusted telemetry.
   pub struct ActivityObservation {
       pub team: TeamName,
       pub member: AgentName,
-      #[serde(default, skip_serializing_if = "Option::is_none")]
+      #[serde(default, skip_serializing_if = "Option::is_none", deserialize_with = "deserialize_optional_session_id")]
       pub session_id: Option<SessionId>,
       #[serde(default, skip_serializing_if = "Option::is_none")]
       pub pid: Option<u32>,

--- a/docs/plans/phase-aj/sprint-AJ3.md
+++ b/docs/plans/phase-aj/sprint-AJ3.md
@@ -4,7 +4,7 @@ title: CLI Wire Payload Integration
 status: planned
 branch: feature/pAJ-s3-cli-wire-payload
 worktree: ../atm-core-worktrees/feature/pAJ-s3-cli-wire-payload
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.3 — CLI Wire Payload Integration
@@ -34,7 +34,7 @@ must not use that unscoped exclusion to absorb new observation wiring.
 
 - AJ.1 and AJ.2 merged forward into this branch
 - `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
-- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+- Completed Phase-AI reconciliation gate; `integrate/phase-aj` was cut from
   the recorded post-merge `develop` SHA before AJ.1 and AJ.3 begin
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`

--- a/docs/plans/phase-aj/sprint-AJ4.md
+++ b/docs/plans/phase-aj/sprint-AJ4.md
@@ -4,7 +4,7 @@ title: Daemon Cache Touch On Dispatch
 status: planned
 branch: feature/pAJ-s4-daemon-cache-touch
 worktree: ../atm-core-worktrees/feature/pAJ-s4-daemon-cache-touch
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.4 — Daemon Cache Touch On Dispatch
@@ -29,7 +29,7 @@ tests; do not add AJ surface to a file that would exceed the 1,000-line ceiling.
   unified HTTP-framed local transport, UDS in
   `local_ipc_transport/request_worker.rs` and TCP in
   `local_tcp_transport.rs`, both dispatching into `ApiRouter`
-- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+- Completed Phase-AI reconciliation gate; `integrate/phase-aj` was cut from
   the recorded post-merge `develop` SHA before AJ.1 and AJ.4 begin
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`

--- a/docs/plans/phase-aj/sprint-AJ5.md
+++ b/docs/plans/phase-aj/sprint-AJ5.md
@@ -4,7 +4,7 @@ title: HTTP Heartbeat Session State
 status: planned
 branch: feature/pAJ-s5-heartbeat-session
 worktree: ../atm-core-worktrees/feature/pAJ-s5-heartbeat-session
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.5 — HTTP Heartbeat Session State
@@ -25,7 +25,7 @@ never waive or exclude the line-count rule.
 
 - AJ.1 through AJ.4 merged forward into this branch
 - `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
-- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+- Completed Phase-AI reconciliation gate; `integrate/phase-aj` was cut from
   the recorded post-merge `develop` SHA before AJ.1 and AJ.5 begin
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`

--- a/docs/plans/phase-aj/sprint-AJ6.md
+++ b/docs/plans/phase-aj/sprint-AJ6.md
@@ -4,7 +4,7 @@ title: Runtime Observation Snapshot Projection
 status: planned
 branch: feature/pAJ-s6-runtime-observation-snapshot
 worktree: ../atm-core-worktrees/feature/pAJ-s6-runtime-observation-snapshot
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.6 — Runtime Observation Snapshot Projection
@@ -19,7 +19,7 @@ snapshot feature and its direct tests; AJ.7 owns the source-use guard.
 
 - AJ.1 through AJ.5 merged forward into this branch
 - `integrate/phase-ai-31-33 @ 150391ecdf2e003185bff7d78427cd21509a7981`
-- Completed Phase-AI reconciliation gate; `integrate/phase-AJ` was cut from
+- Completed Phase-AI reconciliation gate; `integrate/phase-aj` was cut from
   the recorded post-merge `develop` SHA before AJ.1 and AJ.6 begin
 - `docs/plans/phase-aj/plan-phase-aj.md`
 - `docs/plans/phase-aj/phase-aj-research.md`

--- a/docs/plans/phase-aj/sprint-AJ7.md
+++ b/docs/plans/phase-aj/sprint-AJ7.md
@@ -4,7 +4,7 @@ title: Runtime Observation Source-Use Guard
 status: planned
 branch: feature/pAJ-s7-runtime-observation-source-guard
 worktree: ../atm-core-worktrees/feature/pAJ-s7-runtime-observation-source-guard
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.7 — Runtime Observation Source-Use Guard

--- a/docs/plans/phase-aj/sprint-AJ8.md
+++ b/docs/plans/phase-aj/sprint-AJ8.md
@@ -4,7 +4,7 @@ title: Runtime Observation Boundary Record
 status: planned
 branch: feature/pAJ-s8-runtime-observation-boundary-record
 worktree: ../atm-core-worktrees/feature/pAJ-s8-runtime-observation-boundary-record
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.8 — Runtime Observation Boundary Record

--- a/docs/plans/phase-aj/sprint-AJ9.md
+++ b/docs/plans/phase-aj/sprint-AJ9.md
@@ -4,7 +4,7 @@ title: Runtime Observation Governing Contract Reconciliation
 status: planned
 branch: feature/pAJ-s9-runtime-observation-contract-reconciliation
 worktree: ../atm-core-worktrees/feature/pAJ-s9-runtime-observation-contract-reconciliation
-target: integrate/phase-AJ
+target: integrate/phase-aj
 ---
 
 # Sprint AJ.9 — Runtime Observation Governing Contract Reconciliation


### PR DESCRIPTION
## Sprint AJ.2 — CallerContext Env Resolution

Authoritative sprint doc: `docs/plans/phase-aj/sprint-AJ2.md`

Depends on AJ.1 (#735) — per the AJ merge-forward rule this PR completes only after AJ.1's PR merges.

### Delivered
- `ActivityObservation` DTO (transient, not mail persistence)
- `CallerContext.activity_observation`, attested only when `ATM_IDENTITY`/`ATM_TEAM` match the resolved caller
- `read_cli_session_id_from_env()` / `read_cli_pid_from_env()`, bounded and non-fallible
- `ATM_SESSION_ID`/`ATM_PID` added to the env-var boundary lint with a sole-reader allowlist

### Validation (commit `df8b97625930ca9265e562b01d471cbae683baf3`)
- `cargo build -p agent-team-mail-core`: PASS
- `cargo clippy -p agent-team-mail-core --all-targets -- -D warnings`: PASS
- `cargo test -p agent-team-mail-core`: PASS (422 tests)
- env-boundary unit suite/checker: PASS
- `git diff --check`: PASS

QA-1 (quality-mgr) to follow.