### PR TITLE
Phase AJ: AJ.9 — Runtime observation governing contract reconciliation

### DIFF
--- a/docs/adr/ADR-045-runtime-observation-attribution.md
+++ b/docs/adr/ADR-045-runtime-observation-attribution.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Accepted |
 | Scope | Phase AJ runtime observation |
 | Relates to | `REQ-CORE-RUNTIME-002`, `REQ-CORE-RUNTIME-004`, ADR-015 |
 
@@ -62,3 +62,13 @@ The existing roster view may render defined state age, pid, and a shortened
 session for its matching member. JSON retains raw values; human output omits
 default `Unknown` / absent-session telemetry and never uses display state to
 make a workflow decision.
+
+## Implementation evidence
+
+| Clause | Source symbol | Test evidence |
+| --- | --- | --- |
+| Accepted local/heartbeat ingress and no-overwrite merge | `RuntimeStatusCache::merge_observation` | `session_ended_preserves_last_known_session` |
+| Remote stripping and local-only cache touch | `clear_remote_activity_observation`, `TrustedActivityObservation::from_local` | HTTPS transport regression tests |
+| No conflict policy; changed metadata retained | `RuntimeStatusCache::record_heartbeat` | `heartbeat_replaces_pid_and_preserves_session_without_conflict_policy` |
+| Snapshot projection | `build_runtime_snapshot_scoped` | `runtime_status_cache_scoped_snapshot_reads_do_not_require_shared_locking` |
+| Default-deny source use | `.just/check_runtime_observation_boundary.py` | `test_runtime_observation_boundary.py` |

--- a/docs/adr/ADR-045-runtime-observation-attribution.md
+++ b/docs/adr/ADR-045-runtime-observation-attribution.md
@@ -67,8 +67,20 @@ make a workflow decision.
 
 | Clause | Source symbol | Test evidence |
 | --- | --- | --- |
-| Accepted local/heartbeat ingress and no-overwrite merge | `RuntimeStatusCache::merge_observation` | `session_ended_preserves_last_known_session` |
-| Remote stripping and local-only cache touch | `clear_remote_activity_observation`, `TrustedActivityObservation::from_local` | HTTPS transport regression tests |
-| No conflict policy; changed metadata retained | `RuntimeStatusCache::record_heartbeat` | `heartbeat_replaces_pid_and_preserves_session_without_conflict_policy` |
-| Snapshot projection | `build_runtime_snapshot_scoped` | `runtime_status_cache_scoped_snapshot_reads_do_not_require_shared_locking` |
-| Default-deny source use | `.just/check_runtime_observation_boundary.py` | `test_runtime_observation_boundary.py` |
+| Accepted local/heartbeat ingress and no-overwrite merge | `RuntimeStatusCache::merge_observation` | `normal_updates_never_regress_known_state_or_session_to_default` |
+| Remote stripping and local-only cache touch | `clear_remote_activity_observation`, `TrustedActivityObservation::from_local` | `peer_wire_strips_forged_activity_observation_before_routing` |
+| No conflict policy; changed metadata retained | `RuntimeStatusCache::record_heartbeat` | `changed_pid_or_session_is_retained_evidence_not_identity_conflict` |
+| Snapshot projection and roster scoping | `build_runtime_snapshot_scoped`, `RuntimeStatusCache::snapshot_for_members` | `runtime_status_cache_scoped_snapshot_reads_do_not_require_shared_locking`, `run_lists_member_roster_without_daemon` |
+| Human/JSON roster projection | `MembersCommand::print_members_result`, `render_runtime_observation` | `short_session_id_uses_unicode_scalar_limit`, `run_lists_member_roster_without_daemon` |
+| Cross-transport convergence | `DaemonRequestDispatcher::dispatch` | `heartbeat_and_local_dispatch_converge_on_cache`, `send_read_ack_reflects_each_caller_session_in_runtime_cache` |
+| Session provenance edge gating | `RuntimeStatusCache::merge_observation` | `session_changed_by_and_at_update_only_on_session_edge` |
+| PID replacement semantics | `ObservationMergeOutcome::pid_changed` | `pid_changed_response_is_false_for_initial_set_and_true_for_replacement` |
+| Lifecycle state mapping | `RuntimeStatusCache::record_heartbeat` | `unknown_and_offline_are_distinct_states_with_distinct_provenance`, `trusted_cli_activity_transitions_offline_or_idle_to_active` |
+| State-edge timestamps | `RuntimeStatusCache::merge_observation` | `state_changed_at_updates_only_on_real_state_transition`, `state_changed_by_updates_only_on_real_state_transition` |
+| Audit event emission | `RuntimeStatusCache::emit_metadata_change` | `session_and_pid_mutations_emit_exactly_one_audit_event`, `no_op_metadata_updates_emit_no_audit_event` |
+| Heartbeat activity ingress | `RuntimeStatusCache::record_heartbeat` | `heartbeat_session_id_round_trip` |
+| External-hook activity mapping | `HeartbeatActivity` conversion at heartbeat ingress | `heartbeat_session_id_round_trip` |
+| Identity/anomaly handling | `RuntimeStatusCache::merge_observation` | `pid_conflict_replacement_emits_one_audit_event_without_identity_conflict` |
+| Pre-AJ reader compatibility | `RuntimeStatusSnapshot` serde defaults | `runtime_status_snapshot_accepts_pre_aj_payload_without_members` |
+| Older reader additive-field compatibility | `RuntimeStatusSnapshot::members` additive field | `older_runtime_snapshot_reader_ignores_additive_members_field` |
+| Default-deny source use | `.just/check_runtime_observation_boundary.py` | `RuntimeObservationBoundaryTests` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1405,6 +1405,10 @@ Architectural rules:
   on without changing the base local verification purpose of the command; the
   enrichment is diagnostic telemetry and is never required for roster
   inspection to succeed
+- this daemon-free fallback is the CLI-side half of the runtime-health
+  observation boundary described in Section 21.6.3: `MembersCommand::run`
+  renders the retained roster even when `runtime_snapshot` cannot obtain a
+  daemon response, while any returned observation remains telemetry only
 
 ## 7. Read Pipeline
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3049,14 +3049,12 @@ Architectural rules:
   - aggregate active/idle/offline/unknown member counts
 - CLI code must not inspect private daemon state directly to synthesize health
   answers
-- **Phase AJ planned target — not implemented on the current baseline:** runtime
-  observation (state, pid, session, and timestamps) will be daemon-memory
+- Runtime observation (state, pid, session, and timestamps) is daemon-memory
   telemetry. Only heartbeat and successful environment-attested local CLI or
-  graft ingress may update it; it must never select routing, nudge, retry,
-  admission, delivery, notification, or policy behavior.
-- **Phase AJ planned target — not implemented on the current baseline:** a
-  changed trusted pid/session will replace the current observation and emit
-  retained diagnostic evidence. It must not reject ingress, create an
+  graft ingress update it; it never selects routing, nudge, retry, admission,
+  delivery, notification, or policy behavior.
+- Changed trusted pid/session replaces the current observation and emits
+  retained diagnostic evidence. It does not reject ingress, create an
   `IdentityConflict` lifecycle state, degrade readiness, or alter cache policy.
 
 Phase AA target doctor split:

--- a/docs/plans/phase-aj/sprint-AJ9.md
+++ b/docs/plans/phase-aj/sprint-AJ9.md
@@ -1,7 +1,7 @@
 ---
 id: AJ.9
 title: Runtime Observation Governing Contract Reconciliation
-status: planned
+status: complete
 branch: feature/pAJ-s9-runtime-observation-contract-reconciliation
 worktree: ../atm-core-worktrees/feature/pAJ-s9-runtime-observation-contract-reconciliation
 target: integrate/phase-aj

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1095,7 +1095,7 @@ nudge, retry, admission, delivery, notification, or policy.
 | `AJ.6` | `complete` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
 | `AJ.7` | `complete` | `feature/pAJ-s7-runtime-observation-source-guard` | non-authoritative source-use guard |
 | `AJ.8` | `complete` | `feature/pAJ-s8-runtime-observation-boundary-record` | machine and human daemon boundary record |
-| `AJ.9` | `planned` | `feature/pAJ-s9-runtime-observation-contract-reconciliation` | requirements, ADR, architecture, and team-state reconciliation |
+| `AJ.9` | `complete` | `feature/pAJ-s9-runtime-observation-contract-reconciliation` | requirements, ADR, architecture, and team-state reconciliation |
 | `AJ.10` | `planned` | `feature/pAJ-s10-runtime-observation-phase-closeout` | evidence-backed phase and status closeout |
 
 Each AJ successor begins immediately when its parent's development head is

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3521,9 +3521,8 @@ mail correctness.
 - `pid` is transient daemon-owned runtime state rather than durable roster
   truth and must not be persisted in SQLite
 
-> **Phase AJ planned target — not implemented on the current baseline.** The
-> following runtime-observation clauses become current only after AJ.9 compares
-> each claim with the merged AJ.1–AJ.8 source symbols and named tests.
+> **Phase AJ implemented contract.** The following clauses are reconciled with
+> the merged AJ.1–AJ.8 source and tests in ADR-045's evidence table.
 
 - `REQ-CORE-RUNTIME-004` Runtime observation is best-effort telemetry, not a
   business-policy input.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3540,7 +3540,7 @@ mail correctness.
   truth and must not be persisted in SQLite
 
 > **Phase AJ implemented contract.** The following clauses are reconciled with
-> the merged AJ.1–AJ.8 source and tests in ADR-045's evidence table.
+> the merged AJ.1–AJ.8 source and named tests in ADR-045's evidence table.
 
 - `REQ-CORE-RUNTIME-004` Runtime observation is best-effort telemetry, not a
   business-policy input.

--- a/docs/team-member-state.md
+++ b/docs/team-member-state.md
@@ -3,8 +3,8 @@
 This document is the authoritative contract for roster truth and the daemon's
 runtime observation after Phase AJ.
 
-> **Phase AJ planned target — not implemented on the current baseline.** The
-> rules and Rust shapes below describe the planned AJ end state. AJ.9 must
+> **Phase AJ implemented contract.** The rules and Rust shapes below describe
+> the reconciled AJ implementation. AJ.9 must
 > reconcile each clause with merged implementation source and named tests before
 > this marker is removed.
 

--- a/docs/team-member-state.md
+++ b/docs/team-member-state.md
@@ -4,9 +4,8 @@ This document is the authoritative contract for roster truth and the daemon's
 runtime observation after Phase AJ.
 
 > **Phase AJ implemented contract.** The rules and Rust shapes below describe
-> the reconciled AJ implementation. AJ.9 must
-> reconcile each clause with merged implementation source and named tests before
-> this marker is removed.
+> the reconciled AJ implementation. Clause-level source and test evidence is
+> recorded in ADR-045's implementation-evidence table.
 
 ## Ownership
 


### PR DESCRIPTION
## Sprint AJ.9 — Runtime Observation Governing Contract Reconciliation

Authoritative sprint doc: `docs/plans/phase-aj/sprint-AJ9.md`

Depends on AJ.8 (#743) — per the AJ merge-forward rule this PR completes after AJ.8's PR merges.

### Delivered
- Reconciled `docs/requirements.md`, `docs/adr/ADR-045-runtime-observation-attribution.md`, `docs/architecture.md`, and `docs/team-member-state.md` from planned to implemented contract
- Clause-to-source/test evidence table (per-clause source symbol + test name, not prose)
- No production code changes

### Validation (commit `6ad81304bf3b11c91533859101a360a7987843e2`)
- `just lint`: PASS (25 checks)
- `git diff --check`: PASS

QA-1 (quality-mgr) to follow.