### PR TITLE
docs(phase-ak): AK.8-11 plan documents (cherry-pick to develop)

### DIFF
--- a/docs/plans/phase-ak/plan-phase-ak.md
+++ b/docs/plans/phase-ak/plan-phase-ak.md
@@ -19,6 +19,9 @@ Phase AK starts only after Phase AI merges to `develop`, on
 `integrate/phase-ak`. It does not alter the already-planned Phase AJ
 runtime-observation work. AK.2's temporary no-delivery state must never merge
 to `develop`; AK.4 restores and proves direct delivery on this phase branch.
+AK.7 is an independent daemon-launch hardening sprint: it has no peer-routing,
+transport, retry, or lifecycle-state dependency and may merge on its own QA
+result.
 
 ## Documentation transition
 
@@ -32,22 +35,33 @@ ADR-040, and the corresponding admission language in ADR-035. AK.4 owns the
 active direct-delivery subclauses (`REQ-CORE-TRANSPORT-002`, `-002B`, `-002B1`,
 `-002C`, `-004`, and `-005A`) and creates ADR-047; it must not revise
 AK.3's alias semantics. AK.5 creates ADR-046 and exclusively defines the new
-resend-cache semantics for `REQ-CORE-TRANSPORT-003/-003B`. AK.6 finalizes
+resend-cache semantics for `REQ-CORE-TRANSPORT-003/-003B`. AK.8 owns the
+one-request `messages[]` peer-receive contract; AK.9 owns its sender use,
+atomic outbound confirmation, and resend-state simplification. AK.6 finalizes
 supersession markers and removes obsolete wording without changing AK.3's
-alias contract or AK.4/AK.5 active semantics. No sprint may claim a code/doc
-mismatch as an acceptable interim state after its own PR completes.
+alias contract or AK.8/AK.9 active semantics. AK.10 closes the final
+post-write-router boundary contract after AK.9, and AK.11 is a separate,
+post-AK.6 physical M5 proof sprint. No sprint may claim a code/doc mismatch as
+an acceptable interim state after its own PR completes.
+
+AK.7 implements the existing `REQ-P-RUNTIME-006` launch-environment boundary:
+every standard daemon launcher strips `ATM_TEAM`, `ATM_IDENTITY`, and
+`ATM_ENVIRONMENT` before `atm-daemon` starts, and daemon production code has
+no ambient caller-context fallback. It updates only daemon-launch/
+daemon-boundary documentation; it neither changes Phase AJ caller-context
+semantics nor adds agent-state behavior.
 
 ## MVP contract
 
 | Concern | Decision |
 | --- | --- |
 | Peer configuration | Canonical full hostname plus explicit aliases and port. Configuration changes populate a small alias index. SQLite stores the full hostname, never a resolved IP. |
-| Wire | HTTP/1.1 `POST /v1/atm/messages`, JSON `WriteRequest`, JSON `SendResponseEnvelope`. `send_peer_http_frames` accepts an array but issues this one existing request shape per immutable write; AK adds no batch route or second receiver handler. |
+| Wire | HTTP/1.1 `POST /v1/atm/messages`. A peer singleton and a peer `messages[]` array normalize at the existing receiver boundary into the same canonical write admission path. One peer array request receives one success only after the entire array is durably accepted; it is not HTTP keep-alive framing of independent writes. |
 | Security | Explicit trusted-LAN MVP: no mTLS, certificate pinning, or claimed-source authentication. The sender-host header is display provenance only. AK.4 refuses wildcard or multicast peer-listener binds and binds only configured local interface addresses; network isolation beyond that explicit bind allowlist remains a deployment/firewall responsibility, not an ATM-enforced Internet-exposure guarantee. |
-| Receiver | AK.4 renames the retained plain half of `HttpsListenerSet` to `PeerHttpListenerSet`. Its bounded accept/request execution, HTTP decoder, canonical write handler, SQLite transaction, ACK semantics, and post-write nudge remain the only ingress path. |
-| Sender | CLI and graft use their existing local daemon HTTP call. After canonical SQLite persistence, the daemon makes one private `send_peer_http_frames(config, endpoint, &[write], deadline)` call with the in-memory write and returns the ordinary response. `config` is the immutable configured source-host snapshot, never CLI input or a per-send peer scan. |
+| Receiver | AK.4 creates the minimal plain `PeerHttpListenerSet` after AK.2 removes `HttpsListenerSet`. AK.8 extends its existing HTTP decoder to accept peer `messages[]`, normalize each item into the canonical write admission path, and make the full accepted array durable before one response. Post-write nudges remain best-effort after commit and never change receive success. |
+| Sender | CLI and graft use their existing local daemon HTTP call. After canonical SQLite persistence, the daemon makes one private batch request: an immediate delivery carries one message and a recovered page carries its ordered array. One successful response atomically retires that exact array's durable outbound markers. `config` is the immutable configured source-host snapshot, never CLI input or a per-send peer scan. |
 | AK.4 baseline | No automatic retry. A failed direct send returns an ordinary delivery error and leaves the admitted SQLite record undelivered. |
-| AK.5 resend cache | Adds optional per-endpoint `Connected`/`Disconnected`/`Queued` state, one aggregate, and one timer. `peer_resend_cache = true` is the default; `false` preserves AK.4's no-retry behavior. |
+| AK.5 resend cache | Adds optional per-endpoint `Connected`/`Disconnected`/`Queued` state and one timer. `peer_resend_cache = true` is the default; `false` preserves AK.4's no-retry behavior. AK.9 flattens the redundant one-field aggregate without changing the timer's bounded state ownership. |
 | Failure | Ordinary typed send failure; no receipt synthesis, remote mailbox mutation, or local nudge fallback. |
 
 Every sprint inventories its important structs, enums, traits, and execution
@@ -69,11 +83,10 @@ Delete, not adapt:
   and peer delivery post-commit queue key.
 - `crates/atm-daemon/src/peer_resolution.rs` and literal-IP authority
   discovery in `runtime_health/peer_authority.rs`.
-- Active `HttpsTransport`, `PinnedClientVerifier`, `TlsIdentity`, custom
-  rustls client/server handshake code, and certificate/fingerprint peer
-  transport configuration once the plain `PeerHttpListenerSet` is live. AK.6 preserves
-  verified TLS provisioning/configuration and curl-interoperable receiver
-  support only in `crates/atm-peer-tls-interop`, an isolated, unused TLS crate.
+- The legacy custom TLS module in AK.2. AK.6 begins independently from the
+  pre-AK.2 Phase AK baseline and preserves verified TLS provisioning/
+  configuration and curl-interoperable receiver support only in
+  `crates/atm-peer-tls-interop`, an isolated, unused TLS crate.
   No daemon, CLI, graft, or active send-path crate may depend on it. It is not a native
   peer transport: no native ATM TLS sender is known to work. It does not
   preserve the failing native outbound client in active code.
@@ -88,11 +101,11 @@ The existing simple-send path is intentionally reduced in explicit steps:
 | Start a coordinator thread. | AK.2 | Delete. |
 | Start a per-message thread. | AK.2 | Delete. |
 | Re-scan SQLite for the write just saved. | AK.2 | Delete. AK.4 uses the in-memory `WriteRequest` for an immediate send. |
-| Read every trusted-peer row. | AK.3/AK.6 | AK.3 creates the O(1) alias-to-full-host index; AK.6 deletes the old broad scan. |
-| Resolve every peer hostname for literal-IP alias discovery. | AK.3/AK.6 | AK.3 permits only explicit configured IP aliases; AK.6 deletes inferred discovery. |
-| Start a DNS thread for the selected peer. | AK.6 | Delete. Resolve the persisted full hostname only when connecting; never in an ATM DNS thread. |
-| Open custom TCP/rustls HTTP. | AK.4/AK.6 | AK.4 creates its replacement; AK.6 deletes the unused legacy stack. |
-| Receive a successful peer response. | AK.4 | One idempotent `MessageStore::confirm_peer_delivery(PeerDeliveryConfirmation)` mutation removes only matching `peerOutbound`; accepted writes do not re-enter AK.5's backlog. |
+| Read every trusted-peer row. | AK.3 | Replace with the O(1) immutable alias-to-full-host index; delete the old broad scan. |
+| Resolve every peer hostname for literal-IP alias discovery. | AK.3 | Replace with explicit configured IP aliases; delete inferred discovery. |
+| Start a DNS thread for the selected peer. | AK.3 | Delete. Resolve the persisted full hostname only when connecting; never in an ATM DNS thread. |
+| Open custom TCP/rustls HTTP. | AK.2/AK.4 | AK.2 deletes the legacy stack; AK.4 creates the plain direct-HTTP replacement. |
+| Receive a successful peer response. | AK.9 | One `MessageStore::confirm_peer_delivery_batch` transaction removes the exact accepted array's `peerOutbound` markers; accepted writes do not re-enter AK.5's backlog. |
 
 Retain unchanged unless a direct compile consumer proves otherwise:
 
@@ -112,8 +125,14 @@ authoritative:
 - AK.3: alias persistence and staged curl receiver/nudge proof.
 - AK.4: direct production send/receiver/nudge chain and bind control.
 - AK.5: cache-disabled, immediate, due-batch, restart, and nudge proofs.
-- AK.6: active-transport deletion, isolated curl-mTLS fixture, and final
-  bidirectional production evidence.
+- AK.8: one-request peer `messages[]` decoding, canonical atomic receive, and non-fatal post-commit nudge proof.
+- AK.9: singleton/page sender use of that request, whole-array confirmation, and flattened resend-state proof.
+- AK.10: final post-write-router boundary/source comparison and executable three-route contract proof.
+- AK.6: isolated pre-AK.2 curl-mTLS fixture and final documentation evidence.
+- AK.11: independent, retained physical M5 cross-host proof after AK.10 merges
+  (and therefore after AK.6).
+- AK.7: daemon launch-environment sanitation and ambient-context boundary
+  proof.
 
 `atm-peer-tls-interop` is a preservation boundary, not a service component:
 it may contain provisioning/configuration value objects and a curl-mTLS
@@ -127,8 +146,12 @@ Every sprint runs `just lint`, `just test`, `just smoke localhost`, and
 the bidirectional current-configured `crosshost-curl-tls` receiver/nudge proof,
 because it intentionally has no production sender after AK.2. AK.4 converts
 the standard `crosshost-curl-plain` lane to its configured production listener;
-AK.4, AK.5, and AK.6 each then run it with bidirectional `crosshost-send` and
-`crosshost-ack` on M4/M5. Every successful receiver case must prove one remote
+AK.4, AK.5, AK.8, AK.9, and AK.6 each then run it with bidirectional
+`crosshost-send` and `crosshost-ack` on M4/M5. AK.11 runs after the AK.10
+merge (and therefore after AK.6) and is the only sprint that may close the
+outstanding disabled-cache-first physical proof finding: it retains an
+independently reviewable M5 evidence bundle, including the induced
+failure/no-retry case. Every successful receiver case must prove one remote
 read, exact ULID/body, host-qualified rendering where applicable, and exactly
 one nudge; every rejected/truncated/failed case must prove no false
 confirmation or nudge. Curl remains independent protocol evidence, never a
@@ -143,7 +166,12 @@ substitute for the production-sender proof.
 | AK.3 | Normalize configured aliases to full hostnames before persistence, with no outbound delivery behavior change; prove canonical ingress/nudge with curl. | Must follow AK.2 development push and merge-forward. AK.2 PR must merge before AK.3 PR completion. | arch-ctm |
 | AK.4 | Prove direct full-host HTTP delivery with no retry, including one production sender/receiver/nudge chain. | Must follow AK.3 development push and merge-forward. AK.3 PR must merge before AK.4 PR completion. | arch-ctm |
 | AK.5 | Add optional default-on resend caching through AK.4's proven HTTP function, including restart recovery and disabled-cache behavior. | Must follow AK.4 development push and merge-forward. AK.4 PR must merge before AK.5 PR completion. | arch-ctm |
-| AK.6 | Delete now-dead peer scans, inferred literal-IP discovery, DNS threads, and active custom TLS; isolate provisioning/receiver curl interop. | May develop in parallel after the Phase AI→`develop` entry gate. Before final validation or PR completion, merge-forward AK.5; AK.5 PR must merge before AK.6 PR completion. | Cipher-311d |
+| AK.8 | Replace peer HTTP keep-alive frame loops with the one-request `messages[]` receive contract while retaining the canonical inbound admission/nudge path. | Must follow AK.5 development push and merge-forward. AK.5 PR must merge before AK.8 PR completion. | arch-ctm |
+| AK.9 | Send immediate and recovered arrays through AK.8's contract, atomically retire their backlog markers, and flatten the resend aggregate wrapper. | Must follow AK.8 development push and merge-forward. AK.8 PR must merge before AK.9 PR completion. | arch-ctm |
+| AK.6 | Independently preserve provisioning/receiver curl-mTLS interop from the pre-AK.2 baseline in an inactive crate. | Complete — merged to `integrate/phase-ak` as `1edd1e94` after current-head merge-forward and validation. | Cipher-311d |
+| AK.10 | Resolve `AK5-BOUNDARY-DRIFT-001` with a direct comparison of the final post-write router and its boundary record, then lock the three route outcomes with an executable guard. | Must follow the AK.6 merge and AK.9 development push/merge-forward. AK.6 and AK.9 PRs must merge before AK.10 PR completion. | arch-ctm |
+| AK.11 | Resolve `AK5-CROSSHOST-PROOF-001` with a dedicated disabled-cache-first physical M5 proof bundle. | Starts only after AK.10 merges to `integrate/phase-ak` (therefore after AK.6 and AK.9); it is an independent evidence sprint, not an AK.6 smoke subtask. | arch-ctm + M5 operator |
+| AK.7 | Strip caller identity/team/environment from every daemon launch and remove daemon ambient-caller reads. | May develop and merge independently after the Phase AI→`develop` entry gate. Its owned launch/boundary paths do not overlap AK.1–AK.6. | Cipher-311d |
 
 Each dependent sprint begins immediately after its predecessor development is
 pushed and merge-forwarded; it does **not** wait for predecessor QA approval.
@@ -151,10 +179,25 @@ Every dependent development or fix round first merges its predecessor. A
 dependent PR cannot complete before its predecessor PR merges.
 
 AK.6 is the explicit parallel exception: Cipher may start its isolated
-interop-fixture and deletion-ledger work immediately after the Phase AI entry
-gate, without waiting for AK.5. It must not merge an active-transport deletion
-until AK.5 is merged forward, and it must merge AK.5 before its final
-validation, any final fix round, and PR completion.
+pre-AK.2-baseline interop fixture immediately after
+the Phase AI entry gate, without waiting for AK.5, AK.8, or AK.9. Before final
+validation, any final fix round, and PR completion, it merges the current
+integration head; it must never restore active legacy TLS code to the post-AK.2
+line.
+
+AK.10 begins after the AK.6 merge and AK.9 development push. It merges both
+accepted prerequisites before final validation and PR completion. AK.11 is
+deliberately not folded into AK.6: it begins only after AK.10 merges to
+`integrate/phase-ak`, from that accepted line and with a real M5 peer. Its
+immutable evidence bundle is the closure artifact for
+`AK5-CROSSHOST-PROOF-001`; a unit test, a localhost result, or an ignored
+ad-hoc smoke report cannot close that finding.
+
+AK.7 is also parallel-safe: Cipher may start from the `integrate/phase-ak`
+baseline immediately after the Phase AI entry gate and merge as soon as AK.7
+QA passes. It does not wait for, merge-forward, or modify AK.1–AK.6. If the
+shared baseline advances before an AK.7 fix round, merge it first; resolve only
+the AK.7-owned launch/boundary files.
 
 ## Governing changes
 
@@ -162,8 +205,19 @@ AK.1 records and implements the surviving cross-host provenance fixes. AK.2
 marks only the worker/replay portion of `REQ-CORE-TRANSPORT-003B` and ADR-038
 superseded, then updates project/architecture/boundary text to retire
 worker-specific AI.28/AI.31/AI.32 claims; AK.5 later owns the replacement
-resend-cache semantics. AK.6 completes ADR-047's supersession of
+resend-cache semantics. AK.8/AK.9 amend ADR-047 and the active direct-delivery
+requirements to define one request/one response batch delivery and one atomic
+outbound confirmation. AK.10 corrects the post-write-router boundary contract
+and its route/error outcomes against that final implementation. AK.6 completes
+ADR-047's supersession of
 ADR-034/040/041 and the corresponding requirements/boundary rules: peer host
 alias configuration remains; custom TLS/pinning, inferred literal-IP authority
 discovery, and daemon worker delivery do not. ADR-035 remains the canonical
 single-ingress/nudge rule.
+
+AK.7 implements and makes testable `REQ-P-RUNTIME-006` plus the existing
+daemon-ambient-identity prohibition in `REQ-CORE-CONFIG-001`. It updates
+`docs/atm-daemon-client/boundaries.md`, `docs/atm-daemon/requirements.md`, and
+the daemon startup documentation to make the shared CLI/graft auto-start
+boundary explicit. No new ADR is needed: this is enforcement of the accepted
+runtime requirement, not a new architectural option.

--- a/docs/plans/phase-ak/sprint-AK10-post-write-router-boundary.md
+++ b/docs/plans/phase-ak/sprint-AK10-post-write-router-boundary.md
@@ -1,0 +1,93 @@
+---
+title: AK.10 Post-write router boundary closure
+status: proposed
+branch: feature/pak-s10-post-write-router-boundary
+worktree: ../atm-core-worktrees/feature/pak-s10-post-write-router-boundary
+target: integrate/phase-ak
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+must_follow: AK.6 merged to integrate/phase-ak, AK.9
+merge_gate: AK.6 merge commit, AK.9
+parallel_safe: false
+quality_findings: [AK5-BOUNDARY-DRIFT-001]
+---
+
+# AK.10 — post-write router boundary closure
+
+## Closure
+
+Close `AK5-BOUNDARY-DRIFT-001` against the final AK.9 line by comparing
+`boundaries/atm-daemon/post-write-router.toml` directly with
+`crates/atm-daemon/src/runtime_health/peer_delivery_router.rs`. The obsolete
+`socket_io` claim has already been removed from the integration baseline; this
+sprint must resolve the remaining contract drift rather than re-litigating the
+old finding text.
+
+The final boundary record must accurately state the three router outcomes:
+
+1. an inbound peer receipt signals ordinary local post-write/nudge work and
+   returns success;
+2. a host-qualified origin invokes the one AK.9 direct batch sender and may
+   return a typed unconfirmed-delivery error, without scheduling a local nudge;
+3. a hostless origin signals ordinary local post-write/nudge work and returns
+   success.
+
+This is a boundary-and-proof sprint, not a new routing design. It must not
+introduce a coordinator, queue, sender abstraction, or second receive path.
+
+## Type and boundary inventory
+
+| Item | AK.10 role |
+| --- | --- |
+| `PostWriteRouter::dispatch` | Existing sole post-persistence route selector. Its three existing branch outcomes are asserted and documented; it is not split or replaced. |
+| `send_peer_http_batch` | AK.9's free-function sole host-qualified outbound operation. AK.10 names it in the boundary record and proves no second send path is selected. |
+| `PostCommitWorkKey` | Existing local receiver/hostless signal. It remains absent from a successful or failed host-qualified-send branch. |
+| `AtmErrorCode::RemoteDeliveryUnconfirmed` | Permitted host-qualified stable error code. The boundary record must not claim `error_types = ["none"]` while this path propagates that error. |
+
+No new public type, trait, thread, task, channel, queue, listener, persistence
+table, or route is authorized.
+
+## Deliverables
+
+1. Produce a source-to-boundary comparison in the PR that identifies every
+   `io_owns`, `io_forbidden`, request/response/error contract, and route note
+   in `post-write-router.toml` against the final AK.9 router. Amend the TOML
+   only where the source comparison requires it. In particular, distinguish
+   the host-qualified direct batch request from local post-write signals and
+   declare the actual typed error behavior.
+2. Add an executable source-level or focused integration guard covering all
+   three outcomes above. It must prove host-qualified sends use the shared
+   AK.9 batch sender exactly once and do not enqueue/signal a local nudge;
+   peer-receipt and hostless writes must prove the ordinary local signal.
+3. Confirm the boundary lint has no stale ownership or forbidden-I/O claim.
+   The permitted direct HTTP ownership must be no broader than the configured
+   batch send; SQLite remains outside the router, and TLS, DNS worker,
+   fallback, graft delivery, and hook execution remain forbidden.
+4. In the PR, close `AK5-BOUNDARY-DRIFT-001` only with links to the direct
+   comparison and executable proof. If the actual AK.9 implementation differs,
+   update this sprint plan before changing behavior.
+
+## Explicit prohibitions
+
+- No `PeerDrainCoordinator`, per-message delivery loop, extra retry policy,
+  broad peer scan, or local nudge fallback for a host-qualified send.
+- No boundary-file-only closure: the record and a direct executable proof must
+  agree with the implementation.
+- No claim that a receiver nudge can alter host-qualified sender confirmation
+  or error handling.
+
+## Required validation
+
+- `just lint` validates the amended boundary record and dependency edges.
+- Focused tests prove the three branch outcomes, one batch request for the
+  host-qualified path, no host-qualified local post-write signal, and typed
+  propagation of a direct-delivery failure.
+- `just test`, `just smoke localhost`, and `just smoke local-ip` pass.
+- PR evidence links the final AK.9 commit, the source-to-boundary comparison,
+  and the focused proof before the triage finding changes state.
+
+## Dependencies
+
+AK.6 must merge before AK.10 begins. Start AK.10 after AK.9 is pushed, but
+merge both AK.6 and AK.9 before every AK.10 development/fix round and before
+PR completion. AK.11 does not start until AK.10 itself merges.

--- a/docs/plans/phase-ak/sprint-AK11-m5-crosshost-proof.md
+++ b/docs/plans/phase-ak/sprint-AK11-m5-crosshost-proof.md
@@ -1,0 +1,112 @@
+---
+title: AK.11 Independent M5 disabled-cache cross-host proof
+status: proposed
+branch: feature/pak-s11-m5-crosshost-proof
+worktree: ../atm-core-worktrees/feature/pak-s11-m5-crosshost-proof
+target: integrate/phase-ak
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+must_follow: AK.10 merged to integrate/phase-ak
+merge_gate: AK.10 merge commit
+parallel_safe: false
+quality_findings: [AK5-CROSSHOST-PROOF-001]
+---
+
+# AK.11 — independent M5 disabled-cache cross-host proof
+
+## Closure
+
+Close `AK5-CROSSHOST-PROOF-001` only with a physical, bidirectional M5 proof
+run from the accepted `integrate/phase-ak` line **after AK.10 merges** (and
+therefore after AK.6). This is an independent sprint: it is not an AK.6 smoke
+subtask, a localhost result, a unit mock, or a claim based on ignored
+`reports/smoke` output.
+
+The receiver remains the one canonical inbound path for CLI, graft, and
+cross-host HTTP. It accepts the AK.8 `messages[]` envelope, durably admits the
+entire accepted request, then attempts the ordinary post-commit nudge
+best-effort. A nudge error is diagnostic evidence only; it cannot make the
+receive fail. The sender either posts the immediate singleton when healthy or
+one recovered ordered array after a healthy transition. One whole-array success
+advances the durable outbound cursor once.
+
+## Physical proof contract
+
+1. Pin the exact post-AK.10 `integrate/phase-ak` SHA and record both M4 and M5
+   ATM binary versions, host identities, peer configuration fingerprints, run
+   ID, and timestamps. Do not record credentials or private key material.
+2. First set `peer_resend_cache = false` on both physical peers and prove it
+   from the effective daemon configuration. Run M4→M5 and M5→M4
+   `crosshost-send`, `crosshost-ack`, and `crosshost-curl-plain` lanes. Each
+   production-send case proves exact remote ULID/body, host-qualified
+   rendering, one ordinary receiver nudge, and no sender-side cross-host nudge.
+3. While cache is disabled, induce one controlled transport failure in each
+   direction. Prove the send returns the persisted-but-unconfirmed typed
+   failure, leaves the origin `peerOutbound` marker durable, and makes no
+   automatic resend through at least one complete configured due window. The
+   receiver must have no false delivery/nudge for the failed request.
+4. Only after the disabled-cache proof succeeds, enable the cache and run a
+   separate recovery proof: the retained ordered backlog is delivered as one
+   array request on a healthy transition and one success atomically retires the
+   full submitted marker set. This must not be presented as disabled-cache
+   behavior.
+5. Retain a sanitized, reviewable evidence bundle under a non-ignored tracked
+   path such as `artifacts/phase-ak/AK11-m5-crosshost-proof/`. Include a
+   README, machine-readable manifest, normalized command/config transcript,
+   sender/receiver result identifiers, durable-marker observations, and nudge
+   observations. The raw ignored smoke report may be referenced by run ID but
+   is not the only retained proof artifact.
+
+## Type and boundary inventory
+
+| Item | AK.11 role |
+| --- | --- |
+| `PeerMessageArray` | Existing AK.8 request envelope exercised physically; AK.11 does not change its schema. |
+| `send_peer_http_batch` | Existing AK.9 sender exercised as immediate singleton and recovered array; AK.11 does not add a transport. |
+| `MessageStore::confirm_peer_delivery_batch` | Existing atomic cursor operation observed through durable marker evidence; AK.11 does not change storage semantics. |
+| Receiver post-write nudge | Existing best-effort post-commit effect. Its failure remains non-fatal to receive success. |
+| `scripts/smoke/run_feature_smoke.py` | May gain deterministic evidence-bundle export only if needed; the physical M5 run remains required. |
+
+## Deliverables
+
+1. Add or refine a deterministic proof harness only where needed to emit the
+   sanitized tracked evidence manifest. It must use the public send/read/ack
+   interface and the existing peer route; it may not bypass daemon admission or
+   inspect secrets.
+2. Execute the physical M4/M5 run described above after AK.6 is merged and
+   commit its sanitized evidence bundle with the exact accepted baseline SHA.
+3. Update `docs/peer-pair-smoke.md` with the reproducible disabled-cache-first
+   procedure and artifact location, without claiming the proof passes until the
+   real manifest is committed.
+4. Close `AK5-CROSSHOST-PROOF-001` only when reviewers can reproduce or audit
+   the retained M5 evidence. If M5 access or a controlled failure cannot be
+   obtained, leave the sprint and finding open rather than manufacturing proof.
+
+## Explicit prohibitions
+
+- No start before AK.10 merges to `integrate/phase-ak`, and no reuse of a run
+  against an earlier SHA as final evidence.
+- No localhost-only, curl-only, mocked, or transient ignored-log closure.
+- No treating a receiver nudge error as receive failure, and no sender-side
+  nudge for a cross-host delivery attempt.
+- No implementation redesign: this sprint proves the accepted AK.8/AK.9
+  contract; material behavior drift returns to a separately planned fix.
+
+## Required validation
+
+- `just lint`, `just test`, `just smoke localhost`, and `just smoke local-ip`
+  pass on the exact accepted baseline before the physical run.
+- The tracked M5 manifest proves all disabled-cache-first and enabled-recovery
+  assertions, both directions, and the required durable-marker/nudge
+  observations.
+- Review verifies no secret material or ignored-only report is required to
+  assess the proof, then links the artifact when closing the triage finding.
+
+## Dependencies
+
+AK.11 starts only after the AK.10 PR merges to `integrate/phase-ak`; AK.10 in
+turn requires the completed AK.6 merge and AK.9 final route. It is separate
+from AK.6 so that physical M5 availability, evidence capture, and proof-only
+harness work cannot delay or dilute implementation review. If a proof exposes
+real behavior drift, stop evidence closure, file the new defect, and plan a
+corrective sprint before rerunning AK.11.

--- a/docs/plans/phase-ak/sprint-AK8-peer-message-array-ingress.md
+++ b/docs/plans/phase-ak/sprint-AK8-peer-message-array-ingress.md
@@ -1,0 +1,142 @@
+---
+title: AK.8 Atomic peer message-array ingress
+status: proposed
+branch: feature/pak-s8-peer-message-array-ingress
+worktree: ../atm-core-worktrees/feature/pak-s8-peer-message-array-ingress
+target: integrate/phase-ak
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+must_follow: AK.5
+merge_gate: AK.5
+parallel_safe: false
+---
+
+# AK.8 — atomic peer message-array ingress
+
+## Closure
+
+Replace AK.4/AK.5's HTTP keep-alive sequence of independent writes with one
+peer `POST /v1/atm/messages` body containing `messages[]`. The configured peer
+listener continues to be the only receiver. It decodes either the ordinary
+singleton write or an authenticated peer array, normalizes the items through
+the same canonical inbound admission rules, persists the accepted array as one
+unit, and returns one response only after that commit. It creates no second
+listener, route, worker, nudge path, or cross-host-specific recipient path.
+
+Historical context only: the AK.5 implementation uses per-frame peer writes
+and per-item confirmation. AK.8 replaces only the receiver side with one
+atomic `messages[]` ingress request. AK.9 exclusively owns sender migration,
+whole-array `confirm_peer_delivery_batch`, and flattening
+`PeerResendAggregate`; none is an AK.8 deliverable.
+
+## Fixed contract
+
+```rust
+struct PeerMessageArray {
+    messages: Vec<WriteRequest>,
+}
+
+fn admit_peer_messages_atomically(
+    requests: Vec<WriteRequest>,
+    source_host: HostName,
+    runtime: &LocalServiceRuntime,
+) -> Result<SendResponseEnvelope, AtmError>;
+
+trait MessageStore {
+    fn save_messages_atomically(&self, messages: &[Message]) -> Result<(), AtmError>;
+}
+```
+
+`PeerMessageArray` is a wire body, not a second API route or a second receiver
+service. The only route stays `POST /v1/atm/messages`. The peer listener adds
+the configured source-host provenance to every item, performs the same
+canonical validation and idempotency preparation that a singleton peer write
+uses, and rejects the entire request before persistence when any item is
+invalid, duplicated within the array, or exceeds existing request bounds.
+
+After all items prepare successfully, the receiver uses the existing atomic
+storage boundary to make the complete immutable array durable. A single
+success response means exactly that commit completed; a validation, storage, or
+response error is not success for any subset. Existing single-message CLI,
+graft, and curl requests retain their existing request body and normalize to
+the same canonical admission path.
+
+The post-commit dispatcher registers ordinary local post-write effects only
+after the durable commit. Each accepted item may produce its ordinary local
+nudge, but a queue-full event, nudge failure, hook failure, or notification-log
+failure is a warning after receive success and never changes the peer HTTP
+response to failure. Nudge is not a delivery receipt and is never consulted by
+the sender.
+
+## Type and boundary inventory
+
+| Item | AK.8 role |
+| --- | --- |
+| `PeerMessageArray` | New peer-only JSON request body carrying one non-empty bounded ordered `messages` array. It owns no I/O, retry, route, or lifecycle behavior. |
+| Existing `POST /v1/atm/messages` and `PeerHttpListenerSet` | The sole receiver endpoint and lifecycle. AK.8 extends its decoder; it creates no batch URL, second listener, or alternate peer receiver. |
+| Canonical write preparation/admission | Existing singleton rules, invoked for every normalized item before any array persistence. No local-vs-cross-host recipient branch is introduced. |
+| `MessageStore::save_messages_atomically` | Existing sealed durable batch boundary used for a fully prepared peer array. It must not expose partial acceptance. |
+| `SendResponseEnvelope` | Existing response family. AK.8 defines one peer-array success response after the full durable commit; it does not emit an item-by-item response stream. |
+| Existing post-commit local-nudge queue and emitter | Retained best-effort post-commit effect. It is outside receipt success/failure and remains the canonical receive-side nudge path. |
+
+No batch receiver trait, receiver worker, transaction coordinator, nudge
+receipt, sender callback, alternate route, or per-item HTTP response framing is
+authorized.
+
+## Deliverables
+
+1. Extend only the existing peer HTTP request decoder so one request body can
+   express a bounded non-empty `messages[]` peer array. Preserve ordinary
+   singleton CLI/graft/curl `WriteRequest` bodies and the existing route.
+2. Normalize singleton and array items into the common canonical write
+   preparation path. Apply peer provenance and all validation to every item
+   before any array persistence. Reject duplicate origin ULIDs within the
+   request deterministically.
+3. Commit an accepted array through one existing atomic storage operation, then
+   return one success response. An error at validation, preparation, or commit
+   must leave no subset newly accepted by that request.
+4. Signal ordinary post-commit local effects after the commit only. Explicitly
+   prove that nudge/hook/notification failures are retained as warnings and do
+   not turn an already committed peer receive into an error response.
+5. Amend ADR-047 and the active direct-delivery requirements/boundaries to
+   replace the old per-frame meaning of a batch with this one-request atomic
+   receiver contract. AK.9 exclusively owns sender use and confirmation.
+
+## Explicit prohibitions
+
+- No new listener, URL, API service, receiver trait, worker, timer, task,
+  channel, queue, or post-commit retry mechanism.
+- No partial success response, per-item HTTP response, or persistence of a
+  subset of a valid submitted array.
+- No sender-side or receiver-side use of a nudge result as receive/delivery
+  success.
+- No change to local CLI/graft request routing or a local/cross-host receiver
+  branch after normalization.
+
+## Required validation
+
+- Unit: singleton peer and one-item array normalize to the same prepared
+  canonical write and response semantics.
+- Unit: a multi-item array validates provenance, recipients, origin ULIDs, and
+  duplicates for every item before persistence; one invalid item yields no new
+  persisted member of the array.
+- Storage integration: successful arrays are durable atomically, retain input
+  order for post-commit effects, and preserve existing idempotent replay
+  semantics.
+- Integration: one `POST /v1/atm/messages` array produces one response only
+  after all items commit and uses the same receiver/post-write route as curl,
+  CLI, and graft ingress.
+- Integration: injected nudge/hook/notification failure follows a successful
+  peer receive response and is observable as a warning, never a receive error.
+- Regression: existing singleton local and peer request framing remains
+  compatible; malformed/oversized/empty arrays have no false commit or nudge.
+- `just lint`, `just test`, `just smoke localhost`, `just smoke local-ip`, and
+  isolated bidirectional `crosshost-curl-plain` evidence pass.
+
+## Dependencies
+
+Before every AK.8 development/fix round, merge AK.5 into AK.8. Start AK.8 as
+soon as AK.5 is pushed; do not wait for QA. AK.8 PR completion waits for AK.5
+merge. AK.9 may start only after AK.8 is pushed and merge-forwarded; it must
+merge AK.8 before every development/fix round and before PR completion. AK.6
+is already merged as `1edd1e94` and places no open-work dependency on AK.8.

--- a/docs/plans/phase-ak/sprint-AK9-peer-batch-confirmation.md
+++ b/docs/plans/phase-ak/sprint-AK9-peer-batch-confirmation.md
@@ -1,0 +1,152 @@
+---
+title: AK.9 Unified peer batch send and atomic confirmation
+status: proposed
+branch: feature/pak-s9-peer-batch-confirmation
+worktree: ../atm-core-worktrees/feature/pak-s9-peer-batch-confirmation
+target: integrate/phase-ak
+recommended_agent: arch-ctm
+recommended_model: deep-reasoning
+must_follow: AK.8
+merge_gate: AK.8
+parallel_safe: false
+---
+
+# AK.9 — unified peer batch send and atomic confirmation
+
+## Closure
+
+Use AK.8's one-request peer array contract for both direct singleton delivery
+and AK.5's recovered oldest-first page. One successful response atomically
+retires exactly the submitted durable outbound markers. Replace the current
+per-frame transport loop and per-message confirmation loop, then flatten
+AK.5's one-field `PeerResendAggregate`; retain its bounded timer and state
+semantics.
+
+## Fixed contract
+
+```rust
+fn send_peer_http_batch(
+    config: &PeerHttpRuntimeConfig,
+    endpoint: &PeerEndpoint,
+    writes: &[WriteRequest],
+    deadline: RequestDeadline,
+) -> Result<SendResponseEnvelope, AtmError>;
+
+trait MessageStore {
+    fn confirm_peer_delivery_batch(
+        &self,
+        canonical_host: &HostName,
+        message_ids: &[AtmMessageId],
+    ) -> Result<(), AtmError>;
+}
+
+struct PeerResendState {
+    states: HashMap<PeerEndpoint, PeerConnectionState>,
+    earliest_due: Option<Instant>,
+}
+```
+
+The sender serializes the supplied ordered slice into exactly one AK.8 peer
+array request, including the one-element direct-send case. It accepts only the
+one whole-array success response. A timeout, malformed response, error
+response, or broken connection leaves every submitted marker eligible for the
+next attempt and returns the stable `AtmErrorCode::RemoteDeliveryUnconfirmed`
+error code; it does not infer which remote messages might have arrived.
+
+Only after that one success does `confirm_peer_delivery_batch` remove the
+matching `peerOutbound` markers in one SQLite transaction. A failure while
+retiring the marker set is surfaced as a local storage error and must leave the
+entire set unchanged. This is the sender cursor: it moves once for the exact
+array, never once per HTTP frame or per item.
+
+AK.5's immediate `Connected` attempt passes a singleton slice. Its due
+callback passes one bounded oldest-first page. Both call the same function and
+share the same confirmation operation. The `Connected`/`Disconnected`/`Queued`
+state machine, `earliest_due`, one due endpoint per loop turn, retry delay, and
+no-I/O-under-lock property remain unchanged. `PeerResendAggregate` disappears:
+the map stores `PeerConnectionState` directly.
+
+The cache-disabled direct path is an equally required migration target. In
+`DaemonRequestDispatcher::dispatch`, the host-qualified `else` arm reached
+when `peer_resend_scheduler` is unset currently calls the direct frame sender.
+AK.9 replaces that call with `send_peer_http_batch` and the one transactional
+`confirm_peer_delivery_batch` operation. It must not route this fast path
+through the scheduler, emit a local nudge, or preserve a compatibility sender.
+
+## Type and boundary inventory
+
+| Item | AK.9 role |
+| --- | --- |
+| `send_peer_http_batch` | Replacement sole outbound peer sender. It issues one HTTP request and reads one response for a supplied ordered slice; no keep-alive frame loop or response vector remains. |
+| `PeerMessageArray` | AK.8's wire value. AK.9 uses it for both singleton and recovered-page sends; it does not create a second transport protocol. |
+| `DaemonRequestDispatcher::dispatch` cache-disabled host-qualified `else` arm | Required direct-path migration target when `peer_resend_scheduler` is unset. It sends the singleton through `send_peer_http_batch` and invokes `confirm_peer_delivery_batch` only after the one whole-array response. |
+| `MessageStore::confirm_peer_delivery_batch` | New sealed atomic durable marker-retirement operation. It verifies the canonical host and exact submitted message set in one transaction. |
+| `PeerDeliveryConfirmation`, `MessageStore::confirm_peer_delivery` | Removed from active peer delivery after all direct and retry callers migrate to batch confirmation. |
+| `PeerResendState::states` | AK.5 state map simplified to `HashMap<PeerEndpoint, PeerConnectionState>`. It retains `earliest_due` as the one serve-loop timer deadline. |
+| `PeerResendScheduler` | Retained bounded state owner. It neither gains a coordinator, worker, queue, thread, pool, payload cache, nor a second cursor. |
+
+## Deliverables
+
+1. Replace `send_peer_http_frames` and its per-write request/response loop with
+   `send_peer_http_batch`, which emits one AK.8 array request and accepts one
+   whole-array response. Delete obsolete frame-reader/vector response behavior
+   used only for peer delivery.
+2. Replace singular peer-delivery confirmation with
+   `confirm_peer_delivery_batch`, implemented as one storage transaction over
+   the exact ordered input set and configured canonical host. Migrate immediate
+   cache-disabled dispatch and enabled-scheduler due-page callers together; do
+   not leave a compatibility sender path.
+3. Prove direct singleton success, recovered-page success, response failure,
+   and local marker-retirement failure preserve the all-or-nothing sender
+   cursor contract.
+4. Flatten `PeerResendAggregate` to a direct endpoint-to-state map. Preserve
+   `earliest_due`, deterministic due selection, bounded page size, and mutex
+   scope; do not add a coordinator or replace the timer with a worker.
+5. Update ADR-046/ADR-047, requirements, daemon/storage boundaries, and
+   smoke documentation to describe one request/one response delivery and one
+   atomic outbound confirmation. Specifically amend
+   `boundaries/atm-daemon/peer-resend-scheduler.toml` and the
+   `DirectPeerResendAggregate` section of `docs/atm-daemon/boundaries.md`.
+
+## Explicit prohibitions
+
+- No HTTP keep-alive loop of independent peer writes, per-frame response
+  vector, partial cursor advancement, or per-message confirmation transaction.
+- No new sender trait, coordinator, worker, task, channel, queue, connection
+  pool, retry policy, or second timer.
+- No recovery decision based on a remote nudge, agent state, roster state, or
+  session identity.
+
+## Required validation
+
+- Unit: singleton direct delivery and a recovered page each issue exactly one
+  peer HTTP request and require exactly one matching whole-array response.
+- Focused dispatch integration: with `peer_resend_scheduler` unset, a
+  host-qualified write takes the cache-disabled `else` arm, issues exactly one
+  singleton `messages[]` request through `send_peer_http_batch`, atomically
+  confirms its marker only after success, returns
+  `AtmErrorCode::RemoteDeliveryUnconfirmed` on transport failure with the
+  marker retained, and emits no local sender-side nudge.
+- Integration: a successful array response atomically removes every submitted
+  `peerOutbound` marker; a failed/invalid/missing response removes none.
+- Storage integration: a failure during batch marker retirement rolls back the
+  full marker set; a mismatch of host or message set cannot retire unrelated
+  durable records.
+- Regression: replay after any transport error resends the complete retained
+  array, while a success cannot create duplicate recovery delivery or nudge.
+- Unit: flattening the aggregate preserves `Connected`, `Disconnected`, and
+  `Queued` transitions, one earliest deadline, deterministic due ordering, and
+  no network or SQLite work while holding the state mutex.
+- Integration/smoke: enabled recovery performs one healthy transition batch
+  with one receiver persistence result and ordinary non-fatal post-commit
+  nudges; disabled cache makes no retry. Run bidirectionally for
+  `crosshost-send`, `crosshost-ack`, and `crosshost-curl-plain`.
+- `just lint`, `just test`, `just smoke localhost`, and `just smoke local-ip`
+  pass.
+
+## Dependencies
+
+Before every AK.9 development/fix round, merge AK.8 into AK.9. Start AK.9 as
+soon as AK.8 is pushed; do not wait for QA. AK.9 PR completion waits for AK.8
+merge. AK.6 is already merged as `1edd1e94` and places no open-work dependency
+on AK.9.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1032,11 +1032,14 @@ Authoritative plan: [Phase AI plan](./plans/phase-ai/plan-phase-ai.md).
 AI.3 (`feature/pAI-s3-error-contract-foundation`) completes the two-field
 serializable error contract and removes the retired protocol error envelope.
 
-## 41. Phase AK — Direct peer HTTP delivery [PROPOSED]
+## 41. Phase AK — Direct peer HTTP delivery [IN PROGRESS]
 
 Status summary:
 - Phase AK is the planned simplification line for replacing the Phase AI peer
   worker and custom TLS sender with one direct HTTP delivery function.
+- `AK.2` is in progress: Phase AI's daemon worker, replay policy, and delivery
+  projection are historical and are being deleted before AK.4 restores direct
+  delivery.
 - Planning branch: `plan/mvp-simplification`.
 - Integration branch: `integrate/phase-ak`.
 - Entry gate: Phase AI must merge to `develop` before AK implementation starts.
@@ -1053,6 +1056,10 @@ Goal:
 Deliverables:
 - direct host-alias normalization, one direct no-retry HTTP sender, optional
   timer-driven resend cache, and isolated curl-mTLS provisioning evidence
+- one atomic `messages[]` peer receive request, one-request batch send, atomic
+  outbound-marker confirmation, and flattened resend aggregate state
+- direct post-write-router boundary/source closure and a final independent,
+  disabled-cache-first M5 cross-host evidence bundle
 - deletion of obsolete worker/replay/TLS transport state with governed
   boundary-record updates
 
@@ -1062,12 +1069,23 @@ Sprint line:
 - `AK.3` `feature/pak-s3-canonical-peer-aliases`
 - `AK.4` `feature/pak-s4-direct-peer-http-no-retry`
 - `AK.5` `feature/pak-s5-direct-peer-timer-state`
-- `AK.6` `feature/pak-s6-remove-legacy-peer-transport`
+- `AK.8` `feature/pak-s8-peer-message-array-ingress`
+- `AK.9` `feature/pak-s9-peer-batch-confirmation`
+- `AK.10` `feature/pak-s10-post-write-router-boundary`
+- `AK.6` `complete` `feature/pak-s6-remove-legacy-peer-transport` — merged as
+  `1edd1e94`
+- `AK.11` `feature/pak-s11-m5-crosshost-proof` — independent physical proof,
+  starts only after AK.10 merges (and therefore after AK.6)
+- `AK.7` `complete` `feature/pak-s7-daemon-environment-neutrality` — daemon
+  launch environment sanitation and ambient-context boundary
 
 Acceptance:
 - Phase AK acceptance is defined by the authoritative plan's sprint
   validations and its required bidirectional production send/read/ACK/nudge
-  proof on the accepted `integrate/phase-ak` line.
+  proof on the accepted `integrate/phase-ak` line. The final disabled-cache
+  cross-host proof is an independently retained M5 artifact from AK.11, run
+  only after AK.10 merges (and therefore after AK.6); it is not satisfied by a
+  prior sprint's smoke log.
 
 ## 42. Phase AJ — Runtime observation [PLANNED — gated by Phase AI closeout]
 


### PR DESCRIPTION
## Summary
- Cherry-picks the AK.8-11 sprint plan (peer message-array ingress, batch confirmation, post-write-router boundary closure, M5 crosshost proof) onto `develop`.
- `plan/message-array-send` (PR #751) was mistakenly forked from `integrate/phase-ak` instead of `develop`; per standing rule, plan branches must fork from `develop` so plan docs land there directly. This PR corrects that by landing the reviewed plan-doc content on `develop`.
- Adds `sprint-AK8`..`sprint-AK11` docs, refreshes `plan-phase-ak.md`, and refreshes the Phase AK section of `docs/project-plan.md` to the current AK.1-11 state (AK.6/AK.7 marked complete/merged) for internal doc consistency.

## Already reviewed
- 2-round background plan-hardening (plan-scope-reviewer + critical-plan-reviewer), round 2 clean 0B/0I/0M verified against live source.
- quality-mgr AK811-PLANQA-1: PASS (docs-only), merged into `integrate/phase-ak` at 4eab740c via PR #751.
- Open GAP noted by quality-mgr (routed to arch-ctm separately): ATM-QA-001-AK1 and ATM-QA-005-AK7-ENVGUARD-NOOP are not covered by AK.8-11 and need explicit fold-in or waiver.

## Test plan
- [x] Docs-only change, no code
- [x] quality-mgr plan-doc QA already passed on equivalent content (PR #751)

🤖 Generated with [Claude Code](https://claude.com/claude-code)