### PR TITLE
fix(triage-report): accept concatenated sprint-<prefix><number> naming

### DIFF
--- a/.claude/skills/triage-report/scripts/triage_report.py
+++ b/.claude/skills/triage-report/scripts/triage_report.py
@@ -266,14 +266,16 @@ def _phase_sprint(criteria: str) -> str | None:
     """Derive the human phase sprint label from a criteria filename.
 
     Criteria are conventionally named ``sprint-<prefix>-<number>`` (with an
-    optional suffix such as ``-pre``).  Prefixes are intentionally not
-    hard-coded to AI: the same report producer is used by every phase.  A
-    path that advertises the convention but cannot be parsed is rejected so
-    a row is never silently labelled with the wrong sprint.
+    optional suffix such as ``-pre``) or, in this repo's longer-standing
+    convention predating Phase AI, the separator-free ``sprint-<prefix><number>``
+    (e.g. ``sprint-AJ1.md``).  Prefixes are intentionally not hard-coded to any
+    phase: the same report producer is used by every phase.  A path that
+    advertises the convention but cannot be parsed is rejected so a row is
+    never silently labelled with the wrong sprint.
     """
     basename = Path(criteria).name
     match = re.search(
-        r"^sprint-([A-Za-z][A-Za-z0-9]*)[-.]([0-9]+)(?:-([A-Za-z][A-Za-z0-9]*))?",
+        r"^sprint-([A-Za-z][A-Za-z0-9]*?)[-.]?([0-9]+)(?:-([A-Za-z][A-Za-z0-9]*))?",
         basename,
     )
     if not match:

--- a/.claude/skills/triage-report/tests/test_triage_report.py
+++ b/.claude/skills/triage-report/tests/test_triage_report.py
@@ -335,6 +335,18 @@ def test_phase_sprint_accepts_non_ai_prefix_and_rejects_bad_convention():
         triage_report._phase_sprint("docs/sprint-ak-not-number.md")
 
 
+def test_phase_sprint_accepts_concatenated_prefix_and_number():
+    # This repo's longer-standing convention (phases AA through AJ, predating
+    # Phase AI's hyphenated style) has no separator between the letter prefix
+    # and the sprint number.
+    assert triage_report._phase_sprint("docs/plans/phase-aj/sprint-AJ1.md") == "AJ.1"
+    assert triage_report._phase_sprint("docs/plans/phase-aj/sprint-AJ10.md") == "AJ.10"
+    assert (
+        triage_report._phase_sprint("docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md")
+        == "AK.1-crosshost"
+    )
+
+
 def test_current_open_replay_beats_historical_merged_pr():
     merged = {
         "number": 631,


### PR DESCRIPTION
## Problem

\`triage_report.py\`'s \`_phase_sprint\` regex required a hyphen or dot between the letter prefix and sprint number (e.g. \`sprint-ai-21-...\`), matching Phase AI's naming convention. This repo's longer-standing convention — every lettered phase from AA through AJ — has no separator (\`sprint-AJ1.md\`, \`sprint-AK1-crosshost-salvage-audit.md\`), which the regex rejected outright as "unsupported sprint criteria filename".

Discovered while setting up \`.sprints/AJ/structure.ttl\` for Phase AJ's \`/sprint-report\` support.

## Fix

Loosened the prefix match to non-greedy and the separator to optional, so both the older concatenated form and the newer hyphenated form parse correctly.

## Validation
- \`python3 -m pytest .claude/skills/triage-report/tests/test_triage_report.py\`: 19/19 pass (18 pre-existing + 1 new regression test covering \`sprint-AJ1.md\`, \`sprint-AJ10.md\`, \`sprint-AK1-crosshost-salvage-audit.md\`)
- Re-ran \`triage_report.py --phase AJ\` end-to-end against the real \`integrate/phase-aj\` worktree — all 10 sprints now report correctly