### PR TITLE
AL.2 — Canonical Typed HTTP Handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "tokio",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,8 +227,11 @@ dependencies = [
  "hyper",
  "reqwest",
  "rustls",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
+ "tower",
 ]
 
 [[package]]
@@ -658,6 +661,12 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -2057,6 +2066,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,8 +2130,10 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tokio = { version = "1.48", default-features = false, features = ["macros", "net
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 hyper = { version = "1.8", default-features = false, features = ["client", "http1"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+tower = { version = "0.5", default-features = false, features = ["limit", "load-shed", "util"] }
 sha2 = "0.10"
 ulid = { version = "1.2.1", features = ["serde"] }
 base64 = "0.22"

--- a/crates/atm-architecture/tests/boundary_enforcement.rs
+++ b/crates/atm-architecture/tests/boundary_enforcement.rs
@@ -1919,7 +1919,8 @@ fn al1_http_runtime_is_core_contract_only_and_excludes_retired_transport_shapes(
     );
 
     let root = workspace_root();
-    let source = read_source(&root.join("crates/atm-http-runtime/src/lib.rs"));
+    let runtime_root = root.join("crates/atm-http-runtime/src");
+    let source = read_source(&runtime_root.join("lib.rs"));
     assert!(
         source.contains("../../../docs/plans/phase-al-am-runtime-boundary-checklist.md")
             && root
@@ -1927,9 +1928,16 @@ fn al1_http_runtime_is_core_contract_only_and_excludes_retired_transport_shapes(
                 .is_file(),
         "the public runtime crate documentation must link the shared AL/AM boundary checklist"
     );
-    let code = source
-        .lines()
-        .filter(|line| !line.trim_start().starts_with("//"))
+    let code = ["lib.rs", "message_handler.rs"]
+        .into_iter()
+        .map(|file| read_source(&runtime_root.join(file)))
+        .flat_map(|source| {
+            source
+                .lines()
+                .filter(|line| !line.trim_start().starts_with("//"))
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
         .collect::<Vec<_>>()
         .join("\n");
     for prohibited in [

--- a/crates/atm-core/src/api.rs
+++ b/crates/atm-core/src/api.rs
@@ -30,6 +30,8 @@ pub const MAX_HTTP_REQUEST_BODY_BYTES: usize = 1_048_576;
 pub const HTTP_API_VERSION: &str = crate::protocol::HTTP_API_VERSION;
 const MAX_HTTP_HEADER_BYTES: usize = 16 * 1024;
 const CLEAR_OUTCOME_HEADER: &str = "X-ATM-Clear-Outcome";
+/// Adapter-owned provenance header for the explicit plaintext peer smoke mode.
+pub const PEER_SOURCE_HOST_HEADER: &str = "X-ATM-Peer-Source-Host";
 const MESSAGES_PATH: &str = "/v1/atm/messages";
 const INSPECT_PATH: &str = "/v1/atm/messages/inspect";
 const READ_PATH: &str = "/v1/atm/messages/read";

--- a/crates/atm-daemon/src/https_transport.rs
+++ b/crates/atm-daemon/src/https_transport.rs
@@ -15,9 +15,9 @@ use std::time::Duration;
 
 use atm_core::api::{
     ApiRequest, ApiRouter, AuthenticatedIngress, HttpFrameReader, MessageCollectionRequest,
-    RequestDeadline, UntrustedSmokeProvenance, decode_request, read_http_request,
-    read_http_response_with_frame_reader, write_http_request, write_http_request_with_headers,
-    write_http_response,
+    PEER_SOURCE_HOST_HEADER, RequestDeadline, UntrustedSmokeProvenance, decode_request,
+    read_http_request, read_http_response_with_frame_reader, write_http_request,
+    write_http_request_with_headers, write_http_response,
 };
 use atm_core::error::AtmError;
 use atm_core::protocol::{RequestEnvelope, ResponseEnvelope};
@@ -39,7 +39,6 @@ use crate::active_connection_registry::{
 
 const HTTPS_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_PEER_HTTP_CONNECTIONS: usize = 64;
-const PLAINTEXT_PEER_SOURCE_HOST_HEADER: &str = "X-ATM-Peer-Source-Host";
 
 /// The peer wire-security setting. Mutual TLS is the production default.
 /// Plain HTTP is deliberately available only for an explicit, temporary smoke
@@ -623,12 +622,14 @@ fn route_peer_http_request(
     };
     remaining_budget(deadline)?;
     let plaintext_source_host = request
-        .header(PLAINTEXT_PEER_SOURCE_HOST_HEADER)
+        .header(PEER_SOURCE_HOST_HEADER)
         .map(str::parse)
         .transpose()
         .map_err(|source| {
             AtmError::validation(
-                "invalid X-ATM-Peer-Source-Host header; use a valid configured test host or restart without --peer-wire-security plaintext-test",
+                format!(
+                    "invalid {PEER_SOURCE_HOST_HEADER} header; use a valid configured test host or restart without --peer-wire-security plaintext-test"
+                ),
             )
             .with_cause(source)
         })?;
@@ -644,9 +645,9 @@ fn route_peer_http_request(
             AuthenticatedIngress::UntrustedSmoke(UntrustedSmokeProvenance::new(source_host))
         }
         (None, None) if matches!(request, ApiRequest::Write(_)) => {
-            return Err(AtmError::validation(
-                "plaintext peer write requests require X-ATM-Peer-Source-Host; restart without --peer-wire-security plaintext-test to restore mTLS",
-            ));
+            return Err(AtmError::validation(format!(
+                "plaintext peer write requests require {PEER_SOURCE_HOST_HEADER}; restart without --peer-wire-security plaintext-test to restore mTLS"
+            )));
         }
         // Read-only plaintext diagnostics are deliberately anonymous. They
         // must never be labelled as the authenticated mTLS peer ingress.
@@ -687,7 +688,7 @@ fn write_plaintext_http_request_with_source_host(
     write_http_request_with_headers(
         stream,
         request,
-        &[(PLAINTEXT_PEER_SOURCE_HOST_HEADER, source_host.as_str())],
+        &[(PEER_SOURCE_HOST_HEADER, source_host.as_str())],
     )
 }
 
@@ -1004,7 +1005,8 @@ mod tests {
     use super::clear_remote_activity_observation;
     use atm_core::api::{
         ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, MessageCollectionRequest,
-        RequestDeadline, read_http_response, write_http_request, write_http_request_with_headers,
+        PEER_SOURCE_HOST_HEADER, RequestDeadline, read_http_response, write_http_request,
+        write_http_request_with_headers,
     };
     use atm_core::boundary::RosterHarness;
     use atm_core::caller_context::ActivityObservation;
@@ -1267,10 +1269,7 @@ mod tests {
         write_http_request_with_headers(
             &mut stream,
             &request,
-            &[(
-                super::PLAINTEXT_PEER_SOURCE_HOST_HEADER,
-                "smoke-peer.invalid",
-            )],
+            &[(PEER_SOURCE_HOST_HEADER, "smoke-peer.invalid")],
         )
         .expect("write plain peer request");
         let _ = read_http_response(&mut stream, &request).expect("shared router response");
@@ -1393,10 +1392,7 @@ mod tests {
         write_http_request_with_headers(
             &mut stream,
             &write,
-            &[(
-                super::PLAINTEXT_PEER_SOURCE_HOST_HEADER,
-                "smoke-peer.invalid",
-            )],
+            &[(PEER_SOURCE_HOST_HEADER, "smoke-peer.invalid")],
         )
         .expect("write peer request");
         let _ = read_http_response(&mut stream, &write).expect("write response");

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -15,7 +15,10 @@ axum.workspace = true
 hyper.workspace = true
 reqwest.workspace = true
 rustls.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
+tower.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/atm-http-runtime/Cargo.toml
+++ b/crates/atm-http-runtime/Cargo.toml
@@ -21,4 +21,5 @@ tokio.workspace = true
 tower.workspace = true
 
 [dev-dependencies]
+serde_yaml = "0.9"
 tempfile = "3"

--- a/crates/atm-http-runtime/src/lib.rs
+++ b/crates/atm-http-runtime/src/lib.rs
@@ -41,6 +41,10 @@ use std::time::Duration;
 use atm_core::ApiRouter;
 use atm_core::error::AtmError;
 
+mod message_handler;
+
+pub use message_handler::{AuthenticatedConnector, canonical_message_router};
+
 /// Validated configuration for the future maintained Tokio HTTP runtime.
 ///
 /// The fields remain private so composition cannot bypass validation before a

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -279,6 +279,7 @@ mod tests {
     use axum::body::{Body, to_bytes};
     use axum::http::header::{CONTENT_TYPE, HeaderName};
     use axum::http::{Request, StatusCode};
+    use serde_json::{Value, json};
     use tower::ServiceExt;
 
     use super::{
@@ -737,10 +738,52 @@ mod tests {
     }
 
     #[test]
-    fn openapi_and_handler_keep_the_existing_typed_write_contract() {
-        let openapi = include_str!("../../../docs/atm-daemon/openapi.yaml");
-        assert!(openapi.contains("operationId: writeMessage"));
-        assert!(openapi.contains("$ref: '#/components/schemas/WriteRequest'"));
+    fn openapi_and_serde_keep_the_existing_typed_write_contract() {
+        let openapi: Value =
+            serde_yaml::from_str(include_str!("../../../docs/atm-daemon/openapi.yaml"))
+                .expect("parse checked-in OpenAPI document");
+        let write_operation = openapi
+            .pointer("/paths/~1messages/post")
+            .expect("OpenAPI must declare POST /messages");
+
+        assert_eq!(
+            write_operation,
+            &json!({
+                "operationId": "writeMessage",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/WriteRequest"}
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created message",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Message"}
+                            }
+                        }
+                    },
+                    "default": {"$ref": "#/components/responses/AtmError"}
+                }
+            }),
+            "the parsed OpenAPI write operation must remain the AL.1 compatibility oracle"
+        );
+
+        let serialized = serde_json::to_value(write_request())
+            .expect("serialize the existing route-specific WriteRequest");
+        let round_tripped: atm_core::send::WriteRequest =
+            serde_json::from_value(serialized.clone())
+                .expect("deserialize the existing route-specific WriteRequest");
+        assert_eq!(
+            serde_json::to_value(round_tripped).expect("re-serialize WriteRequest"),
+            serialized,
+            "the handler must retain the existing WriteRequest Serde representation"
+        );
+
         let forbidden = ["Http", "Frame", "Reader"].concat();
         assert!(!include_str!("message_handler.rs").contains(&forbidden));
         let forbidden = ["Peer", "Message", "Array"].concat();

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -7,7 +7,9 @@
 use std::sync::Arc;
 
 use atm_core::ApiRouter;
-use atm_core::api::{ApiRequest, ApiResponse, AuthenticatedIngress, RequestDeadline};
+use atm_core::api::{
+    ApiRequest, ApiResponse, AuthenticatedIngress, RequestDeadline, http_route_surface,
+};
 use atm_core::error::AtmError;
 use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
 use atm_core::send::WriteRequest;
@@ -29,7 +31,6 @@ use tower::load_shed::LoadShedLayer;
 
 use crate::{RuntimeLimits, RuntimeTimeouts};
 
-const MESSAGES_PATH: &str = "/v1/atm/messages";
 const LEGACY_PEER_SOURCE_HEADER: HeaderName = HeaderName::from_static("x-atm-peer-source-host");
 
 /// Provenance established by the transport adapter after authentication.
@@ -104,9 +105,27 @@ pub fn canonical_message_router(
         .layer(ConcurrencyLimitLayer::new(limits.max_connections));
 
     Router::new()
-        .route(MESSAGES_PATH, post(post_messages).layer(admission))
+        .route(canonical_write_path(), post(post_messages).layer(admission))
         .layer(DefaultBodyLimit::max(limits.max_body_bytes))
         .with_state(state)
+}
+
+/// Returns the write path from the core-owned HTTP route surface.
+///
+/// The framework adapter intentionally has no path literal of its own: the
+/// existing request codec and the runtime binding must select one declaration.
+fn canonical_write_path() -> &'static str {
+    let mut matches = http_route_surface()
+        .filter(|route| route.method == "POST" && route.path_template.ends_with("/messages"));
+    let path = matches
+        .next()
+        .expect("core HTTP route surface must declare one POST messages route")
+        .path_template;
+    assert!(
+        matches.next().is_none(),
+        "core HTTP route surface must declare only one POST messages route"
+    );
+    path
 }
 
 async fn post_messages(
@@ -263,7 +282,8 @@ mod tests {
     use tower::ServiceExt;
 
     use super::{
-        AuthenticatedConnector, canonical_message_router, json_response, map_write_response,
+        AuthenticatedConnector, canonical_message_router, canonical_write_path, json_response,
+        map_write_response,
     };
     use crate::{NonZeroDuration, RuntimeLimits, RuntimeTimeouts};
 
@@ -423,7 +443,9 @@ mod tests {
         body: Vec<u8>,
         headers: &[(HeaderName, &str)],
     ) -> axum::response::Response {
-        let mut request = Request::builder().method("POST").uri("/v1/atm/messages");
+        let mut request = Request::builder()
+            .method("POST")
+            .uri(canonical_write_path());
         for (name, value) in headers {
             request = request.header(name, *value);
         }
@@ -589,6 +611,13 @@ mod tests {
             Err(error) => error,
         };
         assert_eq!(serialization.code(), AtmErrorCode::SerializationFailed);
+    }
+
+    #[test]
+    fn canonical_route_is_selected_from_the_core_route_surface() {
+        assert!(atm_core::api::http_route_surface().any(|route| {
+            route.method == "POST" && route.path_template == canonical_write_path()
+        }));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -124,12 +124,33 @@ async fn post_messages(
     let ingress = state.connector.normalize_write(&mut request);
     let deadline = RequestDeadline::after(state.request_timeout);
 
-    let response = state
-        .router
-        .route(ApiRequest::Write(Box::new(request)), ingress, deadline);
+    let response =
+        dispatch_on_blocking_pool(Arc::clone(&state.router), request, ingress, deadline).await;
     response
         .and_then(map_write_response)
         .unwrap_or_else(error_response)
+}
+
+/// Calls the synchronous sealed application boundary without stalling a Tokio
+/// worker. The boundary remains synchronous until its owning core contract is
+/// deliberately changed; this adapter owns the asynchronous isolation only.
+async fn dispatch_on_blocking_pool(
+    router: Arc<dyn ApiRouter>,
+    request: WriteRequest,
+    ingress: AuthenticatedIngress,
+    deadline: RequestDeadline,
+) -> Result<ApiResponse, AtmError> {
+    tokio::task::spawn_blocking(move || {
+        router.route(ApiRequest::Write(Box::new(request)), ingress, deadline)
+    })
+    .await
+    .map_err(|source| {
+        AtmError::new(
+            atm_core::error::AtmErrorCode::InternalError,
+            "canonical HTTP dispatch task ended unexpectedly",
+        )
+        .with_cause(source)
+    })?
 }
 
 fn validate_request_headers(headers: &HeaderMap) -> Result<(), AtmError> {
@@ -216,6 +237,7 @@ fn json_response<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroUsize;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Condvar, Mutex};
     use std::time::Duration;
 
@@ -597,6 +619,44 @@ mod tests {
         assert_eq!(
             first.join().expect("first request thread").status(),
             StatusCode::CREATED
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn synchronous_router_dispatch_does_not_stall_the_tokio_worker() {
+        let gate = Arc::new(Gate::default());
+        let app = canonical_message_router(
+            Arc::new(BlockingRouter {
+                gate: Arc::clone(&gate),
+                response: sent_response(),
+            }),
+            AuthenticatedConnector::local(),
+            limits(4096, 1),
+            timeouts(),
+        );
+        let runtime_progressed = Arc::new(AtomicBool::new(false));
+        let progressed = Arc::clone(&runtime_progressed);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            progressed.store(true, Ordering::Release);
+        });
+        let release_gate = Arc::clone(&gate);
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            release_gate.release();
+        });
+
+        let response = post(
+            app,
+            serde_json::to_vec(&write_request()).expect("typed JSON"),
+        )
+        .await;
+
+        release.join().expect("release gate thread");
+        assert_eq!(response.status(), StatusCode::CREATED);
+        assert!(
+            runtime_progressed.load(Ordering::Acquire),
+            "the Tokio worker must remain schedulable while the synchronous router runs"
         );
     }
 

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -1,0 +1,575 @@
+//! Canonical typed HTTP ingress for message writes.
+//!
+//! This module owns HTTP extraction, connector-provenance normalization, and
+//! response translation only.  It deliberately delegates persistence and all
+//! message policy to the sealed [`ApiRouter`] boundary exactly once.
+
+use std::sync::Arc;
+
+use atm_core::ApiRouter;
+use atm_core::api::{ApiRequest, ApiResponse, AuthenticatedIngress, RequestDeadline};
+use atm_core::error::AtmError;
+use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
+use atm_core::send::WriteRequest;
+use atm_core::types::HostName;
+use axum::body::Body;
+use axum::error_handling::HandleErrorLayer;
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{DefaultBodyLimit, State};
+use axum::http::header::{CONTENT_TYPE, HeaderName, LOCATION};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::response::Response;
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::Serialize;
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::limit::ConcurrencyLimitLayer;
+use tower::load_shed::LoadShedLayer;
+
+use crate::{RuntimeLimits, RuntimeTimeouts};
+
+const MESSAGES_PATH: &str = "/v1/atm/messages";
+const LEGACY_PEER_SOURCE_HEADER: HeaderName = HeaderName::from_static("x-atm-peer-source-host");
+
+/// Provenance established by the transport adapter after authentication.
+///
+/// The handler never derives this fact from a socket address or from JSON.  A
+/// local adapter strips a client-supplied host claim; an authenticated peer
+/// adapter replaces that claim with its TLS-authenticated source host before
+/// the one application dispatch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthenticatedConnector {
+    /// A local UDS or loopback-capability connection.
+    Local,
+    /// A peer connection authenticated by the TLS adapter.
+    Peer { source_host: HostName },
+}
+
+impl AuthenticatedConnector {
+    /// Returns local connector provenance.
+    #[must_use]
+    pub const fn local() -> Self {
+        Self::Local
+    }
+
+    /// Returns authenticated peer provenance from the adapter-owned TLS identity.
+    #[must_use]
+    pub fn peer(source_host: HostName) -> Self {
+        Self::Peer { source_host }
+    }
+
+    fn normalize_write(&self, request: &mut WriteRequest) -> AuthenticatedIngress {
+        match self {
+            Self::Local => {
+                request.authenticated_source_host = None;
+                AuthenticatedIngress::Local
+            }
+            Self::Peer { source_host } => {
+                request.authenticated_source_host = Some(source_host.clone());
+                AuthenticatedIngress::Peer
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct MessageRouteState {
+    router: Arc<dyn ApiRouter>,
+    connector: AuthenticatedConnector,
+    request_timeout: std::time::Duration,
+}
+
+/// Builds the one framework-owned typed message-write route.
+///
+/// `limits` and `timeouts` are the validated AL.1 runtime values. The Tower
+/// layers bound body memory and in-flight work; `LoadShedLayer` rejects rather
+/// than queues a request whenever the configured capacity is unavailable.
+pub fn canonical_message_router(
+    router: Arc<dyn ApiRouter>,
+    connector: AuthenticatedConnector,
+    limits: RuntimeLimits,
+    timeouts: RuntimeTimeouts,
+) -> Router {
+    let state = MessageRouteState {
+        router,
+        connector,
+        request_timeout: timeouts.request,
+    };
+    let admission = ServiceBuilder::new()
+        .layer(HandleErrorLayer::new(|error: BoxError| async move {
+            overload_response(error).await
+        }))
+        .layer(LoadShedLayer::new())
+        .layer(ConcurrencyLimitLayer::new(limits.max_connections));
+
+    Router::new()
+        .route(MESSAGES_PATH, post(post_messages).layer(admission))
+        .layer(DefaultBodyLimit::max(limits.max_body_bytes))
+        .with_state(state)
+}
+
+async fn post_messages(
+    State(state): State<MessageRouteState>,
+    headers: HeaderMap,
+    request: Result<Json<WriteRequest>, JsonRejection>,
+) -> Response {
+    if let Err(error) = validate_request_headers(&headers) {
+        return error_response(error);
+    }
+    let Json(mut request) = match request {
+        Ok(request) => request,
+        Err(rejection) => return error_response(framework_rejection(rejection)),
+    };
+    let ingress = state.connector.normalize_write(&mut request);
+    let deadline = RequestDeadline::after(state.request_timeout);
+
+    let response = state
+        .router
+        .route(ApiRequest::Write(Box::new(request)), ingress, deadline);
+    response
+        .and_then(map_write_response)
+        .unwrap_or_else(error_response)
+}
+
+fn validate_request_headers(headers: &HeaderMap) -> Result<(), AtmError> {
+    if headers.contains_key(&LEGACY_PEER_SOURCE_HEADER) {
+        return Err(AtmError::validation(
+            "X-ATM-Peer-Source-Host is not accepted by canonical HTTP ingress",
+        ));
+    }
+    Ok(())
+}
+
+async fn overload_response(_: BoxError) -> Response {
+    error_response(AtmError::daemon_unavailable(
+        "HTTP message ingress is at its configured in-flight capacity",
+    ))
+}
+
+fn framework_rejection(rejection: JsonRejection) -> AtmError {
+    AtmError::validation("invalid HTTP messages request").with_cause(rejection)
+}
+
+fn map_write_response(response: ApiResponse) -> Result<Response, AtmError> {
+    match response.into_inner() {
+        ResponseEnvelope::Send(SendResponseEnvelope::Sent(outcome)) => json_response(
+            StatusCode::CREATED,
+            &outcome,
+            Some(outcome.message_id.to_string()),
+        ),
+        ResponseEnvelope::Send(SendResponseEnvelope::Acknowledged(outcome)) => json_response(
+            StatusCode::CREATED,
+            &outcome,
+            Some(outcome.message_id.to_string()),
+        ),
+        ResponseEnvelope::Error(error) => Ok(error_response(error)),
+        _ => Err(AtmError::daemon_unavailable(
+            "canonical message route received a non-write application response",
+        )),
+    }
+}
+
+fn error_response(error: AtmError) -> Response {
+    let status = if error.is_validation() {
+        StatusCode::BAD_REQUEST
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    // `AtmError` is the repository-wide serde error contract. If serialization
+    // itself fails, return a minimal 503 without inventing another JSON shape.
+    json_response(status, &error, None).unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+fn json_response<T: Serialize>(
+    status: StatusCode,
+    value: &T,
+    message_id: Option<String>,
+) -> Result<Response, AtmError> {
+    let body = serde_json::to_vec(value).map_err(|source| {
+        AtmError::daemon_unavailable("failed to serialize canonical HTTP response")
+            .with_cause(source)
+    })?;
+    let mut response = Response::new(Body::from(body));
+    *response.status_mut() = status;
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    if let Some(message_id) = message_id {
+        let location = format!("/v1/atm/message/{message_id}");
+        let location = HeaderValue::from_str(&location).map_err(|source| {
+            AtmError::daemon_unavailable("failed to serialize message location header")
+                .with_cause(source)
+        })?;
+        response.headers_mut().insert(LOCATION, location);
+    }
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::time::Duration;
+
+    use atm_core::boundary;
+    use atm_core::error::AtmError;
+    use atm_core::protocol::ResponseEnvelope;
+    use atm_core::send::{SendCommandOutcome, SendMessageSource, SendOutcome};
+    use atm_core::types::CommandAction;
+    use atm_core::{ApiRequest, ApiResponse, ApiRouter, AuthenticatedIngress, RequestDeadline};
+    use axum::body::{Body, to_bytes};
+    use axum::http::header::{CONTENT_TYPE, HeaderName};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use super::{AuthenticatedConnector, canonical_message_router};
+    use crate::{NonZeroDuration, RuntimeLimits, RuntimeTimeouts};
+
+    #[derive(Clone)]
+    struct RecordingRouter {
+        response: ResponseEnvelope,
+        calls: Arc<Mutex<Vec<(atm_core::send::WriteRequest, AuthenticatedIngress)>>>,
+    }
+
+    impl boundary::sealed::Sealed for RecordingRouter {}
+
+    impl ApiRouter for RecordingRouter {
+        fn route(
+            &self,
+            request: ApiRequest,
+            ingress: AuthenticatedIngress,
+            _deadline: RequestDeadline,
+        ) -> Result<ApiResponse, AtmError> {
+            let ApiRequest::Write(request) = request else {
+                return Err(AtmError::validation("test expected a write request"));
+            };
+            self.calls
+                .lock()
+                .expect("record calls")
+                .push((*request, ingress));
+            Ok(ApiResponse::new(self.response.clone()))
+        }
+    }
+
+    struct BlockingRouter {
+        gate: Arc<Gate>,
+        response: ResponseEnvelope,
+    }
+
+    impl boundary::sealed::Sealed for BlockingRouter {}
+
+    impl ApiRouter for BlockingRouter {
+        fn route(
+            &self,
+            _request: ApiRequest,
+            _ingress: AuthenticatedIngress,
+            _deadline: RequestDeadline,
+        ) -> Result<ApiResponse, AtmError> {
+            self.gate.wait_until_released();
+            Ok(ApiResponse::new(self.response.clone()))
+        }
+    }
+
+    #[derive(Default)]
+    struct Gate {
+        state: Mutex<GateState>,
+        changed: Condvar,
+    }
+
+    #[derive(Default)]
+    struct GateState {
+        entered: bool,
+        released: bool,
+    }
+
+    impl Gate {
+        fn wait_until_released(&self) {
+            let mut state = self.state.lock().expect("lock gate");
+            state.entered = true;
+            self.changed.notify_all();
+            while !state.released {
+                state = self.changed.wait(state).expect("wait gate");
+            }
+        }
+
+        fn wait_until_entered(&self) {
+            let mut state = self.state.lock().expect("lock gate");
+            while !state.entered {
+                state = self.changed.wait(state).expect("wait gate");
+            }
+        }
+
+        fn release(&self) {
+            self.state.lock().expect("lock gate").released = true;
+            self.changed.notify_all();
+        }
+    }
+
+    fn limits(body_bytes: usize, in_flight: usize) -> RuntimeLimits {
+        RuntimeLimits::new(
+            NonZeroUsize::new(body_bytes).expect("non-zero body limit"),
+            NonZeroUsize::new(in_flight).expect("non-zero in-flight limit"),
+        )
+    }
+
+    fn timeouts() -> RuntimeTimeouts {
+        RuntimeTimeouts::new(
+            NonZeroDuration::new(Duration::from_secs(1)).expect("non-zero request timeout"),
+            NonZeroDuration::new(Duration::from_secs(1)).expect("non-zero shutdown timeout"),
+        )
+    }
+
+    fn write_request() -> atm_core::send::WriteRequest {
+        atm_core::send::WriteRequest::new(
+            PathBuf::from("/tmp/atm-http-runtime-test-home"),
+            PathBuf::from("/tmp/atm-http-runtime-test-workspace"),
+            "sender".parse().expect("agent"),
+            "recipient@test-team",
+            "test-team".parse().expect("team"),
+            SendMessageSource::Inline("typed route fixture".to_owned()),
+            None,
+            false,
+            None,
+            false,
+        )
+        .expect("write request")
+    }
+
+    fn sent_response() -> ResponseEnvelope {
+        ResponseEnvelope::Send(atm_core::protocol::SendResponseEnvelope::Sent(
+            SendOutcome {
+                action: CommandAction::Send,
+                team: "test-team".parse().expect("team"),
+                agent: "recipient".parse().expect("agent"),
+                sender: "sender".parse().expect("agent"),
+                outcome: SendCommandOutcome::Sent,
+                message_id: atm_core::schema::AtmMessageId::new(),
+                requires_ack: false,
+                task_id: None,
+                summary: None,
+                message: Some("typed route fixture".to_owned()),
+                warnings: Vec::new(),
+                dry_run: false,
+            },
+        ))
+    }
+
+    async fn post(app: axum::Router, body: Vec<u8>) -> axum::response::Response {
+        post_with_headers(app, body, &[(CONTENT_TYPE, "application/json")]).await
+    }
+
+    async fn post_with_headers(
+        app: axum::Router,
+        body: Vec<u8>,
+        headers: &[(HeaderName, &str)],
+    ) -> axum::response::Response {
+        let mut request = Request::builder().method("POST").uri("/v1/atm/messages");
+        for (name, value) in headers {
+            request = request.header(name, *value);
+        }
+        app.oneshot(request.body(Body::from(body)).expect("HTTP request"))
+            .await
+            .expect("infallible Axum service")
+    }
+
+    async fn response_body(response: axum::response::Response) -> Vec<u8> {
+        to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response bytes")
+            .to_vec()
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn local_and_peer_use_identical_write_json_and_one_dispatch() {
+        let mut request = write_request();
+        request.authenticated_source_host = Some("forged.example.test".parse().expect("host"));
+        let body = serde_json::to_vec(&request).expect("typed write JSON");
+        let response = sent_response();
+        let expected = match &response {
+            ResponseEnvelope::Send(atm_core::protocol::SendResponseEnvelope::Sent(outcome)) => {
+                serde_json::to_vec(outcome).expect("typed outcome JSON")
+            }
+            _ => unreachable!("test response is a send outcome"),
+        };
+
+        let local_calls = Arc::new(Mutex::new(Vec::new()));
+        let local = canonical_message_router(
+            Arc::new(RecordingRouter {
+                response: response.clone(),
+                calls: Arc::clone(&local_calls),
+            }),
+            AuthenticatedConnector::local(),
+            limits(4096, 2),
+            timeouts(),
+        );
+        let local_response = post(local, body.clone()).await;
+        assert_eq!(local_response.status(), StatusCode::CREATED);
+        assert_eq!(response_body(local_response).await, expected);
+
+        let peer_calls = Arc::new(Mutex::new(Vec::new()));
+        let peer = canonical_message_router(
+            Arc::new(RecordingRouter {
+                response,
+                calls: Arc::clone(&peer_calls),
+            }),
+            AuthenticatedConnector::peer("trusted.example.test".parse().expect("host")),
+            limits(4096, 2),
+            timeouts(),
+        );
+        let peer_response = post(peer, body.clone()).await;
+        assert_eq!(peer_response.status(), StatusCode::CREATED);
+        assert_eq!(response_body(peer_response).await, expected);
+
+        assert_eq!(body, serde_json::to_vec(&request).expect("same typed JSON"));
+        let local_calls = local_calls.lock().expect("local calls");
+        let peer_calls = peer_calls.lock().expect("peer calls");
+        assert_eq!(local_calls.len(), 1, "local request has one core dispatch");
+        assert_eq!(peer_calls.len(), 1, "peer request has one core dispatch");
+        assert_eq!(local_calls[0].0.authenticated_source_host, None);
+        assert_eq!(local_calls[0].1, AuthenticatedIngress::Local);
+        assert_eq!(
+            peer_calls[0].0.authenticated_source_host,
+            Some("trusted.example.test".parse().expect("host"))
+        );
+        assert_eq!(peer_calls[0].1, AuthenticatedIngress::Peer);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn framework_json_and_body_rejections_keep_the_adr_032_schema() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let app = canonical_message_router(
+            Arc::new(RecordingRouter {
+                response: sent_response(),
+                calls: Arc::clone(&calls),
+            }),
+            AuthenticatedConnector::local(),
+            limits(32, 1),
+            timeouts(),
+        );
+
+        for body in [b"not-json".to_vec(), vec![b'x'; 33]] {
+            let response = post(app.clone(), body).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let error: AtmError =
+                serde_json::from_slice(&response_body(response).await).expect("ADR-032 error JSON");
+            assert!(error.is_validation(), "{error:?}");
+        }
+        assert!(calls.lock().expect("calls").is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn malformed_headers_are_rejected_as_direct_adr_032_errors() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let app = canonical_message_router(
+            Arc::new(RecordingRouter {
+                response: sent_response(),
+                calls: Arc::clone(&calls),
+            }),
+            AuthenticatedConnector::local(),
+            limits(4096, 1),
+            timeouts(),
+        );
+        let request = serde_json::to_vec(&write_request()).expect("typed JSON");
+
+        for headers in [
+            vec![(CONTENT_TYPE, "text/plain")],
+            vec![
+                (CONTENT_TYPE, "application/json"),
+                (
+                    HeaderName::from_static("x-atm-peer-source-host"),
+                    "not a valid host",
+                ),
+            ],
+        ] {
+            let response = post_with_headers(app.clone(), request.clone(), &headers).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let error: AtmError = serde_json::from_slice(&response_body(response).await)
+                .expect("ADR-032 header error JSON");
+            assert!(error.is_validation(), "{error:?}");
+        }
+        assert!(calls.lock().expect("calls").is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn typed_core_errors_use_the_one_adr_032_response_mapper() {
+        let expected = AtmError::daemon_unavailable("test core failure");
+        let app = canonical_message_router(
+            Arc::new(RecordingRouter {
+                response: ResponseEnvelope::Error(expected.clone()),
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }),
+            AuthenticatedConnector::local(),
+            limits(4096, 1),
+            timeouts(),
+        );
+
+        let response = post(
+            app,
+            serde_json::to_vec(&write_request()).expect("typed JSON"),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response_body(response).await,
+            serde_json::to_vec(&expected).expect("typed ADR-032 JSON")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_shed_rejects_without_an_application_queue() {
+        let gate = Arc::new(Gate::default());
+        let app = canonical_message_router(
+            Arc::new(BlockingRouter {
+                gate: Arc::clone(&gate),
+                response: sent_response(),
+            }),
+            AuthenticatedConnector::local(),
+            limits(4096, 1),
+            timeouts(),
+        );
+        let first_app = app.clone();
+        let first_body = serde_json::to_vec(&write_request()).expect("typed write JSON");
+        let first = std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime")
+                .block_on(post(first_app, first_body))
+        });
+        gate.wait_until_entered();
+
+        let started = std::time::Instant::now();
+        let overloaded = post(
+            app,
+            serde_json::to_vec(&write_request()).expect("typed JSON"),
+        )
+        .await;
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "load shedding must reject within the configured request budget"
+        );
+        assert_eq!(overloaded.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let error: AtmError = serde_json::from_slice(&response_body(overloaded).await)
+            .expect("ADR-032 overload JSON");
+        assert!(error.is_daemon_unavailable(), "{error:?}");
+
+        gate.release();
+        assert_eq!(
+            first.join().expect("first request thread").status(),
+            StatusCode::CREATED
+        );
+    }
+
+    #[test]
+    fn openapi_and_handler_keep_the_existing_typed_write_contract() {
+        let openapi = include_str!("../../../docs/atm-daemon/openapi.yaml");
+        assert!(openapi.contains("operationId: writeMessage"));
+        assert!(openapi.contains("$ref: '#/components/schemas/WriteRequest'"));
+        let forbidden = ["Http", "Frame", "Reader"].concat();
+        assert!(!include_str!("message_handler.rs").contains(&forbidden));
+        let forbidden = ["Peer", "Message", "Array"].concat();
+        assert!(!include_str!("message_handler.rs").contains(&forbidden));
+    }
+}

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -142,7 +142,7 @@ fn validate_request_headers(headers: &HeaderMap) -> Result<(), AtmError> {
 }
 
 async fn overload_response(_: BoxError) -> Response {
-    error_response(AtmError::daemon_unavailable(
+    error_response(AtmError::daemon_connection_saturated(
         "HTTP message ingress is at its configured in-flight capacity",
     ))
 }
@@ -213,7 +213,7 @@ mod tests {
     use std::time::Duration;
 
     use atm_core::boundary;
-    use atm_core::error::AtmError;
+    use atm_core::error::{AtmError, AtmErrorCode};
     use atm_core::protocol::ResponseEnvelope;
     use atm_core::send::{SendCommandOutcome, SendMessageSource, SendOutcome};
     use atm_core::types::CommandAction;
@@ -553,7 +553,7 @@ mod tests {
         assert_eq!(overloaded.status(), StatusCode::SERVICE_UNAVAILABLE);
         let error: AtmError = serde_json::from_slice(&response_body(overloaded).await)
             .expect("ADR-032 overload JSON");
-        assert!(error.is_daemon_unavailable(), "{error:?}");
+        assert_eq!(error.code(), AtmErrorCode::DaemonConnectionSaturated);
 
         gate.release();
         assert_eq!(

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -209,7 +209,6 @@ fn json_response<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroUsize;
-    use std::path::PathBuf;
     use std::sync::{Arc, Condvar, Mutex};
     use std::time::Duration;
 
@@ -322,9 +321,10 @@ mod tests {
     }
 
     fn write_request() -> atm_core::send::WriteRequest {
+        let temporary_root = tempfile::tempdir().expect("temporary request paths");
         atm_core::send::WriteRequest::new(
-            PathBuf::from("/tmp/atm-http-runtime-test-home"),
-            PathBuf::from("/tmp/atm-http-runtime-test-workspace"),
+            temporary_root.path().join("home"),
+            temporary_root.path().join("workspace"),
             "sender".parse().expect("agent"),
             "recipient@test-team",
             "test-team".parse().expect("team"),

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -164,7 +164,8 @@ fn map_write_response(response: ApiResponse) -> Result<Response, AtmError> {
             Some(outcome.message_id.to_string()),
         ),
         ResponseEnvelope::Error(error) => Ok(error_response(error)),
-        _ => Err(AtmError::daemon_unavailable(
+        _ => Err(AtmError::new(
+            atm_core::error::AtmErrorCode::InternalError,
             "canonical message route received a non-write application response",
         )),
     }
@@ -187,8 +188,11 @@ fn json_response<T: Serialize>(
     message_id: Option<String>,
 ) -> Result<Response, AtmError> {
     let body = serde_json::to_vec(value).map_err(|source| {
-        AtmError::daemon_unavailable("failed to serialize canonical HTTP response")
-            .with_cause(source)
+        AtmError::new(
+            atm_core::error::AtmErrorCode::SerializationFailed,
+            "failed to serialize canonical HTTP response",
+        )
+        .with_cause(source)
     })?;
     let mut response = Response::new(Body::from(body));
     *response.status_mut() = status;
@@ -198,8 +202,11 @@ fn json_response<T: Serialize>(
     if let Some(message_id) = message_id {
         let location = format!("/v1/atm/message/{message_id}");
         let location = HeaderValue::from_str(&location).map_err(|source| {
-            AtmError::daemon_unavailable("failed to serialize message location header")
-                .with_cause(source)
+            AtmError::new(
+                atm_core::error::AtmErrorCode::SerializationFailed,
+                "failed to serialize message location header",
+            )
+            .with_cause(source)
         })?;
         response.headers_mut().insert(LOCATION, location);
     }
@@ -223,7 +230,9 @@ mod tests {
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
-    use super::{AuthenticatedConnector, canonical_message_router};
+    use super::{
+        AuthenticatedConnector, canonical_message_router, json_response, map_write_response,
+    };
     use crate::{NonZeroDuration, RuntimeLimits, RuntimeTimeouts};
 
     #[derive(Clone)]
@@ -255,6 +264,19 @@ mod tests {
     struct BlockingRouter {
         gate: Arc<Gate>,
         response: ResponseEnvelope,
+    }
+
+    struct FailingSerialize;
+
+    impl serde::Serialize for FailingSerialize {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            Err(serde::ser::Error::custom(
+                "intentional serialization failure",
+            ))
+        }
     }
 
     impl boundary::sealed::Sealed for BlockingRouter {}
@@ -515,6 +537,22 @@ mod tests {
             response_body(response).await,
             serde_json::to_vec(&expected).expect("typed ADR-032 JSON")
         );
+    }
+
+    #[test]
+    fn response_translation_uses_internal_and_serialization_error_codes() {
+        let mismatch =
+            match map_write_response(ApiResponse::new(ResponseEnvelope::RuntimeViewReloaded)) {
+                Ok(_) => panic!("non-write response must be rejected"),
+                Err(error) => error,
+            };
+        assert_eq!(mismatch.code(), AtmErrorCode::InternalError);
+
+        let serialization = match json_response(StatusCode::OK, &FailingSerialize, None) {
+            Ok(_) => panic!("failing serializer must be rejected"),
+            Err(error) => error,
+        };
+        assert_eq!(serialization.code(), AtmErrorCode::SerializationFailed);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -265,7 +265,6 @@ fn json_response<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroUsize;
-    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Condvar, Mutex};
     use std::time::Duration;
 
@@ -356,6 +355,7 @@ mod tests {
     struct GateState {
         entered: bool,
         released: bool,
+        scheduler_progressed: bool,
     }
 
     impl Gate {
@@ -378,6 +378,18 @@ mod tests {
         fn release(&self) {
             self.state.lock().expect("lock gate").released = true;
             self.changed.notify_all();
+        }
+
+        fn note_scheduler_progress(&self) {
+            self.state.lock().expect("lock gate").scheduler_progressed = true;
+            self.changed.notify_all();
+        }
+
+        fn wait_until_scheduler_progresses(&self) {
+            let mut state = self.state.lock().expect("lock gate");
+            while !state.scheduler_progressed {
+                state = self.changed.wait(state).expect("wait gate");
+            }
         }
     }
 
@@ -679,15 +691,22 @@ mod tests {
             limits(4096, 1),
             timeouts(),
         );
-        let runtime_progressed = Arc::new(AtomicBool::new(false));
-        let progressed = Arc::clone(&runtime_progressed);
+        let (start_progress, wait_for_start) = tokio::sync::oneshot::channel();
+        let progressed = Arc::clone(&gate);
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(5)).await;
-            progressed.store(true, Ordering::Release);
+            wait_for_start
+                .await
+                .expect("blocking router entered before scheduler progress check");
+            progressed.note_scheduler_progress();
         });
+        let entered = Arc::clone(&gate);
         let release_gate = Arc::clone(&gate);
         let release = std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(50));
+            entered.wait_until_entered();
+            start_progress
+                .send(())
+                .expect("scheduler progress task remains available");
+            release_gate.wait_until_scheduler_progresses();
             release_gate.release();
         });
 
@@ -700,7 +719,7 @@ mod tests {
         release.join().expect("release gate thread");
         assert_eq!(response.status(), StatusCode::CREATED);
         assert!(
-            runtime_progressed.load(Ordering::Acquire),
+            gate.state.lock().expect("lock gate").scheduler_progressed,
             "the Tokio worker must remain schedulable while the synchronous router runs"
         );
     }
@@ -717,20 +736,16 @@ mod tests {
             limits(4096, 1),
             timeouts_with_request(Duration::from_millis(10)),
         );
-        let release_gate = Arc::clone(&gate);
-        let release = std::thread::spawn(move || {
-            release_gate.wait_until_entered();
-            std::thread::sleep(Duration::from_millis(50));
-            release_gate.release();
-        });
-
-        let response = post(
-            app,
-            serde_json::to_vec(&write_request()).expect("typed JSON"),
+        let response = tokio::time::timeout(
+            Duration::from_secs(1),
+            post(
+                app,
+                serde_json::to_vec(&write_request()).expect("typed JSON"),
+            ),
         )
         .await;
-
-        release.join().expect("release gate thread");
+        gate.release();
+        let response = response.expect("handler must enforce its request timeout");
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         let error: AtmError =
             serde_json::from_slice(&response_body(response).await).expect("ADR-032 timeout JSON");

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -124,8 +124,18 @@ async fn post_messages(
     let ingress = state.connector.normalize_write(&mut request);
     let deadline = RequestDeadline::after(state.request_timeout);
 
-    let response =
-        dispatch_on_blocking_pool(Arc::clone(&state.router), request, ingress, deadline).await;
+    let response = tokio::time::timeout(
+        state.request_timeout,
+        dispatch_on_blocking_pool(Arc::clone(&state.router), request, ingress, deadline),
+    )
+    .await
+    .map_err(|_| {
+        AtmError::new(
+            atm_core::error::AtmErrorCode::WaitTimeout,
+            "canonical HTTP dispatch exceeded the configured request timeout",
+        )
+    })
+    .and_then(|response| response);
     response
         .and_then(map_write_response)
         .unwrap_or_else(error_response)
@@ -358,8 +368,12 @@ mod tests {
     }
 
     fn timeouts() -> RuntimeTimeouts {
+        timeouts_with_request(Duration::from_secs(1))
+    }
+
+    fn timeouts_with_request(request: Duration) -> RuntimeTimeouts {
         RuntimeTimeouts::new(
-            NonZeroDuration::new(Duration::from_secs(1)).expect("non-zero request timeout"),
+            NonZeroDuration::new(request).expect("non-zero request timeout"),
             NonZeroDuration::new(Duration::from_secs(1)).expect("non-zero shutdown timeout"),
         )
     }
@@ -658,6 +672,38 @@ mod tests {
             runtime_progressed.load(Ordering::Acquire),
             "the Tokio worker must remain schedulable while the synchronous router runs"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_timeout_returns_the_adr_032_timeout_error() {
+        let gate = Arc::new(Gate::default());
+        let app = canonical_message_router(
+            Arc::new(BlockingRouter {
+                gate: Arc::clone(&gate),
+                response: sent_response(),
+            }),
+            AuthenticatedConnector::local(),
+            limits(4096, 1),
+            timeouts_with_request(Duration::from_millis(10)),
+        );
+        let release_gate = Arc::clone(&gate);
+        let release = std::thread::spawn(move || {
+            release_gate.wait_until_entered();
+            std::thread::sleep(Duration::from_millis(50));
+            release_gate.release();
+        });
+
+        let response = post(
+            app,
+            serde_json::to_vec(&write_request()).expect("typed JSON"),
+        )
+        .await;
+
+        release.join().expect("release gate thread");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let error: AtmError =
+            serde_json::from_slice(&response_body(response).await).expect("ADR-032 timeout JSON");
+        assert_eq!(error.code(), AtmErrorCode::WaitTimeout);
     }
 
     #[test]

--- a/crates/atm-http-runtime/src/message_handler.rs
+++ b/crates/atm-http-runtime/src/message_handler.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 
 use atm_core::ApiRouter;
 use atm_core::api::{
-    ApiRequest, ApiResponse, AuthenticatedIngress, RequestDeadline, http_route_surface,
+    ApiRequest, ApiResponse, AuthenticatedIngress, PEER_SOURCE_HOST_HEADER, RequestDeadline,
+    http_route_surface,
 };
 use atm_core::error::AtmError;
 use atm_core::protocol::{ResponseEnvelope, SendResponseEnvelope};
@@ -18,7 +19,7 @@ use axum::body::Body;
 use axum::error_handling::HandleErrorLayer;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{DefaultBodyLimit, State};
-use axum::http::header::{CONTENT_TYPE, HeaderName, LOCATION};
+use axum::http::header::{CONTENT_TYPE, LOCATION};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::Response;
 use axum::routing::post;
@@ -30,8 +31,6 @@ use tower::limit::ConcurrencyLimitLayer;
 use tower::load_shed::LoadShedLayer;
 
 use crate::{RuntimeLimits, RuntimeTimeouts};
-
-const LEGACY_PEER_SOURCE_HEADER: HeaderName = HeaderName::from_static("x-atm-peer-source-host");
 
 /// Provenance established by the transport adapter after authentication.
 ///
@@ -183,10 +182,10 @@ async fn dispatch_on_blocking_pool(
 }
 
 fn validate_request_headers(headers: &HeaderMap) -> Result<(), AtmError> {
-    if headers.contains_key(&LEGACY_PEER_SOURCE_HEADER) {
-        return Err(AtmError::validation(
-            "X-ATM-Peer-Source-Host is not accepted by canonical HTTP ingress",
-        ));
+    if headers.contains_key(PEER_SOURCE_HOST_HEADER) {
+        return Err(AtmError::validation(format!(
+            "{PEER_SOURCE_HOST_HEADER} is not accepted by canonical HTTP ingress"
+        )));
     }
     Ok(())
 }
@@ -270,6 +269,7 @@ mod tests {
     use std::sync::{Arc, Condvar, Mutex};
     use std::time::Duration;
 
+    use atm_core::api::PEER_SOURCE_HOST_HEADER;
     use atm_core::boundary;
     use atm_core::error::{AtmError, AtmErrorCode};
     use atm_core::protocol::ResponseEnvelope;
@@ -558,7 +558,8 @@ mod tests {
             vec![
                 (CONTENT_TYPE, "application/json"),
                 (
-                    HeaderName::from_static("x-atm-peer-source-host"),
+                    HeaderName::from_bytes(PEER_SOURCE_HOST_HEADER.as_bytes())
+                        .expect("canonical peer source header"),
                     "not a valid host",
                 ),
             ],

--- a/crates/atm-storage/src/error.rs
+++ b/crates/atm-storage/src/error.rs
@@ -232,6 +232,11 @@ impl AtmError {
         Self::new(AtmErrorCode::DaemonAutoStartFailed, message)
     }
 
+    /// Reports bounded daemon admission capacity without claiming the daemon is unavailable.
+    pub fn daemon_connection_saturated(message: impl Into<String>) -> Self {
+        Self::new(AtmErrorCode::DaemonConnectionSaturated, message)
+    }
+
     pub fn help_topic_not_found(message: impl Into<String>) -> Self {
         Self::new(AtmErrorCode::HelpTopicNotFound, message)
     }

--- a/crates/atm-storage/src/error_catalog.rs
+++ b/crates/atm-storage/src/error_catalog.rs
@@ -104,7 +104,6 @@ const fn daemon_guidance(code: AtmErrorCode) -> Option<&'static str> {
         | AtmErrorCode::DaemonServingStateRejected
         | AtmErrorCode::DaemonStaleOwnerRecoveryFailed
         | AtmErrorCode::DaemonAutoStartFailed
-        | AtmErrorCode::DaemonConnectionSaturated
         | AtmErrorCode::PeerConfigValidationFailed
         | AtmErrorCode::CertificateOperationFailed
         | AtmErrorCode::BindPreflightFailed
@@ -114,6 +113,9 @@ const fn daemon_guidance(code: AtmErrorCode) -> Option<&'static str> {
         | AtmErrorCode::DaemonAdvisorySessionCleanupFailed => Some(
             "Ensure atm-daemon binary is installed, then restore the single local daemon to a healthy serving state and retry.",
         ),
+        AtmErrorCode::DaemonConnectionSaturated => {
+            Some("Wait for the daemon to finish an in-flight request, then retry.")
+        }
         _ => None,
     }
 }

--- a/docs/plans/phase-al/sprint-AL2-canonical-handler.md
+++ b/docs/plans/phase-al/sprint-AL2-canonical-handler.md
@@ -1,6 +1,6 @@
 ---
 title: AL.2 Canonical Typed HTTP Handler
-status: proposed
+status: complete
 branch: feature/pal-s2-canonical-handler
 worktree: ../atm-core-worktrees/feature/pal-s2-canonical-handler
 target: integrate/phase-al

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1147,7 +1147,7 @@ Status summary:
 Sprint line:
 - `AL.1` `sprint-AL1-runtime-contract.md` — runtime contract and archived-hook
   transplant
-- `AL.2` `sprint-AL2-canonical-handler.md` — canonical handler
+- `AL.2 [COMPLETE]` `sprint-AL2-canonical-handler.md` — canonical handler
 - `AL.3` `sprint-AL3-received-hook.md` — received hook wiring
 - `AL.4` `sprint-AL4-shared-client.md` — shared client
 - `AL.5` `sprint-AL5-unix-uds.md` — Unix UDS listener


### PR DESCRIPTION
## Summary
Implements the framework-owned `POST /v1/atm/messages` route as the sole application ingress, per `docs/plans/phase-al/sprint-AL2-canonical-handler.md`.

- Sole typed HTTP handler with one `ApiRouter` dispatch call (no `PeerMessageArray`/second request form)
- Connector provenance normalization before dispatch
- Existing typed error/result semantics preserved via one response mapper (ADR-032 error contract)
- Bounded overload control via Tower/Axum layers (body limit, in-flight concurrency limit, load-shed)
- Axum service integration tests added

## Sprint doc
docs/plans/phase-al/sprint-AL2-canonical-handler.md

## must_follow
AL.2 must_follow AL.1 (PR #765, merged to `integrate/phase-al` @ 4e4f2eb1). This branch has AL.1's integration baseline merged in.

## Status
arch-ctm reports full `just lint`/`just test` running on this exact commit (d557d662). QA-1 to be dispatched to quality-mgr once validation completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)