### PR TITLE
Add closing-triage skill: branch-scoped findings query + dev fix loop

### DIFF
--- a/.claude/skills/closing-triage/SKILL.md
+++ b/.claude/skills/closing-triage/SKILL.md
@@ -42,10 +42,17 @@ a fix. Since this skill never writes to the triage store (see above), the
 live query alone cannot tell that you already fixed something: it will keep
 returning the same finding on every call until QA closes it upstream.
 
-So you maintain your own **branch-local task list** — a plain JSON file at
-`.git/closing-triage-tasklist.json` inside your worktree (`.git/` is never
-tracked or pushed, so this stays purely local bookkeeping and never becomes
-repo content). It is a list of objects:
+So you maintain your own **branch-local task list** — a plain JSON file in
+your worktree's private git directory. In linked worktrees `.git` is a file,
+not a directory, so always resolve the path with git itself:
+
+```bash
+TASKLIST="$(git rev-parse --git-path closing-triage-tasklist.json)"
+```
+
+This resolves to the per-worktree git directory (never tracked or pushed),
+so the file stays purely local bookkeeping and never becomes repo content.
+It is a list of objects:
 
 ```json
 {
@@ -174,8 +181,8 @@ atm send quality-mgr "Fixed <FINDING-ID>: <short description>. Branch <BRANCH> @
 Do not batch this across multiple findings — one message per finding fixed,
 sent right after its own commit/push, so quality-mgr's view of progress
 stays in sync with what's actually pushed. Do **not** message team-lead per
-finding; team-lead receives exactly one summary when all findings are
-closed (see Exit condition).
+finding; team-lead receives exactly one summary when your developer work is
+complete (see Exit condition).
 
 Return to step (b) if any `queued` entries remain in your task list.
 Otherwise, return to step (a) to check whether new findings have appeared
@@ -190,16 +197,18 @@ reproduced (recorded `not-reproduced`, reported to quality-mgr), or you
 fixed it, tested it, committed and pushed it, and recorded it `implemented`
 with its commit SHA.
 
-You MUST then notify team-lead — exactly once, and only now — that all
-findings are closed, with the git commits containing the fixes. This is the
-only message team-lead receives from this skill. Build the payload directly
-from `.git/closing-triage-tasklist.json` (every entry appears in exactly one
-of the two arrays; fill the placeholders from the task list, one object per
-finding):
+You MUST then notify team-lead — exactly once, and only now — that your
+developer work is complete, with the git commits containing the fixes.
+(QA owns finding closure; this summary claims only that your side is done.)
+This is the only message team-lead receives from this skill. Build the
+payload directly from the task list at
+`"$(git rev-parse --git-path closing-triage-tasklist.json)"` (every entry
+appears in exactly one of the two arrays; fill the placeholders from the
+task list, one object per finding):
 
 ````bash
 atm send team-lead "$(cat <<'EOF'
-All findings closed for <BRANCH>.
+Developer work complete for <BRANCH>.
 ```json
 {
   "branch": "<BRANCH>",

--- a/.claude/skills/closing-triage/SKILL.md
+++ b/.claude/skills/closing-triage/SKILL.md
@@ -37,9 +37,22 @@ environment; it operates purely on the current worktree's branch.
 - There is exactly one reachable `integrate/phase-*` worktree for your phase,
   or you know its path to pass explicitly.
 
+## Why the loop needs a local seen-log
+
+A finding's `triage:status` and any `triage:Resolution` record only change
+once QA/team-lead verify and close it — never the moment you commit and push
+a fix. Since this skill never writes to the triage store (see above), the
+query alone cannot tell that you already fixed something: it would keep
+returning the same finding forever. `query_open_findings.py` supports
+`--seen-log PATH` for exactly this: a plain newline-delimited list of finding
+IDs to exclude from results. Use `.git/closing-triage-seen.txt` inside your
+worktree as that path — `.git/` is never tracked or pushed, so this stays
+purely local bookkeeping for your loop and never becomes repo content.
+
 ## The Loop
 
-Repeat until step (a) returns zero findings for your branch. Do not stop
+Repeat until step (a) returns zero *unseen* findings for your branch — i.e.
+every finding your seen-log doesn't already exclude is gone. Do not stop
 early because a fix "looks small enough to batch" — each finding gets its own
 full pass through (a)–(g) so the query, the fix, the commit, and the report
 stay traceable to exactly one finding.
@@ -47,14 +60,17 @@ stay traceable to exactly one finding.
 ### a) Query
 
 From your sprint worktree, determine your current branch and run the query
-against the integrate worktree for your phase:
+against the integrate worktree for your phase, excluding findings you've
+already fixed this loop-run:
 
 ```bash
 BRANCH="$(git branch --show-current)"
+SEEN_LOG="$(git rev-parse --git-dir)/closing-triage-seen.txt"
 python3 /path/to/.claude/skills/closing-triage/scripts/query_open_findings.py \
   --branch "$BRANCH" \
   --integration-root ../../atm-core-worktrees/integrate/phase-<name> \
   --phase <PHASE> \
+  --seen-log "$SEEN_LOG" \
   --json
 ```
 
@@ -80,9 +96,12 @@ Before writing any code:
 
 - Confirm the defect the finding describes is still actually present at the
   cited location, in this branch's current state. If it doesn't reproduce
-  (already fixed by other work, code path no longer exists, superseded),
-  do not invent speculative work to "address" it — note why in your commit
-  message instead and move to the next finding.
+  (already fixed by other work, code path no longer exists, superseded), do
+  not invent speculative work to "address" it. There is no code change and
+  therefore no commit for this finding: instead, `atm send team-lead` a short
+  note naming the finding ID and why it didn't reproduce, append the finding
+  ID to `$SEEN_LOG` yourself (skipping steps d–g, since there's nothing to
+  implement, test, or push), and return to step (a).
 - Look for the fix that removes the underlying cause, not one that patches
   around it. If the finding describes duplicated logic, prefer consolidating
   to one owner over re-syncing two copies. If it describes a missing test,
@@ -109,20 +128,27 @@ Fix any failures your change introduced or exposed, then rerun. Repeat until
 
 ### f) Commit, push, and reference the finding
 
-Commit with a message that names the finding ID, so the fix is traceable back
-to exactly the finding it closes:
+Review what's actually changed before staging anything — your worktree may
+already have unrelated in-progress or untracked files from other work. Stage
+only the paths your fix touched, not the whole tree:
 
 ```bash
-git add -A
+git status
+git add <path1> <path2> ...   # exactly the files your fix touched -- never `git add -A`
 git commit -m "$(cat <<'EOF'
 <short description of the fix>
 
 Finding: <FINDING-ID>
-
-Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
 EOF
 )"
 git push origin "$BRANCH"
+```
+
+Then record the finding ID in your local seen-log so step (a) stops
+returning it on the next iteration:
+
+```bash
+echo "<FINDING-ID>" >> "$SEEN_LOG"
 ```
 
 ### g) Report completion
@@ -137,14 +163,18 @@ Do not batch this across multiple findings — one message per finding fixed,
 sent right after its own commit/push, so team-lead's view of progress stays
 in sync with what's actually pushed.
 
-Then return to step (a). The next query reflects your branch's real current
-state — a finding you just fixed should no longer appear (it may still show
-as open in the `.ttl` record itself until QA verifies and closes it; that's
-expected and not a bug in this loop).
+Then return to step (a). The finding you just fixed will not reappear
+because it's now in your seen-log — not because its TTL record changed; it
+almost certainly still shows `triage:status "open"` until QA closes it. That
+is expected, not a bug.
 
 ## Exit condition
 
-The loop ends when step (a)'s query returns zero findings for your branch.
-At that point every finding this tool can see against your branch has a
-corresponding fix commit pushed. QA verification and finding closure in the
-triage store happen next, outside this skill.
+The loop ends when step (a)'s query, with your seen-log applied, returns zero
+findings. At that point, for every finding the query could see against your
+branch: either it didn't reproduce (and you noted why instead of touching
+code for it), or you fixed it, tested it, committed and pushed it, and
+recorded its ID in your seen-log. None of that means QA has verified or
+closed anything yet — it only means your side of the work is done. QA
+verification and finding closure in the triage store happen next, outside
+this skill.

--- a/.claude/skills/closing-triage/SKILL.md
+++ b/.claude/skills/closing-triage/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: closing-triage
+version: 1.0.0
+description: >
+  Work a sprint branch's open triage findings down to zero, one finding at a
+  time: query, fix cleanly, verify, test, commit/push, report, repeat.
+depends_on:
+  graph-orchestration: 1.x
+---
+
+# Closing Triage
+
+Audience: the developer assigned to a sprint branch. Invoke with `/closing-triage`
+while standing in that sprint's own worktree (the one you were assigned —
+`../atm-core-worktrees/<your-branch>`, not an `integrate/*` worktree).
+
+This skill does not decide who runs it or read any identity from the
+environment; it operates purely on the current worktree's branch.
+
+## What this skill does not do
+
+- It does not write to the `.triage/*/findings/*.ttl` store. Finding closure
+  (`triage:status`, `triage:Resolution`) is owned by QA/team-lead once they
+  independently verify your fix — never by this skill or by you self-marking
+  a finding fixed. Confirming the fix satisfies the finding (step d below) is
+  your own sanity check before testing and committing, not a triage-store
+  write.
+- It does not dispatch QA reviewers. That happens separately, after you push.
+- It does not decide phase/merge sequencing.
+
+## Prerequisites
+
+- You are in your assigned sprint worktree, on your assigned branch.
+- `.claude/skills/closing-triage/scripts/query_open_findings.py` is reachable
+  (present on this branch, or merged forward from wherever it landed).
+- `rdflib` is installed (`pip install rdflib`) — required by the query script.
+- There is exactly one reachable `integrate/phase-*` worktree for your phase,
+  or you know its path to pass explicitly.
+
+## The Loop
+
+Repeat until step (a) returns zero findings for your branch. Do not stop
+early because a fix "looks small enough to batch" — each finding gets its own
+full pass through (a)–(g) so the query, the fix, the commit, and the report
+stay traceable to exactly one finding.
+
+### a) Query
+
+From your sprint worktree, determine your current branch and run the query
+against the integrate worktree for your phase:
+
+```bash
+BRANCH="$(git branch --show-current)"
+python3 /path/to/.claude/skills/closing-triage/scripts/query_open_findings.py \
+  --branch "$BRANCH" \
+  --integration-root ../../atm-core-worktrees/integrate/phase-<name> \
+  --phase <PHASE> \
+  --json
+```
+
+Omit `--integration-root` only if you are literally standing in the integrate
+worktree itself (you normally are not — you're in your sprint worktree). The
+script refuses to run against anything that isn't an `integrate/*` branch, on
+purpose: findings only live there, and a sprint worktree's own copy of the
+triage store (if any) may be stale.
+
+If the query returns zero findings, you are done. Stop here — do not invent
+work.
+
+### b) Take the most significant finding
+
+Results are already ordered Blocking → Important → Minor (ties broken by
+`found_at`). Take the first one. Do not skip ahead to an easier finding
+further down the list, and do not batch multiple findings into one pass.
+
+### c) Determine a clean, simplifying fix
+
+Read the finding's full description and the file(s)/line(s) it points at.
+Before writing any code:
+
+- Confirm the defect the finding describes is still actually present at the
+  cited location, in this branch's current state. If it doesn't reproduce
+  (already fixed by other work, code path no longer exists, superseded),
+  do not invent speculative work to "address" it — note why in your commit
+  message instead and move to the next finding.
+- Look for the fix that removes the underlying cause, not one that patches
+  around it. If the finding describes duplicated logic, prefer consolidating
+  to one owner over re-syncing two copies. If it describes a missing test,
+  write the real test against the actual code path, not a shallow smoke
+  check. Simpler and smaller is the goal — do not add abstractions, options,
+  or generality the finding didn't ask for.
+
+### d) Implement, then confirm the fix actually satisfies the finding
+
+Make the change. Before moving on, re-read the finding's description against
+your diff and answer honestly: does this fix the thing the finding actually
+describes, or does it just make the symptom quieter? This is your own
+verification pass — hold yourself to the same standard you'd want from an
+independent reviewer. If the fix is partial, keep going until it isn't.
+
+### e) Test
+
+```bash
+just test
+```
+
+Fix any failures your change introduced or exposed, then rerun. Repeat until
+`just test` passes cleanly. Do not commit against a red test run.
+
+### f) Commit, push, and reference the finding
+
+Commit with a message that names the finding ID, so the fix is traceable back
+to exactly the finding it closes:
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+<short description of the fix>
+
+Finding: <FINDING-ID>
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+git push origin "$BRANCH"
+```
+
+### g) Report completion
+
+Send an ATM completion message to team-lead naming the fix and the commit:
+
+```bash
+atm send team-lead "Fixed <FINDING-ID>: <short description>. Branch <BRANCH> @ <commit-sha>."
+```
+
+Do not batch this across multiple findings — one message per finding fixed,
+sent right after its own commit/push, so team-lead's view of progress stays
+in sync with what's actually pushed.
+
+Then return to step (a). The next query reflects your branch's real current
+state — a finding you just fixed should no longer appear (it may still show
+as open in the `.ttl` record itself until QA verifies and closes it; that's
+expected and not a bug in this loop).
+
+## Exit condition
+
+The loop ends when step (a)'s query returns zero findings for your branch.
+At that point every finding this tool can see against your branch has a
+corresponding fix commit pushed. QA verification and finding closure in the
+triage store happen next, outside this skill.

--- a/.claude/skills/closing-triage/SKILL.md
+++ b/.claude/skills/closing-triage/SKILL.md
@@ -17,16 +17,12 @@ while standing in that sprint's own worktree (the one you were assigned —
 This skill does not decide who runs it or read any identity from the
 environment; it operates purely on the current worktree's branch.
 
-## What this skill does not do
+## Scope boundary
 
-- It does not write to the `.triage/*/findings/*.ttl` store. Finding closure
-  (`triage:status`, `triage:Resolution`) is owned by QA/team-lead once they
-  independently verify your fix — never by this skill or by you self-marking
-  a finding fixed. Confirming the fix satisfies the finding (step d below) is
-  your own sanity check before testing and committing, not a triage-store
-  write.
-- It does not dispatch QA reviewers. That happens separately, after you push.
-- It does not decide phase/merge sequencing.
+This skill never writes to the `.triage/*/findings/*.ttl` store: finding
+closure (`triage:status`, `triage:Resolution`) belongs to QA/team-lead after
+they independently verify your fix. QA dispatch and phase/merge sequencing
+happen elsewhere, after you push.
 
 ## Prerequisites
 
@@ -34,8 +30,9 @@ environment; it operates purely on the current worktree's branch.
 - `.claude/skills/closing-triage/scripts/query_open_findings.py` is reachable
   (present on this branch, or merged forward from wherever it landed).
 - `rdflib` is installed (`pip install rdflib`) — required by the query script.
-- There is exactly one reachable `integrate/phase-*` worktree for your phase,
-  or you know its path to pass explicitly.
+- Exactly one sibling `integrate/*` worktree exists — the query script
+  auto-discovers it via `git worktree list`. Pass `--integration-root` only
+  if discovery reports zero or multiple candidates.
 
 ## Why the loop needs a local task list
 
@@ -56,13 +53,16 @@ repo content). It is a list of objects:
   "severity": "blocking",
   "description": "...",
   "status": "queued",
-  "commit_sha": null
+  "commit_sha": null,
+  "reason": null
 }
 ```
 
-`status` is one of `queued`, `implemented`, or `not-reproduced`. You are the
-sole writer of this file. You work through `queued` items; the query is only
-ever used to (re-)populate it, never to decide what's already done.
+`status` is one of `queued`, `implemented`, or `not-reproduced`. `reason` is
+set only on `not-reproduced` entries (why the finding didn't reproduce); it
+feeds the final team-lead summary. You are the sole writer of this file.
+You work through `queued` items; the query is only ever used to
+(re-)populate it, never to decide what's already done.
 
 ## The Loop
 
@@ -74,16 +74,15 @@ Run the canonical query once:
 BRANCH="$(git branch --show-current)"
 python3 /path/to/.claude/skills/closing-triage/scripts/query_open_findings.py \
   --branch "$BRANCH" \
-  --integration-root ../../atm-core-worktrees/integrate/phase-<name> \
-  --phase <PHASE> \
   --json
 ```
 
-Omit `--integration-root` only if you are literally standing in the integrate
-worktree itself (you normally are not — you're in your sprint worktree). The
-script refuses to run against anything that isn't an `integrate/*` branch, on
-purpose: findings only live there, and a sprint worktree's own copy of the
-triage store (if any) may be stale.
+Run this from your sprint worktree — do not move to the integrate worktree.
+The script auto-discovers the sibling `integrate/*` worktree via
+`git worktree list` and queries its triage store, never a sprint worktree's
+own (potentially stale) copy. Pass `--integration-root` (and `--phase` if
+more than one phase exists there) only when the script reports that
+auto-discovery found zero or multiple integrate worktrees.
 
 Diff the result against your task list by `finding_id`: for every finding in
 the query result that is **not already present** in your task list (under
@@ -112,10 +111,12 @@ Before writing any code:
   cited location, in this branch's current state. If it doesn't reproduce
   (already fixed by other work, code path no longer exists, superseded), do
   not invent speculative work to "address" it. There is no code change and
-  therefore no commit for this item: `atm send team-lead` a short note
-  naming the finding ID and why it didn't reproduce, set this task-list
-  entry's `status` to `not-reproduced`, and go back to step (b) (skipping
-  d–g, since there's nothing to implement, test, or push).
+  therefore no commit for this item: `atm send quality-mgr` a short note
+  naming the finding ID and why it didn't reproduce (so QA can independently
+  verify the finding no longer exists or was fixed elsewhere), set this
+  task-list entry's `status` to `not-reproduced` and record that same reason
+  in its `reason` field, and go back to step (b) (skipping d–g, since
+  there's nothing to implement, test, or push).
 - Look for the fix that removes the underlying cause, not one that patches
   around it. If the finding describes duplicated logic, prefer consolidating
   to one owner over re-syncing two copies. If it describes a missing test,
@@ -164,15 +165,17 @@ any other entry, and do not touch the triage TTL.
 
 ### g) Report completion
 
-Send an ATM completion message to team-lead naming the fix and the commit:
+Send an ATM completion message to quality-mgr naming the fix and the commit:
 
 ```bash
-atm send team-lead "Fixed <FINDING-ID>: <short description>. Branch <BRANCH> @ <commit-sha>."
+atm send quality-mgr "Fixed <FINDING-ID>: <short description>. Branch <BRANCH> @ <commit-sha>."
 ```
 
 Do not batch this across multiple findings — one message per finding fixed,
-sent right after its own commit/push, so team-lead's view of progress stays
-in sync with what's actually pushed.
+sent right after its own commit/push, so quality-mgr's view of progress
+stays in sync with what's actually pushed. Do **not** message team-lead per
+finding; team-lead receives exactly one summary when all findings are
+closed (see Exit condition).
 
 Return to step (b) if any `queued` entries remain in your task list.
 Otherwise, return to step (a) to check whether new findings have appeared
@@ -183,8 +186,35 @@ against your branch since your last refresh.
 The loop ends when a refresh at step (a) adds zero new entries to your task
 list *and* your task list has zero `queued` entries left. At that point, for
 every finding the query could ever see against your branch: either it never
-reproduced (recorded `not-reproduced`, reported), or you fixed it, tested it,
-committed and pushed it, and recorded it `implemented` with its commit SHA.
-None of that means QA has verified or closed anything yet — it only means
+reproduced (recorded `not-reproduced`, reported to quality-mgr), or you
+fixed it, tested it, committed and pushed it, and recorded it `implemented`
+with its commit SHA.
+
+You MUST then notify team-lead — exactly once, and only now — that all
+findings are closed, with the git commits containing the fixes. This is the
+only message team-lead receives from this skill. Build the payload directly
+from `.git/closing-triage-tasklist.json` (every entry appears in exactly one
+of the two arrays; fill the placeholders from the task list, one object per
+finding):
+
+````bash
+atm send team-lead "$(cat <<'EOF'
+All findings closed for <BRANCH>.
+```json
+{
+  "branch": "<BRANCH>",
+  "implemented": [
+    {"finding_id": "<FINDING-ID>", "commit_sha": "<sha>"}
+  ],
+  "not_reproduced": [
+    {"finding_id": "<FINDING-ID>", "reason": "<why it didn't reproduce>"}
+  ]
+}
+```
+EOF
+)"
+````
+
+None of this means QA has verified or closed anything yet — it only means
 your side of the work is done. QA verification and finding closure in the
 triage store happen next, outside this skill.

--- a/.claude/skills/closing-triage/SKILL.md
+++ b/.claude/skills/closing-triage/SKILL.md
@@ -37,40 +37,45 @@ environment; it operates purely on the current worktree's branch.
 - There is exactly one reachable `integrate/phase-*` worktree for your phase,
   or you know its path to pass explicitly.
 
-## Why the loop needs a local seen-log
+## Why the loop needs a local task list
 
 A finding's `triage:status` and any `triage:Resolution` record only change
 once QA/team-lead verify and close it — never the moment you commit and push
 a fix. Since this skill never writes to the triage store (see above), the
-query alone cannot tell that you already fixed something: it would keep
-returning the same finding forever. `query_open_findings.py` supports
-`--seen-log PATH` for exactly this: a plain newline-delimited list of finding
-IDs to exclude from results. Use `.git/closing-triage-seen.txt` inside your
-worktree as that path — `.git/` is never tracked or pushed, so this stays
-purely local bookkeeping for your loop and never becomes repo content.
+live query alone cannot tell that you already fixed something: it will keep
+returning the same finding on every call until QA closes it upstream.
+
+So you maintain your own **branch-local task list** — a plain JSON file at
+`.git/closing-triage-tasklist.json` inside your worktree (`.git/` is never
+tracked or pushed, so this stays purely local bookkeeping and never becomes
+repo content). It is a list of objects:
+
+```json
+{
+  "finding_id": "AJ6-ATM-QA-001-MEMBERS-CLI-MISSING",
+  "severity": "blocking",
+  "description": "...",
+  "status": "queued",
+  "commit_sha": null
+}
+```
+
+`status` is one of `queued`, `implemented`, or `not-reproduced`. You are the
+sole writer of this file. You work through `queued` items; the query is only
+ever used to (re-)populate it, never to decide what's already done.
 
 ## The Loop
 
-Repeat until step (a) returns zero *unseen* findings for your branch — i.e.
-every finding your seen-log doesn't already exclude is gone. Do not stop
-early because a fix "looks small enough to batch" — each finding gets its own
-full pass through (a)–(g) so the query, the fix, the commit, and the report
-stay traceable to exactly one finding.
+### a) Build or refresh the task list
 
-### a) Query
-
-From your sprint worktree, determine your current branch and run the query
-against the integrate worktree for your phase, excluding findings you've
-already fixed this loop-run:
+Run the canonical query once:
 
 ```bash
 BRANCH="$(git branch --show-current)"
-SEEN_LOG="$(git rev-parse --git-dir)/closing-triage-seen.txt"
 python3 /path/to/.claude/skills/closing-triage/scripts/query_open_findings.py \
   --branch "$BRANCH" \
   --integration-root ../../atm-core-worktrees/integrate/phase-<name> \
   --phase <PHASE> \
-  --seen-log "$SEEN_LOG" \
   --json
 ```
 
@@ -80,14 +85,23 @@ script refuses to run against anything that isn't an `integrate/*` branch, on
 purpose: findings only live there, and a sprint worktree's own copy of the
 triage store (if any) may be stale.
 
-If the query returns zero findings, you are done. Stop here — do not invent
-work.
+Diff the result against your task list by `finding_id`: for every finding in
+the query result that is **not already present** in your task list (under
+any status), append it as a new `queued` entry (with its severity and
+description recorded from the query). Never touch an entry that's already
+recorded, whatever its status — a finding that still shows up in TTL because
+QA hasn't closed it yet must not be re-queued. Re-sort the full set of
+`queued` entries by severity (Blocking → Important → Minor, ties by the
+query's own order) so step (b) stays correct across multiple refreshes.
 
-### b) Take the most significant finding
+If, after this diff, your task list has zero `queued` entries, you are done
+— go to **Exit condition** below. Do not invent work.
 
-Results are already ordered Blocking → Important → Minor (ties broken by
-`found_at`). Take the first one. Do not skip ahead to an easier finding
-further down the list, and do not batch multiple findings into one pass.
+### b) Take the most significant queued item
+
+Take the first `queued` entry from your (now-sorted) task list. Do not skip
+ahead to an easier item further down, and do not batch multiple items into
+one pass.
 
 ### c) Determine a clean, simplifying fix
 
@@ -98,10 +112,10 @@ Before writing any code:
   cited location, in this branch's current state. If it doesn't reproduce
   (already fixed by other work, code path no longer exists, superseded), do
   not invent speculative work to "address" it. There is no code change and
-  therefore no commit for this finding: instead, `atm send team-lead` a short
-  note naming the finding ID and why it didn't reproduce, append the finding
-  ID to `$SEEN_LOG` yourself (skipping steps d–g, since there's nothing to
-  implement, test, or push), and return to step (a).
+  therefore no commit for this item: `atm send team-lead` a short note
+  naming the finding ID and why it didn't reproduce, set this task-list
+  entry's `status` to `not-reproduced`, and go back to step (b) (skipping
+  d–g, since there's nothing to implement, test, or push).
 - Look for the fix that removes the underlying cause, not one that patches
   around it. If the finding describes duplicated logic, prefer consolidating
   to one owner over re-syncing two copies. If it describes a missing test,
@@ -126,7 +140,7 @@ just test
 Fix any failures your change introduced or exposed, then rerun. Repeat until
 `just test` passes cleanly. Do not commit against a red test run.
 
-### f) Commit, push, and reference the finding
+### f) Commit, push, and update the task list
 
 Review what's actually changed before staging anything — your worktree may
 already have unrelated in-progress or untracked files from other work. Stage
@@ -144,12 +158,9 @@ EOF
 git push origin "$BRANCH"
 ```
 
-Then record the finding ID in your local seen-log so step (a) stops
-returning it on the next iteration:
-
-```bash
-echo "<FINDING-ID>" >> "$SEEN_LOG"
-```
+Then set this task-list entry's `status` to `implemented` and record the
+commit SHA (`git rev-parse HEAD`) in its `commit_sha` field. Do not modify
+any other entry, and do not touch the triage TTL.
 
 ### g) Report completion
 
@@ -163,18 +174,17 @@ Do not batch this across multiple findings — one message per finding fixed,
 sent right after its own commit/push, so team-lead's view of progress stays
 in sync with what's actually pushed.
 
-Then return to step (a). The finding you just fixed will not reappear
-because it's now in your seen-log — not because its TTL record changed; it
-almost certainly still shows `triage:status "open"` until QA closes it. That
-is expected, not a bug.
+Return to step (b) if any `queued` entries remain in your task list.
+Otherwise, return to step (a) to check whether new findings have appeared
+against your branch since your last refresh.
 
 ## Exit condition
 
-The loop ends when step (a)'s query, with your seen-log applied, returns zero
-findings. At that point, for every finding the query could see against your
-branch: either it didn't reproduce (and you noted why instead of touching
-code for it), or you fixed it, tested it, committed and pushed it, and
-recorded its ID in your seen-log. None of that means QA has verified or
-closed anything yet — it only means your side of the work is done. QA
-verification and finding closure in the triage store happen next, outside
-this skill.
+The loop ends when a refresh at step (a) adds zero new entries to your task
+list *and* your task list has zero `queued` entries left. At that point, for
+every finding the query could ever see against your branch: either it never
+reproduced (recorded `not-reproduced`, reported), or you fixed it, tested it,
+committed and pushed it, and recorded it `implemented` with its commit SHA.
+None of that means QA has verified or closed anything yet — it only means
+your side of the work is done. QA verification and finding closure in the
+triage store happen next, outside this skill.

--- a/.claude/skills/closing-triage/scripts/query_open_findings.py
+++ b/.claude/skills/closing-triage/scripts/query_open_findings.py
@@ -19,10 +19,23 @@ whose own branch begins with ``integrate``. This is a hard guard, not a
 default, precisely so a stale sprint-worktree copy is never queried by
 accident.
 
+A finding's ``triage:status`` and ``triage:Resolution`` records only change
+once QA/team-lead verify and close it -- not the moment a fix is committed
+and pushed. So a finding this script already reported will keep showing up
+on every subsequent call, even after it has been fixed, until QA closes it
+upstream. Callers that loop over results (e.g. a dev fix loop) must track
+which finding IDs they have already pushed a fix for themselves and skip
+those on the next call -- pass ``--seen-log PATH`` to have this script do
+that tracking for you: it reads a newline-delimited list of finding IDs to
+exclude from the file (if it exists) and excludes them from the results.
+Nothing is written to that file by this script; the caller appends to it
+after each fix (see the closing-triage SKILL.md).
+
 Usage:
     python3 query_open_findings.py --branch feature/pAJ-s6-runtime-observation-snapshot
     python3 query_open_findings.py --branch <name> --integration-root /path/to/integrate-worktree
     python3 query_open_findings.py --branch <name> --phase AJ --json
+    python3 query_open_findings.py --branch <name> --seen-log .closing-triage-seen.txt
 """
 
 from __future__ import annotations
@@ -98,6 +111,24 @@ def resolve_integration_root(explicit_root: Path | None, cwd: Path) -> Path:
     return Path(_git(cwd, "rev-parse", "--show-toplevel"))
 
 
+def _read_seen_log(path: Path | None) -> set[str]:
+    """Return finding IDs the caller has already pushed a fix for.
+
+    Missing file means nothing has been marked seen yet -- that is not an
+    error, since the log does not exist until the first fix is recorded.
+    """
+    if path is None:
+        return set()
+    if not path.is_file():
+        return set()
+    seen = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            seen.add(stripped)
+    return seen
+
+
 def _phase_dir(root: Path, requested: str | None) -> tuple[str, Path]:
     sprints = root / ".sprints"
     if requested:
@@ -141,6 +172,7 @@ def query_open_findings(
     branch: str,
     phase: str | None,
     script_dir: Path,
+    seen: set[str] | None = None,
 ) -> list[dict[str, Any]]:
     if _RDFLIB_ERROR:
         raise QueryError(f"rdflib is required; install it with pip install rdflib ({_RDFLIB_ERROR})")
@@ -169,13 +201,21 @@ def query_open_findings(
     # open-findings-for-sprint.sparql already orders by severity (blocking,
     # then important, then minor; invalid severities sort first, fail-closed)
     # and, within a severity, by foundAt. Preserve that order as-is.
+    seen = seen or set()
     findings: list[dict[str, Any]] = []
     for row in rows:
         finding_uri, finding_id, severity, raw_severity, status, found_at, description = row
+        resolved_id = str(finding_id) if finding_id is not None else str(finding_uri).rsplit(":", 1)[-1]
+        if resolved_id in seen:
+            # Already fixed and pushed by the caller this loop-run; the TTL
+            # record itself won't reflect that until QA closes it, so this is
+            # the only signal that lets a caller's loop actually progress
+            # instead of re-selecting the same finding forever.
+            continue
         findings.append(
             {
                 "finding": str(finding_uri),
-                "finding_id": str(finding_id) if finding_id is not None else str(finding_uri).rsplit(":", 1)[-1],
+                "finding_id": resolved_id,
                 "severity": str(severity),
                 "raw_severity": str(raw_severity),
                 "status": str(status) if status is not None else None,
@@ -214,12 +254,20 @@ def main(argv: list[str] | None = None) -> int:
         "branch does not begin with 'integrate'",
     )
     parser.add_argument("--phase", default=None, help="phase name (e.g. AJ); auto-detected if only one exists")
+    parser.add_argument(
+        "--seen-log",
+        type=Path,
+        default=None,
+        help="path to a newline-delimited file of finding IDs to exclude from results "
+        "(already fixed and pushed, pending QA closure); not written by this script",
+    )
     parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
     args = parser.parse_args(argv)
 
     try:
         root = resolve_integration_root(args.integration_root, Path.cwd())
-        findings = query_open_findings(root, args.branch, args.phase, Path(__file__).parent)
+        seen = _read_seen_log(args.seen_log)
+        findings = query_open_findings(root, args.branch, args.phase, Path(__file__).parent, seen=seen)
     except QueryError as exc:
         payload = {"kind": "error", "message": str(exc)}
         if args.json:

--- a/.claude/skills/closing-triage/scripts/query_open_findings.py
+++ b/.claude/skills/closing-triage/scripts/query_open_findings.py
@@ -11,25 +11,19 @@ graph-orchestration skill (``query_runner.py``) instead of re-implementing
 Turtle loading or finding-scope filtering, so results here always agree with
 what the live merge/dispatch gate sees.
 
-Safety: findings only live in ``integrate/phase-*`` worktrees (sprint
-worktrees carry copied, potentially stale TTL). This script therefore refuses
-to run unless either (a) the current working directory's git branch begins
-with ``integrate``, or (b) ``--integration-root`` explicitly names a path
-whose own branch begins with ``integrate``. This is a hard guard, not a
-default, precisely so a stale sprint-worktree copy is never queried by
-accident.
+Safety: findings only live in integration worktrees -- branch beginning with
+``integrat`` (covers both ``integrate/*`` and ``integration/*``) -- while
+sprint worktrees carry copied, potentially stale TTL; this script only ever
+queries an integration worktree. Run it from your sprint worktree: it
+auto-discovers the sibling integration worktree via ``git worktree list``,
+failing closed (and requiring ``--integration-root``) unless exactly one
+exists.
 
-A finding's ``triage:status`` and ``triage:Resolution`` records only change
-once QA/team-lead verify and close it -- not the moment a fix is committed
-and pushed. So a finding this script already reported will keep showing up
-on every subsequent call, even after it has been fixed, until QA closes it
-upstream. A caller that loops over results (e.g. a dev fix loop) is
-responsible for tracking which finding IDs it has already pushed a fix for
-and diffing that against each fresh call's results itself (see the
-closing-triage SKILL.md) -- this script always reports the canonical live
-query result and does not track caller-side progress.
+Note: a finding stays "open" here until QA closes it upstream -- not when a
+fix is pushed -- so a looping caller must track its own already-fixed set
+(see the closing-triage SKILL.md).
 
-Usage:
+Usage (from your sprint worktree; integrate worktree is auto-discovered):
     python3 query_open_findings.py --branch feature/pAJ-s6-runtime-observation-snapshot
     python3 query_open_findings.py --branch <name> --integration-root /path/to/integrate-worktree
     python3 query_open_findings.py --branch <name> --phase AJ --json
@@ -78,34 +72,64 @@ def _current_branch(cwd: Path) -> str:
 
 
 def resolve_integration_root(explicit_root: Path | None, cwd: Path) -> Path:
-    """Return a worktree root whose branch begins with 'integrate'.
+    """Return a worktree root whose branch begins with 'integrat'.
 
-    Findings only live in integrate/phase-* worktrees. Refuse to guess: either
-    the caller is already standing in such a worktree, or they must say
-    exactly which one to use via --integration-root.
+    Findings only live in integration worktrees (branch prefix ``integrat``,
+    matching both integrate/* and integration/*). Resolution order:
+    1. An explicit --integration-root (validated to be on an integrat* branch).
+    2. The current worktree, if it is already on an integrat* branch.
+    3. Auto-discovery via ``git worktree list --porcelain``: succeeds only if
+       exactly one worktree of this repo is on an integrat* branch; zero or
+       multiple candidates fail closed and require --integration-root.
+    A sprint worktree's own (potentially stale) triage copy is never queried.
     """
     if explicit_root is not None:
         root = explicit_root.resolve()
         if not root.is_dir():
             raise QueryError(f"--integration-root does not exist: {root}")
         branch = _current_branch(root)
-        if not branch.startswith("integrate"):
+        if not branch.startswith("integrat"):
             raise QueryError(
                 f"--integration-root {root} is on branch {branch!r}, which does not "
-                "begin with 'integrate'. Point --integration-root at an "
-                "integrate/phase-* worktree."
+                "begin with 'integrat'. Point --integration-root at an "
+                "integrate/phase-* (or integration/*) worktree."
             )
         return root
 
     branch = _current_branch(cwd)
-    if not branch.startswith("integrate"):
+    if branch.startswith("integrat"):
+        return Path(_git(cwd, "rev-parse", "--show-toplevel"))
+
+    # Auto-discover the sibling integration worktree from a sprint worktree.
+    # Same worktree-walk pattern as triage-report's discover_integration_root:
+    # fail closed unless exactly one integrat* worktree exists. The prefix is
+    # 'integrat' (not 'integrate') so both integrate/* and integration/*
+    # branch spellings match.
+    candidates: list[tuple[Path, str]] = []
+    current_path: Path | None = None
+    current_branch: str | None = None
+    for line in _git(cwd, "worktree", "list", "--porcelain").splitlines() + [""]:
+        if line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree "))
+        elif line.startswith("branch refs/heads/"):
+            current_branch = line.removeprefix("branch refs/heads/")
+        elif not line.strip():
+            if (
+                current_path is not None
+                and current_branch is not None
+                and current_branch.startswith("integrat")
+            ):
+                candidates.append((current_path, current_branch))
+            current_path = current_branch = None
+    if len(candidates) != 1:
+        names = ", ".join(f"{path} ({br})" for path, br in candidates) or "none"
         raise QueryError(
-            f"current branch {branch!r} does not begin with 'integrate'. "
-            "Run this script from an integrate/phase-* worktree, or pass "
-            "--integration-root /path/to/integrate-worktree to specify one "
-            "explicitly."
+            f"current branch {branch!r} does not begin with 'integrat' and "
+            f"auto-discovery found {len(candidates)} integration worktree(s) "
+            f"({names}); pass --integration-root /path/to/integrate-worktree "
+            "to name one explicitly."
         )
-    return Path(_git(cwd, "rev-parse", "--show-toplevel"))
+    return candidates[0][0]
 
 
 def _phase_dir(root: Path, requested: str | None) -> tuple[str, Path]:
@@ -220,8 +244,8 @@ def main(argv: list[str] | None = None) -> int:
         "--integration-root",
         type=Path,
         default=None,
-        help="path to an integrate/phase-* worktree; required if the current directory's "
-        "branch does not begin with 'integrate'",
+        help="path to an integrate* worktree; overrides auto-discovery, and is required "
+        "only when auto-discovery finds zero or multiple integrate worktrees",
     )
     parser.add_argument("--phase", default=None, help="phase name (e.g. AJ); auto-detected if only one exists")
     parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")

--- a/.claude/skills/closing-triage/scripts/query_open_findings.py
+++ b/.claude/skills/closing-triage/scripts/query_open_findings.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Query all open findings for one branch from the canonical triage graph.
+
+An "open" finding is defined exactly the same way the live QA/merge gate
+defines it (see ``open-findings-for-sprint.sparql``): its occurrence on the
+requested branch is neither ``closed`` nor carries a terminal status (fixed,
+deferred, waived, etc.), and no ``triage:Resolution`` record resolves it.
+
+This script deliberately reuses the shared graph loader/query runner from the
+graph-orchestration skill (``query_runner.py``) instead of re-implementing
+Turtle loading or finding-scope filtering, so results here always agree with
+what the live merge/dispatch gate sees.
+
+Safety: findings only live in ``integrate/phase-*`` worktrees (sprint
+worktrees carry copied, potentially stale TTL). This script therefore refuses
+to run unless either (a) the current working directory's git branch begins
+with ``integrate``, or (b) ``--integration-root`` explicitly names a path
+whose own branch begins with ``integrate``. This is a hard guard, not a
+default, precisely so a stale sprint-worktree copy is never queried by
+accident.
+
+Usage:
+    python3 query_open_findings.py --branch feature/pAJ-s6-runtime-observation-snapshot
+    python3 query_open_findings.py --branch <name> --integration-root /path/to/integrate-worktree
+    python3 query_open_findings.py --branch <name> --phase AJ --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from rdflib import Literal
+    _RDFLIB_ERROR: str | None = None
+except ImportError as exc:  # pragma: no cover - environment error
+    Literal = None  # type: ignore[assignment]
+    _RDFLIB_ERROR = str(exc)
+
+
+class QueryError(RuntimeError):
+    """An operational error which prevents a trustworthy query result."""
+
+
+def _git(cwd: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise QueryError(f"git {' '.join(args)} failed: {detail.strip()}") from exc
+    return result.stdout.strip()
+
+
+def _current_branch(cwd: Path) -> str:
+    return _git(cwd, "branch", "--show-current")
+
+
+def resolve_integration_root(explicit_root: Path | None, cwd: Path) -> Path:
+    """Return a worktree root whose branch begins with 'integrate'.
+
+    Findings only live in integrate/phase-* worktrees. Refuse to guess: either
+    the caller is already standing in such a worktree, or they must say
+    exactly which one to use via --integration-root.
+    """
+    if explicit_root is not None:
+        root = explicit_root.resolve()
+        if not root.is_dir():
+            raise QueryError(f"--integration-root does not exist: {root}")
+        branch = _current_branch(root)
+        if not branch.startswith("integrate"):
+            raise QueryError(
+                f"--integration-root {root} is on branch {branch!r}, which does not "
+                "begin with 'integrate'. Point --integration-root at an "
+                "integrate/phase-* worktree."
+            )
+        return root
+
+    branch = _current_branch(cwd)
+    if not branch.startswith("integrate"):
+        raise QueryError(
+            f"current branch {branch!r} does not begin with 'integrate'. "
+            "Run this script from an integrate/phase-* worktree, or pass "
+            "--integration-root /path/to/integrate-worktree to specify one "
+            "explicitly."
+        )
+    return Path(_git(cwd, "rev-parse", "--show-toplevel"))
+
+
+def _phase_dir(root: Path, requested: str | None) -> tuple[str, Path]:
+    sprints = root / ".sprints"
+    if requested:
+        phase = requested.removeprefix("phase-")
+        path = sprints / phase
+        if not (path / "structure.ttl").is_file():
+            raise QueryError(f"missing phase structure: {path / 'structure.ttl'}")
+        return phase, path
+    candidates = sorted(p.parent for p in sprints.glob("*/structure.ttl"))
+    if len(candidates) != 1:
+        names = ", ".join(p.name for p in candidates) or "none"
+        raise QueryError(
+            f"cannot determine a unique phase under {sprints}; found {len(candidates)} "
+            f"({names}); pass --phase"
+        )
+    return candidates[0].name, candidates[0]
+
+
+def _graph_runner(script_dir: Path):
+    """Load graph-orchestration's public graph/query helpers once.
+
+    Reusing this module (rather than a parallel Turtle loader) guarantees
+    this script's notion of "open" always matches the live merge/dispatch
+    gate's notion of "open".
+    """
+    runner_path = (
+        script_dir.resolve().parents[1] / "graph-orchestration" / "scripts" / "query_runner.py"
+    )
+    if not runner_path.is_file():
+        raise QueryError(f"cannot find graph query runner: {runner_path}")
+    spec = importlib.util.spec_from_file_location("closing_triage_graph_runner", runner_path)
+    if spec is None or spec.loader is None:
+        raise QueryError(f"cannot load graph query runner: {runner_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def query_open_findings(
+    root: Path,
+    branch: str,
+    phase: str | None,
+    script_dir: Path,
+) -> list[dict[str, Any]]:
+    if _RDFLIB_ERROR:
+        raise QueryError(f"rdflib is required; install it with pip install rdflib ({_RDFLIB_ERROR})")
+
+    phase_name, phase_path = _phase_dir(root, phase)
+    runner = _graph_runner(script_dir)
+    try:
+        source = runner.resolve_phase_source(phase_name, str(phase_path))
+    except Exception as exc:  # noqa: BLE001 - normalize shared source errors
+        raise QueryError(f"could not resolve current integration phase source: {exc}") from exc
+
+    try:
+        graph = runner.load_graph(str(source.ttl_dir), findings_dir=source.findings_dir)
+    except Exception as exc:  # noqa: BLE001 - normalize graph runner failures
+        raise QueryError(f"could not load finding graph: {exc}") from exc
+
+    query_path = script_dir.resolve().parents[1] / "graph-orchestration" / "scripts" / "open-findings-for-sprint.sparql"
+    if not query_path.is_file():
+        raise QueryError(f"cannot find shared query file: {query_path}")
+
+    try:
+        rows = runner.run_sparql(graph, query_path, {"BRANCH": Literal(branch)})
+    except Exception as exc:  # noqa: BLE001 - normalize graph runner failures
+        raise QueryError(f"query failed: {exc}") from exc
+
+    # open-findings-for-sprint.sparql already orders by severity (blocking,
+    # then important, then minor; invalid severities sort first, fail-closed)
+    # and, within a severity, by foundAt. Preserve that order as-is.
+    findings: list[dict[str, Any]] = []
+    for row in rows:
+        finding_uri, finding_id, severity, raw_severity, status, found_at, description = row
+        findings.append(
+            {
+                "finding": str(finding_uri),
+                "finding_id": str(finding_id) if finding_id is not None else str(finding_uri).rsplit(":", 1)[-1],
+                "severity": str(severity),
+                "raw_severity": str(raw_severity),
+                "status": str(status) if status is not None else None,
+                "found_at": str(found_at),
+                "description": str(description),
+            }
+        )
+    return findings
+
+
+def _print_table(branch: str, findings: list[dict[str, Any]]) -> None:
+    if not findings:
+        print(f"No open findings for branch {branch!r}.")
+        return
+    print(f"Open findings for branch {branch!r} ({len(findings)}):")
+    print()
+    for item in findings:
+        status = item["status"] or "open"
+        print(f"- [{item['severity'].upper()}] {item['finding_id']} (status: {status})")
+        print(f"    found_at: {item['found_at']}")
+        description = item["description"]
+        if len(description) > 200:
+            description = description[:197] + "..."
+        print(f"    {description}")
+        print()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--branch", required=True, help="branch name to query open findings for")
+    parser.add_argument(
+        "--integration-root",
+        type=Path,
+        default=None,
+        help="path to an integrate/phase-* worktree; required if the current directory's "
+        "branch does not begin with 'integrate'",
+    )
+    parser.add_argument("--phase", default=None, help="phase name (e.g. AJ); auto-detected if only one exists")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    args = parser.parse_args(argv)
+
+    try:
+        root = resolve_integration_root(args.integration_root, Path.cwd())
+        findings = query_open_findings(root, args.branch, args.phase, Path(__file__).parent)
+    except QueryError as exc:
+        payload = {"kind": "error", "message": str(exc)}
+        if args.json:
+            print(json.dumps(payload, sort_keys=True))
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps({"branch": args.branch, "count": len(findings), "findings": findings}, indent=2, sort_keys=True))
+    else:
+        _print_table(args.branch, findings)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/closing-triage/scripts/query_open_findings.py
+++ b/.claude/skills/closing-triage/scripts/query_open_findings.py
@@ -23,19 +23,16 @@ A finding's ``triage:status`` and ``triage:Resolution`` records only change
 once QA/team-lead verify and close it -- not the moment a fix is committed
 and pushed. So a finding this script already reported will keep showing up
 on every subsequent call, even after it has been fixed, until QA closes it
-upstream. Callers that loop over results (e.g. a dev fix loop) must track
-which finding IDs they have already pushed a fix for themselves and skip
-those on the next call -- pass ``--seen-log PATH`` to have this script do
-that tracking for you: it reads a newline-delimited list of finding IDs to
-exclude from the file (if it exists) and excludes them from the results.
-Nothing is written to that file by this script; the caller appends to it
-after each fix (see the closing-triage SKILL.md).
+upstream. A caller that loops over results (e.g. a dev fix loop) is
+responsible for tracking which finding IDs it has already pushed a fix for
+and diffing that against each fresh call's results itself (see the
+closing-triage SKILL.md) -- this script always reports the canonical live
+query result and does not track caller-side progress.
 
 Usage:
     python3 query_open_findings.py --branch feature/pAJ-s6-runtime-observation-snapshot
     python3 query_open_findings.py --branch <name> --integration-root /path/to/integrate-worktree
     python3 query_open_findings.py --branch <name> --phase AJ --json
-    python3 query_open_findings.py --branch <name> --seen-log .closing-triage-seen.txt
 """
 
 from __future__ import annotations
@@ -111,24 +108,6 @@ def resolve_integration_root(explicit_root: Path | None, cwd: Path) -> Path:
     return Path(_git(cwd, "rev-parse", "--show-toplevel"))
 
 
-def _read_seen_log(path: Path | None) -> set[str]:
-    """Return finding IDs the caller has already pushed a fix for.
-
-    Missing file means nothing has been marked seen yet -- that is not an
-    error, since the log does not exist until the first fix is recorded.
-    """
-    if path is None:
-        return set()
-    if not path.is_file():
-        return set()
-    seen = set()
-    for line in path.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        if stripped and not stripped.startswith("#"):
-            seen.add(stripped)
-    return seen
-
-
 def _phase_dir(root: Path, requested: str | None) -> tuple[str, Path]:
     sprints = root / ".sprints"
     if requested:
@@ -172,7 +151,6 @@ def query_open_findings(
     branch: str,
     phase: str | None,
     script_dir: Path,
-    seen: set[str] | None = None,
 ) -> list[dict[str, Any]]:
     if _RDFLIB_ERROR:
         raise QueryError(f"rdflib is required; install it with pip install rdflib ({_RDFLIB_ERROR})")
@@ -201,21 +179,13 @@ def query_open_findings(
     # open-findings-for-sprint.sparql already orders by severity (blocking,
     # then important, then minor; invalid severities sort first, fail-closed)
     # and, within a severity, by foundAt. Preserve that order as-is.
-    seen = seen or set()
     findings: list[dict[str, Any]] = []
     for row in rows:
         finding_uri, finding_id, severity, raw_severity, status, found_at, description = row
-        resolved_id = str(finding_id) if finding_id is not None else str(finding_uri).rsplit(":", 1)[-1]
-        if resolved_id in seen:
-            # Already fixed and pushed by the caller this loop-run; the TTL
-            # record itself won't reflect that until QA closes it, so this is
-            # the only signal that lets a caller's loop actually progress
-            # instead of re-selecting the same finding forever.
-            continue
         findings.append(
             {
                 "finding": str(finding_uri),
-                "finding_id": resolved_id,
+                "finding_id": str(finding_id) if finding_id is not None else str(finding_uri).rsplit(":", 1)[-1],
                 "severity": str(severity),
                 "raw_severity": str(raw_severity),
                 "status": str(status) if status is not None else None,
@@ -254,20 +224,12 @@ def main(argv: list[str] | None = None) -> int:
         "branch does not begin with 'integrate'",
     )
     parser.add_argument("--phase", default=None, help="phase name (e.g. AJ); auto-detected if only one exists")
-    parser.add_argument(
-        "--seen-log",
-        type=Path,
-        default=None,
-        help="path to a newline-delimited file of finding IDs to exclude from results "
-        "(already fixed and pushed, pending QA closure); not written by this script",
-    )
     parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
     args = parser.parse_args(argv)
 
     try:
         root = resolve_integration_root(args.integration_root, Path.cwd())
-        seen = _read_seen_log(args.seen_log)
-        findings = query_open_findings(root, args.branch, args.phase, Path(__file__).parent, seen=seen)
+        findings = query_open_findings(root, args.branch, args.phase, Path(__file__).parent)
     except QueryError as exc:
         payload = {"kind": "error", "message": str(exc)}
         if args.json:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,13 @@ For Rust design and review work, also read:
 
 Use it as the baseline for state machines, newtypes, sealed traits, structured error design, and crate-boundary review.
 
+## Sprint Finding Closure
+
+When assigned to close triage findings on a sprint branch, read and follow:
+- `.claude/skills/closing-triage/SKILL.md`
+
+Use its branch-local task list to track implemented finding IDs and commit SHAs; QA retains authority to close canonical triage records.
+
 ## Architectural Decisions
 
 Boundary trait sealing in atm-core is governed by an ADR. Do NOT modify `pub mod sealed`, its visibility, or implement `sealed::Sealed` in unauthorized crates without reading this first:


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/closing-triage/scripts/query_open_findings.py`, a script that queries the canonical `.triage/*/findings/*.ttl` store for all open findings on a given branch. Reuses graph-orchestration's existing rdflib loader and `open-findings-for-sprint.sparql` query in its branch-scoped mode, so results always agree with the live QA/merge gate. Guarded to only run against an `integrate/*` worktree (findings only live there; sprint-worktree copies may be stale), with an explicit `--integration-root` override for running from elsewhere.
- Adds `.claude/skills/closing-triage/SKILL.md`, a developer-facing (role-agnostic) loop: refresh a branch-local task list from the query -> take the most significant queued finding -> design a fix that removes the root cause and simplifies the code -> implement and self-verify against the finding -> `just test` until clean -> commit/push referencing the finding ID -> report to team-lead -> repeat until the task list is empty. The skill never writes to the triage TTL store itself; QA/team-lead retain sole authority to close findings.
- Adds a short pointer in `AGENTS.md` under "Sprint Finding Closure" so any developer picking up finding-closure work discovers the skill.

## Review history
Reviewed by arch-ctm on the branch before this PR:
- Caught a real design bug in an earlier revision (the loop assumed a fixed finding would stop appearing in the query, but the query only reflects TTL state, which the dev never writes to -- would have looped forever on the same finding). Fixed by introducing branch-local progress tracking.
- Proposed a better tracking mechanism than the original fix (a structured branch-local task list recording severity/description/status/commit-SHA per finding, rather than a flat exclusion list) -- adopted in full; simplified the script back down since the task list replaces the need for any caller-progress bookkeeping in the script itself.
- Caught `git add -A` risking staging unrelated dirty-tree files, and a hardcoded Claude co-author line inconsistent with the skill being deliberately dev-agnostic -- both fixed.
- Added the `AGENTS.md` discoverability pointer.

## Test plan
- [x] Script syntax-checked (`python3 -m ast`)
- [x] Guard tested on-integrate (succeeds without override) and off-integrate (fails closed without `--integration-root`, succeeds with it), confirming the main repo checkout's branch is never switched
- [x] Query verified against real Phase AJ findings (20 open findings returned for a test branch, correctly ordered Blocking -> Important -> Minor, including inherited cross-branch findings)
- [ ] No Rust/CI-relevant code touched; `just test` not run for this PR (docs + standalone Python tooling only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)