### PR TITLE
docs(phase-ak): AK.1 doc-only fix — defer cross-host smoke to AK.4

### DIFF
--- a/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
+++ b/docs/plans/phase-ak/sprint-AK1-crosshost-salvage-audit.md
@@ -63,10 +63,11 @@ AK.1. The keep/discard ledger below is the full change authority.
 4. Reimplement/cherry-pick only the retained changes as small focused commits
    on `feature/pak-s1-crosshost-ack-provenance-recovery`; do not merge or
    cherry-pick the branch wholesale.
-5. Prove M4→M5 and M5→M4 curl message delivery, receiver host rendering,
-   ordinary nudge, host-qualified ACK reply, and reply receipt. This proves the
-   preserved receiver/provenance behavior only; it does not claim native peer
-   sender success.
+5. Preserve the receiver/provenance evidence already recorded for the retained
+   code. AK.4 owns fresh M4↔M5 direct-HTTP delivery, host rendering, ordinary
+   nudge, and host-qualified ACK-reply smoke against the surviving plain
+   receiver; AK.1 does not require live transport proof for the receiver AK.2
+   deletes.
 6. Discard `d4681010` address-fallback/DNS-thread changes, `8fc886df` handoff
    prose, `c808547e` version normalization, and any merge/CI bookkeeping not
    needed by the retained changes. Do not cherry-pick the branch wholesale.
@@ -79,11 +80,6 @@ AK.1. The keep/discard ledger below is the full change authority.
 
 - Test: inbound authenticated host renders compactly in mailbox and nudge, and
   a host-qualified ACK retains its origin ULID/provenance.
-- Live smoke: curl M4→M5 and M5→M4 each prove exact message ULID/body, host
-  rendering, receiver nudge, and ordinary ACK reply receipt.
-- Smoke: run `just smoke localhost` and `just smoke local-ip` against an
-  isolated test home/database; each preserves the same canonical receiver,
-  provenance rendering, and ordinary nudge path.
 - `git diff --check`, `just lint`, and `just test` pass.
 
 ## Dependencies


### PR DESCRIPTION
Follow-up to AK1-QA-1. Sprint doc deliverable 5 and validation now defer fresh direct-HTTP cross-host smoke to AK.4, which owns the surviving receiver. Retained provenance unit coverage and diff/lint/test gates remain. Doc-only; PR #729 (original AK.1 sprint) already merged.