### PR TITLE
Phase AJ: AJ.6 — Runtime observation snapshot projection

### DIFF
--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -466,7 +466,8 @@ mod tests {
 
     use super::{
         DAEMON_SOCKET_FILENAME, HeartbeatActivity, RequestEnvelope, ResponseEnvelope,
-        RuntimeLivenessState, RuntimeMemberState, RuntimeReadinessState, RuntimeStatusCounts,
+        RuntimeLivenessState, RuntimeMemberObservation, RuntimeMemberState, RuntimeReadinessState,
+        RuntimeStatusCounts,
         RuntimeStatusSnapshot, TeamMemberHeartbeatRequest, TeamMemberHeartbeatResponse,
         daemon_socket_path, daemon_socket_path_from_home,
     };
@@ -476,6 +477,7 @@ mod tests {
     use crate::send::{SendMessageSource, SendRequest};
     use crate::test_support::{EnvGuard, TEST_SENDER, TEST_TEAM};
     use crate::types::{AgentName, IsoTimestamp, ReadSelection, SessionId, TeamName};
+    use serde::Deserialize;
     use serial_test::serial;
     use tempfile::TempDir;
 
@@ -603,6 +605,71 @@ mod tests {
             serde_json::from_slice(&encoded).expect("decode runtime snapshot");
 
         assert_eq!(decoded, snapshot);
+    }
+
+    #[test]
+    fn runtime_status_snapshot_accepts_pre_aj_payload_without_members() {
+        let legacy_payload = serde_json::json!({
+            "liveness": "running",
+            "readiness": "ready",
+            "degraded_ingest": false,
+            "member_counts": {
+                "active_members": 1,
+                "idle_members": 0,
+                "offline_members": 0,
+                "unknown_members": 0
+            }
+        });
+
+        let decoded: RuntimeStatusSnapshot =
+            serde_json::from_value(legacy_payload).expect("decode pre-AJ snapshot");
+        assert!(decoded.members.is_empty());
+    }
+
+    #[test]
+    fn older_runtime_snapshot_reader_ignores_additive_members_field() {
+        #[derive(Debug, Deserialize, PartialEq, Eq)]
+        struct LegacyRuntimeStatusSnapshot {
+            liveness: RuntimeLivenessState,
+            readiness: RuntimeReadinessState,
+            #[serde(default)]
+            degraded_ingest: bool,
+            #[serde(default)]
+            member_counts: RuntimeStatusCounts,
+        }
+
+        let snapshot = RuntimeStatusSnapshot {
+            liveness: RuntimeLivenessState::Running,
+            readiness: RuntimeReadinessState::Ready,
+            detail: None,
+            singleton_owner_pid: None,
+            degraded_ingest: false,
+            member_counts: RuntimeStatusCounts::default(),
+            members: vec![RuntimeMemberObservation {
+                team: TeamName::from_validated("test-team"),
+                member: AgentName::from_validated("test-agent"),
+                state: RuntimeMemberState::Active,
+                session_id: Some(SessionId::new("session-1").expect("session")),
+                pid: Some(42),
+                last_active_at: None,
+                state_changed_by: None,
+                state_changed_at: None,
+                session_changed_by: None,
+                session_changed_at: None,
+            }],
+        };
+        let decoded: LegacyRuntimeStatusSnapshot =
+            serde_json::from_value(serde_json::to_value(snapshot).expect("encode snapshot"))
+                .expect("decode additive snapshot as legacy reader");
+        assert_eq!(
+            decoded,
+            LegacyRuntimeStatusSnapshot {
+                liveness: RuntimeLivenessState::Running,
+                readiness: RuntimeReadinessState::Ready,
+                degraded_ingest: false,
+                member_counts: RuntimeStatusCounts::default(),
+            }
+        );
     }
 
     #[test]

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -396,6 +396,28 @@ pub enum RuntimeMemberState {
     Active,
 }
 
+/// Current non-authoritative runtime observation for one roster member.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeMemberObservation {
+    pub team: TeamName,
+    pub member: AgentName,
+    pub state: RuntimeMemberState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<SessionId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_active_at: Option<IsoTimestamp>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_changed_by: Option<RuntimeObservationSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_changed_at: Option<IsoTimestamp>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_changed_by: Option<RuntimeObservationSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_changed_at: Option<IsoTimestamp>,
+}
+
 /// Process-level daemon liveness state used by doctor and status queries.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -435,6 +457,8 @@ pub struct RuntimeStatusSnapshot {
     pub degraded_ingest: bool,
     #[serde(default)]
     pub member_counts: RuntimeStatusCounts,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub members: Vec<RuntimeMemberObservation>,
 }
 #[cfg(test)]
 mod tests {
@@ -571,6 +595,7 @@ mod tests {
                 offline_members: 1,
                 unknown_members: 3,
             },
+            members: Vec::new(),
         };
 
         let encoded = serde_json::to_vec(&snapshot).expect("encode runtime snapshot");

--- a/crates/atm-core/src/protocol.rs
+++ b/crates/atm-core/src/protocol.rs
@@ -467,9 +467,8 @@ mod tests {
     use super::{
         DAEMON_SOCKET_FILENAME, HeartbeatActivity, RequestEnvelope, ResponseEnvelope,
         RuntimeLivenessState, RuntimeMemberObservation, RuntimeMemberState, RuntimeReadinessState,
-        RuntimeStatusCounts,
-        RuntimeStatusSnapshot, TeamMemberHeartbeatRequest, TeamMemberHeartbeatResponse,
-        daemon_socket_path, daemon_socket_path_from_home,
+        RuntimeStatusCounts, RuntimeStatusSnapshot, TeamMemberHeartbeatRequest,
+        TeamMemberHeartbeatResponse, daemon_socket_path, daemon_socket_path_from_home,
     };
     use crate::error::AtmError;
     use crate::error_codes::AtmErrorCode;

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -369,14 +369,7 @@ fn evict_status_cache_entry_if_needed(
 fn build_runtime_snapshot_all(cache: &RuntimeStatusCacheState) -> RuntimeStatusSnapshot {
     let mut counts = RuntimeStatusCounts::default();
     for record in cache.members.values() {
-        match record.state {
-            RuntimeMemberState::Active => counts.active_members += 1,
-            RuntimeMemberState::Idle => counts.idle_members += 1,
-            RuntimeMemberState::Offline => counts.offline_members += 1,
-            RuntimeMemberState::Unknown | RuntimeMemberState::IdentityConflict => {
-                counts.unknown_members += 1
-            }
-        }
+        tally_runtime_member_state(&mut counts, record.state);
     }
     let members = cache.members.iter().map(observation_from_record).collect();
     finish_runtime_snapshot(cache, counts, members)
@@ -393,14 +386,7 @@ fn build_runtime_snapshot_scoped(
         match cache.members.get(&key) {
             Some(record) => {
                 observations.push(observation_from_record((&key, record)));
-                match record.state {
-                    RuntimeMemberState::Active => counts.active_members += 1,
-                    RuntimeMemberState::Idle => counts.idle_members += 1,
-                    RuntimeMemberState::Offline => counts.offline_members += 1,
-                    RuntimeMemberState::Unknown | RuntimeMemberState::IdentityConflict => {
-                        counts.unknown_members += 1
-                    }
-                }
+                tally_runtime_member_state(&mut counts, record.state);
             }
             None => {
                 observations.push(RuntimeMemberObservation {
@@ -420,6 +406,17 @@ fn build_runtime_snapshot_scoped(
         }
     }
     finish_runtime_snapshot(cache, counts, observations)
+}
+
+fn tally_runtime_member_state(counts: &mut RuntimeStatusCounts, state: RuntimeMemberState) {
+    match state {
+        RuntimeMemberState::Active => counts.active_members += 1,
+        RuntimeMemberState::Idle => counts.idle_members += 1,
+        RuntimeMemberState::Offline => counts.offline_members += 1,
+        RuntimeMemberState::Unknown | RuntimeMemberState::IdentityConflict => {
+            counts.unknown_members += 1
+        }
+    }
 }
 
 fn observation_from_record(

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -5,9 +5,9 @@ use arc_swap::ArcSwap;
 use atm_core::doctor::{DoctorFinding, DoctorSeverity};
 use atm_core::error::AtmError;
 use atm_core::protocol::{
-    HeartbeatActivity, RuntimeLivenessState, RuntimeMemberState, RuntimeObservationSource,
-    RuntimeReadinessState, RuntimeStatusCounts, RuntimeStatusSnapshot, TeamMemberHeartbeatRequest,
-    TeamMemberHeartbeatResponse,
+    HeartbeatActivity, RuntimeLivenessState, RuntimeMemberObservation, RuntimeMemberState,
+    RuntimeObservationSource, RuntimeReadinessState, RuntimeStatusCounts, RuntimeStatusSnapshot,
+    TeamMemberHeartbeatRequest, TeamMemberHeartbeatResponse,
 };
 use atm_core::types::{AgentName, IsoTimestamp, SessionId, TeamName};
 use atm_storage::RosterStore;
@@ -305,7 +305,8 @@ fn build_runtime_snapshot_all(cache: &RuntimeStatusCacheState) -> RuntimeStatusS
             }
         }
     }
-    finish_runtime_snapshot(cache, counts)
+    let members = cache.members.iter().map(observation_from_record).collect();
+    finish_runtime_snapshot(cache, counts, members)
 }
 
 fn build_runtime_snapshot_scoped(
@@ -313,24 +314,62 @@ fn build_runtime_snapshot_scoped(
     scope: impl IntoIterator<Item = (TeamName, AgentName)>,
 ) -> RuntimeStatusSnapshot {
     let mut counts = RuntimeStatusCounts::default();
+    let mut observations = Vec::new();
     for (team, member) in scope {
         let key = RuntimeMemberKey { team, member };
-        match cache.members.get(&key).map(|record| record.state) {
-            Some(RuntimeMemberState::Active) => counts.active_members += 1,
-            Some(RuntimeMemberState::Idle) => counts.idle_members += 1,
-            Some(RuntimeMemberState::Offline) => counts.offline_members += 1,
-            Some(RuntimeMemberState::Unknown) | Some(RuntimeMemberState::IdentityConflict) => {
-                counts.unknown_members += 1
+        match cache.members.get(&key) {
+            Some(record) => {
+                observations.push(observation_from_record((&key, record)));
+                match record.state {
+                    RuntimeMemberState::Active => counts.active_members += 1,
+                    RuntimeMemberState::Idle => counts.idle_members += 1,
+                    RuntimeMemberState::Offline => counts.offline_members += 1,
+                    RuntimeMemberState::Unknown | RuntimeMemberState::IdentityConflict => {
+                        counts.unknown_members += 1
+                    }
+                }
             }
-            None => counts.unknown_members += 1,
+            None => {
+                observations.push(RuntimeMemberObservation {
+                    team: key.team,
+                    member: key.member,
+                    state: RuntimeMemberState::Unknown,
+                    session_id: None,
+                    pid: None,
+                    last_active_at: None,
+                    state_changed_by: None,
+                    state_changed_at: None,
+                    session_changed_by: None,
+                    session_changed_at: None,
+                });
+                counts.unknown_members += 1;
+            }
         }
     }
-    finish_runtime_snapshot(cache, counts)
+    finish_runtime_snapshot(cache, counts, observations)
+}
+
+fn observation_from_record(
+    (key, record): (&RuntimeMemberKey, &RuntimeMemberRecord),
+) -> RuntimeMemberObservation {
+    RuntimeMemberObservation {
+        team: key.team.clone(),
+        member: key.member.clone(),
+        state: record.state,
+        session_id: record.session_id.clone(),
+        pid: record.pid,
+        last_active_at: record.last_active_at,
+        state_changed_by: record.state_changed_by,
+        state_changed_at: record.state_changed_at,
+        session_changed_by: record.session_changed_by,
+        session_changed_at: record.session_changed_at,
+    }
 }
 
 fn finish_runtime_snapshot(
     cache: &RuntimeStatusCacheState,
     counts: RuntimeStatusCounts,
+    members: Vec<RuntimeMemberObservation>,
 ) -> RuntimeStatusSnapshot {
     let tracked_members = counts.active_members
         + counts.idle_members
@@ -363,6 +402,7 @@ fn finish_runtime_snapshot(
         singleton_owner_pid: Some(std::process::id()),
         degraded_ingest: cache.degraded_ingest,
         member_counts: counts,
+        members,
     }
 }
 

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -309,7 +309,7 @@ impl RuntimeStatusCache {
         members: impl IntoIterator<Item = (TeamName, AgentName)>,
     ) -> RuntimeStatusSnapshot {
         let cache = self.state.load();
-        build_runtime_snapshot_scoped(&cache, members)
+        build_runtime_snapshot_scoped(&cache, members.into_iter().take(MAX_STATUS_CACHE_ENTRIES))
     }
 }
 
@@ -761,6 +761,28 @@ mod tests {
         assert_eq!(snapshot.member_counts.idle_members, 1);
         assert_eq!(snapshot.member_counts.offline_members, 0);
         assert_eq!(snapshot.member_counts.unknown_members, 1);
+    }
+
+    #[test]
+    fn scoped_snapshot_caps_roster_projection_work() {
+        let status_cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let members = (0..=MAX_STATUS_CACHE_ENTRIES)
+            .map(|index| {
+                (
+                    team.clone(),
+                    format!("member-{index}").parse().expect("member"),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let snapshot = status_cache.snapshot_for_members_for_test(members);
+
+        assert_eq!(snapshot.members.len(), MAX_STATUS_CACHE_ENTRIES);
+        assert_eq!(
+            snapshot.member_counts.unknown_members,
+            MAX_STATUS_CACHE_ENTRIES
+        );
     }
 
     #[test]

--- a/crates/atm-daemon/src/tests/runtime_heartbeat.rs
+++ b/crates/atm-daemon/src/tests/runtime_heartbeat.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(not(windows))]
+use crate::test_support::connect_local_ipc_with_timeout;
 use atm_core::ack::AckRequest;
 
 #[test]

--- a/crates/atm-daemon/src/tests/runtime_heartbeat.rs
+++ b/crates/atm-daemon/src/tests/runtime_heartbeat.rs
@@ -151,9 +151,8 @@ fn heartbeat_and_local_dispatch_converge_on_cache() {
     };
     configure_test_local_ipc_timeouts(&read_stream);
     write_test_local_ipc_request(&mut read_stream, &read_request).expect("write read request");
-    let read_response =
-        atm_core::api::read_http_response(&mut read_stream, &read_request)
-            .expect("read read response");
+    let read_response = atm_core::api::read_http_response(&mut read_stream, &read_request)
+        .expect("read read response");
     assert!(matches!(read_response, ResponseEnvelope::Receive(_)));
     assert_eq!(
         status_cache.cached_session_id(test_team(), &ROLE_TEAM_LEAD.parse().expect("member")),

--- a/crates/atm-daemon/src/tests/runtime_heartbeat.rs
+++ b/crates/atm-daemon/src/tests/runtime_heartbeat.rs
@@ -1,4 +1,5 @@
 use super::*;
+use atm_core::ack::AckRequest;
 
 #[test]
 #[serial_test::serial(env)]
@@ -88,7 +89,7 @@ fn heartbeat_and_local_dispatch_converge_on_cache() {
             TEST_TEAM.parse().expect("team"),
             SendMessageSource::Inline("hello local ipc".to_string()),
             None,
-            false,
+            true,
             None,
             false,
         )
@@ -105,12 +106,55 @@ fn heartbeat_and_local_dispatch_converge_on_cache() {
     write_test_local_ipc_request(&mut stream, &request).expect("write send request");
     let response =
         atm_core::api::read_http_response(&mut stream, &request).expect("read send response");
-    match response {
+    let sent_message_id = match response {
         ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => {
             assert_eq!(outcome.outcome.as_str(), "sent");
+            outcome.message_id
         }
         other => panic!("unexpected response: {other:?}"),
-    }
+    };
+
+    let read_request = RequestEnvelope::Receive(
+        ReadQuery::new(
+            atm_home.clone(),
+            workspace_dir.clone(),
+            "qa-a".parse().expect("reader"),
+            None,
+            TEST_TEAM.parse().expect("team"),
+            ReadSelection::All,
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("read request"),
+    );
+    #[cfg(not(windows))]
+    let mut read_stream = {
+        let ipc_name = atm_core::protocol::daemon_local_ipc_name_from_path(&socket_path)
+            .expect("ipc name")
+            .into_owned();
+        connect_local_ipc_with_timeout(ipc_name, Duration::from_secs(5))
+            .expect("connect local IPC for read")
+    };
+    #[cfg(windows)]
+    let mut read_stream = match atm_daemon_client::try_connect(
+        &atm_daemon_client::resolve_daemon_local_ipc_endpoint().expect("endpoint"),
+    )
+    .expect("connect local HTTP for read")
+    {
+        atm_daemon_client::LocalDaemonConnection::TcpLoopback(stream) => stream,
+    };
+    configure_test_local_ipc_timeouts(&read_stream);
+    write_test_local_ipc_request(&mut read_stream, &read_request).expect("write read request");
+    let read_response =
+        atm_core::api::read_http_response(&mut read_stream, &read_request)
+            .expect("read read response");
+    assert!(matches!(read_response, ResponseEnvelope::Receive(_)));
     assert_eq!(
         status_cache.cached_session_id(test_team(), &ROLE_TEAM_LEAD.parse().expect("member")),
         Some(atm_core::types::SessionId::new("transport-session").expect("session")),
@@ -188,6 +232,38 @@ fn heartbeat_and_local_dispatch_converge_on_cache() {
     assert_eq!(
         status_cache.cached_session_id(test_team(), &ROLE_TEAM_LEAD.parse().expect("member")),
         Some(atm_core::types::SessionId::new("transport-session").expect("session")),
+    );
+
+    let ack = AckRequest {
+        home_dir: atm_home,
+        current_dir: workspace_dir,
+        caller_identity: "qa-a".parse().expect("ack caller"),
+        caller_chat_id: None,
+        caller_team: TEST_TEAM.parse().expect("team"),
+        activity_observation: None,
+        message_id: sent_message_id,
+        reply_body: "acknowledged over TCP".to_owned(),
+    };
+    let ack_request = RequestEnvelope::Write(Box::new(ack.into_write_request()));
+    let mut ack_stream = std::net::TcpStream::connect(record.ipv4_loopback.expect("loopback"))
+        .expect("connect loopback TCP ack");
+    atm_core::api::write_http_request_with_headers(
+        &mut ack_stream,
+        &ack_request,
+        &[(
+            atm_core::local_http::LOCAL_CAPABILITY_HEADER,
+            capability.as_str(),
+        )],
+    )
+    .expect("write TCP ack request");
+    let ack_response = atm_core::api::read_http_response(&mut ack_stream, &ack_request)
+        .expect("read TCP ack response");
+    assert!(
+        matches!(
+            ack_response,
+            ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(_))
+        ),
+        "unexpected TCP ack response: {ack_response:?}"
     );
 
     lifecycle.set_terminate_for_test(true);

--- a/crates/atm-daemon/src/tests/runtime_heartbeat.rs
+++ b/crates/atm-daemon/src/tests/runtime_heartbeat.rs
@@ -142,13 +142,11 @@ fn heartbeat_and_local_dispatch_converge_on_cache() {
             .expect("connect local IPC for read")
     };
     #[cfg(windows)]
-    let mut read_stream = match atm_daemon_client::try_connect(
-        &atm_daemon_client::resolve_daemon_local_ipc_endpoint().expect("endpoint"),
-    )
-    .expect("connect local HTTP for read")
-    {
-        atm_daemon_client::LocalDaemonConnection::TcpLoopback(stream) => stream,
-    };
+    let atm_daemon_client::LocalDaemonConnection::TcpLoopback(mut read_stream) =
+        atm_daemon_client::try_connect(
+            &atm_daemon_client::resolve_daemon_local_ipc_endpoint().expect("endpoint"),
+        )
+        .expect("connect local HTTP for read");
     configure_test_local_ipc_timeouts(&read_stream);
     write_test_local_ipc_request(&mut read_stream, &read_request).expect("write read request");
     let read_response = atm_core::api::read_http_response(&mut read_stream, &read_request)

--- a/crates/atm-daemon/src/tests/runtime_root.rs
+++ b/crates/atm-daemon/src/tests/runtime_root.rs
@@ -28,8 +28,7 @@ mod peer_reconciliation;
 mod runtime_heartbeat;
 use crate::test_support::{
     configure_test_local_ipc_timeouts, connect_daemon_local_ipc_until_ready,
-    connect_local_ipc_with_timeout,
-    write_test_local_ipc_request,
+    connect_local_ipc_with_timeout, write_test_local_ipc_request,
 };
 
 #[derive(Default)]

--- a/crates/atm-daemon/src/tests/runtime_root.rs
+++ b/crates/atm-daemon/src/tests/runtime_root.rs
@@ -28,7 +28,7 @@ mod peer_reconciliation;
 mod runtime_heartbeat;
 use crate::test_support::{
     configure_test_local_ipc_timeouts, connect_daemon_local_ipc_until_ready,
-    connect_local_ipc_with_timeout, write_test_local_ipc_request,
+    write_test_local_ipc_request,
 };
 
 #[derive(Default)]

--- a/crates/atm-daemon/src/tests/runtime_root.rs
+++ b/crates/atm-daemon/src/tests/runtime_root.rs
@@ -28,6 +28,7 @@ mod peer_reconciliation;
 mod runtime_heartbeat;
 use crate::test_support::{
     configure_test_local_ipc_timeouts, connect_daemon_local_ipc_until_ready,
+    connect_local_ipc_with_timeout,
     write_test_local_ipc_request,
 };
 

--- a/crates/atm/src/commands/members.rs
+++ b/crates/atm/src/commands/members.rs
@@ -4,16 +4,22 @@
 )]
 
 use anyhow::Result;
+use chrono::Utc;
+use atm_core::doctor::DoctorQuery;
 use atm_core::home;
+use atm_core::protocol::{RuntimeMemberObservation, RuntimeMemberState, RuntimeStatusSnapshot};
 use atm_core::team_admin::{self, MembersQuery};
+use atm_core::types::TeamName;
 use clap::Args;
 
 use crate::commands::caller_context::{
     CallerContextOverrides, CallerTeamOverride, resolve_cli_caller_context,
 };
 use crate::commands::retained_roster::with_retained_roster_store;
+use crate::composition::{
+    AtmHomePath, CliComposition, InvocationDir, resolve_command_runtime_context,
+};
 use crate::observability::CliObservability;
-use crate::output;
 
 #[derive(Debug, Args)]
 /// List the current member roster for one ATM team.
@@ -27,16 +33,18 @@ pub struct MembersCommand {
 
 impl MembersCommand {
     /// Execute the `atm members` command.
-    pub fn run(self, _observability: &CliObservability) -> Result<()> {
+    pub fn run(self, observability: &CliObservability) -> Result<()> {
         let json = self.json;
         let query = self.build_query()?;
+        let team = query.team.clone();
         let outcome = with_retained_roster_store(|roster_store| {
             team_admin::list_members_with_roster_store(roster_store, query)
         })?;
-        output::print_members_result(&outcome, json)
+        let runtime = self.runtime_snapshot(&team, observability);
+        print_members_result(&outcome, runtime.as_ref(), json)
     }
 
-    fn build_query(self) -> Result<MembersQuery> {
+    fn build_query(&self) -> Result<MembersQuery> {
         let current_dir = home::command_invocation_dir()?;
         let caller_context = resolve_cli_caller_context(CallerContextOverrides {
             identity_override: None,
@@ -49,6 +57,159 @@ impl MembersCommand {
             live_cwd: Some(current_dir),
         })
     }
+
+    fn runtime_snapshot(
+        &self,
+        team: &TeamName,
+        observability: &CliObservability,
+    ) -> Option<RuntimeStatusSnapshot> {
+        let (home_dir, current_dir) = resolve_command_runtime_context("members").ok()?;
+        let caller_team =
+            atm_core::caller_context::read_cli_team_from_env_or_warn("atm::members::runtime");
+        let caller_identity = atm_core::caller_context::read_cli_identity_from_env_or_warn(
+            "atm::members::runtime",
+        );
+        let query = DoctorQuery {
+            home_dir,
+            current_dir,
+            team_override: Some(team.clone()),
+            caller_team,
+            caller_identity,
+        };
+        let composition = CliComposition::bootstrap(
+            "members",
+            observability,
+            InvocationDir::new(&query.current_dir),
+            AtmHomePath::new(&query.home_dir),
+        )
+        .ok()?;
+        composition.doctor(query).ok()?.runtime_status
+    }
+}
+
+/// Render a session id using the stable, bounded human-readable form required by AJ.6.
+fn short_session_id_for_human(session_id: &atm_core::types::SessionId) -> String {
+    let mut short = session_id.as_ref().chars().take(12).collect::<String>();
+    if session_id.as_ref().chars().count() > 12 {
+        short.push('…');
+    }
+    short
+}
+
+fn print_members_result(
+    outcome: &atm_core::team_admin::MembersList,
+    runtime: Option<&RuntimeStatusSnapshot>,
+    json: bool,
+) -> Result<()> {
+    if json {
+        let mut value = serde_json::to_value(outcome)?;
+        if let Some(runtime) = runtime {
+            if let Some(members) = value.get_mut("members").and_then(serde_json::Value::as_array_mut)
+            {
+                for member in members {
+                    let Some(name) = member.get("name").and_then(serde_json::Value::as_str) else {
+                        continue;
+                    };
+                    let Some(observation) = runtime
+                        .members
+                        .iter()
+                        .find(|observation| observation.member.as_str() == name)
+                    else {
+                        continue;
+                    };
+                    let observation_value = serde_json::to_value(observation)?;
+                    if let Some(fields) = observation_value.as_object() {
+                        for (key, field) in fields {
+                            if key != "team" && key != "member" {
+                                member[key] = field.clone();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+
+    println!("Team: {}", outcome.team);
+    if outcome.members.is_empty() {
+        println!("  No members");
+        return Ok(());
+    }
+    for member in &outcome.members {
+        let home_dir = member.home_dir.as_path().display().to_string();
+        let observation = runtime.and_then(|snapshot| {
+            snapshot
+                .members
+                .iter()
+                .find(|observation| observation.member == member.name)
+        });
+        let runtime_text = render_runtime_observation(observation);
+        println!(
+            "  {} | type={} harness={} model={} home_dir={} live_cwd={} pane={}{}",
+            member.name,
+            empty_dash(&member.agent_type),
+            member.harness,
+            empty_dash(&member.model),
+            empty_dash(&home_dir),
+            empty_dash_opt(member.live_cwd.as_deref()),
+            empty_dash_opt(member.tmux_pane_id.as_deref()),
+            runtime_text,
+        );
+    }
+    Ok(())
+}
+
+fn render_runtime_observation(observation: Option<&RuntimeMemberObservation>) -> String {
+    let Some(observation) = observation.filter(|value| {
+        !(value.state == RuntimeMemberState::Unknown
+            && value.session_id.is_none()
+            && value.pid.is_none()
+            && value.last_active_at.is_none()
+            && value.state_changed_by.is_none()
+            && value.state_changed_at.is_none()
+            && value.session_changed_by.is_none()
+            && value.session_changed_at.is_none())
+    }) else {
+        return String::new();
+    };
+    let state = serde_json::to_value(observation.state)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_owned))
+        .unwrap_or_else(|| "unknown".to_owned());
+    let mut rendered = format!(" state={state}");
+    if let Some(changed_at) = observation.state_changed_at {
+        let age = (Utc::now() - changed_at.into_inner()).num_seconds().max(0);
+        let age = if age < 60 {
+            format!("{age}s")
+        } else if age < 3_600 {
+            format!("{}m", age / 60)
+        } else {
+            format!("{}h", age / 3_600)
+        };
+        rendered.push_str(&format!(" age={age}"));
+    }
+    if let Some(pid) = observation.pid {
+        rendered.push_str(&format!(" pid={pid}"));
+    }
+    if let Some(session_id) = &observation.session_id {
+        rendered.push_str(&format!(" session={}", short_session_id_for_human(session_id)));
+    }
+    rendered
+}
+
+fn empty_dash(value: &impl std::fmt::Display) -> String {
+    let rendered = value.to_string();
+    if rendered.is_empty() {
+        "-".to_owned()
+    } else {
+        rendered
+    }
+}
+
+fn empty_dash_opt(value: Option<&str>) -> String {
+    value.filter(|value| !value.is_empty()).unwrap_or("-").to_owned()
 }
 
 #[cfg(test)]
@@ -66,7 +227,7 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
-    use super::MembersCommand;
+    use super::{MembersCommand, short_session_id_for_human};
     use crate::observability::CliObservability;
 
     struct Fixture {
@@ -244,5 +405,11 @@ mod tests {
                 .run(&CliObservability::fallback())
                 .expect("members run");
         });
+    }
+
+    #[test]
+    fn short_session_id_uses_unicode_scalar_limit() {
+        let session = atm_core::types::SessionId::new("ééééééééééééé").expect("session");
+        assert_eq!(short_session_id_for_human(&session), "éééééééééééé…");
     }
 }

--- a/crates/atm/src/commands/members.rs
+++ b/crates/atm/src/commands/members.rs
@@ -4,12 +4,12 @@
 )]
 
 use anyhow::Result;
-use chrono::Utc;
 use atm_core::doctor::DoctorQuery;
 use atm_core::home;
 use atm_core::protocol::{RuntimeMemberObservation, RuntimeMemberState, RuntimeStatusSnapshot};
 use atm_core::team_admin::{self, MembersQuery};
 use atm_core::types::TeamName;
+use chrono::Utc;
 use clap::Args;
 
 use crate::commands::caller_context::{
@@ -66,9 +66,8 @@ impl MembersCommand {
         let (home_dir, current_dir) = resolve_command_runtime_context("members").ok()?;
         let caller_team =
             atm_core::caller_context::read_cli_team_from_env_or_warn("atm::members::runtime");
-        let caller_identity = atm_core::caller_context::read_cli_identity_from_env_or_warn(
-            "atm::members::runtime",
-        );
+        let caller_identity =
+            atm_core::caller_context::read_cli_identity_from_env_or_warn("atm::members::runtime");
         let query = DoctorQuery {
             home_dir,
             current_dir,
@@ -103,26 +102,27 @@ fn print_members_result(
 ) -> Result<()> {
     if json {
         let mut value = serde_json::to_value(outcome)?;
-        if let Some(runtime) = runtime {
-            if let Some(members) = value.get_mut("members").and_then(serde_json::Value::as_array_mut)
-            {
-                for member in members {
-                    let Some(name) = member.get("name").and_then(serde_json::Value::as_str) else {
-                        continue;
-                    };
-                    let Some(observation) = runtime
-                        .members
-                        .iter()
-                        .find(|observation| observation.member.as_str() == name)
-                    else {
-                        continue;
-                    };
-                    let observation_value = serde_json::to_value(observation)?;
-                    if let Some(fields) = observation_value.as_object() {
-                        for (key, field) in fields {
-                            if key != "team" && key != "member" {
-                                member[key] = field.clone();
-                            }
+        if let Some(runtime) = runtime
+            && let Some(members) = value
+                .get_mut("members")
+                .and_then(serde_json::Value::as_array_mut)
+        {
+            for member in members {
+                let Some(name) = member.get("name").and_then(serde_json::Value::as_str) else {
+                    continue;
+                };
+                let Some(observation) = runtime
+                    .members
+                    .iter()
+                    .find(|observation| observation.member.as_str() == name)
+                else {
+                    continue;
+                };
+                let observation_value = serde_json::to_value(observation)?;
+                if let Some(fields) = observation_value.as_object() {
+                    for (key, field) in fields {
+                        if key != "team" && key != "member" {
+                            member[key] = field.clone();
                         }
                     }
                 }
@@ -194,7 +194,10 @@ fn render_runtime_observation(observation: Option<&RuntimeMemberObservation>) ->
         rendered.push_str(&format!(" pid={pid}"));
     }
     if let Some(session_id) = &observation.session_id {
-        rendered.push_str(&format!(" session={}", short_session_id_for_human(session_id)));
+        rendered.push_str(&format!(
+            " session={}",
+            short_session_id_for_human(session_id)
+        ));
     }
     rendered
 }
@@ -209,7 +212,10 @@ fn empty_dash(value: &impl std::fmt::Display) -> String {
 }
 
 fn empty_dash_opt(value: Option<&str>) -> String {
-    value.filter(|value| !value.is_empty()).unwrap_or("-").to_owned()
+    value
+        .filter(|value| !value.is_empty())
+        .unwrap_or("-")
+        .to_owned()
 }
 
 #[cfg(test)]

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -13,7 +13,7 @@ use atm_core::read::ReadOutcome;
 use atm_core::send::SendOutcome;
 use atm_core::team_admin::{
     AddMemberOutcome, BackupOutcome, ClearNudgeTemplateOverrideOutcome,
-    DisableNudgeTemplateOverrideOutcome, MembersList, RemoveMemberOutcome, RestoreOutcome,
+    DisableNudgeTemplateOverrideOutcome, RemoveMemberOutcome, RestoreOutcome,
     RestorePlan, SetNudgeTemplateOverrideOutcome, TeamsList, UpdateMemberOutcome,
 };
 
@@ -507,35 +507,6 @@ pub fn print_teams_result(outcome: &TeamsList, json: bool) -> Result<()> {
     println!("Teams:");
     for team in &outcome.teams {
         println!("  {} ({})", team.name, team.member_count);
-    }
-    Ok(())
-}
-
-/// Print one members listing in human-readable or JSON form.
-pub fn print_members_result(outcome: &MembersList, json: bool) -> Result<()> {
-    if json {
-        println!("{}", serde_json::to_string_pretty(outcome)?);
-        return Ok(());
-    }
-
-    println!("Team: {}", outcome.team);
-    if outcome.members.is_empty() {
-        println!("  No members");
-        return Ok(());
-    }
-
-    for member in &outcome.members {
-        let home_dir = member.home_dir.as_path().display().to_string();
-        println!(
-            "  {} | type={} harness={} model={} home_dir={} live_cwd={} pane={}",
-            member.name,
-            empty_dash(&member.agent_type),
-            member.harness,
-            empty_dash(&member.model),
-            empty_dash(&home_dir),
-            empty_dash_opt(member.live_cwd.as_deref()),
-            empty_dash_opt(member.tmux_pane_id.as_deref())
-        );
     }
     Ok(())
 }

--- a/crates/atm/src/output.rs
+++ b/crates/atm/src/output.rs
@@ -13,8 +13,8 @@ use atm_core::read::ReadOutcome;
 use atm_core::send::SendOutcome;
 use atm_core::team_admin::{
     AddMemberOutcome, BackupOutcome, ClearNudgeTemplateOverrideOutcome,
-    DisableNudgeTemplateOverrideOutcome, RemoveMemberOutcome, RestoreOutcome,
-    RestorePlan, SetNudgeTemplateOverrideOutcome, TeamsList, UpdateMemberOutcome,
+    DisableNudgeTemplateOverrideOutcome, RemoveMemberOutcome, RestoreOutcome, RestorePlan,
+    SetNudgeTemplateOverrideOutcome, TeamsList, UpdateMemberOutcome,
 };
 
 /// Print one send result in human-readable or JSON form.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1394,13 +1394,17 @@ Architectural rules:
 The retained `members` surface is a local roster inspection service.
 
 Architectural rules:
-- it must succeed without daemon or hook-only state
+- it must succeed without daemon or hook-only state; live runtime enrichment is
+  best-effort and the command falls back to the durable local roster when the
+  daemon is unavailable
 - it must load the roster from local team config
 - it should order members deterministically, with `team-lead` first when
   present
 - it may surface persisted member metadata already present in config
-- later hook/session enrichment may be layered on without changing the base
-  local verification purpose of the command
+- daemon-sourced session, pid, state, and timestamp enrichment may be layered
+  on without changing the base local verification purpose of the command; the
+  enrichment is diagnostic telemetry and is never required for roster
+  inspection to succeed
 
 ## 7. Read Pipeline
 

--- a/docs/plans/phase-aj/sprint-AJ6.md
+++ b/docs/plans/phase-aj/sprint-AJ6.md
@@ -1,7 +1,7 @@
 ---
 id: AJ.6
 title: Runtime Observation Snapshot Projection
-status: complete
+status: in_progress
 branch: feature/pAJ-s6-runtime-observation-snapshot
 worktree: ../atm-core-worktrees/feature/pAJ-s6-runtime-observation-snapshot
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ6.md
+++ b/docs/plans/phase-aj/sprint-AJ6.md
@@ -1,7 +1,7 @@
 ---
 id: AJ.6
 title: Runtime Observation Snapshot Projection
-status: planned
+status: complete
 branch: feature/pAJ-s6-runtime-observation-snapshot
 worktree: ../atm-core-worktrees/feature/pAJ-s6-runtime-observation-snapshot
 target: integrate/phase-aj

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1110,7 +1110,7 @@ nudge, retry, admission, delivery, notification, or policy.
 | `AJ.3` | `planned` | `feature/pAJ-s3-cli-wire-payload` | transient local CLI/graft request metadata |
 | `AJ.4` | `complete` | `feature/pAJ-s4-daemon-cache-touch` | shared daemon cache merge after successful local dispatch |
 | `AJ.5` | `complete` | `feature/pAJ-s5-heartbeat-session` | heartbeat session observation convergence |
-| `AJ.6` | `complete` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
+| `AJ.6` | `in_progress` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
 | `AJ.7` | `planned` | `feature/pAJ-s7-runtime-observation-source-guard` | non-authoritative source-use guard |
 | `AJ.8` | `planned` | `feature/pAJ-s8-runtime-observation-boundary-record` | machine and human daemon boundary record |
 | `AJ.9` | `planned` | `feature/pAJ-s9-runtime-observation-contract-reconciliation` | requirements, ADR, architecture, and team-state reconciliation |

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1092,7 +1092,7 @@ nudge, retry, admission, delivery, notification, or policy.
 | `AJ.3` | `planned` | `feature/pAJ-s3-cli-wire-payload` | transient local CLI/graft request metadata |
 | `AJ.4` | `complete` | `feature/pAJ-s4-daemon-cache-touch` | shared daemon cache merge after successful local dispatch |
 | `AJ.5` | `complete` | `feature/pAJ-s5-heartbeat-session` | heartbeat session observation convergence |
-| `AJ.6` | `planned` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
+| `AJ.6` | `complete` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
 | `AJ.7` | `planned` | `feature/pAJ-s7-runtime-observation-source-guard` | non-authoritative source-use guard |
 | `AJ.8` | `planned` | `feature/pAJ-s8-runtime-observation-boundary-record` | machine and human daemon boundary record |
 | `AJ.9` | `planned` | `feature/pAJ-s9-runtime-observation-contract-reconciliation` | requirements, ADR, architecture, and team-state reconciliation |


### PR DESCRIPTION
## Sprint AJ.6 — Runtime Observation Snapshot Projection

Authoritative sprint doc: `docs/plans/phase-aj/sprint-AJ6.md`

Depends on AJ.5 (#740) — per the AJ merge-forward rule this PR completes after AJ.5's PR merges.

### Delivered
- `RuntimeMemberObservation` (additive), `RuntimeStatusSnapshot.members`
- `atm members` human/JSON projection of current session/pid, omitting default `Unknown` observation from human output
- Preserves existing snapshot fields, `member_counts`, `CLI_SCHEMA_VERSION`, and wire compatibility

### Validation (commit `00d675633261665b3f80276965013c29f70aaae0`)
- `cargo test -p atm-core -p atm-daemon -p atm`: PASS
- `cargo clippy -p atm-core -p atm-daemon -p atm --all-targets -- -D warnings`: PASS
- `git diff --check`: PASS

QA-1 (quality-mgr) to follow.