### PR TITLE
fix(phase-aj): recover merge-conflict content loss from 596f0b89

### DIFF
--- a/crates/atm-daemon/src/integration_tests.rs
+++ b/crates/atm-daemon/src/integration_tests.rs
@@ -1,12 +1,302 @@
-//! Transport-level runtime-observation integration coverage.
+//! Cross-transport runtime-observation integration regressions.
 
 use crate::runtime_health::dispatch::TrustedActivityObservation;
+use crate::runtime_health::{DaemonRequestDispatcher, RuntimeStatusCache};
+use atm_core::ack::AckRequest;
+use atm_core::protocol::{
+    HeartbeatActivity, RequestEnvelope, ResponseEnvelope, SendResponseEnvelope,
+    TeamMemberHeartbeatRequest,
+};
+use atm_core::read::ReadQuery;
+use atm_core::send::{SendMessageSource, SendRequest};
+use atm_core::test_support::{ROLE_TEAM_LEAD, TEST_QA};
+use atm_core::types::{AgentName, IsoTimestamp, ReadSelection, SessionId, TeamName};
+use atm_core::{ApiRequest, ApiRouter, AuthenticatedIngress, RequestDeadline};
 
-// This compile-only binding is deliberately crate-internal: external callers
-// cannot construct the capability because its constructor is private.
+// The constructor for this capability is private to the authenticated router;
+// retaining the type requirement here makes the boundary compile-time checked.
 fn requires_trusted_observation(_: TrustedActivityObservation) {}
 
 #[test]
 fn trusted_activity_observation_capability_gate_is_compile_time_enforced() {
     let _ = requires_trusted_observation;
+}
+
+#[test]
+fn heartbeat_session_id_round_trip() {
+    let tempdir = tempfile::TempDir::new().expect("tempdir");
+    let home = tempdir.path().join("home");
+    std::fs::create_dir_all(&home).expect("home");
+    let db_path = tempdir.path().join("runtime.db");
+    crate::tests::install_test_roster(&db_path, &[ROLE_TEAM_LEAD]);
+    let dispatcher =
+        DaemonRequestDispatcher::new_for_test(home, RuntimeStatusCache::new(), db_path);
+    let team: TeamName = crate::tests::TEST_TEAM.parse().expect("team");
+    let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+    let session = SessionId::new("three-step").expect("session");
+    for incoming in [Some(session.clone()), None, Some(session.clone())] {
+        let response = dispatcher
+            .dispatch(RequestEnvelope::Heartbeat(TeamMemberHeartbeatRequest {
+                team: team.clone(),
+                member: member.clone(),
+                pid: 1,
+                observed_at: IsoTimestamp::now(),
+                activity: HeartbeatActivity::ActiveToolUse,
+                session_id: incoming,
+            }))
+            .expect("heartbeat");
+        let ResponseEnvelope::Heartbeat(response) = response else {
+            panic!("heartbeat response")
+        };
+        assert_eq!(response.session_id, Some(session.clone()));
+    }
+}
+
+#[test]
+fn send_read_ack_reflects_each_caller_session_in_runtime_cache() {
+    let tempdir = tempfile::TempDir::new().expect("tempdir");
+    let home = tempdir.path().join("home");
+    let workspace = tempdir.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    let db_path = tempdir.path().join("runtime.db");
+    crate::tests::install_test_roster(&db_path, &[ROLE_TEAM_LEAD, TEST_QA]);
+    let cache = RuntimeStatusCache::new();
+    let dispatcher = DaemonRequestDispatcher::new_for_test(home.clone(), cache.clone(), db_path);
+    let team: TeamName = crate::tests::TEST_TEAM.parse().expect("team");
+    let lead: AgentName = ROLE_TEAM_LEAD.parse().expect("lead");
+    let qa: AgentName = TEST_QA.parse().expect("qa");
+
+    let send_session = SessionId::new("send-session").expect("session");
+    let sent = dispatcher
+        .dispatch(RequestEnvelope::Write(Box::new(
+            SendRequest::new(
+                home.clone(),
+                workspace.clone(),
+                lead.clone(),
+                &format!("{TEST_QA}@{}", crate::tests::TEST_TEAM),
+                team.clone(),
+                SendMessageSource::Inline("please acknowledge".to_string()),
+                None,
+                true,
+                None,
+                false,
+            )
+            .expect("send request")
+            .with_activity_observation(Some(
+                atm_core::caller_context::ActivityObservation {
+                    team: team.clone(),
+                    member: lead.clone(),
+                    session_id: Some(send_session.clone()),
+                    pid: Some(1),
+                },
+            )),
+        )))
+        .expect("send response");
+    let ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) = sent else {
+        panic!("send response")
+    };
+    assert_eq!(cache.cached_session_id(&team, &lead), Some(send_session));
+
+    let read_session = SessionId::new("read-session").expect("session");
+    let read = ReadQuery::new(
+        home.clone(),
+        workspace.clone(),
+        qa.clone(),
+        None,
+        team.clone(),
+        ReadSelection::All,
+        false,
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("read query")
+    .with_activity_observation(Some(atm_core::caller_context::ActivityObservation {
+        team: team.clone(),
+        member: qa.clone(),
+        session_id: Some(read_session.clone()),
+        pid: Some(2),
+    }));
+    assert!(matches!(
+        dispatcher
+            .dispatch(RequestEnvelope::Receive(read))
+            .expect("read response"),
+        ResponseEnvelope::Receive(_)
+    ));
+    assert_eq!(cache.cached_session_id(&team, &qa), Some(read_session));
+
+    let ack_session = SessionId::new("ack-session").expect("session");
+    let mut ack = AckRequest {
+        home_dir: home,
+        current_dir: workspace,
+        caller_identity: qa.clone(),
+        caller_chat_id: None,
+        caller_team: team.clone(),
+        activity_observation: None,
+        message_id: outcome.message_id,
+        reply_body: "acknowledged".to_string(),
+    };
+    ack.activity_observation = Some(atm_core::caller_context::ActivityObservation {
+        team: team.clone(),
+        member: qa.clone(),
+        session_id: Some(ack_session.clone()),
+        pid: Some(2),
+    });
+    assert!(matches!(
+        dispatcher
+            .dispatch(RequestEnvelope::Write(Box::new(ack.into_write_request())))
+            .expect("ack response"),
+        ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(_))
+    ));
+    assert_eq!(cache.cached_session_id(&team, &qa), Some(ack_session));
+}
+
+#[test]
+fn failed_dispatch_does_not_partially_mutate_runtime_cache() {
+    let tempdir = tempfile::TempDir::new().expect("tempdir");
+    let home = tempdir.path().join("home");
+    let workspace = tempdir.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    let db_path = tempdir.path().join("runtime.db");
+    crate::tests::install_test_roster(&db_path, &[ROLE_TEAM_LEAD]);
+    let cache = RuntimeStatusCache::new();
+    let dispatcher = DaemonRequestDispatcher::new_for_test(home.clone(), cache.clone(), db_path);
+    let team: TeamName = crate::tests::TEST_TEAM.parse().expect("team");
+    let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+    let request = SendRequest::new(
+        home,
+        workspace,
+        member.clone(),
+        &format!("missing@{}", crate::tests::TEST_TEAM),
+        team.clone(),
+        SendMessageSource::Inline("will fail".to_string()),
+        None,
+        false,
+        None,
+        false,
+    )
+    .expect("request")
+    .with_activity_observation(Some(atm_core::caller_context::ActivityObservation {
+        team: team.clone(),
+        member: member.clone(),
+        session_id: Some(SessionId::new("must-not-stick").expect("session")),
+        pid: Some(1),
+    }));
+    assert!(
+        dispatcher
+            .dispatch(RequestEnvelope::Write(Box::new(request)))
+            .is_err()
+    );
+    assert_eq!(cache.cached_session_id(&team, &member), None);
+}
+
+#[test]
+fn forged_peer_ingress_does_not_mutate_runtime_cache() {
+    let tempdir = tempfile::TempDir::new().expect("tempdir");
+    let home = tempdir.path().join("home");
+    let workspace = tempdir.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    let db_path = tempdir.path().join("runtime.db");
+    crate::tests::install_test_roster(&db_path, &[ROLE_TEAM_LEAD, TEST_QA]);
+    let cache = RuntimeStatusCache::new();
+    let dispatcher = DaemonRequestDispatcher::new_for_test(home.clone(), cache.clone(), db_path);
+    let team: TeamName = crate::tests::TEST_TEAM.parse().expect("team");
+    let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+    let request = SendRequest::new(
+        home,
+        workspace,
+        member.clone(),
+        &format!("{TEST_QA}@{}", crate::tests::TEST_TEAM),
+        team.clone(),
+        SendMessageSource::Inline("peer".to_string()),
+        None,
+        false,
+        None,
+        false,
+    )
+    .expect("request")
+    .with_activity_observation(Some(atm_core::caller_context::ActivityObservation {
+        team: team.clone(),
+        member: member.clone(),
+        session_id: Some(SessionId::new("forged").expect("session")),
+        pid: Some(1),
+    }));
+    assert!(
+        dispatcher
+            .route(
+                ApiRequest::new(RequestEnvelope::Write(Box::new(request))),
+                AuthenticatedIngress::Peer,
+                RequestDeadline::after(std::time::Duration::from_secs(1)),
+            )
+            .is_err()
+    );
+    assert_eq!(cache.cached_session_id(&team, &member), None);
+}
+
+#[test]
+fn deadline_before_dispatch_does_not_record_observation() {
+    let tempdir = tempfile::TempDir::new().expect("tempdir");
+    let home = tempdir.path().join("home");
+    std::fs::create_dir_all(&home).expect("home");
+    let db_path = tempdir.path().join("runtime.db");
+    crate::tests::install_test_roster(&db_path, &[ROLE_TEAM_LEAD]);
+    let cache = RuntimeStatusCache::new();
+    let dispatcher = DaemonRequestDispatcher::new_for_test(home, cache.clone(), db_path);
+    let team: TeamName = crate::tests::TEST_TEAM.parse().expect("team");
+    let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+    let request = TeamMemberHeartbeatRequest {
+        team: team.clone(),
+        member: member.clone(),
+        pid: 1,
+        observed_at: IsoTimestamp::now(),
+        activity: HeartbeatActivity::ActiveToolUse,
+        session_id: Some(SessionId::new("late").expect("session")),
+    };
+    assert!(
+        dispatcher
+            .route(
+                ApiRequest::new(RequestEnvelope::Heartbeat(request)),
+                AuthenticatedIngress::Local,
+                RequestDeadline::after(std::time::Duration::ZERO)
+            )
+            .is_err()
+    );
+    assert_eq!(cache.cached_session_id(&team, &member), None);
+}
+
+#[test]
+fn deadline_inside_dispatch_records_observation() {
+    let tempdir = tempfile::TempDir::new().expect("tempdir");
+    let home = tempdir.path().join("home");
+    std::fs::create_dir_all(&home).expect("home");
+    let db_path = tempdir.path().join("runtime.db");
+    crate::tests::install_test_roster(&db_path, &[ROLE_TEAM_LEAD]);
+    let cache = RuntimeStatusCache::new();
+    let dispatcher = DaemonRequestDispatcher::new_for_test(home, cache.clone(), db_path);
+    let team: TeamName = crate::tests::TEST_TEAM.parse().expect("team");
+    let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
+    let session = SessionId::new("on-time").expect("session");
+    let request = TeamMemberHeartbeatRequest {
+        team: team.clone(),
+        member: member.clone(),
+        pid: 1,
+        observed_at: IsoTimestamp::now(),
+        activity: HeartbeatActivity::ActiveToolUse,
+        session_id: Some(session.clone()),
+    };
+    dispatcher
+        .route(
+            ApiRequest::new(RequestEnvelope::Heartbeat(request)),
+            AuthenticatedIngress::Local,
+            RequestDeadline::after(std::time::Duration::from_secs(1)),
+        )
+        .expect("on-time request");
+    assert_eq!(cache.cached_session_id(&team, &member), Some(session));
 }

--- a/crates/atm-daemon/src/runtime_health.rs
+++ b/crates/atm-daemon/src/runtime_health.rs
@@ -59,7 +59,9 @@ fn lock_runtime_mutex<'a, T>(
     resource: &'static str,
 ) -> Result<MutexGuard<'a, T>, AtmError> {
     mutex.lock().map_err(|_| {
-        AtmError::daemon_unavailable(format!("{resource} lock poisoned; restart atm-daemon"))
+        AtmError::daemon_unavailable(format!(
+            "{resource} lock poisoned; restart atm-daemon to restore runtime coordination"
+        ))
     })
 }
 pub(crate) struct DaemonRequestDispatcher {
@@ -506,6 +508,7 @@ impl DaemonRequestDispatcher {
         ) {
             Ok(state) => status_cache.publish_state(state),
             Err(error) => {
+                status_cache.mark_degraded_ingest();
                 tracing::warn!(
                     subsystem = "runtime_health",
                     action = "sqlite_cache_hydration",

--- a/crates/atm-daemon/src/runtime_health/dispatch.rs
+++ b/crates/atm-daemon/src/runtime_health/dispatch.rs
@@ -279,10 +279,6 @@ impl DaemonRequestDispatcher {
             )
         })?;
         let reloaded_members = self.status_cache.reload_state(|current_state| {
-            // Keep this hook within the cache write boundary.  It can perform
-            // disk-backed trust refresh work; allowing an activity writer to
-            // run between the roster snapshot and publication loses that
-            // activity when the rebuilt projection is installed.
             self.refresh_https_trust()?;
             build_runtime_status_cache_state(Some(current_state), roster_store.as_ref())
         })?;

--- a/crates/atm-daemon/src/runtime_status_cache.rs
+++ b/crates/atm-daemon/src/runtime_status_cache.rs
@@ -40,19 +40,17 @@ pub(crate) struct ObservationMergeOutcome {
     pub(crate) pid_changed: bool,
     pub(crate) session_changed: bool,
     pub(crate) state_changed: bool,
-    last_active_at: Option<IsoTimestamp>,
-    session_id: Option<SessionId>,
+    pub(crate) last_active_at: Option<IsoTimestamp>,
+    pub(crate) session_id: Option<SessionId>,
 }
 
-struct MetadataChange<'a> {
-    key: &'a RuntimeMemberKey,
+struct MetadataChange {
     source: RuntimeObservationSource,
     observed_at: IsoTimestamp,
     previous_pid: Option<u32>,
     pid: Option<u32>,
     previous_session: Option<SessionId>,
     session_id: Option<SessionId>,
-    changed: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -106,10 +104,8 @@ impl RuntimeStatusCache {
         self.state.store(Arc::new(next));
     }
 
-    /// Rebuild and replace the projected roster view while excluding concurrent
-    /// heartbeat and local-command writers.  The rebuild must use the state it
-    /// receives: publishing a snapshot built from an earlier read would erase
-    /// activity observed during a configuration reload.
+    /// Rebuild and replace the roster projection while excluding observation
+    /// writers, so a reload cannot publish a stale snapshot over new activity.
     pub(crate) fn reload_state(
         &self,
         rebuild: impl FnOnce(&RuntimeStatusCacheState) -> Result<RuntimeStatusCacheState, AtmError>,
@@ -119,8 +115,7 @@ impl RuntimeStatusCache {
                 "runtime status cache writer lock poisoned; restart atm-daemon before reloading",
             )
         })?;
-        let current = self.clone_state();
-        let next = rebuild(&current)?;
+        let next = rebuild(&self.clone_state())?;
         let reloaded_members = next.member_count();
         self.publish_state(next);
         Ok(reloaded_members)
@@ -243,16 +238,19 @@ impl RuntimeStatusCache {
         let last_active_at = record.last_active_at;
         let session_id = record.session_id.clone();
         self.publish_state(cache);
-        self.emit_metadata_change(&MetadataChange {
-            key,
-            source,
-            observed_at,
-            previous_pid,
-            pid,
-            previous_session,
-            session_id: session_id.clone(),
-            changed: pid_mutated || session_changed,
-        });
+        if pid_mutated || session_changed {
+            self.emit_metadata_change(
+                key,
+                MetadataChange {
+                    source,
+                    observed_at,
+                    previous_pid,
+                    pid,
+                    previous_session,
+                    session_id: session_id.clone(),
+                },
+            );
+        }
         ObservationMergeOutcome {
             pid_changed: previous_pid
                 .is_some_and(|previous| pid.is_some_and(|next| previous != next)),
@@ -263,10 +261,7 @@ impl RuntimeStatusCache {
         }
     }
 
-    fn emit_metadata_change(&self, change: &MetadataChange<'_>) {
-        if !change.changed {
-            return;
-        }
+    fn emit_metadata_change(&self, key: &RuntimeMemberKey, change: MetadataChange) {
         let event = self
             .observability
             .event(
@@ -274,8 +269,8 @@ impl RuntimeStatusCache {
                 "success",
                 "runtime observation metadata changed",
             )
-            .with_team(change.key.team.clone())
-            .with_agent(change.key.member.clone())
+            .with_team(key.team.clone())
+            .with_agent(key.member.clone())
             .with_extra_string_field("source", format!("{:?}", change.source))
             .with_extra_string_field("observed_at", change.observed_at.to_string())
             .with_extra_string_field("previous_pid", format!("{:?}", change.previous_pid))
@@ -314,7 +309,7 @@ impl RuntimeStatusCache {
         members: impl IntoIterator<Item = (TeamName, AgentName)>,
     ) -> RuntimeStatusSnapshot {
         let cache = self.state.load();
-        build_runtime_snapshot_scoped(&cache, members)
+        build_runtime_snapshot_scoped(&cache, members.into_iter().take(MAX_STATUS_CACHE_ENTRIES))
     }
 }
 
@@ -330,11 +325,20 @@ fn evict_status_cache_entry_if_needed(
     let eviction_candidate = cache
         .members
         .iter()
+        .filter(|(_, record)| record.state != RuntimeMemberState::IdentityConflict)
         .min_by_key(|(_, record)| {
             (
                 record.state != RuntimeMemberState::Unknown,
                 record.last_active_at.or(record.state_changed_at),
             )
+        })
+        .or_else(|| {
+            cache.members.iter().min_by_key(|(_, record)| {
+                (
+                    record.state != RuntimeMemberState::IdentityConflict,
+                    record.last_active_at.or(record.state_changed_at),
+                )
+            })
         })
         .map(|(key, record)| (key.clone(), record.clone()));
     if let Some((evicted_key, evicted_record)) = eviction_candidate {
@@ -365,14 +369,7 @@ fn evict_status_cache_entry_if_needed(
 fn build_runtime_snapshot_all(cache: &RuntimeStatusCacheState) -> RuntimeStatusSnapshot {
     let mut counts = RuntimeStatusCounts::default();
     for record in cache.members.values() {
-        match record.state {
-            RuntimeMemberState::Active => counts.active_members += 1,
-            RuntimeMemberState::Idle => counts.idle_members += 1,
-            RuntimeMemberState::Offline => counts.offline_members += 1,
-            RuntimeMemberState::Unknown | RuntimeMemberState::IdentityConflict => {
-                counts.unknown_members += 1
-            }
-        }
+        tally_runtime_member_state(&mut counts, record.state);
     }
     let members = cache.members.iter().map(observation_from_record).collect();
     finish_runtime_snapshot(cache, counts, members)
@@ -389,14 +386,7 @@ fn build_runtime_snapshot_scoped(
         match cache.members.get(&key) {
             Some(record) => {
                 observations.push(observation_from_record((&key, record)));
-                match record.state {
-                    RuntimeMemberState::Active => counts.active_members += 1,
-                    RuntimeMemberState::Idle => counts.idle_members += 1,
-                    RuntimeMemberState::Offline => counts.offline_members += 1,
-                    RuntimeMemberState::Unknown | RuntimeMemberState::IdentityConflict => {
-                        counts.unknown_members += 1
-                    }
-                }
+                tally_runtime_member_state(&mut counts, record.state);
             }
             None => {
                 observations.push(RuntimeMemberObservation {
@@ -416,6 +406,17 @@ fn build_runtime_snapshot_scoped(
         }
     }
     finish_runtime_snapshot(cache, counts, observations)
+}
+
+fn tally_runtime_member_state(counts: &mut RuntimeStatusCounts, state: RuntimeMemberState) {
+    match state {
+        RuntimeMemberState::Active => counts.active_members += 1,
+        RuntimeMemberState::Idle => counts.idle_members += 1,
+        RuntimeMemberState::Offline => counts.offline_members += 1,
+        RuntimeMemberState::Unknown | RuntimeMemberState::IdentityConflict => {
+            counts.unknown_members += 1
+        }
+    }
 }
 
 fn observation_from_record(
@@ -440,6 +441,11 @@ fn finish_runtime_snapshot(
     counts: RuntimeStatusCounts,
     members: Vec<RuntimeMemberObservation>,
 ) -> RuntimeStatusSnapshot {
+    let conflict_count = cache
+        .members
+        .values()
+        .filter(|record| record.state == RuntimeMemberState::IdentityConflict)
+        .count();
     let tracked_members = counts.active_members
         + counts.idle_members
         + counts.offline_members
@@ -451,7 +457,7 @@ fn finish_runtime_snapshot(
         && counts.offline_members > 0;
     let readiness = if all_tracked_members_offline {
         RuntimeReadinessState::Unavailable
-    } else if cache.degraded_ingest {
+    } else if cache.degraded_ingest || conflict_count > 0 {
         RuntimeReadinessState::Degraded
     } else {
         RuntimeReadinessState::Ready
@@ -459,6 +465,11 @@ fn finish_runtime_snapshot(
     let mut details = Vec::new();
     if cache.degraded_ingest {
         details.push("runtime heartbeat ingest is degraded".to_string());
+    }
+    if conflict_count > 0 {
+        details.push(format!(
+            "{conflict_count} runtime member identity conflict(s) require admin takeover or dead-pid retry"
+        ));
     }
     if all_tracked_members_offline {
         details.push("all tracked daemon members are offline".to_string());
@@ -483,7 +494,7 @@ pub(crate) fn build_runtime_status_cache_state(
     let teams = roster_store.list_teams()?;
     if teams.len() > MAX_RELOAD_TEAMS {
         return Err(AtmError::config(format!(
-            "daemon runtime reload rejected because persisted roster state contains more than {MAX_RELOAD_TEAMS} teams"
+            "daemon runtime reload rejected because persisted roster state contains more than {MAX_RELOAD_TEAMS} teams; reduce the roster scope and retry the reload"
         )));
     }
     for team in teams {
@@ -511,7 +522,7 @@ fn hydrate_runtime_status_cache_team(
     for member in roster.members {
         if next_state.members.len() >= MAX_STATUS_CACHE_ENTRIES {
             return Err(AtmError::config(format!(
-                "daemon runtime reload rejected because status-cache capacity {MAX_STATUS_CACHE_ENTRIES} would be exceeded while loading roster for team {}; reduce the tracked roster or restart with a fresh runtime cache",
+                "daemon runtime reload rejected because status-cache capacity {MAX_STATUS_CACHE_ENTRIES} would be exceeded while loading roster for team {}; reduce the roster scope and retry the reload",
                 team
             )));
         }
@@ -714,26 +725,106 @@ mod tests {
     }
 
     #[test]
-    fn session_changed_by_and_at_update_only_on_session_edge() {
+    fn runtime_status_cache_scoped_snapshot_reads_do_not_require_shared_locking() {
         let status_cache = RuntimeStatusCache::new();
         let team = test_team();
-        let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
-        let session = SessionId::new("session-a").expect("session");
+        let active: AgentName = TEST_QA.parse().expect("member");
+        let idle: AgentName = TEST_RECIPIENT.parse().expect("member");
+        let missing: AgentName = TEST_SENDER.parse().expect("member");
+
+        status_cache.insert_member_for_test(
+            team.clone(),
+            active.clone(),
+            Some(100),
+            RuntimeMemberState::Active,
+            Some(IsoTimestamp::now()),
+        );
+        status_cache.insert_member_for_test(
+            team.clone(),
+            idle.clone(),
+            Some(101),
+            RuntimeMemberState::Idle,
+            Some(IsoTimestamp::now()),
+        );
+
+        let snapshot = status_cache.snapshot_for_members_for_test([
+            (team.clone(), active),
+            (team.clone(), idle),
+            (team, missing),
+        ]);
+
+        assert_eq!(snapshot.readiness, RuntimeReadinessState::Ready);
+        assert_eq!(snapshot.member_counts.active_members, 1);
+        assert_eq!(snapshot.member_counts.idle_members, 1);
+        assert_eq!(snapshot.member_counts.offline_members, 0);
+        assert_eq!(snapshot.member_counts.unknown_members, 1);
+    }
+
+    #[test]
+    fn scoped_snapshot_caps_roster_projection_work() {
+        let status_cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let members = (0..=MAX_STATUS_CACHE_ENTRIES)
+            .map(|index| {
+                (
+                    team.clone(),
+                    format!("member-{index}").parse().expect("member"),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let snapshot = status_cache.snapshot_for_members_for_test(members);
+
+        assert_eq!(snapshot.members.len(), MAX_STATUS_CACHE_ENTRIES);
+        assert_eq!(
+            snapshot.member_counts.unknown_members,
+            MAX_STATUS_CACHE_ENTRIES
+        );
+    }
+
+    #[test]
+    fn runtime_status_cache_all_tracked_members_offline_are_unavailable() {
+        let status_cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let member: AgentName = TEST_SENDER.parse().expect("member");
+
+        status_cache.insert_member_for_test(
+            team,
+            member,
+            Some(200),
+            RuntimeMemberState::Offline,
+            Some(IsoTimestamp::now()),
+        );
+
+        let snapshot = status_cache.snapshot();
+        assert_eq!(snapshot.readiness, RuntimeReadinessState::Unavailable);
+        assert_eq!(snapshot.member_counts.active_members, 0);
+        assert_eq!(snapshot.member_counts.offline_members, 1);
+        assert_eq!(snapshot.member_counts.unknown_members, 0);
+        assert_eq!(
+            snapshot.detail.as_deref(),
+            Some("all tracked daemon members are offline")
+        );
+    }
+
+    #[test]
+    fn session_changed_by_and_at_update_only_on_session_edge() {
+        let cache = RuntimeStatusCache::new();
         let key = RuntimeMemberKey {
-            team: team.clone(),
-            member: member.clone(),
+            team: test_team(),
+            member: ROLE_TEAM_LEAD.parse().expect("member"),
         };
-        let first = IsoTimestamp::now();
-        status_cache.merge_observation(
+        let session = SessionId::new("session-a").expect("session");
+        cache.merge_observation(
             &key,
             RuntimeObservationSource::Heartbeat,
             RuntimeMemberState::Active,
             Some(&session),
             Some(7),
-            first,
+            IsoTimestamp::now(),
         );
-        let initial = status_cache.state.load().members[&key].clone();
-        status_cache.merge_observation(
+        let initial = cache.state.load().members[&key].clone();
+        cache.merge_observation(
             &key,
             RuntimeObservationSource::LocalCommand,
             RuntimeMemberState::Active,
@@ -741,7 +832,7 @@ mod tests {
             None,
             IsoTimestamp::now(),
         );
-        let repeated = &status_cache.state.load().members[&key];
+        let repeated = &cache.state.load().members[&key];
         assert_eq!(repeated.session_changed_by, initial.session_changed_by);
         assert_eq!(repeated.session_changed_at, initial.session_changed_at);
     }
@@ -865,28 +956,28 @@ mod tests {
             team: test_team(),
             member: ROLE_TEAM_LEAD.parse().expect("member"),
         };
-        cache.merge_observation(
-            &key,
-            RuntimeObservationSource::Heartbeat,
-            RuntimeMemberState::Offline,
-            None,
-            Some(1),
-            IsoTimestamp::now(),
-        );
-        cache.merge_observation(
-            &key,
-            RuntimeObservationSource::LocalCommand,
-            RuntimeMemberState::Active,
-            None,
-            None,
-            IsoTimestamp::now(),
-        );
-        let record = &cache.state.load().members[&key];
-        assert_eq!(record.state, RuntimeMemberState::Active);
-        assert_eq!(
-            record.state_changed_by,
-            Some(RuntimeObservationSource::LocalCommand)
-        );
+        for state in [RuntimeMemberState::Offline, RuntimeMemberState::Idle] {
+            cache.merge_observation(
+                &key,
+                RuntimeObservationSource::Heartbeat,
+                state,
+                None,
+                Some(1),
+                IsoTimestamp::now(),
+            );
+            cache.merge_observation(
+                &key,
+                RuntimeObservationSource::LocalCommand,
+                RuntimeMemberState::Active,
+                None,
+                None,
+                IsoTimestamp::now(),
+            );
+            assert_eq!(
+                cache.state.load().members[&key].state,
+                RuntimeMemberState::Active
+            );
+        }
     }
 
     #[test]
@@ -1133,100 +1224,67 @@ mod tests {
             IsoTimestamp::now(),
         );
         assert!(outcome.session_changed);
-        // One merge call is the sole event-emission site for both mutations.
         assert!(!outcome.pid_changed);
     }
 
     #[test]
-    fn session_ended_preserves_last_known_session() {
-        let status_cache = RuntimeStatusCache::new();
+    fn pid_conflict_replacement_emits_one_audit_event_without_identity_conflict() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir");
+        let observability =
+            crate::test_observability::TestDaemonObservability::new(tempdir.path().to_path_buf())
+                .expect("observability");
+        let cache = RuntimeStatusCache::new_with_observability(SubsystemObservability::new(
+            DaemonSubsystem::RuntimeStatusCache,
+            std::sync::Arc::new(observability),
+        ));
         let team = test_team();
         let member: AgentName = ROLE_TEAM_LEAD.parse().expect("member");
-        let session_id = SessionId::new("s-1").expect("session id");
-        status_cache.record_heartbeat_for_test(
-            &TeamMemberHeartbeatRequest {
-                team: team.clone(),
-                member: member.clone(),
-                pid: 42,
-                observed_at: IsoTimestamp::now(),
-                activity: HeartbeatActivity::ActiveToolUse,
-                session_id: Some(session_id.clone()),
-            },
-            false,
-        );
-        let response = status_cache.record_heartbeat_for_test(
-            &TeamMemberHeartbeatRequest {
-                team,
-                member,
-                pid: 42,
-                observed_at: IsoTimestamp::now(),
-                activity: HeartbeatActivity::SessionEnded,
-                session_id: None,
-            },
-            false,
-        );
-        assert_eq!(response.state, RuntimeMemberState::Offline);
-        assert_eq!(response.session_id, Some(session_id));
-    }
-
-    #[test]
-    fn runtime_status_cache_scoped_snapshot_reads_do_not_require_shared_locking() {
-        let status_cache = RuntimeStatusCache::new();
-        let team = test_team();
-        let active: AgentName = TEST_QA.parse().expect("member");
-        let idle: AgentName = TEST_RECIPIENT.parse().expect("member");
-        let missing: AgentName = TEST_SENDER.parse().expect("member");
-
-        status_cache.insert_member_for_test(
-            team.clone(),
-            active.clone(),
-            Some(100),
-            RuntimeMemberState::Active,
-            Some(IsoTimestamp::now()),
-        );
-        status_cache.insert_member_for_test(
-            team.clone(),
-            idle.clone(),
-            Some(101),
-            RuntimeMemberState::Idle,
-            Some(IsoTimestamp::now()),
-        );
-
-        let snapshot = status_cache.snapshot_for_members_for_test([
-            (team.clone(), active),
-            (team.clone(), idle),
-            (team, missing),
-        ]);
-
-        assert_eq!(snapshot.readiness, RuntimeReadinessState::Ready);
-        assert_eq!(snapshot.member_counts.active_members, 1);
-        assert_eq!(snapshot.member_counts.idle_members, 1);
-        assert_eq!(snapshot.member_counts.offline_members, 0);
-        assert_eq!(snapshot.member_counts.unknown_members, 1);
-    }
-
-    #[test]
-    fn runtime_status_cache_all_tracked_members_offline_are_unavailable() {
-        let status_cache = RuntimeStatusCache::new();
-        let team = test_team();
-        let member: AgentName = TEST_SENDER.parse().expect("member");
-
-        status_cache.insert_member_for_test(
-            team,
-            member,
-            Some(200),
-            RuntimeMemberState::Offline,
-            Some(IsoTimestamp::now()),
-        );
-
-        let snapshot = status_cache.snapshot();
-        assert_eq!(snapshot.readiness, RuntimeReadinessState::Unavailable);
-        assert_eq!(snapshot.member_counts.active_members, 0);
-        assert_eq!(snapshot.member_counts.offline_members, 1);
-        assert_eq!(snapshot.member_counts.unknown_members, 0);
+        let session = SessionId::new("session-a").expect("session");
+        let heartbeat = |pid| TeamMemberHeartbeatRequest {
+            team: team.clone(),
+            member: member.clone(),
+            pid,
+            observed_at: IsoTimestamp::now(),
+            activity: HeartbeatActivity::ActiveToolUse,
+            session_id: Some(session.clone()),
+        };
+        cache.record_heartbeat(&heartbeat(1));
+        let replacement = cache.record_heartbeat(&heartbeat(2));
+        assert!(replacement.pid_changed);
+        assert_eq!(replacement.state, RuntimeMemberState::Active);
+        assert_ne!(replacement.state, RuntimeMemberState::IdentityConflict);
+        let log = std::fs::read_to_string(tempdir.path().join("atm.log.jsonl")).expect("audit log");
         assert_eq!(
-            snapshot.detail.as_deref(),
-            Some("all tracked daemon members are offline")
+            log.matches("runtime_observation_metadata_changed").count(),
+            2,
+            "one audit event per metadata-changing heartbeat"
         );
+        assert!(!log.contains("record_identity_conflict"));
+    }
+
+    #[test]
+    fn concurrent_observation_writers_preserve_distinct_members() {
+        let cache = RuntimeStatusCache::new();
+        let team = test_team();
+        let first: AgentName = "writer-a".parse().expect("member");
+        let second: AgentName = "writer-b".parse().expect("member");
+        std::thread::scope(|scope| {
+            for member in [first.clone(), second.clone()] {
+                let cache = cache.clone();
+                let team = team.clone();
+                scope.spawn(move || {
+                    let key = RuntimeMemberKey { team, member };
+                    cache.merge_observation(
+                        &key,
+                        RuntimeObservationSource::LocalCommand,
+                        RuntimeMemberState::Active,
+                        None,
+                        None,
+                        IsoTimestamp::now(),
+                    );
+                });
+            }
+        });
+        assert_eq!(cache.member_count_for_test(), 2);
     }
 }

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -54,19 +54,21 @@ even though they are not public cross-crate traits:
   - must remain separate from socket serving code
   - immutable snapshot publication is the accepted design for readers; no
     daemon-shared mutable cache lock is used
-  - session, pid, heartbeat activity, and derived state are telemetry only.
-    This boundary may merge/publish them, but routing, nudge, notification,
-    retry, admission, and delivery code must not consume them.
+  - session, pid, heartbeat activity, and derived state are telemetry only;
+    their non-authoritative consumption rule follows the canonical statement in
+    the `DaemonStatusSourceAdapter` section below.
   - local `ActivityObservation` is transient request metadata. Only accepted
     heartbeat and successful environment-attested local CLI/graft ingress may
-    reach this cache; HTTPS peer ingress clears it before shared dispatch.
-    Changed session/PID values are diagnostic evidence, never a liveness or
-    conflict decision.
+    reach this cache; HTTPS peer ingress must clear it before shared dispatch.
+    Changed session/PID metadata follows the canonical non-authoritative rule
+    in the `DaemonStatusSourceAdapter` section below.
   - removal of the former conflict-driven `Degraded` readiness projection is
-    intentional. Downstream alerting consumes the retained
-    `runtime_observation_metadata_changed` diagnostic event as
-    non-authoritative evidence; AJ adds no replacement readiness signal or
-    doctor aggregate.
+    intentional. Its retained diagnostic metadata follows the canonical
+    non-authoritative rule in the `DaemonStatusSourceAdapter` section below.
+    The boundary/isolation contract is lint-verified; the
+    user-facing `atm members` CLI projection required by AJ.6 remains
+    unimplemented despite that sprint's `status: complete` marking (AJ.6
+    QA-1/fix-in-progress).
 
 ## Planned R.20 partition map
 

--- a/docs/atm-daemon/boundaries.md
+++ b/docs/atm-daemon/boundaries.md
@@ -52,8 +52,8 @@ even though they are not public cross-crate traits:
   - hydrates durable team/member truth only through `RosterStore`; it must not
     rediscover teams by walking `ATM_HOME/.claude/teams`
   - must remain separate from socket serving code
-  - immutable snapshot publication is the accepted design for readers; no
-    daemon-shared mutable cache lock is used
+  - immutable snapshot publication is the accepted design for readers; cache
+    mutations are serialized by the daemon-owned writer mutex
   - session, pid, heartbeat activity, and derived state are telemetry only;
     their non-authoritative consumption rule follows the canonical statement in
     the `DaemonStatusSourceAdapter` section below.
@@ -65,10 +65,7 @@ even though they are not public cross-crate traits:
   - removal of the former conflict-driven `Degraded` readiness projection is
     intentional. Its retained diagnostic metadata follows the canonical
     non-authoritative rule in the `DaemonStatusSourceAdapter` section below.
-    The boundary/isolation contract is lint-verified; the
-    user-facing `atm members` CLI projection required by AJ.6 remains
-    unimplemented despite that sprint's `status: complete` marking (AJ.6
-    QA-1/fix-in-progress).
+    The boundary/isolation contract is lint-verified.
 
 ## Planned R.20 partition map
 
@@ -476,7 +473,7 @@ Notes:
 - The cache-cap rule must bound actual retained entries, not only member-state
   labels.
 - immutable snapshot publication through `ArcSwap` is the accepted design for
-  readers; no daemon-shared mutable cache lock is used.
+  readers; cache mutations are serialized by the daemon-owned writer mutex.
 - Runtime observation is non-authoritative. Cache merge and snapshot projection
   may inspect it; routing, nudge, notification, retry, admission, delivery,
   and policy must not. The machine-readable

--- a/docs/plans/phase-aj/sprint-AJ5.md
+++ b/docs/plans/phase-aj/sprint-AJ5.md
@@ -2,8 +2,6 @@
 id: AJ.5
 title: HTTP Heartbeat Session State
 status: complete
-implementation_status: complete
-phase_closeout: pending-parent-pr-merges
 branch: feature/pAJ-s5-heartbeat-session
 worktree: ../atm-core-worktrees/feature/pAJ-s5-heartbeat-session
 target: integrate/phase-aj
@@ -163,7 +161,7 @@ session-rejection behavior may consume a PID/session conflict.
 - Regression test: a prior pid plus a heartbeat with a different pid
   succeeds, updates the current pid, retains one change event, and never emits
   `IdentityConflict`.
-- `rg -n "merge_observation|record_identity_conflict|process_is_alive" crates/atm-daemon/src/runtime_health/dispatch.rs crates/atm-daemon/src/runtime_status_cache.rs`
+- `rg -n "merge_observation|record_heartbeat" crates/atm-daemon/src/runtime_health/dispatch.rs crates/atm-daemon/src/runtime_status_cache.rs`
   shows the shared merge flow and no live-pid conflict producer or guard
 - `rg -n "record_identity_conflict_for_test|AtmErrorCode::IdentityConflict" crates/atm-daemon/src/tests.rs`
   returns no matches

--- a/docs/plans/phase-aj/sprint-AJ6.md
+++ b/docs/plans/phase-aj/sprint-AJ6.md
@@ -1,9 +1,7 @@
 ---
 id: AJ.6
 title: Runtime Observation Snapshot Projection
-status: complete
-implementation_status: complete
-phase_closeout: pending-parent-pr-merges
+status: in_progress
 branch: feature/pAJ-s6-runtime-observation-snapshot
 worktree: ../atm-core-worktrees/feature/pAJ-s6-runtime-observation-snapshot
 target: integrate/phase-aj

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1095,7 +1095,7 @@ nudge, retry, admission, delivery, notification, or policy.
 | `AJ.3` | `implementation complete` | `feature/pAJ-s3-cli-wire-payload` | transient local CLI/graft request metadata |
 | `AJ.4` | `implementation complete` | `feature/pAJ-s4-daemon-cache-touch` | shared daemon cache merge after successful local dispatch |
 | `AJ.5` | `implementation complete` | `feature/pAJ-s5-heartbeat-session` | heartbeat session observation convergence |
-| `AJ.6` | `implementation complete` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
+| `AJ.6` | `in_progress` | `feature/pAJ-s6-runtime-observation-snapshot` | runtime snapshot and roster projection |
 | `AJ.7` | `implementation complete` | `feature/pAJ-s7-runtime-observation-source-guard` | non-authoritative source-use guard |
 | `AJ.8` | `implementation complete` | `feature/pAJ-s8-runtime-observation-boundary-record` | machine and human daemon boundary record |
 | `AJ.9` | `implementation complete` | `feature/pAJ-s9-runtime-observation-contract-reconciliation` | requirements, ADR, architecture, and team-state reconciliation |


### PR DESCRIPTION
## Summary

Merge commit `596f0b89` (AJ.9 -> AJ.10 merge-forward) resolved textual conflicts on 6 files toward the stale side instead of AJ.9's already-fixed side, silently reintroducing 9 previously-closed findings' worth of regressions into `integrate/phase-aj`. This branch reapplies only the dropped hunks (not a blind overwrite) against the current `integrate/phase-aj` tip.

Root-caused by quality-mgr, independently verified by team-lead (diffed both merge parents directly), fix implemented by arch-ctm.

## Findings resolved
- AJ4-QA1-TESTS-INTEGRATION
- AJ4-RBP-F003-RELOAD-CAPACITY-GUIDANCE
- AJ5-RSH-004-DEGRADED-INGEST-NOT-SET
- AJ5-ARCH-003-MISSING-AUDIT-ASSERTION
- AJ5-ATM-QA-006-VALIDATION-CMD-MISMATCH
- AJ5-RBQA-F002-STALE-DOCS
- AJ6-ATM-QA-004-STATUS-COMPLETE-PREMATURE
- AJ6-RSH-001-UNBOUNDED-SNAPSHOT
- AJ6-RBQA-F004-DUPLICATED-TALLY-LOGIC

## Test plan
- [x] `just test` passed (arch-ctm)
- [x] `git diff --check` passed (arch-ctm)
- [x] Team-lead independently verified 2 findings' content directly on the branch
- [ ] quality-mgr final recheck of all 9 findings
- [ ] CI green

🤖 Generated with team-lead orchestration (Claude Code)