### PR TITLE
Phase AJ: AJ.3 — CLI wire payload integration

### DIFF
--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -43,7 +43,6 @@ max_scoped_code_lines = 0
 
 [line_counts.exclusions]
 "crates/atm-core/src/mailbox/lock.rs" = "Q.6 split pending"
-"crates/atm-core/src/read/mod.rs" = "Q.6 split pending"
 "crates/atm-storage-rusqlite/src/tests.rs" = "Q.6 split pending"
 
 [cargo_shear.allowed_empty_files]

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -228,6 +228,8 @@ enum AtomicAcknowledgementKind {
 
 struct AtomicAcknowledgementBuilder {
     kind: AtomicAcknowledgementKind,
+    // The storage callback requires `&self`; this narrow mutex publishes one
+    // immutable reply assembled exactly once across that callback boundary.
     built: Mutex<Option<AtomicAcknowledgementWrite>>,
 }
 
@@ -559,10 +561,13 @@ fn ensure_roster_member_exists<R: RetainedServiceRuntime>(
     runtime: &R,
     team: &TeamName,
     agent: &AgentName,
-    _recovery: &str,
+    recovery: &str,
 ) -> Result<(), AtmError> {
     if runtime.load_roster_member(team, agent)?.is_none() {
-        return Err(AtmError::agent_not_found(agent, team));
+        return Err(AtmError::new(
+            crate::error_codes::AtmErrorCode::AgentNotFound,
+            format!("agent '{agent}' was not found in team '{team}'\n  Recovery: {recovery}"),
+        ));
     }
     Ok(())
 }

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -474,24 +474,14 @@ fn persist_peer_outbound_reply(
     message_id: AtmMessageId,
     timestamp: IsoTimestamp,
 ) -> Result<(), AtmError> {
-    if canonical_request.authenticated_source_host.is_some()
-        || canonical_request.origin_message_id.is_some()
-    {
-        return Ok(());
+    if let Some((host, request_json)) = crate::send::build_peer_outbound_replay(
+        canonical_request,
+        destination,
+        message_id,
+        timestamp,
+    )? {
+        crate::schema::set_peer_outbound_write(envelope, &host, request_json);
     }
-    let Some(host) = destination.host() else {
-        return Ok(());
-    };
-    let request_json = serde_json::to_string(
-        &canonical_request
-            .clone()
-            .with_origin_metadata(message_id, timestamp)
-            .with_activity_observation(None),
-    )
-    .map_err(|_| {
-        AtmError::mailbox_write("failed to serialize immutable acknowledgement peer write")
-    })?;
-    crate::schema::set_peer_outbound_write(envelope, host, request_json);
     Ok(())
 }
 

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -636,11 +636,40 @@ mod tests {
         reply_target_host,
     };
     use crate::boundary::{Message, MessageKey};
+    use crate::caller_context::ActivityObservation;
     use crate::schema::{
         AckIntentFields, AtmMessageId, InboxMessage, authenticated_source_host,
         set_authenticated_source_host, set_peer_outbound_write,
     };
-    use crate::types::{AgentName, ChatId, HostName, IsoTimestamp, TeamName};
+    use crate::types::{AgentName, ChatId, HostName, IsoTimestamp, SessionId, TeamName};
+
+    #[test]
+    fn acknowledgement_round_trip_preserves_activity_observation() {
+        let observation = ActivityObservation {
+            team: "local-team".parse().expect("team"),
+            member: "local-agent".parse().expect("agent"),
+            session_id: Some(SessionId::new("session-17").expect("session")),
+            pid: Some(17),
+        };
+        let request = AckRequest {
+            home_dir: PathBuf::from("/tmp/atm-test"),
+            current_dir: PathBuf::from("/tmp/atm-test"),
+            caller_identity: "local-agent".parse().expect("agent"),
+            caller_chat_id: None,
+            caller_team: "local-team".parse().expect("team"),
+            activity_observation: Some(observation.clone()),
+            message_id: AtmMessageId::new(),
+            reply_body: "ack".to_string(),
+        };
+        let write = request.clone().into_write_request();
+        assert_eq!(write.activity_observation, Some(observation));
+        assert_eq!(
+            AckRequest::from_unresolved_write(write)
+                .expect("round trip")
+                .activity_observation,
+            request.activity_observation
+        );
+    }
 
     #[test]
     fn remote_ack_is_the_canonical_host_qualified_write() {

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use crate::boundary;
+use crate::caller_context::ActivityObservation;
 use crate::error::AtmError;
 use crate::observability::{CommandEvent, ObservabilityPort, action_name, outcome_label};
 use crate::provenance::{WriteIngress, WriteProvenance, validate_write_provenance};
@@ -24,6 +25,8 @@ pub struct AckRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub caller_chat_id: Option<ChatId>,
     pub caller_team: TeamName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity_observation: Option<ActivityObservation>,
     pub message_id: AtmMessageId,
     pub reply_body: String,
 }
@@ -36,6 +39,7 @@ impl AckRequest {
             caller_identity: self.caller_identity,
             caller_chat_id: self.caller_chat_id,
             caller_team: self.caller_team,
+            activity_observation: self.activity_observation,
             authenticated_source_host: None,
             origin_message_id: None,
             origin_timestamp: None,
@@ -67,6 +71,7 @@ impl AckRequest {
             caller_identity: request.caller_identity,
             caller_chat_id: request.caller_chat_id,
             caller_team: request.caller_team,
+            activity_observation: request.activity_observation,
             message_id,
             reply_body,
         })
@@ -217,7 +222,7 @@ pub(crate) struct AtomicAcknowledgementWrite {
 
 #[derive(Clone)]
 enum AtomicAcknowledgementKind {
-    Local(AckRequest),
+    Local(Box<AckRequest>),
     Received(Box<SendRequest>),
 }
 
@@ -376,7 +381,7 @@ pub(crate) fn admit_acknowledgement_write<
                 message_id: request.message_id,
             },
             Arc::new(AtomicAcknowledgementBuilder::new(
-                AtomicAcknowledgementKind::Local(request),
+                AtomicAcknowledgementKind::Local(Box::new(request)),
             )),
         )
     };
@@ -524,6 +529,7 @@ fn canonical_ack_write_request(
         caller_identity: actor.clone(),
         caller_chat_id: request.caller_chat_id.clone(),
         caller_team: team.clone(),
+        activity_observation: request.activity_observation.clone(),
         authenticated_source_host: None,
         origin_message_id: None,
         origin_timestamp: None,
@@ -659,6 +665,7 @@ mod tests {
             caller_identity: "local-agent".parse().expect("agent"),
             caller_chat_id: Some("chat-42".parse::<ChatId>().expect("chat id")),
             caller_team: "local-team".parse().expect("team"),
+            activity_observation: None,
             message_id,
             reply_body: "acknowledged".to_string(),
         };

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -437,19 +437,7 @@ fn build_atomic_acknowledgement(
         task_id: None,
         extra: serde_json::Map::new(),
     };
-    if canonical_request.authenticated_source_host.is_none()
-        && canonical_request.origin_message_id.is_none()
-        && let Some(host) = destination.host()
-    {
-        let request_json =
-            serde_json::to_string(&canonical_request.clone().with_activity_observation(None))
-                .map_err(|_| {
-                    AtmError::mailbox_write(
-                        "failed to serialize immutable acknowledgement peer write",
-                    )
-                })?;
-        crate::schema::set_peer_outbound_write(&mut envelope, host, request_json);
-    }
+    persist_peer_outbound_reply(&canonical_request, destination, &mut envelope)?;
     let reply = StoredMessage {
         team: destination.team().cloned().ok_or_else(|| {
             AtmError::validation("acknowledgement reply destination is missing a team")
@@ -471,6 +459,27 @@ fn build_atomic_acknowledgement(
         canonical_request,
         acknowledgement,
     })
+}
+
+fn persist_peer_outbound_reply(
+    canonical_request: &SendRequest,
+    destination: &crate::address::AgentAddress,
+    envelope: &mut InboxMessage,
+) -> Result<(), AtmError> {
+    if canonical_request.authenticated_source_host.is_some()
+        || canonical_request.origin_message_id.is_some()
+    {
+        return Ok(());
+    }
+    let Some(host) = destination.host() else {
+        return Ok(());
+    };
+    let request_json =
+        serde_json::to_string(&canonical_request.clone().with_activity_observation(None)).map_err(
+            |_| AtmError::mailbox_write("failed to serialize immutable acknowledgement peer write"),
+        )?;
+    crate::schema::set_peer_outbound_write(envelope, host, request_json);
+    Ok(())
 }
 
 fn reply_target_from_source(

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -637,11 +637,71 @@ mod tests {
     };
     use crate::boundary::{Message, MessageKey};
     use crate::caller_context::ActivityObservation;
+    use crate::read::{MailboxQueryFilters, ReadQuery};
     use crate::schema::{
         AckIntentFields, AtmMessageId, InboxMessage, authenticated_source_host,
         set_authenticated_source_host, set_peer_outbound_write,
     };
-    use crate::types::{AgentName, ChatId, HostName, IsoTimestamp, SessionId, TeamName};
+    use crate::send::{SendMessageSource, WriteRequest};
+    use crate::types::{
+        AgentName, ChatId, HostName, IsoTimestamp, ReadSelection, SessionId, TeamName,
+    };
+
+    #[test]
+    fn request_json_omits_or_includes_activity_observation() {
+        let observation = ActivityObservation {
+            team: "local-team".parse().expect("team"),
+            member: "local-agent".parse().expect("agent"),
+            session_id: Some(SessionId::new("session-17").expect("session")),
+            pid: Some(17),
+        };
+        let write = WriteRequest::new(
+            PathBuf::from("/tmp"),
+            PathBuf::from("/tmp"),
+            "local-agent".parse().expect("agent"),
+            "remote@remote-team",
+            "local-team".parse().expect("team"),
+            SendMessageSource::Inline("body".to_string()),
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("write");
+        assert!(
+            serde_json::to_value(&write)
+                .expect("json")
+                .get("activity_observation")
+                .is_none()
+        );
+        assert_eq!(
+            serde_json::to_value(write.with_activity_observation(Some(observation.clone())))
+                .expect("json")["activity_observation"]["pid"],
+            17
+        );
+        let query = ReadQuery::from_filters(
+            PathBuf::from("/tmp"),
+            PathBuf::from("/tmp"),
+            "local-agent".parse().expect("agent"),
+            "local-team".parse().expect("team"),
+            ReadSelection::All,
+            false,
+            false,
+            MailboxQueryFilters::default(),
+        )
+        .expect("query");
+        assert!(
+            serde_json::to_value(&query)
+                .expect("json")
+                .get("activity_observation")
+                .is_none()
+        );
+        assert_eq!(
+            serde_json::to_value(query.with_activity_observation(Some(observation))).expect("json")
+                ["activity_observation"]["session_id"],
+            "session-17"
+        );
+    }
 
     #[test]
     fn acknowledgement_round_trip_preserves_activity_observation() {

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -437,7 +437,13 @@ fn build_atomic_acknowledgement(
         task_id: None,
         extra: serde_json::Map::new(),
     };
-    persist_peer_outbound_reply(&canonical_request, destination, &mut envelope)?;
+    persist_peer_outbound_reply(
+        &canonical_request,
+        destination,
+        &mut envelope,
+        message_id,
+        timestamp,
+    )?;
     let reply = StoredMessage {
         team: destination.team().cloned().ok_or_else(|| {
             AtmError::validation("acknowledgement reply destination is missing a team")
@@ -465,6 +471,8 @@ fn persist_peer_outbound_reply(
     canonical_request: &SendRequest,
     destination: &crate::address::AgentAddress,
     envelope: &mut InboxMessage,
+    message_id: AtmMessageId,
+    timestamp: IsoTimestamp,
 ) -> Result<(), AtmError> {
     if canonical_request.authenticated_source_host.is_some()
         || canonical_request.origin_message_id.is_some()
@@ -474,10 +482,15 @@ fn persist_peer_outbound_reply(
     let Some(host) = destination.host() else {
         return Ok(());
     };
-    let request_json =
-        serde_json::to_string(&canonical_request.clone().with_activity_observation(None)).map_err(
-            |_| AtmError::mailbox_write("failed to serialize immutable acknowledgement peer write"),
-        )?;
+    let request_json = serde_json::to_string(
+        &canonical_request
+            .clone()
+            .with_origin_metadata(message_id, timestamp)
+            .with_activity_observation(None),
+    )
+    .map_err(|_| {
+        AtmError::mailbox_write("failed to serialize immutable acknowledgement peer write")
+    })?;
     crate::schema::set_peer_outbound_write(envelope, host, request_json);
     Ok(())
 }
@@ -711,9 +724,10 @@ mod tests {
             session_id: Some(SessionId::new("session-17").expect("session")),
             pid: Some(17),
         };
+        let temp_dir = std::env::temp_dir();
         let request = AckRequest {
-            home_dir: PathBuf::from("/tmp/atm-test"),
-            current_dir: PathBuf::from("/tmp/atm-test"),
+            home_dir: temp_dir.clone(),
+            current_dir: temp_dir,
             caller_identity: "local-agent".parse().expect("agent"),
             caller_chat_id: None,
             caller_team: "local-team".parse().expect("team"),
@@ -766,9 +780,10 @@ mod tests {
             message_key: MessageKey::new("ack-source").expect("key"),
             envelope,
         };
+        let temp_dir = std::env::temp_dir();
         let request = AckRequest {
-            home_dir: PathBuf::from("/tmp/atm-test"),
-            current_dir: PathBuf::from("/tmp/atm-test"),
+            home_dir: temp_dir.clone(),
+            current_dir: temp_dir,
             caller_identity: "local-agent".parse().expect("agent"),
             caller_chat_id: Some("chat-42".parse::<ChatId>().expect("chat id")),
             caller_team: "local-team".parse().expect("team"),
@@ -824,6 +839,19 @@ mod tests {
             acknowledged.reply.envelope.acknowledges_message_id,
             Some(message_id),
             "the acknowledgement response keeps the exact send ULID it causally acknowledges"
+        );
+        let stored_request = acknowledged.reply.envelope.extra["peerOutbound"]["request"]
+            .as_str()
+            .expect("stored peer request");
+        let decoded: WriteRequest = serde_json::from_str(stored_request).expect("decoded request");
+        assert_eq!(
+            decoded.origin_message_id,
+            Some(acknowledgement_id),
+            "peer recovery must replay the canonical acknowledgement origin ULID"
+        );
+        assert_eq!(
+            decoded.origin_timestamp,
+            Some(acknowledged.reply.envelope.timestamp)
         );
     }
 

--- a/crates/atm-core/src/ack/mod.rs
+++ b/crates/atm-core/src/ack/mod.rs
@@ -439,9 +439,13 @@ fn build_atomic_acknowledgement(
         && canonical_request.origin_message_id.is_none()
         && let Some(host) = destination.host()
     {
-        let request_json = serde_json::to_string(&canonical_request).map_err(|_| {
-            AtmError::mailbox_write("failed to serialize immutable acknowledgement peer write")
-        })?;
+        let request_json =
+            serde_json::to_string(&canonical_request.clone().with_activity_observation(None))
+                .map_err(|_| {
+                    AtmError::mailbox_write(
+                        "failed to serialize immutable acknowledgement peer write",
+                    )
+                })?;
         crate::schema::set_peer_outbound_write(&mut envelope, host, request_json);
     }
     let reply = StoredMessage {

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -1291,6 +1291,7 @@ mod tests {
                 caller_identity: TEST_SENDER.parse().expect("sender"),
                 caller_chat_id: None,
                 caller_team: TEST_TEAM.parse().expect("team"),
+                activity_observation: None,
                 message_id: AtmMessageId::new(),
                 reply_body: "acknowledged".to_string(),
             }

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod filters;
 pub(crate) mod metadata_selection;
+mod request;
 pub(crate) mod seen_state;
 pub(crate) mod state;
 pub(crate) mod wait;
@@ -8,7 +9,6 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::address::{AgentAddress, MessageParticipantFilter, ParticipantDirection};
 use crate::boundary;
 use crate::error::AtmError;
 use crate::mailbox::source::resolve_target;
@@ -17,273 +17,18 @@ use crate::schema::{AtmMessageId, InboxMessage};
 use crate::service_runtime::{LocalServiceRuntime, RetainedServiceRuntime};
 use crate::service_runtime_store::{RetainedMailboxRuntime, default_runtime};
 use crate::types::{
-    AgentName, ChatId, CommandAction, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection,
-    SourceIndex, TaskId, TeamName,
+    AgentName, CommandAction, DisplayBucket, IsoTimestamp, MessageClass, ReadSelection,
+    SourceIndex, TeamName,
 };
 use metadata_selection::{
     filter_metadata_backed_contains_candidates, load_durable_metadata_message,
     selection_state_for_mailbox_metadata_rows, sort_and_limit_selected,
 };
 
-pub const MAX_CONTAINS_FILTER_LEN: usize = 1024;
-pub const MAX_TIMEOUT_SECS: u64 = 3600;
-
-/// Parameters for querying and optionally mutating one mailbox display surface.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MailboxQueryFields {
-    pub(crate) home_dir: PathBuf,
-    pub(crate) current_dir: PathBuf,
-    pub(crate) target_address: Option<AgentAddress>,
-    pub(crate) selection_mode: ReadSelection,
-    pub(crate) seen_state_filter: bool,
-    pub(crate) message_id_filter: Option<AtmMessageId>,
-    pub(crate) sender_filter: Option<AgentName>,
-    pub(crate) participant_filter: Option<MessageParticipantFilter>,
-    pub(crate) timestamp_filter: Option<IsoTimestamp>,
-    pub(crate) task_filter: Option<TaskId>,
-    pub(crate) contains_filter: Option<String>,
-    pub(crate) timeout_secs: Option<u64>,
-}
-
-impl MailboxQueryFields {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        home_dir: PathBuf,
-        current_dir: PathBuf,
-        target_address: Option<&str>,
-        selection_mode: ReadSelection,
-        seen_state_filter: bool,
-        message_id_filter: Option<&str>,
-        sender_filter: Option<&str>,
-        timestamp_filter: Option<IsoTimestamp>,
-        task_filter: Option<&str>,
-        contains_filter: Option<&str>,
-        timeout_secs: Option<u64>,
-    ) -> Result<Self, AtmError> {
-        let contains_filter = normalize_contains_filter(contains_filter)?;
-        let timeout_secs = validate_timeout_secs(timeout_secs)?;
-        Ok(Self {
-            home_dir,
-            current_dir,
-            target_address: target_address.map(str::parse).transpose()?,
-            selection_mode,
-            seen_state_filter,
-            message_id_filter: message_id_filter
-                .map(|value| {
-                    value.parse::<AtmMessageId>().map_err(|_source| {
-                        AtmError::validation(format!("invalid message id: {value}"))
-                    })
-                })
-                .transpose()?,
-            sender_filter: sender_filter.map(str::parse).transpose()?,
-            participant_filter: None,
-            timestamp_filter,
-            task_filter: task_filter.map(str::parse).transpose()?,
-            contains_filter,
-            timeout_secs,
-        })
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn build_mailbox_query_fields(
-    home_dir: PathBuf,
-    current_dir: PathBuf,
-    target_address: Option<&str>,
-    selection_mode: ReadSelection,
-    seen_state_filter: bool,
-    message_id_filter: Option<&str>,
-    sender_filter: Option<&str>,
-    timestamp_filter: Option<IsoTimestamp>,
-    task_filter: Option<&str>,
-    contains_filter: Option<&str>,
-    timeout_secs: Option<u64>,
-) -> Result<MailboxQueryFields, AtmError> {
-    MailboxQueryFields::new(
-        home_dir,
-        current_dir,
-        target_address,
-        selection_mode,
-        seen_state_filter,
-        message_id_filter,
-        sender_filter,
-        timestamp_filter,
-        task_filter,
-        contains_filter,
-        timeout_secs,
-    )
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PeekQuery {
-    pub(crate) mailbox: MailboxQueryFields,
-    pub(crate) caller_identity: AgentName,
-    pub(crate) caller_team: TeamName,
-}
-
-impl PeekQuery {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        home_dir: PathBuf,
-        current_dir: PathBuf,
-        caller_identity: AgentName,
-        target_address: Option<&str>,
-        caller_team: TeamName,
-        selection_mode: ReadSelection,
-        seen_state_filter: bool,
-        message_id_filter: Option<&str>,
-        sender_filter: Option<&str>,
-        timestamp_filter: Option<IsoTimestamp>,
-        task_filter: Option<&str>,
-        contains_filter: Option<&str>,
-        timeout_secs: Option<u64>,
-    ) -> Result<Self, AtmError> {
-        let mut mailbox = build_mailbox_query_fields(
-            home_dir,
-            current_dir,
-            target_address,
-            selection_mode,
-            seen_state_filter,
-            message_id_filter,
-            sender_filter,
-            timestamp_filter,
-            task_filter,
-            contains_filter,
-            timeout_secs,
-        )?;
-        mailbox.participant_filter = Some(MessageParticipantFilter {
-            agent: caller_identity.clone(),
-            chat_id: None,
-            direction: ParticipantDirection::To,
-        });
-        Ok(Self {
-            mailbox,
-            caller_identity,
-            caller_team,
-        })
-    }
-}
-
-/// Parameters for querying and optionally mutating one mailbox display surface.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReadQuery {
-    pub(crate) mailbox: MailboxQueryFields,
-    pub(crate) caller_identity: AgentName,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) caller_chat_id: Option<ChatId>,
-    pub(crate) caller_team: TeamName,
-    pub(crate) seen_state_update: bool,
-}
-
-impl ReadQuery {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        home_dir: PathBuf,
-        current_dir: PathBuf,
-        caller_identity: AgentName,
-        target_address: Option<&str>,
-        caller_team: TeamName,
-        selection_mode: ReadSelection,
-        seen_state_filter: bool,
-        seen_state_update: bool,
-        message_id_filter: Option<&str>,
-        sender_filter: Option<&str>,
-        timestamp_filter: Option<IsoTimestamp>,
-        task_filter: Option<&str>,
-        contains_filter: Option<&str>,
-        timeout_secs: Option<u64>,
-    ) -> Result<Self, AtmError> {
-        Ok(Self {
-            mailbox: build_mailbox_query_fields(
-                home_dir,
-                current_dir,
-                target_address,
-                selection_mode,
-                seen_state_filter,
-                message_id_filter,
-                sender_filter,
-                timestamp_filter,
-                task_filter,
-                contains_filter,
-                timeout_secs,
-            )?,
-            caller_identity,
-            caller_chat_id: None,
-            caller_team,
-            seen_state_update,
-        })
-    }
-
-    pub fn team_override(&self) -> Option<&TeamName> {
-        Some(&self.caller_team)
-    }
-
-    pub fn selection_mode(&self) -> ReadSelection {
-        self.mailbox.selection_mode
-    }
-
-    pub fn seen_state_filter(&self) -> bool {
-        self.mailbox.seen_state_filter
-    }
-
-    pub fn seen_state_update(&self) -> bool {
-        self.seen_state_update
-    }
-
-    pub fn message_id_filter(&self) -> Option<&AtmMessageId> {
-        self.mailbox.message_id_filter.as_ref()
-    }
-
-    pub fn timeout_secs(&self) -> Option<u64> {
-        self.mailbox.timeout_secs
-    }
-
-    pub fn caller_chat_id(&self) -> Option<&ChatId> {
-        self.caller_chat_id.as_ref()
-    }
-
-    #[must_use]
-    pub fn with_caller_chat_id(mut self, caller_chat_id: Option<ChatId>) -> Self {
-        self.mailbox.participant_filter = Some(MessageParticipantFilter {
-            agent: self.caller_identity.clone(),
-            chat_id: caller_chat_id.clone(),
-            direction: ParticipantDirection::To,
-        });
-        self.caller_chat_id = caller_chat_id;
-        self
-    }
-
-    pub fn with_selection_mode(mut self, selection_mode: ReadSelection) -> Self {
-        self.mailbox.selection_mode = selection_mode;
-        self
-    }
-}
-
-pub(crate) fn normalize_contains_filter(
-    contains_filter: Option<&str>,
-) -> Result<Option<String>, AtmError> {
-    match contains_filter
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        Some(value) if value.len() > MAX_CONTAINS_FILTER_LEN => Err(AtmError::validation(format!(
-            "contains filter exceeds the {}-byte maximum",
-            MAX_CONTAINS_FILTER_LEN
-        ))),
-        Some(value) => Ok(Some(value.to_ascii_lowercase())),
-        None => Ok(None),
-    }
-}
-
-fn validate_timeout_secs(timeout_secs: Option<u64>) -> Result<Option<u64>, AtmError> {
-    match timeout_secs {
-        Some(value) if value > MAX_TIMEOUT_SECS => Err(AtmError::validation(format!(
-            "timeout exceeds the {} second maximum",
-            MAX_TIMEOUT_SECS
-        ))),
-        _ => Ok(timeout_secs),
-    }
-}
+pub(crate) use request::normalize_contains_filter;
+pub use request::{
+    MAX_CONTAINS_FILTER_LEN, MAX_TIMEOUT_SECS, MailboxQueryFields, PeekQuery, ReadQuery,
+};
 
 /// Bucket counts for one classified mailbox surface.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -384,6 +129,7 @@ fn peek_mail_with_runtime_impl<R: RetainedServiceRuntime + RetainedMailboxRuntim
         caller_chat_id: None,
         caller_team: query.caller_team,
         seen_state_update: false,
+        activity_observation: None,
     };
     let ReadRuntimeContext {
         actor,

--- a/crates/atm-core/src/read/mod.rs
+++ b/crates/atm-core/src/read/mod.rs
@@ -27,7 +27,8 @@ use metadata_selection::{
 
 pub(crate) use request::normalize_contains_filter;
 pub use request::{
-    MAX_CONTAINS_FILTER_LEN, MAX_TIMEOUT_SECS, MailboxQueryFields, PeekQuery, ReadQuery,
+    MAX_CONTAINS_FILTER_LEN, MAX_TIMEOUT_SECS, MailboxQueryFields, MailboxQueryFilters, PeekQuery,
+    ReadQuery,
 };
 
 /// Bucket counts for one classified mailbox surface.

--- a/crates/atm-core/src/read/request.rs
+++ b/crates/atm-core/src/read/request.rs
@@ -279,6 +279,10 @@ pub struct ReadQuery {
     pub activity_observation: Option<ActivityObservation>,
 }
 impl ReadQuery {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the request boundary keeps caller, selection, and mutation state explicit; all optional filters are named in MailboxQueryFilters"
+    )]
     pub fn from_filters(
         home_dir: PathBuf,
         current_dir: PathBuf,

--- a/crates/atm-core/src/read/request.rs
+++ b/crates/atm-core/src/read/request.rs
@@ -11,6 +11,108 @@ use crate::types::{AgentName, ChatId, IsoTimestamp, ReadSelection, TaskId, TeamN
 pub const MAX_CONTAINS_FILTER_LEN: usize = 1024;
 pub const MAX_TIMEOUT_SECS: u64 = 3600;
 
+/// Named query filters for read and peek requests.
+///
+/// This builder keeps the string-backed filters distinct at the call site, so
+/// a sender, task, message ID, and body-match value cannot be accidentally
+/// transposed by a positional constructor call.
+#[derive(Debug, Clone, Default)]
+pub struct MailboxQueryFilters {
+    target_address: Option<String>,
+    message_id: Option<String>,
+    sender: Option<String>,
+    timestamp: Option<IsoTimestamp>,
+    task: Option<String>,
+    contains: Option<String>,
+    timeout_secs: Option<u64>,
+}
+
+impl MailboxQueryFilters {
+    #[must_use]
+    pub fn target_address_opt(mut self, value: Option<&str>) -> Self {
+        self.target_address = value.map(str::to_owned);
+        self
+    }
+
+    #[must_use]
+    pub fn target_address(mut self, value: impl Into<String>) -> Self {
+        self.target_address = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn message_id(mut self, value: impl Into<String>) -> Self {
+        self.message_id = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn message_id_opt(mut self, value: Option<&str>) -> Self {
+        self.message_id = value.map(str::to_owned);
+        self
+    }
+
+    #[must_use]
+    pub fn sender(mut self, value: impl Into<String>) -> Self {
+        self.sender = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn sender_opt(mut self, value: Option<&str>) -> Self {
+        self.sender = value.map(str::to_owned);
+        self
+    }
+
+    #[must_use]
+    pub fn timestamp(mut self, value: IsoTimestamp) -> Self {
+        self.timestamp = Some(value);
+        self
+    }
+
+    #[must_use]
+    pub const fn timestamp_opt(mut self, value: Option<IsoTimestamp>) -> Self {
+        self.timestamp = value;
+        self
+    }
+
+    #[must_use]
+    pub fn task(mut self, value: impl Into<String>) -> Self {
+        self.task = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn task_opt(mut self, value: Option<&str>) -> Self {
+        self.task = value.map(str::to_owned);
+        self
+    }
+
+    #[must_use]
+    pub fn contains(mut self, value: impl Into<String>) -> Self {
+        self.contains = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn contains_opt(mut self, value: Option<&str>) -> Self {
+        self.contains = value.map(str::to_owned);
+        self
+    }
+
+    #[must_use]
+    pub const fn timeout_secs(mut self, value: u64) -> Self {
+        self.timeout_secs = Some(value);
+        self
+    }
+
+    #[must_use]
+    pub const fn timeout_secs_opt(mut self, value: Option<u64>) -> Self {
+        self.timeout_secs = value;
+        self
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MailboxQueryFields {
     pub(crate) home_dir: PathBuf,
@@ -98,6 +200,32 @@ pub struct PeekQuery {
     pub(crate) caller_team: TeamName,
 }
 impl PeekQuery {
+    pub fn from_filters(
+        home_dir: PathBuf,
+        current_dir: PathBuf,
+        caller_identity: AgentName,
+        caller_team: TeamName,
+        selection_mode: ReadSelection,
+        seen_state_filter: bool,
+        filters: MailboxQueryFilters,
+    ) -> Result<Self, AtmError> {
+        Self::new(
+            home_dir,
+            current_dir,
+            caller_identity,
+            filters.target_address.as_deref(),
+            caller_team,
+            selection_mode,
+            seen_state_filter,
+            filters.message_id.as_deref(),
+            filters.sender.as_deref(),
+            filters.timestamp,
+            filters.task.as_deref(),
+            filters.contains.as_deref(),
+            filters.timeout_secs,
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         home_dir: PathBuf,
@@ -151,6 +279,34 @@ pub struct ReadQuery {
     pub activity_observation: Option<ActivityObservation>,
 }
 impl ReadQuery {
+    pub fn from_filters(
+        home_dir: PathBuf,
+        current_dir: PathBuf,
+        caller_identity: AgentName,
+        caller_team: TeamName,
+        selection_mode: ReadSelection,
+        seen_state_filter: bool,
+        seen_state_update: bool,
+        filters: MailboxQueryFilters,
+    ) -> Result<Self, AtmError> {
+        Self::new(
+            home_dir,
+            current_dir,
+            caller_identity,
+            filters.target_address.as_deref(),
+            caller_team,
+            selection_mode,
+            seen_state_filter,
+            seen_state_update,
+            filters.message_id.as_deref(),
+            filters.sender.as_deref(),
+            filters.timestamp,
+            filters.task.as_deref(),
+            filters.contains.as_deref(),
+            filters.timeout_secs,
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         home_dir: PathBuf,

--- a/crates/atm-core/src/read/request.rs
+++ b/crates/atm-core/src/read/request.rs
@@ -165,34 +165,6 @@ impl MailboxQueryFields {
         })
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn build_mailbox_query_fields(
-    home_dir: PathBuf,
-    current_dir: PathBuf,
-    target_address: Option<&str>,
-    selection_mode: ReadSelection,
-    seen_state_filter: bool,
-    message_id_filter: Option<&str>,
-    sender_filter: Option<&str>,
-    timestamp_filter: Option<IsoTimestamp>,
-    task_filter: Option<&str>,
-    contains_filter: Option<&str>,
-    timeout_secs: Option<u64>,
-) -> Result<MailboxQueryFields, AtmError> {
-    MailboxQueryFields::new(
-        home_dir,
-        current_dir,
-        target_address,
-        selection_mode,
-        seen_state_filter,
-        message_id_filter,
-        sender_filter,
-        timestamp_filter,
-        task_filter,
-        contains_filter,
-        timeout_secs,
-    )
-}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeekQuery {
     pub(crate) mailbox: MailboxQueryFields,
@@ -242,7 +214,7 @@ impl PeekQuery {
         contains_filter: Option<&str>,
         timeout_secs: Option<u64>,
     ) -> Result<Self, AtmError> {
-        let mut mailbox = build_mailbox_query_fields(
+        let mut mailbox = MailboxQueryFields::new(
             home_dir,
             current_dir,
             target_address,
@@ -329,7 +301,7 @@ impl ReadQuery {
         timeout_secs: Option<u64>,
     ) -> Result<Self, AtmError> {
         Ok(Self {
-            mailbox: build_mailbox_query_fields(
+            mailbox: MailboxQueryFields::new(
                 home_dir,
                 current_dir,
                 target_address,

--- a/crates/atm-core/src/read/request.rs
+++ b/crates/atm-core/src/read/request.rs
@@ -1,0 +1,259 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::address::{AgentAddress, MessageParticipantFilter, ParticipantDirection};
+use crate::caller_context::ActivityObservation;
+use crate::error::AtmError;
+use crate::schema::AtmMessageId;
+use crate::types::{AgentName, ChatId, IsoTimestamp, ReadSelection, TaskId, TeamName};
+
+pub const MAX_CONTAINS_FILTER_LEN: usize = 1024;
+pub const MAX_TIMEOUT_SECS: u64 = 3600;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MailboxQueryFields {
+    pub(crate) home_dir: PathBuf,
+    pub(crate) current_dir: PathBuf,
+    pub(crate) target_address: Option<AgentAddress>,
+    pub(crate) selection_mode: ReadSelection,
+    pub(crate) seen_state_filter: bool,
+    pub(crate) message_id_filter: Option<AtmMessageId>,
+    pub(crate) sender_filter: Option<AgentName>,
+    pub(crate) participant_filter: Option<MessageParticipantFilter>,
+    pub(crate) timestamp_filter: Option<IsoTimestamp>,
+    pub(crate) task_filter: Option<TaskId>,
+    pub(crate) contains_filter: Option<String>,
+    pub(crate) timeout_secs: Option<u64>,
+}
+impl MailboxQueryFields {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        home_dir: PathBuf,
+        current_dir: PathBuf,
+        target_address: Option<&str>,
+        selection_mode: ReadSelection,
+        seen_state_filter: bool,
+        message_id_filter: Option<&str>,
+        sender_filter: Option<&str>,
+        timestamp_filter: Option<IsoTimestamp>,
+        task_filter: Option<&str>,
+        contains_filter: Option<&str>,
+        timeout_secs: Option<u64>,
+    ) -> Result<Self, AtmError> {
+        Ok(Self {
+            home_dir,
+            current_dir,
+            target_address: target_address.map(str::parse).transpose()?,
+            selection_mode,
+            seen_state_filter,
+            message_id_filter: message_id_filter
+                .map(|value| {
+                    value
+                        .parse::<AtmMessageId>()
+                        .map_err(|_| AtmError::validation(format!("invalid message id: {value}")))
+                })
+                .transpose()?,
+            sender_filter: sender_filter.map(str::parse).transpose()?,
+            participant_filter: None,
+            timestamp_filter,
+            task_filter: task_filter.map(str::parse).transpose()?,
+            contains_filter: normalize_contains_filter(contains_filter)?,
+            timeout_secs: validate_timeout_secs(timeout_secs)?,
+        })
+    }
+}
+#[allow(clippy::too_many_arguments)]
+fn build_mailbox_query_fields(
+    home_dir: PathBuf,
+    current_dir: PathBuf,
+    target_address: Option<&str>,
+    selection_mode: ReadSelection,
+    seen_state_filter: bool,
+    message_id_filter: Option<&str>,
+    sender_filter: Option<&str>,
+    timestamp_filter: Option<IsoTimestamp>,
+    task_filter: Option<&str>,
+    contains_filter: Option<&str>,
+    timeout_secs: Option<u64>,
+) -> Result<MailboxQueryFields, AtmError> {
+    MailboxQueryFields::new(
+        home_dir,
+        current_dir,
+        target_address,
+        selection_mode,
+        seen_state_filter,
+        message_id_filter,
+        sender_filter,
+        timestamp_filter,
+        task_filter,
+        contains_filter,
+        timeout_secs,
+    )
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeekQuery {
+    pub(crate) mailbox: MailboxQueryFields,
+    pub(crate) caller_identity: AgentName,
+    pub(crate) caller_team: TeamName,
+}
+impl PeekQuery {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        home_dir: PathBuf,
+        current_dir: PathBuf,
+        caller_identity: AgentName,
+        target_address: Option<&str>,
+        caller_team: TeamName,
+        selection_mode: ReadSelection,
+        seen_state_filter: bool,
+        message_id_filter: Option<&str>,
+        sender_filter: Option<&str>,
+        timestamp_filter: Option<IsoTimestamp>,
+        task_filter: Option<&str>,
+        contains_filter: Option<&str>,
+        timeout_secs: Option<u64>,
+    ) -> Result<Self, AtmError> {
+        let mut mailbox = build_mailbox_query_fields(
+            home_dir,
+            current_dir,
+            target_address,
+            selection_mode,
+            seen_state_filter,
+            message_id_filter,
+            sender_filter,
+            timestamp_filter,
+            task_filter,
+            contains_filter,
+            timeout_secs,
+        )?;
+        mailbox.participant_filter = Some(MessageParticipantFilter {
+            agent: caller_identity.clone(),
+            chat_id: None,
+            direction: ParticipantDirection::To,
+        });
+        Ok(Self {
+            mailbox,
+            caller_identity,
+            caller_team,
+        })
+    }
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadQuery {
+    pub(crate) mailbox: MailboxQueryFields,
+    pub(crate) caller_identity: AgentName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) caller_chat_id: Option<ChatId>,
+    pub(crate) caller_team: TeamName,
+    pub(crate) seen_state_update: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity_observation: Option<ActivityObservation>,
+}
+impl ReadQuery {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        home_dir: PathBuf,
+        current_dir: PathBuf,
+        caller_identity: AgentName,
+        target_address: Option<&str>,
+        caller_team: TeamName,
+        selection_mode: ReadSelection,
+        seen_state_filter: bool,
+        seen_state_update: bool,
+        message_id_filter: Option<&str>,
+        sender_filter: Option<&str>,
+        timestamp_filter: Option<IsoTimestamp>,
+        task_filter: Option<&str>,
+        contains_filter: Option<&str>,
+        timeout_secs: Option<u64>,
+    ) -> Result<Self, AtmError> {
+        Ok(Self {
+            mailbox: build_mailbox_query_fields(
+                home_dir,
+                current_dir,
+                target_address,
+                selection_mode,
+                seen_state_filter,
+                message_id_filter,
+                sender_filter,
+                timestamp_filter,
+                task_filter,
+                contains_filter,
+                timeout_secs,
+            )?,
+            caller_identity,
+            caller_chat_id: None,
+            caller_team,
+            seen_state_update,
+            activity_observation: None,
+        })
+    }
+    pub fn team_override(&self) -> Option<&TeamName> {
+        Some(&self.caller_team)
+    }
+    pub fn selection_mode(&self) -> ReadSelection {
+        self.mailbox.selection_mode
+    }
+    pub fn seen_state_filter(&self) -> bool {
+        self.mailbox.seen_state_filter
+    }
+    pub fn seen_state_update(&self) -> bool {
+        self.seen_state_update
+    }
+    pub fn message_id_filter(&self) -> Option<&AtmMessageId> {
+        self.mailbox.message_id_filter.as_ref()
+    }
+    pub fn timeout_secs(&self) -> Option<u64> {
+        self.mailbox.timeout_secs
+    }
+    pub fn caller_chat_id(&self) -> Option<&ChatId> {
+        self.caller_chat_id.as_ref()
+    }
+    #[must_use]
+    pub fn with_caller_chat_id(mut self, caller_chat_id: Option<ChatId>) -> Self {
+        self.mailbox.participant_filter = Some(MessageParticipantFilter {
+            agent: self.caller_identity.clone(),
+            chat_id: caller_chat_id.clone(),
+            direction: ParticipantDirection::To,
+        });
+        self.caller_chat_id = caller_chat_id;
+        self
+    }
+    #[must_use]
+    pub fn with_activity_observation(
+        mut self,
+        activity_observation: Option<ActivityObservation>,
+    ) -> Self {
+        self.activity_observation = activity_observation;
+        self
+    }
+    pub fn with_selection_mode(mut self, selection_mode: ReadSelection) -> Self {
+        self.mailbox.selection_mode = selection_mode;
+        self
+    }
+}
+pub(crate) fn normalize_contains_filter(
+    contains_filter: Option<&str>,
+) -> Result<Option<String>, AtmError> {
+    match contains_filter
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(value) if value.len() > MAX_CONTAINS_FILTER_LEN => Err(AtmError::validation(format!(
+            "contains filter exceeds the {}-byte maximum",
+            MAX_CONTAINS_FILTER_LEN
+        ))),
+        Some(value) => Ok(Some(value.to_ascii_lowercase())),
+        None => Ok(None),
+    }
+}
+fn validate_timeout_secs(timeout_secs: Option<u64>) -> Result<Option<u64>, AtmError> {
+    match timeout_secs {
+        Some(value) if value > MAX_TIMEOUT_SECS => Err(AtmError::validation(format!(
+            "timeout exceeds the {} second maximum",
+            MAX_TIMEOUT_SECS
+        ))),
+        _ => Ok(timeout_secs),
+    }
+}

--- a/crates/atm-core/src/send/hook.rs
+++ b/crates/atm-core/src/send/hook.rs
@@ -14,10 +14,7 @@ use serde_json::{Map, Value, json};
 use tracing::Level;
 use tracing::{debug, error, info, warn};
 
-use super::{
-    POST_SEND_HOOK_TIMEOUT, ResolvedRecipient, WarningEntry, nudge_template,
-    qualified_sender_identity,
-};
+use super::{POST_SEND_HOOK_TIMEOUT, ResolvedRecipient, WarningEntry, nudge_template};
 use crate::boundary::{
     BuiltInPostSendDispatch, GraftNudgeTarget, HookExecutionSummary, LocalTmuxNudgeTarget,
     PostSendBuiltInTarget, PostSendEmissionOutcome, PostSendEmissionPath, PostSendHookEmitter,
@@ -377,7 +374,7 @@ fn prepare_post_send_hook_execution(
 
 fn post_send_hook_payload(event: &PostSendHookEvent) -> Value {
     let mut payload = json!({
-        "from": qualified_sender_identity(&event.sender, Some(&event.sender_team)),
+        "from": event.source_address().to_string(),
         "to": format!("{}@{}", event.recipient, event.recipient_team),
         "sender": event.sender.as_str(),
         "recipient": event.recipient.as_str(),

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -985,7 +985,10 @@ fn persist_send_message<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
         && request.origin_message_id.is_none()
         && let Some(host) = request.to.as_ref().and_then(|address| address.host())
     {
-        let exact_request = request.clone().with_origin_metadata(message_id, timestamp);
+        let exact_request = request
+            .clone()
+            .with_origin_metadata(message_id, timestamp)
+            .with_activity_observation(None);
         let request_json = serde_json::to_string(&exact_request).map_err(|_source| {
             AtmError::mailbox_write("failed to serialize immutable peer outbound write")
         })?;

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -62,7 +62,6 @@ pub use nudge_template::{
 pub(crate) use persistence::persist_message;
 pub use post_write::emit_persisted_local_post_write;
 pub(crate) use recipient::{ResolvedRecipient, resolve_recipient, validate_non_self_recipient};
-pub(super) use request::qualified_sender_identity;
 use request::{prepare_threaded_message, resolve_message_body};
 
 pub(super) const POST_SEND_HOOK_TIMEOUT: Duration = Duration::from_secs(5);

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -1,6 +1,6 @@
 //! Send command service implementation and post-send hook handling.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -12,6 +12,7 @@ use crate::address::AgentAddress;
 use crate::boundary;
 #[cfg(test)]
 use crate::boundary::PostSendHookEmitter;
+use crate::caller_context::ActivityObservation;
 #[cfg(test)]
 use crate::config;
 use crate::delivery_execution::{
@@ -35,7 +36,6 @@ use crate::schema::{
 };
 use crate::service_runtime::{LocalServiceRuntime, RetainedServiceRuntime};
 use crate::service_runtime_store::{RetainedMailboxRuntime, default_runtime};
-use crate::threading::{ThreadIndex, canonical_sender_identity, is_ephemeral};
 use crate::types::{AgentName, ChatId, CommandAction, HostName, IsoTimestamp, TaskId, TeamName};
 
 mod delivery_persistence;
@@ -47,6 +47,7 @@ pub(crate) mod nudge_template;
 mod persistence;
 mod post_write;
 mod recipient;
+mod request;
 pub(crate) mod summary;
 
 pub(crate) use delivery_persistence::{
@@ -61,8 +62,14 @@ pub use nudge_template::{
 pub(crate) use persistence::persist_message;
 pub use post_write::emit_persisted_local_post_write;
 pub(crate) use recipient::{ResolvedRecipient, resolve_recipient, validate_non_self_recipient};
+pub(super) use request::qualified_sender_identity;
+use request::{prepare_threaded_message, resolve_message_body};
 
 pub(super) const POST_SEND_HOOK_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SendMessageSource {
@@ -81,6 +88,8 @@ pub struct WriteRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub caller_chat_id: Option<ChatId>,
     pub caller_team: TeamName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity_observation: Option<ActivityObservation>,
     /// Set only by the authenticated HTTPS ingress before the shared writer
     /// persists an inbound record. It is not trusted from wire JSON.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -132,6 +141,7 @@ impl WriteRequest {
             caller_identity,
             caller_chat_id: None,
             caller_team,
+            activity_observation: None,
             authenticated_source_host: None,
             origin_message_id: None,
             origin_timestamp: None,
@@ -151,6 +161,15 @@ impl WriteRequest {
     #[must_use]
     pub fn with_caller_chat_id(mut self, caller_chat_id: Option<ChatId>) -> Self {
         self.caller_chat_id = caller_chat_id;
+        self
+    }
+
+    #[must_use]
+    pub fn with_activity_observation(
+        mut self,
+        activity_observation: Option<ActivityObservation>,
+    ) -> Self {
+        self.activity_observation = activity_observation;
         self
     }
 
@@ -1058,117 +1077,6 @@ fn emit_send_command_event(
     }) {
         warn!(%error, command = "send", action = "send", "failed to emit send command event");
     }
-}
-
-fn resolve_message_body(
-    source: &SendMessageSource,
-    current_dir: &Path,
-    home_dir: &Path,
-    team_name: &TeamName,
-) -> Result<String, AtmError> {
-    match source {
-        SendMessageSource::Inline(message) => input::validate_message_text(message.clone()),
-        SendMessageSource::File { path, message } => {
-            input::validate_message_text(file_policy::process_file_reference(
-                path,
-                message.as_deref(),
-                team_name,
-                current_dir,
-                home_dir,
-            )?)
-        }
-    }
-}
-
-fn is_false(value: &bool) -> bool {
-    !*value
-}
-
-fn prepare_threaded_message(
-    envelope: &mut InboxMessage,
-    inbox_messages: &[InboxMessage],
-) -> Result<(), AtmError> {
-    match (
-        envelope.parent_message_id,
-        envelope.thread_mode,
-        envelope.expires_at,
-    ) {
-        (None, None, _) => Ok(()),
-        (Some(_), Some(_), Some(_)) => Err(AtmError::validation(
-            "ephemeral messages may not participate in a message thread",
-        )),
-        (Some(parent_id), Some(_), None) => {
-            validate_thread_append(envelope, inbox_messages, parent_id)
-        }
-        (Some(_), None, _) | (None, Some(_), _) => Err(AtmError::validation(
-            "thread updates must set both parent_message_id and thread_mode",
-        )),
-    }
-}
-
-fn validate_thread_append(
-    envelope: &mut InboxMessage,
-    inbox_messages: &[InboxMessage],
-    parent_id: AtmMessageId,
-) -> Result<(), AtmError> {
-    let index = ThreadIndex::new(inbox_messages);
-    let parent = index.message(parent_id).ok_or_else(|| {
-        AtmError::validation(format!(
-            "thread parent message {} was not found in the recipient inbox",
-            parent_id
-        ))
-    })?;
-
-    if is_ephemeral(parent) {
-        return Err(AtmError::validation(
-            "ephemeral messages may not be updated or superseded",
-        ));
-    }
-
-    let Some(root_id) = index.root_id(parent_id) else {
-        return Err(AtmError::validation(format!(
-            "thread root could not be resolved for parent message {}",
-            parent_id
-        )));
-    };
-    let root = index.message(root_id).ok_or_else(|| {
-        AtmError::validation(format!(
-            "thread root message {} was not found in the recipient inbox",
-            root_id
-        ))
-    })?;
-
-    if canonical_sender_identity(root) != canonical_sender_identity(envelope) {
-        return Err(AtmError::validation(
-            "only the original sender may append details or supersede a message thread",
-        ));
-    }
-
-    if index.has_successor(parent_id) {
-        return Err(AtmError::validation(format!(
-            "message {} already has a successor; ATM threads are strictly linear",
-            parent_id
-        )));
-    }
-
-    let thread_requires_ack = index.thread_requires_ack(parent_id);
-    envelope.requires_ack = thread_requires_ack;
-    envelope.pending_ack_at = thread_requires_ack.then_some(envelope.timestamp);
-    envelope.acknowledged_at = None;
-    Ok(())
-}
-
-#[allow(
-    dead_code,
-    reason = "Retained for the dormant direct post-send hook helper."
-)]
-pub(super) fn qualified_sender_identity(
-    sender: &AgentName,
-    sender_team: Option<&TeamName>,
-) -> String {
-    sender_team
-        .map(|team| format!("{sender}@{team}"))
-        .unwrap_or_else(|| sender.to_string())
 }
 
 #[cfg(test)]

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -66,6 +66,31 @@ use request::{prepare_threaded_message, resolve_message_body};
 
 pub(super) const POST_SEND_HOOK_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Builds the durable replay payload for an origin write addressed to a peer.
+/// Both ordinary sends and acknowledgement replies use this single boundary so
+/// their replay copies always retain origin metadata and omit local activity.
+pub(crate) fn build_peer_outbound_replay(
+    request: &WriteRequest,
+    destination: &AgentAddress,
+    message_id: AtmMessageId,
+    timestamp: IsoTimestamp,
+) -> Result<Option<(HostName, String)>, AtmError> {
+    if request.authenticated_source_host.is_some() || request.origin_message_id.is_some() {
+        return Ok(None);
+    }
+    let Some(host) = destination.host() else {
+        return Ok(None);
+    };
+    let replay = request
+        .clone()
+        .with_origin_metadata(message_id, timestamp)
+        .with_activity_observation(None);
+    let request_json = serde_json::to_string(&replay).map_err(|_| {
+        AtmError::mailbox_write("failed to serialize immutable peer outbound write")
+    })?;
+    Ok(Some((host.clone(), request_json)))
+}
+
 fn is_false(value: &bool) -> bool {
     !*value
 }
@@ -980,18 +1005,11 @@ fn persist_send_message<R: RetainedServiceRuntime + RetainedMailboxRuntime>(
     // required on every peer receipt. It prevents an inbound peer write from
     // becoming a second outbound peer delivery while preserving its original
     // host-qualified address for the shared writer and a later ACK.
-    if request.authenticated_source_host.is_none()
-        && request.origin_message_id.is_none()
-        && let Some(host) = request.to.as_ref().and_then(|address| address.host())
+    if let Some(destination) = request.to.as_ref()
+        && let Some((host, request_json)) =
+            build_peer_outbound_replay(request, destination, message_id, timestamp)?
     {
-        let exact_request = request
-            .clone()
-            .with_origin_metadata(message_id, timestamp)
-            .with_activity_observation(None);
-        let request_json = serde_json::to_string(&exact_request).map_err(|_source| {
-            AtmError::mailbox_write("failed to serialize immutable peer outbound write")
-        })?;
-        set_peer_outbound_write(&mut envelope, host, request_json);
+        set_peer_outbound_write(&mut envelope, &host, request_json);
     }
     persistence::persist_message_with_ack_update(
         runtime,

--- a/crates/atm-core/src/send/post_write_tests.rs
+++ b/crates/atm-core/src/send/post_write_tests.rs
@@ -9,11 +9,12 @@ use super::{
     persist_message, write_mail_with_runtime_impl, write_mail_with_runtime_impl_with_mode,
 };
 use crate::boundary::{MailStoreMailboxMetadataRow, Message, MessageKey};
+use crate::caller_context::ActivityObservation;
 use crate::delivery_policy::DeliveryHarnessPath;
 use crate::error_codes::AtmErrorCode;
 use crate::schema::{AtmMessageId, set_authenticated_source_host, set_peer_outbound_write};
 use crate::test_support::{TEST_SENDER, TEST_TEAM};
-use crate::types::{AgentName, HostName, IsoTimestamp, TeamName};
+use crate::types::{AgentName, HostName, IsoTimestamp, SessionId, TeamName};
 
 #[test]
 fn host_qualified_origin_write_persists_without_remote_roster_and_preserves_origin_ulid() {
@@ -42,6 +43,38 @@ fn host_qualified_origin_write_persists_without_remote_roster_and_preserves_orig
         .expect("persisted records lock");
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].message_key, MessageKey::from(origin_id));
+}
+
+#[test]
+fn peer_outbound_payload_excludes_local_activity_observation() {
+    let tempdir = tempdir().expect("tempdir");
+    let runtime = TestRuntime::new(None, DeliveryHarnessPath::NonClaude);
+    let observability = RecordingObservability::default();
+    let mut request = send_request(tempdir.path());
+    request.to = Some(
+        "recipient@test-team.peer.example.test"
+            .parse()
+            .expect("remote address"),
+    );
+    request.activity_observation = Some(ActivityObservation {
+        team: "test-team".parse().expect("team"),
+        member: "sender".parse().expect("agent"),
+        session_id: Some(SessionId::new("session-17").expect("session")),
+        pid: Some(17),
+    });
+
+    write_mail_with_runtime_impl(request, &observability, &runtime).expect("origin write");
+
+    let records = runtime.persisted_records.lock().expect("persisted records");
+    let peer_outbound = records[0].envelope.extra["peerOutbound"]
+        .as_object()
+        .expect("peer outbound metadata");
+    let payload = peer_outbound["request"].as_str().expect("request payload");
+    let payload: serde_json::Value = serde_json::from_str(payload).expect("request JSON");
+    assert!(
+        payload.get("activity_observation").is_none(),
+        "durable peer replay payload must not retain local session or PID metadata"
+    );
 }
 
 #[test]

--- a/crates/atm-core/src/send/post_write_tests.rs
+++ b/crates/atm-core/src/send/post_write_tests.rs
@@ -396,6 +396,7 @@ fn failed_peer_route_leaves_acknowledgement_source_pending() {
         caller_identity: AgentName::from_validated(TEST_SENDER),
         caller_chat_id: None,
         caller_team: TeamName::from_validated(TEST_TEAM),
+        activity_observation: None,
         message_id: source_id,
         reply_body: "acknowledged".to_string(),
     }

--- a/crates/atm-core/src/send/request.rs
+++ b/crates/atm-core/src/send/request.rs
@@ -93,15 +93,3 @@ fn validate_thread_append(
     envelope.acknowledged_at = None;
     Ok(())
 }
-#[allow(
-    dead_code,
-    reason = "Retained for the dormant direct post-send hook helper."
-)]
-pub(crate) fn qualified_sender_identity(
-    sender: &crate::types::AgentName,
-    sender_team: Option<&TeamName>,
-) -> String {
-    sender_team
-        .map(|team| format!("{sender}@{team}"))
-        .unwrap_or_else(|| sender.to_string())
-}

--- a/crates/atm-core/src/send/request.rs
+++ b/crates/atm-core/src/send/request.rs
@@ -1,0 +1,107 @@
+use std::path::Path;
+
+use crate::error::AtmError;
+use crate::schema::{AtmMessageId, InboxMessage};
+use crate::threading::{ThreadIndex, canonical_sender_identity, is_ephemeral};
+use crate::types::TeamName;
+
+use super::{SendMessageSource, file_policy, input};
+
+pub(super) fn resolve_message_body(
+    source: &SendMessageSource,
+    current_dir: &Path,
+    home_dir: &Path,
+    team_name: &TeamName,
+) -> Result<String, AtmError> {
+    match source {
+        SendMessageSource::Inline(message) => input::validate_message_text(message.clone()),
+        SendMessageSource::File { path, message } => {
+            input::validate_message_text(file_policy::process_file_reference(
+                path,
+                message.as_deref(),
+                team_name,
+                current_dir,
+                home_dir,
+            )?)
+        }
+    }
+}
+pub(super) fn prepare_threaded_message(
+    envelope: &mut InboxMessage,
+    inbox_messages: &[InboxMessage],
+) -> Result<(), AtmError> {
+    match (
+        envelope.parent_message_id,
+        envelope.thread_mode,
+        envelope.expires_at,
+    ) {
+        (None, None, _) => Ok(()),
+        (Some(_), Some(_), Some(_)) => Err(AtmError::validation(
+            "ephemeral messages may not participate in a message thread",
+        )),
+        (Some(parent_id), Some(_), None) => {
+            validate_thread_append(envelope, inbox_messages, parent_id)
+        }
+        (Some(_), None, _) | (None, Some(_), _) => Err(AtmError::validation(
+            "thread updates must set both parent_message_id and thread_mode",
+        )),
+    }
+}
+fn validate_thread_append(
+    envelope: &mut InboxMessage,
+    inbox_messages: &[InboxMessage],
+    parent_id: AtmMessageId,
+) -> Result<(), AtmError> {
+    let index = ThreadIndex::new(inbox_messages);
+    let parent = index.message(parent_id).ok_or_else(|| {
+        AtmError::validation(format!(
+            "thread parent message {} was not found in the recipient inbox",
+            parent_id
+        ))
+    })?;
+    if is_ephemeral(parent) {
+        return Err(AtmError::validation(
+            "ephemeral messages may not be updated or superseded",
+        ));
+    }
+    let root_id = index.root_id(parent_id).ok_or_else(|| {
+        AtmError::validation(format!(
+            "thread root could not be resolved for parent message {}",
+            parent_id
+        ))
+    })?;
+    let root = index.message(root_id).ok_or_else(|| {
+        AtmError::validation(format!(
+            "thread root message {} was not found in the recipient inbox",
+            root_id
+        ))
+    })?;
+    if canonical_sender_identity(root) != canonical_sender_identity(envelope) {
+        return Err(AtmError::validation(
+            "only the original sender may append details or supersede a message thread",
+        ));
+    }
+    if index.has_successor(parent_id) {
+        return Err(AtmError::validation(format!(
+            "message {} already has a successor; ATM threads are strictly linear",
+            parent_id
+        )));
+    }
+    let requires_ack = index.thread_requires_ack(parent_id);
+    envelope.requires_ack = requires_ack;
+    envelope.pending_ack_at = requires_ack.then_some(envelope.timestamp);
+    envelope.acknowledged_at = None;
+    Ok(())
+}
+#[allow(
+    dead_code,
+    reason = "Retained for the dormant direct post-send hook helper."
+)]
+pub(crate) fn qualified_sender_identity(
+    sender: &crate::types::AgentName,
+    sender_team: Option<&TeamName>,
+) -> String {
+    sender_team
+        .map(|team| format!("{sender}@{team}"))
+        .unwrap_or_else(|| sender.to_string())
+}

--- a/crates/atm-core/tests/mailbox_locking.rs
+++ b/crates/atm-core/tests/mailbox_locking.rs
@@ -862,6 +862,7 @@ fn cross_team_ack_closes_the_recipient_pending_row_and_delivers_reply_to_source_
             caller_identity: RECEIVER.parse().expect("receiver identity"),
             caller_chat_id: None,
             caller_team: RECEIVER_TEAM.parse().expect("receiver team"),
+            activity_observation: None,
             message_id,
             reply_body: "cross-team acknowledgement delivered".to_string(),
         },
@@ -1255,6 +1256,7 @@ impl Fixture {
             caller_identity: actor.parse().expect("caller"),
             caller_chat_id: None,
             caller_team: PRIMARY_TEAM.parse().expect("team"),
+            activity_observation: None,
             message_id,
             reply_body: reply_body.to_string(),
         }

--- a/crates/atm-daemon/src/https_transport.rs
+++ b/crates/atm-daemon/src/https_transport.rs
@@ -1000,11 +1000,13 @@ mod tests {
 
     use crate::active_connection_registry::ActiveConnectionRegistry;
 
+    use super::clear_remote_activity_observation;
     use atm_core::api::{
-        ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, RequestDeadline,
-        read_http_response, write_http_request, write_http_request_with_headers,
+        ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, MessageCollectionRequest,
+        RequestDeadline, read_http_response, write_http_request, write_http_request_with_headers,
     };
     use atm_core::boundary::RosterHarness;
+    use atm_core::caller_context::ActivityObservation;
     use atm_core::doctor::DoctorQuery;
     use atm_core::error::AtmError;
     use atm_core::graft::{
@@ -1015,7 +1017,7 @@ mod tests {
     use atm_core::schema::{AgentMember, AtmMessageId};
     use atm_core::send::{SendMessageSource, SendRequest, WriteRequest};
     use atm_core::test_support::{EnvGuard, ROLE_TEAM_LEAD};
-    use atm_core::types::{AgentName, HostName, IsoTimestamp, ReadSelection, TeamName};
+    use atm_core::types::{AgentName, HostName, IsoTimestamp, ReadSelection, SessionId, TeamName};
     use atm_runtime_test_support::{SQLITE_RUNTIME_PATH_ENV, open_sqlite_boundary};
     use atm_storage::{
         CertificateFingerprint, HttpsInterface, LocalCertificate, PrivateKeyRef, TrustedPeer,
@@ -1284,6 +1286,58 @@ mod tests {
             Some(AuthenticatedIngress::UntrustedSmoke(_))
         ));
         listener.shutdown().expect("shutdown listener");
+    }
+
+    #[test]
+    fn remote_ingress_clears_forged_activity_observation_for_write_and_receive() {
+        let observation = ActivityObservation {
+            team: "test-team".parse().expect("team"),
+            member: "sender".parse().expect("member"),
+            session_id: Some(SessionId::new("forged").expect("session")),
+            pid: Some(7),
+        };
+        let write = WriteRequest::new(
+            std::env::temp_dir(),
+            std::env::temp_dir(),
+            "sender".parse().expect("sender"),
+            "recipient@test-team",
+            "test-team".parse().expect("team"),
+            SendMessageSource::Inline("message".to_string()),
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("write")
+        .with_activity_observation(Some(observation.clone()));
+        let mut write = ApiRequest::Write(Box::new(write));
+        clear_remote_activity_observation(&mut write);
+        assert!(
+            matches!(write, ApiRequest::Write(ref request) if request.activity_observation.is_none())
+        );
+        let query = ReadQuery::new(
+            std::env::temp_dir(),
+            std::env::temp_dir(),
+            "sender".parse().expect("sender"),
+            None,
+            "test-team".parse().expect("team"),
+            ReadSelection::All,
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("query")
+        .with_activity_observation(Some(observation));
+        let mut receive = ApiRequest::Messages(Box::new(MessageCollectionRequest::Receive(query)));
+        clear_remote_activity_observation(&mut receive);
+        assert!(
+            matches!(receive, ApiRequest::Messages(ref request) if matches!(request.as_ref(), MessageCollectionRequest::Receive(query) if query.activity_observation.is_none()))
+        );
     }
 
     #[test]

--- a/crates/atm-daemon/src/https_transport.rs
+++ b/crates/atm-daemon/src/https_transport.rs
@@ -1341,6 +1341,84 @@ mod tests {
     }
 
     #[test]
+    fn peer_wire_strips_forged_activity_observation_before_routing() {
+        let router = Arc::new(RecordingRouter::default());
+        let listener = HttpsListenerSet::bind_plaintext_test(
+            &[HttpsInterface {
+                bind_addr: "127.0.0.1:0".parse().expect("bind address"),
+                advertise_host: "localhost".parse().expect("host"),
+                enabled: true,
+            }],
+            router.clone(),
+        )
+        .expect("start plaintext test listener");
+        let observation = ActivityObservation {
+            team: "test-team".parse().expect("team"),
+            member: "sender".parse().expect("member"),
+            session_id: Some(SessionId::new("forged").expect("session")),
+            pid: Some(7),
+        };
+        let write = WriteRequest::new(
+            std::env::temp_dir(),
+            std::env::temp_dir(),
+            "sender".parse().expect("sender"),
+            "recipient@test-team.example.invalid",
+            "test-team".parse().expect("team"),
+            SendMessageSource::Inline("message".to_string()),
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("write")
+        .with_activity_observation(Some(observation.clone()));
+        let write = RequestEnvelope::Write(Box::new(write));
+        let mut stream = TcpStream::connect(listener.listeners[0].address).expect("connect");
+        write_http_request_with_headers(
+            &mut stream,
+            &write,
+            &[(
+                super::PLAINTEXT_PEER_SOURCE_HOST_HEADER,
+                "smoke-peer.invalid",
+            )],
+        )
+        .expect("write peer request");
+        let _ = read_http_response(&mut stream, &write).expect("write response");
+
+        let query = ReadQuery::new(
+            std::env::temp_dir(),
+            std::env::temp_dir(),
+            "sender".parse().expect("sender"),
+            None,
+            "test-team".parse().expect("team"),
+            ReadSelection::All,
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("query")
+        .with_activity_observation(Some(observation));
+        let receive = RequestEnvelope::Receive(query);
+        let mut stream = TcpStream::connect(listener.listeners[0].address).expect("connect");
+        write_http_request(&mut stream, &receive).expect("write receive request");
+        let _ = read_http_response(&mut stream, &receive).expect("receive response");
+
+        let requests = router.requests.lock().expect("recorded requests");
+        assert!(matches!(
+            requests.as_slice(),
+            [ApiRequest::Write(write), ApiRequest::Messages(messages)]
+                if write.activity_observation.is_none()
+                    && matches!(messages.as_ref(), MessageCollectionRequest::Receive(query) if query.activity_observation.is_none())
+        ));
+        listener.shutdown().expect("shutdown listener");
+    }
+
+    #[test]
     #[serial_test::serial(env)]
     fn advertised_ip_peer_write_uses_real_dispatcher_persists_and_nudges() {
         crate::tests::install_retained_runtime_factory();

--- a/crates/atm-daemon/src/https_transport.rs
+++ b/crates/atm-daemon/src/https_transport.rs
@@ -14,8 +14,8 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use atm_core::api::{
-    ApiRequest, ApiRouter, AuthenticatedIngress, HttpFrameReader, RequestDeadline,
-    UntrustedSmokeProvenance, decode_request, read_http_request,
+    ApiRequest, ApiRouter, AuthenticatedIngress, HttpFrameReader, MessageCollectionRequest,
+    RequestDeadline, UntrustedSmokeProvenance, decode_request, read_http_request,
     read_http_response_with_frame_reader, write_http_request, write_http_request_with_headers,
     write_http_response,
 };
@@ -633,6 +633,7 @@ fn route_peer_http_request(
             .with_cause(source)
         })?;
     let mut request = decode_request(request)?;
+    clear_remote_activity_observation(&mut request);
     let ingress = match (authenticated_source_host, plaintext_source_host) {
         (Some(source_host), _) => {
             normalize_peer_write_for_local_delivery(&mut request, source_host);
@@ -662,6 +663,18 @@ fn route_peer_http_request(
 fn normalize_untrusted_smoke_write_for_local_delivery(request: &mut ApiRequest) {
     if let ApiRequest::Write(write) = request {
         write.authenticated_source_host = None;
+    }
+}
+
+fn clear_remote_activity_observation(request: &mut ApiRequest) {
+    match request {
+        ApiRequest::Write(write) => write.activity_observation = None,
+        ApiRequest::Messages(messages) => {
+            if let MessageCollectionRequest::Receive(query) = messages.as_mut() {
+                query.activity_observation = None;
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/atm-daemon/src/test_support.rs
+++ b/crates/atm-daemon/src/test_support.rs
@@ -32,6 +32,7 @@ pub(crate) fn test_ack_write_request(
         caller_identity,
         caller_chat_id: None,
         caller_team,
+        activity_observation: None,
         message_id,
         reply_body: reply_body.to_string(),
     }

--- a/crates/atm-daemon/src/tests/runtime_root/peer_reconciliation.rs
+++ b/crates/atm-daemon/src/tests/runtime_root/peer_reconciliation.rs
@@ -150,6 +150,7 @@ fn response_write_failure_keeps_source_pending_until_the_shared_write_retries() 
         caller_identity: "local-recipient".parse().expect("recipient"),
         caller_chat_id: None,
         caller_team: TEST_TEAM.parse().expect("team"),
+        activity_observation: None,
         message_id: source_message_id,
         reply_body: "acknowledged".to_string(),
     };

--- a/crates/atm-daemon/src/tests_post_send_graft_warning.rs
+++ b/crates/atm-daemon/src/tests_post_send_graft_warning.rs
@@ -183,6 +183,7 @@ fn dispatcher_ack_keeps_post_commit_graft_failure_out_of_admission_response() {
                 caller_identity: ROLE_TEAM_LEAD.parse().expect("caller"),
                 caller_chat_id: None,
                 caller_team: TEST_TEAM.parse().expect("team"),
+                activity_observation: None,
                 message_id: source_message_id,
                 reply_body: "ack reply".to_string(),
             }

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -13,6 +13,7 @@ use ::atm_graft::{
 use atm_core::ack::AckRequest;
 use atm_core::address::AgentAddress;
 use atm_core::boundary::PostSendHookEvent;
+use atm_core::caller_context::activity_observation_for_resolved_caller;
 use atm_core::error::{AtmError, AtmErrorCode};
 use atm_core::graft::AtmGraftClient;
 use atm_core::home::{atm_home, command_invocation_dir};
@@ -346,12 +347,13 @@ impl PyGraftSession {
 
     fn build_read_query(&self, seen_state_update: bool) -> PyResult<ReadQuery> {
         let (home_dir, current_dir) = Self::command_paths()?;
-        ReadQuery::new(
+        let team = self.caller_team()?;
+        let query = ReadQuery::new(
             home_dir,
             current_dir,
             self.caller.agent().clone(),
             None,
-            self.caller_team()?,
+            team.clone(),
             ReadSelection::All,
             false,
             seen_state_update,
@@ -362,8 +364,13 @@ impl PyGraftSession {
             None,
             None,
         )
-        .map_err(atm_error)
-        .map(|query| query.with_caller_chat_id(self.caller.chat_id().cloned()))
+        .map_err(atm_error)?;
+        Ok(query
+            .with_caller_chat_id(self.caller.chat_id().cloned())
+            .with_activity_observation(activity_observation_for_resolved_caller(
+                self.caller.agent(),
+                &team,
+            )))
     }
 }
 
@@ -395,6 +402,10 @@ impl PyGraftSession {
         )
         .map_err(atm_error)?
         .with_caller_chat_id(self.caller.chat_id().cloned());
+        let request = request.with_activity_observation(activity_observation_for_resolved_caller(
+            self.caller.agent(),
+            &self.caller_team()?,
+        ));
         self.client()?.send_message(request).map_err(atm_error)?;
         Ok(())
     }
@@ -420,6 +431,10 @@ impl PyGraftSession {
             caller_identity: self.caller.agent().clone(),
             caller_chat_id: self.caller.chat_id().cloned(),
             caller_team: self.caller_team()?,
+            activity_observation: activity_observation_for_resolved_caller(
+                self.caller.agent(),
+                &self.caller_team()?,
+            ),
             message_id: message_id
                 .parse()
                 .map_err(|error| PyValueError::new_err(format!("invalid message id: {error}")))?,

--- a/crates/atm-graft-python/src/lib.rs
+++ b/crates/atm-graft-python/src/lib.rs
@@ -388,12 +388,13 @@ impl PyGraftSession {
     #[pyo3(signature = (to, body, requires_ack=false))]
     fn send(&self, to: PyAgentAddress, body: String, requires_ack: bool) -> PyResult<()> {
         let (home_dir, current_dir) = Self::command_paths()?;
+        let caller_team = self.caller_team()?;
         let request = SendRequest::new(
             home_dir,
             current_dir,
             self.caller.agent().clone(),
             &to.to_typed()?.to_string(),
-            self.caller_team()?,
+            caller_team.clone(),
             SendMessageSource::Inline(body),
             None,
             requires_ack,
@@ -404,7 +405,7 @@ impl PyGraftSession {
         .with_caller_chat_id(self.caller.chat_id().cloned());
         let request = request.with_activity_observation(activity_observation_for_resolved_caller(
             self.caller.agent(),
-            &self.caller_team()?,
+            &caller_team,
         ));
         self.client()?.send_message(request).map_err(atm_error)?;
         Ok(())
@@ -425,15 +426,16 @@ impl PyGraftSession {
 
     fn acknowledge(&self, message_id: String, reply_body: String) -> PyResult<()> {
         let (home_dir, current_dir) = Self::command_paths()?;
+        let caller_team = self.caller_team()?;
         let request = AckRequest {
             home_dir,
             current_dir,
             caller_identity: self.caller.agent().clone(),
             caller_chat_id: self.caller.chat_id().cloned(),
-            caller_team: self.caller_team()?,
+            caller_team: caller_team.clone(),
             activity_observation: activity_observation_for_resolved_caller(
                 self.caller.agent(),
-                &self.caller_team()?,
+                &caller_team,
             ),
             message_id: message_id
                 .parse()

--- a/crates/atm-graft/examples/smoke_same_host.rs
+++ b/crates/atm-graft/examples/smoke_same_host.rs
@@ -201,6 +201,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         caller_identity: args.agent.parse().expect("caller"),
         caller_chat_id: None,
         caller_team: args.team.parse().expect("team"),
+        activity_observation: None,
         message_id: nudge.message_id,
         reply_body: "graft smoke ack reply".to_string(),
     })?;

--- a/crates/atm-graft/src/lib.rs
+++ b/crates/atm-graft/src/lib.rs
@@ -748,6 +748,7 @@ mod tests {
             caller_identity: AgentName::from_validated(TEST_LEAD),
             caller_chat_id: None,
             caller_team: TeamName::from_validated(TEST_TEAM),
+            activity_observation: None,
             message_id: atm_core::schema::AtmMessageId::new(),
             reply_body: "ack".to_string(),
         };

--- a/crates/atm/src/commands/ack.rs
+++ b/crates/atm/src/commands/ack.rs
@@ -58,6 +58,7 @@ impl AckCommand {
             caller_identity: caller_context.caller_identity,
             caller_chat_id: caller_context.caller_chat_id,
             caller_team: caller_context.caller_team,
+            activity_observation: caller_context.activity_observation,
             message_id,
             reply_body: self.reply,
         })

--- a/crates/atm/src/commands/peek.rs
+++ b/crates/atm/src/commands/peek.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use atm_core::read::{MAX_TIMEOUT_SECS, PeekQuery};
+use atm_core::read::{MAX_TIMEOUT_SECS, MailboxQueryFilters, PeekQuery};
 use atm_core::types::ReadSelection;
 use clap::Args;
 
@@ -113,20 +113,22 @@ impl PeekCommand {
         let _ = self.since_last_seen;
         let selection_mode = self.selection_mode();
         let timestamp_filter = self.since.as_deref().map(parse_timestamp).transpose()?;
-        PeekQuery::new(
+        let filters = MailboxQueryFilters::default()
+            .target_address_opt(self.target.as_deref())
+            .message_id_opt(self.message_id.as_deref())
+            .sender_opt(self.from.as_deref())
+            .timestamp_opt(timestamp_filter)
+            .task_opt(self.task.as_deref())
+            .contains_opt(self.contains.as_deref())
+            .timeout_secs_opt(self.timeout);
+        PeekQuery::from_filters(
             home_dir,
             current_dir,
             caller_context.caller_identity,
-            self.target.as_deref(),
             caller_context.caller_team,
             selection_mode,
             !self.no_since_last_seen && selection_mode != ReadSelection::All,
-            self.message_id.as_deref(),
-            self.from.as_deref(),
-            timestamp_filter,
-            self.task.as_deref(),
-            self.contains.as_deref(),
-            self.timeout,
+            filters,
         )
         .map_err(Into::into)
     }

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use atm_core::read::{MAX_TIMEOUT_SECS, ReadQuery};
+use atm_core::read::{MAX_TIMEOUT_SECS, MailboxQueryFilters, ReadQuery};
 use atm_core::types::ReadSelection;
 use clap::Args;
 
@@ -118,21 +118,22 @@ impl ReadCommand {
         let _ = self.since_last_seen;
         let selection_mode = self.selection_mode();
         let timestamp_filter = self.since.as_deref().map(parse_timestamp).transpose()?;
-        ReadQuery::new(
+        let filters = MailboxQueryFilters::default()
+            .message_id_opt(self.message_id.as_deref())
+            .sender_opt(self.from.as_deref())
+            .timestamp_opt(timestamp_filter)
+            .task_opt(self.task.as_deref())
+            .contains_opt(self.contains.as_deref())
+            .timeout_secs_opt(self.timeout);
+        ReadQuery::from_filters(
             home_dir,
             current_dir,
             caller_context.caller_identity,
-            None,
             caller_context.caller_team,
             selection_mode,
             !self.no_since_last_seen && selection_mode != ReadSelection::All,
             true,
-            self.message_id.as_deref(),
-            self.from.as_deref(),
-            timestamp_filter,
-            self.task.as_deref(),
-            self.contains.as_deref(),
-            self.timeout,
+            filters,
         )
         .map(|query| {
             query

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -134,7 +134,11 @@ impl ReadCommand {
             self.contains.as_deref(),
             self.timeout,
         )
-        .map(|query| query.with_caller_chat_id(caller_context.caller_chat_id))
+        .map(|query| {
+            query
+                .with_caller_chat_id(caller_context.caller_chat_id)
+                .with_activity_observation(caller_context.activity_observation)
+        })
         .map_err(Into::into)
     }
 

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -105,7 +105,11 @@ impl SendCommand {
             self.task_id,
             self.dry_run,
         )
-        .map(|request| request.with_caller_chat_id(caller_context.caller_chat_id))
+        .map(|request| {
+            request
+                .with_caller_chat_id(caller_context.caller_chat_id)
+                .with_activity_observation(caller_context.activity_observation)
+        })
         .map_err(Into::into)
     }
 

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -58,28 +58,6 @@ fn install_retained_runtime_factory() {
     });
 }
 
-// ARCH: reserved for future command-routing phase — entry-point types hold
-// per-command policy once send/receive gain context-sensitive dispatch logic.
-#[derive(Debug, Default)]
-pub(crate) struct SendCommandEntryPoint;
-
-impl SendCommandEntryPoint {
-    pub(crate) const fn new() -> Self {
-        Self
-    }
-}
-
-// ARCH: reserved for future command-routing phase — symmetric pair with
-// SendCommandEntryPoint for receive-side dispatch policy.
-#[derive(Debug, Default)]
-pub(crate) struct ReceiveCommandEntryPoint;
-
-impl ReceiveCommandEntryPoint {
-    pub(crate) const fn new() -> Self {
-        Self
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct InvocationDir<'a>(&'a Path);
 
@@ -206,8 +184,6 @@ pub(crate) struct CliComposition<'a> {
     transport: Arc<dyn DaemonApiClient + Send + Sync + 'a>,
     observability_port: &'a CliObservability,
     bootstrap_trace: Option<BootstrapTraceReport>,
-    send_command: SendCommandEntryPoint,
-    receive_command: ReceiveCommandEntryPoint,
 }
 
 impl fmt::Debug for CliComposition<'_> {
@@ -216,8 +192,6 @@ impl fmt::Debug for CliComposition<'_> {
             .field("transport", &"dyn DaemonApiClient")
             .field("observability_port", &"dyn ObservabilityPort")
             .field("bootstrap_trace", &self.bootstrap_trace)
-            .field("send_command", &self.send_command)
-            .field("receive_command", &self.receive_command)
             .finish()
     }
 }
@@ -232,8 +206,6 @@ impl<'a> CliComposition<'a> {
             transport,
             observability_port,
             bootstrap_trace: None,
-            send_command: SendCommandEntryPoint::new(),
-            receive_command: ReceiveCommandEntryPoint::new(),
         }
     }
 
@@ -248,8 +220,6 @@ impl<'a> CliComposition<'a> {
             transport,
             observability_port,
             bootstrap_trace: Some(bootstrap_trace),
-            send_command: SendCommandEntryPoint::new(),
-            receive_command: ReceiveCommandEntryPoint::new(),
         }
     }
 

--- a/crates/atm/src/composition.rs
+++ b/crates/atm/src/composition.rs
@@ -914,6 +914,7 @@ mod tests {
                 caller_identity: TEST_SENDER.parse().expect("caller"),
                 caller_chat_id: None,
                 caller_team: TEST_TEAM.parse().expect("team"),
+                activity_observation: None,
                 message_id,
                 reply_body: reply_body.to_string(),
             }

--- a/docs/plans/phase-aj/sprint-AJ3.md
+++ b/docs/plans/phase-aj/sprint-AJ3.md
@@ -1,7 +1,7 @@
 ---
 id: AJ.3
 title: CLI Wire Payload Integration
-status: planned
+status: complete
 branch: feature/pAJ-s3-cli-wire-payload
 worktree: ../atm-core-worktrees/feature/pAJ-s3-cli-wire-payload
 target: integrate/phase-aj


### PR DESCRIPTION
## Sprint AJ.3 — CLI Wire Payload Integration

Authoritative sprint doc: `docs/plans/phase-aj/sprint-AJ3.md`

Depends on AJ.1 (#735) and AJ.2 (#736) — per the AJ merge-forward rule this PR completes only after AJ.2's PR merges.

### Delivered
- Decomposed `send/mod.rs` and `read/mod.rs` below the 1000-non-test-line ceiling into `send/request.rs`/`read/request.rs` (precondition, no behavior change), removing `read/mod.rs`'s prior lint exclusion
- Additive `activity_observation` builders/fields on `WriteRequest`, `ReadQuery`, `AckRequest`
- CLI/graft attach only AJ.2-attested values
- HTTPS peer ingress strips the field from both Write and Receive before routing

### Validation (commit `f0813d5ef9bb1125a84a24e62686b08e6843b075`)
- `cargo build --workspace`: PASS
- `cargo clippy --workspace --all-targets -- -D warnings`: PASS
- `just lint`: PASS (24 checks)
- `cargo test -p agent-team-mail-core -p agent-team-mail -p atm-graft-python -p atm-daemon`: PASS

QA-1 (quality-mgr) to follow.