### PR TITLE
codex-orchestration: fix-assignment prompts closing-triage on triaged fixes

### DIFF
--- a/.claude/skills/codex-orchestration/fix-assignment.xml.j2
+++ b/.claude/skills/codex-orchestration/fix-assignment.xml.j2
@@ -69,6 +69,7 @@ defaults:
     <step id="e">Fix every promoted-branch occurrence in scope. Do not stop at the first location when the triage record marks the finding as repeatable.</step>
     <step id="f">As soon as the branch is pushable, commit and push immediately. Send branch name and commit hash right away so follow-up QA can start in parallel.</step>
     <step id="g">Run the required validation after the push report and send a second report with PASS or FAIL plus concrete failure details.</step>
-    <step id="h">After the validation report, read ATM again for follow-up work.</step>
+{% if triage_records and triage_records.strip() %}    <step id="g1">Triage records are attached to this assignment. Use the `/closing-triage` skill to close out the findings fixed on this branch before reporting.</step>
+{% endif %}    <step id="h">After the validation report, read ATM again for follow-up work.</step>
   </workflow>
 </atm-task>

--- a/.claude/skills/codex-orchestration/fix-assignment.xml.j2
+++ b/.claude/skills/codex-orchestration/fix-assignment.xml.j2
@@ -69,7 +69,7 @@ defaults:
     <step id="e">Fix every promoted-branch occurrence in scope. Do not stop at the first location when the triage record marks the finding as repeatable.</step>
     <step id="f">As soon as the branch is pushable, commit and push immediately. Send branch name and commit hash right away so follow-up QA can start in parallel.</step>
     <step id="g">Run the required validation after the push report and send a second report with PASS or FAIL plus concrete failure details.</step>
-{% if triage_records and triage_records.strip() %}    <step id="g1">Triage records are attached to this assignment. Use the `/closing-triage` skill to close out the findings fixed on this branch before reporting.</step>
+{% if triage_records and triage_records|trim %}    <step id="g1">Triage records are attached to this assignment. Use the `/closing-triage` skill to close out the findings fixed on this branch before reporting.</step>
 {% endif %}    <step id="h">After the validation report, read ATM again for follow-up work.</step>
   </workflow>
 </atm-task>


### PR DESCRIPTION
## Summary
- `fix-assignment.xml.j2` now adds a workflow step (`g1`) directing arch-ctm to use `/closing-triage` to close out findings when the assignment carries `triage_records`
- Closing-triage iterates the finding list and reports each closure as a separate commit/message to QA, speeding up closure turnaround
- Step is conditional on `triage_records` being non-empty, consistent with existing mandatory-gate/solo-plan-doc skip cases where triage isn't used

🤖 Generated with [Claude Code](https://claude.com/claude-code)