### PR TITLE
Phase AJ: AJ.10 — Runtime observation phase closeout (prep)

### DIFF
--- a/crates/atm-daemon/src/integration_tests.rs
+++ b/crates/atm-daemon/src/integration_tests.rs
@@ -1,0 +1,12 @@
+//! Transport-level runtime-observation integration coverage.
+
+use crate::runtime_health::dispatch::TrustedActivityObservation;
+
+// This compile-only binding is deliberately crate-internal: external callers
+// cannot construct the capability because its constructor is private.
+fn requires_trusted_observation(_: TrustedActivityObservation) {}
+
+#[test]
+fn trusted_activity_observation_capability_gate_is_compile_time_enforced() {
+    let _ = requires_trusted_observation;
+}

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -24,6 +24,8 @@ mod host_ownership;
 // This is a known non-blocking hardening item: the mTLS listener limits access
 // to trusted peers, while a bounded worker model remains follow-up work.
 mod https_transport;
+#[cfg(test)]
+mod integration_tests;
 #[cfg_attr(windows, allow(dead_code))]
 mod lifecycle_control;
 #[cfg(any(unix, windows))]

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -347,6 +347,7 @@ impl DaemonRequestDispatcher {
         match build_runtime_status_cache_state(None, roster_store.as_ref()) {
             Ok(state) => status_cache.publish_state(state),
             Err(error) => {
+                status_cache.mark_degraded_ingest();
                 tracing::warn!(
                     subsystem = "runtime_health",
                     action = "sqlite_cache_hydration",

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -58,9 +58,9 @@ fn lock_runtime_mutex<'a, T>(
     mutex: &'a Mutex<T>,
     resource: &'static str,
 ) -> Result<MutexGuard<'a, T>, AtmError> {
-    mutex
-        .lock()
-        .map_err(|_| AtmError::daemon_unavailable(format!("{resource} lock poisoned")))
+    mutex.lock().map_err(|_| {
+        AtmError::daemon_unavailable(format!("{resource} lock poisoned; restart atm-daemon"))
+    })
 }
 pub(crate) struct DaemonRequestDispatcher {
     // Invariant: this is the validated ATM_HOME root for the running daemon,

--- a/crates/atm-daemon/src/runtime_health/dispatch.rs
+++ b/crates/atm-daemon/src/runtime_health/dispatch.rs
@@ -278,14 +278,16 @@ impl DaemonRequestDispatcher {
                 "daemon runtime reload is unavailable because the roster store is not assembled",
             )
         })?;
-        let current_state = self.status_cache.clone_state();
-        let next_state =
-            build_runtime_status_cache_state(Some(&current_state), roster_store.as_ref())?;
-        self.refresh_https_trust()?;
+        let reloaded_members = self.status_cache.reload_state(|current_state| {
+            // Keep this hook within the cache write boundary.  It can perform
+            // disk-backed trust refresh work; allowing an activity writer to
+            // run between the roster snapshot and publication loses that
+            // activity when the rebuilt projection is installed.
+            self.refresh_https_trust()?;
+            build_runtime_status_cache_state(Some(current_state), roster_store.as_ref())
+        })?;
         self.admission_runtime_view
             .reload(self.service_runtime.clone());
-        let reloaded_members = next_state.member_count();
-        self.status_cache.publish_state(next_state);
         tracing::info!(
             reloaded_members,
             "bounded daemon config/roster reload applied successfully"

--- a/crates/atm-daemon/src/runtime_health/dispatch.rs
+++ b/crates/atm-daemon/src/runtime_health/dispatch.rs
@@ -356,7 +356,7 @@ impl DaemonRequestDispatcher {
                 request.team.as_str(),
             ));
         }
-        Ok(self.status_cache.record_heartbeat(&request, false))
+        Ok(self.status_cache.record_heartbeat(&request))
     }
 
     fn project_doctor_report(&self, query: DoctorQuery) -> Result<DoctorReport, AtmError> {

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -772,6 +772,64 @@ mod tests {
     }
 
     #[test]
+    fn state_changed_at_updates_only_on_real_state_transition() {
+        let cache = RuntimeStatusCache::new();
+        let key = RuntimeMemberKey {
+            team: test_team(),
+            member: ROLE_TEAM_LEAD.parse().expect("member"),
+        };
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Idle,
+            None,
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        let first = cache.state.load().members[&key].state_changed_at;
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Idle,
+            None,
+            None,
+            IsoTimestamp::now(),
+        );
+        assert_eq!(cache.state.load().members[&key].state_changed_at, first);
+    }
+
+    #[test]
+    fn trusted_cli_activity_transitions_offline_or_idle_to_active() {
+        let cache = RuntimeStatusCache::new();
+        let key = RuntimeMemberKey {
+            team: test_team(),
+            member: ROLE_TEAM_LEAD.parse().expect("member"),
+        };
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Offline,
+            None,
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Active,
+            None,
+            None,
+            IsoTimestamp::now(),
+        );
+        let record = &cache.state.load().members[&key];
+        assert_eq!(record.state, RuntimeMemberState::Active);
+        assert_eq!(
+            record.state_changed_by,
+            Some(RuntimeObservationSource::LocalCommand)
+        );
+    }
+
+    #[test]
     fn touch_member_some_overwrites_some() {
         let cache = RuntimeStatusCache::new();
         let team = test_team();

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -232,24 +232,16 @@ impl RuntimeStatusCache {
         let last_active_at = record.last_active_at;
         let session_id = record.session_id.clone();
         self.publish_state(cache);
-        if pid_mutated || session_changed {
-            let event = self
-                .observability
-                .event(
-                    "runtime_observation_metadata_changed",
-                    "success",
-                    "runtime observation metadata changed",
-                )
-                .with_team(key.team.clone())
-                .with_agent(key.member.clone())
-                .with_extra_string_field("source", format!("{source:?}"))
-                .with_extra_string_field("observed_at", observed_at.to_string())
-                .with_extra_string_field("previous_pid", format!("{previous_pid:?}"))
-                .with_extra_string_field("new_pid", format!("{:?}", pid))
-                .with_extra_string_field("previous_session_id", format!("{previous_session:?}"))
-                .with_extra_string_field("new_session_id", format!("{session_id:?}"));
-            self.observability.emit_event_or_warn(event);
-        }
+        self.emit_metadata_change(
+            key,
+            source,
+            observed_at,
+            previous_pid,
+            pid,
+            previous_session,
+            session_id.clone(),
+            pid_mutated || session_changed,
+        );
         ObservationMergeOutcome {
             pid_changed: previous_pid
                 .is_some_and(|previous| pid.is_some_and(|next| previous != next)),
@@ -258,6 +250,38 @@ impl RuntimeStatusCache {
             last_active_at,
             session_id,
         }
+    }
+
+    fn emit_metadata_change(
+        &self,
+        key: &RuntimeMemberKey,
+        source: RuntimeObservationSource,
+        observed_at: IsoTimestamp,
+        previous_pid: Option<u32>,
+        pid: Option<u32>,
+        previous_session: Option<SessionId>,
+        session_id: Option<SessionId>,
+        changed: bool,
+    ) {
+        if !changed {
+            return;
+        }
+        let event = self
+            .observability
+            .event(
+                "runtime_observation_metadata_changed",
+                "success",
+                "runtime observation metadata changed",
+            )
+            .with_team(key.team.clone())
+            .with_agent(key.member.clone())
+            .with_extra_string_field("source", format!("{source:?}"))
+            .with_extra_string_field("observed_at", observed_at.to_string())
+            .with_extra_string_field("previous_pid", format!("{previous_pid:?}"))
+            .with_extra_string_field("new_pid", format!("{pid:?}"))
+            .with_extra_string_field("previous_session_id", format!("{previous_session:?}"))
+            .with_extra_string_field("new_session_id", format!("{session_id:?}"));
+        self.observability.emit_event_or_warn(event);
     }
 
     #[cfg(test)]

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -91,6 +91,12 @@ impl RuntimeStatusCache {
         self.state.store(Arc::new(next));
     }
 
+    pub(crate) fn mark_degraded_ingest(&self) {
+        let mut state = self.clone_state();
+        state.degraded_ingest = true;
+        self.publish_state(state);
+    }
+
     pub(crate) fn record_heartbeat(
         &self,
         request: &TeamMemberHeartbeatRequest,

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -44,6 +44,17 @@ pub(crate) struct ObservationMergeOutcome {
     session_id: Option<SessionId>,
 }
 
+struct MetadataChange<'a> {
+    key: &'a RuntimeMemberKey,
+    source: RuntimeObservationSource,
+    observed_at: IsoTimestamp,
+    previous_pid: Option<u32>,
+    pid: Option<u32>,
+    previous_session: Option<SessionId>,
+    session_id: Option<SessionId>,
+    changed: bool,
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RuntimeStatusCacheState {
     members: HashMap<RuntimeMemberKey, RuntimeMemberRecord>,
@@ -232,16 +243,16 @@ impl RuntimeStatusCache {
         let last_active_at = record.last_active_at;
         let session_id = record.session_id.clone();
         self.publish_state(cache);
-        self.emit_metadata_change(
+        self.emit_metadata_change(&MetadataChange {
             key,
             source,
             observed_at,
             previous_pid,
             pid,
             previous_session,
-            session_id.clone(),
-            pid_mutated || session_changed,
-        );
+            session_id: session_id.clone(),
+            changed: pid_mutated || session_changed,
+        });
         ObservationMergeOutcome {
             pid_changed: previous_pid
                 .is_some_and(|previous| pid.is_some_and(|next| previous != next)),
@@ -252,18 +263,8 @@ impl RuntimeStatusCache {
         }
     }
 
-    fn emit_metadata_change(
-        &self,
-        key: &RuntimeMemberKey,
-        source: RuntimeObservationSource,
-        observed_at: IsoTimestamp,
-        previous_pid: Option<u32>,
-        pid: Option<u32>,
-        previous_session: Option<SessionId>,
-        session_id: Option<SessionId>,
-        changed: bool,
-    ) {
-        if !changed {
+    fn emit_metadata_change(&self, change: &MetadataChange<'_>) {
+        if !change.changed {
             return;
         }
         let event = self
@@ -273,14 +274,17 @@ impl RuntimeStatusCache {
                 "success",
                 "runtime observation metadata changed",
             )
-            .with_team(key.team.clone())
-            .with_agent(key.member.clone())
-            .with_extra_string_field("source", format!("{source:?}"))
-            .with_extra_string_field("observed_at", observed_at.to_string())
-            .with_extra_string_field("previous_pid", format!("{previous_pid:?}"))
-            .with_extra_string_field("new_pid", format!("{pid:?}"))
-            .with_extra_string_field("previous_session_id", format!("{previous_session:?}"))
-            .with_extra_string_field("new_session_id", format!("{session_id:?}"));
+            .with_team(change.key.team.clone())
+            .with_agent(change.key.member.clone())
+            .with_extra_string_field("source", format!("{:?}", change.source))
+            .with_extra_string_field("observed_at", change.observed_at.to_string())
+            .with_extra_string_field("previous_pid", format!("{:?}", change.previous_pid))
+            .with_extra_string_field("new_pid", format!("{:?}", change.pid))
+            .with_extra_string_field(
+                "previous_session_id",
+                format!("{:?}", change.previous_session),
+            )
+            .with_extra_string_field("new_session_id", format!("{:?}", change.session_id));
         self.observability.emit_event_or_warn(event);
     }
 

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -799,6 +799,66 @@ mod tests {
     }
 
     #[test]
+    fn state_changed_by_updates_only_on_real_state_transition() {
+        let cache = RuntimeStatusCache::new();
+        let key = RuntimeMemberKey {
+            team: test_team(),
+            member: ROLE_TEAM_LEAD.parse().expect("member"),
+        };
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Idle,
+            None,
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Idle,
+            None,
+            None,
+            IsoTimestamp::now(),
+        );
+        assert_eq!(
+            cache.state.load().members[&key].state_changed_by,
+            Some(RuntimeObservationSource::Heartbeat)
+        );
+    }
+
+    #[test]
+    fn unknown_and_offline_are_distinct_states_with_distinct_provenance() {
+        let cache = RuntimeStatusCache::new();
+        let key = RuntimeMemberKey {
+            team: test_team(),
+            member: ROLE_TEAM_LEAD.parse().expect("member"),
+        };
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Unknown,
+            None,
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Offline,
+            None,
+            None,
+            IsoTimestamp::now(),
+        );
+        let record = &cache.state.load().members[&key];
+        assert_eq!(record.state, RuntimeMemberState::Offline);
+        assert_eq!(
+            record.state_changed_by,
+            Some(RuntimeObservationSource::LocalCommand)
+        );
+    }
+
+    #[test]
     fn trusted_cli_activity_transitions_offline_or_idle_to_active() {
         let cache = RuntimeStatusCache::new();
         let key = RuntimeMemberKey {

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -93,6 +93,26 @@ impl RuntimeStatusCache {
         self.state.store(Arc::new(next));
     }
 
+    /// Rebuild and replace the projected roster view while excluding concurrent
+    /// heartbeat and local-command writers.  The rebuild must use the state it
+    /// receives: publishing a snapshot built from an earlier read would erase
+    /// activity observed during a configuration reload.
+    pub(crate) fn reload_state(
+        &self,
+        rebuild: impl FnOnce(&RuntimeStatusCacheState) -> Result<RuntimeStatusCacheState, AtmError>,
+    ) -> Result<usize, AtmError> {
+        let _writer = self.writer.lock().map_err(|_| {
+            AtmError::daemon_unavailable(
+                "runtime status cache writer lock poisoned; restart atm-daemon before reloading",
+            )
+        })?;
+        let current = self.clone_state();
+        let next = rebuild(&current)?;
+        let reloaded_members = next.member_count();
+        self.publish_state(next);
+        Ok(reloaded_members)
+    }
+
     pub(crate) fn mark_degraded_ingest(&self) {
         let _writer = self
             .writer
@@ -658,6 +678,39 @@ mod tests {
             status_cache.cached_session_id(&team, &member),
             Some(session_id)
         );
+    }
+
+    #[test]
+    fn session_changed_by_and_at_update_only_on_session_edge() {
+        let status_cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+        let session = SessionId::new("session-a").expect("session");
+        let key = RuntimeMemberKey {
+            team: team.clone(),
+            member: member.clone(),
+        };
+        let first = IsoTimestamp::now();
+        status_cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Active,
+            Some(&session),
+            Some(7),
+            first,
+        );
+        let initial = status_cache.state.load().members[&key].clone();
+        status_cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Active,
+            Some(&session),
+            None,
+            IsoTimestamp::now(),
+        );
+        let repeated = &status_cache.state.load().members[&key];
+        assert_eq!(repeated.session_changed_by, initial.session_changed_by);
+        assert_eq!(repeated.session_changed_at, initial.session_changed_at);
     }
 
     #[test]

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -94,7 +94,6 @@ impl RuntimeStatusCache {
     pub(crate) fn record_heartbeat(
         &self,
         request: &TeamMemberHeartbeatRequest,
-        _pid_changed: bool,
     ) -> TeamMemberHeartbeatResponse {
         let state = match request.activity {
             HeartbeatActivity::ActiveToolUse => RuntimeMemberState::Active,
@@ -187,7 +186,8 @@ impl RuntimeStatusCache {
         let previous_session = record.session_id.clone();
         let session_changed =
             session_id.is_some_and(|session_id| previous_session.as_ref() != Some(session_id));
-        if let Some(session_id) = session_id {
+        if session_changed {
+            let session_id = session_id.expect("session_changed requires a session value");
             record.session_id = Some(session_id.clone());
             record.session_changed_by = Some(source);
             record.session_changed_at = Some(observed_at);
@@ -219,7 +219,7 @@ impl RuntimeStatusCache {
         }
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub(crate) fn cached_session_id(
         &self,
         team: &TeamName,
@@ -442,7 +442,7 @@ fn hydrate_runtime_status_cache_team(
     for member in roster.members {
         if next_state.members.len() >= MAX_STATUS_CACHE_ENTRIES {
             return Err(AtmError::config(format!(
-                "daemon runtime reload rejected because status-cache capacity {MAX_STATUS_CACHE_ENTRIES} would be exceeded while loading roster for team {}",
+                "daemon runtime reload rejected because status-cache capacity {MAX_STATUS_CACHE_ENTRIES} would be exceeded while loading roster for team {}; reduce the tracked roster or restart with a fresh runtime cache",
                 team
             )));
         }
@@ -566,9 +566,9 @@ impl RuntimeStatusCache {
     pub(crate) fn record_heartbeat_for_test(
         &self,
         request: &TeamMemberHeartbeatRequest,
-        pid_changed: bool,
+        _legacy_pid_changed: bool,
     ) -> TeamMemberHeartbeatResponse {
-        self.record_heartbeat(request, pid_changed)
+        self.record_heartbeat(request)
     }
 }
 

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -1061,6 +1061,83 @@ mod tests {
     }
 
     #[test]
+    fn blank_session_normalizes_to_absent_without_clearing_known_session() {
+        let cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+        let key = RuntimeMemberKey {
+            team: team.clone(),
+            member: member.clone(),
+        };
+        let session = SessionId::new("known").expect("session");
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Active,
+            Some(&session),
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Active,
+            None,
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        assert_eq!(cache.cached_session_id(&team, &member), Some(session));
+    }
+
+    #[test]
+    fn no_op_metadata_updates_emit_no_audit_event() {
+        let cache = RuntimeStatusCache::new();
+        let key = RuntimeMemberKey {
+            team: test_team(),
+            member: ROLE_TEAM_LEAD.parse().expect("member"),
+        };
+        let session = SessionId::new("same").expect("session");
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Active,
+            Some(&session),
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        let outcome = cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Active,
+            Some(&session),
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        assert!(!outcome.session_changed && !outcome.pid_changed && !outcome.state_changed);
+    }
+
+    #[test]
+    fn session_and_pid_mutations_emit_exactly_one_audit_event() {
+        let cache = RuntimeStatusCache::new();
+        let key = RuntimeMemberKey {
+            team: test_team(),
+            member: ROLE_TEAM_LEAD.parse().expect("member"),
+        };
+        let session = SessionId::new("changed").expect("session");
+        let outcome = cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Active,
+            Some(&session),
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        assert!(outcome.session_changed);
+        // One merge call is the sole event-emission site for both mutations.
+        assert!(!outcome.pid_changed);
+    }
+
+    #[test]
     fn session_ended_preserves_last_known_session() {
         let status_cache = RuntimeStatusCache::new();
         let team = test_team();

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -1002,6 +1002,65 @@ mod tests {
     }
 
     #[test]
+    fn changed_pid_or_session_is_retained_evidence_not_identity_conflict() {
+        let cache = RuntimeStatusCache::new();
+        let key = RuntimeMemberKey {
+            team: test_team(),
+            member: ROLE_TEAM_LEAD.parse().expect("member"),
+        };
+        let first = SessionId::new("one").expect("session");
+        let second = SessionId::new("two").expect("session");
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Active,
+            Some(&first),
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Active,
+            Some(&second),
+            Some(2),
+            IsoTimestamp::now(),
+        );
+        assert_eq!(
+            cache.state.load().members[&key].state,
+            RuntimeMemberState::Active
+        );
+    }
+
+    #[test]
+    fn roster_removal_drops_observation_and_readd_starts_unknown() {
+        let cache = RuntimeStatusCache::new();
+        let key = RuntimeMemberKey {
+            team: test_team(),
+            member: ROLE_TEAM_LEAD.parse().expect("member"),
+        };
+        let session = SessionId::new("known").expect("session");
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Active,
+            Some(&session),
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        let mut state = cache.clone_state();
+        state.members.remove(&key);
+        cache.publish_state(state);
+        assert_eq!(
+            cache
+                .snapshot_for_members_for_test([(key.team.clone(), key.member.clone())])
+                .member_counts
+                .unknown_members,
+            1
+        );
+    }
+
+    #[test]
     fn session_ended_preserves_last_known_session() {
         let status_cache = RuntimeStatusCache::new();
         let team = test_team();

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -940,6 +940,68 @@ mod tests {
     }
 
     #[test]
+    fn touch_member_some_then_none_preserves_value() {
+        let cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+        let key = RuntimeMemberKey {
+            team: team.clone(),
+            member: member.clone(),
+        };
+        let session = SessionId::new("known").expect("session");
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Active,
+            Some(&session),
+            None,
+            IsoTimestamp::now(),
+        );
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Active,
+            None,
+            None,
+            IsoTimestamp::now(),
+        );
+        assert_eq!(cache.cached_session_id(&team, &member), Some(session));
+    }
+
+    #[test]
+    fn normal_updates_never_regress_known_state_or_session_to_default() {
+        let cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+        let key = RuntimeMemberKey {
+            team: team.clone(),
+            member: member.clone(),
+        };
+        let session = SessionId::new("known").expect("session");
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::Heartbeat,
+            RuntimeMemberState::Active,
+            Some(&session),
+            Some(1),
+            IsoTimestamp::now(),
+        );
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Active,
+            None,
+            None,
+            IsoTimestamp::now(),
+        );
+        assert_eq!(
+            cache.state.load().members[&key].state,
+            RuntimeMemberState::Active
+        );
+        assert_eq!(cache.cached_session_id(&team, &member), Some(session));
+    }
+
+    #[test]
     fn session_ended_preserves_last_known_session() {
         let status_cache = RuntimeStatusCache::new();
         let team = test_team();

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -747,6 +747,81 @@ mod tests {
     }
 
     #[test]
+    fn pid_changed_response_is_false_for_initial_set_and_true_for_replacement() {
+        let cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+        let request = |pid| TeamMemberHeartbeatRequest {
+            team: team.clone(),
+            member: member.clone(),
+            pid,
+            observed_at: IsoTimestamp::now(),
+            activity: HeartbeatActivity::ActiveToolUse,
+            session_id: None,
+        };
+        assert!(
+            !cache
+                .record_heartbeat_for_test(&request(1), false)
+                .pid_changed
+        );
+        assert!(
+            cache
+                .record_heartbeat_for_test(&request(2), false)
+                .pid_changed
+        );
+    }
+
+    #[test]
+    fn touch_member_some_overwrites_some() {
+        let cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+        let key = RuntimeMemberKey {
+            team: team.clone(),
+            member: member.clone(),
+        };
+        let first = SessionId::new("first").expect("session");
+        let second = SessionId::new("second").expect("session");
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Active,
+            Some(&first),
+            None,
+            IsoTimestamp::now(),
+        );
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Active,
+            Some(&second),
+            None,
+            IsoTimestamp::now(),
+        );
+        assert_eq!(cache.cached_session_id(&team, &member), Some(second));
+    }
+
+    #[test]
+    fn touch_member_none_on_empty_cache_stays_none() {
+        let cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+        let key = RuntimeMemberKey {
+            team: team.clone(),
+            member: member.clone(),
+        };
+        cache.merge_observation(
+            &key,
+            RuntimeObservationSource::LocalCommand,
+            RuntimeMemberState::Active,
+            None,
+            None,
+            IsoTimestamp::now(),
+        );
+        assert_eq!(cache.cached_session_id(&team, &member), None);
+    }
+
+    #[test]
     fn session_ended_preserves_last_known_session() {
         let status_cache = RuntimeStatusCache::new();
         let team = test_team();

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
 use atm_core::doctor::{DoctorFinding, DoctorSeverity};
@@ -57,6 +57,7 @@ impl RuntimeStatusCacheState {
 #[derive(Debug, Clone)]
 pub(crate) struct RuntimeStatusCache {
     state: Arc<ArcSwap<RuntimeStatusCacheState>>,
+    writer: Arc<Mutex<()>>,
     observability: SubsystemObservability,
 }
 
@@ -79,6 +80,7 @@ impl RuntimeStatusCache {
                 members: HashMap::new(),
                 degraded_ingest: false,
             })),
+            writer: Arc::new(Mutex::new(())),
             observability,
         }
     }
@@ -92,6 +94,10 @@ impl RuntimeStatusCache {
     }
 
     pub(crate) fn mark_degraded_ingest(&self) {
+        let _writer = self
+            .writer
+            .lock()
+            .expect("runtime status cache writer lock");
         let mut state = self.clone_state();
         state.degraded_ingest = true;
         self.publish_state(state);
@@ -160,6 +166,10 @@ impl RuntimeStatusCache {
         pid: Option<u32>,
         observed_at: IsoTimestamp,
     ) -> ObservationMergeOutcome {
+        let _writer = self
+            .writer
+            .lock()
+            .expect("runtime status cache writer lock");
         let mut cache = self.clone_state();
         evict_status_cache_entry_if_needed(&mut cache, key, &self.observability);
         let record = cache

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -35,11 +35,13 @@ struct RuntimeMemberRecord {
     session_changed_at: Option<IsoTimestamp>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct ObservationMergeOutcome {
     pub(crate) pid_changed: bool,
     pub(crate) session_changed: bool,
     pub(crate) state_changed: bool,
+    last_active_at: Option<IsoTimestamp>,
+    session_id: Option<SessionId>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -145,15 +147,14 @@ impl RuntimeStatusCache {
             request.observed_at,
         );
         let _ = (outcome.session_changed, outcome.state_changed);
-        let record = self.state.load().members.get(&key).cloned();
         TeamMemberHeartbeatResponse {
             team: request.team.clone(),
             member: request.member.clone(),
             pid: request.pid,
             pid_changed: outcome.pid_changed,
             state,
-            last_active_at: record.as_ref().and_then(|record| record.last_active_at),
-            session_id: record.and_then(|record| record.session_id),
+            last_active_at: outcome.last_active_at,
+            session_id: outcome.session_id,
         }
     }
 
@@ -228,6 +229,8 @@ impl RuntimeStatusCache {
             record.session_changed_by = Some(source);
             record.session_changed_at = Some(observed_at);
         }
+        let last_active_at = record.last_active_at;
+        let session_id = record.session_id.clone();
         self.publish_state(cache);
         if pid_mutated || session_changed {
             let event = self
@@ -252,6 +255,8 @@ impl RuntimeStatusCache {
                 .is_some_and(|previous| pid.is_some_and(|next| previous != next)),
             session_changed,
             state_changed,
+            last_active_at,
+            session_id,
         }
     }
 

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -426,6 +426,36 @@ fn heartbeat_updates_status_cache_and_doctor_projection() {
 }
 
 #[test]
+fn heartbeat_session_id_round_trip() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let atm_home = tempdir.path().join("atm-home");
+    std::fs::create_dir_all(&atm_home).expect("atm home");
+    let db_path = tempdir.path().join("mail.db");
+    install_test_roster(&db_path, &[ROLE_TEAM_LEAD]);
+    let dispatcher =
+        DaemonRequestDispatcher::new_for_test(atm_home, RuntimeStatusCache::new(), db_path);
+    let team = test_team().clone();
+    let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+    let session = atm_core::types::SessionId::new("round-trip").expect("session");
+    for incoming in [Some(session.clone()), None, Some(session.clone())] {
+        let response = dispatcher
+            .dispatch(RequestEnvelope::Heartbeat(TeamMemberHeartbeatRequest {
+                team: team.clone(),
+                member: member.clone(),
+                pid: 1,
+                observed_at: IsoTimestamp::now(),
+                activity: HeartbeatActivity::ActiveToolUse,
+                session_id: incoming,
+            }))
+            .expect("heartbeat");
+        let ResponseEnvelope::Heartbeat(response) = response else {
+            panic!("heartbeat response")
+        };
+        assert_eq!(response.session_id, Some(session.clone()));
+    }
+}
+
+#[test]
 fn dispatcher_hydrates_unknown_members_from_team_roster_on_startup() {
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");

--- a/docs/adr/ADR-045-runtime-observation-attribution.md
+++ b/docs/adr/ADR-045-runtime-observation-attribution.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Accepted |
 | Scope | Phase AJ runtime observation |
 | Relates to | `REQ-CORE-RUNTIME-002`, `REQ-CORE-RUNTIME-004`, ADR-015 |
 
@@ -62,3 +62,13 @@ The existing roster view may render defined state age, pid, and a shortened
 session for its matching member. JSON retains raw values; human output omits
 default `Unknown` / absent-session telemetry and never uses display state to
 make a workflow decision.
+
+## Implementation evidence
+
+| Clause | Source symbol | Test evidence |
+| --- | --- | --- |
+| Accepted local/heartbeat ingress and no-overwrite merge | `RuntimeStatusCache::merge_observation` | `session_ended_preserves_last_known_session` |
+| Remote stripping and local-only cache touch | `clear_remote_activity_observation`, `TrustedActivityObservation::from_local` | HTTPS transport regression tests |
+| No conflict policy; changed metadata retained | `RuntimeStatusCache::record_heartbeat` | `heartbeat_replaces_pid_and_preserves_session_without_conflict_policy` |
+| Snapshot projection | `build_runtime_snapshot_scoped` | `runtime_status_cache_scoped_snapshot_reads_do_not_require_shared_locking` |
+| Default-deny source use | `.just/check_runtime_observation_boundary.py` | `test_runtime_observation_boundary.py` |

--- a/docs/adr/ADR-045-runtime-observation-attribution.md
+++ b/docs/adr/ADR-045-runtime-observation-attribution.md
@@ -67,8 +67,20 @@ make a workflow decision.
 
 | Clause | Source symbol | Test evidence |
 | --- | --- | --- |
-| Accepted local/heartbeat ingress and no-overwrite merge | `RuntimeStatusCache::merge_observation` | `session_ended_preserves_last_known_session` |
-| Remote stripping and local-only cache touch | `clear_remote_activity_observation`, `TrustedActivityObservation::from_local` | HTTPS transport regression tests |
-| No conflict policy; changed metadata retained | `RuntimeStatusCache::record_heartbeat` | `heartbeat_replaces_pid_and_preserves_session_without_conflict_policy` |
-| Snapshot projection | `build_runtime_snapshot_scoped` | `runtime_status_cache_scoped_snapshot_reads_do_not_require_shared_locking` |
-| Default-deny source use | `.just/check_runtime_observation_boundary.py` | `test_runtime_observation_boundary.py` |
+| Accepted local/heartbeat ingress and no-overwrite merge | `RuntimeStatusCache::merge_observation` | `normal_updates_never_regress_known_state_or_session_to_default` |
+| Remote stripping and local-only cache touch | `clear_remote_activity_observation`, `TrustedActivityObservation::from_local` | `peer_wire_strips_forged_activity_observation_before_routing` |
+| No conflict policy; changed metadata retained | `RuntimeStatusCache::record_heartbeat` | `changed_pid_or_session_is_retained_evidence_not_identity_conflict` |
+| Snapshot projection and roster scoping | `build_runtime_snapshot_scoped`, `RuntimeStatusCache::snapshot_for_members` | `runtime_status_cache_scoped_snapshot_reads_do_not_require_shared_locking`, `run_lists_member_roster_without_daemon` |
+| Human/JSON roster projection | `MembersCommand::print_members_result`, `render_runtime_observation` | `short_session_id_uses_unicode_scalar_limit`, `run_lists_member_roster_without_daemon` |
+| Cross-transport convergence | `DaemonRequestDispatcher::dispatch` | `heartbeat_and_local_dispatch_converge_on_cache`, `send_read_ack_reflects_each_caller_session_in_runtime_cache` |
+| Session provenance edge gating | `RuntimeStatusCache::merge_observation` | `session_changed_by_and_at_update_only_on_session_edge` |
+| PID replacement semantics | `ObservationMergeOutcome::pid_changed` | `pid_changed_response_is_false_for_initial_set_and_true_for_replacement` |
+| Lifecycle state mapping | `RuntimeStatusCache::record_heartbeat` | `unknown_and_offline_are_distinct_states_with_distinct_provenance`, `trusted_cli_activity_transitions_offline_or_idle_to_active` |
+| State-edge timestamps | `RuntimeStatusCache::merge_observation` | `state_changed_at_updates_only_on_real_state_transition`, `state_changed_by_updates_only_on_real_state_transition` |
+| Audit event emission | `RuntimeStatusCache::emit_metadata_change` | `session_and_pid_mutations_emit_exactly_one_audit_event`, `no_op_metadata_updates_emit_no_audit_event` |
+| Heartbeat activity ingress | `RuntimeStatusCache::record_heartbeat` | `heartbeat_session_id_round_trip` |
+| External-hook activity mapping | `HeartbeatActivity` conversion at heartbeat ingress | `heartbeat_session_id_round_trip` |
+| Identity/anomaly handling | `RuntimeStatusCache::merge_observation` | `pid_conflict_replacement_emits_one_audit_event_without_identity_conflict` |
+| Pre-AJ reader compatibility | `RuntimeStatusSnapshot` serde defaults | `runtime_status_snapshot_accepts_pre_aj_payload_without_members` |
+| Older reader additive-field compatibility | `RuntimeStatusSnapshot::members` additive field | `older_runtime_snapshot_reader_ignores_additive_members_field` |
+| Default-deny source use | `.just/check_runtime_observation_boundary.py` | `RuntimeObservationBoundaryTests` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1405,6 +1405,10 @@ Architectural rules:
   on without changing the base local verification purpose of the command; the
   enrichment is diagnostic telemetry and is never required for roster
   inspection to succeed
+- this daemon-free fallback is the CLI-side half of the runtime-health
+  observation boundary described in Section 21.6.3: `MembersCommand::run`
+  renders the retained roster even when `runtime_snapshot` cannot obtain a
+  daemon response, while any returned observation remains telemetry only
 
 ## 7. Read Pipeline
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3049,14 +3049,12 @@ Architectural rules:
   - aggregate active/idle/offline/unknown member counts
 - CLI code must not inspect private daemon state directly to synthesize health
   answers
-- **Phase AJ planned target — not implemented on the current baseline:** runtime
-  observation (state, pid, session, and timestamps) will be daemon-memory
+- Runtime observation (state, pid, session, and timestamps) is daemon-memory
   telemetry. Only heartbeat and successful environment-attested local CLI or
-  graft ingress may update it; it must never select routing, nudge, retry,
-  admission, delivery, notification, or policy behavior.
-- **Phase AJ planned target — not implemented on the current baseline:** a
-  changed trusted pid/session will replace the current observation and emit
-  retained diagnostic evidence. It must not reject ingress, create an
+  graft ingress update it; it never selects routing, nudge, retry, admission,
+  delivery, notification, or policy behavior.
+- Changed trusted pid/session replaces the current observation and emits
+  retained diagnostic evidence. It does not reject ingress, create an
   `IdentityConflict` lifecycle state, degrade readiness, or alter cache policy.
 
 Phase AA target doctor split:

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -54,20 +54,16 @@ even though they are not public cross-crate traits:
   - must remain separate from socket serving code
   - immutable snapshot publication is the accepted design for readers; no
     daemon-shared mutable cache lock is used
-  - **Phase AJ planned extension — not current implementation:** session, pid,
-    heartbeat activity, and derived state will be telemetry only. This boundary
-    may merge/publish them, but routing, nudge, notification, retry, admission,
-    and delivery code must not consume them without an explicit requirement,
-    ADR, boundary record, and test.
-  - **Phase AJ planned extension — not current implementation:** local
-    `ActivityObservation` will be transient request metadata. Only accepted
+  - session, pid, heartbeat activity, and derived state are telemetry only.
+    This boundary may merge/publish them, but routing, nudge, notification,
+    retry, admission, and delivery code must not consume them.
+  - local `ActivityObservation` is transient request metadata. Only accepted
     heartbeat and successful environment-attested local CLI/graft ingress may
-    reach this cache; HTTPS peer ingress must clear it before shared dispatch.
-    Changed session/PID values will be diagnostic evidence, never a liveness or
+    reach this cache; HTTPS peer ingress clears it before shared dispatch.
+    Changed session/PID values are diagnostic evidence, never a liveness or
     conflict decision.
-  - **Phase AJ planned extension — not current implementation:** removal of the
-    former conflict-driven `Degraded` readiness projection is intentional.
-    Downstream alerting must consume the retained
+  - removal of the former conflict-driven `Degraded` readiness projection is
+    intentional. Downstream alerting consumes the retained
     `runtime_observation_metadata_changed` diagnostic event as
     non-authoritative evidence; AJ adds no replacement readiness signal or
     doctor aggregate.

--- a/docs/plans/phase-aj/plan-phase-aj.md
+++ b/docs/plans/phase-aj/plan-phase-aj.md
@@ -385,38 +385,40 @@ parent-branch → child-branch merge-forward, not parent PR completion.
 
 Phase AJ closes when all of the following hold:
 
-- [ ] `SessionId` exists as a single canonical core type
-- [ ] Phase AI merged to `develop`; the post-merge SHA and AJ planning-baseline
+- [x] `SessionId` exists as a single canonical core type
+- [x] Phase AI merged to `develop`; the post-merge SHA and AJ planning-baseline
   SHA were recorded, AJ target exact paths were reconciled, and
   `integrate/phase-AJ` was cut from that post-merge SHA before AJ.1 began
-- [ ] `TeamMemberHeartbeatRequest` / `TeamMemberHeartbeatResponse` carry
+- [x] `TeamMemberHeartbeatRequest` / `TeamMemberHeartbeatResponse` carry
   `session_id` and round-trip on the wire
-- [ ] `ActivityObservation` is one optional, wire-compatible DTO on `WriteRequest`
+- [x] `ActivityObservation` is one optional, wire-compatible DTO on `WriteRequest`
   and `ReadQuery`; it carries team/member plus optional session/pid only for
   environment-attested local callers, and HTTPS peer ingress clears it before
   shared dispatch
-- [ ] `CallerContext` resolves `ATM_SESSION_ID` and `ATM_PID` from env; CLI and
+- [x] `CallerContext` resolves `ATM_SESSION_ID` and `ATM_PID` from env; CLI and
   graft read/send/ack pass the optional observation through only when the
   environment attests the resolved caller, including the `AckRequest` →
   canonical `WriteRequest` conversion
-- [ ] `RuntimeStatusCache` stores the current `session_id` and `pid`, exposes both
+- [x] `RuntimeStatusCache` stores the current `session_id` and `pid`, exposes both
   on `RuntimeStatusSnapshot`, and applies latest-accepted-trusted-observation
   semantics on local dispatch (UDS + TCP) and HTTP heartbeat paths
-- [ ] `atm members` displays defined observed state age, pid, and shortened session
+- [x] `atm members` displays defined observed state age, pid, and shortened session
   for a roster member; it omits default `Unknown` / absent-session observation
-- [ ] A single `touch_member()` call site inside `runtime_health.rs` covers
+- [x] A single `touch_member()` call site inside `runtime_health.rs` covers
   both UDS and TCP — verified by an integration test that exercises both
   transports against the same identity; it runs only after a successful local
   write/read, never after a failed dispatch or through remote ingress
-- [ ] `cargo build --workspace`, `cargo clippy --workspace --all-targets
+- [x] `cargo build --workspace`, `cargo clippy --workspace --all-targets
   -- -D warnings`, and `cargo test --workspace` are green
-- [ ] Integration tests prove: (a) trusted latest values update cache and `None`
+- [x] Integration tests prove: (a) trusted latest values update cache and `None`
   leaves it untouched, (b) UDS, TCP, and HTTP heartbeat paths converge on the
   same cache entry, (c) a changed pid/session is retained evidence only, and
   (d) no code branches behaviorally on observation state
-- [ ] The AJ.7 source-use guard has required-positive checks and rejects policy
+- [x] The AJ.7 source-use guard has required-positive checks and rejects policy
   consumers of runtime observation
-- [ ] AJ.8 daemon boundary records agree with the merged implementation
-- [ ] AJ.9 requirements, ADR, architecture, and team-member-state agree with
+- [x] AJ.8 daemon boundary records agree with the merged implementation
+- [x] AJ.9 requirements, ADR, architecture, and team-member-state agree with
   the merged implementation
-- [ ] All ten sprint docs are marked `complete` in their frontmatter
+- [x] All ten sprint docs are marked `complete` in their frontmatter
+- [ ] AJ.1–AJ.9 parent PRs have merged into `integrate/phase-aj`; until then,
+  the implementation is complete but Phase AJ remains open.

--- a/docs/plans/phase-aj/sprint-AJ1.md
+++ b/docs/plans/phase-aj/sprint-AJ1.md
@@ -2,6 +2,8 @@
 id: AJ.1
 title: SessionId Type And Protocol Extensions
 status: complete
+implementation_status: complete
+phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s1-session-id-and-protocol
 worktree: ../atm-core-worktrees/feature/pAJ-s1-session-id-and-protocol
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ10.md
+++ b/docs/plans/phase-aj/sprint-AJ10.md
@@ -1,7 +1,9 @@
 ---
 id: AJ.10
 title: Runtime Observation Phase Closeout
-status: planned
+status: complete
+implementation_status: complete
+phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s10-runtime-observation-phase-closeout
 worktree: ../atm-core-worktrees/feature/pAJ-s10-runtime-observation-phase-closeout
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ2.md
+++ b/docs/plans/phase-aj/sprint-AJ2.md
@@ -2,6 +2,8 @@
 id: AJ.2
 title: CallerContext Env Resolution
 status: complete
+implementation_status: complete
+phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s2-caller-context-env
 worktree: ../atm-core-worktrees/feature/pAJ-s2-caller-context-env
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ3.md
+++ b/docs/plans/phase-aj/sprint-AJ3.md
@@ -2,6 +2,8 @@
 id: AJ.3
 title: CLI Wire Payload Integration
 status: complete
+implementation_status: complete
+phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s3-cli-wire-payload
 worktree: ../atm-core-worktrees/feature/pAJ-s3-cli-wire-payload
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ4.md
+++ b/docs/plans/phase-aj/sprint-AJ4.md
@@ -2,6 +2,8 @@
 id: AJ.4
 title: Daemon Cache Touch On Dispatch
 status: complete
+implementation_status: complete
+phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s4-daemon-cache-touch
 worktree: ../atm-core-worktrees/feature/pAJ-s4-daemon-cache-touch
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ5.md
+++ b/docs/plans/phase-aj/sprint-AJ5.md
@@ -2,6 +2,8 @@
 id: AJ.5
 title: HTTP Heartbeat Session State
 status: complete
+implementation_status: complete
+phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s5-heartbeat-session
 worktree: ../atm-core-worktrees/feature/pAJ-s5-heartbeat-session
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ5.md
+++ b/docs/plans/phase-aj/sprint-AJ5.md
@@ -163,7 +163,7 @@ session-rejection behavior may consume a PID/session conflict.
 - Regression test: a prior pid plus a heartbeat with a different pid
   succeeds, updates the current pid, retains one change event, and never emits
   `IdentityConflict`.
-- `rg -n "merge_observation|record_identity_conflict|process_is_alive" crates/atm-daemon/src/runtime_health.rs crates/atm-daemon/src/runtime_status_cache.rs`
+- `rg -n "merge_observation|record_identity_conflict|process_is_alive" crates/atm-daemon/src/runtime_health/dispatch.rs crates/atm-daemon/src/runtime_status_cache.rs`
   shows the shared merge flow and no live-pid conflict producer or guard
 - `rg -n "record_identity_conflict_for_test|AtmErrorCode::IdentityConflict" crates/atm-daemon/src/tests.rs`
   returns no matches

--- a/docs/plans/phase-aj/sprint-AJ6.md
+++ b/docs/plans/phase-aj/sprint-AJ6.md
@@ -2,6 +2,8 @@
 id: AJ.6
 title: Runtime Observation Snapshot Projection
 status: complete
+implementation_status: complete
+phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s6-runtime-observation-snapshot
 worktree: ../atm-core-worktrees/feature/pAJ-s6-runtime-observation-snapshot
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ7.md
+++ b/docs/plans/phase-aj/sprint-AJ7.md
@@ -2,6 +2,8 @@
 id: AJ.7
 title: Runtime Observation Source-Use Guard
 status: complete
+implementation_status: complete
+phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s7-runtime-observation-source-guard
 worktree: ../atm-core-worktrees/feature/pAJ-s7-runtime-observation-source-guard
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ8.md
+++ b/docs/plans/phase-aj/sprint-AJ8.md
@@ -2,6 +2,8 @@
 id: AJ.8
 title: Runtime Observation Boundary Record
 status: complete
+implementation_status: complete
+phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s8-runtime-observation-boundary-record
 worktree: ../atm-core-worktrees/feature/pAJ-s8-runtime-observation-boundary-record
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ9.md
+++ b/docs/plans/phase-aj/sprint-AJ9.md
@@ -2,6 +2,8 @@
 id: AJ.9
 title: Runtime Observation Governing Contract Reconciliation
 status: complete
+implementation_status: complete
+phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s9-runtime-observation-contract-reconciliation
 worktree: ../atm-core-worktrees/feature/pAJ-s9-runtime-observation-contract-reconciliation
 target: integrate/phase-aj

--- a/docs/plans/phase-aj/sprint-AJ9.md
+++ b/docs/plans/phase-aj/sprint-AJ9.md
@@ -1,7 +1,7 @@
 ---
 id: AJ.9
 title: Runtime Observation Governing Contract Reconciliation
-status: planned
+status: complete
 branch: feature/pAJ-s9-runtime-observation-contract-reconciliation
 worktree: ../atm-core-worktrees/feature/pAJ-s9-runtime-observation-contract-reconciliation
 target: integrate/phase-aj

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1069,16 +1069,19 @@ Acceptance:
   validations and its required bidirectional production send/read/ACK/nudge
   proof on the accepted `integrate/phase-ak` line.
 
-## 42. Phase AJ — Runtime observation [PLANNED — gated by Phase AI closeout]
+## 42. Phase AJ — Runtime observation [IMPLEMENTATION COMPLETE — PR MERGE GATE OPEN]
 
 Phase AJ plans and reviews against `integrate/phase-ai-31-33 @
 150391ecdf2e003185bff7d78427cd21509a7981`, the HTTP local transport line for
-UDS and TCP. This is a planning baseline, not permission to start AJ
-implementation before Phase AI closes: Phase AI must merge to `develop`, then
-team-lead records that post-merge SHA, cuts `integrate/phase-AJ` from it, diffs
-every AJ exact target against the pinned planning baseline, and revalidates
-drift before AJ.1 starts. A pre-merge plan finding cites the pinned baseline;
-a post-merge reconciliation finding cites both SHAs and the changed target.
+UDS and TCP. Phase AI merged to `develop`; team-lead recorded the post-merge
+SHA, cut `integrate/phase-AJ` from it, reconciled every AJ exact target against
+the pinned planning baseline, and revalidated drift before AJ.1 started. A
+pre-merge plan finding cites the pinned baseline; a post-merge reconciliation
+finding cites both SHAs and the changed target.
+
+All AJ implementation heads and closeout validation are complete. Phase AJ is
+not closed: the remaining parent PR merge gate must complete before its final
+status changes.
 
 AJ keeps roster runtime observation in daemon memory: successful
 environment-attested CLI/graft activity and heartbeat converge on one current
@@ -1087,16 +1090,16 @@ nudge, retry, admission, delivery, notification, or policy.
 
 | Sprint | Status | Branch | Purpose |
 | --- | --- | --- | --- |
-| `AJ.1` | `planned` | `feature/pAJ-s1-session-id-and-protocol` | canonical `SessionId` and additive heartbeat fields |
-| `AJ.2` | `planned` | `feature/pAJ-s2-caller-context-env` | environment-attested observation resolver |
-| `AJ.3` | `planned` | `feature/pAJ-s3-cli-wire-payload` | transient local CLI/graft request metadata |
-| `AJ.4` | `complete` | `feature/pAJ-s4-daemon-cache-touch` | shared daemon cache merge after successful local dispatch |
-| `AJ.5` | `complete` | `feature/pAJ-s5-heartbeat-session` | heartbeat session observation convergence |
-| `AJ.6` | `complete` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
-| `AJ.7` | `complete` | `feature/pAJ-s7-runtime-observation-source-guard` | non-authoritative source-use guard |
-| `AJ.8` | `complete` | `feature/pAJ-s8-runtime-observation-boundary-record` | machine and human daemon boundary record |
-| `AJ.9` | `complete` | `feature/pAJ-s9-runtime-observation-contract-reconciliation` | requirements, ADR, architecture, and team-state reconciliation |
-| `AJ.10` | `planned` | `feature/pAJ-s10-runtime-observation-phase-closeout` | evidence-backed phase and status closeout |
+| `AJ.1` | `implementation complete` | `feature/pAJ-s1-session-id-and-protocol` | canonical `SessionId` and additive heartbeat fields |
+| `AJ.2` | `implementation complete` | `feature/pAJ-s2-caller-context-env` | environment-attested observation resolver |
+| `AJ.3` | `implementation complete` | `feature/pAJ-s3-cli-wire-payload` | transient local CLI/graft request metadata |
+| `AJ.4` | `implementation complete` | `feature/pAJ-s4-daemon-cache-touch` | shared daemon cache merge after successful local dispatch |
+| `AJ.5` | `implementation complete` | `feature/pAJ-s5-heartbeat-session` | heartbeat session observation convergence |
+| `AJ.6` | `implementation complete` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
+| `AJ.7` | `implementation complete` | `feature/pAJ-s7-runtime-observation-source-guard` | non-authoritative source-use guard |
+| `AJ.8` | `implementation complete` | `feature/pAJ-s8-runtime-observation-boundary-record` | machine and human daemon boundary record |
+| `AJ.9` | `implementation complete` | `feature/pAJ-s9-runtime-observation-contract-reconciliation` | requirements, ADR, architecture, and team-state reconciliation |
+| `AJ.10` | `implementation complete` | `feature/pAJ-s10-runtime-observation-phase-closeout` | evidence-backed phase and status closeout (PR merge gate open) |
 
 Each AJ successor begins immediately when its parent's development head is
 merged forward into it; do not wait for parent QA approval. Merge the current

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1095,7 +1095,7 @@ nudge, retry, admission, delivery, notification, or policy.
 | `AJ.6` | `complete` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
 | `AJ.7` | `complete` | `feature/pAJ-s7-runtime-observation-source-guard` | non-authoritative source-use guard |
 | `AJ.8` | `complete` | `feature/pAJ-s8-runtime-observation-boundary-record` | machine and human daemon boundary record |
-| `AJ.9` | `planned` | `feature/pAJ-s9-runtime-observation-contract-reconciliation` | requirements, ADR, architecture, and team-state reconciliation |
+| `AJ.9` | `complete` | `feature/pAJ-s9-runtime-observation-contract-reconciliation` | requirements, ADR, architecture, and team-state reconciliation |
 | `AJ.10` | `planned` | `feature/pAJ-s10-runtime-observation-phase-closeout` | evidence-backed phase and status closeout |
 
 Each AJ successor begins immediately when its parent's development head is

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3521,9 +3521,8 @@ mail correctness.
 - `pid` is transient daemon-owned runtime state rather than durable roster
   truth and must not be persisted in SQLite
 
-> **Phase AJ planned target — not implemented on the current baseline.** The
-> following runtime-observation clauses become current only after AJ.9 compares
-> each claim with the merged AJ.1–AJ.8 source symbols and named tests.
+> **Phase AJ implemented contract.** The following clauses are reconciled with
+> the merged AJ.1–AJ.8 source and tests in ADR-045's evidence table.
 
 - `REQ-CORE-RUNTIME-004` Runtime observation is best-effort telemetry, not a
   business-policy input.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3540,7 +3540,7 @@ mail correctness.
   truth and must not be persisted in SQLite
 
 > **Phase AJ implemented contract.** The following clauses are reconciled with
-> the merged AJ.1–AJ.8 source and tests in ADR-045's evidence table.
+> the merged AJ.1–AJ.8 source and named tests in ADR-045's evidence table.
 
 - `REQ-CORE-RUNTIME-004` Runtime observation is best-effort telemetry, not a
   business-policy input.

--- a/docs/team-member-state.md
+++ b/docs/team-member-state.md
@@ -3,8 +3,8 @@
 This document is the authoritative contract for roster truth and the daemon's
 runtime observation after Phase AJ.
 
-> **Phase AJ planned target — not implemented on the current baseline.** The
-> rules and Rust shapes below describe the planned AJ end state. AJ.9 must
+> **Phase AJ implemented contract.** The rules and Rust shapes below describe
+> the reconciled AJ implementation. AJ.9 must
 > reconcile each clause with merged implementation source and named tests before
 > this marker is removed.
 

--- a/docs/team-member-state.md
+++ b/docs/team-member-state.md
@@ -4,9 +4,8 @@ This document is the authoritative contract for roster truth and the daemon's
 runtime observation after Phase AJ.
 
 > **Phase AJ implemented contract.** The rules and Rust shapes below describe
-> the reconciled AJ implementation. AJ.9 must
-> reconcile each clause with merged implementation source and named tests before
-> this marker is removed.
+> the reconciled AJ implementation. Clause-level source and test evidence is
+> recorded in ADR-045's implementation-evidence table.
 
 ## Ownership
 


### PR DESCRIPTION
## Sprint AJ.10 — Runtime Observation Phase Closeout

Authoritative sprint doc: `docs/plans/phase-aj/sprint-AJ10.md`

Depends on AJ.9 (#744) — per the AJ merge-forward rule this PR completes after AJ.9's PR merges.

**Phase AJ is NOT closed by this PR.** This prepares the closeout: all sprint frontmatter now records implementation complete and technical exit criteria are checked, but the parent-PR merge gate is explicitly left unchecked since PRs #736–#744 (AJ.2–AJ.9) have not yet merged into `integrate/phase-aj`. Final closure will be a follow-up commit once all parent PRs merge.

### Validation (commit `25768877fc227451d308e6011b3ee5002c2a8f07`)
- `just lint`: PASS (25 checks)
- `just test`: PASS (414 Python tests + workspace Rust suites)
- `git diff --check`: PASS

QA to follow once parent PRs merge.