### PR TITLE
Add closing-triage sprint finding workflow

### DIFF
--- a/.claude/skills/closing-triage/SKILL.md
+++ b/.claude/skills/closing-triage/SKILL.md
@@ -87,9 +87,13 @@ python3 /path/to/.claude/skills/closing-triage/scripts/query_open_findings.py \
 Run this from your sprint worktree — do not move to the integrate worktree.
 The script auto-discovers the sibling `integrate/*` worktree via
 `git worktree list` and queries its triage store, never a sprint worktree's
-own (potentially stale) copy. Pass `--integration-root` (and `--phase` if
-more than one phase exists there) only when the script reports that
-auto-discovery found zero or multiple integrate worktrees.
+own (potentially stale) copy. It maps your branch to its declaring sprint
+via the phase structure, so results are scoped to findings **found in your
+own sprint** (`triage:foundIn`): findings from earlier sprints whose
+defects also exist in your checkout are the upstream developer's work and
+arrive fixed via merge — never fix them here. Pass `--integration-root`
+only if worktree auto-discovery reports ambiguity, and `--phase` only if
+your branch is declared in more than one phase structure.
 
 Diff the result against your task list by `finding_id`: for every finding in
 the query result that is **not already present** in your task list (under

--- a/.claude/skills/closing-triage/scripts/query_open_findings.py
+++ b/.claude/skills/closing-triage/scripts/query_open_findings.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-"""Query all open findings for one branch from the canonical triage graph.
+"""Query all open findings for one sprint branch from the canonical triage graph.
 
-An "open" finding is defined exactly the same way the live QA/merge gate
-defines it (see ``open-findings-for-sprint.sparql``): its occurrence on the
-requested branch is neither ``closed`` nor carries a terminal status (fixed,
+An "open" finding is one the live QA/merge gate would still count against
+your sprint (see ``open-findings-for-sprint.sparql``, origin-sprint mode):
+it was found in the sprint that owns the requested branch
+(``triage:foundIn``), carries no terminal ``triage:status`` (fixed,
 deferred, waived, etc.), and no ``triage:Resolution`` record resolves it.
+
+Scoping is by origin sprint, not by branch occurrence: findings from
+earlier sprints whose defects merely propagate onto this branch's checkout
+belong to their origin sprint's developer and arrive fixed via merge --
+they are deliberately excluded here.
 
 This script deliberately reuses the shared graph loader/query runner from the
 graph-orchestration skill (``query_runner.py``) instead of re-implementing
@@ -41,11 +47,13 @@ from pathlib import Path
 from typing import Any
 
 try:
-    from rdflib import Literal
+    from rdflib import Graph, Namespace, RDF, URIRef
     _RDFLIB_ERROR: str | None = None
 except ImportError as exc:  # pragma: no cover - environment error
-    Literal = None  # type: ignore[assignment]
+    Graph = Namespace = RDF = URIRef = None  # type: ignore[assignment]
     _RDFLIB_ERROR = str(exc)
+
+TRIAGE = Namespace("urn:atm:triage:") if Namespace else None
 
 
 class QueryError(RuntimeError):
@@ -132,22 +140,72 @@ def resolve_integration_root(explicit_root: Path | None, cwd: Path) -> Path:
     return candidates[0][0]
 
 
-def _phase_dir(root: Path, requested: str | None) -> tuple[str, Path]:
-    sprints = root / ".sprints"
-    if requested:
-        phase = requested.removeprefix("phase-")
-        path = sprints / phase
-        if not (path / "structure.ttl").is_file():
-            raise QueryError(f"missing phase structure: {path / 'structure.ttl'}")
-        return phase, path
-    candidates = sorted(p.parent for p in sprints.glob("*/structure.ttl"))
-    if len(candidates) != 1:
-        names = ", ".join(p.name for p in candidates) or "none"
+def _branch_from_criteria(criteria: str) -> str | None:
+    """Derive the documented sprint-branch convention from a criteria path.
+
+    ``triage:branch`` is preferred when a phase records it explicitly; this
+    fallback (same as triage-report's) keeps older phase records usable.
+    """
+    match = re.fullmatch(
+        r"sprint-([a-z][a-z0-9]*)-([0-9]+)(?:-(pre))?-(.+)",
+        Path(criteria).stem,
+    )
+    if not match:
+        return None
+    prefix, number, suffix, slug = match.groups()
+    return f"feature/p{prefix.upper()}-s{number}{suffix or ''}-{slug}"
+
+
+def _sprint_for_branch(
+    root: Path, branch: str, requested_phase: str | None
+) -> tuple[str, Path, "URIRef"]:
+    """Map the sprint branch to its declaring phase and sprint IRI.
+
+    Scans ``.sprints/*/structure.ttl`` for a ``triage:Sprint`` whose
+    ``triage:branch`` (or branch derived from its criteria filename, for
+    older phases without an explicit branch) equals the requested branch.
+    Exactly one match is required across the searched phases; anything else
+    fails closed. This mapping is what scopes results to the branch's own
+    sprint (``triage:foundIn``) rather than to every finding whose defect
+    happens to occur on the branch's checkout.
+    """
+    sprints_dir = root / ".sprints"
+    if requested_phase:
+        phase = requested_phase.removeprefix("phase-")
+        candidates = [sprints_dir / phase]
+        if not (candidates[0] / "structure.ttl").is_file():
+            raise QueryError(f"missing phase structure: {candidates[0] / 'structure.ttl'}")
+    else:
+        candidates = sorted(p.parent for p in sprints_dir.glob("*/structure.ttl"))
+        if not candidates:
+            raise QueryError(f"no phase structures found under {sprints_dir}")
+
+    matches: list[tuple[str, Path, URIRef]] = []
+    for phase_path in candidates:
+        structure = Graph()
+        structure_path = phase_path / "structure.ttl"
+        try:
+            structure.parse(structure_path, format="turtle")
+        except Exception as exc:  # noqa: BLE001 - convert parser failures
+            raise QueryError(f"{structure_path}: malformed Turtle ({exc})") from exc
+        for sprint in structure.subjects(RDF.type, TRIAGE.Sprint):
+            declared = [str(value) for value in structure.objects(sprint, TRIAGE.branch)]
+            if branch in declared:
+                matches.append((phase_path.name, phase_path, sprint))
+            elif not declared:
+                criteria = next(structure.objects(sprint, TRIAGE.criteria), None)
+                if criteria is not None and _branch_from_criteria(str(criteria)) == branch:
+                    matches.append((phase_path.name, phase_path, sprint))
+    if len(matches) != 1:
+        searched = ", ".join(path.name for path in candidates)
+        found = ", ".join(f"{phase}:{sprint}" for phase, _, sprint in matches) or "none"
         raise QueryError(
-            f"cannot determine a unique phase under {sprints}; found {len(candidates)} "
-            f"({names}); pass --phase"
+            f"branch {branch!r} must map to exactly one declared sprint; searched "
+            f"phase(s) [{searched}] under {sprints_dir} and found {len(matches)} "
+            f"({found}). Is this branch part of the current integration phase? "
+            "Pass --phase to narrow the search, or fix the phase structure."
         )
-    return candidates[0].name, candidates[0]
+    return matches[0]
 
 
 def _graph_runner(script_dir: Path):
@@ -179,7 +237,7 @@ def query_open_findings(
     if _RDFLIB_ERROR:
         raise QueryError(f"rdflib is required; install it with pip install rdflib ({_RDFLIB_ERROR})")
 
-    phase_name, phase_path = _phase_dir(root, phase)
+    phase_name, phase_path, sprint = _sprint_for_branch(root, branch, phase)
     runner = _graph_runner(script_dir)
     try:
         source = runner.resolve_phase_source(phase_name, str(phase_path))
@@ -196,7 +254,12 @@ def query_open_findings(
         raise QueryError(f"cannot find shared query file: {query_path}")
 
     try:
-        rows = runner.run_sparql(graph, query_path, {"BRANCH": Literal(branch)})
+        # Origin-sprint mode: bind SPRINT only. Binding BRANCH would switch
+        # the shared query to occurrence-level scoping, which returns every
+        # finding whose defect propagates onto this branch's checkout --
+        # including upstream sprints' findings that are not this branch's
+        # work (see module docstring).
+        rows = runner.run_sparql(graph, query_path, {"SPRINT": sprint})
     except Exception as exc:  # noqa: BLE001 - normalize graph runner failures
         raise QueryError(f"query failed: {exc}") from exc
 
@@ -247,7 +310,12 @@ def main(argv: list[str] | None = None) -> int:
         help="path to an integrate* worktree; overrides auto-discovery, and is required "
         "only when auto-discovery finds zero or multiple integrate worktrees",
     )
-    parser.add_argument("--phase", default=None, help="phase name (e.g. AJ); auto-detected if only one exists")
+    parser.add_argument(
+        "--phase",
+        default=None,
+        help="phase name (e.g. AJ); narrows the branch-to-sprint search when the "
+        "branch is declared in more than one phase structure (normally auto-detected)",
+    )
     parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
Adds the closing-triage skill and branch-scoped open-findings query helper. The workflow uses a worktree-safe local task list, preserves QA ownership of canonical finding closure, and supports explicit or branch-scoped phase resolution.