### PR TITLE
AK.7: Daemon environment neutrality

### DIFF
--- a/.just/allowlists/env_var_boundary_allowlist.toml
+++ b/.just/allowlists/env_var_boundary_allowlist.toml
@@ -91,35 +91,3 @@ symbol = "environment_visibility"
 line = 'read_cli_identity_from_env_or_warn("atm_core::doctor::environment_visibility")'
 why = "doctor diagnostic snapshot now routes malformed ATM_IDENTITY handling through the wrapper helper, but still performs the same known-debt env read inside atm-core until the caller passes already-resolved values."
 sunset_sprint = "follow-up: have the atm CLI doctor command pass resolved team/identity into environment_visibility"
-
-[[allow]]
-rule = "ATM-ENV-BOUNDARY-001"
-path = "crates/atm-daemon/src/runtime_health.rs"
-symbol = "project_doctor_report"
-line = "team: atm_core::caller_context::read_cli_team_from_env()"
-why = "daemon-side doctor report assembly reports the daemon process's own ATM_TEAM/ATM_IDENTITY for diagnostic context; needs the daemon bootstrap boundary to resolve and pass these values explicitly instead of reading them again inside atm-daemon."
-sunset_sprint = "follow-up: have daemon bootstrap pass resolved team/identity into project_doctor_report"
-
-[[allow]]
-rule = "ATM-ENV-BOUNDARY-001"
-path = "crates/atm-daemon/src/runtime_health.rs"
-symbol = "project_doctor_report"
-line = "identity: atm_core::caller_context::read_cli_identity_from_env()"
-why = "daemon-side doctor report assembly reports the daemon process's own ATM_TEAM/ATM_IDENTITY for diagnostic context; needs the daemon bootstrap boundary to resolve and pass these values explicitly instead of reading them again inside atm-daemon."
-sunset_sprint = "follow-up: have daemon bootstrap pass resolved team/identity into project_doctor_report"
-
-[[allow]]
-rule = "ATM-ENV-BOUNDARY-001"
-path = "crates/atm-daemon/src/runtime_health.rs"
-symbol = "project_doctor_report"
-line = "team: atm_core::caller_context::read_cli_team_from_env_or_warn("
-why = "daemon-side doctor report assembly now routes malformed ATM_TEAM handling through the wrapper helper, but still performs the same known-debt launch-time env read inside atm-daemon until daemon bootstrap passes resolved values explicitly."
-sunset_sprint = "follow-up: have daemon bootstrap pass resolved team/identity into project_doctor_report"
-
-[[allow]]
-rule = "ATM-ENV-BOUNDARY-001"
-path = "crates/atm-daemon/src/runtime_health.rs"
-symbol = "project_doctor_report"
-line = "identity: atm_core::caller_context::read_cli_identity_from_env_or_warn("
-why = "daemon-side doctor report assembly now routes malformed ATM_IDENTITY handling through the wrapper helper, but still performs the same known-debt launch-time env read inside atm-daemon until daemon bootstrap passes resolved values explicitly."
-sunset_sprint = "follow-up: have daemon bootstrap pass resolved team/identity into project_doctor_report"

--- a/.just/check_env_var_boundary.py
+++ b/.just/check_env_var_boundary.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Enforce the ATM_TEAM/ATM_IDENTITY client-boundary rule.
+"""Enforce the daemon ambient-caller environment boundary.
 
-ATM_TEAM and ATM_IDENTITY are CLI-identity environment variables that must
-only be read at client entry points (the `atm` CLI and the `atm-graft`
-client). Library crates (`atm-core`, `atm-daemon`) must receive already
-resolved values as parameters instead of reading these variables themselves.
+ATM_TEAM, ATM_IDENTITY, and ATM_ENVIRONMENT are caller-scoped environment
+variables that must only be read at client entry points (the `atm` CLI and the
+`atm-graft` client). Library crates (`atm-core`, `atm-daemon`, and
+`atm-daemon-bootstrap`) must receive already resolved values as parameters
+instead of reading these variables themselves.
 
 This lint flags:
   * direct `env::var("ATM_TEAM"/"ATM_IDENTITY")` /

--- a/.just/lint-config.toml
+++ b/.just/lint-config.toml
@@ -22,8 +22,8 @@ allowed_paths = ["crates/atm-core/tests/mailbox_locking.rs"]
 config_home_env = "ATM_CONFIG_HOME"
 
 [env_var_boundary]
-forbidden_env_vars = ["ATM_TEAM", "ATM_IDENTITY", "ATM_CHAT_ID", "ATM_SESSION_ID", "ATM_PID"]
-restricted_crate_roots = ["crates/atm-core/src", "crates/atm-daemon/src"]
+forbidden_env_vars = ["ATM_TEAM", "ATM_IDENTITY", "ATM_CHAT_ID", "ATM_SESSION_ID", "ATM_PID", "ATM_ENVIRONMENT"]
+restricted_crate_roots = ["crates/atm-core/src", "crates/atm-daemon/src", "crates/atm-daemon-bootstrap/src"]
 # Seed boundary readers. The lint expands this set transitively to include
 # same-file wrappers (for example `*_or_warn`) that call these functions.
 # The session/PID readers are the sole atm-core exceptions: they construct

--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -996,12 +996,15 @@ pub fn is_launch_gate_contention_error(error: &std::io::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use std::ffi::{OsStr, OsString};
+    #[cfg(unix)]
     use std::fs;
     use std::io::{self, Read};
     use std::net::{Ipv4Addr, TcpListener};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+    use std::sync::{Arc, Mutex};
+    #[cfg(unix)]
+    use std::sync::{MutexGuard, OnceLock};
     use std::time::{Duration, Instant};
 
     use atm_storage::{AtmError, AtmErrorCode};
@@ -1064,11 +1067,13 @@ mod tests {
             .map(|(_, value)| value.map(OsStr::to_os_string))
     }
 
+    #[cfg(unix)]
     struct ProcessEnvironmentGuard {
         originals: Vec<(&'static str, Option<OsString>)>,
         _lock: MutexGuard<'static, ()>,
     }
 
+    #[cfg(unix)]
     impl ProcessEnvironmentGuard {
         fn set(changes: [(&'static str, Option<&str>); 5]) -> Self {
             static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -1099,6 +1104,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     impl Drop for ProcessEnvironmentGuard {
         fn drop(&mut self) {
             for (key, value) in self.originals.iter().rev() {

--- a/crates/atm-daemon-client/src/lib.rs
+++ b/crates/atm-daemon-client/src/lib.rs
@@ -45,6 +45,8 @@ const LOCAL_IPC_CONNECT_DEADLINE: Duration = Duration::from_millis(250);
 const LOCAL_IPC_RESPONSE_GRACE: Duration = Duration::from_millis(250);
 const AUTO_START_MAX_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
+const DAEMON_STRIPPED_ENVIRONMENT: [&str; 3] = ["ATM_TEAM", "ATM_IDENTITY", "ATM_ENVIRONMENT"];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BootstrapCommandEvent {
     pub command: &'static str,
@@ -126,6 +128,17 @@ fn validate_daemon_path(label: &str, path: &Path) -> Result<(), AtmError> {
         )));
     }
     Ok(())
+}
+
+/// Remove caller-scoped environment from a daemon child before it is exec'd.
+///
+/// The invoking CLI/graft process resolves caller context into typed request
+/// data.  The long-lived daemon must never inherit those ambient values, and
+/// this helper deliberately does not inspect or mutate the parent environment.
+fn sanitize_daemon_child_environment(command: &mut Command) {
+    for variable in DAEMON_STRIPPED_ENVIRONMENT {
+        command.env_remove(variable);
+    }
 }
 
 #[cfg(windows)]
@@ -838,6 +851,7 @@ impl DaemonSupervisor {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
+        sanitize_daemon_child_environment(&mut command);
         command.spawn().map_err(|source| {
             AtmError::daemon_auto_start_failed(format!(
                 "failed to spawn daemon binary at {}: {source}",
@@ -981,11 +995,13 @@ pub fn is_launch_gate_contention_error(error: &std::io::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::{OsStr, OsString};
+    use std::fs;
     use std::io::{self, Read};
     use std::net::{Ipv4Addr, TcpListener};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
     use std::time::{Duration, Instant};
 
     use atm_storage::{AtmError, AtmErrorCode};
@@ -999,11 +1015,12 @@ mod tests {
     use super::{
         AUTO_START_PUBLISH_TIMEOUT, BootstrapAutoStartOutcome, BootstrapCommandEvent,
         BootstrapConnectOutcome, BootstrapLaunchGateOutcome, BootstrapTraceReport,
-        BootstrapTraceability, DaemonBinaryPath, DaemonLocalIpcEndpoint, DaemonSupervisor,
-        HOST_RUNTIME_LAUNCH_LOCK_FILE, LaunchGateGuard, LocalDaemonTransport,
-        LocalIpcDeadlineSupport, apply_local_ipc_deadline, exchange_request_with_transport,
-        next_auto_start_poll_interval, read_http_response_with_deadline,
-        resolve_daemon_local_ipc_endpoint, resolve_daemon_local_ipc_endpoint_from_home,
+        BootstrapTraceability, DAEMON_STRIPPED_ENVIRONMENT, DaemonBinaryPath,
+        DaemonLocalIpcEndpoint, DaemonSupervisor, HOST_RUNTIME_LAUNCH_LOCK_FILE, LaunchGateGuard,
+        LocalDaemonTransport, LocalIpcDeadlineSupport, apply_local_ipc_deadline,
+        exchange_request_with_transport, next_auto_start_poll_interval,
+        read_http_response_with_deadline, resolve_daemon_local_ipc_endpoint,
+        resolve_daemon_local_ipc_endpoint_from_home, sanitize_daemon_child_environment,
     };
     #[cfg(unix)]
     use super::{FailedAutoStartChild, reap_failed_auto_start, try_connect_with_transport};
@@ -1038,6 +1055,141 @@ mod tests {
 
     fn launch_lock_path(tempdir: &TempDir) -> PathBuf {
         tempdir.path().join(HOST_RUNTIME_LAUNCH_LOCK_FILE)
+    }
+
+    fn configured_environment(command: &super::Command, key: &str) -> Option<Option<OsString>> {
+        command
+            .get_envs()
+            .find(|(name, _)| *name == OsStr::new(key))
+            .map(|(_, value)| value.map(OsStr::to_os_string))
+    }
+
+    struct ProcessEnvironmentGuard {
+        originals: Vec<(&'static str, Option<OsString>)>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl ProcessEnvironmentGuard {
+        fn set(changes: [(&'static str, Option<&str>); 5]) -> Self {
+            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+            let lock = LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .expect("environment lock");
+            let originals = changes
+                .into_iter()
+                .map(|(key, value)| {
+                    let original = std::env::var_os(key);
+                    // SAFETY: the test holds the process-local environment lock
+                    // for the complete period during which child inheritance is
+                    // observed, and restores every value on drop.
+                    unsafe {
+                        match value {
+                            Some(value) => std::env::set_var(key, value),
+                            None => std::env::remove_var(key),
+                        }
+                    }
+                    (key, original)
+                })
+                .collect();
+            Self {
+                originals,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for ProcessEnvironmentGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.originals.iter().rev() {
+                // SAFETY: restoration is serialized by the guard's process-local
+                // environment lock and mirrors the guarded mutations above.
+                unsafe {
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn daemon_child_environment_removes_caller_context_and_preserves_unrelated_values() {
+        let mut command = super::Command::new("daemon-fixture");
+        command
+            .env("ATM_TEAM", "hostile-team")
+            .env("ATM_IDENTITY", "hostile-identity")
+            .env("ATM_ENVIRONMENT", "hostile-environment")
+            .env("ATM_AK7_UNRELATED", "preserve-me");
+
+        sanitize_daemon_child_environment(&mut command);
+
+        for variable in DAEMON_STRIPPED_ENVIRONMENT {
+            assert_eq!(
+                configured_environment(&command, variable),
+                Some(None),
+                "{variable} must be explicitly removed from the child command"
+            );
+        }
+        assert_eq!(
+            configured_environment(&command, "ATM_AK7_UNRELATED"),
+            Some(Some(OsString::from("preserve-me")))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_auto_start_child_cannot_observe_caller_context_environment() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tempdir = TempDir::new().expect("tempdir");
+        let output_path = tempdir.path().join("child-environment.txt");
+        let script_path = tempdir.path().join("atm-daemon-fixture");
+        fs::write(
+            &script_path,
+            r##"#!/bin/sh
+set -eu
+{
+  printf 'ATM_TEAM=%s\n' "${ATM_TEAM-<unset>}"
+  printf 'ATM_IDENTITY=%s\n' "${ATM_IDENTITY-<unset>}"
+  printf 'ATM_ENVIRONMENT=%s\n' "${ATM_ENVIRONMENT-<unset>}"
+  printf 'ATM_AK7_UNRELATED=%s\n' "${ATM_AK7_UNRELATED-<unset>}"
+} > "$ATM_AK7_ENV_OUTPUT"
+"##,
+        )
+        .expect("write daemon child fixture");
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o700))
+            .expect("make daemon child fixture executable");
+
+        let output = output_path.to_str().expect("UTF-8 fixture output path");
+        let _env = ProcessEnvironmentGuard::set([
+            ("ATM_TEAM", Some("hostile-team")),
+            ("ATM_IDENTITY", Some("hostile-identity")),
+            ("ATM_ENVIRONMENT", Some("hostile-environment")),
+            ("ATM_AK7_UNRELATED", Some("preserve-me")),
+            ("ATM_AK7_ENV_OUTPUT", Some(output)),
+        ]);
+        let daemon = DaemonSupervisor::new(
+            DaemonLocalIpcEndpoint::new(tempdir.path().join("unused.sock")).expect("endpoint"),
+            DaemonBinaryPath::new(script_path).expect("daemon fixture path"),
+        );
+
+        let mut child = daemon.spawn_daemon().expect("spawn daemon child fixture");
+        assert!(
+            child
+                .wait()
+                .expect("wait for daemon child fixture")
+                .success()
+        );
+        let observed = fs::read_to_string(output_path).expect("read child environment");
+        assert!(observed.contains("ATM_TEAM=<unset>"), "{observed}");
+        assert!(observed.contains("ATM_IDENTITY=<unset>"), "{observed}");
+        assert!(observed.contains("ATM_ENVIRONMENT=<unset>"), "{observed}");
+        assert!(
+            observed.contains("ATM_AK7_UNRELATED=preserve-me"),
+            "{observed}"
+        );
     }
 
     #[test]

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -810,15 +810,12 @@ impl DaemonRequestDispatcher {
             });
         }
         report.runtime_status = Some(runtime_status);
-        // This is existing doctor-only launch context. Client context remains
-        // request-scoped and is reported separately.
+        // Daemon context is process metadata only. Caller identity and team
+        // remain request-scoped in `client_context`; the daemon never reads
+        // ambient caller variables to populate either context.
         report.daemon_context = Some(DoctorExecutionContext {
-            team: atm_core::caller_context::read_cli_team_from_env_or_warn(
-                "atm_daemon::runtime_health::daemon_context",
-            ),
-            identity: atm_core::caller_context::read_cli_identity_from_env_or_warn(
-                "atm_daemon::runtime_health::daemon_context",
-            ),
+            team: None,
+            identity: None,
             version: Some(ReleaseVersion::current()),
             cli_schema_version: Some(atm_core::protocol::CLI_SCHEMA_VERSION),
             http_api_version: Some(atm_core::protocol::HttpApiVersion::current()),

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -954,17 +954,11 @@ fn doctor_client_context_reflects_caller_over_daemon_launch_environment() {
                     .map(AgentName::as_str),
                 Some(atm_core::test_support::TEST_SENDER)
             );
-            // daemon_context stays distinct: it reports the daemon's own
-            // launch-time process env, not the caller.
+            // daemon_context intentionally omits caller-derived fields even
+            // when hostile values are present in the daemon process env.
             let daemon_context = report.daemon_context.expect("daemon context");
-            assert_eq!(
-                daemon_context.team.as_ref().map(TeamName::as_str),
-                Some("daemon-launch-team")
-            );
-            assert_eq!(
-                daemon_context.identity.as_ref().map(AgentName::as_str),
-                Some("daemon-launch-identity")
-            );
+            assert!(daemon_context.team.is_none());
+            assert!(daemon_context.identity.is_none());
         }
         other => panic!("expected doctor response, got {other:?}"),
     }

--- a/crates/atm-daemon/src/tests.rs
+++ b/crates/atm-daemon/src/tests.rs
@@ -916,6 +916,7 @@ fn doctor_client_context_reflects_caller_over_daemon_launch_environment() {
         ),
         ("ATM_TEAM", Some("daemon-launch-team")),
         ("ATM_IDENTITY", Some("daemon-launch-identity")),
+        ("ATM_ENVIRONMENT", Some("daemon-launch-environment")),
     ]);
 
     install_test_roster(&db_path, &[ROLE_TEAM_LEAD]);

--- a/docs/atm-daemon-client/boundaries.md
+++ b/docs/atm-daemon-client/boundaries.md
@@ -38,6 +38,21 @@ Rules:
   `atm-storage-rusqlite`
 - `atm-daemon-client` must not grow daemon business logic or graft-session logic
 
+### Launch environment boundary
+
+`DaemonSupervisor::spawn_daemon` is the single repository-owned shared
+auto-start boundary used by both `atm` and `atm-graft`. Immediately before
+`Command::spawn`, it removes `ATM_TEAM`, `ATM_IDENTITY`, and
+`ATM_ENVIRONMENT` from the child command. The private sanitation helper does
+not inspect those values and does not mutate the invoking process environment;
+caller identity and team continue to travel in typed request data.
+
+The repository contains no separate OS-native `atm-daemon` service template,
+launch script, or installer entry point. The checked-in Hermes launchd plist
+is a graft bridge launcher, not a daemon launcher, and therefore does not
+replace or bypass this shared boundary. Any future native service launcher
+must apply the same three pre-exec removals before daemon execution.
+
 ## RpcEnvelope
 
 Canonical machine-readable boundary source:

--- a/docs/atm-daemon/requirements.md
+++ b/docs/atm-daemon/requirements.md
@@ -30,6 +30,20 @@ The canonical daemon observability boundary contract lives in:
 The canonical daemon/client recovery text rule set lives in:
 - [`./recovery-text-rules.md`](./recovery-text-rules.md)
 
+## 1.1 Launch environment neutrality
+
+The daemon is launched through the shared `atm-daemon-client` bootstrap path.
+Before the child is executed, that path removes `ATM_TEAM`, `ATM_IDENTITY`,
+and `ATM_ENVIRONMENT`. This is pre-exec defense in depth: `atm-daemon` does
+not read, default from, or report those ambient caller variables, and it does
+not perform a runtime self-sanitization pass. Caller identity and team are
+supplied only through the typed request context resolved by the invoking CLI
+or graft.
+
+There is no repository-owned native daemon service template or script to audit
+in addition to the shared path. The checked-in Hermes launchd plist launches a
+graft bridge and is not an `atm-daemon` launcher.
+
 ## 2. Ownership
 
 `atm-daemon` owns:

--- a/docs/atm-daemon/startup-state-machine.md
+++ b/docs/atm-daemon/startup-state-machine.md
@@ -51,6 +51,13 @@ Code:
 - `crates/atm/src/composition.rs::CliComposition::bootstrap`
 - `crates/atm-daemon-client/src/lib.rs::DaemonSupervisor`
 
+Before the `spawn` transition, the shared supervisor removes the caller-only
+`ATM_TEAM`, `ATM_IDENTITY`, and `ATM_ENVIRONMENT` variables from the child
+environment. This is a pre-exec launch guard; it does not alter the parent
+CLI/graft environment or add a daemon runtime state. The only repository-owned
+standard launcher is this shared CLI/graft path; no native daemon service
+template is checked in.
+
 This machine ends before any request is sent. If it fails, the caller gets a
 typed bootstrap error and `doctor` does not return a report.
 

--- a/docs/plans/phase-ak/sprint-AK7-daemon-environment-neutrality.md
+++ b/docs/plans/phase-ak/sprint-AK7-daemon-environment-neutrality.md
@@ -1,6 +1,6 @@
 ---
 title: AK.7 Daemon environment neutrality
-status: proposed
+status: complete
 branch: feature/pak-s7-daemon-environment-neutrality
 worktree: ../atm-core-worktrees/feature/pak-s7-daemon-environment-neutrality
 target: integrate/phase-ak
@@ -145,3 +145,20 @@ code. Start immediately; do not wait for any AK.1–AK.6 QA result.
 AK.7 has no AK predecessor merge-forward. Its PR may merge immediately after
 its own QA approval. Before any AK.7 fix round, merge the current
 `integrate/phase-ak` baseline and retain the fixed pre-exec sanitation boundary.
+
+## Closure evidence
+
+- `DaemonSupervisor::spawn_daemon` removes exactly `ATM_TEAM`,
+  `ATM_IDENTITY`, and `ATM_ENVIRONMENT` immediately before child spawn.
+- `atm-daemon-client` unit and Unix disposable-child process tests prove all
+  three values are absent while an unrelated inherited variable remains.
+- The repository launcher audit found no native `atm-daemon` service template,
+  launch script, or installer entry point; the checked-in Hermes plist is a
+  graft bridge launcher and does not start the daemon.
+- `doctor_client_context_reflects_caller_over_daemon_launch_environment` now
+  includes a hostile `ATM_ENVIRONMENT` value, and the source gate covers both
+  `atm-daemon` and `atm-daemon-bootstrap`.
+- `just lint`, `just test`, `just smoke localhost`, and `just smoke local-ip`
+  passed on the AK.7 worktree. Smoke evidence is retained under
+  `reports/smoke/20260804T044635Z/` and
+  `reports/smoke/20260804T044643Z/`.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1063,7 +1063,8 @@ Sprint line:
 - `AK.4` `feature/pak-s4-direct-peer-http-no-retry`
 - `AK.5` `feature/pak-s5-direct-peer-timer-state`
 - `AK.6` `feature/pak-s6-remove-legacy-peer-transport`
-- `AK.7` `feature/pak-s7-daemon-environment-neutrality`
+- `AK.7` `complete` `feature/pak-s7-daemon-environment-neutrality` — daemon
+  launch environment sanitation and ambient-context boundary
 
 Acceptance:
 - Phase AK acceptance is defined by the authoritative plan's sprint

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -270,6 +270,11 @@ Satisfied by:
   - daemon production code must not read, default from, or report these three
     values as caller context; resolved caller identity/team arrive only in
     typed request data from the invoking CLI/graft process
+  - the shared `atm-daemon-client` auto-start boundary removes all three names
+    immediately before child spawn and has a regression test that preserves
+    unrelated inherited variables
+  - this repository has no separate OS-native `atm-daemon` service launcher;
+    any future native launcher must apply the same pre-exec removals
 
 - `REQ-P-DAEMON-PARTITION-001` Phase R daemon cleanup work must use one
   explicit daemon-private partition map so ownership, review scope, and later


### PR DESCRIPTION
Pre-exec removal of ATM_TEAM/ATM_IDENTITY/ATM_ENVIRONMENT in shared atm-daemon-client spawn, hostile-env unit/process tests, daemon doctor regression coverage, env boundary lint root/config, launcher audit docs, REQ-P-RUNTIME-006 docs, project-plan/sprint closure.

Validation: just lint PASS; just test PASS; just smoke localhost PASS (10/10); just smoke local-ip PASS (10/10).

🤖 Generated with team-lead orchestration