### PR TITLE
AK.4: Direct peer HTTP without retry

### DIFF
--- a/.just/lint_boundaries.py
+++ b/.just/lint_boundaries.py
@@ -103,6 +103,10 @@ IO_FORBIDDEN_SOURCE_PATTERNS: dict[str, tuple[str, ...]] = {
     "delivery_queue": (r"\bdelivery_queue\b", r"\bDeliveryQueue\b", r"\bqueue_delivery\s*\("),
     "delivery_state": (r"\bdelivery_state\b", r"\bDeliveryState\b"),
     "dns": (r"\b(?:lookup_host|to_socket_addrs|DnsResolver|resolve_peer_authority)\b",),
+    "dns_thread": (
+        r"\b(?:spawn|start)_(?:dns|resolver)[A-Za-z0-9_]*\s*\(",
+        r"\b(?:Dns|Resolver)[A-Za-z0-9_]*Thread\b",
+    ),
     "direct_socket_io": (
         r"\b(?:std|tokio)::net::",
         r"\b(?:Tcp|Udp|Unix)(?:Stream|Listener|Socket)\b",
@@ -131,6 +135,14 @@ IO_FORBIDDEN_SOURCE_PATTERNS: dict[str, tuple[str, ...]] = {
     ),
     "retry_queue": (r"\bretry_queue\b", r"\bRetryQueue\b", r"\bqueue_retry\s*\("),
     "retry_state": (r"\bretry_state\b", r"\bRetryState\b"),
+    "outbound_worker": (
+        r"\bspawn_(?:outbound|peer_delivery)[A-Za-z0-9_]*\s*\(",
+        r"\b(?:Outbound|PeerDelivery)[A-Za-z0-9_]*Worker\b",
+    ),
+    "retry": (
+        r"\b(?:retry|resend|backoff)_[A-Za-z0-9_]*\s*\(",
+        r"\b(?:Retry|Resend|Backoff)[A-Za-z0-9_]*(?:State|Policy|Worker|Queue)\b",
+    ),
     "router": (r"\brouter\b", r"\bRouter\b"),
     "socket_io": (
         r"\b(?:std|tokio)::net::",
@@ -138,6 +150,10 @@ IO_FORBIDDEN_SOURCE_PATTERNS: dict[str, tuple[str, ...]] = {
         r"\bsocket_io\b",
     ),
     "tls": (r"\b(?:TlsConnector|TlsAcceptor|rustls|ServerName)\b",),
+    "timer": (
+        r"\b(?:Timer|Interval|Scheduled)[A-Za-z0-9_]*(?:State|Worker|Queue|Task)\b",
+        r"\b(?:schedule|arm)_timer\s*\(",
+    ),
     "sqlite": (
         r"\b(?:rusqlite|sqlx)::",
         r"\b(?:Sqlite|SQLite)(?:Connection|Transaction|Store|Database|Pool|Backend)\b",

--- a/boundaries/atm-daemon/peer-http-adapter.toml
+++ b/boundaries/atm-daemon/peer-http-adapter.toml
@@ -1,0 +1,46 @@
+boundary_id = "BOUNDARY-PeerHttpAdapter-Daemon"
+owner_package = "atm-daemon"
+owner_crate_path = "atm_daemon"
+name = "PeerHttpListenerSet"
+
+[public]
+trait = "none"
+
+[implementation]
+type = "PeerHttpListenerSet"
+module = "atm_daemon::peer_http_listener"
+visibility = "pub(crate)"
+constructor = "pub(crate)"
+
+[composition]
+roots = ["atm_daemon::composition::RuntimeComposition::start"]
+
+[ownership]
+io_owns = ["configured_peer_listener_bind", "peer_http_accept", "bounded_peer_http_request", "direct_peer_http_send"]
+io_forbidden = ["sqlite", "dns_thread", "outbound_worker", "retry", "timer", "tls", "process_spawn"]
+
+[dependencies]
+allowed_dependents = []
+allowed_dependencies = ["atm-core", "atm-storage"]
+forbidden_edges = ["atm -> atm-daemon", "atm-graft -> atm-daemon"]
+
+[references]
+scope = "outside_owner_crate"
+forbidden = ["PeerHttpListenerSet", "PeerHttpListener", "send_peer_http_frames"]
+
+[contracts]
+request_types = ["WriteRequest", "RequestEnvelope::Write", "PeerHttpRuntimeConfig", "PeerHttpBindConfig"]
+response_types = ["ResponseEnvelope::Send"]
+error_types = ["AtmError"]
+
+[testing]
+allowed_test_double_paths = ["atm_daemon::peer_http_listener::tests::PeerWriteRecorder"]
+forbidden_test_bypasses = ["PeerHttpSender", "PeerHttpListenerMock", "AlternatePeerReceiver"]
+
+[enforcement]
+lint_rules = ["LINT-BOUNDARY-PEER-HTTP-ADAPTER"]
+review_gates = ["one_direct_sender", "one_peer_receiver", "no_outbound_worker", "no_tls_or_resolver_state"]
+
+[status]
+state = "active"
+notes = ["AK.4 replaces the deleted HttpsListenerSet with one configured plain-HTTP peer adapter."]

--- a/boundaries/atm-storage/message-store.toml
+++ b/boundaries/atm-storage/message-store.toml
@@ -28,7 +28,7 @@ scope = "outside_owner_crate"
 forbidden = []
 
 [contracts]
-request_types = ["Message", "MessageKey", "MessageQuery"]
+request_types = ["Message", "MessageKey", "MessageQuery", "PeerDeliveryConfirmation"]
 response_types = ["Message", "Vec<Message>"]
 error_types = ["AtmError"]
 

--- a/boundaries/atm-storage/peer-config-store.toml
+++ b/boundaries/atm-storage/peer-config-store.toml
@@ -5,7 +5,7 @@ name = "PeerConfigStore"
 
 [public]
 trait = "PeerConfigStore"
-notes = "storage-neutral durable configuration for cross-host HTTPS peers and explicit canonical aliases"
+notes = "storage-neutral durable configuration for configured peer HTTP hosts and explicit canonical aliases"
 
 [implementation]
 visibility = "trait_only"
@@ -15,11 +15,11 @@ constructor = "none"
 roots = []
 
 [ownership]
-io_owns = ["https_interface_configuration", "certificate_reference_metadata", "trusted_peer_configuration", "peer_alias_configuration"]
+io_owns = ["peer_http_interface_configuration", "certificate_reference_metadata", "trusted_peer_configuration", "peer_alias_configuration"]
 io_forbidden = ["socket_io", "tls_handshake", "message_delivery", "retry_queue", "process_spawn"]
 
 [dependencies]
-allowed_dependents = ["atm", "atm-core", "atm-daemon", "atm-daemon-bootstrap", "atm-daemon-client", "atm-runtime", "atm-storage-rusqlite", "atm-storage-sqlserver-proof"]
+allowed_dependents = ["atm", "atm-core", "atm-daemon", "atm-daemon-bootstrap", "atm-runtime", "atm-storage-rusqlite"]
 allowed_dependencies = []
 forbidden_edges = ["atm-storage -> atm-core", "atm-storage -> atm-storage-rusqlite"]
 
@@ -42,4 +42,4 @@ review_gates = ["no_transport_or_delivery_logic_in_configuration_store"]
 
 [status]
 state = "concrete_landed"
-notes = ["AI.8 establishes configuration only; AI.9 owns HTTPS listener and transport implementation"]
+notes = ["AK.3 establishes canonical peer configuration; AK.4 owns the direct peer HTTP listener and transport implementation"]

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -208,7 +208,12 @@ fn canonical_write_router_has_one_host_routing_decision() {
     assert_eq!(
         visitor.peer_delivery_calls(),
         0,
-        "AI.31 forbids peer delivery from PostWriteRouter::dispatch"
+        "AK.2's retired peer-delivery methods must not return through PostWriteRouter::dispatch"
+    );
+    assert_eq!(
+        visitor.direct_peer_http_calls(),
+        1,
+        "AK.4 permits exactly one direct configured-peer HTTP call in PostWriteRouter::dispatch"
     );
     assert_eq!(
         visitor.message_writer_implementations, 1,
@@ -249,7 +254,7 @@ fn canonical_write_router_has_one_host_routing_decision() {
 }
 
 #[test]
-fn ai23_peer_adapter_never_matches_localhost_or_own_ip() {
+fn ak4_peer_adapter_never_matches_localhost_or_own_ip() {
     let root = workspace_root();
     let router_path = root.join("crates/atm-daemon/src/runtime_health/peer_delivery_router.rs");
     let source = read_source(&router_path);
@@ -277,15 +282,20 @@ fn ai23_peer_adapter_never_matches_localhost_or_own_ip() {
         .find(".and_then(|address| address.host())")
         .expect("the generic local/peer routing guard must inspect an optional host");
     let peer_branch = dispatch
-        .find("Host-qualified origin writes are durable immutable records only")
-        .expect("AK.2 must explicitly return after host-qualified persistence");
+        .find("send_peer_http_frames(")
+        .expect("AK.4 must make one direct configured-peer HTTP call after persistence");
     assert!(
         peer_receipt_guard < peer_branch && host_guard < peer_branch,
         "peer receipts and host-qualified origin writes must share the one generic input router"
     );
     assert!(
-        !dispatch.contains("PeerDelivery") && !dispatch.contains("signal_after_persist"),
-        "AK.2 forbids a peer worker signal after local admission"
+        dispatch.contains("endpoint_for_canonical_host(host)")
+            && dispatch.contains("confirm_peer_delivery(PeerDeliveryConfirmation"),
+        "AK.4's direct call must use the canonical in-memory endpoint and matching durable confirmation"
+    );
+    assert!(
+        !dispatch.contains("signal_after_persist"),
+        "AK.4 forbids restoring a peer worker signal after local admission"
     );
     for forbidden in ["localhost", "127.0.0.1", "is_loopback", "is_loopback()"] {
         assert!(
@@ -555,6 +565,7 @@ struct HostRoutingFunction {
     accesses_host: bool,
     calls_delivery: bool,
     peer_delivery_calls: usize,
+    direct_peer_http_calls: usize,
     reconciliation_delivery_calls: usize,
     https_transport_bindings: BTreeSet<String>,
     function_bindings: BTreeMap<String, FunctionBinding>,
@@ -676,11 +687,13 @@ impl<'ast> Visit<'ast> for HostRoutingVisitor {
     }
 
     fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        let direct_peer_http_call = is_direct_peer_http_call(&node.func);
         if self.is_delivery_function_call(&node.func)
             && let Some(function) = self.current_function_mut()
             && !function.is_test
         {
             function.calls_delivery = true;
+            function.direct_peer_http_calls += usize::from(direct_peer_http_call);
         }
         syn::visit::visit_expr_call(self, node);
     }
@@ -892,6 +905,14 @@ impl HostRoutingVisitor {
             .sum()
     }
 
+    fn direct_peer_http_calls(&self) -> usize {
+        self.functions
+            .iter()
+            .filter(|function| function.is_post_write_dispatch)
+            .map(|function| function.direct_peer_http_calls)
+            .sum()
+    }
+
     fn reconciliation_delivery_calls(&self) -> usize {
         self.functions
             .iter()
@@ -906,6 +927,7 @@ impl HostRoutingVisitor {
             .filter(|function| {
                 function.calls_delivery
                     && !function.is_post_write_router_helper
+                    && !function.is_post_write_dispatch
                     && function.reconciliation_delivery_calls == 0
             })
             .map(|function| {
@@ -959,7 +981,13 @@ impl HostRoutingVisitor {
 }
 
 fn is_delivery_function_name(name: &str) -> bool {
-    name.starts_with("emit_local_post_write") || name == "deliver_to_peer"
+    name.starts_with("emit_local_post_write")
+        || name == "deliver_to_peer"
+        || name == "send_peer_http_frames"
+}
+
+fn is_direct_peer_http_call(function: &syn::Expr) -> bool {
+    matches!(function, syn::Expr::Path(path) if path.path.segments.last().is_some_and(|segment| segment.ident == "send_peer_http_frames"))
 }
 
 fn is_path_suffix(path: &Path, suffixes: &[&str]) -> bool {

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -1,6 +1,6 @@
 //! Transport-neutral API request and response contracts.
 //!
-//! UDS and future HTTPS adapters translate HTTP into this surface.  The
+//! UDS, loopback, and configured peer HTTP adapters translate HTTP into this surface. The
 //! application router receives no socket, storage, or nudge capability.
 
 use std::io::{Read, Write};
@@ -17,7 +17,6 @@ use crate::protocol::{
 };
 use crate::read::{PeekQuery, ReadQuery};
 use crate::send::WriteRequest;
-use crate::types::HostName;
 use base64::Engine as _;
 
 mod http_frame_reader;
@@ -207,6 +206,18 @@ pub fn write_http_request_with_headers(
     request: &RequestEnvelope,
     headers: &[(&str, &str)],
 ) -> Result<(), AtmError> {
+    write_http_request_with_headers_and_connection(writer, request, headers, false)
+}
+
+/// Serializes one route-specific HTTP request with caller-selected bounded
+/// connection reuse.  The public default stays close-after-response; peer
+/// delivery uses keep-alive only while emitting a supplied finite frame slice.
+pub fn write_http_request_with_headers_and_connection(
+    writer: &mut impl Write,
+    request: &RequestEnvelope,
+    headers: &[(&str, &str)],
+    keep_alive: bool,
+) -> Result<(), AtmError> {
     // The protocol envelope is an in-process dispatch type, never an HTTP
     // representation. Each route serializes its own OpenAPI request body.
     let body = encode_request_body(request)?;
@@ -217,8 +228,9 @@ pub fn write_http_request_with_headers(
         .collect::<String>();
     write!(
         writer,
-        "{method} {path} HTTP/1.1\r\nContent-Type: application/json\r\n{headers}Content-Length: {}\r\nConnection: close\r\n\r\n",
-        body.len()
+        "{method} {path} HTTP/1.1\r\nContent-Type: application/json\r\n{headers}Content-Length: {}\r\nConnection: {}\r\n\r\n",
+        body.len(),
+        if keep_alive { "keep-alive" } else { "close" },
     )
     .map_err(|source| {
         AtmError::daemon_unavailable(format!("failed to write daemon HTTP request headers: {source}"))
@@ -669,31 +681,9 @@ impl ApiResponse {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthenticatedIngress {
     Local,
-    /// A peer that completed the HTTPS adapter's mutual-TLS and exact-pin
-    /// checks. The application router receives no socket or peer configuration.
+    /// A configured peer HTTP frame. The application router receives no socket
+    /// or peer configuration.
     Peer,
-    /// Explicit plaintext-test provenance. This is not peer authentication.
-    UntrustedSmoke(UntrustedSmokeProvenance),
-    /// A plaintext diagnostic request without declared source provenance.
-    /// It is never peer authentication and cannot carry a write.
-    AnonymousSmoke,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UntrustedSmokeProvenance {
-    declared_source_host: HostName,
-}
-
-impl UntrustedSmokeProvenance {
-    pub const fn new(declared_source_host: HostName) -> Self {
-        Self {
-            declared_source_host,
-        }
-    }
-
-    pub const fn declared_source_host(&self) -> &HostName {
-        &self.declared_source_host
-    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/atm-core/src/provenance.rs
+++ b/crates/atm-core/src/provenance.rs
@@ -10,12 +10,8 @@ pub enum WriteIngress {
     Canonical,
     /// A request received through the local IPC/TCP boundary.
     Local,
-    /// A request received through authenticated mutual TLS.
+    /// A request received through configured peer HTTP.
     Peer,
-    /// A request received through the explicitly opt-in plaintext smoke path.
-    UntrustedSmoke,
-    /// A plaintext diagnostic request that cannot submit writes.
-    AnonymousSmoke,
 }
 
 /// The provenance fields relevant to one write admission decision.
@@ -94,17 +90,7 @@ pub fn validate_write_provenance(
                 "peer write requests require authenticated source provenance and immutable origin metadata",
             ));
         }
-        WriteIngress::UntrustedSmoke if authenticated_peer || !has_complete_origin_metadata => {
-            return Err(AtmError::validation(
-                "plaintext smoke ingress must carry origin metadata but no authenticated peer identity",
-            ));
-        }
-        WriteIngress::AnonymousSmoke => {
-            return Err(AtmError::validation(
-                "anonymous plaintext diagnostics cannot submit writes; include explicit peer provenance or use authenticated HTTPS",
-            ));
-        }
-        WriteIngress::Local | WriteIngress::Peer | WriteIngress::UntrustedSmoke => {}
+        WriteIngress::Local | WriteIngress::Peer => {}
     }
 
     Ok(ValidatedWriteProvenance {
@@ -146,20 +132,6 @@ mod tests {
             validate_write_provenance(WriteIngress::Peer, provenance(true, true, true, true))
                 .is_ok()
         );
-        assert!(
-            validate_write_provenance(
-                WriteIngress::UntrustedSmoke,
-                provenance(false, false, true, true)
-            )
-            .is_ok()
-        );
-        assert!(
-            validate_write_provenance(
-                WriteIngress::AnonymousSmoke,
-                provenance(false, false, false, false)
-            )
-            .is_err()
-        );
     }
 
     #[test]
@@ -176,13 +148,6 @@ mod tests {
         assert!(
             validate_write_provenance(WriteIngress::Local, provenance(false, true, true, true))
                 .is_err()
-        );
-        assert!(
-            validate_write_provenance(
-                WriteIngress::UntrustedSmoke,
-                provenance(false, true, true, true)
-            )
-            .is_err()
         );
         assert!(
             validate_write_provenance(WriteIngress::Peer, provenance(false, false, true, true))

--- a/crates/atm-core/src/send/mod.rs
+++ b/crates/atm-core/src/send/mod.rs
@@ -81,7 +81,7 @@ pub struct WriteRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub caller_chat_id: Option<ChatId>,
     pub caller_team: TeamName,
-    /// Set only by the authenticated HTTPS ingress before the shared writer
+    /// Set only by configured peer HTTP ingress before the shared writer
     /// persists an inbound record. It is not trusted from wire JSON.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub authenticated_source_host: Option<HostName>,

--- a/crates/atm-daemon/src/active_connection_registry.rs
+++ b/crates/atm-daemon/src/active_connection_registry.rs
@@ -30,7 +30,6 @@ const TRACKED_DISPATCH_JOIN_POLICY: JoinTimeoutPolicy = JoinTimeoutPolicy {
 enum DispatchPanicHandling {
     /// Log the panic and continue; used by opportunistic bookkeeping reaps where a single
     /// panicked worker must not be treated as a fatal accept-loop or connection error.
-    #[cfg(any(windows, test))]
     LogAndContinue,
     /// Propagate the panic as an error; used by the deliberate shutdown drain, where a
     /// wedged or panicked worker blocking graceful shutdown is worth surfacing.
@@ -69,7 +68,6 @@ impl ActiveConnectionRegistry {
     /// Reserve a connection slot before spawning its worker.  Admission is
     /// decided atomically so an accept loop cannot over-admit while a newly
     /// spawned worker has not yet incremented the counter.
-    #[cfg(any(windows, test))]
     pub(crate) fn try_register(
         self: &Arc<Self>,
         maximum_connections: usize,
@@ -123,7 +121,6 @@ impl ActiveConnectionRegistry {
             .map_err(|_| AtmError::daemon_unavailable("active dispatch handle lock poisoned"))
     }
 
-    #[cfg(any(windows, test))]
     pub(crate) fn push_dispatch_handle(
         &self,
         handle: TrackedDispatchHandle,
@@ -155,7 +152,6 @@ impl ActiveConnectionRegistry {
     /// the whole daemon runtime depending on which caller wins the race. A panicked dispatch
     /// worker is logged and otherwise ignored; it has already been removed from the tracked
     /// handle list and cannot be reaped again.
-    #[cfg(any(windows, test))]
     pub(crate) fn reap_finished_dispatches(&self) -> Result<DispatchReapSummary, AtmError> {
         self.reap_finished_dispatches_with(DispatchPanicHandling::LogAndContinue)
     }
@@ -190,15 +186,11 @@ impl ActiveConnectionRegistry {
             *handles = pending;
             finished
         };
-        #[cfg(any(windows, test))]
         let mut summary = DispatchReapSummary::default();
-        #[cfg(not(any(windows, test)))]
-        let summary = DispatchReapSummary::default();
         for handle in finished {
             if let Err(error) = join_dispatch_handle(handle) {
                 match panic_handling {
                     DispatchPanicHandling::Escalate => return Err(error),
-                    #[cfg(any(windows, test))]
                     DispatchPanicHandling::LogAndContinue => {
                         summary.recovered_panics += 1;
                         tracing::warn!(

--- a/crates/atm-daemon/src/composition.rs
+++ b/crates/atm-daemon/src/composition.rs
@@ -5,6 +5,7 @@ use crate::local_ipc_transport::{PreparedRuntimeServer, RuntimeServeHooks, Socke
 #[cfg(windows)]
 use crate::local_tcp_transport::{PreparedRuntimeServer, RuntimeServeHooks, SocketEndpointGuard};
 use crate::non_claude_outbound_runtime::DaemonNonClaudeOutbound;
+use crate::peer_http_listener::PeerHttpListenerSet;
 use crate::runtime_health::DaemonRequestDispatcher;
 use crate::runtime_health::{DaemonStatusSource, RuntimeStatusCache};
 #[cfg(test)]
@@ -121,6 +122,7 @@ pub(crate) struct RuntimeComposition {
     // Endpoint cleanup ownership moves between startup, serve, and teardown transitions, so this
     // mutex protects exclusive handoff/drop of the guard rather than a simple ready flag.
     endpoint_guard: Mutex<Option<SocketEndpointGuard>>,
+    peer_http_listener_set: Mutex<Option<PeerHttpListenerSet>>,
     server_transport: LocalIpcServerTransportAdapter,
     request_dispatcher: Arc<DaemonRequestDispatcher>,
     composition_observability: SubsystemObservability,
@@ -195,6 +197,7 @@ impl RuntimeComposition {
             lifecycle: Arc::new(RuntimeLifecycle::new()),
             _host_ownership_adapter: host_ownership_adapter,
             endpoint_guard: Mutex::new(None),
+            peer_http_listener_set: Mutex::new(None),
             server_transport,
             request_dispatcher,
             composition_observability,
@@ -233,7 +236,47 @@ impl RuntimeComposition {
             "daemon shutdown requested",
         );
         self.lifecycle.transition(RuntimeLifecycleState::Draining)?;
+        self.stop_peer_http_listener()?;
         self.request_dispatcher.stop_local_post_write_executor()?;
+        Ok(())
+    }
+
+    fn start_peer_http_listener(&self) -> Result<(), AtmError> {
+        let Some(mut listener_set) = self.request_dispatcher.prepare_peer_http_listener()? else {
+            return Ok(());
+        };
+        listener_set.start(self.request_dispatcher())?;
+        let mut slot = match self.peer_http_listener_set.lock() {
+            Ok(slot) => slot,
+            Err(_) => {
+                listener_set.shutdown()?;
+                return Err(AtmError::daemon_unavailable(
+                    "peer HTTP listener lifecycle slot lock poisoned",
+                ));
+            }
+        };
+        if slot.is_some() {
+            drop(slot);
+            listener_set.shutdown()?;
+            return Err(AtmError::daemon_unavailable(
+                "peer HTTP listener was already started",
+            ));
+        }
+        *slot = Some(listener_set);
+        Ok(())
+    }
+
+    fn stop_peer_http_listener(&self) -> Result<(), AtmError> {
+        let listener_set = self
+            .peer_http_listener_set
+            .lock()
+            .map_err(|_| {
+                AtmError::daemon_unavailable("peer HTTP listener lifecycle slot lock poisoned")
+            })?
+            .take();
+        if let Some(mut listener_set) = listener_set {
+            listener_set.shutdown()?;
+        }
         Ok(())
     }
 
@@ -253,6 +296,24 @@ impl RuntimeComposition {
             "failed",
             "daemon startup failed",
         );
+        if let Err(cleanup_error) = self.stop_peer_http_listener() {
+            tracing::warn!(
+                subsystem = "composition",
+                action = "startup_rollback_peer_listener",
+                outcome = "failed",
+                %cleanup_error,
+                "failed to stop peer HTTP listener after startup failure"
+            );
+        }
+        if let Err(cleanup_error) = self.request_dispatcher.stop_local_post_write_executor() {
+            tracing::warn!(
+                subsystem = "composition",
+                action = "startup_rollback_post_write_executor",
+                outcome = "failed",
+                %cleanup_error,
+                "failed to stop local post-write executor after startup failure"
+            );
+        }
         self.lifecycle.force_stopped()?;
         Err(error)
     }
@@ -310,6 +371,8 @@ impl RuntimeComposition {
         self.request_dispatcher
             .start_local_post_write_executor()
             .or_else(|error| self.rollback_failed_startup(error))?;
+        self.start_peer_http_listener()
+            .or_else(|error| self.rollback_failed_startup(error))?;
         self.serve_runtime(runtime, || Ok(()))
     }
 
@@ -332,6 +395,8 @@ impl RuntimeComposition {
             .or_else(|error| self.rollback_failed_startup(error))?;
         self.request_dispatcher
             .start_local_post_write_executor()
+            .or_else(|error| self.rollback_failed_startup(error))?;
+        self.start_peer_http_listener()
             .or_else(|error| self.rollback_failed_startup(error))?;
         self.serve_runtime(runtime, move || {
             self.request_dispatcher.preflush_observability_shutdown();

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -3,10 +3,10 @@
 #![deny(unsafe_code)]
 //! Daemon runtime composition and portability adapters.
 
-#[cfg_attr(not(windows), allow(dead_code))]
+#[cfg_attr(windows, allow(dead_code))]
 mod active_connection_registry;
 pub(crate) mod composition;
-#[cfg_attr(not(windows), allow(dead_code))]
+#[cfg_attr(windows, allow(dead_code))]
 mod daemon_runtime_observability;
 mod daemon_worker_join;
 mod ready_signal;

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -25,6 +25,7 @@ mod local_ipc_transport;
 #[cfg(any(unix, windows, test))]
 mod local_tcp_transport;
 mod non_claude_outbound_runtime;
+mod peer_http_listener;
 mod post_send_emitter;
 #[cfg(any(unix, windows))]
 #[cfg_attr(windows, allow(dead_code))]

--- a/crates/atm-daemon/src/local_tcp_transport.rs
+++ b/crates/atm-daemon/src/local_tcp_transport.rs
@@ -414,7 +414,7 @@ impl PreparedRuntimeServer {
                     }
                     Err(source) if source.kind() == std::io::ErrorKind::WouldBlock => {
                         registry.reap_finished_dispatches()?;
-                        thread::sleep(ACCEPT_POLL_INTERVAL);
+                        sleep_for_next_accept_poll();
                     }
                     Err(source) => {
                         return Err(AtmError::daemon_unavailable(format!(
@@ -428,6 +428,11 @@ impl PreparedRuntimeServer {
         drop(hooks.endpoint_guard);
         serve_result.and(worker_shutdown_result)
     }
+}
+
+#[cfg(windows)]
+fn sleep_for_next_accept_poll() {
+    thread::sleep(ACCEPT_POLL_INTERVAL);
 }
 
 #[cfg(windows)]

--- a/crates/atm-daemon/src/peer_http_listener.rs
+++ b/crates/atm-daemon/src/peer_http_listener.rs
@@ -490,10 +490,11 @@ mod tests {
         PeerHttpListenerSet, PeerHttpRuntimeConfig, send_peer_http_frames,
     };
     use std::io::Write;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
     use std::num::NonZeroU16;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, mpsc};
     use std::thread;
+    use std::time::Duration;
 
     use atm_core::api::{
         ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, HttpFrameReader, RequestDeadline,
@@ -587,9 +588,37 @@ mod tests {
         }
     }
 
+    fn loopback_listener() -> TcpListener {
+        TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).expect("listener")
+    }
+
+    fn peer_endpoint(port: u16) -> PeerEndpoint {
+        PeerEndpoint {
+            canonical_host: "localhost".parse().expect("host"),
+            port: NonZeroU16::new(port).expect("port"),
+        }
+    }
+
+    fn peer_runtime_config() -> PeerHttpRuntimeConfig {
+        PeerHttpRuntimeConfig {
+            source_host: "origin.example.test".parse().expect("source host"),
+        }
+    }
+
+    fn read_one_peer_request(stream: &mut TcpStream) {
+        let _ = HttpFrameReader::new()
+            .read_request(stream)
+            .expect("read request")
+            .expect("one request");
+    }
+
+    fn assert_delivery_unconfirmed(error: AtmError) {
+        assert_eq!(error.code(), AtmErrorCode::RemoteDeliveryUnconfirmed);
+    }
+
     #[test]
     fn direct_sender_uses_shared_http_frame_and_configured_source_header() {
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
+        let listener = loopback_listener();
         let port = listener.local_addr().expect("address").port();
         let message_id = AtmMessageId::new();
         let server = thread::spawn(move || {
@@ -622,14 +651,9 @@ mod tests {
             stream.flush().expect("flush response");
         });
 
-        let endpoint = PeerEndpoint {
-            canonical_host: "localhost".parse::<HostName>().expect("host"),
-            port: NonZeroU16::new(port).expect("port"),
-        };
+        let endpoint = peer_endpoint(port);
         let response = send_peer_http_frames(
-            &PeerHttpRuntimeConfig {
-                source_host: "origin.example.test".parse().expect("source host"),
-            },
+            &peer_runtime_config(),
             &endpoint,
             &[write(message_id)],
             RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
@@ -641,7 +665,7 @@ mod tests {
 
     #[test]
     fn direct_sender_rejects_a_response_for_a_different_immutable_write() {
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
+        let listener = loopback_listener();
         let port = listener.local_addr().expect("address").port();
         let message_id = AtmMessageId::new();
         let server = thread::spawn(move || {
@@ -657,21 +681,157 @@ mod tests {
             )
             .expect("write mismatched response");
         });
-        let endpoint = PeerEndpoint {
-            canonical_host: "localhost".parse().expect("host"),
-            port: NonZeroU16::new(port).expect("port"),
-        };
+        let endpoint = peer_endpoint(port);
 
         let error = send_peer_http_frames(
-            &PeerHttpRuntimeConfig {
-                source_host: "origin.example.test".parse().expect("source host"),
-            },
+            &peer_runtime_config(),
             &endpoint,
             &[write(message_id)],
             RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
         )
         .expect_err("a response for a different write cannot confirm delivery");
-        assert_eq!(error.code(), AtmErrorCode::RemoteDeliveryUnconfirmed);
+        assert_delivery_unconfirmed(error);
+        server.join().expect("server");
+    }
+
+    #[test]
+    fn direct_sender_rejects_budget_expiry_under_stall() {
+        let listener = loopback_listener();
+        let port = listener.local_addr().expect("address").port();
+        let (request_seen_tx, request_seen_rx) = mpsc::channel();
+        let (release_stall_tx, release_stall_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            read_one_peer_request(&mut stream);
+            request_seen_tx.send(()).expect("report request");
+            release_stall_rx.recv().expect("release stalled peer");
+        });
+
+        let error = send_peer_http_frames(
+            &peer_runtime_config(),
+            &peer_endpoint(port),
+            &[write(AtmMessageId::new())],
+            RequestDeadline::after(Duration::from_millis(10)),
+        )
+        .expect_err("a stalled peer cannot outlive the caller deadline");
+        assert_delivery_unconfirmed(error);
+        request_seen_rx.recv().expect("peer received request");
+        release_stall_tx.send(()).expect("release stalled peer");
+        server.join().expect("server");
+    }
+
+    #[test]
+    fn direct_sender_rejects_dns_failure() {
+        let endpoint = PeerEndpoint {
+            canonical_host: "peer-does-not-exist.invalid".parse().expect("host"),
+            port: NonZeroU16::new(43101).expect("port"),
+        };
+        let error = send_peer_http_frames(
+            &peer_runtime_config(),
+            &endpoint,
+            &[write(AtmMessageId::new())],
+            RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
+        )
+        .expect_err("an unresolvable peer host cannot confirm delivery");
+        assert_delivery_unconfirmed(error);
+    }
+
+    #[test]
+    fn direct_sender_rejects_connect_refusal() {
+        let port = loopback_listener().local_addr().expect("address").port();
+        let error = send_peer_http_frames(
+            &peer_runtime_config(),
+            &peer_endpoint(port),
+            &[write(AtmMessageId::new())],
+            RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
+        )
+        .expect_err("a refused peer connection cannot confirm delivery");
+        assert_delivery_unconfirmed(error);
+    }
+
+    #[test]
+    fn direct_sender_rejects_receiver_4xx_and_5xx_responses() {
+        for response in [
+            ResponseEnvelope::Error(AtmError::validation("receiver rejected write")),
+            ResponseEnvelope::Error(AtmError::daemon_unavailable("receiver unavailable")),
+        ] {
+            let listener = loopback_listener();
+            let port = listener.local_addr().expect("address").port();
+            let server = thread::spawn(move || {
+                let (mut stream, _) = listener.accept().expect("accept");
+                read_one_peer_request(&mut stream);
+                write_http_response(&mut stream, &response).expect("write error response");
+            });
+
+            let error = send_peer_http_frames(
+                &peer_runtime_config(),
+                &peer_endpoint(port),
+                &[write(AtmMessageId::new())],
+                RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
+            )
+            .expect_err("a non-success peer response cannot confirm delivery");
+            assert_delivery_unconfirmed(error);
+            server.join().expect("server");
+        }
+    }
+
+    #[test]
+    fn direct_sender_rejects_malformed_response() {
+        let listener = loopback_listener();
+        let port = listener.local_addr().expect("address").port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            read_one_peer_request(&mut stream);
+            stream
+                .write_all(b"HTTP/1.1 201 Created\r\nContent-Length: invalid\r\n\r\n")
+                .expect("write malformed response");
+            stream.flush().expect("flush malformed response");
+        });
+
+        let error = send_peer_http_frames(
+            &peer_runtime_config(),
+            &peer_endpoint(port),
+            &[write(AtmMessageId::new())],
+            RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
+        )
+        .expect_err("a malformed peer response cannot confirm delivery");
+        assert_delivery_unconfirmed(error);
+        server.join().expect("server");
+    }
+
+    #[test]
+    fn direct_sender_rejects_mismatched_response_count() {
+        let listener = loopback_listener();
+        let port = listener.local_addr().expect("address").port();
+        let first_message_id = AtmMessageId::new();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let raw_request = HttpFrameReader::new()
+                .read_request(&mut stream)
+                .expect("read first request")
+                .expect("first request");
+            let RequestEnvelope::Write(write) = decode_request(raw_request)
+                .expect("decode first request")
+                .into_inner()
+            else {
+                panic!("peer sender must emit a write request");
+            };
+            let message_id = write.origin_message_id.expect("immutable message ID");
+            write_http_response(
+                &mut stream,
+                &ResponseEnvelope::Send(SendResponseEnvelope::Sent(send_outcome(message_id))),
+            )
+            .expect("write first response");
+        });
+
+        let error = send_peer_http_frames(
+            &peer_runtime_config(),
+            &peer_endpoint(port),
+            &[write(first_message_id), write(AtmMessageId::new())],
+            RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
+        )
+        .expect_err("a peer must respond to every frame in a batch");
+        assert_delivery_unconfirmed(error);
         server.join().expect("server");
     }
 
@@ -701,7 +861,7 @@ mod tests {
     #[test]
     fn configured_peer_listener_routes_http_write_as_peer_ingress() {
         let mut listener_set = PeerHttpListenerSet::bind(&PeerHttpBindConfig {
-            bind_addrs: vec![SocketAddr::from((Ipv4Addr::LOCALHOST, 0))],
+            bind_addrs: vec![SocketAddr::from((Ipv6Addr::LOCALHOST, 0))],
         })
         .expect("bind configured peer listener");
         let port = listener_set.listeners[0]
@@ -716,14 +876,9 @@ mod tests {
 
         let first_message_id = AtmMessageId::new();
         let second_message_id = AtmMessageId::new();
-        let endpoint = PeerEndpoint {
-            canonical_host: "localhost".parse().expect("host"),
-            port: NonZeroU16::new(port).expect("port"),
-        };
+        let endpoint = peer_endpoint(port);
         let responses = send_peer_http_frames(
-            &PeerHttpRuntimeConfig {
-                source_host: "origin.example.test".parse().expect("source host"),
-            },
+            &peer_runtime_config(),
             &endpoint,
             &[write(first_message_id), write(second_message_id)],
             RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),

--- a/crates/atm-daemon/src/peer_http_listener.rs
+++ b/crates/atm-daemon/src/peer_http_listener.rs
@@ -182,18 +182,44 @@ fn accept_peer_connections(
     stop: Arc<AtomicBool>,
 ) {
     while !stop.load(Ordering::SeqCst) {
-        let _ = registry.reap_finished_dispatches();
+        if let Err(error) = registry.reap_finished_dispatches() {
+            tracing::warn!(
+                subsystem = "peer_http_listener",
+                action = "reap_request_workers",
+                outcome = "failed",
+                %error,
+                "configured peer HTTP request-worker cleanup failed"
+            );
+        }
         match listener.accept() {
             Ok((stream, _peer_addr)) => {
                 let Some(active_connection) = registry.try_register(MAX_PEER_HTTP_CONNECTIONS)
                 else {
-                    let _ = write_peer_capacity_rejection(stream);
+                    if let Err(error) = write_peer_capacity_rejection(stream) {
+                        tracing::warn!(
+                            subsystem = "peer_http_listener",
+                            action = "reject_over_capacity_connection",
+                            outcome = "failed",
+                            %error,
+                            "configured peer HTTP capacity rejection could not be written"
+                        );
+                    }
                     continue;
                 };
                 let admission = PeerConnectionAdmission {
                     _active_connection: active_connection,
                 };
-                let _ = spawn_request_worker(stream, router.clone(), registry.clone(), admission);
+                if let Err(error) =
+                    spawn_request_worker(stream, router.clone(), registry.clone(), admission)
+                {
+                    tracing::warn!(
+                        subsystem = "peer_http_listener",
+                        action = "spawn_request_worker",
+                        outcome = "failed",
+                        %error,
+                        "configured peer HTTP request worker could not be started"
+                    );
+                }
             }
             Err(source) if source.kind() == std::io::ErrorKind::WouldBlock => {
                 thread::sleep(PEER_HTTP_ACCEPT_POLL_INTERVAL);
@@ -477,6 +503,7 @@ mod tests {
     #[derive(Default)]
     struct PeerWriteRecorder {
         source_hosts: Mutex<Vec<HostName>>,
+        message_ids: Mutex<Vec<AtmMessageId>>,
     }
 
     impl atm_core::boundary::sealed::Sealed for PeerWriteRecorder {}
@@ -502,6 +529,10 @@ mod tests {
             let message_id = write.origin_message_id.ok_or_else(|| {
                 AtmError::validation("peer listener did not preserve origin message ID")
             })?;
+            self.message_ids
+                .lock()
+                .expect("message ID recorder")
+                .push(message_id);
             Ok(ApiResponse::new(ResponseEnvelope::Send(
                 SendResponseEnvelope::Sent(send_outcome(message_id)),
             )))
@@ -647,6 +678,7 @@ mod tests {
                 SocketAddr::from((Ipv4Addr::LOCALHOST, 43101)),
             ],
             vec![SocketAddr::from((Ipv4Addr::UNSPECIFIED, 43101))],
+            vec![SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 43101))],
             vec![SocketAddr::new(
                 IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),
                 43101,
@@ -682,7 +714,7 @@ mod tests {
             canonical_host: "localhost".parse().expect("host"),
             port: NonZeroU16::new(port).expect("port"),
         };
-        send_peer_http_frames(
+        let responses = send_peer_http_frames(
             &PeerHttpRuntimeConfig {
                 source_host: "origin.example.test".parse().expect("source host"),
             },
@@ -691,6 +723,21 @@ mod tests {
             RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
         )
         .expect("configured peer sender/receiver round trip");
+        let returned_message_ids = responses
+            .iter()
+            .map(|response| match response {
+                ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => outcome.message_id,
+                response => panic!("expected sent response, got {response:?}"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            returned_message_ids,
+            vec![first_message_id, second_message_id]
+        );
+        assert_eq!(
+            *recorder.message_ids.lock().expect("message ID recorder"),
+            vec![first_message_id, second_message_id]
+        );
         assert_eq!(
             *recorder.source_hosts.lock().expect("recorder"),
             vec![

--- a/crates/atm-daemon/src/peer_http_listener.rs
+++ b/crates/atm-daemon/src/peer_http_listener.rs
@@ -135,11 +135,17 @@ impl PeerHttpListenerSet {
             .listeners
             .iter()
             .map(|peer_listener| {
-                peer_listener.listener.try_clone().map_err(|source| {
+                let listener = peer_listener.listener.try_clone().map_err(|source| {
                     AtmError::daemon_unavailable(format!(
                         "failed to clone configured peer HTTP listener: {source}"
                     ))
-                })
+                })?;
+                listener.set_nonblocking(true).map_err(|source| {
+                    AtmError::daemon_unavailable(format!(
+                        "failed to configure cloned peer HTTP listener mode: {source}"
+                    ))
+                })?;
+                Ok(listener)
             })
             .collect::<Result<Vec<_>, AtmError>>()?;
         for listener in listeners {

--- a/crates/atm-daemon/src/peer_http_listener.rs
+++ b/crates/atm-daemon/src/peer_http_listener.rs
@@ -1,0 +1,703 @@
+//! Minimal configured peer HTTP transport.
+//!
+//! AK.4 keeps outbound peer delivery deliberately synchronous: the origin
+//! request worker writes its already-persisted immutable frame once, then
+//! either receives the matching ordinary send response or returns the
+//! persisted-but-undelivered error.  This module has no queue, retry state,
+//! worker, resolver, or connection lifecycle.
+
+use std::collections::HashSet;
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use atm_core::api::{
+    ApiRequest, ApiRouter, AuthenticatedIngress, RequestDeadline, decode_request,
+    read_http_response_with_frame_reader, write_http_request_with_headers_and_connection,
+};
+use atm_core::error::AtmError;
+use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
+use atm_core::send::WriteRequest;
+use atm_storage::{HostName, PeerEndpoint};
+
+use crate::active_connection_registry::{
+    ActiveConnectionGuard, ActiveConnectionRegistry, TrackedDispatchHandle,
+};
+use crate::daemon_worker_join::CompletionTrackedJoinHandle;
+
+pub(crate) const PEER_HTTP_LOCAL_RESPONSE_BUDGET: Duration = Duration::from_secs(3);
+pub(crate) const PLAINTEXT_PEER_SOURCE_HOST_HEADER: &str = "X-ATM-Peer-Source-Host";
+pub(crate) const MAX_PEER_HTTP_CONNECTIONS: usize = 64;
+const PEER_HTTP_ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Immutable local configuration captured by daemon assembly/reload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PeerHttpRuntimeConfig {
+    pub(crate) source_host: HostName,
+}
+
+/// Finite configured peer-listener bind allowlist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PeerHttpBindConfig {
+    pub(crate) bind_addrs: Vec<SocketAddr>,
+}
+
+impl PeerHttpBindConfig {
+    pub(crate) fn validate_at_startup(&self) -> Result<(), AtmError> {
+        if self.bind_addrs.is_empty() {
+            return Err(AtmError::bind_preflight(
+                "configured peer HTTP listener requires at least one explicit bind address",
+            ));
+        }
+        let mut seen = HashSet::with_capacity(self.bind_addrs.len());
+        for bind_addr in &self.bind_addrs {
+            if bind_addr.ip().is_unspecified() {
+                return Err(AtmError::bind_preflight(format!(
+                    "configured peer HTTP bind address `{bind_addr}` must not be unspecified"
+                )));
+            }
+            if bind_addr.ip().is_multicast() {
+                return Err(AtmError::bind_preflight(format!(
+                    "configured peer HTTP bind address `{bind_addr}` must not be multicast"
+                )));
+            }
+            if !seen.insert(*bind_addr) {
+                return Err(AtmError::bind_preflight(format!(
+                    "configured peer HTTP bind address `{bind_addr}` is duplicated"
+                )));
+            }
+            // This asks the operating system whether the address is local
+            // without DNS or interface discovery. The temporary socket is
+            // dropped before the production listener binds it.
+            TcpListener::bind(bind_addr).map_err(|source| {
+                AtmError::bind_preflight(format!(
+                    "configured peer HTTP bind address `{bind_addr}` is not available on this host: {source}"
+                ))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+/// One accepted peer socket with a reservation in the shared bounded registry.
+pub(crate) struct PeerConnectionAdmission {
+    _active_connection: ActiveConnectionGuard,
+}
+
+/// One explicit production peer listener.
+pub(crate) struct PeerHttpListener {
+    listener: TcpListener,
+}
+
+/// Lifecycle owner for configured plain-HTTP peer listeners.
+pub(crate) struct PeerHttpListenerSet {
+    listeners: Vec<PeerHttpListener>,
+    stop: Arc<AtomicBool>,
+    registry: Arc<ActiveConnectionRegistry>,
+    accept_threads: Vec<JoinHandle<()>>,
+}
+
+impl PeerHttpListenerSet {
+    pub(crate) fn bind(config: &PeerHttpBindConfig) -> Result<Self, AtmError> {
+        config.validate_at_startup()?;
+        let listeners = config
+            .bind_addrs
+            .iter()
+            .map(|bind_addr| {
+                let listener = TcpListener::bind(bind_addr).map_err(|source| {
+                    AtmError::daemon_unavailable(format!(
+                        "failed to bind configured peer HTTP listener `{bind_addr}`: {source}"
+                    ))
+                })?;
+                listener.set_nonblocking(true).map_err(|source| {
+                    AtmError::daemon_unavailable(format!(
+                        "failed to configure configured peer HTTP listener `{bind_addr}`: {source}"
+                    ))
+                })?;
+                Ok(PeerHttpListener { listener })
+            })
+            .collect::<Result<Vec<_>, AtmError>>()?;
+        Ok(Self {
+            listeners,
+            stop: Arc::new(AtomicBool::new(false)),
+            registry: Arc::new(ActiveConnectionRegistry::default()),
+            accept_threads: Vec::new(),
+        })
+    }
+
+    pub(crate) fn start(
+        &mut self,
+        router: Arc<dyn ApiRouter + Send + Sync>,
+    ) -> Result<(), AtmError> {
+        let listeners = self
+            .listeners
+            .iter()
+            .map(|peer_listener| {
+                peer_listener.listener.try_clone().map_err(|source| {
+                    AtmError::daemon_unavailable(format!(
+                        "failed to clone configured peer HTTP listener: {source}"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, AtmError>>()?;
+        for listener in listeners {
+            let stop = Arc::clone(&self.stop);
+            let registry = Arc::clone(&self.registry);
+            let router = Arc::clone(&router);
+            let accept_thread = match thread::Builder::new()
+                .name("peer-http-accept".to_owned())
+                .spawn(move || accept_peer_connections(listener, router, registry, stop))
+            {
+                Ok(handle) => handle,
+                Err(source) => {
+                    self.shutdown()?;
+                    return Err(AtmError::daemon_unavailable(format!(
+                        "failed to start configured peer HTTP accept thread: {source}"
+                    )));
+                }
+            };
+            self.accept_threads.push(accept_thread);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn shutdown(&mut self) -> Result<(), AtmError> {
+        self.stop.store(true, Ordering::SeqCst);
+        for accept_thread in self.accept_threads.drain(..) {
+            accept_thread.join().map_err(|_| {
+                AtmError::daemon_unavailable("peer HTTP accept thread panicked during shutdown")
+            })?;
+        }
+        self.registry
+            .join_tracked_dispatches(PEER_HTTP_LOCAL_RESPONSE_BUDGET)
+    }
+}
+
+fn accept_peer_connections(
+    listener: TcpListener,
+    router: Arc<dyn ApiRouter + Send + Sync>,
+    registry: Arc<ActiveConnectionRegistry>,
+    stop: Arc<AtomicBool>,
+) {
+    while !stop.load(Ordering::SeqCst) {
+        let _ = registry.reap_finished_dispatches();
+        match listener.accept() {
+            Ok((stream, _peer_addr)) => {
+                let Some(active_connection) = registry.try_register(MAX_PEER_HTTP_CONNECTIONS)
+                else {
+                    let _ = write_peer_capacity_rejection(stream);
+                    continue;
+                };
+                let admission = PeerConnectionAdmission {
+                    _active_connection: active_connection,
+                };
+                let _ = spawn_request_worker(stream, router.clone(), registry.clone(), admission);
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(PEER_HTTP_ACCEPT_POLL_INTERVAL);
+            }
+            Err(source) => {
+                tracing::warn!(
+                    subsystem = "peer_http_listener",
+                    action = "accept",
+                    outcome = "failed",
+                    %source,
+                    "configured peer HTTP accept failed"
+                );
+                thread::sleep(PEER_HTTP_ACCEPT_POLL_INTERVAL);
+            }
+        }
+    }
+}
+
+fn spawn_request_worker(
+    stream: TcpStream,
+    router: Arc<dyn ApiRouter + Send + Sync>,
+    registry: Arc<ActiveConnectionRegistry>,
+    admission: PeerConnectionAdmission,
+) -> Result<(), AtmError> {
+    let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(1);
+    let join_handle = thread::Builder::new()
+        .name("peer-http-request".to_owned())
+        .spawn(move || {
+            let _completion_tx = completion_tx;
+            let _admission = admission;
+            if let Err(error) = handle_peer_connection(stream, router) {
+                tracing::debug!(
+                    subsystem = "peer_http_listener",
+                    action = "request",
+                    outcome = "closed",
+                    %error,
+                    "peer HTTP request connection ended"
+                );
+            }
+        })
+        .map_err(|source| {
+            AtmError::daemon_unavailable(format!(
+                "failed to start configured peer HTTP request worker: {source}"
+            ))
+        })?;
+    track_request_worker(
+        registry.as_ref(),
+        CompletionTrackedJoinHandle {
+            completion_rx,
+            join_handle,
+        },
+    )
+}
+
+fn track_request_worker(
+    registry: &ActiveConnectionRegistry,
+    handle: TrackedDispatchHandle,
+) -> Result<(), AtmError> {
+    registry.push_dispatch_handle(handle, MAX_PEER_HTTP_CONNECTIONS)
+}
+
+fn handle_peer_connection(
+    mut stream: TcpStream,
+    router: Arc<dyn ApiRouter + Send + Sync>,
+) -> Result<(), AtmError> {
+    // Accepted sockets can inherit the nonblocking listener mode on macOS.
+    // Request framing is deliberately blocking under the explicit deadline.
+    stream.set_nonblocking(false).map_err(|source| {
+        AtmError::daemon_unavailable(format!(
+            "failed to configure peer HTTP connection mode: {source}"
+        ))
+    })?;
+    stream
+        .set_read_timeout(Some(PEER_HTTP_LOCAL_RESPONSE_BUDGET))
+        .map_err(|source| {
+            AtmError::daemon_unavailable(format!("failed to set peer HTTP read deadline: {source}"))
+        })?;
+    stream
+        .set_write_timeout(Some(PEER_HTTP_LOCAL_RESPONSE_BUDGET))
+        .map_err(|source| {
+            AtmError::daemon_unavailable(format!(
+                "failed to set peer HTTP write deadline: {source}"
+            ))
+        })?;
+    let mut frames = atm_core::api::HttpFrameReader::new();
+    for request_count in 1..=crate::MAX_KEEP_ALIVE_REQUESTS {
+        let Some(raw_request) = frames.read_request(&mut stream)? else {
+            return Ok(());
+        };
+        let keep_alive = raw_request
+            .header("connection")
+            .is_some_and(|value| value.eq_ignore_ascii_case("keep-alive"))
+            && request_count < crate::MAX_KEEP_ALIVE_REQUESTS;
+        let response = route_peer_http_request(router.as_ref(), raw_request);
+        atm_core::api::write_local_http_response(&mut stream, &response, keep_alive)?;
+        if !keep_alive {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+fn route_peer_http_request(
+    router: &dyn ApiRouter,
+    raw_request: atm_core::api::HttpRequest,
+) -> ResponseEnvelope {
+    let source_host = raw_request
+        .header(PLAINTEXT_PEER_SOURCE_HOST_HEADER)
+        .ok_or_else(|| AtmError::validation("peer HTTP write is missing X-ATM-Peer-Source-Host"))
+        .and_then(|value| {
+            value.parse::<HostName>().map_err(|error| {
+                AtmError::validation(format!("peer HTTP source host is invalid: {error}"))
+            })
+        });
+    let response = source_host.and_then(|source_host| {
+        let mut request = decode_request(raw_request)?;
+        match &mut request {
+            ApiRequest::Write(write) => {
+                write.authenticated_source_host = Some(source_host);
+                router
+                    .route(
+                        request,
+                        AuthenticatedIngress::Peer,
+                        RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
+                    )
+                    .map(|response| response.into_inner())
+            }
+            _ => Err(AtmError::validation(
+                "configured peer HTTP listener accepts write requests only",
+            )),
+        }
+    });
+    response.unwrap_or_else(ResponseEnvelope::Error)
+}
+
+fn write_peer_capacity_rejection(mut stream: TcpStream) -> Result<(), AtmError> {
+    atm_core::api::write_local_http_response(
+        &mut stream,
+        &ResponseEnvelope::Error(AtmError::daemon_unavailable(
+            "configured peer HTTP listener is at its concurrent connection capacity",
+        )),
+        false,
+    )
+}
+
+/// Sends one finite ordered slice through one operating-system-resolved TCP
+/// connection.  It is intentionally the sole production peer sender so the
+/// immediate and future batch paths cannot diverge.
+pub(crate) fn send_peer_http_frames(
+    config: &PeerHttpRuntimeConfig,
+    endpoint: &PeerEndpoint,
+    writes: &[WriteRequest],
+    deadline: RequestDeadline,
+) -> Result<Vec<ResponseEnvelope>, AtmError> {
+    if writes.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut stream = TcpStream::connect((endpoint.canonical_host.as_str(), endpoint.port.get()))
+        .map_err(|source| peer_delivery_failure("connect to configured peer", source))?;
+    let mut frames = atm_core::api::HttpFrameReader::new();
+    let mut responses = Vec::with_capacity(writes.len());
+
+    for (index, write) in writes.iter().enumerate() {
+        let remaining = peer_response_budget(deadline)?;
+        stream.set_read_timeout(Some(remaining)).map_err(|source| {
+            peer_delivery_failure("configure configured-peer response timeout", source)
+        })?;
+        stream
+            .set_write_timeout(Some(remaining))
+            .map_err(|source| {
+                peer_delivery_failure("configure configured-peer write timeout", source)
+            })?;
+
+        let request = RequestEnvelope::Write(Box::new(write.clone()));
+        write_http_request_with_headers_and_connection(
+            &mut stream,
+            &request,
+            &[(
+                PLAINTEXT_PEER_SOURCE_HOST_HEADER,
+                config.source_host.as_str(),
+            )],
+            index + 1 < writes.len(),
+        )
+        .map_err(|error| {
+            AtmError::remote_delivery_unconfirmed(format!(
+                "local persistence succeeded but write to configured peer `{}` failed: {error}",
+                endpoint.canonical_host
+            ))
+        })?;
+
+        let response = read_http_response_with_frame_reader(&mut frames, &mut stream, &request)
+            .map_err(|error| {
+                AtmError::remote_delivery_unconfirmed(format!(
+                    "local persistence succeeded but configured peer `{}` did not return a valid response: {error}",
+                    endpoint.canonical_host
+                ))
+            })?;
+        ensure_matching_send_response(&response, write, endpoint)?;
+        responses.push(response);
+    }
+    Ok(responses)
+}
+
+fn peer_response_budget(deadline: RequestDeadline) -> Result<Duration, AtmError> {
+    deadline
+        .remaining()
+        .map(|remaining| remaining.min(PEER_HTTP_LOCAL_RESPONSE_BUDGET))
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| {
+            AtmError::remote_delivery_unconfirmed(
+                "local persistence succeeded but the peer response deadline expired before delivery completed",
+            )
+        })
+}
+
+fn ensure_matching_send_response(
+    response: &ResponseEnvelope,
+    write: &WriteRequest,
+    endpoint: &PeerEndpoint,
+) -> Result<(), AtmError> {
+    let expected_message_id = write.origin_message_id.ok_or_else(|| {
+        AtmError::remote_delivery_unconfirmed(
+            "local persistence succeeded but peer delivery write had no immutable origin message ID",
+        )
+    })?;
+    let actual_message_id = match response {
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => outcome.message_id,
+        ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => outcome.message_id,
+        ResponseEnvelope::Error(error) => {
+            return Err(AtmError::remote_delivery_unconfirmed(format!(
+                "local persistence succeeded but configured peer `{}` rejected the write: {error}",
+                endpoint.canonical_host
+            )));
+        }
+        response => {
+            return Err(AtmError::remote_delivery_unconfirmed(format!(
+                "local persistence succeeded but configured peer `{}` returned unexpected response `{response:?}`",
+                endpoint.canonical_host
+            )));
+        }
+    };
+    if actual_message_id != expected_message_id {
+        return Err(AtmError::remote_delivery_unconfirmed(format!(
+            "local persistence succeeded but configured peer `{}` confirmed message `{actual_message_id}` instead of `{expected_message_id}`",
+            endpoint.canonical_host
+        )));
+    }
+    Ok(())
+}
+
+fn peer_delivery_failure(action: &str, source: std::io::Error) -> AtmError {
+    AtmError::remote_delivery_unconfirmed(format!(
+        "local persistence succeeded but failed to {action}: {source}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        PEER_HTTP_LOCAL_RESPONSE_BUDGET, PLAINTEXT_PEER_SOURCE_HOST_HEADER, PeerHttpBindConfig,
+        PeerHttpListenerSet, PeerHttpRuntimeConfig, send_peer_http_frames,
+    };
+    use std::io::Write;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+    use std::num::NonZeroU16;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    use atm_core::api::{
+        ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, HttpFrameReader, RequestDeadline,
+        decode_request, write_http_response,
+    };
+    use atm_core::error::AtmError;
+    use atm_core::error_codes::AtmErrorCode;
+    use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
+    use atm_core::send::{SendCommandOutcome, SendMessageSource, SendOutcome, WriteRequest};
+    use atm_core::types::{AgentName, CommandAction, TeamName};
+    use atm_storage::{AtmMessageId, HostName, PeerEndpoint};
+
+    #[derive(Default)]
+    struct PeerWriteRecorder {
+        source_hosts: Mutex<Vec<HostName>>,
+    }
+
+    impl atm_core::boundary::sealed::Sealed for PeerWriteRecorder {}
+
+    impl ApiRouter for PeerWriteRecorder {
+        fn route(
+            &self,
+            request: ApiRequest,
+            ingress: AuthenticatedIngress,
+            _deadline: RequestDeadline,
+        ) -> Result<ApiResponse, AtmError> {
+            assert_eq!(ingress, AuthenticatedIngress::Peer);
+            let ApiRequest::Write(write) = request else {
+                return Err(AtmError::validation("peer listener must receive a write"));
+            };
+            let source_host = write.authenticated_source_host.clone().ok_or_else(|| {
+                AtmError::validation("peer listener did not attach configured source host")
+            })?;
+            self.source_hosts
+                .lock()
+                .expect("source host recorder")
+                .push(source_host);
+            let message_id = write.origin_message_id.ok_or_else(|| {
+                AtmError::validation("peer listener did not preserve origin message ID")
+            })?;
+            Ok(ApiResponse::new(ResponseEnvelope::Send(
+                SendResponseEnvelope::Sent(send_outcome(message_id)),
+            )))
+        }
+    }
+
+    fn team() -> TeamName {
+        "peer-test".parse().expect("team")
+    }
+
+    fn agent() -> AgentName {
+        "sender".parse().expect("agent")
+    }
+
+    fn write(message_id: AtmMessageId) -> WriteRequest {
+        WriteRequest::new(
+            std::path::PathBuf::from("/tmp/atm-peer-test"),
+            std::path::PathBuf::from("/tmp/atm-peer-test"),
+            agent(),
+            "receiver@peer-test.127.0.0.1",
+            team(),
+            SendMessageSource::Inline("peer frame".to_owned()),
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("write")
+        .with_origin_message_id(message_id)
+    }
+
+    fn send_outcome(message_id: AtmMessageId) -> SendOutcome {
+        SendOutcome {
+            action: CommandAction::Send,
+            team: team(),
+            agent: "receiver".parse().expect("receiver"),
+            sender: agent(),
+            outcome: SendCommandOutcome::Sent,
+            message_id,
+            requires_ack: false,
+            task_id: None,
+            summary: None,
+            message: None,
+            warnings: Vec::new(),
+            dry_run: false,
+        }
+    }
+
+    #[test]
+    fn direct_sender_uses_shared_http_frame_and_configured_source_header() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
+        let port = listener.local_addr().expect("address").port();
+        let message_id = AtmMessageId::new();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let raw_request = HttpFrameReader::new()
+                .read_request(&mut stream)
+                .expect("read request")
+                .expect("one request");
+            assert_eq!(
+                raw_request.header(PLAINTEXT_PEER_SOURCE_HOST_HEADER),
+                Some("origin.example.test")
+            );
+            let request = decode_request(raw_request).expect("decode request");
+            let RequestEnvelope::Write(write) = request.into_inner() else {
+                panic!("peer sender must emit a write request");
+            };
+            assert_eq!(write.origin_message_id, Some(message_id));
+            let response =
+                ResponseEnvelope::Send(SendResponseEnvelope::Sent(send_outcome(message_id)));
+            let mut encoded_response = Vec::new();
+            write_http_response(&mut encoded_response, &response).expect("encode response");
+            let split_at = encoded_response.len() / 2;
+            stream
+                .write_all(&encoded_response[..split_at])
+                .expect("write split response prefix");
+            stream.flush().expect("flush response");
+            stream
+                .write_all(&encoded_response[split_at..])
+                .expect("write split response suffix");
+            stream.flush().expect("flush response");
+        });
+
+        let endpoint = PeerEndpoint {
+            canonical_host: "localhost".parse::<HostName>().expect("host"),
+            port: NonZeroU16::new(port).expect("port"),
+        };
+        let response = send_peer_http_frames(
+            &PeerHttpRuntimeConfig {
+                source_host: "origin.example.test".parse().expect("source host"),
+            },
+            &endpoint,
+            &[write(message_id)],
+            RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
+        )
+        .expect("direct send succeeds");
+        assert!(matches!(response.as_slice(), [ResponseEnvelope::Send(_)]));
+        server.join().expect("server");
+    }
+
+    #[test]
+    fn direct_sender_rejects_a_response_for_a_different_immutable_write() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("listener");
+        let port = listener.local_addr().expect("address").port();
+        let message_id = AtmMessageId::new();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let _ = HttpFrameReader::new()
+                .read_request(&mut stream)
+                .expect("read request");
+            write_http_response(
+                &mut stream,
+                &ResponseEnvelope::Send(SendResponseEnvelope::Sent(send_outcome(
+                    AtmMessageId::new(),
+                ))),
+            )
+            .expect("write mismatched response");
+        });
+        let endpoint = PeerEndpoint {
+            canonical_host: "localhost".parse().expect("host"),
+            port: NonZeroU16::new(port).expect("port"),
+        };
+
+        let error = send_peer_http_frames(
+            &PeerHttpRuntimeConfig {
+                source_host: "origin.example.test".parse().expect("source host"),
+            },
+            &endpoint,
+            &[write(message_id)],
+            RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
+        )
+        .expect_err("a response for a different write cannot confirm delivery");
+        assert_eq!(error.code(), AtmErrorCode::RemoteDeliveryUnconfirmed);
+        server.join().expect("server");
+    }
+
+    #[test]
+    fn bind_config_rejects_empty_duplicate_wildcard_and_multicast() {
+        for bind_addrs in [
+            vec![],
+            vec![
+                SocketAddr::from((Ipv4Addr::LOCALHOST, 43101)),
+                SocketAddr::from((Ipv4Addr::LOCALHOST, 43101)),
+            ],
+            vec![SocketAddr::from((Ipv4Addr::UNSPECIFIED, 43101))],
+            vec![SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),
+                43101,
+            )],
+        ] {
+            assert!(
+                PeerHttpBindConfig { bind_addrs }
+                    .validate_at_startup()
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn configured_peer_listener_routes_http_write_as_peer_ingress() {
+        let mut listener_set = PeerHttpListenerSet::bind(&PeerHttpBindConfig {
+            bind_addrs: vec![SocketAddr::from((Ipv4Addr::LOCALHOST, 0))],
+        })
+        .expect("bind configured peer listener");
+        let port = listener_set.listeners[0]
+            .listener
+            .local_addr()
+            .expect("listener address")
+            .port();
+        let recorder = Arc::new(PeerWriteRecorder::default());
+        listener_set
+            .start(recorder.clone())
+            .expect("start configured peer listener");
+
+        let first_message_id = AtmMessageId::new();
+        let second_message_id = AtmMessageId::new();
+        let endpoint = PeerEndpoint {
+            canonical_host: "localhost".parse().expect("host"),
+            port: NonZeroU16::new(port).expect("port"),
+        };
+        send_peer_http_frames(
+            &PeerHttpRuntimeConfig {
+                source_host: "origin.example.test".parse().expect("source host"),
+            },
+            &endpoint,
+            &[write(first_message_id), write(second_message_id)],
+            RequestDeadline::after(PEER_HTTP_LOCAL_RESPONSE_BUDGET),
+        )
+        .expect("configured peer sender/receiver round trip");
+        assert_eq!(
+            *recorder.source_hosts.lock().expect("recorder"),
+            vec![
+                "origin.example.test".parse().expect("source host"),
+                "origin.example.test".parse().expect("source host"),
+            ]
+        );
+        listener_set.shutdown().expect("shutdown peer listener");
+    }
+}

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -2,6 +2,7 @@ use crate::AtmHomeDir;
 use crate::daemon_runtime_observability::{
     DaemonRuntimeObservability, DaemonSubsystem, SubsystemObservability,
 };
+use arc_swap::ArcSwapOption;
 use atm_core::{
     ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, LocalServiceRuntime, RequestDeadline,
     RequestEnvelope, ResponseEnvelope, boundary,
@@ -25,13 +26,14 @@ mod admission_view;
 use admission_view::AdmissionRuntimeView;
 mod doctor_reporting;
 mod post_commit_work;
+use crate::peer_http_listener::{PeerHttpBindConfig, PeerHttpListenerSet, PeerHttpRuntimeConfig};
 #[cfg(test)]
 pub(crate) use crate::runtime_status_cache::MAX_STATUS_CACHE_ENTRIES;
 pub(crate) use crate::runtime_status_cache::RuntimeStatusCache;
 use crate::runtime_status_cache::{build_runtime_status_cache_state, runtime_status_finding};
 use atm_runtime::RuntimeAssembly;
-use atm_storage::PeerConfigStore;
 use atm_storage::RosterStore;
+use atm_storage::{MessageStore, PeerConfigStore};
 use doctor_reporting::{daemon_observability_finding, finalize_doctor_report};
 use post_commit_work::{LocalPostCommitWorkQueue, PostCommitWorkKey, PostCommitWorkQueue};
 mod peer_delivery_router;
@@ -54,6 +56,8 @@ pub(crate) struct DaemonRequestDispatcher {
     status_cache: RuntimeStatusCache,
     service_runtime: LocalServiceRuntime,
     admission_runtime_view: AdmissionRuntimeView,
+    peer_http_runtime_config: Arc<ArcSwapOption<PeerHttpRuntimeConfig>>,
+    message_store: Arc<dyn MessageStore + Send + Sync>,
     doctor_ports: atm_core::doctor::RuntimeDoctorPorts,
     roster_store: Option<Arc<dyn RosterStore + Send + Sync>>,
     peer_config_store: Arc<dyn PeerConfigStore + Send + Sync>,
@@ -70,6 +74,7 @@ impl std::fmt::Debug for DaemonRequestDispatcher {
             .field("doctor_ports", &self.doctor_ports)
             .field("roster_store_present", &self.roster_store.is_some())
             .field("peer_config_store", &"dyn PeerConfigStore")
+            .field("message_store", &"dyn MessageStore")
             .finish()
     }
 }
@@ -300,8 +305,10 @@ impl DaemonRequestDispatcher {
         let runtime_health_observability =
             SubsystemObservability::new(DaemonSubsystem::RuntimeHealth, Arc::clone(&observability));
         let roster_store = runtime_assembly.shared_roster_store_arc();
+        let message_store = runtime_assembly.message_store_arc();
         let peer_config_store = runtime_assembly.peer_config_store();
         let peer_directory = peer_config_store.peer_directory()?;
+        let peer_http_runtime_config = peer_http_runtime_config(peer_config_store.as_ref())?;
         match build_runtime_status_cache_state(None, roster_store.as_ref()) {
             Ok(state) => status_cache.publish_state(state),
             Err(error) => {
@@ -335,6 +342,10 @@ impl DaemonRequestDispatcher {
             status_cache,
             service_runtime,
             admission_runtime_view,
+            peer_http_runtime_config: Arc::new(ArcSwapOption::from(
+                peer_http_runtime_config.map(Arc::new),
+            )),
+            message_store,
             doctor_ports: runtime_assembly.doctor_ports,
             roster_store: Some(roster_store),
             peer_config_store,
@@ -349,6 +360,22 @@ impl DaemonRequestDispatcher {
 
     pub(crate) fn stop_local_post_write_executor(&self) -> Result<(), AtmError> {
         self.post_commit_signals.stop()
+    }
+
+    pub(crate) fn prepare_peer_http_listener(
+        &self,
+    ) -> Result<Option<PeerHttpListenerSet>, AtmError> {
+        let bind_addrs: Vec<std::net::SocketAddr> = self
+            .peer_config_store
+            .list_interfaces()?
+            .into_iter()
+            .filter(|interface| interface.enabled)
+            .map(|interface| interface.bind_addr)
+            .collect();
+        if bind_addrs.is_empty() {
+            return Ok(None);
+        }
+        PeerHttpListenerSet::bind(&PeerHttpBindConfig { bind_addrs }).map(Some)
     }
 
     #[cfg(test)]
@@ -389,10 +416,14 @@ trait MessageWriter: Send + Sync {
 }
 
 pub(super) trait PostWriteRouter: Send + Sync {
-    /// Non-blocking, infallible post-commit scheduling. A committed admission
-    /// response is constructed before this signal and cannot be relabelled by
-    /// worker availability or notification delivery.
-    fn dispatch(&self, message: &mut MessageRecord);
+    /// Routes one already-committed write. Local notification stays
+    /// best-effort; direct peer delivery can instead return the explicit
+    /// persisted-but-undelivered result to the initiating caller.
+    fn dispatch(
+        &self,
+        message: &mut MessageRecord,
+        deadline: RequestDeadline,
+    ) -> Result<(), AtmError>;
 }
 
 impl DaemonRequestDispatcher {
@@ -409,14 +440,18 @@ impl DaemonRequestDispatcher {
         let side_effecting = request_may_have_side_effects(&request);
         require_dispatch_budget(deadline, false)?;
         let response = match request {
-            RequestEnvelope::Write(request) => self.route_write(*request),
+            RequestEnvelope::Write(request) => self.route_write(*request, deadline),
             request => self.dispatch_non_write(request),
         }?;
         require_dispatch_budget(deadline, side_effecting)?;
         Ok(response)
     }
 
-    fn route_write(&self, request: WriteRequest) -> Result<ResponseEnvelope, AtmError> {
+    fn route_write(
+        &self,
+        request: WriteRequest,
+        deadline: RequestDeadline,
+    ) -> Result<ResponseEnvelope, AtmError> {
         let mut message = MessageWriter::write(self, request)?;
         let requires_post_commit_signal = message.prepared.requires_post_write_route();
         // Admission is complete before any post-commit work is even signalled.
@@ -434,7 +469,7 @@ impl DaemonRequestDispatcher {
             }
         };
         if requires_post_commit_signal {
-            PostWriteRouter::dispatch(self, &mut message);
+            PostWriteRouter::dispatch(self, &mut message, deadline)?;
         }
         Ok(response)
     }
@@ -510,6 +545,28 @@ fn request_may_have_side_effects(request: &RequestEnvelope) -> bool {
     )
 }
 
+fn peer_http_runtime_config(
+    peer_config_store: &dyn PeerConfigStore,
+) -> Result<Option<PeerHttpRuntimeConfig>, AtmError> {
+    let mut advertised_hosts = peer_config_store
+        .list_interfaces()?
+        .into_iter()
+        .filter(|interface| interface.enabled)
+        .map(|interface| interface.advertise_host)
+        .collect::<Vec<_>>();
+    advertised_hosts.sort();
+    advertised_hosts.dedup();
+    match advertised_hosts.as_slice() {
+        [] => Ok(None),
+        [source_host] => Ok(Some(PeerHttpRuntimeConfig {
+            source_host: source_host.clone(),
+        })),
+        _ => Err(AtmError::peer_config_validation(
+            "enabled peer interfaces must advertise one canonical source host for direct peer HTTP delivery",
+        )),
+    }
+}
+
 impl MessageWriter for DaemonRequestDispatcher {
     fn write(&self, request: WriteRequest) -> Result<MessageRecord, AtmError> {
         self.persist_local_write(request).map(|prepared| {
@@ -566,8 +623,11 @@ impl DaemonRequestDispatcher {
         let next_state =
             build_runtime_status_cache_state(Some(&current_state), roster_store.as_ref())?;
         let peer_directory = self.peer_config_store.peer_directory()?;
+        let peer_http_runtime_config = peer_http_runtime_config(self.peer_config_store.as_ref())?;
         self.admission_runtime_view
             .reload(self.service_runtime.clone(), peer_directory);
+        self.peer_http_runtime_config
+            .store(peer_http_runtime_config.map(Arc::new));
         let reloaded_members = next_state.member_count();
         self.status_cache.publish_state(next_state);
         tracing::info!(
@@ -717,8 +777,6 @@ impl ApiRouter for DaemonRequestDispatcher {
             let write_ingress = match &ingress {
                 AuthenticatedIngress::Local => WriteIngress::Local,
                 AuthenticatedIngress::Peer => WriteIngress::Peer,
-                AuthenticatedIngress::UntrustedSmoke(_) => WriteIngress::UntrustedSmoke,
-                AuthenticatedIngress::AnonymousSmoke => WriteIngress::AnonymousSmoke,
             };
             validate_write_provenance(
                 write_ingress,
@@ -811,6 +869,9 @@ impl DaemonRequestDispatcher {
             std::sync::Arc::clone(&runtime_observability),
         );
         let peer_config_store = runtime_assembly.peer_config_store();
+        let message_store = runtime_assembly.message_store_arc();
+        let peer_http_runtime_config = peer_http_runtime_config(peer_config_store.as_ref())
+            .expect("test peer HTTP runtime config");
         let service_runtime = runtime_assembly.service_runtime.clone();
         let daemon_home = crate::AtmHomeDir::from_path_for_test(home_dir.clone());
         let post_commit_signals = Arc::new(LocalPostCommitWorkQueue::new(
@@ -834,6 +895,10 @@ impl DaemonRequestDispatcher {
                     .peer_directory()
                     .expect("test peer directory"),
             ),
+            peer_http_runtime_config: Arc::new(ArcSwapOption::from(
+                peer_http_runtime_config.map(Arc::new),
+            )),
+            message_store,
             doctor_ports: runtime_assembly.doctor_ports.clone(),
             roster_store: Some(runtime_assembly.shared_roster_store_arc()),
             peer_config_store,

--- a/crates/atm-daemon/src/runtime_health/admission_view.rs
+++ b/crates/atm-daemon/src/runtime_health/admission_view.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use atm_core::send::{PreparedWrite, WriteRequest, prepare_write_with_runtime};
 use atm_core::{LocalServiceRuntime, error::AtmError};
-use atm_storage::{PeerAliasKey, PeerDirectory};
+use atm_storage::{HostName, PeerAliasKey, PeerDirectory, PeerEndpoint};
 
 use crate::daemon_runtime_observability::DaemonRuntimeObservability;
 
@@ -59,5 +59,15 @@ impl AdmissionRuntimeView {
             runtime,
             peer_directory,
         }));
+    }
+
+    /// Resolves one already-canonical host from the immutable configuration
+    /// snapshot published with local admission. This is an in-memory lookup,
+    /// never a per-send storage read or hostname-resolution step.
+    pub(crate) fn endpoint_for_canonical_host(&self, host: &HostName) -> Option<PeerEndpoint> {
+        self.state
+            .load()
+            .peer_directory
+            .endpoint_for_canonical_host(host)
     }
 }

--- a/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
+++ b/crates/atm-daemon/src/runtime_health/peer_delivery_router.rs
@@ -1,7 +1,15 @@
+use atm_storage::PeerDeliveryConfirmation;
+
+use crate::peer_http_listener::send_peer_http_frames;
+
 use super::{DaemonRequestDispatcher, MessageRecord, PostCommitWorkKey, PostWriteRouter};
 
 impl PostWriteRouter for DaemonRequestDispatcher {
-    fn dispatch(&self, message: &mut MessageRecord) {
+    fn dispatch(
+        &self,
+        message: &mut MessageRecord,
+        deadline: atm_core::api::RequestDeadline,
+    ) -> Result<(), atm_core::error::AtmError> {
         if message.prepared.is_peer_receipt() {
             tracing::info!(
                 subsystem = "runtime_health",
@@ -11,21 +19,50 @@ impl PostWriteRouter for DaemonRequestDispatcher {
                 "authenticated peer receipt uses the canonical local post-write route"
             );
             self.signal_local_post_write(message);
-            return;
+            return Ok(());
         }
-        if message
+        if let Some(host) = message
             .outbound_request
             .to
             .as_ref()
             .and_then(|address| address.host())
-            .is_some()
         {
-            // Host-qualified origin writes are durable immutable records only
-            // until AK.4 introduces the direct peer HTTP sender. They neither
-            // emit a local nudge nor start work after this admission response.
-            return;
+            let endpoint = self
+                .admission_runtime_view
+                .endpoint_for_canonical_host(host)
+                .ok_or_else(|| {
+                    atm_core::error::AtmError::remote_delivery_unconfirmed(format!(
+                        "local persistence succeeded but canonical peer `{host}` is no longer enabled"
+                    ))
+                })?;
+            let config = self.peer_http_runtime_config.load_full().ok_or_else(|| {
+                atm_core::error::AtmError::remote_delivery_unconfirmed(
+                    "local persistence succeeded but no enabled local peer interface advertises a source host",
+                )
+            })?;
+            send_peer_http_frames(
+                &config,
+                &endpoint,
+                std::slice::from_ref(&message.outbound_request),
+                deadline,
+            )?;
+            let confirmed = self
+                .message_store
+                .confirm_peer_delivery(PeerDeliveryConfirmation {
+                    message_id: message.prepared.persisted_message_id(),
+                    canonical_host: endpoint.canonical_host,
+                })?;
+            tracing::info!(
+                subsystem = "runtime_health",
+                action = "peer_delivery_confirmation",
+                outcome = if confirmed { "confirmed" } else { "already_confirmed" },
+                message_id = ?message.prepared.persisted_message_id(),
+                "direct configured-peer HTTP delivery completed"
+            );
+            return Ok(());
         }
         self.signal_local_post_write(message);
+        Ok(())
     }
 }
 

--- a/crates/atm-daemon/src/tests/runtime_root.rs
+++ b/crates/atm-daemon/src/tests/runtime_root.rs
@@ -1,17 +1,24 @@
 use super::*;
+use atm_core::api::{HttpFrameReader, decode_request, write_http_response};
 use atm_core::error::AtmError;
 use atm_core::error_codes::AtmErrorCode;
 use atm_core::protocol::{RequestEnvelope, ResponseEnvelope, SendResponseEnvelope};
 use atm_core::read::ReadQuery;
+use atm_core::send::{SendCommandOutcome, SendOutcome};
 use atm_core::send::{SendMessageSource, SendRequest};
 use atm_core::team_admin::{AddMemberRequest, add_member_with_roster_store};
 use atm_core::test_support::{EnvGuard, ROLE_TEAM_LEAD};
+use atm_core::types::CommandAction;
 use atm_core::types::ReadSelection;
 use atm_core::{ApiRequest, ApiRouter, AuthenticatedIngress, RequestDeadline};
 use atm_runtime_test_support::{SQLITE_RUNTIME_PATH_ENV, open_sqlite_boundary};
-use atm_storage::{HostName, MessageKey, PeerAliasKey, TrustedPeer};
+use atm_storage::{HostName, HttpsInterface, MessageKey, MessageQuery, PeerAliasKey, TrustedPeer};
+use std::io::Write;
+use std::net::{IpAddr, Ipv4Addr, TcpListener};
+use std::num::NonZeroU16;
 use std::sync::Arc;
 use std::sync::mpsc;
+use std::thread;
 use std::time::Duration;
 use tempfile::TempDir;
 
@@ -46,6 +53,10 @@ fn add_member_via_retained_admin(
 }
 
 fn configure_trusted_peer(db_path: &std::path::Path, canonical_host: &str, aliases: &[&str]) {
+    assert!(
+        canonical_host.parse::<IpAddr>().is_err(),
+        "test canonical peer hosts must be stable DNS names; use an IP alias instead"
+    );
     let assembly = open_sqlite_boundary(db_path).expect("sqlite boundary");
     let store = assembly.peer_config_store();
     let canonical_host: HostName = canonical_host.parse().expect("canonical host");
@@ -67,9 +78,65 @@ fn configure_trusted_peer(db_path: &std::path::Path, canonical_host: &str, alias
     }
 }
 
+fn configure_peer_http_source(db_path: &std::path::Path) {
+    let assembly = open_sqlite_boundary(db_path).expect("sqlite boundary");
+    assembly
+        .peer_config_store()
+        .save_interface(&HttpsInterface {
+            // `new_for_test` does not start listeners. This supplies only the
+            // explicitly configured source-host provenance required by AK.4.
+            bind_addr: "127.0.0.1:43101".parse().expect("bind address"),
+            advertise_host: "origin.example.test".parse().expect("source host"),
+            enabled: true,
+        })
+        .expect("save configured peer HTTP source");
+}
+
+fn serve_direct_peer_responses(request_count: usize) -> (NonZeroU16, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("peer listener");
+    let port = NonZeroU16::new(listener.local_addr().expect("peer address").port())
+        .expect("non-zero peer port");
+    let server = thread::spawn(move || {
+        for _ in 0..request_count {
+            let (mut stream, _) = listener.accept().expect("peer accept");
+            let raw_request = HttpFrameReader::new()
+                .read_request(&mut stream)
+                .expect("read peer HTTP request")
+                .expect("one peer HTTP request");
+            let request = decode_request(raw_request).expect("decode peer HTTP request");
+            let ApiRequest::Write(write) = request else {
+                panic!("direct peer sender must issue a write request");
+            };
+            let message_id = write
+                .origin_message_id
+                .expect("direct peer write preserves immutable message ID");
+            write_http_response(
+                &mut stream,
+                &ResponseEnvelope::Send(SendResponseEnvelope::Sent(SendOutcome {
+                    action: CommandAction::Send,
+                    team: TEST_TEAM.parse().expect("team"),
+                    agent: "remote-agent".parse().expect("recipient"),
+                    sender: ROLE_TEAM_LEAD.parse().expect("sender"),
+                    outcome: SendCommandOutcome::Sent,
+                    message_id,
+                    requires_ack: false,
+                    task_id: None,
+                    summary: None,
+                    message: None,
+                    warnings: Vec::new(),
+                    dry_run: false,
+                })),
+            )
+            .expect("write peer HTTP response");
+            stream.flush().expect("flush peer HTTP response");
+        }
+    });
+    (port, server)
+}
+
 #[test]
 #[serial_test::serial(env)]
-fn host_qualified_write_is_admitted_without_foreground_https_delivery() {
+fn host_qualified_write_persists_then_confirms_direct_peer_http_delivery() {
     install_retained_runtime_factory();
     let tempdir = TempDir::new().expect("tempdir");
     let atm_home = tempdir.path().join("atm-home");
@@ -85,7 +152,19 @@ fn host_qualified_write_is_admitted_without_foreground_https_delivery() {
         ROLE_TEAM_LEAD,
         &workspace_dir,
     );
-    configure_trusted_peer(&db_path, "rand-m5.local", &["peer.example.test"]);
+    let (port, server) = serve_direct_peer_responses(1);
+    configure_trusted_peer(&db_path, "localhost", &["peer.example.test", "127.0.0.1"]);
+    let assembly = open_sqlite_boundary(&db_path).expect("sqlite boundary");
+    assembly
+        .peer_config_store()
+        .save_trusted_peer(&TrustedPeer {
+            host: "localhost".parse().expect("canonical host"),
+            fingerprint: "sha256:test".parse().expect("fingerprint"),
+            enabled: true,
+            https_port: port,
+        })
+        .expect("replace peer endpoint with test listener");
+    configure_peer_http_source(&db_path);
     let dispatcher = DaemonRequestDispatcher::new_for_test(
         atm_home.clone(),
         RuntimeStatusCache::new(),
@@ -108,7 +187,7 @@ fn host_qualified_write_is_admitted_without_foreground_https_delivery() {
             )
             .expect("remote write request"),
         )))
-        .expect("local admission must succeed without waiting for peer delivery");
+        .expect("local admission and direct peer delivery must succeed");
     let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = response else {
         panic!("host-qualified admission must return sent");
     };
@@ -126,9 +205,96 @@ fn host_qualified_write_is_admitted_without_foreground_https_delivery() {
             .get("peerOutbound")
             .and_then(|value| value.get("host"))
             .and_then(serde_json::Value::as_str),
-        Some("rand-m5.local"),
-        "AK.3 persists the canonical host-qualified immutable record"
+        None,
+        "AK.4 removes the peer marker only after the direct peer confirms the immutable message ID"
     );
+    server.join().expect("peer server");
+}
+
+#[test]
+#[serial_test::serial(env)]
+fn failed_direct_peer_response_retains_the_unconfirmed_marker() {
+    install_retained_runtime_factory();
+    let tempdir = TempDir::new().expect("tempdir");
+    let atm_home = tempdir.path().join("atm-home");
+    let workspace_dir = tempdir.path().join("workspace");
+    std::fs::create_dir_all(&atm_home).expect("atm home dir");
+    std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+    let db_path = tempdir.path().join("mail.db");
+    write_team_config(&atm_home, &[]);
+    add_member_via_retained_admin(
+        &db_path,
+        &atm_home,
+        TEST_TEAM,
+        ROLE_TEAM_LEAD,
+        &workspace_dir,
+    );
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("peer listener");
+    let port = NonZeroU16::new(listener.local_addr().expect("peer address").port())
+        .expect("non-zero peer port");
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("peer accept");
+        let _ = HttpFrameReader::new()
+            .read_request(&mut stream)
+            .expect("read peer request");
+        // Closing after receipt models an unknown receiver outcome. The origin
+        // must not treat it as confirmation or remove its durable marker.
+    });
+    configure_trusted_peer(&db_path, "localhost", &["peer.example.test", "127.0.0.1"]);
+    let assembly = open_sqlite_boundary(&db_path).expect("sqlite boundary");
+    assembly
+        .peer_config_store()
+        .save_trusted_peer(&TrustedPeer {
+            host: "localhost".parse().expect("canonical host"),
+            fingerprint: "sha256:test".parse().expect("fingerprint"),
+            enabled: true,
+            https_port: port,
+        })
+        .expect("replace peer endpoint with test listener");
+    configure_peer_http_source(&db_path);
+    let dispatcher =
+        DaemonRequestDispatcher::new_for_test(atm_home.clone(), RuntimeStatusCache::new(), db_path);
+
+    let error = dispatcher
+        .dispatch(RequestEnvelope::Write(Box::new(
+            SendRequest::new(
+                atm_home,
+                workspace_dir,
+                ROLE_TEAM_LEAD.parse().expect("caller"),
+                "remote-agent@remote-team.peer.example.test",
+                TEST_TEAM.parse().expect("team"),
+                SendMessageSource::Inline("unconfirmed peer write".to_owned()),
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("remote write request"),
+        )))
+        .expect_err("closed peer response is unconfirmed delivery");
+    assert_eq!(error.code(), AtmErrorCode::RemoteDeliveryUnconfirmed);
+
+    let stored = assembly
+        .message_store_arc()
+        .list_messages(&MessageQuery {
+            team: "remote-team".parse().expect("remote team"),
+            agent: "remote-agent".parse().expect("remote agent"),
+            sender: None,
+            task_id: None,
+            limit: None,
+        })
+        .expect("load durable remote origin record");
+    assert_eq!(stored.len(), 1);
+    assert_eq!(
+        stored[0]
+            .envelope
+            .extra
+            .get("peerOutbound")
+            .and_then(|value| value.get("host"))
+            .and_then(serde_json::Value::as_str),
+        Some("localhost")
+    );
+    server.join().expect("peer server");
 }
 
 #[test]
@@ -149,7 +315,19 @@ fn peer_alias_reload_swaps_the_admission_directory_without_a_message_store_looku
         ROLE_TEAM_LEAD,
         &workspace_dir,
     );
-    configure_trusted_peer(&db_path, "rand-m5.local", &[]);
+    let (port, server) = serve_direct_peer_responses(1);
+    configure_trusted_peer(&db_path, "localhost", &[]);
+    let assembly = open_sqlite_boundary(&db_path).expect("sqlite boundary");
+    assembly
+        .peer_config_store()
+        .save_trusted_peer(&TrustedPeer {
+            host: "localhost".parse().expect("canonical host"),
+            fingerprint: "sha256:test".parse().expect("fingerprint"),
+            enabled: true,
+            https_port: port,
+        })
+        .expect("replace peer endpoint with test listener");
+    configure_peer_http_source(&db_path);
     let dispatcher = DaemonRequestDispatcher::new_for_test(
         atm_home.clone(),
         RuntimeStatusCache::new(),
@@ -176,12 +354,11 @@ fn peer_alias_reload_swaps_the_admission_directory_without_a_message_store_looku
         .expect_err("unknown aliases fail before admission");
     assert_eq!(error.code(), AtmErrorCode::PeerConfigValidationFailed);
 
-    let assembly = open_sqlite_boundary(&db_path).expect("sqlite boundary");
     assembly
         .peer_config_store()
         .save_peer_alias(
             "peer.example.test".parse().expect("host alias"),
-            "rand-m5.local".parse().expect("canonical host"),
+            "localhost".parse().expect("canonical host"),
         )
         .expect("save alias");
     dispatcher
@@ -190,7 +367,7 @@ fn peer_alias_reload_swaps_the_admission_directory_without_a_message_store_looku
 
     let response = dispatcher
         .dispatch(RequestEnvelope::Write(Box::new(request())))
-        .expect("reloaded alias is admitted without a peer worker");
+        .expect("reloaded alias is delivered through the direct peer path");
     let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = response else {
         panic!("expected persisted host-qualified send");
     };
@@ -206,8 +383,10 @@ fn peer_alias_reload_swaps_the_admission_directory_without_a_message_store_looku
             .get("peerOutbound")
             .and_then(|value| value.get("host"))
             .and_then(serde_json::Value::as_str),
-        Some("rand-m5.local")
+        None,
+        "a direct peer confirmation clears only the matching marker"
     );
+    server.join().expect("peer server");
 }
 
 #[test]
@@ -447,7 +626,19 @@ fn host_qualified_self_addresses_use_the_ordinary_admission_route() {
         ROLE_TEAM_LEAD,
         &workspace_dir,
     );
+    let (port, server) = serve_direct_peer_responses(2);
     configure_trusted_peer(&db_path, "localhost", &["127.0.0.1"]);
+    let assembly = open_sqlite_boundary(&db_path).expect("sqlite boundary");
+    assembly
+        .peer_config_store()
+        .save_trusted_peer(&TrustedPeer {
+            host: "localhost".parse().expect("canonical host"),
+            fingerprint: "sha256:test".parse().expect("fingerprint"),
+            enabled: true,
+            https_port: port,
+        })
+        .expect("replace peer endpoint with test listener");
+    configure_peer_http_source(&db_path);
     let dispatcher =
         DaemonRequestDispatcher::new_for_test(atm_home.clone(), RuntimeStatusCache::new(), db_path);
 
@@ -475,6 +666,7 @@ fn host_qualified_self_addresses_use_the_ordinary_admission_route() {
             ResponseEnvelope::Send(SendResponseEnvelope::Sent(_))
         ));
     }
+    server.join().expect("peer server");
 }
 
 #[test]

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -119,7 +119,12 @@ impl OutboundMessageQuery for SqliteOutboundMessageQuery {
 #[cfg(any(test, feature = "test-support"))]
 impl Drop for SqliteWriterLockGuard {
     fn drop(&mut self) {
-        let _ = self.connection.execute_batch("ROLLBACK;");
+        if let Err(error) = self.connection.execute_batch("ROLLBACK;") {
+            tracing::warn!(
+                %error,
+                "test-only SQLite writer-lock rollback failed during cleanup"
+            );
+        }
     }
 }
 

--- a/crates/atm-storage-rusqlite/src/lib.rs
+++ b/crates/atm-storage-rusqlite/src/lib.rs
@@ -20,7 +20,8 @@ pub use crate::observability::{
 };
 use atm_storage::contract::{
     AcknowledgementCommit, AcknowledgementReplyBuilder, AcknowledgementSource, MailboxBucketCounts,
-    Message, MessageKey, MessageQuery, MessageStore, PeerConfigStore, RosterStore,
+    Message, MessageKey, MessageQuery, MessageStore, PeerConfigStore, PeerDeliveryConfirmation,
+    RosterStore,
 };
 #[cfg(test)]
 use atm_storage::schema::ThreadMode;
@@ -314,6 +315,28 @@ impl MessageStore for SqliteMessageStore {
         builder: Arc<dyn AcknowledgementReplyBuilder>,
     ) -> Result<AcknowledgementCommit, AtmError> {
         self.db.submit_acknowledgement(source.clone(), builder)
+    }
+
+    fn confirm_peer_delivery(
+        &self,
+        confirmation: PeerDeliveryConfirmation,
+    ) -> Result<bool, AtmError> {
+        let message_key = MessageKey::from(confirmation.message_id);
+        self.db.with_transaction(|transaction| {
+            let changed = transaction
+                .execute(
+                    "UPDATE mail_messages
+                     SET envelope_json = json_remove(envelope_json, '$.peerOutbound')
+                     WHERE message_key = ?1
+                       AND json_extract(envelope_json, '$.peerOutbound.host') = ?2;",
+                    params![message_key.as_ref(), confirmation.canonical_host.as_str()],
+                )
+                .map_err(|error| {
+                    self.db
+                        .error("failed to confirm sqlite peer message delivery", error)
+                })?;
+            Ok(changed == 1)
+        })
     }
 
     fn load_message(&self, key: &MessageKey) -> Result<Option<Message>, AtmError> {
@@ -714,13 +737,13 @@ impl SqliteStorageBackend {
 #[cfg(test)]
 mod tests {
     use super::SqliteStorageBackend;
-    use atm_storage::StoredPeerWrite;
     use atm_storage::contract::{
         AcknowledgementReplyBuilder, AcknowledgementSource, AgentType, Message, MessageKey,
         MessageQuery, RosterHarness, RosterMember, RosterMemberKind, RosterSnapshot,
     };
     use atm_storage::schema::{AtmMessageId, MessageEnvelope};
     use atm_storage::types::{AgentName, HostName, IsoTimestamp, ModelName, TeamName};
+    use atm_storage::{PeerDeliveryConfirmation, StoredPeerWrite};
     use chrono::{Duration, Utc};
     use rusqlite::params;
     use serde_json::{Map, json};
@@ -833,6 +856,60 @@ mod tests {
                 request_json: "retained-request".to_string(),
             }],
             "only recent immutable writes for the requested peer are eligible"
+        );
+    }
+
+    #[test]
+    fn confirm_peer_delivery_removes_only_the_matching_outbound_marker() {
+        let backend = SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let message_id = AtmMessageId::new();
+        let canonical_host: HostName = "peer.example.test".parse().expect("host");
+        let timestamp = IsoTimestamp::from_datetime(Utc::now());
+        let message = peer_outbound_message(
+            &format!("atm:{message_id}"),
+            canonical_host.as_str(),
+            "request-json",
+            timestamp,
+        );
+        let store = backend.message_store();
+        store.save_message(&message).expect("save message");
+
+        assert!(
+            store
+                .confirm_peer_delivery(PeerDeliveryConfirmation {
+                    message_id,
+                    canonical_host: canonical_host.clone(),
+                })
+                .expect("confirm delivery")
+        );
+        assert!(
+            !store
+                .confirm_peer_delivery(PeerDeliveryConfirmation {
+                    message_id,
+                    canonical_host,
+                })
+                .expect("repeat confirmation is a no-op")
+        );
+
+        let retained = store
+            .load_message(&message.message_key)
+            .expect("load message")
+            .expect("message remains durable");
+        assert_eq!(retained.envelope.text, "request-json");
+        assert!(!retained.envelope.extra.contains_key("peerOutbound"));
+        assert!(
+            backend
+                .outbound_message_query()
+                .page_for_peer(
+                    &"peer.example.test".parse().expect("host"),
+                    timestamp,
+                    None,
+                    NonZeroU16::new(1).expect("non-zero limit"),
+                    std::time::Duration::from_secs(1),
+                )
+                .expect("query confirmed peer writes")
+                .is_empty(),
+            "confirmation removes the write from the later peer-outbound query"
         );
     }
 

--- a/crates/atm-storage-rusqlite/src/peer_config_store.rs
+++ b/crates/atm-storage-rusqlite/src/peer_config_store.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use atm_storage::{
     CertificateFingerprint, HostName, HttpsInterface, LocalCertificate, PeerAliasKey,
-    PeerConfigStore, PeerDirectory, PrivateKeyRef, TrustedPeer,
+    PeerConfigStore, PeerDirectory, PrivateKeyRef, TrustedPeer, validate_canonical_peer_host,
 };
 use rusqlite::{OptionalExtension, params};
 
@@ -187,6 +187,7 @@ impl PeerConfigStore for SqlitePeerConfigStore {
     }
 
     fn save_trusted_peer(&self, peer: &TrustedPeer) -> Result<(), atm_storage::AtmError> {
+        validate_canonical_peer_host(&peer.host)?;
         let fingerprint = peer.fingerprint.as_str();
         self.db.with_connection(|connection| {
             connection
@@ -258,6 +259,7 @@ impl PeerConfigStore for SqlitePeerConfigStore {
         alias: PeerAliasKey,
         canonical_host: HostName,
     ) -> Result<(), atm_storage::AtmError> {
+        validate_canonical_peer_host(&canonical_host)?;
         let alias_kind = alias.alias_kind();
         let alias_value = alias.alias_value();
         self.db.with_connection(|connection| {
@@ -300,15 +302,7 @@ impl PeerConfigStore for SqlitePeerConfigStore {
                     params![alias_kind, alias_value, canonical_host.as_str()],
                 )
                 .map(|_| ())
-                .map_err(|error| {
-                    if matches!(error, rusqlite::Error::SqliteFailure(_, _)) {
-                        atm_storage::AtmError::peer_config_validation(format!(
-                            "peer alias `{alias}` already exists or references an invalid canonical peer"
-                        ))
-                    } else {
-                        self.db.error("failed to save peer alias", error)
-                    }
-                })
+                .map_err(|error| self.db.error("failed to save peer alias", error))
         })
     }
 
@@ -334,9 +328,11 @@ fn parse_bind_addr(value: &str) -> Result<SocketAddr, atm_storage::AtmError> {
 }
 
 fn parse_host(value: &str) -> Result<HostName, atm_storage::AtmError> {
-    value.parse().map_err(|error| {
+    let host = value.parse().map_err(|error| {
         atm_storage::AtmError::validation(format!("invalid stored peer host `{value}`: {error}"))
-    })
+    })?;
+    validate_canonical_peer_host(&host)?;
+    Ok(host)
 }
 
 fn parse_peer_alias(kind: &str, value: &str) -> Result<PeerAliasKey, atm_storage::AtmError> {
@@ -420,6 +416,33 @@ mod tests {
     fn peer_configuration_rejects_blank_secret_references_and_fingerprints() {
         assert!(" ".parse::<atm_storage::CertificateFingerprint>().is_err());
         assert!(" ".parse::<atm_storage::PrivateKeyRef>().is_err());
+    }
+
+    #[test]
+    fn peer_configuration_rejects_ip_literal_canonical_hosts_but_accepts_ip_aliases() {
+        let backend = crate::SqliteStorageBackend::in_memory_for_test().expect("backend");
+        let store = backend.peer_config_store();
+        let peer = TrustedPeer {
+            host: "127.0.0.1".parse().expect("host syntax"),
+            fingerprint: "sha256:peer".parse().expect("fingerprint"),
+            enabled: true,
+            https_port: std::num::NonZeroU16::new(43101).expect("port"),
+        };
+        let error = store
+            .save_trusted_peer(&peer)
+            .expect_err("an address cannot be the stable canonical peer identity");
+        assert!(error.message().contains("must not be an IP literal"));
+
+        let canonical: HostName = "rand-m5.local".parse().expect("canonical host");
+        store
+            .save_trusted_peer(&TrustedPeer {
+                host: canonical.clone(),
+                ..peer
+            })
+            .expect("DNS canonical peer");
+        store
+            .save_peer_alias("127.0.0.1".parse().expect("IP alias"), canonical)
+            .expect("IP aliases remain valid peer lookup inputs");
     }
 
     #[test]

--- a/crates/atm-storage/src/contract.rs
+++ b/crates/atm-storage/src/contract.rs
@@ -542,6 +542,18 @@ pub trait MessageStore: sealed::Sealed + Send + Sync {
             "message store does not implement atomic acknowledgement admission",
         ))
     }
+    /// Retires the durable peer-delivery marker after the configured peer has
+    /// accepted this exact immutable write.  The message itself remains
+    /// immutable; a mismatched or already-confirmed write is an idempotent
+    /// no-op.
+    fn confirm_peer_delivery(
+        &self,
+        _confirmation: PeerDeliveryConfirmation,
+    ) -> Result<bool, AtmError> {
+        Err(AtmError::daemon_unavailable(
+            "message store does not implement peer delivery confirmation",
+        ))
+    }
     fn load_message(&self, key: &MessageKey) -> Result<Option<Message>, AtmError>;
     fn list_messages(&self, query: &MessageQuery) -> Result<Vec<Message>, AtmError>;
     /// Returns mailbox display counts when the backend can aggregate them
@@ -554,6 +566,16 @@ pub trait MessageStore: sealed::Sealed + Send + Sync {
         Ok(None)
     }
     fn delete_message(&self, key: &MessageKey) -> Result<(), AtmError>;
+}
+
+/// Exact durable write accepted by one configured canonical peer.
+///
+/// This is deliberately not delivery state: it authorizes only removal of
+/// the transient `peerOutbound` marker from the already-persisted message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerDeliveryConfirmation {
+    pub message_id: AtmMessageId,
+    pub canonical_host: HostName,
 }
 
 pub trait RosterStore: sealed::Sealed + Send + Sync {
@@ -667,6 +689,20 @@ pub struct TrustedPeer {
     pub https_port: NonZeroU16,
 }
 
+/// Validate the stable hostname used as a configured peer authority.
+///
+/// Literal IPs are accepted only as explicit `PeerAliasKey::Ip` inputs. They
+/// cannot become canonical storage or connection identities because an address
+/// can change independently of the configured peer hostname.
+pub fn validate_canonical_peer_host(host: &HostName) -> Result<(), AtmError> {
+    if host.as_str().parse::<IpAddr>().is_ok() {
+        return Err(AtmError::peer_config_validation(format!(
+            "canonical peer host `{host}` must not be an IP literal"
+        )));
+    }
+    Ok(())
+}
+
 /// One normalized key accepted for a trusted-peer endpoint.
 ///
 /// IP literals are intentionally a separate variant: callers parse an IP
@@ -745,7 +781,11 @@ impl PeerDirectory {
     ) -> Result<Self, AtmError> {
         let mut endpoints = HashMap::new();
         let mut by_alias = HashMap::new();
-        for peer in peers.into_iter().filter(|peer| peer.enabled) {
+        for peer in peers {
+            validate_canonical_peer_host(&peer.host)?;
+            if !peer.enabled {
+                continue;
+            }
             let endpoint = PeerEndpoint {
                 canonical_host: peer.host.clone(),
                 port: peer.https_port,
@@ -761,6 +801,7 @@ impl PeerDirectory {
                     "host peer alias `{alias}` must not be an IP literal"
                 )));
             }
+            validate_canonical_peer_host(&canonical_host)?;
             let endpoint = endpoints.get(&canonical_host).cloned().ok_or_else(|| {
                 AtmError::peer_config_validation(format!(
                     "peer alias `{alias}` references unknown or disabled canonical peer `{canonical_host}`"
@@ -791,10 +832,10 @@ impl PeerDirectory {
     }
 }
 
-/// Backend-neutral durable cross-host configuration.
+/// Backend-neutral durable configured-peer HTTP configuration.
 ///
 /// This boundary deliberately excludes transport state, retries, receipts,
-/// and mailbox state. HTTPS adapters consume this contract but never SQLite
+/// and mailbox state. Peer HTTP adapters consume this contract but never SQLite
 /// implementation types.
 pub trait PeerConfigStore: sealed::Sealed + Send + Sync {
     fn list_interfaces(&self) -> Result<Vec<HttpsInterface>, AtmError>;
@@ -1203,5 +1244,12 @@ mod tests {
         )
         .expect_err("disabled canonical peer must fail closed");
         assert!(error.message().contains("unknown or disabled"));
+    }
+
+    #[test]
+    fn peer_directory_rejects_an_ip_literal_canonical_host() {
+        let error = PeerDirectory::from_configuration([enabled_peer("127.0.0.1", 43101)], [])
+            .expect_err("canonical peer hosts are stable DNS names, not addresses");
+        assert!(error.message().contains("must not be an IP literal"));
     }
 }

--- a/crates/atm-storage/src/lib.rs
+++ b/crates/atm-storage/src/lib.rs
@@ -17,10 +17,11 @@ pub use contract::{
     CertificateFingerprint, HttpsInterface, LocalCertificate, MailMessageState,
     MailboxBucketCounts, Message, MessageFingerprint, MessageKey, MessageQuery,
     MessageReceivedEvent, MessageStore, NudgeTemplateOverrideStore, OutboundMessageQuery,
-    PeerAliasKey, PeerConfigStore, PeerDirectory, PeerEndpoint, PrivateKeyRef, RosterChangedEvent,
-    RosterHarness, RosterMember, RosterMemberKind, RosterSnapshot, RosterStore, StorageNotifier,
-    StoredPeerWrite, TaskState, TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow,
-    TrustedPeer, derive_ack_requirement,
+    PeerAliasKey, PeerConfigStore, PeerDeliveryConfirmation, PeerDirectory, PeerEndpoint,
+    PrivateKeyRef, RosterChangedEvent, RosterHarness, RosterMember, RosterMemberKind,
+    RosterSnapshot, RosterStore, StorageNotifier, StoredPeerWrite, TaskState,
+    TeamNudgeTemplateOverrideMode, TeamNudgeTemplateOverrideRow, TrustedPeer,
+    derive_ack_requirement, validate_canonical_peer_host,
 };
 pub use error::AtmError;
 pub use error_codes::AtmErrorCode;

--- a/crates/atm/src/commands/peer.rs
+++ b/crates/atm/src/commands/peer.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use atm_daemon_bootstrap::with_default_peer_config_store;
 use atm_storage::{
     AtmError, CertificateFingerprint, HostName, HttpsInterface, LocalCertificate, PeerAliasKey,
-    PeerConfigStore, TrustedPeer,
+    PeerConfigStore, TrustedPeer, validate_canonical_peer_host,
 };
 use clap::{Args, Subcommand};
 use serde::Serialize;
@@ -354,10 +354,12 @@ fn peer(
     fingerprint: String,
     https_port: u16,
 ) -> std::result::Result<TrustedPeer, AtmError> {
+    let host = host
+        .parse()
+        .map_err(|_source| AtmError::peer_config_validation("invalid --host"))?;
+    validate_canonical_peer_host(&host)?;
     Ok(TrustedPeer {
-        host: host
-            .parse()
-            .map_err(|_source| AtmError::peer_config_validation("invalid --host"))?,
+        host,
         fingerprint: fingerprint
             .parse::<CertificateFingerprint>()
             .map_err(|_source| AtmError::peer_config_validation("invalid --fingerprint"))?,
@@ -414,7 +416,7 @@ fn render_output<T: Serialize>(value: &T, json: bool) -> Result<String, AtmError
 
 #[cfg(test)]
 mod tests {
-    use super::{certificate, render_output, require_confirmation};
+    use super::{certificate, peer, render_output, require_confirmation};
     use std::sync::Mutex;
 
     use atm_storage::{
@@ -667,6 +669,14 @@ mod tests {
         let error = certificate("   ".to_string(), "keychain:atm".to_string())
             .expect_err("blank certificate fingerprint must fail");
         assert_eq!(error.code(), AtmErrorCode::CertificateOperationFailed);
+    }
+
+    #[test]
+    fn trusted_peer_requires_a_hostname_while_aliases_may_be_ip_literals() {
+        let error = peer("127.0.0.1".to_owned(), "sha256:peer".to_owned(), 43101)
+            .expect_err("a literal address is an alias, not a canonical trusted peer");
+        assert_eq!(error.code(), AtmErrorCode::PeerConfigValidationFailed);
+        assert!(peer("rand-m5.local".to_owned(), "sha256:peer".to_owned(), 43101).is_ok());
     }
 
     #[test]

--- a/docs/adr/ADR-034-minimal-cross-host-https-transport.md
+++ b/docs/adr/ADR-034-minimal-cross-host-https-transport.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | ID | ADR-034 |
-| Status | Accepted |
+| Status | Superseded by ADR-047 |
 | Scope | Repository-wide |
 | Relates to | ADR-018, ADR-028, ADR-029, ADR-030, ADR-033, Phase AI |
 

--- a/docs/adr/ADR-035-canonical-write-ingress-and-host-routing.md
+++ b/docs/adr/ADR-035-canonical-write-ingress-and-host-routing.md
@@ -3,17 +3,17 @@
 | Field | Value |
 | --- | --- |
 | ID | ADR-035 |
-| Status | Accepted |
+| Status | Accepted; amended by ADR-047 |
 | Scope | Repository-wide |
 | Relates to | ADR-012, ADR-018, ADR-019, ADR-033, ADR-034, Phase AI |
 
 ## Decision
 
 Every write—CLI send, CLI ack, graft send, Unix UDS HTTP, loopback-TCP HTTP,
-and inbound HTTPS—uses one canonical `WriteRequest`, one write handler, and
+and configured peer HTTP—uses one canonical `WriteRequest`, one write handler, and
 one storage method. The handler orders work exactly as: idempotent persistence,
 optional receiver-side acknowledgement transition, then one post-write event.
-An event cannot precede a visible persisted write. Inbound HTTPS has no
+An event cannot precede a visible persisted write. Inbound peer HTTP has no
 cross-host-specific mailbox, acknowledgement, or nudge branch.
 
 Before the canonical write, a host-qualified origin destination is normalized
@@ -24,18 +24,18 @@ no DNS, SQLite query, peer scan, worker, or socket operation.
 
 Routing is decided exactly once by the post-write event router:
 
-- an empty destination host selects a local-nudge work key; and
-- every validated present destination host selects a peer-delivery work key,
-  including `localhost` and this daemon's advertised or bound IP address.
+- an empty destination host selects the ordinary local post-write nudge; and
+- every validated present destination host, including `localhost` and this
+  daemon's advertised or bound IP address, selects the one direct configured
+  peer HTTP call.
 
 For a remote destination, the local write records the sender's immutable
-outbound message before this decision; the router signals the bounded
-post-commit scheduler and returns the local admission response. The worker,
-not the router, invokes HTTPS; the remote daemon performs the recipient-side
-write when it receives the same `WriteRequest`. A failed HTTPS attempt does
-not add local delivery state, a remote recipient row, a receipt, or a retry
-queue. It records a typed asynchronous unconfirmed outcome; a repeated
-canonical write reuses the same immutable message ULID.
+outbound message before this decision. The initiating request worker then
+makes one bounded direct peer HTTP call with that exact immutable
+`WriteRequest`; a matching canonical response confirms delivery. A failure
+returns `REMOTE_DELIVERY_UNCONFIRMED` after persistence and leaves only the
+existing `peerOutbound` marker. It adds no local delivery state, remote row,
+receipt, worker, scheduler, or retry queue.
 
 The source host is durable message provenance. The destination host is an
 origin-side routing selector consumed before an authenticated peer ingress is
@@ -43,7 +43,7 @@ given to the receiver-side post-write router; it is not re-forwarded by that
 receiver. A transient authenticated peer identity is request context for
 authorization and observability only; it cannot replace source provenance or
 invent a routing selector. `localhost` and a daemon's own advertised address
-are ordinary host values and exercise the HTTPS route rather than a special
+are ordinary host values and exercise the configured peer HTTP route rather than a special
 loopback implementation.
 
 The destination routing selector is not part of the immutable receiver message
@@ -90,14 +90,11 @@ second routing or acknowledgement path.
 Architecture checks must reject these shapes structurally, not merely by a
 denylist of historical identifiers.
 
-The router receives an ingress context. The normal peer form is an opaque
-`AuthenticatedPeer` constructed only by the HTTPS adapter after mTLS and exact
-configured-host/fingerprint verification; adapters cannot fabricate it. The
-explicit daemon-only `plaintext-test` smoke profile may construct a separately
-typed untrusted test-peer provenance context. Both forms reach the same router
-and handler; the test form cannot authorize a recipient or claim peer
-authentication. This preserves the production authenticate-before-route
-invariant without adding a peer-specific application handler.
+The configured peer HTTP adapter supplies `AuthenticatedIngress::Peer` after
+validating its finite local bind configuration. Its `X-ATM-Peer-Source-Host`
+header is display provenance only: it cannot authorize a sender, select a
+recipient, or choose a second route. Every accepted local, loopback, same-IP,
+and cross-host frame reaches the same router, handler, and post-write nudge.
 
 ## Compliance status
 

--- a/docs/adr/ADR-040-peer-authority-resolution.md
+++ b/docs/adr/ADR-040-peer-authority-resolution.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | ID | ADR-040 |
-| Status | Accepted |
+| Status | Superseded by ADR-047 |
 | Scope | Repository-wide |
 | Relates to | ADR-034, ADR-035, Phase AI.25 |
 

--- a/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
+++ b/docs/adr/ADR-041-end-to-end-peer-write-outcome.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | ID | ADR-041 |
-| Status | Accepted |
+| Status | Superseded by ADR-047 |
 | Scope | Repository-wide |
 | Relates to | ADR-032, ADR-034, ADR-035, Phase AI.26–AI.31 |
 

--- a/docs/adr/ADR-047-direct-trusted-lan-http.md
+++ b/docs/adr/ADR-047-direct-trusted-lan-http.md
@@ -1,0 +1,50 @@
+# ADR-047 — Direct Trusted-LAN Peer HTTP
+
+| Field | Value |
+| --- | --- |
+| ID | ADR-047 |
+| Status | Accepted |
+| Scope | Repository-wide |
+| Supersedes | ADR-034, ADR-040, ADR-041 |
+| Amends | ADR-035 |
+
+## Decision
+
+ATM peer delivery is one direct plain-HTTP request over one `TcpStream` after
+the origin SQLite admission commits. The configured canonical hostname and
+port are the sole connection input; the operating system resolves the
+hostname. ATM neither saves an address nor enumerates addresses, starts a DNS
+thread, reloads SQLite, scans peers, creates an outbound worker, or retries.
+
+The origin emits the exact immutable `WriteRequest`, including its origin ULID
+and timestamp, through the shared HTTP frame writer. The configured local
+advertised host is attached as `X-ATM-Peer-Source-Host`. It is display
+provenance only, not authentication or routing input. The configured peer
+listener accepts that write as `WriteIngress::Peer`, performs the existing
+provenance validation and canonical admission, then takes the same ordinary
+post-write nudge path used for loopback, same-IP, and cross-host frames.
+
+One matching `ResponseEnvelope::Send` confirms delivery. The origin then
+atomically removes only that message's `peerOutbound` marker for the matching
+canonical host. Any connect, write, read, frame, response, or confirmation
+failure returns `REMOTE_DELIVERY_UNCONFIRMED` after local persistence and
+leaves the marker intact. This is a no-retry baseline; later retry policy must
+call the same finite-frame function and may not create another sender path.
+
+Peer listeners bind only a finite, enabled, explicit local-address allowlist.
+Startup rejects empty, duplicate, wildcard, multicast, or non-local bind
+addresses. The listener has a 64-connection cap and uses bounded HTTP framing;
+it owns no outbound lifecycle. Network isolation outside explicit binding is a
+deployment/firewall responsibility.
+
+## Consequences
+
+- TLS, certificate pinning, custom resolver behavior, and the retired peer
+  coordinator are not active delivery-path concerns.
+- An unavailable configured peer is a clear, durable-but-undelivered result,
+  not a background task or a local success.
+- Local, loopback, same-IP, and cross-host write frames converge on one
+  receiver and nudge path. Only self-send validation is origin-side special
+  handling.
+- mTLS remains an interop-only preservation fixture until a separately scoped
+  future transport decision adopts it; it is not a production fallback.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -53,6 +53,7 @@ crate-local ADR records that remain embedded in crate architecture documents.
 - [ADR-043 — Hermes Graft Wake-up Ownership and Recovery](./ADR-043-hermes-graft-wake-up-ownership.md)
 - [ADR-044 — Public Verification Report Classification](./ADR-044-public-verification-report-classification.md)
 - [ADR-045 — Runtime Observation Attribution](./ADR-045-runtime-observation-attribution.md)
+- [ADR-047 — Direct Trusted-LAN Peer HTTP](./ADR-047-direct-trusted-lan-http.md)
 
 ## Extracted Crate-Local ADRs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,9 @@
 # ATM CLI Architecture
 
-> **Phase AI target — not yet implemented:** the daemon API becomes REST over
-> HTTP: Unix HTTP/UDS or loopback TCP, Windows loopback TCP, and HTTPS/TCP for
-> remote peers. ADR-032 through ADR-038 and `REQ-CORE-TRANSPORT-*` govern that
-> migration. The current implementation remains the custom transport contract
-> documented by the current boundary manifests.
+> **Phase AK.4 transport:** the daemon API uses one REST router over Unix
+> HTTP/UDS or loopback TCP, Windows loopback TCP, and configured trusted-LAN
+> HTTP/TCP for remote peers. ADR-047 and `REQ-CORE-TRANSPORT-*` govern the
+> direct one-shot peer path.
 
 ## 1. Overview
 

--- a/docs/atm-daemon/architecture.md
+++ b/docs/atm-daemon/architecture.md
@@ -1,11 +1,11 @@
 # ATM-Daemon Crate Architecture
 
-> **Phase AI supersession notice:** the planned daemon has one REST router,
+> **Phase AK.4 architecture:** the daemon has one REST router,
 > reached through Unix HTTP/UDS or loopback TCP, Windows loopback TCP, and
-> HTTPS/TCP remotely. Legacy Windows local transports, custom ATM frames,
+> configured trusted-LAN HTTP/TCP remotely. Legacy Windows local transports, custom ATM frames,
 > replay/retry runtime state, and separate peer handling are not
-> accepted architecture for new work; ADR-033 through ADR-036 govern the
-> migration.
+> accepted architecture for new work; ADR-047 governs direct configured peer
+> delivery.
 
 ## 1. Purpose
 
@@ -188,7 +188,7 @@ Current retained ATM surfaces outside the daemon request/response packet family:
   accepted runtime architecture
 - Historical through AI.5 only: the daemon owned custom-frame transport
   implementations. The accepted Phase AI line is one HTTP router reached by
-  UDS/loopback TCP locally, HTTPS remotely, and an in-process HTTP adapter in
+  UDS/loopback TCP locally, configured peer HTTP remotely, and an in-process HTTP adapter in
   tests. No custom frame header or `LoopbackClientTransport` may be retained as
   a fallback.
 - the accepted same-host Windows local-IPC depth contract is fail-fast and
@@ -277,7 +277,7 @@ Current retained ATM surfaces outside the daemon request/response packet family:
 - UDP is not an approved daemon control-plane transport for same-host CLI
   request/response traffic; same-host and remote request families use the
   shared HTTP request/response contract, carried by UDS or loopback TCP
-  locally and HTTPS/TCP remotely
+  locally and configured trusted-LAN HTTP/TCP remotely
 - Phase AD note:
   - watcher/reconcile compatibility-projection behavior is retired
   - daemon architecture no longer depends on `ADR-010`

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -62,7 +62,7 @@ even though they are not public cross-crate traits:
   - **Phase AJ planned extension — not current implementation:** local
     `ActivityObservation` will be transient request metadata. Only accepted
     heartbeat and successful environment-attested local CLI/graft ingress may
-    reach this cache; HTTPS peer ingress must clear it before shared dispatch.
+    reach this cache; peer HTTP ingress must clear it before shared dispatch.
     Changed session/PID values will be diagnostic evidence, never a liveness or
     conflict decision.
   - **Phase AJ planned extension — not current implementation:** removal of the
@@ -161,6 +161,16 @@ current adapter, module, manifest, timeout/retry, or replay behavior. The
 current daemon API contract is the HTTP/OpenAPI surface documented in
 [`http-api.md`](./http-api.md).
 
+## Peer HTTP adapter
+
+Canonical machine-readable boundary source:
+- [../../boundaries/atm-daemon/peer-http-adapter.toml](../../boundaries/atm-daemon/peer-http-adapter.toml)
+
+`PeerHttpListenerSet` owns the finite configured trusted-LAN HTTP listener and
+the sole direct peer sender. It may use bounded receiver accept/request work,
+but owns no outbound worker, DNS resolver, retry, timer, TLS state, or second
+ingress/nudge path.
+
 ## Phase AI post-commit admission boundary
 
 Current AK.3 admission boundary:
@@ -169,9 +179,10 @@ Current AK.3 admission boundary:
   service runtime. It replaces an explicit configured host/IP alias with its
   canonical host before one write and has no storage or network dependency on
   its hot path.
-- `runtime_health` and `PostWriteRouter` now retain only the ordinary local
-  post-write nudge signal. Host-qualified origin admission persists immutable
-  data and starts no worker, queue, retry, DNS, socket, or TLS work.
+- `runtime_health` and `PostWriteRouter` route an empty destination host to
+  the ordinary local post-write nudge. A host-qualified origin persists its
+  immutable data then makes the one bounded `PeerHttpListenerSet` sender call;
+  it starts no worker, queue, retry, DNS, or TLS work.
 
 Historical Phase AI worker model, superseded by AK.2:
 

--- a/docs/atm-daemon/http-api.md
+++ b/docs/atm-daemon/http-api.md
@@ -2,21 +2,21 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed — Phase AI target |
+| Status | Implemented — Phase AK.4 |
 | HTTP API SemVer | `1.0.0`; major is `/v1/atm` |
 | Authoritative ADR | ADR-033 |
 | Machine-readable publication | checked-in OpenAPI 3.1 and `atm api spec` |
 
 ## Transport and handler rule
 
-The same REST router serves HTTP over Unix UDS, local loopback TCP, and HTTPS
+The same REST router serves HTTP over Unix UDS, local loopback TCP, and configured peer HTTP
 over TCP. Windows uses loopback TCP only; Unix supports both UDS and loopback
 TCP. A local client supplies the structured caller address in the canonical write request;
-the shared handler validates it under the local caller/roster policy. HTTPS
-authentication establishes the peer identity for transport authorization and
-never rewrites that caller address. The router maps resources to shared
-application handlers only. It does not touch SQLite, choose a host, or emit
-nudges.
+the shared handler validates it under the local caller/roster policy. The
+configured peer listener supplies peer ingress and display-only source-host
+provenance; it never rewrites the caller address or creates a distinct write
+route. The router maps resources to shared application handlers only. It does
+not choose a host or emit nudges.
 
 Every message projection uses structured `from` and `to` addresses. Each has
 `agent`, optional `chat_id`, `team`, and optional `host`. Storage keeps the
@@ -27,8 +27,8 @@ Thus `hendrix:12345@hermes` and `hendrix:98765@hermes` are independent inbox
 and reply identities. `chat_id` is not a daemon session or a message-thread
 field.
 
-Remote HTTPS requires mTLS plus the configured canonical peer hostname and
-pinned certificate fingerprint. A host or literal IP destination is accepted
+Remote peer HTTP uses the configured canonical peer hostname and port. A host
+or literal IP destination is accepted
 only through the immutable configured `PeerDirectory`; its canonical hostname
 is persisted and no DNS/reverse-DNS discovery occurs at admission. Unix UDS uses endpoint ownership/permissions.
 Loopback TCP binds only a loopback address and requires the daemon-created
@@ -42,7 +42,7 @@ or mismatched metadata before opening a connection. Shutdown syncs a revoked
 record before removing it.
 
 All routes have one bounded absolute request deadline and reject a body over
-`1_048_576` bytes before decode. HTTPS consumes the remaining request budget;
+`1_048_576` bytes before decode. Peer HTTP consumes the remaining request budget;
 it cannot start an independent longer connect, handshake, or request deadline.
 Both listeners stop accepting new requests during shutdown and drain or cancel
 tracked requests within the daemon shutdown deadline.
@@ -115,18 +115,19 @@ Product release versions are diagnostic only and are not HTTP admission input.
 
 ## Peer authority
 
-Cross-host authority is configured as a canonical hostname, HTTPS port, and
-certificate pin. Explicit host and literal-IP aliases select that authority
+Cross-host authority is configured as a canonical hostname and HTTP port.
+Explicit host and literal-IP aliases select that authority
 from the immutable `PeerDirectory`; aliases and canonical hosts are
-configuration, not DNS results. The configured canonical hostname and port
-remain the TLS authority and the canonical host is the only value persisted in
+configuration, not DNS results. The configured canonical hostname and port are
+the direct connection target; the canonical host is the only value persisted in
 `peerOutbound.host`. After an `atm peer trust` or `atm peer alias` mutation,
 the CLI invokes the authenticated local `POST /v1/atm/runtime/reload` control
 operation to atomically install the updated snapshot; it does not start a
 second daemon.
 
 `atm doctor --json` projects each configured authority as
-`trusted_peers[] = { host, https_port, enabled }`. Alias display is
+`trusted_peers[] = { host, https_port, enabled }`; `https_port` is the retained
+storage field name and carries the direct HTTP port during AK.4. Alias display is
 configuration visibility only: it deliberately excludes any dynamically
 resolved address, private-key reference, and certificate material.
 

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -2,7 +2,7 @@
 
 > **Phase AI supersession notice:** `REQ-DAEMON-TRANSPORT-001` through `008`
 > are the proposed target contract for Unix UDS/loopback-TCP HTTP, Windows
-> loopback-TCP HTTP, and remote HTTPS. Any
+> loopback-TCP HTTP, and configured trusted-LAN peer HTTP. Any
 > older text in this document that permits a custom ATM frame, replay/retry
 > state, or a peer-transport runtime is historical and will be
 > removed by the owning Phase AI sprint; it is not authority for new work.
@@ -144,7 +144,7 @@ Initial crate requirement IDs:
   - Unix: HTTP over UDS and supported HTTP over loopback TCP for same-host
     access
   - Windows: HTTP over loopback TCP only for same-host access
-  - HTTPS over TCP for cross-host daemon-to-daemon traffic
+  - configured trusted-LAN HTTP over TCP for cross-host daemon-to-daemon traffic
   - an in-process HTTP adapter; see ADR-003 §Tier 2 — for transport-boundary
     tests
   Satisfies:
@@ -160,28 +160,25 @@ Initial crate requirement IDs:
   It performs no DNS, peer scan, SQLite query, delivery, retry, timer, worker,
   or thread. Satisfies: `REQ-CORE-TRANSPORT-002D`.
 - `REQ-DAEMON-TRANSPORT-002A` `atm-daemon` owns loading and enforcing durable
-  cross-host HTTPS bind, certificate, trusted-peer, and explicit alias records.
+  cross-host peer HTTP bind, trusted-peer, and explicit alias records.
   It swaps the assembled snapshot only at startup or authenticated reload. Satisfies:
   `REQ-CORE-TRANSPORT-002A`.
-- `REQ-DAEMON-TRANSPORT-002B` `atm-daemon` enforces mTLS plus a durable
-  deny-by-default registered-hostname and certificate-fingerprint allowlist
-  before routing. It accepts direct IP targets only through an explicit
-  ADR-040 alias and never performs DNS discovery at admission. Satisfies:
+- `REQ-DAEMON-TRANSPORT-002B` `atm-daemon` enforces a finite explicit local
+  peer-HTTP bind allowlist before routing. It accepts direct IP targets only
+  through an explicit ADR-040 alias and never performs DNS discovery at
+  admission. Satisfies:
   `REQ-CORE-TRANSPORT-002B`.
-- `REQ-DAEMON-TRANSPORT-002B1` `atm-daemon` accepts the explicit
-  non-durable `--peer-wire-security plaintext-test` process mode only for
-  debug/smoke diagnosis. It disables peer TLS/pin/allowlist checks without
-  changing HTTP routing, canonical writes, persistence, or post-write routing;
-  declared source-host data is untrusted smoke provenance. Normal startup is
-  mTLS, never falls back to plaintext, and doctor/logs must expose the active
-  mode. Satisfies: `REQ-CORE-TRANSPORT-002B1`.
+- `REQ-DAEMON-TRANSPORT-002B1` is historical. The configured trusted-LAN
+  peer-HTTP listener has no plaintext-test mode or alternate receiver
+  classification. mTLS fixtures are retained only as non-production AK.6
+  interop evidence. Satisfies: `REQ-CORE-TRANSPORT-002B1`.
 - `REQ-DAEMON-TRANSPORT-002C` localhost and a daemon's own advertised address
-  are ordinary HTTPS peer targets; no loopback-only transport branch exists.
+  are ordinary configured peer HTTP targets; no loopback-only transport branch exists.
   Satisfies:
   `REQ-CORE-TRANSPORT-002C`.
 - `REQ-DAEMON-TRANSPORT-003` `atm-daemon` owns the one absolute request
   deadline budget for HTTP(S), store busy timeout, ingest batch, and doctor
-  query operations. It propagates the remaining request budget to HTTPS and
+  query operations. It propagates the remaining request budget to peer HTTP and
   returns the ADR-041 typed outcome rather than misclassifying a live daemon
   as unavailable. Satisfies:
   `REQ-CORE-TRANSPORT-005`, `REQ-CORE-DOCTOR-002`.
@@ -190,7 +187,7 @@ Initial crate requirement IDs:
   cancelled; detached untracked request execution is forbidden. Satisfies:
   `REQ-DAEMON-RUNTIME-003`, `REQ-P-DAEMON-DISPATCHER-001`,
   `REQ-CORE-DAEMON-001`.
-- `REQ-DAEMON-TRANSPORT-005` Unix UDS HTTP, loopback-TCP HTTP, and HTTPS must call one router and one
+- `REQ-DAEMON-TRANSPORT-005` Unix UDS HTTP, loopback-TCP HTTP, and configured peer HTTP must call one router and one
   canonical read/write application contract rather than separate local and
   remote message systems. Satisfies:
   `REQ-CORE-TRANSPORT-001`, `REQ-CORE-TRANSPORT-002`,

--- a/docs/atm-storage/boundaries.md
+++ b/docs/atm-storage/boundaries.md
@@ -8,7 +8,7 @@ Canonical machine-readable boundary source:
 - [../../boundaries/atm-storage/peer-config-store.toml](../../boundaries/atm-storage/peer-config-store.toml)
 
 Purpose:
-- own backend-neutral durable records for enabled HTTPS interfaces, the local
+- own backend-neutral durable records for enabled peer HTTP interfaces, the local
   certificate reference, exact trusted peers, and explicit canonical aliases
 
 Rules:

--- a/docs/atm-storage/boundaries.md
+++ b/docs/atm-storage/boundaries.md
@@ -8,14 +8,22 @@ Canonical machine-readable boundary source:
 - [../../boundaries/atm-storage/peer-config-store.toml](../../boundaries/atm-storage/peer-config-store.toml)
 
 Purpose:
-- own backend-neutral durable records for enabled peer HTTP interfaces, the local
-  certificate reference, exact trusted peers, and explicit canonical aliases
+- own backend-neutral durable records for enabled peer HTTP interfaces, exact
+  trusted peer hostnames/ports, and explicit canonical aliases
 
 Rules:
-- this contract must not perform socket I/O, TLS, delivery, retry, or message
-  state management
+- this contract must not perform socket I/O, TLS, DNS, delivery attempts,
+  retries, peer scans, timers, or outbound worker coordination
 - `atm-runtime`, `atm-daemon-bootstrap`, and the CLI consume the contract;
   concrete backends implement it without leaking backend details upstream
+
+## MessageStore peer confirmation
+
+`MessageStore::confirm_peer_delivery` is the sole storage mutation following a
+matching direct peer HTTP response. It removes the matching `peerOutbound`
+marker and leaves the immutable message, ACK/read state, and mailbox history
+unchanged. A failed direct attempt retains that marker; storage creates no
+outbox, receipt table, or delivery-state machine.
 
 ## NudgeTemplateOverrideStore
 

--- a/docs/atm/architecture.md
+++ b/docs/atm/architecture.md
@@ -10,7 +10,7 @@ It complements the product architecture in
 The crate-local machine-readable boundary inventory lives in:
 - [`./boundaries.md`](./boundaries.md)
 
-The Phase AI target daemon API contract lives in:
+The Phase AK.4 daemon API contract lives in:
 - [`../atm-daemon/http-api.md`](../atm-daemon/http-api.md)
 
 ## 2. Responsibilities
@@ -33,7 +33,7 @@ The `atm` crate is responsible for:
 
 The `atm` crate must remain thin.
 
-Phase AI target:
+Phase AK.4 target:
 - the CLI depends on `DaemonApiClient` and transport-neutral application DTOs,
   never daemon internals or SQLite adapters
 - send and ack create the same canonical `WriteRequest`; ack only populates

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -50,6 +50,7 @@ Initial allocation:
 - `REQ-ATM-OUT-*` for output/rendering requirements
 - `REQ-ATM-OBS-*` for observability-bootstrap requirements
 - `REQ-ATM-RUNTIME-*` for daemon-client/runtime-entry requirements
+- `REQ-ATM-TRANSPORT-*` for CLI-to-daemon peer-delivery requirements
 - `REQ-ATM-ERROR-*` for CLI/runtime error-presentation requirements
 
 Initial crate requirement IDs:
@@ -84,12 +85,14 @@ Initial crate requirement IDs:
   support injected in-process transport doubles without real daemon spawning as
   the ordinary test path. Satisfies:
   `REQ-P-TEST-001`, `REQ-CORE-TEST-RUNTIME-001`.
-- `REQ-ATM-CMD-PEER-001` `atm` parses `peer alias list|add|remove`, validates
-  a host-or-IP `PeerAliasKey`, invokes only `PeerConfigStore`, and requests one
-  runtime reload after a successful mutation. Canonical trusted peers must use
-  a hostname; literal IPs are aliases only. It must not resolve DNS, open a
-  peer connection, or deliver a message. Satisfies:
-  `REQ-CORE-TRANSPORT-002A`, `REQ-CORE-TRANSPORT-002D`.
+- `REQ-ATM-TRANSPORT-002` `atm` submits every host-qualified `send` to its
+  local daemon through the same daemon HTTP request contract as a local send.
+  It does not resolve DNS, open a peer socket, run a retry, or create delivery
+  state. After durable local admission, the daemon owns exactly one bounded
+  direct configured-peer HTTP attempt; success is a matching peer response and
+  failure remains persisted-but-undelivered. Satisfies:
+  `REQ-CORE-TRANSPORT-002`, `REQ-CORE-TRANSPORT-003`,
+  `REQ-CORE-TRANSPORT-004`.
 - `REQ-ATM-ERROR-001` `atm` owns CLI-side rendering/preservation of typed
   runtime errors from `atm-core` and `atm-daemon`. Satisfies:
   `REQ-CORE-BOUNDARY-002`.

--- a/docs/atm/requirements.md
+++ b/docs/atm/requirements.md
@@ -86,7 +86,8 @@ Initial crate requirement IDs:
   `REQ-P-TEST-001`, `REQ-CORE-TEST-RUNTIME-001`.
 - `REQ-ATM-CMD-PEER-001` `atm` parses `peer alias list|add|remove`, validates
   a host-or-IP `PeerAliasKey`, invokes only `PeerConfigStore`, and requests one
-  runtime reload after a successful mutation. It must not resolve DNS, open a
+  runtime reload after a successful mutation. Canonical trusted peers must use
+  a hostname; literal IPs are aliases only. It must not resolve DNS, open a
   peer connection, or deliver a message. Satisfies:
   `REQ-CORE-TRANSPORT-002A`, `REQ-CORE-TRANSPORT-002D`.
 - `REQ-ATM-ERROR-001` `atm` owns CLI-side rendering/preservation of typed

--- a/docs/peer-pair-smoke.md
+++ b/docs/peer-pair-smoke.md
@@ -1,6 +1,6 @@
 # Peer-pair release smoke
 
-Run this procedure for every release that changes daemon, HTTP, TLS, storage
+Run this procedure for every release that changes daemon, HTTP, peer listener, storage
 write, acknowledgement, or peer-transport code. It proves ATM message handling;
 a raw TCP connection is not evidence of success.
 
@@ -17,6 +17,7 @@ just smoke local-ip
 just smoke peer-preflight m5 fastpc4
 just smoke crosshost-send m5 fastpc4
 just smoke crosshost-ack m5 fastpc4
+just smoke crosshost-curl-plain m5 fastpc4
 ```
 
 `localhost` proves host-qualified localhost send/read and requires-ack/ack.
@@ -27,6 +28,10 @@ enabled advertised host; it never starts, stops, or retries a remote daemon.
 read` return the exact same ULID and body. `crosshost-ack` repeats that proof
 with `--requires-ack`, has the remote peer acknowledge it, and proves the
 reply reaches the local inbox with the original acknowledged-message ID.
+`crosshost-curl-plain` independently posts the production `WriteRequest` JSON
+with `X-ATM-Peer-Source-Host` to the configured peer HTTP listener in both
+directions, then proves the exact ULID/body by public `atm read`. It is not a
+plaintext-test mode and does not start, configure, or bypass either daemon.
 
 Before any host-qualified smoke, configure each target as an enabled canonical
 trusted peer and configure every non-canonical hostname/IP used by the smoke as
@@ -56,10 +61,7 @@ capabilities, or secrets. It has this shape:
   "role": "A",
   "commit": "<tested-commit>",
   "client_version_command": ["atm", "--version"],
-  "peer_security": {
-    "trust_id": "<approved-peer-trust-record>",
-    "certificate_fingerprint": "<peer-certificate-fingerprint>"
-  },
+  "peer_endpoint": {"canonical_host": "<configured-peer-host>", "port": 43101},
   "daemon": {
     "endpoint": "<host>:43101",
     "version_command": ["atm", "doctor", "--json"],
@@ -77,7 +79,7 @@ capabilities, or secrets. It has this shape:
     {"id": "requires_ack_reply", "expect": "success", "message_ulid": "<ulid>", "command": ["atm", "send", "..."], "verification": {"assertions": {"ack_reply_visible": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "selected_message_id", "equals": "$message_ulid"}}}},
     {"id": "duplicate_ulid", "expect": "success", "message_ulid": "<ulid>", "command": ["atm", "send", "..."], "verification": {"assertions": {"receiver_visible": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "selected_message_id", "equals": "$message_ulid"}, "single_record_retained": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "match_count", "equals": 1}, "no_repeat_nudge": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "additional_match_count", "equals": 0}, "no_ack_mutation": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "message.acknowledgedAt", "absent": true}}}},
     {"id": "unavailable_peer", "expect": "typed_error", "typed_error_code": "<code>", "message_ulid": "<ulid>", "command": ["atm", "send", "..."], "verification": {"assertions": {"no_prohibited_delivery_state": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "count", "equals": 0}}}},
-    {"id": "untrusted_or_allowlist_rejection", "expect": "typed_error", "typed_error_code": "<code>", "message_ulid": "<ulid>", "command": ["atm", "send", "..."], "verification": {"assertions": {"rejected_before_routing": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "count", "equals": 0}}, "required_daemon_log_events": [{"action": "request", "outcome": "rejected", "message": "HTTPS peer request was rejected before or during shared API routing", "fields": {"subsystem": "https_transport"}}], "forbidden_daemon_log_events": [{"action": "peer_delivery", "outcome": "write_persisted"}]}},
+    {"id": "invalid_peer_request", "expect": "typed_error", "typed_error_code": "<code>", "message_ulid": "<ulid>", "command": ["curl", "..."], "verification": {"assertions": {"rejected_before_routing": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "count", "equals": 0}}}},
     {"id": "failed_remote_ack", "expect": "typed_error", "typed_error_code": "<code>", "message_ulid": "<ulid>", "command": ["atm", "ack", "..."], "verification": {"assertions": {"ack_source_unchanged": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "message.requires_ack", "equals": true}, "no_remote_ack_state": {"command": ["atm", "read", "--message-id", "<ulid>", "--json"], "json_path": "message.acknowledgedAt", "absent": true}}}}
   ]
 }
@@ -100,9 +102,8 @@ teardown.
 Daemon log assertions use exact structured event selectors against the retained
 JSONL delta. A selector may match top-level `action`, `outcome`, `message`,
 `level`, `service`, or `target` fields and scalar values under `fields`; it is
-not a free-form substring search. The untrusted/allowlist case requires the
-real HTTPS rejection event (`action=request`, `outcome=rejected`,
-`fields.subsystem=https_transport`) to appear after the command. Optional
+not a free-form substring search. The invalid-peer case must be rejected
+before canonical write routing. Optional
 `forbidden_daemon_log_events` selectors must not appear. Rotation, truncation,
 malformed JSONL, or a missing required event fails the case and is recorded in
 the evidence with an actionable message.
@@ -134,11 +135,9 @@ python3 scripts/smoke/run_inbound_peer_smoke.py \
   --evidence-dir artifacts/peer-smoke/inbound
 ```
 
-When diagnosing the explicit `plaintext-test` profile, bind every enabled peer
-interface only to the private test overlay address used by the participating
-hosts. The profile disables TLS, certificate pinning, and the peer allowlist;
-it is never safe to bind it to a public or shared network interface. Restart
-without `--peer-wire-security plaintext-test` before any non-diagnostic use.
+The configured production peer listener binds only its explicit enabled local
+addresses. Do not use wildcard, multicast, inferred, or temporary
+plaintext-test listeners for release smoke.
 
 The runner prints one `PASS` or `FAIL` line for local doctor, each peer doctor,
 each peer send/read pair, and the evidence path. It exits zero only when every

--- a/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
+++ b/docs/plans/phase-ak/sprint-AK3-peer-alias-canonicalization.md
@@ -1,6 +1,6 @@
 ---
 title: AK.3 Canonical peer alias persistence
-status: proposed
+status: complete
 branch: feature/pak-s3-canonical-peer-aliases
 worktree: ../atm-core-worktrees/feature/pak-s3-canonical-peer-aliases
 target: integrate/phase-ak

--- a/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
+++ b/docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md
@@ -1,6 +1,6 @@
 ---
 title: AK.4 Direct peer HTTP without retry
-status: proposed
+status: complete
 branch: feature/pak-s4-direct-peer-http-no-retry
 worktree: ../atm-core-worktrees/feature/pak-s4-direct-peer-http-no-retry
 target: integrate/phase-ak

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -17,7 +17,8 @@ The product is a local command-line tool named `atm`.
 The current target architecture uses a tightly-bounded singleton daemon runtime
 for same-host local IPC, mail routing, and native-agent notification. ATM
 command behavior remains the user-facing surface. The prior custom cross-host
-transport is superseded; Phase AI defines the replacement HTTPS/TCP adapter.
+transport is superseded; Phase AK.4 defines the replacement direct
+trusted-LAN HTTP/TCP adapter.
 
 Phase-AA simplification direction:
 - the daemon remains part of the product, but it must return to the original
@@ -145,7 +146,7 @@ Phase-R redesign note:
 Phase-AI portability note:
 - ATM daemon functionality is first-class on Windows as well as Unix-like hosts
 - the authoritative local access contract is Unix HTTP/UDS or loopback TCP and
-  Windows loopback TCP; peer access is HTTPS/TCP
+  Windows loopback TCP; peer access is configured trusted-LAN HTTP/TCP
 - the canonical daemon interface is documented in
   [`./atm-daemon/http-api.md`](./atm-daemon/http-api.md) and ADR-033
 - route-specific schemas, HTTP status codes, and the OpenAPI artifact are
@@ -324,10 +325,10 @@ Satisfied by:
 - SQLite-backed ATM mail source of truth
 - SQLite-backed team roster source of truth
 - singleton daemon runtime
-- Phase AI target daemon API: Unix HTTP over local UDS and loopback TCP,
-  Windows HTTP over loopback TCP, and HTTPS over TCP for remote
-  peers. AI.1 intentionally retains the pre-migration local IPC baseline; the
-  local HTTP target becomes live in AI.6 and the remote HTTPS target in AI.9.
+- Phase AK.4 daemon API: Unix HTTP over local UDS and loopback TCP, Windows
+  HTTP over loopback TCP, and configured trusted-LAN HTTP over TCP for remote
+  peers. The peer receiver and direct one-shot sender use the same canonical
+  HTTP write route.
 - Claude-compatible JSONL inbox ingress and export
 - configuration resolution
 - caller identity resolution through explicit CLI override or invoking-shell
@@ -3590,7 +3591,7 @@ mail correctness.
   - local read/write request DTOs carry one optional `ActivityObservation`
     (team, member, optional session/pid), constructed only by that
     environment-attestation step; the daemon accepts it only on existing
-    authenticated local UDS/loopback ingress, and remote HTTPS ingress clears
+    authenticated local UDS/loopback ingress, and remote peer HTTP ingress clears
     it before shared dispatch
   - session, pid, heartbeat activity, and derived state must not drive routing,
     nudge, notification, retry, admission, delivery, or policy logic
@@ -3728,9 +3729,8 @@ mail correctness.
     `atm-daemon-client` facade and may use HTTP over loopback TCP; consumers
     such as `atm-graft` must not take a direct `interprocess` dependency.
     Windows same-host clients use HTTP over loopback TCP only
-  - normal remote peers use HTTPS over TCP; the explicit daemon-only
-    `plaintext-test` smoke profile is governed by
-    `REQ-CORE-TRANSPORT-002B1` and cannot create a second HTTP route
+  - normal remote peers use configured trusted-LAN HTTP over TCP; no
+    plaintext-test profile, TLS fallback, or second HTTP route exists
   - all production adapters call one HTTP router and the same application handlers
   - the stable initial resources are `/v1/atm/messages`,
     `/v1/atm/message/{message-id}`, `/v1/atm/message/{message-id}/read`, and
@@ -3745,9 +3745,9 @@ mail correctness.
     created owner-readable endpoint record plus a 32-byte base64url local
     capability; Unix UDS uses owner-only endpoint permissions
   - ingress authentication creates `AuthenticatedIngress::Local` only after
-    the local capability or UDS ownership check, and
-    `AuthenticatedIngress::Peer` only after mTLS plus allowlist verification;
-    adapters must not infer local/peer status from socket family or address
+    the local capability or UDS ownership check. The configured peer listener
+    creates `AuthenticatedIngress::Peer`; its source-host header is display
+    provenance, not authentication or routing input
   - Unix/Windows parity requires equivalent local HTTP request/response tests:
     UDS plus loopback TCP on Unix and loopback TCP on Windows
   - Unix clients select UDS by default. `ATM_LOCAL_TRANSPORT=tcp` is the
@@ -3785,8 +3785,8 @@ mail correctness.
     closed with typed backpressure instead of silently buffering unbounded
     plugin traffic
 
-- `REQ-CORE-TRANSPORT-002` After AI.9, cross-host traffic must be daemon-to-daemon HTTPS
-  only.
+- `REQ-CORE-TRANSPORT-002` After AK.4, cross-host traffic must be direct
+  daemon-to-daemon plain HTTP over configured trusted-LAN TCP only.
 
   Required behavior:
   - native agent/plugin code talks only to the local daemon
@@ -3808,13 +3808,14 @@ mail correctness.
   - because team names cannot contain `.`, the inline form splits at the first
     `.` after `@`; the remainder is the host and may be a DNS name or IP
     address containing additional periods
-  - one post-write router selects local nudge for an empty destination host and
-    the HTTPS adapter for every present destination host, including `localhost`
-    and the daemon's own advertised or bound IP address
+  - one post-write router selects the ordinary local nudge for an empty
+    destination host and the direct configured peer HTTP sender for every
+    present destination host, including `localhost` and the daemon's own
+    advertised or bound IP address
   - local CLI HTTP, host-qualified same-host HTTP, and remote peer HTTP submit
-    the same canonical write resource and request schema; TLS/authentication
-    is adapter work before that resource, never a second write endpoint,
-    persistence path, ACK path, or nudge path
+    the same canonical write resource and request schema; the configured peer
+    adapter is never a second write endpoint, persistence path, ACK path, or
+    nudge path
   - every canonical write orders idempotent persistence, optional receiver-side
     acknowledgement mutation, and exactly one post-write router dispatch;
     nudge or peer delivery must never occur before persistence
@@ -3835,27 +3836,27 @@ mail correctness.
     origin destination metadata and still creates the ordinary canonical ACK
     write
 
-- `REQ-CORE-TRANSPORT-002A` Cross-host HTTPS listener, local certificate,
-  trusted peers, and explicit peer aliases must use durable storage-backed
-  state rather than environment variables. SQLite is the initial backend
-  behind that trait.
+- `REQ-CORE-TRANSPORT-002A` Cross-host peer-listener interfaces, trusted-peer
+  hostname/port records, and explicit peer aliases must use durable
+  storage-backed state rather than environment variables. SQLite is the
+  initial backend.
 
   Required behavior:
-  - the daemon reads enabled bind/advertise interfaces, certificate identity,
-    trusted peers, and explicit aliases from durable state into one immutable
-    configuration snapshot
+  - the daemon reads enabled bind/advertise interfaces, trusted peers, and
+    explicit aliases from durable state into one immutable configuration
+    snapshot
   - CLI commands are the sole operator surface for adding, enabling,
     disabling, replacing, removing, and listing those records
   - if no enabled interface rows exist, no cross-host listener binds
   - environment variables must not configure cross-host networking or trust
 
-- `REQ-CORE-TRANSPORT-002D` A peer authority is one durable canonical
-  hostname, HTTPS port, and pinned certificate fingerprint. Explicit host and
-  IP aliases are durable configuration that select that authority.
+- `REQ-CORE-TRANSPORT-002D` A peer authority is one durable canonical hostname
+  and HTTP port. Explicit host and IP aliases are durable configuration that
+  select that authority.
 
   Required behavior:
   - a canonical hostname and its synthesized self-alias select its durable
-    HTTPS port; an explicitly configured host or IP alias selects the same
+    HTTP port; an explicitly configured host or IP alias selects the same
     canonical hostname
   - alias normalization is one in-memory expected-O(1) snapshot lookup at
     admission. It performs no DNS, reverse lookup, peer scan, socket I/O, or
@@ -3865,43 +3866,28 @@ mail correctness.
   - unknown, disabled, duplicate, or malformed aliases fail closed at the
     configuration boundary
   - several account-owned daemons may use the same current host IP only when
-    each authority has a distinct `(hostname, port)` endpoint and certificate
-    pin; an OS bind collision fails closed and must not select another port
+    each authority has a distinct `(hostname, port)` endpoint; an OS bind
+    collision fails closed and must not select another port
   - trust and alias mutations refresh the one live daemon's immutable
     configuration snapshot atomically without starting a second daemon
 
-- `REQ-CORE-TRANSPORT-002B` Cross-host inbound authorization must use mTLS and
-  a durable deny-by-default exact peer allowlist before routing.
+- `REQ-CORE-TRANSPORT-002B` Cross-host ingress must use the configured finite
+  local bind allowlist and the one common peer-write route before routing.
 
   Required behavior:
-  - inbound peers are rejected unless their declared stable host identity,
-    configured HTTPS port, and pinned certificate fingerprint match one
-    enabled record; the TCP source IP is routing information only
-  - wildcard, prefix/suffix, subnet-derived, and regex trust are forbidden
-  - rejection happens before router, mailbox, acknowledgement, or roster work
-  - doctor output must surface listener, certificate, and trust state without
-    exposing private key material
+  - wildcard, unspecified, multicast, duplicate, and non-local listener binds
+    are rejected before any listener is published
+  - the source-host header is display provenance only; it does not authorize a
+    sender, select a recipient, or create a routing branch
+  - all accepted peer writes route through `WriteIngress::Peer`, the shared
+    write handler, and the ordinary post-write nudge path
 
-- `REQ-CORE-TRANSPORT-002B1` A daemon may run an explicit, process-local
-  plaintext peer-wire profile only for debug/smoke diagnosis.
+- `REQ-CORE-TRANSPORT-002B1` is historical. AK.4's configured trusted-LAN HTTP
+  receiver has no plaintext-test mode or alternate receiver classification.
 
   Required behavior:
-  - default and every normal release invocation use mTLS plus the exact peer
-    allowlist; no TLS, certificate, or allowlist failure may fall back to
-    plaintext
-  - only `atm-daemon --peer-wire-security plaintext-test` enables plaintext;
-    the setting is non-durable, not environment-driven, and a restart without
-    that argument restores mTLS
-  - plaintext-test uses the same HTTP resource, `WriteRequest`, router,
-    persistence, and post-write path as mTLS. It must not introduce a
-    plaintext-only message shape, route, nudge, or acknowledgement path
-  - plaintext-test does not authenticate or authorize a peer. A declared
-    source-host is untrusted smoke provenance only and must not be presented as
-    authenticated, used to authorize a recipient, or treated as production
-    trust evidence
-  - doctor, retained logs, smoke JSON, and XHTML label the active wire-security
-    mode. Plaintext-test evidence never satisfies mTLS/allowlist acceptance
-    criteria
+  - mTLS fixtures are interop-only preservation evidence and cannot be a
+    production fallback, route, receiver classification, or smoke substitute
 
 - `REQ-CORE-TRANSPORT-002C` Same-host proof must use the ordinary remote-host
   contract and must not be implemented as a special loopback-only send mode.
@@ -3921,26 +3907,24 @@ mail correctness.
 
 - `REQ-CORE-TRANSPORT-003` Cross-host transport owns no delivery state.
 
-  **AK.3 status:** no outbound peer attempt occurs after host-qualified local
-  admission. AK.2 removed the retired worker model; AK.4 and AK.5 define
-  direct delivery and optional resend semantics separately.
+  **AK.4 status:** host-qualified admission makes exactly one direct bounded
+  HTTP attempt after local persistence. AK.2 removed the retired worker model;
+  no-retry delivery retains only `peerOutbound` when that attempt fails.
 
   Required behavior:
   - no replay store, outbox, retry queue, deferred receipt, remote
     acknowledgement state, or duplicate-delivery subsystem may exist
-  - AK.3 persists a configured host-qualified message locally under its
-    canonical host and does not attempt a peer connection or report a delivery
-    outcome. AK.4's direct attempt reuses that immutable identity
+  - AK.4's direct attempt reuses the persisted immutable identity and removes
+    only its matching `peerOutbound` marker after a matching peer response
   - duplicate arrival is idempotent at storage by the existing message ULID;
     an identical already-delivered remote duplicate has no side effect, while
     the narrow same-host retained-origin receipt defined by
     `REQ-CORE-TRANSPORT-002` logs its skipped write and continues the ordinary
     inbound recipient nudge without a second database write
 
-- `REQ-CORE-TRANSPORT-003A` **Historical; superseded by
-  `REQ-CORE-TRANSPORT-003B`.** It records the AI.28 ordered-coordinator
-  contract and is not an active implementation requirement. Phase AK
-  supersedes the remaining worker model.
+- `REQ-CORE-TRANSPORT-003A` **Historical; superseded by ADR-047.** It records
+  the AI.28 ordered-coordinator contract and is not an active implementation
+  requirement.
 
   Required behavior:
   - durable backend-neutral `PeerSyncPolicy.max_message_age` and
@@ -3966,13 +3950,13 @@ mail correctness.
   - explicit sync runs one bounded pass through the same per-host coordinator
     as automatic recovery; it introduces no second transport or write route
 
-- `REQ-CORE-TRANSPORT-004` AK.4's direct remote write succeeds only after the
+- `REQ-CORE-TRANSPORT-004` AK.4's direct remote HTTP write succeeds only after the
   remote daemon accepts the canonical write request. It is not an AK.3
   admission-response condition.
 
   Required behavior:
   - local admission alone is not remote success
-  - a failed HTTPS request may leave the already-persisted immutable local
+  - a failed HTTP request may leave the already-persisted immutable local
     sender record, but creates no remote recipient row, delivery receipt,
     retry state, or sender-side acknowledgement mutation
   - the receiving daemon validates the recipient against its own local roster
@@ -4012,52 +3996,47 @@ mail correctness.
   - live status-cache cap: `4096`
   - saturation behavior must fail with typed errors or structured degradation,
     never silent drop
-  - inbound HTTPS listeners bound to wildcard/unspecified local addresses must
-    survive ordinary interface rebinding without daemon restart
-  - if the configured listener bind address itself changes or disappears, the
-    daemon must require bounded reload/rebind through the documented reload
-    path and must surface degraded status until rebind succeeds
+  - peer HTTP listeners bind only explicit finite local addresses; wildcard,
+    unspecified, multicast, duplicate, and non-local addresses fail startup
   - HTTP request bodies are capped at `1_048_576` bytes and rejected before decode; UDS,
-    loopback TCP, and HTTPS shutdown stop accepts then drain or cancel tracked requests within
+    loopback TCP, and peer HTTP shutdown stop accepts then drain tracked requests within
     the one documented daemon shutdown deadline
 
 - `REQ-CORE-TRANSPORT-005A` A remote write is confirmed only after the peer
   daemon returns canonical HTTP acceptance.
 
-  **AK.2 status:** the asynchronous worker clauses below are historical until
-  AK.4 restores direct delivery. Local admission remains durable and distinct
-  from remote acceptance.
+  **AK.4 status:** delivery is one synchronous bounded call made by the
+  initiating local request worker after SQLite admission. There is no
+  coordinator, outbound worker, retry, queue, timer, or detached peer work.
 
   Required behavior:
   - origin persistence is observable separately and is never labelled sent
   - deadline, disconnect, or failed response after dispatch returns the typed
     `REMOTE_DELIVERY_UNCONFIRMED` error, never `DAEMON_UNAVAILABLE` when the
     local daemon accepted the request
-  - local admission completes at the SQLite response boundary. Later bounded
-    peer work is runtime-tracked independently of the closed local connection;
-    it is not detached, because the scheduler owns cancellation, concurrency,
-    and observability, but it is not cancelled by the completed admission
-    request
+  - the direct peer call consumes only the initiating request's remaining
+    absolute deadline, capped at three seconds of local response time; it does
+    not create a fresh peer deadline
   - the possible remote side effect is resolved only by repeating the same
     immutable ULID through ordinary idempotent write handling
   - daemon logs record `write_persisted`, `peer_delivery_confirmed`, or
     `peer_delivery_unconfirmed`; terminal handler/response-write failures are
     retained structured events
 
-- `REQ-CORE-TRANSPORT-005B` The local daemon must admit and respond to at
-  least 1,000 host-qualified `send` requests per second through the public ATM
-  API.
+- `REQ-CORE-TRANSPORT-005B` The daemon must complete at least 1,000
+  host-qualified `send` requests per second through the public ATM API against
+  a responsive configured peer.
 
-  **AK.2 status:** worker signalling, DNS, connection, TLS, and remote receipt
-  clauses below are historical. The local SQLite admission requirement and
-  its isolated evidence remain active.
+  **AK.4 status:** the direct configured-peer HTTP attempt follows local
+  SQLite admission and is part of the host-qualified response. Worker,
+  coordinator, DNS-thread, TLS, and retry clauses below are historical.
 
   Required behavior:
-  - the SQLite transaction that durably persists the immutable origin record
-    is the only synchronous operation on the admission-response path. Once it
-    commits, the daemon returns the typed local admission response. Any
-    ordinary local nudge or hook work occurs after that response; admission
-    performs no peer-job signalling, DNS, connection, TLS, or remote receipt
+  - the SQLite transaction durably persists the immutable origin record before
+    one direct peer HTTP call. A matching peer response returns `Sent`; a
+    failed peer call returns `REMOTE_DELIVERY_UNCONFIRMED` and preserves only
+    `peerOutbound`. It starts no peer-job signalling, worker, retry, timer,
+    DNS thread, TLS path, or remote-receipt state
   - pre-persistence admission validation uses only request syntax, provenance,
     and identity rules. The sole post-persistence `PostWriteRouter` remains
     the owner of local-versus-host-qualified routing and consults a
@@ -4066,8 +4045,8 @@ mail correctness.
     An acknowledgement resolves its source, inserts its immutable reply, and
     conditionally marks the source acknowledged within one SQLite transaction;
     it has no application-layer source read before that transaction
-  - the response proves only local admission. Until AK.4 implements a direct
-    peer attempt, it must never claim remote delivery
+  - a successful response proves both local persistence and the matching peer
+    acceptance for that immutable ULID
   - distinct CLI/API write requests are independent. ATM makes no ordering
     promise between their delivery attempts, even when they target the same
     peer. Byte ordering is required only within one HTTP request/response
@@ -4075,9 +4054,9 @@ mail correctness.
     message ULID
   - post-commit local nudge and hook work remains bounded and non-durable. It
     holds no host-qualified delivery, receipt, retry, or recovery state
-  - the throughput requirement applies while the destination peer is
-    unavailable as well as healthy. Release evidence runs ten consecutive
-    one-second admission intervals against one release-built daemon using a
+  - the throughput requirement uses a responsive configured peer listener.
+    Release evidence runs ten consecutive one-second intervals against one
+    release-built daemon using a
     disposable isolated `ATM_HOME` and SQLite database; it must never run
     against a shared or production ATM store. Each interval has at least 1,000
     accepted requests and responses. Mock routers, direct dispatcher calls,

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -272,6 +272,125 @@ def add_dns_case(
         add_case(cases, name, False, str(error), origin=origin, destination=destination)
 
 
+def smoke_ulid() -> str:
+    """Generate one canonical 26-character ULID without a package dependency."""
+    timestamp_ms = time.time_ns() // 1_000_000
+    value = (timestamp_ms << 80) | int.from_bytes(os.urandom(10), "big")
+    alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+    return "".join(alphabet[(value >> shift) & 0x1F] for shift in range(125, -1, -5))
+
+
+def peer_write_payload(
+    sender_identity: str,
+    sender_team: str,
+    recipient_identity: str,
+    recipient_team: str,
+    body: str,
+    message_id: str,
+) -> dict[str, Any]:
+    """Build the route body emitted by the production peer sender.
+
+    HTTP transports encode ``WriteRequest`` directly, rather than serializing
+    the in-process ``RequestEnvelope`` wrapper. The receiver ignores any wire
+    provenance field and attaches the source-host header as display provenance.
+    """
+    return {
+        "home_dir": "/tmp/atm-peer-smoke",
+        "current_dir": "/tmp/atm-peer-smoke",
+        "caller_identity": sender_identity,
+        "caller_team": sender_team,
+        "origin_message_id": message_id,
+        "origin_timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "to": {"agent": recipient_identity, "team": recipient_team},
+        "message_source": {"Inline": body},
+        "summary_override": None,
+        "requires_ack": False,
+        "task_id": None,
+        "parent_message_id": None,
+        "thread_mode": None,
+        "expires_at": None,
+        "acknowledges_message_id": None,
+        "dry_run": False,
+    }
+
+
+def peer_write_response_matches(value: Any, message_id: str) -> bool:
+    """Recognize the route-local ``SendResponseEnvelope`` emitted by curl."""
+    if not isinstance(value, dict):
+        return False
+    sent = value.get("Sent", value.get("sent"))
+    return isinstance(sent, dict) and sent.get("message_id", sent.get("messageId")) == message_id
+
+
+def curl_peer_write(
+    cases: list[dict[str, Any]], peer: str, atm: str, remote_atm: str,
+    remote_host: str, local_host: str, identity: str, team: str,
+    remote_identity: str, remote_team: str,
+) -> None:
+    """Prove curl and production send use one configured peer HTTP ingress."""
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    message_id = smoke_ulid()
+    body = f"smoke-curl-peer-write-{peer}-{stamp}"
+    payload = peer_write_payload(identity, team, remote_identity, remote_team, body, message_id)
+    try:
+        response = parse_json(
+            command([
+                "curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5",
+                "-H", "Content-Type: application/json",
+                "-H", f"X-ATM-Peer-Source-Host: {local_host}",
+                "--data", json.dumps(payload, separators=(",", ":")),
+                f"http://{remote_host}:43101/v1/atm/messages",
+            ]),
+            f"curl peer write to {peer}",
+        )
+        remote_read = parse_json(
+            remote_command(peer, remote_atm, ["read", "--team", remote_team, "--message-id", message_id, "--json"]),
+            f"{peer} read curl peer write",
+        )
+        received = selected_message(remote_read, message_id)
+        passed = peer_write_response_matches(response, message_id) and message_has_text(received, body)
+        add_case(
+            cases,
+            f"curl configured peer write to {peer}",
+            passed,
+            message_id if passed else "peer response or remote read did not preserve the curl write ULID/body",
+            origin=platform.node(),
+            destination=peer,
+        )
+    except SmokeError as error:
+        add_case(cases, f"curl configured peer write to {peer}", False, str(error), origin=platform.node(), destination=peer)
+
+    reverse_message_id = smoke_ulid()
+    reverse_body = f"smoke-curl-peer-write-reverse-{peer}-{stamp}"
+    reverse_payload = peer_write_payload(
+        remote_identity, remote_team, identity, team, reverse_body, reverse_message_id
+    )
+    remote_curl = [
+        "curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5",
+        "-H", "Content-Type: application/json",
+        "-H", f"X-ATM-Peer-Source-Host: {remote_host}",
+        "--data", json.dumps(reverse_payload, separators=(",", ":")),
+        f"http://{local_host}:43101/v1/atm/messages",
+    ]
+    try:
+        response = parse_json(
+            remote_shell(peer, " ".join(shlex.quote(value) for value in remote_curl)),
+            f"{peer} curl peer write to local",
+        )
+        received = wait_for_message(atm, team, reverse_message_id)
+        passed = peer_write_response_matches(response, reverse_message_id) and message_has_text(received, reverse_body)
+        add_case(
+            cases,
+            f"{peer} curl configured peer write to local",
+            passed,
+            reverse_message_id if passed else "peer response or local read did not preserve the curl write ULID/body",
+            origin=peer,
+            destination=platform.node(),
+        )
+    except SmokeError as error:
+        add_case(cases, f"{peer} curl configured peer write to local", False, str(error), origin=peer, destination=platform.node())
+
+
 def curl_doctor(
     cases: list[dict[str, Any]], peer: str, atm: str, remote_atm: str, remote_host: str, expected_version: str,
     *, plaintext: bool,
@@ -786,7 +905,18 @@ def run_live_attempt(feature: str, peers: list[str]) -> list[dict[str, Any]]:
             if remote_host is None or feature == PEER_PREFLIGHT:
                 continue
             if feature == CROSSHOST_CURL_PLAINTEXT:
-                curl_doctor(cases, peer, atm, remote_atm, remote_host, expected_version, plaintext=True)
+                curl_peer_write(
+                    cases,
+                    peer,
+                    atm,
+                    remote_atm,
+                    remote_host,
+                    physical_host,
+                    identity,
+                    team,
+                    remote_identity,
+                    remote_team,
+                )
                 continue
             if feature == CROSSHOST_CURL_MTLS:
                 curl_doctor(cases, peer, atm, remote_atm, remote_host, expected_version, plaintext=False)

--- a/scripts/smoke/run_feature_smoke.py
+++ b/scripts/smoke/run_feature_smoke.py
@@ -393,14 +393,8 @@ def curl_peer_write(
 
 def curl_doctor(
     cases: list[dict[str, Any]], peer: str, atm: str, remote_atm: str, remote_host: str, expected_version: str,
-    *, plaintext: bool,
 ) -> None:
-    """Call the real peer doctor route with curl in both directions.
-
-    Plaintext mode is only meaningful after the caller has started both
-    managed smoke daemons with ``--peer-wire-security plaintext-test``. The
-    runner never changes that daemon state itself.
-    """
+    """Call the real peer mTLS doctor route with curl in both directions."""
     try:
         local_bundle = certificate_bundle(atm)
         remote_certificate = parse_json(
@@ -431,24 +425,21 @@ def curl_doctor(
                     raise SmokeError(f"could not copy {peer} public certificate: {copied_remote['stderr'].strip()}")
                 local_authority = certificate_authority(local_public)
                 remote_authority = certificate_authority(remote_public)
-                scheme = "http" if plaintext else "https"
-                local_url = f"{scheme}://{local_authority}:43101/v1/atm/doctor"
-                remote_url = f"{scheme}://{remote_authority}:43101/v1/atm/doctor"
+                local_url = f"https://{local_authority}:43101/v1/atm/doctor"
+                remote_url = f"https://{remote_authority}:43101/v1/atm/doctor"
                 headers = ["-H", "Content-Type: application/json"]
                 remote_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
-                if not plaintext:
-                    remote_curl.extend(["--cert", remote_bundle, "--cacert", remote_local_ca])
+                remote_curl.extend(["--cert", remote_bundle, "--cacert", remote_local_ca])
                 remote_curl.extend(["--resolve", f"{local_authority}:43101:{advertised_host(atm)}", "--data", DOCTOR_BODY, local_url])
                 remote_result = remote_shell(peer, " ".join(shlex.quote(value) for value in remote_curl))
                 remote_report = parse_json(remote_result, f"{peer} curl doctor to local")
-                add_case(cases, f"{peer} curl {'plaintext' if plaintext else 'mTLS'} to local doctor", doctor_ready(remote_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(remote_report, expected_version) else "doctor response was not healthy/ready", origin=peer, destination=platform.node())
+                add_case(cases, f"{peer} curl mTLS to local doctor", doctor_ready(remote_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(remote_report, expected_version) else "doctor response was not healthy/ready", origin=peer, destination=platform.node())
                 local_curl = ["curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET", *headers]
-                if not plaintext:
-                    local_curl.extend(["--cert", local_bundle, "--cacert", str(remote_public)])
+                local_curl.extend(["--cert", local_bundle, "--cacert", str(remote_public)])
                 local_curl.extend(["--resolve", f"{remote_authority}:43101:{remote_host}", "--data", DOCTOR_BODY, remote_url])
                 local_result = command(local_curl)
                 local_report = parse_json(local_result, f"curl doctor to {peer}")
-                add_case(cases, f"local curl {'plaintext' if plaintext else 'mTLS'} to {peer} doctor", doctor_ready(local_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(local_report, expected_version) else "doctor response was not healthy/ready", origin=platform.node(), destination=peer)
+                add_case(cases, f"local curl mTLS to {peer} doctor", doctor_ready(local_report, expected_version), "HTTP 200 real daemon doctor" if doctor_ready(local_report, expected_version) else "doctor response was not healthy/ready", origin=platform.node(), destination=peer)
             # These checks use each host's ordinary DNS resolver. The mTLS
             # request below intentionally omits --resolve, proving that the
             # TCP connection follows DNS rather than the explicit-IP proof.
@@ -476,13 +467,12 @@ def curl_doctor(
                 "curl", "--silent", "--show-error", "--fail", "--connect-timeout", "2", "--max-time", "5", "-X", "GET",
                 *headers,
             ]
-            if not plaintext:
-                dns_curl.extend(["--cert", local_bundle, "--cacert", str(remote_public)])
+            dns_curl.extend(["--cert", local_bundle, "--cacert", str(remote_public)])
             dns_curl.extend(["--data", DOCTOR_BODY, remote_url])
             dns_report = parse_json(command(dns_curl), f"DNS curl doctor to {peer}")
             add_case(
                 cases,
-                f"local DNS curl {'plaintext' if plaintext else 'mTLS'} to {peer} doctor",
+                f"local DNS curl mTLS to {peer} doctor",
                 doctor_ready(dns_report, expected_version),
                 "HTTP 200 real daemon doctor via DNS" if doctor_ready(dns_report, expected_version) else "doctor response was not healthy/ready",
                 origin=platform.node(),
@@ -491,7 +481,7 @@ def curl_doctor(
     except SmokeError as error:
         add_case(
             cases,
-            f"{peer} curl {'plaintext' if plaintext else 'mTLS'} evidence",
+            f"{peer} curl mTLS evidence",
             False,
             str(error),
             origin=platform.node(),
@@ -919,7 +909,7 @@ def run_live_attempt(feature: str, peers: list[str]) -> list[dict[str, Any]]:
                 )
                 continue
             if feature == CROSSHOST_CURL_MTLS:
-                curl_doctor(cases, peer, atm, remote_atm, remote_host, expected_version, plaintext=False)
+                curl_doctor(cases, peer, atm, remote_atm, remote_host, expected_version)
                 continue
             crosshost_send(
                 cases,

--- a/scripts/smoke/run_inbound_peer_smoke.py
+++ b/scripts/smoke/run_inbound_peer_smoke.py
@@ -219,7 +219,7 @@ def doctor_summary(result: dict[str, Any] | None) -> str:
     def walk(item: Any) -> None:
         if isinstance(item, dict):
             for key, nested in item.items():
-                if key in {"pid", "daemon_pid", "readiness", "daemon_version", "client_version", "version", "peer_wire_security", "http_api_version"} and key not in found:
+                if key in {"pid", "daemon_pid", "readiness", "daemon_version", "client_version", "version", "http_api_version"} and key not in found:
                     found[key] = nested
                 walk(nested)
         elif isinstance(item, list):
@@ -227,7 +227,7 @@ def doctor_summary(result: dict[str, Any] | None) -> str:
                 walk(nested)
 
     walk(value)
-    details = [f"{key}={found[key]}" for key in ("client_version", "daemon_version", "version", "http_api_version", "peer_wire_security", "pid", "daemon_pid", "readiness") if key in found]
+    details = [f"{key}={found[key]}" for key in ("client_version", "daemon_version", "version", "http_api_version", "pid", "daemon_pid", "readiness") if key in found]
     return ", ".join(details) if details else "doctor ready (version/PID fields absent)"
 
 

--- a/scripts/smoke/run_inbound_peer_smoke.py
+++ b/scripts/smoke/run_inbound_peer_smoke.py
@@ -249,17 +249,17 @@ def doctor_matches_expected(local: dict[str, Any], result: dict[str, Any]) -> tu
     if result["exit_code"] != 0:
         return False, result["stderr"] or "doctor failed"
     daemon_version = doctor_field(result, "daemon_context", "version")
-    api_version = doctor_field(result, "daemon_runtime", "http_api_version")
-    wire_security = doctor_field(result, "daemon_runtime", "peer_wire_security")
+    api_version = doctor_field(result, "daemon_context", "http_api_version")
+    readiness = doctor_field(result, "runtime_status", "readiness")
     expected_version = local["expected_daemon_version"]
     expected_api = local["expected_http_api_version"]
     if daemon_version != expected_version:
         return False, f"daemon version {daemon_version!r} != expected {expected_version!r}"
-    if api_version != expected_api:
+    if not isinstance(api_version, str) or api_version.split(".", 1)[0] != str(expected_api):
         return False, f"HTTP API version {api_version!r} != expected {expected_api!r}"
-    if wire_security not in {"mutual_tls", "plaintext_test"}:
-        return False, f"doctor did not report a valid peer wire security profile: {wire_security!r}"
-    return True, f"daemon={daemon_version}, http_api={api_version}, wire={wire_security}"
+    if readiness != "ready":
+        return False, f"daemon readiness {readiness!r} != 'ready'"
+    return True, f"daemon={daemon_version}, http_api={api_version}, readiness={readiness}"
 
 
 def status_for(records: list[dict[str, Any]], phase: str) -> tuple[str, str]:

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -319,6 +319,16 @@ class FeatureSmokeTests(unittest.TestCase):
             ],
         )
 
+    def test_curl_peer_write_payload_is_the_direct_write_route_shape(self):
+        payload = RUNNER.peer_write_payload(
+            "arch-ctm", "atm-dev", "quality-mgr", "atm-dev", "curl proof", "01J00000000000000000000000"
+        )
+        self.assertEqual(payload["origin_message_id"], "01J00000000000000000000000")
+        self.assertEqual(payload["to"], {"agent": "quality-mgr", "team": "atm-dev"})
+        self.assertEqual(payload["message_source"], {"Inline": "curl proof"})
+        self.assertNotIn("authenticated_source_host", payload)
+        self.assertTrue(RUNNER.peer_write_response_matches({"Sent": {"message_id": payload["origin_message_id"]}}, payload["origin_message_id"]))
+
     def test_curl_doctor_records_real_route_evidence_in_both_directions(self):
         doctor = {
             "summary": {"status": "healthy"},

--- a/scripts/smoke/test_run_feature_smoke.py
+++ b/scripts/smoke/test_run_feature_smoke.py
@@ -369,7 +369,6 @@ class FeatureSmokeTests(unittest.TestCase):
                 "/opt/homebrew/bin/atm",
                 "192.0.2.20",
                 "1.4.0-beta-ai",
-                plaintext=False,
             )
         self.assertEqual([case["status"] for case in cases], ["PASS", "PASS", "PASS", "PASS", "PASS"])
         curl_calls = [call.args[0] for call in command.call_args_list if call.args[0][0] == "curl"]

--- a/scripts/smoke/test_run_inbound_peer_smoke.py
+++ b/scripts/smoke/test_run_inbound_peer_smoke.py
@@ -75,8 +75,8 @@ class InboundPeerSmokeTests(unittest.TestCase):
     def test_doctor_version_or_api_mismatch_is_a_hard_failure(self):
         local = {"expected_daemon_version": TEST_VERSION, "expected_http_api_version": 1}
         result = {"exit_code": 0, "stderr": "", "stdout": json.dumps({
-            "daemon_context": {"version": "1.3.1"},
-            "daemon_runtime": {"http_api_version": 1, "peer_wire_security": "mutual_tls"},
+            "daemon_context": {"version": "1.3.1", "http_api_version": "1.0.0"},
+            "runtime_status": {"readiness": "ready"},
         })}
         passed, detail = RUNNER.doctor_matches_expected(local, result)
         self.assertFalse(passed)
@@ -141,8 +141,8 @@ class InboundPeerSmokeTests(unittest.TestCase):
             "peers": [],
         }
         doctor = json.dumps({
-            "daemon_context": {"version": TEST_VERSION},
-            "daemon_runtime": {"http_api_version": 1, "peer_wire_security": "mutual_tls"},
+            "daemon_context": {"version": TEST_VERSION, "http_api_version": "1.0.0"},
+            "runtime_status": {"readiness": "ready"},
         })
 
         def command_result(command, _timeout):


### PR DESCRIPTION
Implements AK.4 per docs/plans/phase-ak/sprint-AK4-direct-peer-http-no-retry.md. Includes cfg_attr Windows dead-code gate fix (2540949a) opportunistically landed here per merge-forward policy (see AK2-QA-1 finding, not duplicated on s2/s3).

Dev still in progress: AK2-ABSENCE-GATE-SCOPE-001 and AK2-FRONTMATTER-STATUS-001 remain to land from arch-ctm before this is QA-ready. Opening now so review findings have a PR to attach to.